### PR TITLE
[ML] Prevent trend detection during a change in a time series creating a poorly reinitialised model

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -68,6 +68,10 @@ Fix cause of hard_limit memory error for jobs with bucket span greater than one 
 
 Fix cause of "Failed to compute significance..." log errors ({ml-pull}272[272])"
 
+Prevent detecting a trend component during a possible change in the time series. The resulting
+model was poorly reinitialised in this case which damaged anomaly detection for some time. (See
+{ml-pull}287[#287].)
+
 //=== Regressions
 
 == {es} version 6.4.3

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -94,6 +94,9 @@ public:
     //! Check if the decomposition has any initialized components.
     virtual bool initialized() const;
 
+    //! Set whether or not we're testing for a change.
+    virtual void testingForChange(bool value);
+
     //! Adds a time series point \f$(t, f(t))\f$.
     //!
     //! \param[in] time The time of the function point.

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -370,6 +370,9 @@ public:
         //! Create a new calendar component.
         virtual void handle(const SDetectedCalendar& message);
 
+        //! Set whether or not we're testing for a change.
+        void testingForChange(bool value);
+
         //! Start observing for new components.
         void observeComponentsAdded();
 
@@ -836,6 +839,9 @@ public:
 
         //! The moments of the error in the predictions including the trend.
         TMeanVarAccumulator m_PredictionErrorWithTrend;
+
+        //! Set to true when testing for a change.
+        bool m_TestingForChange = false;
 
         //! Set to true if the trend model should be used for prediction.
         bool m_UsingTrendForPrediction = false;

--- a/include/maths/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/CTimeSeriesDecompositionInterface.h
@@ -73,6 +73,9 @@ public:
     //! Check if this is initialized.
     virtual bool initialized() const = 0;
 
+    //! Set whether or not we're testing for a change.
+    virtual void testingForChange(bool value) = 0;
+
     //! Adds a time series point \f$(t, f(t))\f$.
     //!
     //! \param[in] time The time of the function point.

--- a/include/maths/CTimeSeriesDecompositionStub.h
+++ b/include/maths/CTimeSeriesDecompositionStub.h
@@ -37,6 +37,9 @@ public:
     //! Returns false.
     virtual bool initialized() const;
 
+    //! No-op.
+    virtual void testingForChange(bool value);
+
     //! No-op returning false.
     virtual bool addPoint(core_t::TTime time,
                           double value,

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -211,6 +211,10 @@ bool CTimeSeriesDecomposition::initialized() const {
     return m_Components.initialized();
 }
 
+void CTimeSeriesDecomposition::testingForChange(bool value) {
+    m_Components.testingForChange(value);
+}
+
 bool CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                                         double value,
                                         const maths_t::TDoubleWeightsAry& weights) {

--- a/lib/maths/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/CTimeSeriesDecompositionStub.cc
@@ -33,6 +33,9 @@ bool CTimeSeriesDecompositionStub::initialized() const {
     return false;
 }
 
+void CTimeSeriesDecompositionStub::testingForChange(bool /*value*/) {
+}
+
 bool CTimeSeriesDecompositionStub::addPoint(core_t::TTime /*time*/,
                                             double /*value*/,
                                             const maths_t::TDoubleWeightsAry& /*weights*/) {


### PR DESCRIPTION
Our QA suite showed up an issue where detecting a trend interferes with detecting a change. The resulting model is poorly reinitialised in this case which damages anomaly detection for some time.

This PR prevents us adding a trend component whilst change detection is occurring. If no change is subsequently detected we'll add a trend component as soon as change detection is abandoned, so this simply marginally delays when we first detect a trend.

Since this is covered by a regression test I haven't duplicated as a unit test.