### PR TITLE
[ML-Dataframe][FEATURE] A dense data frame

### DIFF
--- a/include/core/CDataAdder.h
+++ b/include/core/CDataAdder.h
@@ -26,7 +26,7 @@ namespace core {
 //! Contains methods that require data be known in advance, plus a
 //! method that returns a stream to which the data to be persisted
 //! can be written.  This latter method is obviously much more
-//! memory-efficient in cases where is is a viable option.
+//! memory-efficient in cases where it is a viable option.
 //!
 //! IMPLEMENTATION DECISIONS:\n
 //! There's an assumption that persisted state will be saved to a

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -1,0 +1,375 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_core_CDataFrame_h
+#define INCLUDED_ml_core_CDataFrame_h
+
+#include <core/CConcurrentQueue.h>
+#include <core/CDataFrameRowSlice.h>
+#include <core/CFloatStorage.h>
+#include <core/ImportExport.h>
+
+#include <boost/optional.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <future>
+#include <iterator>
+#include <memory>
+#include <vector>
+
+namespace ml {
+namespace core {
+
+namespace data_frame_detail {
+
+using TFloatVec = std::vector<CFloatStorage>;
+using TFloatVecCItr = TFloatVec::const_iterator;
+
+//! \brief A lightweight wrapper around a single row of the data frame.
+//!
+//! DESCRIPTION:\n
+//! This is a helper class used to read rows of a CDataFrame object. It is
+//! lightweight (24 bytes) and is expected to only be valid transiently
+//! during a read. It should not be stored. If a copy of the underlying
+//! row is required call copyTo and supply an output iterator that must be
+//! able to receive number of columns of data.
+class CORE_EXPORT CRowCRef {
+public:
+    //! \param[in] index The row index.
+    //! \param[in] beginColumns The iterator for the columns of row \p index.
+    //! \param[in] endColumns The iterator for the end of the columns of row
+    //! \p index.
+    CRowCRef(std::size_t index, TFloatVecCItr beginColumns, TFloatVecCItr endColumns);
+
+    //! Get column \p i value.
+    CFloatStorage operator[](std::size_t i) const;
+
+    //! Get the row's index.
+    std::size_t index() const;
+
+    //! Get the number of columns.
+    std::size_t numberColumns() const;
+
+    //! Copy the range to \p output iterator.
+    template<typename ITR>
+    void copyTo(ITR output) const {
+        std::copy(m_BeginColumns, m_EndColumns, output);
+    }
+
+private:
+    std::size_t m_Index;
+    TFloatVecCItr m_BeginColumns;
+    TFloatVecCItr m_EndColumns;
+};
+
+//! \brief Decorates CRowCRef to give it pointer semantics.
+class CORE_EXPORT CRowCPtr : public CRowCRef {
+public:
+    template<typename... ARGS>
+    CRowCPtr(ARGS&&... args) : CRowCRef{std::forward<ARGS>(args)...} {}
+
+    CRowCPtr* operator->() { return this; }
+    const CRowCPtr* operator->() const { return this; }
+};
+
+//! \brief A forward iterator over rows of the data frame.
+//!
+//! DESCRIPTION:\n
+//! This is a helper class used to read rows of a CDataFrame object which
+//! dereferences to CRowRef objects.
+class CORE_EXPORT CRowConstIterator
+    : public std::iterator<std::forward_iterator_tag, CRowCRef, std::ptrdiff_t, CRowCPtr, CRowCRef> {
+public:
+    CRowConstIterator() = default;
+
+    //! \param[in] numberColumns The number of columns in the data frame.
+    //! \param[in] index The row index.
+    //! \param[in] base The iterator for the columns of row \p index.
+    CRowConstIterator(std::size_t numberColumns, std::size_t index, TFloatVecCItr base);
+
+    //! \name Forward Iterator Contract
+    //@{
+    bool operator==(const CRowConstIterator& rhs) const;
+    bool operator!=(const CRowConstIterator& rhs) const;
+    CRowCRef operator*() const;
+    CRowCPtr operator->() const;
+    CRowConstIterator& operator++();
+    CRowConstIterator operator++(int);
+    //@}
+
+    TFloatVecCItr base() const;
+
+private:
+    std::size_t m_NumberColumns = 0;
+    std::size_t m_Index = 0;
+    TFloatVecCItr m_Base;
+};
+}
+
+//! \brief A data frame representation.
+//!
+//! DESECRIPTION:\n
+//! A table data structure with fixed number of columns and a dynamic number
+//! of rows.
+//!
+//! It can be read in row order and is append only. Reading rows can also be
+//! parallelized in which case each reader reads a disjoint subset of the data
+//! frame's rows.
+//!
+//! Space can be reserved at any point to hold one or more additional columns.
+//! These are not visible until they are written by the appendColumns function.
+//!
+//! IMPLEMENTATION:\n
+//! This is a fairly lightweight container which is essentially responsible
+//! for managing the read and write process to some underlying store format.
+//! The store format is determined by the user implementing callbacks which are
+//! passed to the data frame constructor to read and write state from the store.
+//! For example, these could just copy to/from main memory, write to / read from
+//! disk, etc. Copying these functions is assumed to have no side effects and they
+//! are assumed to be thread safe. If they have shared state the implementation
+//! must ensure that access to this is synchronized.
+//!
+//! The data frame is divided into slices each of which represent a number of
+//! contiguous rows. The idea is that they contain a reasonable amount of memory
+//! such that, for example, they significantly reduce the number of writes to /
+//! reads from disk since a slice is written or read in one go.
+//!
+//! Reads and writes of a single row are also done via call backs supplied to the
+//! readRows and writeRows functions. This is to achieve maximum decoupling from
+//! the calling code for how the underlying values are used or where they come
+//! from. For example, a stream can be attached to a row writer which copies the
+//! values directly into the data frame storage. Read and writes to storage can
+//! optionally happen in a separate thread to the row reading and writing.
+class CORE_EXPORT CDataFrame final {
+public:
+    using TFloatVec = std::vector<CFloatStorage>;
+    using TFloatVecItr = TFloatVec::iterator;
+    using TSizeFloatVecPr = std::pair<std::size_t, TFloatVec>;
+    using TRowCItr = data_frame_detail::CRowConstIterator;
+    using TReadFunc = std::function<void(TRowCItr, TRowCItr)>;
+    using TReadFuncVec = std::vector<TReadFunc>;
+    using TReadFuncVecBoolPr = std::pair<TReadFuncVec, bool>;
+    using TWriteFunc = std::function<void(TFloatVecItr)>;
+    using TRowSlicePtr = std::unique_ptr<CDataFrameRowSlice>;
+    using TRowSlicePtrVec = std::vector<TRowSlicePtr>;
+    using TSizeRowSliceHandlePr = std::pair<std::size_t, CDataFrameRowSliceHandle>;
+    using TWriteSliceToStoreFunc = std::function<TRowSlicePtr(std::size_t, TFloatVec)>;
+    using TReadSliceFromStoreFunc =
+        std::function<TSizeRowSliceHandlePr(const TRowSlicePtr&)>;
+    using TSizeFloatVecPrQueue = CConcurrentQueue<TSizeFloatVecPr, 1>;
+
+    //! Controls whether to read and write to storage asynchronously.
+    enum class EReadWriteToStorage { E_Async, E_Sync };
+
+public:
+    //! \param[in] numberColumns The number of columns in the data frame.
+    //! \param[in] sliceCapacity The capacity of a slice of the data frame as
+    //! a number of rows.
+    //! \param[in] asyncReadAndWriteToStore Controls whether reads and writes
+    //! from slice storage are synchronous or asynchronous.
+    //! \param[in] writeSliceToStore The callback to write a slice to storage.
+    //! \param[in] readSliceFromStore The callback to read a slice from storage.
+    //!
+    //! \warning This requires that \p writeSliceToStore and \p readSliceFromStore
+    //! can be copied and are thread safe. If they are not stateless then it is
+    //! the implementers responsibility to ensure these conditions are satisfied.
+    CDataFrame(std::size_t numberColumns,
+               std::size_t sliceCapacity,
+               EReadWriteToStorage asyncReadAndWriteToStore,
+               const TWriteSliceToStoreFunc& writeSliceToStore,
+               const TReadSliceFromStoreFunc& readSliceFromStore);
+
+    //! Overload which manages the setting of slice capacity to a sensible default.
+    CDataFrame(std::size_t numberColumns,
+               EReadWriteToStorage asyncReadAndWriteToStore,
+               const TWriteSliceToStoreFunc& writeSliceToStore,
+               const TReadSliceFromStoreFunc& readSliceFromStore);
+
+    CDataFrame(const CDataFrame&) = delete;
+    CDataFrame& operator=(const CDataFrame&) = delete;
+
+    CDataFrame(CDataFrame&&) = default;
+    CDataFrame& operator=(CDataFrame&&) = default;
+
+    //! Reserve space for up to \p numberColumns.
+    //!
+    //! This enables in-place updates of the data frame for analytics operations
+    //! that append columns.
+    //!
+    //! \param[in] numberThreads The target number of threads to use.
+    //! \param[in] numberColumns The desired number of columns.
+    bool reserve(std::size_t numberThreads, std::size_t numberColumns);
+
+    //! This reads rows using one or more readers.
+    //!
+    //! One reader is bound to one thread. Each thread reads a disjoint subset
+    //! of slices of the data frame with the i'th reader reading slices
+    //! \f$[ i \lfloor m / \min(m,n) \rfloor, (i+1) \lfloor m / \min(m,n) \rfloor)\f$
+    //! for \f$m\f$ slices and \f$n\f$ readers to eliminate contention on the
+    //! data frame state.
+    //!
+    //! \warning If there is more than one reader and these have shared state
+    //! then the caller is responsible for synchronization of access to this
+    //! state.
+    //!
+    //! \param[in] numberThreads The target number of threads to use.
+    //! \param[in] reader The callback to read rows.
+    //! \return The readers used. This is intended to allow the reader to
+    //! accumulate state in the reader which is passed back. RVO means any
+    //! copy will be elided. Otherwise, the reader must hold the state by
+    //! reference and must synchronize access to it.
+    TReadFuncVecBoolPr readRows(std::size_t numberThreads, TReadFunc reader) const;
+
+    // TODO Modify in-place maybe something like:
+    // void readAndAppend(TReadFunc reader, std::size_t numberColumnsToAppend, TWriteFunc appender);
+    // Delaying adding more than the bare functionality until more of the calling
+    // infrastructure is available.
+
+    //! This writes a single row of the data frame via a callback.
+    //!
+    //! If asynchronous read and write to store was selected in the constructor
+    //! this creates a thread to store slices which is only joined when the
+    //! finishWritingRows is called (or the data frame is destroyed).
+    //!
+    //! Until finishWritingRows is called the written row is not visible outside
+    //! the data frame.
+    //!
+    //! \param[in] writeRow A function which writes a single row setting the
+    //! values in supplied an output iterator to the column values of the row.
+    //!
+    //! \warning The caller MUST call finishWritingRows after they have finished
+    //! writing rows.
+    void writeRow(const TWriteFunc& writeRow);
+
+    //! This retrieves the asynchronous work from writing the rows to the store
+    //! and updates the stored rows.
+    //!
+    //! Until this is called the written rows are not visible outside the data
+    //! frame.
+    //!
+    //! \warning This MUST be called after the last row is written to commit the
+    //! work and to join the thread used to store the slices.
+    void finishWritingRows();
+
+    //! Get the memory used by the data frame.
+    std::size_t memoryUsage() const;
+
+    // TODO Better error case diagnostics.
+
+    // TODO We may want an architecture agnostic check pointing mechanism for long
+    // running tasks.
+
+private:
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+    using TSizeDataFrameRowSlicePtrVecPr = std::pair<std::size_t, TRowSlicePtrVec>;
+
+    //! \brief Writes rows to the data frame.
+    class CDataFrameRowSliceWriter final {
+    public:
+        CDataFrameRowSliceWriter(std::size_t numberRows,
+                                 std::size_t numberColumns,
+                                 std::size_t sliceCapacity,
+                                 EReadWriteToStorage ayncWriteToStore,
+                                 TWriteSliceToStoreFunc writeSliceToStore);
+        ~CDataFrameRowSliceWriter();
+
+        //! Write a single row using the callback \p writeRow.
+        void operator()(const TWriteFunc& writeRow);
+
+        //! Finish writing the rows and return the number of rows written and
+        //! the slices.
+        TSizeDataFrameRowSlicePtrVecPr finishWritingRows();
+
+    private:
+        //! This is called to flush the queue to write to the store.
+        void finishAsyncWriteToStore();
+
+    private:
+        std::size_t m_NumberRows;
+        std::size_t m_NumberColumns;
+        std::size_t m_SliceCapacity;
+        EReadWriteToStorage m_AsyncWriteToStore;
+        TWriteSliceToStoreFunc m_WriteSliceToStore;
+
+        TFloatVec m_SliceBeingWritten;
+
+        //! This is true while the rows are still being added.
+        bool m_Writing = true;
+        //! A queue of finished slices shared with the thread that writes
+        //! them to storage if writes to storage are asynchronous.
+        TSizeFloatVecPrQueue m_SlicesToAsyncWriteToStore;
+        //! The result of the asynchronous work to write slices to storage
+        //! if there is any.
+        std::future<TRowSlicePtrVec> m_AsyncWriteToStoreResult;
+        //! The synchronously written stored slices.
+        TRowSlicePtrVec m_SyncWrittenSlices;
+    };
+    using TRowSliceWriterPtr = std::unique_ptr<CDataFrameRowSliceWriter>;
+
+private:
+    //! Get the number of threads and the stride (in the data frame) for the
+    //! target number of threads \p target.
+    //!
+    //! \note This is always less than or equal to \p target.
+    TSizeSizePr numberOfThreadsAndStride(std::size_t target) const;
+
+private:
+    //! The number of columns in the data frame.
+    std::size_t m_NumberColumns;
+    //! The number of rows in the data frame.
+    std::size_t m_NumberRows = 0;
+    //! The capacity of a slice of the data frame as a number of rows.
+    std::size_t m_SliceCapacity;
+
+    //! If true read and write asynchronously to storage.
+    EReadWriteToStorage m_AsyncReadAndWriteToStore;
+    //! The callback to write a slice to storage.
+    TWriteSliceToStoreFunc m_WriteSliceToStore;
+    //! The callback to read a slice from storage.
+    TReadSliceFromStoreFunc m_ReadSliceFromStore;
+
+    //! The stored slices.
+    TRowSlicePtrVec m_Slices;
+
+    //! The slice writer which is currently active.
+    TRowSliceWriterPtr m_Writer;
+};
+
+//! Make a data frame which uses main memory storage for its slices.
+//!
+//! \param[in] numberColumns The number of columns in the data frame created.
+//! \param[in] sliceCapacity If none null this overrides the default slice
+//! capacity in rows.
+//! \param[in] readWriteToStoreAsync Controls whether reads and writes from
+//! slice storage are synchronous or asynchronous.
+CORE_EXPORT
+CDataFrame makeMainStorageDataFrame(std::size_t numberColumns,
+                                    boost::optional<std::size_t> sliceCapacity = boost::none,
+                                    CDataFrame::EReadWriteToStorage readWriteToStoreAsync =
+                                        CDataFrame::EReadWriteToStorage::E_Sync);
+
+//! Make a data frame which uses disk storage for its slices.
+//!
+//! \param[in] rootDirectory The name of the directory to which write the
+//! data frame slices.
+//! \param[in] numberColumns The number of columns in the data frame created.
+//! \param[in] numberRows The number of rows that will be added.
+//! \param[in] sliceCapacity If none null this overrides the default slice
+//! capacity in rows.
+//! \param[in] readWriteToStoreAsync Controls whether reads and writes from
+//! slice storage are synchronous or asynchronous.
+CORE_EXPORT
+CDataFrame makeDiskStorageDataFrame(const std::string& rootDirectory,
+                                    std::size_t numberColumns,
+                                    std::size_t numberRows,
+                                    boost::optional<std::size_t> sliceCapacity = boost::none,
+                                    CDataFrame::EReadWriteToStorage readWriteToStoreAsync =
+                                        CDataFrame::EReadWriteToStorage::E_Async);
+}
+}
+
+#endif // INCLUDED_ml_core_CDataFrame_h

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -180,8 +180,8 @@ public:
     //! \param[in] numberColumns The number of columns in the data frame.
     //! \param[in] sliceCapacityInRows The capacity of a slice of the data frame
     //! as a number of rows.
-    //! \param[in] asyncReadAndWriteToStore Controls whether reads and writes
-    //! from slice storage are synchronous or asynchronous.
+    //! \param[in] readAndWriteToStoreSyncStrategy Controls whether reads and
+    //! writes from slice storage are synchronous or asynchronous.
     //! \param[in] writeSliceToStore The callback to write a slice to storage.
     //!
     //! \warning This requires that \p writeSliceToStore and \p readSliceFromStore
@@ -189,12 +189,12 @@ public:
     //! the implementers responsibility to ensure these conditions are satisfied.
     CDataFrame(std::size_t numberColumns,
                std::size_t sliceCapacityInRows,
-               EReadWriteToStorage asyncReadAndWriteToStore,
+               EReadWriteToStorage readAndWriteToStoreSyncStrategy,
                const TWriteSliceToStoreFunc& writeSliceToStore);
 
     //! Overload which manages the setting of slice capacity to a sensible default.
     CDataFrame(std::size_t numberColumns,
-               EReadWriteToStorage asyncReadAndWriteToStore,
+               EReadWriteToStorage readAndWriteToStoreSyncStrategy,
                const TWriteSliceToStoreFunc& writeSliceToStore);
 
     CDataFrame(const CDataFrame&) = delete;
@@ -241,7 +241,8 @@ public:
     //!
     //! \note READER must implement the TReadFunc contract.
     template<typename READER>
-    std::pair<std::vector<READER>, bool> readRows(std::size_t numberThreads, READER reader) const {
+    std::pair<std::vector<READER>, bool>
+    readRows(std::size_t numberThreads, READER reader) const {
 
         TReadFuncVecBoolPr result_{readRows(numberThreads, TReadFunc(reader))};
 
@@ -303,7 +304,7 @@ private:
         CDataFrameRowSliceWriter(std::size_t numberRows,
                                  std::size_t rowCapacity,
                                  std::size_t sliceCapacityInRows,
-                                 EReadWriteToStorage ayncWriteToStore,
+                                 EReadWriteToStorage writeToStoreSyncStrategy,
                                  TWriteSliceToStoreFunc writeSliceToStore);
         ~CDataFrameRowSliceWriter();
 
@@ -322,7 +323,7 @@ private:
         std::size_t m_NumberRows;
         std::size_t m_RowCapacity;
         std::size_t m_SliceCapacityInRows;
-        EReadWriteToStorage m_AsyncWriteToStore;
+        EReadWriteToStorage m_WriteToStoreSyncStrategy;
         TWriteSliceToStoreFunc m_WriteSliceToStore;
 
         TFloatVec m_SliceBeingWritten;
@@ -359,7 +360,7 @@ private:
     std::size_t m_SliceCapacityInRows;
 
     //! If true read and write asynchronously to storage.
-    EReadWriteToStorage m_AsyncReadAndWriteToStore;
+    EReadWriteToStorage m_ReadAndWriteToStoreSyncStrategy;
     //! The callback to write a slice to storage.
     TWriteSliceToStoreFunc m_WriteSliceToStore;
 
@@ -375,12 +376,12 @@ private:
 //! \param[in] numberColumns The number of columns in the data frame created.
 //! \param[in] sliceCapacity If none null this overrides the default slice
 //! capacity in rows.
-//! \param[in] readWriteToStoreAsync Controls whether reads and writes from
-//! slice storage are synchronous or asynchronous.
+//! \param[in] readWriteToStoreSyncStrategy Controls whether reads and writes
+//! from slice storage are synchronous or asynchronous.
 CORE_EXPORT
 CDataFrame makeMainStorageDataFrame(std::size_t numberColumns,
                                     boost::optional<std::size_t> sliceCapacity = boost::none,
-                                    CDataFrame::EReadWriteToStorage readWriteToStoreAsync =
+                                    CDataFrame::EReadWriteToStorage readWriteToStoreSyncStrategy =
                                         CDataFrame::EReadWriteToStorage::E_Sync);
 
 //! Make a data frame which uses disk storage for its slices.
@@ -391,14 +392,14 @@ CDataFrame makeMainStorageDataFrame(std::size_t numberColumns,
 //! \param[in] numberRows The number of rows that will be added.
 //! \param[in] sliceCapacity If none null this overrides the default slice
 //! capacity in rows.
-//! \param[in] readWriteToStoreAsync Controls whether reads and writes from
-//! slice storage are synchronous or asynchronous.
+//! \param[in] readWriteToStoreSyncStrategy Controls whether reads and writes
+//! from slice storage are synchronous or asynchronous.
 CORE_EXPORT
 CDataFrame makeDiskStorageDataFrame(const std::string& rootDirectory,
                                     std::size_t numberColumns,
                                     std::size_t numberRows,
                                     boost::optional<std::size_t> sliceCapacity = boost::none,
-                                    CDataFrame::EReadWriteToStorage readWriteToStoreAsync =
+                                    CDataFrame::EReadWriteToStorage readWriteToStoreSyncStrategy =
                                         CDataFrame::EReadWriteToStorage::E_Async);
 }
 }

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -87,9 +87,13 @@ public:
     CRowConstIterator() = default;
 
     //! \param[in] numberColumns The number of columns in the data frame.
+    //! \param[in] rowCapacity The capacity of each row in the data frame.
     //! \param[in] index The row index.
     //! \param[in] base The iterator for the columns of row \p index.
-    CRowConstIterator(std::size_t numberColumns, std::size_t index, TFloatVecCItr base);
+    CRowConstIterator(std::size_t numberColumns,
+                      std::size_t rowCapacity,
+                      std::size_t index,
+                      TFloatVecCItr base);
 
     //! \name Forward Iterator Contract
     //@{
@@ -105,6 +109,7 @@ public:
 
 private:
     std::size_t m_NumberColumns = 0;
+    std::size_t m_RowCapacity = 0;
     std::size_t m_Index = 0;
     TFloatVecCItr m_Base;
 };
@@ -167,8 +172,8 @@ public:
 
 public:
     //! \param[in] numberColumns The number of columns in the data frame.
-    //! \param[in] sliceCapacity The capacity of a slice of the data frame as
-    //! a number of rows.
+    //! \param[in] sliceCapacityInRows The capacity of a slice of the data frame
+    //! as a number of rows.
     //! \param[in] asyncReadAndWriteToStore Controls whether reads and writes
     //! from slice storage are synchronous or asynchronous.
     //! \param[in] writeSliceToStore The callback to write a slice to storage.
@@ -178,7 +183,7 @@ public:
     //! can be copied and are thread safe. If they are not stateless then it is
     //! the implementers responsibility to ensure these conditions are satisfied.
     CDataFrame(std::size_t numberColumns,
-               std::size_t sliceCapacity,
+               std::size_t sliceCapacityInRows,
                EReadWriteToStorage asyncReadAndWriteToStore,
                const TWriteSliceToStoreFunc& writeSliceToStore,
                const TReadSliceFromStoreFunc& readSliceFromStore);
@@ -201,8 +206,8 @@ public:
     //! that append columns.
     //!
     //! \param[in] numberThreads The target number of threads to use.
-    //! \param[in] numberColumns The desired number of columns.
-    bool reserve(std::size_t numberThreads, std::size_t numberColumns);
+    //! \param[in] rowCapacity The desired number of columns.
+    bool reserve(std::size_t numberThreads, std::size_t rowCapacity);
 
     //! This reads rows using one or more readers.
     //!
@@ -271,8 +276,8 @@ private:
     class CDataFrameRowSliceWriter final {
     public:
         CDataFrameRowSliceWriter(std::size_t numberRows,
-                                 std::size_t numberColumns,
-                                 std::size_t sliceCapacity,
+                                 std::size_t rowCapacity,
+                                 std::size_t sliceCapacityInRows,
                                  EReadWriteToStorage ayncWriteToStore,
                                  TWriteSliceToStoreFunc writeSliceToStore);
         ~CDataFrameRowSliceWriter();
@@ -290,8 +295,8 @@ private:
 
     private:
         std::size_t m_NumberRows;
-        std::size_t m_NumberColumns;
-        std::size_t m_SliceCapacity;
+        std::size_t m_RowCapacity;
+        std::size_t m_SliceCapacityInRows;
         EReadWriteToStorage m_AsyncWriteToStore;
         TWriteSliceToStoreFunc m_WriteSliceToStore;
 
@@ -318,12 +323,15 @@ private:
     TSizeSizePr numberOfThreadsAndStride(std::size_t target) const;
 
 private:
-    //! The number of columns in the data frame.
-    std::size_t m_NumberColumns;
     //! The number of rows in the data frame.
     std::size_t m_NumberRows = 0;
+    //! The number of columns in the data frame.
+    std::size_t m_NumberColumns;
+    //! The number of columns a row could contain. This is greater than or
+    //! equal to m_NumberColumns.
+    std::size_t m_RowCapacity;
     //! The capacity of a slice of the data frame as a number of rows.
-    std::size_t m_SliceCapacity;
+    std::size_t m_SliceCapacityInRows;
 
     //! If true read and write asynchronously to storage.
     EReadWriteToStorage m_AsyncReadAndWriteToStore;

--- a/include/core/CDataFrameRowSlice.h
+++ b/include/core/CDataFrameRowSlice.h
@@ -30,7 +30,6 @@ public:
 public:
     virtual ~CDataFrameRowSliceHandleImpl() = default;
     virtual TImplPtr clone() const = 0;
-    virtual bool reserve(std::size_t numberColumns, std::size_t extraColumns) = 0;
     virtual const TFloatVec& values() const = 0;
     virtual bool bad() const = 0;
 };
@@ -53,7 +52,6 @@ public:
     CDataFrameRowSliceHandle& operator=(const CDataFrameRowSliceHandle& other);
     CDataFrameRowSliceHandle& operator=(CDataFrameRowSliceHandle&& other);
 
-    bool reserve(std::size_t numberColumns, std::size_t extraColumns);
     std::size_t size() const;
     TFloatVecCItr begin() const;
     TFloatVecCItr end() const;

--- a/include/core/CDataFrameRowSlice.h
+++ b/include/core/CDataFrameRowSlice.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_core_CDataFrameRowSlice_h
+#define INCLUDED_ml_core_CDataFrameRowSlice_h
+
+#include <core/CFloatStorage.h>
+#include <core/CompressUtils.h>
+#include <core/ImportExport.h>
+
+#include <boost/filesystem.hpp>
+
+#include <string>
+#include <vector>
+
+namespace ml {
+namespace core {
+class CDataFrame;
+
+namespace data_frame_row_slice_detail {
+//! \brief The implementation backing a data frame row slice handle.
+class CORE_EXPORT CDataFrameRowSliceHandleImpl {
+public:
+    using TFloatVec = std::vector<CFloatStorage>;
+    using TImplPtr = std::unique_ptr<CDataFrameRowSliceHandleImpl>;
+
+public:
+    virtual ~CDataFrameRowSliceHandleImpl() = default;
+    virtual TImplPtr clone() const = 0;
+    virtual const TFloatVec& values() const = 0;
+    virtual bool bad() const = 0;
+};
+}
+
+//! \brief A handle which can be used to read values from a slice of
+//! CDataFrame storage.
+class CORE_EXPORT CDataFrameRowSliceHandle {
+public:
+    using TFloatVec = std::vector<CFloatStorage>;
+    using TFloatVecCItr = TFloatVec::const_iterator;
+    using TImplPtr = std::unique_ptr<data_frame_row_slice_detail::CDataFrameRowSliceHandleImpl>;
+
+public:
+    CDataFrameRowSliceHandle() = default;
+    CDataFrameRowSliceHandle(TImplPtr impl);
+    CDataFrameRowSliceHandle(const CDataFrameRowSliceHandle& other);
+    CDataFrameRowSliceHandle(CDataFrameRowSliceHandle&& other);
+
+    CDataFrameRowSliceHandle& operator=(const CDataFrameRowSliceHandle& other);
+    CDataFrameRowSliceHandle& operator=(CDataFrameRowSliceHandle&& other);
+
+    std::size_t size() const;
+    TFloatVecCItr begin() const;
+    TFloatVecCItr end() const;
+    bool bad() const;
+
+private:
+    TImplPtr m_Impl;
+};
+
+//! \brief CDataFrame slice storage interface.
+class CORE_EXPORT CDataFrameRowSlice {
+public:
+    using TFloatVec = std::vector<CFloatStorage>;
+    using TSizeHandlePr = std::pair<std::size_t, CDataFrameRowSliceHandle>;
+
+public:
+    virtual ~CDataFrameRowSlice() = default;
+    virtual TSizeHandlePr read() const = 0;
+    virtual std::size_t staticSize() const = 0;
+    virtual std::size_t memoryUsage() const = 0;
+};
+
+//! \brief In main memory CDataFrame slice storage.
+//!
+//! DESCRIPTION:\n
+//! This provides maximum speed at the expense of maximum main memory
+//! usage. The intention is to provide a speed optimized implementation
+//! suitable for small data frames which comfortably fit into memory.
+//!
+//! IMPLEMENTATION:\n
+//! This is basically a wrapper around a single std::vector storing all
+//! rows to adapt it for use by the data frame.
+class CORE_EXPORT CMainMemoryDataFrameRowSlice final : public CDataFrameRowSlice {
+public:
+    CMainMemoryDataFrameRowSlice(std::size_t firstRow, TFloatVec state);
+    virtual TSizeHandlePr read() const;
+    virtual std::size_t staticSize() const;
+    virtual std::size_t memoryUsage() const;
+
+private:
+    std::size_t m_FirstRow;
+    TFloatVec m_State;
+};
+
+//! \brief On disk CDataFrame slice storage.
+//!
+//! DESCRIPTION:\n
+//! This writes the data in binary format to a single file. As such, there is
+//! essentially no main memory usage per slice. The intention is that the data
+//! the corresponding frame can be linearly scanned efficiently and specific
+//! rows can be copied to main memory during the running of some ML task over
+//! the data frame. It is the task responsibility to decide how best to do this
+//! whilst meeting some specified memory constraint.
+//!
+//! IMPLEMENTATION:\n
+//! A temporary directory is created to hold the data frame files. It is the
+//! calling code's responsibility to provide a suitable path for this.
+//!
+//! We have one directory for all slices and one file per slice. These are deleted
+//! in one go when the data frame object is destroyed. The cleanup is performed
+//! in the destructor of CTemporaryDirectory. There is one such object per data
+//! frame object whose ownership is shared between all slices and the data frame
+//! itself.
+//!
+//! The slices are stored in binary format to maximize the read and write speed.
+//! We cache the number of bytes so we can read the file directory into a pre
+//! allocated vector. Note that these files are intended to be short lived and
+//! stay on the machine (or in the container) where the analysis action is being
+//! performed. So we have no architecture related issues with interpreting the
+//! stored bytes as floating point values.
+class CORE_EXPORT COnDiskDataFrameRowSlice final : public CDataFrameRowSlice {
+public:
+    //! \brief Manages the resource associated with the temporary directory
+    //! which contains all the slices of a single data frame.
+    class CORE_EXPORT CTemporaryDirectory {
+    public:
+        CTemporaryDirectory(const std::string& name, std::size_t minimumSpace);
+        ~CTemporaryDirectory();
+        const std::string& name() const;
+        bool bad() const;
+
+    private:
+        bool m_StateIsBad = false;
+        boost::filesystem::path m_Name;
+    };
+
+    using TTemporaryDirectoryPtr = std::shared_ptr<CTemporaryDirectory>;
+
+public:
+    COnDiskDataFrameRowSlice(const TTemporaryDirectoryPtr& directory,
+                             std::size_t firstRow,
+                             TFloatVec state);
+    virtual TSizeHandlePr read() const;
+    virtual std::size_t staticSize() const;
+    virtual std::size_t memoryUsage() const;
+
+private:
+    using TByteVec = CCompressUtil::TByteVec;
+
+private:
+    mutable bool m_StateIsBad = false;
+    std::size_t m_FirstRow;
+    std::size_t m_NumberRows;
+    TTemporaryDirectoryPtr m_Directory;
+    boost::filesystem::path m_FileName;
+    uint64_t m_Checksum;
+};
+}
+}
+
+#endif // INCLUDED_ml_core_CDataFrameRowSlice_h

--- a/lib/core/CCompressOStream.cc
+++ b/lib/core/CCompressOStream.cc
@@ -39,9 +39,7 @@ void CCompressOStream::close() {
 CCompressOStream::CCompressThread::CCompressThread(CCompressOStream& stream,
                                                    CDualThreadStreamBuf& streamBuf,
                                                    CStateCompressor::CChunkFilter& filter)
-    : m_Stream(stream), m_StreamBuf(streamBuf), m_FilterSink(filter), m_OutFilter()
-
-{
+    : m_Stream(stream), m_StreamBuf(streamBuf), m_FilterSink(filter), m_OutFilter() {
     m_OutFilter.push(boost::iostreams::gzip_compressor());
     m_OutFilter.push(CBase64Encoder());
     m_OutFilter.push(boost::ref(m_FilterSink));

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -1,0 +1,462 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CDataFrame.h>
+
+#include <core/CConcurrentWrapper.h>
+#include <core/CDataFrameRowSlice.h>
+#include <core/CLogger.h>
+#include <core/CMemory.h>
+
+#include <boost/make_unique.hpp>
+
+#include <algorithm>
+#include <future>
+#include <memory>
+
+namespace ml {
+namespace core {
+namespace data_frame_detail {
+
+CRowCRef::CRowCRef(std::size_t index, TFloatVecCItr beginColumns, TFloatVecCItr endColumns)
+    : m_Index{index}, m_BeginColumns{beginColumns}, m_EndColumns{endColumns} {
+}
+
+CFloatStorage CRowCRef::operator[](std::size_t i) const {
+    return *(m_BeginColumns + i);
+}
+
+std::size_t CRowCRef::index() const {
+    return m_Index;
+}
+
+std::size_t CRowCRef::numberColumns() const {
+    return std::distance(m_BeginColumns, m_EndColumns);
+}
+
+CRowConstIterator::CRowConstIterator(std::size_t numberColumns, std::size_t index, TFloatVecCItr base)
+    : m_NumberColumns{numberColumns}, m_Index{index}, m_Base{base} {
+}
+
+bool CRowConstIterator::operator==(const CRowConstIterator& rhs) const {
+    return m_Base == rhs.m_Base;
+}
+
+bool CRowConstIterator::operator!=(const CRowConstIterator& rhs) const {
+    return m_Base != rhs.m_Base;
+}
+
+CRowCRef CRowConstIterator::operator*() const {
+    return CRowCRef{m_Index, m_Base, m_Base + m_NumberColumns};
+}
+
+CRowCPtr CRowConstIterator::operator->() const {
+    return CRowCPtr{m_Index, m_Base, m_Base + m_NumberColumns};
+}
+
+CRowConstIterator& CRowConstIterator::operator++() {
+    ++m_Index;
+    m_Base += m_NumberColumns;
+    return *this;
+}
+
+CRowConstIterator CRowConstIterator::operator++(int) {
+    CRowConstIterator result{*this};
+    ++m_Index;
+    m_Base += m_NumberColumns;
+    return result;
+}
+
+TFloatVecCItr CRowConstIterator::base() const {
+    return m_Base;
+}
+}
+using namespace data_frame_detail;
+
+namespace {
+using TFloatVec = CDataFrame::TFloatVec;
+using TSizeFloatVecPrQueue = CDataFrame::TSizeFloatVecPrQueue;
+using TRowSlicePtr = CDataFrame::TRowSlicePtr;
+using TRowSlicePtrVec = CDataFrame::TRowSlicePtrVec;
+using TRowSlicePtrVecCItr = TRowSlicePtrVec::const_iterator;
+
+//! \brief A worker function object used to asynchronously write slices
+//! to storage.
+class CAsyncDataFrameStorageWriter final {
+public:
+    using TWriteSliceToStoreFunc = CDataFrame::TWriteSliceToStoreFunc;
+
+public:
+    CAsyncDataFrameStorageWriter(std::size_t sliceCapacity,
+                                 const TWriteSliceToStoreFunc& writeSliceToStore)
+        : m_SliceCapacity{sliceCapacity}, m_WriteSliceToStore{writeSliceToStore} {}
+
+    TRowSlicePtrVec operator()(TSizeFloatVecPrQueue& sliceQueue) {
+        // Loop until we're signaled to exit by an empty slice.
+
+        TRowSlicePtrVec slices;
+
+        std::size_t firstRow;
+        TFloatVec slice;
+        for (;;) {
+            std::tie(firstRow, slice) = sliceQueue.pop();
+            std::size_t size{slice.size()};
+            if (size > 0) {
+                auto storedSlice = m_WriteSliceToStore(firstRow, std::move(slice));
+                slices.push_back(std::move(storedSlice));
+            } else {
+                break;
+            }
+        }
+
+        return slices;
+    }
+
+private:
+    std::size_t m_SliceCapacity;
+    TWriteSliceToStoreFunc m_WriteSliceToStore;
+};
+
+//! \brief Reads a collection of slices from a data frame.
+class CDataFrameRowSliceReader final {
+public:
+    using TReadFunc = CDataFrame::TReadFunc;
+    using TReadFuncRef = std::reference_wrapper<TReadFunc>;
+    using TReadSliceFromStoreFunc = CDataFrame::TReadSliceFromStoreFunc;
+
+public:
+    CDataFrameRowSliceReader(TReadFunc& reader,
+                             std::size_t numberColumns,
+                             CDataFrame::EReadWriteToStorage asyncReadFromStore,
+                             const TReadSliceFromStoreFunc& readSliceFromStore)
+        : m_Reader{reader}, m_NumberColumns{numberColumns},
+          m_AsyncReadFromStore{asyncReadFromStore}, m_ReadSliceFromStore{readSliceFromStore} {}
+
+    //! Read all slices in [\p beginSlices, \p endSlices) passing to the
+    //! callback supplied to the constructor.
+    //!
+    //! \return False if the rows couldn't all be read.
+    bool operator()(TRowSlicePtrVecCItr beginSlices, TRowSlicePtrVecCItr endSlices) {
+        std::size_t firstRow;
+        CDataFrameRowSliceHandle sliceBeingRead;
+        std::size_t cols{m_NumberColumns};
+
+        switch (m_AsyncReadFromStore) {
+        case CDataFrame::EReadWriteToStorage::E_Async: {
+            // The slices get read from storage on the thread executing this
+            // function each slice is then concurrently read by the callback
+            // on a worker thread managed by the concurrent wrapper. We use
+            // a queue of length one so the memory used by the queue is only
+            // one slice.
+
+            CConcurrentWrapper<TReadFunc, 1, 1> asyncReader{m_Reader};
+            for (auto i = beginSlices; i != endSlices; ++i) {
+                std::tie(firstRow, sliceBeingRead) = m_ReadSliceFromStore(*i);
+                if (sliceBeingRead.bad()) {
+                    return false;
+                }
+                LOG_TRACE(<< "reading slice starting at row " << firstRow);
+                asyncReader(
+                    [ firstRow, slice = std::move(sliceBeingRead), cols ](TReadFuncRef reader) {
+                        std::size_t rows = slice.size() / cols;
+                        reader(CRowConstIterator{cols, firstRow, slice.begin()},
+                               CRowConstIterator{cols, firstRow + rows, slice.end()});
+                    });
+            }
+            break;
+        }
+        case CDataFrame::EReadWriteToStorage::E_Sync:
+            for (auto i = beginSlices; i != endSlices; ++i) {
+                std::tie(firstRow, sliceBeingRead) = m_ReadSliceFromStore(*i);
+                if (sliceBeingRead.bad()) {
+                    return false;
+                }
+                LOG_TRACE(<< "reading slice starting at row " << firstRow);
+                std::size_t rows = sliceBeingRead.size() / cols;
+                m_Reader(CRowConstIterator{cols, firstRow, sliceBeingRead.begin()},
+                         CRowConstIterator{cols, firstRow + rows, sliceBeingRead.end()});
+            }
+            break;
+        }
+
+        return true;
+    }
+
+private:
+    TReadFuncRef m_Reader;
+    std::size_t m_NumberColumns;
+    CDataFrame::EReadWriteToStorage m_AsyncReadFromStore;
+    TReadSliceFromStoreFunc m_ReadSliceFromStore;
+};
+
+//! Compute the default slice capacity in rows.
+std::size_t computeSliceCapacity(std::size_t numberColumns) {
+    return std::max(1000000 / sizeof(CFloatStorage) / numberColumns, std::size_t(100));
+}
+}
+
+CDataFrame::CDataFrame(std::size_t numberColumns,
+                       std::size_t sliceCapacity,
+                       EReadWriteToStorage asyncReadAndWriteToStore,
+                       const TWriteSliceToStoreFunc& writeSliceToStore,
+                       const TReadSliceFromStoreFunc& readSliceFromStore)
+    : m_NumberColumns{numberColumns}, m_SliceCapacity{sliceCapacity},
+      m_AsyncReadAndWriteToStore{asyncReadAndWriteToStore},
+      m_WriteSliceToStore{writeSliceToStore}, m_ReadSliceFromStore{readSliceFromStore} {
+}
+
+CDataFrame::CDataFrame(std::size_t numberColumns,
+                       EReadWriteToStorage asyncReadAndWriteToStore,
+                       const TWriteSliceToStoreFunc& writeSliceToStore,
+                       const TReadSliceFromStoreFunc& readSliceFromStore)
+    : CDataFrame{numberColumns, computeSliceCapacity(numberColumns),
+                 asyncReadAndWriteToStore, writeSliceToStore, readSliceFromStore} {
+}
+
+bool CDataFrame::reserve(std::size_t numberThreads, std::size_t numberColumns) {
+    if (m_NumberColumns < numberColumns) {
+        std::size_t stride;
+        std::tie(numberThreads, stride) = this->numberOfThreadsAndStride(numberThreads);
+
+        // TODO
+    }
+    return true;
+}
+
+CDataFrame::TReadFuncVecBoolPr CDataFrame::readRows(std::size_t numberThreads,
+                                                    TReadFunc reader) const {
+    if (m_NumberRows == 0) {
+        return {{reader}, true};
+    }
+
+    if (numberThreads == 1) {
+        // This all happens on the main thread to avoid a context switch.
+
+        CDataFrameRowSliceReader sliceReader{
+            reader, m_NumberColumns, m_AsyncReadAndWriteToStore, m_ReadSliceFromStore};
+        bool successful{sliceReader(m_Slices.begin(), m_Slices.end())};
+        return {{std::move(reader)}, successful};
+    }
+
+    // We use a fixed schedule whereby each reader reads non-overlapping
+    // slices. This means we can get no contention on reads from the slice
+    // vector. This is naturally load balanced because we arrange for each
+    // reader to read, as close as possible, the same number of rows.
+
+    std::size_t stride;
+    std::tie(numberThreads, stride) = this->numberOfThreadsAndStride(numberThreads);
+
+    TReadFuncVec readers{numberThreads, reader};
+
+    std::vector<std::future<bool>> reads;
+    reads.reserve(numberThreads);
+    std::size_t j{0};
+    for (std::size_t i = 0; i + 1 < numberThreads; ++i, j += stride) {
+        auto begin = m_Slices.begin() + j;
+        auto end = m_Slices.begin() + j + stride;
+        CDataFrameRowSliceReader sliceReader{readers[i], m_NumberColumns, m_AsyncReadAndWriteToStore,
+                                             m_ReadSliceFromStore};
+        reads.push_back(std::async(std::launch::async, sliceReader, begin, end));
+    }
+    auto begin = m_Slices.begin() + j;
+    auto end = m_Slices.end();
+    CDataFrameRowSliceReader sliceReader{readers.back(), m_NumberColumns,
+                                         m_AsyncReadAndWriteToStore, m_ReadSliceFromStore};
+    reads.push_back(std::async(std::launch::async, sliceReader, begin, end));
+
+    bool successful{true};
+    for (auto& read : reads) {
+        successful &= read.get();
+    }
+
+    return {std::move(readers), successful};
+}
+
+void CDataFrame::writeRow(const TWriteFunc& writeRow) {
+    if (m_Writer == nullptr) {
+        m_Writer = boost::make_unique<CDataFrameRowSliceWriter>(
+            m_NumberRows, m_NumberColumns, m_SliceCapacity,
+            m_AsyncReadAndWriteToStore, m_WriteSliceToStore);
+    }
+    (*m_Writer)(writeRow);
+}
+
+void CDataFrame::finishWritingRows() {
+    // Get any slices which have been written, append and clear the writer.
+
+    if (m_Writer != nullptr) {
+        TRowSlicePtrVec slices;
+        std::tie(m_NumberRows, slices) = m_Writer->finishWritingRows();
+        m_Writer.reset();
+
+        m_Slices.reserve(m_Slices.size() + slices.size());
+        for (auto& slice : slices) {
+            m_Slices.push_back(std::move(slice));
+        }
+        LOG_TRACE(<< "# slices = " << m_Slices.size());
+    }
+}
+
+std::size_t CDataFrame::memoryUsage() const {
+    return CMemory::dynamicSize(m_Slices) + CMemory::dynamicSize(m_Writer);
+}
+
+CDataFrame::CDataFrameRowSliceWriter::CDataFrameRowSliceWriter(std::size_t numberRows,
+                                                               std::size_t numberColumns,
+                                                               std::size_t sliceCapacity,
+                                                               EReadWriteToStorage asyncWriteToStore,
+                                                               TWriteSliceToStoreFunc writeSliceToStore)
+    : m_NumberRows{numberRows}, m_NumberColumns{numberColumns}, m_SliceCapacity{sliceCapacity},
+      m_AsyncWriteToStore{asyncWriteToStore}, m_WriteSliceToStore{writeSliceToStore} {
+    m_SliceBeingWritten.reserve(m_SliceCapacity * m_NumberColumns);
+    if (m_AsyncWriteToStore == EReadWriteToStorage::E_Async) {
+        m_AsyncWriteToStoreResult =
+            std::async(std::launch::async,
+                       CAsyncDataFrameStorageWriter{sliceCapacity, writeSliceToStore},
+                       std::ref(m_SlicesToAsyncWriteToStore));
+    }
+}
+
+CDataFrame::CDataFrameRowSliceWriter::~CDataFrameRowSliceWriter() {
+    this->finishAsyncWriteToStore();
+}
+
+void CDataFrame::CDataFrameRowSliceWriter::operator()(const TWriteFunc& writeRow) {
+    // Write the next row at the end of the current slice being written
+    // and if the slice is full pass to the thread storing slices.
+
+    std::size_t end{m_SliceBeingWritten.size()};
+
+    m_SliceBeingWritten.resize(end + m_NumberColumns);
+    writeRow(m_SliceBeingWritten.begin() + end);
+    ++m_NumberRows;
+
+    if (m_SliceBeingWritten.size() == m_SliceCapacity * m_NumberColumns) {
+        std::size_t firstRow{m_NumberRows - m_SliceCapacity};
+        LOG_TRACE(<< "Storing slice [" << firstRow << "," << m_NumberRows << ")");
+
+        switch (m_AsyncWriteToStore) {
+        case EReadWriteToStorage::E_Async: {
+            TSizeFloatVecPr slice{firstRow, std::move(m_SliceBeingWritten)};
+            m_SlicesToAsyncWriteToStore.push(std::move(slice));
+            break;
+        }
+        case EReadWriteToStorage::E_Sync:
+            m_SyncWrittenSlices.push_back(
+                m_WriteSliceToStore(firstRow, std::move(m_SliceBeingWritten)));
+            break;
+        }
+        m_SliceBeingWritten.clear();
+        m_SliceBeingWritten.reserve(m_SliceCapacity * m_NumberColumns);
+    }
+}
+
+CDataFrame::TSizeDataFrameRowSlicePtrVecPr
+CDataFrame::CDataFrameRowSliceWriter::finishWritingRows() {
+    // Passing a partial slice signals to the thread writing slices to
+    // storage that we're done.
+
+    std::size_t firstRow{m_NumberRows - m_SliceBeingWritten.size() / m_NumberColumns};
+    LOG_TRACE(<< "Last slice "
+              << (firstRow == m_NumberRows ? "empty"
+                                           : "[" + std::to_string(firstRow) + "," +
+                                                 std::to_string(m_NumberRows) + ")"));
+
+    switch (m_AsyncWriteToStore) {
+    case EReadWriteToStorage::E_Async:
+        if (m_SliceBeingWritten.size() > 0) {
+            TSizeFloatVecPr slice{firstRow, std::move(m_SliceBeingWritten)};
+            m_SlicesToAsyncWriteToStore.push(std::move(slice));
+        }
+        this->finishAsyncWriteToStore();
+        return {m_NumberRows, m_AsyncWriteToStoreResult.get()};
+    case EReadWriteToStorage::E_Sync:
+        if (m_SliceBeingWritten.size() > 0) {
+            m_SyncWrittenSlices.push_back(
+                m_WriteSliceToStore(firstRow, std::move(m_SliceBeingWritten)));
+        }
+        break;
+    }
+    return {m_NumberRows, std::move(m_SyncWrittenSlices)};
+}
+
+CDataFrame::TSizeSizePr CDataFrame::numberOfThreadsAndStride(std::size_t target) const {
+
+    std::size_t numberSlices{m_Slices.size()};
+    std::size_t numberThreads{std::min(numberSlices, target)};
+    std::size_t strideLowerBound{numberSlices / numberThreads};
+    std::size_t strideUpperBound{strideLowerBound + 1};
+
+    if (numberSlices % numberThreads == 0) {
+        return {numberThreads, strideLowerBound};
+    }
+    if (numberSlices % strideUpperBound == 0) {
+        return {numberThreads - 1, strideUpperBound};
+    }
+    return {numberThreads, strideUpperBound};
+}
+
+void CDataFrame::CDataFrameRowSliceWriter::finishAsyncWriteToStore() {
+    // Signal to the thread writing slices to storage that we're done.
+
+    if (m_Writing) {
+        if (m_AsyncWriteToStore == EReadWriteToStorage::E_Async) {
+            m_SlicesToAsyncWriteToStore.push({0, TFloatVec{}});
+        }
+        m_Writing = false;
+    }
+}
+
+CDataFrame makeMainStorageDataFrame(std::size_t numberColumns,
+                                    boost::optional<std::size_t> sliceCapacity,
+                                    CDataFrame::EReadWriteToStorage readWriteToStoreAsync) {
+
+    // The return copy is elided so we never need to call the explicitly
+    // deleted the data frame copy constructor.
+
+    auto writer = [](std::size_t firstRow, TFloatVec slice) {
+        return boost::make_unique<CMainMemoryDataFrameRowSlice>(firstRow, std::move(slice));
+    };
+    auto reader = [](const TRowSlicePtr& slice) { return slice->read(); };
+
+    if (sliceCapacity != boost::none) {
+        return {numberColumns, *sliceCapacity, readWriteToStoreAsync, writer, reader};
+    }
+
+    return {numberColumns, readWriteToStoreAsync, writer, reader};
+}
+
+CDataFrame makeDiskStorageDataFrame(const std::string& rootDirectory,
+                                    std::size_t numberColumns,
+                                    std::size_t numberRows,
+                                    boost::optional<std::size_t> sliceCapacity,
+                                    CDataFrame::EReadWriteToStorage readWriteToStoreAsync) {
+    // The return copy is elided so we never need to call the explicitly
+    // deleted the data frame copy constructor.
+
+    std::size_t minimumSpace{2 * numberRows * numberColumns * sizeof(CFloatStorage)};
+
+    COnDiskDataFrameRowSlice::TTemporaryDirectoryPtr directory{
+        std::make_shared<COnDiskDataFrameRowSlice::CTemporaryDirectory>(
+            rootDirectory, minimumSpace)};
+
+    // Note the writer lambda holds a reference to the directory shared
+    // pointer is copied to the data frame. So this isn't destroyed, and
+    // the folder cleaned up, until the data frame itself is destroyed.
+
+    auto writer = [directory](std::size_t firstRow, TFloatVec slice) {
+        return boost::make_unique<COnDiskDataFrameRowSlice>(directory, firstRow,
+                                                            std::move(slice));
+    };
+    auto reader = [](const TRowSlicePtr& slice) { return slice->read(); };
+
+    if (sliceCapacity != boost::none) {
+        return {numberColumns, *sliceCapacity, readWriteToStoreAsync, writer, reader};
+    }
+    return {numberColumns, readWriteToStoreAsync, writer, reader};
+}
+}
+}

--- a/lib/core/CDataFrameRowSlice.cc
+++ b/lib/core/CDataFrameRowSlice.cc
@@ -1,0 +1,278 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CDataFrameRowSlice.h>
+
+#include <core/CBase64Filter.h>
+#include <core/CDataFrame.h>
+#include <core/CHashing.h>
+#include <core/CLogger.h>
+#include <core/CMemory.h>
+#include <core/CompressUtils.h>
+
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/make_unique.hpp>
+
+#include <memory>
+
+namespace ml {
+namespace core {
+using TFloatVec = std::vector<CFloatStorage>;
+using TFloatVecCItr = TFloatVec::const_iterator;
+
+namespace {
+using namespace data_frame_row_slice_detail;
+
+//! \brief A handle for reading CRawDataFrameRowSlice objects.
+//!
+//! DESCRIPTION:\n
+//! This stores a reference to the underlying memory. This is primarily
+//! intended to stop duplication of the underlying data frame state.
+//! Together with our memory mapped vector type this means algorithms
+//! on top of a raw data frame can work entirely in terms of the raw
+//! values stored in the data frame.
+class CORE_EXPORT CMainMemoryDataFrameRowSliceHandle : public CDataFrameRowSliceHandleImpl {
+public:
+    CMainMemoryDataFrameRowSliceHandle(const TFloatVec& values)
+        : m_Values{values} {}
+    virtual TImplPtr clone() const {
+        return boost::make_unique<CMainMemoryDataFrameRowSliceHandle>(m_Values);
+    }
+    virtual const TFloatVec& values() const { return m_Values; }
+    virtual bool bad() const { return false; }
+
+private:
+    using TFloatVecCRef = std::reference_wrapper<const TFloatVec>;
+
+private:
+    //! A reference to the data frame slice.
+    TFloatVecCRef m_Values;
+};
+
+//! \brief A handle for reading CRawDataFrameRowSlice objects.
+//!
+//! DESCRIPTION:\n
+//! This stores a copy of values since these are created on-the-fly when
+//! the slice is inflated.
+class CORE_EXPORT COnDiskDataFrameRowSliceHandle : public CDataFrameRowSliceHandleImpl {
+public:
+    COnDiskDataFrameRowSliceHandle(TFloatVec values)
+        : m_Values{std::move(values)} {}
+    virtual TImplPtr clone() const {
+        return boost::make_unique<COnDiskDataFrameRowSliceHandle>(m_Values);
+    }
+    virtual const TFloatVec& values() const { return m_Values; }
+    virtual bool bad() const { return false; }
+
+private:
+    //! A copy of the values in the data frame slice.
+    TFloatVec m_Values;
+};
+
+//! \brief An implementation of a bad handle.
+//!
+//! DESCRIPTION:\n
+//! This is used to signal that there is a problem accessing the slice.
+class CORE_EXPORT CBadDataFrameRowSliceHandle : public CDataFrameRowSliceHandleImpl {
+public:
+    virtual TImplPtr clone() const {
+        return boost::make_unique<CBadDataFrameRowSliceHandle>();
+    }
+    virtual const TFloatVec& values() const { return m_Empty; }
+    virtual bool bad() const { return true; }
+
+private:
+    //! Stub for the values.
+    TFloatVec m_Empty;
+};
+}
+
+//////// CDataFrameRowSliceHandle ////////
+
+CDataFrameRowSliceHandle::CDataFrameRowSliceHandle(TImplPtr impl)
+    : m_Impl{std::move(impl)} {
+}
+
+CDataFrameRowSliceHandle::CDataFrameRowSliceHandle(const CDataFrameRowSliceHandle& other)
+    : m_Impl{other.m_Impl->clone()} {
+}
+
+CDataFrameRowSliceHandle::CDataFrameRowSliceHandle(CDataFrameRowSliceHandle&& other)
+    : m_Impl{std::move(other.m_Impl)} {
+}
+
+CDataFrameRowSliceHandle& CDataFrameRowSliceHandle::
+operator=(const CDataFrameRowSliceHandle& other) {
+    m_Impl = other.m_Impl->clone();
+    return *this;
+}
+
+CDataFrameRowSliceHandle& CDataFrameRowSliceHandle::operator=(CDataFrameRowSliceHandle&& other) {
+    m_Impl = std::move(other.m_Impl);
+    return *this;
+}
+
+bool CDataFrameRowSliceHandle::bad() const {
+    return m_Impl->bad();
+}
+
+std::size_t CDataFrameRowSliceHandle::size() const {
+    return m_Impl->values().size();
+}
+
+TFloatVecCItr CDataFrameRowSliceHandle::begin() const {
+    return m_Impl->values().begin();
+}
+
+TFloatVecCItr CDataFrameRowSliceHandle::end() const {
+    return m_Impl->values().end();
+}
+
+//////// CMainMemoryDataFrameRowSlice ////////
+
+CMainMemoryDataFrameRowSlice::CMainMemoryDataFrameRowSlice(std::size_t firstRow, TFloatVec state)
+    : m_FirstRow{firstRow}, m_State{std::move(state)} {
+    LOG_TRACE(<< "slice size = " << m_State.size() << " capacity = " << m_State.capacity());
+    m_State.shrink_to_fit();
+}
+
+CMainMemoryDataFrameRowSlice::TSizeHandlePr CMainMemoryDataFrameRowSlice::read() const {
+    return {m_FirstRow, {boost::make_unique<CMainMemoryDataFrameRowSliceHandle>(m_State)}};
+}
+
+std::size_t CMainMemoryDataFrameRowSlice::staticSize() const {
+    return sizeof(*this);
+}
+
+std::size_t CMainMemoryDataFrameRowSlice::memoryUsage() const {
+    return CMemory::dynamicSize(m_State);
+}
+
+//////// COnDiskDataFrameRowSlice ////////
+
+namespace {
+
+//! Check if there is \p minimumSpace disk space available.
+bool sufficientDiskSpaceAvailable(const boost::filesystem::path& path, std::size_t minimumSpace) {
+    boost::system::error_code errorCode;
+    auto spaceInfo = boost::filesystem::space(path, errorCode);
+    if (errorCode) {
+        LOG_ERROR(<< "Failed to retrieve disk information for " << path
+                  << " error " << errorCode.message());
+        return false;
+    }
+    if (spaceInfo.available < minimumSpace) {
+        LOG_ERROR(<< "Insufficient space have " << spaceInfo.available
+                  << " and need " << minimumSpace);
+        return false;
+    }
+    return true;
+}
+
+//! Checksum \p slice.
+uint64_t checksum(const TFloatVec& slice) {
+    return CHashing::murmurHash64(
+        slice.data(), static_cast<int>(sizeof(CFloatStorage) * slice.size()), 0);
+}
+}
+
+COnDiskDataFrameRowSlice::COnDiskDataFrameRowSlice(const TTemporaryDirectoryPtr& directory,
+                                                   std::size_t firstRow,
+                                                   TFloatVec state)
+    : m_StateIsBad{directory->bad()}, m_FirstRow{firstRow}, m_NumberRows{state.size()},
+      m_Directory{directory}, m_FileName{directory->name()}, m_Checksum{checksum(state)} {
+    m_FileName /= boost::filesystem::unique_path(
+        "rows-" + std::to_string(firstRow) + "-%%%%-%%%%-%%%%-%%%%");
+
+    if (m_StateIsBad == false) {
+        std::size_t bytes{sizeof(CFloatStorage) * m_NumberRows};
+        LOG_TRACE(<< "bytes = " << bytes);
+
+        std::ofstream file{m_FileName.string(), std::ios_base::out | std::ios_base::binary};
+        file.write(reinterpret_cast<const char*>(state.data()), bytes);
+    }
+}
+
+COnDiskDataFrameRowSlice::TSizeHandlePr COnDiskDataFrameRowSlice::read() const {
+
+    if (m_StateIsBad) {
+        LOG_ERROR(<< "Bad row slice 'rows-" << m_FirstRow << "'");
+        return {0, {boost::make_unique<CBadDataFrameRowSliceHandle>()}};
+    }
+
+    std::size_t bytes{sizeof(CFloatStorage) * m_NumberRows};
+
+    std::ifstream file{m_FileName.string(), std::ios_base::in | std::ios_base::binary};
+    TFloatVec result(m_NumberRows);
+    file.read(reinterpret_cast<char*>(result.data()), bytes);
+
+    LOG_TRACE(<< "state = " << result[0] << "," << result[1] << ",...");
+
+    if (file.bad()) {
+        LOG_ERROR(<< "Failed to read 'rows-" << m_FirstRow << "'");
+        m_StateIsBad = true;
+        return {0, {boost::make_unique<CBadDataFrameRowSliceHandle>()}};
+    }
+
+    if (checksum(result) != m_Checksum) {
+        LOG_ERROR(<< "Corrupt 'rows-" << m_FirstRow << "'");
+        m_StateIsBad = true;
+        return {0, {boost::make_unique<CBadDataFrameRowSliceHandle>()}};
+    }
+
+    return {m_FirstRow,
+            {boost::make_unique<COnDiskDataFrameRowSliceHandle>(std::move(result))}};
+}
+
+std::size_t COnDiskDataFrameRowSlice::staticSize() const {
+    return sizeof(*this);
+}
+
+std::size_t COnDiskDataFrameRowSlice::memoryUsage() const {
+    return CMemory::dynamicSize(m_Directory) + CMemory::dynamicSize(m_FileName.string());
+}
+
+COnDiskDataFrameRowSlice::CTemporaryDirectory::CTemporaryDirectory(const std::string& name,
+                                                                   std::size_t minimumSpace)
+    : m_Name{name} {
+    m_Name /= boost::filesystem::unique_path("dataframe-%%%%-%%%%-%%%%-%%%%");
+    LOG_TRACE(<< "Trying to create directory '" << m_Name << "'");
+
+    boost::system::error_code errorCode;
+    boost::filesystem::create_directories(m_Name, errorCode);
+    if (errorCode) {
+        LOG_ERROR(<< "Failed to create temporary data from: '" << m_Name
+                  << "' error " << errorCode.message());
+        m_StateIsBad = true;
+    }
+
+    if (m_StateIsBad == false) {
+        m_StateIsBad = (sufficientDiskSpaceAvailable(m_Name, minimumSpace) == false);
+    }
+
+    if (m_StateIsBad == false) {
+        LOG_TRACE(<< "Created '" << m_Name << "'");
+    }
+}
+
+COnDiskDataFrameRowSlice::CTemporaryDirectory::~CTemporaryDirectory() {
+    boost::system::error_code errorCode;
+    boost::filesystem::remove_all(m_Name, errorCode);
+    if (errorCode) {
+        LOG_ERROR(<< "Failed to cleanup temporary data from: '" << m_Name
+                  << "' error " << errorCode.message());
+    }
+}
+
+const std::string& COnDiskDataFrameRowSlice::CTemporaryDirectory::name() const {
+    return m_Name.string();
+}
+
+bool COnDiskDataFrameRowSlice::CTemporaryDirectory::bad() const {
+    return m_StateIsBad;
+}
+}
+}

--- a/lib/core/Makefile
+++ b/lib/core/Makefile
@@ -74,6 +74,8 @@ CCompressOStream.cc \
 CompressUtils.cc \
 CContainerPrinter.cc \
 CDataAdder.cc \
+CDataFrame.cc \
+CDataFrameRowSlice.cc \
 CDataSearcher.cc \
 CDelimiter.cc \
 CDualThreadStreamBuf.cc \

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -1,0 +1,320 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CDataFrameTest.h"
+
+#include <core/CContainerPrinter.h>
+#include <core/CDataFrame.h>
+#include <core/CDataFrameRowSlice.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <boost/filesystem/path.hpp>
+#include <boost/unordered_map.hpp>
+
+#include <functional>
+#include <vector>
+
+using namespace ml;
+
+namespace {
+using TBoolVec = std::vector<bool>;
+using TDoubleVec = std::vector<double>;
+using TFloatVec = std::vector<core::CFloatStorage>;
+using TFloatVecItr = TFloatVec::iterator;
+using TFloatVecCItr = TFloatVec::const_iterator;
+using TSizeFloatVecUMap = boost::unordered_map<std::size_t, TFloatVec>;
+using TRowCItr = core::CDataFrame::TRowCItr;
+using TReadFunc = std::function<void(TRowCItr, TRowCItr)>;
+
+TFloatVec testData(std::size_t numberRows, std::size_t numberColumns) {
+    test::CRandomNumbers rng;
+    TDoubleVec uniform;
+    rng.generateUniformSamples(0.0, 10.0, numberRows * numberColumns, uniform);
+    TFloatVec components(uniform.begin(), uniform.end());
+    uniform.clear();
+    uniform.shrink_to_fit();
+    return components;
+}
+
+std::function<void(std::size_t&, TRowCItr, TRowCItr)>
+makeReader(TFloatVec& components, std::size_t cols, bool& passed) {
+    return [&components, cols, &passed](std::size_t& i, TRowCItr begin, TRowCItr end) mutable {
+        TFloatVec expectedRow(cols);
+        TFloatVec row(cols);
+        for (auto j = begin; j != end; ++j) {
+            std::copy(components.begin() + i, components.begin() + i + cols,
+                      expectedRow.begin());
+            j->copyTo(row.begin());
+            if (passed && expectedRow != row) {
+                LOG_DEBUG(<< "mismatch for row " << i / cols)
+                LOG_DEBUG(<< "expected = " << core::CContainerPrinter::print(expectedRow));
+                LOG_DEBUG(<< "actual   = " << core::CContainerPrinter::print(row));
+                passed = false;
+            } else if (passed && i / cols != j->index()) {
+                LOG_DEBUG(<< "mismatch for row index " << i / cols << " vs " << j->index());
+                passed = false;
+            }
+            i += cols;
+        }
+    };
+}
+
+class CThreadReader {
+public:
+    void operator()(TRowCItr begin, TRowCItr end) {
+        TSizeFloatVecUMap::iterator entry;
+        for (auto i = begin; i != end; ++i) {
+            bool added;
+            std::tie(entry, added) = m_Rows.emplace(i->index(), TFloatVec{});
+            m_Duplicates |= (added == false);
+            entry->second.resize(i->numberColumns());
+            i->copyTo(entry->second.begin());
+        }
+    }
+
+    bool duplicates() const {
+        return m_Duplicates;
+    }
+
+    const TSizeFloatVecUMap& rowsRead() const {
+        return m_Rows;
+    }
+
+private:
+    bool m_Duplicates = false;
+    TSizeFloatVecUMap m_Rows;
+};
+}
+
+void CDataFrameTest::testInMainMemoryBasicReadWrite() {
+
+    // Check we get the rows we write to the data frame in the order we write them.
+
+    std::size_t rows{5000};
+    std::size_t cols{10};
+    TFloatVec components{testData(rows, cols)};
+
+    bool passed{true};
+    auto reader = makeReader(components, cols, passed);
+
+    std::string type[]{"raw", "compressed"};
+    std::string sync[]{"sync", "async"};
+    std::size_t t{0};
+    for (const auto& factory : {core::makeMainStorageDataFrame}) {
+        LOG_DEBUG(<< "Test read/write " << type[t++]);
+
+        for (auto readWriteToStoreAsync :
+             {core::CDataFrame::EReadWriteToStorage::E_Sync,
+              core::CDataFrame::EReadWriteToStorage::E_Async}) {
+            LOG_DEBUG(<< "Read write to store "
+                      << sync[static_cast<int>(readWriteToStoreAsync)]);
+
+            for (auto end : {500 * cols, 2000 * cols, components.size()}) {
+                core::CDataFrame frame{factory(cols, 1000, readWriteToStoreAsync)};
+
+                for (std::size_t i = 0; i < end; i += cols) {
+                    auto writer = [&components, cols, i](TFloatVecItr output) mutable {
+                        for (std::size_t end_ = i + cols; i < end_; ++i, ++output) {
+                            *output = components[i];
+                        }
+                    };
+                    frame.writeRow(writer);
+                }
+                frame.finishWritingRows();
+
+                bool successful;
+                std::size_t i{0};
+                std::tie(std::ignore, successful) = frame.readRows(
+                    1, std::bind(reader, std::ref(i), std::placeholders::_1,
+                                 std::placeholders::_2));
+                CPPUNIT_ASSERT(successful);
+                CPPUNIT_ASSERT(passed);
+            }
+        }
+    }
+}
+
+void CDataFrameTest::testInMainMemoryParallelRead() {
+
+    // Check we get the rows we write to the data frame and that we get balanced
+    // reads per thread.
+
+    std::size_t cols{10};
+
+    for (std::size_t rows : {4000, 5000, 6000}) {
+        LOG_DEBUG(<< "Testing " << rows << " rows");
+
+        TFloatVec components{testData(rows, cols)};
+
+        core::CDataFrame frame{core::makeMainStorageDataFrame(cols, 1000)};
+        for (std::size_t i = 0; i < components.size(); i += cols) {
+            auto writer = [&components, cols, i](TFloatVecItr output) mutable {
+                for (std::size_t end = i + cols; i < end; ++i, ++output) {
+                    *output = components[i];
+                }
+            };
+            frame.writeRow(writer);
+        }
+        frame.finishWritingRows();
+
+        std::vector<TReadFunc> readers;
+        bool successful;
+        std::tie(readers, successful) = frame.readRows(3, CThreadReader{});
+        CPPUNIT_ASSERT(successful);
+        CPPUNIT_ASSERT_EQUAL(std::size_t{(rows + 1999) / 2000}, readers.size());
+
+        TBoolVec rowRead(rows, false);
+        for (const auto& reader_ : readers) {
+            const auto& reader = *reader_.target<CThreadReader>();
+            CPPUNIT_ASSERT_EQUAL(false, reader.duplicates());
+            CPPUNIT_ASSERT(reader.rowsRead().size() <= 2000);
+            for (const auto& row : reader.rowsRead()) {
+                CPPUNIT_ASSERT(std::equal(components.begin() + row.first * cols,
+                                          components.begin() + (row.first + 1) * cols,
+                                          row.second.begin()));
+                rowRead[row.first] = true;
+            }
+        }
+
+        std::size_t rowsRead(std::count(rowRead.begin(), rowRead.end(), true));
+        CPPUNIT_ASSERT_EQUAL(rows, rowsRead);
+    }
+}
+
+void CDataFrameTest::testOnDiskBasicReadWrite() {
+
+    // Check we get the rows we write to the data frame in the order we write them.
+
+    std::size_t rows{5500};
+    std::size_t cols{10};
+    TFloatVec components{testData(rows, cols)};
+
+    bool passed{true};
+    auto reader = makeReader(components, cols, passed);
+
+    core::CDataFrame frame{core::makeDiskStorageDataFrame(
+        boost::filesystem::current_path().string(), cols, rows, 1000)};
+
+    for (std::size_t i = 0; i < components.size(); i += cols) {
+        auto writer = [&components, cols, i](TFloatVecItr output) mutable {
+            for (std::size_t end = i + cols; i < end; ++i, ++output) {
+                *output = components[i];
+            }
+        };
+        frame.writeRow(writer);
+    }
+    frame.finishWritingRows();
+
+    bool result;
+    std::size_t i{0};
+    std::tie(std::ignore, result) = frame.readRows(
+        1, std::bind(reader, std::ref(i), std::placeholders::_1, std::placeholders::_2));
+    CPPUNIT_ASSERT(result);
+    CPPUNIT_ASSERT(passed);
+}
+
+void CDataFrameTest::testOnDiskParallelRead() {
+
+    std::size_t rows{5000};
+    std::size_t cols{10};
+
+    TFloatVec components{testData(rows, cols)};
+
+    core::CDataFrame frame{core::makeDiskStorageDataFrame(
+        boost::filesystem::current_path().string(), cols, rows, 1000)};
+
+    for (std::size_t i = 0; i < components.size(); i += cols) {
+        auto writer = [&components, cols, i](TFloatVecItr output) mutable {
+            for (std::size_t end = i + cols; i < end; ++i, ++output) {
+                *output = components[i];
+            }
+        };
+        frame.writeRow(writer);
+    }
+    frame.finishWritingRows();
+
+    std::vector<TReadFunc> readers;
+    bool successful;
+    std::tie(readers, successful) = frame.readRows(3, CThreadReader{});
+    CPPUNIT_ASSERT(successful);
+    CPPUNIT_ASSERT_EQUAL(std::size_t{(rows + 1999) / 2000}, readers.size());
+
+    TBoolVec rowRead(rows, false);
+    for (const auto& reader_ : readers) {
+        const auto& reader = *reader_.target<CThreadReader>();
+        CPPUNIT_ASSERT_EQUAL(false, reader.duplicates());
+        CPPUNIT_ASSERT(reader.rowsRead().size() <= 2000);
+        for (const auto& row : reader.rowsRead()) {
+            CPPUNIT_ASSERT(std::equal(components.begin() + row.first * cols,
+                                      components.begin() + (row.first + 1) * cols,
+                                      row.second.begin()));
+            rowRead[row.first] = true;
+        }
+    }
+
+    std::size_t rowsRead(std::count(rowRead.begin(), rowRead.end(), true));
+    CPPUNIT_ASSERT_EQUAL(rows, rowsRead);
+}
+
+void CDataFrameTest::testMemoryUsage() {
+
+    // This asserts on the memory used by the different types of data frames. This
+    // is meant to catch large regressions in memory usage and as such the thresholds
+    // shouldn't be treated as hard.
+
+    std::size_t rows{10000};
+    std::size_t cols{10};
+    TFloatVec components{testData(rows, cols)};
+
+    using TFactoryFunc = std::function<core::CDataFrame()>;
+
+    TFactoryFunc makeOnDisk = std::bind(
+        &core::makeDiskStorageDataFrame, boost::filesystem::current_path().string(),
+        cols, 10000, 5000, core::CDataFrame::EReadWriteToStorage::E_Async);
+    TFactoryFunc makeMainMemory = std::bind(&core::makeMainStorageDataFrame, cols, 5000,
+                                            core::CDataFrame::EReadWriteToStorage::E_Sync);
+
+    // 600 bytes and data size + 200 byte overhead.
+    std::size_t maximumMemory[]{600, 10000 * cols * 4 + 200};
+
+    std::size_t f{0};
+    for (const auto& factory : {makeOnDisk, makeMainMemory}) {
+        core::CDataFrame frame{factory()};
+
+        for (std::size_t i = 0; i < components.size(); i += cols) {
+            auto writer = [&components, cols, i](TFloatVecItr output) mutable {
+                for (std::size_t end = i + cols; i < end; ++i, ++output) {
+                    *output = components[i];
+                }
+            };
+            frame.writeRow(writer);
+        }
+        frame.finishWritingRows();
+
+        LOG_DEBUG(<< "Memory = " << frame.memoryUsage());
+        CPPUNIT_ASSERT(frame.memoryUsage() < maximumMemory[f++]);
+    }
+}
+
+CppUnit::Test* CDataFrameTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CDataFrameTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameTest>(
+        "CDataFrameTest::testInMainMemoryBasicReadWrite",
+        &CDataFrameTest::testInMainMemoryBasicReadWrite));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameTest>(
+        "CDataFrameTest::testInMainMemoryParallelRead",
+        &CDataFrameTest::testInMainMemoryParallelRead));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameTest>(
+        "CDataFrameTest::testOnDiskBasicReadWrite", &CDataFrameTest::testOnDiskBasicReadWrite));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameTest>(
+        "CDataFrameTest::testOnDiskParallelRead", &CDataFrameTest::testOnDiskParallelRead));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameTest>(
+        "CDataFrameTest::testMemoryUsage", &CDataFrameTest::testMemoryUsage));
+
+    return suiteOfTests;
+}

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -153,15 +153,14 @@ void CDataFrameTest::testInMainMemoryParallelRead() {
         }
         frame.finishWritingRows();
 
