### PR TITLE
[ML] Correct the multimodal prior confidence interval calculation

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -62,6 +62,9 @@ Fix corner case failing to calculate lgamma values and the correspoinding log er
 Influence count per bucket for metric population analyses was wrong and lead to wrong influencer scoring ({pull}#150[#150])
 Fix a possible SIGSEGV for jobs with multivariate by fields enabled which would lead to the job failing ({pull}#170[#170])
 
+Correct the model bounds and typical value calculation for time series models which use a multimodal distribution.
+This issue could cause "Unable to bracket left percentile =..." errors to appear in the logs. ({pull}#176[#176])
+
 === Regressions
 
 === Known Issues

--- a/include/maths/CMultimodalPriorUtils.h
+++ b/include/maths/CMultimodalPriorUtils.h
@@ -206,8 +206,8 @@ public:
             return support;
         }
 
-        double p1 = std::log((1.0 - percentage) / 2.0);
-        double p2 = std::log((1.0 + percentage) / 2.0);
+        double p1 = maths_t::count(weights) * std::log((1.0 - percentage) / 2.0);
+        double p2 = maths_t::count(weights) * std::log((1.0 + percentage) / 2.0);
 
         CLogCdf<PRIOR> fl(CLogCdf<PRIOR>::E_Lower, prior, weights);
         CLogCdf<PRIOR> fu(CLogCdf<PRIOR>::E_Upper, prior, weights);

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2504,8 +2504,8 @@ void CEventRateModelTest::testComputeProbabilityGivenDetectionRule() {
     CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
 
     SAnnotatedProbability annotatedProbability;
-    CPPUNIT_ASSERT(model->computeProbability(0 /*pid*/, now, now + bucketLength, partitioningFields,
-                                             1, annotatedProbability));
+    CPPUNIT_ASSERT(model->computeProbability(0 /*pid*/, now, now + bucketLength,
+                                             partitioningFields, 1, annotatedProbability));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(annotatedProbability.s_Probability, 1.0, 0.00001);
 }
 


### PR DESCRIPTION
The multimodal confidence interval calculation solves for specific values of the c.d.f. However, if a count weight is applied it scales the log of the c.d.f. by this weight. No scaling should be applied for the purpose of computing confidence intervals. The easiest fix is to apply the equivalent scaling to the target value to solve for, which this change makes.

We were getting log errors generated as a result, see #155, because we couldn't solve for the target value after scaling.

This could affect the predicted value and model bounds for the model, but shouldn't affect the probability calculation and so anomalies detected.

Fixes #155.