### PR TITLE
[ML] Set default version qualifier to nothing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,7 @@ import org.gradle.util.DistributionLocator
 
 import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
-// TODO: change default qualifier from alpha1 to empty string once release manager is updated
-String versionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+String versionQualifier = System.getProperty("build.version_qualifier", "")
 boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 
 boolean isWindows = OperatingSystem.current().isWindows()

--- a/dev-tools/docker_build.sh
+++ b/dev-tools/docker_build.sh
@@ -41,11 +41,7 @@ if [ -z "$PLATFORMS" ] ; then
     usage
 fi
 
-# Default to alpha1 qualifier
-# TODO: remove this once release manager is updated
-if [ -z "$VERSION_QUALIFIER" ] ; then
-    VERSION_QUALIFIER=alpha1
-fi
+# Default to no version qualifier
 
 # Default to a snapshot build
 if [ -z "$SNAPSHOT" ] ; then

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -41,11 +41,7 @@ if [ -z "$PLATFORMS" ] ; then
     usage
 fi
 
-# Default to alpha1 qualifier
-# TODO: remove this once release manager is updated
-if [ -z "$VERSION_QUALIFIER" ] ; then
-    VERSION_QUALIFIER=alpha1
-fi
+# Default to no version qualifier
 
 # Default to a snapshot build
 if [ -z "$SNAPSHOT" ] ; then

--- a/upload.gradle
+++ b/upload.gradle
@@ -6,8 +6,7 @@ import org.gradle.util.DistributionLocator
 
 import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
-// TODO: change default qualifier from alpha1 to empty string once release manager is updated
-String versionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+String versionQualifier = System.getProperty("build.version_qualifier", "")
 boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 
 allprojects {


### PR DESCRIPTION
When the version-qualifier-in-a-variable functionality was first
added in #179 it defaulted to "alpha1" to preserve the previous
default for 7.0.0 because the tools that kick off builds had not
been updated.

Now the external tools have been updated there is no need for a
default version qualifier; builds where no version qualifier is
specified in the appropriate variable will have no version
qualifier.