### PR TITLE
[ML] Global max score to trigger renormalizations

### DIFF
--- a/include/model/CAnomalyScore.h
+++ b/include/model/CAnomalyScore.h
@@ -254,6 +254,10 @@ public:
         //! The dictionary to use to associate partitions to their maximum scores
         TDictionary m_Dictionary;
 
+        //! The maximum score seen for the normalizer as a whole
+        //! Strictly used to trigger renormalizations on big change
+        TMaxValueAccumulator m_MaxScore;
+
         //! The set of maximum scores ever received for partitions.
         TWordMaxValueAccumulatorUMap m_MaxScores;
 


### PR DESCRIPTION
Using a global maximum score (the maximum score see for the normalizer
as a whole) to trigger renormalization when a big change occurs.

Current behaviour is to set the 'big change' flag on the normalizer when
the maximum score of any partition has changed a significant amount.
This ultimately results in the normalizer state being persisted
triggering a renormalizationi.

This change heavily reduces the number of renormalization events produced and
results in a significant performance increase.