### PR TITLE
[ML] Correct the way internal linkage of constants is achieved

### DIFF
--- a/include/core/COsFileFuncs.h
+++ b/include/core/COsFileFuncs.h
@@ -70,7 +70,7 @@ public:
     static const int EXECUTABLE;
 
     //! The name of the magic file that discards everything written to it
-    static const char* NULL_FILENAME;
+    static const char* const NULL_FILENAME;
 
 public:
     //! Signed size type (to be used instead of ssize_t)

--- a/include/core/CProcess.h
+++ b/include/core/CProcess.h
@@ -40,10 +40,10 @@ namespace core {
 class CORE_EXPORT CProcess : private CNonCopyable {
 public:
     //! These messages need to be 100% standard across all services
-    static const char* STARTING_MSG;
-    static const char* STARTED_MSG;
-    static const char* STOPPING_MSG;
-    static const char* STOPPED_MSG;
+    static const char* const STARTING_MSG;
+    static const char* const STARTED_MSG;
+    static const char* const STOPPING_MSG;
+    static const char* const STOPPED_MSG;
 
 public:
     //! Prototype of the mlMain() function

--- a/include/core/CWordDictionary.h
+++ b/include/core/CWordDictionary.h
@@ -149,7 +149,7 @@ private:
 
 private:
     //! Name of the file to load that contains the dictionary words.
-    static const char* DICTIONARY_FILE;
+    static const char* const DICTIONARY_FILE;
 
     //! The constructor loads a file, and hence may take a while.  This
     //! mutex prevents the singleton object being constructed simultaneously

--- a/include/core/CXmlParser.h
+++ b/include/core/CXmlParser.h
@@ -59,7 +59,7 @@ public:
     static const std::string ATTRIBUTE_EQUALS;
     static const size_t DEFAULT_INDENT_SPACES;
     static const size_t MAX_INDENT_SPACES;
-    static const char* INDENT_SPACE_STR;
+    static const char* const INDENT_SPACE_STR;
 
 public:
     using TStrVec = std::vector<std::string>;

--- a/include/core/CoreTypes.h
+++ b/include/core/CoreTypes.h
@@ -17,17 +17,12 @@ using TTime = time_t;
 
 //! The standard line ending for the platform - DON'T make this std::string as
 //! that would cause many strings to be constructed (since the variable is
-//! static const at the namespace level, so is internal to each file this
-//! header is included in)
+//! const at the namespace level, so is internal to each file this header is
+//! included in)
 #ifdef Windows
-static const char* LINE_ENDING = "\r\n";
+const char* const LINE_ENDING = "\r\n";
 #else
-#ifdef __GNUC__
-// Tell g++ that it's reasonable that this variable isn't used
-__attribute__((unused)) static const char* LINE_ENDING = "\n";
-#else
-static const char* LINE_ENDING = "\n";
-#endif
+const char* const LINE_ENDING = "\n";
 #endif
 }
 }

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -701,7 +701,7 @@ enum EMetricCategory {
 };
 
 //! Must correspond to the number of enumeration values of EMetricCategory
-static const size_t NUM_METRIC_CATEGORIES = 9;
+const size_t NUM_METRIC_CATEGORIES = 9;
 
 //! Get the metric feature data corresponding to \p feature
 //! if there is one.

--- a/lib/api/unittest/CIoManagerTest.cc
+++ b/lib/api/unittest/CIoManagerTest.cc
@@ -25,19 +25,19 @@ const uint32_t PAUSE_TIME_MS = 10;
 const size_t MAX_ATTEMPTS = 100;
 const size_t TEST_SIZE = 10000;
 const char TEST_CHAR = 'a';
-const char* GOOD_INPUT_FILE_NAME = "testfiles/good_input_file";
-const char* GOOD_OUTPUT_FILE_NAME = "testfiles/good_output_file";
+const char* const GOOD_INPUT_FILE_NAME = "testfiles/good_input_file";
+const char* const GOOD_OUTPUT_FILE_NAME = "testfiles/good_output_file";
 #ifdef Windows
-const char* GOOD_INPUT_PIPE_NAME = "\\\\.\\pipe\\good_input_pipe";
-const char* GOOD_OUTPUT_PIPE_NAME = "\\\\.\\pipe\\good_output_pipe";
+const char* const GOOD_INPUT_PIPE_NAME = "\\\\.\\pipe\\good_input_pipe";
+const char* const GOOD_OUTPUT_PIPE_NAME = "\\\\.\\pipe\\good_output_pipe";
 #else
