### PR TITLE
[ML] Only run the long time range periodicity test if the data bucketing precludes the short time range test

### DIFF
--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -231,7 +231,7 @@ public:
         void apply(std::size_t symbol, const SMessage& message);
 
         //! Check if we should run the periodicity test on \p window.
-        bool shouldTest(const TExpandingWindowPtr& window, core_t::TTime time) const;
+        bool shouldTest(ETest test, core_t::TTime time) const;
 
         //! Get a new \p test. (Warning owned by the caller.)
         CExpandingWindow* newWindow(ETest test) const;

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -333,8 +333,8 @@ void CTimeSeriesDecompositionTest::testDistortedPeriodic() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.17 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.23 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.18 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.22 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 }
 

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -173,11 +173,16 @@ void importData(ml::core_t::TTime firstTime,
 }
 
 void CEventRateAnomalyDetectorTest::testAnomalies() {
-    static const size_t EXPECTED_ANOMALOUS_HOURS(12);
+
+    // We have 10 instances of correlated 503s and unusual SQL statements
+    // and one significant drop in status 200s, which are the principal
+    // anomalies to find in this data set.
+    static const double HIGH_ANOMALY_SCORE(0.004);
+    static const size_t EXPECTED_ANOMALOUS_HOURS(11);
+
     static const ml::core_t::TTime FIRST_TIME(1346713620);
     static const ml::core_t::TTime LAST_TIME(1347317974);
     static const ml::core_t::TTime BUCKET_SIZE(1800);
-    static const double HIGH_ANOMALY_SCORE(0.003);
 
     ml::model::CAnomalyDetectorModelConfig modelConfig =
         ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
@@ -198,7 +203,6 @@ void CEventRateAnomalyDetectorTest::testAnomalies() {
     importData(FIRST_TIME, LAST_TIME, BUCKET_SIZE, writer, files, detector);
 
     LOG_DEBUG(<< "visitor.calls() = " << writer.calls());
-    // CPPUNIT_ASSERT_EQUAL(writer.calls(), writer.numDistinctTimes());
 
     const TTimeDoubleMap& anomalyScores = writer.anomalyScores();
     TTimeVec peaks;


### PR DESCRIPTION
As of 6.3, we started running the long and short time range periodicity tests at additional times (so that we can detect diurnal periodicity early). However, we only need to run the long time range test if the short time range one is not available, since its resolution, hence accuracy for these periods, is worse.

For example, #75 showed up the case that we're now detecting periodicity in the long range test, because of the extra smoothing due to longer buckets, in data for which don't want to model periodicity at the selected bucket length.

A step towards #75.