### PR TITLE
[ML] Check range in bounds when clearing recycled models

### DIFF
--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -286,12 +286,6 @@ private:
     //! Get the interim corrections of the current bucket.
     TFeatureSizeSizeTripleDouble1VecUMap& currentBucketInterimCorrections() const;
 
-    //! Create the time series models for "n" newly observed people.
-    virtual void createNewModels(std::size_t n, std::size_t m);
-
-    //! Reinitialize the time series models for recycled people.
-    virtual void updateRecycledModels();
-
     //! Clear out large state objects for people that are pruned.
     virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
 

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -196,10 +196,10 @@ protected:
     void createUpdateNewModels(core_t::TTime time, CResourceMonitor& resourceMonitor);
 
     //! Create the time series models for "n" newly observed people.
-    virtual void createNewModels(std::size_t n, std::size_t m) = 0;
+    virtual void createNewModels(std::size_t n, std::size_t m);
 
     //! Reinitialize the time series models for recycled people.
-    virtual void updateRecycledModels() = 0;
+    virtual void updateRecycledModels();
 
     //! Update the correlation models.
     void refreshCorrelationModels(std::size_t resourceLimit, CResourceMonitor& resourceMonitor);

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -285,12 +285,6 @@ private:
     //! Set the current bucket total count.
     virtual void currentBucketTotalCount(uint64_t totalCount);
 
