### PR TITLE
[ML] Add Boost Test to build environment

### DIFF
--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -16,7 +16,7 @@
 
 ACCOUNT=droberts195
 REPOSITORY=ml-linux-build
-VERSION=3
+VERSION=5
 
 set -e
 

--- a/dev-tools/docker/build_linux_test_image.sh
+++ b/dev-tools/docker/build_linux_test_image.sh
@@ -16,7 +16,7 @@
 
 ACCOUNT=droberts195
 REPOSITORY=ml-linux-test
-VERSION=2
+VERSION=4
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM droberts195/ml-linux-build:3
+FROM droberts195/ml-linux-build:5
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new unit test image is built
-FROM droberts195/ml-linux-test:2
+FROM droberts195/ml-linux-test:4
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -4,9 +4,9 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2012_r2-5.zip"
+$Archive="usr-x86_64-windows-2012_r2-7.zip"
 $Destination="C:\"
-if (!(Test-Path "$Destination\usr\local\lib\boost_system-vc141-mt-1_65_1.dll")) {
+if (!(Test-Path "$Destination\usr\local\lib\boost_unit_test_framework-vc141-mt-1_65_1.dll")) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore
     $ZipSource="https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/$Archive"
     $ZipDestination="$Env:TEMP\$Archive"


### PR DESCRIPTION
Relates #156

This is basically the other half of #157.  It does the things that
were done for the 6.x branch in #263 that weren't done in #157.

One extra point of confusion is that the macOS Docker image does
not need updating in this PR because it was already rebuilt by #225
using the updated instructions of #157.  So #225 added Boost Test
for macOS for the master branch.