### PR TITLE
[6.4][ML] Trap zero variance in forecast confidence interval calculation causing error to be logged

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ new processes being created and macOS uses the sandbox functionality ({pull}98[#
 
 Age seasonal components in proportion to the fraction of values with which they're updated ({pull}88[#88])
 Persist and restore was missing some of the trend model state ({pull}#99[#99])
+Stop zero variance data generating a log error in the forecast confidence interval calculation ({pull}#107[#107])
 
 === Regressions
 

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -56,6 +56,9 @@ double scaleTime(core_t::TTime time, core_t::TTime origin) {
 
 //! Get the \p confidence interval for \p prediction and \p variance.
 TOptionalDoubleDoublePr confidenceInterval(double prediction, double variance, double confidence) {
+    if (variance == 0.0) {
+        return std::make_pair(prediction, prediction);
+    }
     try {
         boost::math::normal normal{prediction, std::sqrt(variance)};
         double ql{boost::math::quantile(normal, (100.0 - confidence) / 200.0)};


### PR DESCRIPTION
Backport of #107.