### PR TITLE
[ML] Improve and use periodic boundary condition in seasonal component

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -15,6 +15,8 @@
 
 === Enhancements
 
+Improve and use periodic boundary condition for seasonal component modeling ({pull}84[#84])
+
 === Bug Fixes
 
 === Regressions

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -15,8 +15,6 @@
 
 === Enhancements
 
-Improve and use periodic boundary condition for seasonal component modeling ({pull}84[#84])
-
 === Bug Fixes
 
 === Regressions
@@ -28,6 +26,8 @@ Improve and use periodic boundary condition for seasonal component modeling ({pu
 === New Features
 
 === Enhancements
+
+Improve and use periodic boundary condition for seasonal component modeling ({pull}84[#84])
 
 === Bug Fixes
 

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1423,12 +1423,14 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
         TFloatMeanAccumulatorVec values;
         for (const auto& seasonalTime : newSeasonalTimes) {
             values = window.valuesMinusPrediction(predictor);
+            core_t::TTime period{seasonalTime->period()};
             components.emplace_back(*seasonalTime, m_SeasonalComponentSize,
                                     m_DecayRate, static_cast<double>(m_BucketLength),
-                                    CSplineTypes::E_Natural);
+                                    period > seasonalTime->windowLength()
+                                        ? CSplineTypes::E_Natural
+                                        : CSplineTypes::E_Periodic);
             components.back().initialize(window.startTime(), window.endTime(), values);
-            components.back().interpolate(
-                CIntegerTools::floor(window.endTime(), seasonalTime->period()));
+            components.back().interpolate(CIntegerTools::floor(window.endTime(), period));
         }
 
         CTrendComponent windowTrend{trend.defaultDecayRate()};

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -105,7 +105,7 @@ void CForecastTest::testDailyConstantLongTermTrend() {
                y[i] + noise;
     };
 
-    this->test(trend, bucketLength, 60, 64.0, 15.0, 0.02);
+    this->test(trend, bucketLength, 60, 64.0, 16.0, 0.02);
 }
 
 void CForecastTest::testDailyVaryingLongTermTrend() {
@@ -146,7 +146,7 @@ void CForecastTest::testComplexNoLongTermTrend() {
         return scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 24.0, 34.0, 0.13);
+    this->test(trend, bucketLength, 60, 24.0, 28.0, 0.13);
 }
 
 void CForecastTest::testComplexConstantLongTermTrend() {
@@ -163,7 +163,7 @@ void CForecastTest::testComplexConstantLongTermTrend() {
                scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 24.0, 13.0, 0.01);
+    this->test(trend, bucketLength, 60, 24.0, 14.0, 0.01);
 }
 
 void CForecastTest::testComplexVaryingLongTermTrend() {
@@ -193,7 +193,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 4.0, 24.0, 0.051);
+    this->test(trend, bucketLength, 60, 4.0, 28.0, 0.053);
 }
 
 void CForecastTest::testNonNegative() {

--- a/lib/maths/unittest/CSeasonalComponentAdaptiveBucketingTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentAdaptiveBucketingTest.cc
@@ -43,7 +43,7 @@ void CSeasonalComponentAdaptiveBucketingTest::testInitialize() {
 
     const std::string expectedEndpoints("[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]");
     const std::string expectedKnots("[0, 4, 14, 24, 34, 44, 54, 64, 74, 84, 94, 100]");
-    const std::string expectedValues("[50, 5, 15, 25, 35, 45, 55, 65, 75, 85, 95, 50]");
+    const std::string expectedValues("[41, 5, 15, 25, 35, 45, 55, 65, 75, 85, 95, 41]");
 
     CPPUNIT_ASSERT(bucketing.initialize(10));
     const TFloatVec& endpoints = bucketing.endpoints();

--- a/lib/maths/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentTest.cc
@@ -302,7 +302,7 @@ void CSeasonalComponentTest::testConstantPeriodic() {
         totalError2 /= 30.0;
         LOG_DEBUG(<< "totalError1 = " << totalError1);
         LOG_DEBUG(<< "totalError2 = " << totalError2);
-        CPPUNIT_ASSERT(totalError1 < 0.5);
+        CPPUNIT_ASSERT(totalError1 < 0.42);
         CPPUNIT_ASSERT(totalError2 < 0.01);
     }
 
@@ -515,15 +515,15 @@ void CSeasonalComponentTest::testTimeVaryingPeriodic() {
                           << mean(seasonal.value(time + core::constants::DAY - 1, 0.0)));
                 CPPUNIT_ASSERT_DOUBLES_EQUAL(
                     mean(seasonal.value(time, 0.0)),
-                    mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.1);
+                    mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.2);
             }
 
             error1 /= static_cast<double>(function.size());
             error2 /= static_cast<double>(function.size());
             LOG_DEBUG(<< "error1 = " << error1);
             LOG_DEBUG(<< "error2 = " << error2);
-            CPPUNIT_ASSERT(error1 < 42.0);
-            CPPUNIT_ASSERT(error2 < 20.0);
+            CPPUNIT_ASSERT(error1 < 27.0);
+            CPPUNIT_ASSERT(error2 < 19.0);
             totalError1 += error1;
             totalError2 += error2;
             numberErrors += 1.0;

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -126,8 +126,8 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                CPPUNIT_ASSERT(sumResidual < 0.04 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.04 * maxValue);
+                CPPUNIT_ASSERT(sumResidual < 0.042 * sumValue);
+                CPPUNIT_ASSERT(maxResidual < 0.040 * maxValue);
                 CPPUNIT_ASSERT(percentileError < 0.02 * sumValue);
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -149,7 +149,7 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
     //file << "plot(t(1:length(fe)), fe, 'r');\n";
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.018 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.019 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.021 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 }
@@ -449,7 +449,7 @@ void CTimeSeriesDecompositionTest::testMinimizeLongComponents() {
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
     CPPUNIT_ASSERT(totalSumResidual < 0.06 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.27 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.22 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 
     meanSlope /= refinements;
@@ -531,7 +531,7 @@ void CTimeSeriesDecompositionTest::testWeekend() {
 
             if (time >= 3 * WEEK) {
                 CPPUNIT_ASSERT(sumResidual < 0.07 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.15 * maxValue);
+                CPPUNIT_ASSERT(maxResidual < 0.17 * maxValue);
                 CPPUNIT_ASSERT(percentileError < 0.03 * sumValue);
 
                 totalSumResidual += sumResidual;
@@ -554,8 +554,8 @@ void CTimeSeriesDecompositionTest::testWeekend() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.027 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.12 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.026 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.13 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.012 * totalSumValue);
 }
 
@@ -657,7 +657,7 @@ void CTimeSeriesDecompositionTest::testSinglePeriodicity() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
     CPPUNIT_ASSERT(totalSumResidual < 0.015 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.042 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.024 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 
     // Check that only the daily component has been initialized.
@@ -782,7 +782,7 @@ void CTimeSeriesDecompositionTest::testSeasonalOnset() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
     CPPUNIT_ASSERT(totalSumResidual < 0.07 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.09 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.08 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 }
 
@@ -836,7 +836,7 @@ void CTimeSeriesDecompositionTest::testVarianceScale() {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError))
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.29);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.23);
         CPPUNIT_ASSERT(maths::CBasicStatistics::mean(percentileError) < 0.05);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, maths::CBasicStatistics::mean(meanScale), 0.04);
     }
@@ -1016,7 +1016,7 @@ void CTimeSeriesDecompositionTest::testSpikeyDataProblemCase() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.19 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.20 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.33 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.14 * totalSumValue);
 
@@ -1662,11 +1662,12 @@ void CTimeSeriesDecompositionTest::testLongTermTrendAndPeriodicity() {
 void CTimeSeriesDecompositionTest::testNonDiurnal() {
     test::CRandomNumbers rng;
 
-    LOG_DEBUG(<< "Hourly") {
+    LOG_DEBUG(<< "Hourly");
+    {
         const core_t::TTime length = 21 * DAY;
 
         double periodic[]{10.0, 1.0, 0.5, 0.5, 1.0, 5.0,
-                          2.0,  1.0, 0.5, 0.5, 1.0, 3.0};
+                          2.0,  1.0, 0.5, 0.5, 1.0, 6.0};
 
         TTimeVec times;
         TDoubleVec trends[2]{TDoubleVec(), TDoubleVec(8 * DAY / FIVE_MINS)};
@@ -1680,7 +1681,7 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
         rng.generateNormalSamples(0.0, 1.0, trends[1].size(), noise);
 
         core_t::TTime startTesting[]{3 * HOUR, 16 * DAY};
-        TDoubleVec thresholds[]{TDoubleVec{0.07, 0.06}, TDoubleVec{0.18, 0.13}};
+        TDoubleVec thresholds[]{TDoubleVec{0.09, 0.07}, TDoubleVec{0.19, 0.16}};
 
         for (std::size_t t = 0u; t < 2; ++t) {
             //std::ofstream file;
@@ -1731,8 +1732,8 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
                         totalSumValue += sumValue;
                         totalMaxValue += maxValue;
 
-                        CPPUNIT_ASSERT(sumResidual / sumValue < 0.33);
-                        CPPUNIT_ASSERT(maxResidual / maxValue < 0.28);
+                        CPPUNIT_ASSERT(sumResidual / sumValue < 0.35);
+                        CPPUNIT_ASSERT(maxResidual / maxValue < 0.33);
                     }
                     lastHour += HOUR;
                 }
@@ -1840,7 +1841,7 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
         //file << "plot(t, fe);\n";
 
         CPPUNIT_ASSERT(totalSumResidual / totalSumValue < 0.1);
-        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.18);
+        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.17);
     }
 }
 
