### PR TITLE
[ML] Set forecast progress to 100% and status finished in the case of insufficient history (data)

### DIFF
--- a/lib/api/unittest/CForecastRunnerTest.cc
+++ b/lib/api/unittest/CForecastRunnerTest.cc
@@ -248,6 +248,7 @@ void CForecastRunnerTest::testInsufficientData() {
     CPPUNIT_ASSERT(!doc.HasParseError());
     CPPUNIT_ASSERT_EQUAL(std::string("31"), std::string(forecastStats["forecast_id"].GetString()));
     CPPUNIT_ASSERT_EQUAL(std::string("finished"), std::string(forecastStats["forecast_status"].GetString()));
+    CPPUNIT_ASSERT_EQUAL(1.0, forecastStats["forecast_progress"].GetDouble());
     CPPUNIT_ASSERT_EQUAL(ml::api::CForecastRunner::INFO_NO_MODELS_CAN_CURRENTLY_BE_FORECAST,
                          std::string(forecastStats["forecast_messages"].GetArray()[0].GetString()));
     CPPUNIT_ASSERT_EQUAL((1511370819 + 14 * ml::core::constants::DAY) * int64_t(1000),

--- a/lib/model/CForecastDataSink.cc
+++ b/lib/model/CForecastDataSink.cc
@@ -159,6 +159,7 @@ void CForecastDataSink::writeFinalMessage(const std::string& message) {
     this->writeCommonStatsFields(doc);
     TStrVec messages{message};
     m_Writer.addStringArrayFieldToObj(MESSAGES, messages, doc);
+    m_Writer.addDoubleFieldToObj(PROGRESS, 1.0, doc);
     m_Writer.addStringFieldReferenceToObj(STATUS, STATUS_FINISHED, doc);
     this->push(true /*important, therefore flush*/, doc);
 }


### PR DESCRIPTION
set the progress value to 1.0 and status finished for the case of insufficient history. In this special case forecast is not run but the call succeeds.

This fixes a rare case when the model has not been established yet and `writeFinalMessage` is called. Before the fix the progress was not set which implicitly means `0.0` after parsing and persisting on X-Pack side. Therefore setting the progress to `1.0` explicitly.