### PR TITLE
[ML] Fix unused template warnings

### DIFF
--- a/include/core/CMemory.h
+++ b/include/core/CMemory.h
@@ -164,7 +164,7 @@ struct STypeInfoLess {
 //! that we can't simply check if capacity > N because N is treated
 //! as a guideline.
 template<typename T, std::size_t N>
-static bool inplace(const CSmallVector<T, N>& t) {
+bool inplace(const CSmallVector<T, N>& t) {
     const char* address = reinterpret_cast<const char*>(&t);
     const char* storage = reinterpret_cast<const char*>(t.data());
     return storage >= address && storage < address + sizeof t;


### PR DESCRIPTION
Clang has the diagnostic flag `-Wunused-template` which will warn if there is a _static_ template function not used by the compilation unit. A lot of classes include `CMemory.h` but not all of them instantiate `template<typename T, std::size_t N> static bool inplace(const CSmallVector<T, N>& t)` meaning a lot of warnings are generated.

One fix is to make the function non-static I think this is ok as it's defined in the `memory_detail` namespace an alternative would be to put the function in an anonymous namespace