### PR TITLE
[6.4][ML] Don't use higher resolution for cyclic component models than data bucketing supports

### DIFF
--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -657,14 +657,17 @@ std::size_t CAdaptiveBucketing::memoryUsage() const {
 void CAdaptiveBucketing::maybeSplitBucket() {
     double largeErrorCount{std::accumulate(m_LargeErrorCounts.begin(),
                                            m_LargeErrorCounts.end(), 0.0)};
-    if (largeErrorCount >= MINIMUM_LARGE_ERROR_COUNT_TO_SPLIT) {
+    double period{m_Endpoints[m_Endpoints.size() - 1] - m_Endpoints[0]};
+
+    if (static_cast<double>(this->size() + 1) * m_MinimumBucketLength <= period &&
+        largeErrorCount >= MINIMUM_LARGE_ERROR_COUNT_TO_SPLIT) {
+
         m_LargeErrorCountSignificances = TFloatUInt32PrMinAccumulator{};
 
         // We compute the right tail p-value of the count of large errors
         // in a bucket for the null hypothesis that they are uniformly
         // distributed on the total bucketed period and split if this is
         // less than a specified threshold.
-        double period{m_Endpoints[m_Endpoints.size() - 1] - m_Endpoints[0]};
         for (std::size_t i = 1u; i < m_Endpoints.size(); ++i) {
             double interval{m_Endpoints[i] - m_Endpoints[i - 1]};
             try {

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -747,8 +747,8 @@ void CTimeSeriesDecompositionTest::testSeasonalOnset() {
     LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
-    CPPUNIT_ASSERT(totalSumResidual < 0.054 * totalSumValue);
-    CPPUNIT_ASSERT(totalMaxResidual < 0.068 * totalMaxValue);
+    CPPUNIT_ASSERT(totalSumResidual < 0.053 * totalSumValue);
+    CPPUNIT_ASSERT(totalMaxResidual < 0.07 * totalMaxValue);
     CPPUNIT_ASSERT(totalPercentileError < 0.02 * totalSumValue);
 }
 


### PR DESCRIPTION
Backport of #163.