### PR TITLE
[ML] Skip model update in anomaly model

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -78,4 +78,8 @@ Change linker options on macOS to allow Homebrew installs ({ml-pull}225[225])
 
 //=== Bug Fixes
 
+Rules that trigger the `skip_model_update` action should also apply to the anomaly model.
+This fixes an issue where anomaly scores and probabilities on results that triggered
+the rule would reduce is they occurred frequently. (See {pull}222[#222].)
+
 //=== Regressions

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -79,7 +79,7 @@ Change linker options on macOS to allow Homebrew installs ({ml-pull}225[225])
 //=== Bug Fixes
 
 Rules that trigger the `skip_model_update` action should also apply to the anomaly model.
-This fixes an issue where anomaly scores and probabilities on results that triggered
-the rule would reduce is they occurred frequently. (See {pull}222[#222].)
+This fixes an issue where anomaly scores of results that triggered the rule would decrease
+if they occurred frequently. (See {ml-pull}222[#222].)
 
 //=== Regressions

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -205,6 +205,11 @@ public:
     //! Get whether or not to use the anomaly model.
     bool useAnomalyModel() const;
 
+    //! Set whether or not to skip updating the anomaly model.
+    CModelProbabilityParams& skipAnomalyModelUpdate(bool skipAnomalyModelUpdate);
+    //! Get whether or not to skip updating the anomaly model.
+    bool skipAnomalyModelUpdate() const;
+
 private:
     //! The coordinates' probability calculations.
     TProbabilityCalculation2Vec m_Calculations;
@@ -222,6 +227,9 @@ private:
     bool m_UseMultibucketFeatures = true;
     //! Whether or not to use the anomaly model.
     bool m_UseAnomalyModel = true;
+    //! Whether or not to skip updating the anomaly model
+    //! because a rule triggered.
+    bool m_SkipAnomalyModelUpdate = false;
 };
 
 //! \brief Describes the result of the model probability calculation.

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -273,6 +273,15 @@ bool CModelProbabilityParams::useAnomalyModel() const {
     return m_UseAnomalyModel;
 }
 
+CModelProbabilityParams& CModelProbabilityParams::skipAnomalyModelUpdate(bool skipAnomalyModelUpdate) {
+    m_SkipAnomalyModelUpdate = skipAnomalyModelUpdate;
+    return *this;
+}
+
+bool CModelProbabilityParams::skipAnomalyModelUpdate() const {
+    return m_SkipAnomalyModelUpdate;
+}
+
 //////// SModelProbabilityResult::SFeatureProbability ////////
 
 SModelProbabilityResult::SFeatureProbability::SFeatureProbability()

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -394,7 +394,7 @@ private:
     static const maths_t::TDouble10VecWeightsAry1Vec UNIT;
 
 private:
-    //! Update the appropriate anomaly model with \p weight.
+    //! Update the anomaly model with a sample of the current feature vector.
     void sample(const CModelProbabilityParams& params, core_t::TTime time, double weight);
 
     //! Compute the probability of the anomaly feature vector.

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2361,7 +2361,7 @@ void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
                 currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
             } else {
                 model.addSamples(addSampleParams(weights),
-                                {core::make_triple(time, TDouble2Vec{sample}, TAG)});
+                                 {core::make_triple(time, TDouble2Vec{sample}, TAG)});
             }
             maths::SModelProbabilityResult result;
             model.probability(currentComputeProbabilityParams, {{time}}, {{sample}}, result);
@@ -2375,7 +2375,8 @@ void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
 
         // Assert probs are decreasing
         double previousProbability = probabilities[0];
-        for (std::size_t currentProbability = 1; currentProbability < probabilities.size(); ++currentProbability) {
+        for (std::size_t currentProbability = 1;
+             currentProbability < probabilities.size(); ++currentProbability) {
             CPPUNIT_ASSERT(probabilities[currentProbability] <= previousProbability);
             previousProbability = probabilities[currentProbability];
         }
@@ -2406,7 +2407,7 @@ void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
                 currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
             } else {
                 model.addSamples(addSampleParams(weights),
-                             {core::make_triple(time, TDouble2Vec(sample), TAG)});
+                                 {core::make_triple(time, TDouble2Vec(sample), TAG)});
             }
 
             maths::SModelProbabilityResult result;
@@ -2421,7 +2422,8 @@ void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
 
         // Assert probs are decreasing
         double previousProbability = probabilities[0];
-        for (std::size_t currentProbability = 1; currentProbability < probabilities.size(); ++currentProbability) {
+        for (std::size_t currentProbability = 1;
+             currentProbability < probabilities.size(); ++currentProbability) {
             CPPUNIT_ASSERT(probabilities[currentProbability] <= previousProbability);
             previousProbability = probabilities[currentProbability];
         }
@@ -2467,7 +2469,8 @@ CppUnit::Test* CTimeSeriesModelTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesModelTest>(
         "CTimeSeriesModelTest::testDaylightSaving", &CTimeSeriesModelTest::testDaylightSaving));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesModelTest>(
-        "CTimeSeriesModelTest::testSkipAnomalyModelUpdate", &CTimeSeriesModelTest::testSkipAnomalyModelUpdate));
+        "CTimeSeriesModelTest::testSkipAnomalyModelUpdate",
+        &CTimeSeriesModelTest::testSkipAnomalyModelUpdate));
 
     return suiteOfTests;
 }

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2360,12 +2360,14 @@ void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
             if (bucket >= 1700 && bucket < 1710) {
                 sample = 100.0;
                 currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
-                model.probability(currentComputeProbabilityParams, {{time}}, {{sample}}, result);
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {{sample}}, result);
                 probabilities.push_back(result.s_Probability);
             } else {
                 model.addSamples(addSampleParams(weights),
                                  {core::make_triple(time, TDouble2Vec{sample}, TAG)});
-                model.probability(currentComputeProbabilityParams, {{time}}, {{sample}}, result);
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {{sample}}, result);
             }
 
             time += bucketLength;
