### PR TITLE
[ML] Add multi_bucket_impact label to anomalies

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -51,6 +51,10 @@ Increased independence of anomaly scores across partitions (See {ml-pull}182[182
 Avoid potential false positives at model start up when first detecting new components of the time
 series decomposition. (See {ml-pull}218[218].)
 
+Add a new label - multi_bucket_impact - to record level anomaly results.
+The value will be on a scale of -5 to +5 where -5 means the anomaly is purely single bucket
+and +5 means the anomaly is purely multi bucket. ({ml-pull}230[230])
+
 === Bug Fixes
 
 Fix cause of "Bad density value..." log errors whilst forecasting. ({ml-pull}207[207])

--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -97,6 +97,7 @@ public:
                  double rawAnomalyScore,
                  double normalizedAnomalyScore,
                  double probability,
+                 double multiBucketImpact,
                  const std::string& metricValueField,
                  const TStoredStringPtrStoredStringPtrPrDoublePrVec& influences,
                  bool useNull,
@@ -131,6 +132,7 @@ public:
         double s_RawAnomalyScore;
         double s_NormalizedAnomalyScore;
         double s_Probability;
+        double s_MultiBucketImpact;
         const TStoredStringPtrStoredStringPtrPrDoublePrVec& s_Influences;
         int s_Identifier;
         TStr1Vec s_ScheduledEventDescriptions;

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -230,12 +230,19 @@ struct MATHS_EXPORT SModelProbabilityResult {
     using TSize1Vec = core::CSmallVector<std::size_t, 1>;
     using TTail2Vec = core::CSmallVector<maths_t::ETail, 2>;
 
+    //! Labels for different contributions to the overall probability.
+    enum EFeatureProbabilityLabel {
+        E_SingleBucketProbability,
+        E_MultiBucketProbability,
+        E_AnomalyModelProbability,
+        E_UndefinedProbability
+    };
+
     //! \brief Wraps up a feature label and probability.
     struct MATHS_EXPORT SFeatureProbability {
-        using TStrCRef = boost::reference_wrapper<const std::string>;
         SFeatureProbability();
-        SFeatureProbability(const std::string& label, double probability);
-        TStrCRef s_Label;
+        SFeatureProbability(EFeatureProbabilityLabel label, double probability);
+        EFeatureProbabilityLabel s_Label;
         double s_Probability = 1.0;
     };
     using TFeatureProbability4Vec = core::CSmallVector<SFeatureProbability, 4>;

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -751,7 +751,8 @@ public:
 
         //! Adjust the values to remove any piecewise constant linear scales
         //! of the component with period \p period.
-        void adjustValuesForPiecewiseConstantScaling(std::size_t period, TFloatMeanAccumulatorVec& values) const;
+        void adjustValuesForPiecewiseConstantScaling(std::size_t period,
+                                                     TFloatMeanAccumulatorVec& values) const;
 
         //! Reweight the outlier values in \p values.
         //!

--- a/include/model/CAnnotatedProbability.h
+++ b/include/model/CAnnotatedProbability.h
@@ -137,6 +137,9 @@ struct MODEL_EXPORT SAnnotatedProbability {
     //! The probability of seeing the series' sample in a time interval.
     double s_Probability;
 
+    //! The impact of multi/single bucket analysis on the probability
+    double s_MultiBucketImpact;
+
     //! The smallest attribute probabilities and associated data describing
     //! the calculation.
     TAttributeProbability1Vec s_AttributeProbabilities;

--- a/include/model/CAnnotatedProbabilityBuilder.h
+++ b/include/model/CAnnotatedProbabilityBuilder.h
@@ -50,6 +50,7 @@ public:
     void personAttributeProbabilityPrior(const maths::CMultinomialConjugate* prior);
     void personFrequency(double frequency, bool everSeenBefore);
     void probability(double p);
+    void multiBucketImpact(double multiBucketImpact);
     void addAttributeProbability(std::size_t cid,
                                  const core::CStoredStringPtr& attribute,
                                  double pAttribute,

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -166,6 +166,12 @@ public:
     //! for anomaly detection.
     static const std::size_t MULTIBUCKET_FEATURES_WINDOW_LENGTH;
 
+    //! The maximum value that the multi_bucket_impact can take
+    static const double MAXIMUM_MULTI_BUCKET_IMPACT;
+
+    //! The minimum value that the multi_bucket_impact can take
+    static const double MINIMUM_MULTI_BUCKET_IMPACT;
+
     //! The maximum number of times we'll update a model in a bucketing
     //! interval. This only applies to our metric statistics, which are
     //! computed on a fixed number of measurements rather than a fixed

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -167,10 +167,7 @@ public:
     static const std::size_t MULTIBUCKET_FEATURES_WINDOW_LENGTH;
 
     //! The maximum value that the multi_bucket_impact can take
-    static const double MAXIMUM_MULTI_BUCKET_IMPACT;
-
-    //! The minimum value that the multi_bucket_impact can take
-    static const double MINIMUM_MULTI_BUCKET_IMPACT;
+    static const double MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE;
 
     //! The maximum number of times we'll update a model in a bucketing
     //! interval. This only applies to our metric statistics, which are

--- a/include/model/CProbabilityAndInfluenceCalculator.h
+++ b/include/model/CProbabilityAndInfluenceCalculator.h
@@ -71,9 +71,10 @@ public:
     using TStrCRefDouble1VecDouble1VecPrPrVec = std::vector<TStrCRefDouble1VecDouble1VecPrPr>;
     using TStrCRefDouble1VecDouble1VecPrPrVecVec =
         std::vector<TStrCRefDouble1VecDouble1VecPrPrVec>;
-    using TStrDoubleUMap = boost::unordered_map<std::string, double>;
-    using TStrProbabilityAggregatorMap =
-        boost::unordered_map<std::string, CModelTools::CProbabilityAggregator>;
+    using TFeatureProbabilityLabelDoubleUMap =
+        boost::unordered_map<maths::SModelProbabilityResult::EFeatureProbabilityLabel, double>;
+    using TFeatureProbabilityLabelProbabilityAggregatorUMap =
+        boost::unordered_map<maths::SModelProbabilityResult::EFeatureProbabilityLabel, CModelTools::CProbabilityAggregator>;
     using TStoredStringPtrStoredStringPtrPr =
         std::pair<core::CStoredStringPtr, core::CStoredStringPtr>;
     using TStoredStringPtrStoredStringPtrPrVec = std::vector<TStoredStringPtrStoredStringPtrPr>;
@@ -322,7 +323,7 @@ private:
     void commitInfluences(model_t::EFeature feature, double logp, double weight);
 
     //! calculate the explaining probabilities
-    bool calculateExplainingProbabilities(TStrDoubleUMap& explainingProbabilities) const;
+    bool calculateExplainingProbabilities(TFeatureProbabilityLabelDoubleUMap& explainingProbabilities) const;
 
 private:
     //! The minimum value for the influence for which an influencing
@@ -340,7 +341,7 @@ private:
     CModelTools::CProbabilityAggregator m_Probability;
 
     //! holds the probabilities of explanatory features
-    TStrProbabilityAggregatorMap m_ExplainingProbabilities;
+    TFeatureProbabilityLabelProbabilityAggregatorUMap m_ExplainingProbabilities;
 
     //! The probability calculation cache if there is one.
     CModelTools::CProbabilityCache* m_ProbabilityCache;

--- a/include/model/CProbabilityAndInfluenceCalculator.h
+++ b/include/model/CProbabilityAndInfluenceCalculator.h
@@ -71,6 +71,8 @@ public:
     using TStrCRefDouble1VecDouble1VecPrPrVec = std::vector<TStrCRefDouble1VecDouble1VecPrPr>;
     using TStrCRefDouble1VecDouble1VecPrPrVecVec =
         std::vector<TStrCRefDouble1VecDouble1VecPrPrVec>;
+    using TStrDoubleUMap = boost::unordered_map<std::string, double>;
+    using TStrProbabilityAggregatorMap = boost::unordered_map<std::string, CModelTools::CProbabilityAggregator>;
     using TStoredStringPtrStoredStringPtrPr =
         std::pair<core::CStoredStringPtr, core::CStoredStringPtr>;
     using TStoredStringPtrStoredStringPtrPrVec = std::vector<TStoredStringPtrStoredStringPtrPr>;
@@ -308,10 +310,18 @@ public:
     bool calculate(double& probability,
                    TStoredStringPtrStoredStringPtrPrDoublePrVec& influences) const;
 
+    //! Calculate a measure of the impact of both the single bucket and multi 
+    //! bucket probabilities on the make up of the overall probability.
+    //!
+    //! \param[out] multiBucketImpact Filled in with the impact of constituent probabilities.
+    bool calculateMultiBucketImpact(double& multiBucketImpact) const;
+
 private:
     //! Actually commit any influences we've found.
     void commitInfluences(model_t::EFeature feature, double logp, double weight);
 
+    //! calculate the explaining probabilities
+    bool calculateExplainingProbabilities(TStrDoubleUMap &explainingProbabilities) const;
 private:
     //! The minimum value for the influence for which an influencing
     //! field value is judged to have any influence on a feature value.
@@ -326,6 +336,9 @@ private:
 
     //! The probability calculator.
     CModelTools::CProbabilityAggregator m_Probability;
+
+    //! holds the probabilities of explanatory features
+    TStrProbabilityAggregatorMap m_ExplainingProbabilities;
 
     //! The probability calculation cache if there is one.
     CModelTools::CProbabilityCache* m_ProbabilityCache;

--- a/include/model/CProbabilityAndInfluenceCalculator.h
+++ b/include/model/CProbabilityAndInfluenceCalculator.h
@@ -72,7 +72,8 @@ public:
     using TStrCRefDouble1VecDouble1VecPrPrVecVec =
         std::vector<TStrCRefDouble1VecDouble1VecPrPrVec>;
     using TStrDoubleUMap = boost::unordered_map<std::string, double>;
-    using TStrProbabilityAggregatorMap = boost::unordered_map<std::string, CModelTools::CProbabilityAggregator>;
+    using TStrProbabilityAggregatorMap =
+        boost::unordered_map<std::string, CModelTools::CProbabilityAggregator>;
     using TStoredStringPtrStoredStringPtrPr =
         std::pair<core::CStoredStringPtr, core::CStoredStringPtr>;
     using TStoredStringPtrStoredStringPtrPrVec = std::vector<TStoredStringPtrStoredStringPtrPr>;
@@ -310,7 +311,7 @@ public:
     bool calculate(double& probability,
                    TStoredStringPtrStoredStringPtrPrDoublePrVec& influences) const;
 
-    //! Calculate a measure of the impact of both the single bucket and multi 
+    //! Calculate a measure of the impact of both the single bucket and multi
     //! bucket probabilities on the make up of the overall probability.
     //!
     //! \param[out] multiBucketImpact Filled in with the impact of constituent probabilities.
@@ -321,7 +322,8 @@ private:
     void commitInfluences(model_t::EFeature feature, double logp, double weight);
 
     //! calculate the explaining probabilities
-    bool calculateExplainingProbabilities(TStrDoubleUMap &explainingProbabilities) const;
+    bool calculateExplainingProbabilities(TStrDoubleUMap& explainingProbabilities) const;
+
 private:
     //! The minimum value for the influence for which an influencing
     //! field value is judged to have any influence on a feature value.

--- a/include/model/CProbabilityAndInfluenceCalculator.h
+++ b/include/model/CProbabilityAndInfluenceCalculator.h
@@ -315,6 +315,10 @@ public:
     //! Calculate a measure of the impact of both the single bucket and multi
     //! bucket probabilities on the make up of the overall probability.
     //!
+    //! The calculation is designed  such that the impact saturates when
+    //! one of the probabilities is less than a small fraction of the other or
+    //! when one probability is close to one, i.e. when one factor is not at all anomalous.
+    //!
     //! \param[out] multiBucketImpact Filled in with the impact of constituent probabilities.
     bool calculateMultiBucketImpact(double& multiBucketImpact) const;
 

--- a/lib/api/CHierarchicalResultsWriter.cc
+++ b/lib/api/CHierarchicalResultsWriter.cc
@@ -61,7 +61,7 @@ CHierarchicalResultsWriter::SResults::SResults(
       s_PopulationAverage(populationAverage), s_BaselineRate(0.0),
       s_CurrentRate(currentRate), s_BaselineMean{0.0}, s_CurrentMean{0.0},
       s_RawAnomalyScore(rawAnomalyScore),
-      s_NormalizedAnomalyScore(normalizedAnomalyScore), s_Probability(probability),
+      s_NormalizedAnomalyScore(normalizedAnomalyScore), s_Probability(probability), s_MultiBucketImpact{-5.0},
       s_Influences(influences), s_Identifier(identifier) {
 }
 
@@ -82,6 +82,7 @@ CHierarchicalResultsWriter::SResults::SResults(
     double rawAnomalyScore,
     double normalizedAnomalyScore,
     double probability,
+    double multiBucketImpact,
     const std::string& metricValueField,
     const TStoredStringPtrStoredStringPtrPrDoublePrVec& influences,
     bool useNull,
@@ -103,7 +104,7 @@ CHierarchicalResultsWriter::SResults::SResults(
       s_BaselineRate(baselineRate), s_CurrentRate(currentRate),
       s_BaselineMean(baselineMean), s_CurrentMean(currentMean),
       s_RawAnomalyScore(rawAnomalyScore),
-      s_NormalizedAnomalyScore(normalizedAnomalyScore), s_Probability(probability),
+      s_NormalizedAnomalyScore(normalizedAnomalyScore), s_Probability(probability), s_MultiBucketImpact{multiBucketImpact},
       s_Influences(influences), s_Identifier(identifier),
       s_ScheduledEventDescriptions(scheduledEventDescriptions) {
 }
@@ -238,7 +239,7 @@ void CHierarchicalResultsWriter::writeIndividualResult(const model::CHierarchica
     const model::SAttributeProbability& attributeProbability =
         node.s_AnnotatedProbability.s_AttributeProbabilities[0];
 
-    m_ResultWriterFunc(TResults(
+    SResults individualResult = TResults(
         E_Result, *node.s_Spec.s_PartitionFieldName, *node.s_Spec.s_PartitionFieldValue,
         *node.s_Spec.s_ByFieldName, *node.s_Spec.s_PersonFieldValue,
         attributeProbability.s_CorrelatedAttributes.empty()
@@ -248,10 +249,12 @@ void CHierarchicalResultsWriter::writeIndividualResult(const model::CHierarchica
         model_t::outputFunctionName(feature), node.s_AnnotatedProbability.s_BaselineBucketCount,
         node.s_AnnotatedProbability.s_CurrentBucketCount,
         attributeProbability.s_BaselineBucketMean, attributeProbability.s_CurrentBucketValue,
-        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(),
+        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(), node.s_AnnotatedProbability.s_MultiBucketImpact,
         *node.s_Spec.s_ValueFieldName, node.s_AnnotatedProbability.s_Influences,
         node.s_Spec.s_UseNull, model::function_t::isMetric(node.s_Spec.s_Function),
-        node.s_Spec.s_Detector, node.s_BucketLength, EMPTY_STRING_LIST));
+        node.s_Spec.s_Detector, node.s_BucketLength, EMPTY_STRING_LIST);
+
+    m_ResultWriterFunc(individualResult);
 }
 
 void CHierarchicalResultsWriter::writePivotResult(const model::CHierarchicalResults& results,
@@ -284,7 +287,7 @@ void CHierarchicalResultsWriter::writeSimpleCountResult(const TNode& node) {
         m_BucketTime, EMPTY_STRING, EMPTY_STRING, baselineCount, currentCount,
         baselineCount ? TDouble1Vec(1, *baselineCount) : TDouble1Vec(),
         currentCount ? TDouble1Vec(1, static_cast<double>(*currentCount)) : TDouble1Vec(),
-        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(),
+        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(), -5.0,
         *node.s_Spec.s_ValueFieldName, node.s_AnnotatedProbability.s_Influences,
         node.s_Spec.s_UseNull, model::function_t::isMetric(node.s_Spec.s_Function),
         node.s_Spec.s_Detector, node.s_BucketLength, node.s_Spec.s_ScheduledEventDescriptions));

--- a/lib/api/CHierarchicalResultsWriter.cc
+++ b/lib/api/CHierarchicalResultsWriter.cc
@@ -62,7 +62,7 @@ CHierarchicalResultsWriter::SResults::SResults(
       s_CurrentRate(currentRate), s_BaselineMean{0.0}, s_CurrentMean{0.0},
       s_RawAnomalyScore(rawAnomalyScore),
       s_NormalizedAnomalyScore(normalizedAnomalyScore),
-      s_Probability(probability), s_MultiBucketImpact{-5.0},
+      s_Probability(probability), s_MultiBucketImpact{model::CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT},
       s_Influences(influences), s_Identifier(identifier) {
 }
 
@@ -290,11 +290,11 @@ void CHierarchicalResultsWriter::writeSimpleCountResult(const TNode& node) {
         m_BucketTime, EMPTY_STRING, EMPTY_STRING, baselineCount, currentCount,
         baselineCount ? TDouble1Vec(1, *baselineCount) : TDouble1Vec(),
         currentCount ? TDouble1Vec(1, static_cast<double>(*currentCount)) : TDouble1Vec(),
-        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore,
-        node.probability(), -5.0, *node.s_Spec.s_ValueFieldName,
-        node.s_AnnotatedProbability.s_Influences, node.s_Spec.s_UseNull,
-        model::function_t::isMetric(node.s_Spec.s_Function), node.s_Spec.s_Detector,
-        node.s_BucketLength, node.s_Spec.s_ScheduledEventDescriptions));
+        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(),
+        model::CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT,
+        *node.s_Spec.s_ValueFieldName, node.s_AnnotatedProbability.s_Influences,
+        node.s_Spec.s_UseNull, model::function_t::isMetric(node.s_Spec.s_Function),
+        node.s_Spec.s_Detector, node.s_BucketLength, node.s_Spec.s_ScheduledEventDescriptions));
 }
 
 void CHierarchicalResultsWriter::findParentProbabilities(const TNode& node,

--- a/lib/api/CHierarchicalResultsWriter.cc
+++ b/lib/api/CHierarchicalResultsWriter.cc
@@ -61,7 +61,8 @@ CHierarchicalResultsWriter::SResults::SResults(
       s_PopulationAverage(populationAverage), s_BaselineRate(0.0),
       s_CurrentRate(currentRate), s_BaselineMean{0.0}, s_CurrentMean{0.0},
       s_RawAnomalyScore(rawAnomalyScore),
-      s_NormalizedAnomalyScore(normalizedAnomalyScore), s_Probability(probability), s_MultiBucketImpact{-5.0},
+      s_NormalizedAnomalyScore(normalizedAnomalyScore),
+      s_Probability(probability), s_MultiBucketImpact{-5.0},
       s_Influences(influences), s_Identifier(identifier) {
 }
 
@@ -104,7 +105,8 @@ CHierarchicalResultsWriter::SResults::SResults(
       s_BaselineRate(baselineRate), s_CurrentRate(currentRate),
       s_BaselineMean(baselineMean), s_CurrentMean(currentMean),
       s_RawAnomalyScore(rawAnomalyScore),
-      s_NormalizedAnomalyScore(normalizedAnomalyScore), s_Probability(probability), s_MultiBucketImpact{multiBucketImpact},
+      s_NormalizedAnomalyScore(normalizedAnomalyScore),
+      s_Probability(probability), s_MultiBucketImpact{multiBucketImpact},
       s_Influences(influences), s_Identifier(identifier),
       s_ScheduledEventDescriptions(scheduledEventDescriptions) {
 }
@@ -249,7 +251,8 @@ void CHierarchicalResultsWriter::writeIndividualResult(const model::CHierarchica
         model_t::outputFunctionName(feature), node.s_AnnotatedProbability.s_BaselineBucketCount,
         node.s_AnnotatedProbability.s_CurrentBucketCount,
         attributeProbability.s_BaselineBucketMean, attributeProbability.s_CurrentBucketValue,
-        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(), node.s_AnnotatedProbability.s_MultiBucketImpact,
+        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore,
+        node.probability(), node.s_AnnotatedProbability.s_MultiBucketImpact,
         *node.s_Spec.s_ValueFieldName, node.s_AnnotatedProbability.s_Influences,
         node.s_Spec.s_UseNull, model::function_t::isMetric(node.s_Spec.s_Function),
         node.s_Spec.s_Detector, node.s_BucketLength, EMPTY_STRING_LIST);
@@ -287,10 +290,11 @@ void CHierarchicalResultsWriter::writeSimpleCountResult(const TNode& node) {
         m_BucketTime, EMPTY_STRING, EMPTY_STRING, baselineCount, currentCount,
         baselineCount ? TDouble1Vec(1, *baselineCount) : TDouble1Vec(),
         currentCount ? TDouble1Vec(1, static_cast<double>(*currentCount)) : TDouble1Vec(),
-        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(), -5.0,
-        *node.s_Spec.s_ValueFieldName, node.s_AnnotatedProbability.s_Influences,
-        node.s_Spec.s_UseNull, model::function_t::isMetric(node.s_Spec.s_Function),
-        node.s_Spec.s_Detector, node.s_BucketLength, node.s_Spec.s_ScheduledEventDescriptions));
+        node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore,
+        node.probability(), -5.0, *node.s_Spec.s_ValueFieldName,
+        node.s_AnnotatedProbability.s_Influences, node.s_Spec.s_UseNull,
+        model::function_t::isMetric(node.s_Spec.s_Function), node.s_Spec.s_Detector,
+        node.s_BucketLength, node.s_Spec.s_ScheduledEventDescriptions));
 }
 
 void CHierarchicalResultsWriter::findParentProbabilities(const TNode& node,

--- a/lib/api/CHierarchicalResultsWriter.cc
+++ b/lib/api/CHierarchicalResultsWriter.cc
@@ -62,7 +62,7 @@ CHierarchicalResultsWriter::SResults::SResults(
       s_CurrentRate(currentRate), s_BaselineMean{0.0}, s_CurrentMean{0.0},
       s_RawAnomalyScore(rawAnomalyScore),
       s_NormalizedAnomalyScore(normalizedAnomalyScore),
-      s_Probability(probability), s_MultiBucketImpact{model::CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT},
+      s_Probability(probability), s_MultiBucketImpact{-1.0 * model::CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE},
       s_Influences(influences), s_Identifier(identifier) {
 }
 
@@ -291,7 +291,7 @@ void CHierarchicalResultsWriter::writeSimpleCountResult(const TNode& node) {
         baselineCount ? TDouble1Vec(1, *baselineCount) : TDouble1Vec(),
         currentCount ? TDouble1Vec(1, static_cast<double>(*currentCount)) : TDouble1Vec(),
         node.s_RawAnomalyScore, node.s_NormalizedAnomalyScore, node.probability(),
-        model::CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT,
+        -1.0 * model::CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE,
         *node.s_Spec.s_ValueFieldName, node.s_AnnotatedProbability.s_Influences,
         node.s_Spec.s_UseNull, model::function_t::isMetric(node.s_Spec.s_Function),
         node.s_Spec.s_Detector, node.s_BucketLength, node.s_Spec.s_ScheduledEventDescriptions));

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -33,6 +33,7 @@ const std::string RECORDS("records");
 const std::string EVENT_COUNT("event_count");
 const std::string IS_INTERIM("is_interim");
 const std::string PROBABILITY("probability");
+const std::string MULTI_BUCKET_IMPACT("multi_bucket_impact");
 const std::string RAW_ANOMALY_SCORE("raw_anomaly_score");
 const std::string ANOMALY_SCORE("anomaly_score");
 const std::string RECORD_SCORE("record_score");
@@ -534,6 +535,7 @@ void CJsonOutputWriter::addMetricFields(const CHierarchicalResultsWriter::TResul
                                  results.s_NormalizedAnomalyScore, *docPtr);
     m_Writer.addDoubleFieldToObj(RECORD_SCORE, results.s_NormalizedAnomalyScore, *docPtr);
     m_Writer.addDoubleFieldToObj(PROBABILITY, results.s_Probability, *docPtr);
+    m_Writer.addDoubleFieldToObj(MULTI_BUCKET_IMPACT, results.s_MultiBucketImpact, *docPtr);
     m_Writer.addStringFieldCopyToObj(FIELD_NAME, results.s_MetricValueField, *docPtr);
     if (!results.s_ByFieldName.empty()) {
         m_Writer.addStringFieldCopyToObj(BY_FIELD_NAME, results.s_ByFieldName, *docPtr);
@@ -736,6 +738,7 @@ void CJsonOutputWriter::addEventRateFields(const CHierarchicalResultsWriter::TRe
                                  results.s_NormalizedAnomalyScore, *docPtr);
     m_Writer.addDoubleFieldToObj(RECORD_SCORE, results.s_NormalizedAnomalyScore, *docPtr);
     m_Writer.addDoubleFieldToObj(PROBABILITY, results.s_Probability, *docPtr);
+    m_Writer.addDoubleFieldToObj(MULTI_BUCKET_IMPACT, results.s_MultiBucketImpact, *docPtr);
     m_Writer.addStringFieldCopyToObj(FIELD_NAME, results.s_MetricValueField, *docPtr);
     if (!results.s_ByFieldName.empty()) {
         m_Writer.addStringFieldCopyToObj(BY_FIELD_NAME, results.s_ByFieldName, *docPtr);

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -364,8 +364,8 @@ void CJsonOutputWriterTest::testBucketWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 1, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, -5.0,
-                fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0,
+                -5.0, fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result13(
                 ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
@@ -413,8 +413,8 @@ void CJsonOutputWriterTest::testBucketWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 2, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, -5.0,
-                fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0,
+                -5.0, fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result23(
                 ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
@@ -462,8 +462,8 @@ void CJsonOutputWriterTest::testBucketWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 3, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0,
-                fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0,
+                -5.0, fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result33(
                 ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
@@ -817,32 +817,32 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result111));
 
             ml::api::CHierarchicalResultsWriter::SResults result112(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.2, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.2, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result112));
 
             ml::api::CHierarchicalResultsWriter::SResults result113(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 2.0, 0.0, 0.4, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 2.0, 0.0, 0.4, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result113));
 
             ml::api::CHierarchicalResultsWriter::SResults result114(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 12.0, 0.0, 0.4, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 12.0, 0.0, 0.4, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result114));
             CPPUNIT_ASSERT(writer.acceptResult(result114));
 
@@ -901,24 +901,24 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 2,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 1.0, 0.0, 0.05, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 1.0, 0.0, 0.05, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result211));
 
             ml::api::CHierarchicalResultsWriter::SResults result212(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 2,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 7.0, 0.0, 0.001, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 7.0, 0.0, 0.001, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result212));
 
             ml::api::CHierarchicalResultsWriter::SResults result213(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 2,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 0.6, 0.0, 0.1, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 0.6, 0.0, 0.1, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result213));
             CPPUNIT_ASSERT(writer.acceptResult(result213));
 
@@ -964,8 +964,8 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 3,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 30.0, 0.0, 0.02, -5.0, fieldName, influences,
-                false, true, 1, 100, EMPTY_STRING_LIST);
+                TDouble1Vec(1, 10090.0), 30.0, 0.0, 0.02, -5.0, fieldName,
+                influences, false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result311));
 
             overFieldName = "ofn";
