### PR TITLE
[ML] Always combine duplicate samples when updating population models

### DIFF
--- a/include/model/CModelParams.h
+++ b/include/model/CModelParams.h
@@ -154,7 +154,7 @@ struct MODEL_EXPORT SModelParams {
 
     //! The minimum data size to trigger fuzzy de-duplication of samples to add
     //! to population models.
-    std::size_t s_MinimumToDeduplicate;
+    std::size_t s_MinimumToFuzzyDeduplicate;
 
     //! If true then cache the results of the probability calculation.
     bool s_CacheProbabilities;

--- a/include/model/CModelTools.h
+++ b/include/model/CModelTools.h
@@ -87,8 +87,6 @@ public:
         core_t::TTime quantize(core_t::TTime time) const;
 
     private:
-        //! If false then quantization is disabled.
-        bool m_Quantize = true;
         //! The count of values added.
         std::size_t m_Count = 0;
         //! The time quantization interval.

--- a/lib/model/CModelParams.cc
+++ b/lib/model/CModelParams.cc
@@ -51,7 +51,7 @@ SModelParams::SModelParams(core_t::TTime bucketLength)
       s_MinimumSignificantCorrelation(
           CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_SIGNIFICANT_CORRELATION),
       s_DetectionRules(EMPTY_RULES), s_ScheduledEvents(EMPTY_SCHEDULED_EVENTS),
-      s_BucketResultsDelay(0), s_MinimumToDeduplicate(10000),
+      s_BucketResultsDelay(0), s_MinimumToFuzzyDeduplicate(10000),
       s_CacheProbabilities(true), s_SamplingAgeCutoff(SAMPLING_AGE_CUTOFF_DEFAULT) {
 }
 
@@ -93,7 +93,7 @@ uint64_t SModelParams::checksum(uint64_t seed) const {
     seed = maths::CChecksum::calculate(seed, s_CorrelationModelsOverhead);
     seed = maths::CChecksum::calculate(seed, s_MultivariateByFields);
     seed = maths::CChecksum::calculate(seed, s_MinimumSignificantCorrelation);
-    return maths::CChecksum::calculate(seed, s_MinimumToDeduplicate);
+    return maths::CChecksum::calculate(seed, s_MinimumToFuzzyDeduplicate);
 }
 }
 }

