### PR TITLE
[ML] Speed up trend model component prediction

### DIFF
--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -90,7 +90,7 @@ void CForecastTest::testDailyNoLongTermTrend() {
         return 40.0 + alpha * y[i / 6] + beta * y[(i / 6 + 1) % y.size()] + noise;
     };
 
-    this->test(trend, bucketLength, 60, 64.0, 4.0, 0.13);
+    this->test(trend, bucketLength, 60, 64.0, 5.0, 0.14);
 }
 
 void CForecastTest::testDailyConstantLongTermTrend() {
@@ -163,7 +163,7 @@ void CForecastTest::testComplexConstantLongTermTrend() {
                scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 24.0, 17.0, 0.04);
+    this->test(trend, bucketLength, 60, 24.0, 13.0, 0.01);
 }
 
 void CForecastTest::testComplexVaryingLongTermTrend() {
@@ -193,7 +193,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 4.0, 23.0, 0.05);
+    this->test(trend, bucketLength, 60, 4.0, 24.0, 0.051);
 }
 
 void CForecastTest::testNonNegative() {
@@ -363,7 +363,7 @@ void CForecastTest::testFinancialIndex() {
     //file << "my = " << core::CContainerPrinter::print(my) << ";\n";
     //file << "uy = " << core::CContainerPrinter::print(uy) << ";\n";
 
-    CPPUNIT_ASSERT(percentageOutOfBounds < 53.0);
+    CPPUNIT_ASSERT(percentageOutOfBounds < 52.0);
     CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.1);
 }
 


### PR DESCRIPTION
Whilst profiling end-of-bucket processing to evaluate #54 another hotspot was uncovered.

We have multiple trend models and use a weighted combination of these to make a prediction at some future time. However, depending on the time the prediction is required and the current decay rate, a number of these will have very low weight. We can exclude these altogether from the prediction and save the time to compute corresponding prediction with minimal impact on the result.

This saves another 7% on the end-of-bucket processing for the test scenario described in #53. It has a small impact on predictions for count and metric model and so a small impact on results.