@@ -1287,9 +1287,10 @@ void CJsonOutputWriterTest::testWriteInfluencersWithLimit() {
         std::string emptyStr;
         ml::api::CHierarchicalResultsWriter::TStoredStringPtrStoredStringPtrPrDoublePrVec influences;
         ml::api::CHierarchicalResultsWriter::SResults result(
-            ml::api::CHierarchicalResultsWriter::E_Result, pfn, pfv, bfn, bfv, emptyStr,
-            0, fun, fund, 42.0, 79, TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0),
-            0.0, 0.1, 0.1, -5.0, fn, influences, false, true, 1, 100, EMPTY_STRING_LIST);
+            ml::api::CHierarchicalResultsWriter::E_Result, pfn, pfv, bfn, bfv,
+            emptyStr, 0, fun, fund, 42.0, 79, TDouble1Vec(1, 6953.0),
+            TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0, fn, influences, false,
+            true, 1, 100, EMPTY_STRING_LIST);
 
         CPPUNIT_ASSERT(writer.acceptResult(result));
 
@@ -1619,8 +1620,8 @@ void CJsonOutputWriterTest::testWriteScheduledEvent() {
             ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
             partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
             emptyString, 100, function, functionDescription, 42.0, 79,
-            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0,
-            fieldName, influences, false, true, 1, 100, EMPTY_STRING_LIST);
+            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1,
+            -5.0, fieldName, influences, false, true, 1, 100, EMPTY_STRING_LIST);
         CPPUNIT_ASSERT(writer.acceptResult(result));
 
         // This result has 2 scheduled events
