### PR TITLE
[ML] Clean up intermediate images and containers in Docker builds

### DIFF
--- a/dev-tools/docker_build.sh
+++ b/dev-tools/docker_build.sh
@@ -67,10 +67,10 @@ do
     DOCKERFILE="$TOOLS_DIR/docker/${PLATFORM}_builder/Dockerfile"
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
-    docker build -t $TEMP_TAG --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
+    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
     # Using tar to copy the build artifacts out of the container seems more reliable
     # than docker cp, and also means the files end up with the correct uid/gid
-    docker run --workdir=/ml-cpp $TEMP_TAG tar cf - build/distributions | tar xvf -
+    docker run --rm --workdir=/ml-cpp $TEMP_TAG tar cf - build/distributions | tar xvf -
     docker rmi --force $TEMP_TAG
 
 done

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -68,11 +68,11 @@ do
     DOCKERFILE="$TOOLS_DIR/docker/${PLATFORM}_tester/Dockerfile"
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
-    docker build -t $TEMP_TAG --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
+    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
     # Using tar to copy the build and test artifacts out of the container seems
     # more reliable than docker cp, and also means the files end up with the
     # correct uid/gid
-    docker run --workdir=/ml-cpp $TEMP_TAG bash -c 'find . -name cppunit_results.xml | xargs tar cf - build/distributions' | tar xvf -
+    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c 'find . -name cppunit_results.xml | xargs tar cf - build/distributions' | tar xvf -
     docker rmi --force $TEMP_TAG
 
 done


### PR DESCRIPTION
Previously we were leaving intermediate images and containers behind,
leading to a build-up over time on machines running repeated Docker
builds.