-    //! Create the time series models for "n" newly observed people.
-    virtual void createNewModels(std::size_t n, std::size_t m);
-
-    //! Reinitialize the time series models for recycled people.
-    virtual void updateRecycledModels();
-
     //! Clear out large state objects for people that are pruned.
     virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
 

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -451,8 +451,8 @@ void CAnomalyDetectorModel::updateRecycledModels() {
         if (pid < m_PersonBucketCounts.size()) {
             m_PersonBucketCounts[pid] = 0.0;
         } else {
-            LOG_ERROR("Recycled person identifier '"
-                      << pid << "' out-of-range [," << m_PersonBucketCounts.size() << ")");
+            LOG_ERROR(<< "Recycled person identifier '" << pid << "' out-of-range [,"
+                      << m_PersonBucketCounts.size() << ")");
         }
     }
     people.clear();

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -448,7 +448,12 @@ void CAnomalyDetectorModel::createNewModels(std::size_t n, std::size_t /*m*/) {
 void CAnomalyDetectorModel::updateRecycledModels() {
     TSizeVec& people{m_DataGatherer->recycledPersonIds()};
     for (auto pid : people) {
-        m_PersonBucketCounts[pid] = 0.0;
+        if (pid < m_PersonBucketCounts.size()) {
+            m_PersonBucketCounts[pid] = 0.0;
+        } else {
+            LOG_ERROR("Recycled person identifier '"
+                      << pid << "' out-of-range [," << m_PersonBucketCounts.size() << ")");
+        }
     }
     people.clear();
 }

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -390,8 +390,10 @@ void CCountingModel::updateCurrentBucketsStats(core_t::TTime time) {
 }
 
 void CCountingModel::updateRecycledModels() {
-    for (auto person : this->dataGatherer().recycledPersonIds()) {
-        m_MeanCounts[person] = TMeanAccumulator();
+    for (auto pid : this->dataGatherer().recycledPersonIds()) {
+        if (pid < m_MeanCounts.size()) {
+            m_MeanCounts[pid] = TMeanAccumulator();
+        }
     }
     this->CAnomalyDetectorModel::updateRecycledModels();
 }

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -528,14 +528,6 @@ CEventRateModel::currentBucketInterimCorrections() const {
     return m_CurrentBucketStats.s_InterimCorrections;
 }
 
-void CEventRateModel::createNewModels(std::size_t n, std::size_t m) {
-    this->CIndividualModel::createNewModels(n, m);
-}
-
-void CEventRateModel::updateRecycledModels() {
-    this->CIndividualModel::updateRecycledModels();
-}
-
 void CEventRateModel::clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) {
     CDataGatherer& gatherer = this->dataGatherer();
 

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -474,13 +474,15 @@ void CIndividualModel::createNewModels(std::size_t n, std::size_t m) {
 
 void CIndividualModel::updateRecycledModels() {
     for (auto pid : this->dataGatherer().recycledPersonIds()) {
-        m_FirstBucketTimes[pid] = CAnomalyDetectorModel::TIME_UNSET;
-        m_LastBucketTimes[pid] = CAnomalyDetectorModel::TIME_UNSET;
-        for (auto& feature : m_FeatureModels) {
-            feature.s_Models[pid].reset(feature.s_NewModel->clone(pid));
-            for (const auto& correlates : m_FeatureCorrelatesModels) {
-                if (feature.s_Feature == correlates.s_Feature) {
-                    feature.s_Models.back()->modelCorrelations(*correlates.s_Models);
+        if (pid < m_FirstBucketTimes.size()) {
+            m_FirstBucketTimes[pid] = CAnomalyDetectorModel::TIME_UNSET;
+            m_LastBucketTimes[pid] = CAnomalyDetectorModel::TIME_UNSET;
+            for (auto& feature : m_FeatureModels) {
+                feature.s_Models[pid].reset(feature.s_NewModel->clone(pid));
+                for (const auto& correlates : m_FeatureCorrelatesModels) {
+                    if (feature.s_Feature == correlates.s_Feature) {
+                        feature.s_Models.back()->modelCorrelations(*correlates.s_Models);
+                    }
                 }
             }
         }

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -461,27 +461,6 @@ CMetricModel::featureData(model_t::EFeature feature, std::size_t pid, core_t::TT
                                                m_CurrentBucketStats.s_FeatureData);
 }
 
-void CMetricModel::createNewModels(std::size_t n, std::size_t m) {
-    this->CIndividualModel::createNewModels(n, m);
-}
-
-void CMetricModel::updateRecycledModels() {
-    this->CIndividualModel::updateRecycledModels();
-}
-
-void CMetricModel::clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) {
-    CDataGatherer& gatherer = this->dataGatherer();
-
-    // Stop collecting for these people and add them to the free list.
-    gatherer.recyclePeople(people);
-    if (gatherer.dataAvailable(m_CurrentBucketStats.s_StartTime)) {
-        gatherer.featureData(m_CurrentBucketStats.s_StartTime, gatherer.bucketLength(),
-                             m_CurrentBucketStats.s_FeatureData);
-    }
-
-    this->CIndividualModel::clearPrunedResources(people, attributes);
-}
-
 core_t::TTime CMetricModel::currentBucketStartTime() const {
     return m_CurrentBucketStats.s_StartTime;
 }
@@ -509,6 +488,19 @@ CMetricModel::TSizeUInt64PrVec& CMetricModel::currentBucketPersonCounts() {
 
 void CMetricModel::currentBucketTotalCount(uint64_t totalCount) {
     m_CurrentBucketStats.s_TotalCount = totalCount;
+}
+
+void CMetricModel::clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) {
+    CDataGatherer& gatherer = this->dataGatherer();
+
+    // Stop collecting for these people and add them to the free list.
+    gatherer.recyclePeople(people);
+    if (gatherer.dataAvailable(m_CurrentBucketStats.s_StartTime)) {
+        gatherer.featureData(m_CurrentBucketStats.s_StartTime, gatherer.bucketLength(),
+                             m_CurrentBucketStats.s_FeatureData);
+    }
+
+    this->CIndividualModel::clearPrunedResources(people, attributes);
 }
 
 bool CMetricModel::correlates(model_t::EFeature feature, std::size_t pid, core_t::TTime time) const {

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -445,16 +445,24 @@ void CPopulationModel::createNewModels(std::size_t n, std::size_t m) {
 void CPopulationModel::updateRecycledModels() {
     CDataGatherer& gatherer = this->dataGatherer();
     for (auto pid : gatherer.recycledPersonIds()) {
-        m_PersonLastBucketTimes[pid] = 0;
+        if (pid < m_PersonLastBucketTimes.size()) {
+            m_PersonLastBucketTimes[pid] = 0;
+        }
     }
 
     TSizeVec& attributes = gatherer.recycledAttributeIds();
     for (auto cid : attributes) {
-        m_AttributeFirstBucketTimes[cid] = CAnomalyDetectorModel::TIME_UNSET;
-        m_AttributeLastBucketTimes[cid] = CAnomalyDetectorModel::TIME_UNSET;
-        m_DistinctPersonCounts[cid] = m_NewDistinctPersonCounts;
-        if (m_NewPersonBucketCounts) {
-            m_PersonAttributeBucketCounts[cid] = *m_NewPersonBucketCounts;
+        if (cid < m_AttributeFirstBucketTimes.size()) {
+            m_AttributeFirstBucketTimes[cid] = CAnomalyDetectorModel::TIME_UNSET;
+            m_AttributeLastBucketTimes[cid] = CAnomalyDetectorModel::TIME_UNSET;
+            m_DistinctPersonCounts[cid] = m_NewDistinctPersonCounts;
+            if (m_NewPersonBucketCounts) {
+                m_PersonAttributeBucketCounts[cid] = *m_NewPersonBucketCounts;
+            }
+        } else {
+            LOG_ERROR("Recycled attribute identifier '"
+                      << cid << "' out-of-range [0,"
+                      << m_AttributeFirstBucketTimes.size() << ")");
         }
     }
     attributes.clear();

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -460,8 +460,7 @@ void CPopulationModel::updateRecycledModels() {
                 m_PersonAttributeBucketCounts[cid] = *m_NewPersonBucketCounts;
             }
         } else {
-            LOG_ERROR("Recycled attribute identifier '"
-                      << cid << "' out-of-range [0,"
+            LOG_ERROR(<< "Recycled attribute identifier '" << cid << "' out-of-range [0,"
                       << m_AttributeFirstBucketTimes.size() << ")");
         }
     }


### PR DESCRIPTION
Add failsafes to ensure that we never try and reset state for identifiers outside vector bounds. This shouldn't happen, but this is the likely cause of #76 and there are no side effects from checking and issuing an error in such cases. Investigating and fixing the root cause of #76 will be the subject of separate PR.