@@ -1629,8 +1630,8 @@ void CJsonOutputWriterTest::testWriteScheduledEvent() {
             ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
             partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
             emptyString, 200, function, functionDescription, 42.0, 79,
-            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0,
-            fieldName, influences, false, true, 1, 100, eventDescriptions);
+            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1,
+            -5.0, fieldName, influences, false, true, 1, 100, eventDescriptions);
 
         CPPUNIT_ASSERT(writer.acceptResult(result2));
         CPPUNIT_ASSERT(writer.endOutputBatch(false, 1U));
@@ -1711,8 +1712,8 @@ void CJsonOutputWriterTest::testThroughputHelper(bool useScopedAllocator) {
         ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
         partitionFieldValue, byFieldName, byFieldValue, correlatedByFieldValue,
         1, function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-        TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, -5.0, fieldName, influences, false,
-        true, 2, 100, EMPTY_STRING_LIST);
+        TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, -5.0, fieldName, influences,
+        false, true, 2, 100, EMPTY_STRING_LIST);
 
     ml::api::CHierarchicalResultsWriter::SResults result13(
         ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
@@ -1725,8 +1726,8 @@ void CJsonOutputWriterTest::testThroughputHelper(bool useScopedAllocator) {
         ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
         partitionFieldValue, byFieldName, byFieldValue, correlatedByFieldValue,
         1, function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-        TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0, fieldName, influences, false,
-        false, 4, 100, EMPTY_STRING_LIST);
+        TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0, fieldName, influences,
+        false, false, 4, 100, EMPTY_STRING_LIST);
 
     // 1st bucket
     writer.acceptBucketTimeInfluencer(1, 0.01, 13.44, 70.0);

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -364,21 +364,21 @@ void CJsonOutputWriterTest::testBucketWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 1, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, -5.0,
                 fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result13(
                 ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
                 partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 1, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.5, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.5, 0.0, -5.0,
                 fieldName, influences, false, false, 3, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result14(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 1, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0,
                 fieldName, influences, false, false, 4, 100, EMPTY_STRING_LIST);
 
             // 1st bucket
@@ -413,21 +413,21 @@ void CJsonOutputWriterTest::testBucketWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 2, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, -5.0,
                 fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result23(
                 ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
                 partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 2, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0,
                 fieldName, influences, false, false, 3, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result24(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 2, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0,
                 fieldName, influences, false, false, 4, 100, EMPTY_STRING_LIST);
 
             // 2nd bucket
@@ -462,21 +462,21 @@ void CJsonOutputWriterTest::testBucketWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 3, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0,
                 fieldName, influences, false, true, 2, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result33(
                 ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
                 partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 3, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0,
                 fieldName, influences, false, false, 3, 100, EMPTY_STRING_LIST);
 
             ml::api::CHierarchicalResultsWriter::SResults result34(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
                 correlatedByFieldValue, 3, function, functionDescription, 42.0, 79,
-                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0,
+                TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0,
                 fieldName, influences, false, false, 4, 100, EMPTY_STRING_LIST);
 
             // 3rd bucket
@@ -817,7 +817,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result111));
 
