### PR TITLE
[ML] Fixes potentials for SIGSEGV in multivariate probability calculation

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ Persist and restore was missing some of the trend model state ({pull}#99[#99])
 Stop zero variance data generating a log error in the forecast confidence interval calculation ({pull}#107[#107])
 Fix corner case failing to calculate lgamma values and the correspoinding log errors ({pull}#126[#126])
 Influence count per bucket for metric population analyses was wrong and lead to wrong influencer scoring ({pull}#150[#150])
+Fix a possible SIGSEGV for jobs with multivariate by fields enabled which would lead to the job failing ({pull}#170[#170])
 
 === Regressions
 

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -247,7 +247,7 @@ private:
 
     //! Reinitialize state after detecting a new component of the trend
     //! decomposition.
-    void reinitializeStateGivenNewComponent(void);
+    void reinitializeStateGivenNewComponent();
 
     //! Get the models for the correlations and the models of the correlated
     //! time series.
@@ -458,8 +458,11 @@ private:
     //! Add the time series identified by \p id.
     void addTimeSeries(std::size_t id, const CUnivariateTimeSeriesModel& model);
 
-    //! Remove the correlates of \p id.
+    //! Remove the time series identified by \p id.
     void removeTimeSeries(std::size_t id);
+
+    //! Clear all correlation information for time series identified \p id.
+    void clearCorrelationModels(std::size_t id);
 
     //! Add a sample for the time series identified by \p id.
     void addSamples(std::size_t id,

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -249,6 +249,22 @@ private:
     //! decomposition.
     void reinitializeStateGivenNewComponent();
 
+    //! Compute the probability for uncorrelated series.
+    bool uncorrelatedProbability(const CModelProbabilityParams& params,
+                                 const TTime2Vec1Vec& time,
+                                 const TDouble2Vec1Vec& value,
+                                 double& probability,
+                                 TTail2Vec& tail) const;
+
+    //! Compute the probability for correlated series.
+    bool correlatedProbability(const CModelProbabilityParams& params,
+                               const TTime2Vec1Vec& time,
+                               const TDouble2Vec1Vec& value,
+                               double& probability,
+                               TTail2Vec& tail,
+                               bool& conditional,
+                               TSize1Vec& mostAnomalousCorrelate) const;
+
     //! Get the models for the correlations and the models of the correlated
     //! time series.
     bool correlationModels(TSize1Vec& correlated,

--- a/lib/maths/CMultivariateOneOfNPrior.cc
+++ b/lib/maths/CMultivariateOneOfNPrior.cc
@@ -23,6 +23,7 @@
 #include <maths/Constants.h>
 
 #include <boost/bind.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
 #include <boost/ref.hpp>
 
@@ -438,7 +439,7 @@ CMultivariateOneOfNPrior::univariate(const TSize10Vec& marginalize,
         models[i].first *= std::exp(weights[i] - maxWeight[0]) / Z;
     }
 
-    return {TUnivariatePriorPtr(new COneOfNPrior(models, this->dataType(), this->decayRate())),
+    return {boost::make_unique<COneOfNPrior>(models, this->dataType(), this->decayRate()),
             maxWeight.count() > 0 ? maxWeight[0] : 0.0};
 }
 
@@ -471,8 +472,8 @@ CMultivariateOneOfNPrior::bivariate(const TSize10Vec& marginalize,
         models[i].first *= std::exp(weights[i] - maxWeight[0]) / Z;
     }
 
-    return {TPriorPtr(new CMultivariateOneOfNPrior(2, models, this->dataType(),
-                                                   this->decayRate())),
+    return {boost::make_unique<CMultivariateOneOfNPrior>(2, models, this->dataType(),
+                                                         this->decayRate()),
             maxWeight.count() > 0 ? maxWeight[0] : 0.0};
 }
 

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -856,9 +856,6 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
 }
 
 void CEventRateModelTest::testOnlineCorrelatedTrend() {
-    // FIXME
-    return;
-
     // Check we find the correct correlated variables, and identify
     // correlate and marginal anomalies.
 
@@ -901,8 +898,8 @@ void CEventRateModelTest::testOnlineCorrelatedTrend() {
     std::size_t anomalyBuckets[] = {1950, 2400, 2700, b};
     double anomalies[][4] = {
         {-23.9, 19.7, 0.0, 0.0}, {0.0, 0.0, 36.4, 36.4}, {-28.7, 30.4, 36.4, 36.4}};
-    TMinAccumulator probabilities[4] = {TMinAccumulator(2), TMinAccumulator(2),
-                                        TMinAccumulator(2), TMinAccumulator(2)};
+    TMinAccumulator probabilities[4] = {TMinAccumulator(3), TMinAccumulator(3),
+                                        TMinAccumulator(3), TMinAccumulator(3)};
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.0002;
@@ -916,8 +913,10 @@ void CEventRateModelTest::testOnlineCorrelatedTrend() {
 
     core_t::TTime time = startTime;
     for (std::size_t i = 0u, anomaly = 0u; i < b; ++i) {
-        LOG_DEBUG(<< i << ") processing bucket [" << time << ", "
-                  << time + bucketLength << ")");
+        if (i % 10 == 0) {
+            LOG_DEBUG(<< i << ") processing bucket [" << time << ", "
+                      << time + bucketLength << ")");
+        }
 
         std::size_t hour1 = static_cast<std::size_t>((time / 3600) % 24);
         std::size_t hour2 = (hour1 + 1) % 24;
@@ -959,18 +958,21 @@ void CEventRateModelTest::testOnlineCorrelatedTrend() {
         time += bucketLength;
     }
 
-    std::string expected[] = {"[(1950,p2), (2700,p2)]", "[(1950,p1), (2700,p1)]",
-                              "[(2400,p4), (2700,p4)]", "[(2400,p3), (2700,p3)]"};
-    for (std::size_t i = 0u; i < boost::size(probabilities); ++i) {
-        LOG_DEBUG(<< probabilities[i].print());
-        std::string actual[2];
-        for (std::size_t j = 0u; j < 2; ++j) {
-            actual[j] = std::string("(") +
-                        core::CStringUtils::typeToString(probabilities[i][j].second) +
-                        "," + probabilities[i][j].third + ")";
+    std::string expectedResults[][2]{{"1950,p2", "2700,p2"},
+                                     {"1950,p1", "2700,p1"},
+                                     {"2400,p4", "2700,p4"},
+                                     {"2400,p3", "2700,p3"}};
+    for (std::size_t i = 0u; i < 4; ++i) {
+        LOG_DEBUG(<< "probabilities = " << probabilities[i].print());
+        TStrVec results;
+        for (const auto& result : probabilities[i]) {
+            results.push_back(core::CStringUtils::typeToString(result.second) +
+                              "," + result.third);
         }
-        std::sort(actual, actual + 2);
-        CPPUNIT_ASSERT_EQUAL(expected[i], core::CContainerPrinter::print(actual));
+        for (const auto& expectedResult : expectedResults[i]) {
+            CPPUNIT_ASSERT(std::find(results.begin(), results.end(),
+                                     expectedResult) != results.end());
+        }
     }
 }
 


### PR DESCRIPTION
There were a couple of issues in the multivariate probability calculation for discovered correlations:
1. When detecting a trend the only the correlation models should have been cleared, since the univariate time series model still exists.
2. When copying and swapping the multivariate distribution models we need to handle the case that no clusterer is present (marginal and conditional distributions are initialised without one).
3. The indexing of some quantities relating to the different correlated variables was incorrect.

This also splits up the probability calculation into a correlated and uncorrelated version since the existing function was cumbersome.

This can only affect results, but only for analysis with multivariate by fields enabled.