-        std::vector<TReadFunc> readers;
+        std::vector<CThreadReader> readers;
         bool successful;
         std::tie(readers, successful) = frame.readRows(3, CThreadReader{});
         CPPUNIT_ASSERT(successful);
         CPPUNIT_ASSERT_EQUAL(std::size_t{(rows + 1999) / 2000}, readers.size());
 
         TBoolVec rowRead(rows, false);
-        for (const auto& reader_ : readers) {
-            const auto& reader = *reader_.target<CThreadReader>();
+        for (const auto& reader : readers) {
             CPPUNIT_ASSERT_EQUAL(false, reader.duplicates());
             CPPUNIT_ASSERT(reader.rowsRead().size() <= 2000);
             for (const auto& row : reader.rowsRead()) {
@@ -230,15 +229,14 @@ void CDataFrameTest::testOnDiskParallelRead() {
     }
     frame.finishWritingRows();
 
-    std::vector<TReadFunc> readers;
+    std::vector<CThreadReader> readers;
     bool successful;
     std::tie(readers, successful) = frame.readRows(3, CThreadReader{});
     CPPUNIT_ASSERT(successful);
     CPPUNIT_ASSERT_EQUAL(std::size_t{(rows + 1999) / 2000}, readers.size());
 
     TBoolVec rowRead(rows, false);
-    for (const auto& reader_ : readers) {
-        const auto& reader = *reader_.target<CThreadReader>();
+    for (const auto& reader : readers) {
         CPPUNIT_ASSERT_EQUAL(false, reader.duplicates());
         CPPUNIT_ASSERT(reader.rowsRead().size() <= 2000);
         for (const auto& row : reader.rowsRead()) {

--- a/lib/core/unittest/CDataFrameTest.h
+++ b/lib/core/unittest/CDataFrameTest.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CDataFrameTest_h
+#define INCLUDED_CDataFrameTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CDataFrameTest : public CppUnit::TestFixture {
+public:
+    void testInMainMemoryBasicReadWrite();
+    void testInMainMemoryParallelRead();
+    void testOnDiskBasicReadWrite();
+    void testOnDiskParallelRead();
+    void testMemoryUsage();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CDataFrameTest_h

--- a/lib/core/unittest/CDataFrameTest.h
+++ b/lib/core/unittest/CDataFrameTest.h
@@ -16,6 +16,7 @@ public:
     void testOnDiskBasicReadWrite();
     void testOnDiskParallelRead();
     void testMemoryUsage();
+    void testReserve();
 
     static CppUnit::Test* suite();
 };

--- a/lib/core/unittest/Main.cc
+++ b/lib/core/unittest/Main.cc
@@ -14,6 +14,7 @@
 #include "CConcurrentWrapperTest.h"
 #include "CContainerPrinterTest.h"
 #include "CContainerThroughputTest.h"
+#include "CDataFrameTest.h"
 #include "CDelimiterTest.h"
 #include "CDetachedProcessSpawnerTest.h"
 #include "CDualThreadStreamBufTest.h"
@@ -88,6 +89,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CConcurrentWrapperTest::suite());
     runner.addTest(CContainerPrinterTest::suite());
     runner.addTest(CContainerThroughputTest::suite());
+    runner.addTest(CDataFrameTest::suite());
     runner.addTest(CDelimiterTest::suite());
     runner.addTest(CDetachedProcessSpawnerTest::suite());
     runner.addTest(CDualThreadStreamBufTest::suite());

--- a/lib/core/unittest/Makefile
+++ b/lib/core/unittest/Makefile
@@ -34,6 +34,7 @@ CCompressUtilsTest.cc \
 CConcurrentWrapperTest.cc \
 CContainerPrinterTest.cc \
 CContainerThroughputTest.cc \
+CDataFrameTest.cc \
 CDelimiterTest.cc \
 CDetachedProcessSpawnerTest.cc \
 CDualThreadStreamBufTest.cc \


### PR DESCRIPTION
This is a first step towards supporting ML tasks on dense (i.e. mostly no missing elements) Elastic Dataframes.

It provides infrastructure for creating and reading (pieces of) data frames in a process to perform some ML task on them.

The interface is purposely minimal at this point: it supports threaded non-contending reads, sequential writes and the ability to reserve space to append new columns. This should cover many of our planned use cases. The read and write operations are via callbacks to maximally decouple from calling code and also to allow us to do certain operations efficiently. For example, a stream can be read/written directly to/from the data frame storage by wrapping in the appropriate writer/reader functions.

We will have to extend the interface somewhat (for example providing append column values as a minimum). I prefer to wait until the calling code is written to do this, so I've left a couple of TODOs since this is on a feature branch. There is also work to do to communicate errors back to the calling process and some further instrumentation to perform.

These objects come in two flavours: 1) in main memory and 2) on disk to allow us to efficiently process across a range of data scales.

The in main memory variety has very low overhead on top of the storage for the frame elements, typically a few hundred bytes **in total**. For example, using the float storage type, this gives us just under 13.5 million rows with 20 columns per GB. Together with memory mapped linear algebra types (coming soon) we should be able to process reasonably large frames in memory as a result.

The on disk variety has very little main memory usage (typically a few hundred bytes in total) and stores in a specified directory in binary format to maximise read and write speed. (Note these will be local to any machine (container) running the process, so we don't need to worry about the architecture changing between writing and reading.) The intention is that the client code will copy in as much as they need, subject to the memory constraint, and be responsible for partitioning strategies. These are problem specific in any case. Reads and writes from and to storage format are optionally asynchronous to support this variety.