@@ -825,7 +825,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.2, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.2, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result112));
 
@@ -833,7 +833,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 2.0, 0.0, 0.4, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 2.0, 0.0, 0.4, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result113));
 
@@ -841,7 +841,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 12.0, 0.0, 0.4, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 12.0, 0.0, 0.4, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result114));
             CPPUNIT_ASSERT(writer.acceptResult(result114));
@@ -901,7 +901,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 2,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 1.0, 0.0, 0.05, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 1.0, 0.0, 0.05, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result211));
 
@@ -909,7 +909,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 2,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 7.0, 0.0, 0.001, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 7.0, 0.0, 0.001, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result212));
 
@@ -917,7 +917,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 2,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 0.6, 0.0, 0.1, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 0.6, 0.0, 0.1, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result213));
             CPPUNIT_ASSERT(writer.acceptResult(result213));
@@ -964,7 +964,7 @@ void CJsonOutputWriterTest::testLimitedRecordsWriteHelper(bool isInterim) {
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue, emptyString, 3,
                 function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-                TDouble1Vec(1, 10090.0), 30.0, 0.0, 0.02, fieldName, influences,
+                TDouble1Vec(1, 10090.0), 30.0, 0.0, 0.02, -5.0, fieldName, influences,
                 false, true, 1, 100, EMPTY_STRING_LIST);
             CPPUNIT_ASSERT(writer.acceptResult(result311));
 
@@ -1289,7 +1289,7 @@ void CJsonOutputWriterTest::testWriteInfluencersWithLimit() {
         ml::api::CHierarchicalResultsWriter::SResults result(
             ml::api::CHierarchicalResultsWriter::E_Result, pfn, pfv, bfn, bfv, emptyStr,
             0, fun, fund, 42.0, 79, TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0),
-            0.0, 0.1, 0.1, fn, influences, false, true, 1, 100, EMPTY_STRING_LIST);
+            0.0, 0.1, 0.1, -5.0, fn, influences, false, true, 1, 100, EMPTY_STRING_LIST);
 
         CPPUNIT_ASSERT(writer.acceptResult(result));
 
@@ -1435,7 +1435,7 @@ void CJsonOutputWriterTest::testWriteWithInfluences() {
             ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
             partitionFieldValue, byFieldName, byFieldValue, emptyString, 1,
             function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-            TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, fieldName, influences,
+            TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0, fieldName, influences,
             false, true, 1, 100, EMPTY_STRING_LIST);
 
         ml::core::CJsonOutputStreamWrapper outputStream(sstream);