--- a/lib/model/CModelTools.cc
+++ b/lib/model/CModelTools.cc
@@ -124,8 +124,7 @@ void CModelTools::CFuzzyDeduplicate::add(TDouble2Vec value) {
 
 void CModelTools::CFuzzyDeduplicate::computeEpsilons(core_t::TTime bucketLength,
                                                      std::size_t desiredNumberSamples) {
-    m_Quantize = m_Count > 0;
-    if (m_Quantize) {
+    if (m_Count > 0) {
         m_QuantizedValues.reserve(std::min(m_Count, desiredNumberSamples));
         m_TimeEps = std::max(bucketLength / 60, core_t::TTime(1));
         m_ValueEps.assign(m_RandomSample[0].size(), 0.0);
@@ -144,19 +143,15 @@ void CModelTools::CFuzzyDeduplicate::computeEpsilons(core_t::TTime bucketLength,
                                 static_cast<double>(desiredNumberSamples);
             }
         }
-        m_Count = 0;
     }
 }
 
 std::size_t CModelTools::CFuzzyDeduplicate::duplicate(core_t::TTime time, TDouble2Vec value) {
-    return !m_Quantize
-               ? m_Count++
-               : m_QuantizedValues
-                     .emplace(boost::unordered::piecewise_construct,
-                              std::forward_as_tuple(this->quantize(time),
-                                                    this->quantize(value)),
-                              std::forward_as_tuple(m_QuantizedValues.size()))
-                     .first->second;
+    return m_QuantizedValues
+        .emplace(boost::unordered::piecewise_construct,
+                 std::forward_as_tuple(this->quantize(time), this->quantize(value)),
+                 std::forward_as_tuple(m_QuantizedValues.size()))
+        .first->second;
 }
 
 CModelTools::TDouble2Vec CModelTools::CFuzzyDeduplicate::quantize(TDouble2Vec value) const {
@@ -169,7 +164,7 @@ CModelTools::TDouble2Vec CModelTools::CFuzzyDeduplicate::quantize(TDouble2Vec va
 }
 
 core_t::TTime CModelTools::CFuzzyDeduplicate::quantize(core_t::TTime time) const {
-    return maths::CIntegerTools::floor(time, m_TimeEps);
+    return m_TimeEps > 0 ? maths::CIntegerTools::floor(time, m_TimeEps) : time;
 }
 
 std::size_t CModelTools::CFuzzyDeduplicate::SDuplicateValueHash::

--- a/lib/model/unittest/CModelToolsTest.cc
+++ b/lib/model/unittest/CModelToolsTest.cc
@@ -29,6 +29,7 @@ namespace {
 
 using TDoubleVec = std::vector<double>;
 using TDouble2Vec = core::CSmallVector<double, 2>;
+using TTimeVec = std::vector<core_t::TTime>;
 
 const double MINIMUM_SEASONAL_SCALE{0.25};
 const double DECAY_RATE{0.0005};
@@ -57,7 +58,55 @@ maths::CMultimodalPrior multimodal() {
 }
 
 void CModelToolsTest::testFuzzyDeduplicate() {
+    // Test de-duplication and fuzzy de-duplication.
+    //
+    // We shouldn't have repeated values and no value should be further
+    // from its fuzzy duplicate than an expected tolerance.
+    //
+    // Finally, we test we get good reduction in the number of values
+    // when fuzzily de-duplicating over a range of data distributions.
+
     test::CRandomNumbers rng;
+
+    auto fuzzyUniqueValues = [&](const TDoubleVec& values, double q80, TDoubleVec& uniques) {
+        std::size_t desiredSamples{10000};
+        double tolerance{1.5 * q80 / static_cast<double>(desiredSamples)};
+        LOG_DEBUG(<< "tolerance = " << tolerance);
+
+        model::CModelTools::CFuzzyDeduplicate duplicates;
+        for (auto value : values) {
+            duplicates.add({value});
+        }
+        duplicates.computeEpsilons(600 /*bucketLength*/, desiredSamples);
+
+        uniques.clear();
+        for (auto value : values) {
+            std::size_t duplicate{duplicates.duplicate(300, {value})};
+            if (duplicate < uniques.size()) {
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(uniques[duplicate], value, tolerance);
+            } else {
+                uniques.push_back(value);
+            }
+        }
+    };
+
+    LOG_DEBUG("Duplicates");
+    {
+        model::CModelTools::CFuzzyDeduplicate duplicates;
+        TTimeVec times{300, 300, 300, 900, 300, 300, 300};
+        TDoubleVec values{1.0, 1.0, 4.0, 1.0, 3.0, 1.2, 25.0};
+        TDoubleVec uniques;
+        for (std::size_t i = 0; i < times.size(); ++i) {
+            std::size_t duplicate{duplicates.duplicate(times[i], {values[i]})};
+            if (duplicate == uniques.size()) {
+                uniques.push_back(values[i]);
+            } else {
+                CPPUNIT_ASSERT_EQUAL(values[i], uniques[duplicate]);
+            }
+        }
+        CPPUNIT_ASSERT_EQUAL(std::string("[1, 4, 1, 3, 1.2, 25]"),
+                             core::CContainerPrinter::print(uniques));
+    }
 
     TDoubleVec values;
     TDoubleVec uniques;
@@ -67,28 +116,9 @@ void CModelToolsTest::testFuzzyDeduplicate() {
     LOG_DEBUG(<< "Normal");
     for (auto variance : {1.0, 10.0, 100.0, 1000.0}) {
         rng.generateNormalSamples(0.0, variance, 200000, values);
-
-        model::CModelTools::CFuzzyDeduplicate fuzzy;
-        for (auto value : values) {
-            fuzzy.add(TDouble2Vec{value});
-        }
-        fuzzy.computeEpsilons(600, 10000);
-
         boost::math::normal normal{variance, std::sqrt(variance)};
-        double eps{(boost::math::quantile(normal, 0.9) - boost::math::quantile(normal, 0.1)) /
-                   10000.0};
-        LOG_DEBUG(<< "eps = " << eps);
-
-        uniques.clear();
-        for (auto value : values) {
-            std::size_t duplicate{fuzzy.duplicate(300, TDouble2Vec{value})};
-            if (duplicate < uniques.size()) {
-                CPPUNIT_ASSERT_DOUBLES_EQUAL(uniques[duplicate], value, 1.5 * eps);
-            } else {
-                uniques.push_back(value);
-            }
-        }
-
+        double q80{(boost::math::quantile(normal, 0.9) - boost::math::quantile(normal, 0.1))};
+        fuzzyUniqueValues(values, q80, uniques);
         LOG_DEBUG(<< "Got " << uniques.size() << "/" << values.size());
         CPPUNIT_ASSERT(uniques.size() < 25000);
     }
@@ -96,26 +126,8 @@ void CModelToolsTest::testFuzzyDeduplicate() {
     LOG_DEBUG(<< "Uniform");
     for (auto range : {1.0, 10.0, 100.0, 1000.0}) {
         rng.generateUniformSamples(0.0, range, 200000, values);
-
-        model::CModelTools::CFuzzyDeduplicate fuzzy;
-        for (auto value : values) {
-            fuzzy.add(TDouble2Vec{value});
-        }
-        fuzzy.computeEpsilons(600, 10000);
-
-        double eps{0.8 * range / 10000.0};
-        LOG_DEBUG(<< "eps = " << eps);
-
-        uniques.clear();
-        for (auto value : values) {
-            std::size_t duplicate{fuzzy.duplicate(300, TDouble2Vec{value})};
-            if (duplicate < uniques.size()) {
-                CPPUNIT_ASSERT_DOUBLES_EQUAL(uniques[duplicate], value, 1.5 * eps);
-            } else {
-                uniques.push_back(value);
-            }
-        }
-
+        double q80{0.8 * range};
+        fuzzyUniqueValues(values, q80, uniques);
         LOG_DEBUG(<< "Got " << uniques.size() << "/" << values.size());
         CPPUNIT_ASSERT(uniques.size() < 15000);
     }
@@ -124,26 +136,8 @@ void CModelToolsTest::testFuzzyDeduplicate() {
     {
         rng.generateUniformSamples(0.0, 100.0, 200000, values);
         std::sort(values.begin(), values.end());
-
-        model::CModelTools::CFuzzyDeduplicate fuzzy;
-        for (auto value : values) {
-            fuzzy.add(TDouble2Vec{value});
-        }
-        fuzzy.computeEpsilons(600, 10000);
-
-        double eps{80.0 / 10000.0};
-        LOG_DEBUG(<< "eps = " << eps);
-
-        uniques.clear();
-        for (auto value : values) {
-            std::size_t duplicate{fuzzy.duplicate(300, TDouble2Vec{value})};
-            if (duplicate < uniques.size()) {
-                CPPUNIT_ASSERT_DOUBLES_EQUAL(uniques[duplicate], value, 1.5 * eps);
-            } else {
-                uniques.push_back(value);
-            }
-        }
-
+        double q80{80.0};
+        fuzzyUniqueValues(values, q80, uniques);
         LOG_DEBUG(<< "Got " << uniques.size() << "/" << values.size());
         CPPUNIT_ASSERT(uniques.size() < 15000);
     }
@@ -151,35 +145,19 @@ void CModelToolsTest::testFuzzyDeduplicate() {
     LOG_DEBUG(<< "Log-Normal");
     for (auto variance : {1.0, 2.0, 4.0, 8.0}) {
         rng.generateLogNormalSamples(variance, variance, 200000, values);
-
-        model::CModelTools::CFuzzyDeduplicate fuzzy;
-        for (auto value : values) {
-            fuzzy.add(TDouble2Vec{value});
-        }
-        fuzzy.computeEpsilons(600, 10000);
-
         boost::math::lognormal lognormal{variance, std::sqrt(variance)};
-        double eps{(boost::math::quantile(lognormal, 0.9) -
-                    boost::math::quantile(lognormal, 0.1)) /
-                   10000.0};
-        LOG_DEBUG(<< "eps = " << eps);
-
-        uniques.clear();
-        for (auto value : values) {
-            std::size_t duplicate{fuzzy.duplicate(300, TDouble2Vec{value})};
-            if (duplicate < uniques.size()) {
-                CPPUNIT_ASSERT_DOUBLES_EQUAL(uniques[duplicate], value, 1.5 * eps);
-            } else {
-                uniques.push_back(value);
-            }
-        }
-
+        double q80{boost::math::quantile(lognormal, 0.9) -
+                   boost::math::quantile(lognormal, 0.1)};
+        fuzzyUniqueValues(values, q80, uniques);
         LOG_DEBUG(<< "Got " << uniques.size() << "/" << values.size());
         CPPUNIT_ASSERT(uniques.size() < 30000);
     }
 }
 
 void CModelToolsTest::testProbabilityCache() {
+    // Test the error introduced by caching the probability and that we
+    // don't get any errors in the tailness we calculate for the value.
+
     using TBool2Vec = core::CSmallVector<bool, 2>;
     using TSize1Vec = core::CSmallVector<std::size_t, 1>;
     using TTime2Vec = core::CSmallVector<core_t::TTime, 2>;


### PR DESCRIPTION
Whilst investigating #57 it became clear that at least for this analysis we get many exact duplicates per bucket. It is reasonable to expect this may be relatively common, at least for integer valued data.

We already have a mechanism (for fuzzy de-duplication) to combine equivalent samples and re-weight the unique values. Therefore, it is relatively easy to always combine identical values.

De-duplicating has two advantages: 1) it makes the job of clustering somewhat easier since we only visit the values serially, 2) for cases such as the analysis described in #57 we get significant runtime improvements. In particular, with this change we get more stable model selection and the runtime to process all 14M records on my laptop drops from around 9m40s to around 6m40s for this job.

This will potentially affect count and metric population analysis results. The changes should be relatively small and will depend on the degree of duplication for the particular data set and function.

(I created a separate change for test changes to aid review.)