### PR TITLE
[ML] Do not log incorrect model memory limit

### DIFF
--- a/include/model/CLimits.h
+++ b/include/model/CLimits.h
@@ -75,9 +75,6 @@ class MODEL_EXPORT CLimits
         //! nothing is anomalous on a whole-system basis
         static const double DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD;
 
-        //! Default memory limit for resource monitor
-        static const size_t DEFAULT_MEMORY_LIMIT_MB;
-
     public:
         //! Default constructor
         CLimits();

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -63,12 +63,12 @@ class MODEL_EXPORT CResourceMonitor
         //! The minimum time between prunes
         static const core_t::TTime MINIMUM_PRUNE_FREQUENCY;
 
+        //! Default memory limit for resource monitor
+        static const std::size_t DEFAULT_MEMORY_LIMIT_MB;
+
     public:
         //! Default constructor
         CResourceMonitor(void);
-
-        //! Constructor with a set memory limit
-        CResourceMonitor(std::size_t limit);
 
         //! Query the resource monitor to find out if the models are
         //! taking up too much memory and further allocations should be banned
@@ -100,7 +100,7 @@ class MODEL_EXPORT CResourceMonitor
         void forceRefresh(CAnomalyDetector &detector);
 
         //! Set the internal memory limit, as specified in a limits config file
-        void memoryLimit(std::size_t limit);
+        void memoryLimit(std::size_t limitMBs);
 
         //! Get the memory status
         model_t::EMemoryStatus getMemoryStatus();
@@ -140,6 +140,11 @@ class MODEL_EXPORT CResourceMonitor
         //! Clears all extra memory
         void clearExtraMemory(void);
     private:
+
+        //! Updates the memory limit fields and the prune threshold
+        //! to the given value.
+        void updateMemoryLimitsAndPruneThreshold(std::size_t limitMBs);
+
         //! Update the given model and recalculate the total usage
         void memUsage(CAnomalyDetectorModel *model);
 

--- a/lib/model/CLimits.cc
+++ b/lib/model/CLimits.cc
@@ -33,15 +33,14 @@ const size_t CLimits::DEFAULT_ANOMALY_MAX_TIME_BUCKETS(1000000);
 const size_t CLimits::DEFAULT_RESULTS_MAX_EXAMPLES(4);
 // The probability threshold is stored as a percentage in the config file
 const double CLimits::DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD(3.5);
-const size_t CLimits::DEFAULT_MEMORY_LIMIT_MB(4096);
 
 
 CLimits::CLimits() : m_AutoConfigEvents(DEFAULT_AUTOCONFIG_EVENTS),
     m_AnomalyMaxTimeBuckets(DEFAULT_ANOMALY_MAX_TIME_BUCKETS),
     m_MaxExamples(DEFAULT_RESULTS_MAX_EXAMPLES),
     m_UnusualProbabilityThreshold(DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD),
-    m_MemoryLimitMB(DEFAULT_MEMORY_LIMIT_MB),
-    m_ResourceMonitor(DEFAULT_MEMORY_LIMIT_MB)
+    m_MemoryLimitMB(CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB),
+    m_ResourceMonitor()
 {
 }
 
@@ -89,7 +88,7 @@ bool CLimits::init(const std::string &configFile)
                              m_UnusualProbabilityThreshold) == false ||
         this->processSetting(propTree,
                              "memory.modelmemorylimit",
-                             DEFAULT_MEMORY_LIMIT_MB,
+                             CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB,
                              m_MemoryLimitMB) == false)
     {
         LOG_ERROR("Error processing config file " << configFile);

--- a/lib/model/unittest/CLimitsTest.cc
+++ b/lib/model/unittest/CLimitsTest.cc
@@ -43,8 +43,7 @@ void CLimitsTest::testTrivial(void)
     CPPUNIT_ASSERT_EQUAL(ml::model::CLimits::DEFAULT_RESULTS_MAX_EXAMPLES, config.maxExamples());
     CPPUNIT_ASSERT_EQUAL(ml::model::CLimits::DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD / 100.0,
                          config.unusualProbabilityThreshold());
-    CPPUNIT_ASSERT_EQUAL(ml::model::CLimits::DEFAULT_MEMORY_LIMIT_MB,
-                         config.memoryLimitMB());
+    CPPUNIT_ASSERT_EQUAL(ml::model::CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB, config.memoryLimitMB());
 }
 
 void CLimitsTest::testValid(void)

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -111,7 +111,8 @@ void CResourceMonitorTest::testMonitor(void)
     }
     {
         // Test size constructor
-        CResourceMonitor mon(543);
+        CResourceMonitor mon;
+        mon.memoryLimit(543);
         CPPUNIT_ASSERT_EQUAL(std::size_t(569376768 / 2), mon.m_ByteLimitHigh);
         CPPUNIT_ASSERT_EQUAL(std::size_t(569376768 / 2 - 1024), mon.m_ByteLimitLow);
         CPPUNIT_ASSERT(mon.m_AllowAllocations);


### PR DESCRIPTION
Previously, the model memory limit was logged twice:
once when the CResourceMonitor was constructed and once
when the limit was read from the config file. The first
time the log message contained the default limit (4GB).
The second time it contained the actual limit.

The first message is incorrect. In addition, 6.3 is
changed so that the limit is always set explicitly. Thus,
there is no reason to keep logging in the constructor of
the monitor.

This commit removes the logging from the constructor of
the resource monitor.