### PR TITLE
[ML] Fix valgrind errors in maths library tests

### DIFF
--- a/lib/maths/unittest/CBoundingBoxTest.cc
+++ b/lib/maths/unittest/CBoundingBoxTest.cc
@@ -129,7 +129,7 @@ void CBoundingBoxTest::testCloserTo() {
         TBoundingBox2 bb(x1);
         bb.add(x2);
 
-        for (std::size_t j = 0u; j < probes.size(); j += 4) {
+        for (std::size_t j = 0u; j + 4 <= probes.size(); j += 4) {
             TVector2 y1(&probes[j], &probes[j + 2]);
             TVector2 y2(&probes[j + 2], &probes[j + 4]);
             bool closer = closerToX(bb, y1, y2);
@@ -154,7 +154,7 @@ void CBoundingBoxTest::testCloserTo() {
         TBoundingBox4 bb(x1);
         bb.add(x2);
 
-        for (std::size_t j = 0u; j < probes.size(); j += 4) {
+        for (std::size_t j = 0u; j + 8 <= probes.size(); j += 4) {
             TVector4 y1(&probes[j], &probes[j + 4]);
             TVector4 y2(&probes[j + 4], &probes[j + 8]);
             bool closer = closerToX(bb, y1, y2);

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -1555,7 +1555,7 @@ void CTimeSeriesDecompositionTest::testLongTermTrend() {
         trend.clear();
 
         {
-            std::size_t i = 0u;
+            std::size_t i = 1;
             for (core_t::TTime time = 0; time < length;
                  time += HALF_HOUR, (time > drops[i] ? ++i : i)) {
                 times.push_back(time);


### PR DESCRIPTION
This fixes a couple of places that valgrind revealed where the
maths library unit tests could read beyond the end of an array.

The one in `CTimeSeriesDecompositionTest.cc` is the one that
caused the nightly tests of the debug build with assertions enabled
to fail on macOS for the last 2 days.