### PR TITLE
[ML] Improve partition analysis memory usage

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ Improve and use periodic boundary condition for seasonal component modeling ({pu
 Improve robustness w.r.t. outliers of detection and initialisation of seasonal components ({pull}90[#90])
 Improve behavior when there are abrupt changes in the seasonal components present in a time series ({pull}91[#91])
 Explicit change point detection and modelling ({pull}92[#92])
+Improve partition analysis memory usage ({pull}97[#97])
 
 Forecasting of Machine Learning job time series is now supported for large jobs by temporarily storing
 model state on disk ({pull}89[#89])

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -16,6 +16,7 @@
 #include <model/CHierarchicalResults.h>
 #include <model/CHierarchicalResultsAggregator.h>
 #include <model/CHierarchicalResultsNormalizer.h>
+#include <model/CInterimBucketCorrector.h>
 #include <model/CResourceMonitor.h>
 #include <model/CResultsQueue.h>
 #include <model/CSearchKey.h>
@@ -131,6 +132,7 @@ public:
                                const TModelPlotDataVecQueue& modelPlotQueue,
                                core_t::TTime time,
                                const model::CResourceMonitor::SResults& modelSizeStats,
+                               const model::CInterimBucketCorrector& interimBucketCorrector,
                                const model::CHierarchicalResultsAggregator& aggregator,
                                core_t::TTime latestRecordTime,
                                core_t::TTime lastResultsTime);
@@ -139,6 +141,7 @@ public:
         TModelPlotDataVecQueue s_ModelPlotQueue;
         core_t::TTime s_Time;
         model::CResourceMonitor::SResults s_ModelSizeStats;
+        model::CInterimBucketCorrector s_InterimBucketCorrector;
         model::CHierarchicalResultsAggregator s_Aggregator;
         std::string s_NormalizerState;
         core_t::TTime s_LatestRecordTime;
@@ -263,6 +266,7 @@ private:
                       core_t::TTime time,
                       const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
                       const model::CResourceMonitor::SResults& modelSizeStats,
+                      const model::CInterimBucketCorrector& interimBucketCorrector,
                       const model::CHierarchicalResultsAggregator& aggregator,
                       const std::string& normalizerState,
                       core_t::TTime latestRecordTime,

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -656,8 +656,8 @@ protected:
     //! Clear out large state objects for people/attributes that are pruned
     virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) = 0;
 
-    //! Get the objects which calculates corrections for interim buckets.
-    const CInterimBucketCorrector& interimValueCorrector() const;
+    //! Get the object which calculates corrections for interim buckets.
+    virtual const CInterimBucketCorrector& interimValueCorrector() const = 0;
 
     //! Check if any of the sample-filtering detection rules apply to this series.
     bool shouldIgnoreSample(model_t::EFeature feature,
@@ -675,25 +675,14 @@ protected:
     //! Get the non-estimated value of the the memory used by this model.
     virtual std::size_t computeMemoryUsage() const = 0;
 
-    //! Restore interim bucket corrector.
-    bool interimBucketCorrectorAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
-
-    //! Persist the interim bucket corrector.
-    void interimBucketCorrectorAcceptPersistInserter(const std::string& tag,
-                                                     core::CStatePersistInserter& inserter) const;
-
     //! Create a stub version of maths::CModel for use when pruning people
     //! or attributes to free memory resource.
     static maths::CModel* tinyModel();
 
 private:
     using TModelParamsCRef = boost::reference_wrapper<const SModelParams>;
-    using TInterimBucketCorrectorPtr = std::shared_ptr<CInterimBucketCorrector>;
 
 private:
-    //! Set the current bucket total count.
-    virtual void currentBucketTotalCount(uint64_t totalCount) = 0;
-
     //! Skip sampling the interval \p endTime - \p startTime.
     virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) = 0;
 
@@ -718,9 +707,6 @@ private:
     //! The influence calculators to use for each feature which is being
     //! modeled.
     TFeatureInfluenceCalculatorCPtrPrVecVec m_InfluenceCalculators;
-
-    //! A corrector that calculates adjustments for values of interim buckets.
-    TInterimBucketCorrectorPtr m_InterimBucketCorrector;
 };
 }
 }

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -29,6 +29,7 @@
 namespace ml {
 namespace model {
 class CDetectionRule;
+class CInterimBucketCorrector;
 class CSearchKey;
 class CModelAutoConfigurer;
 class CModelFactory;
@@ -68,6 +69,7 @@ public:
     using TFeatureVec = model_t::TFeatureVec;
     using TStrVec = std::vector<std::string>;
     using TStrVecCItr = TStrVec::const_iterator;
+    using TInterimBucketCorrectorPtr = std::shared_ptr<CInterimBucketCorrector>;
     using TModelFactoryPtr = std::shared_ptr<CModelFactory>;
     using TModelFactoryCPtr = std::shared_ptr<const CModelFactory>;
     using TFactoryTypeFactoryPtrMap = std::map<EFactoryType, TModelFactoryPtr>;
@@ -276,6 +278,8 @@ public:
     //! Set the number of buckets to delay finalizing out-of-phase buckets.
     void bucketResultsDelay(std::size_t delay);
 
+    //! Set the single interim bucket correction calculator.
+    void interimBucketCorrector(const TInterimBucketCorrectorPtr& interimBucketCorrector);
     //! Set whether multivariate analysis of correlated 'by' fields should
     //! be performed.
     void multivariateByFields(bool enabled);
@@ -369,6 +373,9 @@ public:
     //! Get the multiple bucket lengths.
     const TTimeVec& multipleBucketLengths() const;
 
+    //! Get the single interim bucket correction calculator.
+    const CInterimBucketCorrector& interimBucketCorrector() const;
+
     //! Should multivariate analysis of correlated 'by' fields be performed?
     bool multivariateByFields() const;
 
@@ -452,6 +459,9 @@ private:
 
     //! Should multivariate analysis of correlated 'by' fields be performed?
     bool m_MultivariateByFields;
+
+    //! The single interim bucket correction calculator.
+    TInterimBucketCorrectorPtr m_InterimBucketCorrector;
 
     //! The new model factories for each data type.
     TFactoryTypeFactoryPtrMap m_Factories;

--- a/include/model/CCountingModelFactory.h
+++ b/include/model/CCountingModelFactory.h
@@ -32,9 +32,10 @@ public:
     //! intended for unit testing and are not necessarily good defaults.
     //! The CModelConfig class is responsible for providing sensible
     //! default values for the factory for use within our products.
-    explicit CCountingModelFactory(const SModelParams& params,
-                                   model_t::ESummaryMode summaryMode = model_t::E_None,
-                                   const std::string& summaryCountFieldName = "");
+    CCountingModelFactory(const SModelParams& params,
+                          const TInterimBucketCorrectorWPtr& interimBucketCorrector,
+                          model_t::ESummaryMode summaryMode = model_t::E_None,
+                          const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
     virtual CCountingModelFactory* clone() const;

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -60,6 +60,7 @@ public:
     using TSizeFeatureDataPrVec = std::vector<TSizeFeatureDataPr>;
     using TFeatureSizeFeatureDataPrVecPr = std::pair<model_t::EFeature, TSizeFeatureDataPrVec>;
     using TFeatureSizeFeatureDataPrVecPrVec = std::vector<TFeatureSizeFeatureDataPrVecPr>;
+    using TInterimBucketCorrectorCPtr = std::shared_ptr<const CInterimBucketCorrector>;
     using TCategoryProbabilityCache = CModelTools::CCategoryProbabilityCache;
 
     //! The statistics we maintain about a bucketing interval.
@@ -70,8 +71,6 @@ public:
         core_t::TTime s_StartTime;
         //! The non-zero person counts in the current bucket.
         TSizeUInt64PrVec s_PersonCounts;
-        //! The total count in the current bucket.
-        uint64_t s_TotalCount;
         //! The feature data samples for the current bucketing interval.
         TFeatureSizeFeatureDataPrVecPrVec s_FeatureData;
         //! A cache of the corrections applied to interim results.
@@ -94,13 +93,16 @@ public:
     //! of seeing the people we are modeling.
     //! \param[in] influenceCalculators The influence calculators to use
     //! for each feature.
+    //! \param[in] interimBucketCorrector Calculates corrections for interim
+    //! buckets.
     CEventRateModel(const SModelParams& params,
                     const TDataGathererPtr& dataGatherer,
                     const TFeatureMathsModelPtrPrVec& newFeatureModels,
                     const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
                     const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
                     const maths::CMultinomialConjugate& probabilityPrior,
-                    const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators);
+                    const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+                    const TInterimBucketCorrectorCPtr& interimBucketCorrector);
 
     //! Constructor used for restoring persisted models.
     //!
@@ -112,6 +114,7 @@ public:
                     const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
                     const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
                     const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+                    const TInterimBucketCorrectorCPtr& interimBucketCorrector,
                     core::CStateRestoreTraverser& traverser);
 
     //! Create a copy that will result in the same persisted state as the
@@ -277,17 +280,14 @@ private:
     //! Get writable person counts in the current bucket.
     virtual TSizeUInt64PrVec& currentBucketPersonCounts();
 
-    //! Set the current bucket total count.
-    virtual void currentBucketTotalCount(uint64_t totalCount);
-
-    //! Get the total count of the current bucket.
-    uint64_t currentBucketTotalCount() const;
-
     //! Get the interim corrections of the current bucket.
     TFeatureSizeSizeTripleDouble1VecUMap& currentBucketInterimCorrections() const;
 
     //! Clear out large state objects for people that are pruned.
     virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+
+    //! Get the object which calculates corrections for interim buckets.
+    virtual const CInterimBucketCorrector& interimValueCorrector() const;
 
     //! Check if there are correlates for \p feature and the person
     //! identified by \p pid.
@@ -318,6 +318,9 @@ private:
     //! we are modeling (this captures information about the person
     //! rarity).
     maths::CMultinomialConjugate m_ProbabilityPrior;
+
+    //! Calculates corrections for interim buckets.
+    TInterimBucketCorrectorCPtr m_InterimBucketCorrector;
 
     //! A cache of the person probabilities as of the start of the
     //! for the bucketing interval.

--- a/include/model/CEventRateModelFactory.h
+++ b/include/model/CEventRateModelFactory.h
@@ -22,7 +22,7 @@ namespace model {
 //! This concrete factory implements the methods to make new models
 //! and data gatherers, and create default priors suitable for the
 //! CEventRateModel class.
-class MODEL_EXPORT CEventRateModelFactory : public CModelFactory {
+class MODEL_EXPORT CEventRateModelFactory final : public CModelFactory {
 public:
     //! Lift all overloads into scope.
     using CModelFactory::defaultMultivariatePrior;
@@ -33,9 +33,10 @@ public:
     //! intended for unit testing and are not necessarily good defaults.
     //! The CModelConfig class is responsible for providing sensible
     //! default values for the factory for use within our products.
-    explicit CEventRateModelFactory(const SModelParams& params,
-                                    model_t::ESummaryMode summaryMode = model_t::E_None,
-                                    const std::string& summaryCountFieldName = "");
+    CEventRateModelFactory(const SModelParams& params,
+                           const TInterimBucketCorrectorWPtr& interimBucketCorrector,
+                           model_t::ESummaryMode summaryMode = model_t::E_None,
+                           const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
     virtual CEventRateModelFactory* clone() const;
@@ -140,7 +141,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier;
+    int m_Identifier = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process
@@ -165,13 +166,13 @@ private:
     TStrVec m_InfluenceFieldNames;
 
     //! If true the models will process missing person fields.
-    bool m_UseNull;
+    bool m_UseNull = false;
 
     //! The count features which will be modeled.
     TFeatureVec m_Features;
 
     //! The bucket results delay.
-    std::size_t m_BucketResultsDelay;
+    std::size_t m_BucketResultsDelay = 0;
 
     //! A cached search key.
     mutable TOptionalSearchKey m_SearchKeyCache;

--- a/include/model/CEventRatePopulationModelFactory.h
+++ b/include/model/CEventRatePopulationModelFactory.h
@@ -22,7 +22,7 @@ namespace model {
 //! This concrete factory implements the methods to make new models
 //! and data gatherers, and create default priors suitable for the
 //! CEventRatePopulationModel class.
-class MODEL_EXPORT CEventRatePopulationModelFactory : public CModelFactory {
+class MODEL_EXPORT CEventRatePopulationModelFactory final : public CModelFactory {
 public:
     //! Lift all overloads into scope.
     using CModelFactory::defaultMultivariatePrior;
@@ -33,9 +33,10 @@ public:
     //! intended for unit testing and are not necessarily good defaults.
     //! The CModelConfig class is responsible for providing sensible
     //! default values for the factory for use within our products.
-    explicit CEventRatePopulationModelFactory(const SModelParams& params,
-                                              model_t::ESummaryMode summaryMode = model_t::E_None,
-                                              const std::string& summaryCountFieldName = "");
+    CEventRatePopulationModelFactory(const SModelParams& params,
+                                     const TInterimBucketCorrectorWPtr& interimBucketCorrector,
+                                     model_t::ESummaryMode summaryMode = model_t::E_None,
+                                     const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
     virtual CEventRatePopulationModelFactory* clone() const;
@@ -142,7 +143,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier;
+    int m_Identifier = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process.
@@ -173,13 +174,13 @@ private:
 
     //! If true the models will process missing person and attribute
     //! fields.
-    bool m_UseNull;
+    bool m_UseNull = false;
 
     //! The count features which will be modeled.
     TFeatureVec m_Features;
 
     //! The bucket results delay.
-    std::size_t m_BucketResultsDelay;
+    std::size_t m_BucketResultsDelay = 0;
 
     //! A cached search key.
     mutable TOptionalSearchKey m_SearchKeyCache;

--- a/include/model/CInterimBucketCorrector.h
+++ b/include/model/CInterimBucketCorrector.h
@@ -57,6 +57,9 @@ public:
     void finalBucketCount(core_t::TTime time, std::uint64_t bucketCount);
 
     //! Get an estimate of the current bucket completeness.
+    //!
+    //! \note This is a value between 0 and 1 with 0 representing an empty
+    //! bucket and 1 a bucket which is complete.
     double completeness() const;
 
     //! Calculates corrections for the \p value based on the given \p mode

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -57,6 +57,7 @@ public:
     using TSizeFeatureDataPrVec = std::vector<TSizeFeatureDataPr>;
     using TFeatureSizeFeatureDataPrVecPr = std::pair<model_t::EFeature, TSizeFeatureDataPrVec>;
     using TFeatureSizeFeatureDataPrVecPrVec = std::vector<TFeatureSizeFeatureDataPrVecPr>;
+    using TInterimBucketCorrectorCPtr = std::shared_ptr<const CInterimBucketCorrector>;
 
     //! The statistics we maintain about a bucketing interval.
     struct MODEL_EXPORT SBucketStats {
@@ -66,8 +67,6 @@ public:
         core_t::TTime s_StartTime;
         //! The non-zero person counts in the current bucket.
         TSizeUInt64PrVec s_PersonCounts;
-        //! The total count in the current bucket.
-        uint64_t s_TotalCount;
         //! The feature data samples for the current bucketing interval.
         TFeatureSizeFeatureDataPrVecPrVec s_FeatureData;
         //! A cache of the corrections applied to interim results.
@@ -88,12 +87,15 @@ public:
     //! each feature.
     //! \param[in] influenceCalculators The influence calculators to use
     //! for each feature.
+    //! \param[in] interimBucketCorrector Calculates corrections for interim
+    //! buckets.
     CMetricModel(const SModelParams& params,
                  const TDataGathererPtr& dataGatherer,
                  const TFeatureMathsModelPtrPrVec& newFeatureModels,
                  const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
                  const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
-                 const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators);
+                 const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+                 const TInterimBucketCorrectorCPtr& interimBucketCorrector);
 
     //! Constructor used for restoring persisted models.
     //!
@@ -105,6 +107,7 @@ public:
                  const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
                  const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
                  const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+                 const TInterimBucketCorrectorCPtr& interimBucketCorrector,
                  core::CStateRestoreTraverser& traverser);
 
     //! Create a copy that will result in the same persisted state as the
@@ -270,9 +273,6 @@ private:
     //! Set the start time of the current bucket.
     virtual void currentBucketStartTime(core_t::TTime time);
 
-    //! Get the total count of the current bucket.
-    uint64_t currentBucketTotalCount() const;
-
     //! Get the interim corrections of the current bucket.
     TFeatureSizeSizeTripleDouble1VecUMap& currentBucketInterimCorrections() const;
 
@@ -282,11 +282,11 @@ private:
     //! Get writable person counts in the current bucket.
     virtual TSizeUInt64PrVec& currentBucketPersonCounts();
 
-    //! Set the current bucket total count.
-    virtual void currentBucketTotalCount(uint64_t totalCount);
-
     //! Clear out large state objects for people that are pruned.
     virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+
+    //! Get the object which calculates corrections for interim buckets.
+    virtual const CInterimBucketCorrector& interimValueCorrector() const;
 
     //! Check if there are correlates for \p feature and the person
     //! identified by \p pid.
@@ -312,6 +312,9 @@ private:
 private:
     //! The statistics we maintain about the bucket.
     SBucketStats m_CurrentBucketStats;
+
+    //! Calculates corrections for interim buckets.
+    TInterimBucketCorrectorCPtr m_InterimBucketCorrector;
 
     friend class CMetricModelDetailsView;
     friend class ::CMockMetricModel;

--- a/include/model/CMetricModelFactory.h
+++ b/include/model/CMetricModelFactory.h
@@ -22,7 +22,7 @@ namespace model {
 //! This concrete factory implements the methods to make new models
 //! and data gatherers, and create default priors suitable for the
 //! CMetricModel class.
-class MODEL_EXPORT CMetricModelFactory : public CModelFactory {
+class MODEL_EXPORT CMetricModelFactory final : public CModelFactory {
 public:
     //! Lift all overloads into scope.
     using CModelFactory::defaultMultivariatePrior;
@@ -33,9 +33,10 @@ public:
     //! intended for unit testing and are not necessarily good defaults.
     //! The CModelConfig class is responsible for providing sensible
     //! default values for the factory for use within our products.
-    explicit CMetricModelFactory(const SModelParams& params,
-                                 model_t::ESummaryMode summaryMode = model_t::E_None,
-                                 const std::string& summaryCountFieldName = "");
+    CMetricModelFactory(const SModelParams& params,
+                        const TInterimBucketCorrectorWPtr& interimBucketCorrector,
+                        model_t::ESummaryMode summaryMode = model_t::E_None,
+                        const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
     virtual CMetricModelFactory* clone() const;
@@ -143,7 +144,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier;
+    int m_Identifier = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process.
@@ -170,7 +171,7 @@ private:
     TStrVec m_InfluenceFieldNames;
 
     //! If true the models will process missing person fields.
-    bool m_UseNull;
+    bool m_UseNull = false;
 
     //! The count features which will be modeled.
     TFeatureVec m_Features;
@@ -179,7 +180,7 @@ private:
     core_t::TTime m_BucketLength;
 
     //! The bucket results delay.
-    std::size_t m_BucketResultsDelay;
+    std::size_t m_BucketResultsDelay = 0;
 
     //! A cached search key.
     mutable TOptionalSearchKey m_SearchKeyCache;

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -64,6 +64,7 @@ public:
     using TSizeSizePrFeatureDataPrVec = std::vector<TSizeSizePrFeatureDataPr>;
     using TFeatureSizeSizePrFeatureDataPrVecMap =
         std::map<model_t::EFeature, TSizeSizePrFeatureDataPrVec>;
+    using TInterimBucketCorrectorCPtr = std::shared_ptr<const CInterimBucketCorrector>;
     using TProbabilityCache = CModelTools::CProbabilityCache;
 
     //! The statistics we maintain about a bucketing interval.
@@ -75,8 +76,6 @@ public:
         //! The non-zero counts of messages by people in the bucketing
         //! interval.
         TSizeUInt64PrVec s_PersonCounts;
-        //! The total count in the current bucket.
-        uint64_t s_TotalCount;
         //! The metric features we are modeling.
         TFeatureSizeSizePrFeatureDataPrVecMap s_FeatureData;
         //! A cache of the corrections applied to interim results.
@@ -104,6 +103,8 @@ public:
     //! each feature.
     //! \param[in] influenceCalculators The influence calculators to use
     //! for each feature.
+    //! \param[in] interimBucketCorrector Calculates corrections for interim
+    //! buckets.
     //! \note The current bucket statistics are left default initialized
     //! and so must be sampled for before this model can be used.
     CMetricPopulationModel(const SModelParams& params,
@@ -111,7 +112,8 @@ public:
                            const TFeatureMathsModelPtrPrVec& newFeatureModels,
                            const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
                            const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
-                           const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators);
+                           const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+                           const TInterimBucketCorrectorCPtr& interimBucketCorrector);
 
     //! Constructor used for restoring persisted models.
     //!
@@ -123,6 +125,7 @@ public:
                            const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
                            const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
                            const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+                           const TInterimBucketCorrectorCPtr& interimBucketCorrector,
                            core::CStateRestoreTraverser& traverser);
 
     //! Create a copy that will result in the same persisted state as the
@@ -292,12 +295,6 @@ private:
     //! Set the start time of the current bucket.
     virtual void currentBucketStartTime(core_t::TTime time);
 
-    //! Get the total count of the current bucket.
-    uint64_t currentBucketTotalCount() const;
-
-    //! Set the current bucket total count.
-    virtual void currentBucketTotalCount(uint64_t totalCount);
-
     //! Get the current bucket person counts.
     virtual const TSizeUInt64PrVec& personCounts() const;
 
@@ -317,6 +314,9 @@ private:
 
     //! Clear out large state objects for people/attributes that are pruned
     virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+
+    //! Get the object which calculates corrections for interim buckets.
+    virtual const CInterimBucketCorrector& interimValueCorrector() const;
 
     //! Skip sampling the interval \p endTime - \p startTime.
     virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime);
@@ -358,6 +358,9 @@ private:
 
     //! The population attribute models for each feature.
     TFeatureModelsVec m_FeatureModels;
+
+    //! Calculates corrections for interim buckets.
+    TInterimBucketCorrectorCPtr m_InterimBucketCorrector;
 
     //! A cache of the probability calculation results.
     mutable TProbabilityCache m_Probabilities;

--- a/include/model/CMetricPopulationModelFactory.h
+++ b/include/model/CMetricPopulationModelFactory.h
@@ -22,7 +22,7 @@ namespace model {
 //! This concrete factory implements the methods to make new models
 //! and data gatherers, and create default priors suitable for the
 //! CMetricPopulationModel class.
-class MODEL_EXPORT CMetricPopulationModelFactory : public CModelFactory {
+class MODEL_EXPORT CMetricPopulationModelFactory final : public CModelFactory {
 public:
     //! Lift all overloads into scope.
     using CModelFactory::defaultMultivariatePrior;
@@ -33,9 +33,10 @@ public:
     //! intended for unit testing and are not necessarily good defaults.
     //! The CModelConfig class is responsible for providing sensible
     //! default values for the factory for use within our products.
-    explicit CMetricPopulationModelFactory(const SModelParams& params,
-                                           model_t::ESummaryMode summaryMode = model_t::E_None,
-                                           const std::string& summaryCountFieldName = "");
+    CMetricPopulationModelFactory(const SModelParams& params,
+                                  const TInterimBucketCorrectorWPtr& interimBucketCorrector,
+                                  model_t::ESummaryMode summaryMode = model_t::E_None,
+                                  const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
     virtual CMetricPopulationModelFactory* clone() const;
@@ -147,7 +148,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier;
+    int m_Identifier = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process
@@ -179,13 +180,13 @@ private:
 
     //! If true the models will process missing person and attribute
     //! fields.
-    bool m_UseNull;
+    bool m_UseNull = false;
 
     //! The count features which will be modeled.
     TFeatureVec m_Features;
 
     //! The bucket results delay.
-    std::size_t m_BucketResultsDelay;
+    std::size_t m_BucketResultsDelay = 0;
 
     //! A cached search key.
     mutable TOptionalSearchKey m_SearchKeyCache;

--- a/include/model/CModelFactory.h
+++ b/include/model/CModelFactory.h
@@ -46,6 +46,7 @@ class CAnomalyDetectorModel;
 class CDataGatherer;
 class CDetectionRule;
 class CInfluenceCalculator;
+class CInterimBucketCorrector;
 class CSearchKey;
 
 //! \brief A factory class interface for the CAnomalyDetectorModel hierarchy.
@@ -91,6 +92,8 @@ public:
     using TFeatureInfluenceCalculatorCPtrPrVec = std::vector<TFeatureInfluenceCalculatorCPtrPr>;
     using TFeatureInfluenceCalculatorCPtrPrVecVec =
         std::vector<TFeatureInfluenceCalculatorCPtrPrVec>;
+    using TInterimBucketCorrectorWPtr = std::weak_ptr<CInterimBucketCorrector>;
+    using TInterimBucketCorrectorPtr = std::shared_ptr<CInterimBucketCorrector>;
     using TDetectionRuleVec = std::vector<CDetectionRule>;
     using TDetectionRuleVecCRef = boost::reference_wrapper<const TDetectionRuleVec>;
     using TStrDetectionRulePr = std::pair<std::string, model::CDetectionRule>;
@@ -105,7 +108,7 @@ public:
     //! need to change the signature of every factory function each
     //! time we need extra data to initialize a model.
     struct MODEL_EXPORT SModelInitializationData {
-        explicit SModelInitializationData(const TDataGathererPtr& dataGatherer);
+        SModelInitializationData(const TDataGathererPtr& dataGatherer);
 
         TDataGathererPtr s_DataGatherer;
     };
@@ -121,7 +124,7 @@ public:
                                     const std::string& partitionFieldValue,
                                     unsigned int sampleOverrideCount = 0u);
 
-        //! This constructor is meant to simplify unit tests
+        //! This constructor to simplify unit tests.
         SGathererInitializationData(const core_t::TTime startTime);
 
         core_t::TTime s_StartTime;
@@ -133,7 +136,8 @@ public:
     static const std::string EMPTY_STRING;
 
 public:
-    CModelFactory(const SModelParams& params);
+    CModelFactory(const SModelParams& params,
+                  const TInterimBucketCorrectorWPtr& interimBucketCorrector);
     virtual ~CModelFactory() = default;
 
     //! Create a copy of the factory owned by the calling code.
@@ -290,8 +294,11 @@ public:
     void detectionRules(TDetectionRuleVecCRef detectionRules);
     //@}
 
-    //! Set the scheduled events
+    //! Set the scheduled events.
     void scheduledEvents(TStrDetectionRulePrVecCRef scheduledEvents);
+
+    //! Set the interim bucket corrector.
+    void interimBucketCorrector(const TInterimBucketCorrectorWPtr& interimBucketCorrector);
 
     //! \name Customization by mlmodel.conf
     //@{
@@ -359,6 +366,9 @@ protected:
     //! \note This only swaps the state held on this base class.
     void swap(CModelFactory& other);
 
+    //! Get the singleton interim bucket correction calculator.
+    TInterimBucketCorrectorPtr interimBucketCorrector() const;
+
     //! Get a multivariate normal prior with dimension \p dimension.
     //!
     //! \param[in] dimension The dimension.
@@ -416,6 +426,12 @@ private:
 private:
     //! The global model configuration parameters.
     SModelParams m_ModelParams;
+
+    //! A reference to the singleton interim bucket correction calculator.
+    //!
+    //! \note That this is stored by weak pointer since we don't want this
+    //! to update the reference count or our memory accounting will be wrong.
+    TInterimBucketCorrectorWPtr m_InterimBucketCorrector;
 
     //! A cache of models for collections of features.
     mutable TFeatureVecMathsModelMap m_MathsModelCache;

--- a/include/model/CModelFactory.h
+++ b/include/model/CModelFactory.h
@@ -124,7 +124,7 @@ public:
                                     const std::string& partitionFieldValue,
                                     unsigned int sampleOverrideCount = 0u);
 
-        //! This constructor to simplify unit tests.
+        //! This constructor is to simplify unit testing.
         SGathererInitializationData(const core_t::TTime startTime);
 
         core_t::TTime s_StartTime;

--- a/include/model/CModelFactory.h
+++ b/include/model/CModelFactory.h
@@ -136,6 +136,9 @@ public:
     static const std::string EMPTY_STRING;
 
 public:
+    //! \warning The user must ensure that \p interimBucketCorrector
+    //! outlives this object. If model factories are obtained from
+    //! CModelConfig this is ensured for you.
     CModelFactory(const SModelParams& params,
                   const TInterimBucketCorrectorWPtr& interimBucketCorrector);
     virtual ~CModelFactory() = default;
@@ -298,6 +301,10 @@ public:
     void scheduledEvents(TStrDetectionRulePrVecCRef scheduledEvents);
 
     //! Set the interim bucket corrector.
+    //!
+    //! \warning The caller must ensure that \p interimBucketCorrector
+    //! outlives this object. If model factories are obtained from
+    //! CModelConfig this is ensured for you.
     void interimBucketCorrector(const TInterimBucketCorrectorWPtr& interimBucketCorrector);
 
     //! \name Customization by mlmodel.conf
@@ -429,8 +436,11 @@ private:
 
     //! A reference to the singleton interim bucket correction calculator.
     //!
-    //! \note That this is stored by weak pointer since we don't want this
-    //! to update the reference count or our memory accounting will be wrong.
+    //! \note It is the responsibility of the user of the factory class
+    //! to ensure that the interim bucket corrector is not deleted whilst
+    //! still in use. We store it here by weak pointer since we don't want
+    //! this to update the reference count so we properly account for its
+    //! memory usage in the objects this creates.
     TInterimBucketCorrectorWPtr m_InterimBucketCorrector;
 
     //! A cache of models for collections of features.

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -72,6 +72,7 @@ const std::string HIERARCHICAL_RESULTS_TAG("f");
 const std::string LATEST_RECORD_TIME_TAG("h");
 const std::string MODEL_PLOT_TAG("i");
 const std::string LAST_RESULTS_TIME_TAG("j");
+const std::string INTERIM_BUCKET_CORRECTOR_TAG("k");
 
 //! The minimum version required to read the state corresponding to a model snapshot.
 //! This should be updated every time there is a breaking change to the model state.
@@ -873,7 +874,18 @@ bool CAnomalyJob::restoreState(core::CStateRestoreTraverser& traverser,
 
     while (traverser.next()) {
         const std::string& name = traverser.name();
-        if (name == TOP_LEVEL_DETECTOR_TAG) {
+        if (name == INTERIM_BUCKET_CORRECTOR_TAG) {
+            // Note that this has to be persisted and restored before any detectors.
+            auto interimBucketCorrector = std::make_shared<model::CInterimBucketCorrector>(
+                m_ModelConfig.bucketLength());
+            if (traverser.traverseSubLevel(
+                    boost::bind(&model::CInterimBucketCorrector::acceptRestoreTraverser,
+                                interimBucketCorrector.get(), _1)) == false) {
+                LOG_ERROR(<< "Cannot restore interim bucket corrector");
+                return false;
+            }
+            m_ModelConfig.interimBucketCorrector(interimBucketCorrector);
+        } else if (name == TOP_LEVEL_DETECTOR_TAG) {
             if (traverser.traverseSubLevel(boost::bind(
                     &CAnomalyJob::restoreSingleDetector, this, _1)) == false) {
                 LOG_ERROR(<< "Cannot restore anomaly detector");
@@ -990,8 +1002,7 @@ bool CAnomalyJob::restoreDetectorState(const model::CSearchKey& key,
                              key, partitionFieldValue, m_Limits.resourceMonitor());
     if (!detector) {
         LOG_ERROR(<< "Detector with key '" << key.debug() << '/' << partitionFieldValue
-                  << "' "
-                     "was not recreated on restore - "
+                  << "' was not recreated on restore - "
                      "memory limit is too low to continue this job");
 
         m_RestoredStateDetail.s_RestoredStateStatus = E_MemoryLimitReached;
@@ -1042,7 +1053,8 @@ bool CAnomalyJob::persistState(core::CDataAdder& persister) {
         m_ModelPlotQueue, m_LastFinalisedBucketEndTime, detectors,
         m_Limits.resourceMonitor().createMemoryUsageReport(
             m_LastFinalisedBucketEndTime - m_ModelConfig.bucketLength()),
-        m_Aggregator, normaliserState, m_LatestRecordTime, m_LastResultsTime, persister);
+        m_ModelConfig.interimBucketCorrector(), m_Aggregator, normaliserState,
+        m_LatestRecordTime, m_LastResultsTime, persister);
 }
 
 bool CAnomalyJob::backgroundPersistState(CBackgroundPersister& backgroundPersister) {
@@ -1056,7 +1068,8 @@ bool CAnomalyJob::backgroundPersistState(CBackgroundPersister& backgroundPersist
         m_ResultsQueue, m_ModelPlotQueue, m_LastFinalisedBucketEndTime,
         m_Limits.resourceMonitor().createMemoryUsageReport(
             m_LastFinalisedBucketEndTime - m_ModelConfig.bucketLength()),
-        m_Aggregator, m_LatestRecordTime, m_LastResultsTime);
+        m_ModelConfig.interimBucketCorrector(), m_Aggregator,
+        m_LatestRecordTime, m_LastResultsTime);
 
     // The normaliser is non-copyable, so we have to make do with JSONifying it now;
     // it should be relatively fast though
@@ -1101,11 +1114,11 @@ bool CAnomalyJob::runBackgroundPersist(TBackgroundPersistArgsPtr args,
         return false;
     }
 
-    return this->persistState("Periodic background persist at ", args->s_ResultsQueue,
-                              args->s_ModelPlotQueue, args->s_Time, args->s_Detectors,
-                              args->s_ModelSizeStats, args->s_Aggregator,
-                              args->s_NormalizerState, args->s_LatestRecordTime,
-                              args->s_LastResultsTime, persister);
+    return this->persistState(
+        "Periodic background persist at ", args->s_ResultsQueue,
+        args->s_ModelPlotQueue, args->s_Time, args->s_Detectors, args->s_ModelSizeStats,
+        args->s_InterimBucketCorrector, args->s_Aggregator, args->s_NormalizerState,
+        args->s_LatestRecordTime, args->s_LastResultsTime, persister);
 }
 
 bool CAnomalyJob::persistState(const std::string& descriptionPrefix,
@@ -1114,6 +1127,7 @@ bool CAnomalyJob::persistState(const std::string& descriptionPrefix,
                                core_t::TTime lastFinalisedBucketEnd,
                                const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
                                const model::CResourceMonitor::SResults& modelSizeStats,
+                               const model::CInterimBucketCorrector& interimBucketCorrector,
                                const model::CHierarchicalResultsAggregator& aggregator,
                                const std::string& normalizerState,
                                core_t::TTime latestRecordTime,
@@ -1146,6 +1160,10 @@ bool CAnomalyJob::persistState(const std::string& descriptionPrefix,
                 if (modelPlotQueue.size() > 1) {
                     core::CPersistUtils::persist(MODEL_PLOT_TAG, modelPlotQueue, inserter);
                 }
+
+                inserter.insertLevel(INTERIM_BUCKET_CORRECTOR_TAG,
+                                     boost::bind(&model::CInterimBucketCorrector::acceptPersistInserter,
+                                                 &interimBucketCorrector, _1));
 
                 for (const auto& detector_ : detectors) {
                     const model::CAnomalyDetector* detector(detector_.second.get());
@@ -1489,11 +1507,13 @@ CAnomalyJob::SBackgroundPersistArgs::SBackgroundPersistArgs(
     const TModelPlotDataVecQueue& modelPlotQueue,
     core_t::TTime time,
     const model::CResourceMonitor::SResults& modelSizeStats,
+    const model::CInterimBucketCorrector& interimBucketCorrector,
     const model::CHierarchicalResultsAggregator& aggregator,
     core_t::TTime latestRecordTime,
     core_t::TTime lastResultsTime)
     : s_ResultsQueue(resultsQueue), s_ModelPlotQueue(modelPlotQueue),
-      s_Time(time), s_ModelSizeStats(modelSizeStats), s_Aggregator(aggregator),
+      s_Time(time), s_ModelSizeStats(modelSizeStats),
+      s_InterimBucketCorrector(interimBucketCorrector), s_Aggregator(aggregator),
       s_LatestRecordTime(latestRecordTime), s_LastResultsTime(lastResultsTime) {
 }
 }

--- a/lib/api/unittest/CAnomalyJobLimitTest.h
+++ b/lib/api/unittest/CAnomalyJobLimitTest.h
@@ -12,6 +12,7 @@ class CAnomalyJobLimitTest : public CppUnit::TestFixture {
 public:
     void testLimit();
     void testAccuracy();
+    void testModelledEntityCountForFixedMemoryLimit();
 
     static CppUnit::Test* suite();
 };

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -301,7 +301,6 @@ const std::string MOMENTS_6_3_TAG{"i"};
 const std::string MOMENTS_MINUS_TREND_6_3_TAG{"j"};
 const std::string USING_TREND_FOR_PREDICTION_6_3_TAG{"k"};
 const std::string GAIN_CONTROLLER_6_3_TAG{"l"};
-
 // Version < 6.3
 const std::string COMPONENTS_MACHINE_OLD_TAG{"a"};
 const std::string TREND_OLD_TAG{"b"};

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -81,8 +81,7 @@ CAnomalyDetectorModel::CAnomalyDetectorModel(const SModelParams& params,
                                              const TDataGathererPtr& dataGatherer,
                                              const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators)
     : m_Params(params), m_DataGatherer(dataGatherer), m_BucketCount(0.0),
-      m_InfluenceCalculators(influenceCalculators),
-      m_InterimBucketCorrector(new CInterimBucketCorrector(dataGatherer->bucketLength())) {
+      m_InfluenceCalculators(influenceCalculators) {
     if (!m_DataGatherer) {
         LOG_ABORT(<< "Must provide a data gatherer");
     }
@@ -101,8 +100,7 @@ CAnomalyDetectorModel::CAnomalyDetectorModel(bool isForPersistence,
       // data gatherer that are invariant.
       m_Params(other.m_Params), m_DataGatherer(other.m_DataGatherer),
       m_PersonBucketCounts(other.m_PersonBucketCounts),
-      m_BucketCount(other.m_BucketCount), m_InfluenceCalculators(),
-      m_InterimBucketCorrector(new CInterimBucketCorrector(*other.m_InterimBucketCorrector)) {
+      m_BucketCount(other.m_BucketCount) {
     if (!isForPersistence) {
         LOG_ABORT(<< "This constructor only creates clones for persistence");
     }
@@ -175,21 +173,6 @@ std::string CAnomalyDetectorModel::printAttributes(const TSizeVec& cids,
     return result;
 }
 
-void CAnomalyDetectorModel::sampleBucketStatistics(core_t::TTime startTime,
-                                                   core_t::TTime endTime,
-                                                   CResourceMonitor& /*resourceMonitor*/) {
-    const CDataGatherer& gatherer{this->dataGatherer()};
-    core_t::TTime bucketLength{this->bucketLength()};
-    for (core_t::TTime time = startTime; time < endTime; time += bucketLength) {
-        const auto& counts = gatherer.bucketCounts(time);
-        std::size_t totalBucketCount{0u};
-        for (const auto& count : counts) {
-            totalBucketCount += CDataGatherer::extractData(count);
-        }
-        this->currentBucketTotalCount(totalBucketCount);
-    }
-}
-
 void CAnomalyDetectorModel::sample(core_t::TTime startTime,
                                    core_t::TTime endTime,
                                    CResourceMonitor& /*resourceMonitor*/) {
@@ -200,7 +183,6 @@ void CAnomalyDetectorModel::sample(core_t::TTime startTime,
     core_t::TTime bucketLength{this->bucketLength()};
     for (core_t::TTime time = startTime; time < endTime; time += bucketLength) {
         const auto& counts = gatherer.bucketCounts(time);
-        std::size_t totalBucketCount{0u};
 
         TSizeUSet uniquePeople;
         for (const auto& count : counts) {
@@ -208,11 +190,8 @@ void CAnomalyDetectorModel::sample(core_t::TTime startTime,
             if (uniquePeople.insert(pid).second) {
                 m_PersonBucketCounts[pid] += 1.0;
             }
-            totalBucketCount += CDataGatherer::extractData(count);
         }
 
-        m_InterimBucketCorrector->update(time, totalBucketCount);
-        this->currentBucketTotalCount(totalBucketCount);
         m_BucketCount += 1.0;
 
         double alpha{std::exp(-this->params().s_DecayRate)};
@@ -329,8 +308,6 @@ void CAnomalyDetectorModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr
     core::CMemoryDebug::dynamicSize("m_Params", m_Params, mem);
     core::CMemoryDebug::dynamicSize("m_PersonBucketCounts", m_PersonBucketCounts, mem);
     core::CMemoryDebug::dynamicSize("m_InfluenceCalculators", m_InfluenceCalculators, mem);
-    core::CMemoryDebug::dynamicSize("m_InterimBucketCorrector",
-                                    m_InterimBucketCorrector, mem);
 }
 
 std::size_t CAnomalyDetectorModel::memoryUsage() const {
@@ -338,7 +315,6 @@ std::size_t CAnomalyDetectorModel::memoryUsage() const {
     mem += core::CMemory::dynamicSize(m_DataGatherer);
     mem += core::CMemory::dynamicSize(m_PersonBucketCounts);
     mem += core::CMemory::dynamicSize(m_InfluenceCalculators);
-    mem += core::CMemory::dynamicSize(m_InterimBucketCorrector);
     return mem;
 }
 
@@ -458,10 +434,6 @@ void CAnomalyDetectorModel::updateRecycledModels() {
     people.clear();
 }
 
-const CInterimBucketCorrector& CAnomalyDetectorModel::interimValueCorrector() const {
-    return *m_InterimBucketCorrector;
-}
-
 bool CAnomalyDetectorModel::shouldIgnoreResult(model_t::EFeature feature,
                                                const model_t::CResultType& resultType,
                                                std::size_t pid,
@@ -490,22 +462,6 @@ bool CAnomalyDetectorModel::shouldIgnoreSample(model_t::EFeature feature,
                    SKIP_SAMPLING_RESULT_TYPE, pid, cid, time);
 
     return shouldIgnore;
-}
-
-bool CAnomalyDetectorModel::interimBucketCorrectorAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    if (traverser.traverseSubLevel(boost::bind(&CInterimBucketCorrector::acceptRestoreTraverser,
-                                               m_InterimBucketCorrector.get(), _1)) == false) {
-        LOG_ERROR(<< "Invalid interim bucket corrector");
-        return false;
-    }
-    return true;
-}
-
-void CAnomalyDetectorModel::interimBucketCorrectorAcceptPersistInserter(
-    const std::string& tag,
-    core::CStatePersistInserter& inserter) const {
-    inserter.insertLevel(tag, boost::bind(&CInterimBucketCorrector::acceptPersistInserter,
-                                          m_InterimBucketCorrector.get(), _1));
 }
 
 const CAnomalyDetectorModel::TStr1Vec&

--- a/lib/model/CCountingModelFactory.cc
+++ b/lib/model/CCountingModelFactory.cc
@@ -21,11 +21,12 @@ namespace ml {
 namespace model {
 
 CCountingModelFactory::CCountingModelFactory(const SModelParams& params,
+                                             const TInterimBucketCorrectorWPtr& interimBucketCorrector,
                                              model_t::ESummaryMode summaryMode,
                                              const std::string& summaryCountFieldName)
-    : CModelFactory(params), m_Identifier(), m_SummaryMode(summaryMode),
-      m_SummaryCountFieldName(summaryCountFieldName), m_UseNull(false),
-      m_BucketResultsDelay(0) {
+    : CModelFactory(params, interimBucketCorrector), m_Identifier(),
+      m_SummaryMode(summaryMode), m_SummaryCountFieldName(summaryCountFieldName),
+      m_UseNull(false), m_BucketResultsDelay(0) {
 }
 
 CCountingModelFactory* CCountingModelFactory::clone() const {
@@ -39,7 +40,8 @@ CCountingModelFactory::makeModel(const SModelInitializationData& initData) const
         LOG_ERROR(<< "NULL data gatherer");
         return nullptr;
     }
-    return new CCountingModel(this->modelParams(), dataGatherer);
+    return new CCountingModel(this->modelParams(), dataGatherer,
+                              this->interimBucketCorrector());
 }
 
 CAnomalyDetectorModel*
@@ -50,7 +52,8 @@ CCountingModelFactory::makeModel(const SModelInitializationData& initData,
         LOG_ERROR(<< "NULL data gatherer");
         return nullptr;
     }
-    return new CCountingModel(this->modelParams(), dataGatherer, traverser);
+    return new CCountingModel(this->modelParams(), dataGatherer,
+                              this->interimBucketCorrector(), traverser);
 }
 
 CDataGatherer*

--- a/lib/model/CEventRateModelFactory.cc
+++ b/lib/model/CEventRateModelFactory.cc
@@ -29,11 +29,11 @@ namespace ml {
 namespace model {
 
 CEventRateModelFactory::CEventRateModelFactory(const SModelParams& params,
+                                               const TInterimBucketCorrectorWPtr& interimBucketCorrector,
                                                model_t::ESummaryMode summaryMode,
                                                const std::string& summaryCountFieldName)
-    : CModelFactory(params), m_Identifier(), m_SummaryMode(summaryMode),
-      m_SummaryCountFieldName(summaryCountFieldName), m_UseNull(false),
-      m_BucketResultsDelay(0) {
+    : CModelFactory(params, interimBucketCorrector), m_SummaryMode(summaryMode),
+      m_SummaryCountFieldName(summaryCountFieldName) {
 }
 
 CEventRateModelFactory* CEventRateModelFactory::clone() const {
@@ -59,8 +59,9 @@ CEventRateModelFactory::makeModel(const SModelInitializationData& initData) cons
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(),
                                    this->minimumSeasonalVarianceScale(), true),
-        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
-        this->defaultCategoricalPrior(), influenceCalculators);
+        this->defaultCorrelatePriors(features),
+        this->defaultCorrelates(features), this->defaultCategoricalPrior(),
+        influenceCalculators, this->interimBucketCorrector());
 }
 
 CAnomalyDetectorModel*
@@ -82,8 +83,8 @@ CEventRateModelFactory::makeModel(const SModelInitializationData& initData,
     return new CEventRateModel(
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(), 0.4, true),
-        this->defaultCorrelatePriors(features),
-        this->defaultCorrelates(features), influenceCalculators, traverser);
+        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
+        influenceCalculators, this->interimBucketCorrector(), traverser);
 }
 
 CDataGatherer*

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -73,7 +73,8 @@ CEventRatePopulationModel::CEventRatePopulationModel(
     const TFeatureMathsModelPtrPrVec& newFeatureModels,
     const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
     const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
-    const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators)
+    const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+    const TInterimBucketCorrectorCPtr& interimBucketCorrector)
     : CPopulationModel(params, dataGatherer, influenceCalculators),
       m_CurrentBucketStats(dataGatherer->currentBucketStartTime() -
                            dataGatherer->bucketLength()),
@@ -83,7 +84,7 @@ CEventRatePopulationModel::CEventRatePopulationModel(
       m_AttributeProbabilityPrior(maths::CMultinomialConjugate::nonInformativePrior(
           boost::numeric::bounds<int>::highest(),
           params.s_DecayRate)),
-      m_Probabilities(0.05) {
+      m_InterimBucketCorrector(interimBucketCorrector), m_Probabilities(0.05) {
     this->initialize(newFeatureModels, newFeatureCorrelateModelPriors, featureCorrelatesModels);
 }
 
@@ -94,11 +95,12 @@ CEventRatePopulationModel::CEventRatePopulationModel(
     const TFeatureMultivariatePriorPtrPrVec& newFeatureCorrelateModelPriors,
     const TFeatureCorrelationsPtrPrVec& featureCorrelatesModels,
     const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators,
+    const TInterimBucketCorrectorCPtr& interimBucketCorrector,
     core::CStateRestoreTraverser& traverser)
     : CPopulationModel(params, dataGatherer, influenceCalculators),
       m_CurrentBucketStats(dataGatherer->currentBucketStartTime() -
                            dataGatherer->bucketLength()),
-      m_Probabilities(0.05) {
+      m_InterimBucketCorrector(interimBucketCorrector), m_Probabilities(0.05) {
     this->initialize(newFeatureModels, newFeatureCorrelateModelPriors, featureCorrelatesModels);
     traverser.traverseSubLevel(
         boost::bind(&CEventRatePopulationModel::acceptRestoreTraverser, this, _1));
@@ -305,9 +307,6 @@ void CEventRatePopulationModel::sampleBucketStatistics(core_t::TTime startTime,
     this->currentBucketInterimCorrections().clear();
 
     for (core_t::TTime time = startTime; time < endTime; time += bucketLength) {
-        this->CAnomalyDetectorModel::sampleBucketStatistics(time, time + bucketLength,
-                                                            resourceMonitor);
-
         // Currently, we only remember one bucket.
         m_CurrentBucketStats.s_StartTime = time;
         TSizeUInt64PrVec& personCounts = m_CurrentBucketStats.s_PersonCounts;
@@ -810,6 +809,8 @@ void CEventRatePopulationModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsag
     core::CMemoryDebug::dynamicSize("m_FeatureModels", m_FeatureModels, mem);
     core::CMemoryDebug::dynamicSize("m_FeatureCorrelatesModels",
                                     m_FeatureCorrelatesModels, mem);
+    core::CMemoryDebug::dynamicSize("m_InterimBucketCorrector",
+                                    m_InterimBucketCorrector, mem);
     core::CMemoryDebug::dynamicSize("m_MemoryEstimator", m_MemoryEstimator, mem);
 }
 
@@ -831,6 +832,7 @@ std::size_t CEventRatePopulationModel::computeMemoryUsage() const {
     mem += core::CMemory::dynamicSize(m_AttributeProbabilityPrior);
     mem += core::CMemory::dynamicSize(m_FeatureModels);
     mem += core::CMemory::dynamicSize(m_FeatureCorrelatesModels);
+    mem += core::CMemory::dynamicSize(m_InterimBucketCorrector);
     mem += core::CMemory::dynamicSize(m_MemoryEstimator);
     return mem;
 }
@@ -866,14 +868,6 @@ core_t::TTime CEventRatePopulationModel::currentBucketStartTime() const {
 
 void CEventRatePopulationModel::currentBucketStartTime(core_t::TTime startTime) {
     m_CurrentBucketStats.s_StartTime = startTime;
-}
-
-void CEventRatePopulationModel::currentBucketTotalCount(uint64_t totalCount) {
-    m_CurrentBucketStats.s_TotalCount = totalCount;
-}
-
-uint64_t CEventRatePopulationModel::currentBucketTotalCount() const {
-    return m_CurrentBucketStats.s_TotalCount;
 }
 
 const CEventRatePopulationModel::TSizeUInt64PrVec&
@@ -948,6 +942,10 @@ void CEventRatePopulationModel::clearPrunedResources(const TSizeVec& /*people*/,
     }
 }
 
+const CInterimBucketCorrector& CEventRatePopulationModel::interimValueCorrector() const {
+    return *m_InterimBucketCorrector;
+}
+
 void CEventRatePopulationModel::doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) {
     core_t::TTime gap = endTime - startTime;
     for (auto& feature : m_FeatureModels) {
@@ -1014,12 +1012,11 @@ void CEventRatePopulationModel::fill(model_t::EFeature feature,
     params.s_Feature = feature;
     params.s_Model = model;
     params.s_ElapsedTime = bucketTime - this->attributeFirstBucketTimes()[cid];
-    params.s_Time.assign(1, TTime2Vec{time});
-    params.s_Value.assign(1, TDouble2Vec{value});
+    params.s_Time.assign(1, {time});
+    params.s_Value.assign(1, {value});
     if (interim && model_t::requiresInterimResultAdjustment(feature)) {
         double mode{params.s_Model->mode(time, weight)[0]};
-        TDouble2Vec correction{this->interimValueCorrector().corrections(
-            time, this->currentBucketTotalCount(), mode, value)};
+        TDouble2Vec correction{this->interimValueCorrector().corrections(mode, value)};
         params.s_Value[0] += correction;
         this->currentBucketInterimCorrections().emplace(
             CCorrectionKey(feature, pid, cid), correction);
@@ -1035,7 +1032,7 @@ void CEventRatePopulationModel::fill(model_t::EFeature feature,
 ////////// CEventRatePopulationModel::SBucketStats Implementation //////////
 
 CEventRatePopulationModel::SBucketStats::SBucketStats(core_t::TTime startTime)
-    : s_StartTime(startTime), s_TotalCount(0), s_InterimCorrections(1) {
+    : s_StartTime(startTime), s_InterimCorrections(1) {
 }
 }
 }

--- a/lib/model/CEventRatePopulationModelFactory.cc
+++ b/lib/model/CEventRatePopulationModelFactory.cc
@@ -28,12 +28,13 @@
 namespace ml {
 namespace model {
 
-CEventRatePopulationModelFactory::CEventRatePopulationModelFactory(const SModelParams& params,
-                                                                   model_t::ESummaryMode summaryMode,
-                                                                   const std::string& summaryCountFieldName)
-    : CModelFactory(params), m_Identifier(), m_SummaryMode(summaryMode),
-      m_SummaryCountFieldName(summaryCountFieldName), m_UseNull(false),
-      m_BucketResultsDelay(0) {
+CEventRatePopulationModelFactory::CEventRatePopulationModelFactory(
+    const SModelParams& params,
+    const TInterimBucketCorrectorWPtr& interimBucketCorrector,
+    model_t::ESummaryMode summaryMode,
+    const std::string& summaryCountFieldName)
+    : CModelFactory(params, interimBucketCorrector), m_SummaryMode(summaryMode),
+      m_SummaryCountFieldName(summaryCountFieldName) {
 }
 
 CEventRatePopulationModelFactory* CEventRatePopulationModelFactory::clone() const {
@@ -59,8 +60,8 @@ CEventRatePopulationModelFactory::makeModel(const SModelInitializationData& init
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(),
                                    this->minimumSeasonalVarianceScale(), false),
-        this->defaultCorrelatePriors(features),
-        this->defaultCorrelates(features), influenceCalculators);
+        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
+        influenceCalculators, this->interimBucketCorrector());
 }
 
 CAnomalyDetectorModel*
@@ -82,8 +83,8 @@ CEventRatePopulationModelFactory::makeModel(const SModelInitializationData& init
     return new CEventRatePopulationModel(
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(), 1.0, false),
-        this->defaultCorrelatePriors(features),
-        this->defaultCorrelates(features), influenceCalculators, traverser);
+        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
+        influenceCalculators, this->interimBucketCorrector(), traverser);
 }
 
 CDataGatherer*

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -63,12 +63,10 @@ const std::string FIRST_BUCKET_TIME_TAG("c");
 const std::string LAST_BUCKET_TIME_TAG("d");
 const std::string FEATURE_MODELS_TAG("e");
 const std::string FEATURE_CORRELATE_MODELS_TAG("f");
-
 // Extra data tag deprecated at model version 34
 // TODO remove on next version bump
-// const std::string EXTRA_DATA_TAG("g");
-
-const std::string INTERIM_BUCKET_CORRECTOR_TAG("h");
+//const std::string EXTRA_DATA_TAG("g");
+//const std::string INTERIM_BUCKET_CORRECTOR_TAG("h");
 const std::string MEMORY_ESTIMATOR_TAG("i");
 }
 
@@ -166,9 +164,6 @@ void CIndividualModel::sampleBucketStatistics(core_t::TTime startTime,
 
     for (core_t::TTime time = startTime, bucketLength = gatherer.bucketLength();
          time < endTime; time += bucketLength) {
-        this->CAnomalyDetectorModel::sampleBucketStatistics(time, time + bucketLength,
-                                                            resourceMonitor);
-
         // Currently, we only remember one bucket.
         this->currentBucketStartTime(time);
         TSizeUInt64PrVec& personCounts = this->currentBucketPersonCounts();
@@ -354,7 +349,6 @@ void CIndividualModel::doAcceptPersistInserter(core::CStatePersistInserter& inse
                              boost::bind(&SFeatureCorrelateModels::acceptPersistInserter,
                                          &feature, _1));
     }
-    this->interimBucketCorrectorAcceptPersistInserter(INTERIM_BUCKET_CORRECTOR_TAG, inserter);
     core::CPersistUtils::persist(MEMORY_ESTIMATOR_TAG, m_MemoryEstimator, inserter);
 }
 
@@ -381,8 +375,6 @@ bool CIndividualModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser& tr
                     traverser.traverseSubLevel(boost::bind(
                         &SFeatureCorrelateModels::acceptRestoreTraverser,
                         &m_FeatureCorrelatesModels[j++], boost::cref(this->params()), _1)))
-        RESTORE(INTERIM_BUCKET_CORRECTOR_TAG,
-                this->interimBucketCorrectorAcceptRestoreTraverser(traverser))
         RESTORE(MEMORY_ESTIMATOR_TAG,
                 core::CPersistUtils::restore(MEMORY_ESTIMATOR_TAG, m_MemoryEstimator, traverser))
     } while (traverser.next());

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -155,7 +155,7 @@ bool CIndividualModel::bucketStatsAvailable(core_t::TTime time) const {
 
 void CIndividualModel::sampleBucketStatistics(core_t::TTime startTime,
                                               core_t::TTime endTime,
-                                              CResourceMonitor& resourceMonitor) {
+                                              CResourceMonitor& /*resourceMonitor*/) {
     CDataGatherer& gatherer = this->dataGatherer();
 
     if (!gatherer.dataAvailable(startTime)) {

--- a/lib/model/CInterimBucketCorrector.cc
+++ b/lib/model/CInterimBucketCorrector.cc
@@ -22,8 +22,9 @@ namespace ml {
 namespace model {
 namespace {
 const std::size_t COMPONENT_SIZE(24);
-const std::string COUNT_TREND_TAG("a");
-const std::string COUNT_MEAN_TAG("b");
+const std::string COMPLETENESS_TAG{"a"};
+const std::string FINAL_COUNT_TREND_TAG{"b"};
+const std::string FINAL_COUNT_MEAN_TAG{"c"};
 
 double decayRate(core_t::TTime bucketLength) {
     return CAnomalyDetectorModelConfig::DEFAULT_DECAY_RATE *
@@ -36,58 +37,38 @@ double trendDecayRate(core_t::TTime bucketLength) {
 }
 
 CInterimBucketCorrector::CInterimBucketCorrector(core_t::TTime bucketLength)
-    : m_BucketLength(bucketLength),
-      m_CountTrend(trendDecayRate(bucketLength), bucketLength, COMPONENT_SIZE) {
+    : m_BucketLength(bucketLength), m_Completeness{0.0},
+      m_FinalCountTrend(trendDecayRate(bucketLength), bucketLength, COMPONENT_SIZE) {
 }
 
-CInterimBucketCorrector::CInterimBucketCorrector(const CInterimBucketCorrector& other)
-    : m_BucketLength(other.m_BucketLength), m_CountTrend(other.m_CountTrend),
-      m_CountMean(other.m_CountMean) {
+void CInterimBucketCorrector::currentBucketCount(core_t::TTime time, uint64_t count) {
+    m_Completeness = this->estimateBucketCompleteness(time, count);
 }
 
-core_t::TTime CInterimBucketCorrector::calcBucketMidPoint(core_t::TTime time) const {
-    return maths::CIntegerTools::floor(time, m_BucketLength) + m_BucketLength / 2;
+void CInterimBucketCorrector::finalBucketCount(core_t::TTime time, uint64_t count) {
+    core_t::TTime bucketMidPoint{this->calcBucketMidPoint(time)};
+    m_Completeness = 1.0;
+    m_FinalCountTrend.addPoint(bucketMidPoint, static_cast<double>(count));
+    m_FinalCountMean.age(std::exp(-decayRate(m_BucketLength)));
+    m_FinalCountMean.add(static_cast<double>(count));
 }
 
-void CInterimBucketCorrector::update(core_t::TTime time, std::size_t bucketCount) {
-    core_t::TTime bucketMidPoint = this->calcBucketMidPoint(time);
-
-    m_CountTrend.addPoint(bucketMidPoint, static_cast<double>(bucketCount));
-
-    double alpha = std::exp(-decayRate(m_BucketLength));
-    m_CountMean.age(alpha);
-    m_CountMean.add(bucketCount);
+double CInterimBucketCorrector::completeness() const {
+    return m_Completeness;
 }
 
-double CInterimBucketCorrector::estimateBucketCompleteness(core_t::TTime time,
-                                                           std::size_t currentCount) const {
-    core_t::TTime bucketMidPoint = this->calcBucketMidPoint(time);
-    double bucketCount = m_CountTrend.initialized()
-                             ? maths::CBasicStatistics::mean(m_CountTrend.value(bucketMidPoint))
-                             : maths::CBasicStatistics::mean(m_CountMean);
-    return bucketCount > 0.0
-               ? maths::CTools::truncate(
-                     static_cast<double>(currentCount) / bucketCount, 0.0, 1.0)
-               : 1.0;
-}
-
-double CInterimBucketCorrector::corrections(core_t::TTime time,
-                                            std::size_t currentCount,
-                                            double mode,
-                                            double value) const {
-    double correction = (1.0 - this->estimateBucketCompleteness(time, currentCount)) * mode;
+double CInterimBucketCorrector::corrections(double mode, double value) const {
+    double correction{(1.0 - m_Completeness) * mode};
     return maths::CTools::truncate(mode - value, std::min(0.0, correction),
                                    std::max(0.0, correction));
 }
 
 CInterimBucketCorrector::TDouble10Vec
-CInterimBucketCorrector::corrections(core_t::TTime time,
-                                     std::size_t currentCount,
-                                     const TDouble10Vec& modes,
+CInterimBucketCorrector::corrections(const TDouble10Vec& modes,
                                      const TDouble10Vec& values) const {
     TDouble10Vec corrections(values.size(), 0.0);
-    double incompleteBucketFraction = 1.0 - this->estimateBucketCompleteness(time, currentCount);
-    double correction = 0.0;
+    double incompleteBucketFraction{1.0 - m_Completeness};
+    double correction{0.0};
     for (std::size_t i = 0; i < corrections.size(); ++i) {
         correction = incompleteBucketFraction * modes[i];
         corrections[i] = maths::CTools::truncate(
@@ -98,33 +79,49 @@ CInterimBucketCorrector::corrections(core_t::TTime time,
 
 void CInterimBucketCorrector::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
     mem->setName("CInterimBucketCorrector");
-    core::CMemoryDebug::dynamicSize("m_CountTrend", m_CountTrend, mem);
+    core::CMemoryDebug::dynamicSize("m_CountTrend", m_FinalCountTrend, mem);
 }
 
 std::size_t CInterimBucketCorrector::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_CountTrend);
+    return core::CMemory::dynamicSize(m_FinalCountTrend);
 }
 
 void CInterimBucketCorrector::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    inserter.insertValue(COUNT_MEAN_TAG, m_CountMean.toDelimited());
-    core::CPersistUtils::persist(COUNT_TREND_TAG, m_CountTrend, inserter);
+    inserter.insertValue(COMPLETENESS_TAG, m_Completeness, core::CIEEE754::E_DoublePrecision);
+    inserter.insertValue(FINAL_COUNT_MEAN_TAG, m_FinalCountMean.toDelimited());
+    core::CPersistUtils::persist(FINAL_COUNT_TREND_TAG, m_FinalCountTrend, inserter);
 }
 
 bool CInterimBucketCorrector::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     do {
         const std::string& name = traverser.name();
-        if (name == COUNT_TREND_TAG) {
+        RESTORE_BUILT_IN(COMPLETENESS_TAG, m_Completeness)
+        if (name == FINAL_COUNT_TREND_TAG) {
             maths::SDistributionRestoreParams changeModelParams{
                 maths_t::E_ContinuousData, decayRate(m_BucketLength)};
             maths::STimeSeriesDecompositionRestoreParams params{
                 trendDecayRate(m_BucketLength), m_BucketLength, COMPONENT_SIZE, changeModelParams};
             maths::CTimeSeriesDecomposition restored(params, traverser);
-            m_CountTrend.swap(restored);
+            m_FinalCountTrend.swap(restored);
             continue;
         }
-        RESTORE(COUNT_MEAN_TAG, m_CountMean.fromDelimited(traverser.value()))
+        RESTORE(FINAL_COUNT_MEAN_TAG, m_FinalCountMean.fromDelimited(traverser.value()))
     } while (traverser.next());
     return true;
+}
+
+core_t::TTime CInterimBucketCorrector::calcBucketMidPoint(core_t::TTime time) const {
+    return maths::CIntegerTools::floor(time, m_BucketLength) + m_BucketLength / 2;
+}
+
+double CInterimBucketCorrector::estimateBucketCompleteness(core_t::TTime time,
+                                                           std::uint64_t count_) const {
+    double count{static_cast<double>(count_)};
+    core_t::TTime bucketMidPoint{this->calcBucketMidPoint(time)};
+    double bucketCount{m_FinalCountTrend.initialized()
+                           ? maths::CBasicStatistics::mean(m_FinalCountTrend.value(bucketMidPoint))
+                           : maths::CBasicStatistics::mean(m_FinalCountMean)};
+    return bucketCount > 0.0 ? maths::CTools::truncate(count / bucketCount, 0.0, 1.0) : 1.0;
 }
 }
 }

--- a/lib/model/CMetricModelFactory.cc
+++ b/lib/model/CMetricModelFactory.cc
@@ -27,12 +27,12 @@ namespace ml {
 namespace model {
 
 CMetricModelFactory::CMetricModelFactory(const SModelParams& params,
+                                         const TInterimBucketCorrectorWPtr& interimBucketCorrector,
                                          model_t::ESummaryMode summaryMode,
                                          const std::string& summaryCountFieldName)
-    : CModelFactory(params), m_Identifier(), m_SummaryMode(summaryMode),
-      m_SummaryCountFieldName(summaryCountFieldName), m_UseNull(false),
-      m_BucketLength(CAnomalyDetectorModelConfig::DEFAULT_BUCKET_LENGTH),
-      m_BucketResultsDelay(0) {
+    : CModelFactory(params, interimBucketCorrector), m_SummaryMode(summaryMode),
+      m_SummaryCountFieldName(summaryCountFieldName),
+      m_BucketLength(CAnomalyDetectorModelConfig::DEFAULT_BUCKET_LENGTH) {
 }
 
 CMetricModelFactory* CMetricModelFactory::clone() const {
@@ -58,8 +58,8 @@ CMetricModelFactory::makeModel(const SModelInitializationData& initData) const {
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(),
                                    this->minimumSeasonalVarianceScale(), true),
-        this->defaultCorrelatePriors(features),
-        this->defaultCorrelates(features), influenceCalculators);
+        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
+        influenceCalculators, this->interimBucketCorrector());
 }
 
 CAnomalyDetectorModel*
@@ -81,8 +81,8 @@ CMetricModelFactory::makeModel(const SModelInitializationData& initData,
     return new CMetricModel(
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(), 0.4, true),
-        this->defaultCorrelatePriors(features),
-        this->defaultCorrelates(features), influenceCalculators, traverser);
+        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
+        influenceCalculators, this->interimBucketCorrector(), traverser);
 }
 
 CDataGatherer*

--- a/lib/model/CMetricPopulationModelFactory.cc
+++ b/lib/model/CMetricPopulationModelFactory.cc
@@ -26,12 +26,13 @@
 namespace ml {
 namespace model {
 
-CMetricPopulationModelFactory::CMetricPopulationModelFactory(const SModelParams& params,
-                                                             model_t::ESummaryMode summaryMode,
-                                                             const std::string& summaryCountFieldName)
-    : CModelFactory(params), m_Identifier(), m_SummaryMode(summaryMode),
-      m_SummaryCountFieldName(summaryCountFieldName), m_UseNull(false),
-      m_BucketResultsDelay(0) {
+CMetricPopulationModelFactory::CMetricPopulationModelFactory(
+    const SModelParams& params,
+    const TInterimBucketCorrectorWPtr& interimBucketCorrector,
+    model_t::ESummaryMode summaryMode,
+    const std::string& summaryCountFieldName)
+    : CModelFactory(params, interimBucketCorrector), m_SummaryMode(summaryMode),
+      m_SummaryCountFieldName(summaryCountFieldName) {
 }
 
 CMetricPopulationModelFactory* CMetricPopulationModelFactory::clone() const {
@@ -57,8 +58,8 @@ CMetricPopulationModelFactory::makeModel(const SModelInitializationData& initDat
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(),
                                    this->minimumSeasonalVarianceScale(), false),
-        this->defaultCorrelatePriors(features),
-        this->defaultCorrelates(features), influenceCalculators);
+        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
+        influenceCalculators, this->interimBucketCorrector());
 }
 
 CAnomalyDetectorModel*
@@ -80,8 +81,8 @@ CMetricPopulationModelFactory::makeModel(const SModelInitializationData& initDat
     return new CMetricPopulationModel(
         this->modelParams(), dataGatherer,
         this->defaultFeatureModels(features, dataGatherer->bucketLength(), 1.0, false),
-        this->defaultCorrelatePriors(features),
-        this->defaultCorrelates(features), influenceCalculators, traverser);
+        this->defaultCorrelatePriors(features), this->defaultCorrelates(features),
+        influenceCalculators, this->interimBucketCorrector(), traverser);
 }
 
 CDataGatherer*

--- a/lib/model/CModelFactory.cc
+++ b/lib/model/CModelFactory.cc
@@ -286,7 +286,15 @@ void CModelFactory::swap(CModelFactory& other) {
 }
 
 CModelFactory::TInterimBucketCorrectorPtr CModelFactory::interimBucketCorrector() const {
-    return TInterimBucketCorrectorPtr{m_InterimBucketCorrector};
+    TInterimBucketCorrectorPtr result{m_InterimBucketCorrector.lock()};
+    if (result == nullptr) {
+        // This can never happen if the factory is obtained from the model
+        // config object, which ensures the interim bucket corrector is
+        // always available. The model objects expect this to be available
+        // so failing gracefully here is the best we can do.
+        LOG_ABORT(<< "Unable to get interim bucket corrector");
+    }
+    return result;
 }
 
 CModelFactory::TMultivariatePriorPtr

--- a/lib/model/CModelFactory.cc
+++ b/lib/model/CModelFactory.cc
@@ -36,8 +36,9 @@ namespace model {
 
 const std::string CModelFactory::EMPTY_STRING("");
 
-CModelFactory::CModelFactory(const SModelParams& params)
-    : m_ModelParams(params) {
+CModelFactory::CModelFactory(const SModelParams& params,
+                             const TInterimBucketCorrectorWPtr& interimBucketCorrector)
+    : m_ModelParams(params), m_InterimBucketCorrector(interimBucketCorrector) {
 }
 
 const CModelFactory::TFeatureMathsModelPtrPrVec&
@@ -218,6 +219,10 @@ void CModelFactory::scheduledEvents(TStrDetectionRulePrVecCRef scheduledEvents) 
     m_ModelParams.s_ScheduledEvents = scheduledEvents;
 }
 
+void CModelFactory::interimBucketCorrector(const TInterimBucketCorrectorWPtr& interimBucketCorrector) {
+    m_InterimBucketCorrector = interimBucketCorrector;
+}
+
 void CModelFactory::learnRate(double learnRate) {
     m_ModelParams.s_LearnRate = learnRate;
 }
@@ -278,6 +283,10 @@ void CModelFactory::swap(CModelFactory& other) {
     std::swap(m_ModelParams, other.m_ModelParams);
     m_MathsModelCache.swap(other.m_MathsModelCache);
     m_InfluenceCalculatorCache.swap(other.m_InfluenceCalculatorCache);
+}
+
+CModelFactory::TInterimBucketCorrectorPtr CModelFactory::interimBucketCorrector() const {
+    return TInterimBucketCorrectorPtr{m_InterimBucketCorrector};
 }
 
 CModelFactory::TMultivariatePriorPtr

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -91,12 +91,10 @@ const std::string ATTRIBUTE_FIRST_BUCKET_TIME_TAG("d");
 const std::string ATTRIBUTE_LAST_BUCKET_TIME_TAG("e");
 const std::string PERSON_ATTRIBUTE_BUCKET_COUNT_TAG("f");
 const std::string DISTINCT_PERSON_COUNT_TAG("g");
-
 // Extra data tag deprecated at model version 34
 // TODO remove on next version bump
-// const std::string EXTRA_DATA_TAG("h");
-
-const std::string INTERIM_BUCKET_CORRECTOR_TAG("i");
+//const std::string EXTRA_DATA_TAG("h");
+//const std::string INTERIM_BUCKET_CORRECTOR_TAG("i");
 }
 
 CPopulationModel::CPopulationModel(const SModelParams& params,
@@ -303,7 +301,6 @@ void CPopulationModel::doAcceptPersistInserter(core::CStatePersistInserter& inse
                              boost::bind(&maths::CBjkstUniqueValues::acceptPersistInserter,
                                          &m_DistinctPersonCounts[cid], _1));
     }
-    this->interimBucketCorrectorAcceptPersistInserter(INTERIM_BUCKET_CORRECTOR_TAG, inserter);
 }
 
 bool CPopulationModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
@@ -332,8 +329,6 @@ bool CPopulationModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser& tr
             m_DistinctPersonCounts.back().swap(sketch);
             continue;
         }
-        RESTORE(INTERIM_BUCKET_CORRECTOR_TAG,
-                this->interimBucketCorrectorAcceptRestoreTraverser(traverser))
     } while (traverser.next());
 
     return true;

--- a/lib/model/unittest/CCountingModelTest.h
+++ b/lib/model/unittest/CCountingModelTest.h
@@ -15,6 +15,7 @@ class CCountingModelTest : public CppUnit::TestFixture {
 public:
     void testSkipSampling();
     void testCheckScheduledEvents();
+    void testInterimBucketCorrector();
     static CppUnit::Test* suite();
 
 private:

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -23,6 +23,7 @@
 
 #include <model/CAnnotatedProbability.h>
 #include <model/CAnomalyDetectorModelConfig.h>
+#include <model/CCountingModel.h>
 #include <model/CDataGatherer.h>
 #include <model/CDetectionRule.h>
 #include <model/CEventData.h>
@@ -30,6 +31,7 @@
 #include <model/CEventRateModelFactory.h>
 #include <model/CEventRatePopulationModel.h>
 #include <model/CEventRatePopulationModelFactory.h>
+#include <model/CInterimBucketCorrector.h>
 #include <model/CModelDetailsView.h>
 #include <model/CPartitioningFields.h>
 #include <model/CResourceMonitor.h>
@@ -170,28 +172,6 @@ std::size_t addPersonWithInfluence(const std::string& p,
     return *result.personId();
 }
 
-void makeModel(CEventRateModelFactory& factory,
-               const CDataGatherer::TFeatureVec& features,
-               CResourceMonitor& resourceMonitor,
-               core_t::TTime startTime,
-               core_t::TTime bucketLength,
-               CModelFactory::TDataGathererPtr& gatherer,
-               CAnomalyDetectorModel::TModelPtr& model,
-               std::size_t numberPeople) {
-    factory.features(features);
-    CModelFactory::SGathererInitializationData gathererInitData(startTime);
-    gatherer.reset(factory.makeDataGatherer(gathererInitData));
-    CModelFactory::SModelInitializationData initData(gatherer);
-    model.reset(factory.makeModel(initData));
-    CPPUNIT_ASSERT(model);
-    CPPUNIT_ASSERT_EQUAL(bucketLength, model->bucketLength());
-    for (std::size_t i = 0u; i < numberPeople; ++i) {
-        CPPUNIT_ASSERT_EQUAL(std::size_t(i),
-                             addPerson("p" + core::CStringUtils::typeToString(i + 1),
-                                       gatherer, resourceMonitor));
-    }
-}
-
 void addArrival(CDataGatherer& gatherer,
                 CResourceMonitor& resourceMonitor,
                 core_t::TTime time,
@@ -255,15 +235,12 @@ void testModelWithValueField(model_t::EFeature feature,
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
-    CEventRatePopulationModelFactory factory(params);
-    model_t::TFeatureVec features(1u, feature);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({feature});
     factory.fieldNames("", "", "P", "V", TStrVec());
-    CModelFactory::SGathererInitializationData gathererInitData(startTime);
-    CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
-
-    CModelFactory::SModelInitializationData modelInitData(gatherer);
-    CAnomalyDetectorModel::TModelPtr model(factory.makeModel(modelInitData));
+    CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
+    CModelFactory::TModelPtr model(factory.makeModel(gatherer));
     CPPUNIT_ASSERT(model);
 
     std::size_t anomalousBucket = 20;
@@ -308,16 +285,11 @@ void CEventRateModelTest::testOnlineCountSample() {
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 1);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 1);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
     CPPUNIT_ASSERT(model);
 
-    TMathsModelPtr timeseriesModel{factory.defaultFeatureModel(
+    TMathsModelPtr timeseriesModel{m_Factory->defaultFeatureModel(
         model_t::E_IndividualCountByBucketAndPerson, bucketLength, 0.4, true)};
     maths::CModelAddSamplesParams::TDouble2VecWeightsAryVec weights{
         maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
@@ -337,7 +309,7 @@ void CEventRateModelTest::testOnlineCountSample() {
 
         double count = 0.0;
         for (/**/; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p1");
+            addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
             count += 1.0;
         }
 
@@ -385,9 +357,7 @@ void CEventRateModelTest::testOnlineCountSample() {
     core::CRapidXmlParser parser;
     CPPUNIT_ASSERT(parser.parseStringIgnoreCdata(origXml));
     core::CRapidXmlStateRestoreTraverser traverser(parser);
-
-    CModelFactory::SModelInitializationData initData(gatherer);
-    CAnomalyDetectorModel::TModelPtr restoredModelPtr(factory.makeModel(initData, traverser));
+    CModelFactory::TModelPtr restoredModelPtr(m_Factory->makeModel(m_Gatherer, traverser));
 
     // The XML representation of the new filter should be the same as the original
     std::string newXml;
@@ -408,16 +378,12 @@ void CEventRateModelTest::testOnlineNonZeroCountSample() {
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualNonZeroCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 1);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualNonZeroCountByBucketAndPerson},
+                    startTime, 1);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
     CPPUNIT_ASSERT(model);
 
-    TMathsModelPtr timeseriesModel{factory.defaultFeatureModel(
+    TMathsModelPtr timeseriesModel{m_Factory->defaultFeatureModel(
         model_t::E_IndividualNonZeroCountByBucketAndPerson, bucketLength, 0.4, true)};
     maths::CModelAddSamplesParams::TDouble2VecWeightsAryVec weights{
         maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
@@ -437,7 +403,7 @@ void CEventRateModelTest::testOnlineNonZeroCountSample() {
 
         double count = 0.0;
         for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p1");
+            addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
             count += 1.0;
         }
 
@@ -479,35 +445,31 @@ void CEventRateModelTest::testOnlineRare() {
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features;
-    features.push_back(model_t::E_IndividualTotalBucketCountByPerson);
-    features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 5);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params,
+                    {model_t::E_IndividualTotalBucketCountByPerson,
+                     model_t::E_IndividualIndicatorOfBucketPerson},
+                    startTime, 5);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
     core_t::TTime time = startTime;
     for (/**/; time < startTime + 10 * bucketLength; time += bucketLength) {
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
+        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
+        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
     for (/**/; time < startTime + 50 * bucketLength; time += bucketLength) {
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3");
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4");
+        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
+        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
+        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3");
+        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4");
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
 
-    addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
-    addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
-    addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3");
-    addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4");
-    addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p5");
+    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
+    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
+    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3");
+    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4");
+    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p5");
     model->sample(time, time + bucketLength, m_ResourceMonitor);
 
     TDoubleVec probabilities;
@@ -542,9 +504,7 @@ void CEventRateModelTest::testOnlineRare() {
     core::CRapidXmlParser parser;
     CPPUNIT_ASSERT(parser.parseStringIgnoreCdata(origXml));
     core::CRapidXmlStateRestoreTraverser traverser(parser);
-
-    CModelFactory::SModelInitializationData initData(gatherer);
-    CAnomalyDetectorModel::TModelPtr restoredModelPtr(factory.makeModel(initData, traverser));
+    CModelFactory::TModelPtr restoredModelPtr(m_Factory->makeModel(m_Gatherer, traverser));
 
     // The XML representation of the new filter should be the same as the original
     std::string newXml;
@@ -567,13 +527,8 @@ void CEventRateModelTest::testOnlineProbabilityCalculation() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 1);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 1);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
     TMinAccumulator minProbabilities(2u);
 
@@ -593,7 +548,7 @@ void CEventRateModelTest::testOnlineProbabilityCalculation() {
 
         double count = 0.0;
         for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p1");
+            addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
             count += 1.0;
         }
 
@@ -626,23 +581,19 @@ void CEventRateModelTest::testOnlineProbabilityCalculationForLowNonZeroCount() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualLowNonZeroCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 1);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualLowNonZeroCountByBucketAndPerson},
+                    startTime, 1);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
     TDoubleVec probabilities;
 
     core_t::TTime time = startTime;
-    for (std::size_t i = 0u; i < boost::size(bucketCounts); ++i) {
-        LOG_DEBUG(<< "Writing " << bucketCounts[i] << " values");
+    for (auto count : bucketCounts) {
+        LOG_DEBUG(<< "Writing " << count << " values");
 
-        for (std::size_t j = 0u; j < bucketCounts[i]; ++j) {
-            addArrival(*gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p1");
+        for (std::size_t i = 0u; i < count; ++i) {
+            addArrival(*m_Gatherer, m_ResourceMonitor,
+                       time + static_cast<core_t::TTime>(i), "p1");
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -676,23 +627,19 @@ void CEventRateModelTest::testOnlineProbabilityCalculationForHighNonZeroCount() 
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualHighNonZeroCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 1);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualHighNonZeroCountByBucketAndPerson},
+                    startTime, 1);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
     TDoubleVec probabilities;
 
     core_t::TTime time = startTime;
-    for (std::size_t i = 0u; i < boost::size(bucketCounts); ++i) {
-        LOG_DEBUG(<< "Writing " << bucketCounts[i] << " values");
+    for (auto count : bucketCounts) {
+        LOG_DEBUG(<< "Writing " << count << " values");
 
-        for (std::size_t j = 0u; j < bucketCounts[i]; ++j) {
-            addArrival(*gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p1");
+        for (std::size_t i = 0u; i < count; ++i) {
+            addArrival(*m_Gatherer, m_ResourceMonitor,
+                       time + static_cast<core_t::TTime>(i), "p1");
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -749,13 +696,8 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
         params.s_MinimumModeFraction = CAnomalyDetectorModelConfig::DEFAULT_INDIVIDUAL_MINIMUM_MODE_FRACTION;
         params.s_MinimumModeCount = 24.0;
         params.s_MultivariateByFields = true;
-        CEventRateModelFactory factory(params);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-        CModelFactory::TDataGathererPtr gatherer;
-        CAnomalyDetectorModel::TModelPtr model_;
-        makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-                  gatherer, model_, 4);
-        CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+        this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 4);
+        CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
         CPPUNIT_ASSERT(model);
 
         LOG_DEBUG(<< "Test correlation anomalies");
@@ -778,7 +720,7 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
                     n += anomalies[anomaly][j];
                 }
                 for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                    addArrival(*gatherer, m_ResourceMonitor,
+                    addArrival(*m_Gatherer, m_ResourceMonitor,
                                time + static_cast<core_t::TTime>(j), person);
                 }
             }
@@ -831,9 +773,7 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
         core::CRapidXmlParser parser;
         CPPUNIT_ASSERT(parser.parseStringIgnoreCdata(origXml));
         core::CRapidXmlStateRestoreTraverser traverser(parser);
-
-        CModelFactory::SModelInitializationData initData(gatherer);
-        CAnomalyDetectorModel::TModelPtr restoredModel(factory.makeModel(initData, traverser));
+        CModelFactory::TModelPtr restoredModel(m_Factory->makeModel(m_Gatherer, traverser));
         std::string newXml;
         {
             core::CRapidXmlStatePersistInserter inserter("root");
@@ -852,13 +792,8 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
         params.s_MinimumModeFraction = CAnomalyDetectorModelConfig::DEFAULT_INDIVIDUAL_MINIMUM_MODE_FRACTION;
         params.s_MinimumModeCount = 24.0;
         params.s_MultivariateByFields = true;
-        CEventRateModelFactory factory(params);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-        CModelFactory::TDataGathererPtr gatherer;
-        CAnomalyDetectorModel::TModelPtr model_;
-        makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-                  gatherer, model_, 4);
-        CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+        this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 4);
+        CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
         CPPUNIT_ASSERT(model);
 
         std::size_t anomalyBuckets[] = {100, 160, 190, b};
@@ -880,7 +815,7 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
                 }
                 n = std::max(n, 0.0);
                 for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                    addArrival(*gatherer, m_ResourceMonitor,
+                    addArrival(*m_Gatherer, m_ResourceMonitor,
                                time + static_cast<core_t::TTime>(j), person);
                 }
             }
@@ -975,13 +910,8 @@ void CEventRateModelTest::testOnlineCorrelatedTrend() {
     params.s_MinimumModeFraction = CAnomalyDetectorModelConfig::DEFAULT_INDIVIDUAL_MINIMUM_MODE_FRACTION;
     params.s_MinimumModeCount = 24.0;
     params.s_MultivariateByFields = true;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 4);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 4);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
     CPPUNIT_ASSERT(model);
 
     core_t::TTime time = startTime;
@@ -1004,7 +934,7 @@ void CEventRateModelTest::testOnlineCorrelatedTrend() {
             }
             n = std::max(n / 3.0, 0.0);
             for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                addArrival(*gatherer, m_ResourceMonitor,
+                addArrival(*m_Gatherer, m_ResourceMonitor,
                            time + static_cast<core_t::TTime>(j), person);
             }
         }
@@ -1079,20 +1009,17 @@ void CEventRateModelTest::testPrune() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.01;
-    CEventRateModelFactory factory(params);
     model_t::TFeatureVec features;
     features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
     features.push_back(model_t::E_IndividualTotalBucketCountByPerson);
     CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 0);
+    CModelFactory::TModelPtr model_;
+    this->makeModel(params, features, startTime, 0, gatherer, model_);
     CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
     CPPUNIT_ASSERT(model);
     CModelFactory::TDataGathererPtr expectedGatherer;
-    CAnomalyDetectorModel::TModelPtr expectedModel_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              expectedGatherer, expectedModel_, 0);
+    CModelFactory::TModelPtr expectedModel_;
+    this->makeModel(params, features, startTime, 0, expectedGatherer, expectedModel_);
     CEventRateModel* expectedModel =
         dynamic_cast<CEventRateModel*>(expectedModel_.get());
     CPPUNIT_ASSERT(expectedModel);
@@ -1186,7 +1113,7 @@ void CEventRateModelTest::testPrune() {
     CPPUNIT_ASSERT_EQUAL(expectedModel->checksum(), model->checksum());
 
     // Test that calling prune on a cloned model which has seen no new data does nothing.
-    CAnomalyDetectorModel::TModelPtr clonedModel(model->cloneForPersistence());
+    CModelFactory::TModelPtr clonedModel(model->cloneForPersistence());
     std::size_t numberOfPeopleBeforePrune(clonedModel->dataGatherer().numberActivePeople());
     CPPUNIT_ASSERT(numberOfPeopleBeforePrune > 0);
     clonedModel->prune(clonedModel->defaultPruneWindow());
@@ -1363,18 +1290,15 @@ void CEventRateModelTest::testCountProbabilityCalculationWithInfluence() {
         // Test single influence name, single influence value
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        TStrVec influenceFieldNames;
-        influenceFieldNames.push_back("IF1");
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        TStrVec influenceFieldNames{"IF1"};
         factory.fieldNames("", "", "", "", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1423,18 +1347,15 @@ void CEventRateModelTest::testCountProbabilityCalculationWithInfluence() {
         // Test single influence name, two influence values
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        TStrVec influenceFieldNames;
-        influenceFieldNames.push_back("IF1");
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        TStrVec influenceFieldNames{"IF1"};
         factory.fieldNames("", "", "", "", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1489,18 +1410,15 @@ void CEventRateModelTest::testCountProbabilityCalculationWithInfluence() {
         // Test single influence name, two influence values, less anomalousness for each
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        TStrVec influenceFieldNames;
-        influenceFieldNames.push_back("IF1");
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        TStrVec influenceFieldNames{"IF1"};
         factory.fieldNames("", "", "", "", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1557,18 +1475,15 @@ void CEventRateModelTest::testCountProbabilityCalculationWithInfluence() {
         // Test single influence name, two asymmetric influence values
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        TStrVec influenceFieldNames;
-        influenceFieldNames.push_back("IF1");
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        TStrVec influenceFieldNames{"IF1"};
         factory.fieldNames("", "", "", "", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1623,19 +1538,17 @@ void CEventRateModelTest::testCountProbabilityCalculationWithInfluence() {
         // Test two influence names, two asymmetric influence values in each
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
         TStrVec influenceFieldNames;
         influenceFieldNames.push_back("IF1");
         influenceFieldNames.push_back("IF2");
         factory.fieldNames("", "", "", "", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 2));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1706,19 +1619,16 @@ void CEventRateModelTest::testDistinctCountProbabilityCalculationWithInfluence()
         // Test single influence name, single influence value
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        TStrVec influenceFieldNames;
-        influenceFieldNames.push_back("IF1");
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        TStrVec influenceFieldNames{"IF1"};
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualUniqueCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
                                                     1, TOptionalStr("v")));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1777,19 +1687,16 @@ void CEventRateModelTest::testDistinctCountProbabilityCalculationWithInfluence()
         // Test single influence name, two influence values
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        TStrVec influenceFieldNames;
-        influenceFieldNames.push_back("IF1");
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        TStrVec influenceFieldNames{"IF1"};
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualUniqueCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
                                                     1, TOptionalStr("v")));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1858,19 +1765,16 @@ void CEventRateModelTest::testDistinctCountProbabilityCalculationWithInfluence()
         // Test single influence name, two asymmetric influence values
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        TStrVec influenceFieldNames;
-        influenceFieldNames.push_back("IF1");
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        TStrVec influenceFieldNames{"IF1"};
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualUniqueCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
                                                     1, TOptionalStr("v")));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -1935,20 +1839,18 @@ void CEventRateModelTest::testDistinctCountProbabilityCalculationWithInfluence()
         // Test two influence names, two asymmetric influence values in each
         SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
         TStrVec influenceFieldNames;
         influenceFieldNames.push_back("IF1");
         influenceFieldNames.push_back("IF2");
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
-        model_t::TFeatureVec features(1u, model_t::E_IndividualUniqueCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::SGathererInitializationData gathererInitData(startTime);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+        factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                              addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
                                                     2, TOptionalStr("v")));
-        CModelFactory::SModelInitializationData modelInitData(gatherer);
-        CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+        CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         CPPUNIT_ASSERT(model);
 
@@ -2030,14 +1932,12 @@ void CEventRateModelTest::testOnlineRareWithInfluence() {
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
-    CEventRateModelFactory factory(params);
-    TStrVec influenceFieldNames;
-    influenceFieldNames.push_back("IF1");
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRateModelFactory factory(params, interimBucketCorrector);
+    TStrVec influenceFieldNames{"IF1"};
     factory.fieldNames("", "", "", "", influenceFieldNames);
-    model_t::TFeatureVec features = function_t::features(function_t::E_IndividualRare);
-    factory.features(features);
-    CModelFactory::SGathererInitializationData gathererInitData(startTime);
-    CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
+    factory.features(function_t::features(function_t::E_IndividualRare));
+    CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
     CPPUNIT_ASSERT_EQUAL(std::size_t(0),
                          addPersonWithInfluence("p1", gatherer, m_ResourceMonitor, 1));
     CPPUNIT_ASSERT_EQUAL(std::size_t(1),
@@ -2048,8 +1948,7 @@ void CEventRateModelTest::testOnlineRareWithInfluence() {
                          addPersonWithInfluence("p4", gatherer, m_ResourceMonitor, 1));
     CPPUNIT_ASSERT_EQUAL(std::size_t(4),
                          addPersonWithInfluence("p5", gatherer, m_ResourceMonitor, 1));
-    CModelFactory::SModelInitializationData modelInitData(gatherer);
-    CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+    CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
     CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
     CPPUNIT_ASSERT(model);
 
@@ -2121,9 +2020,7 @@ void CEventRateModelTest::testOnlineRareWithInfluence() {
     core::CRapidXmlParser parser;
     CPPUNIT_ASSERT(parser.parseStringIgnoreCdata(origXml));
     core::CRapidXmlStateRestoreTraverser traverser(parser);
-
-    CAnomalyDetectorModel::TModelPtr restoredModelPtr(
-        factory.makeModel(modelInitData, traverser));
+    CModelFactory::TModelPtr restoredModelPtr(factory.makeModel(gatherer, traverser));
 
     // The XML representation of the new filter should be the same as the original
     std::string newXml;
@@ -2142,13 +2039,11 @@ void CEventRateModelTest::testSkipSampling() {
     std::size_t maxAgeBuckets(5);
 
     SModelParams params(bucketLength);
-    CEventRateModelFactory factory(params);
     params.s_InitialDecayRateMultiplier = 1.0;
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
+    model_t::TFeatureVec features{model_t::E_IndividualCountByBucketAndPerson};
     CModelFactory::TDataGathererPtr gathererNoGap;
-    CAnomalyDetectorModel::TModelPtr modelNoGap_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gathererNoGap, modelNoGap_, 2);
+    CModelFactory::TModelPtr modelNoGap_;
+    this->makeModel(params, features, startTime, 2, gathererNoGap, modelNoGap_);
     CEventRateModel* modelNoGap = dynamic_cast<CEventRateModel*>(modelNoGap_.get());
 
     // p1: |1|1|1|
@@ -2161,10 +2056,9 @@ void CEventRateModelTest::testSkipSampling() {
     addArrival(*gathererNoGap, m_ResourceMonitor, 300, "p1");
     modelNoGap->sample(300, 400, m_ResourceMonitor);
 
-    CAnomalyDetectorModel::TModelPtr modelWithGap_;
     CModelFactory::TDataGathererPtr gathererWithGap;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gathererWithGap, modelWithGap_, 2);
+    CModelFactory::TModelPtr modelWithGap_;
+    this->makeModel(params, features, startTime, 2, gathererWithGap, modelWithGap_);
     CEventRateModel* modelWithGap = dynamic_cast<CEventRateModel*>(modelWithGap_.get());
 
     // p1: |1|1|0|0|0|0|0|0|0|0|1|1|
@@ -2229,12 +2123,11 @@ void CEventRateModelTest::testExplicitNulls() {
 
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
-    CEventRateModelFactory factory(params, model_t::E_Manual, summaryCountField);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
+    model_t::TFeatureVec features{model_t::E_IndividualCountByBucketAndPerson};
     CModelFactory::TDataGathererPtr gathererSkipGap;
-    CAnomalyDetectorModel::TModelPtr modelSkipGap_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gathererSkipGap, modelSkipGap_, 0);
+    CModelFactory::TModelPtr modelSkipGap_;
+    this->makeModel(params, features, startTime, 0, gathererSkipGap,
+                    modelSkipGap_, summaryCountField);
     CEventRateModel* modelSkipGap = dynamic_cast<CEventRateModel*>(modelSkipGap_.get());
 
     // The idea here is to compare a model that has a gap skipped against a model
@@ -2261,9 +2154,9 @@ void CEventRateModelTest::testExplicitNulls() {
     modelSkipGap->sample(600, 700, m_ResourceMonitor);
 
     CModelFactory::TDataGathererPtr gathererExNull;
-    CAnomalyDetectorModel::TModelPtr modelExNullGap_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gathererExNull, modelExNullGap_, 0);
+    CModelFactory::TModelPtr modelExNullGap_;
+    this->makeModel(params, features, startTime, 0, gathererExNull,
+                    modelExNullGap_, summaryCountField);
     CEventRateModel* modelExNullGap =
         dynamic_cast<CEventRateModel*>(modelExNullGap_.get());
 
@@ -2329,13 +2222,9 @@ void CEventRateModelTest::testInterimCorrections() {
     core_t::TTime endTime(2 * 24 * bucketLength);
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 3);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 3);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
+    CCountingModel countingModel(params, m_Gatherer, m_InterimBucketCorrector);
 
     test::CRandomNumbers rng;
     core_t::TTime now = startTime;
@@ -2343,26 +2232,28 @@ void CEventRateModelTest::testInterimCorrections() {
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p1");
+            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[1] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p2");
+            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[2] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p3");
+            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
         }
+        countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p1");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
     }
     for (std::size_t i = 0; i < 1; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p2");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p3");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
     }
+    countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
     CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
@@ -2404,14 +2295,15 @@ void CEventRateModelTest::testInterimCorrections() {
     CPPUNIT_ASSERT(p3Baseline[0] > 57.0 && p3Baseline[0] < 62.0);
 
     for (std::size_t i = 0; i < 25; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p1");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
     }
     for (std::size_t i = 0; i < 59; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p2");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p3");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
     }
+    countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
     CPPUNIT_ASSERT(model->computeProbability(0 /*pid*/, now, now + bucketLength, partitioningFields,
@@ -2449,13 +2341,8 @@ void CEventRateModelTest::testInterimCorrectionsWithCorrelations() {
 
     SModelParams params(bucketLength);
     params.s_MultivariateByFields = true;
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 3);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 3);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
     core_t::TTime now = startTime;
     core_t::TTime endTime(now + 2 * 24 * bucketLength);
@@ -2464,25 +2351,25 @@ void CEventRateModelTest::testInterimCorrectionsWithCorrelations() {
     while (now < endTime) {
         rng.generateUniformSamples(80.0, 100.0, std::size_t(1), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p1");
+            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 10.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p2");
+            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] - 9.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p3");
+            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
         }
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 9; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p1");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
     }
     for (std::size_t i = 0; i < 10; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p2");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
     }
     for (std::size_t i = 0; i < 8; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p3");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
     }
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
@@ -2530,33 +2417,21 @@ void CEventRateModelTest::testInterimCorrectionsWithCorrelations() {
 void CEventRateModelTest::testSummaryCountZeroRecordsAreIgnored() {
     core_t::TTime startTime(100);
     core_t::TTime bucketLength(100);
+
     SModelParams params(bucketLength);
     std::string summaryCountField("count");
-    CEventRateModelFactory factory(params, model_t::E_Manual, summaryCountField);
 
-    CDataGatherer::TFeatureVec features;
-    features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    factory.features(features);
+    CModelFactory::TDataGathererPtr gathererWithZeros;
+    CModelFactory::TModelPtr modelWithZerosPtr;
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime,
+                    0, gathererWithZeros, modelWithZerosPtr, summaryCountField);
+    CEventRateModel& modelWithZeros = static_cast<CEventRateModel&>(*modelWithZerosPtr);
 
-    CModelFactory::SGathererInitializationData gathererWithZerosInitData(startTime);
-    CModelFactory::TDataGathererPtr gathererWithZeros(
-        factory.makeDataGatherer(gathererWithZerosInitData));
-    CModelFactory::SModelInitializationData initDataWithZeros(gathererWithZeros);
-    CAnomalyDetectorModel::TModelPtr modelWithZerosPtr(factory.makeModel(initDataWithZeros));
-    CPPUNIT_ASSERT(modelWithZerosPtr);
-    CPPUNIT_ASSERT_EQUAL(model_t::E_EventRateOnline, modelWithZerosPtr->category());
-    CEventRateModel& modelWithZeros =
-        static_cast<CEventRateModel&>(*modelWithZerosPtr.get());
-
-    CModelFactory::SGathererInitializationData gathererNoZerosInitData(startTime);
-    CModelFactory::TDataGathererPtr gathererNoZeros(
-        factory.makeDataGatherer(gathererNoZerosInitData));
-    CModelFactory::SModelInitializationData initDataNoZeros(gathererNoZeros);
-    CAnomalyDetectorModel::TModelPtr modelNoZerosPtr(factory.makeModel(initDataNoZeros));
-    CPPUNIT_ASSERT(modelNoZerosPtr);
-    CPPUNIT_ASSERT_EQUAL(model_t::E_EventRateOnline, modelNoZerosPtr->category());
-    CEventRateModel& modelNoZeros =
-        static_cast<CEventRateModel&>(*modelNoZerosPtr.get());
+    CModelFactory::TDataGathererPtr gathererNoZeros;
+    CModelFactory::TModelPtr modelNoZerosPtr;
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime,
+                    0, gathererNoZeros, modelNoZerosPtr, summaryCountField);
+    CEventRateModel& modelNoZeros = static_cast<CEventRateModel&>(*modelNoZerosPtr);
 
     // The idea here is to compare a model that has records with summary count of zero
     // against a model that has no records at all where the first model had the zero-count records.
@@ -2603,16 +2478,10 @@ void CEventRateModelTest::testComputeProbabilityGivenDetectionRule() {
     core_t::TTime endTime(24 * bucketLength);
 
     SModelParams params(bucketLength);
-    SModelParams::TDetectionRuleVec rules(1, rule);
+    SModelParams::TDetectionRuleVec rules{rule};
     params.s_DetectionRules = SModelParams::TDetectionRuleVecCRef(rules);
-
-    CEventRateModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_IndividualCountByBucketAndPerson);
-    CModelFactory::TDataGathererPtr gatherer;
-    CAnomalyDetectorModel::TModelPtr model_;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gatherer, model_, 1);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(model_.get());
+    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 1);
+    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
     test::CRandomNumbers rng;
     core_t::TTime now = startTime;
@@ -2620,13 +2489,13 @@ void CEventRateModelTest::testComputeProbabilityGivenDetectionRule() {
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, std::size_t(1), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p1");
+            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
         }
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p1");
+        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
     }
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
@@ -2642,7 +2511,7 @@ void CEventRateModelTest::testDecayRateControl() {
     core_t::TTime bucketLength = 1800;
 
     model_t::EFeature feature = model_t::E_IndividualCountByBucketAndPerson;
-    model_t::TFeatureVec features(1, feature);
+    model_t::TFeatureVec features{feature};
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
@@ -2658,19 +2527,21 @@ void CEventRateModelTest::testDecayRateControl() {
 
         params.s_ControlDecayRate = true;
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        CModelFactory::TDataGathererPtr gatherer;
-        CAnomalyDetectorModel::TModelPtr model;
-        makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-                  gatherer, model, 1);
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        factory.features(features);
+        CModelFactory::TDataGathererPtr gatherer{factory.makeDataGatherer(startTime)};
+        CModelFactory::TModelPtr model{factory.makeModel(gatherer)};
+        addPerson("p1", gatherer, m_ResourceMonitor);
 
         params.s_ControlDecayRate = false;
         params.s_DecayRate = 0.0001;
-        CEventRateModelFactory referenceFactory(params);
-        CModelFactory::TDataGathererPtr referenceGatherer;
-        CAnomalyDetectorModel::TModelPtr referenceModel;
-        makeModel(referenceFactory, features, m_ResourceMonitor, startTime,
-                  bucketLength, referenceGatherer, referenceModel, 1);
+        CEventRateModelFactory referenceFactory(params, interimBucketCorrector);
+        referenceFactory.features(features);
+        CModelFactory::TDataGathererPtr referenceGatherer{
+            referenceFactory.makeDataGatherer(startTime)};
+        CModelFactory::TModelPtr referenceModel{referenceFactory.makeModel(referenceGatherer)};
+        addPerson("p1", referenceGatherer, m_ResourceMonitor);
 
         TMeanAccumulator meanPredictionError;
         TMeanAccumulator meanReferencePredictionError;
@@ -2719,19 +2590,20 @@ void CEventRateModelTest::testDecayRateControl() {
 
         params.s_ControlDecayRate = true;
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        CModelFactory::TDataGathererPtr gatherer;
-        CAnomalyDetectorModel::TModelPtr model;
-        makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-                  gatherer, model, 1);
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        factory.features(features);
+        CModelFactory::TDataGathererPtr gatherer{factory.makeDataGatherer(startTime)};
+        CModelFactory::TModelPtr model{factory.makeModel(gatherer)};
+        addPerson("p1", gatherer, m_ResourceMonitor);
 
         params.s_ControlDecayRate = false;
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory referenceFactory(params);
-        CModelFactory::TDataGathererPtr referenceGatherer;
-        CAnomalyDetectorModel::TModelPtr referenceModel;
-        makeModel(referenceFactory, features, m_ResourceMonitor, startTime,
-                  bucketLength, referenceGatherer, referenceModel, 1);
+        CEventRateModelFactory referenceFactory(params, interimBucketCorrector);
+        referenceFactory.features(features);
+        CModelFactory::TDataGathererPtr referenceGatherer{factory.makeDataGatherer(startTime)};
+        CModelFactory::TModelPtr referenceModel{factory.makeModel(gatherer)};
+        addPerson("p1", referenceGatherer, m_ResourceMonitor);
 
         TMeanAccumulator meanPredictionError;
         TMeanAccumulator meanReferencePredictionError;
@@ -2783,19 +2655,21 @@ void CEventRateModelTest::testDecayRateControl() {
 
         params.s_ControlDecayRate = true;
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory factory(params);
-        CModelFactory::TDataGathererPtr gatherer;
-        CAnomalyDetectorModel::TModelPtr model;
-        makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-                  gatherer, model, 1);
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRateModelFactory factory(params, interimBucketCorrector);
+        factory.features(features);
+        CModelFactory::TDataGathererPtr gatherer{factory.makeDataGatherer(startTime)};
+        CModelFactory::TModelPtr model{factory.makeModel(gatherer)};
+        addPerson("p1", gatherer, m_ResourceMonitor);
 
         params.s_ControlDecayRate = false;
         params.s_DecayRate = 0.001;
-        CEventRateModelFactory referenceFactory(params);
-        CModelFactory::TDataGathererPtr referenceGatherer;
-        CAnomalyDetectorModel::TModelPtr referenceModel;
-        makeModel(referenceFactory, features, m_ResourceMonitor, startTime,
-                  bucketLength, referenceGatherer, referenceModel, 1);
+        CEventRateModelFactory referenceFactory(params, interimBucketCorrector);
+        referenceFactory.features(features);
+        CModelFactory::TDataGathererPtr referenceGatherer{
+            referenceFactory.makeDataGatherer(startTime)};
+        CModelFactory::TModelPtr referenceModel{referenceFactory.makeModel(gatherer)};
+        addPerson("p1", referenceGatherer, m_ResourceMonitor);
 
         TMeanAccumulator meanPredictionError;
         TMeanAccumulator meanReferencePredictionError;
@@ -2857,29 +2731,30 @@ void CEventRateModelTest::testIgnoreSamplingGivenDetectionRules() {
 
     std::size_t bucketLength(100);
     std::size_t startTime(100);
-    SModelParams paramsNoRules(bucketLength);
 
     // Model without the skip sampling rule
-    CEventRateModelFactory factory(paramsNoRules);
+    SModelParams paramsNoRules(bucketLength);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRateModelFactory factory(paramsNoRules, interimBucketCorrector);
     model_t::TFeatureVec features{model_t::E_IndividualCountByBucketAndPerson};
-    CModelFactory::TDataGathererPtr gathererNoSkip;
-    CAnomalyDetectorModel::TModelPtr modelPtrNoSkip;
-    makeModel(factory, features, m_ResourceMonitor, startTime, bucketLength,
-              gathererNoSkip, modelPtrNoSkip, 1);
+    factory.features(features);
+    CModelFactory::TDataGathererPtr gathererNoSkip{factory.makeDataGatherer(startTime)};
+    CModelFactory::TModelPtr modelPtrNoSkip{factory.makeModel(gathererNoSkip)};
     CEventRateModel* modelNoSkip = dynamic_cast<CEventRateModel*>(modelPtrNoSkip.get());
+    addPerson("p1", gathererNoSkip, m_ResourceMonitor);
 
     // Model with the skip sampling rule
     SModelParams paramsWithRules(bucketLength);
     SModelParams::TDetectionRuleVec rules{rule};
     paramsWithRules.s_DetectionRules = SModelParams::TDetectionRuleVecCRef(rules);
-
-    CEventRateModelFactory factoryWithSkip(paramsWithRules);
-    CModelFactory::TDataGathererPtr gathererWithSkip;
-    CAnomalyDetectorModel::TModelPtr modelPtrWithSkip;
-    makeModel(factoryWithSkip, features, m_ResourceMonitor, startTime,
-              bucketLength, gathererWithSkip, modelPtrWithSkip, 1);
+    CEventRateModelFactory factoryWithSkip(paramsWithRules, interimBucketCorrector);
+    factoryWithSkip.features(features);
+    CModelFactory::TDataGathererPtr gathererWithSkip{
+        factoryWithSkip.makeDataGatherer(startTime)};
+    CModelFactory::TModelPtr modelPtrWithSkip{factoryWithSkip.makeModel(gathererWithSkip)};
     CEventRateModel* modelWithSkip =
         dynamic_cast<CEventRateModel*>(modelPtrWithSkip.get());
+    addPerson("p1", gathererWithSkip, m_ResourceMonitor);
 
     std::size_t endTime = startTime + bucketLength;
 
@@ -3027,4 +2902,50 @@ CppUnit::Test* CEventRateModelTest::suite() {
         "CEventRateModelTest::testIgnoreSamplingGivenDetectionRules",
         &CEventRateModelTest::testIgnoreSamplingGivenDetectionRules));
     return suiteOfTests;
+}
+
+void CEventRateModelTest::setUp() {
+    m_InterimBucketCorrector.reset();
+    m_Factory.reset();
+    m_Gatherer.reset();
+    m_Model.reset();
+}
+
+void CEventRateModelTest::makeModel(const SModelParams& params,
+                                    const model_t::TFeatureVec& features,
+                                    core_t::TTime startTime,
+                                    std::size_t numberPeople,
+                                    const std::string& summaryCountField) {
+    this->makeModel(params, features, startTime, numberPeople, m_Gatherer,
+                    m_Model, summaryCountField);
+}
+
+void CEventRateModelTest::makeModel(const SModelParams& params,
+                                    const model_t::TFeatureVec& features,
+                                    core_t::TTime startTime,
+                                    std::size_t numberPeople,
+                                    CModelFactory::TDataGathererPtr& gatherer,
+                                    CModelFactory::TModelPtr& model,
+                                    const std::string& summaryCountField) {
+    if (m_InterimBucketCorrector == nullptr) {
+        m_InterimBucketCorrector =
+            std::make_shared<CInterimBucketCorrector>(params.s_BucketLength);
+    }
+    if (m_Factory == nullptr) {
+        m_Factory.reset(new CEventRateModelFactory(
+            params, m_InterimBucketCorrector,
+            summaryCountField.empty() ? model_t::E_None : model_t::E_Manual,
+            summaryCountField));
+        m_Factory->features(features);
+    }
+    gatherer.reset(m_Factory->makeDataGatherer({startTime}));
+    model.reset(m_Factory->makeModel({gatherer}));
+    CPPUNIT_ASSERT(model);
+    CPPUNIT_ASSERT_EQUAL(model_t::E_EventRateOnline, model->category());
+    CPPUNIT_ASSERT_EQUAL(params.s_BucketLength, model->bucketLength());
+    for (std::size_t i = 0u; i < numberPeople; ++i) {
+        CPPUNIT_ASSERT_EQUAL(std::size_t(i),
+                             addPerson("p" + core::CStringUtils::typeToString(i + 1),
+                                       gatherer, m_ResourceMonitor));
+    }
 }

--- a/lib/model/unittest/CEventRateModelTest.h
+++ b/lib/model/unittest/CEventRateModelTest.h
@@ -7,9 +7,21 @@
 #ifndef INCLUDED_CEventRateModelTest_h
 #define INCLUDED_CEventRateModelTest_h
 
+#include <model/CModelFactory.h>
 #include <model/CResourceMonitor.h>
 
 #include <cppunit/extensions/HelperMacros.h>
+
+#include <memory>
+#include <string>
+
+namespace ml {
+namespace model {
+class CEventRateModelFactory;
+class CInterimBucketCorrector;
+struct SModelParams;
+}
+}
 
 class CEventRateModelTest : public CppUnit::TestFixture {
 public:
@@ -35,9 +47,34 @@ public:
     void testComputeProbabilityGivenDetectionRule();
     void testDecayRateControl();
     void testIgnoreSamplingGivenDetectionRules();
+
+    virtual void setUp();
     static CppUnit::Test* suite();
 
 private:
+    using TInterimBucketCorrectorPtr = std::shared_ptr<ml::model::CInterimBucketCorrector>;
+    using TEventRateModelFactoryPtr = boost::shared_ptr<ml::model::CEventRateModelFactory>;
+
+private:
+    void makeModel(const ml::model::SModelParams& params,
+                   const ml::model_t::TFeatureVec& features,
+                   ml::core_t::TTime startTime,
+                   std::size_t numberPeople,
+                   const std::string& summaryCountField = "");
+
+    void makeModel(const ml::model::SModelParams& params,
+                   const ml::model_t::TFeatureVec& features,
+                   ml::core_t::TTime startTime,
+                   std::size_t numberPeople,
+                   ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                   ml::model::CModelFactory::TModelPtr& model,
+                   const std::string& summaryCountField = "");
+
+private:
+    TInterimBucketCorrectorPtr m_InterimBucketCorrector;
+    TEventRateModelFactoryPtr m_Factory;
+    ml::model::CModelFactory::TDataGathererPtr m_Gatherer;
+    ml::model::CModelFactory::TModelPtr m_Model;
     ml::model::CResourceMonitor m_ResourceMonitor;
 };
 

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -20,11 +20,13 @@
 
 #include <model/CAnnotatedProbabilityBuilder.h>
 #include <model/CAnomalyDetectorModelConfig.h>
+#include <model/CCountingModel.h>
 #include <model/CDataGatherer.h>
 #include <model/CDetectionRule.h>
 #include <model/CEventData.h>
 #include <model/CEventRatePopulationModel.h>
 #include <model/CEventRatePopulationModelFactory.h>
+#include <model/CInterimBucketCorrector.h>
 #include <model/CModelDetailsView.h>
 #include <model/CPartitioningFields.h>
 #include <model/CResourceMonitor.h>
@@ -223,10 +225,9 @@ void CEventRatePopulationModelTest::testBasicAccessors() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRatePopulationModelFactory factory(params);
-    CModelFactory::TFeatureVec features;
-    features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute});
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(
         dynamic_cast<CDataGatherer*>(factory.makeDataGatherer(gathererInitData)));
@@ -354,9 +355,10 @@ void CEventRatePopulationModelTest::testFeatures() {
     // Bucket non-zero count unique person count.
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
-    CEventRatePopulationModelFactory factory(params);
-    CModelFactory::TFeatureVec features{model_t::E_PopulationCountByBucketPersonAndAttribute,
-                                        model_t::E_PopulationUniquePersonCountByAttribute};
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    model_t::TFeatureVec features{model_t::E_PopulationCountByBucketPersonAndAttribute,
+                                  model_t::E_PopulationUniquePersonCountByAttribute};
     factory.features(features);
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(
@@ -489,11 +491,10 @@ void CEventRatePopulationModelTest::testComputeProbability() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRatePopulationModelFactory factory(params);
-    CModelFactory::TFeatureVec features;
-    features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
-    features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute,
+                      model_t::E_PopulationUniquePersonCountByAttribute});
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
     CModelFactory::SModelInitializationData modelInitData(gatherer);
@@ -628,11 +629,10 @@ void CEventRatePopulationModelTest::testPrune() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.01;
-    CEventRatePopulationModelFactory factory(params);
-    CDataGatherer::TFeatureVec features;
-    features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
-    features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute,
+                      model_t::E_PopulationUniquePersonCountByAttribute});
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
     CModelFactory::SModelInitializationData modelInitData(gatherer);
@@ -803,11 +803,10 @@ void CEventRatePopulationModelTest::testFrequency() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRatePopulationModelFactory factory(params);
-    CModelFactory::TFeatureVec features;
-    features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
-    features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute,
+                      model_t::E_PopulationUniquePersonCountByAttribute});
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
     const model::CDataGatherer& populationGatherer(
@@ -914,11 +913,10 @@ void CEventRatePopulationModelTest::testSampleRateWeight() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRatePopulationModelFactory factory(params);
-    CModelFactory::TFeatureVec features;
-    features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
-    features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute,
+                      model_t::E_PopulationUniquePersonCountByAttribute});
 
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
@@ -1020,11 +1018,10 @@ void CEventRatePopulationModelTest::testPeriodicity() {
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
     params.s_MinimumModeCount = 24.0;
-    CEventRatePopulationModelFactory factory(params);
-    CModelFactory::TFeatureVec features;
-    features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
-    features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute,
+                      model_t::E_PopulationUniquePersonCountByAttribute});
 
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
@@ -1101,11 +1098,11 @@ void CEventRatePopulationModelTest::testSkipSampling() {
     core_t::TTime startTime(100);
     std::size_t bucketLength(100);
     std::size_t maxAgeBuckets(5);
-    SModelParams params(bucketLength);
 
-    CEventRatePopulationModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_PopulationCountByBucketPersonAndAttribute);
-    factory.features(features);
+    SModelParams params(bucketLength);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute});
 
     CModelFactory::SGathererInitializationData gathererNoGapInitData(startTime);
     CModelFactory::TDataGathererPtr gathererNoGap(factory.makeDataGatherer(gathererNoGapInitData));
@@ -1185,17 +1182,16 @@ void CEventRatePopulationModelTest::testSkipSampling() {
 void CEventRatePopulationModelTest::testInterimCorrections() {
     core_t::TTime startTime(3600);
     std::size_t bucketLength(3600);
-    SModelParams params(bucketLength);
-    CEventRatePopulationModelFactory factory(params);
-    model_t::TFeatureVec features(1u, model_t::E_PopulationCountByBucketPersonAndAttribute);
-    factory.features(features);
 
-    CModelFactory::SGathererInitializationData gathererInitData(startTime);
-    CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
-    CModelFactory::SModelInitializationData modelInitData(gatherer);
-    CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
+    SModelParams params(bucketLength);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute});
+    CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
+    CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(gatherer));
     CEventRatePopulationModel* model =
         dynamic_cast<CEventRatePopulationModel*>(modelHolder.get());
+    CCountingModel countingModel(params, gatherer, interimBucketCorrector);
 
     test::CRandomNumbers rng;
     core_t::TTime now = startTime;
@@ -1212,6 +1208,7 @@ void CEventRatePopulationModelTest::testInterimCorrections() {
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[2] + 0.5); ++i) {
             addArrival(SMessage(now, "p3", "a2"), gatherer, m_ResourceMonitor);
         }
+        countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
@@ -1224,6 +1221,7 @@ void CEventRatePopulationModelTest::testInterimCorrections() {
     for (std::size_t i = 0; i < 100; ++i) {
         addArrival(SMessage(now, "p3", "a2"), gatherer, m_ResourceMonitor);
     }
+    countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
     CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
@@ -1273,11 +1271,10 @@ void CEventRatePopulationModelTest::testPersistence() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CEventRatePopulationModelFactory factory(params);
-    CModelFactory::TFeatureVec features;
-    features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
-    features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationCountByBucketPersonAndAttribute,
+                      model_t::E_PopulationUniquePersonCountByAttribute});
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
 
@@ -1354,8 +1351,9 @@ void CEventRatePopulationModelTest::testIgnoreSamplingGivenDetectionRules() {
     rule.addCondition(condition);
 
     SModelParams paramsNoRules(bucketLength);
-    CEventRatePopulationModelFactory factory(paramsNoRules);
-    model_t::TFeatureVec features(1u, model_t::E_PopulationCountByBucketPersonAndAttribute);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CEventRatePopulationModelFactory factory(paramsNoRules, interimBucketCorrector);
+    model_t::TFeatureVec features{model_t::E_PopulationCountByBucketPersonAndAttribute};
     factory.features(features);
 
     CModelFactory::SGathererInitializationData gathererNoSkipInitData(startTime);
@@ -1367,8 +1365,11 @@ void CEventRatePopulationModelTest::testIgnoreSamplingGivenDetectionRules() {
     SModelParams paramsWithRules(bucketLength);
     SModelParams::TDetectionRuleVec rules{rule};
     paramsWithRules.s_DetectionRules = SModelParams::TDetectionRuleVecCRef(rules);
+    auto interimBucketCorrectorWithRules =
+        std::make_shared<CInterimBucketCorrector>(bucketLength);
 
-    CEventRatePopulationModelFactory factoryWithSkipRule(paramsWithRules);
+    CEventRatePopulationModelFactory factoryWithSkipRule(
+        paramsWithRules, interimBucketCorrectorWithRules);
     factoryWithSkipRule.features(features);
 
     CModelFactory::SGathererInitializationData gathererWithSkipInitData(startTime);

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -27,6 +27,7 @@
 #include <model/CHierarchicalResultsAggregator.h>
 #include <model/CHierarchicalResultsNormalizer.h>
 #include <model/CHierarchicalResultsProbabilityFinalizer.h>
+#include <model/CInterimBucketCorrector.h>
 #include <model/CLimits.h>
 #include <model/CModelDetailsView.h>
 #include <model/CResourceMonitor.h>
@@ -1474,6 +1475,8 @@ void CHierarchicalResultsTest::testWriter() {
     {
         using TStrCPtrVec = model::CDataGatherer::TStrCPtrVec;
         model::SModelParams params(modelConfig.bucketLength());
+        auto interimBucketCorrector =
+            std::make_shared<model::CInterimBucketCorrector>(modelConfig.bucketLength());
         model::CSearchKey key;
         model::CAnomalyDetectorModel::TDataGathererPtr dataGatherer(new model::CDataGatherer(
             model_t::E_EventRate, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING,
@@ -1492,7 +1495,7 @@ void CHierarchicalResultsTest::testWriter() {
         dataGatherer->addArrival(TStrCPtrVec(1, &p21), dummy, resourceMonitor);
         dummy.clear();
         dataGatherer->addArrival(TStrCPtrVec(1, &p23), dummy, resourceMonitor);
-        model::CCountingModel model(params, dataGatherer);
+        model::CCountingModel model(params, dataGatherer, interimBucketCorrector);
         model::CHierarchicalResults results;
         addResult(1, false, FUNC, function, EMPTY_STRING, EMPTY_STRING,
                   EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, 0.001, &model, results);

--- a/lib/model/unittest/CMetricModelTest.h
+++ b/lib/model/unittest/CMetricModelTest.h
@@ -7,9 +7,20 @@
 #ifndef INCLUDED_CMetricModelTest_h
 #define INCLUDED_CMetricModelTest_h
 
+#include <model/CModelFactory.h>
 #include <model/CResourceMonitor.h>
 
 #include <cppunit/extensions/HelperMacros.h>
+
+#include <memory>
+
+namespace ml {
+namespace model {
+class CMetricModelFactory;
+class CInterimBucketCorrector;
+struct SModelParams;
+}
+}
 
 class CMetricModelTest : public CppUnit::TestFixture {
 public:
@@ -38,9 +49,31 @@ public:
     void testDecayRateControl();
     void testIgnoreSamplingGivenDetectionRules();
 
+    void setUp();
     static CppUnit::Test* suite();
 
 private:
+    using TInterimBucketCorrectorPtr = std::shared_ptr<ml::model::CInterimBucketCorrector>;
+    using TMetricModelFactoryPtr = boost::shared_ptr<ml::model::CMetricModelFactory>;
+
+private:
+    void makeModel(const ml::model::SModelParams& params,
+                   const ml::model_t::TFeatureVec& features,
+                   ml::core_t::TTime startTime,
+                   unsigned int* sampleCount = nullptr);
+
+    void makeModel(const ml::model::SModelParams& params,
+                   const ml::model_t::TFeatureVec& features,
+                   ml::core_t::TTime startTime,
+                   ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                   ml::model::CModelFactory::TModelPtr& model,
+                   unsigned int* sampleCount = nullptr);
+
+private:
+    TInterimBucketCorrectorPtr m_InterimBucketCorrector;
+    TMetricModelFactoryPtr m_Factory;
+    ml::model::CModelFactory::TDataGathererPtr m_Gatherer;
+    ml::model::CModelFactory::TModelPtr m_Model;
     ml::model::CResourceMonitor m_ResourceMonitor;
 };
 

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -14,6 +14,7 @@
 
 #include <model/CDataGatherer.h>
 #include <model/CEventData.h>
+#include <model/CInterimBucketCorrector.h>
 #include <model/CMetricBucketGatherer.h>
 #include <model/CMetricPopulationModelFactory.h>
 #include <model/CResourceMonitor.h>
@@ -34,7 +35,6 @@ using namespace model;
 namespace {
 
 using TDoubleVec = std::vector<double>;
-using TFeatureVec = std::vector<model_t::EFeature>;
 using TStrVec = std::vector<std::string>;
 using TStrStrPr = std::pair<std::string, std::string>;
 using TStrStrPrDoubleMap = std::map<TStrStrPr, double>;
@@ -149,8 +149,9 @@ void CMetricPopulationDataGathererTest::testMean() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CMetricPopulationModelFactory factory(params);
-    TFeatureVec features(1u, model_t::E_PopulationMeanByPersonAndAttribute);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CMetricPopulationModelFactory factory(params, interimBucketCorrector);
+    model_t::TFeatureVec features{model_t::E_PopulationMeanByPersonAndAttribute};
     factory.features(features);
     CModelFactory::SGathererInitializationData initData(startTime);
     CModelFactory::TDataGathererPtr gathererPtr(factory.makeDataGatherer(initData));
@@ -214,8 +215,9 @@ void CMetricPopulationDataGathererTest::testMin() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CMetricPopulationModelFactory factory(params);
-    TFeatureVec features(1u, model_t::E_PopulationMinByPersonAndAttribute);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CMetricPopulationModelFactory factory(params, interimBucketCorrector);
+    model_t::TFeatureVec features{model_t::E_PopulationMinByPersonAndAttribute};
     factory.features(features);
     CModelFactory::SGathererInitializationData initData(startTime);
     CModelFactory::TDataGathererPtr gathererPtr(factory.makeDataGatherer(initData));
@@ -279,8 +281,9 @@ void CMetricPopulationDataGathererTest::testMax() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CMetricPopulationModelFactory factory(params);
-    TFeatureVec features(1u, model_t::E_PopulationMaxByPersonAndAttribute);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CMetricPopulationModelFactory factory(params, interimBucketCorrector);
+    model_t::TFeatureVec features{model_t::E_PopulationMaxByPersonAndAttribute};
     factory.features(features);
     CModelFactory::SGathererInitializationData initData(startTime);
     CModelFactory::TDataGathererPtr gathererPtr(factory.makeDataGatherer(initData));
@@ -339,8 +342,9 @@ void CMetricPopulationDataGathererTest::testSum() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CMetricPopulationModelFactory factory(params);
-    TFeatureVec features(1u, model_t::E_PopulationSumByBucketPersonAndAttribute);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CMetricPopulationModelFactory factory(params, interimBucketCorrector);
+    model_t::TFeatureVec features{model_t::E_PopulationSumByBucketPersonAndAttribute};
     factory.features(features);
     CModelFactory::SGathererInitializationData initData(startTime);
     CModelFactory::TDataGathererPtr gathererPtr(factory.makeDataGatherer(initData));
@@ -416,10 +420,9 @@ void CMetricPopulationDataGathererTest::testSampleCount() {
         }
     }
 
-    CMetricPopulationModelFactory factory(params);
-    TFeatureVec features;
-    features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CMetricPopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationMeanByPersonAndAttribute});
     CModelFactory::SGathererInitializationData initData(startTime);
     CModelFactory::TDataGathererPtr gathererPtr(factory.makeDataGatherer(initData));
     CDataGatherer& gatherer(*gathererPtr);
@@ -468,8 +471,9 @@ void CMetricPopulationDataGathererTest::testFeatureData() {
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    CMetricPopulationModelFactory factory(params);
-    TFeatureVec features;
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CMetricPopulationModelFactory factory(params, interimBucketCorrector);
+    model_t::TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
@@ -644,7 +648,7 @@ void CMetricPopulationDataGathererTest::testRemovePeople() {
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    TFeatureVec features;
+    model_t::TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
@@ -783,7 +787,7 @@ void CMetricPopulationDataGathererTest::testRemoveAttributes() {
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
-    TFeatureVec features;
+    model_t::TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
@@ -951,7 +955,7 @@ void CMetricPopulationDataGathererTest::testInfluenceStatistics() {
         "[(i21, (11, 1)), (i22, (7, 1)), (i23, (12.4, 1))]"};
     const std::string* expected = expectedStatistics;
 
-    TFeatureVec features;
+    model_t::TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
@@ -1014,7 +1018,7 @@ void CMetricPopulationDataGathererTest::testPersistence() {
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
 
-    TFeatureVec features;
+    model_t::TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
@@ -1084,9 +1088,9 @@ void CMetricPopulationDataGathererTest::testReleaseMemory() {
 
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = 3;
-    CMetricPopulationModelFactory factory(params);
-    TFeatureVec features(1u, model_t::E_PopulationMeanByPersonAndAttribute);
-    factory.features(features);
+    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+    CMetricPopulationModelFactory factory(params, interimBucketCorrector);
+    factory.features({model_t::E_PopulationMeanByPersonAndAttribute});
     CModelFactory::SGathererInitializationData initData(startTime);
     CModelFactory::TDataGathererPtr gathererPtr(factory.makeDataGatherer(initData));
     CDataGatherer& gatherer(*gathererPtr);

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -15,7 +15,7 @@ CMockModel::CMockModel(const SModelParams& params,
                        const TDataGathererPtr& dataGatherer,
                        const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators)
     : CAnomalyDetectorModel(params, dataGatherer, influenceCalculators),
-      m_IsPopulation(false) {
+      m_IsPopulation(false), m_InterimBucketCorrector(params.s_BucketLength) {
 }
 
 void CMockModel::acceptPersistInserter(core::CStatePersistInserter& /*inserter*/) const {
@@ -159,7 +159,8 @@ void CMockModel::updateRecycledModels() {
 void CMockModel::clearPrunedResources(const TSizeVec& /*people*/, const TSizeVec& /*attributes*/) {
 }
 
-void CMockModel::currentBucketTotalCount(uint64_t /*totalCount*/) {
+const CInterimBucketCorrector& CMockModel::interimValueCorrector() const {
+    return m_InterimBucketCorrector;
 }
 
 void CMockModel::doSkipSampling(core_t::TTime /*startTime*/, core_t::TTime /*endTime*/) {

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -10,6 +10,7 @@
 #include <core/CTriple.h>
 
 #include <model/CAnomalyDetectorModel.h>
+#include <model/CInterimBucketCorrector.h>
 #include <model/CModelDetailsView.h>
 
 #include <boost/unordered_map.hpp>
@@ -119,13 +120,6 @@ public:
 
     void mockTimeSeriesModels(const TMathsModelPtrVec& model);
 
-protected:
-    virtual core_t::TTime currentBucketStartTime() const;
-    virtual void currentBucketStartTime(core_t::TTime time);
-    virtual void createNewModels(std::size_t n, std::size_t m);
-    virtual void updateRecycledModels();
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
-
 private:
     using TDouble1Vec = CAnomalyDetectorModel::TDouble1Vec;
     using TSizeSizeTimeTriple = core::CTriple<std::size_t, std::size_t, core_t::TTime>;
@@ -134,7 +128,12 @@ private:
         boost::unordered_map<TFeatureSizeSizeTimeTriplePr, TDouble1Vec>;
 
 private:
-    virtual void currentBucketTotalCount(uint64_t totalCount);
+    virtual core_t::TTime currentBucketStartTime() const;
+    virtual void currentBucketStartTime(core_t::TTime time);
+    virtual void createNewModels(std::size_t n, std::size_t m);
+    virtual void updateRecycledModels();
+    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+    virtual const model::CInterimBucketCorrector& interimValueCorrector() const;
     virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime);
     virtual CMemoryUsageEstimator* memoryUsageEstimator() const;
 
@@ -143,6 +142,7 @@ private:
     TFeatureSizeSizeTimeTriplePrDouble1VecUMap m_BucketValues;
     TFeatureSizeSizeTimeTriplePrDouble1VecUMap m_BucketBaselineMeans;
     TMathsModelPtrVec m_Models;
+    model::CInterimBucketCorrector m_InterimBucketCorrector;
 };
 
 //! \brief A details view for a mock model.


### PR DESCRIPTION
Partitioning an analysis using "partition" vs "by" we pay up to 100% increase in memory usage per "partition of the data". A major contributor to this is the cost of the interim bucket corrector.

We estimate the count we expect in a bucket and correct its statistics for interim results if the count is less than expected (to account for missing data). For by analysis we use one estimate for the bucket as a whole; for partition analysis we use one estimate for each partition. This ends up contributing around 60% of the extra memory cost, since the size of the model for the expected count is relatively large.

I think from a QoR perspective, estimating the overall bucket count is actually likely to be more effective since partitions are likely to have significantly greater variance in their count and so any prediction of their expected count would have significantly larger uncertainty. However, the real win is the reduced memory usage. Since any correction we perform is approximate, we don't know what data we'll subsequently receive, I think we must change our strategy here.

I get a pretty consistent relative memory improvement for a range of partition cardinalities and data characteristics:

| # partitions | Old model memory | New model memory | % improvement |
| :---: | :---: | :---: | :---: |
| 10 | 1.4MB | 1MB | 28.6 |
| 20 | 1MB | 0.72MB | 28 |
| 78 | 4.1MB | 3MB | 26.8 |
| 16925 | 559MB | 397MB | 28.9 |

The basic strategy is to move to one shared interim bucket corrector, which is only updated by the (single) counting model. (Note that there is a very small error in the attributed model memory, since there is a contribution to the reference count of 1 from the model config class which is not accounted for in the model memory calculation. In the case where the estimate is important, many partitions of the data, this error is small so I prefer to keep the implementation clean.) I don't think it is worthwhile trying to upgrade this part of the model state, it is good enough to reinitialise the interim bucket corrector state when the model is upgraded, so I haven't bothered to make `CInterimBucketCorrector` restore backwards compatible as we won't try and restore these objects.

This will affect interim results for partition analysis. Also, since it changes the model memory significantly I would expect to get different results on jobs which hit the hard memory limit. Otherwise, the results should be unchanged.

I split the change into two commits, functional changes and test changes, since the mechanical changes need to the tests were reasonably large. Also, since I was forced to update quite a lot of code anyway, I took the opportunity try and streamline model creation in the affected unit tests. There is still quite a lot of copy paste boilerplate code here, which would benefit from further refactor, but that can be the subject of separate PR.