### PR TITLE
[6.6][ML] Fix cause of multimodal prior error (#294)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -72,6 +72,8 @@ Prevent detecting a trend component during a possible change in the time series.
 model was poorly reinitialised in this case which damaged anomaly detection for some time. (See
 {ml-pull}287[#287].)
 
+Fix cause of "MERGE: Sum mode samples = 0, total samples = 4.43521.." log errors ({ml-pull}294[294]) 
+
 //=== Regressions
 
 == {es} version 6.4.3

--- a/lib/maths/CGammaRateConjugate.cc
+++ b/lib/maths/CGammaRateConjugate.cc
@@ -1431,7 +1431,10 @@ void CGammaRateConjugate::print(const std::string& indent, std::string& result) 
 
     result += core_t::LINE_ENDING + indent + "gamma ";
     if (this->isNonInformative()) {
-        result += "non-informative";
+        result +=
+            "non-informative: # sample count = " +
+            core::CStringUtils::typeToStringPretty(CBasicStatistics::count(m_SampleMoments)) +
+            ". priorRate = " + core::CStringUtils::typeToStringPretty(this->priorRate());
         return;
     }
 

--- a/lib/maths/CMultimodalPrior.cc
+++ b/lib/maths/CMultimodalPrior.cc
@@ -583,7 +583,7 @@ bool CMultimodalPrior::checkInvariants(const std::string& tag) const {
     double modeSamples = 0.0;
     for (const auto& mode : m_Modes) {
         if (!m_Clusterer->hasCluster(mode.s_Index)) {
-            LOG_ERROR(<< tag << "Expected cluster for = " << mode.s_Index);
+            LOG_ERROR(<< tag << "Expected cluster for mode = " << mode.s_Index);
             result = false;
         }
         modeSamples += mode.s_Prior->numberSamples();

--- a/lib/maths/COneOfNPrior.cc
+++ b/lib/maths/COneOfNPrior.cc
@@ -672,7 +672,7 @@ void COneOfNPrior::sampleMarginalLikelihood(std::size_t numberSamples,
 
     samples.clear();
 
-    if (numberSamples == 0 || this->isNonInformative()) {
+    if (numberSamples == 0) {
         return;
     }
 


### PR DESCRIPTION
Removed check for 'non informative' modes when sampling marginal
likelihood in COneOfNPrior. The check is unneeded as the modes all
return some form of sample in any case.

backports #294 