### PR TITLE
[ML] Do isnan check when computing significance

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -66,6 +66,8 @@ fields and the bucket is empty. ({pull}219[#219])
 
 Fix cause of hard_limit memory error for jobs with bucket span greater than one day. ({ml-pull}243[243])
 
+Fix cause of "Failed to compute significance..." log errors ({ml-pull}272[272])"
+
 //=== Regressions
 
 == {es} version 6.4.3

--- a/lib/maths/CStatisticalTests.cc
+++ b/lib/maths/CStatisticalTests.cc
@@ -74,6 +74,9 @@ double CStatisticalTests::leftTailFTest(double x, double d1, double d2) {
     if (std::isinf(x)) {
         return 1.0;
     }
+    if (std::isnan(x)) {
+        return 0.0;
+    }
     try {
         boost::math::fisher_f_distribution<> F(d1, d2);
         return boost::math::cdf(F, x);
@@ -89,6 +92,9 @@ double CStatisticalTests::rightTailFTest(double x, double d1, double d2) {
         return 1.0;
     }
     if (std::isinf(x)) {
+        return 0.0;
+    }
+    if (std::isnan(x)) {
         return 0.0;
     }
     try {

--- a/lib/maths/CStatisticalTests.cc
+++ b/lib/maths/CStatisticalTests.cc
@@ -95,7 +95,7 @@ double CStatisticalTests::rightTailFTest(double x, double d1, double d2) {
         return 0.0;
     }
     if (std::isnan(x)) {
-        return 0.0;
+        return 1.0;
     }
     try {
         boost::math::fisher_f_distribution<> F(d1, d2);

--- a/lib/maths/CStatisticalTests.cc
+++ b/lib/maths/CStatisticalTests.cc
@@ -75,7 +75,7 @@ double CStatisticalTests::leftTailFTest(double x, double d1, double d2) {
         return 1.0;
     }
     if (std::isnan(x)) {
-        return 0.0;
+        return 1.0;
     }
     try {
         boost::math::fisher_f_distribution<> F(d1, d2);


### PR DESCRIPTION
A quick-fix for #271 - Perform a check for `isnan` before attempting to compute significance.
A more in-depth analysis of the cause of #271 is required in due course 