### PR TITLE
[ML] Optimization to quantile persistence

### DIFF
--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -409,6 +409,8 @@ void CAnomalyJob::outputBucketResultsUntil(core_t::TTime time) {
             maths::CIntegerTools::floor(time, effectiveBucketLength) - latency);
     }
 
+    m_Normalizer.resetBigChange();
+
     for (core_t::TTime lastBucketEndTime = m_LastFinalisedBucketEndTime;
          lastBucketEndTime + bucketLength + latency <= time;
          lastBucketEndTime += effectiveBucketLength) {
@@ -429,9 +431,6 @@ void CAnomalyJob::outputBucketResultsUntil(core_t::TTime time) {
         (m_MaxQuantileInterval > 0 &&
          core::CTimeUtils::now() > m_LastNormalizerPersistTime + m_MaxQuantileInterval)) {
         m_JsonOutputWriter.persistNormalizer(m_Normalizer, m_LastNormalizerPersistTime);
-        if (m_Normalizer.hasLastUpdateCausedBigChange()) {
-            m_Normalizer.resetBigChange();
-        }
     }
 }
 
@@ -1267,8 +1266,6 @@ void CAnomalyJob::updateAggregatorAndAggregate(bool isInterim,
 
 void CAnomalyJob::updateQuantilesAndNormalize(bool isInterim,
                                               model::CHierarchicalResults& results) {
-    m_Normalizer.resetBigChange();
-
     // The normalizers are NOT updated with interim results, in other
     // words interim results are normalized with respect to previous
     // final results.
@@ -1282,7 +1279,6 @@ void CAnomalyJob::updateQuantilesAndNormalize(bool isInterim,
     m_Normalizer.setJob(model::CHierarchicalResultsNormalizer::E_Normalize);
     results.bottomUpBreadthFirst(m_Normalizer);
     results.pivotsBottomUpBreadthFirst(m_Normalizer);
-
 }
 
 void CAnomalyJob::outputResultsWithinRange(bool isInterim, core_t::TTime start, core_t::TTime end) {

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -424,6 +424,15 @@ void CAnomalyJob::outputBucketResultsUntil(core_t::TTime time) {
             m_PeriodicPersister->startBackgroundPersistIfAppropriate();
         }
     }
+
+    if (m_Normalizer.hasLastUpdateCausedBigChange() ||
+        (m_MaxQuantileInterval > 0 &&
+         core::CTimeUtils::now() > m_LastNormalizerPersistTime + m_MaxQuantileInterval)) {
+        m_JsonOutputWriter.persistNormalizer(m_Normalizer, m_LastNormalizerPersistTime);
+        if (m_Normalizer.hasLastUpdateCausedBigChange()) {
+            m_Normalizer.resetBigChange();
+        }
+    }
 }
 
 void CAnomalyJob::skipTime(const std::string& time_) {
@@ -1274,11 +1283,6 @@ void CAnomalyJob::updateQuantilesAndNormalize(bool isInterim,
     results.bottomUpBreadthFirst(m_Normalizer);
     results.pivotsBottomUpBreadthFirst(m_Normalizer);
 
-    if ((isInterim == false && m_Normalizer.hasLastUpdateCausedBigChange()) ||
-        (m_MaxQuantileInterval > 0 &&
-         core::CTimeUtils::now() > m_LastNormalizerPersistTime + m_MaxQuantileInterval)) {
-        m_JsonOutputWriter.persistNormalizer(m_Normalizer, m_LastNormalizerPersistTime);
-    }
 }
 
 void CAnomalyJob::outputResultsWithinRange(bool isInterim, core_t::TTime start, core_t::TTime end) {


### PR DESCRIPTION
Ensure that normalizers (and hence quantile state) are persisted only
once, when time is advanced