### PR TITLE
[ML] Improvements to model robustness to outliers

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -55,6 +55,8 @@ Add a new label - multi_bucket_impact - to record level anomaly results.
 The value will be on a scale of -5 to +5 where -5 means the anomaly is purely single bucket
 and +5 means the anomaly is purely multi bucket. ({ml-pull}230[230])
 
+Improve our ability to detect change points in the presence of outliers. (See {ml-pull}265[265].)
+
 === Bug Fixes
 
 Fix cause of "Bad density value..." log errors whilst forecasting. ({ml-pull}207[207])

--- a/include/maths/CTimeSeriesChangeDetector.h
+++ b/include/maths/CTimeSeriesChangeDetector.h
@@ -49,7 +49,6 @@ struct MATHS_EXPORT SChangeDescription {
 
     SChangeDescription(EDescription decription,
                        double value,
-                       double magnitude,
                        const TDecompositionPtr& trendModel,
                        const TPriorPtr& residualModel);
 
@@ -61,9 +60,6 @@ struct MATHS_EXPORT SChangeDescription {
 
     //! The change value.
     TDouble2Vec s_Value;
-
-    //! The magnitude of the change.
-    TDouble2Vec s_Magnitude;
 
     //! The time series trend model to use after the change.
     TDecompositionPtr s_TrendModel;
@@ -247,7 +243,7 @@ protected:
     double expectedLogLikelihood() const;
 
     //! Update the log-likelihood with \p samples.
-    void updateLogLikelihood(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    void updateLogLikelihood(TDouble1Vec samples, const TDoubleWeightsAry1Vec& weights);
 
     //! Update the expected log-likelihoods.
     void updateExpectedLogLikelihood(const TDoubleWeightsAry1Vec& weights);
@@ -265,11 +261,17 @@ protected:
     const TPriorPtr& residualModelPtr() const;
 
 private:
+    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+
+private:
     //! The likelihood of the data under this model.
     double m_LogLikelihood;
 
     //! The expected log-likelihood of the data under this model.
     double m_ExpectedLogLikelihood;
+
+    //! The moments of the samples added so far.
+    TMeanVarAccumulator m_SampleMoments;
 
     //! A model decomposing the time series trend.
     TDecompositionPtr m_TrendModel;
@@ -421,7 +423,7 @@ private:
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 private:
-    //! The optimal shift.
+    //! The optimal scale.
     TMeanAccumulator m_Scale;
 
     //! The mean magnitude of the change.

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -198,7 +198,7 @@ public:
     virtual core_t::TTime lastValueTime() const;
 
 private:
-    using TMediatorPtr = std::shared_ptr<CMediator>;
+    using TMediatorPtr = std::unique_ptr<CMediator>;
 
 private:
     //! Set up the communication mediator.

--- a/lib/maths/CTimeSeriesChangeDetector.cc
+++ b/lib/maths/CTimeSeriesChangeDetector.cc
@@ -701,7 +701,7 @@ CUnivariateLinearScaleModel::TOptionalChangeDescription
 CUnivariateLinearScaleModel::change() const {
     TOptionalChangeDescription result;
     result.emplace(SChangeDescription::E_LinearScale,
-                   CTools::truncate(CBasicStatistics::mean(m_Scale), MINIMUM_SCALE, MAXIMUM_SCALE),
+                   CBasicStatistics::mean(m_Scale),
                    this->trendModelPtr(), this->residualModelPtr());
     return result;
 }

--- a/lib/maths/CTimeSeriesChangeDetector.cc
+++ b/lib/maths/CTimeSeriesChangeDetector.cc
@@ -57,6 +57,7 @@ const std::string RESIDUAL_MODEL_TAG{"n"};
 const std::string LOG_INVERSE_DECISION_FUNCTION_TREND_TAG{"p"};
 const std::string TREND_MODEL_TAG{"q"};
 const std::string MAGNITUDE_TAG{"r"};
+const std::string SAMPLE_MOMENTS_TAG{"s"};
 const std::size_t EXPECTED_LOG_LIKELIHOOD_NUMBER_INTERVALS{4u};
 const double EXPECTED_EVIDENCE_THRESHOLD_MULTIPLIER{0.9};
 const double MAGNITUDE_THRESHOLD_STANDARD_DEVIATIONS_MULTPILIER{4.0};
@@ -70,11 +71,9 @@ const double LOG_INV_MAXIMUM_DECISION_FUNCTION{-CTools::fastLog(MAXIMUM_DECISION
 
 SChangeDescription::SChangeDescription(EDescription description,
                                        double value,
-                                       double magnitude,
                                        const TDecompositionPtr& trendModel,
                                        const TPriorPtr& residualModel)
-    : s_Description{description}, s_Value{value}, s_Magnitude{magnitude},
-      s_TrendModel{trendModel}, s_ResidualModel{residualModel} {
+    : s_Description{description}, s_Value{value}, s_TrendModel{trendModel}, s_ResidualModel{residualModel} {
 }
 
 std::string SChangeDescription::print() const {
@@ -222,6 +221,7 @@ double CUnivariateTimeSeriesChangeDetector::decisionFunction(std::size_t& change
     double noChangeBic{m_ChangeModels[0]->bic()};
     TMinAccumulator candidates;
     for (auto i = m_ChangeModels.begin() + 1; i != m_ChangeModels.end(); ++i) {
+        LOG_TRACE(<< "  BIC(" << (*i)->change()->print() << ") = " << (*i)->bic());
         candidates.add({(*i)->bic(), i});
     }
     candidates.sort();
@@ -244,7 +244,7 @@ double CUnivariateTimeSeriesChangeDetector::decisionFunction(std::size_t& change
                    evidence / EXPECTED_EVIDENCE_THRESHOLD_MULTIPLIER / expectedEvidence,
                    normalizedTimeRange, normalizedMagnitude};
         df = 0.5 * MAXIMUM_DECISION_FUNCTION * CTools::logisticFunction(x[0], 0.05, 1.0) *
-             (x[1] < 0.0 ? 1.0 : CTools::logisticFunction(x[1], 0.2, 1.0)) *
+             (x[1] < 0.0 ? 1.0 : CTools::logisticFunction(x[1], 0.3, 1.0)) *
              CTools::logisticFunction(x[2], 0.2, 0.5) *
              CTools::logisticFunction(x[3], 0.1, 1.0);
         LOG_TRACE(<< "df(" << (*candidates[0].second)->change()->print()
@@ -258,7 +258,7 @@ double CUnivariateTimeSeriesChangeDetector::decisionFunction(std::size_t& change
                    normalizedTimeRange, normalizedMagnitude};
         df = MAXIMUM_DECISION_FUNCTION * CTools::logisticFunction(x[0], 0.05, 1.0) *
              CTools::logisticFunction(x[1], 0.1, 1.0) *
-             (x[2] < 0.0 ? 1.0 : CTools::logisticFunction(x[2], 0.2, 1.0)) *
+             (x[2] < 0.0 ? 1.0 : CTools::logisticFunction(x[2], 0.3, 1.0)) *
              CTools::logisticFunction(x[3], 0.2, 0.5) *
              CTools::logisticFunction(x[4], 0.1, 1.0);
         LOG_TRACE(<< "df(" << (*candidates[0].second)->change()->print()
@@ -272,7 +272,7 @@ double CUnivariateTimeSeriesChangeDetector::decisionFunction(std::size_t& change
 
 bool CUnivariateTimeSeriesChangeDetector::stopTesting() const {
     core_t::TTime range{m_TimeRange.range()};
-    return (range > m_MinimumTimeToDetect) &&
+    return (range > 3 * m_MinimumTimeToDetect / 4) &&
            (range > m_MaximumTimeToDetect || m_LogInvDecisionFunctionTrend.count() == 0.0 ||
             m_LogInvDecisionFunctionTrend.predict(1.0) > 2.0);
 }
@@ -341,6 +341,7 @@ bool CUnivariateChangeModel::acceptRestoreTraverser(const SModelRestoreParams& /
         const std::string name{traverser.name()};
         RESTORE_BUILT_IN(LOG_LIKELIHOOD_TAG, m_LogLikelihood);
         RESTORE_BUILT_IN(EXPECTED_LOG_LIKELIHOOD_TAG, m_ExpectedLogLikelihood);
+        RESTORE(SAMPLE_MOMENTS_TAG, m_SampleMoments.fromDelimited(traverser.value()))
         return true;
     } while (traverser.next());
     return true;
@@ -350,6 +351,7 @@ void CUnivariateChangeModel::acceptPersistInserter(core::CStatePersistInserter& 
     inserter.insertValue(LOG_LIKELIHOOD_TAG, m_LogLikelihood, core::CIEEE754::E_SinglePrecision);
     inserter.insertValue(EXPECTED_LOG_LIKELIHOOD_TAG, m_ExpectedLogLikelihood,
                          core::CIEEE754::E_SinglePrecision);
+    inserter.insertValue(SAMPLE_MOMENTS_TAG, m_SampleMoments.toDelimited());
 }
 
 void CUnivariateChangeModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
@@ -369,6 +371,7 @@ std::size_t CUnivariateChangeModel::memoryUsage() const {
 uint64_t CUnivariateChangeModel::checksum(uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_LogLikelihood);
     seed = CChecksum::calculate(seed, m_ExpectedLogLikelihood);
+    seed = CChecksum::calculate(seed, m_SampleMoments);
     seed = CChecksum::calculate(seed, m_TrendModel);
     return CChecksum::calculate(seed, m_ResidualModel);
 }
@@ -394,8 +397,17 @@ double CUnivariateChangeModel::expectedLogLikelihood() const {
     return m_ExpectedLogLikelihood;
 }
 
-void CUnivariateChangeModel::updateLogLikelihood(const TDouble1Vec& samples,
+void CUnivariateChangeModel::updateLogLikelihood(TDouble1Vec samples,
                                                  const TDoubleWeightsAry1Vec& weights) {
+    m_SampleMoments.add(samples);
+    double mean{CBasicStatistics::mean(m_SampleMoments)};
+    double sigma{std::sqrt(CBasicStatistics::variance(m_SampleMoments))};
+    if (sigma > 0.0) {
+        for (auto& sample : samples) {
+            sample = CTools::truncate(sample, mean - 3.0 * sigma, mean + 3.0 * sigma);
+        }
+    }
+
     double logLikelihood{};
     if (m_ResidualModel->jointLogMarginalLikelihood(samples, weights, logLikelihood) ==
         maths_t::E_FpNoErrors) {
@@ -473,7 +485,7 @@ double CUnivariateNoChangeModel::normalizedMagnitude() const {
 }
 
 TOptionalChangeDescription CUnivariateNoChangeModel::change() const {
-    return TOptionalChangeDescription();
+    return {};
 }
 
 void CUnivariateNoChangeModel::addSamples(const std::size_t count,
@@ -494,7 +506,7 @@ void CUnivariateNoChangeModel::addSamples(const std::size_t count,
         for (auto& weight : weights) {
             maths_t::setWinsorisationWeight(1.0, weight);
         }
-        this->updateLogLikelihood(samples, weights);
+        this->updateLogLikelihood(std::move(samples), weights);
     }
 }
 
@@ -564,10 +576,10 @@ double CUnivariateLevelShiftModel::normalizedMagnitude() const {
 }
 
 TOptionalChangeDescription CUnivariateLevelShiftModel::change() const {
-    return SChangeDescription{SChangeDescription::E_LevelShift,
-                              CBasicStatistics::mean(m_Shift),
-                              std::fabs(CBasicStatistics::mean(m_Shift)),
-                              this->trendModelPtr(), this->residualModelPtr()};
+    TOptionalChangeDescription result;
+    result.emplace(SChangeDescription::E_LevelShift, CBasicStatistics::mean(m_Shift),
+                   this->trendModelPtr(), this->residualModelPtr());
+    return result;
 }
 
 void CUnivariateLevelShiftModel::addSamples(const std::size_t count,
@@ -605,7 +617,7 @@ void CUnivariateLevelShiftModel::addSamples(const std::size_t count,
         for (auto& weight : weights) {
             maths_t::setWinsorisationWeight(1.0, weight);
         }
-        this->updateLogLikelihood(samples, weights);
+        this->updateLogLikelihood(std::move(samples), weights);
         this->updateExpectedLogLikelihood(weights);
     }
 
@@ -687,10 +699,11 @@ double CUnivariateLinearScaleModel::normalizedMagnitude() const {
 
 CUnivariateLinearScaleModel::TOptionalChangeDescription
 CUnivariateLinearScaleModel::change() const {
-    return SChangeDescription{SChangeDescription::E_LinearScale,
-                              CBasicStatistics::mean(m_Scale),
-                              CBasicStatistics::mean(m_Magnitude),
-                              this->trendModelPtr(), this->residualModelPtr()};
+    TOptionalChangeDescription result;
+    result.emplace(SChangeDescription::E_LinearScale,
+                   CTools::truncate(CBasicStatistics::mean(m_Scale), MINIMUM_SCALE, MAXIMUM_SCALE),
+                   this->trendModelPtr(), this->residualModelPtr());
+    return result;
 }
 
 void CUnivariateLinearScaleModel::addSamples(const std::size_t count,
@@ -742,7 +755,7 @@ void CUnivariateLinearScaleModel::addSamples(const std::size_t count,
         for (auto& weight : weights) {
             maths_t::setWinsorisationWeight(1.0, weight);
         }
-        this->updateLogLikelihood(samples, weights);
+        this->updateLogLikelihood(std::move(samples), weights);
         this->updateExpectedLogLikelihood(weights);
     }
 }
@@ -807,9 +820,10 @@ double CUnivariateTimeShiftModel::normalizedMagnitude() const {
 }
 
 TOptionalChangeDescription CUnivariateTimeShiftModel::change() const {
-    return SChangeDescription{SChangeDescription::E_TimeShift,
-                              static_cast<double>(m_Shift), 0.0,
-                              this->trendModelPtr(), this->residualModelPtr()};
+    TOptionalChangeDescription result;
+    result.emplace(SChangeDescription::E_TimeShift, static_cast<double>(m_Shift),
+                   this->trendModelPtr(), this->residualModelPtr());
+    return result;
 }
 
 void CUnivariateTimeShiftModel::addSamples(const std::size_t count,
@@ -836,7 +850,7 @@ void CUnivariateTimeShiftModel::addSamples(const std::size_t count,
         for (auto& weight : weights) {
             maths_t::setWinsorisationWeight(1.0, weight);
         }
-        this->updateLogLikelihood(samples, weights);
+        this->updateLogLikelihood(std::move(samples), weights);
         this->updateExpectedLogLikelihood(weights);
     }
 }

--- a/lib/maths/CTimeSeriesChangeDetector.cc
+++ b/lib/maths/CTimeSeriesChangeDetector.cc
@@ -700,8 +700,7 @@ double CUnivariateLinearScaleModel::normalizedMagnitude() const {
 CUnivariateLinearScaleModel::TOptionalChangeDescription
 CUnivariateLinearScaleModel::change() const {
     TOptionalChangeDescription result;
-    result.emplace(SChangeDescription::E_LinearScale,
-                   CBasicStatistics::mean(m_Scale),
+    result.emplace(SChangeDescription::E_LinearScale, CBasicStatistics::mean(m_Scale),
                    this->trendModelPtr(), this->residualModelPtr());
     return result;
 }

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -15,21 +15,18 @@
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBasicStatisticsPersist.h>
-#include <maths/CCalendarComponent.h>
 #include <maths/CChecksum.h>
-#include <maths/CExpandingWindow.h>
 #include <maths/CIntegerTools.h>
 #include <maths/CPrior.h>
 #include <maths/CRestoreParams.h>
 #include <maths/CSeasonalTime.h>
 #include <maths/CTimeSeriesChangeDetector.h>
-#include <maths/CTools.h>
 
 #include <boost/bind.hpp>
 #include <boost/container/flat_map.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/math/distributions/normal.hpp>
-#include <boost/numeric/conversion/bounds.hpp>
-#include <boost/random/normal_distribution.hpp>
+#include <boost/ref.hpp>
 
 #include <cmath>
 #include <string>
@@ -503,7 +500,7 @@ const maths_t::TSeasonalComponentVec& CTimeSeriesDecomposition::seasonalComponen
 }
 
 void CTimeSeriesDecomposition::initializeMediator() {
-    m_Mediator = std::make_shared<CMediator>();
+    m_Mediator = boost::make_unique<CMediator>();
     m_Mediator->registerHandler(m_PeriodicityTest);
     m_Mediator->registerHandler(m_CalendarCyclicTest);
     m_Mediator->registerHandler(m_Components);

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -2320,8 +2320,9 @@ void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::shiftOrigin(core_t:
 
 void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::linearScale(core_t::TTime time,
                                                                          double scale) {
-    for (auto& component : m_Components) {
-        component.linearScale(time, scale);
+    for (std::size_t i = 0; i < m_Components.size(); ++i) {
+        m_Components[i].linearScale(time, scale);
+        m_PredictionErrors[i].clear();
     }
 }
 

--- a/lib/maths/unittest/CTimeSeriesChangeDetectorTest.cc
+++ b/lib/maths/unittest/CTimeSeriesChangeDetectorTest.cc
@@ -162,12 +162,12 @@ void CTimeSeriesChangeDetectorTest::testTimeShift() {
                      [](TGenerator trend, core_t::TTime time) {
                          return trend(time - core::constants::HOUR);
                      },
-                     -static_cast<double>(core::constants::HOUR), 0.03, 23.0);
+                     -static_cast<double>(core::constants::HOUR), 0.04, 23.0);
     this->testChange(trends, maths::SChangeDescription::E_TimeShift,
                      [](TGenerator trend, core_t::TTime time) {
                          return trend(time + core::constants::HOUR);
                      },
-                     +static_cast<double>(core::constants::HOUR), 0.03, 23.0);
+                     +static_cast<double>(core::constants::HOUR), 0.04, 23.0);
 }
 
 void CTimeSeriesChangeDetectorTest::testPersist() {

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2109,7 +2109,7 @@ void CTimeSeriesModelTest::testStepChangeDiscontinuities() {
             time, 50.0, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
         LOG_DEBUG(<< "confidence interval = " << confidenceInterval);
         CPPUNIT_ASSERT(std::fabs(confidenceInterval[1][0] - 40.0) < 1.0);
-        CPPUNIT_ASSERT(confidenceInterval[2][0] - confidenceInterval[0][0] < 3.0);
+        CPPUNIT_ASSERT(confidenceInterval[2][0] - confidenceInterval[0][0] < 4.0);
     }
     LOG_DEBUG(<< "Univariate: Piecewise Constant");
     {

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -70,9 +70,9 @@ const double CAnomalyDetectorModelConfig::DEFAULT_CATEGORY_DELETE_FRACTION(0.8);
 const double CAnomalyDetectorModelConfig::DEFAULT_CUTOFF_TO_MODEL_EMPTY_BUCKETS(0.2);
 const std::size_t CAnomalyDetectorModelConfig::DEFAULT_COMPONENT_SIZE(36u);
 const core_t::TTime
-    CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_TIME_TO_DETECT_CHANGE(16 * core::constants::HOUR);
+    CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_TIME_TO_DETECT_CHANGE(core::constants::DAY);
 const core_t::TTime
-    CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE(core::constants::DAY);
+    CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE(2 * core::constants::DAY);
 const std::size_t CAnomalyDetectorModelConfig::MULTIBUCKET_FEATURES_WINDOW_LENGTH(12);
 const double CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE(5.0);
 const double CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_UPDATES_PER_BUCKET(1.0);


### PR DESCRIPTION
This makes changes driven by latest round reviewing 6.5 results against our QA suite. It primarily targets model robustness to outliers.

In particular, it
1. Mitigates the impact of outliers on change point detection,
2. Delays detecting changes for slightly longer (to reduce false positives detecting time shifts),
3. Increases the sample p-value at we apply minimum weight for model update.