### PR TITLE
[ML] Backport skip model update in anomaly model (#222)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -161,6 +161,10 @@ crash. {ml-pull}140[#140] (issue: {ml-issue}136[#136])
 * Fix typical values, forecast confidence intervals and model plot bounds for models with multiple modes
 
 
+Rules that trigger the `skip_model_update` action should also apply to the anomaly model.
+This fixes an issue where anomaly scores of results that triggered the rule would decrease
+if they occurred frequently. (See {ml-pull}222[#222].)
+
 //=== Regressions
 
 //=== Known Issues

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -205,6 +205,11 @@ public:
     //! Get whether or not to update the anomaly model.
     bool updateAnomalyModel() const;
 
+    //! Set whether or not to skip updating the anomaly model.
+    CModelProbabilityParams& skipAnomalyModelUpdate(bool skipAnomalyModelUpdate);
+    //! Get whether or not to skip updating the anomaly model.
+    bool skipAnomalyModelUpdate() const;
+
 private:
     //! The entity tag (if relevant otherwise 0).
     std::size_t m_Tag;
@@ -222,6 +227,9 @@ private:
     TOptionalSize m_MostAnomalousCorrelate;
     //! Whether or not to update the anomaly model.
     bool m_UpdateAnomalyModel;
+    //! Whether or not to skip updating the anomaly model
+    //! because a rule triggered.
+    bool m_SkipAnomalyModelUpdate = false;
 };
 
 //! \brief The model interface.

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -267,6 +267,17 @@ bool CModelProbabilityParams::updateAnomalyModel() const {
     return m_UpdateAnomalyModel;
 }
 
+CModelProbabilityParams& CModelProbabilityParams::skipAnomalyModelUpdate(bool skipAnomalyModelUpdate) {
+    m_SkipAnomalyModelUpdate = skipAnomalyModelUpdate;
+    return *this;
+}
+
+bool CModelProbabilityParams::skipAnomalyModelUpdate() const {
+    return m_SkipAnomalyModelUpdate;
+}
+
+//////// CModel ////////
+
 CModel::EUpdateResult CModel::combine(EUpdateResult lhs, EUpdateResult rhs) {
     switch (lhs) {
     case E_Success:

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -394,11 +394,19 @@ private:
 
 private:
     //! Update the appropriate anomaly model with \p anomaly.
-    void sample(core_t::TTime time, const CAnomaly& anomaly, double weight) {
-        std::size_t index(anomaly.positive() ? 0 : 1);
-        TDouble10Vec1Vec features{anomaly.features(this->scale(time))};
-        m_AnomalyFeatureModels[index].addSamples(features,
-                                                 {maths_t::countWeight(weight, 2)});
+    void sample(const CModelProbabilityParams& params,
+                core_t::TTime time,
+                const CAnomaly& anomaly,
+                double weight) {
+        if (params.skipAnomalyModelUpdate() == false) {
+            LOG_DEBUG(<< "Executing anomaly update");
+            std::size_t index(anomaly.positive() ? 0 : 1);
+            TDouble10Vec1Vec features{anomaly.features(this->scale(time))};
+            m_AnomalyFeatureModels[index].addSamples(
+                features, {maths_t::countWeight(weight, 2)});
+        } else {
+            LOG_DEBUG(<< "Skipping anomaly update");
+        }
     }
 
     //! Get the scaled time.
@@ -461,7 +469,7 @@ void CTimeSeriesAnomalyModel::updateAnomaly(const CModelProbabilityParams& param
             }
             anomaly->update(norm, sign);
         } else if (anomaly != m_Anomalies.end()) {
-            this->sample(time, *anomaly, 1.0 - anomaly->weight(this->scale(time)));
+            this->sample(params, time, *anomaly, 1.0 - anomaly->weight(this->scale(time)));
             m_Anomalies.erase(anomaly);
         }
     }
@@ -475,7 +483,7 @@ void CTimeSeriesAnomalyModel::sampleAnomaly(const CModelProbabilityParams& param
             m_Anomalies.begin(), m_Anomalies.end(),
             [tag](const CAnomaly& anomaly_) { return anomaly_.tag() == tag; });
         if (anomaly != m_Anomalies.end()) {
-            this->sample(time, *anomaly, anomaly->weight(this->scale(time)));
+            this->sample(params, time, *anomaly, anomaly->weight(this->scale(time)));
         }
     }
 }
@@ -511,7 +519,7 @@ void CTimeSeriesAnomalyModel::probability(const CModelProbabilityParams& params,
             double pGivenAnomalous{(pl + pu) / 2.0};
             double pScore{CTools::anomalyScore(probability)};
             double pScoreGivenAnomalous{CTools::anomalyScore(pGivenAnomalous)};
-            LOG_TRACE(<< "features = " << features << " score(.) = " << pScore
+            LOG_DEBUG(<< "features = " << features << " score(.) = " << pScore
                       << " score(.|anomalous) = " << pScoreGivenAnomalous
                       << " p = " << probability);
             probability = std::min(
@@ -1126,8 +1134,11 @@ bool CUnivariateTimeSeriesModel::correlatedProbability(const CModelProbabilityPa
             (mostAnomalousSample - mostAnomalousCorrelationModel->nearestMarginalLikelihoodMean(
                                        mostAnomalousSample)) /
             std::max(std::sqrt(this->seasonalWeight(0.0, mostAnomalousTime)[0]), 1.0)};
+        LOG_DEBUG(<< "before update p = " << probability);
         m_AnomalyModel->updateAnomaly(params, mostAnomalousTime, residual, probability);
+        LOG_DEBUG(<< "before calc p = " << probability);
         m_AnomalyModel->probability(params, mostAnomalousTime, probability);
+        LOG_DEBUG(<< "after calc p = " << probability);
         m_AnomalyModel->sampleAnomaly(params, mostAnomalousTime);
     }
     return true;
@@ -2395,8 +2406,11 @@ bool CMultivariateTimeSeriesModel::probability(const CModelProbabilityParams& pa
         for (std::size_t i = 0u; i < dimension; ++i) {
             residual[i] = (sample[0][i] - nearest[i]) / std::max(std::sqrt(scale[i]), 1.0);
         }
+        LOG_DEBUG(<< "before update p = " << probability);
         m_AnomalyModel->updateAnomaly(params, time, residual, probability);
+        LOG_DEBUG(<< "before calc p = " << probability);
         m_AnomalyModel->probability(params, time, probability);
+        LOG_DEBUG(<< "after calc p = " << probability);
         m_AnomalyModel->sampleAnomaly(params, time);
     }
 

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2366,7 +2366,6 @@ void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
         TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(3)};
         core_t::TTime time{0};
         for (std::size_t bucket = 0; bucket < samples.size(); ++bucket) {
-            LOG_DEBUG(<< "Bucket = " << bucket);
             auto& sample = samples[bucket];
             auto currentComputeProbabilityParams = computeProbabilityParams(weights[0]);
             TTail2Vec tail;

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2296,6 +2296,112 @@ void CTimeSeriesModelTest::testDaylightSaving() {
     }
 }
 
+void CTimeSeriesModelTest::testSkipAnomalyModelUpdate() {
+    // We test that when parameters dictate to skip updating the anomaly model
+    // probabilities become smaller despite seeing many anomalies.
+
+    test::CRandomNumbers rng;
+
+    std::size_t length = 2000;
+    core_t::TTime bucketLength{600};
+
+    LOG_DEBUG(<< "Univariate");
+    {
+        TDoubleVec samples;
+        rng.generateNormalSamples(10.0, 2.0, length, samples);
+
+        maths::CTimeSeriesDecomposition trend{24.0 * DECAY_RATE, bucketLength};
+        maths::CUnivariateTimeSeriesModel model{modelParams(bucketLength), 1,
+                                                trend, univariateNormal()};
+
+        TDoubleVec probabilities;
+        TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
+        core_t::TTime time{0};
+        for (std::size_t bucket = 0; bucket < samples.size(); ++bucket) {
+            auto sample = samples[bucket];
+            auto currentComputeProbabilityParams = computeProbabilityParams(weights[0]);
+            TTail2Vec tail;
+            double probability;
+            bool conditional;
+            TSize1Vec mostAnomalousCorrelate;
+
+            // We create anomalies in 10 consecutive buckets
+            if (bucket >= 1700 && bucket < 1710) {
+                sample = 100.0;
+                currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {{sample}}, probability, tail, conditional,
+                                  mostAnomalousCorrelate);
+                probabilities.push_back(probability);
+            } else {
+                model.addSamples(addSampleParams(weights),
+                                 {core::make_triple(time, TDouble2Vec{sample}, TAG)});
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {{sample}}, probability, tail, conditional,
+                                  mostAnomalousCorrelate);
+            }
+
+            time += bucketLength;
+        }
+
+        LOG_DEBUG(<< "probabilities = " << core::CContainerPrinter::print(probabilities));
+
+        // Assert probs are decreasing
+        CPPUNIT_ASSERT(probabilities[0] < 0.00001);
+        CPPUNIT_ASSERT(std::is_sorted(probabilities.rbegin(), probabilities.rend()));
+    }
+
+    LOG_DEBUG(<< "Multivariate");
+    {
+        TDoubleVecVec samples;
+        rng.generateMultivariateNormalSamples(
+            {10.0, 10.0, 10.0},
+            {{4.0, 0.9, 0.5}, {0.9, 2.6, 0.1}, {0.5, 0.1, 3.0}}, length, samples);
+
+        maths::CTimeSeriesDecomposition trend{24.0 * DECAY_RATE, bucketLength};
+        maths::CMultivariateNormalConjugate<3> prior{multivariateNormal()};
+        maths::CMultivariateTimeSeriesModel model{modelParams(bucketLength), trend, prior};
+
+        TDoubleVec probabilities;
+        TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(3)};
+        core_t::TTime time{0};
+        for (std::size_t bucket = 0; bucket < samples.size(); ++bucket) {
+            LOG_DEBUG(<< "Bucket = " << bucket);
+            auto& sample = samples[bucket];
+            auto currentComputeProbabilityParams = computeProbabilityParams(weights[0]);
+            TTail2Vec tail;
+            double probability;
+            bool conditional;
+            TSize1Vec mostAnomalousCorrelate;
+
+            if (bucket >= 1700 && bucket < 1710) {
+                for (auto& coordinate : sample) {
+                    coordinate += 100.0;
+                }
+                currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {(sample)}, probability, tail, conditional,
+                                  mostAnomalousCorrelate);
+                probabilities.push_back(probability);
+            } else {
+                model.addSamples(addSampleParams(weights),
+                                 {core::make_triple(time, TDouble2Vec(sample), TAG)});
+                model.probability(currentComputeProbabilityParams, {{time}},
+                                  {(sample)}, probability, tail, conditional,
+                                  mostAnomalousCorrelate);
+            }
+
+            time += bucketLength;
+        }
+
+        LOG_DEBUG(<< "probabilities = " << core::CContainerPrinter::print(probabilities));
+
+        // Assert probs are decreasing
+        CPPUNIT_ASSERT(probabilities[0] < 0.00001);
+        CPPUNIT_ASSERT(std::is_sorted(probabilities.rbegin(), probabilities.rend()));
+    }
+}
+
 CppUnit::Test* CTimeSeriesModelTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CTimeSeriesModelTest");
 
