### PR TITLE
[ML] Correct ageing of windowed seasonal components

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -31,6 +31,8 @@ Improve and use periodic boundary condition for seasonal component modeling ({pu
 
 === Bug Fixes
 
+Age seasonal components in proportion to the fraction of values with which they're updated ({pull}88[#88])
+
 === Regressions
 
 === Known Issues

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -240,6 +240,7 @@ void CSeasonalComponentAdaptiveBucketing::propagateForwardsByTime(double time, b
     if (time < 0.0) {
         LOG_ERROR(<< "Can't propagate bucketing backwards in time");
     } else if (this->initialized()) {
+        time *= m_Time->fractionInWindow();
         double factor{std::exp(-this->CAdaptiveBucketing::decayRate() * time)};
         this->CAdaptiveBucketing::age(factor);
         for (auto& bucket : m_Buckets) {

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -240,8 +240,8 @@ void CSeasonalComponentAdaptiveBucketing::propagateForwardsByTime(double time, b
     if (time < 0.0) {
         LOG_ERROR(<< "Can't propagate bucketing backwards in time");
     } else if (this->initialized()) {
-        time *= m_Time->fractionInWindow();
-        double factor{std::exp(-this->CAdaptiveBucketing::decayRate() * time)};
+        double factor{std::exp(-this->CAdaptiveBucketing::decayRate() *
+                               m_Time->fractionInWindow() * time)};
         this->CAdaptiveBucketing::age(factor);
         for (auto& bucket : m_Buckets) {
             bucket.s_Regression.age(factor, meanRevert);

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1103,9 +1103,8 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SAddValue& messag
         for (std::size_t i = 1u; i <= m; ++i) {
             CSeasonalComponent* component{seasonalComponents[i - 1]};
             CComponentErrors* error_{seasonalErrors[i - 1]};
-            double wi{weight / component->time().fractionInWindow()};
-            component->add(time, values[i], wi);
-            error_->add(error, predictions[i - 1], wi);
+            component->add(time, values[i], weight);
+            error_->add(error, predictions[i - 1], weight);
         }
         for (std::size_t i = m + 1; i <= m + n; ++i) {
             CCalendarComponent* component{calendarComponents[i - m - 1]};

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -83,14 +83,14 @@ void CForecastTest::testDailyNoLongTermTrend() {
 
     test::CRandomNumbers rng;
 
-    auto trend = [&y, bucketLength](core_t::TTime time, double noise) {
-        core_t::TTime i{(time % 86400) / bucketLength};
+    TTrend trend = [&y, bucketLength](core_t::TTime time, double noise) {
+        core_t::TTime i{(time % core::constants::DAY) / bucketLength};
         double alpha{static_cast<double>(i % 6) / 6.0};
         double beta{1.0 - alpha};
         return 40.0 + alpha * y[i / 6] + beta * y[(i / 6 + 1) % y.size()] + noise;
     };
 
-    this->test(trend, bucketLength, 60, 64.0, 5.0, 0.14);
+    this->test(trend, bucketLength, 63, 64.0, 5.0, 0.14);
 }
 
 void CForecastTest::testDailyConstantLongTermTrend() {
@@ -99,18 +99,18 @@ void CForecastTest::testDailyConstantLongTermTrend() {
                  80.0, 100.0, 110.0, 120.0, 110.0, 100.0, 90.0, 80.0,
                  30.0, 15.0,  10.0,  8.0,   5.0,   3.0,   2.0,  0.0};
 
-    auto trend = [&y, bucketLength](core_t::TTime time, double noise) {
-        core_t::TTime i{(time % 86400) / bucketLength};
+    TTrend trend = [&y, bucketLength](core_t::TTime time, double noise) {
+        core_t::TTime i{(time % core::constants::DAY) / bucketLength};
         return 0.25 * static_cast<double>(time) / static_cast<double>(bucketLength) +
                y[i] + noise;
     };
 
-    this->test(trend, bucketLength, 60, 64.0, 16.0, 0.02);
+    this->test(trend, bucketLength, 63, 64.0, 14.0, 0.02);
 }
 
 void CForecastTest::testDailyVaryingLongTermTrend() {
     core_t::TTime bucketLength{3600};
-    double day{86400.0};
+    double day{static_cast<double>(core::constants::DAY)};
     TDoubleVec times{0.0,         5.0 * day,   10.0 * day,  15.0 * day,
                      20.0 * day,  25.0 * day,  30.0 * day,  35.0 * day,
                      40.0 * day,  45.0 * day,  50.0 * day,  55.0 * day,
@@ -124,13 +124,13 @@ void CForecastTest::testDailyVaryingLongTermTrend() {
     maths::CSpline<> trend_(maths::CSplineTypes::E_Cubic);
     trend_.interpolate(times, values, maths::CSplineTypes::E_Natural);
 
-    auto trend = [&trend_](core_t::TTime time, double noise) {
+    TTrend trend = [&trend_](core_t::TTime time, double noise) {
         double time_{static_cast<double>(time)};
         return trend_.value(time_) +
                8.0 * std::sin(boost::math::double_constants::two_pi * time_ / 43200.0) + noise;
     };
 
-    this->test(trend, bucketLength, 100, 9.0, 13.0, 0.04);
+    this->test(trend, bucketLength, 98, 9.0, 14.0, 0.042);
 }
 
 void CForecastTest::testComplexNoLongTermTrend() {
@@ -140,13 +140,13 @@ void CForecastTest::testComplexNoLongTermTrend() {
                  60.0, 40.0,  30.0,  20.0,  10.0,  10.0,  5.0,  0.0};
     TDoubleVec scale{1.0, 1.1, 1.05, 0.95, 0.9, 0.3, 0.2};
 
-    auto trend = [&y, &scale, bucketLength](core_t::TTime time, double noise) {
-        core_t::TTime d{(time % 604800) / 86400};
-        core_t::TTime h{(time % 86400) / bucketLength};
+    TTrend trend = [&y, &scale, bucketLength](core_t::TTime time, double noise) {
+        core_t::TTime d{(time % core::constants::WEEK) / core::constants::DAY};
+        core_t::TTime h{(time % core::constants::DAY) / bucketLength};
         return scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 24.0, 28.0, 0.13);
+    this->test(trend, bucketLength, 63, 24.0, 8.0, 0.13);
 }
 
 void CForecastTest::testComplexConstantLongTermTrend() {
@@ -156,19 +156,19 @@ void CForecastTest::testComplexConstantLongTermTrend() {
                  60.0, 40.0,  30.0,  20.0,  10.0,  10.0,  5.0,  0.0};
     TDoubleVec scale{1.0, 1.1, 1.05, 0.95, 0.9, 0.3, 0.2};
 
-    auto trend = [&y, &scale, bucketLength](core_t::TTime time, double noise) {
-        core_t::TTime d{(time % 604800) / 86400};
-        core_t::TTime h{(time % 86400) / bucketLength};
+    TTrend trend = [&y, &scale, bucketLength](core_t::TTime time, double noise) {
+        core_t::TTime d{(time % core::constants::WEEK) / core::constants::DAY};
+        core_t::TTime h{(time % core::constants::DAY) / bucketLength};
         return 0.25 * static_cast<double>(time) / static_cast<double>(bucketLength) +
                scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 24.0, 14.0, 0.01);
+    this->test(trend, bucketLength, 63, 24.0, 8.0, 0.01);
 }
 
 void CForecastTest::testComplexVaryingLongTermTrend() {
     core_t::TTime bucketLength{3600};
-    double day{86400.0};
+    double day{static_cast<double>(core::constants::DAY)};
     TDoubleVec times{0.0,         5.0 * day,   10.0 * day,  15.0 * day,
                      20.0 * day,  25.0 * day,  30.0 * day,  35.0 * day,
                      40.0 * day,  45.0 * day,  50.0 * day,  55.0 * day,
@@ -186,14 +186,14 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
     maths::CSpline<> trend_(maths::CSplineTypes::E_Cubic);
     trend_.interpolate(times, values, maths::CSplineTypes::E_Natural);
 
-    auto trend = [&trend_, &y, &scale, bucketLength](core_t::TTime time, double noise) {
-        core_t::TTime d{(time % 604800) / 86400};
-        core_t::TTime h{(time % 86400) / bucketLength};
+    TTrend trend = [&trend_, &y, &scale, bucketLength](core_t::TTime time, double noise) {
+        core_t::TTime d{(time % core::constants::WEEK) / core::constants::DAY};
+        core_t::TTime h{(time % core::constants::DAY) / bucketLength};
         double time_{static_cast<double>(time)};
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 60, 4.0, 28.0, 0.053);
+    this->test(trend, bucketLength, 63, 4.0, 42.0, 0.06);
 }
 
 void CForecastTest::testNonNegative() {
@@ -400,7 +400,6 @@ void CForecastTest::test(TTrend trend,
                          double noiseVariance,
                          double maximumPercentageOutOfBounds,
                          double maximumError) {
-
     //std::ofstream file;
     //file.open("results.m");
     //TDoubleVec actual;
@@ -423,7 +422,8 @@ void CForecastTest::test(TTrend trend,
     TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
     for (std::size_t d = 0u; d < daysToLearn; ++d) {
         TDoubleVec noise;
-        rng.generateNormalSamples(0.0, noiseVariance, 86400 / bucketLength, noise);
+        rng.generateNormalSamples(0.0, noiseVariance,
+                                  core::constants::DAY / bucketLength, noise);
 
         for (std::size_t i = 0u; i < noise.size(); ++i, time += bucketLength) {
             maths::CModelAddSamplesParams params;
@@ -450,7 +450,8 @@ void CForecastTest::test(TTrend trend,
 
     for (std::size_t i = 0u; i < prediction.size(); /**/) {
         TDoubleVec noise;
-        rng.generateNormalSamples(0.0, noiseVariance, 86400 / bucketLength, noise);
+        rng.generateNormalSamples(0.0, noiseVariance,
+                                  core::constants::DAY / bucketLength, noise);
         TDoubleVec day;
         for (std::size_t j = 0u; i < prediction.size() && j < noise.size();
              ++i, ++j, time += bucketLength) {

--- a/lib/maths/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentTest.cc
@@ -43,7 +43,6 @@ public:
 public:
     CTestSeasonalComponent(
         core_t::TTime startTime,
-        core_t::TTime window,
         core_t::TTime period,
         std::size_t space,
         double decayRate = 0.0,
@@ -51,7 +50,7 @@ public:
         maths::CSplineTypes::EBoundaryCondition boundaryCondition = maths::CSplineTypes::E_Periodic,
         maths::CSplineTypes::EType valueInterpolationType = maths::CSplineTypes::E_Cubic,
         maths::CSplineTypes::EType varianceInterpolationType = maths::CSplineTypes::E_Linear)
-        : maths::CSeasonalComponent(maths::CDiurnalTime(0, 0, window, period),
+        : maths::CSeasonalComponent(maths::CDiurnalTime(0, 0, core::constants::WEEK, period),
                                     space,
                                     decayRate,
                                     minimumBucketLength,
@@ -104,9 +103,9 @@ void generateSeasonalValues(test::CRandomNumbers& rng,
         std::size_t a = b - 1;
         double m = (function[b].second - function[a].second) /
                    static_cast<double>(function[b].first - function[a].first);
-        samples.push_back(TTimeDoublePr(
+        samples.emplace_back(
             times[i], function[a].second +
-                          m * static_cast<double>(offset - function[a].first)));
+                          m * static_cast<double>(offset - function[a].first));
     }
 }
 
@@ -120,7 +119,7 @@ void CSeasonalComponentTest::testNoPeriodicity() {
 
     TTimeDoublePrVec function;
     for (std::size_t i = 0; i < 25; ++i) {
-        function.push_back(TTimeDoublePr((i * core::constants::DAY) / 24, 0.0));
+        function.emplace_back((i * core::constants::DAY) / 24, 0.0);
     }
 
     test::CRandomNumbers rng;
@@ -137,8 +136,7 @@ void CSeasonalComponentTest::testNoPeriodicity() {
     rng.generateGammaSamples(10.0, 1.2, n, residuals);
     double residualMean = maths::CBasicStatistics::mean(residuals);
 
-    CTestSeasonalComponent seasonal(startTime, core::constants::DAY,
-                                    core::constants::DAY, 24);
+    CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24);
     seasonal.initialize();
 
     //std::ofstream file;
@@ -221,7 +219,7 @@ void CSeasonalComponentTest::testConstantPeriodic() {
             core_t::TTime t = (i * core::constants::DAY) / 48;
             double ft = 100.0 + 40.0 * std::sin(boost::math::double_constants::two_pi *
                                                 static_cast<double>(i) / 48.0);
-            function.push_back(TTimeDoublePr(t, ft));
+            function.emplace_back(t, ft);
         }
 
         std::size_t n = 5000u;
@@ -234,8 +232,7 @@ void CSeasonalComponentTest::testConstantPeriodic() {
         rng.generateGammaSamples(10.0, 1.2, n, residuals);
         double residualMean = maths::CBasicStatistics::mean(residuals);
 
-        CTestSeasonalComponent seasonal(startTime, core::constants::DAY,
-                                        core::constants::DAY, 24, 0.01);
+        CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24, 0.01);
         seasonal.initialize();
 
         //std::ofstream file;
@@ -349,8 +346,7 @@ void CSeasonalComponentTest::testConstantPeriodic() {
         rng.generateGammaSamples(10.0, 1.2, n, residuals);
         double residualMean = maths::CBasicStatistics::mean(residuals);
 
-        CTestSeasonalComponent seasonal(startTime, core::constants::DAY,
-                                        core::constants::DAY, 24, 0.01);
+        CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24, 0.01);
         seasonal.initialize();
 
         //std::ofstream file;
@@ -460,8 +456,7 @@ void CSeasonalComponentTest::testTimeVaryingPeriodic() {
 
     test::CRandomNumbers rng;
 
-    CTestSeasonalComponent seasonal(startTime, core::constants::DAY,
-                                    core::constants::DAY, 24, 0.048);
+    CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24, 0.048);
     seasonal.initialize();
 
     core_t::TTime time = startTime;
@@ -551,7 +546,7 @@ void CSeasonalComponentTest::testVeryLowVariation() {
 
     TTimeDoublePrVec function;
     for (std::size_t i = 0u; i < 25; ++i) {
-        function.push_back(TTimeDoublePr((i * core::constants::DAY) / 24, 50.0));
+        function.emplace_back((i * core::constants::DAY) / 24, 50.0);
     }
 
     test::CRandomNumbers rng;
@@ -568,8 +563,7 @@ void CSeasonalComponentTest::testVeryLowVariation() {
 
     double deviation = std::sqrt(1e-3);
 
-    CTestSeasonalComponent seasonal(startTime, core::constants::DAY,
-                                    core::constants::DAY, 24);
+    CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24);
     seasonal.initialize(startTime);
 
     //std::ofstream file;
@@ -653,11 +647,11 @@ void CSeasonalComponentTest::testVariance() {
         TDoubleVec sample;
         rng.generateNormalSamples(0.0, vt, 10, sample);
         for (std::size_t j = 0u; j < sample.size(); ++j) {
-            function.push_back(TTimeDoublePr(t, sample[j]));
+            function.emplace_back(t, sample[j]);
         }
     }
 
-    CTestSeasonalComponent seasonal(0, core::constants::DAY, core::constants::DAY, 24);
+    CTestSeasonalComponent seasonal(0, core::constants::DAY, 24);
     seasonal.initialize(0);
 
     for (std::size_t i = 0u; i < function.size(); ++i) {
@@ -698,7 +692,7 @@ void CSeasonalComponentTest::testPersist() {
         core_t::TTime t = (i * core::constants::DAY) / 48;
         double ft = 100.0 + 40.0 * std::sin(boost::math::double_constants::two_pi *
                                             static_cast<double>(i) / 48.0);
-        function.push_back(TTimeDoublePr(t, ft));
+        function.emplace_back(t, ft);
     }
 
     std::size_t n = 3300u;
@@ -710,8 +704,7 @@ void CSeasonalComponentTest::testPersist() {
     TDoubleVec residuals;
     rng.generateGammaSamples(10.0, 1.2, n, residuals);
 
-    CTestSeasonalComponent origSeasonal(startTime, core::constants::DAY,
-                                        core::constants::DAY, 24, decayRate);
+    CTestSeasonalComponent origSeasonal(startTime, core::constants::DAY, 24, decayRate);
     origSeasonal.initialize(startTime);
 
     for (std::size_t i = 0u; i < n; ++i) {

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -126,8 +126,8 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                CPPUNIT_ASSERT(sumResidual < 0.042 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.040 * maxValue);
+                CPPUNIT_ASSERT(sumResidual < 0.039 * sumValue);
+                CPPUNIT_ASSERT(maxResidual < 0.041 * maxValue);
                 CPPUNIT_ASSERT(percentileError < 0.02 * sumValue);
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -149,7 +149,7 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
     //file << "plot(t(1:length(fe)), fe, 'r');\n";
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.019 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.020 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.021 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 }
@@ -782,7 +782,7 @@ void CTimeSeriesDecompositionTest::testSeasonalOnset() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
     CPPUNIT_ASSERT(totalSumResidual < 0.07 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.08 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.09 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 }
 
@@ -1161,8 +1161,8 @@ void CTimeSeriesDecompositionTest::testVeryLargeValuesProblemCase() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.32 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.70 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.31 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.72 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.21 * totalSumValue);
 
     //file << "hold on;\n";
@@ -1278,7 +1278,7 @@ void CTimeSeriesDecompositionTest::testMixedSmoothAndSpikeyDataProblemCase() {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     CPPUNIT_ASSERT(totalSumResidual < 0.17 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.38 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.40 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.07 * totalSumValue);
 
     //file << "hold on;\n";


### PR DESCRIPTION
Investigating a forecasting regression associated with changes targeting #87 showed up an issue with the way we age periodically repeating partitions of the data (such as weekday/end splits). In particular, we were ageing them too fast and their decay rate should be prorated by the fraction of values with which they are updated. For subtle reasons, related to interaction between components in the decomposition, this could lead to biased predictions.

This can affect results for metric and count analyses when the data has distinct weekday/end repeating pattern. 