### PR TITLE
[ML] Extend unit testing and make some improvements to deal with changes in seasonal components

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@
 
 Improve and use periodic boundary condition for seasonal component modeling ({pull}84[#84])
 Improve robustness w.r.t. outliers of detection and initialisation of seasonal components ({pull}90[#90])
+Extend unit testing and make some improvements to deal with changes in seasonal components ({pull}91[#91])
 
 === Bug Fixes
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -29,7 +29,7 @@
 
 Improve and use periodic boundary condition for seasonal component modeling ({pull}84[#84])
 Improve robustness w.r.t. outliers of detection and initialisation of seasonal components ({pull}90[#90])
-Extend unit testing and make some improvements to deal with changes in seasonal components ({pull}91[#91])
+Improve behavior when there are abrupt changes in the seasonal components present in a time series ({pull}91[#91])
 Explicit change point detection and modelling ({pull}92[#92])
 
 === Bug Fixes

--- a/include/maths/CAdaptiveBucketing.h
+++ b/include/maths/CAdaptiveBucketing.h
@@ -233,10 +233,10 @@ private:
 
     //! An IIR low pass filter for the total desired end point displacement
     //! in refine.
-    TFloatMeanAccumulator m_LpForce;
+    TFloatMeanAccumulator m_MeanDesiredDisplacement;
 
     //! The total desired end point displacement in refine.
-    TFloatMeanAccumulator m_Force;
+    TFloatMeanAccumulator m_MeanAbsDesiredDisplacement;
 };
 }
 }

--- a/include/maths/CCalendarComponent.h
+++ b/include/maths/CCalendarComponent.h
@@ -128,10 +128,6 @@ public:
     //! Get the mean variance of the component residuals.
     double meanVariance() const;
 
-    //! Get the maximum ratio between a residual variance and the mean
-    //! residual variance.
-    double heteroscedasticity() const;
-
     //! Get a checksum for this object.
     uint64_t checksum(uint64_t seed = 0) const;
 

--- a/include/maths/CDecompositionComponent.h
+++ b/include/maths/CDecompositionComponent.h
@@ -168,10 +168,6 @@ protected:
     //! Get the mean variance of the function residuals.
     double meanVariance() const;
 
-    //! Get the maximum ratio between a residual variance and the mean
-    //! residual variance.
-    double heteroscedasticity() const;
-
     //! Get the maximum size to use for the bucketing.
     std::size_t maxSize() const;
 

--- a/include/maths/CSeasonalComponent.h
+++ b/include/maths/CSeasonalComponent.h
@@ -157,10 +157,6 @@ public:
     //! Get the mean variance of the component residuals.
     double meanVariance() const;
 
-    //! Get the maximum ratio between a residual variance and the mean
-    //! residual variance.
-    double heteroscedasticity() const;
-
     //! Get the covariance matrix of the regression parameters' at \p time.
     //!
     //! \param[in] time The time of interest.

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -75,7 +75,7 @@ const std::string LAST_RESULTS_TIME_TAG("j");
 
 //! The minimum version required to read the state corresponding to a model snapshot.
 //! This should be updated every time there is a breaking change to the model state.
-const std::string MODEL_SNAPSHOT_MIN_VERSION("6.3.0");
+const std::string MODEL_SNAPSHOT_MIN_VERSION("6.4.0");
 }
 
 // Statics

--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -61,8 +61,10 @@ bool CAdaptiveBucketing::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
         RESTORE_BUILT_IN(DECAY_RATE_TAG, m_DecayRate)
         RESTORE(ENDPOINT_TAG, core::CPersistUtils::fromString(traverser.value(), m_Endpoints))
         RESTORE(CENTRES_TAG, core::CPersistUtils::fromString(traverser.value(), m_Centres))
-        RESTORE(MEAN_DESIRED_DISPLACEMENT_TAG, m_MeanDesiredDisplacement.fromDelimited(traverser.value()))
-        RESTORE(MEAN_ABS_DESIRED_DISPLACEMENT_TAG, m_MeanAbsDesiredDisplacement.fromDelimited(traverser.value()))
+        RESTORE(MEAN_DESIRED_DISPLACEMENT_TAG,
+                m_MeanDesiredDisplacement.fromDelimited(traverser.value()))
+        RESTORE(MEAN_ABS_DESIRED_DISPLACEMENT_TAG,
+                m_MeanAbsDesiredDisplacement.fromDelimited(traverser.value()))
     } while (traverser.next());
     return true;
 }
@@ -71,8 +73,10 @@ void CAdaptiveBucketing::acceptPersistInserter(core::CStatePersistInserter& inse
     inserter.insertValue(DECAY_RATE_TAG, m_DecayRate, core::CIEEE754::E_SinglePrecision);
     inserter.insertValue(ENDPOINT_TAG, core::CPersistUtils::toString(m_Endpoints));
     inserter.insertValue(CENTRES_TAG, core::CPersistUtils::toString(m_Centres));
-    inserter.insertValue(MEAN_DESIRED_DISPLACEMENT_TAG, m_MeanDesiredDisplacement.toDelimited());
-    inserter.insertValue(MEAN_ABS_DESIRED_DISPLACEMENT_TAG, m_MeanAbsDesiredDisplacement.toDelimited());
+    inserter.insertValue(MEAN_DESIRED_DISPLACEMENT_TAG,
+                         m_MeanDesiredDisplacement.toDelimited());
+    inserter.insertValue(MEAN_ABS_DESIRED_DISPLACEMENT_TAG,
+                         m_MeanAbsDesiredDisplacement.toDelimited());
 }
 
 CAdaptiveBucketing::CAdaptiveBucketing(double decayRate, double minimumBucketLength)
@@ -291,10 +295,11 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
         // process of adjusting the buckets end points loses a small
         // amount of information, see the comments at the start of
         // refresh for more details.
-        double alpha{ALPHA * (CBasicStatistics::mean(m_MeanAbsDesiredDisplacement) == 0.0
-                                  ? 1.0
-                                  : std::fabs(CBasicStatistics::mean(m_MeanDesiredDisplacement)) /
-                                                 CBasicStatistics::mean(m_MeanAbsDesiredDisplacement))};
+        double alpha{
+            ALPHA * (CBasicStatistics::mean(m_MeanAbsDesiredDisplacement) == 0.0
+                         ? 1.0
+                         : std::fabs(CBasicStatistics::mean(m_MeanDesiredDisplacement)) /
+                               CBasicStatistics::mean(m_MeanAbsDesiredDisplacement))};
         LOG_TRACE(<< "alpha = " << alpha);
         double displacement{0.0};
 

--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -43,8 +43,8 @@ void clearAndShrink(std::vector<T>& vector) {
 const std::string DECAY_RATE_TAG{"a"};
 const std::string ENDPOINT_TAG{"b"};
 const std::string CENTRES_TAG{"c"};
-const std::string LP_FORCE_TAG{"d"};
-const std::string FORCE_TAG{"e"};
+const std::string MEAN_DESIRED_DISPLACEMENT_TAG{"d"};
+const std::string MEAN_ABS_DESIRED_DISPLACEMENT_TAG{"e"};
 const std::string EMPTY_STRING;
 
 const double SMOOTHING_FUNCTION[]{0.25, 0.5, 0.25};
@@ -61,8 +61,8 @@ bool CAdaptiveBucketing::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
         RESTORE_BUILT_IN(DECAY_RATE_TAG, m_DecayRate)
         RESTORE(ENDPOINT_TAG, core::CPersistUtils::fromString(traverser.value(), m_Endpoints))
         RESTORE(CENTRES_TAG, core::CPersistUtils::fromString(traverser.value(), m_Centres))
-        RESTORE(LP_FORCE_TAG, m_LpForce.fromDelimited(traverser.value()))
-        RESTORE(FORCE_TAG, m_Force.fromDelimited(traverser.value()))
+        RESTORE(MEAN_DESIRED_DISPLACEMENT_TAG, m_MeanDesiredDisplacement.fromDelimited(traverser.value()))
+        RESTORE(MEAN_ABS_DESIRED_DISPLACEMENT_TAG, m_MeanAbsDesiredDisplacement.fromDelimited(traverser.value()))
     } while (traverser.next());
     return true;
 }
@@ -71,8 +71,8 @@ void CAdaptiveBucketing::acceptPersistInserter(core::CStatePersistInserter& inse
     inserter.insertValue(DECAY_RATE_TAG, m_DecayRate, core::CIEEE754::E_SinglePrecision);
     inserter.insertValue(ENDPOINT_TAG, core::CPersistUtils::toString(m_Endpoints));
     inserter.insertValue(CENTRES_TAG, core::CPersistUtils::toString(m_Centres));
-    inserter.insertValue(LP_FORCE_TAG, m_LpForce.toDelimited());
-    inserter.insertValue(FORCE_TAG, m_Force.toDelimited());
+    inserter.insertValue(MEAN_DESIRED_DISPLACEMENT_TAG, m_MeanDesiredDisplacement.toDelimited());
+    inserter.insertValue(MEAN_ABS_DESIRED_DISPLACEMENT_TAG, m_MeanAbsDesiredDisplacement.toDelimited());
 }
 
 CAdaptiveBucketing::CAdaptiveBucketing(double decayRate, double minimumBucketLength)
@@ -92,8 +92,8 @@ void CAdaptiveBucketing::swap(CAdaptiveBucketing& other) {
     std::swap(m_MinimumBucketLength, other.m_MinimumBucketLength);
     m_Endpoints.swap(other.m_Endpoints);
     m_Centres.swap(other.m_Centres);
-    std::swap(m_LpForce, other.m_LpForce);
-    std::swap(m_Force, other.m_Force);
+    std::swap(m_MeanDesiredDisplacement, other.m_MeanDesiredDisplacement);
+    std::swap(m_MeanAbsDesiredDisplacement, other.m_MeanAbsDesiredDisplacement);
 }
 
 bool CAdaptiveBucketing::initialized() const {
@@ -180,9 +180,8 @@ double CAdaptiveBucketing::decayRate() const {
 }
 
 void CAdaptiveBucketing::age(double factor) {
-    factor = factor * factor;
-    m_LpForce.age(factor);
-    m_Force.age(factor);
+    m_MeanDesiredDisplacement.age(factor);
+    m_MeanAbsDesiredDisplacement.age(factor);
 }
 
 double CAdaptiveBucketing::minimumBucketLength() const {
@@ -282,22 +281,22 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
         }
         m_Endpoints[n] = b;
     } else {
-        // Noise in the bucket mean values creates a "high"
-        // frequency mean zero driving force on the buckets'
-        // end points desired positions. Once they have stabilized
-        // on their desired location for the trend, we are able
-        // to detect this by comparing an IIR low pass filtered
-        // force and the total force. The lower the ratio the
-        // smaller the force we actually apply. Note we want to
-        // damp the noise out because the process of adjusting
-        // the buckets values loses a small amount of information,
-        // see the comments at the start of refresh for more
-        // details.
-        double alpha{ALPHA * (CBasicStatistics::mean(m_Force) == 0.0
+        // Noise in the bucket mean values creates a "high" frequency
+        // mean zero driving force on the buckets' end points desired
+        // positions. Once they have stabilized on their desired location
+        // for the trend, we are able to detect this by comparing the
+        // time averaged desired displacement and the absolute desired
+        // displacement. The lower the ratio the smaller more smoothing
+        // we apply. Note we want to damp the noise out because the
+        // process of adjusting the buckets end points loses a small
+        // amount of information, see the comments at the start of
+        // refresh for more details.
+        double alpha{ALPHA * (CBasicStatistics::mean(m_MeanAbsDesiredDisplacement) == 0.0
                                   ? 1.0
-                                  : std::fabs(CBasicStatistics::mean(m_LpForce)) /
-                                        CBasicStatistics::mean(m_Force))};
-        double force{0.0};
+                                  : std::fabs(CBasicStatistics::mean(m_MeanDesiredDisplacement)) /
+                                                 CBasicStatistics::mean(m_MeanAbsDesiredDisplacement))};
+        LOG_TRACE(<< "alpha = " << alpha);
+        double displacement{0.0};
 
         // Linearly interpolate between the current end points
         // and points separated by equal total averaging error.
@@ -315,7 +314,7 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
             for (double e_ = step - (error - e); error >= step; e_ += step, error -= step) {
                 double x{h * e_ / averagingErrors[i]};
                 m_Endpoints[j] = endpoints[j] + alpha * (ai + x - endpoints[j]);
-                force += (ai + x) - endpoints[j];
+                displacement += (ai + x) - endpoints[j];
                 LOG_TRACE(<< "interval averaging error = " << e
                           << ", a(i) = " << ai << ", x = " << x << ", endpoint "
                           << endpoints[j] << " -> " << ai + x);
@@ -333,8 +332,8 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
         m_Endpoints[n] = b;
         LOG_TRACE(<< "refinedEndpoints = " << core::CContainerPrinter::print(m_Endpoints));
 
-        m_LpForce.add(force);
-        m_Force.add(std::fabs(force));
+        m_MeanDesiredDisplacement.add(displacement);
+        m_MeanAbsDesiredDisplacement.add(std::fabs(displacement));
     }
 
     this->refresh(endpoints);

--- a/lib/maths/CCalendarComponent.cc
+++ b/lib/maths/CCalendarComponent.cc
@@ -117,7 +117,6 @@ void CCalendarComponent::interpolate(core_t::TTime time, bool refine) {
     if (refine) {
         m_Bucketing.refine(time);
     }
-
     TDoubleVec knots;
     TDoubleVec values;
     TDoubleVec variances;
@@ -160,10 +159,6 @@ TDoubleDoublePr CCalendarComponent::variance(core_t::TTime time, double confiden
 
 double CCalendarComponent::meanVariance() const {
     return this->CDecompositionComponent::meanVariance();
-}
-
-double CCalendarComponent::heteroscedasticity() const {
-    return this->CDecompositionComponent::heteroscedasticity();
 }
 
 uint64_t CCalendarComponent::checksum(uint64_t seed) const {

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -187,23 +187,6 @@ double CDecompositionComponent::meanVariance() const {
     return m_MeanVariance;
 }
 
-double CDecompositionComponent::heteroscedasticity() const {
-    if (m_MeanVariance == 0.0) {
-        return 0.0;
-    }
-
-    using TMaxAccumulator = CBasicStatistics::SMax<double>::TAccumulator;
-
-    TMaxAccumulator result;
-
-    TSplineCRef spline = this->varianceSpline();
-    for (const auto& value : spline.values()) {
-        result.add(value / m_MeanVariance);
-    }
-
-    return result.count() > 0 ? result[0] : 0.0;
-}
-
 std::size_t CDecompositionComponent::maxSize() const {
     return std::max(m_MaxSize, MIN_MAX_SIZE);
 }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1808,9 +1808,8 @@ double CTimeSeriesDecompositionDetail::CComponents::CGainController::gain() cons
 
 void CTimeSeriesDecompositionDetail::CComponents::CGainController::seed(const TDoubleVec& predictions) {
     m_MeanSumAmplitudes.add(std::accumulate(
-        predictions.begin(), predictions.end(), 0.0, [](double sum, double prediction) {
-            return sum + std::fabs(prediction);
-        }));
+        predictions.begin(), predictions.end(), 0.0,
+        [](double sum, double prediction) { return sum + std::fabs(prediction); }));
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::CGainController::add(core_t::TTime time,
@@ -1821,8 +1820,8 @@ void CTimeSeriesDecompositionDetail::CComponents::CGainController::add(core_t::T
                 return sum + std::fabs(prediction);
             }));
         m_MeanSumAmplitudesTrend.add(scaleTime(time, m_RegressionOrigin),
-                                      CBasicStatistics::mean(m_MeanSumAmplitudes),
-                                      CBasicStatistics::count(m_MeanSumAmplitudes));
+                                     CBasicStatistics::mean(m_MeanSumAmplitudes),
+                                     CBasicStatistics::count(m_MeanSumAmplitudes));
     }
 }
 

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -949,8 +949,8 @@ CTimeSeriesDecompositionDetail::CComponents::CComponents(const CComponents& othe
     : m_Machine{other.m_Machine}, m_DecayRate{other.m_DecayRate},
       m_BucketLength{other.m_BucketLength}, m_SeasonalComponentSize{other.m_SeasonalComponentSize},
       m_CalendarComponentSize{other.m_CalendarComponentSize}, m_Trend{other.m_Trend},
-      m_Seasonal{other.m_Seasonal ? new SSeasonal{*other.m_Seasonal} : nullptr},
-      m_Calendar{other.m_Calendar ? new SCalendar{*other.m_Calendar} : nullptr},
+      m_Seasonal{other.m_Seasonal ? new CSeasonal{*other.m_Seasonal} : nullptr},
+      m_Calendar{other.m_Calendar ? new CCalendar{*other.m_Calendar} : nullptr},
       m_MeanVarianceScale{other.m_MeanVarianceScale}, m_Moments{other.m_Moments},
       m_MomentsMinusTrend{other.m_MomentsMinusTrend},
       m_UsingTrendForPrediction{other.m_UsingTrendForPrediction}, m_Watcher{nullptr} {
@@ -970,15 +970,15 @@ bool CTimeSeriesDecompositionDetail::CComponents::acceptRestoreTraverser(
                                        &CTrendComponent::acceptRestoreTraverser,
                                        &m_Trend, boost::cref(params), _1)))
             RESTORE_SETUP_TEARDOWN(
-                SEASONAL_6_3_TAG, m_Seasonal.reset(new SSeasonal),
+                SEASONAL_6_3_TAG, m_Seasonal.reset(new CSeasonal),
                 traverser.traverseSubLevel(
-                    boost::bind(&SSeasonal::acceptRestoreTraverser,
+                    boost::bind(&CSeasonal::acceptRestoreTraverser,
                                 m_Seasonal.get(), m_DecayRate, m_BucketLength, _1)),
                 /**/)
             RESTORE_SETUP_TEARDOWN(
-                CALENDAR_6_3_TAG, m_Calendar.reset(new SCalendar),
+                CALENDAR_6_3_TAG, m_Calendar.reset(new CCalendar),
                 traverser.traverseSubLevel(
-                    boost::bind(&SCalendar::acceptRestoreTraverser,
+                    boost::bind(&CCalendar::acceptRestoreTraverser,
                                 m_Calendar.get(), m_DecayRate, m_BucketLength, _1)),
                 /**/)
             RESTORE(MEAN_VARIANCE_SCALE_6_3_TAG,
@@ -1004,15 +1004,15 @@ bool CTimeSeriesDecompositionDetail::CComponents::acceptRestoreTraverser(
                                        m_BucketLength, boost::ref(m_Trend), _1)),
                                    m_UsingTrendForPrediction = true)
             RESTORE_SETUP_TEARDOWN(
-                SEASONAL_OLD_TAG, m_Seasonal.reset(new SSeasonal),
+                SEASONAL_OLD_TAG, m_Seasonal.reset(new CSeasonal),
                 traverser.traverseSubLevel(
-                    boost::bind(&SSeasonal::acceptRestoreTraverser,
+                    boost::bind(&CSeasonal::acceptRestoreTraverser,
                                 m_Seasonal.get(), m_DecayRate, m_BucketLength, _1)),
                 /**/)
             RESTORE_SETUP_TEARDOWN(
-                CALENDAR_OLD_TAG, m_Calendar.reset(new SCalendar),
+                CALENDAR_OLD_TAG, m_Calendar.reset(new CCalendar),
                 traverser.traverseSubLevel(
-                    boost::bind(&SCalendar::acceptRestoreTraverser,
+                    boost::bind(&CCalendar::acceptRestoreTraverser,
                                 m_Calendar.get(), m_DecayRate, m_BucketLength, _1)),
                 /**/)
         } while (traverser.next());
@@ -1033,11 +1033,11 @@ void CTimeSeriesDecompositionDetail::CComponents::acceptPersistInserter(
     inserter.insertLevel(TREND_6_3_TAG, boost::bind(&CTrendComponent::acceptPersistInserter,
                                                     m_Trend, _1));
     if (m_Seasonal) {
-        inserter.insertLevel(SEASONAL_6_3_TAG, boost::bind(&SSeasonal::acceptPersistInserter,
+        inserter.insertLevel(SEASONAL_6_3_TAG, boost::bind(&CSeasonal::acceptPersistInserter,
                                                            m_Seasonal.get(), _1));
     }
     if (m_Calendar) {
-        inserter.insertLevel(CALENDAR_6_3_TAG, boost::bind(&SCalendar::acceptPersistInserter,
+        inserter.insertLevel(CALENDAR_6_3_TAG, boost::bind(&CCalendar::acceptPersistInserter,
                                                            m_Calendar.get(), _1));
     }
     inserter.insertValue(MEAN_VARIANCE_SCALE_6_3_TAG, m_MeanVarianceScale.toDelimited());
@@ -1180,7 +1180,7 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SDetectedSeasonal
     case SC_NORMAL:
     case SC_NEW_COMPONENTS: {
         if (!m_Seasonal) {
-            m_Seasonal.reset(new SSeasonal);
+            m_Seasonal.reset(new CSeasonal);
         }
 
         core_t::TTime time{message.s_Time};
@@ -1189,11 +1189,7 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SDetectedSeasonal
         const CExpandingWindow& window{message.s_Window};
         const TPredictor& predictor{message.s_Predictor};
 
-        TSeasonalComponentVec& components{m_Seasonal->s_Components};
-        TComponentErrorsVec& errors{m_Seasonal->s_PredictionErrors};
-
-        if (!this->addSeasonalComponents(result, window, predictor, m_Trend,
-                                         components, errors)) {
+        if (!this->addSeasonalComponents(result, window, predictor)) {
             break;
         }
         if (m_Watcher) {
@@ -1226,7 +1222,7 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SDetectedCalendar
     case SC_NORMAL:
     case SC_NEW_COMPONENTS: {
         if (!m_Calendar) {
-            m_Calendar.reset(new SCalendar);
+            m_Calendar.reset(new CCalendar);
         }
 
         core_t::TTime time{message.s_Time};
@@ -1237,10 +1233,7 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SDetectedCalendar
             break;
         }
 
-        TCalendarComponentVec& components{m_Calendar->s_Components};
-        TComponentErrorsVec& errors{m_Calendar->s_PredictionErrors};
-
-        this->addCalendarComponent(feature, time, components, errors);
+        this->addCalendarComponent(feature, time);
         this->apply(SC_ADDED_COMPONENTS, message);
         this->mediator()->forward(
             SNewComponents(time, lastTime, SNewComponents::E_CalendarCyclic));
@@ -1367,12 +1360,12 @@ const CTrendComponent& CTimeSeriesDecompositionDetail::CComponents::trend() cons
 }
 
 const TSeasonalComponentVec& CTimeSeriesDecompositionDetail::CComponents::seasonal() const {
-    return m_Seasonal ? m_Seasonal->s_Components : NO_SEASONAL_COMPONENTS;
+    return m_Seasonal ? m_Seasonal->components() : NO_SEASONAL_COMPONENTS;
 }
 
 const maths_t::TCalendarComponentVec&
 CTimeSeriesDecompositionDetail::CComponents::calendar() const {
-    return m_Calendar ? m_Calendar->s_Components : NO_CALENDAR_COMPONENTS;
+    return m_Calendar ? m_Calendar->components() : NO_CALENDAR_COMPONENTS;
 }
 
 bool CTimeSeriesDecompositionDetail::CComponents::usingTrendForPrediction() const {
@@ -1454,14 +1447,12 @@ std::size_t CTimeSeriesDecompositionDetail::CComponents::maxSize() const {
 bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
     const CPeriodicityHypothesisTestsResult& result,
     const CExpandingWindow& window,
-    const TPredictor& predictor,
-    CTrendComponent& trend,
-    TSeasonalComponentVec& components,
-    TComponentErrorsVec& errors) const {
+    const TPredictor& predictor) {
     using TSeasonalTimePtr = std::shared_ptr<CSeasonalTime>;
     using TSeasonalTimePtrVec = std::vector<TSeasonalTimePtr>;
 
     TSeasonalTimePtrVec newSeasonalTimes;
+    const TSeasonalComponentVec& components{m_Seasonal->components()};
 
     for (const auto& candidate_ : result.components()) {
         TSeasonalTimePtr seasonalTime(candidate_.seasonalTime());
@@ -1476,12 +1467,7 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
 
     if (newSeasonalTimes.size() > 0) {
         for (const auto& seasonalTime : newSeasonalTimes) {
-            components.erase(
-                std::remove_if(components.begin(), components.end(),
-                               [&seasonalTime](const CSeasonalComponent& component) {
-                                   return seasonalTime->excludes(component.time());
-                               }),
-                components.end());
+            m_Seasonal->removeExcludedComponents(*seasonalTime);
         }
 
         std::sort(newSeasonalTimes.begin(), newSeasonalTimes.end(),
@@ -1520,13 +1506,12 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
                 },
                 values);
 
-            components.emplace_back(*seasonalTime, m_SeasonalComponentSize,
-                                    m_DecayRate, bucketLength, boundaryCondition);
-            components.back().initialize(startTime, endTime, values);
-            components.back().interpolate(CIntegerTools::floor(endTime, period));
+            m_Seasonal->add(*seasonalTime, m_SeasonalComponentSize, m_DecayRate,
+                            bucketLength, boundaryCondition, startTime, endTime, values);
         }
+        m_Seasonal->refreshForNewComponents();
 
-        CTrendComponent candidate{trend.defaultDecayRate()};
+        CTrendComponent candidate{m_Trend.defaultDecayRate()};
         values = window.valuesMinusPrediction(predictor);
         this->fit(startTime, dt, values, candidate);
         this->reweightOutliers(startTime, dt,
@@ -1535,31 +1520,18 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
                                },
                                values);
 
-        CTrendComponent trend_{trend.defaultDecayRate()};
-        this->fit(startTime, dt, values, trend_);
-        trend.swap(trend_);
-
-        errors.resize(components.size());
-        COrderings::simultaneousSort(
-            components, errors,
-            [](const CSeasonalComponent& lhs, const CSeasonalComponent& rhs) {
-                return lhs.time() < rhs.time();
-            });
+        CTrendComponent trend{m_Trend.defaultDecayRate()};
+        this->fit(startTime, dt, values, trend);
+        m_Trend.swap(trend);
     }
 
     return newSeasonalTimes.size() > 0;
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::addCalendarComponent(
-    const CCalendarFeature& feature,
-    core_t::TTime time,
-    maths_t::TCalendarComponentVec& components,
-    TComponentErrorsVec& errors) const {
+bool CTimeSeriesDecompositionDetail::CComponents::addCalendarComponent(const CCalendarFeature& feature,
+                                                                       core_t::TTime time) {
     double bucketLength{static_cast<double>(m_BucketLength)};
-    components.emplace_back(feature, m_CalendarComponentSize, m_DecayRate,
-                            bucketLength, CSplineTypes::E_Natural);
-    components.back().initialize();
-    errors.resize(components.size());
+    m_Calendar->add(feature, m_CalendarComponentSize, m_DecayRate, bucketLength);
     LOG_DEBUG(<< "Detected feature '" << feature.print() << "' at " << time);
     return true;
 }
@@ -1626,14 +1598,10 @@ void CTimeSeriesDecompositionDetail::CComponents::fit(core_t::TTime startTime,
 
 void CTimeSeriesDecompositionDetail::CComponents::clearComponentErrors() {
     if (m_Seasonal) {
-        for (auto& errors : m_Seasonal->s_PredictionErrors) {
-            errors.clear();
-        }
+        m_Seasonal->clearPredictionErrors();
     }
     if (m_Calendar) {
-        for (auto& errors : m_Calendar->s_PredictionErrors) {
-            errors.clear();
-        }
+        m_Calendar->clearPredictionErrors();
     }
 }
 
@@ -1699,7 +1667,7 @@ void CTimeSeriesDecompositionDetail::CComponents::canonicalize(core_t::TTime tim
     }
 
     if (m_Seasonal) {
-        TSeasonalComponentVec& seasonal{m_Seasonal->s_Components};
+        TSeasonalComponentVec& seasonal{m_Seasonal->components()};
 
         double slope{0.0};
         TTimeTimePrDoubleFMap windowSlopes;
@@ -1820,7 +1788,7 @@ CTimeSeriesDecompositionDetail::CComponents::CComponentErrors::winsorise(const T
                : squareError;
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::acceptRestoreTraverser(
+bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::acceptRestoreTraverser(
     double decayRate,
     core_t::TTime bucketLength_,
     core::CStateRestoreTraverser& traverser) {
@@ -1829,80 +1797,96 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::acceptRestoreTraver
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_NO_ERROR(COMPONENT_6_4_TAG,
-                             s_Components.emplace_back(decayRate, bucketLength, traverser))
+                             m_Components.emplace_back(decayRate, bucketLength, traverser))
             RESTORE(ERRORS_6_4_TAG,
-                    core::CPersistUtils::restore(ERRORS_6_4_TAG, s_PredictionErrors, traverser))
+                    core::CPersistUtils::restore(ERRORS_6_4_TAG, m_PredictionErrors, traverser))
         }
     } else if (traverser.name() == VERSION_6_3_TAG) {
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_NO_ERROR(COMPONENT_6_3_TAG,
-                             s_Components.emplace_back(decayRate, bucketLength, traverser))
+                             m_Components.emplace_back(decayRate, bucketLength, traverser))
         }
     } else {
         // There is no version string this is historic state.
         do {
             const std::string& name{traverser.name()};
             RESTORE_NO_ERROR(COMPONENT_OLD_TAG,
-                             s_Components.emplace_back(decayRate, bucketLength, traverser))
+                             m_Components.emplace_back(decayRate, bucketLength, traverser))
         } while (traverser.next());
     }
     return true;
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::acceptPersistInserter(
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::acceptPersistInserter(
     core::CStatePersistInserter& inserter) const {
     inserter.insertValue(VERSION_6_4_TAG, "");
-    for (const auto& component : s_Components) {
+    for (const auto& component : m_Components) {
         inserter.insertLevel(COMPONENT_6_4_TAG, boost::bind(&CSeasonalComponent::acceptPersistInserter,
                                                             &component, _1));
     }
-    core::CPersistUtils::persist(ERRORS_6_4_TAG, s_PredictionErrors, inserter);
+    core::CPersistUtils::persist(ERRORS_6_4_TAG, m_PredictionErrors, inserter);
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::decayRate(double decayRate) {
-    for (auto& component : s_Components) {
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::decayRate(double decayRate) {
+    for (auto& component : m_Components) {
         component.decayRate(decayRate);
     }
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::propagateForwards(core_t::TTime start,
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::propagateForwards(core_t::TTime start,
                                                                                core_t::TTime end) {
-    for (std::size_t i = 0u; i < s_Components.size(); ++i) {
-        core_t::TTime period{s_Components[i].time().period()};
+    for (std::size_t i = 0u; i < m_Components.size(); ++i) {
+        core_t::TTime period{m_Components[i].time().period()};
         core_t::TTime a{CIntegerTools::floor(start, period)};
         core_t::TTime b{CIntegerTools::floor(end, period)};
         if (b > a) {
             double time{static_cast<double>(b - a) /
                         static_cast<double>(CTools::truncate(period, DAY, WEEK))};
-            s_Components[i].propagateForwardsByTime(time);
-            s_PredictionErrors[i].age(std::exp(-s_Components[i].decayRate() * time));
+            m_Components[i].propagateForwardsByTime(time);
+            m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
         }
     }
 }
 
-std::size_t CTimeSeriesDecompositionDetail::CComponents::SSeasonal::size() const {
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::clearPredictionErrors() {
+    for (auto& errors : m_PredictionErrors) {
+        errors.clear();
+    }
+}
+
+std::size_t CTimeSeriesDecompositionDetail::CComponents::CSeasonal::size() const {
     std::size_t result{0};
-    for (const auto& component : s_Components) {
+    for (const auto& component : m_Components) {
         result += component.size();
     }
     return result;
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::componentsErrorsAndDeltas(
+const maths_t::TSeasonalComponentVec&
+CTimeSeriesDecompositionDetail::CComponents::CSeasonal::components() const {
+    return m_Components;
+}
+
+maths_t::TSeasonalComponentVec&
+CTimeSeriesDecompositionDetail::CComponents::CSeasonal::components() {
+    return m_Components;
+}
+
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::componentsErrorsAndDeltas(
     core_t::TTime time,
     TSeasonalComponentPtrVec& components,
     TComponentErrorsPtrVec& errors,
     TDoubleVec& deltas) {
-    std::size_t n{s_Components.size()};
+    std::size_t n{m_Components.size()};
 
     components.reserve(n);
     errors.reserve(n);
 
     for (std::size_t i = 0u; i < n; ++i) {
-        if (s_Components[i].time().inWindow(time)) {
-            components.push_back(&s_Components[i]);
-            errors.push_back(&s_PredictionErrors[i]);
+        if (m_Components[i].time().inWindow(time)) {
+            components.push_back(&m_Components[i]);
+            errors.push_back(&m_PredictionErrors[i]);
         }
     }
 
@@ -1923,10 +1907,10 @@ void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::componentsErrorsAnd
     }
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::shouldInterpolate(
+bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::shouldInterpolate(
     core_t::TTime time,
     core_t::TTime last) const {
-    for (const auto& component : s_Components) {
+    for (const auto& component : m_Components) {
         core_t::TTime period{component.time().period()};
         core_t::TTime a{CIntegerTools::floor(last, period)};
         core_t::TTime b{CIntegerTools::floor(time, period)};
@@ -1937,10 +1921,10 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::shouldInterpolate(
     return false;
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::interpolate(core_t::TTime time,
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::interpolate(core_t::TTime time,
                                                                          core_t::TTime lastTime,
                                                                          bool refine) {
-    for (auto& component : s_Components) {
+    for (auto& component : m_Components) {
         core_t::TTime period{component.time().period()};
         core_t::TTime a{CIntegerTools::floor(lastTime, period)};
         core_t::TTime b{CIntegerTools::floor(time, period)};
@@ -1950,8 +1934,8 @@ void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::interpolate(core_t:
     }
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::initialized() const {
-    for (const auto& component : s_Components) {
+bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::initialized() const {
+    for (const auto& component : m_Components) {
         if (component.initialized()) {
             return true;
         }
@@ -1959,15 +1943,47 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::initialized() const
     return false;
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime time,
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::add(
+    const CSeasonalTime& seasonalTime,
+    std::size_t size,
+    double decayRate,
+    double bucketLength,
+    CSplineTypes::EBoundaryCondition boundaryCondition,
+    core_t::TTime startTime,
+    core_t::TTime endTime,
+    const TFloatMeanAccumulatorVec& values) {
+    m_Components.emplace_back(seasonalTime, size, decayRate, bucketLength, boundaryCondition);
+    m_Components.back().initialize(startTime, endTime, values);
+    m_Components.back().interpolate(CIntegerTools::floor(endTime, seasonalTime.period()));
+}
+
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::refreshForNewComponents() {
+    m_PredictionErrors.resize(m_Components.size());
+    COrderings::simultaneousSort(
+        m_Components, m_PredictionErrors,
+        [](const CSeasonalComponent& lhs, const CSeasonalComponent& rhs) {
+            return lhs.time() < rhs.time();
+        });
+}
+
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::removeExcludedComponents(
+    const CSeasonalTime& time) {
+    m_Components.erase(std::remove_if(m_Components.begin(), m_Components.end(),
+                                      [&time](const CSeasonalComponent& component) {
+                                          return time.excludes(component.time());
+                                      }),
+                       m_Components.end());
+}
+
+bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::prune(core_t::TTime time,
                                                                    core_t::TTime bucketLength) {
-    std::size_t n = s_Components.size();
+    std::size_t n{m_Components.size()};
 
     if (n > 1) {
         TTimeTimePrSizeFMap windowed;
         windowed.reserve(n);
-        for (const auto& component : s_Components) {
-            const CSeasonalTime& time_ = component.time();
+        for (const auto& component : m_Components) {
+            const CSeasonalTime& time_{component.time()};
             if (time_.windowed()) {
                 ++windowed[time_.window()];
             }
@@ -1977,25 +1993,25 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime
         TTimeTimePrDoubleFMap shifts;
         shifts.reserve(n);
         for (std::size_t i = 0u; i < n; ++i) {
-            const CSeasonalTime& time_ = s_Components[i].time();
+            const CSeasonalTime& time_{m_Components[i].time()};
             auto j = windowed.find(time_.window());
             if (j == windowed.end() || j->second > 1) {
-                if (s_PredictionErrors[i].remove(5 * time_.period() / bucketLength)) {
+                if (m_PredictionErrors[i].remove(5 * time_.period() / bucketLength)) {
                     LOG_DEBUG(<< "Removing seasonal component"
                               << " with period '" << time_.period() << "' at " << time);
                     remove[i] = true;
-                    shifts[time_.window()] += s_Components[i].meanValue();
+                    shifts[time_.window()] += m_Components[i].meanValue();
                     --j->second;
                 }
             }
         }
 
-        CSetTools::simultaneousRemoveIf(remove, s_Components, s_PredictionErrors,
+        CSetTools::simultaneousRemoveIf(remove, m_Components, m_PredictionErrors,
                                         [](bool remove_) { return remove_; });
 
         for (auto& shift : shifts) {
             if (windowed.count(shift.first) > 0) {
-                for (auto& component : s_Components) {
+                for (auto& component : m_Components) {
                     if (shift.first == component.time().window()) {
                         component.shiftLevel(shift.second);
                         break;
@@ -2003,7 +2019,7 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime
                 }
             } else {
                 bool fallback = true;
-                for (auto& component : s_Components) {
+                for (auto& component : m_Components) {
                     if (!component.time().windowed()) {
                         component.shiftLevel(shift.second);
                         fallback = false;
@@ -2012,8 +2028,8 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime
                 }
                 if (fallback) {
                     TTimeTimePrVec shifted;
-                    shifted.reserve(s_Components.size());
-                    for (auto& component : s_Components) {
+                    shifted.reserve(m_Components.size());
+                    for (auto& component : m_Components) {
                         const CSeasonalTime& time_ = component.time();
                         auto containsWindow = [&time_](const TTimeTimePr& window) {
                             return !(time_.windowEnd() <= window.first ||
@@ -2029,40 +2045,40 @@ bool CTimeSeriesDecompositionDetail::CComponents::SSeasonal::prune(core_t::TTime
         }
     }
 
-    return s_Components.empty();
+    return m_Components.empty();
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::shiftOrigin(core_t::TTime time) {
-    for (auto& component : s_Components) {
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::shiftOrigin(core_t::TTime time) {
+    for (auto& component : m_Components) {
         component.shiftOrigin(time);
     }
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::linearScale(core_t::TTime time,
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::linearScale(core_t::TTime time,
                                                                          double scale) {
-    for (auto& component : s_Components) {
+    for (auto& component : m_Components) {
         component.linearScale(time, scale);
     }
 }
 
-uint64_t CTimeSeriesDecompositionDetail::CComponents::SSeasonal::checksum(uint64_t seed) const {
-    seed = CChecksum::calculate(seed, s_Components);
-    return CChecksum::calculate(seed, s_PredictionErrors);
+uint64_t CTimeSeriesDecompositionDetail::CComponents::CSeasonal::checksum(uint64_t seed) const {
+    seed = CChecksum::calculate(seed, m_Components);
+    return CChecksum::calculate(seed, m_PredictionErrors);
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SSeasonal::debugMemoryUsage(
+void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::debugMemoryUsage(
     core::CMemoryUsage::TMemoryUsagePtr mem) const {
-    mem->setName("SSeasonal");
-    core::CMemoryDebug::dynamicSize("s_Components", s_Components, mem);
-    core::CMemoryDebug::dynamicSize("s_PredictionErrors", s_PredictionErrors, mem);
+    mem->setName("CSeasonal");
+    core::CMemoryDebug::dynamicSize("m_Components", m_Components, mem);
+    core::CMemoryDebug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);
 }
 
-std::size_t CTimeSeriesDecompositionDetail::CComponents::SSeasonal::memoryUsage() const {
-    return core::CMemory::dynamicSize(s_Components) +
-           core::CMemory::dynamicSize(s_PredictionErrors);
+std::size_t CTimeSeriesDecompositionDetail::CComponents::CSeasonal::memoryUsage() const {
+    return core::CMemory::dynamicSize(m_Components) +
+           core::CMemory::dynamicSize(m_PredictionErrors);
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::acceptRestoreTraverser(
+bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::acceptRestoreTraverser(
     double decayRate,
     core_t::TTime bucketLength_,
     core::CStateRestoreTraverser& traverser) {
@@ -2071,66 +2087,77 @@ bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::acceptRestoreTraver
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_NO_ERROR(COMPONENT_6_4_TAG,
-                             s_Components.emplace_back(decayRate, bucketLength, traverser))
+                             m_Components.emplace_back(decayRate, bucketLength, traverser))
             RESTORE(ERRORS_6_4_TAG,
-                    core::CPersistUtils::restore(ERRORS_6_4_TAG, s_PredictionErrors, traverser))
+                    core::CPersistUtils::restore(ERRORS_6_4_TAG, m_PredictionErrors, traverser))
         }
     } else if (traverser.name() == VERSION_6_3_TAG) {
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_NO_ERROR(COMPONENT_6_3_TAG,
-                             s_Components.emplace_back(decayRate, bucketLength, traverser))
+                             m_Components.emplace_back(decayRate, bucketLength, traverser))
         }
     } else {
         // There is no version string this is historic state.
         do {
             const std::string& name{traverser.name()};
             RESTORE_NO_ERROR(COMPONENT_OLD_TAG,
-                             s_Components.emplace_back(decayRate, bucketLength, traverser))
+                             m_Components.emplace_back(decayRate, bucketLength, traverser))
         } while (traverser.next());
     }
     return true;
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SCalendar::acceptPersistInserter(
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::acceptPersistInserter(
     core::CStatePersistInserter& inserter) const {
     inserter.insertValue(VERSION_6_4_TAG, "");
-    for (const auto& component : s_Components) {
+    for (const auto& component : m_Components) {
         inserter.insertLevel(COMPONENT_6_4_TAG, boost::bind(&CCalendarComponent::acceptPersistInserter,
                                                             &component, _1));
     }
-    core::CPersistUtils::persist(ERRORS_6_4_TAG, s_PredictionErrors, inserter);
+    core::CPersistUtils::persist(ERRORS_6_4_TAG, m_PredictionErrors, inserter);
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SCalendar::decayRate(double decayRate) {
-    for (auto& component : s_Components) {
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::decayRate(double decayRate) {
+    for (auto& component : m_Components) {
         component.decayRate(decayRate);
     }
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SCalendar::propagateForwards(core_t::TTime start,
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::propagateForwards(core_t::TTime start,
                                                                                core_t::TTime end) {
-    for (std::size_t i = 0u; i < s_Components.size(); ++i) {
+    for (std::size_t i = 0u; i < m_Components.size(); ++i) {
         core_t::TTime a{CIntegerTools::floor(start, MONTH)};
         core_t::TTime b{CIntegerTools::floor(end, MONTH)};
         if (b > a) {
             double time{static_cast<double>(b - a) / static_cast<double>(MONTH)};
-            s_Components[i].propagateForwardsByTime(time);
-            s_PredictionErrors[i].age(std::exp(-s_Components[i].decayRate() * time));
+            m_Components[i].propagateForwardsByTime(time);
+            m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
         }
     }
 }
 
-std::size_t CTimeSeriesDecompositionDetail::CComponents::SCalendar::size() const {
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::clearPredictionErrors() {
+    for (auto& errors : m_PredictionErrors) {
+        errors.clear();
+    }
+}
+
+std::size_t CTimeSeriesDecompositionDetail::CComponents::CCalendar::size() const {
     std::size_t result{0};
-    for (const auto& component : s_Components) {
+    for (const auto& component : m_Components) {
         result += component.size();
     }
     return result;
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::haveComponent(CCalendarFeature feature) const {
-    for (const auto& component : s_Components) {
+const maths_t::TCalendarComponentVec&
+CTimeSeriesDecompositionDetail::CComponents::CCalendar::components() const {
+    return m_Components;
+}
+
+bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::haveComponent(CCalendarFeature feature) const {
+    for (const auto& component : m_Components) {
         if (component.feature() == feature) {
             return true;
         }
@@ -2138,25 +2165,25 @@ bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::haveComponent(CCale
     return false;
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SCalendar::componentsAndErrors(
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::componentsAndErrors(
     core_t::TTime time,
     TCalendarComponentPtrVec& components,
     TComponentErrorsPtrVec& errors) {
-    std::size_t n = s_Components.size();
+    std::size_t n = m_Components.size();
     components.reserve(n);
     errors.reserve(n);
     for (std::size_t i = 0u; i < n; ++i) {
-        if (s_Components[i].feature().inWindow(time)) {
-            components.push_back(&s_Components[i]);
-            errors.push_back(&s_PredictionErrors[i]);
+        if (m_Components[i].feature().inWindow(time)) {
+            components.push_back(&m_Components[i]);
+            errors.push_back(&m_PredictionErrors[i]);
         }
     }
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::shouldInterpolate(
+bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::shouldInterpolate(
     core_t::TTime time,
     core_t::TTime last) const {
-    for (const auto& component : s_Components) {
+    for (const auto& component : m_Components) {
         CCalendarFeature feature = component.feature();
         if (!feature.inWindow(time) && feature.inWindow(last)) {
             return true;
@@ -2165,10 +2192,10 @@ bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::shouldInterpolate(
     return false;
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SCalendar::interpolate(core_t::TTime time,
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::interpolate(core_t::TTime time,
                                                                          core_t::TTime lastTime,
                                                                          bool refine) {
-    for (auto& component : s_Components) {
+    for (auto& component : m_Components) {
         CCalendarFeature feature = component.feature();
         if (!feature.inWindow(time) && feature.inWindow(lastTime)) {
             component.interpolate(time - feature.offset(time), refine);
@@ -2176,8 +2203,8 @@ void CTimeSeriesDecompositionDetail::CComponents::SCalendar::interpolate(core_t:
     }
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::initialized() const {
-    for (const auto& component : s_Components) {
+bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::initialized() const {
+    for (const auto& component : m_Components) {
         if (component.initialized()) {
             return true;
         }
@@ -2185,45 +2212,54 @@ bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::initialized() const
     return false;
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::SCalendar::prune(core_t::TTime time,
+bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::prune(core_t::TTime time,
                                                                    core_t::TTime bucketLength) {
-    TBoolVec remove(s_Components.size(), false);
-    for (std::size_t i = 0u; i < s_Components.size(); ++i) {
-        if (s_PredictionErrors[i].remove(5 * s_Components[i].feature().window() / bucketLength)) {
+    TBoolVec remove(m_Components.size(), false);
+    for (std::size_t i = 0u; i < m_Components.size(); ++i) {
+        if (m_PredictionErrors[i].remove(5 * m_Components[i].feature().window() / bucketLength)) {
             LOG_DEBUG(<< "Removing calendar component"
-                      << " '" << s_Components[i].feature().print() << "' at " << time);
+                      << " '" << m_Components[i].feature().print() << "' at " << time);
             remove[i] = true;
         }
     }
 
-    CSetTools::simultaneousRemoveIf(remove, s_Components, s_PredictionErrors,
+    CSetTools::simultaneousRemoveIf(remove, m_Components, m_PredictionErrors,
                                     [](bool remove_) { return remove_; });
 
-    return s_Components.empty();
+    return m_Components.empty();
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SCalendar::linearScale(core_t::TTime time,
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::add(const CCalendarFeature& feature,
+                                                                 std::size_t size,
+                                                                 double decayRate,
+                                                                 double bucketLength) {
+    m_Components.emplace_back(feature, size, decayRate, bucketLength, CSplineTypes::E_Natural);
+    m_Components.back().initialize();
+    m_PredictionErrors.resize(m_Components.size());
+}
+
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::linearScale(core_t::TTime time,
                                                                          double scale) {
-    for (auto& component : s_Components) {
+    for (auto& component : m_Components) {
         component.linearScale(time, scale);
     }
 }
 
-uint64_t CTimeSeriesDecompositionDetail::CComponents::SCalendar::checksum(uint64_t seed) const {
-    seed = CChecksum::calculate(seed, s_Components);
-    return CChecksum::calculate(seed, s_PredictionErrors);
+uint64_t CTimeSeriesDecompositionDetail::CComponents::CCalendar::checksum(uint64_t seed) const {
+    seed = CChecksum::calculate(seed, m_Components);
+    return CChecksum::calculate(seed, m_PredictionErrors);
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::SCalendar::debugMemoryUsage(
+void CTimeSeriesDecompositionDetail::CComponents::CCalendar::debugMemoryUsage(
     core::CMemoryUsage::TMemoryUsagePtr mem) const {
-    mem->setName("SCalendar");
-    core::CMemoryDebug::dynamicSize("s_Components", s_Components, mem);
-    core::CMemoryDebug::dynamicSize("s_PredictionErrors", s_PredictionErrors, mem);
+    mem->setName("CCalendar");
+    core::CMemoryDebug::dynamicSize("m_Components", m_Components, mem);
+    core::CMemoryDebug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);
 }
 
-std::size_t CTimeSeriesDecompositionDetail::CComponents::SCalendar::memoryUsage() const {
-    return core::CMemory::dynamicSize(s_Components) +
-           core::CMemory::dynamicSize(s_PredictionErrors);
+std::size_t CTimeSeriesDecompositionDetail::CComponents::CCalendar::memoryUsage() const {
+    return core::CMemory::dynamicSize(m_Components) +
+           core::CMemory::dynamicSize(m_PredictionErrors);
 }
 }
 }

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -368,7 +368,9 @@ void CForecastTest::testFinancialIndex() {
             params, {core::make_triple(timeseries[i].first,
                                        TDouble2Vec{timeseries[i].second}, TAG)});
         debug.addValue(timeseries[i].first, timeseries[i].second);
-        debug.addPrediction(timeseries[i].first, maths::CBasicStatistics::mean(model.predict(timeseries[i].first)));
+        debug.addPrediction(
+            timeseries[i].first,
+            maths::CBasicStatistics::mean(model.predict(timeseries[i].first)));
     }
 
     LOG_DEBUG(<< "*** forecast ***");

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -163,7 +163,7 @@ void CForecastTest::testComplexConstantLongTermTrend() {
                scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 24.0, 11.0, 0.01);
+    this->test(trend, bucketLength, 63, 24.0, 10.0, 0.01);
 }
 
 void CForecastTest::testComplexVaryingLongTermTrend() {
@@ -193,7 +193,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 4.0, 44.0, 0.06);
+    this->test(trend, bucketLength, 63, 4.0, 38.0, 0.06);
 }
 
 void CForecastTest::testNonNegative() {

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -36,6 +36,7 @@ using namespace handy_typedefs;
 
 namespace {
 using TDoubleVec = std::vector<double>;
+using TTimeVec = std::vector<core_t::TTime>;
 using TTimeDoublePr = std::pair<core_t::TTime, double>;
 using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
 using TDouble2Vec = core::CSmallVector<double, 2>;
@@ -45,6 +46,63 @@ using TTimeDouble2VecSizeTrVec = std::vector<TTimeDouble2VecSizeTr>;
 using TErrorBarVec = std::vector<maths::SErrorBar>;
 using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TModelPtr = std::shared_ptr<maths::CModel>;
+
+class CDebugGenerator {
+public:
+    static const bool ENABLED{false};
+
+public:
+    ~CDebugGenerator() {
+        if (ENABLED) {
+            std::ofstream file;
+            file.open("results.m");
+            file << "t = " << core::CContainerPrinter::print(m_ValueTimes) << ";\n";
+            file << "f = " << core::CContainerPrinter::print(m_Values) << ";\n";
+            file << "tp = " << core::CContainerPrinter::print(m_PredictionTimes) << ";\n";
+            file << "fp = " << core::CContainerPrinter::print(m_Predictions) << ";\n";
+            file << "tf = " << core::CContainerPrinter::print(m_ForecastTimes) << ";\n";
+            file << "fl = " << core::CContainerPrinter::print(m_ForecastLower) << ";\n";
+            file << "fm = " << core::CContainerPrinter::print(m_ForecastMean) << ";\n";
+            file << "fu = " << core::CContainerPrinter::print(m_ForecastUpper) << ";\n";
+            file << "hold on;\n";
+            file << "plot(t, f);\n";
+            file << "plot(tp, fp, 'k');\n";
+            file << "plot(tf, fl, 'r');\n";
+            file << "plot(tf, fm, 'k');\n";
+            file << "plot(tf, fu, 'r');\n";
+        }
+    }
+    void addValue(core_t::TTime time, double value) {
+        if (ENABLED) {
+            m_ValueTimes.push_back(time);
+            m_Values.push_back(value);
+        }
+    }
+    void addPrediction(core_t::TTime time, double prediction) {
+        if (ENABLED) {
+            m_PredictionTimes.push_back(time);
+            m_Predictions.push_back(prediction);
+        }
+    }
+    void addForecast(core_t::TTime time, const maths::SErrorBar& forecast) {
+        if (ENABLED) {
+            m_ForecastTimes.push_back(time);
+            m_ForecastLower.push_back(forecast.s_LowerBound);
+            m_ForecastMean.push_back(forecast.s_Predicted);
+            m_ForecastUpper.push_back(forecast.s_UpperBound);
+        }
+    }
+
+private:
+    TTimeVec m_ValueTimes;
+    TDoubleVec m_Values;
+    TTimeVec m_PredictionTimes;
+    TDoubleVec m_Predictions;
+    TTimeVec m_ForecastTimes;
+    TDoubleVec m_ForecastLower;
+    TDoubleVec m_ForecastMean;
+    TDoubleVec m_ForecastUpper;
+};
 
 const double DECAY_RATE{0.0005};
 const std::size_t TAG{0u};
@@ -94,7 +152,7 @@ void CForecastTest::testDailyNoLongTermTrend() {
         return 40.0 + alpha * y[i / 6] + beta * y[(i / 6 + 1) % y.size()] + noise;
     };
 
-    this->test(trend, bucketLength, 63, 64.0, 5.0, 0.13);
+    this->test(trend, bucketLength, 63, 64.0, 5.0, 0.14);
 }
 
 void CForecastTest::testDailyConstantLongTermTrend() {
@@ -134,7 +192,7 @@ void CForecastTest::testDailyVaryingLongTermTrend() {
                8.0 * std::sin(boost::math::double_constants::two_pi * time_ / 43200.0) + noise;
     };
 
-    this->test(trend, bucketLength, 98, 9.0, 24.0, 0.042);
+    this->test(trend, bucketLength, 98, 9.0, 22.0, 0.04);
 }
 
 void CForecastTest::testComplexNoLongTermTrend() {
@@ -150,7 +208,7 @@ void CForecastTest::testComplexNoLongTermTrend() {
         return scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 24.0, 9.0, 0.13);
+    this->test(trend, bucketLength, 63, 24.0, 9.0, 0.14);
 }
 
 void CForecastTest::testComplexConstantLongTermTrend() {
@@ -171,7 +229,7 @@ void CForecastTest::testComplexConstantLongTermTrend() {
 }
 
 void CForecastTest::testComplexVaryingLongTermTrend() {
-    core_t::TTime bucketLength{3600};
+    core_t::TTime bucketLength{1800};
     double day{static_cast<double>(core::constants::DAY)};
     TDoubleVec times{0.0,         5.0 * day,   10.0 * day,  15.0 * day,
                      20.0 * day,  25.0 * day,  30.0 * day,  35.0 * day,
@@ -180,7 +238,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
                      80.0 * day,  85.0 * day,  90.0 * day,  95.0 * day,
                      100.0 * day, 105.0 * day, 110.0 * day, 115.0 * day};
     TDoubleVec values{20.0, 30.0, 25.0, 35.0, 45.0, 40.0,  38.0,  36.0,
-                      35.0, 25.0, 35.0, 45.0, 55.0, 62.0,  70.0,  76.0,
+                      35.0, 34.0, 35.0, 40.0, 48.0, 55.0,  65.0,  76.0,
                       79.0, 82.0, 86.0, 90.0, 95.0, 100.0, 106.0, 112.0};
     TDoubleVec y{0.0, 1.0,  2.0,  2.0,  3.0,  4.0,  5.0, 6.0,
                  8.0, 10.0, 11.0, 12.0, 11.0, 10.0, 9.0, 8.0,
@@ -192,12 +250,12 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
 
     TTrend trend = [&trend_, &y, &scale, bucketLength](core_t::TTime time, double noise) {
         core_t::TTime d{(time % core::constants::WEEK) / core::constants::DAY};
-        core_t::TTime h{(time % core::constants::DAY) / bucketLength};
+        core_t::TTime h{(time % core::constants::DAY) / 2 / bucketLength};
         double time_{static_cast<double>(time)};
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 4.0, 38.0, 0.06);
+    this->test(trend, bucketLength, 63, 4.0, 24.0, 0.05);
 }
 
 void CForecastTest::testNonNegative() {
@@ -212,15 +270,9 @@ void CForecastTest::testNonNegative() {
         decayRateControllers()};
     maths::CUnivariateTimeSeriesModel model(params(bucketLength), TAG, trend,
                                             prior, &controllers);
+    CDebugGenerator debug;
 
     LOG_DEBUG(<< "*** learn ***");
-
-    //std::ofstream file;
-    //file.open("results.m");
-    //TDoubleVec actual;
-    //TDoubleVec ly;
-    //TDoubleVec my;
-    //TDoubleVec uy;
 
     core_t::TTime time{0};
     std::vector<maths_t::TDouble2VecWeightsAry> weights{
@@ -237,7 +289,8 @@ void CForecastTest::testNonNegative() {
                 .priorWeights(weights);
             double y{std::max(*value, 0.0)};
             model.addSamples(params, {core::make_triple(time, TDouble2Vec{y}, TAG)});
-            //actual.push_back(y);
+            debug.addValue(time, y);
+            debug.addPrediction(time, maths::CBasicStatistics::mean(model.predict(time)));
         }
     }
 
@@ -267,21 +320,14 @@ void CForecastTest::testNonNegative() {
             outOfBounds +=
                 (y < prediction[i].s_LowerBound || y > prediction[i].s_UpperBound ? 1 : 0);
             ++count;
-            //actual.push_back(y);
-            //ly.push_back(prediction[i].s_LowerBound);
-            //my.push_back(prediction[i].s_Predicted);
-            //uy.push_back(prediction[i].s_UpperBound);
+            debug.addValue(time, y);
+            debug.addForecast(time, prediction[i]);
         }
     }
 
     double percentageOutOfBounds{100.0 * static_cast<double>(outOfBounds) /
                                  static_cast<double>(count)};
     LOG_DEBUG(<< "% out of bounds = " << percentageOutOfBounds);
-
-    //file << "actual = " << core::CContainerPrinter::print(actual) << ";\n";
-    //file << "ly = " << core::CContainerPrinter::print(ly) << ";\n";
-    //file << "my = " << core::CContainerPrinter::print(my) << ";\n";
-    //file << "uy = " << core::CContainerPrinter::print(uy) << ";\n";
 
     CPPUNIT_ASSERT(percentageOutOfBounds < 8.0);
 }
@@ -308,15 +354,9 @@ void CForecastTest::testFinancialIndex() {
         decayRateControllers()};
     maths::CUnivariateTimeSeriesModel model(params(bucketLength), TAG, trend,
                                             prior, &controllers);
+    CDebugGenerator debug;
 
     LOG_DEBUG(<< "*** learn ***");
-
-    //std::ofstream file;
-    //file.open("results.m");
-    //TDoubleVec actual;
-    //TDoubleVec ly;
-    //TDoubleVec my;
-    //TDoubleVec uy;
 
     std::size_t n{5 * timeseries.size() / 6};
 
@@ -327,7 +367,8 @@ void CForecastTest::testFinancialIndex() {
         model.addSamples(
             params, {core::make_triple(timeseries[i].first,
                                        TDouble2Vec{timeseries[i].second}, TAG)});
-        //actual.push_back(timeseries[i].second);
+        debug.addValue(timeseries[i].first, timeseries[i].second);
+        debug.addPrediction(timeseries[i].first, maths::CBasicStatistics::mean(model.predict(timeseries[i].first)));
     }
 
     LOG_DEBUG(<< "*** forecast ***");
@@ -351,21 +392,14 @@ void CForecastTest::testFinancialIndex() {
             (yi < prediction[j].s_LowerBound || yi > prediction[j].s_UpperBound ? 1 : 0);
         ++count;
         error.add(std::fabs(yi - prediction[j].s_Predicted) / std::fabs(yi));
-        //actual.push_back(yi);
-        //ly.push_back(prediction[j].s_LowerBound);
-        //my.push_back(prediction[j].s_Predicted);
-        //uy.push_back(prediction[j].s_UpperBound);
+        debug.addValue(timeseries[i].first, timeseries[i].second);
+        debug.addForecast(timeseries[i].first, prediction[j]);
     }
 
     double percentageOutOfBounds{100.0 * static_cast<double>(outOfBounds) /
                                  static_cast<double>(count)};
     LOG_DEBUG(<< "% out of bounds = " << percentageOutOfBounds);
     LOG_DEBUG(<< "error = " << maths::CBasicStatistics::mean(error));
-
-    //file << "actual = " << core::CContainerPrinter::print(actual) << ";\n";
-    //file << "ly = " << core::CContainerPrinter::print(ly) << ";\n";
-    //file << "my = " << core::CContainerPrinter::print(my) << ";\n";
-    //file << "uy = " << core::CContainerPrinter::print(uy) << ";\n";
 
     CPPUNIT_ASSERT(percentageOutOfBounds < 52.0);
     CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.1);
@@ -404,13 +438,6 @@ void CForecastTest::test(TTrend trend,
                          double noiseVariance,
                          double maximumPercentageOutOfBounds,
                          double maximumError) {
-    //std::ofstream file;
-    //file.open("results.m");
-    //TDoubleVec actual;
-    //TDoubleVec ly;
-    //TDoubleVec my;
-    //TDoubleVec uy;
-
     LOG_DEBUG(<< "*** learn ***");
 
     test::CRandomNumbers rng;
@@ -421,6 +448,7 @@ void CForecastTest::test(TTrend trend,
         params(bucketLength), TAG, maths::CTimeSeriesDecomposition(0.012, bucketLength),
         maths::CNormalMeanPrecConjugate::nonInformativePrior(maths_t::E_ContinuousData, DECAY_RATE),
         &controllers);
+    CDebugGenerator debug;
 
     core_t::TTime time{0};
     TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
@@ -434,7 +462,8 @@ void CForecastTest::test(TTrend trend,
             params.integer(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
             double yi{trend(time, noise[i])};
             model.addSamples(params, {core::make_triple(time, TDouble2Vec{yi}, TAG)});
-            //actual.push_back(yi);
+            debug.addValue(time, yi);
+            debug.addPrediction(time, maths::CBasicStatistics::mean(model.predict(time)));
         }
     }
 
@@ -465,10 +494,8 @@ void CForecastTest::test(TTrend trend,
                 (yj < prediction[i].s_LowerBound || yj > prediction[i].s_UpperBound ? 1 : 0);
             ++count;
             error.add(std::fabs(yj - prediction[i].s_Predicted) / std::fabs(yj));
-            //actual.push_back(yj);
-            //ly.push_back(prediction[i].s_LowerBound);
-            //my.push_back(prediction[i].s_Predicted);
-            //uy.push_back(prediction[i].s_UpperBound);
+            debug.addValue(time, yj);
+            debug.addForecast(time, prediction[i]);
         }
     }
 
@@ -476,11 +503,6 @@ void CForecastTest::test(TTrend trend,
                                  static_cast<double>(count)};
     LOG_DEBUG(<< "% out of bounds = " << percentageOutOfBounds);
     LOG_DEBUG(<< "error = " << maths::CBasicStatistics::mean(error));
-
-    //file << "actual = " << core::CContainerPrinter::print(actual) << ";\n";
-    //file << "ly = " << core::CContainerPrinter::print(ly) << ";\n";
-    //file << "my = " << core::CContainerPrinter::print(my) << ";\n";
-    //file << "uy = " << core::CContainerPrinter::print(uy) << ";\n";
 
     CPPUNIT_ASSERT(percentageOutOfBounds < maximumPercentageOutOfBounds);
     CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < maximumError);

--- a/lib/maths/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentTest.cc
@@ -396,7 +396,7 @@ void CSeasonalComponentTest::testConstantPeriodic() {
                 LOG_DEBUG(<< "error1 = " << error1);
                 LOG_DEBUG(<< "error2 = " << error2);
                 CPPUNIT_ASSERT(error1 < 11.0);
-                CPPUNIT_ASSERT(error2 < 4.6);
+                CPPUNIT_ASSERT(error2 < 4.7);
                 totalError1 += error1;
                 totalError2 += error2;
 
@@ -414,7 +414,7 @@ void CSeasonalComponentTest::testConstantPeriodic() {
         totalError2 /= 40.0;
         LOG_DEBUG(<< "totalError1 = " << totalError1);
         LOG_DEBUG(<< "totalError2 = " << totalError2);
-        CPPUNIT_ASSERT(totalError1 < 7.3);
+        CPPUNIT_ASSERT(totalError1 < 7.5);
         CPPUNIT_ASSERT(totalError2 < 4.2);
     }
 }
@@ -535,7 +535,7 @@ void CSeasonalComponentTest::testTimeVaryingPeriodic() {
 
     LOG_DEBUG(<< "mean error 1 = " << totalError1 / numberErrors);
     LOG_DEBUG(<< "mean error 2 = " << totalError2 / numberErrors);
-    CPPUNIT_ASSERT(totalError1 / numberErrors < 19.0);
+    CPPUNIT_ASSERT(totalError1 / numberErrors < 18.0);
     CPPUNIT_ASSERT(totalError2 / numberErrors < 14.0);
 }
 

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -149,8 +149,8 @@ void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
     //file << "plot(t(1:length(fe)), fe, 'r');\n";
     //file << "plot(t(1:length(r)), r, 'k');\n";
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.019 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.020 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.020 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.024 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
 }
 
@@ -308,9 +308,9 @@ void CTimeSeriesDecompositionTest::testDistortedPeriodic() {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                CPPUNIT_ASSERT(sumResidual < 0.27 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.56 * maxValue);
-                CPPUNIT_ASSERT(percentileError < 0.16 * sumValue);
+                CPPUNIT_ASSERT(sumResidual < 0.25 * sumValue);
+                CPPUNIT_ASSERT(maxResidual < 0.55 * maxValue);
+                CPPUNIT_ASSERT(percentileError < 0.14 * sumValue);
 
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -333,7 +333,7 @@ void CTimeSeriesDecompositionTest::testDistortedPeriodic() {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    CPPUNIT_ASSERT(totalSumResidual < 0.18 * totalSumValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.17 * totalSumValue);
     CPPUNIT_ASSERT(totalMaxResidual < 0.28 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.09 * totalSumValue);
 }
@@ -413,8 +413,8 @@ void CTimeSeriesDecompositionTest::testMinimizeLongComponents() {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                CPPUNIT_ASSERT(sumResidual < 0.16 * sumValue);
-                CPPUNIT_ASSERT(maxResidual < 0.35 * maxValue);
+                CPPUNIT_ASSERT(sumResidual < 0.15 * sumValue);
+                CPPUNIT_ASSERT(maxResidual < 0.31 * maxValue);
                 CPPUNIT_ASSERT(percentileError < 0.05 * sumValue);
 
                 totalSumResidual += sumResidual;
@@ -428,8 +428,7 @@ void CTimeSeriesDecompositionTest::testMinimizeLongComponents() {
                         double slope = component.valueSpline().absSlope();
                         meanSlope += slope;
                         LOG_DEBUG(<< "weekly |slope| = " << slope);
-
-                        CPPUNIT_ASSERT(slope < 0.0018);
+                        CPPUNIT_ASSERT(slope < 0.0013);
                         refinements += 1.0;
                     }
                 }
@@ -781,8 +780,8 @@ void CTimeSeriesDecompositionTest::testSeasonalOnset() {
     LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
-    CPPUNIT_ASSERT(totalSumResidual < 0.062 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.077 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.065 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.085 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.03 * totalSumValue);
 }
 
@@ -1292,6 +1291,9 @@ void CTimeSeriesDecompositionTest::testMixedSmoothAndSpikeyDataProblemCase() {
 }
 
 void CTimeSeriesDecompositionTest::testDiurnalPeriodicityWithMissingValues() {
+    // Test the accuracy of the modeling when there are periodically missing
+    // values.
+
     test::CRandomNumbers rng;
 
     LOG_DEBUG(<< "Daily Periodic");
@@ -1402,6 +1404,8 @@ void CTimeSeriesDecompositionTest::testDiurnalPeriodicityWithMissingValues() {
 }
 
 void CTimeSeriesDecompositionTest::testLongTermTrend() {
+    // Test a simple linear ramp and non-periodic saw tooth series.
+
     const core_t::TTime length = 120 * DAY;
 
     TTimeVec times;
@@ -1570,7 +1574,7 @@ void CTimeSeriesDecompositionTest::testLongTermTrend() {
 }
 
 void CTimeSeriesDecompositionTest::testLongTermTrendAndPeriodicity() {
-    // Test long term mean reverting component plus daily periodic component.
+    // Test a long term mean reverting component plus daily periodic component.
 
     TTimeVec times;
     TDoubleVec trend;
@@ -1660,6 +1664,8 @@ void CTimeSeriesDecompositionTest::testLongTermTrendAndPeriodicity() {
 }
 
 void CTimeSeriesDecompositionTest::testNonDiurnal() {
+    // Test the accuracy of the modeling of some non-daily or weekly
+    // seasonal components.
     test::CRandomNumbers rng;
 
     LOG_DEBUG(<< "Hourly");
@@ -1670,7 +1676,7 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
                           2.0,  1.0, 0.5, 0.5, 1.0, 6.0};
 
         TTimeVec times;
-        TDoubleVec trends[2]{TDoubleVec(), TDoubleVec(8 * DAY / FIVE_MINS)};
+        TDoubleVec trends[2]{{}, {8 * DAY / FIVE_MINS}};
         for (core_t::TTime time = 0; time < length; time += FIVE_MINS) {
             times.push_back(time);
             trends[0].push_back(periodic[(time / FIVE_MINS) % 12]);
@@ -1823,7 +1829,7 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
                     totalMaxValue += maxValue;
 
                     CPPUNIT_ASSERT(sumResidual / sumValue < 0.17);
-                    CPPUNIT_ASSERT(maxResidual / maxValue < 0.21);
+                    CPPUNIT_ASSERT(maxResidual / maxValue < 0.22);
                 }
                 lastTwoDay += 2 * DAY;
             }
@@ -1841,11 +1847,13 @@ void CTimeSeriesDecompositionTest::testNonDiurnal() {
         //file << "plot(t, fe);\n";
 
         CPPUNIT_ASSERT(totalSumResidual / totalSumValue < 0.1);
-        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.18);
+        CPPUNIT_ASSERT(totalMaxResidual / totalMaxValue < 0.2);
     }
 }
 
 void CTimeSeriesDecompositionTest::testYearly() {
+    // Test a yearly seasonal component.
+
     using TDouble1Vec = core::CSmallVector<double, 1>;
 
     test::CRandomNumbers rng;
@@ -2074,6 +2082,70 @@ void CTimeSeriesDecompositionTest::testConditionOfTrend() {
     }
 }
 
+void CTimeSeriesDecompositionTest::testComponentLifecycle() {
+    // Test we adapt to changing seasonality adding and removing components
+    // as necessary.
+
+    test::CRandomNumbers rng;
+
+    auto trend = [](core_t::TTime time) {
+        return 20.0 + 10.0 * std::sin(boost::math::double_constants::two_pi * time / DAY) +
+               3.0 * (time > 4 * WEEK
+                          ? std::sin(boost::math::double_constants::two_pi * time / HOUR)
+                          : 0.0) -
+               3.0 * (time > 9 * WEEK
+                          ? std::sin(boost::math::double_constants::two_pi * time / HOUR)
+                          : 0.0) +
+               8.0 * (time > 16 * WEEK
+                          ? std::sin(boost::math::double_constants::two_pi * time / 4 / DAY)
+                          : 0.0) -
+               8.0 * (time > 21 * WEEK
+                          ? std::sin(boost::math::double_constants::two_pi * time / 4 / DAY)
+                          : 0.0);
+    };
+
+    maths::CTimeSeriesDecomposition decomposition(0.012, FIVE_MINS);
+
+    //std::ofstream file;
+    //file.open("results.m");
+    //TDoubleVec f;
+    //TDoubleVec times;
+    //TDoubleVec values;
+
+    TMeanAccumulator errors[4];
+    TDoubleVec noise;
+    for (core_t::TTime time = 0; time < 35 * WEEK; time += FIVE_MINS) {
+        rng.generateNormalSamples(0.0, 1.0, 1, noise);
+        decomposition.addPoint(time, trend(time) + noise[0]);
+        double prediction =
+            maths::CBasicStatistics::mean(decomposition.baseline(time, 0.0));
+        if (time > 24 * WEEK) {
+            errors[3].add(std::fabs(prediction - trend(time)) / trend(time));
+        } else if (time > 18 * WEEK && time < 21 * WEEK) {
+            errors[2].add(std::fabs(prediction - trend(time)) / trend(time));
+        } else if (time > 11 * WEEK && time < 14 * WEEK) {
+            errors[1].add(std::fabs(prediction - trend(time)) / trend(time));
+        } else if (time > 6 * WEEK && time < 9 * WEEK) {
+            errors[0].add(std::fabs(prediction - trend(time)) / trend(time));
+        }
+
+        //times.push_back(time);
+        //values.push_back(trend(time) + noise[0]);
+        //f.push_back(maths::CBasicStatistics::mean(decomposition.baseline(time, 0.0)));
+    }
+
+    //file << "t = " << core::CContainerPrinter::print(times) << ";\n";
+    //file << "f = " << core::CContainerPrinter::print(values) << ";\n";
+    //file << "fe = " << core::CContainerPrinter::print(f) << ";\n";
+    //file << "plot(t, f, 'r');\n";
+    //file << "plot(t, fe);\n";
+
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(errors[0]) < 0.01);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(errors[1]) < 0.015);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(errors[2]) < 0.01);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(errors[3]) < 0.1);
+}
+
 void CTimeSeriesDecompositionTest::testSwap() {
     const double decayRate = 0.01;
     const core_t::TTime bucketLength = HALF_HOUR;
@@ -2081,7 +2153,7 @@ void CTimeSeriesDecompositionTest::testSwap() {
     TTimeVec times;
     TDoubleVec trend1;
     TDoubleVec trend2;
-    for (core_t::TTime time = 0; time < 10 * WEEK + 1; time += HALF_HOUR) {
+    for (core_t::TTime time = 0; time <= 10 * WEEK; time += HALF_HOUR) {
         double daily = 15.0 + 10.0 * std::sin(boost::math::double_constants::two_pi *
                                               static_cast<double>(time) /
                                               static_cast<double>(DAY));
@@ -2120,7 +2192,7 @@ void CTimeSeriesDecompositionTest::testPersist() {
 
     TTimeVec times;
     TDoubleVec trend;
-    for (core_t::TTime time = 0; time < 10 * WEEK + 1; time += HALF_HOUR) {
+    for (core_t::TTime time = 0; time <= 10 * WEEK; time += HALF_HOUR) {
         double daily = 15.0 + 10.0 * std::sin(boost::math::double_constants::two_pi *
                                               static_cast<double>(time) /
                                               static_cast<double>(DAY));
@@ -2377,6 +2449,9 @@ CppUnit::Test* CTimeSeriesDecompositionTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
         "CTimeSeriesDecompositionTest::testConditionOfTrend",
         &CTimeSeriesDecompositionTest::testConditionOfTrend));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
+        "CTimeSeriesDecompositionTest::testComponentLifecycle",
+        &CTimeSeriesDecompositionTest::testComponentLifecycle));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
         "CTimeSeriesDecompositionTest::testSwap", &CTimeSeriesDecompositionTest::testSwap));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.h
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.h
@@ -29,6 +29,7 @@ public:
     void testWithOutliers();
     void testCalendar();
     void testConditionOfTrend();
+    void testComponentLifecycle();
     void testSwap();
     void testPersist();
     void testUpgrade();

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -1407,7 +1407,7 @@ void CTimeSeriesModelTest::testWeights() {
             }
         }
         LOG_DEBUG(<< "error = " << maths::CBasicStatistics::mean(error));
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.21);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(error) < 0.26);
 
         LOG_DEBUG(<< "Winsorisation");
         TDouble2Vec prediction(model.predict(time));

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2835,7 +2835,7 @@ void CEventRateModelTest::testDecayRateControl() {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanPredictionError) <
-                       0.7 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                       0.76 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 


### PR DESCRIPTION
In the course of other testing related to #6, I found evidence of potential instability in the decomposition when the seasonal components in the time series abruptly change. In addition, our lifecycle management of seasonal components was not reliably removing components which were no longer improving predictions. This was related to the way we were trying to preserve components which carry information about periodic variance in the data.

This adds a unit test to exercise these problems and makes some related improvements. As part of these I've implemented a failsafe to remove all seasonal components and start again if instability occurs. The current behaviour on this unit test (red actuals, blue predictions) is as follows:
![screen shot 2018-05-10 at 18 11 58](https://user-images.githubusercontent.com/7591487/39916718-3b49a4e4-5503-11e8-89b8-11119d625bdc.png)
![screen shot 2018-05-10 at 18 14 53](https://user-images.githubusercontent.com/7591487/39916722-3ff751a8-5503-11e8-9af4-55ac0a42fc3d.png)
![screen shot 2018-05-10 at 18 15 42](https://user-images.githubusercontent.com/7591487/39916727-4577cf40-5503-11e8-9442-5d44b8f61b48.png)
![screen shot 2018-05-10 at 18 17 16](https://user-images.githubusercontent.com/7591487/39916745-573025a2-5503-11e8-8fa4-f2c9cb069ea1.png)
![screen shot 2018-05-10 at 18 17 56](https://user-images.githubusercontent.com/7591487/39916750-59f15266-5503-11e8-99ca-1be7806804b3.png)

For reference, this is what was happening before:
![screen shot 2018-05-15 at 09 56 29](https://user-images.githubusercontent.com/7591487/40047080-6835ede8-5826-11e8-9bfd-08a1f4df500e.png)

This can affect results on metric and count analysis with seasonal signals where seasonality changes significantly from time to time.