### PR TITLE
[ML][6.4] Add -headerpad_max_install_names to macOS linker args

### DIFF
--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -33,6 +33,7 @@ export CFLAGS='-O3 -msse4.1'
 export CXX='clang++ -std=c++11 -stdlib=libc++'
 export CXXFLAGS='-O3 -msse4.1'
 export CXXCPP='clang++ -std=c++11 -E'
+export LDFLAGS=-Wl,-headerpad_max_install_names
 unset CPATH
 unset C_INCLUDE_PATH
 unset CPLUS_INCLUDE_PATH
@@ -174,8 +175,8 @@ to:
 To complete the build, type:
 
 ```
-./b2 -j8 --layout=versioned --disable-icu cxxflags="-std=c++11 -stdlib=libc++" linkflags="-std=c++11 -stdlib=libc++" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-sudo ./b2 install --layout=versioned --disable-icu cxxflags="-std=c++11 -stdlib=libc++" linkflags="-std=c++11 -stdlib=libc++" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+./b2 -j8 --layout=versioned --disable-icu cxxflags="-std=c++11 -stdlib=libc++" linkflags="-std=c++11 -stdlib=libc++ -Wl,-headerpad_max_install_names" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+sudo ./b2 install --layout=versioned --disable-icu cxxflags="-std=c++11 -stdlib=libc++" linkflags="-std=c++11 -stdlib=libc++ -Wl,-headerpad_max_install_names" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
 cd /usr/local/lib
 for FILE in libboost*1_65_1.dylib ; do sudo install_name_tool -id "@rpath/$FILE" $FILE ; done
 sudo install_name_tool -change libboost_system-clang-darwin42-mt-1_65_1.dylib "@rpath/libboost_system-clang-darwin42-mt-1_65_1.dylib" -add_rpath "@loader_path/../lib" libboost_filesystem-clang-darwin42-mt-1_65_1.dylib

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -16,13 +16,13 @@
 
 ACCOUNT=droberts195
 REPOSITORY=ml-macosx-build
-VERSION=2
+VERSION=4
 
 set -e
 
 cd `dirname $0`
 
-docker build -t $ACCOUNT/$REPOSITORY:$VERSION macosx_image
+docker build --no-cache -t $ACCOUNT/$REPOSITORY:$VERSION macosx_image
 docker login
 docker push $ACCOUNT/$REPOSITORY:$VERSION
 

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM droberts195/ml-macosx-build:2
+FROM droberts195/ml-macosx-build:4
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/macosx_image/Dockerfile
+++ b/dev-tools/docker/macosx_image/Dockerfile
@@ -29,7 +29,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.10/usr && \
   cd /usr/local/sysroot-x86_64-apple-macosx10.10/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.10-2.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.10-3.tar.bz2 | tar jxf - && \
   wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/xcode-x86_64-apple-macosx10.10-1.tar.bz2 | tar jxf -
 
 # Build cctools-port

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -31,6 +31,22 @@
 //=== Known Issues
 ////
 
+== {es} version 6.4.3
+
+//=== Breaking Changes
+
+//=== Deprecations
+
+//=== New Features
+
+=== Enhancements
+
+Change linker options on macOS to allow Homebrew installs ({ml-pull}225[225])
+
+//=== Bug Fixes
+
+//=== Regressions
+
 == Elasticsearch version 6.4.0
 
 //=== Breaking Changes

--- a/mk/linux_crosscompile_macosx.mk
+++ b/mk/linux_crosscompile_macosx.mk
@@ -56,11 +56,11 @@ XMLINCLUDES=-isystem $(SYSROOT)/usr/include/libxml2
 XMLLIBLDFLAGS=-L$(SYSROOT)/usr/lib
 XMLLIBS=-lxml2
 ML_VERSION_NUM=$(shell cat $(CPP_SRC_HOME)/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $$2 }' | xargs echo | sed 's/-.*//')
-DYNAMICLIBLDFLAGS=-current_version $(ML_VERSION_NUM) -compatibility_version $(ML_VERSION_NUM) -dynamiclib -Wl,-dead_strip_dylibs $(COVERAGE) -Wl,-install_name,@rpath/$(notdir $(TARGET)) -L$(CPP_PLATFORM_HOME)/lib -Wl,-rpath,@loader_path/.
+DYNAMICLIBLDFLAGS=-current_version $(ML_VERSION_NUM) -compatibility_version $(ML_VERSION_NUM) -dynamiclib -Wl,-dead_strip_dylibs $(COVERAGE) -Wl,-install_name,@rpath/$(notdir $(TARGET)) -L$(CPP_PLATFORM_HOME)/lib -Wl,-rpath,@loader_path/. -Wl,-headerpad_max_install_names
 CPPUNITLIBS=-lcppunit
 LOG4CXXLIBS=-llog4cxx
 ZLIBLIBS=-lz
-EXELDFLAGS=-bind_at_load -L$(CPP_PLATFORM_HOME)/lib $(COVERAGE) -Wl,-rpath,@loader_path/../lib
+EXELDFLAGS=-bind_at_load -L$(CPP_PLATFORM_HOME)/lib $(COVERAGE) -Wl,-rpath,@loader_path/../lib -Wl,-headerpad_max_install_names
 UTLDFLAGS=$(EXELDFLAGS) -Wl,-rpath,$(CPP_PLATFORM_HOME)/lib
 OBJECT_FILE_EXT=.o
 DYNAMIC_LIB_EXT=.dylib

--- a/mk/macosx.mk
+++ b/mk/macosx.mk
@@ -55,11 +55,11 @@ JAVANATIVEINCLUDES=-I`/usr/libexec/java_home`/include
 JAVANATIVELDFLAGS=-L`/usr/libexec/java_home`/jre/lib/server
 JAVANATIVELIBS=-ljvm
 ML_VERSION_NUM=$(shell cat $(CPP_SRC_HOME)/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $$2 }' | xargs echo | sed 's/-.*//')
-DYNAMICLIBLDFLAGS=-current_version $(ML_VERSION_NUM) -compatibility_version $(ML_VERSION_NUM) -dynamiclib -Wl,-dead_strip_dylibs $(COVERAGE) -Wl,-install_name,@rpath/$(notdir $(TARGET)) -L$(CPP_PLATFORM_HOME)/lib -Wl,-rpath,@loader_path/.
+DYNAMICLIBLDFLAGS=-current_version $(ML_VERSION_NUM) -compatibility_version $(ML_VERSION_NUM) -dynamiclib -Wl,-dead_strip_dylibs $(COVERAGE) -Wl,-install_name,@rpath/$(notdir $(TARGET)) -L$(CPP_PLATFORM_HOME)/lib -Wl,-rpath,@loader_path/. -Wl,-headerpad_max_install_names
 CPPUNITLIBS=-lcppunit
 LOG4CXXLIBS=-llog4cxx
 ZLIBLIBS=-lz
-EXELDFLAGS=-bind_at_load -L$(CPP_PLATFORM_HOME)/lib $(COVERAGE) -Wl,-rpath,@loader_path/../lib
+EXELDFLAGS=-bind_at_load -L$(CPP_PLATFORM_HOME)/lib $(COVERAGE) -Wl,-rpath,@loader_path/../lib -Wl,-headerpad_max_install_names
 UTLDFLAGS=$(EXELDFLAGS) -Wl,-rpath,$(CPP_PLATFORM_HOME)/lib
 OBJECT_FILE_EXT=.o
 DYNAMIC_LIB_EXT=.dylib


### PR DESCRIPTION
This is to support Homebrew, which changes the @rpaths of libraries
it installs to (potentially very long) absolute paths.

Backport of #225.