### PR TITLE
[ML] Switch Docker registry to docker.elastic.co

### DIFF
--- a/dev-tools/docker/build_check_style_image.sh
+++ b/dev-tools/docker/build_check_style_image.sh
@@ -12,7 +12,8 @@
 # clang-format version, increment the image version, change the Dockerfile and
 # build a new image to be used for subsequent builds on this branch.
 
-ACCOUNT=droberts195
+HOST=push.docker.elastic.co
+ACCOUNT=ml-dev
 REPOSITORY=ml-check-style
 VERSION=1
 
@@ -20,7 +21,10 @@ set -e
 
 cd `dirname $0`
 
-docker build --no-cache -t $ACCOUNT/$REPOSITORY:$VERSION check_style_image
-docker login
-docker push $ACCOUNT/$REPOSITORY:$VERSION
+docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION check_style_image
+# Get a username and password for this by visiting
+# https://docker.elastic.co:7000 and allowing it to authenticate against your
+# GitHub account
+docker login $HOST
+docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
 

--- a/dev-tools/docker/build_linux-musl_build_image.sh
+++ b/dev-tools/docker/build_linux-musl_build_image.sh
@@ -14,7 +14,8 @@
 # used for subsequent builds on this branch.  Then update the version to be
 # used for builds in docker/linux_builder/Dockerfile.
 
-ACCOUNT=droberts195
+HOST=push.docker.elastic.co
+ACCOUNT=ml-dev
 REPOSITORY=ml-linux-musl-build
 VERSION=2
 
@@ -22,7 +23,10 @@ set -e
 
 cd `dirname $0`
 
-docker build --no-cache -t $ACCOUNT/$REPOSITORY:$VERSION linux-musl_image
-docker login
-docker push $ACCOUNT/$REPOSITORY:$VERSION
+docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION linux-musl_image
+# Get a username and password for this by visiting
+# https://docker.elastic.co:7000 and allowing it to authenticate against your
+# GitHub account
+docker login $HOST
+docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
 

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -14,7 +14,8 @@
 # used for subsequent builds on this branch.  Then update the version to be
 # used for builds in docker/linux_builder/Dockerfile.
 
-ACCOUNT=droberts195
+HOST=push.docker.elastic.co
+ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
 VERSION=5
 
@@ -22,7 +23,10 @@ set -e
 
 cd `dirname $0`
 
-docker build --no-cache -t $ACCOUNT/$REPOSITORY:$VERSION linux_image
-docker login
-docker push $ACCOUNT/$REPOSITORY:$VERSION
+docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION linux_image
+# Get a username and password for this by visiting
+# https://docker.elastic.co:7000 and allowing it to authenticate against your
+# GitHub account
+docker login $HOST
+docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
 

--- a/dev-tools/docker/build_linux_test_image.sh
+++ b/dev-tools/docker/build_linux_test_image.sh
@@ -14,7 +14,8 @@
 # used for subsequent builds on this branch.  Then update the version to be
 # used for builds in docker/linux_builder/Dockerfile.
 
-ACCOUNT=droberts195
+HOST=push.docker.elastic.co
+ACCOUNT=ml-dev
 REPOSITORY=ml-linux-test
 VERSION=4
 
@@ -22,7 +23,10 @@ set -e
 
 cd `dirname $0`
 
-docker build --no-cache -t $ACCOUNT/$REPOSITORY:$VERSION linux_test_image
-docker login
-docker push $ACCOUNT/$REPOSITORY:$VERSION
+docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION linux_test_image
+# Get a username and password for this by visiting
+# https://docker.elastic.co:7000 and allowing it to authenticate against your
+# GitHub account
+docker login $HOST
+docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
 

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -14,7 +14,8 @@
 # used for subsequent builds on this branch.  Then update the version to be
 # used for builds in docker/macosx_builder/Dockerfile.
 
-ACCOUNT=droberts195
+HOST=push.docker.elastic.co
+ACCOUNT=ml-dev
 REPOSITORY=ml-macosx-build
 VERSION=5
 
@@ -22,7 +23,10 @@ set -e
 
 cd `dirname $0`
 
-docker build --no-cache -t $ACCOUNT/$REPOSITORY:$VERSION macosx_image
-docker login
-docker push $ACCOUNT/$REPOSITORY:$VERSION
+docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION macosx_image
+# Get a username and password for this by visiting
+# https://docker.elastic.co:7000 and allowing it to authenticate against your
+# GitHub account
+docker login $HOST
+docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
 

--- a/dev-tools/docker/linux-musl_builder/Dockerfile
+++ b/dev-tools/docker/linux-musl_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM droberts195/ml-linux-musl-build:2
+FROM docker.elastic.co/ml-dev/ml-linux-musl-build:2
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM droberts195/ml-linux-build:5
+FROM docker.elastic.co/ml-dev/ml-linux-build:5
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_test_image/Dockerfile
+++ b/dev-tools/docker/linux_test_image/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM droberts195/ml-linux-build:3
+FROM docker.elastic.co/ml-dev/ml-linux-build:3
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new unit test image is built
-FROM droberts195/ml-linux-test:4
+FROM docker.elastic.co/ml-dev/ml-linux-test:4
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM droberts195/ml-macosx-build:5
+FROM docker.elastic.co/ml-dev/ml-macosx-build:5
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/style_checker/Dockerfile
+++ b/dev-tools/docker/style_checker/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new check style image is built
-FROM droberts195/ml-check-style:1
+FROM docker.elastic.co/ml-dev/ml-check-style:1
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 


### PR DESCRIPTION
Previously the Docker images were hosted on Docker Hub,
i.e. registry-1.docker.io.  This change moves them to
Elastic's Docker registry at docker.elastic.co.

(I did not actually rebuild all the images using the
updated scripts.  I merely re-tagged the already-built
images and pushed them to the new registry.  But it's
good to update the image build scripts so that the next
change pushes directly to the correct registry.)