### PR TITLE
[ML] Fix sparse data edge cases for periodicity testing

### DIFF
--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -343,14 +343,15 @@ class MATHS_EXPORT CPeriodicityHypothesisTests
             testForDailyWithWeekend(const TFloatMeanAccumulatorCRng &buckets,
                                     STestStats &stats) const;
 
-        //! Test for a weekday/end partition with weekly .
+        //! Test for a weekly period given we think there is a
+        //! weekday/end partition.
         CPeriodicityHypothesisTestsResult
             testForWeeklyGivenDailyWithWeekend(const TTimeTimePr2Vec &window,
                                                const TFloatMeanAccumulatorCRng &buckets,
                                                STestStats &stats) const;
 
-        //! Test for the specified period given we think there is
-        //! some diurnal periodicity.
+        //! Test for the specified period given we think there is diurnal
+        //! periodicity.
         CPeriodicityHypothesisTestsResult
             testForPeriod(const TTimeTimePr2Vec &window,
                           const TFloatMeanAccumulatorCRng &buckets,
@@ -359,6 +360,11 @@ class MATHS_EXPORT CPeriodicityHypothesisTests
         //! Check we've seen sufficient data to test accurately.
         bool seenSufficientDataToTest(core_t::TTime period,
                                       const TFloatMeanAccumulatorCRng &buckets) const;
+
+        //! Check if there are enough non-empty buckets which are repeated
+        //! at at least one \p period in \p buckets.
+        bool seenSufficientPeriodicallyPopulatedBucketsToTest(const TFloatMeanAccumulatorCRng &buckets,
+                                                              std::size_t period) const;
 
         //! Compute various ancillary statistics for testing.
         bool testStatisticsFor(const TFloatMeanAccumulatorCRng &buckets,
@@ -394,11 +400,6 @@ class MATHS_EXPORT CPeriodicityHypothesisTests
                            const TFloatMeanAccumulatorCRng &buckets,
                            core_t::TTime period,
                            double correction, STestStats &stats) const;
-
-        //! Get the number of buckets for which there is at least one repeat
-        //! at \p period in \p buckets.
-        double periodicallyRepeatedBuckets(const TFloatMeanAccumulatorCRng &buckets,
-                                           std::size_t period) const;
 
     private:
         //! The minimum proportion of populated buckets for which


### PR DESCRIPTION
**Description**
This fixes all remaining errors reported in #20. These were down to some more untrapped calls on inputs to the functions, `varianceAtPercentile` and `autocorrelationAtPercentile`, which generate the errors. Digging into the root cause, they were all down to very sparse data over the window we maintain to test for periodicity. This in turn showed up the need to, in addition to handling the error cases, lower bound the count of buckets with periodic repeats when testing for periodic partitions.

**Effects**
This change avoids some false positives in the periodicity test and so can change results. This only affects sparse data modelling, the effects are small and the chance of related false positives in the test is low. For example, on the "gallery" data set I get very slightly different job level anomalies:
![screen shot 2018-03-27 at 19 34 19](https://user-images.githubusercontent.com/7591487/37987565-69b0e340-31f6-11e8-98eb-f19ed3fd1337.png)
The top 25 anomalies are the same in both jobs, albeit the orders are slightly different.