### PR TITLE
[ML] Fix incorrectly missing anomaly influences for empty buckets

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,8 +44,11 @@ anomalies. (See {pull}175[#175].)
 
 Increased independence of anomaly scores across partitions ({pull}182[182])  
 
+//=== Bug Fixes
+
 Fix cause of "Bad density value..." log errors whilst forecasting. ({pull}207[207])
 
-//=== Bug Fixes
+Fix incorrectly missing influencers when the influence field is one of the detector's partitioning
+fields and the bucket is empty. ({pull}219[#219])
 
 //=== Regressions

--- a/include/model/CBucketGatherer.h
+++ b/include/model/CBucketGatherer.h
@@ -142,9 +142,11 @@ public:
     //! Create a new data series gatherer.
     //!
     //! \param[in] dataGatherer The owning data gatherer.
-    //! \param[in] startTime The start of the time interval
+    //! \param[in] startTime The start of the time interval for which
+    //! to gather data.
+    //! \param[in] numberInfluencers The number of result influencers
     //! for which to gather data.
-    CBucketGatherer(CDataGatherer& dataGatherer, core_t::TTime startTime);
+    CBucketGatherer(CDataGatherer& dataGatherer, core_t::TTime startTime, std::size_t numberInfluencers);
 
     //! Create a copy that will result in the same persisted state as the
     //! original.  This is effectively a copy constructor that creates a

--- a/include/model/CBucketGatherer.h
+++ b/include/model/CBucketGatherer.h
@@ -161,10 +161,10 @@ public:
     //! \name Persistence
     //@{
     //! Persist state by passing information to the supplied inserter
-    virtual void baseAcceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void baseAcceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
     //! Restore the state
-    virtual bool baseAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool baseAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Create a clone of this data gatherer that will result in the same
     //! persisted state.  The clone may be incomplete in ways that do not

--- a/include/model/CEventRateBucketGatherer.h
+++ b/include/model/CEventRateBucketGatherer.h
@@ -92,7 +92,7 @@ private:
 //! to model the event rate in an arbitrary time series.
 //!
 //! \sa CDataGatherer.
-class MODEL_EXPORT CEventRateBucketGatherer : public CBucketGatherer {
+class MODEL_EXPORT CEventRateBucketGatherer final : public CBucketGatherer {
 public:
     using TCategoryAnyMap = std::map<model_t::EEventRateCategory, boost::any>;
     using TStrCRef = SEventRateFeatureData::TStrCRef;
@@ -152,10 +152,10 @@ public:
     //! \name Persistence
     //@{
     //! Fill in the state from \p traverser.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
     //! Create a clone of this data gatherer that will result in the same
     //! persisted state.  The clone may be incomplete in ways that do not

--- a/include/model/CMetricBucketGatherer.h
+++ b/include/model/CMetricBucketGatherer.h
@@ -37,7 +37,7 @@ class CResourceMonitor;
 //! to characterize metric time series.
 //!
 //! \sa CDataGatherer.
-class MODEL_EXPORT CMetricBucketGatherer : public CBucketGatherer {
+class MODEL_EXPORT CMetricBucketGatherer final : public CBucketGatherer {
 public:
     using TCategorySizePr = std::pair<model_t::EMetricCategory, std::size_t>;
     using TCategorySizePrAnyMap = std::map<TCategorySizePr, boost::any>;
@@ -90,10 +90,10 @@ public:
     //! \name Persistence
     //@{
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
     //! Fill in the state from \p traverser.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Create a clone of this data gatherer that will result in the same
     //! persisted state.  The clone may be incomplete in ways that do not

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -727,8 +727,8 @@ CEventRateBucketGatherer::CEventRateBucketGatherer(CDataGatherer& dataGatherer,
                                                    const std::string& valueFieldName,
                                                    const TStrVec& influenceFieldNames,
                                                    core_t::TTime startTime)
-    : CBucketGatherer(dataGatherer, startTime), m_BeginInfluencingFields(0),
-      m_BeginValueField(0), m_BeginSummaryFields(0) {
+    : CBucketGatherer(dataGatherer, startTime, influenceFieldNames.size()),
+      m_BeginInfluencingFields(0), m_BeginValueField(0), m_BeginSummaryFields(0) {
     this->initializeFieldNames(personFieldName, attributeFieldName, valueFieldName,
                                summaryCountFieldName, influenceFieldNames);
     this->initializeFeatureData();
@@ -741,8 +741,8 @@ CEventRateBucketGatherer::CEventRateBucketGatherer(CDataGatherer& dataGatherer,
                                                    const std::string& valueFieldName,
                                                    const TStrVec& influenceFieldNames,
                                                    core::CStateRestoreTraverser& traverser)
-    : CBucketGatherer(dataGatherer, 0), m_BeginInfluencingFields(0),
-      m_BeginValueField(0), m_BeginSummaryFields(0) {
+    : CBucketGatherer(dataGatherer, 0, influenceFieldNames.size()),
+      m_BeginInfluencingFields(0), m_BeginValueField(0), m_BeginSummaryFields(0) {
     this->initializeFieldNames(personFieldName, attributeFieldName, valueFieldName,
                                summaryCountFieldName, influenceFieldNames);
     traverser.traverseSubLevel(

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -920,8 +920,9 @@ CMetricBucketGatherer::CMetricBucketGatherer(CDataGatherer& dataGatherer,
                                              const std::string& valueFieldName,
                                              const TStrVec& influenceFieldNames,
                                              core_t::TTime startTime)
-    : CBucketGatherer(dataGatherer, startTime), m_ValueFieldName(valueFieldName),
-      m_BeginInfluencingFields(0), m_BeginValueFields(0) {
+    : CBucketGatherer(dataGatherer, startTime, influenceFieldNames.size()),
+      m_ValueFieldName(valueFieldName), m_BeginInfluencingFields(0),
+      m_BeginValueFields(0) {
     this->initializeFieldNamesPart1(personFieldName, attributeFieldName, influenceFieldNames);
     this->initializeFieldNamesPart2(valueFieldName, summaryCountFieldName);
     this->initializeFeatureData();
@@ -934,8 +935,8 @@ CMetricBucketGatherer::CMetricBucketGatherer(CDataGatherer& dataGatherer,
                                              const std::string& valueFieldName,
                                              const TStrVec& influenceFieldNames,
                                              core::CStateRestoreTraverser& traverser)
-    : CBucketGatherer(dataGatherer, 0), m_ValueFieldName(valueFieldName),
-      m_BeginValueFields(0) {
+    : CBucketGatherer(dataGatherer, 0, influenceFieldNames.size()),
+      m_ValueFieldName(valueFieldName), m_BeginValueFields(0) {
     this->initializeFieldNamesPart1(personFieldName, attributeFieldName, influenceFieldNames);
     traverser.traverseSubLevel(
         boost::bind(&CMetricBucketGatherer::acceptRestoreTraverser, this, _1));

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -1472,7 +1472,7 @@ void CEventRateDataGathererTest::testInfluencerBucketStatistics() {
     std::string expectedPersonCounts[] = {
         std::string("[(0, 6, [[(i, ([6], 1))]])]"),
         std::string("[(0, 3, [[(i, ([3], 1))]])]"),
-        std::string("[(0, 2, [[(i, ([2], 1))]])]"), std::string("[(0, 0)]"),
+        std::string("[(0, 2, [[(i, ([2], 1))]])]"), std::string("[(0, 0, [[]])]"),
         std::string("[(0, 3, [[(i, ([3], 1))]])]")};
     TStrVec expectedPersonCountsVec(&expectedPersonCounts[0], &expectedPersonCounts[5]);
 


### PR DESCRIPTION
We are not correctly attributing all anomalies to influencers in the case that:
1. The bucket is empty,
2. The influencer is one of the job's partitioning fields.

Among the side-effects is that the anomaly explorer can incorrectly colour tiles and put swim lanes in the wrong order. For example:

Before
![screen shot 2018-09-27 at 18 56 38](https://user-images.githubusercontent.com/7591487/46164917-290ea800-c287-11e8-84f8-0c058b3e3881.png)
After
![screen shot 2018-09-27 at 18 56 23](https://user-images.githubusercontent.com/7591487/46164935-33c93d00-c287-11e8-9eca-ab284cfd0565.png)

We can see the major severity anomalies for status 304 corresponding zero count buckets in the single metric viewer
![screen shot 2018-09-27 at 18 56 54](https://user-images.githubusercontent.com/7591487/46165023-6ffc9d80-c287-11e8-859e-e3531087bead.png)