### PR TITLE
[ML] Shuffle some comments that confuse clang-format

### DIFF
--- a/include/core/CMemory.h
+++ b/include/core/CMemory.h
@@ -344,15 +344,15 @@ public:
         // verification
         // See http://linux/wiki/index.php/Technical_design_issues#std::string
 #ifdef MacOSX
-        // For lengths up to 22 bytes there is no allocation
         if (capacity <= 22) {
+            // For lengths up to 22 bytes there is no allocation
             return 0;
         }
         return capacity + 1;
 
-#else // Linux with C++11 ABI and Windows                                                                                                  \
-      // For lengths up to 15 bytes there is no allocation
+#else // Linux with C++11 ABI and Windows
         if (capacity <= 15) {
+            // For lengths up to 15 bytes there is no allocation
             return 0;
         }
         return capacity + 1;
@@ -731,20 +731,20 @@ public:
         std::size_t capacity = t.capacity();
         std::size_t unused = 0;
 #ifdef MacOSX
-        // For lengths up to 22 bytes there is no allocation
         if (capacity > 22) {
             unused = capacity - length;
             ++capacity;
         } else {
+            // For lengths up to 22 bytes there is no allocation
             capacity = 0;
         }
 
-#else // Linux with C++11 ABI and Windows                                                                                                  \
-      // For lengths up to 15 bytes there is no allocation
+#else // Linux with C++11 ABI and Windows
         if (capacity > 15) {
             unused = capacity - length;
             ++capacity;
         } else {
+            // For lengths up to 15 bytes there is no allocation
             capacity = 0;
         }
 #endif


### PR DESCRIPTION
This change moves around some comments that clang-format inappropriately
combined into a single multi-line comment when they were in their previous
locations.

Note the backslash that clang-format added in column 140 of the `#else // blah`
lines.

Previously _some_ versions of clang would spew out this every time the file was
included, which was very noisy:

```
In file included from /ml-cpp/include/model/ModelTypes.h:19:0,
                 from /ml-cpp/include/model/FunctionTypes.h:20,
                 from /ml-cpp/include/model/CSearchKey.h:24,
                 from /ml-cpp/include/model/CAnomalyDetectorModelConfig.h:21,
                 from /ml-cpp/include/api/CResultNormalizer.h:20,
                 from CResultNormalizer.cc:15:
/ml-cpp/include/core/CMemory.h:364:7: warning: multi-line comment [-Wcomment]
 #else // Linux with C++11 ABI and Windows                                                                                                  \
       ^
/ml-cpp/include/core/CMemory.h:764:7: warning: multi-line comment [-Wcomment]
 #else // Linux with C++11 ABI and Windows                                                                                                  \
       ^
```