@@ -1619,7 +1619,7 @@ void CJsonOutputWriterTest::testWriteScheduledEvent() {
             ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
             partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
             emptyString, 100, function, functionDescription, 42.0, 79,
-            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1,
+            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0,
             fieldName, influences, false, true, 1, 100, EMPTY_STRING_LIST);
         CPPUNIT_ASSERT(writer.acceptResult(result));
 
@@ -1629,7 +1629,7 @@ void CJsonOutputWriterTest::testWriteScheduledEvent() {
             ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
             partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
             emptyString, 200, function, functionDescription, 42.0, 79,
-            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1,
+            TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 0.0, 0.1, 0.1, -5.0,
             fieldName, influences, false, true, 1, 100, eventDescriptions);
 
         CPPUNIT_ASSERT(writer.acceptResult(result2));
@@ -1711,21 +1711,21 @@ void CJsonOutputWriterTest::testThroughputHelper(bool useScopedAllocator) {
         ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
         partitionFieldValue, byFieldName, byFieldValue, correlatedByFieldValue,
         1, function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-        TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, fieldName, influences, false,
+        TDouble1Vec(1, 10090.0), 2.24, 0.8, 0.0, -5.0, fieldName, influences, false,
         true, 2, 100, EMPTY_STRING_LIST);
 
     ml::api::CHierarchicalResultsWriter::SResults result13(
         ml::api::CHierarchicalResultsWriter::E_SimpleCountResult,
         partitionFieldName, partitionFieldValue, byFieldName, byFieldValue,
         correlatedByFieldValue, 1, function, functionDescription, 42.0, 79,
-        TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.5, 0.0,
+        TDouble1Vec(1, 6953.0), TDouble1Vec(1, 10090.0), 2.24, 0.5, 0.0, -5.0,
         fieldName, influences, false, false, 3, 100, EMPTY_STRING_LIST);
 
     ml::api::CHierarchicalResultsWriter::SResults result14(
         ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
         partitionFieldValue, byFieldName, byFieldValue, correlatedByFieldValue,
         1, function, functionDescription, 42.0, 79, TDouble1Vec(1, 6953.0),
-        TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, fieldName, influences, false,
+        TDouble1Vec(1, 10090.0), 2.24, 0.0, 0.0, -5.0, fieldName, influences, false,
         false, 4, 100, EMPTY_STRING_LIST);
 
     // 1st bucket

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -276,12 +276,12 @@ bool CModelProbabilityParams::useAnomalyModel() const {
 //////// SModelProbabilityResult::SFeatureProbability ////////
 
 SModelProbabilityResult::SFeatureProbability::SFeatureProbability()
-    : s_Label{boost::cref(EMPTY_STRING)} {
+    : s_Label{E_UndefinedProbability} {
 }
 
-SModelProbabilityResult::SFeatureProbability::SFeatureProbability(const std::string& label,
+SModelProbabilityResult::SFeatureProbability::SFeatureProbability(EFeatureProbabilityLabel label,
                                                                   double probability)
-    : s_Label{boost::cref(label)}, s_Probability{probability} {
+    : s_Label{label}, s_Probability{probability} {
 }
 
 //////// CModel ////////

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1633,7 +1633,8 @@ bool CTimeSeriesDecompositionDetail::CComponents::addCalendarComponent(const CCa
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::adjustValuesForPiecewiseConstantScaling(
-        std::size_t period, TFloatMeanAccumulatorVec& values) const {
+    std::size_t period,
+    TFloatMeanAccumulatorVec& values) const {
 
     // Periodicity testing detected piecewise constant linear scaling
     // of the underlying seasonal component. Here, we adjust all values
@@ -1644,14 +1645,13 @@ void CTimeSeriesDecompositionDetail::CComponents::adjustValuesForPiecewiseConsta
 
     TDoubleVec trend;
     TDoubleVec scales;
-    TSizeVec segmentation(CTimeSeriesSegmentation::piecewiseLinearScaledPeriodic(
-        values, period));
+    TSizeVec segmentation(
+        CTimeSeriesSegmentation::piecewiseLinearScaledPeriodic(values, period));
     std::tie(trend, scales) = CTimeSeriesSegmentation::piecewiseLinearScaledPeriodic(
         values, period, segmentation);
     LOG_TRACE(<< "trend = " << core::CContainerPrinter::print(trend));
     LOG_TRACE(<< "scales = " << core::CContainerPrinter::print(scales));
-    LOG_TRACE(<< "segmentation = "
-              << core::CContainerPrinter::print(segmentation));
+    LOG_TRACE(<< "segmentation = " << core::CContainerPrinter::print(segmentation));
     values = CTimeSeriesSegmentation::removePiecewiseLinearScaledPeriodic(
         values, segmentation, trend, scales);
     TMeanAccumulator scale;
@@ -1666,8 +1666,8 @@ void CTimeSeriesDecompositionDetail::CComponents::adjustValuesForPiecewiseConsta
     }
     LOG_TRACE(<< "scale = " << CBasicStatistics::mean(scale));
     for (std::size_t i = 0; i < values.size(); ++i) {
-        CBasicStatistics::moment<0>(values[i]) +=
-            CBasicStatistics::mean(scale) * trend[i % trend.size()];
+        CBasicStatistics::moment<0>(values[i]) += CBasicStatistics::mean(scale) *
+                                                  trend[i % trend.size()];
     }
 }
 

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -167,12 +167,6 @@ const std::string FIRST_CORRELATE_ID_TAG{"a"};
 const std::string SECOND_CORRELATE_ID_TAG{"b"};
 const std::string CORRELATION_MODEL_TAG{"c"};
 const std::string CORRELATION_TAG{"d"};
-
-// Strings identifying the different features for which time series
-// models compute probabilities.
-const std::string SINGLE_BUCKET_FEATURE_LABEL{"single_bucket"};
-const std::string MULTI_BUCKET_FEATURE_LABEL{"multi_bucket"};
-const std::string ANOMALY_FEATURE_LABEL{"anomaly"};
 }
 
 namespace forecast {
@@ -1002,7 +996,8 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(const CModelProbability
             calculation, value[0], params.bucketEmpty()[0][0],
             this->params().probabilityBucketEmpty(), (pl + pu) / 2.0)};
         probabilities.push_back(probability);
-        featureProbabilities.emplace_back(SINGLE_BUCKET_FEATURE_LABEL, probability);
+        featureProbabilities.emplace_back(
+            SModelProbabilityResult::E_SingleBucketProbability, probability);
     } else {
         LOG_ERROR(<< "Failed to compute P(" << sample
                   << " | weight = " << weights << ", time = " << time << ")");
@@ -1033,7 +1028,8 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(const CModelProbability
             calculation, value[0], params.bucketEmpty()[0][0],
             this->params().probabilityBucketEmpty(), probability);
         probabilities.push_back(probability);
-        featureProbabilities.emplace_back(MULTI_BUCKET_FEATURE_LABEL, probability);
+        featureProbabilities.emplace_back(
+            SModelProbabilityResult::E_MultiBucketProbability, probability);
     }
 
     double probability{aggregateFeatureProbabilities(probabilities, correlation)};
@@ -1047,7 +1043,8 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(const CModelProbability
         std::tie(probability, anomalyProbability) =
             m_AnomalyModel->probability(time, probability);
         probabilities.push_back(anomalyProbability);
-        featureProbabilities.emplace_back(ANOMALY_FEATURE_LABEL, anomalyProbability);
+        featureProbabilities.emplace_back(
+            SModelProbabilityResult::E_AnomalyModelProbability, anomalyProbability);
     }
 
     result.s_Probability = probability;
@@ -1166,7 +1163,8 @@ bool CUnivariateTimeSeriesModel::correlatedProbability(const CModelProbabilityPa
     aggregator.calculate(probability);
     TDouble4Vec probabilities{probability};
     SModelProbabilityResult::TFeatureProbability4Vec featureProbabilities;
-    featureProbabilities.emplace_back(SINGLE_BUCKET_FEATURE_LABEL, probability);
+    featureProbabilities.emplace_back(
+        SModelProbabilityResult::E_SingleBucketProbability, probability);
 
     if (m_AnomalyModel != nullptr && params.useAnomalyModel()) {
         double residual{
@@ -1178,7 +1176,8 @@ bool CUnivariateTimeSeriesModel::correlatedProbability(const CModelProbabilityPa
         std::tie(probability, anomalyProbability) =
             m_AnomalyModel->probability(mostAnomalousTime, probability);
         probabilities.push_back(anomalyProbability);
-        featureProbabilities.emplace_back(ANOMALY_FEATURE_LABEL, anomalyProbability);
+        featureProbabilities.emplace_back(
+            SModelProbabilityResult::E_AnomalyModelProbability, anomalyProbability);
     }
     aggregator.calculate(probability);
 
@@ -2440,7 +2439,7 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
     TTail2Vec tail(coordinates.size(), maths_t::E_UndeterminedTail);
 
     result = SModelProbabilityResult{
-        1.0, false, {{SINGLE_BUCKET_FEATURE_LABEL, 1.0}}, tail, {}};
+        1.0, false, {{SModelProbabilityResult::E_SingleBucketProbability, 1.0}}, tail, {}};
 
     std::size_t dimension{this->dimension()};
     core_t::TTime time{time_[0][0]};
@@ -2535,8 +2534,9 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
                                 2.0);
     }
 
-    TStrCRef labels[]{boost::cref(SINGLE_BUCKET_FEATURE_LABEL),
-                      boost::cref(MULTI_BUCKET_FEATURE_LABEL)};
+    SModelProbabilityResult::EFeatureProbabilityLabel labels[]{
+        SModelProbabilityResult::E_SingleBucketProbability,
+        SModelProbabilityResult::E_MultiBucketProbability};
     SModelProbabilityResult::TFeatureProbability4Vec featureProbabilities;
     for (std::size_t i = 0u; i < probabilities.size(); ++i) {
         featureProbabilities.emplace_back(labels[i], probabilities[i]);
@@ -2556,7 +2556,8 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
         std::tie(probability, anomalyProbability) =
             m_AnomalyModel->probability(time, probability);
         probabilities.push_back(anomalyProbability);
-        featureProbabilities.emplace_back(ANOMALY_FEATURE_LABEL, anomalyProbability);
+        featureProbabilities.emplace_back(
+            SModelProbabilityResult::E_AnomalyModelProbability, anomalyProbability);
     }
 
     result.s_Probability = probability;

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -2439,7 +2439,8 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
     }
     TTail2Vec tail(coordinates.size(), maths_t::E_UndeterminedTail);
 
-    result = SModelProbabilityResult{1.0, false, {{SINGLE_BUCKET_FEATURE_LABEL, 1.0}}, tail, {}};
+    result = SModelProbabilityResult{
+        1.0, false, {{SINGLE_BUCKET_FEATURE_LABEL, 1.0}}, tail, {}};
 
     std::size_t dimension{this->dimension()};
     core_t::TTime time{time_[0][0]};
@@ -2534,7 +2535,8 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
                                 2.0);
     }
 
