### PR TITLE
[ML] Fix influencer count and influence calculation

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -59,7 +59,7 @@ Age seasonal components in proportion to the fraction of values with which they'
 Persist and restore was missing some of the trend model state ({pull}#99[#99])
 Stop zero variance data generating a log error in the forecast confidence interval calculation ({pull}#107[#107])
 Fix corner case failing to calculate lgamma values and the correspoinding log errors ({pull}#126[#126])
-Influence count per bucket was wrong and lead to wrong influencer scoring ({pull}#150[#150])
+Influence count per bucket for metric population analyses was wrong and lead to wrong influencer scoring ({pull}#150[#150])
 
 === Regressions
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -59,6 +59,7 @@ Age seasonal components in proportion to the fraction of values with which they'
 Persist and restore was missing some of the trend model state ({pull}#99[#99])
 Stop zero variance data generating a log error in the forecast confidence interval calculation ({pull}#107[#107])
 Fix corner case failing to calculate lgamma values and the correspoinding log errors ({pull}#126[#126])
+Influence count per bucket was wrong and lead to wrong influencer scoring ({pull}#150[#150])
 
 === Regressions
 

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -943,7 +943,7 @@ void CMetricPopulationModel::fill(model_t::EFeature feature,
         this->currentBucketInterimCorrections().emplace(
             CCorrectionKey(feature, pid, cid), correction);
     }
-    params.s_Count = 1.0;
+    params.s_Count = bucket->count();
     params.s_ComputeProbabilityParams
         .tag(pid) // new line
         .addCalculation(model_t::probabilityCalculation(feature))

--- a/lib/model/CProbabilityAndInfluenceCalculator.cc
+++ b/lib/model/CProbabilityAndInfluenceCalculator.cc
@@ -232,8 +232,8 @@ public:
     //!
     //! \param[in] v overall mean
     //! \param[in] n overall count
-    //! \param[in] vi mean of influencer
-    //! \param[in] ni count of influencer
+    //! \param[in] vi influencer mean
+    //! \param[in] ni influencer count
     //! \param[out] params model parameters to be updated
     //! \param[out] difference computed mean difference
     bool operator()(const TDouble2Vec& v,
@@ -289,6 +289,13 @@ public:
 class CVarianceDifference {
 public:
     //! Features.
+    //!
+    //! \param[in] v overall variance and mean
+    //! \param[in] n overall count
+    //! \param[in] vi influencer variance and mean
+    //! \param[in] ni influencer count
+    //! \param[out] params model parameters to be updated
+    //! \param[out] difference computed mean difference
     bool operator()(const TDouble1Vec& v,
                     double n,
                     const TDouble1Vec& vi,
@@ -418,7 +425,10 @@ void doComputeInfluences(model_t::EFeature feature,
 
         if (computeInfluencedValue(value, count, i->second.first, i->second.second,
                                    params, influencedValue[0]) == false) {
-            LOG_ERROR(<< "Failed to compute influencer value");
+            LOG_ERROR(<< "Failed to compute influencer value (value = " << value
+                      << " , count = " << count
+                      << " , influencer value = " << i->second.first
+                      << " , influencer count = " << i->second.second << ")");
             continue;
         }
 

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -1549,6 +1549,8 @@ CppUnit::Test* CMetricPopulationModelTest::suite() {
         "CMetricPopulationModelTest::testMinMaxAndMean",
         &CMetricPopulationModelTest::testMinMaxAndMean));
     suiteOfTests->addTest(new CppUnit::TestCaller<CMetricPopulationModelTest>(
+        "CMetricPopulationModelTest::testVarp", &CMetricPopulationModelTest::testVarp));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CMetricPopulationModelTest>(
         "CMetricPopulationModelTest::testComputeProbability",
         &CMetricPopulationModelTest::testComputeProbability));
     suiteOfTests->addTest(new CppUnit::TestCaller<CMetricPopulationModelTest>(


### PR DESCRIPTION
This fixes counting of influencer per bucket, prior this fix the count has always been set to 1.

Notes:

- fix == 1st commit, the 2nd and 3rd add test coverage and improve doc/robustness
- it turned out that this functionality had a test (`testVarp`) but test was forgotten to be added in the test suite
- change affects results if influencers are used as influencer score are now changed

Fixes #24 