### PR TITLE
[ML] Improve robustness w.r.t. outliers of detection and initialisation of seasonal components

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@
 === Enhancements
 
 Improve and use periodic boundary condition for seasonal component modeling ({pull}84[#84])
+Improve robustness w.r.t. outliers of detection and initialisation of seasonal components ({pull}90[#90])
 
 === Bug Fixes
 

--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -343,7 +343,7 @@ private:
 
     //! Check if there are enough non-empty buckets which are repeated
     //! at at least one \p period in \p buckets.
-    bool seenSufficientPeriodicallyPopulatedBucketsToTest(const TFloatMeanAccumulatorVec& buckets,
+    bool seenSufficientPeriodicallyPopulatedBucketsToTest(const TFloatMeanAccumulatorCRng& buckets,
                                                           std::size_t period) const;
 
     //! Compute various ancillary statistics for testing.

--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -363,9 +363,7 @@ private:
     //! Condition \p buckets assuming the null hypothesis is true.
     //!
     //! This removes any trend associated with the null hypothesis.
-    void conditionOnHypothesis(const TTimeTimePr2Vec& windows,
-                               const STestStats& stats,
-                               TFloatMeanAccumulatorVec& buckets) const;
+    void conditionOnHypothesis(const STestStats& stats, TFloatMeanAccumulatorVec& buckets) const;
 
     //! Test to see if there is significant evidence for a component
     //! with period \p period.

--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -225,6 +225,8 @@ private:
         CPeriodicityHypothesisTestsResult s_H0;
         //! The variance estimate of H0.
         double s_V0;
+        //! The autocorrelation estimate of H0.
+        double s_R0;
         //! The degrees of freedom in the variance estimate of H0.
         double s_DF0;
         //! The trend for the null hypothesis.
@@ -341,7 +343,7 @@ private:
 
     //! Check if there are enough non-empty buckets which are repeated
     //! at at least one \p period in \p buckets.
-    bool seenSufficientPeriodicallyPopulatedBucketsToTest(const TFloatMeanAccumulatorCRng& buckets,
+    bool seenSufficientPeriodicallyPopulatedBucketsToTest(const TFloatMeanAccumulatorVec& buckets,
                                                           std::size_t period) const;
 
     //! Compute various ancillary statistics for testing.

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -609,6 +609,20 @@ public:
                                   maths_t::TCalendarComponentVec& components,
                                   TComponentErrorsVec& errors) const;
 
+        //! Reweight the outlier values in \p values.
+        //!
+        //! These are the values with largest error w.r.t. \p predictor.
+        void reweightOutliers(core_t::TTime startTime,
+                              core_t::TTime dt,
+                              TPredictor predictor,
+                              TFloatMeanAccumulatorVec& values) const;
+
+        //! Fit the trend component \p component to \p values.
+        void fit(core_t::TTime startTime,
+                 core_t::TTime dt,
+                 const TFloatMeanAccumulatorVec& values,
+                 CTrendComponent& trend) const;
+
         //! Clear all component error statistics.
         void clearComponentErrors();
 

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -665,19 +665,16 @@ public:
     //! Sigmoid function of \p p.
     static double sigmoid(double p) { return 1.0 / (1.0 + 1.0 / p); }
 
-    //! A smooth Heaviside function centred at one.
+    //! The logistic function.
     //!
-    //! This is a smooth version of the Heaviside function implemented
-    //! as \f$sigmoid\left(\frac{sign (x - 1)}{wb}\right)\f$ normalized
-    //! to the range [0, 1], where \f$b\f$ is \p boundary and \f$w\f$
-    //! is \p width. Note, if \p sign is one this is a step up and if
-    //! it is -1 it is a step down.
+    //! i.e. \f$sigmoid\left(\frac{sign (x - x0)}{width}\right)\f$.
     //!
     //! \param[in] x The argument.
     //! \param[in] width The step width.
+    //! \param[in] x0 The centre of the step.
     //! \param[in] sign Determines whether it's a step up or down.
-    static double smoothHeaviside(double x, double width, double sign = 1.0) {
-        return sigmoid(std::exp(sign * (x - 1.0) / width)) / sigmoid(std::exp(1.0 / width));
+    static double logisticFunction(double x, double width, double x0 = 0.0, double sign = 1.0) {
+        return sigmoid(std::exp(std::copysign(1.0, sign) * (x - x0) / width));
     }
 };
 }

--- a/include/maths/Constants.h
+++ b/include/maths/Constants.h
@@ -12,6 +12,8 @@
 #include <maths/ImportExport.h>
 #include <maths/MathsTypes.h>
 
+#include <cmath>
+
 namespace ml {
 namespace maths {
 
@@ -50,30 +52,39 @@ const double LOG_NORMAL_OFFSET_MARGIN{1.0};
 //! reduce the prediction error variance and still be worthwhile
 //! modeling. We have different thresholds because we have inductive
 //! bias for particular types of components.
-const double SIGNIFICANT_VARIANCE_REDUCTION[]{0.6, 0.4};
+const double COMPONENT_SIGNIFICANT_VARIANCE_REDUCTION[]{0.6, 0.4};
 
 //! The minimum repeated amplitude of a seasonal component, as a
 //! multiple of error standard deviation, to be worthwhile modeling.
 //! We have different thresholds because we have inductive bias for
 //! particular types of components.
-const double SIGNIFICANT_AMPLITUDE[]{1.0, 2.0};
+const double SEASONAL_SIGNIFICANT_AMPLITUDE[]{1.0, 2.0};
 
 //! The minimum autocorrelation of a seasonal component to be
 //! worthwhile modeling. We have different thresholds because we
 //! have inductive bias for particular types of components.
-const double SIGNIFICANT_AUTOCORRELATION[]{0.5, 0.6};
+const double SEASONAL_SIGNIFICANT_AUTOCORRELATION[]{0.5, 0.6};
 
-//! The fraction of values which are treated as ouliers when testing
-//! for and initialising new periodic components.
-const double PERIODIC_COMPONENT_OUTLIER_FRACTION{0.1};
+//! The fraction of values which are treated as outliers when testing
+//! for and initializing a seasonal component.
+const double SEASONAL_OUTLIER_FRACTION{0.1};
 
-//! The weight to assign to outliers when initializing a periodic
-//! component.
-const double PERIODIC_COMPONENT_OUTLIER_WEIGHT{0.1};
+//! The minimum multiplier of the mean inlier fraction difference
+//! (from a periodic pattern) to constitute an outlier when testing
+//! for and initializing a seasonal component.
+const double SEASONAL_OUTLIER_DIFFERENCE_THRESHOLD{3.0};
+
+//! The weight to assign outliers when testing for and initializing
+//! a seasonal component.
+const double SEASONAL_OUTLIER_WEIGHT{0.1};
 
 //! The significance of a test statistic to choose to model
 //! a trend decomposition component.
-const double STATISTICALLY_SIGNIFICANT{0.001};
+const double COMPONENT_STATISTICALLY_SIGNIFICANT{0.001};
+
+//! The log of COMPONENT_STATISTICALLY_SIGNIFICANT.
+const double LOG_COMPONENT_STATISTICALLY_SIGNIFICANCE{
+    std::log(COMPONENT_STATISTICALLY_SIGNIFICANT)};
 
 //! The minimum variance scale for which the likelihood function
 //! can be accurately adjusted. For smaller scales errors are

--- a/include/maths/Constants.h
+++ b/include/maths/Constants.h
@@ -50,7 +50,7 @@ const double LOG_NORMAL_OFFSET_MARGIN{1.0};
 //! reduce the prediction error variance and still be worthwhile
 //! modeling. We have different thresholds because we have inductive
 //! bias for particular types of components.
-const double SIGNIFICANT_VARIANCE_REDUCTION[]{0.7, 0.5};
+const double SIGNIFICANT_VARIANCE_REDUCTION[]{0.6, 0.4};
 
 //! The minimum repeated amplitude of a seasonal component, as a
 //! multiple of error standard deviation, to be worthwhile modeling.
@@ -61,11 +61,19 @@ const double SIGNIFICANT_AMPLITUDE[]{1.0, 2.0};
 //! The minimum autocorrelation of a seasonal component to be
 //! worthwhile modeling. We have different thresholds because we
 //! have inductive bias for particular types of components.
-const double SIGNIFICANT_AUTOCORRELATION[]{0.5, 0.7};
+const double SIGNIFICANT_AUTOCORRELATION[]{0.5, 0.6};
 
-//! The maximum significance of a test statistic to choose to model
+//! The fraction of values which are treated as ouliers when testing
+//! for and initialising new periodic components.
+const double PERIODIC_COMPONENT_OUTLIER_FRACTION{0.1};
+
+//! The weight to assign to outliers when initializing a periodic
+//! component.
+const double PERIODIC_COMPONENT_OUTLIER_WEIGHT{0.1};
+
+//! The significance of a test statistic to choose to model
 //! a trend decomposition component.
-const double MAXIMUM_SIGNIFICANCE{0.001};
+const double STATISTICALLY_SIGNIFICANT{0.001};
 
 //! The minimum variance scale for which the likelihood function
 //! can be accurately adjusted. For smaller scales errors are

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -44,6 +44,7 @@ namespace maths {
 namespace {
 
 using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 using TTimeVec = std::vector<core_t::TTime>;
 using TSizeSizePr = std::pair<std::size_t, std::size_t>;
 using TSizeSizePr2Vec = core::CSmallVector<TSizeSizePr, 2>;
@@ -55,12 +56,26 @@ using TTimeTimePr = std::pair<core_t::TTime, core_t::TTime>;
 using TTimeTimePr2Vec = core::CSmallVector<TTimeTimePr, 2>;
 using TTimeTimePrMeanVarAccumulatorPr = std::pair<TTimeTimePr, TMeanVarAccumulator>;
 
+//! The confidence interval used for test statistic values.
+const double CONFIDENCE_INTERVAL{80.0};
+//! The log of the p-value to "pass" the test.
+const double LOG_STATISTICALLY_SIGNIFICANCE{CTools::fastLog(STATISTICALLY_SIGNIFICANT)};
+//! The soft minimum number of repeats which we'll use to test
+//! for periodicity using the variance test.
+const double MINIMUM_REPEATS_TO_TEST_VARIANCE{3.0};
+//! The minimum number of repeats which we'll use to test for
+//! periodicity using the amplitude test.
+const std::size_t MINIMUM_REPEATS_TO_TEST_AMPLITUDE{4};
+//! A high priority for components we want to take precendence.
+double HIGH_PRIORITY{2.0};
+
 //! \brief Accumulates the minimum amplitude.
 class CMinAmplitude {
 public:
     CMinAmplitude(std::size_t n, double level)
-        : m_Level(level), m_Count(0), m_Min(std::max(n, MINIMUM_COUNT_TO_TEST)),
-          m_Max(std::max(n, MINIMUM_COUNT_TO_TEST)) {}
+        : m_Level(level), m_Count(0),
+          m_Min(std::max(n, MINIMUM_REPEATS_TO_TEST_AMPLITUDE)),
+          m_Max(std::max(n, MINIMUM_REPEATS_TO_TEST_AMPLITUDE)) {}
 
     void add(double x, double n) {
         if (n > 0.0) {
@@ -71,7 +86,7 @@ public:
     }
 
     double amplitude() const {
-        if (this->count() >= MINIMUM_COUNT_TO_TEST) {
+        if (this->count() >= MINIMUM_REPEATS_TO_TEST_AMPLITUDE) {
             return std::max(std::max(-m_Min.biggest(), 0.0),
                             std::max(m_Max.biggest(), 0.0));
         }
@@ -79,15 +94,13 @@ public:
     }
 
     double significance(const boost::math::normal& normal) const {
-        if (this->count() < MINIMUM_COUNT_TO_TEST) {
+        if (this->count() < MINIMUM_REPEATS_TO_TEST_AMPLITUDE) {
             return 1.0;
         }
-
         double F{2.0 * CTools::safeCdf(normal, -this->amplitude())};
         if (F == 0.0) {
             return 0.0;
         }
-
         double n{static_cast<double>(this->count())};
         boost::math::binomial binomial(static_cast<double>(m_Count), F);
         return CTools::safeCdfComplement(binomial, n - 1.0);
@@ -102,10 +115,6 @@ private:
     std::size_t count() const { return m_Min.count(); }
 
 private:
-    //! The minimum number of repeats for which we'll test.
-    static const std::size_t MINIMUM_COUNT_TO_TEST;
-
-private:
     //! The mean of the trend.
     double m_Level;
     //! The total count of values added.
@@ -116,18 +125,16 @@ private:
     TMaxAccumulator m_Max;
 };
 
-const std::size_t CMinAmplitude::MINIMUM_COUNT_TO_TEST{4};
-
 using TMinAmplitudeVec = std::vector<CMinAmplitude>;
 
 //! \brief Holds the relevant summary for choosing between alternative
 //! (non-nested) hypotheses.
 struct SHypothesisSummary {
-    SHypothesisSummary(double v, double DF, const CPeriodicityHypothesisTestsResult& H)
-        : s_V(v), s_DF(DF), s_H(H) {}
-
     double s_V;
+    double s_R;
     double s_DF;
+    double s_Vt;
+    double s_Rt;
     CPeriodicityHypothesisTestsResult s_H;
 };
 
@@ -159,25 +166,21 @@ const std::string DIURNAL_COMPONENT_NAMES[] = {
     "weekend daily",  "weekend weekly", "weekday daily",
     "weekday weekly", "daily",          "weekly"};
 
-//! The confidence interval used for test statistic values.
-const double CONFIDENCE_INTERVAL{80.0};
-//! A high priority for components we want to take precendence.
-double HIGH_PRIORITY{2.0};
-
 //! Fit and remove a linear trend from \p values.
 void removeLinearTrend(TFloatMeanAccumulatorVec& values) {
     using TRegression = CRegression::CLeastSquaresOnline<1, double>;
-
     TRegression trend;
-    double time{0.0};
     double dt{10.0 / static_cast<double>(values.size())};
+    double time{dt / 2.0};
     for (const auto& value : values) {
         trend.add(time, CBasicStatistics::mean(value), CBasicStatistics::count(value));
         time += dt;
     }
     time = dt / 2.0;
     for (auto& value : values) {
-        CBasicStatistics::moment<0>(value) -= trend.predict(time);
+        if (CBasicStatistics::count(value) > 0.0) {
+            CBasicStatistics::moment<0>(value) -= trend.predict(time);
+        }
         time += dt;
     }
 }
@@ -285,13 +288,105 @@ void project(const TFloatMeanAccumulatorVec& values,
         calculateIndexWindows(windows_, bucketLength, windows);
         result.reserve(length(windows));
         std::size_t n{values.size()};
-        for (std::size_t i = 0u; i < windows.size(); ++i) {
-            std::size_t a{windows[i].first};
-            std::size_t b{windows[i].second};
+        for (const auto& window : windows) {
+            std::size_t a{window.first};
+            std::size_t b{window.second};
             for (std::size_t j = a; j < b; ++j) {
                 const TFloatMeanAccumulator& value{values[j % n]};
                 result.push_back(value);
             }
+        }
+    }
+}
+
+//! Calculate the number of non-empty buckets at each bucket offset in
+//! the period for the \p values in \p windows.
+TSizeVec calculateRepeats(const TSizeSizePr2Vec& windows,
+                          std::size_t period,
+                          TFloatMeanAccumulatorVec& values) {
+    TSizeVec result(std::min(period, length(windows[0])), 0);
+    std::size_t n{values.size()};
+    for (const auto& window : windows) {
+        std::size_t a{window.first};
+        std::size_t b{window.second};
+        for (std::size_t i = a; i < b; ++i) {
+            if (CBasicStatistics::count(values[i % n]) > 0.0) {
+                ++result[(i - a) % period];
+            }
+        }
+    }
+    return result;
+}
+
+//! Calculate the number of non-empty buckets at each bucket offset in
+//! the period for the \p values in \p windows.
+TSizeVec calculateRepeats(const TTimeTimePr2Vec& windows_,
+                          core_t::TTime period,
+                          core_t::TTime bucketLength,
+                          TFloatMeanAccumulatorVec& values) {
+    TSizeSizePr2Vec windows;
+    calculateIndexWindows(windows_, bucketLength, windows);
+    return calculateRepeats(windows, period / bucketLength, values);
+}
+
+//! Reweight outliers from \p values.
+//!
+//! These are defined as some fraction of the values which are most
+//! different from the periodic trend on the time windows \p windows_.
+void reweightOutliers(const TMeanVarAccumulatorVec& trend,
+                    const TTimeTimePr2Vec& windows_,
+                    core_t::TTime bucketLength,
+                    TFloatMeanAccumulatorVec& values) {
+    using TDoubleSizePr = std::pair<double, std::size_t>;
+    using TMaxAccumulator =
+        CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr, std::greater<TDoubleSizePr>>;
+
+    if (!values.empty()) {
+        TSizeSizePr2Vec windows;
+        calculateIndexWindows(windows_, bucketLength, windows);
+        std::size_t period{trend.size()};
+        std::size_t n{values.size()};
+
+        TSizeVec repeats{calculateRepeats(windows, period, values)};
+        double excess{std::accumulate(
+            repeats.begin(), repeats.end(), 0.0, [](double excess_, std::size_t repeat) {
+                return excess_ + static_cast<double>(repeat > 1 ? repeat - 1 : 0);
+            })};
+        std::size_t numberOutliers{
+            static_cast<std::size_t>(PERIODIC_COMPONENT_OUTLIER_FRACTION * excess)};
+        LOG_TRACE(<< "Number outliers = " << numberOutliers);
+
+        if (numberOutliers > 0) {
+            TMaxAccumulator outliers{numberOutliers};
+            TMeanAccumulator meanDifference;
+            for (const auto& window : windows) {
+                std::size_t a{window.first};
+                std::size_t b{window.second};
+                for (std::size_t j = a; j < b; ++j) {
+                    const TFloatMeanAccumulator& value{values[j % n]};
+                    std::size_t offset{(j - a) % period};
+                    double difference{std::fabs(CBasicStatistics::mean(value) -
+                                                CBasicStatistics::mean(trend[offset]))};
+                    if (CBasicStatistics::count(value) > 0.0) {
+                        outliers.add({difference, j});
+                        meanDifference.add(difference);
+                    }
+                }
+            }
+            TMeanAccumulator meanDifferenceOfOutliers;
+            for (const auto& outlier : outliers) {
+                meanDifferenceOfOutliers.add(outlier.first);
+            }
+            meanDifference -= meanDifferenceOfOutliers;
+            LOG_TRACE(<< "mean difference = " << CBasicStatistics::mean(meanDifference));
+            LOG_TRACE(<< "outliers = " << core::CContainerPrinter::print(outliers));
+
+            for (const auto& outlier : outliers) {
+                if (outlier.first > 3.0 * CBasicStatistics::mean(meanDifference)) {
+                    CBasicStatistics::count(values[outlier.second % n]) *= PERIODIC_COMPONENT_OUTLIER_WEIGHT;
+                }
+            }
+            LOG_TRACE(<< "Values - outliers = " << core::CContainerPrinter::print(values));
         }
     }
 }
@@ -307,9 +402,9 @@ void periodicTrend(const U& values,
         calculateIndexWindows(windows_, bucketLength, windows);
         std::size_t period{trend.size()};
         std::size_t n{values.size()};
-        for (std::size_t i = 0u; i < windows.size(); ++i) {
-            std::size_t a{windows[i].first};
-            std::size_t b{windows[i].second};
+        for (const auto& window : windows) {
+            std::size_t a{window.first};
+            std::size_t b{window.second};
             for (std::size_t j = a; j < b; ++j) {
                 const TFloatMeanAccumulator& value{values[j % n]};
                 trend[(j - a) % period].add(CBasicStatistics::mean(value),
@@ -317,6 +412,18 @@ void periodicTrend(const U& values,
             }
         }
     }
+}
+
+//! Compute the periodic trend on \p values minus outliers.
+template<typename U, typename V>
+void periodicTrendMinusOutliers(U& values,
+                                const TSizeSizePr2Vec& windows,
+                                core_t::TTime bucketLength,
+                                V& trend) {
+    periodicTrend(values, windows, bucketLength, trend);
+    reweightOutliers(trend, windows, bucketLength, values);
+    trend.assign(trend.size(), TMeanVarAccumulator{});
+    periodicTrend(values, windows, bucketLength, trend);
 }
 
 //! Compute the average of the values at \p times.
@@ -881,9 +988,14 @@ void CPeriodicityHypothesisTests::hypothesesForPeriod(const TTimeTimePr2Vec& win
 
 CPeriodicityHypothesisTestsResult
 CPeriodicityHypothesisTests::best(const TNestedHypothesesVec& hypotheses) const {
-    // Note if there isn't a clear cut best hypothesis for variance
-    // reduction we choose the simplest hypothesis, i.e. with maximum
-    // degrees-of-freedom.
+    // We are comparing different accepted hypotheses here. In particular,
+    // diurnal and the best non-diurnal components with and without fitting
+    // a linear ramp to the values. We use a smooth decision function to
+    // select between them preferring:
+    //   1) The hypothesis which explains the most variance,
+    //   2) The simplest hypothesis (fewest parameters),
+    //   3) The hypothesis which most exceeds the minimum autocorrelation
+    //      to accept.
 
     using TMinAccumulator = CBasicStatistics::SMin<double>::TAccumulator;
 
@@ -898,24 +1010,41 @@ CPeriodicityHypothesisTests::best(const TNestedHypothesesVec& hypotheses) const 
         STestStats stats;
         CPeriodicityHypothesisTestsResult resultForHypothesis{hypothesis.test(stats)};
         if (stats.s_B > stats.s_DF0) {
-            summaries.emplace_back(stats.s_V0, stats.s_B - stats.s_DF0,
-                                   std::move(resultForHypothesis));
+            if (!resultForHypothesis.periodic()) {
+                stats.setThresholds(SIGNIFICANT_VARIANCE_REDUCTION[E_HighThreshold],
+                                    SIGNIFICANT_AMPLITUDE[E_HighThreshold],
+                                    SIGNIFICANT_AUTOCORRELATION[E_HighThreshold]);
+                stats.s_R0 = stats.s_Rt;
+            }
+            LOG_TRACE(<< resultForHypothesis.print());
+            summaries.push_back(SHypothesisSummary{
+                stats.s_V0, stats.s_R0, stats.s_B - stats.s_DF0, stats.s_Vt,
+                stats.s_Rt, std::move(resultForHypothesis)});
         }
     }
 
-    TMinAccumulator vCutoff;
-    for (const auto& summary : summaries) {
-        vCutoff.add(varianceAtPercentile(summary.s_V, summary.s_DF,
-                                         50.0 + CONFIDENCE_INTERVAL / 2.0));
-    }
-    if (vCutoff.count() > 0) {
-        LOG_TRACE(<< "variance cutoff = " << vCutoff[0]);
+    if (!summaries.empty()) {
+        TMinAccumulator vmin;
+        TMinAccumulator DFmin;
+        for (const auto& summary : summaries) {
+            vmin.add(varianceAtPercentile(summary.s_V, summary.s_DF,
+                                          50.0 + CONFIDENCE_INTERVAL / 2.0) /
+                     summary.s_Vt);
+            DFmin.add(summary.s_DF);
+        }
 
-        TMinAccumulator df;
+        TMinAccumulator pmin;
         for (const auto& summary : summaries) {
             double v{varianceAtPercentile(summary.s_V, summary.s_DF,
-                                          50.0 - CONFIDENCE_INTERVAL / 2.0)};
-            if (v <= vCutoff[0] && df.add(-summary.s_DF)) {
+                                          50.0 - CONFIDENCE_INTERVAL / 2.0) /
+                     summary.s_Vt / vmin[0]};
+            double R{summary.s_R / summary.s_Rt};
+            double DF{summary.s_DF / DFmin[0]};
+            double p{CTools::logisticFunction(v, 0.2, 1.0, -1.0) *
+                     CTools::logisticFunction(R, 0.2, 1.0, +1.0) *
+                     CTools::logisticFunction(DF, 0.2, 1.0, +1.0)};
+            LOG_TRACE(<< "p = " << p);
+            if (pmin.add(-p)) {
                 result = summary.s_H;
             }
         }
@@ -1116,7 +1245,7 @@ bool CPeriodicityHypothesisTests::seenSufficientDataToTest(core_t::TTime period,
 }
 
 bool CPeriodicityHypothesisTests::seenSufficientPeriodicallyPopulatedBucketsToTest(
-    const TFloatMeanAccumulatorCRng& buckets,
+    const TFloatMeanAccumulatorVec& buckets,
     std::size_t period) const {
     double repeats{0.0};
     for (std::size_t i = 0u; i < period; ++i) {
@@ -1168,14 +1297,15 @@ void CPeriodicityHypothesisTests::nullHypothesis(const TTimeTimePr2Vec& window,
                                                  STestStats& stats) const {
     if (this->testStatisticsFor(buckets, stats)) {
         TMeanVarAccumulatorVec trend(1);
-        periodicTrend(buckets, window, m_BucketLength, trend);
+        TFloatMeanAccumulatorVec values(buckets.begin(), buckets.end());
+        periodicTrendMinusOutliers(values, window, m_BucketLength, trend);
         double mean{CBasicStatistics::mean(trend[0])};
         double v0{CBasicStatistics::variance(trend[0])};
         LOG_TRACE(<< "mean = " << mean);
         LOG_TRACE(<< "variance = " << v0);
         stats.s_DF0 = 1.0;
         stats.s_V0 = v0;
-        stats.s_T0.assign(1, TDoubleVec{mean});
+        stats.s_T0.assign(1, {mean});
         stats.s_Partition = window;
     }
 }
@@ -1188,22 +1318,21 @@ void CPeriodicityHypothesisTests::hypothesis(const TTime2Vec& periods,
         stats.s_DF0 = 0.0;
         stats.s_T0 = TDoubleVec2Vec(stats.s_Partition.size());
         for (std::size_t i = 0u; i < stats.s_Partition.size(); ++i) {
-            core_t::TTime period_{std::min(periods[i], length(stats.s_Partition[i])) / m_BucketLength};
+            core_t::TTime period{std::min(periods[i], length(stats.s_Partition[i])) / m_BucketLength};
             TTimeTimePr2Vec windows(calculateWindows(
                 stats.s_StartOfPartition, length(buckets, m_BucketLength),
                 length(stats.s_Partition), stats.s_Partition[i]));
+
             TMeanVarAccumulatorVec trend(periods[i] / m_BucketLength);
-            periodicTrend(buckets, windows, m_BucketLength, trend);
+            TFloatMeanAccumulatorVec values(buckets.begin(), buckets.end());
+            periodicTrendMinusOutliers(values, windows, m_BucketLength, trend);
+
             stats.s_V0 += residualVariance<double>(trend, 1.0 / stats.s_M);
-            stats.s_DF0 += static_cast<double>(std::count_if(
-                trend.begin(), trend.end(), [](const TMeanVarAccumulator& value) {
-                    return CBasicStatistics::count(value) > 0.0;
-                }));
-            stats.s_T0[i].reserve(period_);
-            std::for_each(trend.begin(), trend.end(),
-                          [&stats, i](const TMeanVarAccumulator& value) {
-                              stats.s_T0[i].push_back(CBasicStatistics::mean(value));
-                          });
+            stats.s_T0[i].reserve(period);
+            std::for_each(trend.begin(), trend.end(), [&stats, i](const TMeanVarAccumulator& value) {
+                stats.s_T0[i].push_back(CBasicStatistics::mean(value));
+                stats.s_DF0 += (CBasicStatistics::count(value) > 0.0 ? 1.0 : 0.0);
+            });
         }
         stats.s_V0 /= static_cast<double>(periods.size());
     }
@@ -1259,97 +1388,165 @@ bool CPeriodicityHypothesisTests::testPeriod(const TTimeTimePr2Vec& windows,
     if (!this->testStatisticsFor(buckets, stats) || stats.nullHypothesisGoodEnough()) {
         return false;
     }
-
-    period_ = std::min(period_, length(windows[0]));
-    std::size_t period{static_cast<std::size_t>(period_ / m_BucketLength)};
-
-    // We need to observe a minimum number of repeated values to test with
-    // an acceptable false positive rate.
-    if (!this->seenSufficientPeriodicallyPopulatedBucketsToTest(buckets, period)) {
-        return false;
-    }
     if (stats.s_HasPeriod) {
+        stats.s_R0 = stats.s_Rt;
         return true;
     }
 
+    period_ = std::min(period_, length(windows[0]));
+    std::size_t period{static_cast<std::size_t>(period_ / m_BucketLength)};
     TTimeTimePr2Vec window{{0, length(windows)}};
-    double M{stats.s_M};
-    double B{stats.s_B};
-    double scale{1.0 / M};
+    double scale{1.0 / stats.s_M};
+    LOG_TRACE(<< "  scale = " << scale);
+
+    TFloatMeanAccumulatorVec varianceTestValues(buckets.begin(), buckets.end());
+    TFloatMeanAccumulatorVec amplitudeTestValues(buckets.begin(), buckets.end());
+    this->conditionOnHypothesis(window, stats, varianceTestValues);
+    this->conditionOnHypothesis(window, stats, amplitudeTestValues);
+    {
+        TMeanVarAccumulatorVec trend(period);
+        periodicTrend(varianceTestValues, window, m_BucketLength, trend);
+        reweightOutliers(trend, windows, m_BucketLength, varianceTestValues);
+    }
+
+    // We need to observe a minimum number of repeated values to test with
+    // an acceptable false positive rate.
+    if (!this->seenSufficientPeriodicallyPopulatedBucketsToTest(varianceTestValues, period)) {
+        return false;
+    }
+
+    double B{static_cast<double>(
+        std::count_if(varianceTestValues.begin(), varianceTestValues.end(),
+                      [](const TFloatMeanAccumulator& value) {
+                          return CBasicStatistics::count(value) > 0.0;
+                      }))};
+
+    // We need fewer degrees of freedom in the null hypothesis trend model
+    // we're fitting than non-empty buckets.
     double df0{B - stats.s_DF0};
     if (df0 <= 0.0) {
         return false;
     }
+
     double v0{varianceAtPercentile(stats.s_V0, df0, 50.0 + CONFIDENCE_INTERVAL / 2.0)};
     double vt{stats.s_Vt * v0};
     double at{stats.s_At * std::sqrt(v0 / scale)};
-    LOG_TRACE(<< "  M = " << M);
 
-    TFloatMeanAccumulatorVec values(buckets.begin(), buckets.end());
-    this->conditionOnHypothesis(window, stats, values);
-
-    // The variance test.
+    // -----------------
+    // The Variance Test
+    // -----------------
 
     TMeanVarAccumulatorVec trend(period);
-    periodicTrend(values, window, m_BucketLength, trend);
+    periodicTrend(varianceTestValues, window, m_BucketLength, trend);
     double b{static_cast<double>(std::count_if(
         trend.begin(), trend.end(), [](const TMeanVarAccumulator& value) {
             return CBasicStatistics::count(value) > 0.0;
         }))};
     LOG_TRACE(<< "  populated = " << b);
 
+    // We need fewer degrees of freedom in the trend model we're fitting
+    // than non-empty buckets.
     double df1{B - b};
-    if (df1 > 0.0) {
-        double v1{varianceAtPercentile(residualVariance<double>(trend, scale),
-                                       df1, 50.0 + CONFIDENCE_INTERVAL / 2.0)};
-        LOG_TRACE(<< "  variance          = " << v1);
-        LOG_TRACE(<< "  varianceThreshold = " << vt);
-        LOG_TRACE(<< "  significance      = "
-                  << CStatisticalTests::leftTailFTest(v1 / v0, df1, df0));
+    if (df1 <= 0.0) {
+        return false;
+    }
 
-        double Rt{stats.s_Rt * CTools::truncate(1.0 - 0.5 * (vt - v1) / vt, 0.9, 1.0)};
-        if (v1 < vt && B > 1.0 &&
-            CStatisticalTests::leftTailFTest(v1 / v0, df1, df0) <= MAXIMUM_SIGNIFICANCE) {
-            double R{CSignal::autocorrelation(period, values)};
-            R = autocorrelationAtPercentile(R, B, 50.0 - CONFIDENCE_INTERVAL / 2.0);
-            LOG_TRACE(<< "  autocorrelation          = " << R);
-            LOG_TRACE(<< "  autocorrelationThreshold = " << Rt);
-            if (R > Rt) {
-                return true;
-            }
-        }
+    double v1{varianceAtPercentile(residualVariance<double>(trend, scale),
+                                   df1, 50.0 + CONFIDENCE_INTERVAL / 2.0)};
+    LOG_TRACE(<< "  variance          = " << v1);
+    LOG_TRACE(<< "  varianceThreshold = " << vt);
+    LOG_TRACE(<< "  significance      = "
+              << CStatisticalTests::leftTailFTest(v1 / v0, df1, df0));
 
-        // The amplitude test.
+    double R{CSignal::autocorrelation(period, varianceTestValues)};
+    R = autocorrelationAtPercentile(R, B, 50.0 - CONFIDENCE_INTERVAL / 2.0);
+    double Rt{stats.s_Rt};
+    LOG_TRACE(<< "  autocorrelation          = " << R);
+    LOG_TRACE(<< "  autocorrelationThreshold = " << Rt);
 
-        double F1{1.0};
-        if (v1 > 0.0) {
-            try {
-                std::size_t n{static_cast<std::size_t>(
-                    std::ceil(Rt * static_cast<double>(length(window) / period_)))};
-                TMeanAccumulator level;
-                for (const auto& value : values) {
-                    if (CBasicStatistics::count(value) > 0.0) {
-                        level.add(CBasicStatistics::mean(value));
-                    }
+    TSizeVec repeats{calculateRepeats(windows, period_, m_BucketLength, varianceTestValues)};
+    double meanRepeats{CBasicStatistics::mean(
+        std::accumulate(repeats.begin(), repeats.end(), TMeanAccumulator{},
+                        [](TMeanAccumulator mean, std::size_t repeat) {
+                            mean.add(static_cast<double>(repeat));
+                            return mean;
+                        }))};
+    LOG_TRACE(<< "  mean repeats = " << meanRepeats);
+
+    // We're trading off:
+    //   1) The significance of the variance reduction,
+    //   2) The cyclic autocorrelation of the periodic component,
+    //   3) The amount of variance reduction and
+    //   4) The number of repeats we've observed.
+    //
+    // Specifically, the period will just be accepted if the p-value is equal
+    // to the threshold to be statistically significant, the autocorrelation
+    // is equal to the threshold, the variance reduction is equal to the
+    // threshold and we've observed three periods on average.
+
+    double logSignificance{
+        CTools::fastLog(CStatisticalTests::leftTailFTest(v1 / v0, df1, df0))};
+    double pVariance{
+        CTools::logisticFunction(logSignificance / LOG_STATISTICALLY_SIGNIFICANCE, 0.1, 1.0) *
+        CTools::logisticFunction(R / Rt, 0.15, 1.0) *
+        (vt > v1 ? CTools::logisticFunction(vt / v1, 1.0, 1.0, +1.0)
+                 : CTools::logisticFunction(v1 / vt, 0.1, 1.0, -1.0)) *
+        CTools::logisticFunction(meanRepeats / MINIMUM_REPEATS_TO_TEST_VARIANCE, 0.25, 1.0)};
+    LOG_TRACE(<< "  p(variance) = " << pVariance);
+
+    if (pVariance >= 0.0625) {
+        stats.s_R0 = R;
+        return true;
+    }
+
+    // ------------------
+    // The Amplitude Test
+    // ------------------
+
+    trend.assign(period, TMeanVarAccumulator{});
+    periodicTrend(amplitudeTestValues, window, m_BucketLength, trend);
+    v1 = varianceAtPercentile(residualVariance<double>(trend, scale), df1,
+                              50.0 + CONFIDENCE_INTERVAL / 2.0);
+
+    double F1{1.0};
+    if (v1 > 0.0) {
+        try {
+            std::size_t n{static_cast<std::size_t>(
+                std::ceil(Rt * static_cast<double>(length(window) / period_)))};
+            LOG_TRACE(<< " n = " << n);
+            TMeanAccumulator level;
+            for (const auto& value : amplitudeTestValues) {
+                if (CBasicStatistics::count(value) > 0.0) {
+                    level.add(CBasicStatistics::mean(value));
                 }
-                TMinAmplitudeVec amplitudes(period, {n, CBasicStatistics::mean(level)});
-                periodicTrend(values, window, m_BucketLength, amplitudes);
-                boost::math::normal normal(0.0, std::sqrt(v1));
-                std::for_each(amplitudes.begin(), amplitudes.end(),
-                              [&F1, &normal, at](CMinAmplitude& x) {
-                                  if (x.amplitude() >= at) {
-                                      F1 = std::min(F1, x.significance(normal));
-                                  }
-                              });
-            } catch (const std::exception& e) {
-                LOG_ERROR(<< "Unable to compute significance of amplitude: " << e.what());
             }
+            TMinAmplitudeVec amplitudes(period, {n, CBasicStatistics::mean(level)});
+            periodicTrend(amplitudeTestValues, window, m_BucketLength, amplitudes);
+            boost::math::normal normal(0.0, std::sqrt(v1));
+            std::for_each(amplitudes.begin(), amplitudes.end(),
+                          [&F1, &normal, at](CMinAmplitude& x) {
+                              if (x.amplitude() >= at) {
+                                  F1 = std::min(F1, x.significance(normal));
+                              }
+                          });
+        } catch (const std::exception& e) {
+            LOG_ERROR(<< "Unable to compute significance of amplitude: " << e.what());
         }
-        LOG_TRACE(<< "  F(amplitude)       = " << F1);
+    }
+    LOG_TRACE(<< "  F(amplitude) = " << F1);
 
-        if (1.0 - std::pow(1.0 - F1, b) <= MAXIMUM_SIGNIFICANCE) {
-            return true;
-        }
+    // Trade off the test significance and the mean number of repeats
+    // we've observed.
+    logSignificance = CTools::fastLog(1.0 - std::pow(1.0 - F1, b));
+    double pAmplitude{
+        CTools::logisticFunction(logSignificance / LOG_STATISTICALLY_SIGNIFICANCE, 0.2, 1.0) *
+        CTools::logisticFunction(meanRepeats / static_cast<double>(2 * MINIMUM_REPEATS_TO_TEST_AMPLITUDE),
+                                 0.5, 1.0)};
+    LOG_TRACE(<< "  p(amplitude) = " << pAmplitude);
+
+    if (pAmplitude >= 0.25) {
+        stats.s_R0 = R;
+        return true;
     }
     return false;
 }
@@ -1359,6 +1556,13 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
                                                 core_t::TTime period_,
                                                 double correction,
                                                 STestStats& stats) const {
+    // We check to see if partitioning the data as well as fitting a periodic
+    // component with period "period_" explains a non-negligible absolute and
+    // statistically significant amount of variance and the cyclic correlation
+    // at the repeat of at least one of the partition's periodic components
+    // is high enough. In order to do this we search over all permitted offsets
+    // for the start of the split.
+
     using TDoubleTimePr = std::pair<double, core_t::TTime>;
     using TDoubleTimePrVec = std::vector<TDoubleTimePr>;
     using TMinAccumulator = CBasicStatistics::COrderStatisticsStack<TDoubleTimePr, 1>;
@@ -1370,39 +1574,53 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
     if (!this->testStatisticsFor(buckets, stats) || stats.nullHypothesisGoodEnough()) {
         return false;
     }
+    if (stats.s_HasPartition) {
+        stats.s_R0 = stats.s_Rt;
+        return true;
+    }
 
     std::size_t period{static_cast<std::size_t>(period_ / m_BucketLength)};
+    core_t::TTime windowLength{length(buckets, m_BucketLength)};
+    core_t::TTime repeat{length(partition)};
+    double scale{1.0 / stats.s_M};
+    LOG_TRACE(<< "scale = " << scale);
+
+    TFloatMeanAccumulatorVec values(buckets.begin(), buckets.end());
+    this->conditionOnHypothesis({{0, windowLength}}, stats, values);
+    {
+        TTimeTimePr2Vec window{{0, windowLength}};
+        TMeanVarAccumulatorVec trend(period);
+        periodicTrend(values, window, m_BucketLength, trend);
+        reweightOutliers(trend, window, m_BucketLength, values);
+    }
 
     // We need to observe a minimum number of repeated values to test with
     // an acceptable false positive rate.
-    if (!this->seenSufficientPeriodicallyPopulatedBucketsToTest(buckets, period)) {
+    if (!this->seenSufficientPeriodicallyPopulatedBucketsToTest(values, period)) {
         return false;
-    }
-    if (stats.s_HasPartition) {
-        return true;
     }
 
     // Find the partition of the data such that the residual variance
     // w.r.t. the period is minimized and check if there is significant
     // evidence that it reduces the residual variance and repeats.
 
-    core_t::TTime windowLength{length(buckets, m_BucketLength)};
-    core_t::TTime repeat{length(partition)};
-    core_t::TTime startOfPartition{stats.s_StartOfPartition};
-    double B{stats.s_B};
-    double scale{1.0 / stats.s_M};
+    double B{static_cast<double>(std::count_if(
+        values.begin(), values.end(), [](const TFloatMeanAccumulator& value) {
+            return CBasicStatistics::count(value) > 0.0;
+        }))};
     double df0{B - stats.s_DF0};
+
+    // We need fewer degrees of freedom in the null hypothesis trend model
+    // we're fitting than non-empty buckets.
     if (df0 <= 0.0) {
         return false;
     }
+
     double v0{varianceAtPercentile(stats.s_V0, df0, 50.0 + CONFIDENCE_INTERVAL / 2.0)};
     double vt{stats.s_Vt * v0};
     LOG_TRACE(<< "period = " << period);
-    LOG_TRACE(<< "scale = " << scale);
 
-    TFloatMeanAccumulatorVec values(buckets.begin(), buckets.end());
-    this->conditionOnHypothesis({{0, windowLength}}, stats, values);
-
+    core_t::TTime startOfPartition{stats.s_StartOfPartition};
     TTimeTimePr2Vec windows[]{
         calculateWindows(startOfPartition, windowLength, repeat, partition[0]),
         calculateWindows(startOfPartition, windowLength, repeat, partition[1])};
@@ -1411,12 +1629,12 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
     TTimeVec deltas[2];
     deltas[0].reserve((length(partition[0]) * windowLength) / (period_ * repeat));
     deltas[1].reserve((length(partition[1]) * windowLength) / (period_ * repeat));
-    for (std::size_t i = 0u; i < 2; ++i) {
-        for (const auto& window : windows[i]) {
+    for (std::size_t j = 0u; j < 2; ++j) {
+        for (const auto& window : windows[j]) {
             core_t::TTime a_{window.first};
             core_t::TTime b_{window.second};
             for (core_t::TTime t = a_ + period_; t <= b_; t += period_) {
-                deltas[i].push_back(t - m_BucketLength);
+                deltas[j].push_back(t - m_BucketLength);
             }
         }
     }
@@ -1428,28 +1646,30 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
     periodicTrend(values, windows[0], m_BucketLength, trends[0]);
     periodicTrend(values, windows[1], m_BucketLength, trends[1]);
 
-    TMeanAccumulator variances[]{residualVariance<TMeanAccumulator>(trends[0], scale),
-                                 residualVariance<TMeanAccumulator>(trends[1], scale)};
+    TMeanAccumulator variances[]{
+        residualVariance<TMeanAccumulator>(trends[0], scale),
+        residualVariance<TMeanAccumulator>(trends[1], scale)};
     LOG_TRACE(<< "variances = " << core::CContainerPrinter::print(variances));
 
     TMinAccumulator minimum;
-    minimum.add({(residualVariance(variances[0]) + residualVariance(variances[1])) / 2.0, 0});
+    minimum.add(
+        {(residualVariance(variances[0]) + residualVariance(variances[1])) / 2.0, 0});
 
     TDoubleTimePrVec candidates;
     candidates.reserve(period);
     for (core_t::TTime time = m_BucketLength; time < repeat; time += m_BucketLength) {
-        for (std::size_t i = 0u; i < 2; ++i) {
-            for (auto& delta : deltas[i]) {
+        for (std::size_t j = 0u; j < 2; ++j) {
+            for (auto& delta : deltas[j]) {
                 delta = (delta + m_BucketLength) % windowLength;
             }
-            TMeanVarAccumulator oldBucket{trends[i].front()};
+            TMeanVarAccumulator oldBucket{trends[j].front()};
             TMeanVarAccumulator newBucket;
-            averageValue(values, deltas[i], m_BucketLength, newBucket);
+            averageValue(values, deltas[j], m_BucketLength, newBucket);
 
-            trends[i].pop_front();
-            trends[i].push_back(newBucket);
-            variances[i] -= residualVariance(oldBucket, scale);
-            variances[i] += residualVariance(newBucket, scale);
+            trends[j].pop_front();
+            trends[j].push_back(newBucket);
+            variances[j] -= residualVariance(oldBucket, scale);
+            variances[j] += residualVariance(newBucket, scale);
         }
         double variance{
             (residualVariance(variances[0]) + residualVariance(variances[1])) / 2.0};
@@ -1466,8 +1686,8 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
     for (const auto& candidate : candidates) {
         if (candidate.first <= 1.05 * minimum[0].first) {
             core_t::TTime candidateStartOfPartition{candidate.second};
-            candidateWindows = calculateWindows(candidateStartOfPartition,
-                                                windowLength, repeat, partition[0]);
+            candidateWindows = calculateWindows(
+                candidateStartOfPartition, windowLength, repeat, partition[0]);
             TMeanAccumulator cost;
             for (const auto& window : candidateWindows) {
                 core_t::TTime a_{window.first / m_BucketLength};
@@ -1478,9 +1698,9 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
             }
             if (best.add({CBasicStatistics::mean(cost), candidateStartOfPartition})) {
                 b = 0.0;
-                for (std::size_t i = 0u; i < 2; ++i) {
-                    candidateWindows = calculateWindows(candidateStartOfPartition, windowLength,
-                                                        repeat, partition[i]);
+                for (const auto& subset : partition) {
+                    candidateWindows = calculateWindows(
+                        candidateStartOfPartition, windowLength, repeat, subset);
 
                     TMeanVarAccumulatorVec trend(period);
                     periodicTrend(values, candidateWindows, m_BucketLength, trend);
@@ -1495,46 +1715,84 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
     }
 
     double df1{B - b};
-    if (df1 > 0.0) {
-        double variance{correction * minimum[0].first};
-        double v1{varianceAtPercentile(variance, df1, 50.0 + CONFIDENCE_INTERVAL / 2.0)};
-        LOG_TRACE(<< "  variance          = " << v1);
-        LOG_TRACE(<< "  varianceThreshold = " << vt);
-        LOG_TRACE(<< "  significance      = "
-                  << CStatisticalTests::leftTailFTest(v1 / v0, df1, df0));
 
-        if (v1 <= vt && CStatisticalTests::leftTailFTest(v1 / v0, df1, df0) <= MAXIMUM_SIGNIFICANCE) {
-            double R{-1.0};
-            double Rt{stats.s_Rt * CTools::truncate(1.0 - 0.5 * (vt - v1) / vt, 0.9, 1.0)};
+    // We need fewer degrees of freedom in the trend model we're fitting
+    // than non-empty buckets.
+    if (df1 <= 0.0) {
+        return false;
+    }
 
-            startOfPartition = best[0].second;
-            windows[0] = calculateWindows(startOfPartition, windowLength,
-                                          repeat, partition[0]);
-            windows[1] = calculateWindows(startOfPartition, windowLength,
-                                          repeat, partition[1]);
-            for (const auto& windows_ : windows) {
-                TFloatMeanAccumulatorVec partitionValues;
-                project(values, windows_, m_BucketLength, partitionValues);
-                std::size_t windowLength_(length(windows_[0]) / m_BucketLength);
-                double BW{std::accumulate(
-                    partitionValues.begin(), partitionValues.end(), 0.0,
-                    [](double n, const TFloatMeanAccumulator& value) {
-                        return n + (CBasicStatistics::count(value) > 0.0 ? 1.0 : 0.0);
-                    })};
-                if (BW > 1.0) {
-                    double RW{CSignal::autocorrelation(windowLength_ + period, partitionValues)};
-                    R = std::max(R, autocorrelationAtPercentile(
-                                        RW, BW, 50.0 - CONFIDENCE_INTERVAL / 2.0));
-                    LOG_TRACE(<< "  autocorrelation          = " << R);
-                    LOG_TRACE(<< "  autocorrelationThreshold = " << Rt);
-                }
-            }
+    double variance{correction * minimum[0].first};
+    double v1{varianceAtPercentile(variance, df1, 50.0 + CONFIDENCE_INTERVAL / 2.0)};
+    LOG_TRACE(<< "  variance          = " << v1);
+    LOG_TRACE(<< "  varianceThreshold = " << vt);
+    LOG_TRACE(<< "  significance      = "
+              << CStatisticalTests::leftTailFTest(v1 / v0, df1, df0));
 
-            if (R > Rt) {
-                stats.s_StartOfPartition = startOfPartition;
-                return true;
-            }
+    startOfPartition = best[0].second;
+    windows[0] = calculateWindows(startOfPartition, windowLength, repeat,
+                                  partition[0]);
+    windows[1] = calculateWindows(startOfPartition, windowLength, repeat,
+                                  partition[1]);
+    LOG_TRACE(<< "  start of partition = " << startOfPartition);
+
+    // In the following we're trading off:
+    //   1) The cyclic autocorrelation of each periodic component in the
+    //      partition,
+    //   2) The number of repeats we've observed of each periodic component
+    //      in the partition,
+    //   3) The significance of the variance reduction, and
+    //   4) The amount of variance reduction.
+
+    double p{0.0};
+    double R{-1.0};
+    double Rt{stats.s_Rt};
+
+    TFloatMeanAccumulatorVec partitionValues;
+    for (const auto& window : windows) {
+        project(values, window, m_BucketLength, partitionValues);
+
+        double RW{-1.0};
+        double BW{std::accumulate(
+            partitionValues.begin(), partitionValues.end(), 0.0,
+            [](double n, const TFloatMeanAccumulator& value) {
+                return n + (CBasicStatistics::count(value) > 0.0 ? 1.0 : 0.0);
+            })};
+        if (BW > 1.0) {
+            RW = CSignal::autocorrelation(
+                length(window[0]) / m_BucketLength + period, partitionValues);
+            RW = autocorrelationAtPercentile(RW, BW, 50.0 - CONFIDENCE_INTERVAL / 2.0);
+            LOG_TRACE(<< "  autocorrelation          = " << RW);
+            LOG_TRACE(<< "  autocorrelationThreshold = " << Rt);
         }
+
+        TSizeVec repeats{calculateRepeats(window, period_, m_BucketLength, values)};
+        double meanRepeats{CBasicStatistics::mean(
+            std::accumulate(repeats.begin(), repeats.end(), TMeanAccumulator{},
+                            [](TMeanAccumulator mean, std::size_t repeat_) {
+                                mean.add(static_cast<double>(repeat_));
+                                return mean;
+                            }))};
+        LOG_TRACE(<< "  mean repeats = " << meanRepeats);
+
+        p = std::max(p, CTools::logisticFunction(RW / Rt, 0.15, 1.0) *
+                            CTools::logisticFunction(meanRepeats / MINIMUM_REPEATS_TO_TEST_VARIANCE,
+                                                     0.25, 1.0));
+        R = std::max(R, RW);
+    }
+
+    double logSignificance{
+        CTools::fastLog(CStatisticalTests::leftTailFTest(v1 / v0, df1, df0))};
+    p *= CTools::logisticFunction(logSignificance / LOG_STATISTICALLY_SIGNIFICANCE,
+                                  0.1, 1.0) *
+         (vt > v1 ? CTools::logisticFunction(vt / v1, 1.0, 1.0, +1.0)
+                  : CTools::logisticFunction(v1 / vt, 0.1, 1.0, -1.0));
+    LOG_TRACE(<< "  p(partition) = " << p);
+
+    if (p >= 0.0625) {
+        stats.s_StartOfPartition = startOfPartition;
+        stats.s_R0 = R;
+        return true;
     }
     return false;
 }
@@ -1543,8 +1801,12 @@ const double CPeriodicityHypothesisTests::ACCURATE_TEST_POPULATED_FRACTION{0.9};
 const double CPeriodicityHypothesisTests::MINIMUM_COEFFICIENT_OF_VARIATION{1e-4};
 
 CPeriodicityHypothesisTests::STestStats::STestStats()
-    : s_HasPeriod(false), s_HasPartition(false), s_Vt(0.0), s_At(0.0), s_Rt(0.0),
-      s_Range(0.0), s_B(0.0), s_M(0.0), s_V0(0.0), s_DF0(0.0), s_StartOfPartition(0) {
+    : s_HasPeriod(false), s_HasPartition(false),
+      s_Vt(SIGNIFICANT_VARIANCE_REDUCTION[E_HighThreshold]),
+      s_At(SIGNIFICANT_AMPLITUDE[E_HighThreshold]),
+      s_Rt(SIGNIFICANT_AUTOCORRELATION[E_HighThreshold]), s_Range(0.0),
+      s_B(0.0), s_M(0.0), s_V0(0.0), s_R0(0.0), s_DF0(0.0),
+      s_StartOfPartition(0) {
 }
 
 void CPeriodicityHypothesisTests::STestStats::setThresholds(double vt, double at, double Rt) {

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -229,7 +229,7 @@ double CSeasonalComponent::delta(core_t::TTime time,
         // a delta for the case that the difference from the mean
         // is 1/3 of the range. We force the delta to zero for values
         // significantly smaller than this.
-        double scale{CTools::smoothHeaviside(3.0 * min[0] / minmax.range(), 1.0 / 12.0)};
+        double scale{CTools::logisticFunction(3.0 * min[0] / minmax.range(), 0.1, 1.0)};
         scale = CTools::truncate(1.002 * scale - 0.001, 0.0, 1.0);
 
         return -scale * min[0] * CTools::sign(shortPeriodValue);

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -580,7 +580,7 @@ double CSeasonalComponentAdaptiveBucketing::predict(std::size_t bucket,
 
     // We mean revert our predictions if trying to predict much further
     // ahead than the observed interval for the data.
-    double alpha{CTools::smoothHeaviside(extrapolateInterval / interval, 1.0 / 12.0, -1.0)};
+    double alpha{CTools::logisticFunction(extrapolateInterval / interval, 0.1, 1.0, -1.0)};
     double beta{1.0 - alpha};
     return alpha * regression.predict(t) + beta * regression.mean();
 }

--- a/lib/maths/CSignal.cc
+++ b/lib/maths/CSignal.cc
@@ -141,8 +141,7 @@ double CSignal::autocorrelation(std::size_t offset, TFloatMeanAccumulatorCRng va
     TMeanVarAccumulator moments;
     for (const auto& value : values) {
         if (CBasicStatistics::count(value) > 0.0) {
-            moments.add(CBasicStatistics::mean(value),
-                        CBasicStatistics::count(value));
+            moments.add(CBasicStatistics::mean(value), CBasicStatistics::count(value));
         }
     }
 
@@ -156,7 +155,7 @@ double CSignal::autocorrelation(std::size_t offset, TFloatMeanAccumulatorCRng va
         if (ni > 0.0 && nj > 0.0) {
             double weight = std::sqrt(ni * nj);
             autocorrelation.add((CBasicStatistics::mean(values[i]) - mean) *
-                                (CBasicStatistics::mean(values[j]) - mean),
+                                    (CBasicStatistics::mean(values[j]) - mean),
                                 weight);
         }
     }

--- a/lib/maths/CSignal.cc
+++ b/lib/maths/CSignal.cc
@@ -141,7 +141,8 @@ double CSignal::autocorrelation(std::size_t offset, TFloatMeanAccumulatorCRng va
     TMeanVarAccumulator moments;
     for (const auto& value : values) {
         if (CBasicStatistics::count(value) > 0.0) {
-            moments.add(CBasicStatistics::mean(value));
+            moments.add(CBasicStatistics::mean(value),
+                        CBasicStatistics::count(value));
         }
     }
 
@@ -153,8 +154,10 @@ double CSignal::autocorrelation(std::size_t offset, TFloatMeanAccumulatorCRng va
         double ni = CBasicStatistics::count(values[i]);
         double nj = CBasicStatistics::count(values[j]);
         if (ni > 0.0 && nj > 0.0) {
+            double weight = std::sqrt(ni * nj);
             autocorrelation.add((CBasicStatistics::mean(values[i]) - mean) *
-                                (CBasicStatistics::mean(values[j]) - mean));
+                                (CBasicStatistics::mean(values[j]) - mean),
+                                weight);
         }
     }
 

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1439,9 +1439,12 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
             }
             double bucketLength{static_cast<double>(m_BucketLength)};
             core_t::TTime period{seasonalTime->period()};
+            auto boundaryCondition = period > seasonalTime->windowLength()
+                                         ? CSplineTypes::E_Natural
+                                         : CSplineTypes::E_Periodic;
 
-            CSeasonalComponent candidate{*seasonalTime, m_SeasonalComponentSize, m_DecayRate,
-                                         bucketLength, CSplineTypes::E_Natural};
+            CSeasonalComponent candidate{*seasonalTime, m_SeasonalComponentSize,
+                                         m_DecayRate, bucketLength, boundaryCondition};
             candidate.initialize(startTime, endTime, values);
             candidate.interpolate(CIntegerTools::floor(endTime, period));
             this->reweightOutliers(
@@ -1451,8 +1454,8 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
                 },
                 values);
 
-            components.emplace_back(*seasonalTime, m_SeasonalComponentSize, m_DecayRate,
-                                    bucketLength, CSplineTypes::E_Natural);
+            components.emplace_back(*seasonalTime, m_SeasonalComponentSize,
+                                    m_DecayRate, bucketLength, boundaryCondition);
             components.back().initialize(startTime, endTime, values);
             components.back().interpolate(CIntegerTools::floor(endTime, period));
         }

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -445,7 +445,7 @@ double CTrendComponent::weightOfPrediction(core_t::TTime time) const {
         return 1.0;
     }
 
-    return CTools::smoothHeaviside(extrapolateInterval / interval, 1.0 / 12.0, -1.0);
+    return CTools::logisticFunction(extrapolateInterval / interval, 0.1, 1.0, -1.0);
 }
 
 CTrendComponent::SModel::SModel(double weight) {

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -193,7 +193,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 4.0, 4.0, 0.04);
+    this->test(trend, bucketLength, 63, 4.0, 44.0, 0.06);
 }
 
 void CForecastTest::testNonNegative() {

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -90,7 +90,7 @@ void CForecastTest::testDailyNoLongTermTrend() {
         return 40.0 + alpha * y[i / 6] + beta * y[(i / 6 + 1) % y.size()] + noise;
     };
 
-    this->test(trend, bucketLength, 63, 64.0, 5.0, 0.14);
+    this->test(trend, bucketLength, 63, 64.0, 5.0, 0.13);
 }
 
 void CForecastTest::testDailyConstantLongTermTrend() {
@@ -130,7 +130,7 @@ void CForecastTest::testDailyVaryingLongTermTrend() {
                8.0 * std::sin(boost::math::double_constants::two_pi * time_ / 43200.0) + noise;
     };
 
-    this->test(trend, bucketLength, 98, 9.0, 14.0, 0.042);
+    this->test(trend, bucketLength, 98, 9.0, 24.0, 0.042);
 }
 
 void CForecastTest::testComplexNoLongTermTrend() {
@@ -146,7 +146,7 @@ void CForecastTest::testComplexNoLongTermTrend() {
         return scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 24.0, 8.0, 0.13);
+    this->test(trend, bucketLength, 63, 24.0, 9.0, 0.13);
 }
 
 void CForecastTest::testComplexConstantLongTermTrend() {
@@ -163,7 +163,7 @@ void CForecastTest::testComplexConstantLongTermTrend() {
                scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 24.0, 8.0, 0.01);
+    this->test(trend, bucketLength, 63, 24.0, 11.0, 0.01);
 }
 
 void CForecastTest::testComplexVaryingLongTermTrend() {
@@ -193,7 +193,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 4.0, 42.0, 0.06);
+    this->test(trend, bucketLength, 63, 4.0, 4.0, 0.04);
 }
 
 void CForecastTest::testNonNegative() {

--- a/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
+++ b/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
@@ -234,8 +234,8 @@ void CPeriodicityHypothesisTestsTest::testDiurnal() {
             core_t::TTime time{timeseries[i].first};
             if (time > lastTest + window) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
-                LOG_DEBUG(<< result.print());
-                CPPUNIT_ASSERT(result.print() == "{ 'weekend daily' 'weekday daily' }" ||
+                LOG_DEBUG(<< "result = " << result.print());
+                CPPUNIT_ASSERT(result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' }" ||
                                result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }");
                 hypotheses = maths::CPeriodicityHypothesisTests();
                 hypotheses.initialize(HOUR, window, DAY);
@@ -308,7 +308,8 @@ void CPeriodicityHypothesisTestsTest::testDiurnal() {
             core_t::TTime time{timeseries[i].first};
             if (time > lastTest + window) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
-                CPPUNIT_ASSERT(result.print() == "{ 'weekend daily' 'weekday daily' }" ||
+                LOG_DEBUG(<< "result = " << result.print());
+                CPPUNIT_ASSERT(result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' }" ||
                                result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }");
                 hypotheses = maths::CPeriodicityHypothesisTests();
                 hypotheses.initialize(HOUR, window, DAY);
@@ -490,8 +491,7 @@ void CPeriodicityHypothesisTestsTest::testWithSparseData() {
             if (t >= 2) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
                 LOG_DEBUG(<< "result = " << result.print());
-                CPPUNIT_ASSERT_EQUAL(std::string("{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }"),
-                                     result.print());
+                CPPUNIT_ASSERT_EQUAL(std::string("{ 'daily' 'weekly' }"), result.print());
             }
         }
     }
@@ -640,8 +640,9 @@ void CPeriodicityHypothesisTestsTest::testWithOutliers() {
             maths::CPeriodicityHypothesisTestsResult result{
                 maths::testForPeriods(config, startTime, bucketLength, values)};
             LOG_DEBUG(<< "result = " << result.print());
-            CPPUNIT_ASSERT_EQUAL(std::string("{ 'weekend daily' 'weekday daily' }"),
-                                 result.print());
+            CPPUNIT_ASSERT(
+                result.print() == std::string("{ 'weekend daily' 'weekday daily' }") ||
+                result.print() == std::string("{ 'weekend daily' 'weekday daily' 'weekend weekly' }"));
         }
     }
 }

--- a/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
+++ b/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
@@ -209,7 +209,7 @@ void CPeriodicityHypothesisTestsTest::testDiurnal() {
     }
 
     LOG_DEBUG(<< "");
-    LOG_DEBUG(<< "*** Diurnal: daily and weekends ***");
+    LOG_DEBUG(<< "*** Diurnal: daily, weekly and weekends + outliers ***");
     {
         TTimeDoublePrVec timeseries;
         core_t::TTime startTime;
@@ -234,8 +234,9 @@ void CPeriodicityHypothesisTestsTest::testDiurnal() {
             core_t::TTime time{timeseries[i].first};
             if (time > lastTest + window) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
-                CPPUNIT_ASSERT_EQUAL(std::string("{ 'weekend daily' 'weekday daily' }"),
-                                     result.print());
+                LOG_DEBUG(<< result.print());
+                CPPUNIT_ASSERT(result.print() == "{ 'weekend daily' 'weekday daily' }" ||
+                               result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }");
                 hypotheses = maths::CPeriodicityHypothesisTests();
                 hypotheses.initialize(HOUR, window, DAY);
                 lastTest += window;
@@ -397,9 +398,13 @@ void CPeriodicityHypothesisTestsTest::testNonDiurnal() {
 }
 
 void CPeriodicityHypothesisTestsTest::testWithSparseData() {
+    // Test we correctly identify periodicity if there are periodically
+    // missing data.
+
     test::CRandomNumbers rng;
 
-    LOG_DEBUG(<< "Daily Periodic") {
+    LOG_DEBUG(<< "Daily Periodic");
+    {
         maths::CPeriodicityHypothesisTests hypotheses;
         hypotheses.initialize(HALF_HOUR, WEEK, DAY);
 
@@ -424,7 +429,8 @@ void CPeriodicityHypothesisTestsTest::testWithSparseData() {
         }
     }
 
-    LOG_DEBUG(<< "Daily Not Periodic") {
+    LOG_DEBUG(<< "Daily Not Periodic");
+    {
         maths::CPeriodicityHypothesisTests hypotheses;
         hypotheses.initialize(HALF_HOUR, WEEK, DAY);
 
@@ -450,7 +456,8 @@ void CPeriodicityHypothesisTestsTest::testWithSparseData() {
         }
     }
 
-    LOG_DEBUG(<< "Weekly") {
+    LOG_DEBUG(<< "Weekly");
+    {
         maths::CPeriodicityHypothesisTests hypotheses;
         hypotheses.initialize(HOUR, 2 * WEEK, WEEK);
 
@@ -483,12 +490,14 @@ void CPeriodicityHypothesisTestsTest::testWithSparseData() {
             if (t >= 2) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
                 LOG_DEBUG(<< "result = " << result.print());
-                CPPUNIT_ASSERT_EQUAL(std::string("{ 'daily' 'weekly' }"), result.print());
+                CPPUNIT_ASSERT_EQUAL(std::string("{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }"),
+                                     result.print());
             }
         }
     }
 
-    LOG_DEBUG(<< "Weekly Not Periodic") {
+    LOG_DEBUG(<< "Weekly Not Periodic");
+    {
         maths::CPeriodicityHypothesisTests hypotheses;
         hypotheses.initialize(HOUR, 4 * WEEK, WEEK);
 
@@ -527,6 +536,116 @@ void CPeriodicityHypothesisTestsTest::testWithSparseData() {
     }
 }
 
+void CPeriodicityHypothesisTestsTest::testWithOutliers() {
+    // Test the we can robustly detect the correct underlying periodic
+    // components.
+
+    TTimeVec windows{WEEK, 2 * WEEK, 16 * DAY, 4 * WEEK};
+    TTimeVec bucketLengths{TEN_MINS, HALF_HOUR};
+    TTimeVec periods{DAY, WEEK};
+    TDoubleVec modulation{0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0};
+    core_t::TTime startTime{10000};
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec noise;
+    TSizeVec outliers;
+    TDoubleVec spikeOrTroughSelector;
+
+    LOG_DEBUG(<< "Daily + Weekly");
+    for (const auto& period : periods) {
+        for (const auto& window : windows) {
+            if (window < 2 * period) {
+                continue;
+            }
+            for (const auto& bucketLength : bucketLengths) {
+                core_t::TTime buckets{window / bucketLength};
+                std::size_t numberOutliers{static_cast<std::size_t>(0.12 * buckets)};
+                rng.generateUniformSamples(0, buckets, numberOutliers, outliers);
+                rng.generateUniformSamples(0, 1.0, numberOutliers, spikeOrTroughSelector);
+                rng.generateNormalSamples(0.0, 9.0, buckets, noise);
+                std::sort(outliers.begin(), outliers.end());
+
+                //std::ofstream file;
+                //file.open("results.m");
+                //TDoubleVec f;
+
+                maths::TFloatMeanAccumulatorVec values(buckets);
+                for (core_t::TTime time = startTime; time < startTime + window;
+                     time += bucketLength) {
+                    std::size_t bucket((time - startTime) / bucketLength);
+                    auto outlier = std::lower_bound(outliers.begin(), outliers.end(), bucket);
+                    if (outlier != outliers.end() && *outlier == bucket) {
+                        values[bucket].add(
+                            spikeOrTroughSelector[outlier - outliers.begin()] > 0.2 ? 0.0 : 100.0);
+                    } else {
+                        values[bucket].add(
+                            20.0 + 20.0 * std::sin(boost::math::double_constants::two_pi *
+                                                   static_cast<double>(time) /
+                                                   static_cast<double>(period)));
+                    }
+                    //f.push_back(maths::CBasicStatistics::mean(values[bucket]));
+                }
+                //file << "f = " << core::CContainerPrinter::print(f) << ";";
+
+                maths::CPeriodicityHypothesisTestsConfig config;
+                maths::CPeriodicityHypothesisTestsResult result{
+                    maths::testForPeriods(config, startTime, bucketLength, values)};
+                LOG_DEBUG(<< "result = " << result.print());
+                if (period == DAY) {
+                    CPPUNIT_ASSERT_EQUAL(std::string{"{ 'daily' }"}, result.print());
+                } else if (period == WEEK) {
+                    CPPUNIT_ASSERT_EQUAL(std::string{"{ 'weekly' }"}, result.print());
+                }
+            }
+        }
+    }
+
+    LOG_DEBUG(<< "Weekday / Weekend");
+    for (const auto& window : windows) {
+        if (window < 2 * WEEK) {
+            continue;
+        }
+        for (const auto& bucketLength : bucketLengths) {
+            core_t::TTime buckets{window / bucketLength};
+            std::size_t numberOutliers{static_cast<std::size_t>(0.12 * buckets)};
+            rng.generateUniformSamples(0, buckets, numberOutliers, outliers);
+            rng.generateUniformSamples(0, 1.0, numberOutliers, spikeOrTroughSelector);
+            rng.generateNormalSamples(0.0, 9.0, buckets, noise);
+            std::sort(outliers.begin(), outliers.end());
+
+            //std::ofstream file;
+            //file.open("results.m");
+            //TDoubleVec f;
+
+            maths::TFloatMeanAccumulatorVec values(buckets);
+            for (core_t::TTime time = startTime; time < startTime + window; time += bucketLength) {
+                std::size_t bucket((time - startTime) / bucketLength);
+                auto outlier = std::lower_bound(outliers.begin(), outliers.end(), bucket);
+                if (outlier != outliers.end() && *outlier == bucket) {
+                    values[bucket].add(
+                        spikeOrTroughSelector[outlier - outliers.begin()] > 0.2 ? 0.0 : 100.0);
+                } else {
+                    values[bucket].add(
+                        modulation[((time - startTime) / DAY) % 7] *
+                        (20.0 + 20.0 * std::sin(boost::math::double_constants::two_pi *
+                                                static_cast<double>(time) /
+                                                static_cast<double>(DAY))));
+                }
+                //f.push_back(maths::CBasicStatistics::mean(values[bucket]));
+            }
+            //file << "f = " << core::CContainerPrinter::print(f) << ";";
+
+            maths::CPeriodicityHypothesisTestsConfig config;
+            maths::CPeriodicityHypothesisTestsResult result{
+                maths::testForPeriods(config, startTime, bucketLength, values)};
+            LOG_DEBUG(<< "result = " << result.print());
+            CPPUNIT_ASSERT_EQUAL(std::string("{ 'weekend daily' 'weekday daily' }"),
+                                 result.print());
+        }
+    }
+}
+
 void CPeriodicityHypothesisTestsTest::testTestForPeriods() {
     // Test the ability to correctly find and test for periodic
     // signals without being told the periods to test a-priori.
@@ -550,15 +669,13 @@ void CPeriodicityHypothesisTestsTest::testTestForPeriods() {
         if (test % 10 == 0) {
             LOG_DEBUG(<< "test " << test << " / 100");
         }
-        for (std::size_t i = 0u; i < windows.size(); ++i) {
-            core_t::TTime window{windows[i]};
-
+        for (const auto& window : windows) {
             TDoubleVec scaling_;
             rng.generateUniformSamples(1.0, 5.0, 1, scaling_);
             double scaling{test % 2 == 0 ? scaling_[0] : 1.0 / scaling_[0]};
 
-            for (std::size_t j = 0u; j < bucketLengths.size(); ++j) {
-                core_t::TTime bucketLength{bucketLengths[j]};
+            for (std::size_t i = 0u; i < bucketLengths.size(); ++i) {
+                core_t::TTime bucketLength{bucketLengths[i]};
                 core_t::TTime period{maths::CIntegerTools::floor(
                     static_cast<core_t::TTime>(static_cast<double>(DAY) / scaling), bucketLength)};
                 scaling = static_cast<double>(DAY) / static_cast<double>(period);
@@ -581,7 +698,7 @@ void CPeriodicityHypothesisTestsTest::testTestForPeriods() {
                     rng.generateLogNormalSamples(0.2, 0.3, window / bucketLength, noise);
                     break;
                 }
-                rng.generateUniformSamples(0, permittedGenerators[j], 1, index);
+                rng.generateUniformSamples(0, permittedGenerators[i], 1, index);
                 rng.generateUniformSamples(3, 20, 1, repeats);
 
                 maths::CPeriodicityHypothesisTests hypotheses;
@@ -646,6 +763,9 @@ CppUnit::Test* CPeriodicityHypothesisTestsTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CPeriodicityHypothesisTestsTest>(
         "CPeriodicityHypothesisTestsTest::testWithSparseData",
         &CPeriodicityHypothesisTestsTest::testWithSparseData));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CPeriodicityHypothesisTestsTest>(
+        "CPeriodicityHypothesisTestsTest::testWithOutliers",
+        &CPeriodicityHypothesisTestsTest::testWithOutliers));
     suiteOfTests->addTest(new CppUnit::TestCaller<CPeriodicityHypothesisTestsTest>(
         "CPeriodicityHypothesisTestsTest::testTestForPeriods",
         &CPeriodicityHypothesisTestsTest::testTestForPeriods));

--- a/lib/maths/unittest/CPeriodicityHypothesisTestsTest.h
+++ b/lib/maths/unittest/CPeriodicityHypothesisTestsTest.h
@@ -15,6 +15,7 @@ public:
     void testDiurnal();
     void testNonDiurnal();
     void testWithSparseData();
+    void testWithOutliers();
     void testTestForPeriods();
 
     static CppUnit::Test* suite();

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -126,8 +126,8 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                CPPUNIT_ASSERT(sumResidual < 0.04 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.04 * maxValue);
+                CPPUNIT_ASSERT(sumResidual < 0.052 * sumValue);
+                CPPUNIT_ASSERT(maxResidual < 0.097 * maxValue);
                 CPPUNIT_ASSERT(percentileError < 0.02 * sumValue);
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -149,8 +149,8 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
     //file << "plot(t(1:length(fe)), fe, 'r');\n";
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.018 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.021 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.017 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.019 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 }
 
@@ -333,9 +333,9 @@ void CTimeSeriesDecompositionTest::testDistortedPeriodic() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.18 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.22 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.19 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.27 * totalMaxValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.11 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testMinimizeLongComponents() {
@@ -449,7 +449,7 @@ void CTimeSeriesDecompositionTest::testMinimizeLongComponents() {
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
     CPPUNIT_ASSERT(totalSumResidual < 0.06 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.27 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.22 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 
     meanSlope /= refinements;
@@ -531,7 +531,7 @@ void CTimeSeriesDecompositionTest::testWeekend() {
 
             if (time >= 3 * WEEK) {
                 CPPUNIT_ASSERT(sumResidual < 0.07 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.15 * maxValue);
+                CPPUNIT_ASSERT(maxResidual < 0.17 * maxValue);
                 CPPUNIT_ASSERT(percentileError < 0.03 * sumValue);
 
                 totalSumResidual += sumResidual;
@@ -554,9 +554,9 @@ void CTimeSeriesDecompositionTest::testWeekend() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.027 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.12 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.012 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.026 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.13 * totalMaxValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.011 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testSinglePeriodicity() {
@@ -656,8 +656,8 @@ void CTimeSeriesDecompositionTest::testSinglePeriodicity() {
     LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
-    CPPUNIT_ASSERT(totalSumResidual < 0.015 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.042 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.013 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.021 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 
     // Check that only the daily component has been initialized.
@@ -836,8 +836,8 @@ void CTimeSeriesDecompositionTest::testVarianceScale() {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError))
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.29);
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(percentileError) < 0.05);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.21);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(percentileError) < 0.04);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, maths::CBasicStatistics::mean(meanScale), 0.04);
     }
     LOG_DEBUG(<< "Smoothly Varying Variance");
@@ -886,7 +886,7 @@ void CTimeSeriesDecompositionTest::testVarianceScale() {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError));
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.22);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.21);
         CPPUNIT_ASSERT(maths::CBasicStatistics::mean(percentileError) < 0.1);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, maths::CBasicStatistics::mean(meanScale), 0.01);
     }
@@ -1017,8 +1017,8 @@ void CTimeSeriesDecompositionTest::testSpikeyDataProblemCase() {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     CPPUNIT_ASSERT(totalSumResidual < 0.19 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.33 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.14 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.31 * totalMaxValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.13 * totalSumValue);
 
     //std::ofstream file;
     //file.open("results.m");
@@ -1161,9 +1161,9 @@ void CTimeSeriesDecompositionTest::testVeryLargeValuesProblemCase() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.32 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.70 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.21 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.27 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.72 * totalMaxValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.15 * totalSumValue);
 
     //file << "hold on;\n";
     //file << "t = " << core::CContainerPrinter::print(times) << ";\n";
@@ -1277,10 +1277,6 @@ void CTimeSeriesDecompositionTest::testMixedSmoothAndSpikeyDataProblemCase() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.17 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.38 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.07 * totalSumValue);
-
     //file << "hold on;\n";
     //file << "t = " << core::CContainerPrinter::print(times) << ";\n";
     //file << "f = " << core::CContainerPrinter::print(values) << ";\n";
@@ -1289,6 +1285,10 @@ void CTimeSeriesDecompositionTest::testMixedSmoothAndSpikeyDataProblemCase() {
     //file << "r = " << core::CContainerPrinter::print(r) << ";\n";
     //file << "plot(t(1:length(fe)), fe);\n";
     //file << "plot(t(1:length(r)), r, 'k');\n";
+
+    CPPUNIT_ASSERT(totalSumResidual < 0.12 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.36 * totalMaxValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.04 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testDiurnalPeriodicityWithMissingValues() {
@@ -1638,7 +1638,7 @@ void CTimeSeriesDecompositionTest::testLongTermTrendAndPeriodicity() {
                 totalMaxValue += maxValue;
 
                 CPPUNIT_ASSERT(sumResidual / sumValue < 0.4);
-                CPPUNIT_ASSERT(maxResidual / maxValue < 0.4);
+                CPPUNIT_ASSERT(maxResidual / maxValue < 0.44);
             }
             lastDay += DAY;
         }
@@ -1662,11 +1662,12 @@ void CTimeSeriesDecompositionTest::testLongTermTrendAndPeriodicity() {
 void CTimeSeriesDecompositionTest::testNonDiurnal() {
     test::CRandomNumbers rng;
 
-    LOG_DEBUG(<< "Hourly") {
+    LOG_DEBUG(<< "Hourly");
+    {
         const core_t::TTime length = 21 * DAY;
 
         double periodic[]{10.0, 1.0, 0.5, 0.5, 1.0, 5.0,
-                          2.0,  1.0, 0.5, 0.5, 1.0, 3.0};
+                          2.0,  1.0, 0.5, 0.5, 1.0, 6.0};
 
         TTimeVec times;
         TDoubleVec trends[2]{TDoubleVec(), TDoubleVec(8 * DAY / FIVE_MINS)};
@@ -1680,7 +1681,7 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
         rng.generateNormalSamples(0.0, 1.0, trends[1].size(), noise);
 
         core_t::TTime startTesting[]{3 * HOUR, 16 * DAY};
-        TDoubleVec thresholds[]{TDoubleVec{0.07, 0.06}, TDoubleVec{0.18, 0.13}};
+        TDoubleVec thresholds[]{TDoubleVec{0.08, 0.07}, TDoubleVec{0.18, 0.15}};
 
         for (std::size_t t = 0u; t < 2; ++t) {
             //std::ofstream file;
@@ -1731,8 +1732,8 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
                         totalSumValue += sumValue;
                         totalMaxValue += maxValue;
 
-                        CPPUNIT_ASSERT(sumResidual / sumValue < 0.33);
-                        CPPUNIT_ASSERT(maxResidual / maxValue < 0.28);
+                        CPPUNIT_ASSERT(sumResidual / sumValue < 0.35);
+                        CPPUNIT_ASSERT(maxResidual / maxValue < 0.33);
                     }
                     lastHour += HOUR;
                 }
@@ -1840,7 +1841,7 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
         //file << "plot(t, fe);\n";
 
         CPPUNIT_ASSERT(totalSumResidual / totalSumValue < 0.1);
-        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.18);
+        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.19);
     }
 }
 
@@ -1854,7 +1855,7 @@ void CTimeSeriesDecompositionTest::testYearly() {
                                                maths::CDecayRateController::E_PredictionErrorIncrease,
                                            1);
     TDoubleVec noise;
-    core_t::TTime time = 0;
+    core_t::TTime time = 2 * HOUR;
     for (/**/; time < 4 * YEAR; time += 4 * HOUR) {
         double trend =
             15.0 * (2.0 + std::sin(boost::math::double_constants::two_pi *
@@ -1872,11 +1873,11 @@ void CTimeSeriesDecompositionTest::testYearly() {
         }
     }
 
-    std::ofstream file;
-    file.open("results.m");
-    TDoubleVec f;
-    TTimeVec times;
-    TDoubleVec values;
+    //std::ofstream file;
+    //file.open("results.m");
+    //TDoubleVec f;
+    //TTimeVec times;
+    //TDoubleVec values;
 
     // Predict over one year and check we get reasonable accuracy.
     TMeanAccumulator meanError;
@@ -1890,9 +1891,9 @@ void CTimeSeriesDecompositionTest::testYearly() {
             maths::CBasicStatistics::mean(decomposition.baseline(time, 0.0));
         double error = std::fabs((prediction - trend) / trend);
         meanError.add(error);
-        times.push_back(time);
-        values.push_back(trend);
-        f.push_back(prediction);
+        //times.push_back(time);
+        //values.push_back(trend);
+        //f.push_back(prediction);
         if (time / HOUR % 40 == 0) {
             LOG_DEBUG(<< "error = " << error);
         }
@@ -1906,7 +1907,69 @@ void CTimeSeriesDecompositionTest::testYearly() {
     //file << "plot(t, fe);\n";
 
     LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanError) < 0.02);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanError) < 0.011);
+}
+
+void CTimeSeriesDecompositionTest::testWithOutliers() {
+    // Test smooth periodic signal polluted with outliers.
+
+    using TSizeVec = std::vector<std::size_t>;
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec noise;
+    TSizeVec outliers;
+    TDoubleVec spikeOrTroughSelector;
+
+    core_t::TTime buckets{WEEK / TEN_MINS};
+    std::size_t numberOutliers{static_cast<std::size_t>(0.1 * buckets)};
+    rng.generateUniformSamples(0, buckets, numberOutliers, outliers);
+    rng.generateUniformSamples(0, 1.0, numberOutliers, spikeOrTroughSelector);
+    rng.generateNormalSamples(0.0, 9.0, buckets, noise);
+    std::sort(outliers.begin(), outliers.end());
+
+    //std::ofstream file;
+    //file.open("results.m");
+    //TTimeVec times;
+    //TDoubleVec values;
+    //TDoubleVec f;
+
+    auto trend = [](core_t::TTime time) {
+        return 25.0 + 20.0 * std::sin(boost::math::double_constants::two_pi *
+                                      static_cast<double>(time) /
+                                      static_cast<double>(DAY));
+    };
+
+    maths::CTimeSeriesDecomposition decomposition(0.01, TEN_MINS);
+
+    for (core_t::TTime time = 0; time < WEEK; time += TEN_MINS) {
+        std::size_t bucket(time / TEN_MINS);
+        auto outlier = std::lower_bound(outliers.begin(), outliers.end(), bucket);
+        double value =
+            outlier != outliers.end() && *outlier == bucket
+                ? (spikeOrTroughSelector[outlier - outliers.begin()] > 0.5 ? 0.0 : 50.0)
+                : trend(time);
+        if (decomposition.addPoint(time, value)) {
+            TMeanAccumulator error;
+            for (core_t::TTime endTime = time + DAY; time < endTime; time += TEN_MINS) {
+                double prediction =
+                    maths::CBasicStatistics::mean(decomposition.baseline(time, 0.0));
+                error.add(std::fabs(prediction - trend(time)) / trend(time));
+                //times.push_back(time);
+                //values.push_back(trend(time));
+                //f.push_back(prediction);
+            }
+            LOG_DEBUG(<< "error = " << maths::CBasicStatistics::mean(error));
+            CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.05);
+            break;
+        }
+    }
+
+    //file << "t = " << core::CContainerPrinter::print(times) << ";\n";
+    //file << "f = " << core::CContainerPrinter::print(values) << ";\n";
+    //file << "fe = " << core::CContainerPrinter::print(f) << ";\n";
+    //file << "plot(t, f, 'r');\n";
+    //file << "plot(t, fe);\n";
 }
 
 void CTimeSeriesDecompositionTest::testCalendar() {
@@ -1999,8 +2062,8 @@ void CTimeSeriesDecompositionTest::testConditionOfTrend() {
 
     maths::CTimeSeriesDecomposition decomposition(0.0005, bucketLength);
     TDoubleVec noise;
-    for (core_t::TTime time = 0; time < 10 * YEAR; time += 6 * HOUR) {
-        rng.generateNormalSamples(0.0, 3.0, 1, noise);
+    for (core_t::TTime time = 0; time < 9 * YEAR; time += 6 * HOUR) {
+        rng.generateNormalSamples(0.0, 4.0, 1, noise);
         decomposition.addPoint(time, trend(time) + noise[0]);
         if (time > 10 * WEEK) {
             CPPUNIT_ASSERT(std::fabs(decomposition.detrend(time, trend(time), 0.0)) < 3.0);
@@ -2302,6 +2365,9 @@ CppUnit::Test* CTimeSeriesDecompositionTest::suite() {
         &CTimeSeriesDecompositionTest::testNonDiurnal));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
         "CTimeSeriesDecompositionTest::testYearly", &CTimeSeriesDecompositionTest::testYearly));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
+        "CTimeSeriesDecompositionTest::testWithOutliers",
+        &CTimeSeriesDecompositionTest::testWithOutliers));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
         "CTimeSeriesDecompositionTest::testCalendar",
         &CTimeSeriesDecompositionTest::testCalendar));

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -333,9 +333,9 @@ void CTimeSeriesDecompositionTest::testDistortedPeriodic() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.19 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.18 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.28 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.11 * totalSumValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.09 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testMinimizeLongComponents() {
@@ -556,7 +556,7 @@ void CTimeSeriesDecompositionTest::testWeekend() {
 
     CPPUNIT_ASSERT(totalSumResidual < 0.024 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.13 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.012 * totalSumValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testSinglePeriodicity() {
@@ -1161,9 +1161,9 @@ void CTimeSeriesDecompositionTest::testVeryLargeValuesProblemCase() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.27 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.26 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.72 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.15 * totalSumValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.14 * totalSumValue);
 
     //file << "hold on;\n";
     //file << "t = " << core::CContainerPrinter::print(times) << ";\n";
@@ -1286,9 +1286,9 @@ void CTimeSeriesDecompositionTest::testMixedSmoothAndSpikeyDataProblemCase() {
     //file << "plot(t(1:length(fe)), fe);\n";
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.12 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.37 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.14 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.38 * totalMaxValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.04 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testDiurnalPeriodicityWithMissingValues() {
@@ -1331,7 +1331,7 @@ void CTimeSeriesDecompositionTest::testDiurnalPeriodicityWithMissingValues() {
         }
 
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.1);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.09);
 
         //file << "hold on;\n";
         //file << "t = " << core::CContainerPrinter::print(times) << ";\n";

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -127,7 +127,7 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
 
             if (time >= 2 * WEEK) {
                 CPPUNIT_ASSERT(sumResidual < 0.052 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.097 * maxValue);
+                CPPUNIT_ASSERT(maxResidual < 0.10 * maxValue);
                 CPPUNIT_ASSERT(percentileError < 0.02 * sumValue);
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -149,8 +149,8 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
     //file << "plot(t(1:length(fe)), fe, 'r');\n";
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.017 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.019 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.019 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.020 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 }
 
@@ -308,9 +308,9 @@ void CTimeSeriesDecompositionTest::testDistortedPeriodic() {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                CPPUNIT_ASSERT(sumResidual < 0.30 * sumValue);
+                CPPUNIT_ASSERT(sumResidual < 0.27 * sumValue);
                 CPPUNIT_ASSERT(maxResidual < 0.56 * maxValue);
-                CPPUNIT_ASSERT(percentileError < 0.21 * sumValue);
+                CPPUNIT_ASSERT(percentileError < 0.16 * sumValue);
 
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -334,7 +334,7 @@ void CTimeSeriesDecompositionTest::testDistortedPeriodic() {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     CPPUNIT_ASSERT(totalSumResidual < 0.19 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.27 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.28 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.11 * totalSumValue);
 }
 
@@ -554,9 +554,9 @@ void CTimeSeriesDecompositionTest::testWeekend() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.026 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.024 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.13 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.011 * totalSumValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.012 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testSinglePeriodicity() {
@@ -657,7 +657,7 @@ void CTimeSeriesDecompositionTest::testSinglePeriodicity() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
     CPPUNIT_ASSERT(totalSumResidual < 0.013 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.021 * totalMaxValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.023 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 
     // Check that only the daily component has been initialized.
@@ -781,8 +781,8 @@ void CTimeSeriesDecompositionTest::testSeasonalOnset() {
     LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
-    CPPUNIT_ASSERT(totalSumResidual < 0.07 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.09 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.062 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.077 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 }
 
@@ -836,8 +836,8 @@ void CTimeSeriesDecompositionTest::testVarianceScale() {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError))
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.21);
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(percentileError) < 0.04);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.24);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(percentileError) < 0.05);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, maths::CBasicStatistics::mean(meanScale), 0.04);
     }
     LOG_DEBUG(<< "Smoothly Varying Variance");
@@ -886,7 +886,7 @@ void CTimeSeriesDecompositionTest::testVarianceScale() {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError));
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.21);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.22);
         CPPUNIT_ASSERT(maths::CBasicStatistics::mean(percentileError) < 0.1);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, maths::CBasicStatistics::mean(meanScale), 0.01);
     }
@@ -1287,8 +1287,8 @@ void CTimeSeriesDecompositionTest::testMixedSmoothAndSpikeyDataProblemCase() {
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
     CPPUNIT_ASSERT(totalSumResidual < 0.12 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.36 * totalMaxValue);
-    CPPUNIT_ASSERT(totalPercentileError < 0.04 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.37 * totalMaxValue);
+    CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 }
 
 void CTimeSeriesDecompositionTest::testDiurnalPeriodicityWithMissingValues() {
@@ -1565,7 +1565,7 @@ void CTimeSeriesDecompositionTest::testLongTermTrend() {
         //file << "plot(t, fe);\n";
 
         CPPUNIT_ASSERT(totalSumResidual / totalSumValue < 0.38);
-        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.42);
+        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.41);
     }
 }
 
@@ -1637,8 +1637,8 @@ void CTimeSeriesDecompositionTest::testLongTermTrendAndPeriodicity() {
                 totalSumValue += sumValue;
                 totalMaxValue += maxValue;
 
-                CPPUNIT_ASSERT(sumResidual / sumValue < 0.4);
-                CPPUNIT_ASSERT(maxResidual / maxValue < 0.44);
+                CPPUNIT_ASSERT(sumResidual / sumValue < 0.34);
+                CPPUNIT_ASSERT(maxResidual / maxValue < 0.39);
             }
             lastDay += DAY;
         }
@@ -1841,7 +1841,7 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
         //file << "plot(t, fe);\n";
 
         CPPUNIT_ASSERT(totalSumResidual / totalSumValue < 0.1);
-        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.19);
+        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.18);
     }
 }
 
@@ -1908,7 +1908,7 @@ void CTimeSeriesDecompositionTest::testYearly() {
 
     LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
 
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanError) < 0.01);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanError) < 0.011);
 }
 
 void CTimeSeriesDecompositionTest::testWithOutliers() {

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.h
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.h
@@ -26,6 +26,7 @@ public:
     void testLongTermTrendAndPeriodicity();
     void testNonDiurnal();
     void testYearly();
+    void testWithOutliers();
     void testCalendar();
     void testConditionOfTrend();
     void testSwap();

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -1394,7 +1394,7 @@ void CTimeSeriesModelTest::testWeights() {
             error.add(std::fabs(scale - dataScale) / dataScale);
         }
         LOG_DEBUG(<< "error = " << maths::CBasicStatistics::mean(error));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.2);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.21);
 
         LOG_DEBUG(<< "Winsorisation");
         TDouble2Vec prediction(model.predict(time));


### PR DESCRIPTION
This makes two principle changes:
1) Iteratively reweights outliers w.r.t. the seasonal component under test and for initialisation. These are defined as a fraction of values with highest residual w.r.t. the component's predictions.
2) Switches marginal test decisions for decomposition components to use logistic regression on top of the various factors, i.e. variance reduction, autocorrelation, number of periods of data observed, etc.

I've tested this on a variety of synthetic and real examples where initial periodic patterns are distorted by outliers and this approach has proved effective, see #87 for more details. Otherwise, it seems to have no detrimental effects.

This will affect results on count and metric analyses when there is seasonality and significant distortion due to outliers.