@@ -2334,6 +2440,9 @@ CppUnit::Test* CTimeSeriesModelTest::suite() {
         "CTimeSeriesModelTest::testLinearScaling", &CTimeSeriesModelTest::testLinearScaling));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesModelTest>(
         "CTimeSeriesModelTest::testDaylightSaving", &CTimeSeriesModelTest::testDaylightSaving));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesModelTest>(
+        "CTimeSeriesModelTest::testSkipAnomalyModelUpdate",
+        &CTimeSeriesModelTest::testSkipAnomalyModelUpdate));
 
     return suiteOfTests;
 }

--- a/lib/maths/unittest/CTimeSeriesModelTest.h
+++ b/lib/maths/unittest/CTimeSeriesModelTest.h
@@ -27,6 +27,7 @@ public:
     void testStepChangeDiscontinuities();
     void testLinearScaling();
     void testDaylightSaving();
+    void testSkipAnomalyModelUpdate();
 
     static CppUnit::Test* suite();
 };

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -1010,6 +1010,7 @@ void CEventRatePopulationModel::fill(model_t::EFeature feature,
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time)));
     double value{model_t::offsetCountToZero(
         feature, static_cast<double>(CDataGatherer::extractData(*data).s_Count))};
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, cid, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -1028,7 +1029,8 @@ void CEventRatePopulationModel::fill(model_t::EFeature feature,
         .tag(pid) // new line
         .addCalculation(model_t::probabilityCalculation(feature))
         .addBucketEmpty({false})
-        .addWeights(weight);
+        .addWeights(weight)
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 }
 
 ////////// CEventRatePopulationModel::SBucketStats Implementation //////////

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -929,6 +929,7 @@ void CMetricPopulationModel::fill(model_t::EFeature feature,
     maths_t::setSeasonalVarianceScale(
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time), weights);
     maths_t::setCountVarianceScale(TDouble2Vec(dimension, bucket->varianceScale()), weights);
+    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, cid, time);
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -948,7 +949,8 @@ void CMetricPopulationModel::fill(model_t::EFeature feature,
         .tag(pid) // new line
         .addCalculation(model_t::probabilityCalculation(feature))
         .addBucketEmpty({false})
-        .addWeights(weights);
+        .addWeights(weights)
+        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 }
 
 ////////// CMetricPopulationModel::SBucketStats Implementation //////////


### PR DESCRIPTION
Skip model update was not being communicated
to the anomaly model resulting to the score/probability
of results triggering the skip-model-update rule
to reduce.

This commit skips updates to the anomaly model as well.

Closes #217