### PR TITLE
[ML] Use std::make_unique where appropriate

### DIFF
--- a/bin/autoconfig/Main.cc
+++ b/bin/autoconfig/Main.cc
@@ -90,13 +90,12 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    using TInputParserCUPtr = const std::unique_ptr<ml::api::CInputParser>;
-    TInputParserCUPtr inputParser{[lengthEncodedInput, &ioMgr,
-                                   delimiter]() -> ml::api::CInputParser* {
+    using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
+    const TInputParserUPtr inputParser{[lengthEncodedInput, &ioMgr, delimiter]() -> TInputParserUPtr {
         if (lengthEncodedInput) {
-            return new ml::api::CLengthEncodedInputParser(ioMgr.inputStream());
+            return std::make_unique<ml::api::CLengthEncodedInputParser>(ioMgr.inputStream());
         }
-        return new ml::api::CCsvInputParser(ioMgr.inputStream(), delimiter);
+        return std::make_unique<ml::api::CCsvInputParser>(ioMgr.inputStream(), delimiter);
     }()};
 
     // This manages the full parameterization of the autoconfigurer.

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -171,9 +171,8 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    using TDataSearcherCUPtr = const std::unique_ptr<ml::core::CDataSearcher>;
-    TDataSearcherCUPtr restoreSearcher{[isRestoreFileNamedPipe,
-                                        &ioMgr]() -> ml::core::CDataSearcher* {
+    using TDataSearcherUPtr = std::unique_ptr<ml::core::CDataSearcher>;
+    const TDataSearcherUPtr restoreSearcher{[isRestoreFileNamedPipe, &ioMgr]() -> TDataSearcherUPtr {
         if (ioMgr.restoreStream()) {
             // Check whether state is restored from a file, if so we assume that this is a debugging case
             // and therefore does not originate from X-Pack.
@@ -182,17 +181,17 @@ int main(int argc, char** argv) {
                 auto strm = std::make_shared<boost::iostreams::filtering_istream>();
                 strm->push(ml::api::CStateRestoreStreamFilter());
                 strm->push(*ioMgr.restoreStream());
-                return new ml::api::CSingleStreamSearcher(strm);
+                return std::make_unique<ml::api::CSingleStreamSearcher>(strm);
             }
-            return new ml::api::CSingleStreamSearcher(ioMgr.restoreStream());
+            return std::make_unique<ml::api::CSingleStreamSearcher>(ioMgr.restoreStream());
         }
         return nullptr;
     }()};
 
-    using TDataAdderCUPtr = const std::unique_ptr<ml::core::CDataAdder>;
-    TDataAdderCUPtr persister{[&ioMgr]() -> ml::core::CDataAdder* {
+    using TDataAdderUPtr = std::unique_ptr<ml::core::CDataAdder>;
+    const TDataAdderUPtr persister{[&ioMgr]() -> TDataAdderUPtr {
         if (ioMgr.persistStream()) {
-            return new ml::api::CSingleStreamDataAdder(ioMgr.persistStream());
+            return std::make_unique<ml::api::CSingleStreamDataAdder>(ioMgr.persistStream());
         }
         return nullptr;
     }()};
@@ -205,21 +204,20 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    using TBackgroundPersisterCUPtr = const std::unique_ptr<ml::api::CBackgroundPersister>;
-    TBackgroundPersisterCUPtr periodicPersister{
-        [persistInterval, &persister]() -> ml::api::CBackgroundPersister* {
-            if (persistInterval >= 0) {
-                return new ml::api::CBackgroundPersister(persistInterval, *persister);
-            }
-            return nullptr;
-        }()};
-
-    using InputParserCUPtr = const std::unique_ptr<ml::api::CInputParser>;
-    InputParserCUPtr inputParser{[lengthEncodedInput, &ioMgr, delimiter]() -> ml::api::CInputParser* {
-        if (lengthEncodedInput) {
-            return new ml::api::CLengthEncodedInputParser(ioMgr.inputStream());
+    using TBackgroundPersisterUPtr = std::unique_ptr<ml::api::CBackgroundPersister>;
+    const TBackgroundPersisterUPtr periodicPersister{[persistInterval, &persister]() -> TBackgroundPersisterUPtr {
+        if (persistInterval >= 0) {
+            return std::make_unique<ml::api::CBackgroundPersister>(persistInterval, *persister);
         }
-        return new ml::api::CCsvInputParser(ioMgr.inputStream(), delimiter);
+        return nullptr;
+    }()};
+
+    using InputParserCUPtr = std::unique_ptr<ml::api::CInputParser>;
+    const InputParserCUPtr inputParser{[lengthEncodedInput, &ioMgr, delimiter]() -> InputParserCUPtr {
+        if (lengthEncodedInput) {
+            return std::make_unique<ml::api::CLengthEncodedInputParser>(ioMgr.inputStream());
+        }
+        return std::make_unique<ml::api::CCsvInputParser>(ioMgr.inputStream(), delimiter);
     }()};
 
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream(ioMgr.outputStream());

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -122,9 +122,8 @@ int main(int argc, char** argv) {
     }
     ml::api::CFieldConfig fieldConfig(categorizationFieldName);
 
-    using TDataSearcherCUPtr = const std::unique_ptr<ml::core::CDataSearcher>;
-    TDataSearcherCUPtr restoreSearcher{[isRestoreFileNamedPipe,
-                                        &ioMgr]() -> ml::core::CDataSearcher* {
+    using TDataSearcherUPtr = std::unique_ptr<ml::core::CDataSearcher>;
+    const TDataSearcherUPtr restoreSearcher{[isRestoreFileNamedPipe, &ioMgr]() -> TDataSearcherUPtr {
         if (ioMgr.restoreStream()) {
             // Check whether state is restored from a file, if so we assume that this is a debugging case
             // and therefore does not originate from X-Pack.
@@ -133,17 +132,17 @@ int main(int argc, char** argv) {
                 auto strm = std::make_shared<boost::iostreams::filtering_istream>();
                 strm->push(ml::api::CStateRestoreStreamFilter());
                 strm->push(*ioMgr.restoreStream());
-                return new ml::api::CSingleStreamSearcher(strm);
+                return std::make_unique<ml::api::CSingleStreamSearcher>(strm);
             }
-            return new ml::api::CSingleStreamSearcher(ioMgr.restoreStream());
+            return std::make_unique<ml::api::CSingleStreamSearcher>(ioMgr.restoreStream());
         }
         return nullptr;
     }()};
 
-    using TDataAdderCUPtr = const std::unique_ptr<ml::core::CDataAdder>;
-    TDataAdderCUPtr persister{[&ioMgr]() -> ml::core::CDataAdder* {
+    using TDataAdderUPtr = std::unique_ptr<ml::core::CDataAdder>;
+    const TDataAdderUPtr persister{[&ioMgr]() -> TDataAdderUPtr {
         if (ioMgr.persistStream()) {
-            return new ml::api::CSingleStreamDataAdder(ioMgr.persistStream());
+            return std::make_unique<ml::api::CSingleStreamDataAdder>(ioMgr.persistStream());
         }
         return nullptr;
     }()};
@@ -155,22 +154,20 @@ int main(int argc, char** argv) {
                      "using the 'persist' argument");
         return EXIT_FAILURE;
     }
-    using TBackgroundPersisterCUPtr = const std::unique_ptr<ml::api::CBackgroundPersister>;
-    TBackgroundPersisterCUPtr periodicPersister{
-        [persistInterval, &persister]() -> ml::api::CBackgroundPersister* {
-            if (persistInterval >= 0) {
-                return new ml::api::CBackgroundPersister(persistInterval, *persister);
-            }
-            return nullptr;
-        }()};
-
-    using TInputParserCUPtr = const std::unique_ptr<ml::api::CInputParser>;
-    TInputParserCUPtr inputParser{[lengthEncodedInput, &ioMgr,
-                                   delimiter]() -> ml::api::CInputParser* {
-        if (lengthEncodedInput) {
-            return new ml::api::CLengthEncodedInputParser(ioMgr.inputStream());
+    using TBackgroundPersisterUPtr = std::unique_ptr<ml::api::CBackgroundPersister>;
+    const TBackgroundPersisterUPtr periodicPersister{[persistInterval, &persister]() -> TBackgroundPersisterUPtr {
+        if (persistInterval >= 0) {
+            return std::make_unique<ml::api::CBackgroundPersister>(persistInterval, *persister);
         }
-        return new ml::api::CCsvInputParser(ioMgr.inputStream(), delimiter);
+        return nullptr;
+    }()};
+
+    using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
+    const TInputParserUPtr inputParser{[lengthEncodedInput, &ioMgr, delimiter]() -> TInputParserUPtr {
+        if (lengthEncodedInput) {
+            return std::make_unique<ml::api::CLengthEncodedInputParser>(ioMgr.inputStream());
+        }
+        return std::make_unique<ml::api::CCsvInputParser>(ioMgr.inputStream(), delimiter);
     }()};
 
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream(ioMgr.outputStream());

--- a/bin/normalize/Main.cc
+++ b/bin/normalize/Main.cc
@@ -101,23 +101,24 @@ int main(int argc, char** argv) {
     modelConfig.perPartitionNormalization(perPartitionNormalization);
 
     // There's a choice of input and output formats for the numbers to be normalised
-    using TInputParserCUPtr = const std::unique_ptr<ml::api::CInputParser>;
-    TInputParserCUPtr inputParser{[lengthEncodedInput, &ioMgr]() -> ml::api::CInputParser* {
+    using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
+    const TInputParserUPtr inputParser{[lengthEncodedInput, &ioMgr]() -> TInputParserUPtr {
         if (lengthEncodedInput) {
-            return new ml::api::CLengthEncodedInputParser(ioMgr.inputStream());
+            return std::make_unique<ml::api::CLengthEncodedInputParser>(ioMgr.inputStream());
         }
-        return new ml::api::CCsvInputParser(ioMgr.inputStream(),
-                                            ml::api::CCsvInputParser::COMMA);
+        return std::make_unique<ml::api::CCsvInputParser>(
+            ioMgr.inputStream(), ml::api::CCsvInputParser::COMMA);
     }()};
 
-    using TOutputHandlerCUPtr = const std::unique_ptr<ml::api::COutputHandler>;
-    TOutputHandlerCUPtr outputWriter{[writeCsv, &ioMgr]() -> ml::api::COutputHandler* {
+    using TOutputHandlerUPtr = std::unique_ptr<ml::api::COutputHandler>;
+    const TOutputHandlerUPtr outputWriter{[writeCsv, &ioMgr]() -> TOutputHandlerUPtr {
         if (writeCsv) {
-            return new ml::api::CCsvOutputWriter(ioMgr.outputStream());
+            return std::make_unique<ml::api::CCsvOutputWriter>(ioMgr.outputStream());
         }
-        return new ml::api::CLineifiedJsonOutputWriter(
-            {ml::api::CResultNormalizer::PROBABILITY_NAME,
-             ml::api::CResultNormalizer::NORMALIZED_SCORE_NAME},
+        return std::make_unique<ml::api::CLineifiedJsonOutputWriter>(
+            ml::api::CLineifiedJsonOutputWriter::TStrSet
+                {ml::api::CResultNormalizer::PROBABILITY_NAME,
+                 ml::api::CResultNormalizer::NORMALIZED_SCORE_NAME},
             ioMgr.outputStream());
     }()};
 

--- a/lib/api/dump_state/Main.cc
+++ b/lib/api/dump_state/Main.cc
@@ -159,12 +159,12 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
                                  boost::bind(&reportPersistComplete, _1),
                                  nullptr, -1, "time", timeFormat);
 
-    using TInputParserCUPtr = const std::unique_ptr<ml::api::CInputParser>;
-    TInputParserCUPtr parser{[&inputFilename, &inputStrm]() -> ml::api::CInputParser* {
+    using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
+    const TInputParserUPtr parser{[&inputFilename, &inputStrm]() -> TInputParserUPtr {
         if (inputFilename.rfind(".csv") == inputFilename.length() - 4) {
-            return new ml::api::CCsvInputParser(inputStrm);
+            return std::make_unique<ml::api::CCsvInputParser>(inputStrm);
         }
-        return new ml::api::CLineifiedJsonInputParser(inputStrm);
+        return std::make_unique<ml::api::CLineifiedJsonInputParser>(inputStrm);
     }()};
 
     if (!parser->readStream(boost::bind(&ml::api::CAnomalyJob::handleRecord, &origJob, _1))) {

--- a/lib/api/unittest/CMultiFileDataAdderTest.cc
+++ b/lib/api/unittest/CMultiFileDataAdderTest.cc
@@ -200,12 +200,12 @@ void CMultiFileDataAdderTest::detectorPersistHelper(const std::string& configFil
                     boost::ref(numOrigDocs)),
         nullptr, -1, "time", timeFormat);
 
-    using TInputParserCUPtr = const std::unique_ptr<ml::api::CInputParser>;
-    TInputParserCUPtr parser{[&inputFilename, &inputStrm]() -> ml::api::CInputParser* {
+    using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
+    const TInputParserUPtr parser{[&inputFilename, &inputStrm]() -> TInputParserUPtr {
         if (inputFilename.rfind(".csv") == inputFilename.length() - 4) {
-            return new ml::api::CCsvInputParser(inputStrm);
+            return std::make_unique<ml::api::CCsvInputParser>(inputStrm);
         }
-        return new ml::api::CLineifiedJsonInputParser(inputStrm);
+        return std::make_unique<ml::api::CLineifiedJsonInputParser>(inputStrm);
     }()};
 
     CPPUNIT_ASSERT(parser->readStream(

--- a/lib/api/unittest/CSingleStreamDataAdderTest.cc
+++ b/lib/api/unittest/CSingleStreamDataAdderTest.cc
@@ -156,12 +156,12 @@ void CSingleStreamDataAdderTest::detectorPersistHelper(const std::string& config
         firstProcessor = &typer;
     }
 
-    using TInputParserCUPtr = const std::unique_ptr<ml::api::CInputParser>;
-    TInputParserCUPtr parser{[&inputFilename, &inputStrm]() -> ml::api::CInputParser* {
+    using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
+    const TInputParserUPtr parser{[&inputFilename, &inputStrm]() -> TInputParserUPtr {
         if (inputFilename.rfind(".csv") == inputFilename.length() - 4) {
-            return new ml::api::CCsvInputParser(inputStrm);
+            return std::make_unique<ml::api::CCsvInputParser>(inputStrm);
         }
-        return new ml::api::CLineifiedJsonInputParser(inputStrm);
+        return std::make_unique<ml::api::CLineifiedJsonInputParser>(inputStrm);
     }()};
 
     CPPUNIT_ASSERT(parser->readStream(


### PR DESCRIPTION
Avoiding the use of explicitly calling operator new in the
initialization of unique_ptr by using the C++14 feature `make_unique`.

Not yet verified on supported Windows platforms.