### PR TITLE
[ML] Account for step discontinuities when reinitialising the residual model after a detecting a change or new decomposition components

### DIFF
--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -170,7 +170,7 @@ public:
     virtual bool mightAddComponents(core_t::TTime time) const;
 
     //! Get the values in a recent time window.
-    virtual TTimeDoublePrVec windowValues() const;
+    virtual TTimeFloatMeanAccumulatorPrVec windowValues() const;
 
     //! Roll time forwards by \p skipInterval.
     virtual void skipTime(core_t::TTime skipInterval);

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -187,8 +187,9 @@ public:
     //! diurnal and any other large amplitude seasonal components.
     class MATHS_EXPORT CPeriodicityTest : public CHandler {
     public:
-        using TTimeDoublePr = std::pair<core_t::TTime, double>;
-        using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
+        using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
+        using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
+        using TTimeFloatMeanAccumulatorPrVec = std::vector<TTimeFloatMeanAccumulatorPr>;
 
         //! Test types (categorised as short and long period tests).
         enum ETest { E_Short, E_Long };
@@ -227,7 +228,7 @@ public:
         void propagateForwards(core_t::TTime start, core_t::TTime end);
 
         //! Get the values in the window if we're going to test at \p time.
-        TTimeDoublePrVec windowValues() const;
+        TTimeFloatMeanAccumulatorPrVec windowValues() const;
 
         //! Get a checksum for this object.
         uint64_t checksum(uint64_t seed = 0) const;

--- a/include/maths/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/CTimeSeriesDecompositionInterface.h
@@ -11,6 +11,7 @@
 #include <core/CSmallVector.h>
 #include <core/CoreTypes.h>
 
+#include <maths/CBasicStatistics.h>
 #include <maths/ImportExport.h>
 #include <maths/MathsTypes.h>
 
@@ -33,8 +34,9 @@ struct SChangeDescription;
 //! calendar periodic and trend components.
 class MATHS_EXPORT CTimeSeriesDecompositionInterface {
 public:
-    using TTimeDoublePr = std::pair<core_t::TTime, double>;
-    using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
+    using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
+    using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
+    using TTimeFloatMeanAccumulatorPrVec = std::vector<TTimeFloatMeanAccumulatorPr>;
     using TDouble3Vec = core::CSmallVector<double, 3>;
     using TDouble3VecVec = std::vector<TDouble3Vec>;
     using TWeights = maths_t::CUnitWeights;
@@ -151,7 +153,7 @@ public:
     virtual bool mightAddComponents(core_t::TTime time) const = 0;
 
     //! Get the values in a recent time window.
-    virtual TTimeDoublePrVec windowValues() const = 0;
+    virtual TTimeFloatMeanAccumulatorPrVec windowValues() const = 0;
 
     //! Roll time forwards by \p skipInterval.
     virtual void skipTime(core_t::TTime skipInterval) = 0;

--- a/include/maths/CTimeSeriesDecompositionStub.h
+++ b/include/maths/CTimeSeriesDecompositionStub.h
@@ -80,7 +80,7 @@ public:
     virtual bool mightAddComponents(core_t::TTime time) const;
 
     //! Returns an empty vector.
-    virtual TTimeDoublePrVec windowValues() const;
+    virtual TTimeFloatMeanAccumulatorPrVec windowValues() const;
 
     //! No-op.
     virtual void skipTime(core_t::TTime skipInterval);

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -54,8 +54,9 @@ double weight(const CMultivariatePrior& prior,
 //! \brief A CModel implementation for modeling a univariate time series.
 class MATHS_EXPORT CUnivariateTimeSeriesModel : public CModel {
 public:
-    using TTimeDoublePr = std::pair<core_t::TTime, double>;
-    using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
+    using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
+    using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
+    using TTimeFloatMeanAccumulatorPrVec = std::vector<TTimeFloatMeanAccumulatorPr>;
     using TDoubleWeightsAry = maths_t::TDoubleWeightsAry;
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
     using TDecayRateController2Ary = boost::array<CDecayRateController, 2>;
@@ -199,6 +200,7 @@ public:
     //@}
 
 private:
+    using TTimeDoublePr = std::pair<core_t::TTime, double>;
     using TSizeVec = std::vector<std::size_t>;
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TDouble1VecVec = std::vector<TDouble1Vec>;
@@ -243,7 +245,7 @@ private:
 
     //! Reinitialize state after detecting a new component of the trend
     //! decomposition.
-    void reinitializeStateGivenNewComponent(const TTimeDoublePrVec& initialValues);
+    void reinitializeStateGivenNewComponent(const TTimeFloatMeanAccumulatorPrVec& initialValues);
 
     //! Compute the probability for uncorrelated series.
     bool uncorrelatedProbability(const CModelProbabilityParams& params,
@@ -522,8 +524,11 @@ class MATHS_EXPORT CMultivariateTimeSeriesModel : public CModel {
 public:
     using TDouble10Vec = core::CSmallVector<double, 10>;
     using TDouble10Vec1Vec = core::CSmallVector<TDouble10Vec, 1>;
-    using TTimeDouble10VecPr = std::pair<core_t::TTime, TDouble10Vec>;
-    using TTimeDouble10VecPrVec = std::vector<TTimeDouble10VecPr>;
+    using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
+    using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
+    using TTimeFloatMeanAccumulatorPrVec = std::vector<TTimeFloatMeanAccumulatorPr>;
+    using TTimeFloatMeanAccumulatorPrVec10Vec =
+        core::CSmallVector<TTimeFloatMeanAccumulatorPrVec, 10>;
     using TDouble10VecWeightsAry = maths_t::TDouble10VecWeightsAry;
     using TDouble10VecWeightsAry1Vec = core::CSmallVector<TDouble10VecWeightsAry, 1>;
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
@@ -697,7 +702,7 @@ private:
 
     //! Reinitialize state after detecting a new component of the trend
     //! decomposition.
-    void reinitializeStateGivenNewComponent(const TTimeDouble10VecPrVec& initialValues);
+    void reinitializeStateGivenNewComponent(const TTimeFloatMeanAccumulatorPrVec10Vec& initialValues);
 
     //! Get the model dimension.
     std::size_t dimension() const;

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -457,7 +457,8 @@ bool CTimeSeriesDecomposition::mightAddComponents(core_t::TTime time) const {
     return false;
 }
 
-CTimeSeriesDecomposition::TTimeDoublePrVec CTimeSeriesDecomposition::windowValues() const {
+CTimeSeriesDecomposition::TTimeFloatMeanAccumulatorPrVec
+CTimeSeriesDecomposition::windowValues() const {
     return m_PeriodicityTest.windowValues();
 }
 

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -649,20 +649,19 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::propagateForwards(core_t:
     stepwisePropagateForwards(WEEK, start, end, m_Windows[E_Long]);
 }
 
-CTimeSeriesDecompositionDetail::CPeriodicityTest::TTimeDoublePrVec
+CTimeSeriesDecompositionDetail::CPeriodicityTest::TTimeFloatMeanAccumulatorPrVec
 CTimeSeriesDecompositionDetail::CPeriodicityTest::windowValues() const {
-    TTimeDoublePrVec result;
+    TTimeFloatMeanAccumulatorPrVec result;
     for (auto i : {E_Short, E_Long}) {
         if (m_Windows[i] != nullptr) {
             TFloatMeanAccumulatorVec values{m_Windows[i]->values()};
             core_t::TTime bucketLength{m_Windows[i]->bucketLength()};
             core_t::TTime time{m_Windows[i]->startTime() + m_Windows[i]->offset()};
             for (const auto& value : values) {
-                if (CBasicStatistics::count(value) > 0.0) {
-                    result.emplace_back(time, CBasicStatistics::mean(value));
-                }
+                result.emplace_back(time, value);
                 time += bucketLength;
             }
+            break;
         }
     }
     return result;

--- a/lib/maths/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/CTimeSeriesDecompositionStub.cc
@@ -89,7 +89,7 @@ bool CTimeSeriesDecompositionStub::mightAddComponents(core_t::TTime /*time*/) co
     return false;
 }
 
-CTimeSeriesDecompositionStub::TTimeDoublePrVec
+CTimeSeriesDecompositionStub::TTimeFloatMeanAccumulatorPrVec
 CTimeSeriesDecompositionStub::windowValues() const {
     return {};
 }

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -25,6 +25,7 @@
 #include <maths/CTimeSeriesDecompositionStateSerialiser.h>
 #include <maths/CTimeSeriesMultibucketFeatureSerialiser.h>
 #include <maths/CTimeSeriesMultibucketFeatures.h>
+#include <maths/CTimeSeriesSegmentation.h>
 #include <maths/CTools.h>
 #include <maths/Constants.h>
 
@@ -43,27 +44,17 @@ namespace {
 using TSizeDoublePr = std::pair<std::size_t, double>;
 using TTimeDoublePr = std::pair<core_t::TTime, double>;
 using TSizeVec = std::vector<std::size_t>;
-using TDouble1Vec = core::CSmallVector<double, 1>;
-using TDouble2Vec = core::CSmallVector<double, 2>;
 using TDouble4Vec = core::CSmallVector<double, 4>;
 using TDouble10Vec = core::CSmallVector<double, 10>;
 using TDouble10Vec1Vec = core::CSmallVector<TDouble10Vec, 1>;
 using TDouble10Vec2Vec = core::CSmallVector<TDouble10Vec, 2>;
-using TSize1Vec = core::CSmallVector<std::size_t, 1>;
-using TSize2Vec = core::CSmallVector<std::size_t, 2>;
 using TSize10Vec = core::CSmallVector<std::size_t, 10>;
-using TSize2Vec1Vec = core::CSmallVector<TSize2Vec, 1>;
 using TTime1Vec = core::CSmallVector<core_t::TTime, 1>;
 using TDoubleDoublePr = std::pair<double, double>;
 using TSizeDoublePr10Vec = core::CSmallVector<TSizeDoublePr, 10>;
 using TCalculation2Vec = core::CSmallVector<maths_t::EProbabilityCalculation, 2>;
 using TTail10Vec = core::CSmallVector<maths_t::ETail, 10>;
-using TStr4Vec = core::CSmallVector<std::string, 4>;
-using TStrCRef = boost::reference_wrapper<const std::string>;
-using TStrCRef4Vec = core::CSmallVector<TStrCRef, 4>;
-using TOptionalSize = boost::optional<std::size_t>;
 using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
-using TChangeDetectorPtr = std::unique_ptr<CUnivariateTimeSeriesChangeDetector>;
 using TMultivariatePriorCPtrSizePr1Vec = CTimeSeriesCorrelations::TMultivariatePriorCPtrSizePr1Vec;
 
 //! The decay rate controllers we maintain.
@@ -308,7 +299,6 @@ public:
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
 private:
-    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMultivariateNormalConjugate = CMultivariateNormalConjugate<2>;
     using TMultivariateNormalConjugateVec = std::vector<TMultivariateNormalConjugate>;
 
@@ -653,7 +643,7 @@ void CUnivariateTimeSeriesModel::modelCorrelations(CTimeSeriesCorrelations& mode
     m_Correlations->addTimeSeries(m_Id, *this);
 }
 
-TSize2Vec1Vec CUnivariateTimeSeriesModel::correlates() const {
+CUnivariateTimeSeriesModel::TSize2Vec1Vec CUnivariateTimeSeriesModel::correlates() const {
     TSize2Vec1Vec result;
     TSize1Vec correlated;
     TSize2Vec1Vec variables;
@@ -1463,7 +1453,7 @@ CUnivariateTimeSeriesModel::applyChange(const SChangeDescription& change) {
 
     change.s_TrendModel->decayRate(m_TrendModel->decayRate());
     m_TrendModel = change.s_TrendModel;
-    TTimeDoublePrVec window(m_TrendModel->windowValues());
+    TTimeFloatMeanAccumulatorPrVec window(m_TrendModel->windowValues());
     if (m_TrendModel->applyChange(timeOfChangePoint, valueAtChangePoint, change)) {
         this->reinitializeStateGivenNewComponent(window);
     } else {
@@ -1500,7 +1490,7 @@ CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
     // Maybe get a window of historical values with which to reinitialize
     // the residual model if new components of the time series decomposition
     // are identified.
-    TTimeDoublePrVec window;
+    TTimeFloatMeanAccumulatorPrVec window;
     for (auto i : timeorder) {
         if (m_TrendModel->mightAddComponents(samples[i].first)) {
             window = m_TrendModel->windowValues();
@@ -1583,17 +1573,45 @@ void CUnivariateTimeSeriesModel::appendPredictionErrors(double interval,
     }
 }
 
-void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(const TTimeDoublePrVec& initialValues) {
+void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(
+    const TTimeFloatMeanAccumulatorPrVec& initialValues) {
+    using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
+
+    // Reinitialize the residual model with any values we've been given. We
+    // remove any trend we can fit accounting for step discontinuities and
+    // re-weight so that the total sample weight corresponds to the sample
+    // weight the model receives from a fixed (shortish) time interval.
+
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
+
     if (initialValues.size() > 0) {
-        double numberInitialValues{static_cast<double>(initialValues.size())};
-        maths_t::TDoubleWeightsAry1Vec weight{maths_t::countWeight(
-            10.0 * std::max(this->params().learnRate(), 1.0) / numberInitialValues)};
+        TFloatMeanAccumulatorVec samples;
+        samples.reserve(initialValues.size());
+        double totalWeight{0.0};
+
         for (const auto& value : initialValues) {
-            TDouble1Vec sample{m_TrendModel->detrend(value.first, value.second, 0.0)};
-            m_ResidualModel->addSamples(sample, weight);
+            CFloatStorage weight(CBasicStatistics::count(value.second));
+            if (weight > 0.0) {
+                samples.push_back(CBasicStatistics::accumulator(
+                    weight, CFloatStorage(m_TrendModel->detrend(
+                                value.first, CBasicStatistics::mean(value.second), 0.0))));
+                totalWeight += weight;
+            }
+        }
+
+        TSizeVec segmentation{CTimeSeriesSegmentation::piecewiseLinear(samples)};
+        samples = CTimeSeriesSegmentation::removePiecewiseLinear(std::move(samples), segmentation);
+
+        maths_t::TDoubleWeightsAry1Vec weight(1);
+        double weightScale{10.0 * std::max(this->params().learnRate(), 1.0) / totalWeight};
+        for (const auto& sample : samples) {
+            weight[0] = maths_t::countWeight(weightScale * CBasicStatistics::count(sample));
+            m_ResidualModel->addSamples({CBasicStatistics::mean(sample)}, weight);
         }
     }
+
+    // Note we can't reinitialize this from the initial values because we do
+    // not expect these to be at the bucket length granularity.
     if (m_MultibucketFeature != nullptr) {
         m_MultibucketFeature->clear();
     }
@@ -1601,6 +1619,7 @@ void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(const TTimeD
         m_MultibucketFeatureModel->setToNonInformative(
             0.0, m_MultibucketFeatureModel->decayRate());
     }
+
     if (m_Correlations != nullptr) {
         m_Correlations->clearCorrelationModels(m_Id);
     }
@@ -2018,7 +2037,7 @@ void CTimeSeriesCorrelations::addSamples(std::size_t id,
     m_Correlations.add(id, CBasicStatistics::median(data.s_Samples));
 }
 
-TSize1Vec CTimeSeriesCorrelations::correlated(std::size_t id) const {
+CTimeSeriesCorrelations::TSize1Vec CTimeSeriesCorrelations::correlated(std::size_t id) const {
     auto correlated = m_CorrelatedLookup.find(id);
     return correlated != m_CorrelatedLookup.end() ? correlated->second : TSize1Vec();
 }
@@ -2167,7 +2186,7 @@ void CMultivariateTimeSeriesModel::modelCorrelations(CTimeSeriesCorrelations& /*
     // no-op
 }
 
-TSize2Vec1Vec CMultivariateTimeSeriesModel::correlates() const {
+CMultivariateTimeSeriesModel::TSize2Vec1Vec CMultivariateTimeSeriesModel::correlates() const {
     return {};
 }
 
@@ -2782,7 +2801,7 @@ CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& sample
     // the residual model if new components of the time series decomposition
     // are identified.
     EUpdateResult result{E_Success};
-    TTimeDouble10VecPrVec window;
+    TTimeFloatMeanAccumulatorPrVec10Vec window;
     for (auto i : timeorder) {
         core_t::TTime time{samples[i].first};
         if (std::any_of(m_TrendModel.begin(), m_TrendModel.end(),
@@ -2790,13 +2809,7 @@ CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& sample
                             return model->mightAddComponents(time);
                         })) {
             for (std::size_t d = 0; d < dimension; ++d) {
-                auto trendWindow = m_TrendModel[d]->windowValues();
-                window.resize(std::max(window.size(), trendWindow.size()),
-                              TTimeDouble10VecPr{0, TDouble10Vec(dimension)});
-                for (std::size_t j = 0; j < window.size(); ++j) {
-                    window[j].first = trendWindow[j].first;
-                    window[j].second[d] = trendWindow[j].second;
-                }
+                window.push_back(m_TrendModel[d]->windowValues());
             }
             break;
         }
@@ -2875,21 +2888,57 @@ void CMultivariateTimeSeriesModel::appendPredictionErrors(double interval,
     }
 }
 
-void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(const TTimeDouble10VecPrVec& initialValues) {
+void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(
+    const TTimeFloatMeanAccumulatorPrVec10Vec& initialValues) {
+    using TDouble10VecVec = std::vector<TDouble10Vec>;
+    using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
+
+    // Reinitialize the residual model with any values we've been given. We
+    // remove any trend we can fit accounting for step discontinuities and
+    // re-weight so that the total sample weight corresponds to the sample
+    // weight the model receives from a fixed (shortish) time interval.
+
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
+
     if (initialValues.size() > 0) {
         std::size_t dimension{this->dimension()};
-        double numberInitialValues{static_cast<double>(initialValues.size())};
-        maths_t::TDouble10VecWeightsAry1Vec weight{maths_t::countWeight(
-            10.0 * std::max(this->params().learnRate(), 1.0) / numberInitialValues, dimension)};
-        for (const auto& value : initialValues) {
-            TDouble10Vec1Vec sample{TDouble10Vec(dimension)};
-            for (std::size_t i = 0u; i < dimension; ++i) {
-                sample[0][i] = m_TrendModel[i]->detrend(value.first, value.second[i], 0.0);
+
+        TDouble10VecVec samples;
+
+        for (std::size_t d = 0; d < dimension; ++d) {
+            TFloatMeanAccumulatorVec dimensionSamples;
+            dimensionSamples.reserve(initialValues[d].size());
+
+            for (const auto& value : initialValues[d]) {
+                CFloatStorage weight(CBasicStatistics::count(value.second));
+                if (weight > 0.0) {
+                    dimensionSamples.push_back(CBasicStatistics::accumulator(
+                        weight, CFloatStorage(m_TrendModel[d]->detrend(
+                                    value.first, CBasicStatistics::mean(value.second), 0.0))));
+                }
             }
-            m_ResidualModel->addSamples(sample, weight);
+
+            TSizeVec segmentation{CTimeSeriesSegmentation::piecewiseLinear(dimensionSamples)};
+            dimensionSamples = CTimeSeriesSegmentation::removePiecewiseLinear(
+                std::move(dimensionSamples), segmentation);
+
+            samples.resize(dimensionSamples.size(), TDouble10Vec(dimension));
+            for (std::size_t i = 0; i < dimensionSamples.size(); ++i) {
+                samples[i][d] = CBasicStatistics::mean(dimensionSamples[i]);
+            }
+        }
+
+        maths_t::TDouble10VecWeightsAry1Vec weight{
+            maths_t::countWeight(10.0 * std::max(this->params().learnRate(), 1.0) /
+                                     static_cast<double>(samples.size()),
+                                 dimension)};
+        for (const auto& sample : samples) {
+            m_ResidualModel->addSamples({sample}, weight);
         }
     }
+
+    // Note we can't reinitialize this from the initial values because we do
+    // not expect these to be at the bucket length granularity.
     if (m_MultibucketFeature != nullptr) {
         m_MultibucketFeature->clear();
     }
@@ -2897,6 +2946,7 @@ void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(const TTim
         m_MultibucketFeatureModel->setToNonInformative(
             0.0, m_MultibucketFeatureModel->decayRate());
     }
+
     if (m_Controllers != nullptr) {
         m_ResidualModel->decayRate(m_ResidualModel->decayRate() /
                                    (*m_Controllers)[E_ResidualControl].multiplier());


### PR DESCRIPTION
This further improves the reinitialisation of the time series residual model after detecting either a change or news component of the decomposition for some edge cases. In particular, as a result of this change we remove any piecewise linear trend and better account for variable weights of the window values.

I've marked this as a non-issue since it is fall out from the change to use the decomposition window to reinitialise the residual model, i.e. #218.