@@ -1854,7 +1855,7 @@ void CTimeSeriesDecompositionTest::testYearly() {
                                                maths::CDecayRateController::E_PredictionErrorIncrease,
                                            1);
     TDoubleVec noise;
-    core_t::TTime time = 0;
+    core_t::TTime time = 2 * HOUR;
     for (/**/; time < 4 * YEAR; time += 4 * HOUR) {
         double trend =
             15.0 * (2.0 + std::sin(boost::math::double_constants::two_pi *
@@ -1872,11 +1873,11 @@ void CTimeSeriesDecompositionTest::testYearly() {
         }
     }
 
-    std::ofstream file;
-    file.open("results.m");
-    TDoubleVec f;
-    TTimeVec times;
-    TDoubleVec values;
+    //std::ofstream file;
+    //file.open("results.m");
+    //TDoubleVec f;
+    //TTimeVec times;
+    //TDoubleVec values;
 
     // Predict over one year and check we get reasonable accuracy.
     TMeanAccumulator meanError;
@@ -1890,9 +1891,9 @@ void CTimeSeriesDecompositionTest::testYearly() {
             maths::CBasicStatistics::mean(decomposition.baseline(time, 0.0));
         double error = std::fabs((prediction - trend) / trend);
         meanError.add(error);
-        times.push_back(time);
-        values.push_back(trend);
-        f.push_back(prediction);
+        //times.push_back(time);
+        //values.push_back(trend);
+        //f.push_back(prediction);
         if (time / HOUR % 40 == 0) {
             LOG_DEBUG(<< "error = " << error);
         }
@@ -1906,7 +1907,7 @@ void CTimeSeriesDecompositionTest::testYearly() {
     //file << "plot(t, fe);\n";
 
     LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanError) < 0.02);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanError) < 0.01);
 }
 
 void CTimeSeriesDecompositionTest::testCalendar() {


### PR DESCRIPTION
We were previously not using periodic boundary conditions when fitting seasonal components. This is because the value need not be the same at the start and end of the period because of variation in the gradient within the component. A better strategy is to use the predicted value in the next and previous period, since we expect the component to be continuous. As a result, we can enable periodic boundary conditions by default.

This gives a smoother fit to periodic signals. We get lower maximum prediction errors for smooth signals as a result which is reflected in some of the tighter unit test thresholds and also some manual testing I've done. This will affect results for event rate and metric analysis of periodic signals.