@@ -2402,12 +2404,14 @@ void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
                     coordinate += 100.0;
                 }
                 currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
-                model.probability(currentComputeProbabilityParams, {{time}}, {(sample)}, result);
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {(sample)}, result);
                 probabilities.push_back(result.s_Probability);
             } else {
                 model.addSamples(addSampleParams(weights),
                                  {core::make_triple(time, TDouble2Vec(sample), TAG)});
-                model.probability(currentComputeProbabilityParams, {{time}}, {(sample)}, result);
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {(sample)}, result);
             }
 
             time += bucketLength;

--- a/lib/maths/unittest/CTimeSeriesModelTest.h
+++ b/lib/maths/unittest/CTimeSeriesModelTest.h
@@ -27,6 +27,7 @@ public:
     void testStepChangeDiscontinuities();
     void testLinearScaling();
     void testDaylightSaving();
+    void testSkipAnomalyModelUpdate();
 
     static CppUnit::Test* suite();
 };

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -381,9 +381,9 @@ bool CEventRateModel::computeProbability(std::size_t pid,
         if (!data) {
             continue;
         }
-        if (this->shouldIgnoreResult(feature, result.s_ResultType, pid,
-                                     model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
-                                     model_t::sampleTime(feature, startTime, bucketLength))) {
+        if (this->shouldIgnoreResult(
+                feature, result.s_ResultType, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
+                model_t::sampleTime(feature, startTime, bucketLength))) {
             skippedResults = true;
             continue;
         }
@@ -590,7 +590,8 @@ void CEventRateModel::fill(model_t::EFeature feature,
     double value{model_t::offsetCountToZero(feature, static_cast<double>(data->s_Count))};
     maths_t::TDouble2VecWeightsAry weight(maths_t::seasonalVarianceScaleWeight(
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time)));
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -625,7 +626,8 @@ void CEventRateModel::fill(model_t::EFeature feature,
     const TSize2Vec1Vec& correlates{model->correlates()};
     const TTimeVec& firstBucketTimes{this->firstBucketTimes()};
     core_t::TTime time{model_t::sampleTime(feature, bucketTime, gatherer.bucketLength())};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
 
     params.s_Feature = feature;
     params.s_Model = model;

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -381,9 +381,9 @@ bool CEventRateModel::computeProbability(std::size_t pid,
         if (!data) {
             continue;
         }
-        if (this->shouldIgnoreResult(
-                feature, result.s_ResultType, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
-                model_t::sampleTime(feature, startTime, bucketLength))) {
+        if (this->shouldIgnoreResult(feature, result.s_ResultType, pid,
+                                     model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
+                                     model_t::sampleTime(feature, startTime, bucketLength))) {
             skippedResults = true;
             continue;
         }
@@ -590,6 +590,7 @@ void CEventRateModel::fill(model_t::EFeature feature,
     double value{model_t::offsetCountToZero(feature, static_cast<double>(data->s_Count))};
     maths_t::TDouble2VecWeightsAry weight(maths_t::seasonalVarianceScaleWeight(
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time)));
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -607,7 +608,8 @@ void CEventRateModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature)) // new line
         .addBucketEmpty({!count || *count == 0})
-        .addWeights(weight);
+        .addWeights(weight)
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 }
 
 void CEventRateModel::fill(model_t::EFeature feature,
@@ -623,6 +625,7 @@ void CEventRateModel::fill(model_t::EFeature feature,
     const TSize2Vec1Vec& correlates{model->correlates()};
     const TTimeVec& firstBucketTimes{this->firstBucketTimes()};
     core_t::TTime time{model_t::sampleTime(feature, bucketTime, gatherer.bucketLength())};
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -633,7 +636,9 @@ void CEventRateModel::fill(model_t::EFeature feature,
     params.s_Variables.resize(correlates.size());
     params.s_CorrelatedLabels.resize(correlates.size());
     params.s_Correlated.resize(correlates.size());
-    params.s_ComputeProbabilityParams.addCalculation(model_t::probabilityCalculation(feature));
+    params.s_ComputeProbabilityParams
+        .addCalculation(model_t::probabilityCalculation(feature))
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 
     // These are indexed as follows:
     //   influenceValues["influencer name"]["correlate"]["influence value"]

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -1010,6 +1010,7 @@ void CEventRatePopulationModel::fill(model_t::EFeature feature,
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time)));
     double value{model_t::offsetCountToZero(
         feature, static_cast<double>(CDataGatherer::extractData(*data).s_Count))};
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, cid, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -1027,7 +1028,8 @@ void CEventRatePopulationModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addBucketEmpty({false})
-        .addWeights(weight);
+        .addWeights(weight)
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 }
 
 ////////// CEventRatePopulationModel::SBucketStats Implementation //////////

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -549,7 +549,8 @@ void CMetricModel::fill(model_t::EFeature feature,
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time), weights);
     maths_t::setCountVarianceScale(TDouble2Vec(dimension, bucket->varianceScale()), weights);
     TOptionalUInt64 count{this->currentBucketCount(pid, bucketTime)};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -586,8 +587,9 @@ void CMetricModel::fill(model_t::EFeature feature,
     const TSize2Vec1Vec& correlates{model->correlates()};
     const TTimeVec& firstBucketTimes{this->firstBucketTimes()};
     core_t::TTime bucketLength{gatherer.bucketLength()};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
-                                                           model_t::sampleTime(feature, bucketTime, bucketLength));
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
+        model_t::sampleTime(feature, bucketTime, bucketLength));
 
     params.s_Feature = feature;
     params.s_Model = model;

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -549,6 +549,7 @@ void CMetricModel::fill(model_t::EFeature feature,
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time), weights);
     maths_t::setCountVarianceScale(TDouble2Vec(dimension, bucket->varianceScale()), weights);
     TOptionalUInt64 count{this->currentBucketCount(pid, bucketTime)};
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -567,7 +568,8 @@ void CMetricModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature)) // new line
         .addBucketEmpty({!count || *count == 0})
