### PR TITLE
[ML] Standardise use of type aliases and rvalue references in for loops

### DIFF
--- a/bin/autoconfig/CCmdLineParser.h
+++ b/bin/autoconfig/CCmdLineParser.h
@@ -36,7 +36,7 @@ namespace autoconfig
 class CCmdLineParser
 {
     public:
-        typedef std::vector<std::string> TStrVec;
+        using TStrVec = std::vector<std::string>;
 
     public:
         //! Parse the arguments and return options if appropriate.

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -121,21 +121,22 @@ class API_EXPORT CAnomalyJob : public CDataProcessor
 
 
     public:
-        typedef std::function<void(const CModelSnapshotJsonWriter::SModelSnapshotReport &)> TPersistCompleteFunc;
-        typedef model::CAnomalyDetector::TAnomalyDetectorPtr TAnomalyDetectorPtr;
-        typedef std::vector<TAnomalyDetectorPtr> TAnomalyDetectorPtrVec;
-        typedef std::vector<TAnomalyDetectorPtr>::iterator TAnomalyDetectorPtrVecItr;
-        typedef std::vector<TAnomalyDetectorPtr>::const_iterator TAnomalyDetectorPtrVecCItr;
-        typedef std::vector<model::CSearchKey> TKeyVec;
-        typedef boost::unordered_map<model::CSearchKey::TStrKeyPr,
-                                     TAnomalyDetectorPtr,
-                                     model::CStrKeyPrHash,
-                                     model::CStrKeyPrEqual> TKeyAnomalyDetectorPtrUMap;
-        typedef std::pair<model::CSearchKey::TStrCRefKeyCRefPr, TAnomalyDetectorPtr> TKeyCRefAnomalyDetectorPtrPr;
-        typedef std::vector<TKeyCRefAnomalyDetectorPtrPr>            TKeyCRefAnomalyDetectorPtrPrVec;
-        typedef model::CAnomalyDetector::TModelPlotDataVec TModelPlotDataVec;
-        typedef TModelPlotDataVec::const_iterator TModelPlotDataVecCItr;
-        typedef model::CBucketQueue<TModelPlotDataVec> TModelPlotDataVecQueue;
+        using TPersistCompleteFunc = std::function<void(const CModelSnapshotJsonWriter::SModelSnapshotReport &)>;
+        using TAnomalyDetectorPtr = model::CAnomalyDetector::TAnomalyDetectorPtr;
+        using TAnomalyDetectorPtrVec = std::vector<TAnomalyDetectorPtr>;
+        using TAnomalyDetectorPtrVecItr = std::vector<TAnomalyDetectorPtr>::iterator;
+        using TAnomalyDetectorPtrVecCItr = std::vector<TAnomalyDetectorPtr>::const_iterator;
+        using TKeyVec = std::vector<model::CSearchKey>;
+        using TKeyAnomalyDetectorPtrUMap =
+                  boost::unordered_map<model::CSearchKey::TStrKeyPr,
+                                       TAnomalyDetectorPtr,
+                                       model::CStrKeyPrHash,
+                                       model::CStrKeyPrEqual>;
+        using TKeyCRefAnomalyDetectorPtrPr = std::pair<model::CSearchKey::TStrCRefKeyCRefPr, TAnomalyDetectorPtr>;
+        using TKeyCRefAnomalyDetectorPtrPrVec = std::vector<TKeyCRefAnomalyDetectorPtrPr>;
+        using TModelPlotDataVec = model::CAnomalyDetector::TModelPlotDataVec;
+        using TModelPlotDataVecCItr = TModelPlotDataVec::const_iterator;
+        using TModelPlotDataVecQueue = model::CBucketQueue<TModelPlotDataVec>;
 
         struct API_EXPORT SRestoredStateDetail
         {
@@ -164,7 +165,7 @@ class API_EXPORT CAnomalyJob : public CDataProcessor
             TKeyCRefAnomalyDetectorPtrPrVec s_Detectors;
         };
 
-        typedef boost::shared_ptr<SBackgroundPersistArgs> TBackgroundPersistArgsPtr;
+        using TBackgroundPersistArgsPtr = boost::shared_ptr<SBackgroundPersistArgs>;
 
     public:
         CAnomalyJob(const std::string &jobId,

--- a/include/api/CBenchMarker.h
+++ b/include/api/CBenchMarker.h
@@ -49,20 +49,20 @@ class API_EXPORT CBenchMarker
 {
     public:
         //! A count and and example string
-        typedef std::pair<size_t, std::string>             TSizeStrPr;
+        using TSizeStrPr = std::pair<size_t, std::string>;
 
         //! Used for mapping Ml type to count and example
-        typedef std::map<int, TSizeStrPr>                  TIntSizeStrPrMap;
-        typedef TIntSizeStrPrMap::iterator                 TIntSizeStrPrMapItr;
-        typedef TIntSizeStrPrMap::const_iterator           TIntSizeStrPrMapCItr;
+        using TIntSizeStrPrMap = std::map<int, TSizeStrPr>;
+        using TIntSizeStrPrMapItr = TIntSizeStrPrMap::iterator;
+        using TIntSizeStrPrMapCItr = TIntSizeStrPrMap::const_iterator;
 
         //! A regex and its corresponding type count map
-        typedef std::pair<core::CRegex, TIntSizeStrPrMap>  TRegexIntSizeStrPrMapPr;
+        using TRegexIntSizeStrPrMapPr = std::pair<core::CRegex, TIntSizeStrPrMap>;
 
         //! Vector of regexes with corresponding type count maps
-        typedef std::vector<TRegexIntSizeStrPrMapPr>       TRegexIntSizeStrPrMapPrVec;
-        typedef TRegexIntSizeStrPrMapPrVec::iterator       TRegexIntSizeStrPrMapPrVecItr;
-        typedef TRegexIntSizeStrPrMapPrVec::const_iterator TRegexIntSizeStrPrMapPrVecCItr;
+        using TRegexIntSizeStrPrMapPrVec = std::vector<TRegexIntSizeStrPrMapPr>;
+        using TRegexIntSizeStrPrMapPrVecItr = TRegexIntSizeStrPrMapPrVec::iterator;
+        using TRegexIntSizeStrPrMapPrVecCItr = TRegexIntSizeStrPrMapPrVec::const_iterator;
 
     public:
         CBenchMarker(void);

--- a/include/api/CCategoryExamplesCollector.h
+++ b/include/api/CCategoryExamplesCollector.h
@@ -42,8 +42,8 @@ namespace api
 class API_EXPORT CCategoryExamplesCollector
 {
     public:
-        typedef std::set<std::string> TStrSet;
-        typedef TStrSet::const_iterator TStrSetCItr;
+        using TStrSet = std::set<std::string>;
+        using TStrSetCItr = TStrSet::const_iterator;
 
         //! Truncate examples to be no longer than this
         static const size_t MAX_EXAMPLE_LENGTH;

--- a/include/api/CCsvOutputWriter.h
+++ b/include/api/CCsvOutputWriter.h
@@ -145,9 +145,9 @@ class API_EXPORT CCsvOutputWriter : public COutputHandler
         //! an appropriate level, avoiding regular memory allocations.
         std::string         m_WorkRecord;
 
-        typedef std::pair<std::string, std::string > TStrStrPr;
-        typedef std::set<TStrStrPr>                  TStrStrPrSet;
-        typedef TStrStrPrSet::const_iterator         TStrStrPrSetCItr;
+        using TStrStrPr = std::pair<std::string, std::string>;
+        using TStrStrPrSet = std::set<TStrStrPr>;
+        using TStrStrPrSetCItr = TStrStrPrSet::const_iterator;
 
         //! Messages to be printed before the next lot of output
         TStrStrPrSet        m_Messages;

--- a/include/api/CDataProcessor.h
+++ b/include/api/CDataProcessor.h
@@ -58,13 +58,13 @@ class API_EXPORT CDataProcessor : private core::CNonCopyable
         static const std::string CONTROL_FIELD_NAME;
 
     public:
-        typedef std::vector<std::string>                       TStrVec;
-        typedef TStrVec::iterator                              TStrVecItr;
-        typedef TStrVec::const_iterator                        TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
+        using TStrVecCItr = TStrVec::const_iterator;
 
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
-        typedef TStrStrUMap::iterator                          TStrStrUMapItr;
-        typedef TStrStrUMap::const_iterator                    TStrStrUMapCItr;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TStrStrUMapItr = TStrStrUMap::iterator;
+        using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
     public:
         CDataProcessor(void);

--- a/include/api/CDataTyper.h
+++ b/include/api/CDataTyper.h
@@ -53,14 +53,14 @@ class API_EXPORT CDataTyper
 {
     public:
         //! Used for storing distinct token IDs
-        typedef boost::unordered_map<std::string, std::string>        TStrStrUMap;
-        typedef TStrStrUMap::const_iterator                           TStrStrUMapCItr;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
         //! Shared pointer to an instance of this class
-        typedef boost::shared_ptr<CDataTyper>                         TDataTyperP;
+        using TDataTyperP = boost::shared_ptr<CDataTyper>;
 
         //! Shared pointer to an instance of this class
-        typedef std::function<void(core::CStatePersistInserter &)>    TPersistFunc;
+        using TPersistFunc = std::function<void(core::CStatePersistInserter &)>;
 
     public:
         CDataTyper(const std::string &fieldName);

--- a/include/api/CDetectionRulesJsonParser.h
+++ b/include/api/CDetectionRulesJsonParser.h
@@ -38,8 +38,8 @@ namespace api
 class API_EXPORT CDetectionRulesJsonParser
 {
     public:
-        typedef std::vector<model::CDetectionRule> TDetectionRuleVec;
-        typedef boost::unordered_map<std::string, core::CPatternSet> TStrPatternSetUMap;
+        using TDetectionRuleVec = std::vector<model::CDetectionRule>;
+        using TStrPatternSetUMap = boost::unordered_map<std::string, core::CPatternSet>;
 
     public:
         //! Default constructor

--- a/include/api/CFieldConfig.h
+++ b/include/api/CFieldConfig.h
@@ -351,7 +351,7 @@ class API_EXPORT CFieldConfig
         //! Uniqueness is enforced by config key and also by the combination of
         //! function, field name, by field name, over field name and
         //! partition field name.
-        typedef boost::multi_index::multi_index_container<
+        using TFieldOptionsMIndex = boost::multi_index::multi_index_container<
             CFieldOptions,
             boost::multi_index::indexed_by<
                 boost::multi_index::ordered_unique<
@@ -370,28 +370,28 @@ class API_EXPORT CFieldConfig
                     >
                 >
             >
-        > TFieldOptionsMIndex;
+        >;
 
-        typedef TFieldOptionsMIndex::iterator              TFieldOptionsMIndexItr;
-        typedef TFieldOptionsMIndex::const_iterator        TFieldOptionsMIndexCItr;
+        using TFieldOptionsMIndexItr = TFieldOptionsMIndex::iterator;
+        using TFieldOptionsMIndexCItr = TFieldOptionsMIndex::const_iterator;
 
         //! Used to maintain a list of all unique config keys
-        typedef std::set<int>                              TIntSet;
+        using TIntSet = std::set<int>;
 
         //! Used to return the superset of enabled field names
-        typedef std::set<std::string>                      TStrSet;
+        using TStrSet = std::set<std::string>;
 
         //! Used to obtain command line clause tokens
-        typedef std::vector<std::string>                   TStrVec;
-        typedef TStrVec::iterator                          TStrVecItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
 
-        typedef std::vector<model::CDetectionRule> TDetectionRuleVec;
-        typedef boost::unordered_map<int, TDetectionRuleVec> TIntDetectionRuleVecUMap;
+        using TDetectionRuleVec = std::vector<model::CDetectionRule>;
+        using TIntDetectionRuleVecUMap = boost::unordered_map<int, TDetectionRuleVec>;
 
-        typedef boost::unordered_map<std::string, core::CPatternSet> TStrPatternSetUMap;
+        using TStrPatternSetUMap = boost::unordered_map<std::string, core::CPatternSet>;
 
-        typedef std::pair<std::string, model::CDetectionRule> TStrDetectionRulePr;
-        typedef std::vector<TStrDetectionRulePr> TStrDetectionRulePrVec;
+        using TStrDetectionRulePr = std::pair<std::string, model::CDetectionRule>;
+        using TStrDetectionRulePrVec = std::vector<TStrDetectionRulePr>;
 
     public:
         //! Construct empty.  This call should generally be followed by a call to

--- a/include/api/CFieldDataTyper.h
+++ b/include/api/CFieldDataTyper.h
@@ -77,17 +77,17 @@ class API_EXPORT CFieldDataTyper : public CDataProcessor
     public:
         // A type of token list data typer that DOESN'T exclude fields from its
         // analysis
-        typedef CTokenListDataTyper<true,  // Warping
-                                    true,  // Underscores
-                                    true,  // Dots
-                                    true,  // Dashes
-                                    true,  // Ignore leading digit
-                                    true,  // Ignore hex
-                                    true,  // Ignore date words
-                                    false, // Ignore field names
-                                    2,     // Min dictionary word length
-                                    core::CWordDictionary::TWeightVerbs5Other2>
-                TTokenListDataTyperKeepsFields;
+        using TTokenListDataTyperKeepsFields =
+                  CTokenListDataTyper<true,  // Warping
+                                      true,  // Underscores
+                                      true,  // Dots
+                                      true,  // Dashes
+                                      true,  // Ignore leading digit
+                                      true,  // Ignore hex
+                                      true,  // Ignore date words
+                                      false, // Ignore field names
+                                      2,     // Min dictionary word length
+                                      core::CWordDictionary::TWeightVerbs5Other2>;
 
     public:
         //! Construct without persistence capability
@@ -160,7 +160,7 @@ class API_EXPORT CFieldDataTyper : public CDataProcessor
         void acknowledgeFlush(const std::string &flushId);
 
     private:
-        typedef CCategoryExamplesCollector::TStrSet TStrSet;
+        using TStrSet = CCategoryExamplesCollector::TStrSet;
 
     private:
         //! The job ID

--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -148,9 +148,9 @@ class API_EXPORT CHierarchicalResultsWriter : public model::CHierarchicalResults
         };
 
     public:
-        typedef SResults                                            TResults;
-        typedef std::function<bool(TResults)>                       TResultWriterFunc;
-        typedef std::function<bool(core_t::TTime, TNode, bool)>     TPivotWriterFunc;
+        using TResults = SResults;
+        using TResultWriterFunc = std::function<bool(TResults)>;
+        using TPivotWriterFunc = std::function<bool(core_t::TTime, TNode, bool)>;
 
     public:
         CHierarchicalResultsWriter(const model::CLimits &limits,

--- a/include/api/CInputParser.h
+++ b/include/api/CInputParser.h
@@ -47,27 +47,27 @@ namespace api
 class API_EXPORT CInputParser : private core::CNonCopyable
 {
     public:
-        typedef std::vector<std::string>                       TStrVec;
-        typedef TStrVec::iterator                              TStrVecItr;
-        typedef TStrVec::const_iterator                        TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
+        using TStrVecCItr = TStrVec::const_iterator;
 
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
-        typedef TStrStrUMap::iterator                          TStrStrUMapItr;
-        typedef TStrStrUMap::const_iterator                    TStrStrUMapCItr;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TStrStrUMapItr = TStrStrUMap::iterator;
+        using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
         //! For fast access to the field values without repeatedly computing the
         //! hash, we maintain references to the values in the hash map
-        typedef boost::reference_wrapper<std::string>          TStrRef;
-        typedef std::vector<TStrRef>                           TStrRefVec;
-        typedef TStrRefVec::iterator                           TStrRefVecItr;
-        typedef TStrRefVec::const_iterator                     TStrRefVecCItr;
+        using TStrRef = boost::reference_wrapper<std::string>;
+        using TStrRefVec = std::vector<TStrRef>;
+        using TStrRefVecItr = TStrRefVec::iterator;
+        using TStrRefVecCItr = TStrRefVec::const_iterator;
 
         //! Callback function prototype that gets called for each record
         //! read from the input stream.  Return false to exit reader loop.
         //! Arguments are:
         //! 1) Header row fields
         //! 2) Data row fields
-        typedef std::function<bool(const TStrStrUMap &)>       TReaderFunc;
+        using TReaderFunc = std::function<bool(const TStrStrUMap &)>;
 
     public:
         CInputParser(void);

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -111,29 +111,29 @@ namespace api
 class API_EXPORT CJsonOutputWriter : public COutputHandler
 {
     public:
-        typedef boost::shared_ptr<rapidjson::Document>      TDocumentPtr;
-        typedef boost::weak_ptr<rapidjson::Document>        TDocumentWeakPtr;
-        typedef std::vector<TDocumentWeakPtr>               TDocumentWeakPtrVec;
-        typedef TDocumentWeakPtrVec::iterator               TDocumentWeakPtrVecItr;
-        typedef TDocumentWeakPtrVec::const_iterator         TDocumentWeakPtrVecCItr;
+        using TDocumentPtr = boost::shared_ptr<rapidjson::Document>;
+        using TDocumentWeakPtr = boost::weak_ptr<rapidjson::Document>;
+        using TDocumentWeakPtrVec = std::vector<TDocumentWeakPtr>;
+        using TDocumentWeakPtrVecItr = TDocumentWeakPtrVec::iterator;
+        using TDocumentWeakPtrVecCItr = TDocumentWeakPtrVec::const_iterator;
 
-        typedef std::pair<TDocumentWeakPtr, int>            TDocumentWeakPtrIntPr;
-        typedef std::vector<TDocumentWeakPtrIntPr>          TDocumentWeakPtrIntPrVec;
-        typedef TDocumentWeakPtrIntPrVec::iterator          TDocumentWeakPtrIntPrVecItr;
-        typedef std::map<std::string, TDocumentWeakPtrVec>  TStrDocumentPtrVecMap;
+        using TDocumentWeakPtrIntPr = std::pair<TDocumentWeakPtr, int>;
+        using TDocumentWeakPtrIntPrVec = std::vector<TDocumentWeakPtrIntPr>;
+        using TDocumentWeakPtrIntPrVecItr = TDocumentWeakPtrIntPrVec::iterator;
+        using TStrDocumentPtrVecMap = std::map<std::string, TDocumentWeakPtrVec>;
 
-        typedef std::vector<std::string>                    TStrVec;
-        typedef core::CSmallVector<std::string, 1>          TStr1Vec;
-        typedef std::vector<core_t::TTime>                  TTimeVec;
-        typedef std::vector<double>                         TDoubleVec;
-        typedef std::pair<double, double>                   TDoubleDoublePr;
-        typedef std::vector<TDoubleDoublePr>                TDoubleDoublePrVec;
-        typedef std::pair<double, TDoubleDoublePr>          TDoubleDoubleDoublePrPr;
-        typedef std::vector<TDoubleDoubleDoublePrPr>        TDoubleDoubleDoublePrPrVec;
-        typedef std::pair<std::string, double>              TStringDoublePr;
-        typedef std::vector<TStringDoublePr>                TStringDoublePrVec;
+        using TStrVec = std::vector<std::string>;
+        using TStr1Vec = core::CSmallVector<std::string, 1>;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleDoublePr = std::pair<double, double>;
+        using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+        using TDoubleDoubleDoublePrPr = std::pair<double, TDoubleDoublePr>;
+        using TDoubleDoubleDoublePrPrVec = std::vector<TDoubleDoubleDoublePrPr>;
+        using TStringDoublePr = std::pair<std::string, double>;
+        using TStringDoublePrVec = std::vector<TStringDoublePr>;
 
-        typedef boost::shared_ptr<rapidjson::Value>         TValuePtr;
+        using TValuePtr = boost::shared_ptr<rapidjson::Value>;
 
         //! Structure to buffer up information about each bucket that we have
         //! unwritten results for
@@ -184,13 +184,13 @@ class API_EXPORT CJsonOutputWriter : public COutputHandler
             TStr1Vec              s_ScheduledEventDescriptions;
         };
 
-        typedef std::map<core_t::TTime, SBucketData>   TTimeBucketDataMap;
-        typedef TTimeBucketDataMap::iterator           TTimeBucketDataMapItr;
-        typedef TTimeBucketDataMap::const_iterator     TTimeBucketDataMapCItr;
+        using TTimeBucketDataMap = std::map<core_t::TTime, SBucketData>;
+        using TTimeBucketDataMapItr = TTimeBucketDataMap::iterator;
+        using TTimeBucketDataMapCItr = TTimeBucketDataMap::const_iterator;
 
     private:
-        typedef CCategoryExamplesCollector::TStrSet TStrSet;
-        typedef TStrSet::const_iterator TStrSetCItr;
+        using TStrSet = CCategoryExamplesCollector::TStrSet;
+        using TStrSetCItr = TStrSet::const_iterator;
 
     public:
         //! Constructor that causes output to be written to the specified wrapped stream

--- a/include/api/CLengthEncodedInputParser.h
+++ b/include/api/CLengthEncodedInputParser.h
@@ -138,7 +138,7 @@ class API_EXPORT CLengthEncodedInputParser : public CInputParser
         //! Reference to the stream we're going to read from
         std::istream     &m_StrmIn;
 
-        typedef boost::scoped_array<char> TScopedCharArray;
+        using TScopedCharArray = boost::scoped_array<char>;
 
         //! The working buffer is also held as a member to avoid constantly
         //! reallocating it.  It is a raw character array rather than a string

--- a/include/api/CLineifiedInputParser.h
+++ b/include/api/CLineifiedInputParser.h
@@ -57,7 +57,7 @@ class API_EXPORT CLineifiedInputParser : public CInputParser
         //! Line end character
         static const char LINE_END;
 
-        typedef std::pair<char *, size_t> TCharPSizePr;
+        using TCharPSizePr = std::pair<char*, size_t>;
 
     protected:
         //! Return a pointer to the start of the next line and its length,
@@ -80,7 +80,7 @@ class API_EXPORT CLineifiedInputParser : public CInputParser
         //! Reference to the stream we're going to read from
         std::istream     &m_StrmIn;
 
-        typedef boost::scoped_array<char> TScopedCharArray;
+        using TScopedCharArray = boost::scoped_array<char>;
 
         //! The working buffer is a raw character array rather than a string to
         //! facilitate the use of std::istream::read() to obtain input rather

--- a/include/api/CLineifiedJsonOutputWriter.h
+++ b/include/api/CLineifiedJsonOutputWriter.h
@@ -49,7 +49,7 @@ namespace api
 class API_EXPORT CLineifiedJsonOutputWriter : public COutputHandler
 {
     public:
-        typedef std::set<std::string> TStrSet;
+        using TStrSet = std::set<std::string>;
 
     public:
         //! Constructor that causes output to be written to the internal string
@@ -111,7 +111,7 @@ class API_EXPORT CLineifiedJsonOutputWriter : public COutputHandler
         //! JSON writer ostream wrapper
         rapidjson::OStreamWrapper     m_WriteStream;
 
-        typedef core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> TGenericLineWriter;
+        using TGenericLineWriter = core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>;
 
         //! JSON writer
         TGenericLineWriter            m_Writer;

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -117,9 +117,9 @@ class API_EXPORT COutputChainer : public COutputHandler
         //! processor
         TStrStrUMap         m_WorkRecordFields;
 
-        typedef boost::reference_wrapper<std::string> TStrRef;
-        typedef std::vector<TStrRef>                  TStrRefVec;
-        typedef TStrRefVec::const_iterator            TStrRefVecCItr;
+        using TStrRef = boost::reference_wrapper<std::string>;
+        using TStrRefVec = std::vector<TStrRef>;
+        using TStrRefVecCItr = TStrRefVec::const_iterator;
 
         //! References to the strings within m_WorkRecordFields in the same
         //! order as the field names in m_FieldNames.  This avoids the need to

--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -60,13 +60,13 @@ class CBackgroundPersister;
 class API_EXPORT COutputHandler : private core::CNonCopyable
 {
     public:
-        typedef std::vector<std::string>                       TStrVec;
-        typedef TStrVec::iterator                              TStrVecItr;
-        typedef TStrVec::const_iterator                        TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
+        using TStrVecCItr = TStrVec::const_iterator;
 
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
-        typedef TStrStrUMap::iterator                          TStrStrUMapItr;
-        typedef TStrStrUMap::const_iterator                    TStrStrUMapCItr;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TStrStrUMapItr = TStrStrUMap::iterator;
+        using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
     public:
         COutputHandler(void);
@@ -139,9 +139,9 @@ class API_EXPORT COutputHandler : private core::CNonCopyable
         //! Used when there are no field overrides
         static const TStrStrUMap EMPTY_FIELD_OVERRIDES;
 
-        typedef std::vector<CPreComputedHash>                  TPreComputedHashVec;
-        typedef TPreComputedHashVec::iterator                  TPreComputedHashVecItr;
-        typedef TPreComputedHashVec::const_iterator            TPreComputedHashVecCItr;
+        using TPreComputedHashVec = std::vector<CPreComputedHash>;
+        using TPreComputedHashVecItr = TPreComputedHashVec::iterator;
+        using TPreComputedHashVecCItr = TPreComputedHashVec::const_iterator;
 };
 
 

--- a/include/api/CResultNormalizer.h
+++ b/include/api/CResultNormalizer.h
@@ -79,13 +79,13 @@ class API_EXPORT CResultNormalizer
         static const std::string ZERO;
 
     public:
-        typedef std::vector<std::string>                       TStrVec;
-        typedef TStrVec::iterator                              TStrVecItr;
-        typedef TStrVec::const_iterator                        TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
+        using TStrVecCItr = TStrVec::const_iterator;
 
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
-        typedef TStrStrUMap::iterator                          TStrStrUMapItr;
-        typedef TStrStrUMap::const_iterator                    TStrStrUMapCItr;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TStrStrUMapItr = TStrStrUMap::iterator;
+        using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
     public:
         CResultNormalizer(const model::CAnomalyDetectorModelConfig &modelConfig,

--- a/include/api/CTokenListType.h
+++ b/include/api/CTokenListType.h
@@ -53,17 +53,17 @@ class API_EXPORT CTokenListType
         //! Used to associate tokens with weightings:
         //! first -> token ID
         //! second -> weighting
-        typedef std::pair<size_t, size_t>      TSizeSizePr;
+        using TSizeSizePr = std::pair<size_t, size_t>;
 
         //! Used for storing token ID sequences
-        typedef std::vector<TSizeSizePr>       TSizeSizePrVec;
-        typedef TSizeSizePrVec::iterator       TSizeSizePrVecItr;
-        typedef TSizeSizePrVec::const_iterator TSizeSizePrVecCItr;
+        using TSizeSizePrVec = std::vector<TSizeSizePr>;
+        using TSizeSizePrVecItr = TSizeSizePrVec::iterator;
+        using TSizeSizePrVecCItr = TSizeSizePrVec::const_iterator;
 
         //! Used for storing distinct token IDs mapped to weightings
-        typedef std::map<size_t, size_t>       TSizeSizeMap;
-        typedef TSizeSizeMap::iterator         TSizeSizeMapItr;
-        typedef TSizeSizeMap::const_iterator   TSizeSizeMapCItr;
+        using TSizeSizeMap = std::map<size_t, size_t>;
+        using TSizeSizeMapItr = TSizeSizeMap::iterator;
+        using TSizeSizeMapCItr = TSizeSizeMap::const_iterator;
 
     public:
         //! Create a new type

--- a/include/config/CAutoconfigurer.h
+++ b/include/config/CAutoconfigurer.h
@@ -73,7 +73,7 @@ class CONFIG_EXPORT CAutoconfigurer : public api::CDataProcessor
         virtual api::COutputHandler &outputHandler(void);
 
     private:
-        typedef boost::shared_ptr<CAutoconfigurerImpl> TImplPtr;
+        using TImplPtr = boost::shared_ptr<CAutoconfigurerImpl>;
 
     private:
         //! The pointer to the actual implementation.

--- a/include/config/CAutoconfigurerDetectorPenalties.h
+++ b/include/config/CAutoconfigurerDetectorPenalties.h
@@ -45,7 +45,7 @@ class CPenalty;
 class CONFIG_EXPORT CAutoconfigurerDetectorPenalties
 {
     public:
-        typedef boost::shared_ptr<CPenalty> TPenaltyPtr;
+        using TPenaltyPtr = boost::shared_ptr<CPenalty>;
 
     public:
         CAutoconfigurerDetectorPenalties(const CAutoconfigurerParams &params,
@@ -55,9 +55,9 @@ class CONFIG_EXPORT CAutoconfigurerDetectorPenalties
         TPenaltyPtr penaltyFor(const CDetectorSpecification &spec);
 
     private:
-        typedef boost::reference_wrapper<const CAutoconfigurerParams> TAutoconfigurerParamsCRef;
-        typedef boost::reference_wrapper<const CAutoconfigurerFieldRolePenalties> TAutoconfigurerFieldRolePenaltiesCRef;
-        typedef std::vector<TPenaltyPtr> TPenaltyPtrVec;
+        using TAutoconfigurerParamsCRef = boost::reference_wrapper<const CAutoconfigurerParams>;
+        using TAutoconfigurerFieldRolePenaltiesCRef = boost::reference_wrapper<const CAutoconfigurerFieldRolePenalties>;
+        using TPenaltyPtrVec = std::vector<TPenaltyPtr>;
 
     private:
         //! Get the penalty for the detector \p spec based on its field roles.

--- a/include/config/CAutoconfigurerFieldRolePenalties.h
+++ b/include/config/CAutoconfigurerFieldRolePenalties.h
@@ -63,7 +63,7 @@ class CONFIG_EXPORT CAutoconfigurerFieldRolePenalties : core::CNonCopyable
         const CPenalty &partitionPenalty(void) const;
 
     private:
-        typedef boost::shared_ptr<const CPenalty> TPenaltyCPtr;
+        using TPenaltyCPtr = boost::shared_ptr<const CPenalty>;
 
     private:
         //! The penalties.

--- a/include/config/CAutoconfigurerParams.h
+++ b/include/config/CAutoconfigurerParams.h
@@ -58,14 +58,14 @@ namespace config
 class CONFIG_EXPORT CAutoconfigurerParams
 {
     public:
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<std::string> TStrVec;
-        typedef boost::optional<TStrVec> TOptionalStrVec;
-        typedef std::pair<std::string, config_t::EUserDataType> TStrUserDataTypePr;
-        typedef std::vector<TStrUserDataTypePr> TStrUserDataTypePrVec;
-        typedef boost::optional<config_t::EUserDataType> TOptionalUserDataType;
-        typedef std::vector<config_t::EFunctionCategory> TFunctionCategoryVec;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TStrVec = std::vector<std::string>;
+        using TOptionalStrVec = boost::optional<TStrVec>;
+        using TStrUserDataTypePr = std::pair<std::string, config_t::EUserDataType>;
+        using TStrUserDataTypePrVec = std::vector<TStrUserDataTypePr>;
+        using TOptionalUserDataType = boost::optional<config_t::EUserDataType>;
+        using TFunctionCategoryVec = std::vector<config_t::EFunctionCategory>;
 
     public:
         CAutoconfigurerParams(const std::string &timeFieldName,
@@ -278,8 +278,8 @@ class CONFIG_EXPORT CAutoconfigurerParams
         std::string print(void) const;
 
     private:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
+        using TDoubleVec = std::vector<double>;
+        using TSizeVecVec = std::vector<TSizeVec>;
 
     private:
         //! Refresh the penalty indices.

--- a/include/config/CDataCountStatistics.h
+++ b/include/config/CDataCountStatistics.h
@@ -49,13 +49,13 @@ class CDetectorSpecification;
 class CONFIG_EXPORT CBucketCountStatistics
 {
     public:
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef core::CTriple<std::size_t, std::size_t, std::size_t> TSizeSizeSizeTr;
-        typedef boost::unordered_map<TSizeSizePr, uint64_t> TSizeSizePrUInt64UMap;
-        typedef boost::unordered_map<TSizeSizeSizeTr, uint64_t> TSizeSizeSizeTrUInt64UMap;
-        typedef std::vector<CDetectorRecord> TDetectorRecordVec;
-        typedef core::CMaskIterator<TDetectorRecordVec::const_iterator> TDetectorRecordCItr;
-        typedef maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator TMoments;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizeSizeTr = core::CTriple<std::size_t, std::size_t, std::size_t>;
+        using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+        using TSizeSizeSizeTrUInt64UMap = boost::unordered_map<TSizeSizeSizeTr, uint64_t>;
+        using TDetectorRecordVec = std::vector<CDetectorRecord>;
+        using TDetectorRecordCItr = core::CMaskIterator<TDetectorRecordVec::const_iterator>;
+        using TMoments = maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator;
 
         //! \brief The moments of a categorical function argument field.
         struct CONFIG_EXPORT SArgumentMoments
@@ -66,11 +66,11 @@ class CONFIG_EXPORT CBucketCountStatistics
             TMoments s_InfoContent;
         };
 
-        typedef boost::unordered_map<TSizeSizePr, TMoments> TSizeSizePrMomentsUMap;
-        typedef boost::unordered_map<TSizeSizePr, SArgumentMoments> TSizeSizePrArgumentMomentsUMap;
-        typedef std::pair<const std::string*, TSizeSizePrArgumentMomentsUMap> TStrCPtrSizeSizePrArgumentMomentsUMapPr;
-        typedef std::vector<TStrCPtrSizeSizePrArgumentMomentsUMapPr> TStrCPtrSizeSizePrArgumentMomentsUMapPrVec;
-        typedef boost::unordered_map<TSizeSizePr, maths::CQuantileSketch> TSizeSizePrQuantileUMap;
+        using TSizeSizePrMomentsUMap = boost::unordered_map<TSizeSizePr, TMoments>;
+        using TSizeSizePrArgumentMomentsUMap = boost::unordered_map<TSizeSizePr, SArgumentMoments>;
+        using TStrCPtrSizeSizePrArgumentMomentsUMapPr = std::pair<const std::string*, TSizeSizePrArgumentMomentsUMap>;
+        using TStrCPtrSizeSizePrArgumentMomentsUMapPrVec = std::vector<TStrCPtrSizeSizePrArgumentMomentsUMapPr>;
+        using TSizeSizePrQuantileUMap = boost::unordered_map<TSizeSizePr, maths::CQuantileSketch>;
 
     public:
         //! Add the record for \p partition.
@@ -95,7 +95,7 @@ class CONFIG_EXPORT CBucketCountStatistics
         const TSizeSizePrArgumentMomentsUMap &argumentMomentsPerPartition(const std::string &name) const;
 
     private:
-        typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMean;
+        using TMean = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
         //! \brief Bucket data stored about argument field.
         struct CONFIG_EXPORT SBucketArgumentData
@@ -109,9 +109,9 @@ class CONFIG_EXPORT CBucketCountStatistics
             TMean s_MeanStringLength;
         };
 
-        typedef boost::unordered_map<TSizeSizeSizeTr, SBucketArgumentData> TSizeSizeSizeTrArgumentDataUMap;
-        typedef std::pair<const std::string*, TSizeSizeSizeTrArgumentDataUMap> TStrCPtrSizeSizeSizeTrBjkstArgumentDataUMapPr;
-        typedef std::vector<TStrCPtrSizeSizeSizeTrBjkstArgumentDataUMapPr> TStrCPtrSizeSizeSizeTrArgumentDataUMapPrVec;
+        using TSizeSizeSizeTrArgumentDataUMap = boost::unordered_map<TSizeSizeSizeTr, SBucketArgumentData>;
+        using TStrCPtrSizeSizeSizeTrBjkstArgumentDataUMapPr = std::pair<const std::string*, TSizeSizeSizeTrArgumentDataUMap>;
+        using TStrCPtrSizeSizeSizeTrArgumentDataUMapPrVec = std::vector<TStrCPtrSizeSizeSizeTrBjkstArgumentDataUMapPr>;
 
     private:
         //! The distinct partitions seen this bucket.
@@ -151,10 +151,10 @@ class CONFIG_EXPORT CBucketCountStatistics
 class CONFIG_EXPORT CDataCountStatistics
 {
     public:
-        typedef std::vector<uint64_t> TUInt64Vec;
-        typedef std::vector<CDetectorRecord> TDetectorRecordVec;
-        typedef core::CMaskIterator<TDetectorRecordVec::const_iterator> TDetectorRecordCItr;
-        typedef std::vector<CBucketCountStatistics> TBucketStatisticsVec;
+        using TUInt64Vec = std::vector<uint64_t>;
+        using TDetectorRecordVec = std::vector<CDetectorRecord>;
+        using TDetectorRecordCItr = core::CMaskIterator<TDetectorRecordVec::const_iterator>;
+        using TBucketStatisticsVec = std::vector<CBucketCountStatistics>;
 
     public:
         CDataCountStatistics(const CAutoconfigurerParams &params);
@@ -197,8 +197,8 @@ class CONFIG_EXPORT CDataCountStatistics
         }
 
     protected:
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef boost::unordered_set<std::size_t> TSizeUSet;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TSizeUSet = boost::unordered_set<std::size_t>;
 
     protected:
         //! Get the parameters.
@@ -208,15 +208,15 @@ class CONFIG_EXPORT CDataCountStatistics
         bool samplePartition(std::size_t partition) const;
 
     private:
-        typedef std::vector<bool> TBoolVec;
-        typedef std::vector<TBoolVec> TBoolVecVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef boost::unordered_set<TSizeSizePr> TSizeSizePrUSet;
-        typedef boost::optional<core_t::TTime> TOptionalTime;
-        typedef boost::reference_wrapper<const CAutoconfigurerParams> TAutoconfigurerParamsCRef;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1> TMinTimeAccumulator;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1, std::greater<core_t::TTime> > TMaxTimeAccumulator;
+        using TBoolVec = std::vector<bool>;
+        using TBoolVecVec = std::vector<TBoolVec>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrUSet = boost::unordered_set<TSizeSizePr>;
+        using TOptionalTime = boost::optional<core_t::TTime>;
+        using TAutoconfigurerParamsCRef = boost::reference_wrapper<const CAutoconfigurerParams>;
+        using TMinTimeAccumulator = maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1>;
+        using TMaxTimeAccumulator = maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1, std::greater<core_t::TTime> >;
 
     private:
         //! Fill in the last bucket end times if they are empty.
@@ -283,10 +283,10 @@ class CONFIG_EXPORT CPartitionDataCountStatistics : public CDataCountStatistics
 class CONFIG_EXPORT CByAndPartitionDataCountStatistics : public CDataCountStatistics
 {
     public:
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef boost::unordered_set<TSizeSizePr> TSizeSizePrUSet;
-        typedef boost::unordered_map<TSizeSizePr, uint64_t> TSizeSizePrUInt64UMap;
-        typedef TSizeSizePrUInt64UMap::const_iterator TSizeSizePrUInt64UMapCItr;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrUSet = boost::unordered_set<TSizeSizePr>;
+        using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+        using TSizeSizePrUInt64UMapCItr = TSizeSizePrUInt64UMap::const_iterator;
 
     public:
         CByAndPartitionDataCountStatistics(const CAutoconfigurerParams &params);
@@ -299,10 +299,10 @@ class CONFIG_EXPORT CByAndPartitionDataCountStatistics : public CDataCountStatis
 class CONFIG_EXPORT CByOverAndPartitionDataCountStatistics : public CDataCountStatistics
 {
     public:
-        typedef boost::unordered_map<std::size_t, uint64_t> TSizeUInt64UMap;
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef boost::unordered_map<TSizeSizePr, maths::CBjkstUniqueValues> TSizeSizePrCBjkstUMap;
-        typedef TSizeSizePrCBjkstUMap::const_iterator TSizeSizePrCBjkstUMapCItr;
+        using TSizeUInt64UMap = boost::unordered_map<std::size_t, uint64_t>;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrCBjkstUMap = boost::unordered_map<TSizeSizePr, maths::CBjkstUniqueValues>;
+        using TSizeSizePrCBjkstUMapCItr = TSizeSizePrCBjkstUMap::const_iterator;
 
     public:
         CByOverAndPartitionDataCountStatistics(const CAutoconfigurerParams &params);
@@ -331,8 +331,8 @@ class CONFIG_EXPORT CByOverAndPartitionDataCountStatistics : public CDataCountSt
 class CONFIG_EXPORT CDataCountStatisticsDirectAddressTable
 {
     public:
-        typedef std::vector<CDetectorRecord> TDetectorRecordVec;
-        typedef std::vector<CDetectorSpecification> TDetectorSpecificationVec;
+        using TDetectorRecordVec = std::vector<CDetectorRecord>;
+        using TDetectorSpecificationVec = std::vector<CDetectorSpecification>;
 
     public:
         CDataCountStatisticsDirectAddressTable(const CAutoconfigurerParams &params);
@@ -350,12 +350,12 @@ class CONFIG_EXPORT CDataCountStatisticsDirectAddressTable
         const CDataCountStatistics &statistics(const CDetectorSpecification &spec) const;
 
     private:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<ptrdiff_t> TPtrDiffVec;
-        typedef std::vector<TPtrDiffVec> TPtrDiffVecVec;
-        typedef boost::reference_wrapper<const CAutoconfigurerParams> TAutoconfigurerParamsCRef;
-        typedef std::shared_ptr<CDataCountStatistics> TDataCountStatisticsPtr;
-        typedef std::vector<TDataCountStatisticsPtr> TDataCountStatisticsPtrVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TPtrDiffVec = std::vector<ptrdiff_t>;
+        using TPtrDiffVecVec = std::vector<TPtrDiffVec>;
+        using TAutoconfigurerParamsCRef = boost::reference_wrapper<const CAutoconfigurerParams>;
+        using TDataCountStatisticsPtr = std::shared_ptr<CDataCountStatistics>;
+        using TDataCountStatisticsPtrVec = std::vector<TDataCountStatisticsPtr>;
 
     private:
         //! Get the statistics for \p spec.

--- a/include/config/CDataSemantics.h
+++ b/include/config/CDataSemantics.h
@@ -54,7 +54,7 @@ namespace config
 class CONFIG_EXPORT CDataSemantics
 {
     public:
-        typedef boost::optional<config_t::EUserDataType> TOptionalUserDataType;
+        using TOptionalUserDataType = boost::optional<config_t::EUserDataType>;
 
     public:
         //! The proportion of values which must be numeric for the
@@ -92,10 +92,10 @@ class CONFIG_EXPORT CDataSemantics
                     return value.hash();
                 }
         };
-        typedef std::vector<std::string> TStrVec;
-        typedef boost::unordered_map<maths::COrdinal, std::size_t, CHashOrdinal> TOrdinalSizeUMap;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<maths::COrdinal, 1> TMinAccumulator;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<maths::COrdinal, 1, std::greater<maths::COrdinal> > TMaxAccumulator;
+        using TStrVec = std::vector<std::string>;
+        using TOrdinalSizeUMap = boost::unordered_map<maths::COrdinal, std::size_t, CHashOrdinal>;
+        using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<maths::COrdinal, 1>;
+        using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<maths::COrdinal, 1, std::greater<maths::COrdinal> >;
 
     private:
         //! The maximum number of values we'll hold in the empirical

--- a/include/config/CDataSummaryStatistics.h
+++ b/include/config/CDataSummaryStatistics.h
@@ -64,8 +64,8 @@ class CONFIG_EXPORT CDataSummaryStatistics
         double meanRate(void) const;
 
     protected:
-        typedef maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1> TMinTimeAccumulator;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1, std::greater<core_t::TTime> > TMaxTimeAccumulator;
+        using TMinTimeAccumulator = maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1>;
+        using TMaxTimeAccumulator = maths::CBasicStatistics::COrderStatisticsStack<core_t::TTime, 1, std::greater<core_t::TTime> >;
 
     private:
         //! The earliest example time.
@@ -90,8 +90,8 @@ class CONFIG_EXPORT CDataSummaryStatistics
 class CONFIG_EXPORT CCategoricalDataSummaryStatistics : public CDataSummaryStatistics
 {
     public:
-        typedef std::pair<std::string, std::size_t> TStrSizePr;
-        typedef std::vector<TStrSizePr> TStrSizePrVec;
+        using TStrSizePr = std::pair<std::string, std::size_t>;
+        using TStrSizePrVec = std::vector<TStrSizePr>;
 
         //! The smallest cardinality at which we'll approximate the statistics.
         static const std::size_t TO_APPROXIMATE = 5000000;
@@ -128,17 +128,17 @@ class CONFIG_EXPORT CCategoricalDataSummaryStatistics : public CDataSummaryStati
         static const std::size_t NUMBER_N_GRAMS = 5;
 
     private:
-        typedef std::pair<uint32_t, uint64_t> TUInt32UInt64Pr;
-        typedef std::vector<TUInt32UInt64Pr> TUInt32UInt64PrVec;
-        typedef boost::unordered_map<std::size_t, uint64_t> TSizeUInt64UMap;
-        typedef boost::unordered_map<std::string, uint64_t> TStrUInt64UMap;
-        typedef TStrUInt64UMap::iterator TStrUInt64UMapItr;
-        typedef TStrUInt64UMap::const_iterator TStrUInt64UMapCItr;
-        typedef std::vector<TStrUInt64UMapCItr> TStrUInt64UMapCItrVec;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<std::size_t, 1> TMinSizeAccumulator;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<std::size_t, 1, std::greater<std::size_t> > TMaxSizeAccumulator;
-        typedef std::vector<maths::CBjkstUniqueValues> TBjkstUniqueValuesVec;
-        typedef std::vector<maths::CEntropySketch> TEntropySketchVec;
+        using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
+        using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
+        using TSizeUInt64UMap = boost::unordered_map<std::size_t, uint64_t>;
+        using TStrUInt64UMap = boost::unordered_map<std::string, uint64_t>;
+        using TStrUInt64UMapItr = TStrUInt64UMap::iterator;
+        using TStrUInt64UMapCItr = TStrUInt64UMap::const_iterator;
+        using TStrUInt64UMapCItrVec = std::vector<TStrUInt64UMapCItr>;
+        using TMinSizeAccumulator = maths::CBasicStatistics::COrderStatisticsStack<std::size_t, 1>;
+        using TMaxSizeAccumulator = maths::CBasicStatistics::COrderStatisticsStack<std::size_t, 1, std::greater<std::size_t> >;
+        using TBjkstUniqueValuesVec = std::vector<maths::CBjkstUniqueValues>;
+        using TEntropySketchVec = std::vector<maths::CEntropySketch>;
 
     private:
         //! Extract the \p n grams and update the relevant statistics.
@@ -222,8 +222,8 @@ class CONFIG_EXPORT CCategoricalDataSummaryStatistics : public CDataSummaryStati
 class CONFIG_EXPORT CNumericDataSummaryStatistics : public CDataSummaryStatistics
 {
     public:
-        typedef std::pair<double, double> TDoubleDoublePr;
-        typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
+        using TDoubleDoublePr = std::pair<double, double>;
+        using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
 
     public:
         CNumericDataSummaryStatistics(bool integer);

--- a/include/config/CDetectorEnumerator.h
+++ b/include/config/CDetectorEnumerator.h
@@ -45,7 +45,7 @@ class CDetectorSpecification;
 class CONFIG_EXPORT CDetectorEnumerator
 {
     public:
-        typedef std::vector<CDetectorSpecification> TDetectorSpecificationVec;
+        using TDetectorSpecificationVec = std::vector<CDetectorSpecification>;
 
     public:
         CDetectorEnumerator(const CAutoconfigurerParams &params);
@@ -81,10 +81,10 @@ class CONFIG_EXPORT CDetectorEnumerator
         void generate(TDetectorSpecificationVec &result);
 
     private:
-        typedef std::vector<std::string> TStrVec;
-        typedef boost::optional<std::string> TOptionalStr;
-        typedef std::vector<config_t::EFunctionCategory> TFunctionCategoryVec;
-        typedef boost::reference_wrapper<const CAutoconfigurerParams> TAutoconfigurerParamsCRef;
+        using TStrVec = std::vector<std::string>;
+        using TOptionalStr = boost::optional<std::string>;
+        using TFunctionCategoryVec = std::vector<config_t::EFunctionCategory>;
+        using TAutoconfigurerParamsCRef = boost::reference_wrapper<const CAutoconfigurerParams>;
 
     private:
         //! Add the detectors with no partitioning fields.

--- a/include/config/CDetectorRecord.h
+++ b/include/config/CDetectorRecord.h
@@ -44,9 +44,9 @@ class CDetectorSpecification;
 class CONFIG_EXPORT CDetectorRecord
 {
     public:
-        typedef boost::array<std::size_t, constants::NUMBER_FIELD_INDICES> TSizeAry;
-        typedef boost::array<const std::string*, constants::NUMBER_FIELD_INDICES> TStrCPtrAry;
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
+        using TSizeAry = boost::array<std::size_t, constants::NUMBER_FIELD_INDICES>;
+        using TStrCPtrAry = boost::array<const std::string*, constants::NUMBER_FIELD_INDICES>;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
 
     public:
         CDetectorRecord(core_t::TTime time,
@@ -129,9 +129,9 @@ class CONFIG_EXPORT CDetectorRecord
 class CONFIG_EXPORT CDetectorRecordDirectAddressTable
 {
     public:
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
-        typedef std::vector<CDetectorSpecification> TDetectorSpecificationVec;
-        typedef std::vector<CDetectorRecord> TDetectorRecordVec;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TDetectorSpecificationVec = std::vector<CDetectorSpecification>;
+        using TDetectorRecordVec = std::vector<CDetectorRecord>;
 
     public:
         //! Build the table from \p specs.
@@ -148,12 +148,12 @@ class CONFIG_EXPORT CDetectorRecordDirectAddressTable
         void clear(void);
 
     private:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::pair<std::string, std::size_t> TStrSizePr;
-        typedef std::vector<TStrSizePr> TStrSizePrVec;
-        typedef boost::array<std::size_t, constants::NUMBER_FIELD_INDICES> TSizeAry;
-        typedef std::vector<TSizeAry> TSizeAryVec;
-        typedef std::vector<const std::string*> TStrCPtrVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TStrSizePr = std::pair<std::string, std::size_t>;
+        using TStrSizePrVec = std::vector<TStrSizePr>;
+        using TSizeAry = boost::array<std::size_t, constants::NUMBER_FIELD_INDICES>;
+        using TSizeAryVec = std::vector<TSizeAry>;
+        using TStrCPtrVec = std::vector<const std::string*>;
 
     private:
         //! A map from field to its value entry in the field value table.

--- a/include/config/CDetectorSpecification.h
+++ b/include/config/CDetectorSpecification.h
@@ -56,14 +56,14 @@ class CONFIG_EXPORT CDetectorSpecification : boost::equality_comparable< CDetect
                                              boost::less_than_comparable< CDetectorSpecification > >
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<TDoubleVec> TDoubleVecVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef std::vector<std::string> TStrVec;
-        typedef boost::optional<std::string> TOptionalStr;
-        typedef std::vector<CFieldStatistics> TFieldStatisticsVec;
-        typedef boost::shared_ptr<CPenalty> TPenaltyPtr;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleVecVec = std::vector<TDoubleVec>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TStrVec = std::vector<std::string>;
+        using TOptionalStr = boost::optional<std::string>;
+        using TFieldStatisticsVec = std::vector<CFieldStatistics>;
+        using TPenaltyPtr = boost::shared_ptr<CPenalty>;
 
         //! Ternary boolean type which supports unknown.
         enum EFuzzyBool
@@ -94,7 +94,7 @@ class CONFIG_EXPORT CDetectorSpecification : boost::equality_comparable< CDetect
             TStrVec s_Descriptions;
         };
 
-        typedef std::vector<SParamScores> TParamScoresVec;
+        using TParamScoresVec = std::vector<SParamScores>;
 
     public:
         CDetectorSpecification(const CAutoconfigurerParams &params,
@@ -221,10 +221,10 @@ class CONFIG_EXPORT CDetectorSpecification : boost::equality_comparable< CDetect
         std::string description(void) const;
 
     private:
-        typedef std::vector<TStrVec> TStrVecVec;
-        typedef boost::optional<core_t::TTime> TOptionalTime;
-        typedef boost::array<const TSizeVec*, 2> TSizeVecCPtrAry;
-        typedef boost::reference_wrapper<const CAutoconfigurerParams> TAutoconfigurerParamsCRef;
+        using TStrVecVec = std::vector<TStrVec>;
+        using TOptionalTime = boost::optional<core_t::TTime>;
+        using TSizeVecCPtrAry = boost::array<const TSizeVec*, 2>;
+        using TAutoconfigurerParamsCRef = boost::reference_wrapper<const CAutoconfigurerParams>;
 
     private:
         //! Get the parameters.

--- a/include/config/CFieldStatistics.h
+++ b/include/config/CFieldStatistics.h
@@ -42,7 +42,7 @@ class CPenalty;
 class CONFIG_EXPORT CFieldStatistics
 {
     public:
-        typedef boost::reference_wrapper<const CAutoconfigurerParams> TAutoconfigurerParamsCRef;
+        using TAutoconfigurerParamsCRef = boost::reference_wrapper<const CAutoconfigurerParams>;
 
     public:
         CFieldStatistics(const std::string &fieldName, const CAutoconfigurerParams &params);
@@ -76,11 +76,12 @@ class CONFIG_EXPORT CFieldStatistics
         double score(const CPenalty &penalty) const;
 
     private:
-        typedef std::pair<core_t::TTime, std::string> TTimeStrPr;
-        typedef std::vector<TTimeStrPr> TTimeStrPrVec;
-        typedef boost::variant<CDataSummaryStatistics,
-                               CCategoricalDataSummaryStatistics,
-                               CNumericDataSummaryStatistics> TDataSummaryStatistics;
+        using TTimeStrPr = std::pair<core_t::TTime, std::string>;
+        using TTimeStrPrVec = std::vector<TTimeStrPr>;
+        using TDataSummaryStatistics =
+                  boost::variant<CDataSummaryStatistics,
+                                 CCategoricalDataSummaryStatistics,
+                                 CNumericDataSummaryStatistics>;
 
     private:
         //! The auto-configuration parameters.

--- a/include/config/CLongTailPenalty.h
+++ b/include/config/CLongTailPenalty.h
@@ -52,7 +52,7 @@ class CONFIG_EXPORT CLongTailPenalty : public CPenalty
         virtual std::string name(void) const;
 
     private:
-        typedef boost::unordered_map<std::size_t, uint64_t> TSizeUInt64UMap;
+        using TSizeUInt64UMap = boost::unordered_map<std::size_t, uint64_t>;
 
     private:
         //! Compute a penalty for rare detectors.

--- a/include/config/CNotEnoughDataPenalty.h
+++ b/include/config/CNotEnoughDataPenalty.h
@@ -51,8 +51,8 @@ class CONFIG_EXPORT CNotEnoughDataPenalty : public CPenalty
         virtual std::string name(void) const;
 
     private:
-        typedef std::vector<uint64_t> TUInt64Vec;
-        typedef std::vector<CBucketCountStatistics> TBucketCountStatisticsVec;
+        using TUInt64Vec = std::vector<uint64_t>;
+        using TBucketCountStatisticsVec = std::vector<CBucketCountStatistics>;
 
     private:
         //! Compute a penalty for rare detectors.

--- a/include/config/CPenalty.h
+++ b/include/config/CPenalty.h
@@ -73,13 +73,13 @@ class CNumericDataSummaryStatistics;
 class CONFIG_EXPORT CPenalty
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef std::vector<std::string> TStrVec;
-        typedef boost::shared_ptr<CPenalty> TPenaltyPtr;
-        typedef boost::shared_ptr<const CPenalty> TPenaltyCPtr;
-        typedef std::vector<TPenaltyCPtr> TPenaltyCPtrVec;
+        using TDoubleVec = std::vector<double>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TStrVec = std::vector<std::string>;
+        using TPenaltyPtr = boost::shared_ptr<CPenalty>;
+        using TPenaltyCPtr = boost::shared_ptr<const CPenalty>;
+        using TPenaltyCPtrVec = std::vector<TPenaltyCPtr>;
 
         //! \brief Represents the result of multiplying penalties.
         class CClosure
@@ -141,7 +141,7 @@ class CONFIG_EXPORT CPenalty
         static bool scoreIsZeroFor(double penalty);
 
     protected:
-        typedef boost::reference_wrapper<const CAutoconfigurerParams> TAutoconfigurerParamsCRef;
+        using TAutoconfigurerParamsCRef = boost::reference_wrapper<const CAutoconfigurerParams>;
 
     protected:
         //! Get the parameters.

--- a/include/config/CPolledDataPenalty.h
+++ b/include/config/CPolledDataPenalty.h
@@ -50,7 +50,7 @@ class CONFIG_EXPORT CPolledDataPenalty : public CPenalty
         virtual std::string name(void) const;
 
     private:
-        typedef boost::optional<core_t::TTime> TOptionalTime;
+        using TOptionalTime = boost::optional<core_t::TTime>;
 
     private:
         //! Compute a penalty for rare detectors.

--- a/include/config/CReportWriter.h
+++ b/include/config/CReportWriter.h
@@ -47,10 +47,10 @@ class CNumericDataSummaryStatistics;
 class CONFIG_EXPORT CReportWriter : public api::COutputHandler
 {
     public:
-        typedef std::vector<std::string> TStrVec;
-        typedef std::vector<TStrVec> TStrVecVec;
-        typedef std::vector<TStrVecVec> TStrVecVecVec;
-        typedef std::vector<TStrVecVecVec> TStrVecVecVecVec;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecVec = std::vector<TStrVec>;
+        using TStrVecVecVec = std::vector<TStrVecVec>;
+        using TStrVecVecVecVec = std::vector<TStrVecVecVec>;
 
         //! \name Summary Statistics.
         //@{

--- a/include/config/CTooMuchDataPenalty.h
+++ b/include/config/CTooMuchDataPenalty.h
@@ -53,8 +53,8 @@ class CONFIG_EXPORT CTooMuchDataPenalty : public CPenalty
         virtual std::string name(void) const;
 
     private:
-        typedef std::vector<uint64_t> TUInt64Vec;
-        typedef std::vector<CBucketCountStatistics> TBucketCountStatisticsVec;
+        using TUInt64Vec = std::vector<uint64_t>;
+        using TBucketCountStatisticsVec = std::vector<CBucketCountStatistics>;
 
     private:
         //! Compute a penalty for rare detectors.

--- a/include/core/CBase64Filter.h
+++ b/include/core/CBase64Filter.h
@@ -60,11 +60,11 @@ namespace core
 class CORE_EXPORT CBase64Encoder
 {
     public:
-        typedef boost::circular_buffer<uint8_t> TUInt8Buf;
-        typedef TUInt8Buf::iterator TUInt8BufItr;
-        typedef TUInt8Buf::const_iterator TUInt8BufCItr;
+        using TUInt8Buf = boost::circular_buffer<uint8_t>;
+        using TUInt8BufItr = TUInt8Buf::iterator;
+        using TUInt8BufCItr = TUInt8Buf::const_iterator;
 
-        typedef char char_type;
+        using char_type = char;
 
         //! Tell boost::iostreams what this filter is capable of
         struct category :
@@ -117,8 +117,8 @@ class CORE_EXPORT CBase64Encoder
         template<typename SINK>
         void Encode(SINK &snk, bool isFinal)
         {
-            typedef boost::archive::iterators::transform_width<TUInt8BufCItr, 6, 8> TUInt8BufCItrTransformItr;
-            typedef boost::archive::iterators::base64_from_binary<TUInt8BufCItrTransformItr> TBase64Text;
+            using TUInt8BufCItrTransformItr = boost::archive::iterators::transform_width<TUInt8BufCItr, 6, 8>;
+            using TBase64Text = boost::archive::iterators::base64_from_binary<TUInt8BufCItrTransformItr>;
 
             TUInt8BufItr endItr = m_Buffer.end();
             // Base64 turns 3 bytes into 4 characters - unless this is the final part
@@ -179,11 +179,11 @@ class CORE_EXPORT CBase64Encoder
 class CORE_EXPORT CBase64Decoder
 {
     public:
-        typedef boost::circular_buffer<uint8_t> TUInt8Buf;
-        typedef TUInt8Buf::iterator TUInt8BufItr;
-        typedef TUInt8Buf::const_iterator TUInt8BufCItr;
-        typedef TUInt8Buf::const_reverse_iterator TUInt8BufCRItr;
-        typedef char char_type;
+        using TUInt8Buf = boost::circular_buffer<uint8_t>;
+        using TUInt8BufItr = TUInt8Buf::iterator;
+        using TUInt8BufCItr = TUInt8Buf::const_iterator;
+        using TUInt8BufCRItr = TUInt8Buf::const_reverse_iterator;
+        using char_type = char;
 
         //! Tell boost::iostreams what this filter is capable of
         struct category :
@@ -292,8 +292,8 @@ class CORE_EXPORT CBase64Decoder
         void Decode(bool isFinal)
         {
             // Base64 turns 4 characters into 3 bytes
-            typedef boost::archive::iterators::binary_from_base64<TUInt8BufCItr> TUInt8BufCItrBinaryBase64Itr;
-            typedef boost::archive::iterators::transform_width<TUInt8BufCItrBinaryBase64Itr, 8, 6, uint8_t> TBase64Binary;
+            using TUInt8BufCItrBinaryBase64Itr = boost::archive::iterators::binary_from_base64<TUInt8BufCItr>;
+            using TBase64Binary = boost::archive::iterators::transform_width<TUInt8BufCItrBinaryBase64Itr, 8, 6, uint8_t>;
 
             std::size_t inBytes = m_BufferIn.size();
             if (inBytes == 0)

--- a/include/core/CBlockingMessageQueue.h
+++ b/include/core/CBlockingMessageQueue.h
@@ -290,7 +290,7 @@ class CBlockingMessageQueue
         //! Using a circular buffer for the queue means that it will not do any
         //! memory allocations after construction (providing the message type
         //! does not allocate any heap memory in its constructor).
-        typedef boost::circular_buffer<MESSAGE> TMessageCircBuf;
+        using TMessageCircBuf = boost::circular_buffer<MESSAGE>;
 
         TMessageCircBuf     m_Queue;
 

--- a/include/core/CCompressUtils.h
+++ b/include/core/CCompressUtils.h
@@ -51,7 +51,7 @@ class CORE_EXPORT CCompressUtils : private CNonCopyable
 {
     public:
         //! The output type
-        typedef std::vector<Bytef> TByteVec;
+        using TByteVec = std::vector<Bytef>;
 
     public:
         explicit CCompressUtils(bool lengthOnly,

--- a/include/core/CCompressedDictionary.h
+++ b/include/core/CCompressedDictionary.h
@@ -55,8 +55,8 @@ template<std::size_t N>
 class CCompressedDictionary
 {
     public:
-        typedef boost::array<uint64_t, N> TUInt64Array;
-        typedef const std::string* TStrCPtr;
+        using TUInt64Array = boost::array<uint64_t, N>;
+        using TStrCPtr = const std::string*;
 
         //! \brief A hash representation of a string in the dictionary
         //! with low probability of collision even for relatively large
@@ -170,10 +170,10 @@ class CCompressedDictionary
         };
 
         //! The type of an ordered set of words.
-        typedef std::set<CWord> TWordSet;
+        using TWordSet = std::set<CWord>;
 
         //! The type of an unordered set of words.
-        typedef boost::unordered_set<CWord, CHash> TWordUSet;
+        using TWordUSet = boost::unordered_set<CWord, CHash>;
 
         //! A "template typedef" of an ordered map from words to
         //! objects of type T.
@@ -181,7 +181,7 @@ class CCompressedDictionary
         class CWordMap
         {
             public:
-                typedef std::map<CWord, T> Type;
+                using Type = std::map<CWord, T>;
         };
 
         //! A "template typedef" of an unordered map from words to
@@ -190,7 +190,7 @@ class CCompressedDictionary
         class CWordUMap
         {
             public:
-                typedef boost::unordered_map<CWord, T, CHash> Type;
+                using Type = boost::unordered_map<CWord, T, CHash>;
         };
 
     public:

--- a/include/core/CContainerPrinter.h
+++ b/include/core/CContainerPrinter.h
@@ -39,15 +39,15 @@ namespace core
 namespace printer_detail
 {
 
-typedef boost::true_type true_;
-typedef boost::false_type false_;
+using true_ = boost::true_type;
+using false_ = boost::false_type;
 
 //! Auxiliary type used by has_const_iterator to test for a nested
 //! typedef.
 template<typename T, typename R = void>
 struct enable_if_has
 {
-    typedef R type;
+    using type = R;
 };
 
 //! Auxiliary type used by has_print_function to test for a nested
@@ -55,7 +55,7 @@ struct enable_if_has
 template<typename T, T, typename R = void>
 struct enable_if_is
 {
-    typedef R type;
+    using type = R;
 };
 
 //! \name Check For Nested "const_iterator"
@@ -74,13 +74,13 @@ struct enable_if_is
 template<typename T, typename ENABLE = void>
 struct has_const_iterator
 {
-    typedef false_ value;
+    using value = false_;
 };
 
 template<typename T>
 struct has_const_iterator<T, typename enable_if_has<typename T::const_iterator>::type>
 {
-    typedef true_ value;
+    using value = true_;
 };
 //@}
 
@@ -101,13 +101,13 @@ struct has_const_iterator<T, typename enable_if_has<typename T::const_iterator>:
 template<typename T, typename U = void>
 struct has_print_function
 {
-    typedef false_ value;
+    using value = false_;
 };
 
 template<typename T>
 struct has_print_function<T, typename enable_if_is<std::string (T::*)(void) const, &T::print>::type>
 {
-    typedef true_ value;
+    using value = true_;
 };
 //@}
 
@@ -264,9 +264,9 @@ class CORE_EXPORT CContainerPrinter : private CNonInstantiatable
         static std::string printElement(const T &value)
         {
             using namespace printer_detail;
-            typedef typename boost::unwrap_reference<T>::type U;
-            typedef CNodePrinter<typename has_const_iterator<U>::value,
-                                 CContainerPrinter> Printer;
+            using U = typename boost::unwrap_reference<T>::type;
+            using Printer = CNodePrinter<typename has_const_iterator<U>::value,
+                                         CContainerPrinter>;
             return Printer::print(boost::unwrap_ref(value));
         }
 

--- a/include/core/CDataAdder.h
+++ b/include/core/CDataAdder.h
@@ -49,10 +49,10 @@ namespace core
 class CORE_EXPORT CDataAdder : private CNonCopyable
 {
     public:
-        typedef boost::shared_ptr<std::ostream> TOStreamP;
-        typedef boost::shared_ptr<CDataAdder>   TDataAdderP;
+        using TOStreamP = boost::shared_ptr<std::ostream>;
+        using TDataAdderP = boost::shared_ptr<CDataAdder>;
 
-        typedef std::function<bool(CDataAdder &)> TPersistFunc;
+        using TPersistFunc = std::function<bool(CDataAdder &)>;
 
     public:
         virtual ~CDataAdder(void);

--- a/include/core/CDataSearcher.h
+++ b/include/core/CDataSearcher.h
@@ -46,10 +46,10 @@ namespace core
 class CORE_EXPORT CDataSearcher : private CNonCopyable
 {
     public:
-        typedef std::vector<std::string>         TStrVec;
-        typedef TStrVec::const_iterator          TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecCItr = TStrVec::const_iterator;
 
-        typedef boost::shared_ptr<std::istream>  TIStreamP;
+        using TIStreamP = boost::shared_ptr<std::istream>;
 
     public:
         //! Empty string

--- a/include/core/CDetachedProcessSpawner.h
+++ b/include/core/CDetachedProcessSpawner.h
@@ -78,9 +78,9 @@ class CTrackerThread;
 class CORE_EXPORT CDetachedProcessSpawner
 {
     public:
-        typedef std::vector<std::string> TStrVec;
+        using TStrVec = std::vector<std::string>;
 
-        typedef boost::shared_ptr<detail::CTrackerThread> TTrackerThreadP;
+        using TTrackerThreadP = boost::shared_ptr<detail::CTrackerThread>;
 
     public:
         //! Permitted paths may be relative or absolute, but each process must

--- a/include/core/CDualThreadStreamBuf.h
+++ b/include/core/CDualThreadStreamBuf.h
@@ -143,7 +143,7 @@ class CORE_EXPORT CDualThreadStreamBuf : public std::streambuf
 
     private:
         //! Used to manage the two buffers.
-        typedef boost::scoped_array<char> TScopedCharArray;
+        using TScopedCharArray = boost::scoped_array<char>;
 
         //! Buffer that put functions will write to.
         TScopedCharArray m_WriteBuffer;

--- a/include/core/CFlatPrefixTree.h
+++ b/include/core/CFlatPrefixTree.h
@@ -59,10 +59,10 @@ namespace core
 class CORE_EXPORT CFlatPrefixTree
 {
     public:
-        typedef std::vector<std::string> TStrVec;
-        typedef TStrVec::const_iterator TStrVecCItr;
-        typedef std::string::const_iterator TStrCItr;
-        typedef std::string::const_reverse_iterator TStrCRItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecCItr = TStrVec::const_iterator;
+        using TStrCItr = std::string::const_iterator;
+        using TStrCRItr = std::string::const_reverse_iterator;
 
     private:
         struct SNode
@@ -92,9 +92,9 @@ class CORE_EXPORT CFlatPrefixTree
         };
 
     private:
-        typedef std::vector<SNode> TNodeVec;
-        typedef TNodeVec::const_iterator TNodeVecCItr;
-        typedef std::vector<SDistinctChar> TDistinctCharVec;
+        using TNodeVec = std::vector<SNode>;
+        using TNodeVecCItr = TNodeVec::const_iterator;
+        using TDistinctCharVec = std::vector<SDistinctChar>;
 
     public:
         //! Default constructor.

--- a/include/core/CHashing.h
+++ b/include/core/CHashing.h
@@ -55,7 +55,7 @@ class CORE_EXPORT CHashing : private CNonInstantiatable
         class CORE_EXPORT CUniversalHash
         {
             public:
-                typedef std::vector<uint32_t> TUInt32Vec;
+                using TUInt32Vec = std::vector<uint32_t>;
 
             public:
                 //! A member of the universal (2-independent) hash family on
@@ -105,7 +105,7 @@ class CORE_EXPORT CHashing : private CNonInstantiatable
                         uint32_t m_M, m_A, m_B;
                 };
 
-                typedef std::vector<CUInt32Hash> TUInt32HashVec;
+                using TUInt32HashVec = std::vector<CUInt32Hash>;
 
                 //! A lightweight implementation universal (2-independent) on
                 //! 32-bit integers. This doesn't further restrict the range
@@ -145,7 +145,7 @@ class CORE_EXPORT CHashing : private CNonInstantiatable
                         uint32_t m_A, m_B;
                 };
 
-                typedef std::vector<CUInt32UnrestrictedHash> TUInt32UnrestrictedHashVec;
+                using TUInt32UnrestrictedHashVec = std::vector<CUInt32UnrestrictedHash>;
 
                 //! A member of the universal (2-independent) hash family on
                 //! vectors of integers (Carter and Wegman):
@@ -221,7 +221,7 @@ class CORE_EXPORT CHashing : private CNonInstantiatable
                         uint32_t m_B;
                 };
 
-                typedef std::vector<CUInt32VecHash> TUInt32VecHashVec;
+                using TUInt32VecHashVec = std::vector<CUInt32VecHash>;
 
                 //! Converts hash function objects to a string.
                 class CORE_EXPORT CToString
@@ -430,7 +430,7 @@ class CORE_EXPORT CHashing : private CNonInstantiatable
             public:
                 //! See CMemory.
                 static bool dynamicSizeAlwaysZero(void) { return true; }
-                typedef boost::reference_wrapper<const std::string> TStrCRef;
+                using TStrCRef = boost::reference_wrapper<const std::string>;
 
             public:
                 CMurmurHash2String(std::size_t seed = 0x5bd1e995) : m_Seed(seed) {}
@@ -463,7 +463,7 @@ class CORE_EXPORT CHashing : private CNonInstantiatable
             public:
                 //! See CMemory.
                 static bool dynamicSizeAlwaysZero(void) { return true; }
-                typedef boost::reference_wrapper<const std::string> TStrCRef;
+                using TStrCRef = boost::reference_wrapper<const std::string>;
 
             public:
                 CSafeMurmurHash2String64(uint64_t seed = 0x5bd1e995) : m_Seed(seed) {}

--- a/include/core/CHexUtils.h
+++ b/include/core/CHexUtils.h
@@ -44,7 +44,7 @@ namespace core
 class CORE_EXPORT CHexUtils
 {
     public:
-        typedef std::vector<uint8_t> TDataVec;
+        using TDataVec = std::vector<uint8_t>;
 
     public:
         //! Construct an object of this class, which can then be output to a

--- a/include/core/CJsonStatePersistInserter.h
+++ b/include/core/CJsonStatePersistInserter.h
@@ -80,7 +80,7 @@ class CORE_EXPORT CJsonStatePersistInserter : public CStatePersistInserter
         //! JSON writer ostream wrapper
         rapidjson::OStreamWrapper     m_WriteStream;
 
-        typedef core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> TGenericLineWriter;
+        using TGenericLineWriter = core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>;
 
         //! JSON writer
         TGenericLineWriter            m_Writer;

--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -146,8 +146,8 @@ class CORE_EXPORT CLogger : private CNonCopyable
         //! 3) %P with the program's process ID
         void massageProperties(log4cxx::helpers::Properties &props) const;
 
-        typedef std::map<log4cxx::logchar, log4cxx::LogString> TLogCharLogStrMap;
-        typedef TLogCharLogStrMap::const_iterator              TLogCharLogStrMapCItr;
+        using TLogCharLogStrMap = std::map<log4cxx::logchar, log4cxx::LogString>;
+        using TLogCharLogStrMapCItr = TLogCharLogStrMap::const_iterator;
 
         //! Replace Ml specific mappings in a single string
         void massageString(const TLogCharLogStrMap &mappings,

--- a/include/core/CMaskIterator.h
+++ b/include/core/CMaskIterator.h
@@ -48,12 +48,12 @@ class CMaskIterator : private boost::incrementable< CMaskIterator<ITR>,
                               boost::subtractable2< CMaskIterator<ITR>, typename std::iterator_traits<ITR>::difference_type > > > >
 {
     public:
-        typedef typename std::iterator_traits<ITR>::difference_type difference_type;
-        typedef typename std::iterator_traits<ITR>::value_type value_type;
-        typedef typename std::iterator_traits<ITR>::pointer pointer;
-        typedef typename std::iterator_traits<ITR>::reference reference;
-        typedef typename std::iterator_traits<ITR>::iterator_category iterator_category;
-        typedef std::vector<difference_type> TDifferenceVec;
+        using difference_type = typename std::iterator_traits<ITR>::difference_type;
+        using value_type = typename std::iterator_traits<ITR>::value_type;
+        using pointer = typename std::iterator_traits<ITR>::pointer;
+        using reference = typename std::iterator_traits<ITR>::reference;
+        using iterator_category = typename std::iterator_traits<ITR>::iterator_category;
+        using TDifferenceVec = std::vector<difference_type>;
 
     public:
         CMaskIterator(ITR begin, const TDifferenceVec &mask, difference_type index) :

--- a/include/core/CMemory.h
+++ b/include/core/CMemory.h
@@ -75,13 +75,13 @@ const std::size_t MIN_DEQUE_PAGE_VEC_ENTRIES = 8;
 template<typename T, std::size_t (T::*)(void) const, typename R = void>
 struct enable_if_member_function
 {
-    typedef R type;
+    using type = R;
 };
 
 template<bool (*)(void), typename R = void>
 struct enable_if_function
 {
-    typedef R type;
+    using type = R;
 };
 
 //! \brief Default template declaration for CMemoryDynamicSize::dispatch.

--- a/include/core/CMemoryUsage.h
+++ b/include/core/CMemoryUsage.h
@@ -70,12 +70,12 @@ class CORE_EXPORT CMemoryUsage
             std::size_t s_Unused;
         };
 
-        typedef CMemoryUsage* TMemoryUsagePtr;
-        typedef std::list<TMemoryUsagePtr> TMemoryUsagePtrList;
-        typedef TMemoryUsagePtrList::const_iterator TMemoryUsagePtrListCItr;
-        typedef TMemoryUsagePtrList::iterator TMemoryUsagePtrListItr;
-        typedef std::vector<SMemoryUsage> TMemoryUsageVec;
-        typedef TMemoryUsageVec::const_iterator TMemoryUsageVecCitr;
+        using TMemoryUsagePtr = CMemoryUsage*;
+        using TMemoryUsagePtrList = std::list<TMemoryUsagePtr>;
+        using TMemoryUsagePtrListCItr = TMemoryUsagePtrList::const_iterator;
+        using TMemoryUsagePtrListItr = TMemoryUsagePtrList::iterator;
+        using TMemoryUsageVec = std::vector<SMemoryUsage>;
+        using TMemoryUsageVecCitr = TMemoryUsageVec::const_iterator;
 
     public:
         //! Constructor

--- a/include/core/CMemoryUsageJsonWriter.h
+++ b/include/core/CMemoryUsageJsonWriter.h
@@ -73,7 +73,7 @@ class CORE_EXPORT CMemoryUsageJsonWriter
         //! JSON writer ostream wrapper
         rapidjson::OStreamWrapper         m_WriteStream;
 
-        typedef CRapidJsonLineWriter<rapidjson::OStreamWrapper> TGenericLineWriter;
+        using TGenericLineWriter = CRapidJsonLineWriter<rapidjson::OStreamWrapper>;
 
         //! JSON writer
         TGenericLineWriter                m_Writer;

--- a/include/core/CMessageBuffer.h
+++ b/include/core/CMessageBuffer.h
@@ -109,7 +109,7 @@ class CMessageBuffer
             protected:
                 void run(void)
                 {
-                    typedef std::vector<MESSAGE> TMessageVec;
+                    using TMessageVec = std::vector<MESSAGE>;
 
                     m_MessageBuffer.m_Mutex.lock();
 

--- a/include/core/CMessageQueue.h
+++ b/include/core/CMessageQueue.h
@@ -327,7 +327,7 @@ class CMessageQueue
         CCondition          m_Condition;
         RECEIVER            &m_Receiver;
 
-        typedef std::queue<MESSAGE>              TMessageQueue;
+        using TMessageQueue = std::queue<MESSAGE>;
 
         TMessageQueue       m_Queue;
 
@@ -337,7 +337,7 @@ class CMessageQueue
         //! A stop watch for timing how long it takes to process messages
         CStopWatch          m_StopWatch;
 
-        typedef boost::circular_buffer<uint64_t> TUIntCircBuf;
+        using TUIntCircBuf = boost::circular_buffer<uint64_t>;
 
         //! Stop watch readings
         TUIntCircBuf        m_Readings;

--- a/include/core/CNamedPipeFactory.h
+++ b/include/core/CNamedPipeFactory.h
@@ -69,9 +69,9 @@ namespace core
 class CORE_EXPORT CNamedPipeFactory : private CNonInstantiatable
 {
     public:
-        typedef boost::shared_ptr<std::istream> TIStreamP;
-        typedef boost::shared_ptr<std::ostream> TOStreamP;
-        typedef boost::shared_ptr<FILE>         TFileP;
+        using TIStreamP = boost::shared_ptr<std::istream>;
+        using TOStreamP = boost::shared_ptr<std::ostream>;
+        using TFileP = boost::shared_ptr<FILE>;
 
     public:
         //! Character that can safely be used to test whether named pipes are
@@ -106,9 +106,9 @@ class CORE_EXPORT CNamedPipeFactory : private CNonInstantiatable
 
     private:
 #ifdef Windows
-        typedef HANDLE TPipeHandle;
+        using TPipeHandle = HANDLE;
 #else
-        typedef int    TPipeHandle;
+        using TPipeHandle = int;
 #endif
 
     private:

--- a/include/core/COsFileFuncs.h
+++ b/include/core/COsFileFuncs.h
@@ -89,30 +89,30 @@ class CORE_EXPORT COsFileFuncs : private CNonInstantiatable
     public:
         //! Signed size type (to be used instead of ssize_t)
 #ifdef Windows
-        typedef int             TSignedSize;
+        using TSignedSize = int;
 #else
-        typedef ssize_t         TSignedSize;
+        using TSignedSize = ssize_t;
 #endif
 
         //! Offset type (to be used instead of off_t)
 #ifdef Windows
-        typedef __int64         TOffset;
+        using TOffset = __int64;
 #else
-        typedef off_t           TOffset;
+        using TOffset = off_t;
 #endif
 
         //! Mode type (to be used instead of mode_t)
 #ifdef Windows
-        typedef int             TMode;
+        using TMode = int;
 #else
-        typedef mode_t          TMode;
+        using TMode = mode_t;
 #endif
 
         //! Inode type (to be used instead of ino_t)
 #ifdef Windows
-        typedef uint64_t        TIno;
+        using TIno = uint64_t;
 #else
-        typedef ino_t           TIno;
+        using TIno = ino_t;
 #endif
 
         //! Stat buffer struct (to be used instead of struct stat)
@@ -135,9 +135,9 @@ class CORE_EXPORT COsFileFuncs : private CNonInstantiatable
             __time64_t     st_ctime;
         };
 
-        typedef SStat           TStat;
+        using TStat = SStat;
 #else
-        typedef struct stat     TStat;
+        using TStat = struct stat;
 #endif
 
     public:

--- a/include/core/CPatternSet.h
+++ b/include/core/CPatternSet.h
@@ -49,9 +49,9 @@ namespace core
 class CORE_EXPORT CPatternSet
 {
     public:
-        typedef std::vector<std::string> TStrVec;
-        typedef TStrVec::const_iterator TStrVecCItr;
-        typedef std::string::const_iterator TStrCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecCItr = TStrVec::const_iterator;
+        using TStrCItr = std::string::const_iterator;
 
     public:
         //! Default constructor.

--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -52,14 +52,14 @@ const std::string SIZE_TAG("d");
 template<typename T>
 struct remove_const
 {
-    typedef typename boost::remove_const<T>::type type;
+    using type = typename boost::remove_const<T>::type;
 };
 
 template<typename U, typename V>
 struct remove_const<std::pair<U, V> >
 {
-    typedef std::pair<typename remove_const<U>::type,
-                      typename remove_const<V>::type> type;
+    using type = std::pair<typename remove_const<U>::type,
+                           typename remove_const<V>::type>;
 };
 
 //! Template specialisation utility classes for selecting various
@@ -78,7 +78,7 @@ class MemberFromDelimited {};
 template<typename T, typename R = void>
 struct enable_if
 {
-    typedef R type;
+    using type = R;
 };
 
 //! Auxiliary type used by has_persist_function to test for a nested
@@ -86,7 +86,7 @@ struct enable_if
 template<typename T, T, typename R = void>
 struct enable_if_is
 {
-    typedef R type;
+    using type = R;
 };
 
 
@@ -96,12 +96,12 @@ struct enable_if_is
 template<typename T, typename ITR = void>
 struct persist_container_selector
 {
-    typedef BasicPersist value;
+    using value = BasicPersist;
 };
 template<typename T>
 struct persist_container_selector<T, typename enable_if<typename T::const_iterator>::type>
 {
-    typedef ContainerPersist value;
+    using value = ContainerPersist;
 };
 //@}
 
@@ -110,17 +110,17 @@ struct persist_container_selector<T, typename enable_if<typename T::const_iterat
 template<typename T, typename ENABLE = void>
 struct persist_selector
 {
-    typedef typename persist_container_selector<T>::value value;
+    using value = typename persist_container_selector<T>::value;
 };
 template<typename T>
 struct persist_selector<T, typename enable_if_is<void (T::*)(CStatePersistInserter &) const, &T::acceptPersistInserter>::type>
 {
-    typedef MemberPersist value;
+    using value = MemberPersist;
 };
 template<typename T>
 struct persist_selector<T, typename enable_if_is<std::string (T::*)(void) const, &T::toDelimited>::type>
 {
-    typedef MemberToDelimited value;
+    using value = MemberToDelimited;
 };
 //@}
 
@@ -142,12 +142,12 @@ bool persist(const std::string &tag, const T &target, CStatePersistInserter &ins
 template<typename T, typename ITR = void>
 struct restore_container_selector
 {
-    typedef BasicRestore value;
+    using value = BasicRestore;
 };
 template<typename T>
 struct restore_container_selector<T, typename enable_if<typename T::const_iterator>::type>
 {
-    typedef ContainerRestore value;
+    using value = ContainerRestore;
 };
 //@}
 
@@ -156,17 +156,17 @@ struct restore_container_selector<T, typename enable_if<typename T::const_iterat
 template<typename T, typename ENABLE = void>
 struct restore_selector
 {
-    typedef typename restore_container_selector<T>::value value;
+    using value = typename restore_container_selector<T>::value;
 };
 template<typename T>
 struct restore_selector<T, typename enable_if_is<bool (T::*)(CStateRestoreTraverser &), &T::acceptRestoreTraverser>::type>
 {
-    typedef MemberRestore value;
+    using value = MemberRestore;
 };
 template<typename T>
 struct restore_selector<T, typename enable_if_is<bool (T::*)(const std::string &), &T::fromDelimited>::type>
 {
-    typedef MemberFromDelimited value;
+    using value = MemberFromDelimited;
 };
 //@}
 
@@ -194,12 +194,12 @@ class CanReserve {};
 template<typename T, typename ENABLE = void>
 struct reserve_selector
 {
-    typedef ENABLE value;
+    using value = ENABLE;
 };
 template<typename T>
 struct reserve_selector<T, typename enable_if_is<void (T::*)(std::size_t), &T::reserve>::type>
 {
-    typedef CanReserve value;
+    using value = CanReserve;
 };
 //@}
 
@@ -640,7 +640,7 @@ class CORE_EXPORT CPersistUtils
                                const char delimiter = DELIMITER,
                                bool append = false)
         {
-            typedef typename persist_utils_detail::remove_const<typename CONTAINER::value_type>::type T;
+            using T = typename persist_utils_detail::remove_const<typename CONTAINER::value_type>::type;
 
             if (!append)
             {
@@ -844,9 +844,9 @@ class CPersisterImpl<ContainerPersist>
                              const boost::unordered_set<T, H, P, A> &container,
                              CStatePersistInserter &inserter)
         {
-            typedef typename std::vector<T> TVec;
-            typedef typename boost::unordered_set<T, H, P, A>::const_iterator TCItr;
-            typedef typename std::vector<TCItr> TCItrVec;
+            using TVec = typename std::vector<T>;
+            using TCItr = typename boost::unordered_set<T, H, P, A>::const_iterator;
+            using TCItrVec = typename std::vector<TCItr>;
 
             if (boost::is_arithmetic<T>::value)
             {
@@ -876,8 +876,8 @@ class CPersisterImpl<ContainerPersist>
                              const boost::unordered_map<K, V, H, P, A> &container,
                              CStatePersistInserter &inserter)
         {
-            typedef typename boost::unordered_map<K, V, H, P, A>::const_iterator TCItr;
-            typedef typename std::vector<TCItr> TCItrVec;
+            using TCItr = typename boost::unordered_map<K, V, H, P, A>::const_iterator;
+            using TCItrVec = typename std::vector<TCItr>;
 
             TCItrVec iterators;
             iterators.reserve(container.size());
@@ -926,7 +926,7 @@ class CPersisterImpl<ContainerPersist>
                              boost::false_type,
                              boost::false_type)
         {
-            typedef typename T::const_iterator TCItr;
+            using TCItr = typename T::const_iterator;
             inserter.insertLevel(tag, boost::bind(&newLevel<TCItr>,
                                                   container.begin(), container.end(), container.size(), _1));
         }
@@ -942,7 +942,7 @@ class CPersisterImpl<ContainerPersist>
                              boost::false_type,
                              boost::true_type)
         {
-            typedef boost::indirect_iterator<typename T::const_iterator> TCItr;
+            using TCItr = boost::indirect_iterator<typename T::const_iterator>;
             inserter.insertLevel(tag, boost::bind(&newLevel<TCItr>,
                                                   TCItr(t.begin()), TCItr(t.end()), t.size(), _1));
         }
@@ -1107,7 +1107,7 @@ class CRestorerImpl<ContainerRestore>
             template<typename T>
             bool operator()(T &container, CStateRestoreTraverser &traverser)
             {
-                typedef typename remove_const<typename T::value_type>::type TValueType;
+                using TValueType = typename remove_const<typename T::value_type>::type;
                 do
                 {
                     if (traverser.name() == SIZE_TAG)
@@ -1140,7 +1140,7 @@ class CRestorerImpl<ContainerRestore>
             template<typename T, std::size_t N>
             bool operator()(boost::array<T, N> &container, CStateRestoreTraverser &traverser)
             {
-                typedef typename remove_const<T>::type TValueType;
+                using TValueType = typename remove_const<T>::type;
                 typename boost::array<T, N>::iterator i = container.begin();
                 do
                 {

--- a/include/core/CPolymorphicStackObjectCPtr.h
+++ b/include/core/CPolymorphicStackObjectCPtr.h
@@ -40,11 +40,11 @@ template<typename BASE, typename D1, typename D2, typename D3 = D2, typename D4 
 class CPolymorphicStackObjectCPtr
 {
     private:
-        typedef const typename boost::remove_const<BASE>::type TConstBase;
-        typedef const typename boost::remove_const<D1>::type   TConstD1;
-        typedef const typename boost::remove_const<D2>::type   TConstD2;
-        typedef const typename boost::remove_const<D3>::type   TConstD3;
-        typedef const typename boost::remove_const<D4>::type   TConstD4;
+        using TConstBase = const typename boost::remove_const<BASE>::type;
+        using TConstD1 = const typename boost::remove_const<D1>::type;
+        using TConstD2 = const typename boost::remove_const<D2>::type;
+        using TConstD3 = const typename boost::remove_const<D3>::type;
+        using TConstD4 = const typename boost::remove_const<D4>::type;
 
     public:
         CPolymorphicStackObjectCPtr(void) : m_Storage(CNullPolymorphicStackObjectCPtr()) {}
@@ -118,7 +118,7 @@ class CPolymorphicStackObjectCPtr
         }
 
     private:
-        typedef boost::variant<D1, D2, D3, D4, CNullPolymorphicStackObjectCPtr> TStorage;
+        using TStorage = boost::variant<D1, D2, D3, D4, CNullPolymorphicStackObjectCPtr>;
 
     private:
         //! The static storage of the actual type.

--- a/include/core/CProcess.h
+++ b/include/core/CProcess.h
@@ -61,20 +61,20 @@ class CORE_EXPORT CProcess : private CNonCopyable
 
     public:
         //! Prototype of the mlMain() function
-        typedef int (*TMlMainFunc)(int, char *[]);
+        using TMlMainFunc = int (*)(int, char *[]);
 
         //! Vector of process arguments
-        typedef std::vector<std::string> TStrVec;
-        typedef TStrVec::const_iterator  TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecCItr = TStrVec::const_iterator;
 
         //! The shutdown function
-        typedef std::function<void()>    TShutdownFunc;
+        using TShutdownFunc = std::function<void()>;
 
         //! Process ID type
 #ifdef Windows
-        typedef DWORD                    TPid;
+        using TPid = DWORD;
 #else
-        typedef pid_t                    TPid;
+        using TPid = pid_t;
 #endif
 
     public:

--- a/include/core/CRapidJsonWriterBase.h
+++ b/include/core/CRapidJsonWriterBase.h
@@ -77,24 +77,24 @@ template<typename OUTPUT_STREAM,
 class CRapidJsonWriterBase : public JSON_WRITER<OUTPUT_STREAM, SOURCE_ENCODING, TARGET_ENCODING, STACK_ALLOCATOR, WRITE_FLAGS>
 {
     public:
-        typedef std::vector<core_t::TTime>              TTimeVec;
-        typedef std::vector<std::string>                TStrVec;
-        typedef std::vector<double>                     TDoubleVec;
-        typedef std::pair<double, double>               TDoubleDoublePr;
-        typedef std::vector<TDoubleDoublePr>            TDoubleDoublePrVec;
-        typedef std::pair<double, TDoubleDoublePr>      TDoubleDoubleDoublePrPr;
-        typedef std::vector<TDoubleDoubleDoublePrPr>    TDoubleDoubleDoublePrPrVec;
-        typedef boost::unordered_set<std::string>       TStrUSet;
-        typedef rapidjson::Document                     TDocument;
-        typedef rapidjson::Value                        TValue;
-        typedef boost::weak_ptr<TDocument>              TDocumentWeakPtr;
-        typedef boost::shared_ptr<TValue>               TValuePtr;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TStrVec = std::vector<std::string>;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleDoublePr = std::pair<double, double>;
+        using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+        using TDoubleDoubleDoublePrPr = std::pair<double, TDoubleDoublePr>;
+        using TDoubleDoubleDoublePrPrVec = std::vector<TDoubleDoubleDoublePrPr>;
+        using TStrUSet = boost::unordered_set<std::string>;
+        using TDocument = rapidjson::Document;
+        using TValue = rapidjson::Value;
+        using TDocumentWeakPtr = boost::weak_ptr<TDocument>;
+        using TValuePtr = boost::shared_ptr<TValue>;
 
-        typedef boost::shared_ptr<CRapidJsonPoolAllocator>              TPoolAllocatorPtr;
-        typedef std::stack< TPoolAllocatorPtr >                         TPoolAllocatorPtrStack;
-        typedef boost::unordered_map< std::string, TPoolAllocatorPtr>   TStrPoolAllocatorPtrMap;
-        typedef TStrPoolAllocatorPtrMap::iterator                       TStrPoolAllocatorPtrMapItr;
-        typedef std::pair<TStrPoolAllocatorPtrMapItr, bool>             TStrPoolAllocatorPtrMapItrBoolPr;
+        using TPoolAllocatorPtr = boost::shared_ptr<CRapidJsonPoolAllocator>;
+        using TPoolAllocatorPtrStack = std::stack< TPoolAllocatorPtr >;
+        using TStrPoolAllocatorPtrMap = boost::unordered_map< std::string, TPoolAllocatorPtr>;
+        using TStrPoolAllocatorPtrMapItr = TStrPoolAllocatorPtrMap::iterator;
+        using TStrPoolAllocatorPtrMapItrBoolPr = std::pair<TStrPoolAllocatorPtrMapItr, bool>;
 
 
     public:

--- a/include/core/CRapidXmlParser.h
+++ b/include/core/CRapidXmlParser.h
@@ -74,8 +74,8 @@ class CRapidXmlStateRestoreTraverser;
 class CORE_EXPORT CRapidXmlParser : public CXmlParserIntf
 {
     public:
-        typedef std::map<std::string, std::string> TStrStrMap;
-        typedef TStrStrMap::const_iterator         TStrStrMapCItr;
+        using TStrStrMap = std::map<std::string, std::string>;
+        using TStrStrMapCItr = TStrStrMap::const_iterator;
 
     public:
         CRapidXmlParser(void);
@@ -144,9 +144,9 @@ class CORE_EXPORT CRapidXmlParser : public CXmlParserIntf
                             std::string &result);
 
     private:
-        typedef rapidxml::xml_document<char>  TCharRapidXmlDocument;
-        typedef rapidxml::xml_node<char>      TCharRapidXmlNode;
-        typedef rapidxml::xml_attribute<char> TCharRapidXmlAttribute;
+        using TCharRapidXmlDocument = rapidxml::xml_document<char>;
+        using TCharRapidXmlNode = rapidxml::xml_node<char>;
+        using TCharRapidXmlAttribute = rapidxml::xml_attribute<char>;
 
         //! Called recursively by the public toNodeHierarchy() method
         bool toNodeHierarchy(const TCharRapidXmlNode &parentNode,
@@ -175,7 +175,7 @@ class CORE_EXPORT CRapidXmlParser : public CXmlParserIntf
         //! than in a string to avoid any problems with reference counting in
         //! STL strings.  (Obviously the template parameter here needs to match
         //! the rapidxml typedef template arguments in the typedefs above.)
-        typedef boost::scoped_array<char>     TScopedCharArray;
+        using TScopedCharArray = boost::scoped_array<char>;
 
         //! RapidXml parses the XML in-situ, so keep a copy of the input
         TScopedCharArray      m_XmlBuf;

--- a/include/core/CRapidXmlStatePersistInserter.h
+++ b/include/core/CRapidXmlStatePersistInserter.h
@@ -44,8 +44,8 @@ namespace core
 class CORE_EXPORT CRapidXmlStatePersistInserter : public CStatePersistInserter
 {
     public:
-        typedef std::map<std::string, std::string> TStrStrMap;
-        typedef TStrStrMap::const_iterator         TStrStrMapCItr;
+        using TStrStrMap = std::map<std::string, std::string>;
+        using TStrStrMapCItr = TStrStrMap::const_iterator;
 
     public:
         //! Root node has no attributes
@@ -85,8 +85,8 @@ class CORE_EXPORT CRapidXmlStatePersistInserter : public CStatePersistInserter
         //! so just store each unique name once for efficiency
         CStringCache          m_NameCache;
 
-        typedef rapidxml::xml_document<char>  TCharRapidXmlDocument;
-        typedef rapidxml::xml_node<char>      TCharRapidXmlNode;
+        using TCharRapidXmlDocument = rapidxml::xml_document<char>;
+        using TCharRapidXmlNode = rapidxml::xml_node<char>;
 
         //! The RapidXml data structure
         TCharRapidXmlDocument m_Doc;

--- a/include/core/CRegex.h
+++ b/include/core/CRegex.h
@@ -40,9 +40,9 @@ namespace core
 class CORE_EXPORT CRegex
 {
     public:
-        typedef std::vector<std::string>    TStrVec;
-        typedef TStrVec::iterator           TStrVecItr;
-        typedef TStrVec::const_iterator     TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
+        using TStrVecCItr = TStrVec::const_iterator;
 
     public:
         CRegex(void);

--- a/include/core/CRegexFilter.h
+++ b/include/core/CRegexFilter.h
@@ -41,8 +41,8 @@ namespace core
 class CORE_EXPORT CRegexFilter
 {
     public:
-        typedef std::vector<CRegex> TRegexVec;
-        typedef std::vector<std::string> TStrVec;
+        using TRegexVec = std::vector<CRegex>;
+        using TStrVec = std::vector<std::string>;
 
     public:
         CRegexFilter(void);

--- a/include/core/CStateCompressor.h
+++ b/include/core/CStateCompressor.h
@@ -57,15 +57,15 @@ class CORE_EXPORT CStateCompressor : public CDataAdder
         static const std::string END_OF_STREAM_ATTRIBUTE;
 
     public:
-        typedef boost::iostreams::filtering_stream<boost::iostreams::output> TFilteredOutput;
-        typedef boost::shared_ptr<TFilteredOutput> TFilteredOutputP;
-        typedef boost::shared_ptr<CCompressOStream> TCompressOStreamP;
+        using TFilteredOutput = boost::iostreams::filtering_stream<boost::iostreams::output>;
+        using TFilteredOutputP = boost::shared_ptr<TFilteredOutput>;
+        using TCompressOStreamP = boost::shared_ptr<CCompressOStream>;
 
         // Implements the boost::iostreams Sink template interface
         class CChunkFilter
         {
             public:
-                typedef char char_type;
+                using char_type = char;
 
                 //! Inform the filtering_stream owning object what this is capable of
                 struct category :

--- a/include/core/CStateDecompressor.h
+++ b/include/core/CStateDecompressor.h
@@ -53,8 +53,8 @@ namespace core
 class CORE_EXPORT CStateDecompressor : public CDataSearcher
 {
     public:
-        typedef boost::iostreams::filtering_stream<boost::iostreams::input> TFilteredInput;
-        typedef boost::shared_ptr<TFilteredInput> TFilteredInputP;
+        using TFilteredInput = boost::iostreams::filtering_stream<boost::iostreams::input>;
+        using TFilteredInputP = boost::shared_ptr<TFilteredInput>;
 
         static const std::string EMPTY_DATA;
 
@@ -62,7 +62,7 @@ class CORE_EXPORT CStateDecompressor : public CDataSearcher
         class CDechunkFilter
         {
             public:
-                typedef char char_type;
+                using char_type = char;
 
                 //! Inform the filtering_stream owning object what this is capable of
                 struct category :

--- a/include/core/CStateMachine.h
+++ b/include/core/CStateMachine.h
@@ -76,9 +76,9 @@ class CStateRestoreTraverser;
 class CORE_EXPORT CStateMachine
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef std::vector<std::string> TStrVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TStrVec = std::vector<std::string>;
 
     public:
         //! Set the number of machines we expect the program to use.
@@ -207,8 +207,8 @@ class CORE_EXPORT CStateMachine
                 void clear(void);
 
             private:
-                typedef std::vector<SMachine> TMachineVec;
-                typedef std::list<TMachineVec> TMachineVecList;
+                using TMachineVec = std::vector<SMachine>;
+                using TMachineVecList = std::list<TMachineVec>;
 
             private:
                 //! The vector capacity.

--- a/include/core/CStatistics.h
+++ b/include/core/CStatistics.h
@@ -141,7 +141,7 @@ class CORE_EXPORT CStatistics : private CNonCopyable
         //@}
 
     private:
-        typedef boost::array<CStat, stat_t::E_LastEnumStat> TStatArray;
+        using TStatArray = boost::array<CStat, stat_t::E_LastEnumStat>;
 
     private:
         //! Constructor of a Singleton is private

--- a/include/core/CStringCache.h
+++ b/include/core/CStringCache.h
@@ -133,8 +133,8 @@ class CORE_EXPORT CStringCache
         //! strings
         bool m_HaveCopyOnWriteStrings;
 
-        typedef boost::unordered_set<std::string, CStrHash> TStrUSet;
-        typedef TStrUSet::const_iterator                    TStrUSetCItr;
+        using TStrUSet = boost::unordered_set<std::string, CStrHash>;
+        using TStrUSetCItr = TStrUSet::const_iterator;
 
         //! The cache of strings
         TStrUSet m_Cache;

--- a/include/core/CStringSimilarityTester.h
+++ b/include/core/CStringSimilarityTester.h
@@ -80,11 +80,11 @@ class CORE_EXPORT CStringSimilarityTester : private CNonCopyable
 {
     public:
         //! Used by the simple Levenshtein distance algorithm
-        typedef boost::scoped_array<size_t> TScopedSizeArray;
+        using TScopedSizeArray = boost::scoped_array<size_t>;
 
         //! Used by the more advanced Berghel-Roach algorithm
-        typedef boost::scoped_array<int>    TScopedIntArray;
-        typedef boost::scoped_array<int *>  TScopedIntPArray;
+        using TScopedIntArray = boost::scoped_array<int>;
+        using TScopedIntPArray = boost::scoped_array<int *>;
 
     public:
         CStringSimilarityTester(void);
@@ -270,7 +270,7 @@ class CORE_EXPORT CStringSimilarityTester : private CNonCopyable
             // one go for efficiency.  Then the current and previous column
             // pointers alternate between pointing and the first and second half
             // of the memory block.
-            typedef boost::scoped_array<size_t> TScopedSizeArray;
+            using TScopedSizeArray = boost::scoped_array<size_t>;
             TScopedSizeArray data(new size_t[(secondLen + 1) * 2]);
             size_t *currentCol(data.get());
             size_t *prevCol(currentCol + (secondLen + 1));

--- a/include/core/CStringUtils.h
+++ b/include/core/CStringUtils.h
@@ -47,9 +47,9 @@ class CORE_EXPORT CStringUtils : private CNonInstantiatable
         static const std::string WHITESPACE_CHARS;
 
     public:
-        typedef std::vector<std::string>    TStrVec;
-        typedef TStrVec::iterator           TStrVecItr;
-        typedef TStrVec::const_iterator     TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
+        using TStrVecCItr = TStrVec::const_iterator;
 
     public:
         //! If \p c is the start of a UTF-8 character, return the number of

--- a/include/core/CThread.h
+++ b/include/core/CThread.h
@@ -46,11 +46,11 @@ class CORE_EXPORT CThread : private CNonCopyable
     public:
         //! Thread ID type
 #ifdef Windows
-        typedef DWORD         TThreadId;
-        typedef unsigned  int TThreadRet;
+        using TThreadId = DWORD;
+        using TThreadRet = unsigned int;
 #else
-        typedef pthread_t     TThreadId;
-        typedef void          *TThreadRet;
+        using TThreadId = pthread_t;
+        using TThreadRet = void*;
 #endif
 
     public:

--- a/include/core/CThreadFarm.h
+++ b/include/core/CThreadFarm.h
@@ -247,16 +247,16 @@ class CThreadFarm : private CNonCopyable
         //! Reference to the object that will handle the results
         HANDLER           &m_Handler;
 
-        typedef CThreadFarm<HANDLER, PROCESSOR, MESSAGE, RESULT>             TThreadFarm;
+        using TThreadFarm = CThreadFarm<HANDLER, PROCESSOR, MESSAGE, RESULT>;
 
-        typedef CThreadFarmReceiver<TThreadFarm, PROCESSOR, MESSAGE, RESULT> TReceiver;
-        typedef boost::shared_ptr<TReceiver>                                 TReceiverP;
-        typedef std::vector<TReceiverP>                                      TReceiverPVec;
-        typedef typename TReceiverPVec::iterator                             TReceiverPVecItr;
+        using TReceiver = CThreadFarmReceiver<TThreadFarm, PROCESSOR, MESSAGE, RESULT>;
+        using TReceiverP = boost::shared_ptr<TReceiver>;
+        using TReceiverPVec = std::vector<TReceiverP>;
+        using TReceiverPVecItr = typename TReceiverPVec::iterator;
 
-        typedef boost::shared_ptr< CMessageQueue<MESSAGE, TReceiver> >       TMessageQueueP;
-        typedef std::vector<TMessageQueueP>                                  TMessageQueuePVec;
-        typedef typename TMessageQueuePVec::iterator                         TMessageQueuePVecItr;
+        using TMessageQueueP = boost::shared_ptr< CMessageQueue<MESSAGE, TReceiver> >;
+        using TMessageQueuePVec = std::vector<TMessageQueueP>;
+        using TMessageQueuePVecItr = typename TMessageQueuePVec::iterator;
 
         TReceiverPVec     m_Receivers;
 

--- a/include/core/CTimeUtils.h
+++ b/include/core/CTimeUtils.h
@@ -116,7 +116,7 @@ class CORE_EXPORT CTimeUtils : private CNonInstantiatable
                 //! value of this variable has made its way into every thread).
                 static volatile CDateWordCache *ms_Instance;
 
-                typedef boost::unordered_set<std::string> TStrUSet;
+                using TStrUSet = boost::unordered_set<std::string>;
 
                 //! Our cache of date words
                 TStrUSet                       m_DateWords;

--- a/include/core/CWordDictionary.h
+++ b/include/core/CWordDictionary.h
@@ -96,7 +96,7 @@ class CORE_EXPORT CWordDictionary : private CNonCopyable
                 }
         };
 
-        typedef CWeightAll<2> TWeightAll2;
+        using TWeightAll2 = CWeightAll<2>;
 
         //! Functor for weighting one type of dictionary word by a certain
         //! amount and all dictionary words by a different amount
@@ -116,7 +116,7 @@ class CORE_EXPORT CWordDictionary : private CNonCopyable
                 }
         };
 
-        typedef CWeightOnePart<E_Verb, 5, 2> TWeightVerbs5Other2;
+        using TWeightVerbs5Other2 = CWeightOnePart<E_Verb, 5, 2>;
 
         //! Functor for weighting two types of dictionary word by certain
         //! amounts and all dictionary words by a different amount
@@ -198,11 +198,11 @@ class CORE_EXPORT CWordDictionary : private CNonCopyable
         //! Stores the dictionary words - using a multi-index even though
         //! there's only one index, because of its flexible key extractors.
         //! The key is the string, but hashed and compared ignoring case.
-        typedef boost::unordered_map<std::string,
-                                     EPartOfSpeech,
-                                     CStrHashIgnoreCase,
-                                     CStrEqualIgnoreCase> TStrUMap;
-        typedef TStrUMap::const_iterator                  TStrUMapCItr;
+        using TStrUMap = boost::unordered_map<std::string,
+                                              EPartOfSpeech,
+                                              CStrHashIgnoreCase,
+                                              CStrEqualIgnoreCase>;
+        using TStrUMapCItr = TStrUMap::const_iterator;
 
         //! Our dictionary of words
         TStrUMap                        m_DictionaryWords;

--- a/include/core/CXmlNode.h
+++ b/include/core/CXmlNode.h
@@ -50,11 +50,11 @@ class CXmlParser;
 class CORE_EXPORT CXmlNode
 {
     public:
-        typedef std::map<std::string, std::string>  TStrStrMap;
-        typedef std::pair<std::string, std::string> TStrStrPr;
-        typedef std::vector<TStrStrPr>              TStrStrPrVec;
-        typedef TStrStrPrVec::iterator              TStrStrPrVecItr;
-        typedef TStrStrPrVec::const_iterator        TStrStrPrVecCItr;
+        using TStrStrMap = std::map<std::string, std::string>;
+        using TStrStrPr = std::pair<std::string, std::string>;
+        using TStrStrPrVec = std::vector<TStrStrPr>;
+        using TStrStrPrVecItr = TStrStrPrVec::iterator;
+        using TStrStrPrVecCItr = TStrStrPrVec::const_iterator;
 
     private:
         class CFirstElementEquals

--- a/include/core/CXmlNodeWithChildren.h
+++ b/include/core/CXmlNodeWithChildren.h
@@ -42,11 +42,11 @@ class CXmlNodeWithChildrenPool;
 class CORE_EXPORT CXmlNodeWithChildren : public CXmlNode
 {
     public:
-        typedef boost::shared_ptr<CXmlNodeWithChildren> TXmlNodeWithChildrenP;
+        using TXmlNodeWithChildrenP = boost::shared_ptr<CXmlNodeWithChildren>;
 
-        typedef std::vector<TXmlNodeWithChildrenP>      TChildNodePVec;
-        typedef TChildNodePVec::iterator                TChildNodePVecItr;
-        typedef TChildNodePVec::const_iterator          TChildNodePVecCItr;
+        using TChildNodePVec = std::vector<TXmlNodeWithChildrenP>;
+        using TChildNodePVecItr = TChildNodePVec::iterator;
+        using TChildNodePVecCItr = TChildNodePVec::const_iterator;
 
     public:
         CXmlNodeWithChildren(void);

--- a/include/core/CXmlParser.h
+++ b/include/core/CXmlParser.h
@@ -75,20 +75,20 @@ class CORE_EXPORT CXmlParser : public CXmlParserIntf
         static const char        *INDENT_SPACE_STR;
 
     public:
-        typedef std::vector<std::string>           TStrVec;
-        typedef TStrVec::iterator                  TStrVecItr;
-        typedef TStrVec::const_iterator            TStrVecCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
+        using TStrVecCItr = TStrVec::const_iterator;
 
-        typedef std::set<std::string>              TStrSet;
-        typedef TStrSet::iterator                  TStrSetItr;
-        typedef TStrSet::const_iterator            TStrSetCItr;
+        using TStrSet = std::set<std::string>;
+        using TStrSetItr = TStrSet::iterator;
+        using TStrSetCItr = TStrSet::const_iterator;
 
-        typedef std::vector<CXmlNode>              TXmlNodeVec;
-        typedef TXmlNodeVec::iterator              TXmlNodeVecItr;
-        typedef TXmlNodeVec::const_iterator        TXmlNodeVecCItr;
+        using TXmlNodeVec = std::vector<CXmlNode>;
+        using TXmlNodeVecItr = TXmlNodeVec::iterator;
+        using TXmlNodeVecCItr = TXmlNodeVec::const_iterator;
 
-        typedef std::map<std::string, std::string> TStrStrMap;
-        typedef TStrStrMap::const_iterator         TStrStrMapCItr;
+        using TStrStrMap = std::map<std::string, std::string>;
+        using TStrStrMapCItr = TStrStrMap::const_iterator;
 
     public:
         CXmlParser(void);

--- a/include/core/CoreTypes.h
+++ b/include/core/CoreTypes.h
@@ -26,7 +26,7 @@ namespace core_t
 
 //! For now just use seconds as the ml time granularity
 //! This is a UTC value
-typedef time_t TTime;
+using TTime = time_t;
 
 
 //! The standard line ending for the platform - DON'T make this std::string as

--- a/include/maths/CAgglomerativeClusterer.h
+++ b/include/maths/CAgglomerativeClusterer.h
@@ -50,12 +50,12 @@ namespace maths
 class MATHS_EXPORT CAgglomerativeClusterer
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<TDoubleVec> TDoubleVecVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef std::pair<double, TSizeVec> TDoubleSizeVecPr;
-        typedef std::vector<TDoubleSizeVecPr> TDoubleSizeVecPrVec;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleVecVec = std::vector<TDoubleVec>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TDoubleSizeVecPr = std::pair<double, TSizeVec>;
+        using TDoubleSizeVecPrVec = std::vector<TDoubleSizeVecPr>;
 
         //! \brief A representation of a node in the tree of clusters.
         class MATHS_EXPORT CNode
@@ -106,7 +106,7 @@ class MATHS_EXPORT CAgglomerativeClusterer
                 double m_Height;
         };
 
-        typedef std::vector<CNode> TNodeVec;
+        using TNodeVec = std::vector<CNode>;
 
     public:
         //! Possible clustering objective functions supported.

--- a/include/maths/CAnnotatedVector.h
+++ b/include/maths/CAnnotatedVector.h
@@ -35,8 +35,8 @@ template<typename VECTOR, typename ANNOTATION>
 class CAnnotatedVector : public VECTOR
 {
     public:
-        typedef ANNOTATION TAnnotation;
-        typedef typename SCoordinate<VECTOR>::Type TCoordinate;
+        using TAnnotation = ANNOTATION;
+        using TCoordinate = typename SCoordinate<VECTOR>::Type;
 
         //! See core::CMemory.
         static bool dynamicSizeAlwaysZero(void)

--- a/include/maths/CAssignment.h
+++ b/include/maths/CAssignment.h
@@ -35,10 +35,10 @@ namespace maths
 class MATHS_EXPORT CAssignment
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<TDoubleVec> TDoubleVecVec;
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef std::vector<TSizeSizePr> TSizeSizePrVec;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleVecVec = std::vector<TDoubleVec>;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrVec = std::vector<TSizeSizePr>;
 
     public:
         //! \brief The Kuhn-Munkres algorithm for solving the

--- a/include/maths/CBjkstUniqueValues.h
+++ b/include/maths/CBjkstUniqueValues.h
@@ -83,7 +83,7 @@ namespace maths
 class MATHS_EXPORT CBjkstUniqueValues
 {
     public:
-        typedef core::CHashing::CUniversalHash::TUInt32UnrestrictedHashVec TUInt32HashVec;
+        using TUInt32HashVec = core::CHashing::CUniversalHash::TUInt32UnrestrictedHashVec;
 
     public:
         //! Get the count of trailing zeros in value.
@@ -127,11 +127,11 @@ class MATHS_EXPORT CBjkstUniqueValues
         std::size_t memoryUsage(void) const;
 
     private:
-        typedef std::vector<uint8_t> TUInt8Vec;
-        typedef std::vector<TUInt8Vec> TUInt8VecVec;
-        typedef std::vector<uint32_t> TUInt32Vec;
-        typedef TUInt32Vec::iterator TUInt32VecItr;
-        typedef TUInt32Vec::const_iterator TUInt32VecCItr;
+        using TUInt8Vec = std::vector<uint8_t>;
+        using TUInt8VecVec = std::vector<TUInt8Vec>;
+        using TUInt32Vec = std::vector<uint32_t>;
+        using TUInt32VecItr = TUInt32Vec::iterator;
+        using TUInt32VecCItr = TUInt32Vec::const_iterator;
 
         //! Wraps up the sketch data.
         struct MATHS_EXPORT SSketch
@@ -168,7 +168,7 @@ class MATHS_EXPORT CBjkstUniqueValues
             TUInt8VecVec s_B;
         };
 
-        typedef boost::variant<TUInt32Vec, SSketch> TUInt32VecOrSketch;
+        using TUInt32VecOrSketch = boost::variant<TUInt32Vec, SSketch>;
 
     private:
         //! Maybe switch to sketching the distinct value set.

--- a/include/maths/CBootstrapClusterer.h
+++ b/include/maths/CBootstrapClusterer.h
@@ -78,24 +78,24 @@ template<typename POINT>
 class CBootstrapClusterer
 {
     public:
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef TSizeVec::iterator TSizeVecItr;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef std::vector<TSizeVecVec> TSizeVecVecVec;
-        typedef std::vector<POINT> TPointVec;
-        typedef std::vector<TPointVec> TPointVecVec;
-        typedef boost::adjacency_list<boost::vecS,
-                                      boost::vecS,
-                                      boost::undirectedS,
-                                      boost::no_property,
-                                      boost::property<boost::edge_weight_t, double> > TGraph;
-        typedef typename boost::graph_traits<TGraph>::vertex_descriptor TVertex;
-        typedef typename boost::graph_traits<TGraph>::edge_descriptor TEdge;
-        typedef typename boost::graph_traits<TGraph>::vertex_iterator TVertexItr;
-        typedef typename boost::graph_traits<TGraph>::edge_iterator TEdgeItr;
-        typedef typename boost::graph_traits<TGraph>::out_edge_iterator TOutEdgeItr;
-        typedef typename boost::graph_traits<TGraph>::adjacency_iterator TAdjacencyItr;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecItr = TSizeVec::iterator;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TSizeVecVecVec = std::vector<TSizeVecVec>;
+        using TPointVec = std::vector<POINT>;
+        using TPointVecVec = std::vector<TPointVec>;
+        using TGraph = boost::adjacency_list<boost::vecS,
+                                             boost::vecS,
+                                             boost::undirectedS,
+                                             boost::no_property,
+                                             boost::property<boost::edge_weight_t, double> >;
+        using TVertex = typename boost::graph_traits<TGraph>::vertex_descriptor;
+        using TEdge = typename boost::graph_traits<TGraph>::edge_descriptor;
+        using TVertexItr = typename boost::graph_traits<TGraph>::vertex_iterator;
+        using TEdgeItr = typename boost::graph_traits<TGraph>::edge_iterator;
+        using TOutEdgeItr = typename boost::graph_traits<TGraph>::out_edge_iterator;
+        using TAdjacencyItr = typename boost::graph_traits<TGraph>::adjacency_iterator;
 
     public:
         CBootstrapClusterer(double overlapThreshold, double chainingFactor) :
@@ -130,11 +130,11 @@ class CBootstrapClusterer
         }
 
     protected:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<bool> TBoolVec;
-        typedef std::vector<TSizeSizePr> TSizeSizePrVec;
-        typedef std::pair<double, std::size_t> TDoubleSizePr;
-        typedef std::vector<TDoubleSizePr> TDoubleSizePrVec;
+        using TDoubleVec = std::vector<double>;
+        using TBoolVec = std::vector<bool>;
+        using TSizeSizePrVec = std::vector<TSizeSizePr>;
+        using TDoubleSizePr = std::pair<double, std::size_t>;
+        using TDoubleSizePrVec = std::vector<TDoubleSizePr>;
 
         //! \brief Checks if a cluster is empty.
         struct SIsEmpty
@@ -329,8 +329,8 @@ class CBootstrapClusterer
                                TSizeVecVecVec &bootstrapClusters,
                                TGraph &graph) const
         {
-            typedef boost::unordered_set<TSizeSizePr> TSizeSizePrUSet;
-            typedef TSizeSizePrUSet::const_iterator TSizeSizePrUSetCItr;
+            using TSizeSizePrUSet = boost::unordered_set<TSizeSizePr>;
+            using TSizeSizePrUSetCItr = TSizeSizePrUSet::const_iterator;
 
             TSizeSizePrUSet edges;
 
@@ -465,9 +465,9 @@ class CBootstrapClusterer
                            const TGraph &graph,
                            TPointVecVec &result) const
         {
-            typedef boost::unordered_map<std::size_t, std::size_t> TSizeSizeUMap;
-            typedef TSizeSizeUMap::const_iterator TSizeSizeUMapCItr;
-            typedef std::vector<TSizeSizeUMap> TSizeSizeUMapVec;
+            using TSizeSizeUMap = boost::unordered_map<std::size_t, std::size_t>;
+            using TSizeSizeUMapCItr = TSizeSizeUMap::const_iterator;
+            using TSizeSizeUMapVec = std::vector<TSizeSizeUMap>;
 
             // Find the maximum connected components.
             TSizeVec components(boost::num_vertices(graph));
@@ -985,7 +985,7 @@ class CBootstrapClusterer
                                               const TBoolVec &parities,
                                               TSizeVec &components) const
         {
-            typedef boost::filtered_graph<TGraph, CParityFilter, CParityFilter> TParityGraph;
+            using TParityGraph = boost::filtered_graph<TGraph, CParityFilter, CParityFilter>;
             CParityFilter parityFilter(graph, parities, true);
             TParityGraph parityGraph(graph, parityFilter, parityFilter);
             components.resize(boost::num_vertices(graph));
@@ -1046,10 +1046,10 @@ template<typename POINT>
 class CBootstrapClustererFacadeExtractClusters
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef std::vector<POINT> TPointVec;
-        typedef typename TPointVec::const_iterator TPointVecCItr;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TPointVec = std::vector<POINT>;
+        using TPointVecCItr = typename TPointVec::const_iterator;
 
     public:
         //! Compute the cluster of each point in \p points.
@@ -1122,9 +1122,9 @@ template<typename POINT, typename COST>
 class CBootstrapClustererFacade<CXMeans<POINT, COST> > : private CBootstrapClustererFacadeExtractClusters<POINT>
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef std::vector<POINT> TPointVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TPointVec = std::vector<POINT>;
 
     public:
         CBootstrapClustererFacade(const CXMeans<POINT, COST> &xmeans,
@@ -1140,8 +1140,8 @@ class CBootstrapClustererFacade<CXMeans<POINT, COST> > : private CBootstrapClust
         //! \note Assumes \p points are sorted.
         void cluster(const TPointVec &points, TSizeVecVec &result)
         {
-            typedef boost::reference_wrapper<const TPointVec> TPointVecCRef;
-            typedef std::vector<TPointVecCRef> TPointVecCRefVec;
+            using TPointVecCRef = boost::reference_wrapper<const TPointVec>;
+            using TPointVecCRefVec = std::vector<TPointVecCRef>;
 
             // Initialize
             TPointVec tmp(points);
@@ -1181,9 +1181,9 @@ template<typename POINT>
 class CBootstrapClustererFacade<CKMeansFast<POINT> > : private CBootstrapClustererFacadeExtractClusters<POINT>
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef std::vector<POINT> TPointVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TPointVec = std::vector<POINT>;
 
     public:
         CBootstrapClustererFacade(const CKMeansFast<POINT> &kmeans,
@@ -1197,7 +1197,7 @@ class CBootstrapClustererFacade<CKMeansFast<POINT> > : private CBootstrapCluster
         //! \note Assumes \p points are sorted.
         void cluster(const TPointVec &points, TSizeVecVec &result)
         {
-            typedef std::vector<TPointVec> TPointVecVec;
+            using TPointVecVec = std::vector<TPointVec>;
 
             // Initialize
             TPointVec tmp(points);

--- a/include/maths/CBoundingBox.h
+++ b/include/maths/CBoundingBox.h
@@ -43,7 +43,7 @@ class CBoundingBox
         {
             return core::memory_detail::SDynamicSizeAlwaysZero<POINT>::value();
         }
-        typedef typename SFloatingPoint<POINT, double>::Type TPointPrecise;
+        using TPointPrecise = typename SFloatingPoint<POINT, double>::Type;
 
     public:
         CBoundingBox(void) : m_Empty(true), m_A(), m_B() {}

--- a/include/maths/CCalendarFeature.h
+++ b/include/maths/CCalendarFeature.h
@@ -49,7 +49,7 @@ class MATHS_EXPORT CCalendarFeature : boost::less_than_comparable< CCalendarFeat
         static const uint16_t BEGIN_FEATURES = 1;
         static const uint16_t END_FEATURES = 5;
 
-        typedef boost::array<CCalendarFeature, 4> TCalendarFeature4Ary;
+        using TCalendarFeature4Ary = boost::array<CCalendarFeature, 4>;
 
     public:
         CCalendarFeature(void);

--- a/include/maths/CChecksum.h
+++ b/include/maths/CChecksum.h
@@ -53,7 +53,7 @@ class MemberHash {};
 template<typename T, typename R = void>
 struct enable_if_type
 {
-    typedef R type;
+    using type = R;
 };
 
 //! Auxiliary type used by has_checksum_function to test for a nested
@@ -61,7 +61,7 @@ struct enable_if_type
 template<typename T, T, typename R = void>
 struct enable_if_is_type
 {
-    typedef R type;
+    using type = R;
 };
 
 //! \name Class used to select appropriate checksum implementation
@@ -78,12 +78,12 @@ struct enable_if_is_type
 template<typename T, typename ITR = void>
 struct container_selector
 {
-    typedef BasicChecksum value;
+    using value = BasicChecksum;
 };
 template<typename T>
 struct container_selector<T, typename enable_if_type<typename T::const_iterator>::type>
 {
-    typedef ContainerChecksum value;
+    using value = ContainerChecksum;
 };
 //@}
 
@@ -103,22 +103,22 @@ struct container_selector<T, typename enable_if_type<typename T::const_iterator>
 template<typename T, typename ENABLE = void>
 struct selector
 {
-    typedef typename container_selector<T>::value value;
+    using value = typename container_selector<T>::value;
 };
 template<typename T>
 struct selector<T, typename enable_if_is_type<uint64_t (T::*)(uint64_t) const, &T::checksum>::type>
 {
-    typedef MemberChecksumWithSeed value;
+    using value = MemberChecksumWithSeed;
 };
 template<typename T>
 struct selector<T, typename enable_if_is_type<uint64_t (T::*)(void) const, &T::checksum>::type>
 {
-    typedef MemberChecksumWithoutSeed value;
+    using value = MemberChecksumWithoutSeed;
 };
 template<typename T>
 struct selector<T, typename enable_if_is_type<std::size_t (T::*)(void) const, &T::hash>::type>
 {
-    typedef MemberHash value;
+    using value = MemberHash;
 };
 //@}
 
@@ -289,7 +289,7 @@ class CChecksumImpl<ContainerChecksum>
         template<typename T>
         static uint64_t dispatch(uint64_t seed, const T &target)
         {
-            typedef typename T::const_iterator CItr;
+            using CItr = typename T::const_iterator;
             uint64_t result = seed;
             for (CItr itr = target.begin(); itr != target.end(); ++itr)
             {
@@ -302,8 +302,8 @@ class CChecksumImpl<ContainerChecksum>
         template<typename T>
         static uint64_t dispatch(uint64_t seed, const boost::unordered_set<T> &target)
         {
-            typedef boost::reference_wrapper<const T> TCRef;
-            typedef std::vector<TCRef> TCRefVec;
+            using TCRef = boost::reference_wrapper<const T>;
+            using TCRefVec = std::vector<TCRef>;
 
             TCRefVec ordered;
             ordered.reserve(target.size());
@@ -323,10 +323,10 @@ class CChecksumImpl<ContainerChecksum>
         template<typename U, typename V>
         static uint64_t dispatch(uint64_t seed, const boost::unordered_map<U, V> &target)
         {
-            typedef boost::reference_wrapper<const U> TUCRef;
-            typedef boost::reference_wrapper<const V> TVCRef;
-            typedef std::pair<TUCRef, TVCRef> TUCRefVCRefPr;
-            typedef std::vector<TUCRefVCRefPr> TUCRefVCRefPrVec;
+            using TUCRef = boost::reference_wrapper<const U>;
+            using TVCRef = boost::reference_wrapper<const V>;
+            using TUCRefVCRefPr = std::pair<TUCRef, TVCRef>;
+            using TUCRefVCRefPrVec = std::vector<TUCRefVCRefPr>;
 
             TUCRefVCRefPrVec ordered;
             ordered.reserve(target.size());

--- a/include/maths/CClusterer.h
+++ b/include/maths/CClusterer.h
@@ -60,10 +60,10 @@ class MATHS_EXPORT CClustererTypes
         };
 
         // Callback function signature for when clusters are split.
-        typedef std::function<void(std::size_t, std::size_t, std::size_t)> TSplitFunc;
+        using TSplitFunc = std::function<void(std::size_t, std::size_t, std::size_t)>;
 
         // Callback function signature for when clusters are merged.
-        typedef std::function<void(std::size_t, std::size_t, std::size_t)> TMergeFunc;
+        using TMergeFunc = std::function<void(std::size_t, std::size_t, std::size_t)>;
 
         //! Generates unique cluster indices.
         class MATHS_EXPORT CIndexGenerator
@@ -97,8 +97,8 @@ class MATHS_EXPORT CClustererTypes
                 std::string print(void) const;
 
             private:
-                typedef std::vector<std::size_t> TSizeVec;
-                typedef boost::shared_ptr<TSizeVec> TSizeVecPtr;
+                using TSizeVec = std::vector<std::size_t>;
+                using TSizeVecPtr = boost::shared_ptr<TSizeVec>;
 
             private:
                 //! A heap of the next available unique indices.
@@ -146,14 +146,14 @@ template<typename POINT>
 class CClusterer : public CClustererTypes
 {
     public:
-        typedef boost::shared_ptr<CClusterer> TClustererPtr;
-        typedef std::vector<POINT> TPointVec;
-        typedef typename SPromoted<POINT>::Type TPointPrecise;
-        typedef std::vector<TPointPrecise> TPointPreciseVec;
-        typedef std::pair<TPointPrecise, double> TPointPreciseDoublePr;
-        typedef std::vector<TPointPreciseDoublePr> TPointPreciseDoublePrVec;
-        typedef std::pair<std::size_t, double> TSizeDoublePr;
-        typedef core::CSmallVector<TSizeDoublePr, 2> TSizeDoublePr2Vec;
+        using TClustererPtr = boost::shared_ptr<CClusterer>;
+        using TPointVec = std::vector<POINT>;
+        using TPointPrecise = typename SPromoted<POINT>::Type;
+        using TPointPreciseVec = std::vector<TPointPrecise>;
+        using TPointPreciseDoublePr = std::pair<TPointPrecise, double>;
+        using TPointPreciseDoublePrVec = std::vector<TPointPreciseDoublePr>;
+        using TSizeDoublePr = std::pair<std::size_t, double>;
+        using TSizeDoublePr2Vec = core::CSmallVector<TSizeDoublePr, 2>;
 
     public:
         //! Create a new clusterer.
@@ -317,7 +317,7 @@ class CClusterer : public CClustererTypes
         TMergeFunc m_MergeFunc;
 };
 
-typedef CClusterer<double> CClusterer1d;
+using CClusterer1d = CClusterer<double>;
 
 }
 }

--- a/include/maths/CClustererStateSerialiser.h
+++ b/include/maths/CClustererStateSerialiser.h
@@ -54,7 +54,7 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CClustererStateSerialiser
 {
     public:
-        typedef boost::shared_ptr<CClusterer1d> TClusterer1dPtr;
+        using TClusterer1dPtr = boost::shared_ptr<CClusterer1d>;
 
     public:
         //! Construct the appropriate CClusterer sub-class from its state

--- a/include/maths/CCompositeFunctions.h
+++ b/include/maths/CCompositeFunctions.h
@@ -43,39 +43,39 @@ struct function_result_type
 template<typename R, typename A1>
 struct function_result_type<R (*)(A1)>
 {
-    typedef typename boost::remove_reference<R>::type type;
+    using type = typename boost::remove_reference<R>::type;
 };
 
 //! Vanilla function type 2: "result type" is the second argument type.
 template<typename R, typename A1, typename A2>
 struct function_result_type<R (*)(A1, A2)>
 {
-    typedef typename boost::remove_reference<A2>::type type;
+    using type = typename boost::remove_reference<A2>::type;
 };
 
-typedef boost::true_type true_;
-typedef boost::false_type false_;
+using true_ = boost::true_type;
+using false_ = boost::false_type;
 
 //! \brief Auxiliary type used by has_result_type to test for
 //! a nested typedef.
 template<typename T, typename R = void>
 struct enable_if_type
 {
-    typedef R type;
+    using type = R;
 };
 
 //! Checks for a nested typedef called result_type.
 template<typename T, typename ENABLE = void>
 struct has_result_type
 {
-    typedef false_ value;
+    using value = false_;
 };
 
 //! Has a nested typedef called result_type.
 template<typename T>
 struct has_result_type<T, typename enable_if_type<typename T::result_type>::type>
 {
-    typedef true_ value;
+    using value = true_;
 };
 
 //! Extracts the result type of a function (object) for composition.
@@ -91,14 +91,14 @@ struct result_type_impl
 template<typename F>
 struct result_type_impl<F, true_>
 {
-    typedef typename F::result_type type;
+    using type = typename F::result_type;
 };
 
 //! Deduce result type from function (object).
 template<typename F>
 struct result_type_impl<F, false_>
 {
-    typedef typename function_result_type<F>::type type;
+    using type = typename function_result_type<F>::type;
 };
 
 //! \brief Tries to deduce the result type of a function (object)
@@ -144,8 +144,8 @@ class MATHS_EXPORT CCompositeFunctions
         class CMinusConstant
         {
             public:
-                typedef typename boost::remove_reference<F_>::type F;
-                typedef T result_type;
+                using F = typename boost::remove_reference<F_>::type;
+                using result_type = T;
 
             public:
                 CMinusConstant(const F &f, double offset) :
@@ -182,8 +182,8 @@ class MATHS_EXPORT CCompositeFunctions
         class CMinus
         {
             public:
-                typedef typename boost::remove_reference<F_>::type F;
-                typedef T result_type;
+                using F = typename boost::remove_reference<F_>::type;
+                using result_type = T;
 
             public:
                 explicit CMinus(const F &f = F()) : m_F(f) {}
@@ -215,8 +215,8 @@ class MATHS_EXPORT CCompositeFunctions
         class CExp
         {
             public:
-                typedef typename boost::remove_reference<F_>::type F;
-                typedef T result_type;
+                using F = typename boost::remove_reference<F_>::type;
+                using result_type = T;
 
             public:
                 explicit CExp(const F &f = F()) : m_F(f) {}
@@ -255,9 +255,9 @@ class MATHS_EXPORT CCompositeFunctions
         class CProduct
         {
             public:
-                typedef typename boost::remove_reference<F_>::type F;
-                typedef typename boost::remove_reference<G_>::type G;
-                typedef U result_type;
+                using F = typename boost::remove_reference<F_>::type;
+                using G = typename boost::remove_reference<G_>::type;
+                using result_type = U;
 
             public:
                 explicit CProduct(const F &f = F(),

--- a/include/maths/CCooccurrences.h
+++ b/include/maths/CCooccurrences.h
@@ -43,10 +43,10 @@ namespace maths
 class MATHS_EXPORT CCooccurrences
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef std::vector<TSizeSizePr> TSizeSizePrVec;
+        using TDoubleVec = std::vector<double>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrVec = std::vector<TSizeSizePr>;
 
     public:
         CCooccurrences(std::size_t maximumLength, std::size_t indicatorWidth);
@@ -95,8 +95,8 @@ class MATHS_EXPORT CCooccurrences
         std::size_t memoryUsage(void) const;
 
     private:
-        typedef boost::unordered_set<std::size_t> TSizeUSet;
-        typedef std::vector<CPackedBitVector> TPackedBitVectorVec;
+        using TSizeUSet = boost::unordered_set<std::size_t>;
+        using TPackedBitVectorVec = std::vector<CPackedBitVector>;
 
     private:
         //! The maximum permitted event sequence length.

--- a/include/maths/CCountMinSketch.h
+++ b/include/maths/CCountMinSketch.h
@@ -126,9 +126,9 @@ class MATHS_EXPORT CCountMinSketch
         std::size_t memoryUsage(void) const;
 
     private:
-        typedef core::CHashing::CUniversalHash::TUInt32UnrestrictedHashVec TUInt32HashVec;
-        typedef std::vector<CFloatStorage> TFloatVec;
-        typedef std::vector<TFloatVec> TFloatVecVec;
+        using TUInt32HashVec = core::CHashing::CUniversalHash::TUInt32UnrestrictedHashVec;
+        using TFloatVec = std::vector<CFloatStorage>;
+        using TFloatVecVec = std::vector<TFloatVec>;
 
         //! Wraps up the sketch data.
         struct MATHS_EXPORT SSketch
@@ -151,9 +151,9 @@ class MATHS_EXPORT CCountMinSketch
             TFloatVecVec s_Counts;
         };
 
-        typedef std::pair<uint32_t, CFloatStorage> TUInt32FloatPr;
-        typedef std::vector<TUInt32FloatPr> TUInt32FloatPrVec;
-        typedef boost::variant<TUInt32FloatPrVec, SSketch> TUInt32FloatPrVecOrSketch;
+        using TUInt32FloatPr = std::pair<uint32_t, CFloatStorage>;
+        using TUInt32FloatPrVec = std::vector<TUInt32FloatPr>;
+        using TUInt32FloatPrVecOrSketch = boost::variant<TUInt32FloatPrVec, SSketch>;
 
         //! Maybe switch to sketching the counts.
         void sketch(void);

--- a/include/maths/CEntropySketch.h
+++ b/include/maths/CEntropySketch.h
@@ -50,8 +50,8 @@ class MATHS_EXPORT CEntropySketch
         double calculate(void) const;
 
     private:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<uint64_t> TUInt64Vec;
+        using TDoubleVec = std::vector<double>;
+        using TUInt64Vec = std::vector<uint64_t>;
 
     private:
         //! Generate the projection of the category counts.

--- a/include/maths/CGammaRateConjugate.h
+++ b/include/maths/CGammaRateConjugate.h
@@ -69,7 +69,7 @@ class MATHS_EXPORT CGammaRateConjugate : public CPrior
         //! See core::CMemory.
         static bool dynamicSizeAlwaysZero(void) { return true; }
 
-        typedef CEqualWithTolerance<double> TEqualWithTolerance;
+        using TEqualWithTolerance = CEqualWithTolerance<double>;
 
         //! Lift the overloads of addSamples into scope.
         using CPrior::addSamples;
@@ -366,8 +366,8 @@ class MATHS_EXPORT CGammaRateConjugate : public CPrior
         //@}
 
     private:
-        typedef CBasicStatistics::SSampleMean<CDoublePrecisionStorage>::TAccumulator TMeanAccumulator;
-        typedef CBasicStatistics::SSampleMeanVar<CDoublePrecisionStorage>::TAccumulator TMeanVarAccumulator;
+        using TMeanAccumulator = CBasicStatistics::SSampleMean<CDoublePrecisionStorage>::TAccumulator;
+        using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<CDoublePrecisionStorage>::TAccumulator;
 
     private:
         //! Read parameters from \p traverser.

--- a/include/maths/CGradientDescent.h
+++ b/include/maths/CGradientDescent.h
@@ -37,8 +37,8 @@ namespace maths
 class MATHS_EXPORT CGradientDescent
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef CVector<double> TVector;
+        using TDoubleVec = std::vector<double>;
+        using TVector = CVector<double>;
 
         //! \brief The interface for the function calculation.
         class MATHS_EXPORT CFunction

--- a/include/maths/CGramSchmidt.h
+++ b/include/maths/CGramSchmidt.h
@@ -42,10 +42,10 @@ namespace maths
 class MATHS_EXPORT CGramSchmidt : private core::CNonInstantiatable
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<TDoubleVec> TDoubleVecVec;
-        typedef CVector<double> TVector;
-        typedef std::vector<TVector> TVectorVec;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleVecVec = std::vector<TDoubleVec>;
+        using TVector = CVector<double>;
+        using TVectorVec = std::vector<TVector>;
 
     public:
         //! Compute an orthonormal basis for the vectors in \p x.

--- a/include/maths/CInformationCriteria.h
+++ b/include/maths/CInformationCriteria.h
@@ -45,7 +45,7 @@ struct SSampleCovariances
 template<typename T, std::size_t N>
 struct SSampleCovariances<CVectorNx1<T, N>>
 {
-    typedef CBasicStatistics::SSampleCovariances<T, N> Type;
+    using Type = CBasicStatistics::SSampleCovariances<T, N>;
 };
 
 //! The confidence interval we use when computing the singular values
@@ -119,12 +119,12 @@ template<typename POINT, EInfoCriterionType TYPE>
 class CSphericalGaussianInfoCriterion
 {
     public:
-        typedef std::vector<POINT> TPointVec;
-        typedef std::vector<TPointVec> TPointVecVec;
-        typedef typename SStripped<POINT>::Type TBarePoint;
-        typedef typename SFloatingPoint<TBarePoint, double>::Type TBarePointPrecise;
-        typedef typename SCoordinate<TBarePointPrecise>::Type TCoordinate;
-        typedef typename CBasicStatistics::SSampleMeanVar<TBarePointPrecise>::TAccumulator TMeanVarAccumulator;
+        using TPointVec = std::vector<POINT>;
+        using TPointVecVec = std::vector<TPointVec>;
+        using TBarePoint = typename SStripped<POINT>::Type;
+        using TBarePointPrecise = typename SFloatingPoint<TBarePoint, double>::Type;
+        using TCoordinate = typename SCoordinate<TBarePointPrecise>::Type;
+        using TMeanVarAccumulator = typename CBasicStatistics::SSampleMeanVar<TBarePointPrecise>::TAccumulator;
 
     public:
         CSphericalGaussianInfoCriterion(void) :
@@ -251,13 +251,13 @@ template<typename POINT, EInfoCriterionType TYPE>
 class CGaussianInfoCriterion
 {
     public:
-        typedef std::vector<POINT> TPointVec;
-        typedef std::vector<TPointVec> TPointVecVec;
-        typedef typename SStripped<POINT>::Type TBarePoint;
-        typedef typename SFloatingPoint<TBarePoint, double>::Type TBarePointPrecise;
-        typedef typename SCoordinate<TBarePointPrecise>::Type TCoordinate;
-        typedef typename information_criteria_detail::SSampleCovariances<TBarePointPrecise>::Type TCovariances;
-        typedef typename SConformableMatrix<TBarePointPrecise>::Type TMatrix;
+        using TPointVec = std::vector<POINT>;
+        using TPointVecVec = std::vector<TPointVec>;
+        using TBarePoint = typename SStripped<POINT>::Type;
+        using TBarePointPrecise = typename SFloatingPoint<TBarePoint, double>::Type;
+        using TCoordinate = typename SCoordinate<TBarePointPrecise>::Type;
+        using TCovariances = typename information_criteria_detail::SSampleCovariances<TBarePointPrecise>::Type;
+        using TMatrix = typename SConformableMatrix<TBarePointPrecise>::Type;
 
     public:
         CGaussianInfoCriterion(void) :

--- a/include/maths/CKMeansFast.h
+++ b/include/maths/CKMeansFast.h
@@ -38,7 +38,7 @@ namespace maths
 {
 namespace kmeans_fast_detail
 {
-typedef std::vector<std::size_t> TSizeVec;
+using TSizeVec = std::vector<std::size_t>;
 
 //! Get the closest filtered centre to \p point.
 template<typename POINT, typename ITR>
@@ -96,10 +96,10 @@ template<typename POINT>
 class CKMeansFast
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::pair<POINT, POINT> TPointPointPr;
-        typedef std::vector<POINT> TPointVec;
-        typedef std::vector<TPointVec> TPointVecVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TPointPointPr = std::pair<POINT, POINT>;
+        using TPointVec = std::vector<POINT>;
+        using TPointVecVec = std::vector<TPointVec>;
 
         //! A cluster.
         //!
@@ -173,16 +173,16 @@ class CKMeansFast
                 uint64_t m_Checksum;
         };
 
-        typedef std::vector<CCluster> TClusterVec;
+        using TClusterVec = std::vector<CCluster>;
 
     protected:
-        typedef typename SStripped<POINT>::Type TBarePoint;
-        typedef typename SFloatingPoint<TBarePoint, double>::Type TBarePointPrecise;
-        typedef typename CBasicStatistics::SSampleMean<TBarePointPrecise>::TAccumulator TMeanAccumulator;
-        typedef std::vector<TMeanAccumulator> TMeanAccumulatorVec;
-        typedef CBoundingBox<TBarePoint> TBoundingBox;
+        using TBarePoint = typename SStripped<POINT>::Type;
+        using TBarePointPrecise = typename SFloatingPoint<TBarePoint, double>::Type;
+        using TMeanAccumulator = typename CBasicStatistics::SSampleMean<TBarePointPrecise>::TAccumulator;
+        using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
+        using TBoundingBox = CBoundingBox<TBarePoint>;
         class CKdTreeNodeData;
-        typedef typename CKdTree<POINT, CKdTreeNodeData>::SNode TNode;
+        using TNode = typename CKdTree<POINT, CKdTreeNodeData>::SNode;
 
         //! \brief The data the x-means algorithm needs at each k-d
         //! tree node.
@@ -559,7 +559,7 @@ class CKMeansFast
         //! Single iteration of Lloyd's algorithm to update \p centres.
         bool updateCentres(void)
         {
-            typedef typename SCoordinate<POINT>::Type TCoordinate;
+            using TCoordinate = typename SCoordinate<POINT>::Type;
             static const TCoordinate PRECISION =  TCoordinate(5)
                                                 * std::numeric_limits<TCoordinate>::epsilon();
             TMeanAccumulatorVec newCentres(m_Centres.size());
@@ -595,9 +595,9 @@ template<typename POINT, typename RNG>
 class CKMeansPlusPlusInitialization : private core::CNonCopyable
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<POINT> TPointVec;
+        using TDoubleVec = std::vector<double>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TPointVec = std::vector<POINT>;
 
     public:
         CKMeansPlusPlusInitialization(RNG &rng) : m_Rng(rng) {}

--- a/include/maths/CKMeansOnline.h
+++ b/include/maths/CKMeansOnline.h
@@ -64,14 +64,14 @@ template<typename POINT>
 class CKMeansOnline
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef typename SFloatingPoint<POINT, double>::Type TDoublePoint;
-        typedef std::vector<TDoublePoint> TDoublePointVec;
-        typedef typename CSphericalCluster<POINT>::Type TSphericalCluster;
-        typedef std::vector<TSphericalCluster> TSphericalClusterVec;
-        typedef std::vector<TSphericalClusterVec> TSphericalClusterVecVec;
-        typedef std::vector<CKMeansOnline> TKMeansOnlineVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TDoublePoint = typename SFloatingPoint<POINT, double>::Type;
+        using TDoublePointVec = std::vector<TDoublePoint>;
+        using TSphericalCluster = typename CSphericalCluster<POINT>::Type;
+        using TSphericalClusterVec = std::vector<TSphericalCluster>;
+        using TSphericalClusterVecVec = std::vector<TSphericalClusterVec>;
+        using TKMeansOnlineVec = std::vector<CKMeansOnline>;
 
     protected:
         //! \brief Checks if a cluster should be deleted based on its count.
@@ -92,15 +92,15 @@ class CKMeansOnline
                 double m_MinimumCategoryCount;
         };
 
-        typedef typename SFloatingPoint<POINT, CFloatStorage>::Type TFloatPoint;
-        typedef typename SCoordinate<TFloatPoint>::Type TFloatCoordinate;
-        typedef std::pair<TFloatPoint, double> TFloatPointDoublePr;
-        typedef std::vector<TFloatPointDoublePr> TFloatPointDoublePrVec;
-        typedef typename CBasicStatistics::SSampleMean<TFloatPoint>::TAccumulator TFloatMeanAccumulator;
-        typedef std::pair<TFloatMeanAccumulator, double> TFloatMeanAccumulatorDoublePr;
-        typedef std::vector<TFloatMeanAccumulatorDoublePr> TFloatMeanAccumulatorDoublePrVec;
-        typedef typename CBasicStatistics::SSampleMean<TDoublePoint>::TAccumulator TDoubleMeanAccumulator;
-        typedef typename CBasicStatistics::SSampleMeanVar<TDoublePoint>::TAccumulator TDoubleMeanVarAccumulator;
+        using TFloatPoint = typename SFloatingPoint<POINT, CFloatStorage>::Type;
+        using TFloatCoordinate = typename SCoordinate<TFloatPoint>::Type;
+        using TFloatPointDoublePr = std::pair<TFloatPoint, double>;
+        using TFloatPointDoublePrVec = std::vector<TFloatPointDoublePr>;
+        using TFloatMeanAccumulator = typename CBasicStatistics::SSampleMean<TFloatPoint>::TAccumulator;
+        using TFloatMeanAccumulatorDoublePr = std::pair<TFloatMeanAccumulator, double>;
+        using TFloatMeanAccumulatorDoublePrVec = std::vector<TFloatMeanAccumulatorDoublePr>;
+        using TDoubleMeanAccumulator = typename CBasicStatistics::SSampleMean<TDoublePoint>::TAccumulator;
+        using TDoubleMeanVarAccumulator = typename CBasicStatistics::SSampleMeanVar<TDoublePoint>::TAccumulator;
 
     protected:
         //! The minimum permitted size for the clusterer.
@@ -428,8 +428,8 @@ class CKMeansOnline
                 return;
             }
 
-            typedef std::vector<double> TDoubleVec;
-            typedef std::pair<double, std::size_t> TDoubleSizePr;
+            using TDoubleVec = std::vector<double>;
+            using TDoubleSizePr = std::pair<double, std::size_t>;
 
             static const double ALMOST_ONE = 0.99999;
 

--- a/include/maths/CKMeansOnline1d.h
+++ b/include/maths/CKMeansOnline1d.h
@@ -41,11 +41,11 @@ namespace maths
 class MATHS_EXPORT CKMeansOnline1d : public CClusterer1d
 {
     public:
-        typedef TPointPreciseVec TDoubleVec;
-        typedef TPointPreciseDoublePrVec TDoubleDoublePrVec;
-        typedef std::vector<CNormalMeanPrecConjugate> TNormalVec;
-        typedef TNormalVec::iterator TNormalVecItr;
-        typedef TNormalVec::const_iterator TNormalVecCItr;
+        using TDoubleVec = TPointPreciseVec;
+        using TDoubleDoublePrVec = TPointPreciseDoublePrVec;
+        using TNormalVec = std::vector<CNormalMeanPrecConjugate>;
+        using TNormalVecItr = TNormalVec::iterator;
+        using TNormalVecCItr = TNormalVec::const_iterator;
 
     public:
         //! Construct a new clusterer.

--- a/include/maths/CKMostCorrelated.h
+++ b/include/maths/CKMostCorrelated.h
@@ -69,15 +69,15 @@ class MATHS_EXPORT CKMostCorrelated
         static const std::size_t NUMBER_PROJECTIONS = 10u;
 
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef std::vector<TSizeSizePr> TSizeSizePrVec;
-        typedef CVectorNx1<maths::CFloatStorage, NUMBER_PROJECTIONS> TVector;
-        typedef std::vector<TVector> TVectorVec;
-        typedef boost::unordered_map<std::size_t, TVector> TSizeVectorUMap;
-        typedef std::pair<TVector, CPackedBitVector> TVectorPackedBitVectorPr;
-        typedef boost::unordered_map<std::size_t, TVectorPackedBitVectorPr> TSizeVectorPackedBitVectorPrUMap;
+        using TDoubleVec = std::vector<double>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrVec = std::vector<TSizeSizePr>;
+        using TVector = CVectorNx1<maths::CFloatStorage, NUMBER_PROJECTIONS>;
+        using TVectorVec = std::vector<TVector>;
+        using TSizeVectorUMap = boost::unordered_map<std::size_t, TVector>;
+        using TVectorPackedBitVectorPr = std::pair<TVector, CPackedBitVector>;
+        using TSizeVectorPackedBitVectorPrUMap = boost::unordered_map<std::size_t, TVectorPackedBitVectorPr>;
 
     public:
         CKMostCorrelated(std::size_t k, double decayRate, bool initialize = true);
@@ -136,11 +136,11 @@ class MATHS_EXPORT CKMostCorrelated
         static const double REPLACE_FRACTION;
 
     protected:
-        typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-        typedef std::vector<TMeanVarAccumulator> TMeanVarAccumulatorVec;
-        typedef TSizeVectorUMap::const_iterator TSizeVectorUMapCItr;
-        typedef TSizeVectorPackedBitVectorPrUMap::iterator TSizeVectorPackedBitVectorPrUMapItr;
-        typedef TSizeVectorPackedBitVectorPrUMap::const_iterator TSizeVectorPackedBitVectorPrUMapCItr;
+        using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+        using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
+        using TSizeVectorUMapCItr = TSizeVectorUMap::const_iterator;
+        using TSizeVectorPackedBitVectorPrUMapItr = TSizeVectorPackedBitVectorPrUMap::iterator;
+        using TSizeVectorPackedBitVectorPrUMapCItr = TSizeVectorPackedBitVectorPrUMap::const_iterator;
 
         //! \brief A pair of variables and their correlation.
         //!
@@ -214,7 +214,7 @@ class MATHS_EXPORT CKMostCorrelated
                 std::size_t m_X;
         };
 
-        typedef std::vector<SCorrelation> TCorrelationVec;
+        using TCorrelationVec = std::vector<SCorrelation>;
 
     protected:
         //! Get the most correlated variables based on the current

--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -78,12 +78,12 @@ template<typename POINT,
 class CKdTree
 {
     public:
-        typedef std::vector<POINT> TPointVec;
-        typedef typename TPointVec::iterator TPointVecItr;
-        typedef typename SCoordinate<POINT>::Type TCoordinate;
-        typedef typename SPromoted<TCoordinate>::Type TCoordinatePrecise;
-        typedef std::pair<TCoordinatePrecise, POINT> TCoordinatePrecisePointPr;
-        typedef CBasicStatistics::COrderStatisticsHeap<TCoordinatePrecisePointPr> TNearestAccumulator;
+        using TPointVec = std::vector<POINT>;
+        using TPointVecItr = typename TPointVec::iterator;
+        using TCoordinate = typename SCoordinate<POINT>::Type;
+        using TCoordinatePrecise = typename SPromoted<TCoordinate>::Type;
+        using TCoordinatePrecisePointPr = std::pair<TCoordinatePrecise, POINT>;
+        using TNearestAccumulator = CBasicStatistics::COrderStatisticsHeap<TCoordinatePrecisePointPr>;
 
         //! Less on a specific coordinate of point position vector.
         class CCoordinateLess
@@ -283,7 +283,7 @@ class CKdTree
         }
 
     private:
-        typedef std::vector<SNode> TNodeVec;
+        using TNodeVec = std::vector<SNode>;
 
     private:
         //! Recursively build the k-d tree.

--- a/include/maths/CLassoLogisticRegression.h
+++ b/include/maths/CLassoLogisticRegression.h
@@ -32,10 +32,10 @@ namespace maths
 namespace lasso_logistic_regression_detail
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::pair<TSizeSizePr, double> TSizeSizePrDoublePr;
-typedef std::vector<TSizeSizePrDoublePr> TSizeSizePrDoublePrVec;
+using TDoubleVec = std::vector<double>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrDoublePr = std::pair<TSizeSizePr, double>;
+using TSizeSizePrDoublePrVec = std::vector<TSizeSizePrDoublePr>;
 
 //! Very simple dynamically sized dense matrix.
 //!
@@ -45,8 +45,8 @@ typedef std::vector<TSizeSizePrDoublePr> TSizeSizePrDoublePrVec;
 class MATHS_EXPORT CDenseMatrix
 {
     public:
-        typedef TDoubleVec::const_iterator iterator;
-        typedef std::vector<TDoubleVec> TDoubleVecVec;
+        using iterator = TDoubleVec::const_iterator;
+        using TDoubleVecVec = std::vector<TDoubleVec>;
 
     public:
         CDenseMatrix(void);
@@ -98,7 +98,7 @@ class MATHS_EXPORT CDenseMatrix
 class MATHS_EXPORT CSparseMatrix
 {
     public:
-        typedef TSizeSizePrDoublePrVec::const_iterator iterator;
+        using iterator = TSizeSizePrDoublePrVec::const_iterator;
 
     public:
         CSparseMatrix(void);
@@ -297,9 +297,9 @@ enum EHyperparametersStyle
 class MATHS_EXPORT CLogisticRegressionModel
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::pair<std::size_t, double> TSizeDoublePr;
-        typedef std::vector<TSizeDoublePr> TSizeDoublePrVec;
+        using TDoubleVec = std::vector<double>;
+        using TSizeDoublePr = std::pair<std::size_t, double>;
+        using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
 
     public:
         CLogisticRegressionModel(void);
@@ -355,8 +355,8 @@ template<typename STORAGE>
 class MATHS_EXPORT CLassoLogisticRegression
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef lasso_logistic_regression_detail::EHyperparametersStyle EHyperparametersStyle;
+        using TDoubleVec = std::vector<double>;
+        using EHyperparametersStyle = lasso_logistic_regression_detail::EHyperparametersStyle;
 
     protected:
         CLassoLogisticRegression(void);
@@ -405,8 +405,8 @@ class MATHS_EXPORT CLassoLogisticRegression
         TDoubleVec m_Beta;
 };
 
-typedef std::vector<std::vector<double> > TDenseStorage;
-typedef std::vector<std::vector<std::pair<std::size_t, double> > > TSparseStorage;
+using TDenseStorage = std::vector<std::vector<double> >;
+using TSparseStorage = std::vector<std::vector<std::pair<std::size_t, double> > >;
 
 //! \brief Lasso logistic regression using dense encoding of the
 //! feature vectors.
@@ -420,8 +420,8 @@ typedef std::vector<std::vector<std::pair<std::size_t, double> > > TSparseStorag
 class MATHS_EXPORT CLassoLogisticRegressionDense : public CLassoLogisticRegression<TDenseStorage>
 {
     public:
-        typedef std::pair<std::size_t, double> TSizeDoublePr;
-        typedef std::vector<TSizeDoublePr> TSizeDoublePrVec;
+        using TSizeDoublePr = std::pair<std::size_t, double>;
+        using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
 
     public:
         //! Add a labeled feature vector \p x. The label is either
@@ -456,9 +456,9 @@ class MATHS_EXPORT CLassoLogisticRegressionDense : public CLassoLogisticRegressi
 class MATHS_EXPORT CLassoLogisticRegressionSparse : CLassoLogisticRegression<TSparseStorage>
 {
     public:
-        typedef std::pair<std::size_t, double> TSizeDoublePr;
-        typedef std::vector<TSizeDoublePr> TSizeDoublePrVec;
-        typedef lasso_logistic_regression_detail::EHyperparametersStyle EHyperparametersStyle;
+        using TSizeDoublePr = std::pair<std::size_t, double>;
+        using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
+        using EHyperparametersStyle = lasso_logistic_regression_detail::EHyperparametersStyle;
 
     public:
         //! Add a labeled feature vector \p x. The label is either

--- a/include/maths/CLogNormalMeanPrecConjugate.h
+++ b/include/maths/CLogNormalMeanPrecConjugate.h
@@ -63,7 +63,7 @@ class MATHS_EXPORT CLogNormalMeanPrecConjugate : public CPrior
         //! See core::CMemory.
         static bool dynamicSizeAlwaysZero(void) { return true; }
 
-        typedef CEqualWithTolerance<double> TEqualWithTolerance;
+        using TEqualWithTolerance = CEqualWithTolerance<double>;
 
         //! Lift the overloads of addSamples into scope.
         using CPrior::addSamples;

--- a/include/maths/CLogTDistribution.h
+++ b/include/maths/CLogTDistribution.h
@@ -44,8 +44,8 @@ namespace maths
 class MATHS_EXPORT CLogTDistribution
 {
     public:
-        typedef std::pair<double, double> TDoubleDoublePr;
-        typedef boost::optional<double> TOptionalDouble;
+        using TDoubleDoublePr = std::pair<double, double>;
+        using TOptionalDouble = boost::optional<double>;
 
     public:
         CLogTDistribution(double degreesFreedom,

--- a/include/maths/CMixtureDistribution.h
+++ b/include/maths/CMixtureDistribution.h
@@ -44,7 +44,7 @@ namespace maths
 namespace mixture_detail
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
+using TDoubleDoublePr = std::pair<double, double>;
 
 //! \brief Implements the "polymorphic" mixture mode.
 class MATHS_EXPORT CMixtureModeImpl
@@ -67,9 +67,9 @@ class MATHS_EXPORT CMixtureModeImpl
         }
 
     private:
-        typedef boost::variant<boost::math::normal_distribution<>,
-                               boost::math::gamma_distribution<>,
-                               boost::math::lognormal_distribution<> > TDistribution;
+        using TDistribution = boost::variant<boost::math::normal_distribution<>,
+                                             boost::math::gamma_distribution<>,
+                                             boost::math::lognormal_distribution<> >;
 
     private:
         //! The actual distribution.
@@ -163,8 +163,8 @@ template<typename T>
 class CMixtureDistribution
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<T> TModeVec;
+        using TDoubleVec = std::vector<double>;
+        using TModeVec = std::vector<T>;
 
     public:
         CMixtureDistribution(void) {}
@@ -251,7 +251,7 @@ template<typename T>
 class CPdfAdpater
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         CPdfAdpater(const CMixtureDistribution<T> &distribution) :
@@ -274,7 +274,7 @@ class CPdfAdpater
 template<typename T>
 mixture_detail::TDoubleDoublePr support(const CMixtureDistribution<T> &distribution)
 {
-    typedef typename CMixtureDistribution<T>::TModeVec TModeVec;
+    using TModeVec = typename CMixtureDistribution<T>::TModeVec;
 
     const TModeVec &modes = distribution.modes();
 
@@ -311,8 +311,8 @@ mixture_detail::TDoubleDoublePr support(const CMixtureDistribution<T> &distribut
 template<typename T>
 double mode(const CMixtureDistribution<T> &distribution)
 {
-    typedef typename CMixtureDistribution<T>::TDoubleVec TDoubleVec;
-    typedef typename CMixtureDistribution<T>::TModeVec TModeVec;
+    using TDoubleVec = typename CMixtureDistribution<T>::TDoubleVec;
+    using TModeVec = typename CMixtureDistribution<T>::TModeVec;
 
     static const std::size_t MAX_ITERATIONS = 20u;
 
@@ -365,8 +365,8 @@ double mode(const CMixtureDistribution<T> &distribution)
 template<typename T>
 double pdf(const CMixtureDistribution<T> &distribution, double x)
 {
-    typedef typename CMixtureDistribution<T>::TDoubleVec TDoubleVec;
-    typedef typename CMixtureDistribution<T>::TModeVec TModeVec;
+    using TDoubleVec = typename CMixtureDistribution<T>::TDoubleVec;
+    using TModeVec = typename CMixtureDistribution<T>::TModeVec;
 
     if (CMathsFuncs::isNan(x))
     {
@@ -418,8 +418,8 @@ double pdf(const CMixtureDistribution<T> &distribution, double x)
 template<typename T>
 double cdf(const CMixtureDistribution<T> &distribution, double x)
 {
-    typedef typename CMixtureDistribution<T>::TDoubleVec TDoubleVec;
-    typedef typename CMixtureDistribution<T>::TModeVec TModeVec;
+    using TDoubleVec = typename CMixtureDistribution<T>::TDoubleVec;
+    using TModeVec = typename CMixtureDistribution<T>::TModeVec;
 
     if (CMathsFuncs::isNan(x))
     {
@@ -476,8 +476,8 @@ double cdf(const CMixtureDistribution<T> &distribution, double x)
 template<typename T>
 double cdfComplement(const CMixtureDistribution<T> &distribution, double x)
 {
-    typedef typename CMixtureDistribution<T>::TDoubleVec TDoubleVec;
-    typedef typename CMixtureDistribution<T>::TModeVec TModeVec;
+    using TDoubleVec = typename CMixtureDistribution<T>::TDoubleVec;
+    using TModeVec = typename CMixtureDistribution<T>::TModeVec;
 
     if (CMathsFuncs::isNan(x))
     {
@@ -537,7 +537,7 @@ template<typename T>
 class CCdfAdapter
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         CCdfAdapter(const CMixtureDistribution<T> &distribution) :
@@ -562,7 +562,7 @@ class CCdfAdapter
 template<typename T>
 double quantile(const CMixtureDistribution<T> &distribution, const double q)
 {
-    typedef typename CMixtureDistribution<T>::TModeVec TModeVec;
+    using TModeVec = typename CMixtureDistribution<T>::TModeVec;
 
     mixture_detail::TDoubleDoublePr s = support(distribution);
 

--- a/include/maths/CModelWeight.h
+++ b/include/maths/CModelWeight.h
@@ -91,8 +91,8 @@ template<typename PRIOR>
 class CScopeCanonicalizeWeights : private core::CNonCopyable
 {
     public:
-        typedef std::pair<CModelWeight, PRIOR> TWeightPriorPr;
-        typedef std::vector<TWeightPriorPr> TWeightPriorPrVec;
+        using TWeightPriorPr = std::pair<CModelWeight, PRIOR>;
+        using TWeightPriorPrVec = std::vector<TWeightPriorPr>;
 
     public:
         CScopeCanonicalizeWeights(TWeightPriorPrVec &models) : m_Models(models) {}
@@ -104,7 +104,7 @@ class CScopeCanonicalizeWeights : private core::CNonCopyable
             {
                 logMaxWeight.add(model.first.logWeight());
             }
-            for (auto &&model : m_Models)
+            for (auto &model : m_Models)
             {
                 model.first.logWeight(model.first.logWeight() - logMaxWeight[0]);
             }

--- a/include/maths/CMultimodalPrior.h
+++ b/include/maths/CMultimodalPrior.h
@@ -63,13 +63,13 @@ namespace maths
 class MATHS_EXPORT CMultimodalPrior : public CPrior
 {
     public:
-        typedef boost::shared_ptr<CClusterer1d> TClustererPtr;
-        typedef boost::shared_ptr<CPrior> TPriorPtr;
-        typedef std::vector<TPriorPtr> TPriorPtrVec;
-        typedef TPriorPtrVec::iterator TPriorPtrVecItr;
-        typedef TPriorPtrVec::const_iterator TPriorPtrVecCItr;
-        typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-        typedef std::vector<TMeanVarAccumulator> TMeanVarAccumulatorVec;
+        using TClustererPtr = boost::shared_ptr<CClusterer1d>;
+        using TPriorPtr = boost::shared_ptr<CPrior>;
+        using TPriorPtrVec = std::vector<TPriorPtr>;
+        using TPriorPtrVecItr = TPriorPtrVec::iterator;
+        using TPriorPtrVecCItr = TPriorPtrVec::const_iterator;
+        using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+        using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
 
         // Lift all overloads into scope.
         //{
@@ -335,8 +335,8 @@ class MATHS_EXPORT CMultimodalPrior : public CPrior
         bool checkInvariants(const std::string &tag = std::string()) const;
 
     private:
-        typedef std::vector<TDouble1Vec> TDouble1VecVec;
-        typedef std::vector<TDouble4Vec1Vec> TDouble4Vec1VecVec;
+        using TDouble1VecVec = std::vector<TDouble1Vec>;
+        using TDouble4Vec1VecVec = std::vector<TDouble4Vec1Vec>;
 
         //! The callback invoked when a mode is split.
         class MATHS_EXPORT CModeSplitCallback
@@ -364,8 +364,8 @@ class MATHS_EXPORT CMultimodalPrior : public CPrior
                 CMultimodalPrior *m_Prior;
         };
 
-        typedef SMultimodalPriorMode<boost::shared_ptr<CPrior> > TMode;
-        typedef std::vector<TMode> TModeVec;
+        using TMode = SMultimodalPriorMode<boost::shared_ptr<CPrior> >;
+        using TModeVec = std::vector<TMode>;
 
     private:
         //! Read parameters from \p traverser.

--- a/include/maths/CMultimodalPriorUtils.h
+++ b/include/maths/CMultimodalPriorUtils.h
@@ -50,13 +50,13 @@ namespace maths
 class MATHS_EXPORT CMultimodalPriorUtils : private core::CNonInstantiatable
 {
     public:
-        typedef std::pair<double, double> TDoubleDoublePr;
-        typedef std::vector<double> TDoubleVec;
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef core::CSmallVector<double, 4> TDouble4Vec;
-        typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-        typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-        typedef CConstantWeights TWeights;
+        using TDoubleDoublePr = std::pair<double, double>;
+        using TDoubleVec = std::vector<double>;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TDouble4Vec = core::CSmallVector<double, 4>;
+        using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+        using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
+        using TWeights = CConstantWeights;
 
         //! Get the mode of the marginal likelihood function.
         template<typename T>
@@ -129,7 +129,7 @@ class MATHS_EXPORT CMultimodalPriorUtils : private core::CNonInstantiatable
                 return modes[0].s_Prior->marginalLikelihoodMode(weightStyles, weights);
             }
 
-            typedef CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> > TMaxAccumulator;
+            using TMaxAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> >;
 
             // We'll approximate this as the maximum likelihood mode (mode).
             double result = 0.0;
@@ -383,8 +383,8 @@ class MATHS_EXPORT CMultimodalPriorUtils : private core::CNonInstantiatable
             // The approximation is increasingly accurate as the prior distribution
             // on each mode narrows.
 
-            typedef std::pair<std::size_t, double> TSizeDoublePr;
-            typedef core::CSmallVector<TSizeDoublePr, 5> TSizeDoublePr5Vec;
+            using TSizeDoublePr = std::pair<std::size_t, double>;
+            using TSizeDoublePr5Vec = core::CSmallVector<TSizeDoublePr, 5>;
 
             result = 0.0;
 
@@ -893,7 +893,7 @@ class MATHS_EXPORT CMultimodalPriorUtils : private core::CNonInstantiatable
         class CLogCdf
         {
             public:
-                typedef double result_type;
+                using result_type = double;
 
                 enum EStyle
                 {
@@ -967,7 +967,7 @@ class MATHS_EXPORT CMultimodalPriorUtils : private core::CNonInstantiatable
                 return minusLogCdf(modes[0].s_Prior, weightStyles, samples, weights, lowerBound, upperBound);
             }
 
-            typedef CBasicStatistics::COrderStatisticsStack<double, 1> TMinAccumulator;
+            using TMinAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1>;
 
             // The c.d.f. of the marginal likelihood is the weighted sum
             // of the c.d.fs of each mode since:

--- a/include/maths/CMultinomialConjugate.h
+++ b/include/maths/CMultinomialConjugate.h
@@ -56,7 +56,7 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CMultinomialConjugate : public CPrior
 {
     public:
-        typedef CEqualWithTolerance<double> TEqualWithTolerance;
+        using TEqualWithTolerance = CEqualWithTolerance<double>;
 
         //! Lift the overloads of addSamples into scope.
         using CPrior::addSamples;

--- a/include/maths/CMultivariateConstantPrior.h
+++ b/include/maths/CMultivariateConstantPrior.h
@@ -45,7 +45,7 @@ namespace maths
 class MATHS_EXPORT CMultivariateConstantPrior : public CMultivariatePrior
 {
     public:
-        typedef boost::optional<TDouble10Vec> TOptionalDouble10Vec;
+        using TOptionalDouble10Vec = boost::optional<TDouble10Vec>;
 
         // Lift all overloads of into scope.
         //{

--- a/include/maths/CMultivariateMultimodalPrior.h
+++ b/include/maths/CMultivariateMultimodalPrior.h
@@ -59,13 +59,13 @@ namespace maths
 namespace multivariate_multimodal_prior_detail
 {
 
-typedef std::pair<size_t, double> TSizeDoublePr;
-typedef core::CSmallVector<TSizeDoublePr, 3> TSizeDoublePr3Vec;
-typedef boost::shared_ptr<CMultivariatePrior> TPriorPtr;
-typedef CMultivariatePrior::TDouble10Vec1Vec TDouble10Vec1Vec;
-typedef CMultivariatePrior::TDouble10Vec4Vec1Vec TDouble10Vec4Vec1Vec;
-typedef SMultimodalPriorMode<boost::shared_ptr<CMultivariatePrior> > TMode;
-typedef std::vector<TMode> TModeVec;
+using TSizeDoublePr = std::pair<size_t, double>;
+using TSizeDoublePr3Vec = core::CSmallVector<TSizeDoublePr, 3>;
+using TPriorPtr = boost::shared_ptr<CMultivariatePrior>;
+using TDouble10Vec1Vec = CMultivariatePrior::TDouble10Vec1Vec;
+using TDouble10Vec4Vec1Vec = CMultivariatePrior::TDouble10Vec4Vec1Vec;
+using TMode = SMultimodalPriorMode<boost::shared_ptr<CMultivariatePrior> >;
+using TModeVec = std::vector<TMode>;
 
 //! Implementation of a sample joint log marginal likelihood calculation.
 MATHS_EXPORT
@@ -140,18 +140,18 @@ template<std::size_t N>
 class CMultivariateMultimodalPrior : public CMultivariatePrior
 {
     public:
-        typedef core::CSmallVector<double, 5> TDouble5Vec;
-        typedef CVectorNx1<double, N> TPoint;
-        typedef CVectorNx1<CFloatStorage, N> TFloatPoint;
-        typedef std::vector<TPoint> TPointVec;
-        typedef core::CSmallVector<TPoint, 4> TPoint4Vec;
-        typedef typename CBasicStatistics::SSampleMean<TPoint>::TAccumulator TMeanAccumulator;
-        typedef CSymmetricMatrixNxN<double, N> TMatrix;
-        typedef std::vector<TMatrix> TMatrixVec;
-        typedef CClusterer<TFloatPoint> TClusterer;
-        typedef boost::shared_ptr<TClusterer> TClustererPtr;
-        typedef std::vector<TPriorPtr> TPriorPtrVec;
-        typedef CConstantWeights TWeights;
+        using TDouble5Vec = core::CSmallVector<double, 5>;
+        using TPoint = CVectorNx1<double, N>;
+        using TFloatPoint = CVectorNx1<CFloatStorage, N>;
+        using TPointVec = std::vector<TPoint>;
+        using TPoint4Vec = core::CSmallVector<TPoint, 4>;
+        using TMeanAccumulator = typename CBasicStatistics::SSampleMean<TPoint>::TAccumulator;
+        using TMatrix = CSymmetricMatrixNxN<double, N>;
+        using TMatrixVec = std::vector<TMatrix>;
+        using TClusterer = CClusterer<TFloatPoint>;
+        using TClustererPtr = boost::shared_ptr<TClusterer>;
+        using TPriorPtrVec = std::vector<TPriorPtr>;
+        using TWeights = CConstantWeights;
 
         // Lift all overloads of into scope.
         //{
@@ -346,7 +346,7 @@ class CMultivariateMultimodalPrior : public CMultivariatePrior
 
             // See CMultimodalPrior::addSamples for discussion.
 
-            typedef core::CSmallVector<TSizeDoublePr, 2> TSizeDoublePr2Vec;
+            using TSizeDoublePr2Vec = core::CSmallVector<TSizeDoublePr, 2>;
 
             // Declared outside the loop to minimize the number of times it
             // is initialized.
@@ -424,7 +424,7 @@ class CMultivariateMultimodalPrior : public CMultivariatePrior
                         {
                             TDouble10Vec &ww = weight[0][winsorisation];
                             double f = (k->weight() + cluster.second) / Z;
-                            for (auto &&w : ww)
+                            for (auto &w : ww)
                             {
                                 w = std::max(1.0 - (1.0 - w) / f, w * f);
                             }
@@ -516,7 +516,7 @@ class CMultivariateMultimodalPrior : public CMultivariatePrior
             }
 
             double Z = 0.0;
-            for (auto &&weight : weights)
+            for (auto &weight : weights)
             {
                 weight = ::exp(weight - maxWeight[0]);
                 Z += weight;
@@ -576,7 +576,7 @@ class CMultivariateMultimodalPrior : public CMultivariatePrior
             }
 
             double Z = 0.0;
-            for (auto &&weight : weights)
+            for (auto &weight : weights)
             {
                 weight = ::exp(weight - maxWeight[0]);
                 Z += weight;
@@ -677,7 +677,7 @@ class CMultivariateMultimodalPrior : public CMultivariatePrior
                 return m_Modes[0].s_Prior->marginalLikelihoodMode(weightStyles, weight);
             }
 
-            typedef CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> > TMaxAccumulator;
+            using TMaxAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> >;
 
             // We'll approximate this as the mode with the maximum likelihood.
             TPoint result(0.0);
@@ -1026,8 +1026,8 @@ class CMultivariateMultimodalPrior : public CMultivariatePrior
         }
 
     protected:
-        typedef multivariate_multimodal_prior_detail::TMode TMode;
-        typedef multivariate_multimodal_prior_detail::TModeVec TModeVec;
+        using TMode = multivariate_multimodal_prior_detail::TMode;
+        using TModeVec = multivariate_multimodal_prior_detail::TModeVec;
 
     protected:
         //! Get the modes.
@@ -1250,7 +1250,7 @@ class CMultivariateMultimodalPrior : public CMultivariatePrior
             //     = Sum_i{ w(i) * (Integral{ x' * x * f(x | i) } - m' * m) }
             //     = Sum_i{ w(i) * ((mi' * mi + Ci) - m' * m) }
 
-            typedef typename CBasicStatistics::SSampleMean<TMatrix>::TAccumulator TMatrixMeanAccumulator;
+            using TMatrixMeanAccumulator = typename CBasicStatistics::SSampleMean<TMatrix>::TAccumulator;
 
             TMatrix mean2 = TPoint(this->marginalLikelihoodMean()).outer();
 

--- a/include/maths/CMultivariateMultimodalPriorFactory.h
+++ b/include/maths/CMultivariateMultimodalPriorFactory.h
@@ -39,7 +39,7 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CMultivariateMultimodalPriorFactory
 {
     public:
-        typedef boost::shared_ptr<CMultivariatePrior> TPriorPtr;
+        using TPriorPtr = boost::shared_ptr<CMultivariatePrior>;
 
     public:
         //! Create a new non-informative multivariate normal prior.

--- a/include/maths/CMultivariateNormalConjugate.h
+++ b/include/maths/CMultivariateNormalConjugate.h
@@ -90,13 +90,13 @@ class CMultivariateNormalConjugate : public CMultivariatePrior
         //! See core::CMemory.
         static bool dynamicSizeAlwaysZero(void) { return true; }
 
-        typedef std::vector<double> TDoubleVec;
-        typedef CVectorNx1<double, N> TPoint;
-        typedef std::vector<TPoint> TPointVec;
-        typedef core::CSmallVector<TPoint, 4> TPoint4Vec;
-        typedef CSymmetricMatrixNxN<double, N> TMatrix;
-        typedef std::vector<TMatrix> TMatrixVec;
-        typedef typename CBasicStatistics::SSampleCovariances<double, N> TCovariance;
+        using TDoubleVec = std::vector<double>;
+        using TPoint = CVectorNx1<double, N>;
+        using TPointVec = std::vector<TPoint>;
+        using TPoint4Vec = core::CSmallVector<TPoint, 4>;
+        using TMatrix = CSymmetricMatrixNxN<double, N>;
+        using TMatrixVec = std::vector<TMatrix>;
+        using TCovariance = typename CBasicStatistics::SSampleCovariances<double, N>;
 
         // Lift all overloads of into scope.
         //{
@@ -105,8 +105,8 @@ class CMultivariateNormalConjugate : public CMultivariatePrior
         //}
 
     private:
-        typedef typename SDenseVector<TPoint>::Type TDenseVector;
-        typedef typename SDenseMatrix<TPoint>::Type TDenseMatrix;
+        using TDenseVector = typename SDenseVector<TPoint>::Type;
+        using TDenseMatrix = typename SDenseMatrix<TPoint>::Type;
 
     public:
         //! \name Life-cycle
@@ -513,8 +513,8 @@ class CMultivariateNormalConjugate : public CMultivariatePrior
                 return {TPriorPtr(CMultivariateNormalConjugate<2>::nonInformativePrior(dataType, decayRate).clone()), 0.0};
             }
 
-            typedef CVectorNx1<double, 2> TPoint2;
-            typedef CSymmetricMatrixNxN<double, 2> TMatrix2;
+            using TPoint2 = CVectorNx1<double, 2>;
+            using TMatrix2 = CSymmetricMatrixNxN<double, 2>;
 
             TPoint2 p;
             p(0) = m_GaussianPrecision(i1[0]);

--- a/include/maths/CMultivariateNormalConjugateFactory.h
+++ b/include/maths/CMultivariateNormalConjugateFactory.h
@@ -39,7 +39,7 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CMultivariateNormalConjugateFactory
 {
     public:
-        typedef boost::shared_ptr<CMultivariatePrior> TPriorPtr;
+        using TPriorPtr = boost::shared_ptr<CMultivariatePrior>;
 
     public:
         //! Create a new non-informative multivariate normal prior.

--- a/include/maths/CMultivariateOneOfNPrior.h
+++ b/include/maths/CMultivariateOneOfNPrior.h
@@ -67,15 +67,15 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CMultivariateOneOfNPrior : public CMultivariatePrior
 {
     public:
-        typedef core::CSmallVector<double, 3> TDouble3Vec;
-        typedef std::vector<TPriorPtr> TPriorPtrVec;
-        typedef std::pair<double, TPriorPtr> TDoublePriorPtrPr;
-        typedef std::vector<TDoublePriorPtrPr> TDoublePriorPtrPrVec;
-        typedef std::pair<CModelWeight, TPriorPtr> TWeightPriorPtrPr;
-        typedef std::vector<TWeightPriorPtrPr> TWeightPriorPtrPrVec;
-        typedef core::CSmallVector<const CMultivariatePrior*, 3> TPriorCPtr3Vec;
-        typedef CBasicStatistics::SMin<double>::TAccumulator TMinAccumulator;
-        typedef CBasicStatistics::SMax<double>::TAccumulator TMaxAccumulator;
+        using TDouble3Vec = core::CSmallVector<double, 3>;
+        using TPriorPtrVec = std::vector<TPriorPtr>;
+        using TDoublePriorPtrPr = std::pair<double, TPriorPtr>;
+        using TDoublePriorPtrPrVec = std::vector<TDoublePriorPtrPr>;
+        using TWeightPriorPtrPr = std::pair<CModelWeight, TPriorPtr>;
+        using TWeightPriorPtrPrVec = std::vector<TWeightPriorPtrPr>;
+        using TPriorCPtr3Vec = core::CSmallVector<const CMultivariatePrior*, 3>;
+        using TMinAccumulator = CBasicStatistics::SMin<double>::TAccumulator;
+        using TMaxAccumulator = CBasicStatistics::SMax<double>::TAccumulator;
 
         // Lift all overloads of into scope.
         //{

--- a/include/maths/CMultivariateOneOfNPriorFactory.h
+++ b/include/maths/CMultivariateOneOfNPriorFactory.h
@@ -39,8 +39,8 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CMultivariateOneOfNPriorFactory
 {
     public:
-        typedef boost::shared_ptr<CMultivariatePrior> TPriorPtr;
-        typedef std::vector<TPriorPtr> TPriorPtrVec;
+        using TPriorPtr = boost::shared_ptr<CMultivariatePrior>;
+        using TPriorPtrVec = std::vector<TPriorPtr>;
 
     public:
         //! Create a new non-informative multivariate normal prior.

--- a/include/maths/CNaturalBreaksClassifier.h
+++ b/include/maths/CNaturalBreaksClassifier.h
@@ -109,15 +109,15 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CNaturalBreaksClassifier
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<double> TDoubleVec;
-        typedef std::pair<double, double> TDoubleDoublePr;
-        typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-        typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TDoubleTuple;
-        typedef std::vector<TDoubleTuple> TDoubleTupleVec;
-        typedef CBasicStatistics::SSampleMeanVar<CFloatStorage>::TAccumulator TTuple;
-        typedef std::vector<TTuple> TTupleVec;
-        typedef std::vector<CNaturalBreaksClassifier> TClassifierVec;
+        using TSizeVec = std::vector<std::size_t>;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleDoublePr = std::pair<double, double>;
+        using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+        using TDoubleTuple = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+        using TDoubleTupleVec = std::vector<TDoubleTuple>;
+        using TTuple = CBasicStatistics::SSampleMeanVar<CFloatStorage>::TAccumulator;
+        using TTupleVec = std::vector<TTuple>;
+        using TClassifierVec = std::vector<CNaturalBreaksClassifier>;
 
     public:
         //! The type of optimization object which it is possible
@@ -291,7 +291,7 @@ class MATHS_EXPORT CNaturalBreaksClassifier
                                   TSizeVec &result);
 
     private:
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
 
     private:
         //! Implementation called by naturalBreaks with explicit

--- a/include/maths/CNormalMeanPrecConjugate.h
+++ b/include/maths/CNormalMeanPrecConjugate.h
@@ -62,8 +62,8 @@ class MATHS_EXPORT CNormalMeanPrecConjugate : public CPrior
         //! See core::CMemory.
         static bool dynamicSizeAlwaysZero(void) { return true; }
 
-        typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-        typedef CEqualWithTolerance<double> TEqualWithTolerance;
+        using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+        using TEqualWithTolerance = CEqualWithTolerance<double>;
 
         //! Lift the overloads of addSamples into scope.
         using CPrior::addSamples;

--- a/include/maths/COneOfNPrior.h
+++ b/include/maths/COneOfNPrior.h
@@ -59,11 +59,11 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT COneOfNPrior : public CPrior
 {
     public:
-        typedef boost::shared_ptr<CPrior> TPriorPtr;
-        typedef std::vector<TPriorPtr> TPriorPtrVec;
-        typedef std::vector<const CPrior*> TPriorCPtrVec;
-        typedef std::pair<double, TPriorPtr> TDoublePriorPtrPr;
-        typedef std::vector<TDoublePriorPtrPr> TDoublePriorPtrPrVec;
+        using TPriorPtr = boost::shared_ptr<CPrior>;
+        using TPriorPtrVec = std::vector<TPriorPtr>;
+        using TPriorCPtrVec = std::vector<const CPrior*>;
+        using TDoublePriorPtrPr = std::pair<double, TPriorPtr>;
+        using TDoublePriorPtrPrVec = std::vector<TDoublePriorPtrPr>;
 
         //! Lift all overloads of the dataType into scope.
         using CPrior::dataType;
@@ -359,11 +359,11 @@ class MATHS_EXPORT COneOfNPrior : public CPrior
         //@}
 
     private:
-        typedef std::pair<double, std::size_t> TDoubleSizePr;
-        typedef core::CSmallVector<TDoubleSizePr, 5> TDoubleSizePr5Vec;
-        typedef std::pair<CModelWeight, TPriorPtr> TWeightPriorPtrPr;
-        typedef std::vector<TWeightPriorPtrPr> TWeightPriorPtrPrVec;
-        typedef CBasicStatistics::SMax<double>::TAccumulator TMaxAccumulator;
+        using TDoubleSizePr = std::pair<double, std::size_t>;
+        using TDoubleSizePr5Vec = core::CSmallVector<TDoubleSizePr, 5>;
+        using TWeightPriorPtrPr = std::pair<CModelWeight, TPriorPtr>;
+        using TWeightPriorPtrPrVec = std::vector<TWeightPriorPtrPr>;
+        using TMaxAccumulator = CBasicStatistics::SMax<double>::TAccumulator;
 
     private:
         //! Read parameters from \p traverser.

--- a/include/maths/COrderings.h
+++ b/include/maths/COrderings.h
@@ -57,7 +57,7 @@ class COrderings : private core::CNonInstantiatable
         //! operator <.
         struct SOptionalLess
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             //! \note U and V must be convertible to T or optional<T>
             //! for some type T and T must support operator <.
@@ -96,7 +96,7 @@ class COrderings : private core::CNonInstantiatable
         //! operator >.
         struct SOptionalGreater
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             //! \note U and V must be convertible to T or optional<T>
             //! for some type T and T must support operator >.
@@ -135,7 +135,7 @@ class COrderings : private core::CNonInstantiatable
         //! operator <.
         struct SPtrLess
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             template<typename T>
             inline bool operator()(const T *lhs, const T *rhs) const
@@ -159,7 +159,7 @@ class COrderings : private core::CNonInstantiatable
         //! the type operator >.
         struct SPtrGreater
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             template<typename T>
             inline bool operator()(const T *lhs, const T *rhs) const
@@ -182,7 +182,7 @@ class COrderings : private core::CNonInstantiatable
         //! comparable with operator <.
         struct SReferenceLess
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             template<typename U, typename V>
             inline bool operator()(const U &lhs, const V &rhs) const
@@ -201,7 +201,7 @@ class COrderings : private core::CNonInstantiatable
         //! comparable with operator >.
         struct SReferenceGreater
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             template<typename U, typename V>
             inline bool operator()(const U &lhs, const V &rhs) const
@@ -311,7 +311,7 @@ class COrderings : private core::CNonInstantiatable
         //! \brief Wrapper around various less than comparisons.
         struct SLess
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             template<typename T>
             bool operator()(const boost::optional<T> &lhs,
@@ -363,7 +363,7 @@ class COrderings : private core::CNonInstantiatable
         //! \brief Wrapper around various less than comparisons.
         struct SGreater
         {
-            typedef bool result_type;
+            using result_type = bool;
 
             template<typename T>
             bool operator()(const boost::optional<T> &lhs,
@@ -720,7 +720,7 @@ class COrderings : private core::CNonInstantiatable
                                {                                                  \
                                    return true;                                   \
                                }                                                  \
-                               typedef std::vector<std::size_t> TSizeVec;         \
+                               using TSizeVec = std::vector<std::size_t>;         \
                                TSizeVec ordering;                                 \
                                ordering.reserve(keys.size());                     \
                                for (std::size_t i = 0u; i < keys.size(); ++i)     \

--- a/include/maths/CPRNG.h
+++ b/include/maths/CPRNG.h
@@ -67,7 +67,7 @@ class MATHS_EXPORT CPRNG : private core::CNonInstantiatable
         class MATHS_EXPORT CSplitMix64
         {
             public:
-                typedef uint64_t result_type;
+                using result_type = uint64_t;
 
             public:
                 CSplitMix64(void);
@@ -126,7 +126,7 @@ class MATHS_EXPORT CPRNG : private core::CNonInstantiatable
         class MATHS_EXPORT CXorOShiro128Plus
         {
             public:
-                typedef uint64_t result_type;
+                using result_type = uint64_t;
 
             public:
                 CXorOShiro128Plus(void);
@@ -222,7 +222,7 @@ class MATHS_EXPORT CPRNG : private core::CNonInstantiatable
         class MATHS_EXPORT CXorShift1024Mult
         {
             public:
-                typedef uint64_t result_type;
+                using result_type = uint64_t;
 
             public:
                 CXorShift1024Mult(void);

--- a/include/maths/CPackedBitVector.h
+++ b/include/maths/CPackedBitVector.h
@@ -59,7 +59,7 @@ class MATHS_EXPORT CPackedBitVector : private boost::equality_comparable< CPacke
                                               boost::partially_ordered< CPackedBitVector > >
 {
     public:
-        typedef std::vector<bool> TBoolVec;
+        using TBoolVec = std::vector<bool>;
 
         //! Operations which can be performed in the inner product.
         enum EOperation
@@ -134,7 +134,7 @@ class MATHS_EXPORT CPackedBitVector : private boost::equality_comparable< CPacke
         std::size_t memoryUsage(void) const;
 
     private:
-        typedef std::vector<uint8_t> TUInt8Vec;
+        using TUInt8Vec = std::vector<uint8_t>;
 
     private:
         //! The maximum permitted run length. Longer runs are encoded

--- a/include/maths/CPoissonMeanConjugate.h
+++ b/include/maths/CPoissonMeanConjugate.h
@@ -60,7 +60,7 @@ struct SDistributionRestoreParams;
 class MATHS_EXPORT CPoissonMeanConjugate : public CPrior
 {
     public:
-        typedef CEqualWithTolerance<double> TEqualWithTolerance;
+        using TEqualWithTolerance = CEqualWithTolerance<double>;
 
         //! Lift the overloads of addSamples into scope.
         using CPrior::addSamples;

--- a/include/maths/CQDigest.h
+++ b/include/maths/CQDigest.h
@@ -91,8 +91,8 @@ namespace maths
 class MATHS_EXPORT CQDigest : private core::CNonCopyable
 {
     public:
-        typedef std::pair<uint32_t, uint64_t> TUInt32UInt64Pr;
-        typedef std::vector<TUInt32UInt64Pr> TUInt32UInt64PrVec;
+        using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
+        using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
 
     public:
         //! \name XML Tag Names
@@ -218,17 +218,17 @@ class MATHS_EXPORT CQDigest : private core::CNonCopyable
         //@}
 
     private:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef TSizeVec::const_iterator TSizeVecCItr;
-        typedef std::greater<std::size_t> TSizeGreater;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecCItr = TSizeVec::const_iterator;
+        using TSizeGreater = std::greater<std::size_t>;
 
         class CNode;
         class CNodeAllocator;
 
-        typedef std::vector<CNode*> TNodePtrVec;
-        typedef TNodePtrVec::iterator TNodePtrVecItr;
-        typedef TNodePtrVec::const_iterator TNodePtrVecCItr;
-        typedef TNodePtrVec::const_reverse_iterator TNodePtrVecCRItr;
+        using TNodePtrVec = std::vector<CNode*>;
+        using TNodePtrVecItr = TNodePtrVec::iterator;
+        using TNodePtrVecCItr = TNodePtrVec::const_iterator;
+        using TNodePtrVecCRItr = TNodePtrVec::const_reverse_iterator;
 
         //! Orders node pointers by level order.
         struct MATHS_EXPORT SLevelLess
@@ -405,12 +405,12 @@ class MATHS_EXPORT CQDigest : private core::CNonCopyable
                 void release(CNode &node);
 
             private:
-                typedef std::vector<TNodePtrVec> TNodePtrVecVec;
-                typedef std::vector<CNode> TNodeVec;
-                typedef std::vector<CNode>::const_iterator TNodeVecCItr;
-                typedef std::list<TNodeVec> TNodeVecList;
-                typedef TNodeVecList::iterator TNodeVecListItr;
-                typedef TNodeVecList::const_iterator TNodeVecListCItr;
+                using TNodePtrVecVec = std::vector<TNodePtrVec>;
+                using TNodeVec = std::vector<CNode>;
+                using TNodeVecCItr = std::vector<CNode>::const_iterator;
+                using TNodeVecList = std::list<TNodeVec>;
+                using TNodeVecListItr = TNodeVecList::iterator;
+                using TNodeVecListCItr = TNodeVecList::const_iterator;
 
             private:
                 //! Find the block to which \p node belongs.

--- a/include/maths/CQuantileSketch.h
+++ b/include/maths/CQuantileSketch.h
@@ -58,8 +58,8 @@ namespace maths
 class MATHS_EXPORT CQuantileSketch : private boost::addable< CQuantileSketch >
 {
     public:
-        typedef std::pair<CFloatStorage, CFloatStorage> TFloatFloatPr;
-        typedef std::vector<TFloatFloatPr> TFloatFloatPrVec;
+        using TFloatFloatPr = std::pair<CFloatStorage, CFloatStorage>;
+        using TFloatFloatPrVec = std::vector<TFloatFloatPr>;
 
         //! The types of interpolation used for computing the quantile.
         enum EInterpolation

--- a/include/maths/CSetTools.h
+++ b/include/maths/CSetTools.h
@@ -45,7 +45,7 @@ class MATHS_EXPORT CSetTools
         class CIndexInSet
         {
             public:
-                typedef std::set<std::size_t> TSizeSet;
+                using TSizeSet = std::set<std::size_t>;
 
             public:
                 CIndexInSet(std::size_t index) : m_IndexSet(index) {}
@@ -64,7 +64,7 @@ class MATHS_EXPORT CSetTools
                 }
 
             private:
-                typedef boost::variant<std::size_t, TSizeSet> TSizeOrSizeSet;
+                using TSizeOrSizeSet = boost::variant<std::size_t, TSizeSet>;
 
             private:
                 TSizeOrSizeSet m_IndexSet;

--- a/include/maths/CSolvers.h
+++ b/include/maths/CSolvers.h
@@ -50,7 +50,7 @@ namespace maths
 class MATHS_EXPORT CSolvers
 {
     private:
-        typedef std::pair<double, double> TDoubleDoublePr;
+        using TDoubleDoublePr = std::pair<double, double>;
 
         //! \name Helpers
         //@{
@@ -930,8 +930,8 @@ class MATHS_EXPORT CSolvers
                                    double &x,
                                    double &fx)
         {
-            typedef std::pair<double, std::size_t> TDoubleSizePr;
-            typedef CBasicStatistics::COrderStatisticsStack<TDoubleSizePr, 1> TMinAccumulator;
+            using TDoubleSizePr = std::pair<double, std::size_t>;
+            using TMinAccumulator = CBasicStatistics::COrderStatisticsStack<TDoubleSizePr, 1>;
 
             std::size_t n = p.size();
 

--- a/include/maths/CSphericalCluster.h
+++ b/include/maths/CSphericalCluster.h
@@ -57,7 +57,7 @@ template<typename POINT>
 class CSphericalCluster
 {
     public:
-        typedef CAnnotatedVector<POINT, SCountAndVariance> Type;
+        using Type = CAnnotatedVector<POINT, SCountAndVariance>;
 
         class CHash
         {
@@ -110,7 +110,7 @@ struct SCentralMomentsCustomAdd<CAnnotatedVector<CVectorNx1<U, N>, SCountAndVari
                            typename SCoordinate<T>::Type n,
                            CBasicStatistics::SSampleCentralMoments<T, 1> &moments)
     {
-        typedef typename SCoordinate<T>::Type TCoordinate;
+        using TCoordinate = typename SCoordinate<T>::Type;
         moments.add(x, TCoordinate(x.annotation().s_Count) * n, 0);
     }
 
@@ -119,7 +119,7 @@ struct SCentralMomentsCustomAdd<CAnnotatedVector<CVectorNx1<U, N>, SCountAndVari
                            typename SCoordinate<T>::Type n,
                            CBasicStatistics::SSampleCentralMoments<T, 2> &moments)
     {
-        typedef typename SCoordinate<T>::Type TCoordinate;
+        using TCoordinate = typename SCoordinate<T>::Type;
         moments += CBasicStatistics::accumulator(TCoordinate(x.annotation().s_Count) * n,
                                                  T(x),
                                                  T(x.annotation().s_Variance));

--- a/include/maths/CSpline.h
+++ b/include/maths/CSpline.h
@@ -40,8 +40,8 @@ namespace maths
 namespace spline_detail
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<CFloatStorage> TFloatVec;
+using TDoubleVec = std::vector<double>;
+using TFloatVec = std::vector<CFloatStorage>;
 
 //! Solves \f$Ax = y\f$ where \f$A\f$ is a tridiagonal matrix
 //! consisting of vectors \f$a\f$, \f$b\f$ and \f$c\f$.
@@ -84,8 +84,8 @@ bool MATHS_EXPORT solvePeturbedTridiagonal(const TDoubleVec &a,
 class MATHS_EXPORT CSplineTypes
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+        using TDoubleVec = std::vector<double>;
+        using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
         //! Types of spline interpolation that this will perform.
         //!
@@ -150,12 +150,12 @@ template<typename KNOTS = std::vector<CFloatStorage>,
 class CSpline : public CSplineTypes
 {
     public:
-        typedef typename boost::unwrap_reference<KNOTS>::type TKnots;
-        typedef typename boost::unwrap_reference<VALUES>::type TValues;
-        typedef typename boost::unwrap_reference<CURVATURES>::type TCurvatures;
-        typedef typename boost::remove_const<TKnots>::type TNonConstKnots;
-        typedef typename boost::remove_const<TValues>::type TNonConstValues;
-        typedef typename boost::remove_const<TCurvatures>::type TNonConstCurvatures;
+        using TKnots = typename boost::unwrap_reference<KNOTS>::type;
+        using TValues = typename boost::unwrap_reference<VALUES>::type;
+        using TCurvatures = typename boost::unwrap_reference<CURVATURES>::type;
+        using TNonConstKnots = typename boost::remove_const<TKnots>::type;
+        using TNonConstValues = typename boost::remove_const<TValues>::type;
+        using TNonConstCurvatures = typename boost::remove_const<TCurvatures>::type;
 
     public:
         CSpline(EType type) : m_Type(type) {}

--- a/include/maths/CStatisticalTests.h
+++ b/include/maths/CStatisticalTests.h
@@ -40,8 +40,8 @@ namespace maths
 class MATHS_EXPORT CStatisticalTests
 {
     public:
-        typedef std::vector<uint16_t> TUInt16Vec;
-        typedef std::vector<double> TDoubleVec;
+        using TUInt16Vec = std::vector<uint16_t>;
+        using TDoubleVec = std::vector<double>;
 
     public:
         //! Get the significance of a left tail F-test for \p x when
@@ -135,7 +135,7 @@ class MATHS_EXPORT CStatisticalTests
                 static const double SCALE;
 
             private:
-                typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+                using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
             private:
                 //! The "count - 1" in the test statistic.

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -298,7 +298,7 @@ class MATHS_EXPORT CTimeSeriesCorrelateModelAllocator
 class MATHS_EXPORT CTimeSeriesCorrelations
 {
     public:
-        using TTime1Vec = core::CSmallVector<core_t::TTime, 1> ;
+        using TTime1Vec = core::CSmallVector<core_t::TTime, 1>;
         using TDouble1Vec = core::CSmallVector<double, 1>;
         using TDouble2Vec = core::CSmallVector<double, 2>;
         using TDouble4Vec = core::CSmallVector<double, 4>;

--- a/include/maths/CXMeans.h
+++ b/include/maths/CXMeans.h
@@ -60,12 +60,12 @@ template<typename POINT, typename COST = CSphericalGaussianInfoCriterion<POINT, 
 class CXMeans
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<POINT> TPointVec;
-        typedef std::vector<TPointVec> TPointVecVec;
-        typedef boost::unordered_set<uint64_t> TUInt64USet;
-        typedef TUInt64USet::iterator TUInt64USetItr;
-        typedef typename CBasicStatistics::SSampleMean<POINT>::TAccumulator TMeanAccumulator;
+        using TDoubleVec = std::vector<double>;
+        using TPointVec = std::vector<POINT>;
+        using TPointVecVec = std::vector<TPointVec>;
+        using TUInt64USet = boost::unordered_set<uint64_t>;
+        using TUInt64USetItr = TUInt64USet::iterator;
+        using TMeanAccumulator = typename CBasicStatistics::SSampleMean<POINT>::TAccumulator;
 
         //! A cluster.
         //!
@@ -153,7 +153,7 @@ class CXMeans
                 uint64_t m_Checksum;
         };
 
-        typedef std::vector<CCluster> TClusterVec;
+        using TClusterVec = std::vector<CCluster>;
 
     public:
         CXMeans(std::size_t kmax) :
@@ -229,8 +229,8 @@ class CXMeans
         //! iterations of Lloyd's algorithm to use.
         void improveParams(std::size_t kmeansIterations)
         {
-            typedef const CCluster *TClusterCPtr;
-            typedef std::vector<TClusterCPtr> TClusterCPtrVec;
+            using TClusterCPtr = const CCluster*;
+            using TClusterCPtrVec = std::vector<TClusterCPtr>;
 
             std::size_t n = m_Clusters.size();
 

--- a/include/maths/CXMeansOnline.h
+++ b/include/maths/CXMeansOnline.h
@@ -85,28 +85,28 @@ template<typename T, std::size_t N>
 class CXMeansOnline : public CClusterer<CVectorNx1<T, N> >
 {
     public:
-        typedef CVectorNx1<T, N> TPoint;
-        typedef std::vector<TPoint> TPointVec;
-        typedef typename CClusterer<TPoint>::TPointPrecise TPointPrecise;
-        typedef typename CClusterer<TPoint>::TPointPreciseVec TPointPreciseVec;
-        typedef typename CClusterer<TPoint>::TPointPreciseDoublePrVec TPointPreciseDoublePrVec;
-        typedef typename CClusterer<TPoint>::TSizeDoublePr TSizeDoublePr;
-        typedef typename CClusterer<TPoint>::TSizeDoublePr2Vec TSizeDoublePr2Vec;
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<TDoubleVec> TDoubleVecVec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<TSizeVec> TSizeVecVec;
-        typedef typename SPromoted<T>::Type TPrecise;
-        typedef CSymmetricMatrixNxN<TPrecise, N> TMatrixPrecise;
-        typedef CBasicStatistics::SSampleCovariances<TPrecise, N> TCovariances;
-        typedef typename CSphericalCluster<TPoint>::Type TSphericalCluster;
-        typedef std::vector<TSphericalCluster> TSphericalClusterVec;
-        typedef std::vector<TSphericalClusterVec> TSphericalClusterVecVec;
-        typedef CKMeansOnline<TPoint> TKMeansOnline;
-        typedef std::vector<TKMeansOnline> TKMeansOnlineVec;
+        using TPoint = CVectorNx1<T, N>;
+        using TPointVec = std::vector<TPoint>;
+        using TPointPrecise = typename CClusterer<TPoint>::TPointPrecise;
+        using TPointPreciseVec = typename CClusterer<TPoint>::TPointPreciseVec;
+        using TPointPreciseDoublePrVec = typename CClusterer<TPoint>::TPointPreciseDoublePrVec;
+        using TSizeDoublePr = typename CClusterer<TPoint>::TSizeDoublePr;
+        using TSizeDoublePr2Vec = typename CClusterer<TPoint>::TSizeDoublePr2Vec;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleVecVec = std::vector<TDoubleVec>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TSizeVecVec = std::vector<TSizeVec>;
+        using TPrecise = typename SPromoted<T>::Type;
+        using TMatrixPrecise = CSymmetricMatrixNxN<TPrecise, N>;
+        using TCovariances = CBasicStatistics::SSampleCovariances<TPrecise, N>;
+        using TSphericalCluster = typename CSphericalCluster<TPoint>::Type;
+        using TSphericalClusterVec = std::vector<TSphericalCluster>;
+        using TSphericalClusterVecVec = std::vector<TSphericalClusterVec>;
+        using TKMeansOnline = CKMeansOnline<TPoint>;
+        using TKMeansOnlineVec = std::vector<TKMeansOnline>;
         class CCluster;
-        typedef std::pair<CCluster, CCluster> TClusterClusterPr;
-        typedef boost::optional<TClusterClusterPr> TOptionalClusterClusterPr;
+        using TClusterClusterPr = std::pair<CCluster, CCluster>;
+        using TOptionalClusterClusterPr = boost::optional<TClusterClusterPr>;
 
         //! \brief Represents a cluster.
         class CCluster
@@ -636,9 +636,9 @@ class CXMeansOnline : public CClusterer<CVectorNx1<T, N> >
                 TKMeansOnline m_Structure;
         };
 
-        typedef std::vector<CCluster> TClusterVec;
-        typedef typename TClusterVec::iterator TClusterVecItr;
-        typedef typename TClusterVec::const_iterator TClusterVecCItr;
+        using TClusterVec = std::vector<CCluster>;
+        using TClusterVecItr = typename TClusterVec::iterator;
+        using TClusterVecCItr = typename TClusterVec::const_iterator;
 
     public:
         //! \name Life-cycle
@@ -946,8 +946,8 @@ class CXMeansOnline : public CClusterer<CVectorNx1<T, N> >
             }
             else
             {
-                typedef std::pair<double, std::size_t> TSizeDoublePr;
-                typedef CBasicStatistics::COrderStatisticsStack<TSizeDoublePr, 2, std::greater<TSizeDoublePr> > TMaxAccumulator;
+                using TSizeDoublePr = std::pair<double, std::size_t>;
+                using TMaxAccumulator = CBasicStatistics::COrderStatisticsStack<TSizeDoublePr, 2, std::greater<TSizeDoublePr> >;
 
                 TMaxAccumulator closest;
                 for (std::size_t i = 0u; i < m_Clusters.size(); ++i)
@@ -1277,8 +1277,8 @@ class CXMeansOnline : public CClusterer<CVectorNx1<T, N> >
                 return false;
             }
 
-            typedef std::pair<double, std::size_t> TDoubleSizePr;
-            typedef CBasicStatistics::COrderStatisticsStack<TDoubleSizePr, 1, COrderings::SFirstLess> TMinAccumulator;
+            using TDoubleSizePr = std::pair<double, std::size_t>;
+            using TMinAccumulator = CBasicStatistics::COrderStatisticsStack<TDoubleSizePr, 1, COrderings::SFirstLess>;
 
             bool result = false;
 
@@ -1332,7 +1332,7 @@ class CXMeansOnline : public CClusterer<CVectorNx1<T, N> >
                 return &m_Clusters[0];
             }
 
-            typedef CBasicStatistics::COrderStatisticsStack<double, 1> TMinAccumulator;
+            using TMinAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1>;
 
             CCluster *result = 0;
             TMinAccumulator min;

--- a/include/maths/CXMeansOnline1d.h
+++ b/include/maths/CXMeansOnline1d.h
@@ -121,11 +121,11 @@ class MATHS_EXPORT CXMeansOnline1d : public CClusterer1d
 {
     public:
         class CCluster;
-        typedef CClusterer1d::TPointPreciseVec TDoubleVec;
-        typedef CClusterer1d::TPointPreciseDoublePrVec TDoubleDoublePrVec;
-        typedef std::pair<CCluster, CCluster> TClusterClusterPr;
-        typedef boost::optional<TClusterClusterPr> TOptionalClusterClusterPr;
-        typedef std::pair<double, double> TDoubleDoublePr;
+        using TDoubleVec = CClusterer1d::TPointPreciseVec;
+        using TDoubleDoublePrVec = CClusterer1d::TPointPreciseDoublePrVec;
+        using TClusterClusterPr = std::pair<CCluster, CCluster>;
+        using TOptionalClusterClusterPr = boost::optional<TClusterClusterPr>;
+        using TDoubleDoublePr = std::pair<double, double>;
         using CClusterer1d::add;
 
         //! \brief Represents a cluster.
@@ -241,9 +241,9 @@ class MATHS_EXPORT CXMeansOnline1d : public CClusterer1d
                 CNaturalBreaksClassifier m_Structure;
         };
 
-        typedef std::vector<CCluster> TClusterVec;
-        typedef TClusterVec::iterator TClusterVecItr;
-        typedef TClusterVec::const_iterator TClusterVecCItr;
+        using TClusterVec = std::vector<CCluster>;
+        using TClusterVecItr = TClusterVec::iterator;
+        using TClusterVecCItr = TClusterVec::const_iterator;
 
     public:
         //! The central confidence interval on which to Winsorise.
@@ -400,8 +400,8 @@ class MATHS_EXPORT CXMeansOnline1d : public CClusterer1d
         CIndexGenerator &indexGenerator(void);
 
     private:
-        typedef CBasicStatistics::COrderStatisticsStack<double, 1> TMinAccumulator;
-        typedef CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> > TMaxAccumulator;
+        using TMinAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1>;
+        using TMaxAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> >;
 
     private:
         //! The minimum Kullback-Leibler divergence at which we'll

--- a/include/maths/MathsTypes.h
+++ b/include/maths/MathsTypes.h
@@ -35,14 +35,14 @@ class CSeasonalComponent;
 namespace maths_t
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<double, 10> TDouble10Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef core::CSmallVector<TDouble10Vec, 4> TDouble10Vec4Vec;
-typedef core::CSmallVector<TDouble10Vec4Vec, 1> TDouble10Vec4Vec1Vec;
-typedef std::vector<maths::CSeasonalComponent> TSeasonalComponentVec;
-typedef std::vector<maths::CCalendarComponent> TCalendarComponentVec;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble10Vec = core::CSmallVector<double, 10>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TDouble10Vec4Vec = core::CSmallVector<TDouble10Vec, 4>;
+using TDouble10Vec4Vec1Vec = core::CSmallVector<TDouble10Vec4Vec, 1>;
+using TSeasonalComponentVec = std::vector<maths::CSeasonalComponent>;
+using TCalendarComponentVec = std::vector<maths::CCalendarComponent>;
 
 //! An enumeration of the types of data which can be modeled.
 //!
@@ -90,7 +90,7 @@ enum ESampleWeightStyle
 //! IMPORTANT: this must be kept this up-to-date with ESampleWeightStyle.
 const std::size_t NUMBER_WEIGHT_STYLES = 4;
 
-typedef core::CSmallVector<ESampleWeightStyle, 4> TWeightStyleVec;
+using TWeightStyleVec = core::CSmallVector<ESampleWeightStyle, 4>;
 
 //! Extract the effective sample count from a collection of weights.
 MATHS_EXPORT

--- a/include/maths/ProbabilityAggregators.h
+++ b/include/maths/ProbabilityAggregators.h
@@ -58,7 +58,7 @@ namespace maths
 class MATHS_EXPORT CJointProbabilityOfLessLikelySamples : private boost::addable<CJointProbabilityOfLessLikelySamples>
 {
     public:
-        typedef boost::optional<double> TOptionalDouble;
+        using TOptionalDouble = boost::optional<double>;
 
         //! Functor wrapper of CJointProbabilityOfLessLikelySamples::add.
         struct SAddProbability
@@ -232,7 +232,7 @@ class MATHS_EXPORT CProbabilityOfExtremeSample : private boost::addable<CProbabi
         std::ostream &print(std::ostream &o) const;
 
     private:
-        typedef CBasicStatistics::COrderStatisticsStack<double, 1u> TMinValueAccumulator;
+        using TMinValueAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1u>;
 
     private:
         TMinValueAccumulator m_MinValue;
@@ -320,7 +320,7 @@ class MATHS_EXPORT CLogProbabilityOfMFromNExtremeSamples : private boost::addabl
         uint64_t checksum(uint64_t seed) const;
 
     private:
-        typedef CBasicStatistics::COrderStatisticsHeap<double> TMinValueAccumulator;
+        using TMinValueAccumulator = CBasicStatistics::COrderStatisticsHeap<double>;
 
     private:
         TMinValueAccumulator m_MinValues;

--- a/include/model/CAnnotatedProbabilityBuilder.h
+++ b/include/model/CAnnotatedProbabilityBuilder.h
@@ -46,11 +46,11 @@ class CModel;
 class MODEL_EXPORT CAnnotatedProbabilityBuilder : private core::CNonCopyable
 {
     public:
-        typedef std::pair<std::size_t, double> TSizeDoublePr;
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef core::CSmallVector<std::size_t, 1> TSize1Vec;
-        typedef core::CSmallVector<TSizeDoublePr, 1> TSizeDoublePr1Vec;
-        typedef core::CSmallVector<core::CStoredStringPtr, 1> TStoredStringPtr1Vec;
+        using TSizeDoublePr = std::pair<std::size_t, double>;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TSize1Vec = core::CSmallVector<std::size_t, 1>;
+        using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
+        using TStoredStringPtr1Vec = core::CSmallVector<core::CStoredStringPtr, 1>;
 
     public:
         CAnnotatedProbabilityBuilder(SAnnotatedProbability &annotatedProbability);
@@ -82,7 +82,7 @@ class MODEL_EXPORT CAnnotatedProbabilityBuilder : private core::CNonCopyable
         void addDescriptiveData(void);
 
     private:
-        typedef maths::CBasicStatistics::COrderStatisticsHeap<SAttributeProbability> TMinAccumulator;
+        using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<SAttributeProbability>;
 
     private:
         SAnnotatedProbability              &m_Result;

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -82,23 +82,23 @@ class CSearchKey;
 class MODEL_EXPORT CAnomalyDetector : private core::CNonCopyable
 {
     public:
-        typedef std::vector<std::string>                        TStrVec;
-        typedef std::vector<const std::string*>                 TStrCPtrVec;
-        typedef std::vector<CModelPlotData>                     TModelPlotDataVec;
+        using TStrVec = std::vector<std::string>;
+        using TStrCPtrVec = std::vector<const std::string*>;
+        using TModelPlotDataVec = std::vector<CModelPlotData>;
 
-        typedef boost::shared_ptr<CDataGatherer> TDataGathererPtr;
-        typedef boost::shared_ptr<const CModelFactory> TModelFactoryCPtr;
-        typedef boost::shared_ptr<CAnomalyDetectorModel> TModelPtr;
+        using TDataGathererPtr = boost::shared_ptr<CDataGatherer>;
+        using TModelFactoryCPtr = boost::shared_ptr<const CModelFactory>;
+        using TModelPtr = boost::shared_ptr<CAnomalyDetectorModel>;
 
         //! A shared pointer to an instance of this class
-        typedef boost::shared_ptr<CAnomalyDetector> TAnomalyDetectorPtr;
+        using TAnomalyDetectorPtr = boost::shared_ptr<CAnomalyDetector>;
 
-        typedef std::function<void (const std::string &,
-                                      const std::string &,
-                                      const std::string &,
-                                      const std::string &,
-                                      const CModelPlotData &)> TOutputModelPlotDataFunc;
-        typedef CAnomalyDetectorModelConfig::TStrSet TStrSet;
+        using  TOutputModelPlotDataFunc = std::function<void (const std::string&,
+                                                              const std::string &,
+                                                              const std::string &,
+                                                              const std::string &,
+                                                              const CModelPlotData &)>;
+        using TStrSet = CAnomalyDetectorModelConfig::TStrSet;
 
     public:
         //! State version.  This must be incremented every time a change to the

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -74,32 +74,32 @@ class MODEL_EXPORT CAnomalyDetectorModelConfig
             E_BadFactory
         };
 
-        typedef std::set<std::string> TStrSet;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef TTimeVec::const_iterator TTimeVecCItr;
-        typedef std::pair<double, double> TDoubleDoublePr;
-        typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-        typedef model_t::TFeatureVec TFeatureVec;
-        typedef std::vector<std::string> TStrVec;
-        typedef TStrVec::const_iterator TStrVecCItr;
-        typedef boost::shared_ptr<CModelFactory> TModelFactoryPtr;
-        typedef boost::shared_ptr<const CModelFactory> TModelFactoryCPtr;
-        typedef std::map<EFactoryType, TModelFactoryPtr> TFactoryTypeFactoryPtrMap;
-        typedef TFactoryTypeFactoryPtrMap::iterator TFactoryTypeFactoryPtrMapItr;
-        typedef TFactoryTypeFactoryPtrMap::const_iterator TFactoryTypeFactoryPtrMapCItr;
-        typedef std::map<CSearchKey, TModelFactoryCPtr> TSearchKeyFactoryCPtrMap;
+        using TStrSet = std::set<std::string>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TTimeVecCItr = TTimeVec::const_iterator;
+        using TDoubleDoublePr = std::pair<double, double>;
+        using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+        using TFeatureVec = model_t::TFeatureVec;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecCItr = TStrVec::const_iterator;
+        using TModelFactoryPtr = boost::shared_ptr<CModelFactory>;
+        using TModelFactoryCPtr = boost::shared_ptr<const CModelFactory>;
+        using TFactoryTypeFactoryPtrMap = std::map<EFactoryType, TModelFactoryPtr>;
+        using TFactoryTypeFactoryPtrMapItr = TFactoryTypeFactoryPtrMap::iterator;
+        using TFactoryTypeFactoryPtrMapCItr = TFactoryTypeFactoryPtrMap::const_iterator;
+        using TSearchKeyFactoryCPtrMap = std::map<CSearchKey, TModelFactoryCPtr>;
 
         // Const ref to detection rules map
-        typedef std::vector<CDetectionRule> TDetectionRuleVec;
-        typedef boost::reference_wrapper<const TDetectionRuleVec> TDetectionRuleVecCRef;
-        typedef boost::unordered_map<int, TDetectionRuleVec> TIntDetectionRuleVecUMap;
-        typedef boost::reference_wrapper<const TIntDetectionRuleVecUMap> TIntDetectionRuleVecUMapCRef;
-        typedef TIntDetectionRuleVecUMap::const_iterator TIntDetectionRuleVecUMapCItr;
+        using TDetectionRuleVec = std::vector<CDetectionRule>;
+        using TDetectionRuleVecCRef = boost::reference_wrapper<const TDetectionRuleVec>;
+        using TIntDetectionRuleVecUMap = boost::unordered_map<int, TDetectionRuleVec>;
+        using TIntDetectionRuleVecUMapCRef = boost::reference_wrapper<const TIntDetectionRuleVecUMap>;
+        using TIntDetectionRuleVecUMapCItr = TIntDetectionRuleVecUMap::const_iterator;
 
-        typedef std::pair<std::string, model::CDetectionRule> TStrDetectionRulePr;
-        typedef std::vector<TStrDetectionRulePr> TStrDetectionRulePrVec;
-        typedef boost::reference_wrapper<const TStrDetectionRulePrVec> TStrDetectionRulePrVecCRef;
+        using TStrDetectionRulePr = std::pair<std::string, model::CDetectionRule>;
+        using TStrDetectionRulePrVec = std::vector<TStrDetectionRulePr>;
+        using TStrDetectionRulePrVecCRef = boost::reference_wrapper<const TStrDetectionRulePrVec>;
 
     public:
         //! The default value used to separate components of a multivariate feature

--- a/include/model/CAnomalyScore.h
+++ b/include/model/CAnomalyScore.h
@@ -58,12 +58,12 @@ class CLimits;
 class MODEL_EXPORT CAnomalyScore
 {
     public:
-        typedef std::vector<double>          TDoubleVec;
-        typedef TDoubleVec::iterator         TDoubleVecItr;
-        typedef TDoubleVec::const_iterator   TDoubleVecCItr;
-        typedef boost::optional<double>      TOptionalDouble;
-        typedef std::vector<TOptionalDouble> TOptionalDoubleVec;
-        typedef std::vector<std::string>     TStrVec;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleVecItr = TDoubleVec::iterator;
+        using TDoubleVecCItr = TDoubleVec::const_iterator;
+        using TOptionalDouble = boost::optional<double>;
+        using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+        using TStrVec = std::vector<std::string>;
 
         //! Attributes for a persisted normalizer
         static const std::string MLCUE_ATTRIBUTE;
@@ -187,11 +187,11 @@ class MODEL_EXPORT CAnomalyScore
                 uint64_t checksum(void) const;
 
             private:
-                typedef std::pair<double, double> TDoubleDoublePr;
-                typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-                typedef TDoubleDoublePrVec::const_iterator TDoubleDoublePrVecCItr;
-                typedef std::greater<double> TGreaterDouble;
-                typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u, TGreaterDouble> TMaxValueAccumulator;
+                using TDoubleDoublePr = std::pair<double, double>;
+                using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+                using TDoubleDoublePrVecCItr = TDoubleDoublePrVec::const_iterator;
+                using TGreaterDouble = std::greater<double>;
+                using TMaxValueAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u, TGreaterDouble>;
 
             private:
                 //! Used to convert raw scores in to integers so that we
@@ -258,7 +258,7 @@ class MODEL_EXPORT CAnomalyScore
                 double m_TimeToQuantileDecay;
         };
 
-        typedef boost::shared_ptr<CNormalizer> TNormalizerP;
+        using TNormalizerP = boost::shared_ptr<CNormalizer>;
 
     public:
         //! Compute a joint anomaly score for a collection of probabilities.

--- a/include/model/CBucketGatherer.h
+++ b/include/model/CBucketGatherer.h
@@ -73,38 +73,38 @@ class CResourceMonitor;
 class MODEL_EXPORT CBucketGatherer
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<std::string> TStrVec;
-        typedef TStrVec::const_iterator TStrVecCItr;
-        typedef std::vector<const std::string*> TStrCPtrVec;
-        typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-        typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
-        typedef model_t::TFeatureVec TFeatureVec;
-        typedef boost::optional<double> TOptionalDouble;
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef std::pair<TSizeSizePr, uint64_t> TSizeSizePrUInt64Pr;
-        typedef std::vector<TSizeSizePrUInt64Pr> TSizeSizePrUInt64PrVec;
-        typedef core::CCompressedDictionary<2> TDictionary;
-        typedef TDictionary::CWordUMap<std::size_t>::Type TWordSizeUMap;
-        typedef TWordSizeUMap::iterator TWordSizeUMapItr;
-        typedef TWordSizeUMap::const_iterator TWordSizeUMapCItr;
-        typedef boost::unordered_map<TSizeSizePr, uint64_t> TSizeSizePrUInt64UMap;
-        typedef TSizeSizePrUInt64UMap::iterator TSizeSizePrUInt64UMapItr;
-        typedef TSizeSizePrUInt64UMap::const_iterator TSizeSizePrUInt64UMapCItr;
-        typedef CBucketQueue<TSizeSizePrUInt64UMap> TSizeSizePrUInt64UMapQueue;
-        typedef std::map<core_t::TTime, TSizeSizePrUInt64UMap> TTimeSizeSizePrUInt64UMapMap;
-        typedef TSizeSizePrUInt64UMapQueue::iterator TSizeSizePrUInt64UMapQueueItr;
-        typedef TSizeSizePrUInt64UMapQueue::const_iterator TSizeSizePrUInt64UMapQueueCItr;
-        typedef TSizeSizePrUInt64UMapQueue::const_reverse_iterator TSizeSizePrUInt64UMapQueueCRItr;
-        typedef boost::unordered_set<TSizeSizePr> TSizeSizePrUSet;
-        typedef TSizeSizePrUSet::const_iterator TSizeSizePrUSetCItr;
-        typedef CBucketQueue<TSizeSizePrUSet> TSizeSizePrUSetQueue;
-        typedef std::map<core_t::TTime, TSizeSizePrUSet> TTimeSizeSizePrUSetMap;
-        typedef TSizeSizePrUSetQueue::const_iterator TSizeSizePrUSetQueueCItr;
-        typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
-        typedef std::pair<TSizeSizePr, core::CStoredStringPtr> TSizeSizePrStoredStringPtrPr;
+        using TDoubleVec = std::vector<double>;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecCItr = TStrVec::const_iterator;
+        using TStrCPtrVec = std::vector<const std::string*>;
+        using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+        using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
+        using TFeatureVec = model_t::TFeatureVec;
+        using TOptionalDouble = boost::optional<double>;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, uint64_t>;
+        using TSizeSizePrUInt64PrVec = std::vector<TSizeSizePrUInt64Pr>;
+        using TDictionary = core::CCompressedDictionary<2>;
+        using TWordSizeUMap = TDictionary::CWordUMap<std::size_t>::Type;
+        using TWordSizeUMapItr = TWordSizeUMap::iterator;
+        using TWordSizeUMapCItr = TWordSizeUMap::const_iterator;
+        using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+        using TSizeSizePrUInt64UMapItr = TSizeSizePrUInt64UMap::iterator;
+        using TSizeSizePrUInt64UMapCItr = TSizeSizePrUInt64UMap::const_iterator;
+        using TSizeSizePrUInt64UMapQueue = CBucketQueue<TSizeSizePrUInt64UMap>;
+        using TTimeSizeSizePrUInt64UMapMap = std::map<core_t::TTime, TSizeSizePrUInt64UMap>;
+        using TSizeSizePrUInt64UMapQueueItr = TSizeSizePrUInt64UMapQueue::iterator;
+        using TSizeSizePrUInt64UMapQueueCItr = TSizeSizePrUInt64UMapQueue::const_iterator;
+        using TSizeSizePrUInt64UMapQueueCRItr = TSizeSizePrUInt64UMapQueue::const_reverse_iterator;
+        using TSizeSizePrUSet = boost::unordered_set<TSizeSizePr>;
+        using TSizeSizePrUSetCItr = TSizeSizePrUSet::const_iterator;
+        using TSizeSizePrUSetQueue = CBucketQueue<TSizeSizePrUSet>;
+        using TTimeSizeSizePrUSetMap = std::map<core_t::TTime, TSizeSizePrUSet>;
+        using TSizeSizePrUSetQueueCItr = TSizeSizePrUSetQueue::const_iterator;
+        using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
+        using TSizeSizePrStoredStringPtrPr = std::pair<TSizeSizePr, core::CStoredStringPtr>;
 
         //! \brief Hashes a ((size_t, size_t), string*) pair.
         struct MODEL_EXPORT SSizeSizePrStoredStringPtrPrHash
@@ -128,22 +128,23 @@ class MODEL_EXPORT CBucketGatherer
             }
         };
 
-        typedef boost::unordered_map<TSizeSizePrStoredStringPtrPr,
-                                     uint64_t,
-                                     SSizeSizePrStoredStringPtrPrHash,
-                                     SSizeSizePrStoredStringPtrPrEqual> TSizeSizePrStoredStringPtrPrUInt64UMap;
-        typedef TSizeSizePrStoredStringPtrPrUInt64UMap::const_iterator TSizeSizePrStoredStringPtrPrUInt64UMapCItr;
-        typedef TSizeSizePrStoredStringPtrPrUInt64UMap::iterator TSizeSizePrStoredStringPtrPrUInt64UMapItr;
-        typedef std::vector<TSizeSizePrStoredStringPtrPrUInt64UMap> TSizeSizePrStoredStringPtrPrUInt64UMapVec;
-        typedef CBucketQueue<TSizeSizePrStoredStringPtrPrUInt64UMapVec> TSizeSizePrStoredStringPtrPrUInt64UMapVecQueue;
-        typedef TSizeSizePrStoredStringPtrPrUInt64UMapVec::const_iterator TSizeSizePrStoredStringPtrPrUInt64UMapVecCItr;
-        typedef std::map<core_t::TTime, TSizeSizePrStoredStringPtrPrUInt64UMapVec> TTimeSizeSizePrStoredStringPtrPrUInt64UMapVecMap;
-        typedef boost::reference_wrapper<const CSearchKey> TSearchKeyCRef;
-        typedef std::pair<model_t::EFeature, boost::any> TFeatureAnyPr;
-        typedef std::vector<TFeatureAnyPr> TFeatureAnyPrVec;
-        typedef std::vector<model_t::EMetricCategory> TMetricCategoryVec;
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef TTimeVec::const_iterator TTimeVecCItr;
+        using TSizeSizePrStoredStringPtrPrUInt64UMap =
+                   boost::unordered_map<TSizeSizePrStoredStringPtrPr,
+                                        uint64_t,
+                                        SSizeSizePrStoredStringPtrPrHash,
+                                        SSizeSizePrStoredStringPtrPrEqual>;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapCItr = TSizeSizePrStoredStringPtrPrUInt64UMap::const_iterator;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapItr = TSizeSizePrStoredStringPtrPrUInt64UMap::iterator;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapVec = std::vector<TSizeSizePrStoredStringPtrPrUInt64UMap>;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapVecQueue = CBucketQueue<TSizeSizePrStoredStringPtrPrUInt64UMapVec>;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapVecCItr = TSizeSizePrStoredStringPtrPrUInt64UMapVec::const_iterator;
+        using TTimeSizeSizePrStoredStringPtrPrUInt64UMapVecMap = std::map<core_t::TTime, TSizeSizePrStoredStringPtrPrUInt64UMapVec>;
+        using TSearchKeyCRef = boost::reference_wrapper<const CSearchKey>;
+        using TFeatureAnyPr = std::pair<model_t::EFeature, boost::any>;
+        using TFeatureAnyPrVec = std::vector<TFeatureAnyPr>;
+        using TMetricCategoryVec = std::vector<model_t::EMetricCategory>;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TTimeVecCItr = TTimeVec::const_iterator;
 
     public:
         static const std::string EVENTRATE_BUCKET_GATHERER_TAG;
@@ -358,22 +359,20 @@ class MODEL_EXPORT CBucketGatherer
                            const F &extractId,
                            CBucketQueue<T> &queue)
         {
-            typedef typename CBucketQueue<T>::iterator TQueueItr;
-
-            for (TQueueItr bucketItr = queue.begin(); bucketItr != queue.end(); ++bucketItr)
+            for (auto bucketItr = queue.begin(); bucketItr != queue.end(); ++bucketItr)
             {
                 T &bucket = *bucketItr;
-                for (typename T::iterator i = bucket.begin(); i != bucket.end(); /**/)
-                 {
-                     if (std::binary_search(toRemove.begin(), toRemove.end(), extractId(*i)))
-                     {
-                         i = bucket.erase(i);
-                     }
-                     else
-                     {
-                         ++i;
-                     }
-                 }
+                for (auto i = bucket.begin(); i != bucket.end(); /**/)
+                {
+                    if (std::binary_search(toRemove.begin(), toRemove.end(), extractId(*i)))
+                    {
+                        i = bucket.erase(i);
+                    }
+                    else
+                    {
+                        ++i;
+                    }
+                }
             }
         }
 
@@ -387,14 +386,12 @@ class MODEL_EXPORT CBucketGatherer
                            const F &extractId,
                            CBucketQueue<std::vector<T> > &queue)
         {
-            typedef typename CBucketQueue<std::vector<T> >::iterator TQueueItr;
-
-            for (TQueueItr bucketItr = queue.begin(); bucketItr != queue.end(); ++bucketItr)
+            for (auto bucketItr = queue.begin(); bucketItr != queue.end(); ++bucketItr)
             {
                 for (std::size_t i = 0u; i < bucketItr->size(); ++i)
                 {
                     T &bucket = (*bucketItr)[i];
-                    for (typename T::iterator j = bucket.begin(); j != bucket.end(); /**/)
+                    for (auto j = bucket.begin(); j != bucket.end(); /**/)
                     {
                         if (std::binary_search(toRemove.begin(), toRemove.end(), extractId(j->first)))
                         {

--- a/include/model/CBucketQueue.h
+++ b/include/model/CBucketQueue.h
@@ -44,11 +44,11 @@ template<typename T>
 class CBucketQueue
 {
     public:
-        typedef boost::circular_buffer<T> TQueue;
-        typedef typename TQueue::value_type value_type;
-        typedef typename TQueue::iterator iterator;
-        typedef typename TQueue::const_iterator const_iterator;
-        typedef typename TQueue::const_reverse_iterator const_reverse_iterator;
+        using TQueue = boost::circular_buffer<T>;
+        using value_type = typename TQueue::value_type;
+        using iterator = typename TQueue::iterator;
+        using const_iterator = typename TQueue::const_iterator;
+        using const_reverse_iterator = typename TQueue::const_reverse_iterator;
 
     public:
         static const std::string BUCKET_TAG;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -231,10 +231,10 @@ class MODEL_EXPORT CCountingModel : public CAnomalyDetectorModel
         virtual const TStr1Vec &scheduledEventDescriptions(core_t::TTime time) const;
 
     public:
-        typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-        typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
-        typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-        typedef std::vector<TMeanAccumulator> TMeanAccumulatorVec;
+        using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+        using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
+        using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+        using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
 
     protected:
         //! Get the start time of the current bucket.
@@ -291,7 +291,7 @@ class MODEL_EXPORT CCountingModel : public CAnomalyDetectorModel
         virtual CMemoryUsageEstimator *memoryUsageEstimator(void) const;
 
     private:
-        typedef boost::unordered_map<core_t::TTime, TStr1Vec> TTimeStr1VecUMap;
+        using TTimeStr1VecUMap = boost::unordered_map<core_t::TTime, TStr1Vec>;
 
     private:
         //! The start time of the last sampled bucket.

--- a/include/model/CCountingModelFactory.h
+++ b/include/model/CCountingModelFactory.h
@@ -132,7 +132,7 @@ class MODEL_EXPORT CCountingModelFactory : public CModelFactory
         virtual void features(const TFeatureVec &features);
 
         //! Set the bucket results delay
-        virtual void bucketResultsDelay(std::size_t bucketResultsDelay) ;
+        virtual void bucketResultsDelay(std::size_t bucketResultsDelay);
         //@}
 
     private:

--- a/include/model/CDataGatherer.h
+++ b/include/model/CDataGatherer.h
@@ -113,41 +113,41 @@ class CSearchKey;
 class MODEL_EXPORT CDataGatherer
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<std::string> TStrVec;
-        typedef TStrVec::const_iterator TStrVecCItr;
-        typedef std::vector<const std::string*> TStrCPtrVec;
-        typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-        typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
-        typedef model_t::TFeatureVec TFeatureVec;
-        typedef TFeatureVec::const_iterator TFeatureVecCItr;
-        typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-        typedef std::pair<TSizeSizePr, uint64_t> TSizeSizePrUInt64Pr;
-        typedef std::vector<TSizeSizePrUInt64Pr> TSizeSizePrUInt64PrVec;
-        typedef boost::unordered_map<TSizeSizePr, uint64_t> TSizeSizePrUInt64UMap;
-        typedef TSizeSizePrUInt64UMap::iterator TSizeSizePrUInt64UMapItr;
-        typedef TSizeSizePrUInt64UMap::const_iterator TSizeSizePrUInt64UMapCItr;
-        typedef CBucketQueue<TSizeSizePrUInt64UMap> TSizeSizePrUInt64UMapQueue;
-        typedef TSizeSizePrUInt64UMapQueue::iterator TSizeSizePrUInt64UMapQueueItr;
-        typedef TSizeSizePrUInt64UMapQueue::const_iterator TSizeSizePrUInt64UMapQueueCItr;
-        typedef TSizeSizePrUInt64UMapQueue::const_reverse_iterator TSizeSizePrUInt64UMapQueueCRItr;
-        typedef CBucketGatherer::TSizeSizePrStoredStringPtrPrUInt64UMap TSizeSizePrStoredStringPtrPrUInt64UMap;
-        typedef TSizeSizePrStoredStringPtrPrUInt64UMap::const_iterator TSizeSizePrStoredStringPtrPrUInt64UMapCItr;
-        typedef TSizeSizePrStoredStringPtrPrUInt64UMap::iterator TSizeSizePrStoredStringPtrPrUInt64UMapItr;
-        typedef std::vector<TSizeSizePrStoredStringPtrPrUInt64UMap> TSizeSizePrStoredStringPtrPrUInt64UMapVec;
-        typedef CBucketQueue<TSizeSizePrStoredStringPtrPrUInt64UMapVec> TSizeSizePrStoredStringPtrPrUInt64UMapVecQueue;
-        typedef boost::reference_wrapper<const CSearchKey> TSearchKeyCRef;
-        typedef std::vector<CBucketGatherer*> TBucketGathererPVec;
-        typedef TBucketGathererPVec::iterator TBucketGathererPVecItr;
-        typedef TBucketGathererPVec::const_iterator TBucketGathererPVecCItr;
-        typedef std::pair<model_t::EFeature, boost::any> TFeatureAnyPr;
-        typedef std::vector<TFeatureAnyPr> TFeatureAnyPrVec;
-        typedef std::vector<model_t::EMetricCategory> TMetricCategoryVec;
-        typedef boost::shared_ptr<CSampleCounts> TSampleCountsPtr;
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef TTimeVec::const_iterator TTimeVecCItr;
+        using TDoubleVec = std::vector<double>;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TSizeVec = std::vector<std::size_t>;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecCItr = TStrVec::const_iterator;
+        using TStrCPtrVec = std::vector<const std::string*>;
+        using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+        using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
+        using TFeatureVec = model_t::TFeatureVec;
+        using TFeatureVecCItr = TFeatureVec::const_iterator;
+        using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+        using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, uint64_t>;
+        using TSizeSizePrUInt64PrVec = std::vector<TSizeSizePrUInt64Pr>;
+        using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+        using TSizeSizePrUInt64UMapItr = TSizeSizePrUInt64UMap::iterator;
+        using TSizeSizePrUInt64UMapCItr = TSizeSizePrUInt64UMap::const_iterator;
+        using TSizeSizePrUInt64UMapQueue = CBucketQueue<TSizeSizePrUInt64UMap>;
+        using TSizeSizePrUInt64UMapQueueItr = TSizeSizePrUInt64UMapQueue::iterator;
+        using TSizeSizePrUInt64UMapQueueCItr = TSizeSizePrUInt64UMapQueue::const_iterator;
+        using TSizeSizePrUInt64UMapQueueCRItr = TSizeSizePrUInt64UMapQueue::const_reverse_iterator;
+        using TSizeSizePrStoredStringPtrPrUInt64UMap = CBucketGatherer::TSizeSizePrStoredStringPtrPrUInt64UMap;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapCItr = TSizeSizePrStoredStringPtrPrUInt64UMap::const_iterator;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapItr = TSizeSizePrStoredStringPtrPrUInt64UMap::iterator;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapVec = std::vector<TSizeSizePrStoredStringPtrPrUInt64UMap>;
+        using TSizeSizePrStoredStringPtrPrUInt64UMapVecQueue = CBucketQueue<TSizeSizePrStoredStringPtrPrUInt64UMapVec>;
+        using TSearchKeyCRef = boost::reference_wrapper<const CSearchKey>;
+        using TBucketGathererPVec = std::vector<CBucketGatherer*>;
+        using TBucketGathererPVecItr = TBucketGathererPVec::iterator;
+        using TBucketGathererPVecCItr = TBucketGathererPVec::const_iterator;
+        using TFeatureAnyPr = std::pair<model_t::EFeature, boost::any>;
+        using TFeatureAnyPrVec = std::vector<TFeatureAnyPr>;
+        using TMetricCategoryVec = std::vector<model_t::EMetricCategory>;
+        using TSampleCountsPtr = boost::shared_ptr<CSampleCounts>;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TTimeVecCItr = TTimeVec::const_iterator;
 
     public:
         //! The summary count indicating an explicit null record.
@@ -735,7 +735,7 @@ class MODEL_EXPORT CDataGatherer
         static const std::string EXPLICIT_NULL;
 
     private:
-        typedef boost::reference_wrapper<const SModelParams> TModelParamsCRef;
+        using TModelParamsCRef = boost::reference_wrapper<const SModelParams>;
 
     private:
         //! Select the correct bucket gatherer based on the time: if we have

--- a/include/model/CDetectorEqualizer.h
+++ b/include/model/CDetectorEqualizer.h
@@ -48,8 +48,8 @@ class CModelConfig;
 class MODEL_EXPORT CDetectorEqualizer
 {
     public:
-        typedef std::pair<int, maths::CQuantileSketch> TIntQuantileSketchPr;
-        typedef std::vector<TIntQuantileSketchPr> TIntQuantileSketchPrVec;
+        using TIntQuantileSketchPr = std::pair<int, maths::CQuantileSketch>;
+        using TIntQuantileSketchPrVec = std::vector<TIntQuantileSketchPr>;
 
     public:
         //! Add \p probability to the detector's quantile sketch.

--- a/include/model/CDynamicStringIdRegistry.h
+++ b/include/model/CDynamicStringIdRegistry.h
@@ -50,13 +50,13 @@ class CResourceMonitor;
 class MODEL_EXPORT CDynamicStringIdRegistry
 {
     public:
-        typedef core::CCompressedDictionary<2> TDictionary;
-        typedef TDictionary::CWordUMap<std::size_t>::Type TWordSizeUMap;
-        typedef TWordSizeUMap::iterator TWordSizeUMapItr;
-        typedef TWordSizeUMap::const_iterator TWordSizeUMapCItr;
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<std::string> TStrVec;
-        typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
+        using TDictionary = core::CCompressedDictionary<2>;
+        using TWordSizeUMap = TDictionary::CWordUMap<std::size_t>::Type;
+        using TWordSizeUMapItr = TWordSizeUMap::iterator;
+        using TWordSizeUMapCItr = TWordSizeUMap::const_iterator;
+        using TSizeVec = std::vector<std::size_t>;
+        using TStrVec = std::vector<std::string>;
+        using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
 
     public:
         //! An identifier which will never be used for a real string.

--- a/include/model/CEventData.h
+++ b/include/model/CEventData.h
@@ -56,18 +56,18 @@ namespace model
 class MODEL_EXPORT CEventData
 {
     public:
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef boost::optional<std::size_t> TOptionalSize;
-        typedef std::vector<TOptionalSize> TOptionalSizeVec;
-        typedef boost::optional<double> TOptionalDouble;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TOptionalSize = boost::optional<std::size_t>;
+        using TOptionalSizeVec = std::vector<TOptionalSize>;
+        using TOptionalDouble = boost::optional<double>;
         // Fixed size array - one element per metric category
-        typedef boost::array<TDouble1Vec, model_t::NUM_METRIC_CATEGORIES> TDouble1VecArray;
+        using TDouble1VecArray = boost::array<TDouble1Vec, model_t::NUM_METRIC_CATEGORIES>;
         // Second element in pair stores count
-        typedef std::pair<TDouble1VecArray, std::size_t> TDouble1VecArraySizePr;
-        typedef boost::optional<TDouble1VecArraySizePr> TOptionalDouble1VecArraySizePr;
-        typedef std::vector<TOptionalDouble1VecArraySizePr> TOptionalDouble1VecArraySizePrVec;
-        typedef boost::optional<std::string> TOptionalStr;
-        typedef std::vector<TOptionalStr> TOptionalStrVec;
+        using TDouble1VecArraySizePr = std::pair<TDouble1VecArray, std::size_t>;
+        using TOptionalDouble1VecArraySizePr = boost::optional<TDouble1VecArraySizePr>;
+        using TOptionalDouble1VecArraySizePrVec = std::vector<TOptionalDouble1VecArraySizePr>;
+        using TOptionalStr = boost::optional<std::string>;
+        using TOptionalStrVec = std::vector<TOptionalStr>;
 
     public:
         //! Create uninitialized event data.

--- a/include/model/CEventRateBucketGatherer.h
+++ b/include/model/CEventRateBucketGatherer.h
@@ -47,21 +47,21 @@ namespace model
 class MODEL_EXPORT CUniqueStringFeatureData
 {
     public:
-        typedef core::CCompressedDictionary<1> TDictionary1;
-        typedef TDictionary1::CWord TWord;
-        typedef TDictionary1::TWordSet TWordSet;
-        typedef TWordSet::const_iterator TWordSetCItr;
-        typedef TDictionary1::CWordUMap<std::string>::Type TWordStringUMap;
-        typedef TWordStringUMap::const_iterator TWordStringUMapCItr;
-        typedef boost::unordered_map<core::CStoredStringPtr, TWordSet> TStoredStringPtrWordSetUMap;
-        typedef TStoredStringPtrWordSetUMap::const_iterator TStoredStringPtrWordSetUMapCItr;
-        typedef std::vector<TStoredStringPtrWordSetUMap> TStoredStringPtrWordSetUMapVec;
-        typedef SEventRateFeatureData::TStrCRef TStrCRef;
-        typedef SEventRateFeatureData::TDouble1Vec TDouble1Vec;
-        typedef SEventRateFeatureData::TDouble1VecDoublePr TDouble1VecDoublePr;
-        typedef SEventRateFeatureData::TStrCRefDouble1VecDoublePrPr TStrCRefDouble1VecDoublePrPr;
-        typedef SEventRateFeatureData::TStrCRefDouble1VecDoublePrPrVec TStrCRefDouble1VecDoublePrPrVec;
-        typedef CBucketGatherer::TStoredStringPtrVec TStoredStringPtrVec;
+        using TDictionary1 = core::CCompressedDictionary<1>;
+        using TWord = TDictionary1::CWord;
+        using TWordSet = TDictionary1::TWordSet;
+        using TWordSetCItr = TWordSet::const_iterator;
+        using TWordStringUMap = TDictionary1::CWordUMap<std::string>::Type;
+        using TWordStringUMapCItr = TWordStringUMap::const_iterator;
+        using TStoredStringPtrWordSetUMap = boost::unordered_map<core::CStoredStringPtr, TWordSet>;
+        using TStoredStringPtrWordSetUMapCItr = TStoredStringPtrWordSetUMap::const_iterator;
+        using TStoredStringPtrWordSetUMapVec = std::vector<TStoredStringPtrWordSetUMap>;
+        using TStrCRef = SEventRateFeatureData::TStrCRef;
+        using TDouble1Vec = SEventRateFeatureData::TDouble1Vec;
+        using TDouble1VecDoublePr = SEventRateFeatureData::TDouble1VecDoublePr;
+        using TStrCRefDouble1VecDoublePrPr = SEventRateFeatureData::TStrCRefDouble1VecDoublePrPr;
+        using TStrCRefDouble1VecDoublePrPrVec = SEventRateFeatureData::TStrCRefDouble1VecDoublePrPrVec;
+        using TStoredStringPtrVec = CBucketGatherer::TStoredStringPtrVec;
 
     public:
         //! Add a string into the collection
@@ -107,17 +107,17 @@ class MODEL_EXPORT CUniqueStringFeatureData
 class MODEL_EXPORT CEventRateBucketGatherer : public CBucketGatherer
 {
     public:
-        typedef std::map<model_t::EEventRateCategory, boost::any> TCategoryAnyMap;
-        typedef SEventRateFeatureData::TStrCRef TStrCRef;
-        typedef SEventRateFeatureData::TDouble1Vec TDouble1Vec;
-        typedef SEventRateFeatureData::TDouble1VecDoublePr TDouble1VecDoublePr;
-        typedef SEventRateFeatureData::TStrCRefDouble1VecDoublePrPr TStrCRefDouble1VecDoublePrPr;
-        typedef SEventRateFeatureData::TStrCRefDouble1VecDoublePrPrVec TStrCRefDouble1VecDoublePrPrVec;
-        typedef SEventRateFeatureData::TStrCRefDouble1VecDoublePrPrVecVec TStrCRefDouble1VecDoublePrPrVecVec;
-        typedef std::pair<std::size_t, SEventRateFeatureData> TSizeFeatureDataPr;
-        typedef std::vector<TSizeFeatureDataPr> TSizeFeatureDataPrVec;
-        typedef std::pair<TSizeSizePr, SEventRateFeatureData> TSizeSizePrFeatureDataPr;
-        typedef std::vector<TSizeSizePrFeatureDataPr> TSizeSizePrFeatureDataPrVec;
+        using TCategoryAnyMap = std::map<model_t::EEventRateCategory, boost::any>;
+        using TStrCRef = SEventRateFeatureData::TStrCRef;
+        using TDouble1Vec = SEventRateFeatureData::TDouble1Vec;
+        using TDouble1VecDoublePr = SEventRateFeatureData::TDouble1VecDoublePr;
+        using TStrCRefDouble1VecDoublePrPr = SEventRateFeatureData::TStrCRefDouble1VecDoublePrPr;
+        using TStrCRefDouble1VecDoublePrPrVec = SEventRateFeatureData::TStrCRefDouble1VecDoublePrPrVec;
+        using TStrCRefDouble1VecDoublePrPrVecVec = SEventRateFeatureData::TStrCRefDouble1VecDoublePrPrVecVec;
+        using TSizeFeatureDataPr = std::pair<std::size_t, SEventRateFeatureData>;
+        using TSizeFeatureDataPrVec = std::vector<TSizeFeatureDataPr>;
+        using TSizeSizePrFeatureDataPr = std::pair<TSizeSizePr, SEventRateFeatureData>;
+        using TSizeSizePrFeatureDataPrVec = std::vector<TSizeSizePrFeatureDataPr>;
 
     public:
         //! \name Life-cycle

--- a/include/model/CEventRateModelFactory.h
+++ b/include/model/CEventRateModelFactory.h
@@ -142,7 +142,7 @@ class MODEL_EXPORT CEventRateModelFactory : public CModelFactory
         virtual void features(const TFeatureVec &features);
 
         //! Set the bucket results delay
-        virtual void bucketResultsDelay(std::size_t bucketResultsDelay) ;
+        virtual void bucketResultsDelay(std::size_t bucketResultsDelay);
         //@}
 
     private:

--- a/include/model/CEventRatePopulationModelFactory.h
+++ b/include/model/CEventRatePopulationModelFactory.h
@@ -144,7 +144,7 @@ class MODEL_EXPORT CEventRatePopulationModelFactory : public CModelFactory
         virtual void features(const TFeatureVec &features);
 
         //! Set the bucket results delay
-        virtual void bucketResultsDelay(std::size_t bucketResultsDelay) ;
+        virtual void bucketResultsDelay(std::size_t bucketResultsDelay);
         //@}
 
     private:

--- a/include/model/CGathererTools.h
+++ b/include/model/CGathererTools.h
@@ -68,17 +68,17 @@ namespace model
 class MODEL_EXPORT CGathererTools
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef boost::optional<double> TOptionalDouble;
-        typedef std::vector<CSample> TSampleVec;
-        typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-        typedef maths::CFixedQuantileSketch<maths::CQuantileSketch::E_PiecewiseConstant, 30> TMedianAccumulator;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u> TMinAccumulator;
-        typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double> > TMaxAccumulator;
-        typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TVarianceAccumulator;
-        typedef CMetricMultivariateStatistic<TMeanAccumulator> TMultivariateMeanAccumulator;
-        typedef CMetricMultivariateStatistic<TMinAccumulator> TMultivariateMinAccumulator;
-        typedef CMetricMultivariateStatistic<TMaxAccumulator> TMultivariateMaxAccumulator;
+        using TDoubleVec = std::vector<double>;
+        using TOptionalDouble = boost::optional<double>;
+        using TSampleVec = std::vector<CSample>;
+        using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+        using TMedianAccumulator = maths::CFixedQuantileSketch<maths::CQuantileSketch::E_PiecewiseConstant, 30>;
+        using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u>;
+        using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double> >;
+        using TVarianceAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+        using TMultivariateMeanAccumulator = CMetricMultivariateStatistic<TMeanAccumulator>;
+        using TMultivariateMinAccumulator = CMetricMultivariateStatistic<TMinAccumulator>;
+        using TMultivariateMaxAccumulator = CMetricMultivariateStatistic<TMaxAccumulator>;
 
         //! \brief Mean arrival time gatherer.
         //!
@@ -88,7 +88,7 @@ class MODEL_EXPORT CGathererTools
         class MODEL_EXPORT CArrivalTimeGatherer
         {
             public:
-                typedef TMeanAccumulator TAccumulator;
+                using TAccumulator = TMeanAccumulator;
 
             public:
                 //! The earliest possible time.
@@ -162,22 +162,22 @@ class MODEL_EXPORT CGathererTools
         //!
         //! This also computes the mean of all measurements in the current
         //! bucketing interval.
-        typedef CSampleGatherer<TMeanAccumulator,
-                                model_t::E_IndividualMeanByPerson> TMeanGatherer;
+        using TMeanGatherer = CSampleGatherer<TMeanAccumulator,
+                                              model_t::E_IndividualMeanByPerson>;
 
         //! \brief Multivariate mean statistic gatherer.
         //!
         //! See TMeanGatherer for details.
-        typedef CSampleGatherer<TMultivariateMeanAccumulator,
-                                model_t::E_IndividualMeanByPerson> TMultivariateMeanGatherer;
+        using TMultivariateMeanGatherer = CSampleGatherer<TMultivariateMeanAccumulator,
+                                                          model_t::E_IndividualMeanByPerson>;
 
         //! \brief Median statistic gatherer.
         //!
         //! DESCRIPTION:\n
         //! Wraps up the functionality to sample the median of a fixed number
         //! of measurements, which are supplied to the add function.
-        typedef CSampleGatherer<TMedianAccumulator,
-                                model_t::E_IndividualMedianByPerson> TMedianGatherer;
+        using TMedianGatherer = CSampleGatherer<TMedianAccumulator,
+                                                model_t::E_IndividualMedianByPerson>;
 
         // TODO Add multivariate median.
 
@@ -189,14 +189,14 @@ class MODEL_EXPORT CGathererTools
         //!
         //! This also computes the minimum of all measurements in the current
         //! bucketing interval.
-        typedef CSampleGatherer<TMinAccumulator,
-                                model_t::E_IndividualMinByPerson> TMinGatherer;
+        using TMinGatherer = CSampleGatherer<TMinAccumulator,
+                                             model_t::E_IndividualMinByPerson>;
 
         //! \brief Multivariate minimum statistic gatherer.
         //!
         //! See TMinGatherer for details.
-        typedef CSampleGatherer<TMultivariateMinAccumulator,
-                                model_t::E_IndividualMinByPerson> TMultivariateMinGatherer;
+        using TMultivariateMinGatherer = CSampleGatherer<TMultivariateMinAccumulator,
+                                                         model_t::E_IndividualMinByPerson>;
 
         //! \brief Maximum statistic gatherer.
         //!
@@ -206,14 +206,14 @@ class MODEL_EXPORT CGathererTools
         //!
         //! This also computes the maximum of all measurements in the current
         //! bucketing interval.
-        typedef CSampleGatherer<TMaxAccumulator,
-                                model_t::E_IndividualMaxByPerson> TMaxGatherer;
+        using TMaxGatherer = CSampleGatherer<TMaxAccumulator,
+                                             model_t::E_IndividualMaxByPerson>;
 
         //! \brief Multivariate maximum statistic gatherer.
         //!
         //! See TMaxGatherer for details.
-        typedef CSampleGatherer<TMultivariateMaxAccumulator,
-                                model_t::E_IndividualMaxByPerson> TMultivariateMaxGatherer;
+        using TMultivariateMaxGatherer = CSampleGatherer<TMultivariateMaxAccumulator,
+                                                         model_t::E_IndividualMaxByPerson>;
 
         //! \brief Variance statistic gatherer.
         //!
@@ -223,8 +223,8 @@ class MODEL_EXPORT CGathererTools
         //!
         //! This also computes the variance of all measurements in the current
         //! bucketing interval.
-        typedef CSampleGatherer<TVarianceAccumulator,
-                                model_t::E_IndividualVarianceByPerson> TVarianceGatherer;
+        using TVarianceGatherer = CSampleGatherer<TVarianceAccumulator,
+                                                  model_t::E_IndividualVarianceByPerson>;
 
         // TODO Add multivariate variance.
 
@@ -236,20 +236,20 @@ class MODEL_EXPORT CGathererTools
         class MODEL_EXPORT CSumGatherer
         {
             public:
-                typedef core::CSmallVector<double, 1> TDouble1Vec;
-                typedef std::vector<std::string> TStrVec;
-                typedef TStrVec::const_iterator TStrVecCItr;
-                typedef boost::optional<std::string> TOptionalStr;
-                typedef std::vector<TOptionalStr> TOptionalStrVec;
-                typedef CBucketQueue<TSampleVec> TSampleVecQueue;
-                typedef TSampleVecQueue::iterator TSampleVecQueueItr;
-                typedef TSampleVecQueue::const_iterator TSampleVecQueueCItr;
-                typedef boost::unordered_map<core::CStoredStringPtr, double> TStoredStringPtrDoubleUMap;
-                typedef TStoredStringPtrDoubleUMap::const_iterator TStoredStringPtrDoubleUMapCItr;
-                typedef CBucketQueue<TStoredStringPtrDoubleUMap> TStoredStringPtrDoubleUMapQueue;
-                typedef TStoredStringPtrDoubleUMapQueue::const_reverse_iterator TStoredStringPtrDoubleUMapQueueCRItr;
-                typedef std::vector<TStoredStringPtrDoubleUMapQueue> TStoredStringPtrDoubleUMapQueueVec;
-                typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
+                using TDouble1Vec = core::CSmallVector<double, 1>;
+                using TStrVec = std::vector<std::string>;
+                using TStrVecCItr = TStrVec::const_iterator;
+                using TOptionalStr = boost::optional<std::string>;
+                using TOptionalStrVec = std::vector<TOptionalStr>;
+                using TSampleVecQueue = CBucketQueue<TSampleVec>;
+                using TSampleVecQueueItr = TSampleVecQueue::iterator;
+                using TSampleVecQueueCItr = TSampleVecQueue::const_iterator;
+                using TStoredStringPtrDoubleUMap = boost::unordered_map<core::CStoredStringPtr, double>;
+                using TStoredStringPtrDoubleUMapCItr = TStoredStringPtrDoubleUMap::const_iterator;
+                using TStoredStringPtrDoubleUMapQueue = CBucketQueue<TStoredStringPtrDoubleUMap>;
+                using TStoredStringPtrDoubleUMapQueueCRItr = TStoredStringPtrDoubleUMapQueue::const_reverse_iterator;
+                using TStoredStringPtrDoubleUMapQueueVec = std::vector<TStoredStringPtrDoubleUMapQueue>;
+                using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
 
             public:
                 CSumGatherer(const SModelParams &params,

--- a/include/model/CHierarchicalResults.h
+++ b/include/model/CHierarchicalResults.h
@@ -52,11 +52,11 @@ class CLimits;
 namespace hierarchical_results_detail
 {
 
-typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
-typedef std::pair<core::CStoredStringPtr, core::CStoredStringPtr> TStoredStringPtrStoredStringPtrPr;
-typedef std::pair<TStoredStringPtrStoredStringPtrPr, double> TStoredStringPtrStoredStringPtrPrDoublePr;
-typedef std::vector<TStoredStringPtrStoredStringPtrPrDoublePr> TStoredStringPtrStoredStringPtrPrDoublePrVec;
-typedef core::CSmallVector<std::string, 1> TStr1Vec;
+using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
+using TStoredStringPtrStoredStringPtrPr = std::pair<core::CStoredStringPtr, core::CStoredStringPtr>;
+using TStoredStringPtrStoredStringPtrPrDoublePr = std::pair<TStoredStringPtrStoredStringPtrPr, double>;
+using TStoredStringPtrStoredStringPtrPrDoublePrVec = std::vector<TStoredStringPtrStoredStringPtrPrDoublePr>;
+using TStr1Vec = core::CSmallVector<std::string, 1>;
 
 //! \brief The data fully describing a result node.
 //!
@@ -145,11 +145,11 @@ struct MODEL_EXPORT SResultSpec
 //! \see buildHierarchicalResults for more details.
 struct MODEL_EXPORT SNode
 {
-    typedef std::vector<SAttributeProbability> TAttributeProbabilityVec;
-    typedef const SNode *TNodeCPtr;
-    typedef std::vector<TNodeCPtr> TNodeCPtrVec;
-    typedef boost::unordered_map<TNodeCPtr, std::size_t> TNodePtrSizeUMap;
-    typedef boost::unordered_map<std::size_t, TNodeCPtr> TSizeNodePtrUMap;
+    using TAttributeProbabilityVec = std::vector<SAttributeProbability>;
+    using TNodeCPtr = const SNode*;
+    using TNodeCPtrVec = std::vector<TNodeCPtr>;
+    using TNodePtrSizeUMap = boost::unordered_map<TNodeCPtr, std::size_t>;
+    using TSizeNodePtrUMap = boost::unordered_map<std::size_t, TNodeCPtr>;
 
     SNode(void);
     SNode(const SResultSpec &simpleSearch, SAnnotatedProbability &annotatedProbability);
@@ -264,19 +264,20 @@ class CHierarchicalResultsVisitor;
 class MODEL_EXPORT CHierarchicalResults
 {
     public:
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<SAttributeProbability> TAttributeProbabilityVec;
-        typedef hierarchical_results_detail::SResultSpec TResultSpec;
-        typedef core::CStoredStringPtr TStoredStringPtr;
-        typedef hierarchical_results_detail::TStoredStringPtrStoredStringPtrPr TStoredStringPtrStoredStringPtrPr;
-        typedef hierarchical_results_detail::TStoredStringPtrStoredStringPtrPrDoublePr TStoredStringPtrStoredStringPtrPrDoublePr;
-        typedef hierarchical_results_detail::TStoredStringPtrStoredStringPtrPrDoublePrVec TStoredStringPtrStoredStringPtrPrDoublePrVec;
-        typedef hierarchical_results_detail::SNode TNode;
-        typedef hierarchical_results_detail::SNode::TNodePtrSizeUMap TNodePtrSizeUMap;
-        typedef hierarchical_results_detail::SNode::TSizeNodePtrUMap TSizeNodePtrUMap;
-        typedef std::deque<TNode> TNodeDeque;
-        typedef std::map<TStoredStringPtrStoredStringPtrPr, TNode, maths::COrderings::SLexicographicalCompare> TStoredStringPtrStoredStringPtrPrNodeMap;
-        typedef std::map<TStoredStringPtr, TNode, maths::COrderings::SLess> TStoredStringPtrNodeMap;
+        using TDoubleVec = std::vector<double>;
+        using TAttributeProbabilityVec = std::vector<SAttributeProbability>;
+        using TResultSpec = hierarchical_results_detail::SResultSpec;
+        using TStoredStringPtr = core::CStoredStringPtr;
+        using TStoredStringPtrStoredStringPtrPr = hierarchical_results_detail::TStoredStringPtrStoredStringPtrPr;
+        using TStoredStringPtrStoredStringPtrPrDoublePr = hierarchical_results_detail::TStoredStringPtrStoredStringPtrPrDoublePr;
+        using TStoredStringPtrStoredStringPtrPrDoublePrVec = hierarchical_results_detail::TStoredStringPtrStoredStringPtrPrDoublePrVec;
+        using TNode = hierarchical_results_detail::SNode;
+        using TNodePtrSizeUMap = hierarchical_results_detail::SNode::TNodePtrSizeUMap;
+        using TSizeNodePtrUMap = hierarchical_results_detail::SNode::TSizeNodePtrUMap;
+        using TNodeDeque = std::deque<TNode>;
+        using TStoredStringPtrStoredStringPtrPrNodeMap =
+                  std::map<TStoredStringPtrStoredStringPtrPr, TNode, maths::COrderings::SLexicographicalCompare>;
+        using TStoredStringPtrNodeMap = std::map<TStoredStringPtr, TNode, maths::COrderings::SLess>;
 
     public:
         CHierarchicalResults(void);
@@ -434,7 +435,7 @@ class MODEL_EXPORT CHierarchicalResults
 class MODEL_EXPORT CHierarchicalResultsVisitor
 {
     public:
-        typedef CHierarchicalResults::TNode TNode;
+        using TNode = CHierarchicalResults::TNode;
 
     public:
         virtual ~CHierarchicalResultsVisitor(void);

--- a/include/model/CHierarchicalResultsLevelSet.h
+++ b/include/model/CHierarchicalResultsLevelSet.h
@@ -54,14 +54,14 @@ template<typename T>
 class CHierarchicalResultsLevelSet : public CHierarchicalResultsVisitor
 {
     protected:
-        typedef T Type;
-        typedef std::vector<Type *> TTypePtrVec;
-        typedef core::CCompressedDictionary<1> TDictionary;
-        typedef TDictionary::CWord TWord;
-        typedef std::pair<TWord, T> TWordTypePr;
-        typedef std::vector<TWordTypePr> TWordTypePrVec;
-        typedef typename TWordTypePrVec::iterator TWordTypePrVecItr;
-        typedef typename TWordTypePrVec::const_iterator TWordTypePrVecCItr;
+        using Type = T;
+        using TTypePtrVec = std::vector<Type *>;
+        using TDictionary = core::CCompressedDictionary<1>;
+        using TWord = TDictionary::CWord;
+        using TWordTypePr = std::pair<TWord, T>;
+        using TWordTypePrVec = std::vector<TWordTypePr>;
+        using TWordTypePrVecItr = typename TWordTypePrVec::iterator;
+        using TWordTypePrVecCItr = typename TWordTypePrVec::const_iterator;
 
     protected:
         explicit CHierarchicalResultsLevelSet(const T &bucketElement) :

--- a/include/model/CHierarchicalResultsNormalizer.h
+++ b/include/model/CHierarchicalResultsNormalizer.h
@@ -36,7 +36,7 @@ class CAnomalyDetectorModelConfig;
 namespace hierarchical_results_normalizer_detail
 {
 
-typedef boost::shared_ptr<CAnomalyScore::CNormalizer> TNormalizerPtr;
+using TNormalizerPtr = boost::shared_ptr<CAnomalyScore::CNormalizer>;
 
 //! \brief A normalizer instance and a descriptive string.
 struct MODEL_EXPORT SNormalizer
@@ -96,12 +96,12 @@ class MODEL_EXPORT CHierarchicalResultsNormalizer :
           private core::CNonCopyable
 {
     public:
-        typedef CHierarchicalResultsLevelSet<hierarchical_results_normalizer_detail::SNormalizer> TBase;
-        typedef TBase::Type TNormalizer;
-        typedef TBase::TTypePtrVec TNormalizerPtrVec;
-        typedef TBase::TWordTypePr TWordNormalizerPr;
-        typedef TBase::TWordTypePrVec TWordNormalizerPrVec;
-        typedef std::vector<std::string> TStrVec;
+        using TBase = CHierarchicalResultsLevelSet<hierarchical_results_normalizer_detail::SNormalizer>;
+        using TNormalizer = TBase::Type;
+        using TNormalizerPtrVec = TBase::TTypePtrVec;
+        using TWordNormalizerPr = TBase::TWordTypePr;
+        using TWordNormalizerPrVec = TBase::TWordTypePrVec;
+        using TStrVec = std::vector<std::string>;
 
         //! Enumeration of the possible jobs that the normalizer can
         //! perform when invoked.

--- a/include/model/CIndividualModelDetail.h
+++ b/include/model/CIndividualModelDetail.h
@@ -31,7 +31,7 @@ void CIndividualModel::currentBucketPersonIds(core_t::TTime time,
                                               const T &featureData,
                                               TSizeVec &result) const
 {
-    typedef boost::unordered_set<std::size_t> TSizeUSet;
+    using TSizeUSet = boost::unordered_set<std::size_t>;
 
     result.clear();
 
@@ -104,7 +104,7 @@ void CIndividualModel::sampleBucketStatistics(core_t::TTime startTime,
         this->CIndividualModel::sampleBucketStatistics(time, time + bucketLength, resourceMonitor);
 
         gatherer.featureData(time, bucketLength, featureData);
-        for (auto &&feature_ : featureData)
+        for (auto &feature_ : featureData)
         {
             T &data = feature_.second;
             LOG_TRACE(model_t::print(feature_.first) << " data = " << core::CContainerPrinter::print(data));

--- a/include/model/CInterimBucketCorrector.h
+++ b/include/model/CInterimBucketCorrector.h
@@ -53,9 +53,9 @@ namespace model
 class MODEL_EXPORT CInterimBucketCorrector
 {
     private:
-        typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef core::CSmallVector<double, 10> TDouble10Vec;
+        using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TDouble10Vec = core::CSmallVector<double, 10>;
 
     public:
         //! Constructs an interim bucket corrector for buckets of length \p bucketLength

--- a/include/model/CMemoryUsageEstimator.h
+++ b/include/model/CMemoryUsageEstimator.h
@@ -60,8 +60,8 @@ class MODEL_EXPORT CMemoryUsageEstimator
             E_Correlations,
             E_NumberPredictors
         };
-        typedef boost::array<std::size_t, E_NumberPredictors> TSizeArray;
-        typedef boost::optional<std::size_t> TOptionalSize;
+        using TSizeArray = boost::array<std::size_t, E_NumberPredictors>;
+        using TOptionalSize = boost::optional<std::size_t>;
 
     public:
         //! Constructor
@@ -92,9 +92,9 @@ class MODEL_EXPORT CMemoryUsageEstimator
         bool acceptRestoreTraverser(core::CStateRestoreTraverser &traverser);
 
     private:
-        typedef std::pair<TSizeArray, std::size_t> TSizeArraySizePr;
-        typedef boost::circular_buffer<TSizeArraySizePr> TSizeArraySizePrBuf;
-        typedef TSizeArraySizePrBuf::const_iterator TSizeArraySizePrBufCItr;
+        using TSizeArraySizePr = std::pair<TSizeArray, std::size_t>;
+        using TSizeArraySizePrBuf = boost::circular_buffer<TSizeArraySizePr>;
+        using TSizeArraySizePrBufCItr = TSizeArraySizePrBuf::const_iterator;
 
     private:
         //! Get the maximum amount by which we'll extrapolate the memory usage.

--- a/include/model/CMetricBucketGatherer.h
+++ b/include/model/CMetricBucketGatherer.h
@@ -52,10 +52,10 @@ class CResourceMonitor;
 class MODEL_EXPORT CMetricBucketGatherer : public CBucketGatherer
 {
     public:
-        typedef std::pair<model_t::EMetricCategory, std::size_t> TCategorySizePr;
-        typedef std::map<TCategorySizePr, boost::any> TCategorySizePrAnyMap;
-        typedef TCategorySizePrAnyMap::iterator TCategorySizePrAnyMapItr;
-        typedef TCategorySizePrAnyMap::const_iterator TCategorySizePrAnyMapCItr;
+        using TCategorySizePr = std::pair<model_t::EMetricCategory, std::size_t>;
+        using TCategorySizePrAnyMap = std::map<TCategorySizePr, boost::any>;
+        using TCategorySizePrAnyMapItr = TCategorySizePrAnyMap::iterator;
+        using TCategorySizePrAnyMapCItr = TCategorySizePrAnyMap::const_iterator;
 
     public:
         //! \name Life-cycle

--- a/include/model/CMetricModelFactory.h
+++ b/include/model/CMetricModelFactory.h
@@ -145,7 +145,7 @@ class MODEL_EXPORT CMetricModelFactory : public CModelFactory
         virtual void bucketLength(core_t::TTime bucketLength);
 
         //! Set the bucket results delay
-        virtual void bucketResultsDelay(std::size_t bucketResultsDelay) ;
+        virtual void bucketResultsDelay(std::size_t bucketResultsDelay);
         //@}
 
     private:

--- a/include/model/CMetricMultivariateStatistic.h
+++ b/include/model/CMetricMultivariateStatistic.h
@@ -54,7 +54,7 @@ template<class STATISTIC>
 class CMetricMultivariateStatistic
 {
     public:
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
 
     public:
         static const std::string VALUE_TAG;
@@ -195,7 +195,7 @@ class CMetricMultivariateStatistic
         }
 
     private:
-        typedef core::CSmallVector<STATISTIC, 2> TStatistic2Vec;
+        using TStatistic2Vec = core::CSmallVector<STATISTIC, 2>;
 
     private:
         TStatistic2Vec m_Values;

--- a/include/model/CMetricPartialStatistic.h
+++ b/include/model/CMetricPartialStatistic.h
@@ -59,8 +59,8 @@ template<class STATISTIC>
 class CMetricPartialStatistic
 {
     public:
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef maths::CBasicStatistics::SSampleMean<maths::CDoublePrecisionStorage>::TAccumulator TMeanAccumulator;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<maths::CDoublePrecisionStorage>::TAccumulator;
 
     public:
         static const std::string VALUE_TAG;

--- a/include/model/CMetricPopulationModelFactory.h
+++ b/include/model/CMetricPopulationModelFactory.h
@@ -144,7 +144,7 @@ class MODEL_EXPORT CMetricPopulationModelFactory : public CModelFactory
         virtual void features(const TFeatureVec &features);
 
         //! Set the bucket results delay
-        virtual void bucketResultsDelay(std::size_t bucketResultsDelay) ;
+        virtual void bucketResultsDelay(std::size_t bucketResultsDelay);
         //@}
 
     private:

--- a/include/model/CMetricStatisticWrappers.h
+++ b/include/model/CMetricStatisticWrappers.h
@@ -73,10 +73,10 @@ struct SMake<CMetricMultivariateStatistic<STATISTIC> >
 //! of which delegate to the appropriate statistic functions.
 struct MODEL_EXPORT CMetricStatisticWrappers
 {
-    typedef core::CSmallVector<double, 1> TDouble1Vec;
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TVarianceAccumulator;
-    typedef maths::CFixedQuantileSketch<maths::CQuantileSketch::E_PiecewiseConstant, 30> TMedianAccumulator;
+    using TDouble1Vec = core::CSmallVector<double, 1>;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TVarianceAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using TMedianAccumulator = maths::CFixedQuantileSketch<maths::CQuantileSketch::E_PiecewiseConstant, 30>;
 
     //! Make a statistic.
     template<typename STATISTIC>

--- a/include/model/CModelPlotData.h
+++ b/include/model/CModelPlotData.h
@@ -40,8 +40,8 @@ namespace model
 class MODEL_EXPORT CModelPlotData
 {
     public:
-        typedef std::pair<std::string, double> TStrDoublePr;
-        typedef std::vector<TStrDoublePr> TStrDoublePrVec;
+        using TStrDoublePr = std::pair<std::string, double>;
+        using TStrDoublePrVec = std::vector<TStrDoublePr>;
 
     public:
         struct MODEL_EXPORT SByFieldData
@@ -62,11 +62,11 @@ class MODEL_EXPORT CModelPlotData
         };
 
     public:
-        typedef boost::unordered_map<std::string, SByFieldData> TStrByFieldDataUMap;
-        typedef std::pair<model_t::EFeature, TStrByFieldDataUMap> TFeatureStrByFieldDataUMapPr;
-        typedef boost::unordered_map<model_t::EFeature, TStrByFieldDataUMap> TFeatureStrByFieldDataUMapUMap;
-        typedef boost::unordered_map<int, TStrByFieldDataUMap> TIntStrByFieldDataUMapUMap;
-        typedef TFeatureStrByFieldDataUMapUMap::const_iterator TFeatureStrByFieldDataUMapUMapCItr;
+        using TStrByFieldDataUMap = boost::unordered_map<std::string, SByFieldData>;
+        using TFeatureStrByFieldDataUMapPr = std::pair<model_t::EFeature, TStrByFieldDataUMap>;
+        using TFeatureStrByFieldDataUMapUMap = boost::unordered_map<model_t::EFeature, TStrByFieldDataUMap>;
+        using TIntStrByFieldDataUMapUMap = boost::unordered_map<int, TStrByFieldDataUMap>;
+        using TFeatureStrByFieldDataUMapUMapCItr = TFeatureStrByFieldDataUMapUMap::const_iterator;
 
     public:
         CModelPlotData(void);

--- a/include/model/CPopulationModel.h
+++ b/include/model/CPopulationModel.h
@@ -72,12 +72,12 @@ namespace model
 class MODEL_EXPORT CPopulationModel : public CAnomalyDetectorModel
 {
     public:
-        typedef std::vector<core_t::TTime> TTimeVec;
-        typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-        typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
-        typedef std::vector<maths::CCountMinSketch> TCountMinSketchVec;
-        typedef std::vector<maths::CBjkstUniqueValues> TBjkstUniqueValuesVec;
-        typedef boost::unordered_map<std::size_t, core_t::TTime> TSizeTimeUMap;
+        using TTimeVec = std::vector<core_t::TTime>;
+        using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+        using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
+        using TCountMinSketchVec = std::vector<maths::CCountMinSketch>;
+        using TBjkstUniqueValuesVec = std::vector<maths::CBjkstUniqueValues>;
+        using TSizeTimeUMap = boost::unordered_map<std::size_t, core_t::TTime>;
 
         //! Lift the overloads of baselineBucketMean into the class scope.
         using CAnomalyDetectorModel::baselineBucketMean;

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -55,10 +55,10 @@ class MODEL_EXPORT CResourceMonitor
         };
 
     public:
-        typedef std::pair<CAnomalyDetectorModel*, std::size_t> TModelPtrSizePr;
-        typedef std::map<CAnomalyDetectorModel*, std::size_t> TModelPtrSizeMap;
-        typedef std::function<void(const CResourceMonitor::SResults&)> TMemoryUsageReporterFunc;
-        typedef std::map<core_t::TTime, std::size_t> TTimeSizeMap;
+        using TModelPtrSizePr = std::pair<CAnomalyDetectorModel*, std::size_t>;
+        using TModelPtrSizeMap = std::map<CAnomalyDetectorModel*, std::size_t>;
+        using TMemoryUsageReporterFunc = std::function<void(const CResourceMonitor::SResults&)>;
+        using TTimeSizeMap = std::map<core_t::TTime, std::size_t>;
 
         //! The minimum time between prunes
         static const core_t::TTime MINIMUM_PRUNE_FREQUENCY;

--- a/include/model/CResultsQueue.h
+++ b/include/model/CResultsQueue.h
@@ -32,7 +32,7 @@ class CHierarchicalResults;
 class MODEL_EXPORT CResultsQueue
 {
     public:
-        typedef CBucketQueue<CHierarchicalResults> THierarchicalResultsQueue;
+        using THierarchicalResultsQueue = CBucketQueue<CHierarchicalResults>;
 
     public:
         //! Constructor

--- a/include/model/CRuleCondition.h
+++ b/include/model/CRuleCondition.h
@@ -44,7 +44,7 @@ class CAnomalyDetectorModel;
 class MODEL_EXPORT CRuleCondition
 {
     public:
-        typedef boost::reference_wrapper<const core::CPatternSet> TPatternSetCRef;
+        using TPatternSetCRef = boost::reference_wrapper<const core::CPatternSet>;
 
     public:
         enum ERuleConditionType

--- a/include/model/CSample.h
+++ b/include/model/CSample.h
@@ -34,7 +34,7 @@ namespace model
 class MODEL_EXPORT CSample
 {
     public:
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
 
         struct MODEL_EXPORT SToString
         {

--- a/include/model/CSampleCounts.h
+++ b/include/model/CSampleCounts.h
@@ -51,9 +51,9 @@ class CDataGatherer;
 class MODEL_EXPORT CSampleCounts
 {
     public:
-        typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-        typedef std::vector<TMeanAccumulator> TMeanAccumulatorVec;
-        typedef std::vector<std::size_t> TSizeVec;
+        using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+        using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
+        using TSizeVec = std::vector<std::size_t>;
 
     public:
         explicit CSampleCounts(unsigned int sampleCountOverride = 0);
@@ -118,7 +118,7 @@ class MODEL_EXPORT CSampleCounts
         void clear(void);
 
     private:
-        typedef std::vector<unsigned int> TUIntVec;
+        using TUIntVec = std::vector<unsigned int>;
 
     private:
         //! Get the name of the entity identified by \p id.

--- a/include/model/CSampleGatherer.h
+++ b/include/model/CSampleGatherer.h
@@ -298,7 +298,7 @@ class CSampleGatherer
         void startNewBucket(core_t::TTime time)
         {
             m_BucketStats.push(TMetricPartialStatistic(m_Dimension), time);
-            for (auto &&stats : m_InfluencerBucketStats)
+            for (auto &stats : m_InfluencerBucketStats)
             {
                 stats.push(TStoredStringPtrStatUMap(1), time);
             }
@@ -309,7 +309,7 @@ class CSampleGatherer
         void resetBucket(core_t::TTime bucketStart)
         {
             m_BucketStats.get(bucketStart) = TMetricPartialStatistic(m_Dimension);
-            for (auto &&stats : m_InfluencerBucketStats)
+            for (auto &stats : m_InfluencerBucketStats)
             {
                 stats.get(bucketStart) = TStoredStringPtrStatUMap(1);
             }

--- a/include/model/CSampleQueue.h
+++ b/include/model/CSampleQueue.h
@@ -65,8 +65,8 @@ template<typename STATISTIC>
 class CSampleQueue
 {
     private:
-        typedef core::CSmallVector<double, 1> TDouble1Vec;
-        typedef CMetricPartialStatistic<STATISTIC> TMetricPartialStatistic;
+        using TDouble1Vec = core::CSmallVector<double, 1>;
+        using TMetricPartialStatistic = CMetricPartialStatistic<STATISTIC>;
 
     private:
         //! A struct grouping together the data that form a sub-sample.
@@ -218,12 +218,12 @@ class CSampleQueue
         };
 
     public:
-        typedef boost::circular_buffer<SSubSample> TQueue;
-        typedef typename TQueue::iterator iterator;
-        typedef typename TQueue::reverse_iterator reverse_iterator;
-        typedef typename TQueue::const_reverse_iterator const_reverse_iterator;
-        typedef std::vector<CSample> TSampleVec;
-        typedef boost::optional<SSubSample> TOptionalSubSample;
+        using TQueue = boost::circular_buffer<SSubSample>;
+        using iterator = typename TQueue::iterator;
+        using reverse_iterator = typename TQueue::reverse_iterator;
+        using const_reverse_iterator = typename TQueue::const_reverse_iterator;
+        using TSampleVec = std::vector<CSample>;
+        using TOptionalSubSample = boost::optional<SSubSample>;
 
     public:
         static const std::string SUB_SAMPLE_TAG;

--- a/include/model/CSearchKey.h
+++ b/include/model/CSearchKey.h
@@ -84,19 +84,19 @@ namespace model
 class MODEL_EXPORT CSearchKey
 {
     public:
-        typedef std::vector<std::string> TStrVec;
-        typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
+        using TStrVec = std::vector<std::string>;
+        using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
 
         //! The type of a search key which mixes in the partition field
         //! value.
-        typedef std::pair<std::string, CSearchKey> TStrKeyPr;
+        using TStrKeyPr = std::pair<std::string, CSearchKey>;
 
         //! The type of a constant reference string search key pair.
         //!
         //! \note This is intended for map lookups when one doesn't want
         //! to copy the strings.
-        typedef std::pair<boost::reference_wrapper<const std::string>,
-                          boost::reference_wrapper<const CSearchKey> > TStrCRefKeyCRefPr;
+        using TStrCRefKeyCRefPr = std::pair<boost::reference_wrapper<const std::string>,
+                                            boost::reference_wrapper<const CSearchKey>>;
 
     public:
         //! If the "by" field name is "count" then the key represents

--- a/include/model/FunctionTypes.h
+++ b/include/model/FunctionTypes.h
@@ -218,7 +218,7 @@ enum EFunction
     E_PeersTimeOfWeek = 414
 };
 
-typedef std::vector<EFunction> TFunctionVec;
+using TFunctionVec = std::vector<EFunction>;
 
 //! Is this function for use with the individual models?
 MODEL_EXPORT

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -53,11 +53,11 @@ struct SModelParams;
 namespace model_t
 {
 
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 2> TDouble2Vec;
-typedef core::CSmallVector<TDouble2Vec, 1> TDouble2Vec1Vec;
-typedef std::pair<TDouble1Vec, TDouble1Vec> TDouble1VecDouble1VecPr;
-typedef boost::shared_ptr<const model::CInfluenceCalculator> TInfluenceCalculatorCPtr;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble2Vec = core::CSmallVector<double, 2>;
+using TDouble2Vec1Vec = core::CSmallVector<TDouble2Vec, 1>;
+using TDouble1VecDouble1VecPr = std::pair<TDouble1Vec, TDouble1Vec>;
+using TInfluenceCalculatorCPtr = boost::shared_ptr<const model::CInfluenceCalculator>;
 
 //! The types of model available.
 //!
@@ -454,7 +454,7 @@ enum EFeature
     E_PeersMedianByPersonAndAttribute = 508
 };
 
-typedef std::vector<EFeature> TFeatureVec;
+using TFeatureVec = std::vector<EFeature>;
 
 //! Get the dimension of the feature \p feature.
 MODEL_EXPORT

--- a/include/test/CTestRunner.h
+++ b/include/test/CTestRunner.h
@@ -117,8 +117,8 @@ class TEST_EXPORT CTestRunner : public CppUnit::TextTestRunner
         void processCmdLine(int argc, const char **argv);
 
     private:
-        typedef std::vector<std::string> TStrVec;
-        typedef TStrVec::iterator        TStrVecItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrVecItr = TStrVec::iterator;
 
         TStrVec            m_TestCases;
         std::string        m_ExeName;

--- a/include/test/CTestTimer.h
+++ b/include/test/CTestTimer.h
@@ -70,8 +70,8 @@ class TEST_EXPORT CTestTimer : public CppUnit::TestListener
         //! Used to time each test
         core::CStopWatch m_StopWatch;
 
-        typedef std::map<std::string, uint64_t> TStrUInt64Map;
-        typedef TStrUInt64Map::const_iterator   TStrUInt64MapCItr;
+        using TStrUInt64Map = std::map<std::string, uint64_t>;
+        using TStrUInt64MapCItr = TStrUInt64Map::const_iterator;
 
         //! Map of test name to time taken (in ms)
         TStrUInt64Map    m_TestTimes;

--- a/include/test/CTimeSeriesTestData.h
+++ b/include/test/CTimeSeriesTestData.h
@@ -36,15 +36,15 @@ namespace test
 class TEST_EXPORT CTimeSeriesTestData
 {
     public:
-        typedef std::vector<double>                  TDoubleVec;
-        typedef TDoubleVec::iterator                 TDoubleVecItr;
-        typedef std::pair<core_t::TTime, double>     TTimeDoublePr;
-        typedef std::vector<TTimeDoublePr>           TTimeDoublePrVec;
-        typedef TTimeDoublePrVec::iterator           TTimeDoublePrVecItr;
-        typedef TTimeDoublePrVec::reverse_iterator   TTimeDoublePrVecRItr;
-        typedef TTimeDoublePrVec::const_iterator     TTimeDoublePrVecCItr;
-        typedef std::pair<core_t::TTime, TDoubleVec> TTimeDoubleVecPr;
-        typedef std::vector<TTimeDoubleVecPr>        TTimeDoubleVecPrVec;
+        using TDoubleVec = std::vector<double>;
+        using TDoubleVecItr = TDoubleVec::iterator;
+        using TTimeDoublePr = std::pair<core_t::TTime, double>;
+        using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
+        using TTimeDoublePrVecItr = TTimeDoublePrVec::iterator;
+        using TTimeDoublePrVecRItr = TTimeDoublePrVec::reverse_iterator;
+        using TTimeDoublePrVecCItr = TTimeDoublePrVec::const_iterator;
+        using TTimeDoubleVecPr = std::pair<core_t::TTime, TDoubleVec>;
+        using TTimeDoubleVecPrVec = std::vector<TTimeDoubleVecPr>;
 
     public:
         //! The default regular expression to extract the date

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -66,7 +66,7 @@ namespace api
 // We use short field names to reduce the state size
 namespace
 {
-typedef boost::reference_wrapper<const std::string> TStrCRef;
+using TStrCRef = boost::reference_wrapper<const std::string>;
 
 //! Convert a (string, key) pair to something readable.
 template<typename T>
@@ -620,7 +620,7 @@ bool CAnomalyJob::parseTimeRangeInControlMessage(const std::string &controlMessa
                                                       core_t::TTime &start,
                                                       core_t::TTime &end)
 {
-    typedef core::CStringUtils::TStrVec TStrVec;
+    using TStrVec = core::CStringUtils::TStrVec;
     TStrVec tokens;
     std::string remainder;
     core::CStringUtils::tokenise(" ", controlMessage.substr(1, std::string::npos), tokens, remainder);
@@ -665,8 +665,8 @@ void CAnomalyJob::doForecast(const std::string &controlMessage)
 
 void CAnomalyJob::outputResults(core_t::TTime bucketStartTime)
 {
-    typedef TKeyAnomalyDetectorPtrUMap::const_iterator TKeyAnomalyDetectorPtrUMapCItr;
-    typedef std::vector<TKeyAnomalyDetectorPtrUMapCItr> TKeyAnomalyDetectorPtrUMapCItrVec;
+    using TKeyAnomalyDetectorPtrUMapCItr = TKeyAnomalyDetectorPtrUMap::const_iterator;
+    using TKeyAnomalyDetectorPtrUMapCItrVec = std::vector<TKeyAnomalyDetectorPtrUMapCItr>;
 
     static uint64_t cumulativeTime = 0;
 
@@ -804,7 +804,7 @@ void CAnomalyJob::writeOutResults(bool interim, model::CHierarchicalResults &res
             results.root()->s_NormalizedAnomalyScore << ", count " << results.resultCount()
             << " at " << bucketTime);
 
-        typedef ml::core::CScopedRapidJsonPoolAllocator<CJsonOutputWriter> TScopedAllocator;
+        using TScopedAllocator = ml::core::CScopedRapidJsonPoolAllocator<CJsonOutputWriter>;
         static const std::string ALLOCATOR_ID("CAnomalyJob::writeOutResults");
         TScopedAllocator scopedAllocator(ALLOCATOR_ID, m_JsonOutputWriter);
 

--- a/lib/api/CBaseTokenListDataTyper.cc
+++ b/lib/api/CBaseTokenListDataTyper.cc
@@ -309,7 +309,7 @@ bool CBaseTokenListDataTyper::createReverseSearch(int type,
 
     // Determine the rarest tokens that we can afford within the available
     // length
-    typedef std::multimap<size_t, TSizeSizePr> TSizeSizeSizePrMMap;
+    using TSizeSizeSizePrMMap = std::multimap<size_t, TSizeSizePr>;
     TSizeSizeSizePrMMap rareIdsWithCost;
     size_t lowestCost(std::numeric_limits<size_t>::max());
     for (const auto &commonUniqueTokenId : commonUniqueTokenIds)
@@ -327,7 +327,7 @@ bool CBaseTokenListDataTyper::createReverseSearch(int type,
         lowestCost = std::min(cost, lowestCost);
     }
 
-    typedef std::set<size_t>         TSizeSet;
+    using TSizeSet = std::set<size_t>;
     TSizeSet costedCommonUniqueTokenIds;
     size_t cheapestCost(std::numeric_limits<size_t>::max());
     auto cheapestIter = rareIdsWithCost.end();

--- a/lib/api/CBenchMarker.cc
+++ b/lib/api/CBenchMarker.cc
@@ -110,9 +110,9 @@ void CBenchMarker::addResult(const std::string &message,
 void CBenchMarker::dumpResults(void) const
 {
     // Sort the results in descending order of actual type occurrence
-    typedef std::pair<size_t, TRegexIntSizeStrPrMapPrVecCItr>       TSizeRegexIntSizeStrPrMapPrVecCItrPr;
-    typedef std::vector<TSizeRegexIntSizeStrPrMapPrVecCItrPr>       TSizeRegexIntSizeStrPrMapPrVecCItrPrVec;
-    typedef TSizeRegexIntSizeStrPrMapPrVecCItrPrVec::const_iterator TSizeRegexIntSizeStrPrMapPrVecCItrPrVecCItr;
+    using TSizeRegexIntSizeStrPrMapPrVecCItrPr = std::pair<size_t, TRegexIntSizeStrPrMapPrVecCItr>;
+    using TSizeRegexIntSizeStrPrMapPrVecCItrPrVec = std::vector<TSizeRegexIntSizeStrPrMapPrVecCItrPr>;
+    using TSizeRegexIntSizeStrPrMapPrVecCItrPrVecCItr = TSizeRegexIntSizeStrPrMapPrVecCItrPrVec::const_iterator;
 
     TSizeRegexIntSizeStrPrMapPrVecCItrPrVec sortVec;
     sortVec.reserve(m_Measures.size());
@@ -135,14 +135,14 @@ void CBenchMarker::dumpResults(void) const
     }
 
     // Sort descending
-    typedef std::greater<TSizeRegexIntSizeStrPrMapPrVecCItrPr> TGreaterSizeRegexIntSizeStrPrMapPrVecCItrPr;
+    using TGreaterSizeRegexIntSizeStrPrMapPrVecCItrPr = std::greater<TSizeRegexIntSizeStrPrMapPrVecCItrPr>;
     TGreaterSizeRegexIntSizeStrPrMapPrVecCItrPr comp;
     std::sort(sortVec.begin(), sortVec.end(), comp);
 
     std::ostringstream strm;
     strm << "Results:" << core_t::LINE_ENDING;
 
-    typedef std::set<int> TIntSet;
+    using TIntSet = std::set<int>;
 
     TIntSet usedTypes;
     size_t observedActuals(0);

--- a/lib/api/CCsvOutputWriter.cc
+++ b/lib/api/CCsvOutputWriter.cc
@@ -175,7 +175,7 @@ bool CCsvOutputWriter::writeRow(const TStrStrUMap &dataRowFields,
     // all gets written to the stream
     m_WorkRecord.clear();
 
-    typedef std::equal_to<std::string> TStrEqualTo;
+    using TStrEqualTo = std::equal_to<std::string>;
     TStrEqualTo pred;
 
     TStrVecCItr fieldNameIter = m_FieldNames.begin();

--- a/lib/api/CFieldConfig.cc
+++ b/lib/api/CFieldConfig.cc
@@ -320,13 +320,13 @@ bool CFieldConfig::tokenise(const std::string &clause,
 {
     // Tokenise on spaces or commas. Double quotes are used
     // for quoting, and the escape character is a backslash.
-    typedef boost::escaped_list_separator<char> TCharEscapedListSeparator;
+    using TCharEscapedListSeparator = boost::escaped_list_separator<char>;
     TCharEscapedListSeparator els("\\",
                                   core::CStringUtils::WHITESPACE_CHARS + ',',
                                   "\"");
     try
     {
-        typedef boost::tokenizer<TCharEscapedListSeparator> TCharEscapedListSeparatorTokenizer;
+        using TCharEscapedListSeparatorTokenizer = boost::tokenizer<TCharEscapedListSeparator>;
         TCharEscapedListSeparatorTokenizer tokenizer(clause, els);
 
         for (TCharEscapedListSeparatorTokenizer::iterator iter = tokenizer.begin();
@@ -558,7 +558,7 @@ bool CFieldConfig::initFromClause(const TStrVec &tokens)
 
 bool CFieldConfig::addOptions(const CFieldOptions &options)
 {
-    typedef std::pair<TFieldOptionsMIndexItr, bool> TFieldOptionsMIndexItrBoolPr;
+    using TFieldOptionsMIndexItrBoolPr = std::pair<TFieldOptionsMIndexItr, bool>;
     TFieldOptionsMIndexItrBoolPr result(m_FieldOptions.insert(options));
     if (result.second == false)
     {
@@ -713,7 +713,7 @@ bool CFieldConfig::parseClause(bool allowMultipleFunctions,
             options.description(description);
         }
 
-        typedef std::pair<TFieldOptionsMIndexItr, bool> TFieldOptionsMIndexItrBoolPr;
+        using TFieldOptionsMIndexItrBoolPr = std::pair<TFieldOptionsMIndexItr, bool>;
         TFieldOptionsMIndexItrBoolPr result(optionsIndex.insert(options));
         if (result.second == false)
         {

--- a/lib/api/CHierarchicalResultsWriter.cc
+++ b/lib/api/CHierarchicalResultsWriter.cc
@@ -28,9 +28,9 @@ namespace api
 
 namespace
 {
-typedef boost::optional<double> TOptionalDouble;
-typedef boost::optional<uint64_t> TOptionalUInt64;
-typedef core::CSmallVector<double, 1> TDouble1Vec;
+using TOptionalDouble = boost::optional<double>;
+using TOptionalUInt64 = boost::optional<uint64_t>;
+using TDouble1Vec = core::CSmallVector<double, 1>;
 const std::string COUNT_NAME("count");
 const std::string EMPTY_STRING;
 const CHierarchicalResultsWriter::TStr1Vec EMPTY_STRING_LIST;

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -797,12 +797,12 @@ void CJsonOutputWriter::addInfluences(const CHierarchicalResultsWriter::TStoredS
     //! influenceResults. These strings must exist up to the time the results
     //! are written
 
-    typedef std::pair<const char *, double>                                 TCharPtrDoublePr;
-    typedef std::vector<TCharPtrDoublePr>                                   TCharPtrDoublePrVec;
-    typedef TCharPtrDoublePrVec::iterator                                   TCharPtrDoublePrVecIter;
-    typedef std::pair<const char *, TCharPtrDoublePrVec>                    TCharPtrCharPtrDoublePrVecPr;
-    typedef boost::unordered_map<std::string, TCharPtrCharPtrDoublePrVecPr> TStrCharPtrCharPtrDoublePrVecPrUMap;
-    typedef TStrCharPtrCharPtrDoublePrVecPrUMap::iterator                   TStrCharPtrCharPtrDoublePrVecPrUMapIter;
+    using TCharPtrDoublePr = std::pair<const char *, double>;
+    using TCharPtrDoublePrVec = std::vector<TCharPtrDoublePr>;
+    using TCharPtrDoublePrVecIter = TCharPtrDoublePrVec::iterator;
+    using TCharPtrCharPtrDoublePrVecPr = std::pair<const char *, TCharPtrDoublePrVec>;
+    using TStrCharPtrCharPtrDoublePrVecPrUMap = boost::unordered_map<std::string, TCharPtrCharPtrDoublePrVecPr>;
+    using TStrCharPtrCharPtrDoublePrVecPrUMapIter = TStrCharPtrCharPtrDoublePrVecPrUMap::iterator;
 
 
     TStrCharPtrCharPtrDoublePrVecPrUMap influences;

--- a/lib/api/COutputChainer.cc
+++ b/lib/api/COutputChainer.cc
@@ -94,7 +94,7 @@ bool COutputChainer::writeRow(const TStrStrUMap &dataRowFields,
         return false;
     }
 
-    typedef std::equal_to<std::string> TStrEqualTo;
+    using TStrEqualTo = std::equal_to<std::string>;
     TStrEqualTo pred;
 
     TPreComputedHashVecCItr preComputedHashIter = m_Hashes.begin();

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -222,7 +222,7 @@ void CAnomalyJobLimitTest::testAccuracy(void)
 
 void CAnomalyJobLimitTest::testLimit(void)
 {
-    typedef std::set<std::string> TStrSet;
+    using TStrSet = std::set<std::string>;
 
     std::stringstream outputStrm;
     {

--- a/lib/api/unittest/CConfigUpdaterTest.cc
+++ b/lib/api/unittest/CConfigUpdaterTest.cc
@@ -74,7 +74,7 @@ void CConfigUpdaterTest::testUpdateGivenUnknownStanzas(void)
 
 void CConfigUpdaterTest::testUpdateGivenModelPlotConfig(void)
 {
-    typedef model::CAnomalyDetectorModelConfig::TStrSet TStrSet;
+    using TStrSet = model::CAnomalyDetectorModelConfig::TStrSet;
 
     CFieldConfig fieldConfig;
     model::CAnomalyDetectorModelConfig modelConfig = model::CAnomalyDetectorModelConfig::defaultConfig();

--- a/lib/api/unittest/CCsvInputParserTest.cc
+++ b/lib/api/unittest/CCsvInputParserTest.cc
@@ -127,7 +127,7 @@ class CVisitor
 class CTimeCheckingVisitor
 {
     public:
-        typedef std::vector<ml::core_t::TTime> TTimeVec;
+        using TTimeVec = std::vector<ml::core_t::TTime>;
 
     public:
         CTimeCheckingVisitor(const std::string &timeField,

--- a/lib/api/unittest/CDetectionRulesJsonParserTest.cc
+++ b/lib/api/unittest/CDetectionRulesJsonParserTest.cc
@@ -26,7 +26,7 @@ using namespace api;
 
 namespace
 {
-typedef CDetectionRulesJsonParser::TStrPatternSetUMap TStrPatternSetUMap;
+using TStrPatternSetUMap = CDetectionRulesJsonParser::TStrPatternSetUMap;
 TStrPatternSetUMap EMPTY_VALUE_FILTER_MAP;
 }
 

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -217,7 +217,7 @@ void CJsonOutputWriterTest::testWriteNonAnomalousBucket(void)
     arrayDoc.Parse<rapidjson::kParseDefaultFlags>(sstream.str().c_str());
 
     rapidjson::StringBuffer strbuf;
-    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
     TStringBufferPrettyWriter prettyPrinter(strbuf);
     arrayDoc.Accept(prettyPrinter);
     LOG_DEBUG("Results:\n" << strbuf.GetString());
@@ -259,7 +259,7 @@ void CJsonOutputWriterTest::testFlush(void)
     CPPUNIT_ASSERT_EQUAL(rapidjson::SizeType(1), arrayDoc.Size());
 
     rapidjson::StringBuffer strbuf;
-    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
     TStringBufferPrettyWriter writer(strbuf);
     arrayDoc.Accept(writer);
     LOG_DEBUG("Flush:\n" << strbuf.GetString());
@@ -284,7 +284,7 @@ void CJsonOutputWriterTest::testWriteCategoryDefinition(void)
     std::string terms("foo bar");
     std::string regex(".*?foo.+?bar.*");
     std::size_t maxMatchingLength(132);
-    typedef std::set<std::string> TStrSet;
+    using TStrSet = std::set<std::string>;
     TStrSet examples;
     examples.insert("User foo failed to log in");
     examples.insert("User bar failed to log in");
@@ -305,7 +305,7 @@ void CJsonOutputWriterTest::testWriteCategoryDefinition(void)
     CPPUNIT_ASSERT_EQUAL(rapidjson::SizeType(1), arrayDoc.Size());
 
     rapidjson::StringBuffer strbuf;
-    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
     TStringBufferPrettyWriter writer(strbuf);
     arrayDoc.Accept(writer);
     LOG_DEBUG("CategoryDefinition:\n" << strbuf.GetString());
@@ -808,7 +808,7 @@ void CJsonOutputWriterTest::testBucketWriteHelper(bool isInterim)
     CPPUNIT_ASSERT(!arrayDoc.HasParseError());
 
     rapidjson::StringBuffer strbuf;
-    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
     TStringBufferPrettyWriter writer(strbuf);
     arrayDoc.Accept(writer);
     LOG_DEBUG("Results:\n" << strbuf.GetString());
@@ -1642,7 +1642,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim)
     arrayDoc.Parse<rapidjson::kParseDefaultFlags>(sstream.str().c_str());
 
     rapidjson::StringBuffer strbuf;
-    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
     TStringBufferPrettyWriter writer(strbuf);
     arrayDoc.Accept(writer);
     LOG_DEBUG("Results:\n" << strbuf.GetString());
@@ -1860,7 +1860,7 @@ void CJsonOutputWriterTest::testWriteInfluencers(void)
 
     // Debug print record
     rapidjson::StringBuffer strbuf;
-    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
     TStringBufferPrettyWriter writer(strbuf);
     doc.Accept(writer);
     LOG_DEBUG("influencers:\n" << strbuf.GetString());
@@ -1990,7 +1990,7 @@ void CJsonOutputWriterTest::testWriteInfluencersWithLimit(void)
 
 
     rapidjson::StringBuffer strbuf;
-    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
     TStringBufferPrettyWriter writer(strbuf);
     doc.Accept(writer);
 
@@ -2147,7 +2147,7 @@ void CJsonOutputWriterTest::testWriteWithInfluences(void)
     // Debug print record
     {
         rapidjson::StringBuffer strbuf;
-        typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+        using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
         TStringBufferPrettyWriter writer(strbuf);
         doc.Accept(writer);
         LOG_DEBUG("Results:\n" << strbuf.GetString());
@@ -2458,7 +2458,7 @@ void CJsonOutputWriterTest::testWriteScheduledEvent(void)
     // Debug print record
     {
         rapidjson::StringBuffer strbuf;
-        typedef rapidjson::PrettyWriter<rapidjson::StringBuffer> TStringBufferPrettyWriter;
+        using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
         TStringBufferPrettyWriter writer(strbuf);
         doc.Accept(writer);
         LOG_DEBUG("Results:\n" << strbuf.GetString());
@@ -2654,7 +2654,7 @@ void CJsonOutputWriterTest::testThroughputHelper(bool useScopedAllocator)
     {
         if (useScopedAllocator)
         {
-            typedef ml::core::CScopedRapidJsonPoolAllocator<ml::api::CJsonOutputWriter> TScopedAllocator;
+            using TScopedAllocator = ml::core::CScopedRapidJsonPoolAllocator<ml::api::CJsonOutputWriter>;
             static const std::string ALLOCATOR_ID("CAnomalyJob::writeOutResults");
             TScopedAllocator scopedAllocator(ALLOCATOR_ID, writer);
 

--- a/lib/api/unittest/CMultiFileDataAdderTest.cc
+++ b/lib/api/unittest/CMultiFileDataAdderTest.cc
@@ -50,7 +50,7 @@
 namespace
 {
 
-typedef std::vector<std::string> TStrVec;
+using TStrVec = std::vector<std::string>;
 
 void reportPersistComplete(ml::api::CModelSnapshotJsonWriter::SModelSnapshotReport modelSnapshotReport,
                            std::string &snapshotIdOut,

--- a/lib/api/unittest/CTokenListDataTyperTest.cc
+++ b/lib/api/unittest/CTokenListDataTyperTest.cc
@@ -28,17 +28,17 @@
 namespace
 {
 
-typedef ml::api::CTokenListDataTyper<true,  // Warping
-                                     true,  // Underscores
-                                     true,  // Dots
-                                     true,  // Dashes
-                                     true,  // Ignore leading digit
-                                     true,  // Ignore hex
-                                     true,  // Ignore date words
-                                     false, // Ignore field names
-                                     2,     // Min dictionary word length
-                                     ml::core::CWordDictionary::TWeightVerbs5Other2>
-        TTokenListDataTyperKeepsFields;
+using TTokenListDataTyperKeepsFields =
+           ml::api::CTokenListDataTyper<true,  // Warping
+                                        true,  // Underscores
+                                        true,  // Dots
+                                        true,  // Dashes
+                                        true,  // Ignore leading digit
+                                        true,  // Ignore hex
+                                        true,  // Ignore date words
+                                        false, // Ignore field names
+                                        2,     // Min dictionary word length
+                                        ml::core::CWordDictionary::TWeightVerbs5Other2>;
 
 const TTokenListDataTyperKeepsFields::TTokenListReverseSearchCreatorIntfCPtr NO_REVERSE_SEARCH_CREATOR;
 

--- a/lib/config/CAutoconfigurer.cc
+++ b/lib/config/CAutoconfigurer.cc
@@ -67,9 +67,9 @@ const core_t::TTime UPDATE_SCORE_TIME_INTERVAL       = 172800;
 class CONFIG_EXPORT CAutoconfigurerImpl : public core::CNonCopyable
 {
     public:
-        typedef std::vector<std::string> TStrVec;
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
-        typedef TStrStrUMap::const_iterator TStrStrUMapCItr;
+        using TStrVec = std::vector<std::string>;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
     public:
         CAutoconfigurerImpl(const CAutoconfigurerParams &params, CReportWriter &reportWriter);
@@ -87,11 +87,11 @@ class CONFIG_EXPORT CAutoconfigurerImpl : public core::CNonCopyable
         uint64_t numRecordsHandled(void) const;
 
     private:
-        typedef std::pair<core_t::TTime, TStrStrUMap> TTimeStrStrUMapPr;
-        typedef std::vector<TTimeStrStrUMapPr> TTimeStrStrUMapPrVec;
-        typedef boost::optional<config_t::EUserDataType> TOptionalUserDataType;
-        typedef std::vector<CDetectorSpecification> TDetectorSpecificationVec;
-        typedef std::vector<CFieldStatistics> TFieldStatisticsVec;
+        using TTimeStrStrUMapPr = std::pair<core_t::TTime, TStrStrUMap>;
+        using TTimeStrStrUMapPrVec = std::vector<TTimeStrStrUMapPr>;
+        using TOptionalUserDataType = boost::optional<config_t::EUserDataType>;
+        using TDetectorSpecificationVec = std::vector<CDetectorSpecification>;
+        using TFieldStatisticsVec = std::vector<CFieldStatistics>;
 
     private:
         //! Extract the time from \p fieldValues.
@@ -427,8 +427,8 @@ void CAutoconfigurerImpl::generateCandidateDetectorsOnce(void)
 
     LOG_DEBUG("Generate Candidate Detectors:");
 
-    typedef void (CDetectorEnumerator::*TAddField)(const std::string &);
-    typedef bool (CAutoconfigurerParams::*TCanUse)(const std::string &) const;
+    using TAddField = void (CDetectorEnumerator::*)(const std::string &);
+    using TCanUse = bool (CAutoconfigurerParams::*)(const std::string &) const;
 
     CDetectorEnumerator enumerator(m_Params);
     for (std::size_t i = 0u; i < m_Params.functionsCategoriesToConfigure().size(); ++i)

--- a/lib/config/CAutoconfigurerFieldRolePenalties.cc
+++ b/lib/config/CAutoconfigurerFieldRolePenalties.cc
@@ -36,7 +36,7 @@ const std::size_t RARE_BY_INDEX              = 3u;
 const std::size_t OVER_INDEX                 = 4u;
 const std::size_t PARTITION_INDEX            = 5u;
 
-typedef std::size_t (CAutoconfigurerParams::*TCountThreshold)(void) const;
+using TCountThreshold = std::size_t (CAutoconfigurerParams::*)(void) const;
 
 const std::size_t PENALTY_INDICES[] =
     {

--- a/lib/config/CAutoconfigurerParams.cc
+++ b/lib/config/CAutoconfigurerParams.cc
@@ -38,7 +38,7 @@ namespace config
 {
 namespace
 {
-typedef std::vector<std::string> TStrVec;
+using TStrVec = std::vector<std::string>;
 
 //! \brief A constraint which applies to a value of type T.
 template<typename T>
@@ -72,7 +72,7 @@ template<typename T>
 class CConstraintConjunction : public CConstraint<T>
 {
     public:
-        typedef boost::shared_ptr<const CConstraint<T> > TConstraintCPtr;
+        using TConstraintCPtr = boost::shared_ptr<const CConstraint<T>>;
 
     public:
         CConstraintConjunction *addConstraint(const CConstraint<T> *constraint)
@@ -247,7 +247,7 @@ template<typename T>
 class CBuiltinParameter : public CParameter
 {
     public:
-        typedef boost::shared_ptr<const CConstraint<T> > TConstraintCPtr;
+        using TConstraintCPtr = boost::shared_ptr<const CConstraint<T>>;
 
     public:
         CBuiltinParameter(T &value) :
@@ -339,7 +339,7 @@ class CBuiltinVectorParameter : public CParameter
 
     private:
         std::vector<T> &m_Value;
-        boost::shared_ptr<const CConstraint<T> > m_Constraint;
+        boost::shared_ptr<const CConstraint<T>> m_Constraint;
 };
 
 //! \brief A parameter which is a vector of strings.
@@ -378,7 +378,7 @@ class COptionalStrVecParameter : public CParameter
 
     private:
         CAutoconfigurerParams::TOptionalStrVec &m_Value;
-        boost::shared_ptr<const CConstraint<std::string> > m_Constraint;
+        boost::shared_ptr<const CConstraint<std::string>> m_Constraint;
 };
 
 //! \brief The field data type parameter.
@@ -505,7 +505,7 @@ class CFunctionCategoryParameter : public CParameter
 
     private:
         CAutoconfigurerParams::TFunctionCategoryVec &m_Value;
-        boost::shared_ptr<const CConstraint<config_t::EFunctionCategory> > m_Constraint;
+        boost::shared_ptr<const CConstraint<config_t::EFunctionCategory>> m_Constraint;
 };
 
 //! boost::ini_parser doesn't like UTF-8 ini files that begin with
@@ -697,7 +697,7 @@ bool CAutoconfigurerParams::init(const std::string &file)
         return true;
     }
 
-    typedef boost::shared_ptr<CParameter> TParameterPtr;
+    using TParameterPtr = boost::shared_ptr<CParameter>;
 
     boost::property_tree::ptree propTree;
     try

--- a/lib/config/CDataCountStatistics.cc
+++ b/lib/config/CDataCountStatistics.cc
@@ -46,7 +46,7 @@ namespace config
 namespace
 {
 
-typedef std::vector<bool> TBoolVec;
+using TBoolVec = std::vector<bool>;
 
 //! We sample a subset of short bucket lengths buckets for runtime.
 TBoolVec bucketSampleMask(core_t::TTime bucketLength)
@@ -59,7 +59,7 @@ TBoolVec bucketSampleMask(core_t::TTime bucketLength)
 
 //! Insert with the same semantics as boost::unordered_map/set::emplace.
 template<typename T>
-std::size_t emplace(const std::string *name, std::vector<std::pair<const std::string*, T> > &stats)
+std::size_t emplace(const std::string *name, std::vector<std::pair<const std::string*, T>> &stats)
 {
     std::size_t i = static_cast<std::size_t>(
                         std::lower_bound(stats.begin(), stats.end(),
@@ -169,8 +169,8 @@ void CBucketCountStatistics::add(const TSizeSizeSizeTr &partition,
 
 void CBucketCountStatistics::capture(void)
 {
-    typedef TSizeSizeSizeTrUInt64UMap::const_iterator TSizeSizeSizeTrUInt64UMapCItr;
-    typedef TSizeSizeSizeTrArgumentDataUMap::iterator TSizeSizeSizeTrArgumentDataUMapItr;
+    using TSizeSizeSizeTrUInt64UMapCItr = TSizeSizeSizeTrUInt64UMap::const_iterator;
+    using TSizeSizeSizeTrArgumentDataUMapItr = TSizeSizeSizeTrArgumentDataUMap::iterator;
 
     m_BucketPartitionCount += m_CurrentBucketPartitionCounts.size();
     for (TSizeSizeSizeTrUInt64UMapCItr i = m_CurrentBucketPartitionCounts.begin();
@@ -220,7 +220,7 @@ const CBucketCountStatistics::TSizeSizePrQuantileUMap &CBucketCountStatistics::c
 const CBucketCountStatistics::TSizeSizePrArgumentMomentsUMap &
     CBucketCountStatistics::argumentMomentsPerPartition(const std::string &name) const
 {
-    typedef TStrCPtrSizeSizePrArgumentMomentsUMapPrVec::const_iterator TStrCPtrPartitionArgumentMomentsUMapPrVecCItr;
+    using TStrCPtrPartitionArgumentMomentsUMapPrVecCItr = TStrCPtrSizeSizePrArgumentMomentsUMapPrVec::const_iterator;
     static const TSizeSizePrArgumentMomentsUMap EMPTY;
     TStrCPtrPartitionArgumentMomentsUMapPrVecCItr result =
             std::lower_bound(m_ArgumentMomentsPerPartition.begin(),
@@ -413,7 +413,7 @@ void CByOverAndPartitionDataCountStatistics::add(TDetectorRecordCItr beginRecord
         return;
     }
 
-    typedef TSizeSizePrCBjkstUMap::iterator TSizeSizePrCBjkstUMapItr;
+    using TSizeSizePrCBjkstUMapItr = TSizeSizePrCBjkstUMap::iterator;
 
     this->CDataCountStatistics::add(beginRecords, endRecords);
 
@@ -442,9 +442,8 @@ CDataCountStatisticsDirectAddressTable::CDataCountStatisticsDirectAddressTable(c
 
 void CDataCountStatisticsDirectAddressTable::build(const TDetectorSpecificationVec &specs)
 {
-    typedef boost::unordered_map<CCountStatisticsKey,
-                                 std::size_t,
-                                 CCountStatisticsKeyHasher> TCountStatisticsKeySizeUMap;
+    using TCountStatisticsKeySizeUMap =
+              boost::unordered_map<CCountStatisticsKey, std::size_t, CCountStatisticsKeyHasher>;
 
     std::size_t size = 0u;
     for (std::size_t i = 0u; i < specs.size(); ++i)
@@ -477,7 +476,7 @@ void CDataCountStatisticsDirectAddressTable::build(const TDetectorSpecificationV
 
 void CDataCountStatisticsDirectAddressTable::pruneUnsed(const TDetectorSpecificationVec &specs)
 {
-    typedef boost::unordered_set<std::size_t> TSizeUSet;
+    using TSizeUSet = boost::unordered_set<std::size_t>;
 
     TSizeUSet used;
     for (std::size_t i = 0u; i < specs.size(); ++i)
@@ -524,7 +523,7 @@ const CDataCountStatistics &
 CDataCountStatisticsDirectAddressTable::TDataCountStatisticsPtr
     CDataCountStatisticsDirectAddressTable::stats(const CDetectorSpecification &spec) const
 {
-    typedef CDataCountStatistics *(*TStatistics)(const CAutoconfigurerParams &);
+    using TStatistics = CDataCountStatistics *(*)(const CAutoconfigurerParams &);
     static TStatistics STATISTICS[] =
         {
             &partitionCountStatistics,

--- a/lib/config/CDataSemantics.cc
+++ b/lib/config/CDataSemantics.cc
@@ -29,8 +29,8 @@ namespace config
 {
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 
 //! \brief Wraps up a mixture model.
 //!
@@ -53,7 +53,7 @@ class CMixtureData
         //! Compute the scale for a mixture of \p m.
         double scale(std::size_t m)
         {
-            typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+            using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
             TSizeVec split;
             m_Classifier.naturalBreaks(m, 2, split);
@@ -119,8 +119,8 @@ class CMixtureData
         }
 
     private:
-        typedef std::vector<boost::math::normal_distribution<> > TNormalVec;
-        typedef maths::CMixtureDistribution<boost::math::normal_distribution<> > TGMM;
+        using TNormalVec = std::vector<boost::math::normal_distribution<>>;
+        using TGMM = maths::CMixtureDistribution<boost::math::normal_distribution<>>;
 
     private:
         void clear(void)
@@ -283,7 +283,7 @@ bool CDataSemantics::GMMGoodFit(void) const
     // The idea is to check the goodness-of-fit of a categorical model
     // to the data verses a normal mixture.
 
-    typedef TOrdinalSizeUMap::const_iterator TOrdinalSizeUMapCItr;
+    using TOrdinalSizeUMapCItr = TOrdinalSizeUMap::const_iterator;
 
     std::size_t N = m_EmpiricalDistribution.size();
     LOG_TRACE("N = " << N);

--- a/lib/config/CDataSummaryStatistics.cc
+++ b/lib/config/CDataSummaryStatistics.cc
@@ -34,8 +34,8 @@ namespace config
 namespace
 {
 
-typedef core::CFunctional::SDereference<maths::COrderings::SSecondLess> TDerefSecondLess;
-typedef core::CFunctional::SDereference<maths::COrderings::SSecondGreater> TDerefSecondGreater;
+using TDerefSecondLess = core::CFunctional::SDereference<maths::COrderings::SSecondLess>;
+using TDerefSecondGreater = core::CFunctional::SDereference<maths::COrderings::SSecondGreater>;
 
 std::size_t topNSize(std::size_t n)
 {
@@ -251,7 +251,7 @@ void CCategoricalDataSummaryStatistics::addNGrams(std::size_t n, const std::stri
 
 void CCategoricalDataSummaryStatistics::approximateIfCardinalityTooHigh(void)
 {
-    typedef TSizeUInt64UMap::const_iterator TSizeUInt64UMapCItr;
+    using TSizeUInt64UMapCItr = TSizeUInt64UMap::const_iterator;
 
     if (m_ValueCounts.size() >= m_ToApproximate)
     {
@@ -293,7 +293,7 @@ double CCategoricalDataSummaryStatistics::calibratedCount(std::size_t category) 
         return static_cast<double>(m_ValueCounts.find(category)->second);
     }
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     TMeanAccumulator error;
     if (m_CountSketch.sketched())
@@ -309,7 +309,7 @@ double CCategoricalDataSummaryStatistics::calibratedCount(std::size_t category) 
 
 void CCategoricalDataSummaryStatistics::findLowestTopN(void)
 {
-    typedef maths::CBasicStatistics::COrderStatisticsStack<TStrUInt64UMapItr, 1, TDerefSecondLess> TMinAccumulator;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<TStrUInt64UMapItr, 1, TDerefSecondLess>;
     TMinAccumulator lowest;
     for (TStrUInt64UMapItr i = m_TopN.begin(); i != m_TopN.end(); ++i)
     {
@@ -320,7 +320,7 @@ void CCategoricalDataSummaryStatistics::findLowestTopN(void)
 
 void CCategoricalDataSummaryStatistics::topN(TStrUInt64UMapCItrVec &result) const
 {
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TStrUInt64UMapCItr, TDerefSecondGreater> TMaxAccumulator;
+    using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TStrUInt64UMapCItr, TDerefSecondGreater>;
     TMaxAccumulator topN(m_N);
     for (TStrUInt64UMapCItr i = m_TopN.begin(); i != m_TopN.end(); ++i)
     {
@@ -406,9 +406,9 @@ bool CNumericDataSummaryStatistics::densityChart(TDoubleDoublePrVec &result) con
         return true;
     }
 
-    typedef std::vector<double> TDoubleVec;
-    typedef std::vector<boost::math::normal_distribution<> > TNormalVec;
-    typedef maths::CMixtureDistribution<boost::math::normal_distribution<> > TGMM;
+    using TDoubleVec = std::vector<double>;
+    using TNormalVec = std::vector<boost::math::normal_distribution<>>;
+    using TGMM = maths::CMixtureDistribution<boost::math::normal_distribution<>>;
 
     const maths::CXMeansOnline1d::TClusterVec &clusters = m_Clusters.clusters();
     std::size_t n = clusters.size();

--- a/lib/config/CDetectorEnumerator.cc
+++ b/lib/config/CDetectorEnumerator.cc
@@ -32,9 +32,9 @@ namespace config
 namespace
 {
 
-typedef std::vector<std::string> TStrVec;
-typedef boost::reference_wrapper<const TStrVec> TStrVecCRef;
-typedef std::vector<TStrVecCRef> TStrVecCRefVec;
+using TStrVec = std::vector<std::string>;
+using TStrVecCRef = boost::reference_wrapper<const TStrVec>;
+using TStrVecCRefVec = std::vector<TStrVecCRef>;
 
 //! Add detectors for the partitioning fields \p candidates.
 void add(std::size_t p,

--- a/lib/config/CDetectorFieldRolePenalty.cc
+++ b/lib/config/CDetectorFieldRolePenalty.cc
@@ -30,7 +30,7 @@ namespace config
 namespace
 {
 
-typedef const CFieldStatistics *(CDetectorSpecification::*TGetStatistics)(void) const;
+using TGetStatistics = const CFieldStatistics *(CDetectorSpecification::*)(void) const;
 const TGetStatistics STATISTIC[] =
     {
         &CDetectorSpecification::argumentFieldStatistics,

--- a/lib/config/CDetectorRecord.cc
+++ b/lib/config/CDetectorRecord.cc
@@ -32,7 +32,7 @@ namespace config
 namespace
 {
 
-typedef const CDetectorSpecification::TOptionalStr &(CDetectorSpecification::*TField)(void) const;
+using TField = const CDetectorSpecification::TOptionalStr &(CDetectorSpecification::*)(void) const;
 const TField FIELDS[] =
     {
         &CDetectorSpecification::argumentField,
@@ -148,8 +148,8 @@ std::string CDetectorRecord::print(void) const
 
 void CDetectorRecordDirectAddressTable::build(const TDetectorSpecificationVec &specs)
 {
-    typedef boost::unordered_map<std::string, std::size_t> TStrSizeUMap;
-    typedef TStrSizeUMap::const_iterator TStrSizeUMapCItr;
+    using TStrSizeUMap = boost::unordered_map<std::string, std::size_t>;
+    using TStrSizeUMapCItr = TStrSizeUMap::const_iterator;
 
     this->clear();
 
@@ -202,7 +202,7 @@ void CDetectorRecordDirectAddressTable::detectorRecords(core_t::TTime time,
         return;
     }
 
-    typedef TStrStrUMap::const_iterator TStrStrUMapCItr;
+    using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
     std::size_t size = 0u;
     for (std::size_t i = 0u; i < specs.size(); ++i)

--- a/lib/config/CDetectorSpecification.cc
+++ b/lib/config/CDetectorSpecification.cc
@@ -38,8 +38,8 @@ namespace config
 namespace
 {
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<double> TDoubleVec;
+using TSizeVec = std::vector<std::size_t>;
+using TDoubleVec = std::vector<double>;
 
 //! \brief Checks if the name of some statistics matches a specified value.
 class CNameEquals
@@ -475,10 +475,9 @@ std::string CDetectorSpecification::detectorConfig(void) const
         return "";
     }
 
-    typedef std::pair<double, core_t::TTime> TDoubleTimePr;
-    typedef maths::CBasicStatistics::COrderStatisticsStack<TDoubleTimePr,
-                                                           1,
-                                                           maths::COrderings::SFirstGreater> TMaxAccumulator;
+    using TDoubleTimePr = std::pair<double, core_t::TTime>;
+    using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<TDoubleTimePr, 1,
+                                                                           maths::COrderings::SFirstGreater>;
 
     const TTimeVec &candidates = this->params().candidateBucketLengths();
 

--- a/lib/config/CLongTailPenalty.cc
+++ b/lib/config/CLongTailPenalty.cc
@@ -133,9 +133,9 @@ void CLongTailPenalty::extractTailCounts(const MAP &counts,
                                          TSizeUInt64UMap &totals,
                                          TSizeUInt64UMap &tail) const
 {
-    typedef maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1> TMinAccumulator;
-    typedef boost::unordered_map<std::size_t, TMinAccumulator> TSizeMinAccumulatorUMap;
-    typedef typename MAP::const_iterator TItr;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1>;
+    using TSizeMinAccumulatorUMap = boost::unordered_map<std::size_t, TMinAccumulator>;
+    using TItr = typename MAP::const_iterator;
 
     TSizeMinAccumulatorUMap mins;
 
@@ -163,8 +163,8 @@ void CLongTailPenalty::extractTailCounts(const MAP &counts,
 
 double CLongTailPenalty::penaltyFor(TSizeUInt64UMap &tail, TSizeUInt64UMap &totals) const
 {
-    typedef TSizeUInt64UMap::const_iterator TSizeUInt64UMapCItr;
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TSizeUInt64UMapCItr = TSizeUInt64UMap::const_iterator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
     TMeanAccumulator result;
     for (TSizeUInt64UMapCItr i = tail.begin(); i != tail.end(); ++i)
     {

--- a/lib/config/CLowVariationPenalty.cc
+++ b/lib/config/CLowVariationPenalty.cc
@@ -33,12 +33,12 @@ namespace config
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator TMomentsAccumulator;
-typedef boost::unordered_map<std::size_t, TMomentsAccumulator> TSizeMomentsUMap;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMomentsAccumulator = maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator;
+using TSizeMomentsUMap = boost::unordered_map<std::size_t, TMomentsAccumulator>;
 
 const double MIN = 0.9 * constants::DETECTOR_SCORE_EPSILON / constants::MAXIMUM_DETECTOR_SCORE;
 const double INF = boost::numeric::bounds<double>::highest();

--- a/lib/config/CNotEnoughDataPenalty.cc
+++ b/lib/config/CNotEnoughDataPenalty.cc
@@ -35,7 +35,7 @@ namespace config
 {
 namespace
 {
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 //! Get the description prefix.
 std::string descriptionPrefix(const CDetectorSpecification &spec,
@@ -127,7 +127,7 @@ void CNotEnoughDataPenalty::penaltyFor(const TUInt64Vec &bucketCounts,
                                        const TBucketCountStatisticsVec &statistics,
                                        CDetectorSpecification &spec) const
 {
-    typedef CBucketCountStatistics::TSizeSizePrMomentsUMap::const_iterator TSizeSizePrMomentsUMapCItr;
+    using TSizeSizePrMomentsUMapCItr = CBucketCountStatistics::TSizeSizePrMomentsUMap::const_iterator;
 
     const CAutoconfigurerParams::TTimeVec &candidates = this->params().candidateBucketLengths();
 

--- a/lib/config/CPolledDataPenalty.cc
+++ b/lib/config/CPolledDataPenalty.cc
@@ -95,8 +95,9 @@ void CPolledDataPenalty::penaltyFromMe(CDetectorSpecification &spec) const
 CPolledDataPenalty::TOptionalTime
     CPolledDataPenalty::pollingInterval(const CDataCountStatistics &stats) const
 {
-    typedef maths::CBasicStatistics::COrderStatisticsStack<maths::CQuantileSketch::TFloatFloatPr,
-                                                           2, maths::COrderings::SSecondGreater> TMaxAccumulator;
+    using TMaxAccumulator =
+               maths::CBasicStatistics::COrderStatisticsStack<maths::CQuantileSketch::TFloatFloatPr,
+                                                              2, maths::COrderings::SSecondGreater>;
 
     const maths::CQuantileSketch &F = stats.arrivalTimeDistribution();
     const maths::CQuantileSketch::TFloatFloatPrVec &knots = F.knots();

--- a/lib/config/CReportWriter.cc
+++ b/lib/config/CReportWriter.cc
@@ -33,9 +33,9 @@ namespace config
 namespace
 {
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::vector<TStrVec> TStrVecVec;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
+using TStrVecVec = std::vector<TStrVec>;
 
 //! Pad \p value.
 inline std::string pad(std::size_t padTo, const std::string &value)
@@ -77,7 +77,7 @@ inline std::string print(const std::pair<U, V> &p, std::size_t padTo = 0)
 
 //! Write out a vector of pairs new line delimited.
 template<typename U, typename V>
-inline std::string print(const std::vector<std::pair<U, V> > &v, std::size_t padTo = 0)
+inline std::string print(const std::vector<std::pair<U, V>> &v, std::size_t padTo = 0)
 {
     std::string result;
     for (std::size_t i = 0u; i < v.size(); ++i)

--- a/lib/config/CSparseCountPenalty.cc
+++ b/lib/config/CSparseCountPenalty.cc
@@ -35,7 +35,7 @@ namespace config
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 //! Extract the \p n quantiles from \p quantiles.
 void extract(const maths::CQuantileSketch &quantiles, std::size_t n, TDoubleVec &result)
@@ -101,13 +101,13 @@ void CSparseCountPenalty::penaltyFromMe(CDetectorSpecification &spec) const
         return;
     }
 
-    typedef std::vector<TDoubleVec> TDoubleVecVec;
-    typedef CBucketCountStatistics::TSizeSizePrQuantileUMap TSizeSizePrQuantileUMap;
-    typedef TSizeSizePrQuantileUMap::const_iterator TSizeSizePrQuantileUMapCItr;
-    typedef std::vector<const TSizeSizePrQuantileUMap *> TSizeSizePrQuantileUMapCPtrVec;
-    typedef std::vector<const CBucketCountStatistics::TSizeSizePrMomentsUMap *> TSizeSizePrMomentsUMapCPtrVec;
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef std::vector<TMeanAccumulator> TMeanAccumulatorVec;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TSizeSizePrQuantileUMap = CBucketCountStatistics::TSizeSizePrQuantileUMap;
+    using TSizeSizePrQuantileUMapCItr = TSizeSizePrQuantileUMap::const_iterator;
+    using TSizeSizePrQuantileUMapCPtrVec = std::vector<const TSizeSizePrQuantileUMap *>;
+    using TSizeSizePrMomentsUMapCPtrVec = std::vector<const CBucketCountStatistics::TSizeSizePrMomentsUMap *>;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
 
     if (const CDataCountStatistics *stats = spec.countStatistics())
     {

--- a/lib/config/CTooMuchDataPenalty.cc
+++ b/lib/config/CTooMuchDataPenalty.cc
@@ -33,7 +33,7 @@ namespace config
 {
 namespace
 {
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 //! Get the description prefix.
 std::string descriptionPrefix(const CDetectorSpecification &spec,
@@ -124,7 +124,7 @@ void CTooMuchDataPenalty::penaltyFor(const TUInt64Vec &bucketCounts,
                                      const TBucketCountStatisticsVec &statistics,
                                      CDetectorSpecification &spec) const
 {
-    typedef CBucketCountStatistics::TSizeSizePrMomentsUMap::const_iterator TSizeSizePrMomentsUMapCItr;
+    using TSizeSizePrMomentsUMapCItr = CBucketCountStatistics::TSizeSizePrMomentsUMap::const_iterator;
 
     const CAutoconfigurerParams::TTimeVec &candidates = this->params().candidateBucketLengths();
 

--- a/lib/config/unittest/CDataSemanticsTest.cc
+++ b/lib/config/unittest/CDataSemanticsTest.cc
@@ -27,9 +27,9 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
 
 void CDataSemanticsTest::testBinary(void)
 {

--- a/lib/config/unittest/CDataSummaryStatisticsTest.cc
+++ b/lib/config/unittest/CDataSummaryStatisticsTest.cc
@@ -35,10 +35,10 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 void CDataSummaryStatisticsTest::testRate(void)
 {

--- a/lib/config/unittest/CReportWriterTest.cc
+++ b/lib/config/unittest/CReportWriterTest.cc
@@ -28,9 +28,9 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
 
 void CReportWriterTest::testPretty(void)
 {

--- a/lib/core/CDetachedProcessSpawner.cc
+++ b/lib/core/CDetachedProcessSpawner.cc
@@ -106,7 +106,7 @@ namespace detail
 class CTrackerThread : public CThread
 {
     public:
-        typedef std::set<CProcess::TPid> TPidSet;
+        using TPidSet = std::set<CProcess::TPid>;
 
     public:
         CTrackerThread(void)
@@ -317,7 +317,7 @@ bool CDetachedProcessSpawner::spawn(const std::string &processPath,
         return false;
     }
 
-    typedef std::vector<char *> TCharPVec;
+    using TCharPVec = std::vector<char *>;
     // Size of argv is two bigger than the number of arguments because:
     // 1) We add the program name at the beginning
     // 2) The list of arguments must be terminated by a NULL pointer

--- a/lib/core/CDetachedProcessSpawner_Windows.cc
+++ b/lib/core/CDetachedProcessSpawner_Windows.cc
@@ -38,7 +38,7 @@ namespace detail
 class CTrackerThread : public CThread
 {
     public:
-        typedef std::map<CProcess::TPid, HANDLE> TPidHandleMap;
+        using TPidHandleMap = std::map<CProcess::TPid, HANDLE>;
 
     public:
         CTrackerThread(void)

--- a/lib/core/CHashing.cc
+++ b/lib/core/CHashing.cc
@@ -36,7 +36,7 @@ namespace core
 namespace
 {
 
-typedef boost::random::uniform_int_distribution<uint32_t> TUniform32;
+using TUniform32 = boost::random::uniform_int_distribution<uint32_t>;
 
 }
 
@@ -322,7 +322,7 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k,
                                               uint32_t m,
                                               TUInt32VecHashVec &result)
 {
-    typedef std::vector<TUInt32Vec> TUInt32VecVec;
+    using TUInt32VecVec = std::vector<TUInt32Vec>;
 
     TUInt32VecVec a;
     TUInt32Vec b;

--- a/lib/core/CJsonLogLayout.cc
+++ b/lib/core/CJsonLogLayout.cc
@@ -115,7 +115,7 @@ void CJsonLogLayout::format(LogString &output,
                             const spi::LoggingEventPtr &event,
                             Pool &/*p*/) const
 {
-    typedef rapidjson::Writer<rapidjson::StringBuffer> TStringBufferWriter;
+    using TStringBufferWriter = rapidjson::Writer<rapidjson::StringBuffer>;
     rapidjson::StringBuffer buffer;
     TStringBufferWriter writer(buffer);
 

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -451,8 +451,8 @@ void CLogger::massageProperties(log4cxx::helpers::Properties &props) const
     mappings.insert(TLogCharLogStrMap::value_type(static_cast<log4cxx::logchar>('P'), logStr));
 
     // Map the properties
-    typedef std::vector<log4cxx::LogString> TLogStringVec;
-    typedef TLogStringVec::const_iterator   TLogStringVecCItr;
+    using TLogStringVec = std::vector<log4cxx::LogString>;
+    using TLogStringVecCItr = TLogStringVec::const_iterator;
 
     TLogStringVec propNames(props.propertyNames());
     for (TLogStringVecCItr iter = propNames.begin();

--- a/lib/core/CMemoryUsage.cc
+++ b/lib/core/CMemoryUsage.cc
@@ -188,8 +188,8 @@ void CMemoryUsage::summary(CMemoryUsageJsonWriter &writer) const
 
 void CMemoryUsage::compress(void)
 {
-    typedef std::map<std::string, std::size_t> TStrSizeMap;
-    typedef TStrSizeMap::const_iterator TStrSizeMapCItr;
+    using TStrSizeMap = std::map<std::string, std::size_t>;
+    using TStrSizeMapCItr = TStrSizeMap::const_iterator;
 
     if (!m_Children.empty())
     {

--- a/lib/core/CNamedPipeFactory.cc
+++ b/lib/core/CNamedPipeFactory.cc
@@ -142,7 +142,7 @@ CNamedPipeFactory::TIStreamP CNamedPipeFactory::openPipeStreamRead(const std::st
     {
         return TIStreamP();
     }
-    typedef boost::iostreams::stream<boost::iostreams::file_descriptor_source> TFileDescriptorSourceStream;
+    using TFileDescriptorSourceStream = boost::iostreams::stream<boost::iostreams::file_descriptor_source>;
     return TIStreamP(new TFileDescriptorSourceStream(
             boost::iostreams::file_descriptor_source(fd, boost::iostreams::close_handle)));
 }
@@ -154,7 +154,7 @@ CNamedPipeFactory::TOStreamP CNamedPipeFactory::openPipeStreamWrite(const std::s
     {
         return TOStreamP();
     }
-    typedef boost::iostreams::stream<CRetryingFileDescriptorSink> TRetryingFileDescriptorSinkStream;
+    using TRetryingFileDescriptorSinkStream = boost::iostreams::stream<CRetryingFileDescriptorSink>;
     return TOStreamP(new TRetryingFileDescriptorSinkStream(
             CRetryingFileDescriptorSink(fd, boost::iostreams::close_handle)));
 }

--- a/lib/core/CNamedPipeFactory_Windows.cc
+++ b/lib/core/CNamedPipeFactory_Windows.cc
@@ -59,7 +59,7 @@ CNamedPipeFactory::TIStreamP CNamedPipeFactory::openPipeStreamRead(const std::st
     {
         return TIStreamP();
     }
-    typedef boost::iostreams::stream<boost::iostreams::file_descriptor_source> TFileDescriptorSourceStream;
+    using TFileDescriptorSourceStream = boost::iostreams::stream<boost::iostreams::file_descriptor_source>;
     return TIStreamP(new TFileDescriptorSourceStream(
             boost::iostreams::file_descriptor_source(handle, boost::iostreams::close_handle)));
 }
@@ -71,7 +71,7 @@ CNamedPipeFactory::TOStreamP CNamedPipeFactory::openPipeStreamWrite(const std::s
     {
         return TOStreamP();
     }
-    typedef boost::iostreams::stream<boost::iostreams::file_descriptor_sink> TFileDescriptorSinkStream;
+    using TFileDescriptorSinkStream = boost::iostreams::stream<boost::iostreams::file_descriptor_sink>;
     return TOStreamP(new TFileDescriptorSinkStream(
             boost::iostreams::file_descriptor_sink(handle, boost::iostreams::close_handle)));
 }

--- a/lib/core/CProcess_Windows.cc
+++ b/lib/core/CProcess_Windows.cc
@@ -258,7 +258,7 @@ void WINAPI CProcess::serviceMain(DWORD argc, char *argv[])
 
     if (process.m_MlMainFunc != 0)
     {
-        typedef boost::scoped_array<char *> TScopedCharPArray;
+        using TScopedCharPArray = boost::scoped_array<char *>;
 
         // Merge the arguments from the service itself with the arguments
         // passed to the original main() call

--- a/lib/core/CStatistics.cc
+++ b/lib/core/CStatistics.cc
@@ -35,7 +35,7 @@ namespace core
 namespace
 {
 
-typedef core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> TGenericLineWriter;
+using TGenericLineWriter = core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>;
 
 static const std::string NAME_TYPE("name");
 static const std::string DESCRIPTION_TYPE("description");

--- a/lib/core/CStringUtils.cc
+++ b/lib/core/CStringUtils.cc
@@ -1057,7 +1057,7 @@ std::string CStringUtils::longestCommonSubstr(const std::string &str1,
     size_t secondLen(str2.length());
 
     // Set up the matrix
-    typedef boost::multi_array<size_t, 2> T2DSizeArray;
+    using T2DSizeArray = boost::multi_array<size_t, 2>;
     T2DSizeArray matrix(boost::extents[firstLen][secondLen]);
 
     size_t maxLen(0);
@@ -1119,7 +1119,7 @@ std::string CStringUtils::longestCommonSubsequence(const std::string &str1,
     size_t secondLen(str2.length());
 
     // Set up the matrix - dimensions are one bigger than the string lengths
-    typedef boost::multi_array<size_t, 2> T2DSizeArray;
+    using T2DSizeArray = boost::multi_array<size_t, 2>;
     T2DSizeArray matrix(boost::extents[firstLen + 1][secondLen + 1]);
 
     // Initialise the top row and left column of the matrix to zero
@@ -1205,7 +1205,7 @@ std::string CStringUtils::wideToNarrow(const std::wstring &wideStr)
     // Note: this won't always work for non-ASCII data, and it can't
     // cope with UTF8 either, so we should replace it with a proper
     // string conversion library, e.g. ICU
-    typedef std::ctype<wchar_t> TWCharTCType;
+    using TWCharTCType = std::ctype<wchar_t>;
     std::use_facet<TWCharTCType>(CStringUtils::locale()).narrow(wideStr.data(),
                                                                 wideStr.data() + wideStr.length(),
                                                                 '?',
@@ -1222,7 +1222,7 @@ std::wstring CStringUtils::narrowToWide(const std::string &narrowStr)
     // Note: this won't always work for non-ASCII data, and it can't
     // cope with UTF8 either, so we should replace it with a proper
     // string conversion library, e.g. ICU
-    typedef std::ctype<wchar_t> TWCharTCType;
+    using TWCharTCType = std::ctype<wchar_t>;
     std::use_facet<TWCharTCType>(CStringUtils::locale()).widen(narrowStr.data(),
                                                                narrowStr.data() + narrowStr.length(),
                                                                &wideStr[0]);

--- a/lib/core/CUname_Windows.cc
+++ b/lib/core/CUname_Windows.cc
@@ -51,7 +51,7 @@ bool queryKernelVersion(uint16_t &major, uint16_t &minor, uint16_t &build)
         return false;
     }
 
-    typedef boost::scoped_array<char> TScopedCharArray;
+    using TScopedCharArray = boost::scoped_array<char>;
     TScopedCharArray buffer(new char[size]);
     if (GetFileVersionInfo(KERNEL32_DLL, handle, size, buffer.get()) == FALSE)
     {
@@ -108,7 +108,7 @@ std::string CUname::nodeName(void)
         return std::string();
     }
 
-    typedef std::vector<char> TCharVec;
+    using TCharVec = std::vector<char>;
     TCharVec buffer(size);
 
     res = GetComputerNameEx(ComputerNameDnsHostname,

--- a/lib/core/CXmlParser.cc
+++ b/lib/core/CXmlParser.cc
@@ -1033,7 +1033,7 @@ bool CXmlParser::stringLatin1ToUtf8(std::string &str)
     // The UTF-8 character corresponding to each Latin1 character will require
     // either 1 or 2 bytes of storage (but note that some UTF-8 characters can
     // require 3 bytes)
-    typedef boost::scoped_array<char> TCharArray;
+    using TCharArray = boost::scoped_array<char>;
     size_t bufferSize(1 + 2 * str.length());
     TCharArray buffer(new char[bufferSize]);
     ::memset(&buffer[0], 0, bufferSize);

--- a/lib/core/unittest/CAllocationStrategyTest.cc
+++ b/lib/core/unittest/CAllocationStrategyTest.cc
@@ -40,7 +40,7 @@ void assertSize(const T &t)
 
 void CAllocationStrategyTest::test(void)
 {
-    typedef std::vector<int> TIntVec;
+    using TIntVec = std::vector<int>;
 
     {
         TIntVec v;

--- a/lib/core/unittest/CBase64FilterTest.cc
+++ b/lib/core/unittest/CBase64FilterTest.cc
@@ -22,10 +22,10 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/generator_iterator.hpp>
 
-typedef boost::mt19937 TRandom;
-typedef boost::uniform_int<> TDistribution;
-typedef boost::random::variate_generator<TRandom&, TDistribution> TGenerator;
-typedef boost::generator_iterator<TGenerator> TGeneratorItr;
+using TRandom = boost::mt19937;
+using TDistribution = boost::uniform_int<>;
+using TGenerator = boost::random::variate_generator<TRandom&, TDistribution>;
+using TGeneratorItr = boost::generator_iterator<TGenerator>;
 
 using namespace ml;
 using namespace core;
@@ -33,14 +33,14 @@ using namespace core;
 namespace
 {
 
-typedef boost::iostreams::filtering_stream<boost::iostreams::output> TFilteredOutput;
-typedef boost::iostreams::filtering_stream<boost::iostreams::input> TFilteredInput;
+using TFilteredOutput = boost::iostreams::filtering_stream<boost::iostreams::output>;
+using TFilteredInput = boost::iostreams::filtering_stream<boost::iostreams::input>;
 
 // Implements the boost::iostreams Source template interface
 class CMockSource
 {
     public:
-        typedef char char_type;
+        using char_type = char;
 
         struct category :
                         public boost::iostreams::source_tag
@@ -77,7 +77,7 @@ class CMockSource
 class CMockSink
 {
     public:
-        typedef char char_type;
+        using char_type = char;
 
         struct category :
                 public boost::iostreams::sink_tag,

--- a/lib/core/unittest/CBlockingMessageQueueTest.cc
+++ b/lib/core/unittest/CBlockingMessageQueueTest.cc
@@ -51,7 +51,7 @@ namespace
             }
 
         private:
-            typedef std::vector<std::string> TStrVec;
+            using TStrVec = std::vector<std::string>;
 
             TStrVec m_Strings;
     };

--- a/lib/core/unittest/CCompressedDictionaryTest.cc
+++ b/lib/core/unittest/CCompressedDictionaryTest.cc
@@ -29,9 +29,9 @@ using namespace test;
 
 void CCompressedDictionaryTest::testAll(void)
 {
-    typedef std::vector<std::string> TStrVec;
-    typedef CCompressedDictionary<2> TDictionary;
-    typedef TDictionary::TWordUSet TWordUSet;
+    using TStrVec = std::vector<std::string>;
+    using TDictionary = CCompressedDictionary<2>;
+    using TWordUSet = TDictionary::TWordUSet;
 
     // Don't set this too high as it slows down every build - it can be
     // temporarily set high in uncommitted code for a thorough soak test
@@ -66,10 +66,10 @@ void CCompressedDictionaryTest::testAll(void)
 
 void CCompressedDictionaryTest::testPersist(void)
 {
-    typedef CCompressedDictionary<1> TDictionary1;
-    typedef CCompressedDictionary<2> TDictionary2;
-    typedef CCompressedDictionary<3> TDictionary3;
-    typedef CCompressedDictionary<4> TDictionary4;
+    using TDictionary1 = CCompressedDictionary<1>;
+    using TDictionary2 = CCompressedDictionary<2>;
+    using TDictionary3 = CCompressedDictionary<3>;
+    using TDictionary4 = CCompressedDictionary<4>;
 
     {
         TDictionary1 dictionary;

--- a/lib/core/unittest/CContainerPrinterTest.cc
+++ b/lib/core/unittest/CContainerPrinterTest.cc
@@ -41,7 +41,7 @@ void CContainerPrinterTest::testAll(void)
     CPPUNIT_ASSERT_EQUAL(std::string("[1.1, 3.2]"),
                          CContainerPrinter::print(vec));
 
-    std::list<std::pair<int, int> > list;
+    std::list<std::pair<int, int>> list;
     list.push_back(std::make_pair(1, 2));
     list.push_back(std::make_pair(2, 2));
     list.push_back(std::make_pair(3, 2));
@@ -49,7 +49,7 @@ void CContainerPrinterTest::testAll(void)
     CPPUNIT_ASSERT_EQUAL(std::string("[(1, 2), (2, 2), (3, 2)]"),
                          CContainerPrinter::print(list));
 
-    std::list<boost::shared_ptr<double> > plist;
+    std::list<boost::shared_ptr<double>> plist;
     plist.push_back(boost::shared_ptr<double>());
     plist.push_back(boost::shared_ptr<double>(new double(3.0)));
     plist.push_back(boost::shared_ptr<double>(new double(1.1)));
@@ -77,14 +77,14 @@ void CContainerPrinterTest::testAll(void)
     CPPUNIT_ASSERT_EQUAL(std::string("[2, 3, 2]"),
                          CContainerPrinter::print(boost::begin(pints), boost::end(pints)));
 
-    std::vector<boost::optional<double> > ovec(2, boost::optional<double>());
+    std::vector<boost::optional<double>> ovec(2, boost::optional<double>());
     LOG_DEBUG("ovec = " << CContainerPrinter::print(ovec));
     CPPUNIT_ASSERT_EQUAL(std::string("[\"null\", \"null\"]"),
                          CContainerPrinter::print(ovec));
 
-    std::vector<std::pair<std::list<std::pair<int, int> >, double> > aggregate;
+    std::vector<std::pair<std::list<std::pair<int, int>>, double>> aggregate;
     aggregate.push_back(std::make_pair(list, 1.3));
-    aggregate.push_back(std::make_pair(std::list<std::pair<int, int> >(), 0.0));
+    aggregate.push_back(std::make_pair(std::list<std::pair<int, int>>(), 0.0));
     aggregate.push_back(std::make_pair(list, 5.1));
     LOG_DEBUG("aggregate = " << CContainerPrinter::print(aggregate));
     CPPUNIT_ASSERT_EQUAL(std::string("[([(1, 2), (2, 2), (3, 2)], 1.3), ([], 0), ([(1, 2), (2, 2), (3, 2)], 5.1)]"),

--- a/lib/core/unittest/CContainerThroughputTest.cc
+++ b/lib/core/unittest/CContainerThroughputTest.cc
@@ -64,7 +64,7 @@ void CContainerThroughputTest::setUp(void)
 
 void CContainerThroughputTest::testVector(void)
 {
-    typedef std::vector<SContent> TContentVec;
+    using TContentVec = std::vector<SContent>;
     TContentVec testVec;
     testVec.reserve(FILL_SIZE);
 
@@ -99,7 +99,7 @@ void CContainerThroughputTest::testVector(void)
 
 void CContainerThroughputTest::testList(void)
 {
-    typedef std::list<SContent> TContentList;
+    using TContentList = std::list<SContent>;
     TContentList testList;
 
     ml::core_t::TTime start(ml::core::CTimeUtils::now());
@@ -133,7 +133,7 @@ void CContainerThroughputTest::testList(void)
 
 void CContainerThroughputTest::testDeque(void)
 {
-    typedef std::deque<SContent> TContentDeque;
+    using TContentDeque = std::deque<SContent>;
     TContentDeque testDeque;
 
     ml::core_t::TTime start(ml::core::CTimeUtils::now());
@@ -167,7 +167,7 @@ void CContainerThroughputTest::testDeque(void)
 
 void CContainerThroughputTest::testMap(void)
 {
-    typedef std::map<size_t, SContent> TSizeContentMap;
+    using TSizeContentMap = std::map<size_t, SContent>;
     TSizeContentMap testMap;
 
     ml::core_t::TTime start(ml::core::CTimeUtils::now());
@@ -201,7 +201,7 @@ void CContainerThroughputTest::testMap(void)
 
 void CContainerThroughputTest::testCircBuf(void)
 {
-    typedef boost::circular_buffer<SContent> TContentCircBuf;
+    using TContentCircBuf = boost::circular_buffer<SContent>;
     TContentCircBuf testCircBuf(FILL_SIZE);
 
     ml::core_t::TTime start(ml::core::CTimeUtils::now());
@@ -235,14 +235,14 @@ void CContainerThroughputTest::testCircBuf(void)
 
 void CContainerThroughputTest::testMultiIndex(void)
 {
-    typedef boost::multi_index::multi_index_container<
+    using TContentMIndex = boost::multi_index::multi_index_container<
         SContent,
         boost::multi_index::indexed_by<
             boost::multi_index::hashed_unique<
                 BOOST_MULTI_INDEX_MEMBER(SContent, size_t, s_Size)
             >
         >
-    > TContentMIndex;
+    >;
     TContentMIndex testMultiIndex;
 
     ml::core_t::TTime start(ml::core::CTimeUtils::now());

--- a/lib/core/unittest/CFunctionalTest.cc
+++ b/lib/core/unittest/CFunctionalTest.cc
@@ -62,7 +62,7 @@ void CFunctionalTest::testDereference(void)
     CPPUNIT_ASSERT(!derefIsNull(notNull));
 
     std::less<double> less;
-    core::CFunctional::SDereference<std::less<double> > derefLess;
+    core::CFunctional::SDereference<std::less<double>> derefLess;
     const double *values[] = { &one, &two, &three };
     for (std::size_t i = 0u; i < boost::size(values); ++i)
     {

--- a/lib/core/unittest/CHashingTest.cc
+++ b/lib/core/unittest/CHashingTest.cc
@@ -110,11 +110,11 @@ void CHashingTest::testUniversalHash(void)
     // We test a large u and m non exhaustively by choosing sufficient
     // different numbers of pairs to hash.
 
-    typedef std::vector<uint32_t> TUInt32Vec;
-    typedef std::pair<uint32_t, uint32_t> TUInt32Pr;
-    typedef std::set<TUInt32Pr> TUInt32PrSet;
-    typedef std::map<TUInt32Pr, unsigned int> TUint32PrUIntMap;
-    typedef TUint32PrUIntMap::const_iterator TUint32PrUIntMapCItr;
+    using TUInt32Vec = std::vector<uint32_t>;
+    using TUInt32Pr = std::pair<uint32_t, uint32_t>;
+    using TUInt32PrSet = std::set<TUInt32Pr>;
+    using TUint32PrUIntMap = std::map<TUInt32Pr, unsigned int>;
+    using TUint32PrUIntMapCItr = TUint32PrUIntMap::const_iterator;
 
     {
         LOG_DEBUG("**** m = " << 10000 << ", U = [" << 10000000 << "] ****");
@@ -259,9 +259,9 @@ void CHashingTest::testMurmurHash(void)
         CPPUNIT_ASSERT_EQUAL(uint64_t(7291323361835448266ull), result);
     }
 
-    typedef std::vector<std::string> TStrVec;
-    typedef std::map<std::size_t, std::size_t> TSizeSizeMap;
-    typedef TSizeSizeMap::const_iterator TSizeSizeMapCItr;
+    using TStrVec = std::vector<std::string>;
+    using TSizeSizeMap = std::map<std::size_t, std::size_t>;
+    using TSizeSizeMapCItr = TSizeSizeMap::const_iterator;
 
     const std::size_t stringSize = 32u;
     const std::size_t numberStrings = 500000u;
@@ -375,8 +375,8 @@ void CHashingTest::testHashCombine(void)
 
     CHashing::CMurmurHash2String hasher;
 
-    typedef std::vector<std::string> TStrVec;
-    typedef std::set<uint64_t> TSizeSet;
+    using TStrVec = std::vector<std::string>;
+    using TSizeSet = std::set<uint64_t>;
 
     const std::size_t stringSize = 32u;
     const std::size_t numberStrings = 2000000u;

--- a/lib/core/unittest/CMapPopulationTest.h
+++ b/lib/core/unittest/CMapPopulationTest.h
@@ -50,8 +50,8 @@ class CMapPopulationTest : public CppUnit::TestFixture
         class CTestData
         {
             public:
-                typedef std::vector<std::string>  TStrVec;
-                typedef std::vector<const char *> TCharPVec;
+                using TStrVec = std::vector<std::string> ;
+                using TCharPVec = std::vector<const char *>;
 
             public:
                 CTestData(size_t fillSize);
@@ -70,10 +70,10 @@ class CMapPopulationTest : public CppUnit::TestFixture
         };
 
     private:
-        typedef std::map<std::string, std::string>             TStrStrMap;
-        typedef std::vector<TStrStrMap>                        TStrStrMapVec;
-        typedef boost::unordered_map<std::string, std::string> TStrStrUMap;
-        typedef std::vector<TStrStrUMap>                       TStrStrUMapVec;
+        using TStrStrMap = std::map<std::string, std::string>;
+        using TStrStrMapVec = std::vector<TStrStrMap>;
+        using TStrStrUMap = boost::unordered_map<std::string, std::string>;
+        using TStrStrUMapVec = std::vector<TStrStrUMap>;
 
         template <typename INPUT_CONTAINER, typename MAP_CONTAINER>
         void addInsert(const INPUT_CONTAINER &keys,

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -49,8 +49,8 @@ enum EFeature
     E_IndividualHighCountsByBucketAndPerson
 };
 
-typedef std::vector<int> TIntVec;
-typedef std::vector<std::string> TStrVec;
+using TIntVec = std::vector<int>;
+using TStrVec = std::vector<std::string>;
 
 struct SPod
 {
@@ -102,7 +102,7 @@ struct SFooWrapper
 
 struct SBar
 {
-    typedef std::vector<SFoo> TFooVec;
+    using TFooVec = std::vector<SFoo>;
 
     explicit SBar(std::size_t key = 0) : s_Key(key), s_State() {}
     bool operator<(const SBar &rhs) const { return s_Key < rhs.s_Key; }
@@ -118,7 +118,7 @@ struct SBar
 
 struct SBarDebug
 {
-    typedef std::vector<SFoo> TFooVec;
+    using TFooVec = std::vector<SFoo>;
 
     explicit SBarDebug(std::size_t key = 0) : s_Key(key), s_State() {}
     bool operator<(const SBarDebug &rhs) const { return s_Key < rhs.s_Key; }
@@ -140,7 +140,7 @@ struct SBarDebug
 
 struct SBarVectorDebug
 {
-    typedef std::vector<SFooWithMemoryUsage> TFooVec;
+    using TFooVec = std::vector<SFooWithMemoryUsage>;
 
     explicit SBarVectorDebug(std::size_t key = 0) : s_Key(key), s_State() {}
     bool operator<(const SBarVectorDebug &rhs) const { return s_Key < rhs.s_Key; }
@@ -231,20 +231,20 @@ template<typename T>
 class CTrackingAllocator
 {
     public:
-        typedef T value_type;
-        typedef value_type *pointer;
-        typedef const value_type *const_pointer;
-        typedef value_type &reference;
-        typedef const value_type &const_reference;
-        typedef std::size_t size_type;
-        typedef std::ptrdiff_t difference_type;
+        using value_type = T;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
 
     public:
         // convert an allocator<T> to allocator<U>
         template<typename U>
         struct rebind
         {
-            typedef CTrackingAllocator<U> other;
+            using other = CTrackingAllocator<U>;
         };
 
     public:
@@ -323,27 +323,27 @@ std::size_t CTrackingAllocator<T>::ms_Allocated = 0;
 
 void CMemoryUsageTest::testUsage(void)
 {
-    typedef std::vector<SFoo> TFooVec;
-    typedef std::vector<SFooWithMemoryUsage> TFooWithMemoryVec;
-    typedef std::list<SFoo> TFooList;
-    typedef std::list<SFooWithMemoryUsage> TFooWithMemoryList;
-    typedef std::deque<SFoo> TFooDeque;
-    typedef std::deque<SFooWithMemoryUsage> TFooWithMemoryDeque;
-    typedef boost::circular_buffer<SFoo> TFooCircBuf;
-    typedef boost::circular_buffer<SFooWithMemoryUsage> TFooWithMemoryCircBuf;
-    typedef std::map<SFoo, SFoo> TFooFooMap;
-    typedef std::map<SFooWithMemoryUsage, SFooWithMemoryUsage> TFooWithMemoryFooWithMemoryMap;
-    typedef boost::unordered_map<SFoo, SFoo, SHash> TFooFooUMap;
-    typedef boost::container::flat_set<SFoo> TFooFSet;
-    typedef boost::unordered_map<SFooWithMemoryUsage, SFooWithMemoryUsage, SHash> TFooWithMemoryFooWithMemoryUMap;
-    typedef std::vector<SBar> TBarVec;
-    typedef std::map<SBar, SBar> TBarBarMap;
-    typedef boost::unordered_map<SBar, SBar, SHash> TBarBarUMap;
-    typedef boost::container::flat_map<SBar, SBar> TBarBarFMap;
-    typedef boost::shared_ptr<SBar> TBarPtr;
-    typedef boost::shared_ptr<CBase> TBasePtr;
-    typedef std::vector<CDerived> TDerivedVec;
-    typedef std::vector<TBasePtr> TBasePtrVec;
+    using TFooVec = std::vector<SFoo>;
+    using TFooWithMemoryVec = std::vector<SFooWithMemoryUsage>;
+    using TFooList = std::list<SFoo>;
+    using TFooWithMemoryList = std::list<SFooWithMemoryUsage>;
+    using TFooDeque = std::deque<SFoo>;
+    using TFooWithMemoryDeque = std::deque<SFooWithMemoryUsage>;
+    using TFooCircBuf = boost::circular_buffer<SFoo>;
+    using TFooWithMemoryCircBuf = boost::circular_buffer<SFooWithMemoryUsage>;
+    using TFooFooMap = std::map<SFoo, SFoo>;
+    using TFooWithMemoryFooWithMemoryMap = std::map<SFooWithMemoryUsage, SFooWithMemoryUsage>;
+    using TFooFooUMap = boost::unordered_map<SFoo, SFoo, SHash>;
+    using TFooFSet = boost::container::flat_set<SFoo>;
+    using TFooWithMemoryFooWithMemoryUMap = boost::unordered_map<SFooWithMemoryUsage, SFooWithMemoryUsage, SHash>;
+    using TBarVec = std::vector<SBar>;
+    using TBarBarMap = std::map<SBar, SBar>;
+    using TBarBarUMap = boost::unordered_map<SBar, SBar, SHash>;
+    using TBarBarFMap = boost::container::flat_map<SBar, SBar>;
+    using TBarPtr = boost::shared_ptr<SBar>;
+    using TBasePtr = boost::shared_ptr<CBase>;
+    using TDerivedVec = std::vector<CDerived>;
+    using TBasePtrVec = std::vector<TBasePtr>;
 
     // We want various invariants to hold for dynamic size:
     //   1) The dynamic size is not affected by adding a memoryUsage
@@ -568,8 +568,8 @@ void CMemoryUsageTest::testUsage(void)
     {
         LOG_DEBUG("*** boost::any ***");
 
-        typedef std::vector<double> TDoubleVec;
-        typedef std::vector<boost::any> TAnyVec;
+        using TDoubleVec = std::vector<double>;
+        using TAnyVec = std::vector<boost::any>;
 
         TDoubleVec a(10);
         TFooVec b(20);
@@ -726,8 +726,8 @@ void CMemoryUsageTest::testUsage(void)
 
 void CMemoryUsageTest::testDebug(void)
 {
-    typedef std::vector<SBar> TBarVec;
-    typedef boost::shared_ptr<TBarVec> TBarVecPtr;
+    using TBarVec = std::vector<SBar>;
+    using TBarVecPtr = boost::shared_ptr<TBarVec>;
 
     // Check that we can get debug info out of classes with vectors of varying size
     {
@@ -782,8 +782,8 @@ void CMemoryUsageTest::testDebug(void)
         CPPUNIT_ASSERT_EQUAL(core::CMemory::dynamicSize(t), memoryUsage.usage());
     }
     {
-        typedef std::pair<EFeature, TBarVecPtr> TFeatureBarVecPtrPr;
-        typedef std::vector<TFeatureBarVecPtrPr> TFeatureBarVecPtrPrVec;
+        using TFeatureBarVecPtrPr = std::pair<EFeature, TBarVecPtr>;
+        using TFeatureBarVecPtrPrVec = std::vector<TFeatureBarVecPtrPr>;
         TFeatureBarVecPtrPrVec t;
 
         TBarVecPtr vec(new TBarVec());
@@ -837,23 +837,23 @@ void CMemoryUsageTest::testDynamicSizeAlwaysZero(void)
     CPPUNIT_ASSERT_EQUAL(true, test);
     test = core::memory_detail::SDynamicSizeAlwaysZero<SPod>::value();
     CPPUNIT_ASSERT_EQUAL(haveStructPodCompilerSupport, test);
-    test = core::memory_detail::SDynamicSizeAlwaysZero<boost::optional<double> >::value();
+    test = core::memory_detail::SDynamicSizeAlwaysZero<boost::optional<double>>::value();
     CPPUNIT_ASSERT_EQUAL(true, test);
-    test = core::memory_detail::SDynamicSizeAlwaysZero<boost::optional<SPod> >::value();
+    test = core::memory_detail::SDynamicSizeAlwaysZero<boost::optional<SPod>>::value();
     CPPUNIT_ASSERT_EQUAL(haveStructPodCompilerSupport, test);
-    test = core::memory_detail::SDynamicSizeAlwaysZero<std::pair<int, int> >::value();
+    test = core::memory_detail::SDynamicSizeAlwaysZero<std::pair<int, int>>::value();
     CPPUNIT_ASSERT_EQUAL(true, test);
     test = boost::is_pod<SFoo>::value;
     CPPUNIT_ASSERT_EQUAL(false, test);
     test = core::memory_detail::SDynamicSizeAlwaysZero<SFoo>::value();
     CPPUNIT_ASSERT_EQUAL(true, test);
-    test = core::memory_detail::SDynamicSizeAlwaysZero<std::pair<boost::optional<double>, SFoo> >::value();
+    test = core::memory_detail::SDynamicSizeAlwaysZero<std::pair<boost::optional<double>, SFoo>>::value();
     CPPUNIT_ASSERT_EQUAL(true, test);
     test = core::memory_detail::SDynamicSizeAlwaysZero<core::CHashing::CUniversalHash::CUInt32Hash>::value();
     CPPUNIT_ASSERT_EQUAL(true, test);
     test = core::memory_detail::SDynamicSizeAlwaysZero<core::CHashing::CUniversalHash::CUInt32UnrestrictedHash>::value();
     CPPUNIT_ASSERT_EQUAL(true, test);
-    test = core::memory_detail::SDynamicSizeAlwaysZero<std::pair<double, SFooWithMemoryUsage> >::value();
+    test = core::memory_detail::SDynamicSizeAlwaysZero<std::pair<double, SFooWithMemoryUsage>>::value();
     CPPUNIT_ASSERT_EQUAL(false, test);
     test = core::memory_detail::SDynamicSizeAlwaysZero<SFooWithMemoryUsage>::value();
     CPPUNIT_ASSERT_EQUAL(false, test);
@@ -1067,7 +1067,7 @@ void CMemoryUsageTest::testStringBehaviour(void)
         LOG_INFO("On this platform clearing can reduce string capacity");
     }
 
-    typedef std::vector<size_t> TSizeVec;
+    using TSizeVec = std::vector<size_t>;
     std::string grower;
     TSizeVec capacities(1, grower.capacity());
     for (size_t count = 0; count < 50000; ++count)
@@ -1101,8 +1101,8 @@ void CMemoryUsageTest::testStringBehaviour(void)
 
 void CMemoryUsageTest::testStringMemory(void)
 {
-    typedef ::CTrackingAllocator<char> TAllocator;
-    typedef std::basic_string<char, std::char_traits<char>, TAllocator> TString;
+    using TAllocator = ::CTrackingAllocator<char>;
+    using TString = std::basic_string<char, std::char_traits<char>, TAllocator>;
 
     for (std::size_t i = 0; i < 1500; ++i)
     {
@@ -1122,8 +1122,8 @@ void CMemoryUsageTest::testStringMemory(void)
 
 void CMemoryUsageTest::testStringClear(void)
 {
-    typedef ::CTrackingAllocator<char> TAllocator;
-    typedef std::basic_string<char, std::char_traits<char>, TAllocator> TString;
+    using TAllocator = ::CTrackingAllocator<char>;
+    using TString = std::basic_string<char, std::char_traits<char>, TAllocator>;
 
     TString empty;
     TString something1("something");
@@ -1143,11 +1143,11 @@ void CMemoryUsageTest::testStringClear(void)
 void CMemoryUsageTest::testSharedPointer(void)
 {
     LOG_DEBUG("*** testSharedPointer ***");
-    typedef std::vector<int> TIntVec;
-    typedef boost::shared_ptr<TIntVec> TIntVecPtr;
-    typedef std::vector<TIntVecPtr> TIntVecPtrVec;
-    typedef boost::shared_ptr<std::string> TStrPtr;
-    typedef std::vector<TStrPtr> TStrPtrVec;
+    using TIntVec = std::vector<int>;
+    using TIntVecPtr = boost::shared_ptr<TIntVec>;
+    using TIntVecPtrVec = std::vector<TIntVecPtr>;
+    using TStrPtr = boost::shared_ptr<std::string>;
+    using TStrPtrVec = std::vector<TStrPtr>;
     TStrPtrVec strings;
 
     TIntVecPtrVec vec1;

--- a/lib/core/unittest/CMessageBufferTest.cc
+++ b/lib/core/unittest/CMessageBufferTest.cc
@@ -36,7 +36,7 @@ namespace
     class CBuffer
     {
         public:
-            typedef std::vector<std::string>    TStrVec;
+            using TStrVec = std::vector<std::string>;
 
         public:
             CBuffer(uint32_t flushInterval) : m_FlushInterval(flushInterval)

--- a/lib/core/unittest/CMessageQueueTest.cc
+++ b/lib/core/unittest/CMessageQueueTest.cc
@@ -69,7 +69,7 @@ namespace
             }
 
         private:
-            typedef std::vector<std::string> TStrVec;
+            using TStrVec = std::vector<std::string>;
 
             TStrVec  m_Strings;
 

--- a/lib/core/unittest/CPersistUtilsTest.cc
+++ b/lib/core/unittest/CPersistUtilsTest.cc
@@ -33,18 +33,18 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef std::map<std::size_t, double> TSizeDoubleMap;
-typedef std::set<int> TIntSet;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::vector<TStrVec> TStrVecVec;
-typedef boost::unordered_map<std::string, int> TStrIntUMap;
-typedef boost::unordered_map<std::string, TDoubleVecVec> TStrDoubleVecVecUMap;
-typedef boost::unordered_set<std::size_t> TSizeUSet;
-typedef std::vector<TSizeUSet> TSizeUSetVec;
-typedef boost::circular_buffer<TSizeDoublePr> TSizeDoublePrBuf;
+using TDoubleVec = std::vector<double>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoubleMap = std::map<std::size_t, double>;
+using TIntSet = std::set<int>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TStrVec = std::vector<std::string>;
+using TStrVecVec = std::vector<TStrVec>;
+using TStrIntUMap = boost::unordered_map<std::string, int>;
+using TStrDoubleVecVecUMap = boost::unordered_map<std::string, TDoubleVecVec>;
+using TSizeUSet = boost::unordered_set<std::size_t>;
+using TSizeUSetVec = std::vector<TSizeUSet>;
+using TSizeDoublePrBuf = boost::circular_buffer<TSizeDoublePr>;
 
 namespace
 {
@@ -55,18 +55,18 @@ class ContainerCompare {};
 template<typename T, typename R = void>
 struct enable_if_type
 {
-    typedef R type;
+    using type = R;
 };
 
 template<typename T, typename ITR = void>
 struct compare_container_selector
 {
-    typedef BasicCompare value;
+    using value = BasicCompare;
 };
 template<typename T>
 struct compare_container_selector<T, typename enable_if_type<typename T::const_iterator>::type>
 {
-    typedef ContainerCompare value;
+    using value = ContainerCompare;
 };
 
 template<typename SELECTOR> class CCompareImpl {};
@@ -135,7 +135,7 @@ class CCompareImpl<ContainerCompare>
         template<typename T>
         static bool dispatch(const T &lhs, const T &rhs)
         {
-            typedef typename T::const_iterator TCItr;
+            using TCItr = typename T::const_iterator;
             if (lhs.size() != rhs.size())
             {
                 return false;
@@ -154,7 +154,7 @@ class CCompareImpl<ContainerCompare>
         static bool dispatch(const boost::unordered_map<K, V> &lhs,
                              const boost::unordered_map<K, V> &rhs)
         {
-            typedef std::vector<std::pair<K, V> > TVec;
+            using TVec = std::vector<std::pair<K, V>>;
             TVec lKeys(lhs.begin(), lhs.end());
             TVec rKeys(rhs.begin(), rhs.end());
             std::sort(lKeys.begin(), lKeys.end(), SFirstLess());
@@ -166,7 +166,7 @@ class CCompareImpl<ContainerCompare>
         static bool dispatch(const boost::unordered_set<T> &lhs,
                              const boost::unordered_set<T> &rhs)
         {
-            typedef std::vector<T> TVec;
+            using TVec = std::vector<T>;
             TVec lKeys(lhs.begin(), lhs.end());
             TVec rKeys(rhs.begin(), rhs.end());
             std::sort(lKeys.begin(), lKeys.end());

--- a/lib/core/unittest/CPolymorphicStackObjectCPtrTest.cc
+++ b/lib/core/unittest/CPolymorphicStackObjectCPtrTest.cc
@@ -59,8 +59,8 @@ class CDerived4 : public CBase
 
 void CPolymorphicStackObjectCPtrTest::testAll(void)
 {
-    typedef core::CPolymorphicStackObjectCPtr<CBase, CDerived1, CDerived2> TStackPtr12;
-    typedef core::CPolymorphicStackObjectCPtr<CBase, CDerived1, CDerived2, CDerived3, CDerived4> TStackPtr1234;
+    using TStackPtr12 = core::CPolymorphicStackObjectCPtr<CBase, CDerived1, CDerived2>;
+    using TStackPtr1234 = core::CPolymorphicStackObjectCPtr<CBase, CDerived1, CDerived2, CDerived3, CDerived4>;
 
     TStackPtr12 test1((CDerived1()));
     CPPUNIT_ASSERT_EQUAL(std::string("d1"), test1->iam());

--- a/lib/core/unittest/CRapidJsonWriterBaseTest.cc
+++ b/lib/core/unittest/CRapidJsonWriterBaseTest.cc
@@ -62,8 +62,9 @@ void CRapidJsonWriterBaseTest::testAddFields(void)
 {
     std::ostringstream strm;
     rapidjson::OStreamWrapper writeStream(strm);
-    typedef ml::core::CRapidJsonWriterBase<rapidjson::OStreamWrapper, rapidjson::UTF8<>, rapidjson::UTF8<>,
-            rapidjson::CrtAllocator> TGenericLineWriter;
+    using TGenericLineWriter =
+         ml::core::CRapidJsonWriterBase<rapidjson::OStreamWrapper, rapidjson::UTF8<>, rapidjson::UTF8<>,
+                                        rapidjson::CrtAllocator>;
     TGenericLineWriter writer(writeStream);
 
     rapidjson::Document doc = writer.makeDoc();;
@@ -115,8 +116,9 @@ void CRapidJsonWriterBaseTest::testRemoveMemberIfPresent(void)
 {
     std::ostringstream strm;
     rapidjson::OStreamWrapper writeStream(strm);
-    typedef ml::core::CRapidJsonWriterBase<rapidjson::OStreamWrapper, rapidjson::UTF8<>, rapidjson::UTF8<>,
-            rapidjson::CrtAllocator> TGenericLineWriter;
+    using TGenericLineWriter =
+        ml::core::CRapidJsonWriterBase<rapidjson::OStreamWrapper, rapidjson::UTF8<>, rapidjson::UTF8<>,
+                                       rapidjson::CrtAllocator>;
     TGenericLineWriter writer(writeStream);
 
     rapidjson::Document doc = writer.makeDoc();;

--- a/lib/core/unittest/CStateCompressorTest.cc
+++ b/lib/core/unittest/CStateCompressorTest.cc
@@ -30,18 +30,18 @@
 using namespace ml;
 using namespace core;
 
-typedef boost::mt19937 TRandom;
-typedef boost::uniform_int<> TDistribution;
-typedef boost::random::variate_generator<TRandom&, TDistribution> TGenerator;
-typedef boost::generator_iterator<TGenerator> TGeneratorItr;
+using TRandom = boost::mt19937;
+using TDistribution = boost::uniform_int<>;
+using TGenerator = boost::random::variate_generator<TRandom&, TDistribution>;
+using TGeneratorItr = boost::generator_iterator<TGenerator>;
 
 namespace
 {
 
-typedef std::map<std::size_t, std::string> TSizeStrMap;
-typedef TSizeStrMap::const_iterator TSizeStrMapCItr;
-typedef core::CDataAdder::TOStreamP TOStreamP;
-typedef core::CDataSearcher::TIStreamP TIStreamP;
+using TSizeStrMap = std::map<std::size_t, std::string>;
+using TSizeStrMapCItr = TSizeStrMap::const_iterator;
+using TOStreamP = core::CDataAdder::TOStreamP;
+using TIStreamP = core::CDataSearcher::TIStreamP;
 
 void insert3rdLevel(ml::core::CStatePersistInserter &inserter)
 {

--- a/lib/core/unittest/CStateMachineTest.cc
+++ b/lib/core/unittest/CStateMachineTest.cc
@@ -34,9 +34,9 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef std::vector<std::string> TStrVec;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TStrVec = std::vector<std::string>;
 
 class CStateMachineClearer : core::CStateMachine
 {
@@ -70,12 +70,12 @@ struct SMachine
     }
 };
 
-typedef std::vector<SMachine> TMachineVec;
+using TMachineVec = std::vector<SMachine>;
 
 class CTestThread : public core::CThread
 {
     public:
-        typedef boost::shared_ptr<CppUnit::Exception> TCppUnitExceptionP;
+        using TCppUnitExceptionP = boost::shared_ptr<CppUnit::Exception>;
 
     public:
         CTestThread(const TMachineVec &machines) :
@@ -250,8 +250,8 @@ void CStateMachineTest::testMultithreaded(void)
     std::sort(machines.begin(), machines.end());
     machines.erase(std::unique(machines.begin(), machines.end()), machines.end());
 
-    typedef boost::shared_ptr<CTestThread> TThreadPtr;
-    typedef std::vector<TThreadPtr> TThreadVec;
+    using TThreadPtr = boost::shared_ptr<CTestThread>;
+    using TThreadVec = std::vector<TThreadPtr>;
     TThreadVec threads;
     for (std::size_t i = 0u; i < 20; ++i)
     {

--- a/lib/core/unittest/CStringSimilarityTesterTest.cc
+++ b/lib/core/unittest/CStringSimilarityTesterTest.cc
@@ -193,7 +193,7 @@ void CStringSimilarityTesterTest::testLevensteinDistance2(void)
 {
     ml::core::CStringSimilarityTester sst;
 
-    typedef std::vector<std::string> TStrVec;
+    using TStrVec = std::vector<std::string>;
 
     TStrVec sourceShutDown1;
     sourceShutDown1.push_back("ml13");
@@ -270,7 +270,7 @@ void CStringSimilarityTesterTest::testLevensteinDistanceThroughputDifferent(void
 {
     ml::core::CStringSimilarityTester sst;
 
-    typedef std::vector<std::string> TStrVec;
+    using TStrVec = std::vector<std::string>;
 
     static const size_t TEST_SIZE(700);
     static const int    MAX_LEN(40);
@@ -316,7 +316,7 @@ void CStringSimilarityTesterTest::testLevensteinDistanceThroughputSimilar(void)
 {
     ml::core::CStringSimilarityTester sst;
 
-    typedef std::vector<std::string> TStrVec;
+    using TStrVec = std::vector<std::string>;
 
     static const size_t TEST_SIZE(700);
     static const int    EXTRA_CHARS(4);
@@ -397,8 +397,8 @@ void CStringSimilarityTesterTest::testWeightedEditDistance(void)
 {
     ml::core::CStringSimilarityTester sst;
 
-    typedef std::pair<std::string, size_t> TStrSizePr;
-    typedef std::vector<TStrSizePr>        TStrSizePrVec;
+    using TStrSizePr = std::pair<std::string, size_t>;
+    using TStrSizePrVec = std::vector<TStrSizePr>;
 
     // These tests give a weight of 3 to dictionary words and 1 to other tokens
 

--- a/lib/core/unittest/CStringUtilsTest.cc
+++ b/lib/core/unittest/CStringUtilsTest.cc
@@ -598,8 +598,8 @@ void CStringUtilsTest::testJoin(void)
     LOG_DEBUG("*** testJoin ***")
     using namespace ml;
     using namespace core;
-    typedef std::vector<std::string> TStrVec;
-    typedef std::set<std::string> TStrSet;
+    using TStrVec = std::vector<std::string>;
+    using TStrSet = std::set<std::string>;
 
     TStrVec strVec;
 

--- a/lib/core/unittest/CThreadFarmTest.cc
+++ b/lib/core/unittest/CThreadFarmTest.cc
@@ -117,7 +117,7 @@ namespace
             }
 
         private:
-            typedef std::set<std::string> TStrSet;
+            using TStrSet = std::set<std::string>;
 
             TStrSet      m_OutstandingOutput;
             ml::core::CMutex m_Mutex;

--- a/lib/core/unittest/CTripleTest.cc
+++ b/lib/core/unittest/CTripleTest.cc
@@ -75,8 +75,8 @@ void CTripleTest::testOperators(void)
 
 void CTripleTest::testBoostHashReady(void)
 {
-    typedef ml::core::CTriple<std::string, std::size_t, short> TStringSizeShortTriple;
-    typedef boost::unordered_map<TStringSizeShortTriple, std::size_t> TStringSizeShortTripleSizeMap;
+    using TStringSizeShortTriple = ml::core::CTriple<std::string, std::size_t, short>;
+    using TStringSizeShortTripleSizeMap = boost::unordered_map<TStringSizeShortTriple, std::size_t>;
 
     TStringSizeShortTripleSizeMap map;
     map.emplace(ml::core::make_triple(std::string("foo"), std::size_t(10), short(3)), 1);

--- a/lib/maths/CAgglomerativeClusterer.cc
+++ b/lib/maths/CAgglomerativeClusterer.cc
@@ -40,15 +40,15 @@ namespace maths
 namespace
 {
 
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::pair<double, TSizeSizePr> TDoubleSizeSizePrPr;
-typedef std::vector<TDoubleSizeSizePrPr> TDoubleSizeSizePrPrVec;
-typedef CAgglomerativeClusterer::TSizeVec TSizeVec;
-typedef CAgglomerativeClusterer::TDoubleVec TDoubleVec;
-typedef CAgglomerativeClusterer::TDoubleVecVec TDoubleVecVec;
-typedef CAgglomerativeClusterer::CNode TNode;
-typedef CAgglomerativeClusterer::TNodeVec TNodeVec;
-typedef std::vector<TNode*> TNodePtrVec;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TDoubleSizeSizePrPr = std::pair<double, TSizeSizePr>;
+using TDoubleSizeSizePrPrVec = std::vector<TDoubleSizeSizePrPr>;
+using TSizeVec = CAgglomerativeClusterer::TSizeVec;
+using TDoubleVec = CAgglomerativeClusterer::TDoubleVec;
+using TDoubleVecVec = CAgglomerativeClusterer::TDoubleVecVec;
+using TNode = CAgglomerativeClusterer::CNode;
+using TNodeVec = CAgglomerativeClusterer::TNodeVec;
+using TNodePtrVec = std::vector<TNode*>;
 
 const double INF = boost::numeric::bounds<double>::highest();
 

--- a/lib/maths/CAssignment.cc
+++ b/lib/maths/CAssignment.cc
@@ -30,13 +30,13 @@ namespace maths
 namespace
 {
 
-typedef std::vector<bool> TBoolVec;
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::vector<TSizeSizePr> TSizeSizePrVec;
+using TBoolVec = std::vector<bool>;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrVec = std::vector<TSizeSizePr>;
 
 const std::size_t UNMATCHED = boost::numeric::bounds<std::size_t>::highest();
 const double MAXIMUM_COST = boost::numeric::bounds<double>::highest();

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -38,9 +38,9 @@ namespace
 namespace detail
 {
 
-typedef std::vector<uint8_t> TUInt8Vec;
-typedef TUInt8Vec::iterator TUInt8VecItr;
-typedef TUInt8Vec::const_iterator TUInt8VecCItr;
+using TUInt8Vec = std::vector<uint8_t>;
+using TUInt8VecItr = TUInt8Vec::iterator;
+using TUInt8VecCItr = TUInt8Vec::const_iterator;
 
 //! Convert the decomposition of the hash into two 8 bit integers
 //! bask into the original hash value.
@@ -53,7 +53,7 @@ inline uint16_t from8Bit(uint8_t leading, uint8_t trailing)
            );
 }
 
-typedef std::pair<uint8_t, uint8_t> TUInt8UInt8Pr;
+using TUInt8UInt8Pr = std::pair<uint8_t, uint8_t>;
 
 //! \brief Random access iterator wrapper for B set iterator.
 //!
@@ -69,7 +69,7 @@ typedef std::pair<uint8_t, uint8_t> TUInt8UInt8Pr;
 class CHashIterator : public std::iterator<std::random_access_iterator_tag, uint16_t>,
                       private boost::less_than_comparable<CHashIterator,
                               boost::addable<CHashIterator, ptrdiff_t,
-                              boost::subtractable<CHashIterator, ptrdiff_t> > >
+                              boost::subtractable<CHashIterator, ptrdiff_t>> >
 {
     public:
         //! The STL that comes with g++ requires a default constructor - this
@@ -231,7 +231,7 @@ void prune(TUInt8Vec &b, uint8_t z)
 
 } // detail::
 
-typedef boost::optional<std::size_t> TOptionalSize;
+using TOptionalSize = boost::optional<std::size_t>;
 
 const char DELIMITER(':');
 const char PAIR_DELIMITER(';');
@@ -784,7 +784,7 @@ void CBjkstUniqueValues::SSketch::remove(uint32_t value)
 
 uint32_t CBjkstUniqueValues::SSketch::number(void) const
 {
-    typedef std::vector<uint32_t> TUInt32Vec;
+    using TUInt32Vec = std::vector<uint32_t>;
 
     // This uses the median trick to reduce the error.
 

--- a/lib/maths/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/CCalendarComponentAdaptiveBucketing.cc
@@ -162,7 +162,7 @@ void CCalendarComponentAdaptiveBucketing::propagateForwardsByTime(double time)
     {
         double factor{::exp(-this->CAdaptiveBucketing::decayRate() * time)};
         this->CAdaptiveBucketing::age(factor);
-        for (auto &&value : m_Values)
+        for (auto &value : m_Values)
         {
             value.age(factor);
         }

--- a/lib/maths/CConstantPrior.cc
+++ b/lib/maths/CConstantPrior.cc
@@ -40,7 +40,7 @@ namespace maths
 
 namespace
 {
-typedef boost::optional<double> TOptionalDouble;
+using TOptionalDouble = boost::optional<double>;
 
 //! Set the constant, validating the input.
 void setConstant(double value, TOptionalDouble &result)

--- a/lib/maths/CCooccurrences.cc
+++ b/lib/maths/CCooccurrences.cc
@@ -37,15 +37,15 @@ namespace maths
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef boost::unordered_set<TSizeSizePr> TSizeSizePrUSet;
-typedef CVector<double> TPoint;
-typedef std::vector<TPoint> TPointVec;
-typedef std::vector<CPackedBitVector> TPackedBitVectorVec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrUSet = boost::unordered_set<TSizeSizePr>;
+using TPoint = CVector<double>;
+using TPointVec = std::vector<TPoint>;
+using TPackedBitVectorVec = std::vector<CPackedBitVector>;
 
 //! \brief Counts the (co-)occurrences of two variables.
 struct SCooccurrence
@@ -67,7 +67,7 @@ struct SCooccurrence
     std::size_t s_X, s_Y;
 };
 
-typedef CBasicStatistics::COrderStatisticsHeap<SCooccurrence> TMostSignificant;
+using TMostSignificant = CBasicStatistics::COrderStatisticsHeap<SCooccurrence>;
 
 //! Compute \p x * \p x.
 double pow2(double x)

--- a/lib/maths/CCountMinSketch.cc
+++ b/lib/maths/CCountMinSketch.cc
@@ -344,7 +344,7 @@ double CCountMinSketch::totalCount(void) const
 
 double CCountMinSketch::count(uint32_t category) const
 {
-    typedef CBasicStatistics::COrderStatisticsStack<double, 1> TMinAccumulator;
+    using TMinAccumulator = CBasicStatistics::COrderStatisticsStack<double, 1>;
 
     const TUInt32FloatPrVec *counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
     if (counts)

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -41,7 +41,7 @@ namespace maths
 namespace
 {
 
-typedef maths_t::TDoubleDoublePr TDoubleDoublePr;
+using TDoubleDoublePr = maths_t::TDoubleDoublePr;
 
 const std::string MAX_SIZE_TAG{"a"};
 const std::string RNG_TAG{"b"};
@@ -236,7 +236,7 @@ double CDecompositionComponent::heteroscedasticity(void) const
         return 0.0;
     }
 
-    typedef CBasicStatistics::SMax<double>::TAccumulator TMaxAccumulator;
+    using TMaxAccumulator = CBasicStatistics::SMax<double>::TAccumulator;
 
     TMaxAccumulator result;
 
@@ -354,7 +354,7 @@ void CDecompositionComponent::CPackedSplines::clear(void)
 
 void CDecompositionComponent::CPackedSplines::shift(ESpline spline, double shift)
 {
-    for (auto &&value : m_Values[static_cast<std::size_t>(spline)])
+    for (auto &value : m_Values[static_cast<std::size_t>(spline)])
     {
         value += shift;
     }

--- a/lib/maths/CGammaRateConjugate.cc
+++ b/lib/maths/CGammaRateConjugate.cc
@@ -59,13 +59,13 @@ namespace
 namespace detail
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef maths_t::TWeightStyleVec TWeightStyleVec;
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef CBasicStatistics::SSampleMean<CDoublePrecisionStorage>::TAccumulator TMeanAccumulator;
-typedef CBasicStatistics::SSampleMeanVar<CDoublePrecisionStorage>::TAccumulator TMeanVarAccumulator;
+using TDoubleDoublePr = std::pair<double, double>;
+using TWeightStyleVec = maths_t::TWeightStyleVec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TMeanAccumulator = CBasicStatistics::SSampleMean<CDoublePrecisionStorage>::TAccumulator;
+using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<CDoublePrecisionStorage>::TAccumulator;
 
 const double NON_INFORMATIVE_COUNT = 3.5;
 
@@ -1606,7 +1606,7 @@ bool CGammaRateConjugate::minusLogJointCdf(const TWeightStyleVec &weightStyles,
                                            double &lowerBound,
                                            double &upperBound) const
 {
-    typedef detail::CEvaluateOnSamples<CTools::SMinusLogCdf> TMinusLogCdf;
+    using TMinusLogCdf = detail::CEvaluateOnSamples<CTools::SMinusLogCdf>;
 
     lowerBound = upperBound = 0.0;
 
@@ -1656,7 +1656,7 @@ bool CGammaRateConjugate::minusLogJointCdfComplement(const TWeightStyleVec &weig
                                                      double &lowerBound,
                                                      double &upperBound) const
 {
-    typedef detail::CEvaluateOnSamples<CTools::SMinusLogCdfComplement> TMinusLogCdfComplement;
+    using TMinusLogCdfComplement = detail::CEvaluateOnSamples<CTools::SMinusLogCdfComplement>;
 
     lowerBound = upperBound = 0.0;
 

--- a/lib/maths/CKMeansOnline1d.cc
+++ b/lib/maths/CKMeansOnline1d.cc
@@ -41,11 +41,11 @@ namespace maths
 namespace
 {
 
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
 
 namespace detail
 {

--- a/lib/maths/CKMostCorrelated.cc
+++ b/lib/maths/CKMostCorrelated.cc
@@ -49,11 +49,11 @@ namespace maths
 namespace
 {
 
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef boost::unordered_set<TSizeSizePr> TSizeSizePrUSet;
-typedef boost::array<double, CKMostCorrelated::NUMBER_PROJECTIONS> TPoint;
-typedef std::pair<TPoint, std::size_t> TPointSizePr;
-typedef std::vector<TPointSizePr> TPointSizePrVec;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrUSet = boost::unordered_set<TSizeSizePr>;
+using TPoint = boost::array<double, CKMostCorrelated::NUMBER_PROJECTIONS>;
+using TPointSizePr = std::pair<TPoint, std::size_t>;
+using TPointSizePrVec = std::vector<TPointSizePr>;
 
 //! \brief Unary predicate to check variables, corresponding
 //! to labeled points, are not equal to a specified variable.
@@ -451,9 +451,9 @@ std::size_t CKMostCorrelated::memoryUsage(void) const
 
 void CKMostCorrelated::mostCorrelated(TCorrelationVec &result) const
 {
-    typedef CBasicStatistics::COrderStatisticsStack<double, 2, std::greater<double> > TMaxDoubleAccumulator;
-    typedef CBasicStatistics::COrderStatisticsHeap<SCorrelation> TMaxCorrelationAccumulator;
-    typedef bgi::rtree<TPointSizePr, bgi::quadratic<16> > TPointRTree;
+    using TMaxDoubleAccumulator = CBasicStatistics::COrderStatisticsStack<double, 2, std::greater<double>>;
+    using TMaxCorrelationAccumulator = CBasicStatistics::COrderStatisticsHeap<SCorrelation>;
+    using TPointRTree = bgi::rtree<TPointSizePr, bgi::quadratic<16>>;
 
     result.clear();
 

--- a/lib/maths/CLassoLogisticRegression.cc
+++ b/lib/maths/CLassoLogisticRegression.cc
@@ -34,7 +34,7 @@ namespace maths
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 //! An upper bound on the second derivative of minus the log of the
 //! logistic link function in a ball, i.e.
@@ -104,7 +104,7 @@ double logLikelihood(const MATRIX &x,
                      const TDoubleVec &lambda,
                      const TDoubleVec &beta)
 {
-    typedef typename MATRIX::iterator iterator;
+    using iterator = typename MATRIX::iterator;
 
     double result = 0.0;
     TDoubleVec f(y.size(), 0.0);
@@ -142,7 +142,7 @@ void CLG(std::size_t maxIterations,
          TDoubleVec &r,
          std::size_t &numberIterations)
 {
-    typedef typename MATRIX::iterator iterator;
+    using iterator = typename MATRIX::iterator;
 
     std::size_t d = x.columns();
     LOG_DEBUG("d = " << d << ", n = " << y.size());
@@ -501,11 +501,11 @@ namespace
 {
 
 using namespace lasso_logistic_regression_detail;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef std::vector<TSizeDoublePr> TSizeDoublePrVec;
-typedef std::vector<TSizeDoublePrVec> TSizeDoublePrVecVec;
-typedef boost::unordered_set<std::size_t> TSizeUSet;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
+using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
+using TSizeUSet = boost::unordered_set<std::size_t>;
 
 //! Set up the masked training data.
 //!
@@ -664,7 +664,7 @@ double element(const TSizeDoublePr &xij)
 template<typename STORAGE>
 double l22Norm(const STORAGE &x)
 {
-    typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     TMeanAccumulator result;
     for (std::size_t i = 0u; i < x.size(); ++i)
     {
@@ -697,7 +697,7 @@ template<typename MATRIX>
 class C2FoldCrossValidatedLogLikelihood
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         C2FoldCrossValidatedLogLikelihood(std::size_t d) :
@@ -751,7 +751,7 @@ class C2FoldCrossValidatedLogLikelihood
         }
 
     private:
-        typedef std::vector<MATRIX> TMatrixVec;
+        using TMatrixVec = std::vector<MATRIX>;
 
     private:
         //! The feature vector dimension.
@@ -793,7 +793,7 @@ void CLassoLogisticRegression<STORAGE>::doLearnHyperparameter(EHyperparametersSt
         return;
     }
 
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     std::size_t n = m_X.size();
     LOG_DEBUG("d = " << m_D << ", n = " << n);

--- a/lib/maths/CLinearAlgebraTools.cc
+++ b/lib/maths/CLinearAlgebraTools.cc
@@ -382,14 +382,14 @@ SAMPLE_GAUSSIAN(double, 5)
 void sampleGaussian(std::size_t d,
                     const CVector<CFloatStorage> &mean,
                     const CSymmetricMatrix<CFloatStorage> &covariance,
-                    std::vector<CVector<double> > &result)
+                    std::vector<CVector<double>> &result)
 {
     return CSampleGaussian<SDenseMatrix<CSymmetricMatrix<CFloatStorage>>::Type>::generate(d, mean, covariance, result);
 }
 void sampleGaussian(std::size_t d,
                     const CVector<double> &mean,
                     const CSymmetricMatrix<double> &covariance,
-                    std::vector<CVector<double> > &result)
+                    std::vector<CVector<double>> &result)
 {
     return CSampleGaussian<SDenseMatrix<CSymmetricMatrix<double>>::Type>::generate(d, mean, covariance, result);
 }

--- a/lib/maths/CLogNormalMeanPrecConjugate.cc
+++ b/lib/maths/CLogNormalMeanPrecConjugate.cc
@@ -57,13 +57,13 @@ namespace maths
 namespace
 {
 
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef maths_t::TWeightStyleVec TWeightStyleVec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TSizeVec = std::vector<std::size_t>;
+using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using TWeightStyleVec = maths_t::TWeightStyleVec;
 
 //! Compute x * x.
 inline double pow2(double x)
@@ -76,8 +76,8 @@ const double MINIMUM_LOGNORMAL_SHAPE = 100.0;
 namespace detail
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
 
 //! \brief Adds "weight" x "right operand" to the "left operand".
 struct SPlusWeight
@@ -316,7 +316,7 @@ class CEvaluateOnSamples : core::CNonCopyable
 class CMeanKernel
 {
     public:
-        typedef CVectorNx1<double, 2> TValue;
+        using TValue = CVectorNx1<double, 2>;
 
     public:
         CMeanKernel(double m, double p, double a, double b) :
@@ -355,7 +355,7 @@ class CMeanKernel
 class CVarianceKernel
 {
     public:
-        typedef CVectorNx1<double, 2> TValue;
+        using TValue = CVectorNx1<double, 2>;
 
     public:
         CVarianceKernel(double mean, double m, double p, double a, double b) :
@@ -1551,7 +1551,7 @@ bool CLogNormalMeanPrecConjugate::minusLogJointCdf(const TWeightStyleVec &weight
                                                    double &lowerBound,
                                                    double &upperBound) const
 {
-    typedef detail::CEvaluateOnSamples<CTools::SMinusLogCdf> TMinusLogCdf;
+    using TMinusLogCdf = detail::CEvaluateOnSamples<CTools::SMinusLogCdf>;
 
     lowerBound = upperBound = 0.0;
 
@@ -1602,7 +1602,7 @@ bool CLogNormalMeanPrecConjugate::minusLogJointCdfComplement(const TWeightStyleV
                                                              double &lowerBound,
                                                              double &upperBound) const
 {
-    typedef detail::CEvaluateOnSamples<CTools::SMinusLogCdfComplement> TMinusLogCdfComplement;
+    using TMinusLogCdfComplement = detail::CEvaluateOnSamples<CTools::SMinusLogCdfComplement>;
 
     lowerBound = upperBound = 0.0;
 

--- a/lib/maths/CMixtureDistribution.cc
+++ b/lib/maths/CMixtureDistribution.cc
@@ -24,7 +24,7 @@ namespace maths
 namespace
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
+using TDoubleDoublePr = std::pair<double, double>;
 
 //! brief Invokes the support function on a distribution.
 struct SSupport
@@ -101,7 +101,7 @@ template<typename RESULT, typename VISITOR_ACTION>
 class CUnaryVisitor
 {
     public:
-        typedef RESULT result_type;
+        using result_type = RESULT;
 
     public:
         template<typename DISTRIBUTION>
@@ -119,7 +119,7 @@ template<typename RESULT, typename VISITOR_ACTION>
 class CBinaryVisitor
 {
     public:
-        typedef RESULT result_type;
+        using result_type = RESULT;
 
     public:
         template<typename DISTRIBUTION>

--- a/lib/maths/CMultimodalPrior.cc
+++ b/lib/maths/CMultimodalPrior.cc
@@ -58,10 +58,10 @@ namespace maths
 namespace
 {
 
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef core::CSmallVector<TSizeDoublePr, 2> TSizeDoublePr2Vec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::set<std::size_t> TSizeSet;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePr2Vec = core::CSmallVector<TSizeDoublePr, 2>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TSizeSet = std::set<std::size_t>;
 
 const std::size_t MODE_SPLIT_NUMBER_SAMPLES(50u);
 const std::size_t MODE_MERGE_NUMBER_SAMPLES(25u);

--- a/lib/maths/CMultinomialConjugate.cc
+++ b/lib/maths/CMultinomialConjugate.cc
@@ -53,13 +53,13 @@ namespace maths
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef TDoubleVec::const_iterator TDoubleVecCItr;
-typedef core::CSmallVector<double, 7> TDouble7Vec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecCItr = TDoubleVec::const_iterator;
+using TDouble7Vec = core::CSmallVector<double, 7>;
 
 namespace detail
 {
-typedef std::pair<double, double> TDoubleDoublePr;
+using TDoubleDoublePr = std::pair<double, double>;
 
 //! Truncate \p to fit into a signed integer.
 int truncate(std::size_t x)
@@ -288,11 +288,11 @@ void generateBetaSamples(double a,
 
 } // detail::
 
-typedef std::map<double, double> TDoubleDoubleMap;
-typedef TDoubleDoubleMap::const_iterator TDoubleDoubleMapCItr;
-typedef boost::tuples::tuple<double, double, std::size_t> TDoubleDoubleSizeTr;
-typedef std::vector<TDoubleDoubleSizeTr> TDoubleDoubleSizeTrVec;
-typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleDoubleMap = std::map<double, double>;
+using TDoubleDoubleMapCItr = TDoubleDoubleMap::const_iterator;
+using TDoubleDoubleSizeTr = boost::tuples::tuple<double, double, std::size_t>;
+using TDoubleDoubleSizeTrVec = std::vector<TDoubleDoubleSizeTr>;
+using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 // We use short field names to reduce the state size
 const std::string NUMBER_AVAILABLE_CATEGORIES_TAG("a");
@@ -639,7 +639,7 @@ double CMultinomialConjugate::marginalLikelihoodMode(const TWeightStyleVec &/*we
 double CMultinomialConjugate::marginalLikelihoodVariance(const TWeightStyleVec &/*weightStyles*/,
                                                          const TDouble4Vec &/*weights*/) const
 {
-    typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
     if (this->isNonInformative())
     {
@@ -1114,7 +1114,7 @@ bool CMultinomialConjugate::probabilityOfLessLikelySamples(maths_t::EProbability
             // P(i in L). In this case we just fall back to using (3) which isn't
             // sharp.
 
-            typedef std::vector<std::size_t> TSizeVec;
+            using TSizeVec = std::vector<std::size_t>;
 
             tail = maths_t::E_MixedOrNeitherTail;
 

--- a/lib/maths/CMultivariateConstantPrior.cc
+++ b/lib/maths/CMultivariateConstantPrior.cc
@@ -45,8 +45,8 @@ namespace maths
 namespace
 {
 
-typedef core::CSmallVector<double, 10> TDouble10Vec;
-typedef boost::optional<TDouble10Vec> TOptionalDouble10Vec;
+using TDouble10Vec = core::CSmallVector<double, 10>;
+using TOptionalDouble10Vec = boost::optional<TDouble10Vec>;
 
 //! \brief Converts a constant value to a string.
 class CConstantToString

--- a/lib/maths/CMultivariateMultimodalPrior.cc
+++ b/lib/maths/CMultivariateMultimodalPrior.cc
@@ -27,9 +27,9 @@ namespace maths
 namespace multivariate_multimodal_prior_detail
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef CMultivariatePrior::TDouble10Vec TDouble10Vec;
-typedef CMultivariatePrior::TDouble10Vec4Vec TDouble10Vec4Vec;
+using TDoubleVec = std::vector<double>;
+using TDouble10Vec = CMultivariatePrior::TDouble10Vec;
+using TDouble10Vec4Vec = CMultivariatePrior::TDouble10Vec4Vec;
 
 namespace
 {
@@ -154,7 +154,7 @@ void sampleMarginalLikelihood(const TModeVec &modes,
         normalizedWeights.push_back(weight);
         Z += weight;
     }
-    for (auto &&weight : normalizedWeights)
+    for (auto &weight : normalizedWeights)
     {
         weight /= Z;
     }
@@ -209,7 +209,7 @@ void modeMergeCallback(std::size_t dimension,
     LOG_TRACE("Merging modes with indices "
               << leftMergeIndex << " " << rightMergeIndex);
 
-    typedef std::set<std::size_t> TSizeSet;
+    using TSizeSet = std::set<std::size_t>;
 
     // Create the new mode.
     TMode newMode(targetIndex, seedPrior);

--- a/lib/maths/CMultivariateMultimodalPriorFactory.cc
+++ b/lib/maths/CMultivariateMultimodalPriorFactory.cc
@@ -46,7 +46,7 @@ class CFactory
                                                      double minimumCategoryCount,
                                                      const CMultivariatePrior &seedPrior)
         {
-            boost::scoped_ptr<CClusterer<CVectorNx1<CFloatStorage, N > > > clusterer(
+            boost::scoped_ptr<CClusterer<CVectorNx1<CFloatStorage, N >> > clusterer(
                     CXMeansOnlineFactory::make<CFloatStorage, N>(dataType,
                                                                  weightCalc,
                                                                  decayRate,

--- a/lib/maths/CMultivariateOneOfNPrior.cc
+++ b/lib/maths/CMultivariateOneOfNPrior.cc
@@ -48,16 +48,16 @@ namespace maths
 namespace
 {
 
-typedef core::CSmallVector<bool, 3> TBool3Vec;
-typedef CMultivariateOneOfNPrior::TDouble3Vec TDouble3Vec;
-typedef CMultivariateOneOfNPrior::TDouble10Vec TDouble10Vec;
-typedef CMultivariateOneOfNPrior::TDouble10VecDouble10VecPr TDouble10VecDouble10VecPr;
-typedef CMultivariateOneOfNPrior::TDouble10Vec1Vec TDouble10Vec1Vec;
-typedef CMultivariateOneOfNPrior::TDouble10Vec10Vec TDouble10Vec10Vec;
-typedef CMultivariateOneOfNPrior::TDouble10Vec4Vec1Vec TDouble10Vec4Vec1Vec;
-typedef CMultivariateOneOfNPrior::TPriorPtr TPriorPtr;
-typedef CMultivariateOneOfNPrior::TWeightPriorPtrPr TWeightPriorPtrPr;
-typedef CMultivariateOneOfNPrior::TWeightPriorPtrPrVec TWeightPriorPtrPrVec;
+using TBool3Vec = core::CSmallVector<bool, 3>;
+using TDouble3Vec = CMultivariateOneOfNPrior::TDouble3Vec;
+using TDouble10Vec = CMultivariateOneOfNPrior::TDouble10Vec;
+using TDouble10VecDouble10VecPr = CMultivariateOneOfNPrior::TDouble10VecDouble10VecPr;
+using TDouble10Vec1Vec = CMultivariateOneOfNPrior::TDouble10Vec1Vec;
+using TDouble10Vec10Vec = CMultivariateOneOfNPrior::TDouble10Vec10Vec;
+using TDouble10Vec4Vec1Vec = CMultivariateOneOfNPrior::TDouble10Vec4Vec1Vec;
+using TPriorPtr = CMultivariateOneOfNPrior::TPriorPtr;
+using TWeightPriorPtrPr = CMultivariateOneOfNPrior::TWeightPriorPtrPr;
+using TWeightPriorPtrPrVec = CMultivariateOneOfNPrior::TWeightPriorPtrPrVec;
 
 // We use short field names to reduce the state size
 const std::string MODEL_TAG("a");
@@ -322,7 +322,7 @@ std::size_t CMultivariateOneOfNPrior::dimension(void) const
 void CMultivariateOneOfNPrior::dataType(maths_t::EDataType value)
 {
     this->CMultivariatePrior::dataType(value);
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.second->dataType(value);
     }
@@ -331,7 +331,7 @@ void CMultivariateOneOfNPrior::dataType(maths_t::EDataType value)
 void CMultivariateOneOfNPrior::decayRate(double value)
 {
     this->CMultivariatePrior::decayRate(value);
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.second->decayRate(this->decayRate());
     }
@@ -339,7 +339,7 @@ void CMultivariateOneOfNPrior::decayRate(double value)
 
 void CMultivariateOneOfNPrior::setToNonInformative(double offset, double decayRate)
 {
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.first.age(0.0);
         model.second->setToNonInformative(offset, decayRate);
@@ -352,7 +352,7 @@ void CMultivariateOneOfNPrior::adjustOffset(const TWeightStyleVec &weightStyles,
                                             const TDouble10Vec1Vec &samples,
                                             const TDouble10Vec4Vec1Vec &weights)
 {
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.second->adjustOffset(weightStyles, samples, weights);
     }
@@ -390,7 +390,7 @@ void CMultivariateOneOfNPrior::addSamples(const TWeightStyleVec &weightStyles,
     TDouble3Vec logLikelihoods;
     TMaxAccumulator maxLogLikelihood;
     TBool3Vec used, uses;
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         bool use = model.second->participatesInModelSelection();
 
@@ -494,7 +494,7 @@ void CMultivariateOneOfNPrior::propagateForwardsByTime(double time)
 
     double alpha = ::exp(-this->scaledDecayRate() * time);
 
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         if (!this->isForForecasting())
         {
@@ -815,7 +815,7 @@ void CMultivariateOneOfNPrior::sampleMarginalLikelihood(std::size_t numberSample
         weights.push_back(model.first);
         Z += model.first;
     }
-    for (auto &&weight : weights)
+    for (auto &weight : weights)
     {
         weight /= Z;
     }
@@ -934,7 +934,7 @@ void CMultivariateOneOfNPrior::acceptPersistInserter(core::CStatePersistInserter
 CMultivariateOneOfNPrior::TDouble3Vec CMultivariateOneOfNPrior::weights(void) const
 {
     TDouble3Vec result = this->logWeights();
-    for (auto &&weight : result)
+    for (auto &weight : result)
     {
         weight = ::exp(weight);
     }
@@ -952,7 +952,7 @@ CMultivariateOneOfNPrior::TDouble3Vec CMultivariateOneOfNPrior::logWeights(void)
         Z += ::exp(result.back());
     }
     Z = ::log(Z);
-    for (auto &&weight : result)
+    for (auto &weight : result)
     {
         weight -= Z;
     }

--- a/lib/maths/CNaturalBreaksClassifier.cc
+++ b/lib/maths/CNaturalBreaksClassifier.cc
@@ -499,7 +499,7 @@ void CNaturalBreaksClassifier::sample(std::size_t numberSamples,
         return;
     }
 
-    typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     static const double ALMOST_ONE = 0.99999;
 
@@ -689,8 +689,8 @@ bool CNaturalBreaksClassifier::naturalBreaksImpl(const std::vector<TUPLE> &categ
 
     double pp = static_cast<double>(p);
 
-    typedef std::vector<TDoubleVec> TDoubleVecVec;
-    typedef std::vector<TSizeVec> TSizeVecVec;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TSizeVecVec = std::vector<TSizeVec>;
 
     std::size_t N = categories.size();
 

--- a/lib/maths/CNormalMeanPrecConjugate.cc
+++ b/lib/maths/CNormalMeanPrecConjugate.cc
@@ -54,19 +54,19 @@ namespace maths
 namespace
 {
 
-typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
 const double MINIMUM_GAUSSIAN_SHAPE = 100.0;
 
 namespace detail
 {
 
-typedef maths_t::TWeightStyleVec TWeightStyleVec;
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
+using TWeightStyleVec = maths_t::TWeightStyleVec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
 
 //! Adds "weight" x "right operand" to the "left operand".
 struct SPlusWeight
@@ -1246,7 +1246,7 @@ bool CNormalMeanPrecConjugate::minusLogJointCdf(const TWeightStyleVec &weightSty
                                                 double &lowerBound,
                                                 double &upperBound) const
 {
-    typedef detail::CEvaluateOnSamples<CTools::SMinusLogCdf> TMinusLogCdf;
+    using TMinusLogCdf = detail::CEvaluateOnSamples<CTools::SMinusLogCdf>;
 
     lowerBound = upperBound = 0.0;
 
@@ -1297,7 +1297,7 @@ bool CNormalMeanPrecConjugate::minusLogJointCdfComplement(const TWeightStyleVec 
                                                           double &lowerBound,
                                                           double &upperBound) const
 {
-    typedef detail::CEvaluateOnSamples<CTools::SMinusLogCdfComplement> TMinusLogCdfComplement;
+    using TMinusLogCdfComplement = detail::CEvaluateOnSamples<CTools::SMinusLogCdfComplement>;
 
     lowerBound = upperBound = 0.0;
 

--- a/lib/maths/COneOfNPrior.cc
+++ b/lib/maths/COneOfNPrior.cc
@@ -50,9 +50,9 @@ namespace maths
 namespace
 {
 
-typedef core::CSmallVector<bool, 5> TBool5Vec;
-typedef core::CSmallVector<double, 5> TDouble5Vec;
-typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TBool5Vec = core::CSmallVector<bool, 5>;
+using TDouble5Vec = core::CSmallVector<double, 5>;
+using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 //! Compute the log of \p n.
 double logn(std::size_t n)
@@ -209,7 +209,7 @@ COneOfNPrior *COneOfNPrior::clone(void) const
 void COneOfNPrior::dataType(maths_t::EDataType value)
 {
     this->CPrior::dataType(value);
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.second->dataType(value);
     }
@@ -218,7 +218,7 @@ void COneOfNPrior::dataType(maths_t::EDataType value)
 void COneOfNPrior::decayRate(double value)
 {
     this->CPrior::decayRate(value);
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.second->decayRate(this->decayRate());
     }
@@ -226,7 +226,7 @@ void COneOfNPrior::decayRate(double value)
 
 void COneOfNPrior::setToNonInformative(double offset, double decayRate)
 {
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.first.age(0.0);
         model.second->setToNonInformative(offset, decayRate);
@@ -273,7 +273,7 @@ double COneOfNPrior::adjustOffset(const TWeightStyleVec &weightStyles,
     TMeanAccumulator result;
 
     TDouble5Vec penalties;
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         double penalty = model.second->adjustOffset(weightStyles, samples, weights);
         penalties.push_back(penalty);
@@ -389,7 +389,7 @@ void COneOfNPrior::addSamples(const TWeightStyleVec &weightStyles,
     TDouble5Vec logLikelihoods;
     TMaxAccumulator maxLogLikelihood;
     TBool5Vec used, uses;
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         bool use = model.second->participatesInModelSelection();
 
@@ -497,7 +497,7 @@ void COneOfNPrior::propagateForwardsByTime(double time)
 
     double alpha = std::exp(-this->decayRate() * time);
 
-    for (auto &&model : m_Models)
+    for (auto &model : m_Models)
     {
         model.first.age(alpha);
         model.second->propagateForwardsByTime(time);
@@ -793,7 +793,7 @@ void COneOfNPrior::sampleMarginalLikelihood(std::size_t numberSamples,
         weights.push_back(model.first);
         Z += model.first;
     }
-    for (auto &&weight : weights)
+    for (auto &weight : weights)
     {
         weight /= Z;
     }
@@ -989,8 +989,8 @@ bool COneOfNPrior::probabilityOfLessLikelySamples(maths_t::EProbabilityCalculati
     //   from the m'th model and
     //   P(m) is the prior probability the data are from the m'th model.
 
-    typedef std::pair<double, maths_t::ETail> TDoubleTailPr;
-    typedef CBasicStatistics::SMax<TDoubleTailPr>::TAccumulator TMaxAccumulator;
+    using TDoubleTailPr = std::pair<double, maths_t::ETail>;
+    using TMaxAccumulator = CBasicStatistics::SMax<TDoubleTailPr>::TAccumulator;
 
     TDoubleSizePr5Vec logWeights = this->normalizedLogWeights();
 
@@ -1135,7 +1135,7 @@ void COneOfNPrior::acceptPersistInserter(core::CStatePersistInserter &inserter) 
 COneOfNPrior::TDoubleVec COneOfNPrior::weights(void) const
 {
     TDoubleVec result = this->logWeights();
-    for (auto &&weight : result)
+    for (auto &weight : result)
     {
         weight = std::exp(weight);
     }
@@ -1154,7 +1154,7 @@ COneOfNPrior::TDoubleVec COneOfNPrior::logWeights(void) const
         Z += std::exp(result.back());
     }
     Z = std::log(Z);
-    for (auto &&weight : result)
+    for (auto &weight : result)
     {
         weight -= Z;
     }
@@ -1224,7 +1224,7 @@ COneOfNPrior::TDoubleSizePr5Vec COneOfNPrior::normalizedLogWeights(void) const
         }
     }
     Z = std::log(Z);
-    for (auto &&logWeight : result)
+    for (auto &logWeight : result)
     {
         logWeight.first -= Z;
     }

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -213,7 +213,7 @@ void removeLinearTrend(TFloatMeanAccumulatorVec &values)
         time += dt;
     }
     time = dt / 2.0;
-    for (auto &&value : values)
+    for (auto &value : values)
     {
         CBasicStatistics::moment<0>(value) -= trend.predict(time);
         time += dt;

--- a/lib/maths/CPoissonMeanConjugate.cc
+++ b/lib/maths/CPoissonMeanConjugate.cc
@@ -70,10 +70,10 @@ struct SStaticCast
 namespace detail
 {
 
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef maths_t::TWeightStyleVec TWeightStyleVec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TWeightStyleVec = maths_t::TWeightStyleVec;
 
 //! Adds "weight" x "right operand" to the "left operand".
 struct SPlusWeight
@@ -343,7 +343,7 @@ double CPoissonMeanConjugate::adjustOffset(const TWeightStyleVec &/*weightStyles
         return 0.0;
     }
 
-    for (auto &&sample : resamples)
+    for (auto &sample : resamples)
     {
         sample = std::max(sample, OFFSET_MARGIN - offset);
     }
@@ -821,9 +821,9 @@ void CPoissonMeanConjugate::sampleMarginalLikelihood(std::size_t numberSamples,
         using boost::math::policies::discrete_quantile;
         using boost::math::policies::real;
 
-        typedef policy<discrete_quantile<real> > TRealQuantilePolicy;
-        typedef boost::math::negative_binomial_distribution<
-                    double, TRealQuantilePolicy> TNegativeBinomialRealQuantile;
+        using TRealQuantilePolicy = policy<discrete_quantile<real>>;
+        using TNegativeBinomialRealQuantile =
+                  boost::math::negative_binomial_distribution<double, TRealQuantilePolicy>;
 
         try
         {

--- a/lib/maths/CQDigest.cc
+++ b/lib/maths/CQDigest.cc
@@ -180,8 +180,8 @@ void CQDigest::propagateForwardsByTime(double time)
 
 bool CQDigest::scale(double factor)
 {
-    typedef boost::tuple<uint32_t, uint32_t, uint64_t> TUInt32UInt32UInt64Tr;
-    typedef std::vector<TUInt32UInt32UInt64Tr> TUInt32UInt32UInt64TrVec;
+    using TUInt32UInt32UInt64Tr = boost::tuple<uint32_t, uint32_t, uint64_t>;
+    using TUInt32UInt32UInt64TrVec = std::vector<TUInt32UInt32UInt64Tr>;
 
     if (factor <= 0.0)
     {
@@ -897,7 +897,7 @@ uint64_t CQDigest::CNode::age(double factor)
 {
     m_SubtreeCount = 0u;
 
-    for (auto &&descendant : m_Descendants)
+    for (auto &descendant : m_Descendants)
     {
         m_SubtreeCount += descendant->age(factor);
     }

--- a/lib/maths/CQuantileSketch.cc
+++ b/lib/maths/CQuantileSketch.cc
@@ -39,10 +39,10 @@ namespace maths
 namespace
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef CQuantileSketch::TFloatFloatPr TFloatFloatPr;
-typedef CQuantileSketch::TFloatFloatPrVec TFloatFloatPrVec;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TFloatFloatPr = CQuantileSketch::TFloatFloatPr;
+using TFloatFloatPrVec = CQuantileSketch::TFloatFloatPrVec;
 
 //! \brief Orders two indices of a value vector by increasing value.
 class CIndexingGreater
@@ -65,7 +65,7 @@ class CIndexingGreater
 //! \brief An iterator over just the unique knot values.
 class CUniqueIterator : private boost::addable2< CUniqueIterator, ptrdiff_t,
                                 boost::subtractable2< CUniqueIterator, ptrdiff_t,
-                                boost::equality_comparable< CUniqueIterator > > >
+                                boost::equality_comparable< CUniqueIterator >> >
 {
     public:
         CUniqueIterator(TFloatFloatPrVec &knots, std::size_t i) :
@@ -467,7 +467,7 @@ std::string CQuantileSketch::print(void) const
 
 void CQuantileSketch::reduce(void)
 {
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     CPRNG::CXorOShiro128Plus rng(static_cast<uint64_t>(m_Count));
     boost::random::uniform_01<double> u01;

--- a/lib/maths/CSampling.cc
+++ b/lib/maths/CSampling.cc
@@ -398,7 +398,7 @@ void doMultivariateNormalSample(RNG &rng,
                                 const CVectorNx1<T, N> &mean,
                                 const CSymmetricMatrixNxN<T, N> &covariance,
                                 std::size_t n,
-                                std::vector<CVectorNx1<T, N> > &samples)
+                                std::vector<CVectorNx1<T, N>> &samples)
 {
     using TDenseVector = typename SDenseVector<CVectorNx1<T, N>>::Type;
     using TDenseMatrix = typename SDenseMatrix<CSymmetricMatrixNxN<T, N>>::Type;
@@ -858,9 +858,9 @@ void CSampling::weightedSample(std::size_t n,
     // that Sum_i{ w(i) } != 1.0 we round the number of samples to
     // the nearest integer to n * Sum_i{ p(i) }.
 
-    typedef std::vector<unsigned int> TUIntVec;
-    typedef std::pair<double, std::size_t> TDoubleSizePr;
-    typedef std::vector<TDoubleSizePr> TDoubleSizePrVec;
+    using TUIntVec = std::vector<unsigned int>;
+    using TDoubleSizePr = std::pair<double, std::size_t>;
+    using TDoubleSizePrVec = std::vector<TDoubleSizePr>;
 
     LOG_TRACE("Number samples = " << n);
 

--- a/lib/maths/CStatisticalTests.cc
+++ b/lib/maths/CStatisticalTests.cc
@@ -217,7 +217,7 @@ void CStatisticalTests::CCramerVonMises::acceptPersistInserter(core::CStatePersi
 
 void CStatisticalTests::CCramerVonMises::addF(double f)
 {
-    typedef std::vector<double> TDoubleVec;
+    using TDoubleVec = std::vector<double>;
 
     if (m_F.size() == m_Size)
     {

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -598,7 +598,7 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::handle(const SAddValue &m
     switch (m_Machine.state())
     {
     case PT_TEST:
-        for (auto &&window : m_Windows)
+        for (auto &window : m_Windows)
         {
             if (window)
             {
@@ -2043,7 +2043,7 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime
         {
             if (windowed.count(shift.first) > 0)
             {
-                for (auto &&component : s_Components)
+                for (auto &component : s_Components)
                 {
                     if (shift.first == component.time().window())
                     {
@@ -2055,7 +2055,7 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime
             else
             {
                 bool fallback = true;
-                for (auto &&component : s_Components)
+                for (auto &component : s_Components)
                 {
                     if (!component.time().windowed())
                     {
@@ -2068,7 +2068,7 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime
                 {
                     TTimeTimePrVec shifted;
                     shifted.reserve(s_Components.size());
-                    for (auto &&component : s_Components)
+                    for (auto &component : s_Components)
                     {
                         const CSeasonalTime &time_ = component.time();
                         if (std::find_if(shifted.begin(), shifted.end(),

--- a/lib/maths/CTrendTests.cc
+++ b/lib/maths/CTrendTests.cc
@@ -98,7 +98,7 @@ void zeroMean(TDoubleVec &samples)
     {
         mean.add(sample);
     }
-    for (auto &&sample : samples)
+    for (auto &sample : samples)
     {
         sample -= CBasicStatistics::mean(mean);
     }

--- a/lib/maths/CXMeansOnline1d.cc
+++ b/lib/maths/CXMeansOnline1d.cc
@@ -58,18 +58,18 @@ namespace maths
 namespace
 {
 
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<std::size_t> TSizeVec;
-typedef CNaturalBreaksClassifier::TTuple TTuple;
-typedef CNaturalBreaksClassifier::TTupleVec TTupleVec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TSizeVec = std::vector<std::size_t>;
+using TTuple = CNaturalBreaksClassifier::TTuple;
+using TTupleVec = CNaturalBreaksClassifier::TTupleVec;
 
 namespace detail
 {
 
-typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
 //! \brief Orders two clusters by their centres.
 struct SClusterCentreLess
@@ -521,7 +521,7 @@ bool splitSearch(double minimumCount,
                  const TTupleVec &categories,
                  TSizeVec &result)
 {
-    typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
 
     LOG_TRACE("begin split search");
 

--- a/lib/maths/ProbabilityAggregators.cc
+++ b/lib/maths/ProbabilityAggregators.cc
@@ -37,8 +37,8 @@ namespace maths
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<double, double> TDoubleDoublePr;
+using TDoubleVec = std::vector<double>;
+using TDoubleDoublePr = std::pair<double, double>;
 
 //! Compute \f$x^2\f$.
 inline double square(double x)
@@ -247,7 +247,7 @@ double logOneMinusX(double x)
 class CNumericalLogProbabilityOfMFromNExtremeSamples
 {
     public:
-        typedef CBasicStatistics::COrderStatisticsHeap<double> TMinValueAccumulator;
+        using TMinValueAccumulator = CBasicStatistics::COrderStatisticsHeap<double>;
 
         //! A recursive integrand for the multi-variable integration.
         class CLogIntegrand

--- a/lib/maths/unittest/CAgglomerativeClustererTest.cc
+++ b/lib/maths/unittest/CAgglomerativeClustererTest.cc
@@ -34,12 +34,12 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef std::pair<double, TSizeVec> TDoubleSizeVecPr;
-typedef std::vector<TDoubleSizeVecPr> TDoubleSizeVecPrVec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TDoubleSizeVecPr = std::pair<double, TSizeVec>;
+using TDoubleSizeVecPrVec = std::vector<TDoubleSizeVecPr>;
 
 class CCluster
 {
@@ -89,7 +89,7 @@ class CCluster
         TSizeVec m_Points;
 };
 
-typedef std::vector<CCluster> TClusterVec;
+using TClusterVec = std::vector<CCluster>;
 
 class CSlinkObjective
 {

--- a/lib/maths/unittest/CAssignmentTest.cc
+++ b/lib/maths/unittest/CAssignmentTest.cc
@@ -33,11 +33,11 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::vector<TSizeSizePr> TSizeSizePrVec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrVec = std::vector<TSizeSizePr>;
 
 template<std::size_t N, std::size_t M>
 void fill(const double (&costs)[N][M], TDoubleVecVec &result)

--- a/lib/maths/unittest/CBasicStatisticsTest.cc
+++ b/lib/maths/unittest/CBasicStatisticsTest.cc
@@ -37,21 +37,21 @@
 namespace
 {
 
-typedef ml::maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef ml::maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef ml::maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator TMeanVarSkewAccumulator;
-typedef ml::core::CSmallVector<TMeanAccumulator, 2> TMeanAccumulator2Vec;
-typedef ml::core::CSmallVector<TMeanVarAccumulator, 2> TMeanVarAccumulator2Vec;
-typedef ml::core::CSmallVector<TMeanVarSkewAccumulator, 2> TMeanVarSkewAccumulator2Vec;
-typedef std::vector<TMeanAccumulator> TMeanAccumulatorVec;
-typedef std::vector<TMeanVarAccumulator> TMeanVarAccumulatorVec;
-typedef std::vector<TMeanVarSkewAccumulator> TMeanVarSkewAccumulatorVec;
+using TMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = ml::maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using TMeanVarSkewAccumulator = ml::maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator;
+using TMeanAccumulator2Vec = ml::core::CSmallVector<TMeanAccumulator, 2>;
+using TMeanVarAccumulator2Vec = ml::core::CSmallVector<TMeanVarAccumulator, 2>;
+using TMeanVarSkewAccumulator2Vec = ml::core::CSmallVector<TMeanVarSkewAccumulator, 2>;
+using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
+using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
+using TMeanVarSkewAccumulatorVec = std::vector<TMeanVarSkewAccumulator>;
 
 const std::string TAG("a");
 
 struct SRestore
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template<typename T>
     bool operator()(std::vector<T> &restored, ml::core::CStateRestoreTraverser &traverser) const
@@ -123,7 +123,7 @@ void CBasicStatisticsTest::testCentralMoments(void)
     LOG_DEBUG("|  CBasicStatisticsTest::testCentralMoments  |");
     LOG_DEBUG("+--------------------------------------------+");
 
-    typedef std::vector<double> TDoubleVec;
+    using TDoubleVec = std::vector<double>;
 
     LOG_DEBUG("Test mean double");
     {
@@ -148,7 +148,7 @@ void CBasicStatisticsTest::testCentralMoments(void)
 
     LOG_DEBUG("Test mean float");
     {
-        typedef ml::maths::CBasicStatistics::SSampleMean<float>::TAccumulator TFloatMeanAccumulator;
+        using TFloatMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<float>::TAccumulator;
 
         float samples[] = { 0.9f, 10.0f, 5.6f, 1.23f, -12.3f, 7.2f, 0.0f, 1.2f };
 
@@ -488,9 +488,9 @@ void CBasicStatisticsTest::testCentralMoments(void)
 
     LOG_DEBUG("test vector")
     {
-        typedef ml::maths::CBasicStatistics::SSampleMean<ml::maths::CVectorNx1<double, 4> >::TAccumulator TVectorMeanAccumulator;
-        typedef ml::maths::CBasicStatistics::SSampleMeanVar<ml::maths::CVectorNx1<double, 4> >::TAccumulator TVectorMeanVarAccumulator;
-        typedef ml::maths::CBasicStatistics::SSampleMeanVarSkew<ml::maths::CVectorNx1<double, 4> >::TAccumulator TVectorMeanVarSkewAccumulator;
+        using TVectorMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<ml::maths::CVectorNx1<double, 4>>::TAccumulator;
+        using TVectorMeanVarAccumulator = ml::maths::CBasicStatistics::SSampleMeanVar<ml::maths::CVectorNx1<double, 4>>::TAccumulator;
+        using TVectorMeanVarSkewAccumulator = ml::maths::CBasicStatistics::SSampleMeanVarSkew<ml::maths::CVectorNx1<double, 4>>::TAccumulator;
 
         ml::test::CRandomNumbers rng;
 
@@ -768,8 +768,8 @@ void CBasicStatisticsTest::testVectorCentralMoments(void)
     LOG_DEBUG("|  CBasicStatisticsTest::testVectorCentralMoments  |");
     LOG_DEBUG("+--------------------------------------------------+");
 
-    typedef ml::core::CSmallVector<double, 2> TDouble2Vec;
-    typedef std::vector<double> TDoubleVec;
+    using TDouble2Vec = ml::core::CSmallVector<double, 2>;
+    using TDoubleVec = std::vector<double>;
 
     {
         TMeanAccumulator2Vec moments1(2);
@@ -914,12 +914,12 @@ void CBasicStatisticsTest::testCovariances(void)
         }
 
         bool dynamicSizeAlwaysZero = ml::core::memory_detail::SDynamicSizeAlwaysZero<
-                                         ml::maths::CBasicStatistics::SSampleCovariances<double, 3> >::value();
+                                         ml::maths::CBasicStatistics::SSampleCovariances<double, 3>>::value();
         CPPUNIT_ASSERT_EQUAL(true, dynamicSizeAlwaysZero);
     }
 
     {
-        typedef std::vector<ml::maths::CVectorNx1<double, 4> > TVectorVec;
+        using TVectorVec = std::vector<ml::maths::CVectorNx1<double, 4>>;
 
         double mean_[] = { 1.0, 3.0, 2.0, 7.0 };
         ml::maths::CVectorNx1<double, 4> mean(mean_);
@@ -983,7 +983,7 @@ void CBasicStatisticsTest::testCovariances(void)
         std::vector<double> coordinates;
         rng.generateUniformSamples(5.0, 10.0, 400, coordinates);
 
-        std::vector<ml::maths::CVectorNx1<double, 4> > points;
+        std::vector<ml::maths::CVectorNx1<double, 4>> points;
         for (std::size_t i = 0u; i < coordinates.size(); i += 4)
         {
             double c[] =
@@ -1021,11 +1021,11 @@ void CBasicStatisticsTest::testCovariancesLedoitWolf(void)
     LOG_DEBUG("|  CBasicStatisticsTest::testCovariancesLedoitWolf  |");
     LOG_DEBUG("+---------------------------------------------------+");
 
-    typedef std::vector<double> TDoubleVec;
-    typedef std::vector<TDoubleVec> TDoubleVecVec;
-    typedef ml::maths::CVectorNx1<double, 2> TVector2;
-    typedef std::vector<TVector2> TVector2Vec;
-    typedef ml::maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
+    using TDoubleVec = std::vector<double>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TVector2 = ml::maths::CVectorNx1<double, 2>;
+    using TVector2Vec = std::vector<TVector2>;
+    using TMatrix2 = ml::maths::CSymmetricMatrixNxN<double, 2>;
 
     ml::test::CRandomNumbers rng;
 
@@ -1176,10 +1176,10 @@ void CBasicStatisticsTest::testOrderStatistics(void)
     // Test that the order statistics accumulators work for finding min and max
     // elements of a collection.
 
-    typedef ml::maths::CBasicStatistics::COrderStatisticsStack<double, 2u> TMinStatsStack;
-    typedef ml::maths::CBasicStatistics::COrderStatisticsStack<double, 3u, std::greater<double> > TMaxStatsStack;
-    typedef ml::maths::CBasicStatistics::COrderStatisticsHeap<double> TMinStatsHeap;
-    typedef ml::maths::CBasicStatistics::COrderStatisticsHeap<double, std::greater<double> > TMaxStatsHeap;
+    using TMinStatsStack = ml::maths::CBasicStatistics::COrderStatisticsStack<double, 2u>;
+    using TMaxStatsStack = ml::maths::CBasicStatistics::COrderStatisticsStack<double, 3u, std::greater<double>>;
+    using TMinStatsHeap = ml::maths::CBasicStatistics::COrderStatisticsHeap<double>;
+    using TMaxStatsHeap = ml::maths::CBasicStatistics::COrderStatisticsHeap<double, std::greater<double>>;
 
     {
         // Test on the stack min, max, combine and persist and restore.
@@ -1371,7 +1371,7 @@ void CBasicStatisticsTest::testMinMax(void)
     LOG_DEBUG("|  CBasicStatisticsTest::testMinMax  |");
     LOG_DEBUG("+------------------------------------+");
 
-    typedef std::vector<double> TDoubleVec;
+    using TDoubleVec = std::vector<double>;
 
     TDoubleVec positive{1.0, 2.7, 4.0, 0.3, 11.7};
     TDoubleVec negative{-3.7, -0.8, -18.2, -0.8};

--- a/lib/maths/unittest/CBjkstUniqueValuesTest.cc
+++ b/lib/maths/unittest/CBjkstUniqueValuesTest.cc
@@ -32,10 +32,10 @@ using namespace test;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::set<uint32_t> TUInt32Set;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TUInt32Set = std::set<uint32_t>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 uint8_t trailingZeros(uint32_t x)
 {

--- a/lib/maths/unittest/CBootstrapClustererTest.cc
+++ b/lib/maths/unittest/CBootstrapClustererTest.cc
@@ -32,16 +32,16 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<bool> TBoolVec;
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef std::vector<TVector2> TVector2Vec;
-typedef std::vector<TVector2Vec> TVector2VecVec;
-typedef maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
-typedef std::vector<TMatrix2> TMatrix2Vec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TBoolVec = std::vector<bool>;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TVector2Vec = std::vector<TVector2>;
+using TVector2VecVec = std::vector<TVector2Vec>;
+using TMatrix2 = maths::CSymmetricMatrixNxN<double, 2>;
+using TMatrix2Vec = std::vector<TMatrix2>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 struct SVector2Hash
 {
@@ -50,17 +50,17 @@ struct SVector2Hash
         return static_cast<std::size_t>(x.checksum());
     }
 };
-typedef boost::unordered_map<TVector2, std::size_t, SVector2Hash> TVector2SizeUMap;
+using TVector2SizeUMap = boost::unordered_map<TVector2, std::size_t, SVector2Hash>;
 
 template<typename POINT>
 class CBootstrapClustererForTest : public maths::CBootstrapClusterer<POINT>
 {
     public:
-        typedef typename maths::CBootstrapClusterer<POINT>::TBoolVec TBoolVec;
-        typedef typename maths::CBootstrapClusterer<POINT>::TSizeVec TSizeVec;
-        typedef typename maths::CBootstrapClusterer<POINT>::TSizeVecVecVec TSizeVecVecVec;
-        typedef typename maths::CBootstrapClusterer<POINT>::TPointVec TPointVec;
-        typedef typename maths::CBootstrapClusterer<POINT>::TGraph TGraph;
+        using TBoolVec = typename maths::CBootstrapClusterer<POINT>::TBoolVec;
+        using TSizeVec = typename maths::CBootstrapClusterer<POINT>::TSizeVec;
+        using TSizeVecVecVec = typename maths::CBootstrapClusterer<POINT>::TSizeVecVecVec;
+        using TPointVec = typename maths::CBootstrapClusterer<POINT>::TPointVec;
+        using TGraph = typename maths::CBootstrapClusterer<POINT>::TGraph;
 
     public:
         CBootstrapClustererForTest(double overlapThreshold, double chainingFactor) :
@@ -100,11 +100,11 @@ class CBootstrapClustererForTest : public maths::CBootstrapClusterer<POINT>
         }
 };
 
-typedef CBootstrapClustererForTest<TVector2> TBootstrapClustererForTest2;
-typedef TBootstrapClustererForTest2::TGraph TGraph;
-typedef boost::graph_traits<TGraph>::vertex_iterator TVertexItr;
-typedef boost::graph_traits<TGraph>::edge_iterator TEdgeItr;
-typedef boost::graph_traits<TGraph>::adjacency_iterator TAdjacencyItr;
+using TBootstrapClustererForTest2 = CBootstrapClustererForTest<TVector2>;
+using TGraph = TBootstrapClustererForTest2::TGraph;
+using TVertexItr = boost::graph_traits<TGraph>::vertex_iterator;
+using TEdgeItr = boost::graph_traits<TGraph>::edge_iterator;
+using TAdjacencyItr = boost::graph_traits<TGraph>::adjacency_iterator;
 
 void clique(std::size_t a, std::size_t b, TGraph &graph)
 {
@@ -162,11 +162,11 @@ void CBootstrapClustererTest::testFacade(void)
         std::sort(points.begin(), points.end());
 
         {
-            maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC> > xmeans(20);
+            maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC>> xmeans(20);
 
             maths::CSampling::seed();
 
-            maths::CBootstrapClustererFacade<maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC> > > clusterer(
+            maths::CBootstrapClustererFacade<maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC>> > clusterer(
                     xmeans,
                     improveParamsKmeansIterations,
                     improveStructureClusterSeeds,
@@ -718,7 +718,7 @@ void CBootstrapClustererTest::testNonConvexClustering(void)
             flatPoints.push_back(point);
             lookup[point] = i;
         }
-        maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC> > xmeans(20);
+        maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC>> xmeans(20);
 
         TVector2VecVec bootstrapClusters;
         maths::bootstrapCluster(flatPoints,
@@ -872,7 +872,7 @@ void CBootstrapClustererTest::testClusteringStability(void)
                       points2.begin() + (3 * points2.size()) / 4);
 
         TVector2VecVec bootstrapClusters;
-        maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC> > xmeans(20);
+        maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC>> xmeans(20);
         maths::bootstrapCluster(points,
                                 20,  // trials
                                 xmeans,

--- a/lib/maths/unittest/CBoundingBoxTest.cc
+++ b/lib/maths/unittest/CBoundingBoxTest.cc
@@ -25,11 +25,11 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef maths::CVectorNx1<double, 4> TVector4;
-typedef maths::CBoundingBox<TVector2> TBoundingBox2;
-typedef maths::CBoundingBox<TVector4> TBoundingBox4;
+using TDoubleVec = std::vector<double>;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TVector4 = maths::CVectorNx1<double, 4>;
+using TBoundingBox2 = maths::CBoundingBox<TVector2>;
+using TBoundingBox4 = maths::CBoundingBox<TVector4>;
 
 namespace
 {

--- a/lib/maths/unittest/CCalendarComponentAdaptiveBucketingTest.cc
+++ b/lib/maths/unittest/CCalendarComponentAdaptiveBucketingTest.cc
@@ -33,11 +33,11 @@ using namespace ml;
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<maths::CFloatStorage> TFloatVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SMin<double>::TAccumulator TMinAccumulator;
-typedef maths::CBasicStatistics::SMax<double>::TAccumulator TMaxAccumulator;
+using TDoubleVec = std::vector<double>;
+using TFloatVec = std::vector<maths::CFloatStorage>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMinAccumulator = maths::CBasicStatistics::SMin<double>::TAccumulator;
+using TMaxAccumulator = maths::CBasicStatistics::SMax<double>::TAccumulator;
 }
 
 void CCalendarComponentAdaptiveBucketingTest::setUp(void)

--- a/lib/maths/unittest/CCalendarFeatureTest.cc
+++ b/lib/maths/unittest/CCalendarFeatureTest.cc
@@ -28,9 +28,9 @@
 
 using namespace ml;
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<core_t::TTime> TTimeVec;
-typedef std::vector<maths::CCalendarFeature> TCalendarFeatureVec;
+using TSizeVec = std::vector<std::size_t>;
+using TTimeVec = std::vector<core_t::TTime>;
+using TCalendarFeatureVec = std::vector<maths::CCalendarFeature>;
 
 namespace
 {

--- a/lib/maths/unittest/CCategoricalToolsTest.cc
+++ b/lib/maths/unittest/CCategoricalToolsTest.cc
@@ -27,8 +27,8 @@
 
 #include <vector>
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 
 using namespace ml;
 
@@ -54,8 +54,8 @@ void CCategoricalToolsTest::testExpectedDistinctCategories(void)
     LOG_DEBUG("|  CCategoricalToolsTest::testExpectedDistinctCategories  |");
     LOG_DEBUG("+---------------------------------------------------------+");
 
-    typedef std::vector<TDoubleVec> TDoubleVecVec;
-    typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
     static const std::size_t nTrials = 4000u;
 

--- a/lib/maths/unittest/CChecksumTest.cc
+++ b/lib/maths/unittest/CChecksumTest.cc
@@ -69,18 +69,18 @@ struct SBar
     uint64_t s_Key;
 };
 
-typedef std::vector<int> TIntVec;
-typedef std::map<std::size_t, EAnEnum> TSizeAnEnumMap;
-typedef std::set<std::string> TStrSet;
-typedef TStrSet::const_iterator TStrSetCItr;
-typedef boost::optional<double> TOptionalDouble;
-typedef std::vector<TOptionalDouble> TOptionalDoubleVec;
-typedef maths::CBasicStatistics::SSampleMeanVar<maths::CFloatStorage>::TAccumulator TMeanVarAccumulator;
-typedef boost::shared_ptr<TMeanVarAccumulator> TMeanVarAccumulatorPtr;
-typedef std::pair<double, TMeanVarAccumulator> TDoubleMeanVarAccumulatorPr;
-typedef std::list<TDoubleMeanVarAccumulatorPr> TDoubleMeanVarAccumulatorPrList;
-typedef std::deque<SFoo> TFooDeque;
-typedef std::vector<SBar> TBarVec;
+using TIntVec = std::vector<int>;
+using TSizeAnEnumMap = std::map<std::size_t, EAnEnum>;
+using TStrSet = std::set<std::string>;
+using TStrSetCItr = TStrSet::const_iterator;
+using TOptionalDouble = boost::optional<double>;
+using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<maths::CFloatStorage>::TAccumulator;
+using TMeanVarAccumulatorPtr = boost::shared_ptr<TMeanVarAccumulator>;
+using TDoubleMeanVarAccumulatorPr = std::pair<double, TMeanVarAccumulator>;
+using TDoubleMeanVarAccumulatorPrList = std::list<TDoubleMeanVarAccumulatorPr>;
+using TFooDeque = std::deque<SFoo>;
+using TBarVec = std::vector<SBar>;
 
 }
 

--- a/lib/maths/unittest/CClustererTest.cc
+++ b/lib/maths/unittest/CClustererTest.cc
@@ -37,10 +37,10 @@ void CClustererTest::testIndexGenerator(void)
     //   2) The highest index in the set is less than the
     //      maximum set size to date.
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef std::vector<double> TDoubleVec;
-    typedef std::set<std::size_t, std::greater<std::size_t> > TSizeSet;
-    typedef TSizeSet::iterator TSizeSetItr;
+    using TSizeVec = std::vector<std::size_t>;
+    using TDoubleVec = std::vector<double>;
+    using TSizeSet = std::set<std::size_t, std::greater<std::size_t>>;
+    using TSizeSetItr = TSizeSet::iterator;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CCountMinSketchTest.cc
+++ b/lib/maths/unittest/CCountMinSketchTest.cc
@@ -26,7 +26,7 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 void CCountMinSketchTest::testCounts(void)
 {
@@ -34,7 +34,7 @@ void CCountMinSketchTest::testCounts(void)
     LOG_DEBUG("|  CCountMinSketchTest::testCounts  |");
     LOG_DEBUG("+-----------------------------------+");
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CEntropySketchTest.cc
+++ b/lib/maths/unittest/CEntropySketchTest.cc
@@ -36,16 +36,16 @@ void CEntropySketchTest::testAll(void)
     LOG_DEBUG("|  CBjkstUniqueValuesTest::testPersist  |");
     LOG_DEBUG("+---------------------------------------+");
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef boost::unordered_map<std::size_t, double> TSizeDoubleUMap;
-    typedef TSizeDoubleUMap::const_iterator TSizeDoubleUMapCItr;
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeDoubleUMap = boost::unordered_map<std::size_t, double>;
+    using TSizeDoubleUMapCItr = TSizeDoubleUMap::const_iterator;
 
     test::CRandomNumbers rng;
 
     TSizeVec numberCategories;
     rng.generateUniformSamples(500, 1001, 1000, numberCategories);
 
-    maths::CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> > maxError[3];
+    maths::CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double>> maxError[3];
     maths::CBasicStatistics::SSampleMean<double>::TAccumulator meanError[3];
 
     double K[] = { 20.0, 40.0, 60.0 };

--- a/lib/maths/unittest/CGammaRateConjugateTest.cc
+++ b/lib/maths/unittest/CGammaRateConjugateTest.cc
@@ -46,12 +46,12 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef CPriorTestInterfaceMixin<maths::CGammaRateConjugate> CGammaRateConjugate;
+using TDoubleVec = std::vector<double>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using CGammaRateConjugate = CPriorTestInterfaceMixin<maths::CGammaRateConjugate>;
 
 CGammaRateConjugate makePrior(maths_t::EDataType dataType = maths_t::E_ContinuousData,
                               const double &offset = 0.0,
@@ -96,7 +96,7 @@ void CGammaRateConjugateTest::testMultipleUpdate(void)
         }
         filter2.addSamples(samples);
 
-        typedef maths::CEqualWithTolerance<double> TEqual;
+        using TEqual = maths::CEqualWithTolerance<double>;
         TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 1e-3);
         CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
     }
@@ -123,7 +123,7 @@ void CGammaRateConjugateTest::testMultipleUpdate(void)
                            scaledSamples,
                            TDouble4Vec1Vec(scaledSamples.size(), TDouble4Vec(1, 2.0)));
 
-        typedef maths::CEqualWithTolerance<double> TEqual;
+        using TEqual = maths::CEqualWithTolerance<double>;
         TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.03);
         CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
     }
@@ -146,7 +146,7 @@ void CGammaRateConjugateTest::testMultipleUpdate(void)
                            TDouble1Vec(1, x),
                            TDouble4Vec1Vec(1, TDouble4Vec(1, static_cast<double>(count))));
 
-        typedef maths::CEqualWithTolerance<double> TEqual;
+        using TEqual = maths::CEqualWithTolerance<double>;
         TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.01);
         CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
     }
@@ -220,7 +220,7 @@ void CGammaRateConjugateTest::testShapeEstimation(void)
             TDoubleVec samples;
             rng.generateGammaSamples(shape, scale, 5050, samples);
 
-            typedef std::vector<CGammaRateConjugate> TGammaRateConjugateVec;
+            using TGammaRateConjugateVec = std::vector<CGammaRateConjugate>;
 
             unsigned int nAggregate = 50u;
             TGammaRateConjugateVec filters(nAggregate, makePrior(maths_t::E_ContinuousData, 0.0, decayRates[i]));
@@ -1049,7 +1049,7 @@ void CGammaRateConjugateTest::testAnomalyScore(void)
     //   1) high probability of detecting the anomalies, and
     //   2) a very low rate of false positives.
 
-    typedef std::vector<unsigned int> TUIntVec;
+    using TUIntVec = std::vector<unsigned int>;
 
     const double decayRates[] = { 0.0, 0.001, 0.01 };
 
@@ -1244,7 +1244,7 @@ void CGammaRateConjugateTest::testOffset(void)
                     CPPUNIT_ASSERT_DOUBLES_EQUAL(probability1, probability2, eps);
                 }
 
-                typedef maths::CEqualWithTolerance<double> TEqual;
+                using TEqual = maths::CEqualWithTolerance<double>;
                 TEqual equal(maths::CToleranceTypes::E_AbsoluteTolerance, eps);
                 CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
             }
@@ -1293,7 +1293,7 @@ void CGammaRateConjugateTest::testIntegerData(void)
                 filter2.addSamples(sample);
             }
 
-            typedef maths::CEqualWithTolerance<double> TEqual;
+            using TEqual = maths::CEqualWithTolerance<double>;
             TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.02);
             CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
         }
@@ -1804,7 +1804,7 @@ void CGammaRateConjugateTest::testNegativeSample(void)
 
     CPPUNIT_ASSERT_EQUAL(filter1.numberSamples(), filter2.numberSamples());
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
     TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.1);
     CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
 }

--- a/lib/maths/unittest/CGramSchmidtTest.cc
+++ b/lib/maths/unittest/CGramSchmidtTest.cc
@@ -30,10 +30,10 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef maths::CVectorNx1<double, 4> TVector4;
-typedef std::vector<TVector4> TVector4Vec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TVector4 = maths::CVectorNx1<double, 4>;
+using TVector4Vec = std::vector<TVector4>;
 
 namespace
 {

--- a/lib/maths/unittest/CInformationCriteriaTest.cc
+++ b/lib/maths/unittest/CInformationCriteriaTest.cc
@@ -28,20 +28,20 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef std::vector<TVector2> TVector2Vec;
-typedef TVector2Vec::const_iterator TVector2VecCItr;
-typedef std::vector<TVector2Vec> TVector2VecVec;
-typedef maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator TMeanVar2Accumulator;
-typedef maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
-typedef std::vector<TMatrix2> TMatrix2Vec;
-typedef maths::CVectorNx1<double, 4> TVector4;
-typedef std::vector<TVector4> TVector4Vec;
-typedef maths::CBasicStatistics::SSampleMeanVar<TVector4>::TAccumulator TMeanVar4Accumulator;
-typedef maths::CSymmetricMatrixNxN<double, 4> TMatrix4;
-typedef std::vector<TMatrix4> TMatrix4Vec;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TVector2Vec = std::vector<TVector2>;
+using TVector2VecCItr = TVector2Vec::const_iterator;
+using TVector2VecVec = std::vector<TVector2Vec>;
+using TMeanVar2Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator;
+using TMatrix2 = maths::CSymmetricMatrixNxN<double, 2>;
+using TMatrix2Vec = std::vector<TMatrix2>;
+using TVector4 = maths::CVectorNx1<double, 4>;
+using TVector4Vec = std::vector<TVector4>;
+using TMeanVar4Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector4>::TAccumulator;
+using TMatrix4 = maths::CSymmetricMatrixNxN<double, 4>;
+using TMatrix4Vec = std::vector<TMatrix4>;
 
 template<typename POINT>
 double logfSphericalGaussian(const POINT &mean,
@@ -249,9 +249,9 @@ void CInformationCriteriaTest::testSphericalGaussianWithSphericalCluster(void)
     // same result working with clusters of points or their
     // spherical cluster representation.
 
-    typedef maths::CSphericalCluster<TVector2>::Type TSphericalCluster2;
-    typedef std::vector<TSphericalCluster2> TSphericalCluster2Vec;
-    typedef std::vector<TSphericalCluster2Vec> TSphericalCluster2VecVec;
+    using TSphericalCluster2 = maths::CSphericalCluster<TVector2>::Type;
+    using TSphericalCluster2Vec = std::vector<TSphericalCluster2>;
+    using TSphericalCluster2VecVec = std::vector<TSphericalCluster2Vec>;
 
     maths::CSampling::seed();
 
@@ -481,9 +481,9 @@ void CInformationCriteriaTest::testGaussianWithSphericalCluster(void)
     LOG_DEBUG("|  CInformationCriteriaTest::testGaussianWithSphericalCluster  |");
     LOG_DEBUG("+--------------------------------------------------------------+");
 
-    typedef maths::CSphericalCluster<TVector2>::Type TSphericalCluster2;
-    typedef std::vector<TSphericalCluster2> TSphericalCluster2Vec;
-    typedef std::vector<TSphericalCluster2Vec> TSphericalCluster2VecVec;
+    using TSphericalCluster2 = maths::CSphericalCluster<TVector2>::Type;
+    using TSphericalCluster2Vec = std::vector<TSphericalCluster2>;
+    using TSphericalCluster2VecVec = std::vector<TSphericalCluster2Vec>;
 
     maths::CSampling::seed();
 

--- a/lib/maths/unittest/CIntegerToolsTest.cc
+++ b/lib/maths/unittest/CIntegerToolsTest.cc
@@ -33,7 +33,7 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<std::size_t> TSizeVec;
+using TSizeVec = std::vector<std::size_t>;
 
 std::string printBits(uint64_t x)
 {

--- a/lib/maths/unittest/CIntegrationTest.cc
+++ b/lib/maths/unittest/CIntegrationTest.cc
@@ -107,7 +107,7 @@ template<unsigned int DIMENSION>
 class CMultivariatePolynomialFunction
 {
     public:
-        typedef CVectorNx1<double, DIMENSION> TVector;
+        using TVector = CVectorNx1<double, DIMENSION>;
 
         struct SMonomial
         {
@@ -120,7 +120,7 @@ class CMultivariatePolynomialFunction
             double s_Powers[DIMENSION];
         };
 
-        typedef std::vector<SMonomial> TMonomialVec;
+        using TMonomialVec = std::vector<SMonomial>;
 
     public:
         void add(double coefficient, double powers[DIMENSION])
@@ -188,7 +188,7 @@ std::ostream &operator<<(std::ostream &o, const CMultivariatePolynomialFunction<
     return o;
 }
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 template<unsigned int DIMENSION>
 double integrate(const CMultivariatePolynomialFunction<DIMENSION> &f,
@@ -210,13 +210,13 @@ double integrate(const CMultivariatePolynomialFunction<DIMENSION> &f,
 }
 
 
-typedef std::vector<TDoubleVec> TDoubleVecVec;
+using TDoubleVecVec = std::vector<TDoubleVec>;
 
 bool readGrid(const std::string &file,
               TDoubleVec &weights,
               TDoubleVecVec &points)
 {
-    typedef std::vector<std::string> TStrVec;
+    using TStrVec = std::vector<std::string>;
     std::ifstream d2_l1;
     d2_l1.open(file.c_str());
     if (!d2_l1)
@@ -261,7 +261,7 @@ bool readGrid(const std::string &file,
 class CSmoothHeavySide
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         CSmoothHeavySide(double slope, double offset) :
@@ -285,7 +285,7 @@ class CSmoothHeavySide
 class CNormal
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         CNormal(double mean, double std) :
@@ -321,17 +321,17 @@ void CIntegrationTest::testAllSingleVariate(void)
     // Test that "low" order polynomials are integrated exactly
     // (as they should be for a higher order quadrature).
 
-    typedef CPolynomialFunction<0u> TConstant;
-    typedef CPolynomialFunction<1u> TLinear;
-    typedef CPolynomialFunction<2u> TQuadratic;
-    typedef CPolynomialFunction<3u> TCubic;
-    typedef CPolynomialFunction<4u> TQuartic;
-    typedef CPolynomialFunction<5u> TQuintic;
-    typedef CPolynomialFunction<6u> THexic;
-    typedef CPolynomialFunction<7u> THeptic;
-    typedef CPolynomialFunction<8u> TOctic;
-    typedef CPolynomialFunction<9u> TNonic;
-    typedef CPolynomialFunction<10u> TDecic;
+    using TConstant = CPolynomialFunction<0u>;
+    using TLinear = CPolynomialFunction<1u>;
+    using TQuadratic = CPolynomialFunction<2u>;
+    using TCubic = CPolynomialFunction<3u>;
+    using TQuartic = CPolynomialFunction<4u>;
+    using TQuintic = CPolynomialFunction<5u>;
+    using THexic = CPolynomialFunction<6u>;
+    using THeptic = CPolynomialFunction<7u>;
+    using TOctic = CPolynomialFunction<8u>;
+    using TNonic = CPolynomialFunction<9u>;
+    using TDecic = CPolynomialFunction<10u>;
 
     static const double EPS = 1e-6;
 
@@ -886,8 +886,8 @@ void CIntegrationTest::testAdaptive(void)
     LOG_DEBUG("|  CIntegerToolsTest::testAdaptive  |");
     LOG_DEBUG("+-----------------------------------+");
 
-    typedef std::pair<double, double> TDoubleDoublePr;
-    typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
+    using TDoubleDoublePr = std::pair<double, double>;
+    using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
 
     {
         LOG_DEBUG("*** Smooth unit step at 20 ***");
@@ -1031,10 +1031,10 @@ void CIntegrationTest::testSparseGrid(void)
                                 expectedWeights,
                                 expectedPoints));
 
-        typedef CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderOne,
-                                                             CIntegration::TwoDimensions> Sparse2do1;
+        using TSparse2do1 = CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderOne,
+                                                                         CIntegration::TwoDimensions>;
 
-        const Sparse2do1 &sparse = Sparse2do1::instance();
+        const TSparse2do1 &sparse = TSparse2do1::instance();
 
         LOG_DEBUG("# points = " << sparse.weights().size());
         CPPUNIT_ASSERT_EQUAL(expectedWeights.size(), sparse.weights().size());
@@ -1064,10 +1064,10 @@ void CIntegrationTest::testSparseGrid(void)
                                 expectedWeights,
                                 expectedPoints));
 
-        typedef CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderTwo,
-                                                             CIntegration::TwoDimensions> Sparse2do2;
+        using TSparse2do2 = CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderTwo,
+                                                                         CIntegration::TwoDimensions>;
 
-        const Sparse2do2 &sparse = Sparse2do2::instance();
+        const TSparse2do2 &sparse = TSparse2do2::instance();
 
         LOG_DEBUG("# points = " << sparse.weights().size());
         CPPUNIT_ASSERT_EQUAL(expectedWeights.size(), sparse.weights().size());
@@ -1097,10 +1097,10 @@ void CIntegrationTest::testSparseGrid(void)
                                 expectedWeights,
                                 expectedPoints));
 
-        typedef CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderFour,
-                                                             CIntegration::TwoDimensions> Sparse2do4;
+        using TSparse2do4 = CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderFour,
+                                                                         CIntegration::TwoDimensions>;
 
-        const Sparse2do4 &sparse = Sparse2do4::instance();
+        const TSparse2do4 &sparse = TSparse2do4::instance();
 
         LOG_DEBUG("# points = " << sparse.weights().size());
         CPPUNIT_ASSERT_EQUAL(expectedWeights.size(), sparse.weights().size());
@@ -1130,10 +1130,10 @@ void CIntegrationTest::testSparseGrid(void)
                                 expectedWeights,
                                 expectedPoints));
 
-        typedef CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderThree,
-                                                             CIntegration::SevenDimensions> Sparse7do3;
+        using TSparse7do3 = CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderThree,
+                                                                         CIntegration::SevenDimensions>;
 
-        const Sparse7do3 &sparse = Sparse7do3::instance();
+        const TSparse7do3 &sparse = TSparse7do3::instance();
 
         LOG_DEBUG("# points = " << sparse.weights().size());
         CPPUNIT_ASSERT_EQUAL(expectedWeights.size(), sparse.weights().size());
@@ -1163,10 +1163,10 @@ void CIntegrationTest::testSparseGrid(void)
                                 expectedWeights,
                                 expectedPoints));
 
-        typedef CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderFive,
-                                                             CIntegration::SevenDimensions> Sparse7do5;
+        using TSparse7do5 = CIntegration::CSparseGaussLegendreQuadrature<CIntegration::OrderFive,
+                                                                         CIntegration::SevenDimensions>;
 
-        const Sparse7do5 &sparse = Sparse7do5::instance();
+        const TSparse7do5 &sparse = TSparse7do5::instance();
 
         LOG_DEBUG("# points = " << sparse.weights().size());
         CPPUNIT_ASSERT_EQUAL(expectedWeights.size(), sparse.weights().size());
@@ -1274,7 +1274,7 @@ void CIntegrationTest::testMultivariateSmooth(void)
     // if its order is no more than 2l - 1. A polynomial order is
     // the largest sum of exponents in any term.
 
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CKMeansFastTest.cc
+++ b/lib/maths/unittest/CKMeansFastTest.cc
@@ -35,28 +35,28 @@ template<typename POINT>
 class CKMeansFastForTest : maths::CKMeansFast<POINT>
 {
     public:
-        typedef typename maths::CKMeansFast<POINT>::TBoundingBox TBoundingBox;
-        typedef typename maths::CKMeansFast<POINT>::CKdTreeNodeData TKdTreeNodeData;
-        typedef typename maths::CKMeansFast<POINT>::SDataPropagator TDataPropagator;
-        typedef typename maths::CKMeansFast<POINT>::CCentreFilter TCentreFilter;
-        typedef typename maths::CKMeansFast<POINT>::CCentroidComputer TCentroidComputer;
-        typedef typename maths::CKMeansFast<POINT>::CClosestPointsCollector TClosestPointsCollector;
+        using TBoundingBox = typename maths::CKMeansFast<POINT>::TBoundingBox;
+        using TKdTreeNodeData = typename maths::CKMeansFast<POINT>::CKdTreeNodeData;
+        using TDataPropagator = typename maths::CKMeansFast<POINT>::SDataPropagator;
+        using TCentreFilter = typename maths::CKMeansFast<POINT>::CCentreFilter;
+        using TCentroidComputer = typename maths::CKMeansFast<POINT>::CCentroidComputer;
+        using TClosestPointsCollector = typename maths::CKMeansFast<POINT>::CClosestPointsCollector;
 };
 
 }
 
-typedef std::vector<double> TDoubleVec;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef std::vector<TVector2> TVector2Vec;
-typedef std::vector<TVector2Vec> TVector2VecVec;
-typedef maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
-typedef std::vector<TMatrix2> TMatrix2Vec;
-typedef maths::CVectorNx1<double, 4> TVector4;
-typedef std::vector<TVector4> TVector4Vec;
-typedef maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator TMean2Accumulator;
-typedef std::vector<TMean2Accumulator> TMean2AccumulatorVec;
-typedef maths::CBasicStatistics::SSampleMean<TVector4>::TAccumulator TMean4Accumulator;
-typedef std::vector<TMean4Accumulator> TMean4AccumulatorVec;
+using TDoubleVec = std::vector<double>;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TVector2Vec = std::vector<TVector2>;
+using TVector2VecVec = std::vector<TVector2Vec>;
+using TMatrix2 = maths::CSymmetricMatrixNxN<double, 2>;
+using TMatrix2Vec = std::vector<TMatrix2>;
+using TVector4 = maths::CVectorNx1<double, 4>;
+using TVector4Vec = std::vector<TVector4>;
+using TMean2Accumulator = maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator;
+using TMean2AccumulatorVec = std::vector<TMean2Accumulator>;
+using TMean4Accumulator = maths::CBasicStatistics::SSampleMean<TVector4>::TAccumulator;
+using TMean4AccumulatorVec = std::vector<TMean4Accumulator>;
 
 namespace
 {
@@ -64,9 +64,9 @@ namespace
 template<typename POINT>
 struct SKdTreeDataInvariantsChecker
 {
-    typedef typename CKMeansFastForTest<POINT>::TKdTreeNodeData TData;
-    typedef typename maths::CBasicStatistics::SSampleMean<POINT>::TAccumulator TMeanAccumulator;
-    typedef typename CKMeansFastForTest<POINT>::TBoundingBox TBoundingBox;
+    using TData = typename CKMeansFastForTest<POINT>::TKdTreeNodeData;
+    using TMeanAccumulator = typename maths::CBasicStatistics::SSampleMean<POINT>::TAccumulator;
+    using TBoundingBox = typename CKMeansFastForTest<POINT>::TBoundingBox;
 
     void operator()(const typename maths::CKdTree<POINT, TData>::SNode &node) const
     {
@@ -96,10 +96,10 @@ template<typename POINT>
 class CCentreFilterChecker
 {
     public:
-        typedef std::vector<std::size_t> TSizeVec;
-        typedef std::vector<POINT> TPointVec;
-        typedef typename CKMeansFastForTest<POINT>::TKdTreeNodeData TData;
-        typedef typename CKMeansFastForTest<POINT>::TCentreFilter TCentreFilter;
+        using TSizeVec = std::vector<std::size_t>;
+        using TPointVec = std::vector<POINT>;
+        using TData = typename CKMeansFastForTest<POINT>::TKdTreeNodeData;
+        using TCentreFilter = typename CKMeansFastForTest<POINT>::TCentreFilter;
 
     public:
         CCentreFilterChecker(const TPointVec &centres,
@@ -111,7 +111,7 @@ class CCentreFilterChecker
 
         bool operator()(const typename maths::CKdTree<POINT, TData>::SNode &node) const
         {
-            typedef std::pair<double, std::size_t> TDoubleSizePr;
+            using TDoubleSizePr = std::pair<double, std::size_t>;
 
             m_CentreFilter.prune(node.boundingBox());
             const TSizeVec &filtered = m_CentreFilter.filter();
@@ -165,7 +165,7 @@ bool kmeans(const std::vector<POINT> &points,
             std::size_t iterations,
             std::vector<POINT> &centres)
 {
-    typedef typename maths::CBasicStatistics::SSampleMean<POINT>::TAccumulator TMeanAccumlator;
+    using TMeanAccumlator = typename maths::CBasicStatistics::SSampleMean<POINT>::TAccumulator;
 
     std::vector<TMeanAccumlator> centroids;
     for (std::size_t i = 0u; i < iterations; ++i)
@@ -431,8 +431,8 @@ void CKMeansFastTest::testClosestPoints(void)
     // Check the obvious invariant that the closest point to each
     // centre is closer to that centre than any other.
 
-    typedef std::vector<TVector2Vec> TVector2VecVec;
-    typedef std::vector<TVector4Vec> TVector4VecVec;
+    using TVector2VecVec = std::vector<TVector2Vec>;
+    using TVector4VecVec = std::vector<TVector4Vec>;
 
     test::CRandomNumbers rng;
 
@@ -569,9 +569,9 @@ void CKMeansFastTest::testRunWithSphericalClusters(void)
     // same result working with clusters of points or their
     // spherical cluster representation.
 
-    typedef maths::CSphericalCluster<TVector2>::Type TSphericalCluster2;
-    typedef std::vector<TSphericalCluster2> TSphericalCluster2Vec;
-    typedef maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator TMeanVar2Accumulator;
+    using TSphericalCluster2 = maths::CSphericalCluster<TVector2>::Type;
+    using TSphericalCluster2Vec = std::vector<TSphericalCluster2>;
+    using TMeanVar2Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator;
 
     double means[][2] =
         {
@@ -661,9 +661,9 @@ void CKMeansFastTest::testPlusPlus(void)
     // clusters present in the data and generally results in lower
     // square residuals of the points from the cluster centres.
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef TVector2Vec::const_iterator TVector2VecCItr;
+    using TSizeVec = std::vector<std::size_t>;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TVector2VecCItr = TVector2Vec::const_iterator;
 
     maths::CSampling::seed();
 

--- a/lib/maths/unittest/CKMeansOnlineTest.cc
+++ b/lib/maths/unittest/CKMeansOnlineTest.cc
@@ -32,26 +32,26 @@ using namespace ml;
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef std::vector<TVector2> TVector2Vec;
-typedef std::vector<TVector2Vec> TVector2VecVec;
-typedef maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator TMean2Accumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator TMeanVar2Accumulator;
-typedef maths::CVectorNx1<double, 5> TVector5;
-typedef std::vector<TVector5> TVector5Vec;
-typedef maths::CBasicStatistics::SSampleMeanVar<TVector5>::TAccumulator TMeanVar5Accumulator;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TVector2Vec = std::vector<TVector2>;
+using TVector2VecVec = std::vector<TVector2Vec>;
+using TMean2Accumulator = maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator;
+using TMeanVar2Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator;
+using TVector5 = maths::CVectorNx1<double, 5>;
+using TVector5Vec = std::vector<TVector5>;
+using TMeanVar5Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector5>::TAccumulator;
 
 template<typename POINT>
 class CKMeansOnlineTestForTest : public maths::CKMeansOnline<POINT>
 {
     public:
-        typedef typename maths::CKMeansOnline<POINT>::TSphericalClusterVec TSphericalClusterVec;
-        typedef typename maths::CKMeansOnline<POINT>::TDoubleMeanVarAccumulator TDoubleMeanVarAccumulator;
-        typedef typename maths::CKMeansOnline<POINT>::TFloatMeanAccumulatorDoublePr TFloatMeanAccumulatorDoublePr;
+        using TSphericalClusterVec = typename maths::CKMeansOnline<POINT>::TSphericalClusterVec;
+        using TDoubleMeanVarAccumulator = typename maths::CKMeansOnline<POINT>::TDoubleMeanVarAccumulator;
+        using TFloatMeanAccumulatorDoublePr = typename maths::CKMeansOnline<POINT>::TFloatMeanAccumulatorDoublePr;
 
     public:
         CKMeansOnlineTestForTest(std::size_t k, double decayRate = 0.0) :
@@ -139,7 +139,7 @@ void CKMeansOnlineTest::testAdd(void)
     // Test that we correctly compute the mean and spherical
     // variance.
 
-    typedef std::pair<TMean2Accumulator, double> TMean2AccumulatorDoublePr;
+    using TMean2AccumulatorDoublePr = std::pair<TMean2Accumulator, double>;
 
     test::CRandomNumbers rng;
 
@@ -431,7 +431,7 @@ void CKMeansOnlineTest::testSplit(void)
     // Test that the clusters are divided amoung the clusterers
     // in the split as expected.
 
-    typedef std::vector<maths::CKMeansOnline<TVector2> > TKMeansOnline2Vec;
+    using TKMeansOnline2Vec = std::vector<maths::CKMeansOnline<TVector2>>;
 
     test::CRandomNumbers rng;
 
@@ -644,7 +644,7 @@ void CKMeansOnlineTest::testSample(void)
     // exactly the points we have added and for a large number
     // of samples we sample the modes of the mixture correctly.
 
-    typedef maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
+    using TMatrix2 = maths::CSymmetricMatrixNxN<double, 2>;
 
     maths::CSampling::seed();
 

--- a/lib/maths/unittest/CKMostCorrelatedTest.cc
+++ b/lib/maths/unittest/CKMostCorrelatedTest.cc
@@ -38,21 +38,21 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef std::vector<TVector2> TVector2Vec;
-typedef maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+using TDoubleVec = std::vector<double>;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TVector2Vec = std::vector<TVector2>;
+using TMatrix2 = maths::CSymmetricMatrixNxN<double, 2>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
 class CKMostCorrelatedForTest : public maths::CKMostCorrelated
 {
     public:
-        typedef maths::CKMostCorrelated::SCorrelation TCorrelation;
-        typedef maths::CKMostCorrelated::TCorrelationVec TCorrelationVec;
-        typedef maths::CKMostCorrelated::TSizeVectorPackedBitVectorPrUMap TSizeVectorPackedBitVectorPrUMap;
-        typedef maths::CKMostCorrelated::TSizeVectorPackedBitVectorPrUMapCItr TSizeVectorPackedBitVectorPrUMapCItr;
-        typedef maths::CKMostCorrelated::TMeanVarAccumulatorVec TMeanVarAccumulatorVec;
+        using TCorrelation = maths::CKMostCorrelated::SCorrelation;
+        using TCorrelationVec = maths::CKMostCorrelated::TCorrelationVec;
+        using TSizeVectorPackedBitVectorPrUMap = maths::CKMostCorrelated::TSizeVectorPackedBitVectorPrUMap;
+        using TSizeVectorPackedBitVectorPrUMapCItr = maths::CKMostCorrelated::TSizeVectorPackedBitVectorPrUMapCItr;
+        using TMeanVarAccumulatorVec = maths::CKMostCorrelated::TMeanVarAccumulatorVec;
         using maths::CKMostCorrelated::mostCorrelated;
         using maths::CKMostCorrelated::correlations;
 
@@ -134,9 +134,9 @@ void estimateCorrelation(const std::size_t trials,
                          const TMatrix2 &covariance,
                          TMeanVarAccumulator &correlationEstimate)
 {
-    typedef maths::CVectorNx1<maths::CFloatStorage, 10> TVector10;
-    typedef std::vector<TVector10> TVector10Vec;
-    typedef maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator TMeanVar2Accumulator;
+    using TVector10 = maths::CVectorNx1<maths::CFloatStorage, 10>;
+    using TVector10Vec = std::vector<TVector10>;
+    using TMeanVar2Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator;
 
     test::CRandomNumbers rng;
 
@@ -265,7 +265,7 @@ void CKMostCorrelatedTest::testNextProjection(void)
     // Test that aging happens correctly and that the projections
     // are have low mutual information.
 
-    typedef std::vector<TDoubleVec> TDoubleVecVec;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
 
     maths::CSampling::seed();
 
@@ -407,7 +407,7 @@ void CKMostCorrelatedTest::testMostCorrelated(void)
 
     // Check the variables with the highest estimated correlation emerge.
 
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<CKMostCorrelatedForTest::TCorrelation> TMaxCorrelationAccumulator;
+    using TMaxCorrelationAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<CKMostCorrelatedForTest::TCorrelation>;
 
     maths::CSampling::seed();
 
@@ -811,8 +811,8 @@ void CKMostCorrelatedTest::testScale(void)
     // Test runtime is approximately linear in the number of variables
     // if we look for O(number of variables) correlations.
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef std::vector<TDoubleVec> TDoubleVecVec;
+    using TSizeVec = std::vector<std::size_t>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
 
     maths::CSampling::seed();
 
@@ -889,7 +889,7 @@ void CKMostCorrelatedTest::testScale(void)
 
         LOG_DEBUG("elapsed time = " << elapsed[s] << "ms");
 
-        //std::vector<std::pair<std::size_t, std::size_t> > pairs;
+        //std::vector<std::pair<std::size_t, std::size_t>> pairs;
         //mostCorrelated.mostCorrelated(n[s] / 2, pairs);
         //LOG_DEBUG("pairs = " << core::CContainerPrinter::print(pairs));
         //TDoubleVec correlations;

--- a/lib/maths/unittest/CKdTreeTest.cc
+++ b/lib/maths/unittest/CKdTreeTest.cc
@@ -29,13 +29,13 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef std::pair<double, TVector2> TDoubleVector2Pr;
-typedef std::vector<TVector2> TVector2Vec;
-typedef maths::CVectorNx1<double, 5> TVector5;
-typedef std::pair<double, TVector5> TDoubleVector5Pr;
-typedef std::vector<TVector5> TVector5Vec;
+using TDoubleVec = std::vector<double>;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TDoubleVector2Pr = std::pair<double, TVector2>;
+using TVector2Vec = std::vector<TVector2>;
+using TVector5 = maths::CVectorNx1<double, 5>;
+using TDoubleVector5Pr = std::pair<double, TVector5>;
+using TVector5Vec = std::vector<TVector5>;
 
 template<typename T>
 std::string print(const T &t)
@@ -127,10 +127,8 @@ void CKdTreeTest::testNearestNeighbour(void)
         }
         for (std::size_t j = 0u; j < tests.size(); ++j)
         {
-            typedef maths::CBasicStatistics::COrderStatisticsStack<
-                        TDoubleVector2Pr,
-                        1,
-                        maths::COrderings::SFirstLess> TMinAccumulator;
+            using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<
+                                        TDoubleVector2Pr, 1, maths::COrderings::SFirstLess>;
 
             TMinAccumulator expectedNearest;
             for (std::size_t k = 0u; k < points.size(); ++k)

--- a/lib/maths/unittest/CLassoLogisticRegressionTest.cc
+++ b/lib/maths/unittest/CLassoLogisticRegressionTest.cc
@@ -34,11 +34,11 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::pair<TSizeSizePr, double> TSizeSizePrDoublePr;
-typedef std::vector<TSizeSizePrDoublePr> TSizeSizePrDoublePrVec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrDoublePr = std::pair<TSizeSizePr, double>;
+using TSizeSizePrDoublePrVec = std::vector<TSizeSizePrDoublePr>;
 
 template<typename ARRAY>
 void initializeMatrix(const ARRAY &x_, TDoubleVecVec &x)

--- a/lib/maths/unittest/CLinearAlgebraTest.cc
+++ b/lib/maths/unittest/CLinearAlgebraTest.cc
@@ -28,8 +28,8 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
 
 void CLinearAlgebraTest::testSymmetricMatrixNxN(void)
 {
@@ -1097,7 +1097,7 @@ void CLinearAlgebraTest::testSampleGaussian(void)
                 +  5.0 * maths::CSymmetricMatrixNxN<double, 4>(maths::E_OuterProduct, e2 / e2.euclidean())
                 +  5.0 * maths::CSymmetricMatrixNxN<double, 4>(maths::E_OuterProduct, e3 / e3.euclidean()));
 
-        std::vector<maths::CVectorNx1<double, 4> > samples;
+        std::vector<maths::CVectorNx1<double, 4>> samples;
         maths::sampleGaussian(100, mean, covariance, samples);
 
         CPPUNIT_ASSERT_EQUAL(std::size_t(99), samples.size());
@@ -1148,7 +1148,7 @@ void CLinearAlgebraTest::testSampleGaussian(void)
                 +  5.0 * maths::CSymmetricMatrixNxN<double, 4>(maths::E_OuterProduct, e3 / e3.euclidean())
                 +  2.0 * maths::CSymmetricMatrixNxN<double, 4>(maths::E_OuterProduct, e4 / e4.euclidean()));
 
-        std::vector<maths::CVectorNx1<double, 4> > samples;
+        std::vector<maths::CVectorNx1<double, 4>> samples;
         maths::sampleGaussian(100, mean, covariance, samples);
 
         CPPUNIT_ASSERT_EQUAL(std::size_t(100), samples.size());
@@ -1280,7 +1280,7 @@ void CLinearAlgebraTest::testProjected(void)
     LOG_DEBUG("|  CLinearAlgebraTest::testProjected  |");
     LOG_DEBUG("+-------------------------------------+");
 
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     const double m[][5] =
         {

--- a/lib/maths/unittest/CLogNormalMeanPrecConjugateTest.cc
+++ b/lib/maths/unittest/CLogNormalMeanPrecConjugateTest.cc
@@ -47,12 +47,12 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate> CLogNormalMeanPrecConjugate;
+using TDoubleVec = std::vector<double>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using CLogNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate>;
 
 CLogNormalMeanPrecConjugate makePrior(maths_t::EDataType dataType = maths_t::E_ContinuousData,
                                       const double &offset = 0.0,
@@ -72,7 +72,7 @@ void CLogNormalMeanPrecConjugateTest::testMultipleUpdate(void)
     // Test that we get the same result updating once with a vector of 100
     // samples of an R.V. versus updating individually 100 times.
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
 
     const maths_t::EDataType dataTypes[] =
         {
@@ -1082,7 +1082,7 @@ void CLogNormalMeanPrecConjugateTest::testAnomalyScore(void)
     //   1) high probability of detecting the anomalies, and
     //   2) a very low rate of false positives.
 
-    typedef std::vector<unsigned int> TUIntVec;
+    using TUIntVec = std::vector<unsigned int>;
 
     const double decayRates[] = { 0.0, 0.001, 0.01 };
 
@@ -1277,7 +1277,7 @@ void CLogNormalMeanPrecConjugateTest::testOffset(void)
                     CPPUNIT_ASSERT_DOUBLES_EQUAL(probability1, probability2, eps);
                 }
 
-                typedef maths::CEqualWithTolerance<double> TEqual;
+                using TEqual = maths::CEqualWithTolerance<double>;
                 TEqual equal(maths::CToleranceTypes::E_AbsoluteTolerance, eps);
                 CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
             }
@@ -1326,7 +1326,7 @@ void CLogNormalMeanPrecConjugateTest::testIntegerData(void)
             filter2.addSamples(sample);
         }
 
-        typedef maths::CEqualWithTolerance<double> TEqual;
+        using TEqual = maths::CEqualWithTolerance<double>;
         TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.01);
         CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
 
@@ -1920,7 +1920,7 @@ void CLogNormalMeanPrecConjugateTest::testNegativeSample(void)
 
     CPPUNIT_ASSERT_EQUAL(filter1.numberSamples(), filter2.numberSamples());
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
     TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.1);
     CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
 }

--- a/lib/maths/unittest/CLogTDistributionTest.cc
+++ b/lib/maths/unittest/CLogTDistributionTest.cc
@@ -29,9 +29,9 @@ using namespace ml;
 using namespace maths;
 using namespace test;
 
-typedef std::vector<double> TDoubleVec;
-typedef TDoubleVec::iterator TDoubleVecItr;
-typedef TDoubleVec::const_iterator TDoubleVecCItr;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecItr = TDoubleVec::iterator;
+using TDoubleVecCItr = TDoubleVec::const_iterator;
 
 void CLogTDistributionTest::testMode(void)
 {

--- a/lib/maths/unittest/CMathsFuncsTest.cc
+++ b/lib/maths/unittest/CMathsFuncsTest.cc
@@ -59,7 +59,7 @@ void CMathsFuncsTest::testIsInf(void)
 
 void CMathsFuncsTest::testIsFinite(void)
 {
-    typedef std::vector<double> TDoubleVec;
+    using TDoubleVec = std::vector<double>;
 
     CPPUNIT_ASSERT(maths::CMathsFuncs::isFinite(0.0));
     CPPUNIT_ASSERT(maths::CMathsFuncs::isFinite(1.3e7));

--- a/lib/maths/unittest/CMathsMemoryTest.cc
+++ b/lib/maths/unittest/CMathsMemoryTest.cc
@@ -137,7 +137,7 @@ void CMathsMemoryTest::testPriors(void)
 
 void CMathsMemoryTest::testBjkstVec(void)
 {
-    typedef std::vector<maths::CBjkstUniqueValues> TBjkstValuesVec;
+    using TBjkstValuesVec = std::vector<maths::CBjkstUniqueValues>;
     {
         // Test empty
         TBjkstValuesVec values;

--- a/lib/maths/unittest/CMixtureDistributionTest.cc
+++ b/lib/maths/unittest/CMixtureDistributionTest.cc
@@ -28,10 +28,10 @@ using namespace ml;
 using namespace maths;
 using namespace test;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<boost::math::normal_distribution<> > TNormalVec;
-typedef std::vector<boost::math::lognormal_distribution<> > TLogNormalVec;
-typedef std::vector<boost::math::gamma_distribution<> > TGammaVec;
+using TDoubleVec = std::vector<double>;
+using TNormalVec = std::vector<boost::math::normal_distribution<>>;
+using TLogNormalVec = std::vector<boost::math::lognormal_distribution<>>;
+using TGammaVec = std::vector<boost::math::gamma_distribution<>>;
 
 void CMixtureDistributionTest::testSupport(void)
 {
@@ -48,7 +48,7 @@ void CMixtureDistributionTest::testSupport(void)
         TNormalVec modes;
         modes.push_back(n1);
         modes.push_back(n2);
-        CMixtureDistribution<boost::math::normal_distribution<> > mixture(weights, modes);
+        CMixtureDistribution<boost::math::normal_distribution<>> mixture(weights, modes);
         CPPUNIT_ASSERT_EQUAL(core::CContainerPrinter::print(boost::math::support(n1)),
                              core::CContainerPrinter::print(support(mixture)));
     }
@@ -61,7 +61,7 @@ void CMixtureDistributionTest::testSupport(void)
         TLogNormalVec modes;
         modes.push_back(l1);
         modes.push_back(l2);
-        CMixtureDistribution<boost::math::lognormal_distribution<> > mixture(weights, modes);
+        CMixtureDistribution<boost::math::lognormal_distribution<>> mixture(weights, modes);
         CPPUNIT_ASSERT_EQUAL(core::CContainerPrinter::print(boost::math::support(l1)),
                              core::CContainerPrinter::print(support(mixture)));
     }
@@ -107,7 +107,7 @@ void CMixtureDistributionTest::testMode(void)
             TNormalVec modes;
             modes.push_back(n1);
             modes.push_back(n2);
-            CMixtureDistribution<boost::math::normal_distribution<> > mixture(weights, modes);
+            CMixtureDistribution<boost::math::normal_distribution<>> mixture(weights, modes);
 
             double x = mode(mixture);
 
@@ -141,7 +141,7 @@ void CMixtureDistributionTest::testMode(void)
         modes.push_back(n1);
         modes.push_back(n2);
         modes.push_back(n3);
-        CMixtureDistribution<boost::math::normal_distribution<> > mixture(weights, modes);
+        CMixtureDistribution<boost::math::normal_distribution<>> mixture(weights, modes);
 
         double x = mode(mixture);
 
@@ -170,7 +170,7 @@ void CMixtureDistributionTest::testMode(void)
         TLogNormalVec modes;
         modes.push_back(l1);
         modes.push_back(l2);
-        CMixtureDistribution<boost::math::lognormal_distribution<> > mixture(weights, modes);
+        CMixtureDistribution<boost::math::lognormal_distribution<>> mixture(weights, modes);
 
         double x = mode(mixture);
 
@@ -258,7 +258,7 @@ void CMixtureDistributionTest::testPdf(void)
             TNormalVec modes;
             modes.push_back(n1);
             modes.push_back(n2);
-            CMixtureDistribution<boost::math::normal_distribution<> > mixture(w, modes);
+            CMixtureDistribution<boost::math::normal_distribution<>> mixture(w, modes);
 
             for (unsigned int p = 1; p < 100; ++p)
             {
@@ -348,7 +348,7 @@ void CMixtureDistributionTest::testCdf(void)
         TGammaVec modes;
         modes.push_back(g1);
         modes.push_back(g2);
-        CMixtureDistribution<boost::math::gamma_distribution<> > mixture(w, modes);
+        CMixtureDistribution<boost::math::gamma_distribution<>> mixture(w, modes);
 
         // Check the data percentiles.
         for (unsigned int p = 1; p < 100; ++p)
@@ -418,7 +418,7 @@ void CMixtureDistributionTest::testQuantile(void)
         modes.push_back(l1);
         modes.push_back(l2);
         modes.push_back(l3);
-        CMixtureDistribution<boost::math::lognormal_distribution<> > mixture(w, modes);
+        CMixtureDistribution<boost::math::lognormal_distribution<>> mixture(w, modes);
 
         for (unsigned int p = 1; p < 100; ++p)
         {

--- a/lib/maths/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultimodalPriorTest.cc
@@ -51,15 +51,15 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef boost::shared_ptr<maths::CPrior> TPriorPtr;
-typedef CPriorTestInterfaceMixin<maths::CGammaRateConjugate> CGammaRateConjugate;
-typedef CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate> CLogNormalMeanPrecConjugate;
-typedef CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate> CNormalMeanPrecConjugate;
-typedef CPriorTestInterfaceMixin<maths::CMultimodalPrior> CMultimodalPrior;
-typedef CPriorTestInterfaceMixin<maths::COneOfNPrior> COneOfNPrior;
+using TDoubleVec = std::vector<double>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TPriorPtr = boost::shared_ptr<maths::CPrior>;
+using CGammaRateConjugate = CPriorTestInterfaceMixin<maths::CGammaRateConjugate>;
+using CLogNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate>;
+using CNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate>;
+using CMultimodalPrior = CPriorTestInterfaceMixin<maths::CMultimodalPrior>;
+using COneOfNPrior = CPriorTestInterfaceMixin<maths::COneOfNPrior>;
 
 //! Make the default mode prior.
 COneOfNPrior makeModePrior(const double &decayRate = 0.0)
@@ -149,7 +149,7 @@ void probabilityOfLessLikelySample(const maths::CMixtureDistribution<T> &mixture
                                    double &probability,
                                    double &deviation)
 {
-    typedef typename maths::CMixtureDistribution<T>::TModeVec TModeVec;
+    using TModeVec = typename maths::CMixtureDistribution<T>::TModeVec;
 
     static const double NUMBER_SAMPLES = 10000.0;
 
@@ -238,7 +238,7 @@ void CMultimodalPriorTest::testPropagation(void)
     // mean and the marginal likelihood confidence intervals increase
     // (due to influence of the prior uncertainty) after propagation.
 
-    typedef std::pair<double, double> TDoubleDoublePr;
+    using TDoubleDoublePr = std::pair<double, double>;
 
     double eps = 0.01;
 
@@ -309,7 +309,7 @@ void CMultimodalPriorTest::testSingleMode(void)
     // that the generating distribution doesn't necessarily have
     // a larger likelihood because we are using a finite sample.
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     test::CRandomNumbers rng;
 
@@ -473,7 +473,7 @@ void CMultimodalPriorTest::testMultipleModes(void)
     // have a larger likelihood because we are using a finite
     // sample.
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     test::CRandomNumbers rng;
 
@@ -768,7 +768,7 @@ void CMultimodalPriorTest::testMarginalLikelihood(void)
     LOG_DEBUG("|  CMultimodalPriorTest::testMarginalLikelihood  |");
     LOG_DEBUG("+------------------------------------------------+");
 
-    typedef std::vector<boost::math::normal_distribution<> > TNormalVec;
+    using TNormalVec = std::vector<boost::math::normal_distribution<>>;
 
     // Check that the c.d.f. <= 1 at extreme.
     {
@@ -939,7 +939,7 @@ void CMultimodalPriorTest::testMarginalLikelihood(void)
         modes.push_back(boost::math::normal_distribution<>(mean1, variance1));
         modes.push_back(boost::math::normal_distribution<>(mean2, variance2));
         modes.push_back(boost::math::normal_distribution<>(mean3, variance3));
-        maths::CMixtureDistribution<boost::math::normal_distribution<> > f(weights, modes);
+        maths::CMixtureDistribution<boost::math::normal_distribution<>> f(weights, modes);
         double expectedDifferentialEntropy = maths::CTools::differentialEntropy(f);
 
         double differentialEntropy = 0.0;
@@ -1091,7 +1091,7 @@ void CMultimodalPriorTest::testMarginalLikelihoodConfidenceInterval(void)
     // Test that marginal likelihood confidence intervals are
     // what we'd expect for various variance scales.
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     LOG_DEBUG("Synthetic");
     {
@@ -1229,9 +1229,9 @@ void CMultimodalPriorTest::testSampleMarginalLikelihood(void)
     // jointLogMarginalLikelihood and minusLogJointCdf so use these
     // to compute the mean and percentiles.
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-    typedef maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator TMeanVarSkewAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using TMeanVarSkewAccumulator = maths::CBasicStatistics::SSampleMeanVarSkew<double>::TAccumulator;
 
     const double eps = 1e-3;
 
@@ -1416,9 +1416,9 @@ void CMultimodalPriorTest::testProbabilityOfLessLikelySamples(void)
     LOG_DEBUG("|  CMultimodalPriorTest::testProbabilityOfLessLikelySamples  |");
     LOG_DEBUG("+------------------------------------------------------------+");
 
-    typedef std::vector<boost::math::normal_distribution<> > TNormalVec;
-    typedef std::vector<boost::math::lognormal_distribution<> > TLogNormalVec;
-    typedef std::vector<boost::math::gamma_distribution<> > TGammaVec;
+    using TNormalVec = std::vector<boost::math::normal_distribution<>>;
+    using TLogNormalVec = std::vector<boost::math::lognormal_distribution<>>;
+    using TGammaVec = std::vector<boost::math::gamma_distribution<>>;
 
     test::CRandomNumbers rng;
 
@@ -1446,7 +1446,7 @@ void CMultimodalPriorTest::testProbabilityOfLessLikelySamples(void)
         TNormalVec modes;
         modes.push_back(boost::math::normal_distribution<>(mean1, variance1));
         modes.push_back(boost::math::normal_distribution<>(mean2, variance2));
-        maths::CMixtureDistribution<boost::math::normal_distribution<> > mixture(weights, modes);
+        maths::CMixtureDistribution<boost::math::normal_distribution<>> mixture(weights, modes);
 
         CMultimodalPrior filter(makePrior());
         filter.addSamples(samples);
@@ -1533,7 +1533,7 @@ void CMultimodalPriorTest::testProbabilityOfLessLikelySamples(void)
         modes.push_back(boost::math::lognormal_distribution<>(locations[0], ::sqrt(squareScales[0])));
         modes.push_back(boost::math::lognormal_distribution<>(locations[1], ::sqrt(squareScales[1])));
         modes.push_back(boost::math::lognormal_distribution<>(locations[2], ::sqrt(squareScales[2])));
-        maths::CMixtureDistribution<boost::math::lognormal_distribution<> > mixture(mixtureWeights, modes);
+        maths::CMixtureDistribution<boost::math::lognormal_distribution<>> mixture(mixtureWeights, modes);
 
         CMultimodalPrior filter(makePrior());
         filter.addSamples(samples);
@@ -1595,7 +1595,7 @@ void CMultimodalPriorTest::testProbabilityOfLessLikelySamples(void)
         TGammaVec modes;
         modes.push_back(boost::math::gamma_distribution<>(shapes[0], scales[0]));
         modes.push_back(boost::math::gamma_distribution<>(shapes[1], scales[1]));
-        maths::CMixtureDistribution<boost::math::gamma_distribution<> > mixture(mixtureWeights, modes);
+        maths::CMixtureDistribution<boost::math::gamma_distribution<>> mixture(mixtureWeights, modes);
 
         CMultimodalPrior filter(makePrior());
         filter.addSamples(samples);

--- a/lib/maths/unittest/CMultinomialConjugateTest.cc
+++ b/lib/maths/unittest/CMultinomialConjugateTest.cc
@@ -42,12 +42,12 @@
 using namespace ml;
 using namespace handy_typedefs;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<unsigned int> TUIntVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef CPriorTestInterfaceMixin<maths::CMultinomialConjugate> CMultinomialConjugate;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TUIntVec = std::vector<unsigned int>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using CMultinomialConjugate = CPriorTestInterfaceMixin<maths::CMultinomialConjugate>;
 
 void CMultinomialConjugateTest::testMultipleUpdate(void)
 {
@@ -77,7 +77,7 @@ void CMultinomialConjugateTest::testMultipleUpdate(void)
     }
     filter2.addSamples(samples);
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
     TEqual equal(maths::CToleranceTypes::E_AbsoluteTolerance, 1e-5);
     CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
 }
@@ -119,7 +119,7 @@ void CMultinomialConjugateTest::testPropagation(void)
               << ", propagatedExpectedProbabilities = "
               << core::CContainerPrinter::print(propagatedExpectedProbabilities));
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
     TEqual equal(maths::CToleranceTypes::E_AbsoluteTolerance, 1e-12);
     CPPUNIT_ASSERT(std::equal(expectedProbabilities.begin(),
                               expectedProbabilities.end(),
@@ -527,8 +527,8 @@ void CMultinomialConjugateTest::testProbabilityOfLessLikelySamples(void)
     LOG_DEBUG("|  CMultinomialConjugateTest::testProbabilityOfLessLikelySamples  |");
     LOG_DEBUG("+-----------------------------------------------------------------+");
 
-    typedef std::pair<double, std::size_t> TDoubleSizePr;
-    typedef std::vector<TDoubleSizePr> TDoubleSizePrVec;
+    using TDoubleSizePr = std::pair<double, std::size_t>;
+    using TDoubleSizePrVec = std::vector<TDoubleSizePr>;
 
     // We test the definition of the various sided calculations:
     //   - one sided below: P(R) = P(y <= x)
@@ -720,10 +720,10 @@ void CMultinomialConjugateTest::testProbabilityOfLessLikelySamples(void)
             }
         }
         {
-            typedef std::map<double, TDoubleVec> TDoubleDoubleVecMap;
-            typedef TDoubleDoubleVecMap::const_iterator TDoubleDoubleVecMapCItr;
-            typedef std::map<TDoubleVec, double> TDoubleVecDoubleMap;
-            typedef TDoubleVecDoubleMap::const_iterator TDoubleVecDoubleMapCItr;
+            using TDoubleDoubleVecMap = std::map<double, TDoubleVec>;
+            using TDoubleDoubleVecMapCItr = TDoubleDoubleVecMap::const_iterator;
+            using TDoubleVecDoubleMap = std::map<TDoubleVec, double>;
+            using TDoubleVecDoubleMapCItr = TDoubleVecDoubleMap::const_iterator;
 
             double categoryProbabilities[] = { 0.10, 0.12, 0.29, 0.39, 0.04, 0.06 };
             TDoubleDoubleVecMap categoryPairProbabilities;

--- a/lib/maths/unittest/CMultivariateMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultivariateMultimodalPriorTest.cc
@@ -36,13 +36,13 @@
 using namespace ml;
 using namespace handy_typedefs;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<TDoubleVecVec> TDoubleVecVecVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator TMean2Accumulator;
-typedef maths::CBasicStatistics::SSampleCovariances<double, 2> TCovariances2;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDoubleVecVecVec = std::vector<TDoubleVecVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMean2Accumulator = maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator;
+using TCovariances2 = maths::CBasicStatistics::SSampleCovariances<double, 2>;
 
 namespace
 {
@@ -56,8 +56,8 @@ template<std::size_t N>
 class CMultivariateMultimodalPriorForTest : public maths::CMultivariateMultimodalPrior<N>
 {
     public:
-        typedef typename maths::CMultivariateMultimodalPrior<N>::TClusterer TClusterer;
-        typedef typename maths::CMultivariateMultimodalPrior<N>::TModeVec TModeVec;
+        using TClusterer = typename maths::CMultivariateMultimodalPrior<N>::TClusterer;
+        using TModeVec = typename maths::CMultivariateMultimodalPrior<N>::TModeVec;
 
     public:
         CMultivariateMultimodalPriorForTest(const maths::CMultivariateMultimodalPrior<N> &prior) :
@@ -485,7 +485,7 @@ void CMultivariateMultimodalPriorTest::testSplitAndMerge(void)
 
     // Test clustering which changes over time.
 
-    typedef std::vector<TDoubleVecVec> TDoubleVecVecVec;
+    using TDoubleVecVecVec = std::vector<TDoubleVecVec>;
 
     maths::CSampling::seed();
 
@@ -827,7 +827,7 @@ void CMultivariateMultimodalPriorTest::testMarginalLikelihoodMode(void)
 
     // Test that the sample mode is close to the generating distribution mode.
 
-    typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> > TMaxAccumulator;
+    using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double>>;
 
     maths::CSampling::seed();
 
@@ -1142,8 +1142,8 @@ void CMultivariateMultimodalPriorTest::testLatLongData(void)
     LOG_DEBUG("|  CMultivariateMultimodalPriorTest::testLatLongData  |");
     LOG_DEBUG("+-----------------------------------------------------+");
 
-    typedef std::pair<core_t::TTime, TDoubleVec> TTimeDoubleVecPr;
-    typedef std::vector<TTimeDoubleVecPr> TTimeDoubleVecPrVec;
+    using TTimeDoubleVecPr = std::pair<core_t::TTime, TDoubleVec>;
+    using TTimeDoubleVecPrVec = std::vector<TTimeDoubleVecPr>;
 
     TTimeDoubleVecPrVec timeseries;
     CPPUNIT_ASSERT(test::CTimeSeriesTestData::parse("testfiles/lat_lng.csv",

--- a/lib/maths/unittest/CMultivariateNormalConjugateTest.cc
+++ b/lib/maths/unittest/CMultivariateNormalConjugateTest.cc
@@ -31,11 +31,11 @@
 using namespace ml;
 using namespace handy_typedefs;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 namespace
 {
@@ -1089,8 +1089,8 @@ void CMultivariateNormalConjugateTest::calibrationExperiment(void)
     LOG_DEBUG("|  CMultivariateNormalConjugateTest::calibrationExperiment  |");
     LOG_DEBUG("+-----------------------------------------------------------+");
 
-    typedef maths::CVectorNx1<double, 10> TVector10;
-    typedef maths::CSymmetricMatrixNxN<double, 10> TMatrix10;
+    using TVector10 = maths::CVectorNx1<double, 10>;
+    using TMatrix10 = maths::CSymmetricMatrixNxN<double, 10>;
 
     double means[] = { 10.0, 10.0, 20.0, 20.0, 30.0, 20.0, 10.0, 40.0, 30.0, 20.0 };
     double covariances[] = { 10.0,

--- a/lib/maths/unittest/CMultivariateOneOfNPriorTest.cc
+++ b/lib/maths/unittest/CMultivariateOneOfNPriorTest.cc
@@ -43,11 +43,11 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef maths::CMultivariateOneOfNPrior::TPriorPtr TPriorPtr;
-typedef maths::CMultivariateOneOfNPrior::TPriorPtrVec TPriorPtrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TPriorPtr = maths::CMultivariateOneOfNPrior::TPriorPtr;
+using TPriorPtrVec = maths::CMultivariateOneOfNPrior::TPriorPtrVec;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 const maths_t::TWeightStyleVec COUNT_WEIGHT(1, maths_t::E_SampleCountWeight);
 const maths_t::TWeightStyleVec VARIANCE_WEIGHT(1, maths_t::E_SampleCountVarianceScaleWeight);
@@ -360,7 +360,7 @@ void CMultivariateOneOfNPriorTest::testWeightUpdate(void)
         TDouble10Vec1Vec samples;
         gaussianSamples(rng, boost::size(n), n, mean, covariance, samples);
 
-        typedef maths::CEqualWithTolerance<double> TEqual;
+        using TEqual = maths::CEqualWithTolerance<double>;
         TEqual equal(maths::CToleranceTypes::E_AbsoluteTolerance, 1e-10);
         const double decayRates[] = { 0.0, 0.004, 0.04 };
 
@@ -491,7 +491,7 @@ void CMultivariateOneOfNPriorTest::testMarginalLikelihood(void)
     //   3) E[(X - m)^2] w.r.t. the marginal likelihood is equal to the predictive
     //      distribution covariance matrix.
 
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     maths::CSampling::seed();
 
@@ -742,10 +742,10 @@ void CMultivariateOneOfNPriorTest::testMarginalLikelihoodMean(void)
     // Test that the marginal likelihood mean is close to the sample
     // mean for a variety of models.
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef std::vector<TSizeVec> TSizeVecVec;
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator TMean2Accumulator;
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMean2Accumulator = maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator;
 
     maths::CSampling::seed();
 

--- a/lib/maths/unittest/CNaturalBreaksClassifierTest.cc
+++ b/lib/maths/unittest/CNaturalBreaksClassifierTest.cc
@@ -35,9 +35,9 @@ using namespace maths;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef CNaturalBreaksClassifier::TTuple TTuple;
-typedef std::vector<TTuple> TTupleVec;
+using TDoubleVec = std::vector<double>;
+using TTuple = CNaturalBreaksClassifier::TTuple;
+using TTupleVec = std::vector<TTuple>;
 
 //! Computes the deviation of a category.mac1Password
 
@@ -57,7 +57,7 @@ bool naturalBreaksBranchAndBound(const TTupleVec &categories,
                                  std::size_t p,
                                  TTupleVec &result)
 {
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     // Find the minimum variance partition.
     //
@@ -577,7 +577,7 @@ void CNaturalBreaksClassifierTest::testSample(void)
     // the points we have added and for a large number of samples we
     // sample the modes of the mixture correctly.
 
-    typedef CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
     static const double NEG_INF = boost::numeric::bounds<double>::lowest();
     static const double POS_INF = boost::numeric::bounds<double>::highest();

--- a/lib/maths/unittest/CNormalMeanPrecConjugateTest.cc
+++ b/lib/maths/unittest/CNormalMeanPrecConjugateTest.cc
@@ -47,12 +47,12 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate> CNormalMeanPrecConjugate;
+using TDoubleVec = std::vector<double>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using CNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate>;
 
 CNormalMeanPrecConjugate makePrior(maths_t::EDataType dataType = maths_t::E_ContinuousData,
                                    const double &decayRate = 0.0)
@@ -71,7 +71,7 @@ void CNormalMeanPrecConjugateTest::testMultipleUpdate(void)
     // Test that we get the same result updating once with a vector of 100
     // samples of an R.V. versus updating individually 100 times.
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
 
     const maths_t::EDataType dataTypes[] =
         {
@@ -1036,7 +1036,7 @@ void CNormalMeanPrecConjugateTest::testAnomalyScore(void)
     //   1) high probability of detecting the anomalies, and
     //   2) a very low rate of false positives.
 
-    typedef std::vector<unsigned int> TUIntVec;
+    using TUIntVec = std::vector<unsigned int>;
 
     const double decayRates[] = { 0.0, 0.001, 0.01 };
 
@@ -1199,7 +1199,7 @@ void CNormalMeanPrecConjugateTest::testIntegerData(void)
             filter2.addSamples(sample);
         }
 
-        typedef maths::CEqualWithTolerance<double> TEqual;
+        using TEqual = maths::CEqualWithTolerance<double>;
         TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.001);
         CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
 

--- a/lib/maths/unittest/COneOfNPriorTest.cc
+++ b/lib/maths/unittest/COneOfNPriorTest.cc
@@ -53,20 +53,20 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<unsigned int> TUIntVec;
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef boost::shared_ptr<maths::CPrior> TPriorPtr;
-typedef std::vector<TPriorPtr> TPriorPtrVec;
-typedef boost::optional<double> TOptionalDouble;
-typedef CPriorTestInterfaceMixin<maths::CGammaRateConjugate> CGammaRateConjugate;
-typedef CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate> CLogNormalMeanPrecConjugate;
-typedef CPriorTestInterfaceMixin<maths::CMultimodalPrior> CMultimodalPrior;
-typedef CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate> CNormalMeanPrecConjugate;
-typedef CPriorTestInterfaceMixin<maths::COneOfNPrior> COneOfNPrior;
-typedef CPriorTestInterfaceMixin<maths::CPoissonMeanConjugate> CPoissonMeanConjugate;
+using TUIntVec = std::vector<unsigned int>;
+using TDoubleVec = std::vector<double>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TPriorPtr = boost::shared_ptr<maths::CPrior>;
+using TPriorPtrVec = std::vector<TPriorPtr>;
+using TOptionalDouble = boost::optional<double>;
+using CGammaRateConjugate = CPriorTestInterfaceMixin<maths::CGammaRateConjugate>;
+using CLogNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate>;
+using CMultimodalPrior = CPriorTestInterfaceMixin<maths::CMultimodalPrior>;
+using CNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate>;
+using COneOfNPrior = CPriorTestInterfaceMixin<maths::COneOfNPrior>;
+using CPoissonMeanConjugate = CPriorTestInterfaceMixin<maths::CPoissonMeanConjugate>;
 
 COneOfNPrior::TPriorPtrVec clone(const TPriorPtrVec &models,
                                  const TOptionalDouble &decayRate = TOptionalDouble())
@@ -152,7 +152,7 @@ void COneOfNPriorTest::testMultipleUpdate(void)
     // Test that we get the same result updating once with a vector of 100
     // samples of an R.V. versus updating individually 100 times.
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
 
     TPriorPtrVec models;
     models.push_back(TPriorPtr(maths::CPoissonMeanConjugate::nonInformativePrior().clone()));
@@ -250,7 +250,7 @@ void COneOfNPriorTest::testWeights(void)
         models.push_back(TPriorPtr(CPoissonMeanConjugate::nonInformativePrior().clone()));
         models.push_back(TPriorPtr(CNormalMeanPrecConjugate::nonInformativePrior(E_ContinuousData).clone()));
 
-        typedef maths::CEqualWithTolerance<double> TEqual;
+        using TEqual = maths::CEqualWithTolerance<double>;
         TEqual equal(maths::CToleranceTypes::E_AbsoluteTolerance, 1e-10);
         const double decayRates[] = { 0.0, 0.001, 0.01 };
 

--- a/lib/maths/unittest/COrdinalTest.cc
+++ b/lib/maths/unittest/COrdinalTest.cc
@@ -34,7 +34,7 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 template<typename T>
 std::string precisePrint(T x)
@@ -319,7 +319,7 @@ void COrdinalTest::testHash(void)
 
     // Test that hashing works over the full range of the distinct types.
 
-    typedef boost::unordered_set<std::size_t> TSizeUSet;
+    using TSizeUSet = boost::unordered_set<std::size_t>;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CPRNGTest.cc
+++ b/lib/maths/unittest/CPRNGTest.cc
@@ -41,7 +41,7 @@ void CPRNGTest::testSplitMix64(void)
 
     // Test min and max.
     maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1> min;
-    maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t> > max;
+    maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t>> max;
     for (std::size_t i = 0u; i < 10000; ++i)
     {
         uint64_t x = rng1();
@@ -155,7 +155,7 @@ void CPRNGTest::testXorOShiro128Plus(void)
 
     // Test min and max.
     maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1> min;
-    maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t> > max;
+    maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t>> max;
     for (std::size_t i = 0u; i < 10000; ++i)
     {
         uint64_t x = rng1();
@@ -287,7 +287,7 @@ void CPRNGTest::testXorShift1024Mult(void)
 
     // Test min and max.
     maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1> min;
-    maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t> > max;
+    maths::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t>> max;
     for (std::size_t i = 0u; i < 10000; ++i)
     {
         uint64_t x = rng1();

--- a/lib/maths/unittest/CPackedBitVectorTest.cc
+++ b/lib/maths/unittest/CPackedBitVectorTest.cc
@@ -30,9 +30,9 @@
 
 using namespace ml;
 
-typedef std::vector<bool> TBoolVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<maths::CPackedBitVector> TPackedBitVectorVec;
+using TBoolVec = std::vector<bool>;
+using TSizeVec = std::vector<std::size_t>;
+using TPackedBitVectorVec = std::vector<maths::CPackedBitVector>;
 
 namespace
 {
@@ -295,8 +295,8 @@ void CPackedBitVectorTest::testInner(void)
     LOG_DEBUG("|  CPackedBitVectorTest::testInner  |");
     LOG_DEBUG("+-----------------------------------+");
 
-    typedef maths::CVector<double> TVector;
-    typedef std::vector<TVector> TVectorVec;
+    using TVector = maths::CVector<double>;
+    using TVectorVec = std::vector<TVector>;
 
     maths::CPackedBitVector test1(10, true);
     maths::CPackedBitVector test2(10, false);
@@ -371,7 +371,7 @@ void CPackedBitVectorTest::testBitwiseOr(void)
     LOG_DEBUG("|  CPackedBitVectorTest::testBitwiseOr  |");
     LOG_DEBUG("+---------------------------------------+");
 
-    typedef std::vector<std::bitset<50> > TBitSetVec;
+    using TBitSetVec = std::vector<std::bitset<50>>;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CPoissonMeanConjugateTest.cc
+++ b/lib/maths/unittest/CPoissonMeanConjugateTest.cc
@@ -46,13 +46,13 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<unsigned int> TUIntVec;
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef CPriorTestInterfaceMixin<maths::CPoissonMeanConjugate> CPoissonMeanConjugate;
+using TUIntVec = std::vector<unsigned int>;
+using TDoubleVec = std::vector<double>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using CPoissonMeanConjugate = CPriorTestInterfaceMixin<maths::CPoissonMeanConjugate>;
 
 }
 
@@ -65,7 +65,7 @@ void CPoissonMeanConjugateTest::testMultipleUpdate(void)
     // Test that we get the same result updating once with a vector of 100
     // samples of an R.V. versus updating individually 100 times.
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
 
     const double rate = 5.0;
 
@@ -979,7 +979,7 @@ void CPoissonMeanConjugateTest::testOffset(void)
                 CPPUNIT_ASSERT_DOUBLES_EQUAL(probability1, probability2, eps);
             }
 
-            typedef maths::CEqualWithTolerance<double> TEqual;
+            using TEqual = maths::CEqualWithTolerance<double>;
             TEqual equal(maths::CToleranceTypes::E_AbsoluteTolerance, eps);
             CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
         }
@@ -1082,7 +1082,7 @@ void CPoissonMeanConjugateTest::testNegativeSample(void)
 
     CPPUNIT_ASSERT_EQUAL(filter1.numberSamples(), filter2.numberSamples());
 
-    typedef maths::CEqualWithTolerance<double> TEqual;
+    using TEqual = maths::CEqualWithTolerance<double>;
     TEqual equal(maths::CToleranceTypes::E_RelativeTolerance, 0.002);
     CPPUNIT_ASSERT(filter1.equalTolerance(filter2, equal));
 }

--- a/lib/maths/unittest/CPriorTest.cc
+++ b/lib/maths/unittest/CPriorTest.cc
@@ -38,7 +38,7 @@ using namespace handy_typedefs;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 class CX
 {
@@ -68,7 +68,7 @@ class CVariance
 class CMinusLogLikelihood
 {
     public:
-        typedef std::vector<TDoubleVec> TDoubleVecVec;
+        using TDoubleVecVec = std::vector<TDoubleVec>;
 
     public:
         CMinusLogLikelihood(const maths::CPrior &prior) :
@@ -105,8 +105,8 @@ void CPriorTest::testExpectation(void)
     LOG_DEBUG("|  CPriorTest::testExpectation  |");
     LOG_DEBUG("+-------------------------------+");
 
-    typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-    typedef CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate> CNormalMeanPrecConjugate;
+    using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using CNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate>;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CProbabilityAggregatorsTest.cc
+++ b/lib/maths/unittest/CProbabilityAggregatorsTest.cc
@@ -35,7 +35,7 @@ using namespace test;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 class CGammaKernel
 {
@@ -100,7 +100,7 @@ double logUpperIncompleteGamma(double s, double x)
 class CExpectedLogProbabilityOfMFromNExtremeSamples
 {
     public:
-        typedef CBasicStatistics::COrderStatisticsHeap<double> TMinValueAccumulator;
+        using TMinValueAccumulator = CBasicStatistics::COrderStatisticsHeap<double>;
 
         class CLogIntegrand
         {
@@ -488,7 +488,7 @@ void CProbabilityAggregatorsTest::testProbabilityOfExtremeSample(void)
                 rng.generateNormalSamples(0.0, 1.0, sampleSizes[i], samples);
                 boost::math::normal_distribution<> normal(0.0, ::sqrt(1.0));
 
-                typedef CBasicStatistics::COrderStatisticsStack<double, 1u> TMinValue;
+                using TMinValue = CBasicStatistics::COrderStatisticsStack<double, 1u>;
 
                 TMinValue minValue;
                 for (std::size_t l = 0u; l < samples.size(); ++l)
@@ -585,7 +585,7 @@ void CProbabilityAggregatorsTest::testProbabilityOfMFromNExtremeSamples(void)
         {
             CPPUNIT_ASSERT(i <= numberProbabilities);
 
-            typedef std::vector<size_t> TSizeVec;
+            using TSizeVec = std::vector<size_t>;
 
             TSizeVec index(i, 0);
             for (std::size_t j = 1; j < i; ++j)
@@ -635,7 +635,7 @@ void CProbabilityAggregatorsTest::testProbabilityOfMFromNExtremeSamples(void)
                     rng.generateNormalSamples(0.0, 1.0, numberSamples, samples);
                     boost::math::normal_distribution<> normal(0.0, ::sqrt(1.0));
 
-                    typedef CBasicStatistics::COrderStatisticsHeap<double> TMinValues;
+                    using TMinValues = CBasicStatistics::COrderStatisticsHeap<double>;
 
                     TMinValues minValues(i);
                     for (std::size_t k = 0u; k < samples.size(); ++k)

--- a/lib/maths/unittest/CProbabilityCalibratorTest.cc
+++ b/lib/maths/unittest/CProbabilityCalibratorTest.cc
@@ -38,9 +38,9 @@ void CProbabilityCalibratorTest::testCalibration(void)
     LOG_DEBUG("|  CProbabilityCalibratorTest::testCalibration  |");
     LOG_DEBUG("+-----------------------------------------------+");
 
-    typedef std::vector<double> TDoubleVec;
-    typedef CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate> CLogNormalMeanPrecConjugate;
-    typedef CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate> CNormalMeanPrecConjugate;
+    using TDoubleVec = std::vector<double>;
+    using CLogNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CLogNormalMeanPrecConjugate>;
+    using CNormalMeanPrecConjugate = CPriorTestInterfaceMixin<maths::CNormalMeanPrecConjugate>;
 
     // Test some things which we know will give poorly calibrated
     // probabilities, i.e. fitting a normal a log-normal and multi-

--- a/lib/maths/unittest/CQDigestTest.cc
+++ b/lib/maths/unittest/CQDigestTest.cc
@@ -35,9 +35,9 @@ using namespace ml;
 using namespace maths;
 using namespace test;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::pair<uint32_t, uint64_t> TUInt32UInt64Pr;
-typedef std::vector<TUInt32UInt64Pr> TUInt32UInt64PrVec;
+using TDoubleVec = std::vector<double>;
+using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
+using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
 
 void CQDigestTest::testAdd(void)
 {
@@ -91,7 +91,7 @@ void CQDigestTest::testAdd(void)
 
     // Large n uniform random.
     {
-        typedef std::multiset<uint64_t> TUInt64Set;
+        using TUInt64Set = std::multiset<uint64_t>;
 
         const double expectedMaxErrors[] = { 0.007, 0.01, 0.12, 0.011, 0.016, 0.018, 0.023, 0.025, 0.02 };
 
@@ -318,7 +318,7 @@ void CQDigestTest::testPropagateForwardByTime(void)
     LOG_DEBUG("|  CQDigestTest::testPropagateForwardByTime  |");
     LOG_DEBUG("+--------------------------------------------+");
 
-    typedef CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumlator;
+    using TMeanAccumlator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     {
         // Check a simple case where exact aging is possible.

--- a/lib/maths/unittest/CQuantileSketchTest.cc
+++ b/lib/maths/unittest/CQuantileSketchTest.cc
@@ -35,8 +35,8 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleVec = std::vector<double>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 void testSketch(maths::CQuantileSketch::EInterpolation interpolation,
                 std::size_t n,

--- a/lib/maths/unittest/CRadialBasisFunctionTest.cc
+++ b/lib/maths/unittest/CRadialBasisFunctionTest.cc
@@ -31,7 +31,7 @@ namespace
 class CValueAdaptor
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         CValueAdaptor(const maths::CRadialBasisFunction &function,

--- a/lib/maths/unittest/CRandomProjectionClustererTest.cc
+++ b/lib/maths/unittest/CRandomProjectionClustererTest.cc
@@ -26,13 +26,13 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef maths::CVector<double> TVector;
-typedef maths::CVectorNx1<double, 5> TVector5;
-typedef maths::CBasicStatistics::SSampleCovariances<double, 5> TCovariances;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TVector = maths::CVector<double>;
+using TVector5 = maths::CVectorNx1<double, 5>;
+using TCovariances = maths::CBasicStatistics::SSampleCovariances<double, 5>;
 
 struct SFirstLess
 {
@@ -46,12 +46,12 @@ template<std::size_t N>
 class CRandomProjectionClustererForTest : public maths::CRandomProjectionClustererBatch<N>
 {
     public:
-        typedef typename maths::CRandomProjectionClustererBatch<N>::TVectorArrayVec TVectorArrayVec;
-        typedef typename maths::CRandomProjectionClustererBatch<N>::TDoubleVecVec TDoubleVecVec;
-        typedef typename maths::CRandomProjectionClustererBatch<N>::TVectorNx1VecVec TVectorNx1VecVec;
-        typedef typename maths::CRandomProjectionClustererBatch<N>::TSvdNxNVecVec TSvdNxNVecVec;
-        typedef typename maths::CRandomProjectionClustererBatch<N>::TSizeUSet TSizeUSet;
-        typedef typename maths::CRandomProjectionClustererBatch<N>::TMeanAccumulatorVecVec TMeanAccumulatorVecVec;
+        using TVectorArrayVec = typename maths::CRandomProjectionClustererBatch<N>::TVectorArrayVec;
+        using TDoubleVecVec = typename maths::CRandomProjectionClustererBatch<N>::TDoubleVecVec;
+        using TVectorNx1VecVec = typename maths::CRandomProjectionClustererBatch<N>::TVectorNx1VecVec;
+        using TSvdNxNVecVec = typename maths::CRandomProjectionClustererBatch<N>::TSvdNxNVecVec;
+        using TSizeUSet = typename maths::CRandomProjectionClustererBatch<N>::TSizeUSet;
+        using TMeanAccumulatorVecVec = typename maths::CRandomProjectionClustererBatch<N>::TMeanAccumulatorVecVec;
 
     public:
         CRandomProjectionClustererForTest(double compression = 1.0) :
@@ -107,9 +107,9 @@ void CRandomProjectionClustererTest::testGenerateProjections(void)
     LOG_DEBUG("|  CRandomProjectionClustererTest::testGenerateProjections  |");
     LOG_DEBUG("+-----------------------------------------------------------+");
 
-    typedef CRandomProjectionClustererForTest<5>::TVectorArrayVec TVectorArrayVec;
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+    using TVectorArrayVec = CRandomProjectionClustererForTest<5>::TVectorArrayVec;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
     // Test corner case when projected dimension is greater
     // than the data dimension.
@@ -309,8 +309,8 @@ void CRandomProjectionClustererTest::testNeighbourhoods(void)
     // isn't perfect because we don't store the full points so are
     // computing distances projections.
 
-    typedef maths::CVector<double> TVector;
-    typedef std::vector<TVector> TVectorVec;
+    using TVector = maths::CVector<double>;
+    using TVectorVec = std::vector<TVector>;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CSamplingTest.cc
+++ b/lib/maths/unittest/CSamplingTest.cc
@@ -26,15 +26,15 @@
 
 #include <numeric>
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 
 using namespace ml;
 
 namespace
 {
 
-typedef std::vector<TDoubleVec> TDoubleVecVec;
+using TDoubleVecVec = std::vector<TDoubleVec>;
 
 double multinomialProbability(const TDoubleVec &probabilities,
                               const TSizeVec &counts)
@@ -158,8 +158,8 @@ void CSamplingTest::testMultinomialSample(void)
     LOG_DEBUG("|  CSamplingTest::testMultinomialSample  |");
     LOG_DEBUG("+----------------------------------------+");
 
-    typedef std::map<TSizeVec, double> TSizeVecDoubleMap;
-    typedef TSizeVecDoubleMap::const_iterator TSizeVecDoubleMapCItr;
+    using TSizeVecDoubleMap = std::map<TSizeVec, double>;
+    using TSizeVecDoubleMapCItr = TSizeVecDoubleMap::const_iterator;
 
     maths::CSampling::seed();
 
@@ -208,7 +208,7 @@ void CSamplingTest::testMultivariateNormalSample(void)
     LOG_DEBUG("|  CSamplingTest::testMultivariateNormalSample  |");
     LOG_DEBUG("+-----------------------------------------------+");
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     maths::CSampling::seed();
 

--- a/lib/maths/unittest/CSeasonalComponentAdaptiveBucketingTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentAdaptiveBucketingTest.cc
@@ -37,12 +37,12 @@ using namespace ml;
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<maths::CFloatStorage> TFloatVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef maths::CBasicStatistics::SMin<double>::TAccumulator TMinAccumulator;
-typedef maths::CBasicStatistics::SMax<double>::TAccumulator TMaxAccumulator;
+using TDoubleVec = std::vector<double>;
+using TFloatVec = std::vector<maths::CFloatStorage>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using TMinAccumulator = maths::CBasicStatistics::SMin<double>::TAccumulator;
+using TMaxAccumulator = maths::CBasicStatistics::SMax<double>::TAccumulator;
 }
 
 void CSeasonalComponentAdaptiveBucketingTest::testInitialize(void)

--- a/lib/maths/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentTest.cc
@@ -39,11 +39,11 @@ using namespace ml;
 namespace
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<core_t::TTime> TTimeVec;
-typedef std::pair<core_t::TTime, double> TTimeDoublePr;
-typedef std::vector<TTimeDoublePr> TTimeDoublePrVec;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleVec = std::vector<double>;
+using TTimeVec = std::vector<core_t::TTime>;
+using TTimeDoublePr = std::pair<core_t::TTime, double>;
+using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
 
 class CTestSeasonalComponent : public maths::CSeasonalComponent
 {
@@ -101,7 +101,7 @@ void generateSeasonalValues(test::CRandomNumbers &rng,
                             std::size_t numberSamples,
                             TTimeDoublePrVec &samples)
 {
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     // Generate time uniformly at random in the interval
     // [startTime, endTime).
@@ -769,7 +769,7 @@ void CSeasonalComponentTest::testVariance(void)
     LOG_DEBUG("|  CSeasonalComponentTest::testVariance  |");
     LOG_DEBUG("+----------------------------------------+");
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     // Check that we estimate a periodic variance.
 

--- a/lib/maths/unittest/CSetToolsTest.cc
+++ b/lib/maths/unittest/CSetToolsTest.cc
@@ -30,8 +30,8 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 
 void CSetToolsTest::testInplaceSetDifference(void)
 {

--- a/lib/maths/unittest/CSolversTest.cc
+++ b/lib/maths/unittest/CSolversTest.cc
@@ -79,7 +79,7 @@ double f6(const double &x)
 class CLog
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         double operator()(const double &x) const
@@ -433,7 +433,7 @@ void CSolversTest::testBrent(void)
 
 void CSolversTest::testSublevelSet(void)
 {
-    typedef std::pair<double, double> TDoubleDoublePr;
+    using TDoubleDoublePr = std::pair<double, double>;
 
     // Should converge immediately to minimum of quadratic.
     TDoubleDoublePr sublevelSet;

--- a/lib/maths/unittest/CSplineTest.cc
+++ b/lib/maths/unittest/CSplineTest.cc
@@ -31,8 +31,8 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 
 class CSplineFunctor
 {
@@ -590,10 +590,10 @@ void CSplineTest::testSplineReference(void)
     LOG_DEBUG("|  CSplineTest::testSplineReference  |");
     LOG_DEBUG("+------------------------------------+");
 
-    typedef std::vector<maths::CFloatStorage> TFloatVec;
-    typedef boost::reference_wrapper<TFloatVec> TFloatVecRef;
-    typedef boost::reference_wrapper<TDoubleVec> TDoubleVecRef;
-    typedef maths::CSpline<TFloatVecRef, TFloatVecRef, TDoubleVecRef> TSplineRef;
+    using TFloatVec = std::vector<maths::CFloatStorage>;
+    using TFloatVecRef = boost::reference_wrapper<TFloatVec>;
+    using TDoubleVecRef = boost::reference_wrapper<TDoubleVec>;
+    using TSplineRef = maths::CSpline<TFloatVecRef, TFloatVecRef, TDoubleVecRef>;
 
     double x_[] = { 0.0, 0.1, 0.3, 0.33, 0.5, 0.75, 0.8, 1.0 };
     TDoubleVec x(boost::begin(x_), boost::end(x_));

--- a/lib/maths/unittest/CStatisticalTestsTest.cc
+++ b/lib/maths/unittest/CStatisticalTestsTest.cc
@@ -38,7 +38,7 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 void CStatisticalTestsTest::testCramerVonMises(void)
 {

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -187,7 +187,7 @@ void reinitializePrior(double learnRate,
     }
     if (controllers)
     {
-        for (auto &&trend : trends)
+        for (auto &trend : trends)
         {
             trend->decayRate(trend->decayRate() / (*controllers)[0].multiplier());
         }
@@ -346,7 +346,7 @@ void CTimeSeriesModelTest::testMode(void)
         maths::CUnivariateTimeSeriesModel model{params(bucketLength), 0, trend, prior};
 
         core_t::TTime time{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
             sample += 20.0 + 10.0 * ::sin(  boost::math::double_constants::two_pi
                                           * static_cast<double>(time)
@@ -466,7 +466,7 @@ void CTimeSeriesModelTest::testMode(void)
         maths::CMultivariateTimeSeriesModel model{params(bucketLength), *trends[0], prior};
 
         core_t::TTime time{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
             double amplitude{10.0};
             for (std::size_t i = 0u; i < sample.size(); ++i)
@@ -856,7 +856,7 @@ void CTimeSeriesModelTest::testAddSamples(void)
         TDouble2Vec4VecVec weights{{{1.0, 1.0, 1.0}}};
 
         core_t::TTime time{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
             bool reinitialize{false};
             bool hasTrend{false};
@@ -1072,9 +1072,9 @@ void CTimeSeriesModelTest::testPredict(void)
 
         TDouble2Vec4VecVec weights{maths::CConstantWeights::unit<TDouble2Vec>(3)};
         core_t::TTime time{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
-            for (auto &&coordinate : sample)
+            for (auto &coordinate : sample)
             {
                 coordinate += 10.0 + 5.0 * ::sin(  boost::math::double_constants::two_pi
                                                  * static_cast<double>(time) / 86400.0);
@@ -1337,7 +1337,7 @@ void CTimeSeriesModelTest::testProbability(void)
 
         core_t::TTime time{0};
         const TDouble2Vec4VecVec weight{maths::CConstantWeights::unit<TDouble2Vec>(3)};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
             maths::CModelAddSamplesParams params;
             params.integer(false)
@@ -1351,7 +1351,7 @@ void CTimeSeriesModelTest::testProbability(void)
 
             double trend{5.0 + 5.0 * ::sin(  boost::math::double_constants::two_pi
                                            * static_cast<double>(time) / 86400.0)};
-            for (auto &&component : sample_)
+            for (auto &component : sample_)
             {
                 component += trend;
             }
@@ -1462,7 +1462,7 @@ void CTimeSeriesModelTest::testProbability(void)
         TDouble2Vec4VecVec weights{weight};
         std::size_t bucket{0};
         core_t::TTime time{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
             if (std::binary_search(anomalies.begin(), anomalies.end(), bucket++))
             {
@@ -1612,7 +1612,7 @@ void CTimeSeriesModelTest::testWeights(void)
         TDouble10Vec4Vec1Vec weight{{{1.0, 1.0, 1.0}}};
         TDouble2Vec4VecVec weights{{{1.0, 1.0, 1.0}}};
         core_t::TTime time{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
             double scale{10.0 + 5.0 * ::sin(  boost::math::double_constants::two_pi
                                             * static_cast<double>(time) / 86400.0)};
@@ -1751,7 +1751,7 @@ void CTimeSeriesModelTest::testMemoryUsage(void)
                   .weightStyles(maths::CConstantWeights::COUNT)
                   .trendWeights(weights)
                   .priorWeights(weights);
-            for (auto &&coordinate : sample)
+            for (auto &coordinate : sample)
             {
                 coordinate += 10.0 + 5.0 * ::sin(  boost::math::double_constants::two_pi
                                                  * static_cast<double>(time) / 86400.0);
@@ -2108,7 +2108,7 @@ void CTimeSeriesModelTest::testAnomalyModel(void)
         TDouble2Vec4VecVec weights{weight};
         std::size_t bucket{0};
         core_t::TTime time{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
             if (std::binary_search(anomalies.begin(), anomalies.end(), bucket++))
             {
@@ -2199,9 +2199,9 @@ void CTimeSeriesModelTest::testAnomalyModel(void)
         TDouble2Vec4VecVec weights{weight};
         core_t::TTime time{0};
         std::size_t bucket{0};
-        for (auto &&sample : samples)
+        for (auto &sample : samples)
         {
-            for (auto &&coordinate : sample)
+            for (auto &coordinate : sample)
             {
                 if (std::binary_search(anomalies.begin(), anomalies.end(), bucket))
                 {

--- a/lib/maths/unittest/CToolsTest.cc
+++ b/lib/maths/unittest/CToolsTest.cc
@@ -43,9 +43,9 @@ using namespace test;
 namespace
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::pair<double, bool> TDoubleBoolPr;
-typedef std::vector<double> TDoubleVec;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleBoolPr = std::pair<double, bool>;
+using TDoubleVec = std::vector<double>;
 
 namespace adapters
 {
@@ -303,7 +303,7 @@ template<typename DISTRIBUTION>
 class CPdf
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         CPdf(const DISTRIBUTION &distribution) :
@@ -324,7 +324,7 @@ class CPdf
 class CIdentity
 {
     public:
-        typedef double result_type;
+        using result_type = double;
 
     public:
         bool operator()(double x, double &result) const
@@ -1025,7 +1025,7 @@ void CToolsTest::testMixtureProbabilityOfLessLikelySample(void)
     LOG_DEBUG("|  CToolsTest::testMixtureProbabilityOfLessLikelySample  |");
     LOG_DEBUG("+--------------------------------------------------------+");
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CTrendComponentTest.cc
+++ b/lib/maths/unittest/CTrendComponentTest.cc
@@ -344,7 +344,7 @@ void CTrendComponentTest::testForecast()
 
             TMeanAccumulator meanError;
             TMeanAccumulator meanErrorAt95;
-            for (auto &&errorbar : forecast)
+            for (auto &errorbar : forecast)
             {
                 core_t::TTime bucket{(time - start) / bucketLength};
                 meanError.add(  std::fabs((values[bucket] - errorbar[1])

--- a/lib/maths/unittest/CTrendTestsTest.cc
+++ b/lib/maths/unittest/CTrendTestsTest.cc
@@ -59,7 +59,7 @@ void CTrendTestsTest::testRandomizedPeriodicity(void)
 
     using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
-    using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double> >;
+    using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1, std::greater<double>>;
     using TFunction = double (*)(core_t::TTime);
 
     test::CRandomNumbers rng;

--- a/lib/maths/unittest/CXMeansOnline1dTest.cc
+++ b/lib/maths/unittest/CXMeansOnline1dTest.cc
@@ -38,9 +38,9 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef maths::CXMeansOnline1d::TClusterVec TClusterVec;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+using TDoubleVec = std::vector<double>;
+using TClusterVec = maths::CXMeansOnline1d::TClusterVec;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
 bool restore(const maths::SDistributionRestoreParams &params,
              core::CRapidXmlStateRestoreTraverser &traverser,
@@ -735,8 +735,8 @@ void CXMeansOnline1dTest::testManyClusters(void)
     LOG_DEBUG("|  CXMeansOnline1dTest::testManyClusters  |");
     LOG_DEBUG("+-----------------------------------------+");
 
-    typedef std::pair<core_t::TTime, double> TTimeDoublePr;
-    typedef std::vector<TTimeDoublePr> TTimeDoublePrVec;
+    using TTimeDoublePr = std::pair<core_t::TTime, double>;
+    using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
 
     TTimeDoublePrVec timeseries;
     core_t::TTime startTime;

--- a/lib/maths/unittest/CXMeansOnlineTest.cc
+++ b/lib/maths/unittest/CXMeansOnlineTest.cc
@@ -33,25 +33,25 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef maths::CBasicStatistics::SSampleCovariances<double, 2> TCovariances2;
-typedef std::vector<TCovariances2> TCovariances2Vec;
-typedef maths::CXMeansOnline<double, 2> TXMeans2;
-typedef TXMeans2::TPointPrecise TPoint;
-typedef std::vector<TPoint> TPointVec;
-typedef std::vector<TPointVec> TPointVecVec;
-typedef TXMeans2::TMatrixPrecise TMatrix;
-typedef std::vector<TMatrix> TMatrixVec;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TCovariances2 = maths::CBasicStatistics::SSampleCovariances<double, 2>;
+using TCovariances2Vec = std::vector<TCovariances2>;
+using TXMeans2 = maths::CXMeansOnline<double, 2>;
+using TPoint = TXMeans2::TPointPrecise;
+using TPointVec = std::vector<TPoint>;
+using TPointVecVec = std::vector<TPointVec>;
+using TMatrix = TXMeans2::TMatrixPrecise;
+using TMatrixVec = std::vector<TMatrix>;
 
 template<typename T, std::size_t N>
 class CXMeansOnlineForTest : public maths::CXMeansOnline<T, N>
 {
     public:
-        typedef typename maths::CXMeansOnline<T, N>::TSizeDoublePr2Vec TSizeDoublePr2Vec;
-        typedef typename maths::CXMeansOnline<T, N>::TPointPrecise TPoint;
-        typedef typename maths::CXMeansOnline<T, N>::TClusterVec TClusterVec;
+        using TSizeDoublePr2Vec = typename maths::CXMeansOnline<T, N>::TSizeDoublePr2Vec;
+        using TPoint = typename maths::CXMeansOnline<T, N>::TPointPrecise;
+        using TClusterVec = typename maths::CXMeansOnline<T, N>::TClusterVec;
         using maths::CXMeansOnline<T, N>::add;
 
     public:
@@ -74,8 +74,8 @@ class CXMeansOnlineForTest : public maths::CXMeansOnline<T, N>
         }
 };
 
-typedef CXMeansOnlineForTest<double, 2> TXMeans2ForTest;
-typedef CXMeansOnlineForTest<maths::CFloatStorage, 2> TXMeans2FloatForTest;
+using TXMeans2ForTest = CXMeansOnlineForTest<double, 2>;
+using TXMeans2FloatForTest = CXMeansOnlineForTest<maths::CFloatStorage, 2>;
 
 bool restore(const maths::SDistributionRestoreParams &params,
              core::CRapidXmlStateRestoreTraverser &traverser,
@@ -528,7 +528,7 @@ void CXMeansOnlineTest::testManyClusters(void)
     LOG_DEBUG("|  CXMeansOnlineTest::testManyClusters  |");
     LOG_DEBUG("+---------------------------------------+");
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     maths::CSampling::seed();
 
@@ -629,7 +629,7 @@ void CXMeansOnlineTest::testAdaption(void)
     // Specifically, the data set starts with one cluster then
     // a new cluster appears and subsequently disappears.
 
-    typedef std::vector<TDoubleVecVec> TDoubleVecVecVec;
+    using TDoubleVecVecVec = std::vector<TDoubleVecVec>;
 
     maths::CSampling::seed();
 
@@ -804,9 +804,9 @@ void CXMeansOnlineTest::testLatLongData(void)
     LOG_DEBUG("|  CXMeansOnlineTest::testLatLongData  |");
     LOG_DEBUG("+--------------------------------------+");
 
-    typedef std::pair<core_t::TTime, TDoubleVec> TTimeDoubleVecPr;
-    typedef std::vector<TTimeDoubleVecPr> TTimeDoubleVecPrVec;
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TTimeDoubleVecPr = std::pair<core_t::TTime, TDoubleVec>;
+    using TTimeDoubleVecPrVec = std::vector<TTimeDoubleVecPr>;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     TTimeDoubleVecPrVec timeseries;
     CPPUNIT_ASSERT(test::CTimeSeriesTestData::parse("testfiles/lat_lng.csv",

--- a/lib/maths/unittest/CXMeansTest.cc
+++ b/lib/maths/unittest/CXMeansTest.cc
@@ -35,32 +35,32 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef std::vector<uint64_t> TUInt64Vec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
-typedef maths::CVectorNx1<double, 2> TVector2;
-typedef std::vector<TVector2> TVector2Vec;
-typedef TVector2Vec::const_iterator TVector2VecCItr;
-typedef std::vector<TVector2Vec> TVector2VecVec;
-typedef maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator TMeanVar2Accumulator;
-typedef maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
-typedef std::vector<TMatrix2> TMatrix2Vec;
-typedef maths::CVectorNx1<double, 4> TVector4;
-typedef std::vector<TVector4> TVector4Vec;
-typedef maths::CBasicStatistics::SSampleMeanVar<TVector4>::TAccumulator TMeanVar4Accumulator;
-typedef maths::CSymmetricMatrixNxN<double, 4> TMatrix4;
-typedef std::vector<TMatrix4> TMatrix4Vec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TUInt64Vec = std::vector<uint64_t>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using TVector2 = maths::CVectorNx1<double, 2>;
+using TVector2Vec = std::vector<TVector2>;
+using TVector2VecCItr = TVector2Vec::const_iterator;
+using TVector2VecVec = std::vector<TVector2Vec>;
+using TMeanVar2Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector2>::TAccumulator;
+using TMatrix2 = maths::CSymmetricMatrixNxN<double, 2>;
+using TMatrix2Vec = std::vector<TMatrix2>;
+using TVector4 = maths::CVectorNx1<double, 4>;
+using TVector4Vec = std::vector<TVector4>;
+using TMeanVar4Accumulator = maths::CBasicStatistics::SSampleMeanVar<TVector4>::TAccumulator;
+using TMatrix4 = maths::CSymmetricMatrixNxN<double, 4>;
+using TMatrix4Vec = std::vector<TMatrix4>;
 
 //! \brief Expose internals of x-means for testing.
 template<typename POINT,
-         typename COST = maths::CSphericalGaussianInfoCriterion<POINT, maths::E_BIC> >
+         typename COST = maths::CSphericalGaussianInfoCriterion<POINT, maths::E_BIC>>
 class CXMeansForTest : public maths::CXMeans<POINT, COST>
 {
     public:
-        typedef typename maths::CXMeans<POINT, COST>::TUInt64USet TUInt64USet;
+        using TUInt64USet = typename maths::CXMeans<POINT, COST>::TUInt64USet;
 
     public:
         CXMeansForTest(std::size_t kmax) :
@@ -158,7 +158,7 @@ void CXMeansTest::testCluster(void)
 
     // Test basic accessors and checksum functionality of cluster.
 
-    typedef std::vector<double> TDoubleVec;
+    using TDoubleVec = std::vector<double>;
 
     maths::CSampling::seed();
 
@@ -229,7 +229,7 @@ void CXMeansTest::testImproveStructure(void)
 
     // Test improve structure finds an obvious split of the data.
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     maths::CSampling::seed();
 
@@ -476,7 +476,7 @@ void CXMeansTest::testFiveClusters(void)
 
         std::size_t ne = flatPoints.size();
 
-        maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_AICc> > xmeans(10);
+        maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_AICc>> xmeans(10);
         xmeans.setPoints(flatPoints);
         xmeans.run(3, 3, 5);
 
@@ -606,7 +606,7 @@ void CXMeansTest::testTwentyClusters(void)
 
     std::size_t ne = flatPoints.size();
 
-    maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_AICc> > xmeans(40);
+    maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_AICc>> xmeans(40);
     xmeans.setPoints(flatPoints);
     xmeans.run(4, 4, 5);
 
@@ -752,7 +752,7 @@ void CXMeansTest::testPoorlyConditioned(void)
     }
     std::sort(cluster3.begin(), cluster3.end());
 
-    maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC> > xmeans(5);
+    maths::CXMeans<TVector2, maths::CGaussianInfoCriterion<TVector2, maths::E_BIC>> xmeans(5);
     for (std::size_t t = 0u; t < 10; ++t)
     {
         LOG_DEBUG("*** test = " << t << " ***");

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -66,7 +66,7 @@ bool checkRules(const SModelParams::TDetectionRuleVec &detectionRules,
                 core_t::TTime time)
 {
     bool isIgnored{false};
-    for (auto &&rule : detectionRules)
+    for (auto &rule : detectionRules)
     {
         isIgnored = isIgnored || rule.apply(action,
                                             model,
@@ -87,7 +87,7 @@ bool checkScheduledEvents(const SModelParams::TStrDetectionRulePrVec &scheduledE
                           core_t::TTime time)
 {
     bool isIgnored{false};
-    for (auto &&event : scheduledEvents)
+    for (auto &event : scheduledEvents)
     {
         isIgnored = isIgnored || event.second.apply(action,
                                                     model,
@@ -113,7 +113,7 @@ CAnomalyDetectorModel::CAnomalyDetectorModel(const SModelParams &params,
     {
         LOG_ABORT("Must provide a data gatherer");
     }
-    for (auto &&calculators : m_InfluenceCalculators)
+    for (auto &calculators : m_InfluenceCalculators)
     {
         std::sort(calculators.begin(), calculators.end(), maths::COrderings::SFirstLess());
     }

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -47,8 +47,8 @@ namespace model
 namespace
 {
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<core_t::TTime> TTimeVec;
+using TSizeVec = std::vector<std::size_t>;
+using TTimeVec = std::vector<core_t::TTime>;
 
 const CAnomalyDetectorModelConfig::TIntDetectionRuleVecUMap EMPTY_RULES_MAP;
 const CAnomalyDetectorModelConfig::TStrDetectionRulePrVec EMPTY_EVENTS;
@@ -206,7 +206,7 @@ CAnomalyDetectorModelConfig::CAnomalyDetectorModelConfig(void) :
 void CAnomalyDetectorModelConfig::bucketLength(core_t::TTime length)
 {
     m_BucketLength = length;
-    for (auto &&factory : m_Factories)
+    for (auto &factory : m_Factories)
     {
         factory.second->updateBucketLength(length);
     }
@@ -524,7 +524,7 @@ bool CAnomalyDetectorModelConfig::configureModelPlot(const boost::property_tree:
     {
         std::string valueStr(propTree.get<std::string>(TERMS_PROPERTY));
 
-        typedef core::CStringUtils::TStrVec TStrVec;
+        using TStrVec = core::CStringUtils::TStrVec;
         TStrVec tokens;
         std::string remainder;
         core::CStringUtils::tokenise(",", valueStr, tokens, remainder);
@@ -763,7 +763,7 @@ CAnomalyDetectorModelConfig::factory(int identifier,
 
 void CAnomalyDetectorModelConfig::decayRate(double value)
 {
-    for (auto &&factory : m_Factories)
+    for (auto &factory : m_Factories)
     {
         factory.second->decayRate(value);
     }
@@ -900,7 +900,7 @@ const std::string PER_PARTITION_NORMALIZATION_PROPERTY("perPartitionNormalizatio
 
 bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptree &propertyTree)
 {
-    typedef std::vector<std::string> TStrVec;
+    using TStrVec = std::vector<std::string>;
 
     bool result = true;
 
@@ -921,7 +921,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
             }
 
             learnRate *= bucketNormalizationFactor(this->bucketLength());
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->learnRate(learnRate);
             }
@@ -937,7 +937,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
             }
 
             decayRate *= bucketNormalizationFactor(this->bucketLength());
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->decayRate(decayRate);
             }
@@ -952,7 +952,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
                 continue;
             }
 
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->initialDecayRateMultiplier(multiplier);
             }
@@ -968,7 +968,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
                 continue;
             }
 
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->maximumUpdatesPerBucket(maximumUpdatesPerBucket);
             }
@@ -983,7 +983,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
                 result = false;
                 continue;
             }
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->totalProbabilityCalcSamplingSize(totalProbabilityCalcSamplingSize);
             }
@@ -1057,7 +1057,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
                 result = false;
                 continue;
             }
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->componentSize(componentSize);
             }
@@ -1071,7 +1071,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
                 result = false;
                 continue;
             }
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->sampleCountFactor(factor);
             }
@@ -1085,7 +1085,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
                 result = false;
                 continue;
             }
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->pruneWindowScaleMinimum(factor);
             }
@@ -1099,7 +1099,7 @@ bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptre
                 result = false;
                 continue;
             }
-            for (auto &&factory : m_Factories)
+            for (auto &factory : m_Factories)
             {
                 factory.second->pruneWindowScaleMaximum(factor);
             }

--- a/lib/model/CAnomalyScore.cc
+++ b/lib/model/CAnomalyScore.cc
@@ -47,7 +47,7 @@ namespace model
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 //! Add valid \p probabilities to \p aggregator and return the
 //! number of valid probabilities.
@@ -616,8 +616,8 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const TDoubleVec &scores)
 
 bool CAnomalyScore::CNormalizer::updateQuantiles(double score)
 {
-    typedef std::pair<uint32_t, uint64_t> TUInt32UInt64Pr;
-    typedef std::vector<TUInt32UInt64Pr> TUInt32UInt64PrVec;
+    using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
+    using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
 
     bool bigChange(false);
     double oldMaxScore(m_MaxScore.count() == 0 ? 0.0 : m_MaxScore[0]);

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -195,7 +195,7 @@ CCountingModel::TDouble1Vec
 
 void CCountingModel::currentBucketPersonIds(core_t::TTime time, TSizeVec &result) const
 {
-    typedef boost::unordered_set<std::size_t> TSizeUSet;
+    using TSizeUSet = boost::unordered_set<std::size_t>;
 
     result.clear();
 
@@ -287,7 +287,7 @@ void CCountingModel::setMatchedEventsDescriptions(core_t::TTime sampleTime, core
     if (matchedEvents.empty() == false)
     {
         TStr1Vec descriptions;
-        for (auto &&event : matchedEvents)
+        for (auto &event : matchedEvents)
         {
             descriptions.push_back(event.first);
         }
@@ -301,7 +301,7 @@ CCountingModel::checkScheduledEvents(core_t::TTime sampleTime) const
     const SModelParams::TStrDetectionRulePrVec &events = this->params().s_ScheduledEvents.get();
     SModelParams::TStrDetectionRulePrVec matchedEvents;
 
-    for (auto &&event : events)
+    for (auto &event : events)
     {
         // Note that as the counting model is not aware of partitions
         // scheduled events cannot support partitions as the code stands.

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -847,7 +847,7 @@ void CDataGatherer::releaseMemory(core_t::TTime samplingCutoffTime)
 {
     if (this->isPopulation())
     {
-        for (auto &&gatherer : m_Gatherers)
+        for (auto &gatherer : m_Gatherers)
         {
             gatherer->releaseMemory(samplingCutoffTime);
         }

--- a/lib/model/CDetectorEqualizer.cc
+++ b/lib/model/CDetectorEqualizer.cc
@@ -150,7 +150,7 @@ void CDetectorEqualizer::clear(void)
 
 void CDetectorEqualizer::age(double factor)
 {
-    for (auto &&sketch : m_Sketches)
+    for (auto &sketch : m_Sketches)
     {
         sketch.second.age(factor);
     }

--- a/lib/model/CDynamicStringIdRegistry.cc
+++ b/lib/model/CDynamicStringIdRegistry.cc
@@ -220,7 +220,7 @@ CDynamicStringIdRegistry::TSizeVec &CDynamicStringIdRegistry::recycledIds(void)
 
 bool CDynamicStringIdRegistry::checkInvariants(void) const
 {
-    typedef boost::unordered_set<std::size_t> TSizeUSet;
+    using TSizeUSet = boost::unordered_set<std::size_t>;
 
     bool result = true;
     if (m_Uids.size() > m_Names.size())
@@ -258,8 +258,8 @@ void CDynamicStringIdRegistry::clear(void)
 
 uint64_t CDynamicStringIdRegistry::checksum(void) const
 {
-    typedef boost::reference_wrapper<const std::string> TStrCRef;
-    typedef std::vector<TStrCRef> TStrCRefVec;
+    using TStrCRef = boost::reference_wrapper<const std::string>;
+    using TStrCRefVec = std::vector<TStrCRef>;
 
     TStrCRefVec people;
     people.reserve(m_Names.size());

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -54,23 +54,23 @@ namespace model
 namespace
 {
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::map<std::string, uint64_t> TStrUInt64Map;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::vector<TSizeSizePr> TSizeSizePrVec;
-typedef std::vector<uint64_t> TUInt64Vec;
-typedef boost::unordered_set<std::size_t> TSizeUSet;
-typedef TSizeUSet::const_iterator TSizeUSetCItr;
-typedef std::vector<TSizeUSet> TSizeUSetVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef boost::unordered_map<TSizeSizePr, TMeanAccumulator> TSizeSizePrMeanAccumulatorUMap;
-typedef std::map<TSizeSizePr, uint64_t> TSizeSizePrUInt64Map;
-typedef CBucketQueue<TSizeSizePrMeanAccumulatorUMap> TSizeSizePrMeanAccumulatorUMapQueue;
-typedef CEventRateBucketGatherer::TCategoryAnyMap TCategoryAnyMap;
-typedef boost::unordered_map<TSizeSizePr, CUniqueStringFeatureData> TSizeSizePrStrDataUMap;
-typedef CBucketQueue<TSizeSizePrStrDataUMap> TSizeSizePrStrDataUMapQueue;
-typedef CBucketGatherer::TStoredStringPtrVec TStoredStringPtrVec;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
+using TStrUInt64Map = std::map<std::string, uint64_t>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrVec = std::vector<TSizeSizePr>;
+using TUInt64Vec = std::vector<uint64_t>;
+using TSizeUSet = boost::unordered_set<std::size_t>;
+using TSizeUSetCItr = TSizeUSet::const_iterator;
+using TSizeUSetVec = std::vector<TSizeUSet>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TSizeSizePrMeanAccumulatorUMap = boost::unordered_map<TSizeSizePr, TMeanAccumulator>;
+using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+using TSizeSizePrMeanAccumulatorUMapQueue = CBucketQueue<TSizeSizePrMeanAccumulatorUMap>;
+using TCategoryAnyMap = CEventRateBucketGatherer::TCategoryAnyMap;
+using TSizeSizePrStrDataUMap = boost::unordered_map<TSizeSizePr, CUniqueStringFeatureData>;
+using TSizeSizePrStrDataUMapQueue = CBucketQueue<TSizeSizePrStrDataUMap>;
+using TStoredStringPtrVec = CBucketGatherer::TStoredStringPtrVec;
 
 // We use short field names to reduce the state size
 const std::string BASE_TAG("a");
@@ -361,8 +361,8 @@ const std::string &overField(bool population, const TStrVec &fieldNames)
 }
 
 template<typename ITR, typename T> struct SMaybeConst {};
-template<typename T> struct SMaybeConst<TCategoryAnyMap::iterator, T> { typedef T &TRef; };
-template<typename T> struct SMaybeConst<TCategoryAnyMap::const_iterator, T> { typedef const T &TRef; };
+template<typename T> struct SMaybeConst<TCategoryAnyMap::iterator, T> { using TRef = T &; };
+template<typename T> struct SMaybeConst<TCategoryAnyMap::const_iterator, T> { using TRef = const T &; };
 
 //! Apply a function \p f to all the data held in [\p begin, \p end).
 template<typename ITR, typename F>
@@ -439,7 +439,7 @@ struct SRemovePeople
                     std::size_t lowestPersonToRemove,
                     std::size_t endPeople) const
     {
-        for (auto &&bucket : peopleAttributeUniqueValues)
+        for (auto &bucket : peopleAttributeUniqueValues)
         {
             for (auto i = bucket.begin(); i != bucket.end(); /**/)
             {
@@ -466,7 +466,7 @@ struct SRemovePeople
                     std::size_t lowestPersonToRemove,
                     std::size_t endPeople) const
     {
-        for (auto &&bucket : arrivalTimes)
+        for (auto &bucket : arrivalTimes)
         {
             for (auto i = bucket.begin(); i != bucket.end(); /**/)
             {
@@ -514,7 +514,7 @@ struct SRemoveAttributes
     void operator()(TSizeSizePrStrDataUMapQueue &peopleAttributeUniqueValues,
                     std::size_t lowestAttributeToRemove) const
     {
-        for (auto &&bucket : peopleAttributeUniqueValues)
+        for (auto &bucket : peopleAttributeUniqueValues)
         {
             for (auto i = bucket.begin(); i != bucket.end(); /**/)
             {
@@ -539,7 +539,7 @@ struct SRemoveAttributes
     void operator()(TSizeSizePrMeanAccumulatorUMapQueue &arrivalTimes,
                     std::size_t lowestAttributeToRemove) const
     {
-        for (auto &&bucket : arrivalTimes)
+        for (auto &bucket : arrivalTimes)
         {
             for (auto i = bucket.begin(); i != bucket.end(); /**/)
             {
@@ -570,8 +570,8 @@ struct SChecksum
                     const CDataGatherer &gatherer,
                     TStrUInt64Map &hashes) const
     {
-        typedef boost::reference_wrapper<const std::string> TStrCRef;
-        typedef std::vector<TStrCRef> TStrCRefVec;
+        using TStrCRef = boost::reference_wrapper<const std::string>;
+        using TStrCRefVec = std::vector<TStrCRef>;
 
         for (std::size_t cid = 0u; cid < attributePeople.size(); ++cid)
         {
@@ -616,7 +616,7 @@ struct SChecksum
                   const CDataGatherer &gatherer,
                   TStrUInt64Map &hashes) const
     {
-        typedef boost::unordered_map<std::size_t, TUInt64Vec> TSizeUInt64VecUMap;
+        using TSizeUInt64VecUMap = boost::unordered_map<std::size_t, TUInt64Vec>;
 
         TSizeUInt64VecUMap attributeHashes;
 
@@ -630,7 +630,7 @@ struct SChecksum
             }
         }
 
-        for (auto &&hash_ : attributeHashes)
+        for (auto &hash_ : attributeHashes)
         {
             std::sort(hash_.second.begin(), hash_.second.end());
             uint64_t &hash = hashes[gatherer.attributeName(hash_.first)];
@@ -764,7 +764,7 @@ const std::string UNIQUE_WORD_TAG("b");
 void persistUniqueStrings(const CUniqueStringFeatureData::TWordStringUMap &map,
                           core::CStatePersistInserter &inserter)
 {
-    typedef std::vector<CUniqueStringFeatureData::TWord> TWordVec;
+    using TWordVec = std::vector<CUniqueStringFeatureData::TWord>;
 
     if (!map.empty())
     {
@@ -804,7 +804,7 @@ bool restoreUniqueStrings(core::CStateRestoreTraverser &traverser,
 void persistInfluencerUniqueStrings(const CUniqueStringFeatureData::TStoredStringPtrWordSetUMap &map,
                                     core::CStatePersistInserter &inserter)
 {
-    typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
+    using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
 
     if (!map.empty())
     {
@@ -1031,8 +1031,8 @@ bool CEventRateBucketGatherer::processFields(const TStrCPtrVec &fieldValues,
                                              CEventData &result,
                                              CResourceMonitor &resourceMonitor)
 {
-    typedef boost::optional<std::size_t> TOptionalSize;
-    typedef boost::optional<std::string> TOptionalStr;
+    using TOptionalSize = boost::optional<std::size_t>;
+    using TOptionalStr = boost::optional<std::string>;
 
     if (fieldValues.size() != m_FieldNames.size())
     {
@@ -2091,7 +2091,7 @@ void CUniqueStringFeatureData::populateDistinctCountFeatureData(SEventRateFeatur
 
 void CUniqueStringFeatureData::populateInfoContentFeatureData(SEventRateFeatureData &featureData) const
 {
-    typedef std::vector<TStrCRef> TStrCRefVec;
+    using TStrCRefVec = std::vector<TStrCRef>;
 
     featureData.s_InfluenceValues.clear();
     core::CCompressUtils compressor(true);

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -223,7 +223,7 @@ CEventRateModel::TDouble1Vec CEventRateModel::baselineBucketMean(model_t::EFeatu
     {
         probability = 1.0;
     }
-    for (auto &&coord : result)
+    for (auto &coord : result)
     {
         coord = probability * model_t::inverseOffsetCountToZero(feature, coord);
     }
@@ -285,7 +285,7 @@ void CEventRateModel::sample(core_t::TTime startTime,
         maths::CModel::TTimeDouble2VecSizeTrVec values;
         maths::CModelAddSamplesParams::TDouble2Vec4VecVec weights(1);
 
-        for (auto &&featureData : m_CurrentBucketStats.s_FeatureData)
+        for (auto &featureData : m_CurrentBucketStats.s_FeatureData)
         {
             model_t::EFeature feature = featureData.first;
             TSizeFeatureDataPrVec &data = featureData.second;

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -239,9 +239,9 @@ bool CEventRatePopulationModel::acceptRestoreTraverser(core::CStateRestoreTraver
     }
     while (traverser.next());
 
-    for (auto &&feature : m_FeatureModels)
+    for (auto &feature : m_FeatureModels)
     {
-        for (auto &&model : feature.s_Models)
+        for (auto &model : feature.s_Models)
         {
             for (const auto &correlates : m_FeatureCorrelatesModels)
             {
@@ -314,7 +314,7 @@ CEventRatePopulationModel::TDouble1Vec
     {
         probability = 1.0;
     }
-    for (auto &&coord : result)
+    for (auto &coord : result)
     {
         coord = probability * model_t::inverseOffsetCountToZero(feature, coord);
     }
@@ -357,7 +357,7 @@ void CEventRatePopulationModel::sampleBucketStatistics(core_t::TTime startTime,
 
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(time, bucketLength, featureData);
-        for (auto &&featureData_ : featureData)
+        for (auto &featureData_ : featureData)
         {
             model_t::EFeature feature = featureData_.first;
             TSizeSizePrFeatureDataPrVec &data = m_CurrentBucketStats.s_FeatureData[feature];
@@ -410,7 +410,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
         this->applyFilter(model_t::E_XF_Over, true, this->personFilter(), personCounts);
 
 
-        for (auto &&featureData_ : featureData)
+        for (auto &featureData_ : featureData)
         {
             model_t::EFeature feature = featureData_.first;
             TSizeSizePrFeatureDataPrVec &data = m_CurrentBucketStats.s_FeatureData[feature];
@@ -455,7 +455,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                     uint64_t count = CDataGatherer::extractData(data_).s_Count;
                     fuzzy[cid].add({static_cast<double>(count)});
                 }
-                for (auto &&fuzzy_ : fuzzy)
+                for (auto &fuzzy_ : fuzzy)
                 {
                     fuzzy_.second.computeEpsilons(bucketLength,
                                                   this->params().s_MinimumToDeduplicate);
@@ -514,7 +514,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 }
             }
 
-            for (auto &&attribute : attributes)
+            for (auto &attribute : attributes)
             {
                 std::size_t cid = attribute.first;
                 maths::CModelAddSamplesParams params;
@@ -572,7 +572,7 @@ void CEventRatePopulationModel::prune(std::size_t maximumAge)
     {
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(m_CurrentBucketStats.s_StartTime, gatherer.bucketLength(), featureData);
-        for (auto &&feature : featureData)
+        for (auto &feature : featureData)
         {
             m_CurrentBucketStats.s_FeatureData[feature.first].swap(feature.second);
         }
@@ -998,7 +998,7 @@ void CEventRatePopulationModel::createNewModels(std::size_t n, std::size_t m)
 {
     if (m > 0)
     {
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             std::size_t newM = feature.s_Models.size() + m;
             core::CAllocationStrategy::reserve(feature.s_Models, newM);
@@ -1023,7 +1023,7 @@ void CEventRatePopulationModel::updateRecycledModels(void)
     CDataGatherer &gatherer = this->dataGatherer();
     for (auto cid : gatherer.recycledAttributeIds())
     {
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             feature.s_Models[cid].reset(feature.s_NewModel->clone(cid));
             for (const auto &correlates : m_FeatureCorrelatesModels)
@@ -1046,7 +1046,7 @@ void CEventRatePopulationModel::refreshCorrelationModels(std::size_t resourceLim
     auto memoryUsage = boost::bind(&CAnomalyDetectorModel::estimateMemoryUsageOrComputeAndUpdate, this, n, 0, _1);
     CTimeSeriesCorrelateModelAllocator allocator(resourceMonitor, memoryUsage, resourceLimit,
                                                  static_cast<std::size_t>(maxNumberCorrelations + 0.5));
-    for (auto &&feature : m_FeatureCorrelatesModels)
+    for (auto &feature : m_FeatureCorrelatesModels)
     {
         allocator.prototypePrior(feature.s_ModelPrior);
         feature.s_Models->refresh(allocator);
@@ -1058,7 +1058,7 @@ void CEventRatePopulationModel::clearPrunedResources(const TSizeVec &/*people*/,
 {
     for (auto cid : attributes)
     {
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             feature.s_Models[cid].reset(this->tinyModel());
         }
@@ -1068,7 +1068,7 @@ void CEventRatePopulationModel::clearPrunedResources(const TSizeVec &/*people*/,
 void CEventRatePopulationModel::doSkipSampling(core_t::TTime startTime, core_t::TTime endTime)
 {
     core_t::TTime gap = endTime - startTime;
-    for (auto &&feature : m_FeatureModels)
+    for (auto &feature : m_FeatureModels)
     {
         for (auto &model : feature.s_Models)
         {

--- a/lib/model/CGathererTools.cc
+++ b/lib/model/CGathererTools.cc
@@ -55,7 +55,7 @@ const std::string SUM_MAP_VALUE_TAG("c");
 //! \brief Manages persistence of bucket sums.
 struct SSumSerializer
 {
-    typedef std::vector<CSample> TSampleVec;
+    using TSampleVec = std::vector<CSample>;
 
     void operator()(const TSampleVec &sample, core::CStatePersistInserter &inserter) const
     {
@@ -79,11 +79,11 @@ struct SSumSerializer
 //! \brief Manages persistence of influence bucket sums.
 struct SInfluencerSumSerializer
 {
-    typedef boost::unordered_map<core::CStoredStringPtr, double> TStoredStringPtrDoubleUMap;
-    typedef TStoredStringPtrDoubleUMap::const_iterator TStoredStringPtrDoubleUMapCItr;
-    typedef boost::reference_wrapper<const std::string> TStrCRef;
-    typedef std::pair<TStrCRef, double> TStrCRefDoublePr;
-    typedef std::vector<TStrCRefDoublePr> TStrCRefDoublePrVec;
+    using TStoredStringPtrDoubleUMap = boost::unordered_map<core::CStoredStringPtr, double>;
+    using TStoredStringPtrDoubleUMapCItr = TStoredStringPtrDoubleUMap::const_iterator;
+    using TStrCRef = boost::reference_wrapper<const std::string>;
+    using TStrCRefDoublePr = std::pair<TStrCRef, double>;
+    using TStrCRefDoublePrVec = std::vector<TStrCRefDoublePr>;
 
     void operator()(const TStoredStringPtrDoubleUMap &map, core::CStatePersistInserter &inserter) const
     {
@@ -218,11 +218,11 @@ std::size_t CGathererTools::CSumGatherer::dimension(void) const
 SMetricFeatureData CGathererTools::CSumGatherer::featureData(core_t::TTime time, core_t::TTime /*bucketLength*/,
                                                      const TSampleVec &emptySample) const
 {
-    typedef boost::reference_wrapper<const std::string> TStrCRef;
-    typedef std::pair<TDouble1Vec, double> TDouble1VecDoublePr;
-    typedef std::pair<TStrCRef, TDouble1VecDoublePr> TStrCRefDouble1VecDoublePrPr;
-    typedef std::vector<TStrCRefDouble1VecDoublePrPr> TStrCRefDouble1VecDoublePrPrVec;
-    typedef std::vector<TStrCRefDouble1VecDoublePrPrVec> TStrCRefDouble1VecDoublePrPrVecVec;
+    using TStrCRef = boost::reference_wrapper<const std::string>;
+    using TDouble1VecDoublePr = std::pair<TDouble1Vec, double>;
+    using TStrCRefDouble1VecDoublePrPr = std::pair<TStrCRef, TDouble1VecDoublePr>;
+    using TStrCRefDouble1VecDoublePrPrVec = std::vector<TStrCRefDouble1VecDoublePrPr>;
+    using TStrCRefDouble1VecDoublePrPrVecVec = std::vector<TStrCRefDouble1VecDoublePrPrVec>;
 
     const TSampleVec *sum = &m_BucketSums.get(time);
     if (sum->empty())

--- a/lib/model/CHierarchicalResults.cc
+++ b/lib/model/CHierarchicalResults.cc
@@ -44,7 +44,7 @@ namespace hierarchical_results_detail
 namespace
 {
 
-typedef SNode::TNodeCPtr TNodeCPtr;
+using TNodeCPtr = SNode::TNodeCPtr;
 
 //! CHierarchicalResults tags
 const std::string NODES_1_TAG("a");
@@ -198,8 +198,8 @@ void aggregateLayer(ITR beginLayer,
                     FACTORY newNode,
                     std::vector<SNode*> &newLayer)
 {
-    typedef std::vector<SNode*> TNodePtrVec;
-    typedef std::map<TNodeCPtr, TNodePtrVec, LESS> TNodeCPtrNodePtrVecMap;
+    using TNodePtrVec = std::vector<SNode*>;
+    using TNodeCPtrNodePtrVecMap = std::map<TNodeCPtr, TNodePtrVec, LESS>;
 
     newLayer.clear();
 
@@ -682,7 +682,7 @@ void CHierarchicalResults::addInfluencer(const std::string &name)
 
 void CHierarchicalResults::buildHierarchy(void)
 {
-    typedef std::vector<SNode*> TNodePtrVec;
+    using TNodePtrVec = std::vector<SNode*>;
 
     m_Nodes.erase(std::remove_if(m_Nodes.begin(), m_Nodes.end(), isAggregate), m_Nodes.end());
 
@@ -787,7 +787,7 @@ void CHierarchicalResults::createPivots(void)
         }
     }
 
-    for (auto &&pivot : m_PivotNodes)
+    for (auto &pivot : m_PivotNodes)
     {
         TNode &root = this->newPivotRoot(pivot.second.s_Spec.s_PersonFieldName);
         root.s_Children.push_back(&pivot.second);
@@ -898,10 +898,10 @@ model_t::CResultType CHierarchicalResults::resultType(void) const
 
 void CHierarchicalResults::acceptPersistInserter(core::CStatePersistInserter &inserter) const
 {
-    typedef TStoredStringPtrNodeMap::const_iterator TStoredStringPtrNodeMapCItr;
-    typedef std::vector<TStoredStringPtrNodeMapCItr> TStoredStringPtrNodeMapCItrVec;
-    typedef TStoredStringPtrStoredStringPtrPrNodeMap::const_iterator TStoredStringPtrStoredStringPtrPrNodeMapCItr;
-    typedef std::vector<TStoredStringPtrStoredStringPtrPrNodeMapCItr> TStoredStringPtrStoredStringPtrPrNodeMapCItrVec;
+    using TStoredStringPtrNodeMapCItr = TStoredStringPtrNodeMap::const_iterator;
+    using TStoredStringPtrNodeMapCItrVec = std::vector<TStoredStringPtrNodeMapCItr>;
+    using TStoredStringPtrStoredStringPtrPrNodeMapCItr = TStoredStringPtrStoredStringPtrPrNodeMap::const_iterator;
+    using TStoredStringPtrStoredStringPtrPrNodeMapCItrVec = std::vector<TStoredStringPtrStoredStringPtrPrNodeMapCItr>;
 
     TNodePtrSizeUMap nodePointers;
 

--- a/lib/model/CHierarchicalResultsAggregator.cc
+++ b/lib/model/CHierarchicalResultsAggregator.cc
@@ -450,7 +450,7 @@ double CHierarchicalResultsAggregator::correctProbability(const TNode &node, boo
         TDetectorEqualizerPtrVec equalizers;
         this->elements(node, pivot, factory, equalizers);
         TMaxAccumulator corrected;
-        for (auto &&equalizer : equalizers)
+        for (auto &equalizer : equalizers)
         {
             switch (m_Job)
             {

--- a/lib/model/CHierarchicalResultsNormalizer.cc
+++ b/lib/model/CHierarchicalResultsNormalizer.cc
@@ -43,7 +43,7 @@ namespace
 class CNormalizerFactory
 {
     public:
-        typedef CHierarchicalResultsNormalizer::TNormalizer TNormalizer;
+        using TNormalizer = CHierarchicalResultsNormalizer::TNormalizer;
 
         CNormalizerFactory(const CAnomalyDetectorModelConfig &modelConfig) : m_ModelConfig(modelConfig) {}
 

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -47,10 +47,10 @@ namespace model
 namespace
 {
 
-typedef boost::reference_wrapper<const std::string> TStrCRef;
-typedef std::map<TStrCRef, uint64_t, maths::COrderings::SLess> TStrCRefUInt64Map;
-typedef std::pair<TStrCRef, TStrCRef> TStrCRefStrCRefPr;
-typedef std::map<TStrCRefStrCRefPr, uint64_t, maths::COrderings::SLess> TStrCRefStrCRefPrUInt64Map;
+using TStrCRef = boost::reference_wrapper<const std::string>;
+using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::COrderings::SLess>;
+using TStrCRefStrCRefPr = std::pair<TStrCRef, TStrCRef>;
+using TStrCRefStrCRefPrUInt64Map = std::map<TStrCRefStrCRefPr, uint64_t, maths::COrderings::SLess>;
 
 //! Update \p hashes with the hashes of the active people in \p values.
 template<typename T>
@@ -441,9 +441,9 @@ bool CIndividualModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser &tr
     }
     while (traverser.next());
 
-    for (auto &&feature : m_FeatureModels)
+    for (auto &feature : m_FeatureModels)
     {
-        for (auto &&model : feature.s_Models)
+        for (auto &model : feature.s_Models)
         {
             for (const auto &correlates : m_FeatureCorrelatesModels)
             {
@@ -515,7 +515,7 @@ void CIndividualModel::createNewModels(std::size_t n, std::size_t m)
         std::size_t newN = m_FirstBucketTimes.size() + n;
         core::CAllocationStrategy::resize(m_FirstBucketTimes, newN, CAnomalyDetectorModel::TIME_UNSET);
         core::CAllocationStrategy::resize(m_LastBucketTimes, newN, CAnomalyDetectorModel::TIME_UNSET);
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             core::CAllocationStrategy::reserve(feature.s_Models, newN);
             for (std::size_t pid = feature.s_Models.size(); pid < newN; ++pid)
@@ -540,7 +540,7 @@ void CIndividualModel::updateRecycledModels(void)
     {
         m_FirstBucketTimes[pid] = CAnomalyDetectorModel::TIME_UNSET;
         m_LastBucketTimes[pid]  = CAnomalyDetectorModel::TIME_UNSET;
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             feature.s_Models[pid].reset(feature.s_NewModel->clone(pid));
             for (const auto &correlates : m_FeatureCorrelatesModels)
@@ -563,7 +563,7 @@ void CIndividualModel::refreshCorrelationModels(std::size_t resourceLimit,
     auto memoryUsage = boost::bind(&CAnomalyDetectorModel::estimateMemoryUsageOrComputeAndUpdate, this, n, 0, _1);
     CTimeSeriesCorrelateModelAllocator allocator(resourceMonitor, memoryUsage, resourceLimit,
                                                  static_cast<std::size_t>(maxNumberCorrelations));
-    for (auto &&feature : m_FeatureCorrelatesModels)
+    for (auto &feature : m_FeatureCorrelatesModels)
     {
         allocator.prototypePrior(feature.s_ModelPrior);
         feature.s_Models->refresh(allocator);
@@ -574,7 +574,7 @@ void CIndividualModel::clearPrunedResources(const TSizeVec &people, const TSizeV
 {
     for (auto pid : people)
     {
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             feature.s_Models[pid].reset(this->tinyModel());
         }
@@ -708,7 +708,7 @@ void CIndividualModel::doSkipSampling(core_t::TTime startTime, core_t::TTime end
 {
     core_t::TTime gap = endTime - startTime;
 
-    for (auto &&time : m_LastBucketTimes)
+    for (auto &time : m_LastBucketTimes)
     {
         if (!CAnomalyDetectorModel::isTimeUnset(time))
         {
@@ -716,7 +716,7 @@ void CIndividualModel::doSkipSampling(core_t::TTime startTime, core_t::TTime end
         }
     }
 
-    for (auto &&feature : m_FeatureModels)
+    for (auto &feature : m_FeatureModels)
     {
         for (auto &model : feature.s_Models)
         {

--- a/lib/model/CMemoryUsageEstimator.cc
+++ b/lib/model/CMemoryUsageEstimator.cc
@@ -49,7 +49,7 @@ CMemoryUsageEstimator::CMemoryUsageEstimator(void)
 CMemoryUsageEstimator::TOptionalSize
 CMemoryUsageEstimator::estimate(const TSizeArray &predictors)
 {
-    typedef boost::array<double, E_NumberPredictors> TDoubleArray;
+    using TDoubleArray = boost::array<double, E_NumberPredictors>;
 
     if (m_Values.size() < E_NumberPredictors)
     {

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -127,18 +127,18 @@ const std::string &overField(bool population, const TStrVec &fieldNames)
 }
 
 template<model_t::EMetricCategory> struct SDataType {};
-template<> struct SDataType<model_t::E_Mean>             { typedef TSizeSizeMeanGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_Median>           { typedef TSizeSizeMedianGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_Min>              { typedef TSizeSizeMinGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_Max>              { typedef TSizeSizeMaxGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_Sum>              { typedef TSizeSizeSumGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_Variance>         { typedef TSizeSizeVarianceGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_MultivariateMean> { typedef TSizeSizeMultivariateMeanGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_MultivariateMin>  { typedef TSizeSizeMultivariateMinGathererUMapUMap Type; };
-template<> struct SDataType<model_t::E_MultivariateMax>  { typedef TSizeSizeMultivariateMaxGathererUMapUMap Type; };
+template<> struct SDataType<model_t::E_Mean>             { using Type = TSizeSizeMeanGathererUMapUMap; };
+template<> struct SDataType<model_t::E_Median>           { using Type = TSizeSizeMedianGathererUMapUMap; };
+template<> struct SDataType<model_t::E_Min>              { using Type = TSizeSizeMinGathererUMapUMap; };
+template<> struct SDataType<model_t::E_Max>              { using Type = TSizeSizeMaxGathererUMapUMap; };
+template<> struct SDataType<model_t::E_Sum>              { using Type = TSizeSizeSumGathererUMapUMap; };
+template<> struct SDataType<model_t::E_Variance>         { using Type = TSizeSizeVarianceGathererUMapUMap; };
+template<> struct SDataType<model_t::E_MultivariateMean> { using Type = TSizeSizeMultivariateMeanGathererUMapUMap; };
+template<> struct SDataType<model_t::E_MultivariateMin>  { using Type = TSizeSizeMultivariateMinGathererUMapUMap; };
+template<> struct SDataType<model_t::E_MultivariateMax>  { using Type = TSizeSizeMultivariateMaxGathererUMapUMap; };
 template<typename ITR, typename T> struct SMaybeConst {};
-template<typename T> struct SMaybeConst<TCategorySizePrAnyMapItr, T> { typedef T Type; };
-template<typename T> struct SMaybeConst<TCategorySizePrAnyMapCItr, T> { typedef const T Type; };
+template<typename T> struct SMaybeConst<TCategorySizePrAnyMapItr, T> { using Type = T;};
+template<typename T> struct SMaybeConst<TCategorySizePrAnyMapCItr, T> { using Type = const T; };
 
 //! Register the callbacks for computing the size of feature data gatherers
 //! with \p visitor.
@@ -1664,7 +1664,7 @@ void CMetricBucketGatherer::startNewBucket(core_t::TTime time, bool skipUpdates)
             }
             double alpha = ::exp(-m_DataGatherer.params().s_DecayRate);
 
-            for (auto &&count : counts)
+            for (auto &count : counts)
             {
                 std::sort(count.second.begin(), count.second.end());
                 std::size_t n = count.second.size() / 2;

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -264,7 +264,7 @@ void CMetricModel::sample(core_t::TTime startTime,
         maths::CModelAddSamplesParams::TDouble2Vec4VecVec trendWeights;
         maths::CModelAddSamplesParams::TDouble2Vec4VecVec priorWeights;
 
-        for (auto &&featureData : m_CurrentBucketStats.s_FeatureData)
+        for (auto &featureData : m_CurrentBucketStats.s_FeatureData)
         {
             model_t::EFeature feature = featureData.first;
             TSizeFeatureDataPrVec &data = featureData.second;

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -225,9 +225,9 @@ bool CMetricPopulationModel::acceptRestoreTraverser(core::CStateRestoreTraverser
     }
     while (traverser.next());
 
-    for (auto &&feature : m_FeatureModels)
+    for (auto &feature : m_FeatureModels)
     {
-        for (auto &&model : feature.s_Models)
+        for (auto &model : feature.s_Models)
         {
             for (const auto &correlates : m_FeatureCorrelatesModels)
             {
@@ -326,7 +326,7 @@ void CMetricPopulationModel::sampleBucketStatistics(core_t::TTime startTime,
 
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(time, bucketLength, featureData);
-        for (auto &&featureData_ : featureData)
+        for (auto &featureData_ : featureData)
         {
             model_t::EFeature feature = featureData_.first;
             TSizeSizePrFeatureDataPrVec &data = m_CurrentBucketStats.s_FeatureData[feature];
@@ -505,7 +505,7 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                 }
             }
 
-            for (auto &&attribute : attributes)
+            for (auto &attribute : attributes)
             {
                 std::size_t cid = attribute.first;
                 core_t::TTime latest = boost::numeric::bounds<core_t::TTime>::lowest();
@@ -569,7 +569,7 @@ void CMetricPopulationModel::prune(std::size_t maximumAge)
     {
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(m_CurrentBucketStats.s_StartTime, gatherer.bucketLength(), featureData);
-        for (auto &&feature : featureData)
+        for (auto &feature : featureData)
         {
             m_CurrentBucketStats.s_FeatureData[feature.first].swap(feature.second);
         }
@@ -902,7 +902,7 @@ void CMetricPopulationModel::createNewModels(std::size_t n, std::size_t m)
 {
     if (m > 0)
     {
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             std::size_t newM = feature.s_Models.size() + m;
             core::CAllocationStrategy::reserve(feature.s_Models, newM);
@@ -927,7 +927,7 @@ void CMetricPopulationModel::updateRecycledModels(void)
     CDataGatherer &gatherer = this->dataGatherer();
     for (auto cid : gatherer.recycledAttributeIds())
     {
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             feature.s_Models[cid].reset(feature.s_NewModel->clone(cid));
             for (const auto &correlates : m_FeatureCorrelatesModels)
@@ -950,7 +950,7 @@ void CMetricPopulationModel::refreshCorrelationModels(std::size_t resourceLimit,
     auto memoryUsage = boost::bind(&CAnomalyDetectorModel::estimateMemoryUsageOrComputeAndUpdate, this, n, 0, _1);
     CTimeSeriesCorrelateModelAllocator allocator(resourceMonitor, memoryUsage, resourceLimit,
                                                  static_cast<std::size_t>(maxNumberCorrelations + 0.5));
-    for (auto &&feature : m_FeatureCorrelatesModels)
+    for (auto &feature : m_FeatureCorrelatesModels)
     {
         allocator.prototypePrior(feature.s_ModelPrior);
         feature.s_Models->refresh(allocator);
@@ -963,7 +963,7 @@ void CMetricPopulationModel::clearPrunedResources(const TSizeVec &/*people*/,
     CDataGatherer &gatherer = this->dataGatherer();
     for (auto cid : gatherer.recycledAttributeIds())
     {
-        for (auto &&feature : m_FeatureModels)
+        for (auto &feature : m_FeatureModels)
         {
             feature.s_Models[cid].reset(feature.s_NewModel->clone(cid));
             for (const auto &correlates : m_FeatureCorrelatesModels)
@@ -980,7 +980,7 @@ void CMetricPopulationModel::clearPrunedResources(const TSizeVec &/*people*/,
 void CMetricPopulationModel::doSkipSampling(core_t::TTime startTime, core_t::TTime endTime)
 {
     core_t::TTime gap = endTime - startTime;
-    for (auto &&feature : m_FeatureModels)
+    for (auto &feature : m_FeatureModels)
     {
         for (auto &model : feature.s_Models)
         {

--- a/lib/model/CModelTools.cc
+++ b/lib/model/CModelTools.cc
@@ -243,7 +243,7 @@ void CModelTools::CProbabilityAggregator::add(const TAggregator &aggregator, dou
 void CModelTools::CProbabilityAggregator::add(double probability, double weight)
 {
     m_TotalWeight += weight;
-    for (auto &&aggregator : m_Aggregators)
+    for (auto &aggregator : m_Aggregators)
     {
         boost::apply_visitor(boost::bind<void>(
                 SAddProbability(), probability, weight, _1), aggregator.first);

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -47,7 +47,7 @@ namespace
 {
 
 using TStrCRef = boost::reference_wrapper<const std::string>;
-using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::COrderings::SLess> ;
+using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::COrderings::SLess>;
 
 enum EEntity
 {
@@ -100,7 +100,7 @@ void hashActive(EEntity entity,
 template<typename T>
 void hashActive(EEntity entity,
                 const CDataGatherer &gatherer,
-                const std::vector<std::pair<model_t::EFeature, std::vector<T> > > &values,
+                const std::vector<std::pair<model_t::EFeature, std::vector<T>> > &values,
                 TStrCRefUInt64Map &hashes)
 {
     for (const auto &value : values)

--- a/lib/model/CProbabilityAndInfluenceCalculator.cc
+++ b/lib/model/CProbabilityAndInfluenceCalculator.cc
@@ -35,30 +35,30 @@ namespace model
 namespace
 {
 
-typedef CProbabilityAndInfluenceCalculator::TSize1Vec TSize1Vec;
-typedef CProbabilityAndInfluenceCalculator::TSize2Vec TSize2Vec;
-typedef CProbabilityAndInfluenceCalculator::TDouble1Vec TDouble1Vec;
-typedef CProbabilityAndInfluenceCalculator::TDouble2Vec TDouble2Vec;
-typedef CProbabilityAndInfluenceCalculator::TDouble4Vec TDouble4Vec;
-typedef CProbabilityAndInfluenceCalculator::TDouble2Vec1Vec TDouble2Vec1Vec;
-typedef CProbabilityAndInfluenceCalculator::TDouble4Vec1Vec TDouble4Vec1Vec;
-typedef CProbabilityAndInfluenceCalculator::TDouble1VecDoublePr TDouble1VecDoublePr;
-typedef CProbabilityAndInfluenceCalculator::TBool2Vec TBool2Vec;
-typedef CProbabilityAndInfluenceCalculator::TTime2Vec TTime2Vec;
-typedef CProbabilityAndInfluenceCalculator::TTime2Vec1Vec TTime2Vec1Vec;
-typedef CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDoublePrPr TStrCRefDouble1VecDoublePrPr;
-typedef CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDoublePrPrVec TStrCRefDouble1VecDoublePrPrVec;
-typedef CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDouble1VecPrPr TStrCRefDouble1VecDouble1VecPrPr;
-typedef CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDouble1VecPrPrVec TStrCRefDouble1VecDouble1VecPrPrVec;
-typedef CProbabilityAndInfluenceCalculator::TStoredStringPtrStoredStringPtrPr TStoredStringPtrStoredStringPtrPr;
-typedef CProbabilityAndInfluenceCalculator::TStoredStringPtrStoredStringPtrPrDoublePr TStoredStringPtrStoredStringPtrPrDoublePr;
-typedef CProbabilityAndInfluenceCalculator::TStoredStringPtrStoredStringPtrPrDoublePrVec TStoredStringPtrStoredStringPtrPrDoublePrVec;
-typedef core::CSmallVector<maths_t::ETail, 2> TTail2Vec;
-typedef core::CSmallVector<maths_t::EProbabilityCalculation, 2> TProbabilityCalculation2Vec;
-typedef core::CSmallVector<TDouble2Vec, 4> TDouble2Vec4Vec;
-typedef core::CSmallVector<TDouble2Vec4Vec, 1> TDouble2Vec4Vec1Vec;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef core::CSmallVector<TSizeDoublePr, 1> TSizeDoublePr1Vec;
+using TSize1Vec = CProbabilityAndInfluenceCalculator::TSize1Vec;
+using TSize2Vec = CProbabilityAndInfluenceCalculator::TSize2Vec;
+using TDouble1Vec = CProbabilityAndInfluenceCalculator::TDouble1Vec;
+using TDouble2Vec = CProbabilityAndInfluenceCalculator::TDouble2Vec;
+using TDouble4Vec = CProbabilityAndInfluenceCalculator::TDouble4Vec;
+using TDouble2Vec1Vec = CProbabilityAndInfluenceCalculator::TDouble2Vec1Vec;
+using TDouble4Vec1Vec = CProbabilityAndInfluenceCalculator::TDouble4Vec1Vec;
+using TDouble1VecDoublePr = CProbabilityAndInfluenceCalculator::TDouble1VecDoublePr;
+using TBool2Vec = CProbabilityAndInfluenceCalculator::TBool2Vec;
+using TTime2Vec = CProbabilityAndInfluenceCalculator::TTime2Vec;
+using TTime2Vec1Vec = CProbabilityAndInfluenceCalculator::TTime2Vec1Vec;
+using TStrCRefDouble1VecDoublePrPr = CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDoublePrPr;
+using TStrCRefDouble1VecDoublePrPrVec = CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDoublePrPrVec;
+using TStrCRefDouble1VecDouble1VecPrPr = CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDouble1VecPrPr;
+using TStrCRefDouble1VecDouble1VecPrPrVec = CProbabilityAndInfluenceCalculator::TStrCRefDouble1VecDouble1VecPrPrVec;
+using TStoredStringPtrStoredStringPtrPr = CProbabilityAndInfluenceCalculator::TStoredStringPtrStoredStringPtrPr;
+using TStoredStringPtrStoredStringPtrPrDoublePr = CProbabilityAndInfluenceCalculator::TStoredStringPtrStoredStringPtrPrDoublePr;
+using TStoredStringPtrStoredStringPtrPrDoublePrVec = CProbabilityAndInfluenceCalculator::TStoredStringPtrStoredStringPtrPrDoublePrVec;
+using TTail2Vec = core::CSmallVector<maths_t::ETail, 2>;
+using TProbabilityCalculation2Vec = core::CSmallVector<maths_t::EProbabilityCalculation, 2>;
+using TDouble2Vec4Vec = core::CSmallVector<TDouble2Vec, 4>;
+using TDouble2Vec4Vec1Vec = core::CSmallVector<TDouble2Vec4Vec, 1>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
 
 //! Get the canonical influence string pointer.
 core::CStoredStringPtr canonical(const std::string &influence)
@@ -88,7 +88,7 @@ class CDecreasingValueInfluence
 class CDecreasingMeanInfluence
 {
     public:
-        typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+        using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     public:
         CDecreasingMeanInfluence(maths_t::ETail tail, const TDouble2Vec &value, double count) :
@@ -121,7 +121,7 @@ class CDecreasingMeanInfluence
 class CDecreasingVarianceInfluence
 {
     public:
-         typedef maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator TMeanVarAccumulator;
+         using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
     public:
         CDecreasingVarianceInfluence(maths_t::ETail tail, const TDouble2Vec &value, double count) :
@@ -764,7 +764,7 @@ bool CProbabilityAndInfluenceCalculator::addProbability(model_t::EFeature featur
 void CProbabilityAndInfluenceCalculator::addProbability(double probability, double weight)
 {
     m_Probability.add(probability, weight);
-    for (auto &&aggregator : m_InfluencerProbabilities)
+    for (auto &aggregator : m_InfluencerProbabilities)
     {
         aggregator.second.add(probability, weight);
     }

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -209,7 +209,7 @@ bool CResourceMonitor::pruneIfRequired(core_t::TTime endTime)
         // Do a prune and see how much we got back
         // These are the expensive operations
         std::size_t usageAfter = 0;
-        for (auto &&model : m_Models)
+        for (auto &model : m_Models)
         {
             model.first->prune(m_PruneWindow);
             model.second = model.first->memoryUsage();

--- a/lib/model/CSample.cc
+++ b/lib/model/CSample.cc
@@ -103,7 +103,7 @@ CSample::CSample(core_t::TTime time,
 
 CSample::TDouble1Vec CSample::value(std::size_t dimension) const
 {
-    typedef std::vector<std::size_t> TSizeVec;
+    using TSizeVec = std::vector<std::size_t>;
 
     TDouble1Vec result;
     const TSizeVec &indices = CFeatureDataIndexing::valueIndices(dimension);

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -213,7 +213,7 @@ void CSearchKey::swap(CSearchKey &other)
 
 bool CSearchKey::operator==(const CSearchKey &rhs) const
 {
-    typedef std::equal_to<std::string> TStrEqualTo;
+    using TStrEqualTo = std::equal_to<std::string>;
 
     return    this->hash() == rhs.hash()
            && m_Identifier == rhs.m_Identifier

--- a/lib/model/FunctionTypes.cc
+++ b/lib/model/FunctionTypes.cc
@@ -30,7 +30,7 @@ namespace model
 namespace function_t
 {
 
-typedef model_t::TFeatureVec TFeatureVec;
+using TFeatureVec = model_t::TFeatureVec;
 
 bool isIndividual(EFunction function)
 {
@@ -552,9 +552,9 @@ bool isForecastSupported(EFunction function)
 namespace
 {
 
-typedef std::map<model_t::EFeature, TFunctionVec> TFeatureFunctionVecMap;
-typedef TFeatureFunctionVecMap::iterator TFeatureFunctionVecMapItr;
-typedef TFeatureFunctionVecMap::const_iterator TFeatureFunctionVecMapCItr;
+using TFeatureFunctionVecMap = std::map<model_t::EFeature, TFunctionVec>;
+using TFeatureFunctionVecMapItr = TFeatureFunctionVecMap::iterator;
+using TFeatureFunctionVecMapCItr = TFeatureFunctionVecMap::const_iterator;
 
 namespace detail
 {

--- a/lib/model/unittest/CAnnotatedProbabilityBuilderTest.cc
+++ b/lib/model/unittest/CAnnotatedProbabilityBuilderTest.cc
@@ -30,12 +30,12 @@ using namespace model;
 
 namespace
 {
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef core::CSmallVector<TSizeDoublePr, 1> TSizeDoublePr1Vec;
-typedef core::CSmallVector<core::CStoredStringPtr, 1> TStoredStringPtr1Vec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
+using TStoredStringPtr1Vec = core::CSmallVector<core::CStoredStringPtr, 1>;
 
 const std::string EMPTY_STRING;
 const core::CStoredStringPtr EMPTY_STRING_PTR(CStringStore::names().getEmpty());

--- a/lib/model/unittest/CAnomalyDetectorModelConfigTest.cc
+++ b/lib/model/unittest/CAnomalyDetectorModelConfigTest.cc
@@ -28,7 +28,7 @@ using namespace model;
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 const function_t::EFunction INDIVIDUAL_COUNT  = function_t::E_IndividualCount;
 const function_t::EFunction INDIVIDUAL_METRIC = function_t::E_IndividualMetricMin;

--- a/lib/model/unittest/CAnomalyScoreTest.cc
+++ b/lib/model/unittest/CAnomalyScoreTest.cc
@@ -45,15 +45,15 @@ using namespace ml;
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 }
 
 void CAnomalyScoreTest::testComputeScores(void)
 {
-    typedef model::CAnomalyScore TScores;
-    typedef maths::CJointProbabilityOfLessLikelySamples TJointProbabilityCalculator;
-    typedef maths::CLogProbabilityOfMFromNExtremeSamples TLogExtremeProbabilityCalculator;
+    using TScores = model::CAnomalyScore;
+    using TJointProbabilityCalculator = maths::CJointProbabilityOfLessLikelySamples;
+    using TLogExtremeProbabilityCalculator = maths::CLogProbabilityOfMFromNExtremeSamples;
 
     const double jointProbabilityWeight = 0.5;
     const double extremeProbabilityWeight = 0.5;
@@ -274,8 +274,8 @@ void CAnomalyScoreTest::testComputeScores(void)
 
 void CAnomalyScoreTest::testNormalizeScoresQuantiles(void)
 {
-    typedef std::multiset<double> TDoubleMSet;
-    typedef TDoubleMSet::iterator TDoubleMSetItr;
+    using TDoubleMSet = std::multiset<double>;
+    using TDoubleMSetItr = TDoubleMSet::iterator;
 
     test::CRandomNumbers rng;
 
@@ -331,8 +331,8 @@ void CAnomalyScoreTest::testNormalizeScoresQuantiles(void)
 
 void CAnomalyScoreTest::testNormalizeScoresNoisy(void)
 {
-    typedef std::multimap<double, std::size_t> TDoubleSizeMap;
-    typedef TDoubleSizeMap::const_iterator TDoubleSizeMapCItr;
+    using TDoubleSizeMap = std::multimap<double, std::size_t>;
+    using TDoubleSizeMapCItr = TDoubleSizeMap::const_iterator;
 
     test::CRandomNumbers rng;
 

--- a/lib/model/unittest/CBucketQueueTest.cc
+++ b/lib/model/unittest/CBucketQueueTest.cc
@@ -28,12 +28,12 @@
 using namespace ml;
 using namespace model;
 
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::pair<TSizeSizePr, uint64_t> TSizeSizePrUInt64Pr;
-typedef std::vector<TSizeSizePrUInt64Pr> TSizeSizePrUInt64PrVec;
-typedef boost::unordered_map<TSizeSizePr, uint64_t> TSizeSizePrUInt64UMap;
-typedef model::CBucketQueue<TSizeSizePrUInt64UMap> TSizeSizePrUInt64UMapQueue;
-typedef TSizeSizePrUInt64UMapQueue::const_iterator TSizeSizePrUInt64UMapQueueCItr;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64PrVec = std::vector<TSizeSizePrUInt64Pr>;
+using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64UMapQueue = model::CBucketQueue<TSizeSizePrUInt64UMap>;
+using TSizeSizePrUInt64UMapQueueCItr = TSizeSizePrUInt64UMapQueue::const_iterator;
 
 void CBucketQueueTest::testConstructorFillsQueue(void)
 {
@@ -105,7 +105,7 @@ void CBucketQueueTest::testClear(void)
 
 void CBucketQueueTest::testIterators(void)
 {
-    typedef CBucketQueue<std::string>::iterator TStringQueueItr;
+    using TStringQueueItr = CBucketQueue<std::string>::iterator;
 
     CBucketQueue<std::string> queue(1, 5, 0);
     queue.push("a", 5);
@@ -124,7 +124,7 @@ void CBucketQueueTest::testIterators(void)
 
 void CBucketQueueTest::testReverseIterators(void)
 {
-    typedef CBucketQueue<std::string>::const_reverse_iterator TStringQueueCRItr;
+    using TStringQueueCRItr = CBucketQueue<std::string>::const_reverse_iterator;
 
     CBucketQueue<std::string> queue(1, 5, 0);
     queue.push("a", 5);

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -36,8 +36,8 @@ using namespace model;
 namespace
 {
 
-typedef std::vector<model_t::EFeature> TFeatureVec;
-typedef std::vector<std::string> TStrVec;
+using TFeatureVec = std::vector<model_t::EFeature>;
+using TStrVec = std::vector<std::string>;
 
 const std::string EMPTY_STRING;
 }

--- a/lib/model/unittest/CDetectorEqualizerTest.cc
+++ b/lib/model/unittest/CDetectorEqualizerTest.cc
@@ -30,12 +30,12 @@
 
 using namespace ml;
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 namespace
 {
 
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 const double THRESHOLD = ::log(0.05);
 
 }

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -41,12 +41,12 @@
 namespace
 {
 
-typedef std::vector<ml::core_t::TTime> TTimeVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::map<ml::core_t::TTime, double> TTimeDoubleMap;
-typedef TTimeDoubleMap::const_iterator TTimeDoubleMapCItr;
-typedef std::pair<ml::core_t::TTime, std::string> TTimeStrPr;
-typedef std::set<TTimeStrPr> TTimeStrPrSet;
+using TTimeVec = std::vector<ml::core_t::TTime>;
+using TStrVec = std::vector<std::string>;
+using TTimeDoubleMap = std::map<ml::core_t::TTime, double>;
+using TTimeDoubleMapCItr = TTimeDoubleMap::const_iterator;
+using TTimeStrPr = std::pair<ml::core_t::TTime, std::string>;
+using TTimeStrPrSet = std::set<TTimeStrPr>;
 
 const std::string EMPTY_STRING;
 
@@ -155,9 +155,9 @@ void importData(ml::core_t::TTime firstTime,
                 const TStrVec &fileNames,
                 ml::model::CAnomalyDetector &detector)
 {
-    typedef boost::shared_ptr<std::ifstream> TifstreamPtr;
-    typedef std::vector<TifstreamPtr> TifstreamPtrVec;
-    typedef std::vector<ml::core_t::TTime> TTimeVec;
+    using TifstreamPtr = boost::shared_ptr<std::ifstream>;
+    using TifstreamPtrVec = std::vector<TifstreamPtr>;
+    using TTimeVec = std::vector<ml::core_t::TTime>;
 
     TifstreamPtrVec ifss;
     for (std::size_t i = 0u; i < fileNames.size(); ++i)

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -42,27 +42,27 @@
 using namespace ml;
 using namespace model;
 
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<model_t::EFeature> TFeatureVec;
-typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
-typedef std::vector<std::string> TStrVec;
-typedef TStrVec::const_iterator TStrVecCItr;
-typedef std::vector<TStrVec> TStrVecVec;
-typedef SEventRateFeatureData TFeatureData;
-typedef std::pair<std::size_t, TFeatureData> TSizeFeatureDataPr;
-typedef std::vector<TSizeFeatureDataPr> TSizeFeatureDataPrVec;
-typedef std::pair<model_t::EFeature, TSizeFeatureDataPrVec> TFeatureSizeFeatureDataPrVecPr;
-typedef std::vector<TFeatureSizeFeatureDataPrVecPr> TFeatureSizeFeatureDataPrVecPrVec;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::pair<TSizeSizePr, TFeatureData> TSizeSizePrFeatureDataPr;
-typedef std::vector<TSizeSizePrFeatureDataPr> TSizeSizePrFeatureDataPrVec;
-typedef std::pair<model_t::EFeature, TSizeSizePrFeatureDataPrVec> TFeatureSizeSizePrFeatureDataPrVecPr;
-typedef std::vector<TFeatureSizeSizePrFeatureDataPrVecPr> TFeatureSizeSizePrFeatureDataPrVecPrVec;
-typedef CBucketGatherer::TSizeSizePrStoredStringPtrPr TSizeSizePrStoredStringPtrPr;
-typedef CBucketGatherer::TSizeSizePrStoredStringPtrPrUInt64UMapVec TSizeSizePrStoredStringPtrPrUInt64UMapVec;
-typedef std::vector<core_t::TTime> TTimeVec;
-typedef CBucketGatherer::TStrCPtrVec TStrCPtrVec;
+using TSizeVec = std::vector<std::size_t>;
+using TFeatureVec = std::vector<model_t::EFeature>;
+using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
+using TStrVec = std::vector<std::string>;
+using TStrVecCItr = TStrVec::const_iterator;
+using TStrVecVec = std::vector<TStrVec>;
+using TFeatureData = SEventRateFeatureData;
+using TSizeFeatureDataPr = std::pair<std::size_t, TFeatureData>;
+using TSizeFeatureDataPrVec = std::vector<TSizeFeatureDataPr>;
+using TFeatureSizeFeatureDataPrVecPr = std::pair<model_t::EFeature, TSizeFeatureDataPrVec>;
+using TFeatureSizeFeatureDataPrVecPrVec = std::vector<TFeatureSizeFeatureDataPrVecPr>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrFeatureDataPr = std::pair<TSizeSizePr, TFeatureData>;
+using TSizeSizePrFeatureDataPrVec = std::vector<TSizeSizePrFeatureDataPr>;
+using TFeatureSizeSizePrFeatureDataPrVecPr = std::pair<model_t::EFeature, TSizeSizePrFeatureDataPrVec>;
+using TFeatureSizeSizePrFeatureDataPrVecPrVec = std::vector<TFeatureSizeSizePrFeatureDataPrVecPr>;
+using TSizeSizePrStoredStringPtrPr = CBucketGatherer::TSizeSizePrStoredStringPtrPr;
+using TSizeSizePrStoredStringPtrPrUInt64UMapVec = CBucketGatherer::TSizeSizePrStoredStringPtrPrUInt64UMapVec;
+using TTimeVec = std::vector<core_t::TTime>;
+using TStrCPtrVec = CBucketGatherer::TStrCPtrVec;
 
 namespace
 {
@@ -283,7 +283,7 @@ void importCsvData(CDataGatherer &gatherer,
                    const std::string &filename,
                    const TSizeVec &fields)
 {
-    typedef boost::shared_ptr<std::ifstream> TifstreamPtr;
+    using TifstreamPtr = boost::shared_ptr<std::ifstream>;
     TifstreamPtr ifs(new std::ifstream(filename.c_str()));
     CPPUNIT_ASSERT(ifs->is_open());
 
@@ -1629,7 +1629,7 @@ void CEventRateDataGathererTest::testInfluencerBucketStatistics(void)
 
 void CEventRateDataGathererTest::testDistinctStrings(void)
 {
-    typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
+    using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
     TSizeSizePr pair(0, 0);
 
     // Test the SUniqueStringFeatureData struct

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -62,26 +62,26 @@ using namespace model;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef std::vector<uint64_t> TUInt64Vec;
-typedef std::vector<core_t::TTime> TTimeVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef std::vector<TSizeVecVec> TSizeVecVecVec;
-typedef std::vector<std::string> TStrVec;
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 2> TDouble2Vec;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef core::CSmallVector<TSizeDoublePr, 1> TSizeDoublePr1Vec;
-typedef boost::optional<std::string> TOptionalStr;
-typedef boost::optional<uint64_t> TOptionalUInt64;
-typedef boost::optional<double> TOptionalDouble;
-typedef std::vector<TOptionalDouble> TOptionalDoubleVec;
-typedef boost::shared_ptr<maths::CModel> TMathsModelPtr;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TUInt64Vec = std::vector<uint64_t>;
+using TTimeVec = std::vector<core_t::TTime>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TSizeVecVecVec = std::vector<TSizeVecVec>;
+using TStrVec = std::vector<std::string>;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble2Vec = core::CSmallVector<double, 2>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
+using TOptionalStr = boost::optional<std::string>;
+using TOptionalUInt64 = boost::optional<uint64_t>;
+using TOptionalDouble = boost::optional<double>;
+using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+using TMathsModelPtr = boost::shared_ptr<maths::CModel>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 const std::string EMPTY_STRING;
 
@@ -630,8 +630,8 @@ void CEventRateModelTest::testOnlineProbabilityCalculation(void)
 {
     LOG_DEBUG("*** testOnlineProbabilityCalculation ***");
 
-    typedef std::pair<double, std::size_t> TDoubleSizePr;
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr> TMinAccumulator;
+    using TDoubleSizePr = std::pair<double, std::size_t>;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr>;
 
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
@@ -807,8 +807,8 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend(void)
     // Check we find the correct correlated variables, and identify
     // correlate and marginal anomalies.
 
-    typedef core::CTriple<double, std::size_t, std::string> TDoubleSizeStrTr;
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizeStrTr> TMinAccumulator;
+    using TDoubleSizeStrTr = core::CTriple<double, std::size_t, std::string>;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizeStrTr>;
 
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
@@ -1062,8 +1062,8 @@ void CEventRateModelTest::testOnlineCorrelatedTrend(void)
     // Check we find the correct correlated variables, and identify
     // correlate and marginal anomalies.
 
-    typedef core::CTriple<double, std::size_t, std::string> TDoubleSizeStrTr;
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizeStrTr> TMinAccumulator;
+    using TDoubleSizeStrTr = core::CTriple<double, std::size_t, std::string>;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizeStrTr>;
 
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 600;
@@ -1204,9 +1204,9 @@ void CEventRateModelTest::testPrune(void)
 {
     LOG_DEBUG("*** testPrune ***");
 
-    typedef std::vector<TUInt64Vec> TUInt64VecVec;
-    typedef std::vector<CEventData> TEventDataVec;
-    typedef std::map<std::size_t, std::size_t> TSizeSizeMap;
+    using TUInt64VecVec = std::vector<TUInt64Vec>;
+    using TEventDataVec = std::vector<CEventData>;
+    using TSizeSizeMap = std::map<std::size_t, std::size_t>;
 
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -66,25 +66,25 @@ struct SMessage
     std::string s_Person;
 };
 
-typedef std::vector<SMessage> TMessageVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
-typedef boost::shared_ptr<CDataGatherer> TEventRateDataGathererPtr;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::map<TSizeSizePr, uint64_t> TSizeSizePrUInt64Map;
-typedef TSizeSizePrUInt64Map::iterator TSizeSizePrUInt64MapCItr;
-typedef std::set<std::size_t> TSizeSet;
-typedef std::map<std::size_t, TSizeSet> TSizeSizeSetMap;
-typedef std::set<std::string> TStrSet;
-typedef std::map<std::size_t, TStrSet> TSizeStrSetMap;
-typedef std::map<std::size_t, TStrSet>::iterator TSizeStrSetMapItr;
-typedef SEventRateFeatureData TFeatureData;
-typedef std::pair<std::string, TFeatureData> TStrFeatureDataPr;
-typedef std::vector<TStrFeatureDataPr> TStrFeatureDataPrVec;
-typedef std::pair<TSizeSizePr, TFeatureData> TSizeSizePrFeatureDataPr;
-typedef std::vector<TSizeSizePrFeatureDataPr> TSizeSizePrFeatureDataPrVec;
-typedef std::pair<model_t::EFeature, TSizeSizePrFeatureDataPrVec> TFeatureSizeSizePrFeatureDataPrVecPr;
-typedef std::vector<TFeatureSizeSizePrFeatureDataPrVecPr> TFeatureSizeSizePrFeatureDataPrVecPrVec;
+using TMessageVec = std::vector<SMessage>;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
+using TEventRateDataGathererPtr = boost::shared_ptr<CDataGatherer>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64MapCItr = TSizeSizePrUInt64Map::iterator;
+using TSizeSet = std::set<std::size_t>;
+using TSizeSizeSetMap = std::map<std::size_t, TSizeSet>;
+using TStrSet = std::set<std::string>;
+using TSizeStrSetMap = std::map<std::size_t, TStrSet>;
+using TSizeStrSetMapItr = std::map<std::size_t, TStrSet>::iterator;
+using TFeatureData = SEventRateFeatureData;
+using TStrFeatureDataPr = std::pair<std::string, TFeatureData>;
+using TStrFeatureDataPrVec = std::vector<TStrFeatureDataPr>;
+using TSizeSizePrFeatureDataPr = std::pair<TSizeSizePr, TFeatureData>;
+using TSizeSizePrFeatureDataPrVec = std::vector<TSizeSizePrFeatureDataPr>;
+using TFeatureSizeSizePrFeatureDataPrVecPr = std::pair<model_t::EFeature, TSizeSizePrFeatureDataPrVec>;
+using TFeatureSizeSizePrFeatureDataPrVecPrVec = std::vector<TFeatureSizeSizePrFeatureDataPrVecPr>;
 
 TStrVec allCategories(void)
 {
@@ -113,8 +113,8 @@ void generateTestMessages(test::CRandomNumbers &rng,
                           core_t::TTime bucketLength,
                           TMessageVec &messages)
 {
-    typedef std::vector<unsigned int> TUIntVec;
-    typedef std::vector<double> TDoubleVec;
+    using TUIntVec = std::vector<unsigned int>;
+    using TDoubleVec = std::vector<double>;
 
     LOG_DEBUG("bucket = [" << time << ", " << time + bucketLength << ")");
 
@@ -262,7 +262,7 @@ void CEventRatePopulationDataGathererTest::testAttributeCounts(void)
     // We check that we correctly sample the unique people per
     // attribute and (attribute, person) pair counts.
 
-    typedef std::map<std::string, std::size_t> TStrSizeMap;
+    using TStrSizeMap = std::map<std::string, std::size_t>;
 
     const core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -658,9 +658,9 @@ void CEventRatePopulationDataGathererTest::testRemovePeople(void)
 {
     LOG_DEBUG("*** CEventRatePopulationDataGathererTest::testRemovePeople ***");
 
-    typedef std::map<std::string, std::size_t> TStrSizeMap;
-    typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-    typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
+    using TStrSizeMap = std::map<std::string, std::size_t>;
+    using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+    using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
 
     const core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -60,21 +60,21 @@ using namespace model;
 namespace
 {
 
-typedef boost::optional<double> TOptionalDouble;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::vector<std::string> TStrVec;
-typedef std::vector<unsigned int> TUIntVec;
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef std::pair<double, std::string> TDoubleStrPr;
-typedef std::vector<TDoubleStrPr> TDoubleStrPrVec;
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef core::CSmallVector<TSizeDoublePr, 1> TSizeDoublePr1Vec;
+using TOptionalDouble = boost::optional<double>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TStrVec = std::vector<std::string>;
+using TUIntVec = std::vector<unsigned int>;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TDoubleStrPr = std::pair<double, std::string>;
+using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
 
 const std::string EMPTY_STRING;
 
@@ -131,7 +131,7 @@ struct SAnomaly
     }
 };
 
-typedef std::vector<SMessage> TMessageVec;
+using TMessageVec = std::vector<SMessage>;
 
 void generateTestMessages(core_t::TTime startTime,
                           core_t::TTime bucketLength,
@@ -151,7 +151,7 @@ void generateTestMessages(core_t::TTime startTime,
     //
     // There are 100 buckets.
 
-    typedef boost::tuple<std::size_t, std::size_t, size_t> TSizeSizeSizeTr;
+    using TSizeSizeSizeTr = boost::tuple<std::size_t, std::size_t, size_t>;
 
     const std::size_t numberBuckets = 100u;
     const std::size_t numberAttributes = 5u;
@@ -255,12 +255,12 @@ void CEventRatePopulationModelTest::testBasicAccessors(void)
     // Check that the correct data is read retrieved by the
     // basic model accessors.
 
-    typedef boost::optional<uint64_t> TOptionalUInt64;
-    typedef std::map<std::string, uint64_t> TStrUInt64Map;
-    typedef TStrUInt64Map::const_iterator TStrUInt64MapCItr;
-    typedef std::pair<std::string, std::string> TStrStrPr;
-    typedef std::map<TStrStrPr, double> TStrStrPrDoubleMap;
-    typedef TStrStrPrDoubleMap::const_iterator TStrStrPrDoubleMapCItr;
+    using TOptionalUInt64 = boost::optional<uint64_t>;
+    using TStrUInt64Map = std::map<std::string, uint64_t>;
+    using TStrUInt64MapCItr = TStrUInt64Map::const_iterator;
+    using TStrStrPr = std::pair<std::string, std::string>;
+    using TStrStrPrDoubleMap = std::map<TStrStrPr, double>;
+    using TStrStrPrDoubleMapCItr = TStrStrPrDoubleMap::const_iterator;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -373,22 +373,22 @@ void CEventRatePopulationModelTest::testFeatures(void)
     // We check that the correct data is read from the gatherer
     // into the model on sample.
 
-    typedef core::CSmallVector<double, 2> TDouble2Vec;
-    typedef std::vector<TDouble2Vec> TDouble2VecVec;
-    typedef core::CSmallVector<TDouble2Vec, 4> TDouble2Vec4Vec;
-    typedef std::vector<TDouble2Vec4Vec> TDouble2Vec4VecVec;
-    typedef std::set<std::size_t> TSizeSet;
-    typedef std::map<std::size_t, TSizeSet> TSizeSizeSetMap;
-    typedef std::pair<std::string, std::string> TStrStrPr;
-    typedef std::map<TStrStrPr, uint64_t> TStrStrPrUint64Map;
-    typedef SEventRateFeatureData TFeatureData;
-    typedef CEventRatePopulationModel::TSizeSizePrFeatureDataPr TSizeSizePrFeatureDataPr;
-    typedef std::vector<TSizeSizePrFeatureDataPr> TSizeSizePrFeatureDataPrVec;
-    typedef std::map<TSizeSizePr, uint64_t> TSizeSizePrUInt64Map;
-    typedef boost::shared_ptr<maths::CModel> TMathsModelPtr;
-    typedef std::map<std::size_t, TMathsModelPtr> TSizeMathsModelPtrMap;
-    typedef std::pair<TDouble2VecVec, TDouble2Vec4VecVec> TDouble2VecVecDouble2Vec4VecVecPr;
-    typedef std::map<std::size_t, TDouble2VecVecDouble2Vec4VecVecPr> TSizeDouble2VecVecDouble2Vec4VecVecPrMap;
+    using TDouble2Vec = core::CSmallVector<double, 2>;
+    using TDouble2VecVec = std::vector<TDouble2Vec>;
+    using TDouble2Vec4Vec = core::CSmallVector<TDouble2Vec, 4>;
+    using TDouble2Vec4VecVec = std::vector<TDouble2Vec4Vec>;
+    using TSizeSet = std::set<std::size_t>;
+    using TSizeSizeSetMap = std::map<std::size_t, TSizeSet>;
+    using TStrStrPr = std::pair<std::string, std::string>;
+    using TStrStrPrUint64Map = std::map<TStrStrPr, uint64_t>;
+    using TFeatureData = SEventRateFeatureData;
+    using TSizeSizePrFeatureDataPr = CEventRatePopulationModel::TSizeSizePrFeatureDataPr;
+    using TSizeSizePrFeatureDataPrVec = std::vector<TSizeSizePrFeatureDataPr>;
+    using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+    using TMathsModelPtr = boost::shared_ptr<maths::CModel>;
+    using TSizeMathsModelPtrMap = std::map<std::size_t, TMathsModelPtr>;
+    using TDouble2VecVecDouble2Vec4VecVecPr = std::pair<TDouble2VecVec, TDouble2Vec4VecVec>;
+    using TSizeDouble2VecVecDouble2Vec4VecVecPrMap = std::map<std::size_t, TDouble2VecVecDouble2Vec4VecVecPr>;
 
     static const maths_t::TWeightStyleVec WEIGHT_STYLES{maths_t::E_SampleCountWeight,
                                                         maths_t::E_SampleWinsorisationWeight};
@@ -535,10 +535,10 @@ void CEventRatePopulationModelTest::testComputeProbability(void)
 
     // Check that we get the probabilities we expect.
 
-    typedef std::vector<SAnomaly> TAnomalyVec;
-    typedef std::pair<double, SAnomaly> TDoubleAnomalyPr;
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TDoubleAnomalyPr,
-                                                          maths::COrderings::SFirstLess> TAnomalyAccumulator;
+    using TAnomalyVec = std::vector<SAnomaly>;
+    using TDoubleAnomalyPr = std::pair<double, SAnomaly>;
+    using TAnomalyAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<
+                                    TDoubleAnomalyPr, maths::COrderings::SFirstLess>;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -631,9 +631,9 @@ void CEventRatePopulationModelTest::testPrune(void)
     // This test has four people and five attributes. We expect
     // person 2 and attributes 1, 2 and 5 to be deleted.
 
-    typedef std::pair<std::string, std::size_t> TStrSizePr;
-    typedef std::vector<TStrSizePr> TStrSizePrVec;
-    typedef std::vector<TStrSizePrVec> TStrSizePrVecVec;
+    using TStrSizePr = std::pair<std::string, std::size_t>;
+    using TStrSizePrVec = std::vector<TStrSizePr>;
+    using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -889,7 +889,7 @@ void CEventRatePopulationModelTest::testFrequency(void)
 {
     LOG_DEBUG("*** CEventRatePopulationModelTest::testFrequency ***");
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     // Test we correctly compute frequencies for people and attributes.
 
@@ -1124,8 +1124,8 @@ void CEventRatePopulationModelTest::testPeriodicity(void)
     // Create a daily periodic population and check that the
     // periodicity is learned and compensated (approximately).
 
-    typedef std::map<std::string, double> TStrDoubleMap;
-    typedef TStrDoubleMap::const_iterator TStrDoubleMapCItr;
+    using TStrDoubleMap = std::map<std::string, double>;
+    using TStrDoubleMapCItr = TStrDoubleMap::const_iterator;
 
     static const core_t::TTime HOUR = 3600;
     static const core_t::TTime DAY = 86400;

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -55,12 +55,12 @@ using namespace ml;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef model::CHierarchicalResults::TAttributeProbabilityVec TAttributeProbabilityVec;
-typedef model::CHierarchicalResults::TStoredStringPtrStoredStringPtrPr TStoredStringPtrStoredStringPtrPr;
-typedef model::CHierarchicalResults::TStoredStringPtrStoredStringPtrPrDoublePr TStoredStringPtrStoredStringPtrPrDoublePr;
-typedef model::CHierarchicalResults::TStoredStringPtrStoredStringPtrPrDoublePrVec TStoredStringPtrStoredStringPtrPrDoublePrVec;
-typedef std::vector<std::string> TStrVec;
+using TDoubleVec = std::vector<double>;
+using TAttributeProbabilityVec = model::CHierarchicalResults::TAttributeProbabilityVec;
+using TStoredStringPtrStoredStringPtrPr = model::CHierarchicalResults::TStoredStringPtrStoredStringPtrPr;
+using TStoredStringPtrStoredStringPtrPrDoublePr = model::CHierarchicalResults::TStoredStringPtrStoredStringPtrPrDoublePr;
+using TStoredStringPtrStoredStringPtrPrDoublePrVec = model::CHierarchicalResults::TStoredStringPtrStoredStringPtrPrDoublePrVec;
+using TStrVec = std::vector<std::string>;
 
 const std::string EMPTY_STRING;
 
@@ -68,8 +68,8 @@ const std::string EMPTY_STRING;
 class CBreadthFirstCheck : public model::CHierarchicalResultsVisitor
 {
     public:
-        typedef std::set<const TNode*> TNodeCPtrSet;
-        typedef std::vector<TNodeCPtrSet> TNodeCPtrSetVec;
+        using TNodeCPtrSet = std::set<const TNode*>;
+        using TNodeCPtrSetVec = std::vector<TNodeCPtrSet>;
 
     public:
         CBreadthFirstCheck(void) :
@@ -117,7 +117,7 @@ class CBreadthFirstCheck : public model::CHierarchicalResultsVisitor
             // Check we have the expected number of layers and that
             // all nodes are in a lower layer than their parents.
 
-            typedef TNodeCPtrSet::const_iterator TNodeCPtrSetCItr;
+            using TNodeCPtrSetCItr = TNodeCPtrSet::const_iterator;
 
             LOG_DEBUG("# layers = " << m_Layers.size());
             CPPUNIT_ASSERT_EQUAL(expectedLayers, m_Layers.size());
@@ -168,7 +168,7 @@ class CBreadthFirstCheck : public model::CHierarchicalResultsVisitor
 class CDepthFirstCheck : public model::CHierarchicalResultsVisitor
 {
     public:
-        typedef std::vector<const TNode*> TNodeCPtrVec;
+        using TNodeCPtrVec = std::vector<const TNode*>;
 
     public:
         virtual void visit(const model::CHierarchicalResults &/*results*/,
@@ -243,7 +243,7 @@ class CPrinter : public model::CHierarchicalResultsVisitor
 class CNodeExtractor : public model::CHierarchicalResultsVisitor
 {
     public:
-        typedef std::vector<const TNode*> TNodeCPtrVec;
+        using TNodeCPtrVec = std::vector<const TNode*>;
 
     public:
         virtual void visit(const model::CHierarchicalResults &/*results*/,
@@ -357,8 +357,8 @@ class CWriteConsistencyChecker : public model::CHierarchicalResultsVisitor
         const model::CLimits &m_Limits;
 };
 
-typedef std::map<int, TDoubleVec> TIntDoubleVecMap;
-typedef TIntDoubleVecMap::const_iterator TIntDoubleVecMapCItr;
+using TIntDoubleVecMap = std::map<int, TDoubleVec>;
+using TIntDoubleVecMapCItr = TIntDoubleVecMap::const_iterator;
 
 //! \brief Node probability container.
 struct SNodeProbabilities
@@ -373,8 +373,8 @@ struct SNodeProbabilities
 class CProbabilityGatherer : public model::CHierarchicalResultsLevelSet<SNodeProbabilities>
 {
     public:
-        typedef model::CHierarchicalResultsLevelSet<SNodeProbabilities> TBase;
-        typedef TBase::TTypePtrVec TNodeProbabilitiesPtrVec;
+        using TBase = model::CHierarchicalResultsLevelSet<SNodeProbabilities>;
+        using TNodeProbabilitiesPtrVec = TBase::TTypePtrVec;
 
         class CFactory
         {
@@ -1056,7 +1056,7 @@ void CHierarchicalResultsTest::testAggregator(void)
 {
     LOG_DEBUG("*** testAggregator ***");
 
-    typedef std::vector<model::SAnnotatedProbability> TAnnotatedProbabilityVec;
+    using TAnnotatedProbabilityVec = std::vector<model::SAnnotatedProbability>;
 
     model::CAnomalyDetectorModelConfig modelConfig = model::CAnomalyDetectorModelConfig::defaultConfig();
     model::CHierarchicalResultsAggregator aggregator(modelConfig);
@@ -1470,7 +1470,7 @@ void CHierarchicalResultsTest::testWriter(void)
 
     // Test complex.
     {
-        typedef model::CDataGatherer::TStrCPtrVec TStrCPtrVec;
+        using TStrCPtrVec = model::CDataGatherer::TStrCPtrVec;
         model::SModelParams params(modelConfig.bucketLength());
         model::CSearchKey key;
         model::CAnomalyDetectorModel::TDataGathererPtr dataGatherer(
@@ -1531,10 +1531,10 @@ void CHierarchicalResultsTest::testNormalizer(void)
 {
     LOG_DEBUG("*** testNormalizer ***");
 
-    typedef boost::shared_ptr<model::CAnomalyScore::CNormalizer> TNormalizerPtr;
-    typedef std::map<std::string, TNormalizerPtr> TStrNormalizerPtrMap;
-    typedef TStrNormalizerPtrMap::iterator TStrNormalizerPtrMapItr;
-    typedef std::set<const model::CHierarchicalResultsVisitor::TNode*> TNodeCPtrSet;
+    using TNormalizerPtr = boost::shared_ptr<model::CAnomalyScore::CNormalizer>;
+    using TStrNormalizerPtrMap = std::map<std::string, TNormalizerPtr>;
+    using TStrNormalizerPtrMapItr = TStrNormalizerPtrMap::iterator;
+    using TNodeCPtrSet = std::set<const model::CHierarchicalResultsVisitor::TNode*>;
 
     model::CAnomalyDetectorModelConfig modelConfig = model::CAnomalyDetectorModelConfig::defaultConfig();
     model::CHierarchicalResultsAggregator aggregator(modelConfig);
@@ -1911,7 +1911,7 @@ void CHierarchicalResultsTest::testDetectorEqualizing(void)
             results.bottomUpBreadthFirst(aggregator);
         }
 
-        typedef std::pair<double, std::size_t> TDoubleSizePr;
+        using TDoubleSizePr = std::pair<double, std::size_t>;
         maths::CBasicStatistics::COrderStatisticsStack<TDoubleSizePr, 2> mostAnomalous;
 
         for (std::size_t i = 0u; i < 100; ++i)

--- a/lib/model/unittest/CInterimBucketCorrectorTest.cc
+++ b/lib/model/unittest/CInterimBucketCorrectorTest.cc
@@ -31,8 +31,8 @@ using namespace model;
 
 namespace
 {
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 10> TDouble10Vec;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble10Vec = core::CSmallVector<double, 10>;
 const double EPSILON = 1e-10;
 }
 

--- a/lib/model/unittest/CMetricAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CMetricAnomalyDetectorTest.cc
@@ -48,9 +48,9 @@ using namespace ml;
 namespace
 {
 
-typedef std::pair<core_t::TTime, core_t::TTime> TTimeTimePr;
-typedef std::vector<TTimeTimePr> TTimeTimePrVec;
-typedef std::vector<double> TDoubleVec;
+using TTimeTimePr = std::pair<core_t::TTime, core_t::TTime>;
+using TTimeTimePrVec = std::vector<TTimeTimePr>;
+using TDoubleVec = std::vector<double>;
 
 bool doIntersect(const TTimeTimePr &i1, const TTimeTimePr &i2)
 {
@@ -221,7 +221,7 @@ void importCsvData(core_t::TTime firstTime,
                    const std::string &fileName,
                    model::CAnomalyDetector &detector)
 {
-    typedef boost::shared_ptr<std::ifstream> TifstreamPtr;
+    using TifstreamPtr = boost::shared_ptr<std::ifstream>;
     TifstreamPtr ifs(new std::ifstream(fileName.c_str()));
     CPPUNIT_ASSERT(ifs->is_open());
 

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -41,23 +41,23 @@ using namespace model;
 
 namespace
 {
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::vector<model_t::EFeature> TFeatureVec;
-typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::pair<std::size_t, SMetricFeatureData> TSizeFeatureDataPr;
-typedef std::vector<TSizeFeatureDataPr> TSizeFeatureDataPrVec;
-typedef std::pair<model_t::EFeature, TSizeFeatureDataPrVec> TFeatureSizeFeatureDataPrVecPr;
-typedef std::vector<TFeatureSizeFeatureDataPrVecPr> TFeatureSizeFeatureDataPrVecPrVec;
-typedef boost::optional<double> TOptionalDouble;
-typedef boost::optional<std::string> TOptionalStr;
-typedef std::pair<core_t::TTime, double> TTimeDoublePr;
-typedef std::vector<TTimeDoublePr> TTimeDoublePrVec;
-typedef std::vector<TTimeDoublePrVec> TTimeDoublePrVecVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TFeatureVec = std::vector<model_t::EFeature>;
+using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
+using TStrVec = std::vector<std::string>;
+using TSizeFeatureDataPr = std::pair<std::size_t, SMetricFeatureData>;
+using TSizeFeatureDataPrVec = std::vector<TSizeFeatureDataPr>;
+using TFeatureSizeFeatureDataPrVecPr = std::pair<model_t::EFeature, TSizeFeatureDataPrVec>;
+using TFeatureSizeFeatureDataPrVecPrVec = std::vector<TFeatureSizeFeatureDataPrVecPr>;
+using TOptionalDouble = boost::optional<double>;
+using TOptionalStr = boost::optional<std::string>;
+using TTimeDoublePr = std::pair<core_t::TTime, double>;
+using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
+using TTimeDoublePrVecVec = std::vector<TTimeDoublePrVec>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 std::size_t addPerson(const std::string &p,
                       CDataGatherer &gatherer,
@@ -1521,10 +1521,10 @@ void CMetricDataGathererTest::testInfluenceStatistics(void)
 {
     LOG_DEBUG("*** CMetricDataGathererTest::testInfluenceStatistics ***");
 
-    typedef boost::tuple<core_t::TTime, double, std::string, std::string> TTimeDoubleStrStrTuple;
-    typedef std::pair<double, double> TDoubleDoublePr;
-    typedef std::pair<std::string, TDoubleDoublePr> TStrDoubleDoublePrPr;
-    typedef std::vector<TStrDoubleDoublePrPr> TStrDoubleDoublePrPrVec;
+    using TTimeDoubleStrStrTuple = boost::tuple<core_t::TTime, double, std::string, std::string>;
+    using TDoubleDoublePr = std::pair<double, double>;
+    using TStrDoubleDoublePrPr = std::pair<std::string, TDoubleDoublePr>;
+    using TStrDoubleDoublePrPrVec = std::vector<TStrDoubleDoublePrPr>;
 
     const core_t::TTime startTime = 0;
     const core_t::TTime bucketLength = 600;
@@ -1666,9 +1666,9 @@ void CMetricDataGathererTest::testInfluenceStatistics(void)
 
 void CMetricDataGathererTest::testMultivariate(void)
 {
-    typedef boost::tuple<core_t::TTime, double, double> TTimeDoubleDoubleTuple;
-    typedef std::vector<TTimeDoubleDoubleTuple> TTimeDoubleDoubleTupleVec;
-    typedef std::vector<TTimeDoubleDoubleTupleVec> TTimeDoubleDoubleTupleVecVec;
+    using TTimeDoubleDoubleTuple = boost::tuple<core_t::TTime, double, double>;
+    using TTimeDoubleDoubleTupleVec = std::vector<TTimeDoubleDoubleTuple>;
+    using TTimeDoubleDoubleTupleVecVec = std::vector<TTimeDoubleDoubleTupleVec>;
 
     static const std::string DELIMITER("__");
 

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -63,36 +63,36 @@ using namespace model;
 namespace
 {
 
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef std::pair<double, std::size_t> TDoubleSizePr;
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<TDoubleVec> TDoubleVecVec;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::vector<TStrVec> TStrVecVec;
-typedef boost::optional<uint64_t> TOptionalUInt64;
-typedef boost::optional<double> TOptionalDouble;
-typedef std::vector<TOptionalDouble> TOptionalDoubleVec;
-typedef boost::optional<std::string> TOptionalStr;
-typedef std::pair<core_t::TTime, double> TTimeDoublePr;
-typedef boost::optional<TTimeDoublePr> TOptionalTimeDoublePr;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u> TMinAccumulator;
-typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double> > TMaxAccumulator;
-typedef boost::shared_ptr<maths::CModel> TMathsModelPtr;
-typedef boost::shared_ptr<maths::CPrior> TPriorPtr;
-typedef boost::shared_ptr<maths::CMultivariatePrior> TMultivariatePriorPtr;
-typedef std::pair<double, std::string> TDoubleStrPr;
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 2> TDouble2Vec;
-typedef core::CSmallVector<double, 4> TDouble4Vec;
-typedef core::CSmallVector<TDouble4Vec, 1> TDouble4Vec1Vec;
-typedef std::pair<std::size_t, double> TSizeDoublePr;
-typedef core::CSmallVector<TSizeDoublePr, 1> TSizeDoublePr1Vec;
-typedef std::vector<std::string> TStrVec;
-typedef std::pair<core_t::TTime, TStrVec> TTimeStrVecPr;
-typedef std::vector<TTimeStrVecPr> TTimeStrVecPrVec;
+using TDoubleDoublePr = std::pair<double, double>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TDoubleSizePr = std::pair<double, std::size_t>;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TStrVec = std::vector<std::string>;
+using TStrVecVec = std::vector<TStrVec>;
+using TOptionalUInt64 = boost::optional<uint64_t>;
+using TOptionalDouble = boost::optional<double>;
+using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+using TOptionalStr = boost::optional<std::string>;
+using TTimeDoublePr = std::pair<core_t::TTime, double>;
+using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u>;
+using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>>;
+using TMathsModelPtr = boost::shared_ptr<maths::CModel>;
+using TPriorPtr = boost::shared_ptr<maths::CPrior>;
+using TMultivariatePriorPtr = boost::shared_ptr<maths::CMultivariatePrior>;
+using TDoubleStrPr = std::pair<double, std::string>;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble2Vec = core::CSmallVector<double, 2>;
+using TDouble4Vec = core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
+using TStrVec = std::vector<std::string>;
+using TTimeStrVecPr = std::pair<core_t::TTime, TStrVec>;
+using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
 
 const std::string EMPTY_STRING;
 
@@ -569,11 +569,11 @@ void CMetricModelTest::testMultivariateSample(void)
 {
     LOG_DEBUG("*** testMultivariateSample ***");
 
-    typedef std::vector<TDoubleVecVec> TDoubleVecVecVec;
-    typedef maths::CVectorNx1<double, 2> TVector2;
-    typedef maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator TMean2Accumulator;
-    typedef std::pair<core_t::TTime, boost::array<double, 2> > TTimeDouble2AryPr;
-    typedef std::vector<TTimeDouble2AryPr> TTimeDouble2AryPrVec;
+    using TDoubleVecVecVec = std::vector<TDoubleVecVec>;
+    using TVector2 = maths::CVectorNx1<double, 2>;
+    using TMean2Accumulator = maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator;
+    using TTimeDouble2AryPr = std::pair<core_t::TTime, boost::array<double, 2>>;
+    using TTimeDouble2AryPrVec = std::vector<TTimeDouble2AryPr>;
 
     core_t::TTime startTime(45);
     core_t::TTime bucketLength(5);
@@ -759,7 +759,7 @@ void CMetricModelTest::testProbabilityCalculationForMetric(void)
 {
     LOG_DEBUG("*** testProbabilityCalculationForMetric ***");
 
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr> TMinAccumulator;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr>;
 
     core_t::TTime startTime(0);
     core_t::TTime bucketLength(10);
@@ -830,7 +830,7 @@ void CMetricModelTest::testProbabilityCalculationForMedian(void)
 {
     LOG_DEBUG("*** testProbabilityCalculationForMedian ***");
 
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr> TMinAccumulator;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr>;
 
     core_t::TTime startTime(0);
     core_t::TTime bucketLength(10);
@@ -1453,10 +1453,10 @@ void CMetricModelTest::testPrune(void)
 
     maths::CSampling::CScopeMockRandomNumberGenerator scopeMockRng;
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef std::vector<TSizeVec> TSizeVecVec;
-    typedef std::vector<CEventData> TEventDataVec;
-    typedef std::map<std::size_t, std::size_t> TSizeSizeMap;
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TEventDataVec = std::vector<CEventData>;
+    using TSizeSizeMap = std::map<std::size_t, std::size_t>;
 
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
@@ -2174,8 +2174,8 @@ void CMetricModelTest::testCorrelatePersist(void)
 {
     LOG_DEBUG("*** testCorrelatePersist ***");
 
-    typedef maths::CVectorNx1<double, 2> TVector2;
-    typedef maths::CSymmetricMatrixNxN<double, 2> TMatrix2;
+    using TVector2 = maths::CVectorNx1<double, 2>;
+    using TMatrix2 = maths::CSymmetricMatrixNxN<double, 2>;
 
     const core_t::TTime startTime = 0;
     const core_t::TTime bucketLength = 600;

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -43,17 +43,17 @@ using namespace model;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<model_t::EFeature> TFeatureVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::pair<std::string, std::string> TStrStrPr;
-typedef std::map<TStrStrPr, double> TStrStrPrDoubleMap;
-typedef boost::optional<std::string> TOptionalStr;
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::pair<TSizeSizePr, SMetricFeatureData> TSizeSizePrFeatureDataPr;
-typedef std::vector<TSizeSizePrFeatureDataPr> TSizeSizePrFeatureDataPrVec;
-typedef std::pair<model_t::EFeature, TSizeSizePrFeatureDataPrVec> TFeatureSizeSizePrFeatureDataPrVecPr;
-typedef std::vector<TFeatureSizeSizePrFeatureDataPrVecPr> TFeatureSizeSizePrFeatureDataPrVecPrVec;
+using TDoubleVec = std::vector<double>;
+using TFeatureVec = std::vector<model_t::EFeature>;
+using TStrVec = std::vector<std::string>;
+using TStrStrPr = std::pair<std::string, std::string>;
+using TStrStrPrDoubleMap = std::map<TStrStrPr, double>;
+using TOptionalStr = boost::optional<std::string>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrFeatureDataPr = std::pair<TSizeSizePr, SMetricFeatureData>;
+using TSizeSizePrFeatureDataPrVec = std::vector<TSizeSizePrFeatureDataPr>;
+using TFeatureSizeSizePrFeatureDataPrVecPr = std::pair<model_t::EFeature, TSizeSizePrFeatureDataPrVec>;
+using TFeatureSizeSizePrFeatureDataPrVecPrVec = std::vector<TFeatureSizeSizePrFeatureDataPrVecPr>;
 
 struct SMessage
 {
@@ -76,7 +76,7 @@ struct SMessage
     double s_Value;
     TStrVec s_Influences;
 };
-typedef std::vector<SMessage> TMessageVec;
+using TMessageVec = std::vector<SMessage>;
 
 TStrVec vec(const std::string &s1, const std::string &s2)
 {
@@ -162,9 +162,9 @@ void CMetricPopulationDataGathererTest::testMean(void)
 
     // Test that we correctly sample the bucket means.
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef std::map<TStrStrPr, TMeanAccumulator> TStrStrPrMeanAccumulatorMap;
-    typedef TStrStrPrMeanAccumulatorMap::const_iterator TStrStrPrMeanAccumulatorMapCItr;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TStrStrPrMeanAccumulatorMap = std::map<TStrStrPr, TMeanAccumulator>;
+    using TStrStrPrMeanAccumulatorMapCItr = TStrStrPrMeanAccumulatorMap::const_iterator;
 
     const core_t::TTime startTime = 1373932800;
     const core_t::TTime bucketLength = 3600;
@@ -235,9 +235,9 @@ void CMetricPopulationDataGathererTest::testMin(void)
 
     // Test that we correctly sample the bucket minimums.
 
-    typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u> TMinAccumulator;
-    typedef std::map<TStrStrPr, TMinAccumulator> TStrStrPrMinAccumulatorMap;
-    typedef TStrStrPrMinAccumulatorMap::const_iterator TStrStrPrMinAccumulatorMapCItr;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u>;
+    using TStrStrPrMinAccumulatorMap = std::map<TStrStrPr, TMinAccumulator>;
+    using TStrStrPrMinAccumulatorMapCItr = TStrStrPrMinAccumulatorMap::const_iterator;
 
     const core_t::TTime startTime = 1373932800;
     const core_t::TTime bucketLength = 3600;
@@ -307,9 +307,9 @@ void CMetricPopulationDataGathererTest::testMax(void)
 
     // Test that we correctly sample the bucket maximums.
 
-    typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double> > TMaxAccumulator;
-    typedef std::map<TStrStrPr, TMaxAccumulator> TStrStrPrMaxAccumulatorMap;
-    typedef TStrStrPrMaxAccumulatorMap::const_iterator TStrStrPrMaxAccumulatorMapCItr;
+    using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>>;
+    using TStrStrPrMaxAccumulatorMap = std::map<TStrStrPr, TMaxAccumulator>;
+    using TStrStrPrMaxAccumulatorMapCItr = TStrStrPrMaxAccumulatorMap::const_iterator;
 
     const core_t::TTime startTime = 1373932800;
     const core_t::TTime bucketLength = 3600;
@@ -519,16 +519,16 @@ void CMetricPopulationDataGathererTest::testFeatureData(void)
 
     // Test we correctly sample the mean, minimum and maximum statistics.
 
-    typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-    typedef std::map<TStrStrPr, TMeanAccumulator> TStrStrPrMeanAccumulatorMap;
-    typedef TStrStrPrMeanAccumulatorMap::const_iterator TStrStrPrMeanAccumulatorMapCItr;
-    typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u> TMinAccumulator;
-    typedef std::map<TStrStrPr, TMinAccumulator> TStrStrPrMinAccumulatorMap;
-    typedef TStrStrPrMinAccumulatorMap::const_iterator TStrStrPrMinAccumulatorMapCItr;
-    typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double> > TMaxAccumulator;
-    typedef std::map<TStrStrPr, TMaxAccumulator> TStrStrPrMaxAccumulatorMap;
-    typedef TStrStrPrMaxAccumulatorMap::const_iterator TStrStrPrMaxAccumulatorMapCItr;
-    typedef std::map<TStrStrPr, TDoubleVec> TStrStrPrDoubleVecMap;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TStrStrPrMeanAccumulatorMap = std::map<TStrStrPr, TMeanAccumulator>;
+    using TStrStrPrMeanAccumulatorMapCItr = TStrStrPrMeanAccumulatorMap::const_iterator;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u>;
+    using TStrStrPrMinAccumulatorMap = std::map<TStrStrPr, TMinAccumulator>;
+    using TStrStrPrMinAccumulatorMapCItr = TStrStrPrMinAccumulatorMap::const_iterator;
+    using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>>;
+    using TStrStrPrMaxAccumulatorMap = std::map<TStrStrPr, TMaxAccumulator>;
+    using TStrStrPrMaxAccumulatorMapCItr = TStrStrPrMaxAccumulatorMap::const_iterator;
+    using TStrStrPrDoubleVecMap = std::map<TStrStrPr, TDoubleVec>;
 
     const core_t::TTime startTime = 1373932800;
     const core_t::TTime bucketLength = 3600;
@@ -722,13 +722,13 @@ void CMetricPopulationDataGathererTest::testRemovePeople(void)
     // Check that all the state is correctly updated when some
     // people are removed.
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef std::vector<std::string> TStrVec;
-    typedef std::pair<std::size_t, uint64_t> TSizeUInt64Pr;
-    typedef std::vector<TSizeUInt64Pr> TSizeUInt64PrVec;
-    typedef std::pair<std::string, SMetricFeatureData> TStrFeatureDataPr;
-    typedef std::vector<TStrFeatureDataPr> TStrFeatureDataPrVec;
-    typedef std::map<std::string, uint64_t> TStrSizeMap;
+    using TSizeVec = std::vector<std::size_t>;
+    using TStrVec = std::vector<std::string>;
+    using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+    using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
+    using TStrFeatureDataPr = std::pair<std::string, SMetricFeatureData>;
+    using TStrFeatureDataPrVec = std::vector<TStrFeatureDataPr>;
+    using TStrSizeMap = std::map<std::string, uint64_t>;
 
     const core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -884,10 +884,10 @@ void CMetricPopulationDataGathererTest::testRemoveAttributes(void)
     // Check that all the state is correctly updated when some
     // attributes are removed.
 
-    typedef std::vector<std::size_t> TSizeVec;
-    typedef std::vector<std::string> TStrVec;
-    typedef std::pair<std::string, SMetricFeatureData> TStrFeatureDataPr;
-    typedef std::vector<TStrFeatureDataPr> TStrFeatureDataPrVec;
+    using TSizeVec = std::vector<std::size_t>;
+    using TStrVec = std::vector<std::string>;
+    using TStrFeatureDataPr = std::pair<std::string, SMetricFeatureData>;
+    using TStrFeatureDataPrVec = std::vector<TStrFeatureDataPr>;
 
     const core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -1021,9 +1021,9 @@ void CMetricPopulationDataGathererTest::testInfluenceStatistics(void)
 {
     LOG_DEBUG("*** CMetricPopulationDataGathererTest::testInfluenceStatistics ***");
 
-    typedef std::pair<double, double> TDoubleDoublePr;
-    typedef std::pair<std::string, TDoubleDoublePr> TStrDoubleDoublePrPr;
-    typedef std::vector<TStrDoubleDoublePrPr> TStrDoubleDoublePrPrVec;
+    using TDoubleDoublePr = std::pair<double, double>;
+    using TStrDoubleDoublePrPr = std::pair<std::string, TDoubleDoublePr>;
+    using TStrDoubleDoublePrPrVec = std::vector<TStrDoubleDoublePrPr>;
 
     const core_t::TTime startTime = 0;
     const core_t::TTime bucketLength = 600;

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -59,23 +59,23 @@ using namespace model;
 namespace
 {
 
-typedef std::pair<std::size_t, std::size_t> TSizeSizePr;
-typedef std::vector<TSizeSizePr> TSizeSizePrVec;
-typedef std::vector<TSizeSizePrVec> TSizeSizePrVecVec;
-typedef std::pair<double, double> TDoubleDoublePr;
-typedef std::vector<TDoubleDoublePr> TDoubleDoublePrVec;
-typedef std::pair<double, std::string> TDoubleStrPr;
-typedef std::vector<TDoubleStrPr> TDoubleStrPrVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::vector<unsigned int> TUIntVec;
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<TSizeVec> TSizeVecVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u> TMinAccumulator;
-typedef maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double> > TMaxAccumulator;
-typedef core::CSmallVector<double, 1> TDouble1Vec;
-typedef core::CSmallVector<double, 2> TDouble2Vec;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrVec = std::vector<TSizeSizePr>;
+using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TDoubleStrPr = std::pair<double, std::string>;
+using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
+using TStrVec = std::vector<std::string>;
+using TUIntVec = std::vector<unsigned int>;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u>;
+using TMaxAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>>;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble2Vec = core::CSmallVector<double, 2>;
 
 const std::string EMPTY_STRING;
 
@@ -145,7 +145,7 @@ struct SMessage
     TDouble1Vec s_Value;
 };
 
-typedef std::vector<SMessage> TMessageVec;
+using TMessageVec = std::vector<SMessage>;
 
 const std::size_t numberAttributes = 5u;
 const std::size_t numberPeople = 10u;
@@ -351,11 +351,11 @@ void CMetricPopulationModelTest::testBasicAccessors(void)
     // Check that the correct data is read retrieved by the
     // basic model accessors.
 
-    typedef boost::optional<uint64_t> TOptionalUInt64;
-    typedef std::map<std::string, uint64_t> TStrUInt64Map;
-    typedef std::vector<TMeanAccumulator> TMeanAccumulatorVec;
-    typedef std::vector<TMinAccumulator> TMinAccumulatorVec;
-    typedef std::vector<TMaxAccumulator> TMaxAccumulatorVec;
+    using TOptionalUInt64 = boost::optional<uint64_t>;
+    using TStrUInt64Map = std::map<std::string, uint64_t>;
+    using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
+    using TMinAccumulatorVec = std::vector<TMinAccumulator>;
+    using TMaxAccumulatorVec = std::vector<TMaxAccumulator>;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -503,19 +503,19 @@ void CMetricPopulationModelTest::testMinMaxAndMean(void)
     // We check that the correct data is read from the gatherer
     // into the model on sample.
 
-    typedef core::CTriple<core_t::TTime, TDouble2Vec, std::size_t> TTimeDouble2VecSizeTr;
-    typedef std::vector<TTimeDouble2VecSizeTr> TTimeDouble2VecSizeTrVec;
-    typedef core::CSmallVector<TDouble2Vec, 4> TDouble2Vec4Vec;
-    typedef std::vector<TDouble2Vec4Vec> TDouble2Vec4VecVec;
-    typedef std::map<TSizeSizePr, TDoubleVec> TSizeSizePrDoubleVecMap;
-    typedef std::map<TSizeSizePr, TMeanAccumulator> TSizeSizePrMeanAccumulatorUMap;
-    typedef std::map<TSizeSizePr, TMinAccumulator> TSizeSizePrMinAccumulatorMap;
-    typedef std::map<TSizeSizePr, TMaxAccumulator> TSizeSizePrMaxAccumulatorMap;
-    typedef boost::shared_ptr<maths::CModel> TMathsModelPtr;
-    typedef std::map<std::size_t, TMathsModelPtr> TSizeMathsModelPtrMap;
-    typedef std::pair<TTimeDouble2VecSizeTrVec, TDouble2Vec4VecVec> TTimeDouble2VecSizeTrVecDouble2Vec4VecVecPr;
-    typedef std::map<std::size_t, TTimeDouble2VecSizeTrVecDouble2Vec4VecVecPr> TSizeTimeDouble2VecSizeTrVecDouble2Vec4VecVecPrMap;
-    typedef std::map<std::size_t, TSizeTimeDouble2VecSizeTrVecDouble2Vec4VecVecPrMap> TSizeSizeTimeDouble2VecSizeTrVecDouble2Vec4VecVecPrMapMap;
+    using TTimeDouble2VecSizeTr = core::CTriple<core_t::TTime, TDouble2Vec, std::size_t>;
+    using TTimeDouble2VecSizeTrVec = std::vector<TTimeDouble2VecSizeTr>;
+    using TDouble2Vec4Vec = core::CSmallVector<TDouble2Vec, 4>;
+    using TDouble2Vec4VecVec = std::vector<TDouble2Vec4Vec>;
+    using TSizeSizePrDoubleVecMap = std::map<TSizeSizePr, TDoubleVec>;
+    using TSizeSizePrMeanAccumulatorUMap = std::map<TSizeSizePr, TMeanAccumulator>;
+    using TSizeSizePrMinAccumulatorMap = std::map<TSizeSizePr, TMinAccumulator>;
+    using TSizeSizePrMaxAccumulatorMap = std::map<TSizeSizePr, TMaxAccumulator>;
+    using TMathsModelPtr = boost::shared_ptr<maths::CModel>;
+    using TSizeMathsModelPtrMap = std::map<std::size_t, TMathsModelPtr>;
+    using TTimeDouble2VecSizeTrVecDouble2Vec4VecVecPr = std::pair<TTimeDouble2VecSizeTrVec, TDouble2Vec4VecVec>;
+    using TSizeTimeDouble2VecSizeTrVecDouble2Vec4VecVecPrMap = std::map<std::size_t, TTimeDouble2VecSizeTrVecDouble2Vec4VecVecPr>;
+    using TSizeSizeTimeDouble2VecSizeTrVecDouble2Vec4VecVecPrMapMap = std::map<std::size_t, TSizeTimeDouble2VecSizeTrVecDouble2Vec4VecVecPrMap>;
 
     static const maths_t::TWeightStyleVec WEIGHT_STYLES{maths_t::E_SampleCountWeight,
                                                         maths_t::E_SampleWinsorisationWeight};
@@ -767,10 +767,10 @@ void CMetricPopulationModelTest::testComputeProbability(void)
     // Test that we correctly pick out synthetic the anomalies,
     // their people and attributes.
 
-    typedef std::vector<SAnomaly> TAnomalyVec;
-    typedef std::pair<double, SAnomaly> TDoubleAnomalyPr;
-    typedef maths::CBasicStatistics::COrderStatisticsHeap<TDoubleAnomalyPr,
-                                                          maths::COrderings::SFirstLess> TAnomalyAccumulator;
+    using TAnomalyVec = std::vector<SAnomaly>;
+    using TDoubleAnomalyPr = std::pair<double, SAnomaly>;
+    using TAnomalyAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<
+                                    TDoubleAnomalyPr, maths::COrderings::SFirstLess>;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -877,9 +877,9 @@ void CMetricPopulationModelTest::testPrune(void)
     // This test has four people and five attributes. We expect
     // person 2 and attributes 1, 2 and 5 to be deleted.
 
-    typedef std::pair<std::string, std::size_t> TStrSizePr;
-    typedef std::vector<TStrSizePr> TStrSizePrVec;
-    typedef std::vector<TStrSizePrVec> TStrSizePrVecVec;
+    using TStrSizePr = std::pair<std::string, std::size_t>;
+    using TStrSizePrVec = std::vector<TStrSizePr>;
+    using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -1393,7 +1393,7 @@ void CMetricPopulationModelTest::testPeriodicity(void)
     // Create a daily periodic population and check that the
     // periodicity is learned and compensated (approximately).
 
-    typedef std::map<std::string, double> TStrDoubleMap;
+    using TStrDoubleMap = std::map<std::string, double>;
 
     static const core_t::TTime HOUR = 3600;
     static const core_t::TTime DAY = 86400;

--- a/lib/model/unittest/CModelMemoryTest.cc
+++ b/lib/model/unittest/CModelMemoryTest.cc
@@ -37,7 +37,7 @@ using namespace model;
 namespace
 {
 
-typedef std::vector<double> TDoubleVec;
+using TDoubleVec = std::vector<double>;
 
 std::size_t addPerson(const std::string &p,
                       const CModelFactory::TDataGathererPtr &gatherer)

--- a/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
+++ b/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
@@ -215,7 +215,7 @@ void computeInfluences(CALCULATOR &calculator,
     params.s_Values.push_back(values_);
     params.s_Counts.push_back(counts_);
     params.s_ComputeProbabilityParams.weightStyles(weightStyles);
-    //for (auto &&weight : weights)
+    //for (auto &weight : weights)
     //{
     //    weight.resize(weightStyles.size(), TDouble2Vec(2, 1.0));
     //    params.s_ComputeProbabilityParams.addWeights(weight);
@@ -466,7 +466,7 @@ void CProbabilityAndInfluenceCalculatorTest::testLogProbabilityComplementInfluen
             {
                 rng.generateNormalSamples(0.0, 100.0, 10 * 86400 / 600, samples);
                 core_t::TTime time{0};
-                for (auto &&sample : samples)
+                for (auto &sample : samples)
                 {
                     sample += 100.0 + 100.0 * ::sin(2.0 * 3.1416 * static_cast<double>(time) / 86400.0);
                     time += bucketLength;
@@ -1138,7 +1138,7 @@ void CProbabilityAndInfluenceCalculatorTest::testLogProbabilityInfluenceCalculat
             {
                 rng.generateNormalSamples(0.0, 100.0, 10 * 86400 / 600, samples);
                 core_t::TTime time{0};
-                for (auto &&sample : samples)
+                for (auto &sample : samples)
                 {
                     sample += 100.0 + 100.0 * ::sin(2.0 * 3.1416 * static_cast<double>(time) / 86400.0);
                     time += bucketLength;

--- a/lib/model/unittest/CResourceLimitTest.cc
+++ b/lib/model/unittest/CResourceLimitTest.cc
@@ -42,17 +42,17 @@
 using namespace ml;
 using namespace model;
 
-typedef std::vector<std::string> TStrVec;
+using TStrVec = std::vector<std::string>;
 
 class CResultWriter : public ml::model::CHierarchicalResultsVisitor
 {
     public:
-        typedef boost::tuple<core_t::TTime,
-                             double /* probability */,
-                             std::string /* byFieldName*/,
-                             std::string /* overFieldName */,
-                             std::string /* partitionFieldName */> TResultsTp;
-        typedef std::vector<TResultsTp> TResultsVec;
+        using TResultsTp = boost::tuple<core_t::TTime,
+                                        double /* probability */,
+                                        std::string /* byFieldName*/,
+                                        std::string /* overFieldName */,
+                                        std::string /* partitionFieldName */>;
+        using TResultsVec = std::vector<TResultsTp>;
 
     public:
         CResultWriter(const CAnomalyDetectorModelConfig &modelConfig,
@@ -625,7 +625,7 @@ void CResourceLimitTest::importCsvDataWithLimiter(core_t::TTime firstTime,
                                                   CResourceMonitor &resourceMonitor)
 {
 
-    typedef boost::shared_ptr<std::ifstream> TifstreamPtr;
+    using TifstreamPtr = boost::shared_ptr<std::ifstream>;
     TifstreamPtr ifs(new std::ifstream(fileName.c_str()));
     CPPUNIT_ASSERT(ifs->is_open());
 

--- a/lib/model/unittest/CRuleConditionTest.cc
+++ b/lib/model/unittest/CRuleConditionTest.cc
@@ -35,7 +35,7 @@ using namespace model;
 namespace
 {
 
-typedef std::vector<std::string> TStrVec;
+using TStrVec = std::vector<std::string>;
 
 const std::string EMPTY_STRING;
 

--- a/lib/model/unittest/CSampleQueueTest.cc
+++ b/lib/model/unittest/CSampleQueueTest.cc
@@ -36,10 +36,10 @@
 using namespace ml;
 using namespace model;
 
-typedef std::vector<double> TDoubleVec;
-typedef std::vector<CSample> TSampleVec;
-typedef maths::CBasicStatistics::SSampleMean<double>::TAccumulator TMeanAccumulator;
-typedef CSampleQueue<TMeanAccumulator> TTestSampleQueue;
+using TDoubleVec = std::vector<double>;
+using TSampleVec = std::vector<CSample>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TTestSampleQueue = CSampleQueue<TMeanAccumulator>;
 
 void CSampleQueueTest::testSampleToString(void)
 {
@@ -1074,7 +1074,7 @@ void CSampleQueueTest::testQualityOfSamplesGivenConstantRate(void)
 
         maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator varianceStat;
         maths::CBasicStatistics::COrderStatisticsStack<double, 5u> varianceMin;
-        maths::CBasicStatistics::COrderStatisticsStack<double, 5u, std::greater<double> > varianceMax;
+        maths::CBasicStatistics::COrderStatisticsStack<double, 5u, std::greater<double>> varianceMax;
         for (std::size_t i = 0; i < samples.size(); ++i)
         {
             varianceStat.add(samples[i].varianceScale());
@@ -1143,7 +1143,7 @@ void CSampleQueueTest::testQualityOfSamplesGivenVariableRate(void)
 
         maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator varianceStat;
         maths::CBasicStatistics::COrderStatisticsStack<double, 5u> varianceMin;
-        maths::CBasicStatistics::COrderStatisticsStack<double, 5u, std::greater<double> > varianceMax;
+        maths::CBasicStatistics::COrderStatisticsStack<double, 5u, std::greater<double>> varianceMax;
         for (std::size_t i = 0; i < samples.size(); ++i)
         {
             varianceStat.add(samples[i].varianceScale());
@@ -1199,7 +1199,7 @@ void CSampleQueueTest::testQualityOfSamplesGivenHighLatencyAndDataInReverseOrder
 
     maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator varianceStat;
     maths::CBasicStatistics::COrderStatisticsStack<double, 1u> varianceMin;
-    maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double> > varianceMax;
+    maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>> varianceMax;
     for (std::size_t i = 0; i < samples.size(); ++i)
     {
         varianceStat.add(samples[i].varianceScale());

--- a/lib/model/unittest/CStringStoreTest.cc
+++ b/lib/model/unittest/CStringStoreTest.cc
@@ -30,15 +30,15 @@ using namespace model;
 
 namespace
 {
-typedef std::vector<std::size_t> TSizeVec;
-typedef std::vector<std::string> TStrVec;
-typedef std::vector<core::CStoredStringPtr> TStoredStringPtrVec;
-typedef boost::unordered_set<const std::string*> TStrCPtrUSet;
+using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
+using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
+using TStrCPtrUSet = boost::unordered_set<const std::string*>;
 
 class CStringThread : public core::CThread
 {
     public:
-        typedef boost::shared_ptr<CppUnit::Exception> TCppUnitExceptionP;
+        using TCppUnitExceptionP = boost::shared_ptr<CppUnit::Exception>;
 
     public:
         CStringThread(std::size_t i, const TStrVec &strings)
@@ -158,8 +158,8 @@ void CStringStoreTest::testStringStore(void)
     {
         LOG_DEBUG("Testing multi-threaded");
 
-        typedef boost::shared_ptr<CStringThread> TThreadPtr;
-        typedef std::vector<TThreadPtr> TThreadVec;
+        using TThreadPtr = boost::shared_ptr<CStringThread>;
+        using TThreadVec = std::vector<TThreadPtr>;
         TThreadVec threads;
         for (std::size_t i = 0; i < 20; ++i)
         {
@@ -205,8 +205,8 @@ void CStringStoreTest::testStringStore(void)
             lotsOfStrings.push_back(core::CStringUtils::typeToString(i));
         }
 
-        typedef boost::shared_ptr<CStringThread> TThreadPtr;
-        typedef std::vector<TThreadPtr> TThreadVec;
+        using TThreadPtr = boost::shared_ptr<CStringThread>;
+        using TThreadVec = std::vector<TThreadPtr>;
         TThreadVec threads;
         for (std::size_t i = 0; i < 20; ++i)
         {

--- a/lib/test/CTimeSeriesTestData.cc
+++ b/lib/test/CTimeSeriesTestData.cc
@@ -88,7 +88,7 @@ bool CTimeSeriesTestData::parseCounter(const std::string &fileName, TTimeDoubleP
 
     double last(0);
     bool   started(false);
-    for (auto &&result : results)
+    for (auto &result : results)
     {
         double value = result.second;
         if (started == false)
@@ -167,7 +167,7 @@ bool CTimeSeriesTestData::pad(const TTimeDoublePrVec &data,
     results.reserve(static_cast<size_t>(maxTime - minTime + 1));
 
     // Inefficient but easy and safe
-    typedef std::map<core_t::TTime, double> TTimeDoubleMap;
+    using TTimeDoubleMap = std::map<core_t::TTime, double>;
 
     TTimeDoubleMap dataMap;
 
@@ -215,7 +215,7 @@ template<typename T>
 bool CTimeSeriesTestData::parse(const std::string &fileName,
                                 const std::string &regex,
                                 const std::string &dateFormat,
-                                std::vector<std::pair<core_t::TTime, T> >  &results,
+                                std::vector<std::pair<core_t::TTime, T>>  &results,
                                 core_t::TTime &minTime,
                                 core_t::TTime &maxTime)
 {
@@ -264,7 +264,7 @@ template<typename T>
 bool CTimeSeriesTestData::parseLine(const core::CRegex &tokenRegex,
                                     const std::string &dateFormat,
                                     const std::string &line,
-                                    std::vector<std::pair<core_t::TTime, T> > &results)
+                                    std::vector<std::pair<core_t::TTime, T>> &results)
 {
     if (line.empty() ||
         line.find_first_not_of(core::CStringUtils::WHITESPACE_CHARS) == std::string::npos)


### PR DESCRIPTION
This is one of a couple of changes related to C++11 language features. With the big change related to automating formatting upcoming, I plan to make these now.

We currently use a mixture of type aliases and typedefs in our code. Since type aliasing provides a strict superset of the functionality of typedefs, but is otherwise essentially equivalent, it seems sensible to standardise on only using type aliasing throughout. This PR makes that change.

It also adopts the convention of not using rvalue references in for loops, except for template code, on grounds of readability.