-    TStrCRef labels[]{boost::cref(SINGLE_BUCKET_FEATURE_LABEL), boost::cref(MULTI_BUCKET_FEATURE_LABEL)};
+    TStrCRef labels[]{boost::cref(SINGLE_BUCKET_FEATURE_LABEL),
+                      boost::cref(MULTI_BUCKET_FEATURE_LABEL)};
     SModelProbabilityResult::TFeatureProbability4Vec featureProbabilities;
     for (std::size_t i = 0u; i < probabilities.size(); ++i) {
         featureProbabilities.emplace_back(labels[i], probabilities[i]);

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -170,8 +170,8 @@ const std::string CORRELATION_TAG{"d"};
 
 // Strings identifying the different features for which time series
 // models compute probabilities.
-const std::string BUCKET_FEATURE_LABEL{"bucket"};
-const std::string MEAN_FEATURE_LABEL{"mean"};
+const std::string SINGLE_BUCKET_FEATURE_LABEL{"single_bucket"};
+const std::string MULTI_BUCKET_FEATURE_LABEL{"multi_bucket"};
 const std::string ANOMALY_FEATURE_LABEL{"anomaly"};
 }
 
@@ -1002,7 +1002,7 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(const CModelProbability
             calculation, value[0], params.bucketEmpty()[0][0],
             this->params().probabilityBucketEmpty(), (pl + pu) / 2.0)};
         probabilities.push_back(probability);
-        featureProbabilities.emplace_back(BUCKET_FEATURE_LABEL, probability);
+        featureProbabilities.emplace_back(SINGLE_BUCKET_FEATURE_LABEL, probability);
     } else {
         LOG_ERROR(<< "Failed to compute P(" << sample
                   << " | weight = " << weights << ", time = " << time << ")");
@@ -1033,7 +1033,7 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(const CModelProbability
             calculation, value[0], params.bucketEmpty()[0][0],
             this->params().probabilityBucketEmpty(), probability);
         probabilities.push_back(probability);
-        featureProbabilities.emplace_back(MEAN_FEATURE_LABEL, probability);
+        featureProbabilities.emplace_back(MULTI_BUCKET_FEATURE_LABEL, probability);
     }
 
     double probability{aggregateFeatureProbabilities(probabilities, correlation)};
@@ -1166,7 +1166,7 @@ bool CUnivariateTimeSeriesModel::correlatedProbability(const CModelProbabilityPa
     aggregator.calculate(probability);
     TDouble4Vec probabilities{probability};
     SModelProbabilityResult::TFeatureProbability4Vec featureProbabilities;
-    featureProbabilities.emplace_back(BUCKET_FEATURE_LABEL, probability);
+    featureProbabilities.emplace_back(SINGLE_BUCKET_FEATURE_LABEL, probability);
 
     if (m_AnomalyModel != nullptr && params.useAnomalyModel()) {
         double residual{
@@ -2439,7 +2439,7 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
     }
     TTail2Vec tail(coordinates.size(), maths_t::E_UndeterminedTail);
 
-    result = SModelProbabilityResult{1.0, false, {{BUCKET_FEATURE_LABEL, 1.0}}, tail, {}};
+    result = SModelProbabilityResult{1.0, false, {{SINGLE_BUCKET_FEATURE_LABEL, 1.0}}, tail, {}};
 
     std::size_t dimension{this->dimension()};
     core_t::TTime time{time_[0][0]};
@@ -2534,7 +2534,7 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
                                 2.0);
     }
 
