### PR TITLE
[ML] Clean shadow warnings

### DIFF
--- a/include/core/CStringSimilarityTester.h
+++ b/include/core/CStringSimilarityTester.h
@@ -231,7 +231,6 @@ public:
         // one go for efficiency.  Then the current and previous column
         // pointers alternate between pointing and the first and second half
         // of the memory block.
-        using TScopedSizeArray = boost::scoped_array<size_t>;
         TScopedSizeArray data(new size_t[(secondLen + 1) * 2]);
         size_t* currentCol(data.get());
         size_t* prevCol(currentCol + (secondLen + 1));

--- a/include/maths/CXMeansOnline.h
+++ b/include/maths/CXMeansOnline.h
@@ -787,8 +787,8 @@ public:
                 this->cluster(x, clusters, count);
             }
         } else {
-            using TSizeDoublePr = std::pair<double, std::size_t>;
-            using TMaxAccumulator = CBasicStatistics::COrderStatisticsStack<TSizeDoublePr, 2, std::greater<TSizeDoublePr>>;
+            using TDoubleSizePr = std::pair<double, std::size_t>;
+            using TMaxAccumulator = CBasicStatistics::COrderStatisticsStack<TDoubleSizePr, 2, std::greater<TDoubleSizePr>>;
 
             TMaxAccumulator closest;
             for (std::size_t i = 0u; i < m_Clusters.size(); ++i) {

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -987,7 +987,6 @@ void CMemoryUsageTest::testStringClear() {
 
 void CMemoryUsageTest::testSharedPointer() {
     LOG_DEBUG("*** testSharedPointer ***");
-    using TIntVec = std::vector<int>;
     using TIntVecPtr = boost::shared_ptr<TIntVec>;
     using TIntVecPtrVec = std::vector<TIntVecPtr>;
     using TStrPtr = boost::shared_ptr<std::string>;

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -572,10 +572,7 @@ void CBjkstUniqueValues::SSketch::remove(uint32_t value) {
 }
 
 uint32_t CBjkstUniqueValues::SSketch::number() const {
-    using TUInt32Vec = std::vector<uint32_t>;
-
     // This uses the median trick to reduce the error.
-
     TUInt32Vec estimates;
     estimates.reserve(s_Z.size());
     for (std::size_t i = 0u; i < s_Z.size(); ++i) {

--- a/lib/maths/COneOfNPrior.cc
+++ b/lib/maths/COneOfNPrior.cc
@@ -837,11 +837,11 @@ bool COneOfNPrior::probabilityOfLessLikelySamples(maths_t::EProbabilityCalculati
     //   P(m) is the prior probability the data are from the m'th model.
 
     using TDoubleTailPr = std::pair<double, maths_t::ETail>;
-    using TMaxAccumulator = CBasicStatistics::SMax<TDoubleTailPr>::TAccumulator;
+    using TDoubleTailPrMaxAccumulator = CBasicStatistics::SMax<TDoubleTailPr>::TAccumulator;
 
     TDoubleSizePr5Vec logWeights = this->normalizedLogWeights();
 
-    TMaxAccumulator tail_;
+    TDoubleTailPrMaxAccumulator tail_;
     for (std::size_t i = 0u; i < logWeights.size(); ++i) {
         double weight = std::exp(logWeights[i].first);
         const CPrior& model = *m_Models[logWeights[i].second].second;

--- a/lib/maths/CStatisticalTests.cc
+++ b/lib/maths/CStatisticalTests.cc
@@ -174,8 +174,6 @@ void CStatisticalTests::CCramerVonMises::acceptPersistInserter(core::CStatePersi
 }
 
 void CStatisticalTests::CCramerVonMises::addF(double f) {
-    using TDoubleVec = std::vector<double>;
-
     if (m_F.size() == m_Size) {
         TDoubleVec ff;
         ff.reserve(m_F.size() + 1);

--- a/lib/maths/unittest/CKMeansFastTest.cc
+++ b/lib/maths/unittest/CKMeansFastTest.cc
@@ -369,7 +369,6 @@ void CKMeansFastTest::testClosestPoints() {
     // Check the obvious invariant that the closest point to each
     // centre is closer to that centre than any other.
 
-    using TVector2VecVec = std::vector<TVector2Vec>;
     using TVector4VecVec = std::vector<TVector4Vec>;
 
     test::CRandomNumbers rng;

--- a/lib/maths/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultimodalPriorTest.cc
@@ -181,8 +181,6 @@ void CMultimodalPriorTest::testPropagation() {
     // mean and the marginal likelihood confidence intervals increase
     // (due to influence of the prior uncertainty) after propagation.
 
-    using TDoubleDoublePr = std::pair<double, double>;
-
     double eps = 0.01;
 
     test::CRandomNumbers rng;

--- a/lib/maths/unittest/CMultivariateMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultivariateMultimodalPriorTest.cc
@@ -388,8 +388,6 @@ void CMultivariateMultimodalPriorTest::testSplitAndMerge() {
 
     // Test clustering which changes over time.
 
-    using TDoubleVecVecVec = std::vector<TDoubleVecVec>;
-
     maths::CSampling::seed();
 
     test::CRandomNumbers rng;

--- a/lib/maths/unittest/CMultivariateOneOfNPriorTest.cc
+++ b/lib/maths/unittest/CMultivariateOneOfNPriorTest.cc
@@ -637,7 +637,6 @@ void CMultivariateOneOfNPriorTest::testMarginalLikelihoodMean() {
 
     using TSizeVec = std::vector<std::size_t>;
     using TSizeVecVec = std::vector<TSizeVec>;
-    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMean2Accumulator = maths::CBasicStatistics::SSampleMean<TVector2>::TAccumulator;
 
     maths::CSampling::seed();

--- a/lib/maths/unittest/COrdinalTest.cc
+++ b/lib/maths/unittest/COrdinalTest.cc
@@ -178,10 +178,11 @@ void COrdinalTest::testLess() {
             CPPUNIT_ASSERT(s1[i] < s1[j]);
         }
     }
+
     CPPUNIT_ASSERT(s1[2] < s2[1]);
-    CPPUNIT_ASSERT(!(s1[3] < s2[0]));
+    CPPUNIT_ASSERT(!(s2[1] < s1[2]));
     CPPUNIT_ASSERT(s2[0] < s1[3]);
-    CPPUNIT_ASSERT(!(s2[3] < s1[0]));
+    CPPUNIT_ASSERT(!(s1[3] < s2[0]));
 }
 
 void COrdinalTest::testIsNan() {

--- a/lib/maths/unittest/CRandomProjectionClustererTest.cc
+++ b/lib/maths/unittest/CRandomProjectionClustererTest.cc
@@ -256,7 +256,6 @@ void CRandomProjectionClustererTest::testNeighbourhoods() {
     // isn't perfect because we don't store the full points so are
     // computing distances projections.
 
-    using TVector = maths::CVector<double>;
     using TVectorVec = std::vector<TVector>;
 
     test::CRandomNumbers rng;

--- a/lib/maths/unittest/CXMeansTest.cc
+++ b/lib/maths/unittest/CXMeansTest.cc
@@ -126,8 +126,6 @@ void CXMeansTest::testCluster() {
 
     // Test basic accessors and checksum functionality of cluster.
 
-    using TDoubleVec = std::vector<double>;
-
     maths::CSampling::seed();
 
     test::CRandomNumbers rng;
@@ -192,8 +190,6 @@ void CXMeansTest::testImproveStructure() {
     LOG_DEBUG("+-------------------------------------+");
 
     // Test improve structure finds an obvious split of the data.
-
-    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
     maths::CSampling::seed();
 

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -424,7 +424,6 @@ bool CAnomalyDetectorModelConfig::configureModelPlot(const boost::property_tree:
     try {
         std::string valueStr(propTree.get<std::string>(TERMS_PROPERTY));
 
-        using TStrVec = core::CStringUtils::TStrVec;
         TStrVec tokens;
         std::string remainder;
         core::CStringUtils::tokenise(",", valueStr, tokens, remainder);
@@ -744,8 +743,6 @@ const std::string PER_PARTITION_NORMALIZATION_PROPERTY("perPartitionNormalizatio
 }
 
 bool CAnomalyDetectorModelConfig::processStanza(const boost::property_tree::ptree& propertyTree) {
-    using TStrVec = std::vector<std::string>;
-
     bool result = true;
 
     for (const auto& property : propertyTree) {

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -599,8 +599,6 @@ bool restoreUniqueStrings(core::CStateRestoreTraverser& traverser, CUniqueString
 //! Persist influencer collections of unique strings.
 void persistInfluencerUniqueStrings(const CUniqueStringFeatureData::TStoredStringPtrWordSetUMap& map,
                                     core::CStatePersistInserter& inserter) {
-    using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;
-
     if (!map.empty()) {
         // Order the map keys to ensure consistent persistence
         TStoredStringPtrVec keys;

--- a/lib/model/CHierarchicalResultsAggregator.cc
+++ b/lib/model/CHierarchicalResultsAggregator.cc
@@ -296,7 +296,6 @@ void CHierarchicalResultsAggregator::detectorProbabilities(const TNode& node,
                                                            int& detector,
                                                            int& aggregation,
                                                            TDouble1Vec& probabilities) {
-    using TDouble1Vec = core::CSmallVector<double, 1>;
     using TIntDouble1VecFMap = boost::container::flat_map<int, TDouble1Vec>;
 
     int fallback{static_cast<int>(model_t::E_AggregatePeople)};

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -121,7 +121,6 @@ void importData(ml::core_t::TTime firstTime,
                 ml::model::CAnomalyDetector& detector) {
     using TifstreamPtr = boost::shared_ptr<std::ifstream>;
     using TifstreamPtrVec = std::vector<TifstreamPtr>;
-    using TTimeVec = std::vector<ml::core_t::TTime>;
 
     TifstreamPtrVec ifss;
     for (std::size_t i = 0u; i < fileNames.size(); ++i) {

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -665,8 +665,6 @@ void CMetricModelTest::testMultivariateSample() {
 void CMetricModelTest::testProbabilityCalculationForMetric() {
     LOG_DEBUG("*** testProbabilityCalculationForMetric ***");
 
-    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr>;
-
     core_t::TTime startTime(0);
     core_t::TTime bucketLength(10);
     SModelParams params(bucketLength);
@@ -729,8 +727,6 @@ void CMetricModelTest::testProbabilityCalculationForMetric() {
 
 void CMetricModelTest::testProbabilityCalculationForMedian() {
     LOG_DEBUG("*** testProbabilityCalculationForMedian ***");
-
-    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr>;
 
     core_t::TTime startTime(0);
     core_t::TTime bucketLength(10);
@@ -1048,8 +1044,6 @@ void CMetricModelTest::testProbabilityCalculationForLatLong() {
 void CMetricModelTest::testInfluence() {
     LOG_DEBUG("*** testInfluence ***");
 
-    using TMinAccumulator = maths::CBasicStatistics::SMin<TDoubleStrPr>::TAccumulator;
-    using TMaxAccumulator = maths::CBasicStatistics::SMax<TDoubleStrPr>::TAccumulator;
     using TStrDoubleDoubleTr = core::CTriple<std::string, double, double>;
     using TStrDoubleDoubleTrVec = std::vector<TStrDoubleDoubleTr>;
     using TStrDoubleDoubleTrVecVec = std::vector<TStrDoubleDoubleTrVec>;

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -600,7 +600,6 @@ void CMetricPopulationDataGathererTest::testRemovePeople() {
     // people are removed.
 
     using TSizeVec = std::vector<std::size_t>;
-    using TStrVec = std::vector<std::string>;
     using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
     using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
     using TStrFeatureDataPr = std::pair<std::string, SMetricFeatureData>;
@@ -746,7 +745,6 @@ void CMetricPopulationDataGathererTest::testRemoveAttributes() {
     // attributes are removed.
 
     using TSizeVec = std::vector<std::size_t>;
-    using TStrVec = std::vector<std::string>;
     using TStrFeatureDataPr = std::pair<std::string, SMetricFeatureData>;
     using TStrFeatureDataPrVec = std::vector<TStrFeatureDataPr>;
 


### PR DESCRIPTION
`-Wshadow` warns if a type alias shadows another in the same cc file or header. There were a number of instances of this warning. 

Also fixes a past end of array access in a `COrdinalTest.cc`