### PR TITLE
[ML] Improve robustness to very low variance data

### DIFF
--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -208,7 +208,7 @@ private:
 
     //! \brief A collection of statistics used during testing.
     struct STestStats {
-        STestStats();
+        explicit STestStats(double meanMagnitude);
         //! Set the various test thresholds.
         void setThresholds(double vt, double at, double Rt);
         //! Check if the null hypothesis is good enough to not need an
@@ -233,6 +233,8 @@ private:
         double s_NonEmptyBuckets;
         //! The average number of measurements per bucket value.
         double s_MeasurementsPerBucket;
+        //! The mean magnitude of the bucket values.
+        double s_MeanMagnitude;
         //! The null hypothesis periodic components.
         CPeriodicityHypothesisTestsResult s_H0;
         //! The variance estimate of H0.

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1215,14 +1215,14 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SAddValue& messag
         for (std::size_t i = 1u; i <= m; ++i) {
             CSeasonalComponent* component{seasonalComponents[i - 1]};
             CComponentErrors* error_{seasonalErrors[i - 1]};
-            double varianceIncrease{variances[i] / variance / expectedVarianceIncrease};
+            double varianceIncrease{variance == 0.0 ? 1.0 : variances[i] / variance / expectedVarianceIncrease};
             component->add(time, values[i], weight);
             error_->add(referenceError, error, predictions[i - 1], varianceIncrease, weight);
         }
         for (std::size_t i = m + 1; i <= m + n; ++i) {
             CCalendarComponent* component{calendarComponents[i - m - 1]};
             CComponentErrors* error_{calendarErrors[i - m - 1]};
-            double varianceIncrease{variances[i] / variance / expectedVarianceIncrease};
+            double varianceIncrease{variance == 0.0 ? 1.0 : variances[i] / variance / expectedVarianceIncrease};
             component->add(time, values[i], weight);
             error_->add(referenceError, error, predictions[i - 1], varianceIncrease, weight);
         }


### PR DESCRIPTION
This fixes a couple of potential issues:
1. If the variance of the data was zero it could cause a nan in the decomposition component errors. The most serious side effect is that it would cause us to fail to restore state on Windows.
2. The check for low coefficient of variation data in the periodic component test should **always** use the raw bucket values to calculate the mean.

This turned up in a unit test failure back porting #198 to 6.5. As such this is effectively a forward port of the fix I made directly to that commit. I've marked this as a non-issue as this is related to unreleased code.