### PR TITLE
[ML][6.5] Fix handling of snapshot flag in CI builds

### DIFF
--- a/dev-tools/ci
+++ b/dev-tools/ci
@@ -24,8 +24,15 @@ set -e
 cd `dirname $0`
 
 # Default to a snapshot build
-if [ -z "$SNAPSHOT" ] ; then
-    SNAPSHOT=yes
+if [ -z "$BUILD_SNAPSHOT" ] ; then
+    BUILD_SNAPSHOT=true
+fi
+
+# Jenkins sets BUILD_SNAPSHOT, but our Docker scripts require SNAPSHOT
+if [ "$BUILD_SNAPSHOT" = false ] ; then
+    export SNAPSHOT=no
+else
+    export SNAPSHOT=yes
 fi
 
 # Remove any old builds
@@ -45,6 +52,6 @@ fi
 # If this isn't a PR build then upload the artifacts
 if [ -z "$PR_AUTHOR" ] ; then
     cd ..
-    ./gradlew --info -b upload.gradle upload
+    ./gradlew --info -b upload.gradle -Dbuild.snapshot=$BUILD_SNAPSHOT upload
 fi
 

--- a/dev-tools/ci.bat
+++ b/dev-tools/ci.bat
@@ -20,12 +20,15 @@ cd ..
 rem Ensure 3rd party dependencies are installed
 powershell.exe -ExecutionPolicy RemoteSigned -File dev-tools\download_windows_deps.ps1 || exit /b %ERRORLEVEL%
 
+rem Default to a snapshot build
+if not defined BUILD_SNAPSHOT set BUILD_SNAPSHOT=true
+
 rem Run the build and unit tests
 set ML_KEEP_GOING=1
-call .\gradlew.bat --info clean buildZip buildZipSymbols check || exit /b %ERRORLEVEL%
+call .\gradlew.bat --info -Dbuild.snapshot=%BUILD_SNAPSHOT% clean buildZip buildZipSymbols check || exit /b %ERRORLEVEL%
 
 rem If this isn't a PR build then upload the artifacts
-if not defined PR_AUTHOR call .\gradlew.bat --info -b upload.gradle upload || exit /b %ERRORLEVEL%
+if not defined PR_AUTHOR call .\gradlew.bat --info -b upload.gradle -Dbuild.snapshot=%BUILD_SNAPSHOT% upload || exit /b %ERRORLEVEL%
 
 endlocal
 


### PR DESCRIPTION
Jenkins will set BUILD_SNAPSHOT to true/false.  We must propagate
this to Gradle and Docker.

Backports #236.