-    TStrCRef labels[]{boost::cref(BUCKET_FEATURE_LABEL), boost::cref(MEAN_FEATURE_LABEL)};
+    TStrCRef labels[]{boost::cref(SINGLE_BUCKET_FEATURE_LABEL), boost::cref(MULTI_BUCKET_FEATURE_LABEL)};
     SModelProbabilityResult::TFeatureProbability4Vec featureProbabilities;
     for (std::size_t i = 0u; i < probabilities.size(); ++i) {
         featureProbabilities.emplace_back(labels[i], probabilities[i]);

--- a/lib/model/CAnnotatedProbabilityBuilder.cc
+++ b/lib/model/CAnnotatedProbabilityBuilder.cc
@@ -68,6 +68,9 @@ void CAnnotatedProbabilityBuilder::personAttributeProbabilityPrior(const maths::
 void CAnnotatedProbabilityBuilder::probability(double p) {
     m_Result.s_Probability = p;
 }
+void CAnnotatedProbabilityBuilder::multiBucketImpact(double multiBucketImpact) {
+    m_Result.s_MultiBucketImpact = multiBucketImpact;
+}
 
 void CAnnotatedProbabilityBuilder::addAttributeProbability(
     std::size_t cid,

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -74,8 +74,7 @@ const core_t::TTime
 const core_t::TTime
     CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE(core::constants::DAY);
 const std::size_t CAnomalyDetectorModelConfig::MULTIBUCKET_FEATURES_WINDOW_LENGTH(12);
-const double CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT(5.0);
-const double CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT(-5.0);
+const double CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE(5.0);
 const double CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_UPDATES_PER_BUCKET(1.0);
 const double CAnomalyDetectorModelConfig::DEFAULT_INFLUENCE_CUTOFF(0.4);
 const double CAnomalyDetectorModelConfig::DEFAULT_PRUNE_WINDOW_SCALE_MINIMUM(0.25);

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -74,6 +74,8 @@ const core_t::TTime
 const core_t::TTime
     CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE(core::constants::DAY);
 const std::size_t CAnomalyDetectorModelConfig::MULTIBUCKET_FEATURES_WINDOW_LENGTH(12);
+const double CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT(5.0);
+const double CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT(-5.0);
 const double CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_UPDATES_PER_BUCKET(1.0);
 const double CAnomalyDetectorModelConfig::DEFAULT_INFLUENCE_CUTOFF(0.4);
 const double CAnomalyDetectorModelConfig::DEFAULT_PRUNE_WINDOW_SCALE_MINIMUM(0.25);

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -433,7 +433,7 @@ bool CEventRateModel::computeProbability(std::size_t pid,
 
     resultBuilder.probability(p);
 
-    double multiBucketImpact{CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT};
+    double multiBucketImpact{-1.0 * CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE};
     if (pJoint.calculateMultiBucketImpact(multiBucketImpact)) {
         resultBuilder.multiBucketImpact(multiBucketImpact);
     }

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -431,6 +431,12 @@ bool CEventRateModel::computeProbability(std::size_t pid,
     LOG_TRACE(<< "probability(" << this->personName(pid) << ") = " << p);
 
     resultBuilder.probability(p);
+
+    double multiBucketImpact{-5.0};
+    if (pJoint.calculateMultiBucketImpact(multiBucketImpact)) {
+        resultBuilder.multiBucketImpact(multiBucketImpact);
+    }
+
     bool everSeenBefore = this->firstBucketTimes()[pid] != startTime;
     resultBuilder.personFrequency(this->personFrequency(pid), everSeenBefore);
     resultBuilder.build();

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -23,6 +23,7 @@
 #include <maths/ProbabilityAggregators.h>
 
 #include <model/CAnnotatedProbabilityBuilder.h>
+#include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CDataGatherer.h>
 #include <model/CIndividualModelDetail.h>
 #include <model/CInterimBucketCorrector.h>
@@ -432,7 +433,7 @@ bool CEventRateModel::computeProbability(std::size_t pid,
 
     resultBuilder.probability(p);
 
-    double multiBucketImpact{-5.0};
+    double multiBucketImpact{CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT};
     if (pJoint.calculateMultiBucketImpact(multiBucketImpact)) {
         resultBuilder.multiBucketImpact(multiBucketImpact);
     }

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -398,7 +398,7 @@ bool CMetricModel::computeProbability(const std::size_t pid,
 
     resultBuilder.probability(p);
 
-    double multiBucketImpact{CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT};
+    double multiBucketImpact{-1.0 * CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE};
     if (pJoint.calculateMultiBucketImpact(multiBucketImpact)) {
         resultBuilder.multiBucketImpact(multiBucketImpact);
     }

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -396,6 +396,12 @@ bool CMetricModel::computeProbability(const std::size_t pid,
     LOG_TRACE(<< "probability(" << this->personName(pid) << ") = " << p);
 
     resultBuilder.probability(p);
+
+    double multiBucketImpact{-5.0};
+    if (pJoint.calculateMultiBucketImpact(multiBucketImpact)) {
+        resultBuilder.multiBucketImpact(multiBucketImpact);
+    }
+
     resultBuilder.build();
 
     return true;

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -22,6 +22,7 @@
 #include <maths/ProbabilityAggregators.h>
 
 #include <model/CAnnotatedProbabilityBuilder.h>
+#include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CDataGatherer.h>
 #include <model/CGathererTools.h>
 #include <model/CIndividualModelDetail.h>
@@ -397,7 +398,7 @@ bool CMetricModel::computeProbability(const std::size_t pid,
 
     resultBuilder.probability(p);
 
-    double multiBucketImpact{-5.0};
+    double multiBucketImpact{CAnomalyDetectorModelConfig::MINIMUM_MULTI_BUCKET_IMPACT};
     if (pJoint.calculateMultiBucketImpact(multiBucketImpact)) {
         resultBuilder.multiBucketImpact(multiBucketImpact);
     }

--- a/lib/model/CProbabilityAndInfluenceCalculator.cc
+++ b/lib/model/CProbabilityAndInfluenceCalculator.cc
@@ -888,13 +888,13 @@ bool CProbabilityAndInfluenceCalculator::calculateMultiBucketImpact(double& mult
     double ls = std::log(std::max(sbProbability, ml::maths::CTools::smallestProbability()));
     double lm = std::log(std::max(mbProbability, ml::maths::CTools::smallestProbability()));
 
-    double scale = CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT *
+    double scale = CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE *
                    std::min(ls, lm) / std::min(std::max(ls, lm), -0.001) /
                    std::log(1000);
 
     multiBucketImpact = std::max(
-        std::min(scale * (ls - lm), CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT),
-        -1.0 * CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT);
+        std::min(scale * (ls - lm), CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE),
+        -1.0 * CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE);
 
     return true;
 }

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -280,7 +280,7 @@ const TSizeDoublePr1Vec NO_CORRELATES;
 
 } // unnamed::
 
-void CEventRateModelTest::testOnlineCountSample() {
+void CEventRateModelTest::testCountSample() {
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
@@ -373,7 +373,7 @@ void CEventRateModelTest::testOnlineCountSample() {
     CPPUNIT_ASSERT_EQUAL(origXml, newXml);
 }
 
-void CEventRateModelTest::testOnlineNonZeroCountSample() {
+void CEventRateModelTest::testNonZeroCountSample() {
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
@@ -441,7 +441,7 @@ void CEventRateModelTest::testOnlineNonZeroCountSample() {
     }
 }
 
-void CEventRateModelTest::testOnlineRare() {
+void CEventRateModelTest::testRare() {
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
@@ -517,60 +517,89 @@ void CEventRateModelTest::testOnlineRare() {
     CPPUNIT_ASSERT_EQUAL(origXml, newXml);
 }
 
-void CEventRateModelTest::testOnlineProbabilityCalculation() {
-    using TDoubleSizePr = std::pair<double, std::size_t>;
-    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr>;
+void CEventRateModelTest::testProbabilityCalculation() {
+    using TDoubleSizeAnotatedProbabilityTr =
+        core::CTriple<double, std::size_t, SAnnotatedProbability>;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<
+        TDoubleSizeAnotatedProbabilityTr,
+        std::function<bool(const TDoubleSizeAnotatedProbabilityTr&, const TDoubleSizeAnotatedProbabilityTr&)>>;
 
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
-    const std::size_t anomalousBucket = 25u;
 
-    SModelParams params(bucketLength);
-    params.s_DecayRate = 0.001;
-    this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 1);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
+    TSizeVec anomalousBuckets[]{TSizeVec{25}, TSizeVec{24, 25, 26, 27}};
+    double anomalousBucketsRateMultipliers[]{3.0, 1.3};
 
-    TMinAccumulator minProbabilities(2u);
+    for (std::size_t t = 0; t < 2; ++t) {
 
-    // Generate some events.
-    TTimeVec eventTimes;
-    TUInt64Vec expectedEventCounts = rawEventCounts(2);
-    expectedEventCounts[anomalousBucket] *= 3;
-    generateEvents(startTime, bucketLength, expectedEventCounts, eventTimes);
-    core_t::TTime endTime = (eventTimes.back() / bucketLength + 1) * bucketLength;
-    LOG_DEBUG(<< "startTime = " << startTime << ", endTime = " << endTime
-              << ", # events = " << eventTimes.size());
+        // Create the model.
+        SModelParams params(bucketLength);
+        params.s_DecayRate = 0.001;
+        this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 1);
+        CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
-    std::size_t i = 0u, j = 0u;
-    for (core_t::TTime bucketStartTime = startTime; bucketStartTime < endTime;
-         bucketStartTime += bucketLength, ++j) {
-        core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
+        // Generate some events.
+        TTimeVec eventTimes;
+        TUInt64Vec expectedEventCounts = rawEventCounts(2);
+        for (auto i : anomalousBuckets[t]) {
+            expectedEventCounts[i] =
+                static_cast<std::size_t>(static_cast<double>(expectedEventCounts[i]) *
+                                         anomalousBucketsRateMultipliers[t]);
+        }
+        generateEvents(startTime, bucketLength, expectedEventCounts, eventTimes);
+        core_t::TTime endTime = (eventTimes.back() / bucketLength + 1) * bucketLength;
+        LOG_DEBUG(<< "startTime = " << startTime << ", endTime = " << endTime
+                  << ", # events = " << eventTimes.size());
 
-        double count = 0.0;
-        for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
-            count += 1.0;
+        // Play the data through the model and get the lowest probability buckets.
+        TMinAccumulator minProbabilities(
+            2, [](const TDoubleSizeAnotatedProbabilityTr& lhs,
+                  const TDoubleSizeAnotatedProbabilityTr& rhs) {
+                return lhs.first < rhs.first;
+            });
+
+        std::size_t i = 0;
+        for (core_t::TTime j = 0, bucketStartTime = startTime;
+             bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
+            core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
+
+            double count = 0.0;
+            for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
+                addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
+                count += 1.0;
+            }
+
+            model->sample(bucketStartTime, bucketEndTime, m_ResourceMonitor);
+
+            SAnnotatedProbability p;
+            CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+            CPPUNIT_ASSERT(model->computeProbability(0 /*pid*/, bucketStartTime, bucketEndTime,
+                                                     partitioningFields, 1, p));
+            LOG_DEBUG(<< "bucket count = " << count << ", probability = " << p.s_Probability);
+            minProbabilities.add({p.s_Probability, j, p});
         }
 
-        LOG_DEBUG(<< "bucket count = " << count);
+        minProbabilities.sort();
 
-        model->sample(bucketStartTime, bucketEndTime, m_ResourceMonitor);
-
-        SAnnotatedProbability p;
-        CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
-        CPPUNIT_ASSERT(model->computeProbability(
-            0 /*pid*/, bucketStartTime, bucketEndTime, partitioningFields, 1, p));
-        LOG_DEBUG(<< "probability = " << p.s_Probability);
-        minProbabilities.add(TDoubleSizePr(p.s_Probability, j));
+        if (anomalousBuckets[t].size() == 1) {
+            // Check the one anomalous bucket has the lowest probability by a significant margin.
+            CPPUNIT_ASSERT_EQUAL(anomalousBuckets[0][0], minProbabilities[0].second);
+            CPPUNIT_ASSERT(minProbabilities[0].first / minProbabilities[1].first < 0.1);
+        } else {
+            // Check the multi-bucket impact values are relatively high
+            // (indicating a large contribution from multi-bucket analysis)
+            double expectedMultiBucketImpactThresholds[2]{0.3, 2.5};
+            for (int j = 0; j < 2; ++j) {
+                double multiBucketImpact = minProbabilities[j].third.s_MultiBucketImpact;
+                LOG_DEBUG(<< "multi_bucket_impact = " << multiBucketImpact);
+                CPPUNIT_ASSERT(multiBucketImpact > expectedMultiBucketImpactThresholds[j]);
+                CPPUNIT_ASSERT(multiBucketImpact <= CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE);
+            }
+        }
     }
-
-    minProbabilities.sort();
-    LOG_DEBUG(<< "minProbabilities = " << core::CContainerPrinter::print(minProbabilities));
-    CPPUNIT_ASSERT_EQUAL(anomalousBucket, minProbabilities[0].second);
-    CPPUNIT_ASSERT(minProbabilities[0].first / minProbabilities[1].first < 0.1);
 }
 
-void CEventRateModelTest::testOnlineProbabilityCalculationForLowNonZeroCount() {
+void CEventRateModelTest::testProbabilityCalculationForLowNonZeroCount() {
     core_t::TTime startTime(0);
     core_t::TTime bucketLength(100);
     std::size_t lowNonZeroCountBucket = 6u;
@@ -616,7 +645,7 @@ void CEventRateModelTest::testOnlineProbabilityCalculationForLowNonZeroCount() {
     CPPUNIT_ASSERT(probabilities[highNonZeroCountBucket] > 0.9);
 }
 
-void CEventRateModelTest::testOnlineProbabilityCalculationForHighNonZeroCount() {
+void CEventRateModelTest::testProbabilityCalculationForHighNonZeroCount() {
     core_t::TTime startTime(0);
     core_t::TTime bucketLength(100);
     std::size_t lowNonZeroCountBucket = 6u;
@@ -662,7 +691,7 @@ void CEventRateModelTest::testOnlineProbabilityCalculationForHighNonZeroCount() 
     CPPUNIT_ASSERT(probabilities[highNonZeroCountBucket] > 0.9);
 }
 
-void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
+void CEventRateModelTest::testCorrelatedNoTrend() {
     // Check we find the correct correlated variables, and identify
     // correlate and marginal anomalies.
 
@@ -860,7 +889,7 @@ void CEventRateModelTest::testOnlineCorrelatedNoTrend() {
     }
 }
 
-void CEventRateModelTest::testOnlineCorrelatedTrend() {
+void CEventRateModelTest::testCorrelatedTrend() {
     // Check we find the correct correlated variables, and identify
     // correlate and marginal anomalies.
 
@@ -1990,7 +2019,7 @@ void CEventRateModelTest::testDistinctCountProbabilityCalculationWithInfluence()
     }
 }
 
-void CEventRateModelTest::testOnlineRareWithInfluence() {
+void CEventRateModelTest::testRareWithInfluence() {
     const core_t::TTime startTime = 1346968800;
     const core_t::TTime bucketLength = 3600;
     SModelParams params(bucketLength);
@@ -2904,29 +2933,25 @@ CppUnit::Test* CEventRateModelTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CEventRateModelTest");
 
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::testOnlineCountSample", &CEventRateModelTest::testOnlineCountSample));
+        "CEventRateModelTest::testCountSample", &CEventRateModelTest::testCountSample));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::testOnlineNonZeroCountSample",
-        &CEventRateModelTest::testOnlineNonZeroCountSample));
+        "CEventRateModelTest::testNonZeroCountSample",
+        &CEventRateModelTest::testNonZeroCountSample));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::testOnlineRare", &CEventRateModelTest::testOnlineRare));
+        "CEventRateModelTest::testRare", &CEventRateModelTest::testRare));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::testOnlineProbabilityCalculation",
-        &CEventRateModelTest::testOnlineProbabilityCalculation));
+        "CEventRateModelTest::testProbabilityCalculation",
+        &CEventRateModelTest::testProbabilityCalculation));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::"
-        "testOnlineProbabilityCalculationForLowNonZeroCount",
-        &CEventRateModelTest::testOnlineProbabilityCalculationForLowNonZeroCount));
+        "CEventRateModelTest::testProbabilityCalculationForLowNonZeroCount",
+        &CEventRateModelTest::testProbabilityCalculationForLowNonZeroCount));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::"
-        "testOnlineProbabilityCalculationForHighNonZeroCount",
-        &CEventRateModelTest::testOnlineProbabilityCalculationForHighNonZeroCount));
+        "CEventRateModelTest::testProbabilityCalculationForHighNonZeroCount",
+        &CEventRateModelTest::testProbabilityCalculationForHighNonZeroCount));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::testOnlineCorrelatedNoTrend",
-        &CEventRateModelTest::testOnlineCorrelatedNoTrend));
+        "CEventRateModelTest::testCorrelatedNoTrend", &CEventRateModelTest::testCorrelatedNoTrend));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::testOnlineCorrelatedTrend",
-        &CEventRateModelTest::testOnlineCorrelatedTrend));
+        "CEventRateModelTest::testCorrelatedTrend", &CEventRateModelTest::testCorrelatedTrend));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
         "CEventRateModelTest::testPrune", &CEventRateModelTest::testPrune));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
