### PR TITLE
[ci][6.4] Add `jenkins-ci` helper scripts for Linux and Windows CI

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -1,0 +1,35 @@
+function Exec {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$cmd,
+        [string]$errorMessage = ($msgs.error_bad_command -f $cmd)
+    )
+
+    try {
+        $global:lastexitcode = 0
+        & $cmd
+        if ($lastexitcode -ne 0) {
+            throw $errorMessage
+        }
+    }
+    catch [Exception] {
+        throw $_
+    }
+}
+
+# Generate a Vault token
+$env:VAULT_TOKEN = & vault write -field=token auth/approle/login role_id="$env:VAULT_ROLE_ID" secret_id="$env:VAULT_SECRET_ID"
+
+# Load aws-creds from vault
+$aws_creds = & vault read -format=json -field=data aws-dev/creds/prelertartifacts
+$env:ML_AWS_ACCESS_KEY=(echo $aws_creds | jq -r ".access_key")
+$env:ML_AWS_SECRET_KEY=(echo $aws_creds | jq -r ".secret_key")
+
+# Remove VAULT_* values
+Remove-Item env:VAULT_TOKEN
+Remove-Item env:VAULT_ROLE_ID
+Remove-Item env:VAULT_SECRET_ID
+
+# Call dev-tools\ci.bat
+exec { cmd /c "dev-tools\ci.bat" } "CI Test FAILURE"

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+: "${HOME:?Need to set HOME to a non-empty value.}"
+: "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
+
+set +x
+export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+
+aws_creds=$(vault read -format=json -field=data aws-dev/creds/prelertartifacts)
+export ML_AWS_ACCESS_KEY=$(echo $aws_creds | jq -r '.access_key')
+export ML_AWS_SECRET_KEY=$(echo $aws_creds | jq -r '.secret_key')
+
+unset VAULT_TOKEN VAULT_ROLE_ID VAULT_SECRET_ID
+set -ex
+
+# Build and test
+./dev-tools/ci
+


### PR DESCRIPTION
Powershell script was modelled on https://github.com/elastic/beats/pull/8268,
and should prevent silent failures such as
https://elasticsearch-ci.elastic.co/job/elastic+machine-learning+master+windows/4/console

Backports #237 and #238.