### PR TITLE
[ML] Trap case triggering "Bad density value..." log errors whilst forecasting

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,6 +44,8 @@ anomalies. (See {pull}175[#175].)
 
 Increased independence of anomaly scores across partitions ({pull}182[182])  
 
+Fix cause of "Bad density value..." log errors whilst forecasting. ({pull}207[207])
+
 //=== Bug Fixes
 
 //=== Regressions

--- a/include/maths/CNaiveBayes.h
+++ b/include/maths/CNaiveBayes.h
@@ -51,6 +51,9 @@ public:
     //! Set the data type.
     virtual void dataType(maths_t::EDataType dataType) = 0;
 
+    //! Check whether the density is improper.
+    virtual bool improper() const = 0;
+
     //! Add the value \p x.
     virtual void add(const TDouble1Vec& x) = 0;
 
@@ -97,6 +100,9 @@ public:
 
     //! Persist state by passing information to \p inserter.
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Check whether the density is improper.
+    virtual bool improper() const;
 
     //! Add the value \p x.
     virtual void add(const TDouble1Vec& x);
@@ -243,6 +249,8 @@ private:
         //! Persist state by passing information to \p inserter.
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
+        //! Check if this class conditional densities are proper.
+        bool initialized() const;
         //! Get the number of examples in this class.
         double count() const;
         //! Get a writable reference of the number of examples in this class.

--- a/lib/maths/CNaiveBayes.cc
+++ b/lib/maths/CNaiveBayes.cc
@@ -23,6 +23,7 @@
 #include <boost/bind.hpp>
 #include <boost/ref.hpp>
 
+#include <algorithm>
 #include <numeric>
 #include <string>
 
@@ -39,6 +40,10 @@ const std::string CONDITIONAL_DENSITY_FROM_PRIOR_TAG{"f"};
 
 CNaiveBayesFeatureDensityFromPrior::CNaiveBayesFeatureDensityFromPrior(const CPrior& prior)
     : m_Prior(prior.clone()) {
+}
+
+bool CNaiveBayesFeatureDensityFromPrior::improper() const {
+    return m_Prior->isNonInformative();
 }
 
 void CNaiveBayesFeatureDensityFromPrior::add(const TDouble1Vec& x) {
@@ -201,7 +206,12 @@ void CNaiveBayes::swap(CNaiveBayes& other) {
 }
 
 bool CNaiveBayes::initialized() const {
-    return m_ClassConditionalDensities.size() > 0;
+    return m_ClassConditionalDensities.size() > 0 &&
+           std::all_of(m_ClassConditionalDensities.begin(),
+                       m_ClassConditionalDensities.end(),
+                       [](const std::pair<std::size_t, CClass>& class_) {
+                           return class_.second.initialized();
+                       });
 }
 
 void CNaiveBayes::initialClassCounts(const TDoubleSizePrVec& counts) {
@@ -408,6 +418,12 @@ void CNaiveBayes::CClass::acceptPersistInserter(core::CStatePersistInserter& ins
         }
         // Add other implementations' persist code here.
     }
+}
+
+bool CNaiveBayes::CClass::initialized() const {
+    return std::none_of(
+        m_ConditionalDensities.begin(), m_ConditionalDensities.end(),
+        [](const TFeatureDensityPtr& density) { return density->improper(); });
 }
 
 double CNaiveBayes::CClass::count() const {

--- a/lib/maths/unittest/CNaiveBayesTest.h
+++ b/lib/maths/unittest/CNaiveBayesTest.h
@@ -12,6 +12,7 @@
 class CNaiveBayesTest : public CppUnit::TestFixture {
 public:
     void testClassification();
+    void testUninitialized();
     void testPropagationByTime();
     void testMemoryUsage();
     void testPersist();


### PR DESCRIPTION
Check that distributions aren't improper before using the NB classifier.

This was sometimes triggering errors when forecasting if there have been no step changes in the time series history.

This only affects forecasting and in this case it shouldn't materially affect the forecasts because we should never create a jump in the roll out because the class probability would be zero.

Closes #206.