### PR TITLE
[ML] By-fields should respect model_plot_config.terms

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,6 +43,8 @@
 
 Function description for population lat_long results should be lat_long instead of mean ({pull}81[#81])
 
+By-fields should respect model_plot_config.terms
+
 === Regressions
 
 === Known Issues

--- a/lib/model/CModelDetailsView.cc
+++ b/lib/model/CModelDetailsView.cc
@@ -159,10 +159,10 @@ bool CModelDetailsView::contains(const TStrSet& terms, const std::string& key) {
 }
 
 bool CModelDetailsView::hasByField() const {
-    return !(this->base().isPopulation()
+    return (this->base().isPopulation()
                 ? this->base().dataGatherer().attributeFieldName()
                 : this->base().dataGatherer().personFieldName())
-        .empty();
+               .empty() == false;
 }
 
 std::size_t CModelDetailsView::maxByFieldId() const {

--- a/lib/model/CModelDetailsView.cc
+++ b/lib/model/CModelDetailsView.cc
@@ -159,10 +159,10 @@ bool CModelDetailsView::contains(const TStrSet& terms, const std::string& key) {
 }
 
 bool CModelDetailsView::hasByField() const {
-    return (this->base().isPopulation()
-                ? this->base().dataGatherer().attributeFieldName()
-                : this->base().dataGatherer().personFieldName())
-               .empty() == false;
+    const std::string& byField = this->base().isPopulation()
+                                     ? this->base().dataGatherer().attributeFieldName()
+                                     : this->base().dataGatherer().personFieldName();
+    return byField.empty() == false;
 }
 
 std::size_t CModelDetailsView::maxByFieldId() const {

--- a/lib/model/CModelDetailsView.cc
+++ b/lib/model/CModelDetailsView.cc
@@ -159,7 +159,7 @@ bool CModelDetailsView::contains(const TStrSet& terms, const std::string& key) {
 }
 
 bool CModelDetailsView::hasByField() const {
-    return (this->base().isPopulation()
+    return !(this->base().isPopulation()
                 ? this->base().dataGatherer().attributeFieldName()
                 : this->base().dataGatherer().personFieldName())
         .empty();


### PR DESCRIPTION
This commit restores respecting the model_plot_config.terms
for by-fields. The bug seems to have been introduced in 6.2.0.
Note that I am also adding an integration test in the java
side to ensure such regressions are caught in the future.

Closes elastic/elasticsearch#30004