### PR TITLE
[6.6][ML] Fix underlying cause of "Failed to compute significance Error in function boost::math::cdf(fisher_f_distribution..." log error

### DIFF
--- a/lib/maths/CStatisticalTests.cc
+++ b/lib/maths/CStatisticalTests.cc
@@ -75,6 +75,7 @@ double CStatisticalTests::leftTailFTest(double x, double d1, double d2) {
         return 1.0;
     }
     if (std::isnan(x)) {
+        LOG_ERROR(<< "Test statistic is nan");
         return 1.0;
     }
     try {
@@ -95,6 +96,7 @@ double CStatisticalTests::rightTailFTest(double x, double d1, double d2) {
         return 0.0;
     }
     if (std::isnan(x)) {
+        LOG_ERROR(<< "Test statistic is nan");
         return 1.0;
     }
     try {

--- a/lib/maths/CTimeSeriesSegmentation.cc
+++ b/lib/maths/CTimeSeriesSegmentation.cc
@@ -183,7 +183,9 @@ centredResidualMoments(ITR begin, ITR end, std::size_t offset, const TDoubleVec&
             norm2.add(p * p, w);
         }
     }
-    double scale{CBasicStatistics::mean(projection) / CBasicStatistics::mean(norm2)};
+    double scale{CBasicStatistics::mean(projection) == CBasicStatistics::mean(norm2)
+                     ? 1.0
+                     : CBasicStatistics::mean(projection) / CBasicStatistics::mean(norm2)};
     LOG_TRACE(<< "  scale = " << scale);
 
     TMeanVarAccumulator moments;
@@ -452,8 +454,8 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
             centredResidualMoments(values.cbegin(), split, startTime, dt)};
         TMeanVarAccumulator rightMoments{
             centredResidualMoments(split, values.cend(), splitTime, dt)};
-        TMeanAccumulator mean;
-        mean.add(values);
+        TMeanAccumulator mean{
+            std::accumulate(values.begin(), values.end(), TMeanAccumulator{})};
         LOG_TRACE(<< "  total moments = " << moments << ", left moments = " << leftMoments
                   << ", right moments = " << rightMoments << ", mean = " << mean);
         double f{CBasicStatistics::variance(moments) /
@@ -596,10 +598,12 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinearScaledPeriodic(ITR begin,
         TMeanVarAccumulator leftMoments{centredResidualMoments(begin, split, offset, model)};
         TMeanVarAccumulator rightMoments{
             centredResidualMoments(split, end, splitOffset, model)};
+        TMeanAccumulator mean{std::accumulate(begin, end, TMeanAccumulator{})};
         LOG_TRACE(<< "  total moments = " << moments << ", left moments = " << leftMoments
                   << ", right moments = " << rightMoments);
         double f{CBasicStatistics::variance(moments) /
-                 CBasicStatistics::variance(leftMoments + rightMoments)};
+                 (CBasicStatistics::variance(leftMoments + rightMoments) +
+                  MINIMUM_COEFFICIENT_OF_VARIATION * std::fabs(CBasicStatistics::mean(mean)))};
         double significance{CStatisticalTests::rightTailFTest(
             f, static_cast<double>(range - 1), static_cast<double>(range - 3))};
         LOG_TRACE(<< "  significance = " << significance);


### PR DESCRIPTION
Backport #280.