-        .addWeights(weights);
+        .addWeights(weights)
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 }
 
 void CMetricModel::fill(model_t::EFeature feature,
@@ -584,6 +586,8 @@ void CMetricModel::fill(model_t::EFeature feature,
     const TSize2Vec1Vec& correlates{model->correlates()};
     const TTimeVec& firstBucketTimes{this->firstBucketTimes()};
     core_t::TTime bucketLength{gatherer.bucketLength()};
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
+                                                           model_t::sampleTime(feature, bucketTime, bucketLength));
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -594,7 +598,9 @@ void CMetricModel::fill(model_t::EFeature feature,
     params.s_Variables.resize(correlates.size());
     params.s_CorrelatedLabels.resize(correlates.size());
     params.s_Correlated.resize(correlates.size());
-    params.s_ComputeProbabilityParams.addCalculation(model_t::probabilityCalculation(feature));
+    params.s_ComputeProbabilityParams
+        .addCalculation(model_t::probabilityCalculation(feature))
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 
     // These are indexed as follows:
     //   influenceValues["influencer name"]["correlate"]["influence value"]

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -929,6 +929,7 @@ void CMetricPopulationModel::fill(model_t::EFeature feature,
     maths_t::setSeasonalVarianceScale(
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time), weights);
     maths_t::setCountVarianceScale(TDouble2Vec(dimension, bucket->varianceScale()), weights);
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, cid, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -947,7 +948,8 @@ void CMetricPopulationModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addBucketEmpty({false})
-        .addWeights(weights);
+        .addWeights(weights)
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 }
 
 ////////// CMetricPopulationModel::SBucketStats Implementation //////////


### PR DESCRIPTION
Skip model update was not being communicated
to the anomaly model resulting to the score/probability
of results triggering the skip-model-update rule
to reduce.

This commit skips updates to the anomaly model as well.

Closes #217