### PR TITLE
[ML] Fix #51 - fix lgamma calculation for x-means clustering

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -53,7 +53,7 @@ by unnecessary reference counting ({pull}108[#108])
 Age seasonal components in proportion to the fraction of values with which they're updated ({pull}88[#88])
 Persist and restore was missing some of the trend model state ({pull}#99[#99])
 Stop zero variance data generating a log error in the forecast confidence interval calculation ({pull}#107[#107])
-Fix cornercase failing to calculate lgamma values and the correspoinding log errors ({pull}#126[#126])
+Fix corner case failing to calculate lgamma values and the correspoinding log errors ({pull}#126[#126])
 
 === Regressions
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ by unnecessary reference counting ({pull}108[#108])
 Age seasonal components in proportion to the fraction of values with which they're updated ({pull}88[#88])
 Persist and restore was missing some of the trend model state ({pull}#99[#99])
 Stop zero variance data generating a log error in the forecast confidence interval calculation ({pull}#107[#107])
+Fix cornercase failing to calculate lgamma values and the correspoinding log errors ({pull}#126[#126])
 
 === Regressions
 

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -693,6 +693,9 @@ public:
     //! A custom implementation of \f$\log(1 - x)\f$ which handles the
     //! cancellation error for small x.
     static double logOneMinusX(double x);
+
+    //! A wrapper around lgamma which handles corner cases if requested
+    static bool lgamma(double value, double& result, bool checkForFinite = false);
 };
 }
 }

--- a/lib/maths/CTools.cc
+++ b/lib/maths/CTools.cc
@@ -2005,5 +2005,10 @@ double CTools::logOneMinusX(double x) {
 
     return result;
 }
+
+bool CTools::lgamma(double value, double& result, bool checkForFinite) {
+    result = std::lgamma(value);
+    return checkForFinite ? std::isfinite(result) : true;
+}
 }
 }

--- a/lib/maths/unittest/CToolsTest.cc
+++ b/lib/maths/unittest/CToolsTest.cc
@@ -26,6 +26,8 @@
 #include <boost/optional.hpp>
 #include <boost/range.hpp>
 
+#include <array>
+
 using namespace ml;
 using namespace maths;
 using namespace test;
@@ -1168,6 +1170,54 @@ void CToolsTest::testMiscellaneous() {
     }
 }
 
+void CToolsTest::testLgamma() {
+    std::array<double, 8> testData = {3.5,
+                                      0.125,
+                                      -0.125,
+                                      0.000244140625,
+                                      1.3552527156068805e-20,
+                                      4.95547e+25,
+                                      5.01753e+25,
+                                      8.64197e+25};
+
+    std::array<double, 8> expectedData = {
+        1.2009736023470742248160218814507129957702389154682,
+        2.0194183575537963453202905211670995899482809521344,
+        2.1653002489051702517540619481440174064962195287626,
+        8.3176252939431805089043336920440196990966796875000,
+        45.7477139169563926657247066032141447067260742187500,
+        2.882355039447984e+27,
+        2.919076782442754e+27,
+        5.074673490557339e+27};
+
+    for (std::size_t i = 0u; i < testData.size(); ++i) {
+        double actual;
+        double expected = expectedData[i];
+        CPPUNIT_ASSERT(maths::CTools::lgamma(testData[i], actual, true));
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, actual, 1e-5 * expected);
+    }
+
+    double result;
+    CPPUNIT_ASSERT(maths::CTools::lgamma(0, result));
+    CPPUNIT_ASSERT_EQUAL(result, std::numeric_limits<double>::infinity());
+
+    CPPUNIT_ASSERT((maths::CTools::lgamma(0, result, true) == false));
+    CPPUNIT_ASSERT_EQUAL(result, std::numeric_limits<double>::infinity());
+
+    CPPUNIT_ASSERT((maths::CTools::lgamma(-1, result)));
+    CPPUNIT_ASSERT_EQUAL(result, std::numeric_limits<double>::infinity());
+
+    CPPUNIT_ASSERT((maths::CTools::lgamma(-1, result, true) == false));
+    CPPUNIT_ASSERT_EQUAL(result, std::numeric_limits<double>::infinity());
+
+    CPPUNIT_ASSERT((maths::CTools::lgamma(std::numeric_limits<double>::max() - 1, result)));
+    CPPUNIT_ASSERT_EQUAL(result, std::numeric_limits<double>::infinity());
+
+    CPPUNIT_ASSERT((maths::CTools::lgamma(std::numeric_limits<double>::max() - 1,
+                                          result, true) == false));
+    CPPUNIT_ASSERT_EQUAL(result, std::numeric_limits<double>::infinity());
+}
+
 CppUnit::Test* CToolsTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CToolsTest");
 
@@ -1187,6 +1237,8 @@ CppUnit::Test* CToolsTest::suite() {
         "CToolsTest::testFastLog", &CToolsTest::testFastLog));
     suiteOfTests->addTest(new CppUnit::TestCaller<CToolsTest>(
         "CToolsTest::testMiscellaneous", &CToolsTest::testMiscellaneous));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CToolsTest>(
+        "CToolsTest::testLgamma", &CToolsTest::testLgamma));
 
     return suiteOfTests;
 }

--- a/lib/maths/unittest/CToolsTest.h
+++ b/lib/maths/unittest/CToolsTest.h
@@ -18,6 +18,7 @@ public:
     void testSpread();
     void testFastLog();
     void testMiscellaneous();
+    void testLgamma();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
Minimal fix for #51, replacing boost::lgamma with std::lgamma and guarding the output of lgamma for finite values.

fixes #51

Notes:

- this is a minimal fix, further re-factorings are target of separate PR's (follow-up issues tbd)
  - I target this for 6.4, but keep the door open for a backport to 6.3 (according to bug report)
- tested on 6.x (VS 2013)
- tested e2e, yields exactly the same results as before (the lgamma calculation failures are therefore benign for the end result, `affect-results` does not apply)