### PR TITLE
[6.4][ML] Skip pre-tokenised performance assertion in CI

### DIFF
--- a/lib/api/unittest/CTokenListDataTyperTest.cc
+++ b/lib/api/unittest/CTokenListDataTyperTest.cc
@@ -470,5 +470,13 @@ void CTokenListDataTyperTest::testPreTokenisedPerformance() {
         LOG_DEBUG(<< "Pre-tokenisation test took " << preTokenisationTime << "ms");
     }
 
-    CPPUNIT_ASSERT(preTokenisationTime <= inlineTokenisationTime);
+    const char* keepGoingEnvVar{std::getenv("ML_KEEP_GOING")};
+    bool likelyInCi = (keepGoingEnvVar != nullptr && *keepGoingEnvVar != '\0');
+    if (likelyInCi) {
+        // CI is most likely running on a VM, and this test can fail quite often
+        // due to the VM stalling or being slowed down by noisy neighbours
+        LOG_INFO(<< "Skipping test pre-tokenised performance assertion");
+    } else {
+        CPPUNIT_ASSERT(preTokenisationTime <= inlineTokenisationTime);
+    }
 }


### PR DESCRIPTION
This test fails annoyingly often in CI running on
overcommitted VMs.  The VM can stall or suffer a noisy
neighbour at the wrong moment.

Backport of #158