### PR TITLE
[ML] Move version qualifier to variable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ String artifactClassifier = (isWindows ? "windows-x86_64" : ((isMacOsX || cppCro
 project.ext.bash = isWindows ? "C:\\Program Files\\Git\\bin\\bash" : "/bin/bash"
 project.ext.make = (isMacOsX || isWindows) ? "gnumake" : (isLinux ? "make" : "gmake")
 project.ext.numCpus = Runtime.runtime.availableProcessors()
+project.ext.makeEnvironment = [ 'CPP_CROSS_COMPILE': cppCrossCompile,
+                                'VERSION_QUALIFIER': versionQualifier,
+                                'SNAPSHOT': (isSnapshot ? 'yes' : 'no') ]
 
 configurations.all {
   // check for updates every build
@@ -51,9 +54,7 @@ configurations.all {
 }
 
 task clean(type: Exec) {
-  environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'VERSION_QUALIFIER', versionQualifier
-  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
+  environment makeEnvironment
   commandLine bash
   args '-c', 'source ./set_env.sh && rm -rf build && ' + make + ' clean'
   workingDir "${projectDir}"
@@ -63,18 +64,14 @@ task compile(type: Exec) {
   // Only do this fully parallelised compile without linking step on a quad core
   // machine or better - with fewer cores it's not worth it
   enabled numCpus >= 4
-  environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'VERSION_QUALIFIER', versionQualifier
-  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
+  environment makeEnvironment
   commandLine bash
   args '-c', 'source ./set_env.sh && ' + make + ' -j' + numCpus + ' objcompile'
   workingDir "${projectDir}"
 }
 
 task make(type: Exec) {
-  environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'VERSION_QUALIFIER', versionQualifier
-  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
+  environment makeEnvironment
   commandLine bash
   args '-c', 'source ./set_env.sh && ' + make + ' -j' + numCpus
   workingDir "${projectDir}"
@@ -82,9 +79,7 @@ task make(type: Exec) {
 }
 
 task strip(type: Exec) {
-  environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'VERSION_QUALIFIER', versionQualifier
-  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
+  environment makeEnvironment
   commandLine bash
   args '-c', 'source ./set_env.sh && dev-tools/strip_binaries.sh'
   workingDir "${projectDir}"
@@ -173,9 +168,7 @@ artifacts {
 }
 
 task test(type: Exec) {
-  environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'VERSION_QUALIFIER', versionQualifier
-  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
+  environment makeEnvironment
   commandLine bash
   args '-c', 'source ./set_env.sh && ' + make + ' -j' + numCpus + ' test'
   workingDir "${projectDir}"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ import org.gradle.util.DistributionLocator
 import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
 // TODO: change default qualifier from alpha1 to empty string once release manager is updated
-String versionQualifier = System.getProperty("version.qualifier", "alpha1")
+String versionQualifier = System.getProperty("build.version_qualifier", "alpha1")
 boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 
 boolean isWindows = OperatingSystem.current().isWindows()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,9 @@ import org.gradle.util.DistributionLocator
 
 import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
-boolean snapshot = "true".equals(System.getProperty("build.snapshot", "true"));
+// TODO: change default qualifier from alpha1 to empty string once release manager is updated
+String versionQualifier = System.getProperty("version.qualifier", "alpha1")
+boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 
 boolean isWindows = OperatingSystem.current().isWindows()
 boolean isLinux = OperatingSystem.current().isLinux()
@@ -16,7 +18,10 @@ boolean isMacOsX = OperatingSystem.current().isMacOsX()
 allprojects {
   group = 'org.elasticsearch.ml'
   version = elasticsearchVersion
-  if (snapshot) {
+  if (versionQualifier != "") {
+    version += '-' + versionQualifier
+  }
+  if (isSnapshot) {
     version += '-SNAPSHOT'
   }
 }
@@ -47,7 +52,8 @@ configurations.all {
 
 task clean(type: Exec) {
   environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'SNAPSHOT', snapshot ? 'yes' : 'no'
+  environment 'VERSION_QUALIFIER', versionQualifier
+  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
   commandLine bash
   args '-c', 'source ./set_env.sh && rm -rf build && ' + make + ' clean'
   workingDir "${projectDir}"
@@ -58,7 +64,8 @@ task compile(type: Exec) {
   // machine or better - with fewer cores it's not worth it
   enabled numCpus >= 4
   environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'SNAPSHOT', snapshot ? 'yes' : 'no'
+  environment 'VERSION_QUALIFIER', versionQualifier
+  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
   commandLine bash
   args '-c', 'source ./set_env.sh && ' + make + ' -j' + numCpus + ' objcompile'
   workingDir "${projectDir}"
@@ -66,7 +73,8 @@ task compile(type: Exec) {
 
 task make(type: Exec) {
   environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'SNAPSHOT', snapshot ? 'yes' : 'no'
+  environment 'VERSION_QUALIFIER', versionQualifier
+  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
   commandLine bash
   args '-c', 'source ./set_env.sh && ' + make + ' -j' + numCpus
   workingDir "${projectDir}"
@@ -75,7 +83,8 @@ task make(type: Exec) {
 
 task strip(type: Exec) {
   environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'SNAPSHOT', snapshot ? 'yes' : 'no'
+  environment 'VERSION_QUALIFIER', versionQualifier
+  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
   commandLine bash
   args '-c', 'source ./set_env.sh && dev-tools/strip_binaries.sh'
   workingDir "${projectDir}"
@@ -165,7 +174,8 @@ artifacts {
 
 task test(type: Exec) {
   environment 'CPP_CROSS_COMPILE', cppCrossCompile
-  environment 'SNAPSHOT', snapshot ? 'yes' : 'no'
+  environment 'VERSION_QUALIFIER', versionQualifier
+  environment 'SNAPSHOT', isSnapshot ? 'yes' : 'no'
   commandLine bash
   args '-c', 'source ./set_env.sh && ' + make + ' -j' + numCpus + ' test'
   workingDir "${projectDir}"

--- a/dev-tools/docker/docker_entrypoint.sh
+++ b/dev-tools/docker/docker_entrypoint.sh
@@ -32,6 +32,9 @@ dev-tools/strip_binaries.sh
 
 # Get the version number
 PRODUCT_VERSION=`cat "$CPP_SRC_HOME/gradle.properties" | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo`
+if [ -n "$VERSION_QUALIFIER" ] ; then
+    PRODUCT_VERSION="$PRODUCT_VERSION-$VERSION_QUALIFIER"
+fi
 if [ "$SNAPSHOT" = yes ] ; then
     PRODUCT_VERSION="$PRODUCT_VERSION-SNAPSHOT"
 fi

--- a/dev-tools/docker/linux-musl_builder/Dockerfile
+++ b/dev-tools/docker/linux-musl_builder/Dockerfile
@@ -12,6 +12,9 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Copy the current Git repository into the container
 COPY . /ml-cpp/
 
+# Pass through any version qualifier (default none)
+ARG VERSION_QUALIFIER=
+
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -12,6 +12,9 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Copy the current Git repository into the container
 COPY . /ml-cpp/
 
+# Pass through any version qualifier (default none)
+ARG VERSION_QUALIFIER=
+
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -12,6 +12,9 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Copy the current Git repository into the container
 COPY . /ml-cpp/
 
+# Pass through any version qualifier (default none)
+ARG VERSION_QUALIFIER=
+
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -15,6 +15,9 @@ COPY . /ml-cpp/
 # Tell the build we want to cross compile
 ENV CPP_CROSS_COMPILE macosx
 
+# Pass through any version qualifier (default none)
+ARG VERSION_QUALIFIER=
+
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 

--- a/dev-tools/docker_build.sh
+++ b/dev-tools/docker_build.sh
@@ -41,6 +41,12 @@ if [ -z "$PLATFORMS" ] ; then
     usage
 fi
 
+# Default to alpha1 qualifier
+# TODO: remove this once release manager is updated
+if [ -z "$VERSION_QUALIFIER" ] ; then
+    VERSION_QUALIFIER=alpha1
+fi
+
 # Default to a snapshot build
 if [ -z "$SNAPSHOT" ] ; then
     SNAPSHOT=yes
@@ -66,7 +72,7 @@ do
     DOCKERFILE="$TOOLS_DIR/docker/${PLATFORM}_builder/Dockerfile"
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
-    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
+    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
     # Using tar to copy the build artifacts out of the container seems more reliable
     # than docker cp, and also means the files end up with the correct uid/gid
     docker run --rm --workdir=/ml-cpp $TEMP_TAG tar cf - build/distributions | tar xvf -

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -41,6 +41,12 @@ if [ -z "$PLATFORMS" ] ; then
     usage
 fi
 
+# Default to alpha1 qualifier
+# TODO: remove this once release manager is updated
+if [ -z "$VERSION_QUALIFIER" ] ; then
+    VERSION_QUALIFIER=alpha1
+fi
+
 # Default to a snapshot build
 if [ -z "$SNAPSHOT" ] ; then
     SNAPSHOT=yes
@@ -67,7 +73,7 @@ do
     DOCKERFILE="$TOOLS_DIR/docker/${PLATFORM}_tester/Dockerfile"
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
-    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
+    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
     # Using tar to copy the build and test artifacts out of the container seems
     # more reliable than docker cp, and also means the files end up with the
     # correct uid/gid

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=false
 
-elasticsearchVersion=7.0.0-alpha1
+elasticsearchVersion=7.0.0
 
 artifactName=ml-cpp

--- a/lib/ver/Makefile
+++ b/lib/ver/Makefile
@@ -16,7 +16,10 @@ CLEAN_CMDS=$(RM) CBuildInfo.cc
 BUILD_YEAR=$(shell date '+%Y')
 USER_NAME_CMD=id | awk -F')' '{ print $$1 }' | awk -F'(' '{ print $$2 }'
 USER_NAME=$(shell $(USER_NAME_CMD))
-PRODUCT_VERSION=$(shell cat $(CPP_SRC_HOME)/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $$2 }' | xargs echo)
+PRODUCT_VERSION:=$(shell cat $(CPP_SRC_HOME)/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $$2 }' | xargs echo)
+ifneq ($(VERSION_QUALIFIER),)
+PRODUCT_VERSION:=$(PRODUCT_VERSION)-$(VERSION_QUALIFIER)
+endif
 ifeq ($(SNAPSHOT),yes)
 PRODUCT_VERSION:=$(PRODUCT_VERSION)-SNAPSHOT
 endif

--- a/mk/make_rc_defines.sh
+++ b/mk/make_rc_defines.sh
@@ -2,8 +2,11 @@
 
 ML_USER=`id | awk -F')' '{ print $1 }' | awk -F'(' '{ print $2 }'`
 ML_VERSION_STR=`cat $CPP_SRC_HOME/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo`
+if [ -n "$VERSION_QUALIFIER" ] ; then
+    ML_VERSION_STR="$ML_VERSION_STR-$VERSION_QUALIFIER"
+fi
 if [ "$SNAPSHOT" != no ] ; then
-    ML_VERSION_STR="$ML_VERSION_STR"-SNAPSHOT
+    ML_VERSION_STR="$ML_VERSION_STR-SNAPSHOT"
 fi
 ML_VERSION=`echo $ML_VERSION_STR | sed 's/-.*//' | tr '.' ','`
 ML_BUILD_STR="Build "`git rev-parse --short=14 HEAD`

--- a/mk/make_rc_defines.sh
+++ b/mk/make_rc_defines.sh
@@ -6,7 +6,7 @@ if [ -n "$VERSION_QUALIFIER" ] ; then
     ML_VERSION_STR="$ML_VERSION_STR-$VERSION_QUALIFIER"
 fi
 if [ "$SNAPSHOT" != no ] ; then
-    ML_VERSION_STR="$ML_VERSION_STR-SNAPSHOT"
+    ML_VERSION_STR="$ML_VERSION_STR"-SNAPSHOT
 fi
 ML_VERSION=`echo $ML_VERSION_STR | sed 's/-.*//' | tr '.' ','`
 ML_BUILD_STR="Build "`git rev-parse --short=14 HEAD`

--- a/mk/make_rc_defines.sh
+++ b/mk/make_rc_defines.sh
@@ -6,7 +6,7 @@ if [ -n "$VERSION_QUALIFIER" ] ; then
     ML_VERSION_STR="$ML_VERSION_STR-$VERSION_QUALIFIER"
 fi
 if [ "$SNAPSHOT" != no ] ; then
-    ML_VERSION_STR="$ML_VERSION_STR"-SNAPSHOT
+    ML_VERSION_STR="$ML_VERSION_STR-SNAPSHOT"
 fi
 ML_VERSION=`echo $ML_VERSION_STR | sed 's/-.*//' | tr '.' ','`
 ML_BUILD_STR="Build "`git rev-parse --short=14 HEAD`

--- a/upload.gradle
+++ b/upload.gradle
@@ -6,12 +6,17 @@ import org.gradle.util.DistributionLocator
 
 import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
-boolean snapshot = "true".equals(System.getProperty("build.snapshot", "true"));
+// TODO: change default qualifier from alpha1 to empty string once release manager is updated
+String versionQualifier = System.getProperty("version.qualifier", "alpha1")
+boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 
 allprojects {
   group = 'org.elasticsearch.ml'
   version = elasticsearchVersion
-  if (snapshot) {
+  if (versionQualifier != "") {
+    version += '-' + versionQualifier
+  }
+  if (isSnapshot) {
     version += '-SNAPSHOT'
   }
 }

--- a/upload.gradle
+++ b/upload.gradle
@@ -7,7 +7,7 @@ import org.gradle.util.DistributionLocator
 import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
 // TODO: change default qualifier from alpha1 to empty string once release manager is updated
-String versionQualifier = System.getProperty("version.qualifier", "alpha1")
+String versionQualifier = System.getProperty("build.version_qualifier", "alpha1")
 boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 
 allprojects {


### PR DESCRIPTION
Preivously version qualifier like "alpha1" or "rc2" have been
part of the version number stored in the repo.  This means that
to move from a release candidate to a GA build we have to change
a file and rebuild, and this runs the risk that other files have
been changed too.  There is a desire for the GA build to be
built from identical code to the final release candidate.

This change moves the version qualifier from gradle.properties
to a Gradle system property and, in the inner workings of the
build system, an environment variable.

For this to fully work as intended release manager and CI also
need to be updated.  In this initial commit the version qualifier
defaults to "alpha1" if not specified.  The default will be
changed to no version qualifier once CI and release manager are
setting the required variables.