### PR TITLE
[ML][6.6] Preserve test report if unit tests fail inside Docker

### DIFF
--- a/dev-tools/docker/docker_entrypoint.sh
+++ b/dev-tools/docker/docker_entrypoint.sh
@@ -25,8 +25,6 @@ cd "$MY_DIR/../.."
 # Build the code
 make -j`grep -c '^processor' /proc/cpuinfo`
 
-# Note: there is no testing so this is not suitable as a CI script!
-
 # Strip the binaries
 dev-tools/strip_binaries.sh
 
@@ -48,6 +46,11 @@ zip -9 ../distributions/$ARTIFACT_NAME-debug-$PRODUCT_VERSION-$BUNDLE_PLATFORM.z
 cd ../..
 
 if [ "x$1" = "x--test" ] ; then
-    make -j`grep -c '^processor' /proc/cpuinfo` ML_KEEP_GOING=1 test
+    # Convert any failure of this make command into the word passed or failed in
+    # a status file - this allows the Docker image build to succeed if the only
+    # failure is the unit tests, and then the detailed test results can be
+    # copied from the image
+    echo passed > build/test_status.txt
+    make -j`grep -c '^processor' /proc/cpuinfo` ML_KEEP_GOING=1 test || echo failed > build/test_status.txt
 fi
 

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -71,8 +71,14 @@ do
     # Using tar to copy the build and test artifacts out of the container seems
     # more reliable than docker cp, and also means the files end up with the
     # correct uid/gid
-    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c 'find . -name cppunit_results.xml | xargs tar cf - build/distributions' | tar xvf -
+    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c 'find . -name cppunit_results.xml | xargs tar cf - build/distributions build/test_status.txt' | tar xvf -
     docker rmi --force $TEMP_TAG
+    # The image build is set to return zero (i.e. succeed as far as Docker is
+    # concerned) when the only problem is that the unit tests fail, as this
+    # gives us the chance to copy the unit test result files out of it.  But
+    # then we need to check if the test status file says the tests passed to
+    # decide whether this script succeeds or fails.
+    grep passed build/test_status.txt
 
 done
 


### PR DESCRIPTION
If the only thing that goes wrong with a Docker build is unit test
failures then we want to keep the cppunit_results.xml files that
store the details of the failure.  Prior to this change these
files were getting lost because the Docker container was discarded
on the first non-zero exit code.  Following this change the status
of the unit tests is stored in a status file and a non-zero exit
code of the unit tests suppressed within the Docker container.
Then the outer script checks the status file after copying out the
cppunit_results.xml files.

Backport of #300