### PR TITLE
[ML] Don't lose mean offset in expanding window when persisting

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ model state on disk ({pull}89[#89])
 === Bug Fixes
 
 Age seasonal components in proportion to the fraction of values with which they're updated ({pull}88[#88])
+Persist and restore was missing some of the trend model state ({pull}#99[#99])
 
 === Regressions
 

--- a/lib/maths/unittest/CExpandingWindowTest.cc
+++ b/lib/maths/unittest/CExpandingWindowTest.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CExpandingWindowTest.h"
+
+#include <core/CContainerPrinter.h>
+#include <core/CLogger.h>
+#include <core/CRapidXmlStatePersistInserter.h>
+#include <core/CRapidXmlStateRestoreTraverser.h>
+#include <core/Constants.h>
+
+#include <maths/CBasicStatistics.h>
+#include <maths/CExpandingWindow.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <boost/math/constants/constants.hpp>
+
+#include <vector>
+
+using namespace ml;
+
+namespace {
+using TDoubleVec = std::vector<double>;
+using TTimeVec = std::vector<core_t::TTime>;
+using TTimeCRng = core::CVectorRange<const TTimeVec>;
+using TFloatMeanAccumulator =
+    maths::CBasicStatistics::SSampleMean<maths::CFloatStorage>::TAccumulator;
+using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
+
+TTimeVec BUCKET_LENGTHS{300, 600, 1800, 3600};
+}
+
+void CExpandingWindowTest::testPersistence() {
+    // Test persist and restore is idempotent.
+
+    core_t::TTime bucketLength{300};
+    std::size_t size{336};
+    double decayRate{0.01};
+
+    test::CRandomNumbers rng;
+
+    maths::CExpandingWindow origWindow{bucketLength, TTimeCRng{BUCKET_LENGTHS, 0, 4},
+                                       size, decayRate};
+
+    TDoubleVec values;
+    rng.generateUniformSamples(0.0, 10.0, size, values);
+    for (core_t::TTime time = 0; time < static_cast<core_t::TTime>(size) * bucketLength;
+         time += bucketLength) {
+        double value{values[time / bucketLength]};
+        origWindow.add(time, value);
+    }
+
+    std::string origXml;
+    {
+        core::CRapidXmlStatePersistInserter inserter("root");
+        origWindow.acceptPersistInserter(inserter);
+        inserter.toXml(origXml);
+    }
+    LOG_TRACE(<< "Window XML = " << origXml);
+    LOG_DEBUG(<< "Window XML size = " << origXml.size());
+
+    // Restore the XML into a new window.
+    {
+        core::CRapidXmlParser parser;
+        CPPUNIT_ASSERT(parser.parseStringIgnoreCdata(origXml));
+        core::CRapidXmlStateRestoreTraverser traverser(parser);
+        maths::CExpandingWindow restoredWindow{
+            bucketLength, TTimeCRng{BUCKET_LENGTHS, 0, 4}, size, decayRate};
+        CPPUNIT_ASSERT_EQUAL(
+            true, traverser.traverseSubLevel(boost::bind(&maths::CExpandingWindow::acceptRestoreTraverser,
+                                                         &restoredWindow, _1)));
+
+        LOG_DEBUG(<< "orig checksum = " << origWindow.checksum()
+                  << ", new checksum = " << restoredWindow.checksum());
+        CPPUNIT_ASSERT_EQUAL(origWindow.checksum(), restoredWindow.checksum());
+    }
+}
+
+CppUnit::Test* CExpandingWindowTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CExpandingWindowTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CExpandingWindowTest>(
+        "CExpandingWindowTest::testPersistence", &CExpandingWindowTest::testPersistence));
+
+    return suiteOfTests;
+}

--- a/lib/maths/unittest/CExpandingWindowTest.h
+++ b/lib/maths/unittest/CExpandingWindowTest.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CExpandingWindowTest_h
+#define INCLUDED_CExpandingWindowTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CExpandingWindowTest : public CppUnit::TestFixture {
+public:
+    void testPersistence();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CExpandingWindowTest_h

--- a/lib/maths/unittest/Main.cc
+++ b/lib/maths/unittest/Main.cc
@@ -21,6 +21,7 @@
 #include "CDecayRateControllerTest.h"
 #include "CEntropySketchTest.h"
 #include "CEqualWithToleranceTest.h"
+#include "CExpandingWindowTest.h"
 #include "CForecastTest.h"
 #include "CGammaRateConjugateTest.h"
 #include "CGramSchmidtTest.h"
@@ -84,6 +85,7 @@
 int main(int argc, const char** argv) {
     ml::test::CTestRunner runner(argc, argv);
 
+    runner.addTest(CExpandingWindowTest::suite());
     runner.addTest(CAgglomerativeClustererTest::suite());
     runner.addTest(CAssignmentTest::suite());
     runner.addTest(CBasicStatisticsTest::suite());

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -32,6 +32,7 @@ SRCS=\
 	CDecayRateControllerTest.cc \
 	CEntropySketchTest.cc \
 	CEqualWithToleranceTest.cc \
+	CExpandingWindowTest.cc \
 	CForecastTest.cc \
 	CGammaRateConjugateTest.cc \
 	CGramSchmidtTest.cc \


### PR DESCRIPTION
We were not persisting and restoring the mean offset time of the values added to the expanding window w.r.t. the start of the data buckets. This was therefore getting reset to 0 on a persist restore cycle.

This will introduce a small error when initialising periodic components after a persist and restore and would affect results in this context.