@@ -2938,12 +2963,10 @@ CppUnit::Test* CEventRateModelTest::suite() {
         "CEventRateModelTest::testCountProbabilityCalculationWithInfluence",
         &CEventRateModelTest::testCountProbabilityCalculationWithInfluence));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::"
-        "testDistinctCountProbabilityCalculationWithInfluence",
+        "CEventRateModelTest::testDistinctCountProbabilityCalculationWithInfluence",
         &CEventRateModelTest::testDistinctCountProbabilityCalculationWithInfluence));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
-        "CEventRateModelTest::testOnlineRareWithInfluence",
-        &CEventRateModelTest::testOnlineRareWithInfluence));
+        "CEventRateModelTest::testRareWithInfluence", &CEventRateModelTest::testRareWithInfluence));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(
         "CEventRateModelTest::testSkipSampling", &CEventRateModelTest::testSkipSampling));
     suiteOfTests->addTest(new CppUnit::TestCaller<CEventRateModelTest>(

--- a/lib/model/unittest/CEventRateModelTest.h
+++ b/lib/model/unittest/CEventRateModelTest.h
@@ -25,20 +25,20 @@ struct SModelParams;
 
 class CEventRateModelTest : public CppUnit::TestFixture {
 public:
-    void testOnlineCountSample();
-    void testOnlineNonZeroCountSample();
-    void testOnlineRare();
-    void testOnlineProbabilityCalculation();
-    void testOnlineProbabilityCalculationForLowNonZeroCount();
-    void testOnlineProbabilityCalculationForHighNonZeroCount();
-    void testOnlineCorrelatedNoTrend();
-    void testOnlineCorrelatedTrend();
+    void testCountSample();
+    void testNonZeroCountSample();
+    void testRare();
+    void testProbabilityCalculation();
+    void testProbabilityCalculationForLowNonZeroCount();
+    void testProbabilityCalculationForHighNonZeroCount();
+    void testCorrelatedNoTrend();
+    void testCorrelatedTrend();
     void testPrune();
     void testKey();
     void testModelsWithValueFields();
     void testCountProbabilityCalculationWithInfluence();
     void testDistinctCountProbabilityCalculationWithInfluence();
-    void testOnlineRareWithInfluence();
+    void testRareWithInfluence();
     void testSkipSampling();
     void testExplicitNulls();
     void testInterimCorrections();


### PR DESCRIPTION
Add a label indicating the impact of the multi bucket analysis on the
overall probability. The value is in the range -5 to 5 where -5
indicates a wholly single bucket contribution and 5 a wholly multi
bucket contribution to the final probability.
