### PR TITLE
[ML] Write out forecasts predictions at "bucket time" rather than the actual times they are made in the time buckets

### DIFF
--- a/lib/model/CForecastDataSink.cc
+++ b/lib/model/CForecastDataSink.cc
@@ -9,6 +9,8 @@
 #include <core/CLogger.h>
 #include <core/CScopedRapidJsonPoolAllocator.h>
 
+#include <maths/CIntegerTools.h>
+
 #include <boost/bind.hpp>
 
 #include <vector>
@@ -230,8 +232,11 @@ void CForecastDataSink::push(const maths::SErrorBar errorBar,
         m_Writer.addStringFieldReferenceToObj(FORECAST_ALIAS, m_ForecastAlias, doc);
     }
     m_Writer.addStringFieldCopyToObj(FEATURE, feature, doc, true);
-    // time is in Java format - milliseconds since the epoch
-    m_Writer.addTimeFieldToObj(TIMESTAMP, errorBar.s_Time, doc);
+    // Time is in Java format - milliseconds since the epoch. Note this
+    // matches the Java notion of "bucket time" which is defined as the
+    // start of the bucket containing the forecast time.
+    core_t::TTime time{maths::CIntegerTools::floor(errorBar.s_Time, errorBar.s_BucketLength)};
+    m_Writer.addTimeFieldToObj(TIMESTAMP, time, doc);
     m_Writer.addIntFieldToObj(BUCKET_SPAN, errorBar.s_BucketLength, doc);
     if (!partitionFieldName.empty()) {
         m_Writer.addStringFieldCopyToObj(PARTITION_FIELD_NAME, partitionFieldName, doc);


### PR DESCRIPTION
The Java notion of "bucket time" is the start of a job's time buckets, i.e. if the job uses 30 minute time buckets then the "bucket time" is the start of each 30 minute time interval (from 00:00:00 in UTC). Currently, all anomaly detection results are written at bucket time for the buckets which contain them.

As a result of #327, we started evaluating forecasts at the sample offset in the time bucket (for good reasons). In addition, we reported their times as at the evaluation time rather than "bucket time" for the bucket which contains them. This change reverts to report them at bucket time.

Going forward we will probably want to revisit this behaviour and decouple the notion of bucket time from forecast documents. They would simply hold a time and the forecast at that time, *whatever* time that may be. However, this requires knock on changes to our UI, which we don't want to make now, and makes more sense in the context of planned changes to the forecast API.

I've marked this as a non-issue, as it is a change to revert behaviour (introduced in #327 which is not yet released).