### PR TITLE
[ML] Fix cause of multimodal prior error

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -68,6 +68,8 @@ Fix cause of hard_limit memory error for jobs with bucket span greater than one 
 
 Fix cause of "Failed to compute significance..." log errors ({ml-pull}272[272])"
 
+Fix cause of "MERGE: Sum mode samples = 0, total samples = 4.43521.." log errors ({ml-pull}294[294]) 
+
 //=== Regressions
 
 == {es} version 6.4.3

--- a/lib/maths/CGammaRateConjugate.cc
+++ b/lib/maths/CGammaRateConjugate.cc
@@ -1431,7 +1431,10 @@ void CGammaRateConjugate::print(const std::string& indent, std::string& result) 
 
     result += core_t::LINE_ENDING + indent + "gamma ";
     if (this->isNonInformative()) {
-        result += "non-informative";
+        result +=
+            "non-informative: # sample moments = " +
+            core::CStringUtils::typeToStringPretty(CBasicStatistics::count(m_SampleMoments)) +
+            ". priorRate = " + core::CStringUtils::typeToStringPretty(this->priorRate());
         return;
     }
 

--- a/lib/maths/CGammaRateConjugate.cc
+++ b/lib/maths/CGammaRateConjugate.cc
@@ -1432,7 +1432,7 @@ void CGammaRateConjugate::print(const std::string& indent, std::string& result) 
     result += core_t::LINE_ENDING + indent + "gamma ";
     if (this->isNonInformative()) {
         result +=
-            "non-informative: # sample moments = " +
+            "non-informative: # sample count = " +
             core::CStringUtils::typeToStringPretty(CBasicStatistics::count(m_SampleMoments)) +
             ". priorRate = " + core::CStringUtils::typeToStringPretty(this->priorRate());
         return;

--- a/lib/maths/CMultimodalPrior.cc
+++ b/lib/maths/CMultimodalPrior.cc
@@ -583,7 +583,7 @@ bool CMultimodalPrior::checkInvariants(const std::string& tag) const {
     double modeSamples = 0.0;
     for (const auto& mode : m_Modes) {
         if (!m_Clusterer->hasCluster(mode.s_Index)) {
-            LOG_ERROR(<< tag << "Expected cluster for = " << mode.s_Index);
+            LOG_ERROR(<< tag << "Expected cluster for mode = " << mode.s_Index);
             result = false;
         }
         modeSamples += mode.s_Prior->numberSamples();

--- a/lib/maths/COneOfNPrior.cc
+++ b/lib/maths/COneOfNPrior.cc
@@ -672,7 +672,7 @@ void COneOfNPrior::sampleMarginalLikelihood(std::size_t numberSamples,
 
     samples.clear();
 
-    if (numberSamples == 0 || this->isNonInformative()) {
+    if (numberSamples == 0) {
         return;
     }
 

--- a/lib/maths/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultimodalPriorTest.cc
@@ -1112,41 +1112,34 @@ void CMultimodalPriorTest::testSampleMarginalLikelihood() {
     TDouble1Vec sampled;
 
     TMeanVarSkewAccumulator sampleMoments;
-    {
+    // A number of sample moments less than 3.5 is considered "non-informative"
+    for (std::size_t i = 0u; i < 3u; ++i) {
+        LOG_DEBUG(<< "sample = " << samples[i]);
+
+        sampleMoments.add(samples[i]);
+        filter.addSamples(TDouble1Vec(1, samples[i]));
+        CPPUNIT_ASSERT_EQUAL(std::string("\nmultimodal non-informative"), filter.print());
+        filter.sampleMarginalLikelihood(10, sampled);
+
         TMeanVarSkewAccumulator sampledMoments;
-        // A number of sample moments less than 3.5 is considered "non-informative"
-        for (std::size_t i = 0u; i < 3u; ++i) {
-            LOG_DEBUG(<< "sample = " << samples[i]);
+        sampledMoments.add(sampled);
 
-            sampleMoments.add(samples[i]);
-            filter.addSamples(TDouble1Vec(1, samples[i]));
-            CPPUNIT_ASSERT_EQUAL(std::string("\nmultimodal non-informative"),
-                                 filter.print());
-            filter.sampleMarginalLikelihood(10, sampled);
+        LOG_DEBUG(<< "Sample moments = " << sampleMoments
+                  << ", sampled moments = " << sampledMoments);
+        LOG_DEBUG(<< "sampleMean = " << maths::CBasicStatistics::mean(sampleMoments)
+                  << ", sampledMean = " << maths::CBasicStatistics::mean(sampledMoments));
+        LOG_DEBUG(<< "sampleVariance = " << maths::CBasicStatistics::variance(sampleMoments)
+                  << ", sampledVariance = "
+                  << maths::CBasicStatistics::variance(sampledMoments));
 
-            sampledMoments.add(sampled[i]);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(maths::CBasicStatistics::mean(sampleMoments),
+                                     maths::CBasicStatistics::mean(sampledMoments),
+                                     0.05 * maths::CBasicStatistics::mean(sampleMoments));
 
-            LOG_DEBUG(<< "Sample moments = " << sampleMoments
-                      << ", sampled moments = " << sampledMoments);
-            LOG_DEBUG(<< "sampleMean = " << maths::CBasicStatistics::mean(sampleMoments)
-                      << ", sampledMean = " << maths::CBasicStatistics::mean(sampledMoments));
-            LOG_DEBUG(<< "sampleVariance = " << maths::CBasicStatistics::variance(sampleMoments)
-                      << ", sampledVariance = "
-                      << maths::CBasicStatistics::variance(sampledMoments));
-            LOG_DEBUG(<< "sampleSkewness = " << maths::CBasicStatistics::skewness(sampleMoments)
-                      << ", sampledSkewness = "
-                      << maths::CBasicStatistics::skewness(sampledMoments));
-
-            CPPUNIT_ASSERT_DOUBLES_EQUAL(
-                maths::CBasicStatistics::mean(sampleMoments),
-                maths::CBasicStatistics::mean(sampledMoments),
-                0.05 * maths::CBasicStatistics::mean(sampleMoments));
-
-            CPPUNIT_ASSERT_DOUBLES_EQUAL(
-                std::fabs(maths::CBasicStatistics::skewness(sampleMoments)),
-                std::fabs(maths::CBasicStatistics::skewness(sampledMoments)),
-                0.1 * std::fabs(maths::CBasicStatistics::skewness(sampleMoments)));
-        }
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(
+            maths::CBasicStatistics::variance(sampleMoments),
+            maths::CBasicStatistics::variance(sampledMoments),
+            std::max(1e-6, 0.55 * maths::CBasicStatistics::variance(sampleMoments)));
     }
 
     TMeanAccumulator meanMeanError;

--- a/lib/maths/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultimodalPriorTest.cc
@@ -1113,35 +1113,40 @@ void CMultimodalPriorTest::testSampleMarginalLikelihood() {
 
     TMeanVarSkewAccumulator sampleMoments;
     {
-		TMeanVarSkewAccumulator sampledMoments;
-		// A number of sample moments less than 3.5 is considered "non-informative"
-		for (std::size_t i = 0u; i < 3u; ++i) {
-			LOG_DEBUG(<< "sample = " << samples[i]);
+        TMeanVarSkewAccumulator sampledMoments;
+        // A number of sample moments less than 3.5 is considered "non-informative"
+        for (std::size_t i = 0u; i < 3u; ++i) {
+            LOG_DEBUG(<< "sample = " << samples[i]);
 
-			sampleMoments.add(samples[i]);
-			filter.addSamples(TDouble1Vec(1, samples[i]));
-			CPPUNIT_ASSERT_EQUAL(std::string("\nmultimodal non-informative"), filter.print());
-			filter.sampleMarginalLikelihood(10, sampled);
+            sampleMoments.add(samples[i]);
+            filter.addSamples(TDouble1Vec(1, samples[i]));
+            CPPUNIT_ASSERT_EQUAL(std::string("\nmultimodal non-informative"),
+                                 filter.print());
+            filter.sampleMarginalLikelihood(10, sampled);
 
-			sampledMoments.add(sampled[i]);
+            sampledMoments.add(sampled[i]);
 
-			LOG_DEBUG(<< "Sample moments = " << sampleMoments << ", sampled moments = " << sampledMoments);
-			LOG_DEBUG(<< "sampleMean = " <<  maths::CBasicStatistics::mean(sampleMoments)
-					  << ", sampledMean = "<< maths::CBasicStatistics::mean(sampledMoments));
-			LOG_DEBUG(<< "sampleVariance = " << maths::CBasicStatistics::variance(sampleMoments)
-					  << ", sampledVariance = "<< maths::CBasicStatistics::variance(sampledMoments));
-			LOG_DEBUG(<< "sampleSkewness = " << maths::CBasicStatistics::skewness(sampleMoments)
-					  << ", sampledSkewness = "<< maths::CBasicStatistics::skewness(sampledMoments));
+            LOG_DEBUG(<< "Sample moments = " << sampleMoments
+                      << ", sampled moments = " << sampledMoments);
+            LOG_DEBUG(<< "sampleMean = " << maths::CBasicStatistics::mean(sampleMoments)
+                      << ", sampledMean = " << maths::CBasicStatistics::mean(sampledMoments));
+            LOG_DEBUG(<< "sampleVariance = " << maths::CBasicStatistics::variance(sampleMoments)
+                      << ", sampledVariance = "
+                      << maths::CBasicStatistics::variance(sampledMoments));
+            LOG_DEBUG(<< "sampleSkewness = " << maths::CBasicStatistics::skewness(sampleMoments)
+                      << ", sampledSkewness = "
+                      << maths::CBasicStatistics::skewness(sampledMoments));
 
-			CPPUNIT_ASSERT_DOUBLES_EQUAL(maths::CBasicStatistics::mean(sampleMoments),
-										 maths::CBasicStatistics::mean(sampledMoments),
-										 0.05 * maths::CBasicStatistics::mean(sampleMoments));
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(
+                maths::CBasicStatistics::mean(sampleMoments),
+                maths::CBasicStatistics::mean(sampledMoments),
+                0.05 * maths::CBasicStatistics::mean(sampleMoments));
 
-			CPPUNIT_ASSERT_DOUBLES_EQUAL(std::fabs(maths::CBasicStatistics::skewness(sampleMoments)),
-										 std::fabs(maths::CBasicStatistics::skewness(sampledMoments)),
-										 0.1 * std::fabs(maths::CBasicStatistics::skewness(sampleMoments)));
-
-		}
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(
+                std::fabs(maths::CBasicStatistics::skewness(sampleMoments)),
+                std::fabs(maths::CBasicStatistics::skewness(sampledMoments)),
+                0.1 * std::fabs(maths::CBasicStatistics::skewness(sampleMoments)));
+        }
     }
 
     TMeanAccumulator meanMeanError;

--- a/lib/maths/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultimodalPriorTest.cc
@@ -1112,14 +1112,36 @@ void CMultimodalPriorTest::testSampleMarginalLikelihood() {
     TDouble1Vec sampled;
 
     TMeanVarSkewAccumulator sampleMoments;
+    {
+		TMeanVarSkewAccumulator sampledMoments;
+		// A number of sample moments less than 3.5 is considered "non-informative"
+		for (std::size_t i = 0u; i < 3u; ++i) {
+			LOG_DEBUG(<< "sample = " << samples[i]);
 
-    // A number of sample moments less than 3.5 is considered "non-informative"
-    for (std::size_t i = 0u; i < 3u; ++i) {
-        LOG_DEBUG(<< "sample = " << samples[i]);
+			sampleMoments.add(samples[i]);
+			filter.addSamples(TDouble1Vec(1, samples[i]));
+			CPPUNIT_ASSERT_EQUAL(std::string("\nmultimodal non-informative"), filter.print());
+			filter.sampleMarginalLikelihood(10, sampled);
 
-        sampleMoments.add(samples[i]);
-        filter.addSamples(TDouble1Vec(1, samples[i]));
-        CPPUNIT_ASSERT_EQUAL(std::string("\nmultimodal non-informative"), filter.print());
+			sampledMoments.add(sampled[i]);
+
+			LOG_DEBUG(<< "Sample moments = " << sampleMoments << ", sampled moments = " << sampledMoments);
+			LOG_DEBUG(<< "sampleMean = " <<  maths::CBasicStatistics::mean(sampleMoments)
+					  << ", sampledMean = "<< maths::CBasicStatistics::mean(sampledMoments));
+			LOG_DEBUG(<< "sampleVariance = " << maths::CBasicStatistics::variance(sampleMoments)
+					  << ", sampledVariance = "<< maths::CBasicStatistics::variance(sampledMoments));
+			LOG_DEBUG(<< "sampleSkewness = " << maths::CBasicStatistics::skewness(sampleMoments)
+					  << ", sampledSkewness = "<< maths::CBasicStatistics::skewness(sampledMoments));
+
+			CPPUNIT_ASSERT_DOUBLES_EQUAL(maths::CBasicStatistics::mean(sampleMoments),
+										 maths::CBasicStatistics::mean(sampledMoments),
+										 0.05 * maths::CBasicStatistics::mean(sampleMoments));
+
+			CPPUNIT_ASSERT_DOUBLES_EQUAL(std::fabs(maths::CBasicStatistics::skewness(sampleMoments)),
+										 std::fabs(maths::CBasicStatistics::skewness(sampledMoments)),
+										 0.1 * std::fabs(maths::CBasicStatistics::skewness(sampleMoments)));
+
+		}
     }
 
     TMeanAccumulator meanMeanError;

--- a/lib/maths/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultimodalPriorTest.cc
@@ -1113,15 +1113,13 @@ void CMultimodalPriorTest::testSampleMarginalLikelihood() {
 
     TMeanVarSkewAccumulator sampleMoments;
 
+    // A number of sample moments less than 3.5 is considered "non-informative"
     for (std::size_t i = 0u; i < 3u; ++i) {
         LOG_DEBUG(<< "sample = " << samples[i]);
 
         sampleMoments.add(samples[i]);
         filter.addSamples(TDouble1Vec(1, samples[i]));
-
-        sampled.clear();
-        filter.sampleMarginalLikelihood(10, sampled);
-        CPPUNIT_ASSERT_EQUAL(std::size_t(0), sampled.size());
+        CPPUNIT_ASSERT_EQUAL(std::string("\nmultimodal non-informative"), filter.print());
     }
 
     TMeanAccumulator meanMeanError;


### PR DESCRIPTION
Removed check for 'non informative' modes when sampling marginal
likelihood in COneOfNPrior. The check is unneeded as the modes all
return some form of sample in any case.

fixes #274 