### PR TITLE
[ML] boost::function cannot be initialised with nullptr

### DIFF
--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -266,7 +266,7 @@ private:
         };
 
     public:
-        explicit CNestedHypotheses(TTestFunc test = nullptr);
+        explicit CNestedHypotheses(TTestFunc test = TTestFunc());
 
         //! Set the null hypothesis.
         CBuilder null(TTestFunc test);


### PR DESCRIPTION
This fixes a compilation failure introduced backporting the `0 -> nullptr` changes.

The 7.0 branch uses std::function which has a conversion from `nullptr` boost::function does not