### PR TITLE
[ML] Fix error causing us to overestimate effective history length

### DIFF
--- a/include/maths/CXMeansOnline.h
+++ b/include/maths/CXMeansOnline.h
@@ -805,8 +805,6 @@ public:
     //! Update the clustering with \p point and return its cluster(s)
     //! together with their weighting factor.
     virtual void add(const TPointPrecise& x, TSizeDoublePr2Vec& clusters, double count = 1.0) {
-        m_HistoryLength += 1.0;
-
         if (m_Clusters.size() == 1) {
             LOG_TRACE(<< "Adding " << x << " to " << m_Clusters[0].centre());
             m_Clusters[0].add(x, count);
@@ -896,7 +894,7 @@ public:
             LOG_ERROR(<< "Can't propagate backwards in time");
             return;
         }
-        m_HistoryLength *= std::exp(-m_DecayRate * time);
+        m_HistoryLength = (m_HistoryLength + time) * std::exp(-m_DecayRate * time);
         for (std::size_t i = 0u; i < m_Clusters.size(); ++i) {
             m_Clusters[i].propagateForwardsByTime(time);
         }

--- a/lib/maths/CXMeansOnline1d.cc
+++ b/lib/maths/CXMeansOnline1d.cc
@@ -857,7 +857,6 @@ void CXMeansOnline1d::cluster(const double& point, TSizeDoublePr2Vec& result, do
 
 void CXMeansOnline1d::add(const double& point, TSizeDoublePr2Vec& clusters, double count) {
 
-    m_HistoryLength += 1.0;
     m_Smallest.add(point);
     m_Largest.add(point);
 
@@ -962,7 +961,7 @@ void CXMeansOnline1d::propagateForwardsByTime(double time) {
         LOG_ERROR(<< "Can't propagate backwards in time");
         return;
     }
-    m_HistoryLength *= std::exp(-m_DecayRate * time);
+    m_HistoryLength = (m_HistoryLength + time) * std::exp(-m_DecayRate * time);
     for (std::size_t i = 0u; i < m_Clusters.size(); ++i) {
         m_Clusters[i].propagateForwardsByTime(time);
     }

--- a/lib/maths/unittest/CXMeansOnline1dTest.cc
+++ b/lib/maths/unittest/CXMeansOnline1dTest.cc
@@ -726,14 +726,15 @@ void CXMeansOnline1dTest::testLargeHistory() {
     TDoubleVec samples2;
     rng.generateNormalSamples(15.0, 1.0, 100, samples2);
 
-    TDoubleVec samples;
-    samples.assign(samples1.begin(), samples1.end());
+    TDoubleVec samples(samples1);
     samples.insert(samples.end(), samples2.begin(), samples2.end());
     rng.random_shuffle(samples.begin() + 5000, samples.end());
 
-    for (std::size_t i = 0u; i < samples.size(); ++i) {
-        reference.add(samples[i]);
-        clusterer.add(samples[i]);
+    for (const auto& sample :  samples) {
+        for (std::size_t i = 0; i < 3; ++i) {
+            reference.add(sample);
+            clusterer.add(sample);
+        }
         reference.propagateForwardsByTime(1.0);
         clusterer.propagateForwardsByTime(1.0);
     }

--- a/lib/maths/unittest/CXMeansOnlineTest.cc
+++ b/lib/maths/unittest/CXMeansOnlineTest.cc
@@ -627,16 +627,18 @@ void CXMeansOnlineTest::testLargeHistory() {
 
     TPointVec samples;
     for (std::size_t i = 0u; i < samples1.size(); i += 2) {
-        samples.push_back(TPoint(TDoubleVec(&samples1[i], &samples1[i + 2])));
+        samples.emplace_back(TDoubleVec(&samples1[i], &samples1[i + 2]));
     }
     for (std::size_t i = 0u; i < samples2.size(); i += 2) {
-        samples.push_back(TPoint(TDoubleVec(&samples2[i], &samples2[i + 2])));
+        samples.emplace_back(TDoubleVec(&samples2[i], &samples2[i + 2]));
     }
     rng.random_shuffle(samples.begin() + 5000, samples.end());
 
-    for (std::size_t i = 0u; i < samples.size(); ++i) {
-        reference.add(samples[i]);
-        clusterer.add(samples[i]);
+    for (const auto& sample : samples) {
+        for (std::size_t i = 0; i < 3; ++i) {
+            reference.add(sample);
+            clusterer.add(sample);
+        }
         reference.propagateForwardsByTime(1.0);
         clusterer.propagateForwardsByTime(1.0);
     }


### PR DESCRIPTION
We calculate the effective history length in our online clustering code and adjust the minimum fraction of samples permitted in a cluster based in this. In particular, if we decrease the decay rate so increase the effective history length we can create clusters containing a smaller fraction of the data. There was a bug in this if we add multiple values per bucket, as we do for population analysis, which means we overestimate the effective history length and so allow clusters containing a smaller fraction than we should. The upshot is we can potentially overfit and specifically fit outlying values by creating a cluster for them.

This was discovered whilst investigating #57. This change can affect results for count and metric population analysis.