### PR TITLE
Add a CHANGELOG file for release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -1,0 +1,48 @@
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+// :issue: https://github.com/elastic/elasticsearch/issues/
+// :pull: https://github.com/elastic/elasticsearch/pull/
+
+= Elasticsearch Release Notes
+
+== Elasticsearch 7.0.0
+
+=== Breaking Changes
+
+=== Breaking Java Changes
+
+=== Deprecations
+
+=== New Features 
+
+=== Enhancements
+
+=== Bug Fixes
+
+=== Regressions
+
+=== Known Issues
+
+== Elasticsearch version 6.4.0
+
+=== New Features
+
+=== Enhancements
+
+=== Bug Fixes
+
+=== Regressions
+
+=== Known Issues
+
+== Elasticsearch version 6.3.0
+
+=== New Features
+
+=== Enhancements
+
+=== Bug Fixes
+
+=== Regressions
+
+=== Known Issues


### PR DESCRIPTION
In order to improve the quality of our release notes, we're going to start using a CHANGELOG file, per https://github.com/elastic/elasticsearch/pull/29450

This content will be integrated into the Elasticsearch release notes before each new release. 