-const char* GOOD_INPUT_PIPE_NAME = "testfiles/good_input_pipe";
-const char* GOOD_OUTPUT_PIPE_NAME = "testfiles/good_output_pipe";
+const char* const GOOD_INPUT_PIPE_NAME = "testfiles/good_input_pipe";
+const char* const GOOD_OUTPUT_PIPE_NAME = "testfiles/good_output_pipe";
 #endif
-const char* BAD_INPUT_FILE_NAME = "can't_create_a_file_here/bad_input_file";
-const char* BAD_OUTPUT_FILE_NAME = "can't_create_a_file_here/bad_output_file";
-const char* BAD_INPUT_PIPE_NAME = "can't_create_a_pipe_here/bad_input_pipe";
-const char* BAD_OUTPUT_PIPE_NAME = "can't_create_a_pipe_here/bad_output_pipe";
+const char* const BAD_INPUT_FILE_NAME = "can't_create_a_file_here/bad_input_file";
+const char* const BAD_OUTPUT_FILE_NAME = "can't_create_a_file_here/bad_output_file";
+const char* const BAD_INPUT_PIPE_NAME = "can't_create_a_pipe_here/bad_input_pipe";
+const char* const BAD_OUTPUT_PIPE_NAME = "can't_create_a_pipe_here/bad_output_pipe";
 
 class CThreadDataWriter : public ml::core::CThread {
 public:

--- a/lib/core/CMutex_Windows.cc
+++ b/lib/core/CMutex_Windows.cc
@@ -8,7 +8,7 @@
 namespace {
 // 4000 is a value that Microsoft uses in some of their code, so it's
 // hopefully a reasonably sensible setting
-static const DWORD SPIN_COUNT(4000);
+const DWORD SPIN_COUNT(4000);
 }
 
 namespace ml {

--- a/lib/core/COsFileFuncs.cc
+++ b/lib/core/COsFileFuncs.cc
@@ -27,7 +27,7 @@ const int COsFileFuncs::READABLE(R_OK);
 const int COsFileFuncs::WRITABLE(W_OK);
 const int COsFileFuncs::EXECUTABLE(X_OK);
 
-const char* COsFileFuncs::NULL_FILENAME("/dev/null");
+const char* const COsFileFuncs::NULL_FILENAME("/dev/null");
 
 int COsFileFuncs::open(const char* path, int oflag) {
     return ::open(path, oflag);

--- a/lib/core/COsFileFuncs_Windows.cc
+++ b/lib/core/COsFileFuncs_Windows.cc
@@ -51,7 +51,7 @@ const int COsFileFuncs::WRITABLE(2);
 // For Windows, consider "executable" the same as "readable" for the time being
 const int COsFileFuncs::EXECUTABLE(4);
 
-const char* COsFileFuncs::NULL_FILENAME("nul");
+const char* const COsFileFuncs::NULL_FILENAME("nul");
 
 int COsFileFuncs::open(const char* path, int oflag) {
     return COsFileFuncs::open(path, oflag, 0);

--- a/lib/core/CProcess.cc
+++ b/lib/core/CProcess.cc
@@ -13,10 +13,10 @@
 namespace ml {
 namespace core {
 
-const char* CProcess::STARTING_MSG("Process Starting.");
-const char* CProcess::STARTED_MSG("Process Started.");
-const char* CProcess::STOPPING_MSG("Process Shutting Down.");
-const char* CProcess::STOPPED_MSG("Process Exiting.");
+const char* const CProcess::STARTING_MSG("Process Starting.");
+const char* const CProcess::STARTED_MSG("Process Started.");
+const char* const CProcess::STOPPING_MSG("Process Shutting Down.");
+const char* const CProcess::STOPPED_MSG("Process Exiting.");
 
 CProcess::CProcess()
     : m_IsService(false), m_Initialised(false), m_Running(false),

--- a/lib/core/CProcess_Windows.cc
+++ b/lib/core/CProcess_Windows.cc
@@ -62,10 +62,10 @@ const DWORD PPID(findParentProcessId());
 namespace ml {
 namespace core {
 
-const char* CProcess::STARTING_MSG("Process Starting.");
-const char* CProcess::STARTED_MSG("Process Started.");
-const char* CProcess::STOPPING_MSG("Process Shutting Down.");
-const char* CProcess::STOPPED_MSG("Process Exiting.");
+const char* const CProcess::STARTING_MSG("Process Starting.");
+const char* const CProcess::STARTED_MSG("Process Started.");
+const char* const CProcess::STOPPING_MSG("Process Shutting Down.");
+const char* const CProcess::STOPPED_MSG("Process Exiting.");
 
 CProcess::CProcess()
     : m_IsService(false), m_Initialised(false), m_Running(false),

--- a/lib/core/CResourceLocator.cc
+++ b/lib/core/CResourceLocator.cc
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 
 namespace {
-const char* CPP_SRC_HOME("CPP_SRC_HOME");
+const char* const CPP_SRC_HOME("CPP_SRC_HOME");
 }
 
 namespace ml {

--- a/lib/core/CStatistics.cc
+++ b/lib/core/CStatistics.cc
@@ -25,13 +25,13 @@ namespace {
 
 using TGenericLineWriter = core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>;
 
-static const std::string NAME_TYPE("name");
-static const std::string DESCRIPTION_TYPE("description");
-static const std::string STAT_TYPE("value");
+const std::string NAME_TYPE("name");
+const std::string DESCRIPTION_TYPE("description");
+const std::string STAT_TYPE("value");
 
 //! Persistence tags
-static const std::string KEY_TAG("a");
-static const std::string VALUE_TAG("b");
+const std::string KEY_TAG("a");
+const std::string VALUE_TAG("b");
 
 //! Helper function to add a string/int pair to JSON writer
 void addStringInt(TGenericLineWriter& writer,

--- a/lib/core/CUname_Windows.cc
+++ b/lib/core/CUname_Windows.cc
@@ -25,7 +25,7 @@ bool queryKernelVersion(uint16_t& major, uint16_t& minor, uint16_t& build) {
     // then distinguish client/server versions of Windows using
     // VerifyVersionInfo().
 
-    static const char* KERNEL32_DLL("kernel32.dll");
+    static const char* const KERNEL32_DLL("kernel32.dll");
 
     DWORD handle(0);
     DWORD size(GetFileVersionInfoSize(KERNEL32_DLL, &handle));

--- a/lib/core/CWindowsError_Windows.cc
+++ b/lib/core/CWindowsError_Windows.cc
@@ -11,7 +11,7 @@
 #include <cmath>
 
 namespace {
-static const size_t BUFFER_SIZE(1024);
+const size_t BUFFER_SIZE(1024);
 }
 
 namespace ml {

--- a/lib/core/CWordDictionary.cc
+++ b/lib/core/CWordDictionary.cc
@@ -65,7 +65,7 @@ CWordDictionary::EPartOfSpeech partOfSpeechFromCode(char partOfSpeechCode) {
 }
 }
 
-const char* CWordDictionary::DICTIONARY_FILE("ml-en.dict");
+const char* const CWordDictionary::DICTIONARY_FILE("ml-en.dict");
 
 CFastMutex CWordDictionary::ms_LoadMutex;
 volatile CWordDictionary* CWordDictionary::ms_Instance(nullptr);

--- a/lib/core/CXmlParser.cc
+++ b/lib/core/CXmlParser.cc
@@ -30,7 +30,7 @@ const std::string CXmlParser::ATTRIBUTE_EQUALS("=");
 const size_t CXmlParser::DEFAULT_INDENT_SPACES(4);
 const size_t CXmlParser::MAX_INDENT_SPACES(10);
 // The number of spaces in this constant MUST match the maximum above
-const char* CXmlParser::INDENT_SPACE_STR("          ");
+const char* const CXmlParser::INDENT_SPACE_STR("          ");
 
 CXmlParser::CXmlParser()
     : m_Doc(nullptr), m_XPathContext(nullptr), m_NavigatedNode(nullptr) {

--- a/lib/core/unittest/CDualThreadStreamBufTest.cc
+++ b/lib/core/unittest/CDualThreadStreamBufTest.cc
@@ -191,7 +191,7 @@ void CDualThreadStreamBufTest::testPutback() {
 
     buf.signalEndOfFile();
 
-    static const char* PUTBACK_CHARS("put this back");
+    static const char* const PUTBACK_CHARS("put this back");
     std::istream strm(&buf);
     char c('\0');
     CPPUNIT_ASSERT(strm.get(c).good());

--- a/lib/core/unittest/CLoggerTest.cc
+++ b/lib/core/unittest/CLoggerTest.cc
@@ -22,9 +22,9 @@
 
 namespace {
 #ifdef Windows
-const char* TEST_PIPE_NAME = "\\\\.\\pipe\\testpipe";
+const char* const TEST_PIPE_NAME = "\\\\.\\pipe\\testpipe";
 #else
-const char* TEST_PIPE_NAME = "testfiles/testpipe";
+const char* const TEST_PIPE_NAME = "testfiles/testpipe";
 #endif
 }
 

--- a/lib/core/unittest/CNamedPipeFactoryTest.cc
+++ b/lib/core/unittest/CNamedPipeFactoryTest.cc
@@ -26,9 +26,9 @@ const size_t MAX_ATTEMPTS = 100;
 const size_t TEST_SIZE = 10000;
 const char TEST_CHAR = 'a';
 #ifdef Windows
-const char* TEST_PIPE_NAME = "\\\\.\\pipe\\testpipe";
+const char* const TEST_PIPE_NAME = "\\\\.\\pipe\\testpipe";
 #else
-const char* TEST_PIPE_NAME = "testfiles/testpipe";
+const char* const TEST_PIPE_NAME = "testfiles/testpipe";
 #endif
 
 class CThreadDataWriter : public ml::core::CThread {
@@ -279,7 +279,7 @@ void CNamedPipeFactoryTest::testErrorIfSymlink() {
     // the file system
     LOG_DEBUG(<< "symlink test not relevant to Windows");
 #else
-    static const char* TEST_SYMLINK_NAME = "test_symlink";
+    static const char* const TEST_SYMLINK_NAME = "test_symlink";
 
     // Remove any files left behind by a previous failed test, but don't check
     // the return codes as these calls will usually fail

--- a/lib/maths/CSampling.cc
+++ b/lib/maths/CSampling.cc
@@ -393,7 +393,7 @@ void sampleQuantiles(const DISTRIBUTION& distribution, std::size_t n, TDoubleVec
     result.push_back(expectation(distribution, a, b));
 }
 
-static const std::string RNG_TAG("a");
+const std::string RNG_TAG("a");
 }
 
 bool CSampling::staticsAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/CXMeansOnline1d.cc
+++ b/lib/maths/CXMeansOnline1d.cc
@@ -588,9 +588,9 @@ const std::string DECAY_RATE_TAG("j");
 const std::string HISTORY_LENGTH_TAG("k");
 
 // CXMeansOnline1d::CCluster
-static const std::string INDEX_TAG("a");
-static const std::string STRUCTURE_TAG("b");
-static const std::string PRIOR_TAG("c");
+const std::string INDEX_TAG("a");
+const std::string STRUCTURE_TAG("b");
+const std::string PRIOR_TAG("c");
 
 const std::string EMPTY_STRING;
 }

--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -22,11 +22,11 @@ namespace ml {
 namespace model {
 
 namespace {
-static const std::string FORECAST_MODEL_PERSIST_TAG("forecast_persist");
-static const std::string FEATURE_TAG("feature");
-static const std::string DATA_TYPE_TAG("datatype");
-static const std::string MODEL_TAG("model");
-static const std::string BY_FIELD_VALUE_TAG("by_field_value");
+const std::string FORECAST_MODEL_PERSIST_TAG("forecast_persist");
+const std::string FEATURE_TAG("feature");
+const std::string DATA_TYPE_TAG("datatype");
+const std::string MODEL_TAG("model");
+const std::string BY_FIELD_VALUE_TAG("by_field_value");
 }
 
 CForecastModelPersist::CPersist::CPersist(const std::string& temporaryPath)


### PR DESCRIPTION
1. There's no need for constants declared in unnamed namespaces
   to be declared `static` - they already have internal linkage.
2. Constants of type `char*` pointing to literals should be
   declared `const char* const` - declaring them `const char*` does
   not result in internal linkage because it allows them to be
   changed to point at something completely different!