### PR TITLE
[ML][6.5] Add support for PR CI builds

### DIFF
--- a/dev-tools/ci
+++ b/dev-tools/ci
@@ -5,14 +5,15 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-# The non-Windows part of ML C++ CI:
+# The non-Windows part of ML C++ CI does the following:
 #
-# 1. Build and unit test the Linux version of the C++
-# 2. Build the macOS version of the C++
-# 3. Upload the builds to the artifacts directory on S3 that
-#    subsequent Java builds will download the C++ components from
+# 1. If this is a PR build, check the code style
+# 2. Build and unit test the Linux version of the C++
+# 3. Build the macOS version of the C++
+# 4. If this is not a PR build, upload the builds to the artifacts directory on
+#    S3 that subsequent Java builds will download the C++ components from
 #
-# The builds run in Docker containers that ensure OS dependencies
+# The steps run in Docker containers that ensure OS dependencies
 # are appropriate given the support matrix.
 #
 # The macOS build cannot be unit tested as it is cross-compiled.
@@ -30,13 +31,20 @@ fi
 # Remove any old builds
 rm -rf ../builds
 
+# If this is a PR build then fail fast on style checks
+if [ -n "$PR_AUTHOR" ] ; then
+    ./docker_check_style.sh
+fi
+
 # Build and test Linux
 ./docker_test.sh linux
 
 # Build macOS
 ./docker_build.sh macosx
 
-# Upload
-cd ..
-./gradlew --info -b upload.gradle upload
+# If this isn't a PR build then upload the artifacts
+if [ -z "$PR_AUTHOR" ] ; then
+    cd ..
+    ./gradlew --info -b upload.gradle upload
+fi
 

--- a/dev-tools/ci.bat
+++ b/dev-tools/ci.bat
@@ -5,11 +5,11 @@ rem or more contributor license agreements. Licensed under the Elastic License;
 rem you may not use this file except in compliance with the Elastic License.
 rem
 
-rem The Windows part of ML C++ CI:
+rem The Windows part of ML C++ CI does the following:
 rem
 rem 1. Build and unit test the Windows version of the C++
-rem 2. Upload the build to the artifacts directory on S3 that
-rem    subsequent Java builds will download the C++ components from
+rem 2. If this is not a PR build, upload the build to the artifacts directory on
+rem    S3 that subsequent Java builds will download the C++ components from
 
 setlocal enableextensions
 
@@ -24,8 +24,8 @@ rem Run the build and unit tests
 set ML_KEEP_GOING=1
 call .\gradlew.bat --info clean buildZip buildZipSymbols check || exit /b %ERRORLEVEL%
 
-rem Upload the artifacts to S3
-call .\gradlew.bat --info -b upload.gradle upload || exit /b %ERRORLEVEL%
+rem If this isn't a PR build then upload the artifacts
+if not defined PR_AUTHOR call .\gradlew.bat --info -b upload.gradle upload || exit /b %ERRORLEVEL%
 
 endlocal
 


### PR DESCRIPTION
The CI scripts will now behave differently if triggered from
a PR build:

1. The code style will be checked first and style violations
   will cause the PR check to fail
2. The artifacts will only be uploaded to S3 for non-PR builds

PR builds are detected by checking whether a PR_AUTHOR environment
variable exists.

Backport of #233.