### PR TITLE
[ML] Add cross links into build setup instructions

### DIFF
--- a/build-setup/macos_cross_compiled.md
+++ b/build-setup/macos_cross_compiled.md
@@ -19,7 +19,7 @@ export CPP_CROSS_COMPILE=macosx
 
 ### Initial Preparation
 
-Start by configuring a native macOS build server as described in [macos.md](build-setup/macos.md).
+Start by configuring a native macOS build server as described in [macos.md](macos.md).
 
 The remainder of these instructions assume the macOS build server you have configured is for macOS 10.11 (El Capitan).  This is what builds for distribution are currently built on.
 

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -2,7 +2,7 @@
 
 These instructions are for setting up a Windows build machine from scratch.
 
-For subsequent machines, the setup can be simplified by copying components from the first machine - see [windows_simple.md](build-setup/windows_simple.md).
+For subsequent machines, the setup can be simplified by copying components from the first machine - see [windows_simple.md](windows_simple.md).
 
 The build system assumes Windows itself is installed on the `C:` drive. If this is not the case on your machine, the Makefiles will not work.
 

--- a/build-setup/windows_simple.md
+++ b/build-setup/windows_simple.md
@@ -1,6 +1,6 @@
 # Machine Learning Build Machine Setup for Windows (simple)
 
-These instructions are an alternative to the "from scratch" instructions in [windows.md](build-setup/windows.md).
+These instructions are an alternative to the "from scratch" instructions in [windows.md](windows.md).
 
 This setup relies on pre-built 3rd party components previously built by the "from scratch" instructions and uploaded to s3. However, you get a fully working dev environment for ml-cpp.
 
@@ -12,7 +12,7 @@ It is possible to build on Windows Server 2012r2, Windows Server 2016 and Window
 
 ### Base requirements
 
-Follow the instructions (**only!**) for Windows 8 SDK and Git for Windows from [windows.md](build-setup/windows.md).
+Follow the instructions (**only!**) for Windows 8 SDK and Git for Windows from [windows.md](windows.md).
 
 ### Microsoft C++ build tools
 
@@ -24,7 +24,7 @@ The github repository contains a script to download the remaining dependencies, 
 
 ### Environment
 
-Create a `.bashrc` similar to that recommended in [windows.md](build-setup/windows.md), but with a couple of extra environment variables.  The build system lets you define `VCBASE` and `WINSDKBASE` to point it to the right compiler and SDK. In addition you have to put the directories into PATH as well. This is how it could look:
+Create a `.bashrc` similar to that recommended in [windows.md](windows.md), but with a couple of extra environment variables.  The build system lets you define `VCBASE` and `WINSDKBASE` to point it to the right compiler and SDK. In addition you have to put the directories into PATH as well. This is how it could look:
 
 ```
 export VCBASE=PROGRA~2/MICROS~2/2017/BUILDT~1


### PR DESCRIPTION
These make navigation easier when viewing the instructions in GitHub.

Also fixed a mistake in the .bashrc in the simple Windows setup.