### PR TITLE
[ML] Trap zero variance in forecast confidence interval calculation causing error to be logged

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ model state on disk ({pull}89[#89])
 
 Age seasonal components in proportion to the fraction of values with which they're updated ({pull}88[#88])
 Persist and restore was missing some of the trend model state ({pull}#99[#99])
+Stop zero variance data generating a log error in the forecast confidence interval calculation ({pull}#107[#107])
 
 === Regressions
 

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -430,8 +430,10 @@ void CTrendComponent::forecast(core_t::TTime startTime,
         double qu{0.0};
         double variance{a * CBasicStatistics::mean(variance_) +
                         b * CBasicStatistics::variance(m_ValueMoments)};
-        if (auto interval = confidenceInterval(0.0, variance, confidence)) {
-            boost::tie(ql, qu) = *interval;
+        if (variance > 0.0) {
+            if (auto interval = confidenceInterval(0.0, variance, confidence)) {
+                boost::tie(ql, qu) = *interval;
+            }
         }
 
         writer(time, {level_[0] + seasonal_[0] + prediction + ql,

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -56,6 +56,9 @@ double scaleTime(core_t::TTime time, core_t::TTime origin) {
 
 //! Get the \p confidence interval for \p prediction and \p variance.
 TOptionalDoubleDoublePr confidenceInterval(double prediction, double variance, double confidence) {
+    if (variance == 0.0) {
+        return std::make_pair(prediction, prediction);
+    }
     try {
         boost::math::normal normal{prediction, std::sqrt(variance)};
         double ql{boost::math::quantile(normal, (100.0 - confidence) / 200.0)};
@@ -430,10 +433,8 @@ void CTrendComponent::forecast(core_t::TTime startTime,
         double qu{0.0};
         double variance{a * CBasicStatistics::mean(variance_) +
                         b * CBasicStatistics::variance(m_ValueMoments)};
-        if (variance > 0.0) {
-            if (auto interval = confidenceInterval(0.0, variance, confidence)) {
-                boost::tie(ql, qu) = *interval;
-            }
+        if (auto interval = confidenceInterval(0.0, variance, confidence)) {
+            boost::tie(ql, qu) = *interval;
         }
 
         writer(time, {level_[0] + seasonal_[0] + prediction + ql,


### PR DESCRIPTION
If all the values added to a model before a forecast are identical, it triggers the following error in the confidence interval when forecasting: `ERROR CTrendComponent.cc@67 Failed calculating confidence interval: Error in function boost::math::normal_distribution<double>::normal_distribution: Scale parameter is 0, but must be > 0 !, prediction = 0, variance = 0, confidence = 95`. In fact, this error is harmless (since we take the correct action in this case).

This change explicitly traps the problem case, i.e. creating a distribution with zero variance. It doesn't result in any change in behaviour, but does suppress the error.