### PR TITLE
[ML] Bugfix. Add value counts to MetricModel results (#189)

### DIFF
--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -635,6 +635,7 @@ void CMetricModel::fill(model_t::EFeature feature,
                 params.s_Values[i][2 * j + 0] = bucket0->value()[j];
                 params.s_Values[i][2 * j + 1] = bucket1->value()[j];
             }
+            params.s_Counts[i] = TDouble2Vec{bucket0->count(), bucket1->count()};
             scale[variables[0]] = bucket0->varianceScale();
             scale[variables[1]] = bucket1->varianceScale();
             maths_t::setCountVarianceScale(scale, weight);


### PR DESCRIPTION
Vector of value counts was never populated causing assertion failures
and hence CMetricModelTest::testInterimCorrectionsWithCorrelations to
fail when run from a debug enabled build.