### PR TITLE
[ML] fix segfault caused by to few outliers and harden container usage

### DIFF
--- a/include/maths/CBasicStatistics.h
+++ b/include/maths/CBasicStatistics.h
@@ -1332,14 +1332,14 @@ public:
         explicit COrderStatisticsHeap(std::size_t n, const LESS& less = LESS{})
             : TImpl{std::vector<T>(std::max(n, std::size_t(1)), T{}), less} {
             if (n == 0) {
-                LOG_ERROR(<< "Invalid size of 0 for statistics accumulator");
+                LOG_ERROR(<< "Invalid size of 0 for order statistics accumulator");
             }
         }
 
         //! Reset the number of statistics to gather to \p n.
         void resize(std::size_t n) {
             if (n == 0) {
-                LOG_ERROR(<< "Invalid resize of 0 for statistics accumulator");
+                LOG_ERROR(<< "Invalid resize to 0 for order statistics accumulator");
                 n = 1;
             }
             this->clear();

--- a/include/maths/CBasicStatistics.h
+++ b/include/maths/CBasicStatistics.h
@@ -1241,6 +1241,9 @@ public:
     class COrderStatisticsStack
         : public COrderStatisticsImpl<T, boost::array<T, N>, LESS>,
           private boost::addable<COrderStatisticsStack<T, N, LESS>> {
+
+        static_assert(N > 0, "N must be > 0");
+
     private:
         using TArray = boost::array<T, N>;
         using TImpl = COrderStatisticsImpl<T, TArray, LESS>;
@@ -1327,10 +1330,18 @@ public:
 
     public:
         explicit COrderStatisticsHeap(std::size_t n, const LESS& less = LESS{})
-            : TImpl{std::vector<T>(n, T{}), less} {}
+            : TImpl{std::vector<T>(std::max(n, std::size_t(1)), T{}), less} {
+            if (n == 0) {
+                LOG_ERROR(<< "Invalid size of 0 for statistics accumulator");
+            }
+        }
 
         //! Reset the number of statistics to gather to \p n.
         void resize(std::size_t n) {
+            if (n == 0) {
+                LOG_ERROR(<< "Invalid resize of 0 for statistics accumulator");
+                n = 1;
+            }
             this->clear();
             this->statistics().resize(n);
         }


### PR DESCRIPTION
Do not re-weight outliers if there is just 1, preventing a crash downstream
and harden accumulators to prevent empty containers.

relates to #90 
fixes #94

Note: backport to be done together with pending backport of #90