### PR TITLE
[FEATURE][ML] Wire outlier detection into the data_frame_analyzer command

### DIFF
--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -103,13 +103,14 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    ml::api::CDataFrameAnalysisSpecification analysisSpecification{analysisSpecificationJson};
-    if (analysisSpecification.bad()) {
+    auto analysisSpecification =
+        std::make_unique<ml::api::CDataFrameAnalysisSpecification>(analysisSpecificationJson);
+    if (analysisSpecification->bad()) {
         LOG_FATAL("Failed to parse analysis specification");
         return EXIT_FAILURE;
     }
-    if (analysisSpecification.threads() > 1) {
-        ml::core::startDefaultAsyncExecutor(analysisSpecification.threads());
+    if (analysisSpecification->numberThreads() > 1) {
+        ml::core::startDefaultAsyncExecutor(analysisSpecification->numberThreads());
     }
 
     ml::api::CDataFrameAnalyzer dataFrameAnalyzer{

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -23,6 +23,10 @@
 namespace ml {
 namespace core {
 class CDataFrame;
+class CRapidJsonConcurrentLineWriter;
+namespace data_frame_detail {
+class CRowRef;
+}
 }
 namespace api {
 class CDataFrameAnalysisSpecification;
@@ -53,6 +57,7 @@ class CDataFrameAnalysisSpecification;
 class API_EXPORT CDataFrameAnalysisRunner {
 public:
     using TStrVec = std::vector<std::string>;
+    using TRowRef = core::data_frame_detail::CRowRef;
 
 public:
     CDataFrameAnalysisRunner(const CDataFrameAnalysisSpecification& spec);
@@ -67,9 +72,25 @@ public:
     //! into main memory during an analysis.
     virtual std::size_t numberOfPartitions() const = 0;
 
-    //! \return The number of columns this analysis requires. This includes
-    //! the columns of the input frame plus any that the analysis will append.
-    virtual std::size_t requiredFrameColumns() const = 0;
+    //! \return The number of columns this analysis appends.
+    virtual std::size_t numberExtraColumns() const = 0;
+
+    //! Write the extra columns of \p row added by the analysis to \p writer.
+    //!
+    //! This should create a new object of the form:
+    //! <pre>
+    //! {
+    //!   "name of column n":   "value of column n",
+    //!   "name of column n+1": "value of column n+1",
+    //!   ...
+    //! }
+    //! </pre>
+    //! with one named member for each column added.
+    //!
+    //! \param[in] row The row to write the columns added by this analysis.
+    //! \param[in,out] writer The stream to which to write the extra columns.
+    virtual void writeOneRow(TRowRef row,
+                             core::CRapidJsonConcurrentLineWriter& writer) const = 0;
 
     //! Checks whether the analysis is already running and if not launches it
     //! in the background.

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -74,20 +74,29 @@ public:
     CDataFrameAnalysisSpecification(TRunnerFactoryUPtrVec runnerFactories,
                                     const std::string& jsonSpecification);
 
+    CDataFrameAnalysisSpecification(const CDataFrameAnalysisSpecification&) = delete;
+    CDataFrameAnalysisSpecification& operator=(const CDataFrameAnalysisSpecification&) = delete;
+    CDataFrameAnalysisSpecification(CDataFrameAnalysisSpecification&&) = delete;
+    CDataFrameAnalysisSpecification& operator=(CDataFrameAnalysisSpecification&&) = delete;
+
     //! Check if the specification is bad.
     bool bad() const;
 
     //! \return The number of rows in the frame.
-    std::size_t rows() const;
+    std::size_t numberRows() const;
 
     //! \return The number of columns in the input frame.
-    std::size_t cols() const;
+    std::size_t numberColumns() const;
+
+    //! \return The number of columns the analysis configured to run will append
+    //! to the data frame.
+    std::size_t numberExtraColumns() const;
 
     //! \return The memory limit for the process.
     std::size_t memoryLimit() const;
 
     //! \return The number of threads the analysis can use.
-    std::size_t threads() const;
+    std::size_t numberThreads() const;
 
     //! Run the analysis in a background thread.
     //!
@@ -107,10 +116,10 @@ private:
 
 private:
     bool m_Bad = false;
-    std::size_t m_Rows = 0;
-    std::size_t m_Cols = 0;
+    std::size_t m_NumberRows = 0;
+    std::size_t m_NumberColumns = 0;
     std::size_t m_MemoryLimit = 0;
-    std::size_t m_Threads = 0;
+    std::size_t m_NumberThreads = 0;
     // TODO Sparse table support
     // double m_TableLoadFactor = 0.0;
     TRunnerFactoryUPtrVec m_RunnerFactories;

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -6,9 +6,6 @@
 #ifndef INCLUDED_ml_api_CDataFrameAnalyzer_h
 #define INCLUDED_ml_api_CDataFrameAnalyzer_h
 
-#include <core/CDataFrame.h>
-
-#include <api/CDataFrameAnalysisSpecification.h>
 #include <api/ImportExport.h>
 
 #include <cinttypes>
@@ -19,9 +16,11 @@
 
 namespace ml {
 namespace core {
+class CDataFrame;
 class CJsonOutputStreamWrapper;
 }
 namespace api {
+class CDataFrameAnalysisSpecification;
 
 //! \brief Handles input to the data_frame_analyzer command.
 class API_EXPORT CDataFrameAnalyzer {
@@ -30,25 +29,34 @@ public:
     using TJsonOutputStreamWrapperUPtr = std::unique_ptr<core::CJsonOutputStreamWrapper>;
     using TJsonOutputStreamWrapperUPtrSupplier =
         std::function<TJsonOutputStreamWrapperUPtr()>;
+    using TDataFrameAnalysisSpecificationUPtr = std::unique_ptr<CDataFrameAnalysisSpecification>;
 
 public:
-    explicit CDataFrameAnalyzer(CDataFrameAnalysisSpecification analysisSpecification,
-                                TJsonOutputStreamWrapperUPtrSupplier outStreamSupplier);
+    CDataFrameAnalyzer(TDataFrameAnalysisSpecificationUPtr analysisSpecification,
+                       TJsonOutputStreamWrapperUPtrSupplier outStreamSupplier);
+    ~CDataFrameAnalyzer();
 
     //! This is true if the analyzer is receiving control messages.
     bool usingControlMessages() const;
 
-    //! Handle adding a row of the data frame or a control message.
+    //! Handle receiving a row of the data frame or a control message.
     bool handleRecord(const TStrVec& fieldNames, const TStrVec& fieldValues);
+
+    //! Call when all row have been received.
+    void receivedAllRows();
 
     //! Run the configured analysis.
     void run();
+
+private:
+    using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
 
 private:
     static const std::ptrdiff_t CONTROL_FIELD_UNSET{-2};
     static const std::ptrdiff_t CONTROL_FIELD_MISSING{-1};
 
 private:
+    bool sufficientFieldValues(const TStrVec& fieldNames) const;
     bool readyToReceiveControlMessages() const;
     bool prepareToReceiveControlMessages(const TStrVec& fieldNames);
     bool isControlMessage(const TStrVec& fieldValues) const;
@@ -57,12 +65,12 @@ private:
 
 private:
     // This has values: -2 (unset), -1 (missing), >= 0 (control field index).
-    std::ptrdiff_t m_ControlFieldValue = CONTROL_FIELD_UNSET;
+    std::ptrdiff_t m_ControlFieldIndex = CONTROL_FIELD_UNSET;
     std::ptrdiff_t m_BeginDataFieldValues = -1;
     std::ptrdiff_t m_EndDataFieldValues = -1;
     std::uint64_t m_BadValueCount;
-    CDataFrameAnalysisSpecification m_AnalysisSpecification;
-    core::CDataFrame m_DataFrame;
+    TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
+    TDataFrameUPtr m_DataFrame;
     TJsonOutputStreamWrapperUPtrSupplier m_OutStreamSupplier;
 };
 }

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -21,6 +21,7 @@ class CDataFrame;
 class CJsonOutputStreamWrapper;
 }
 namespace api {
+class CDataFrameAnalysisRunner;
 class CDataFrameAnalysisSpecification;
 
 //! \brief Handles input to the data_frame_analyzer command.
@@ -63,6 +64,7 @@ private:
     bool isControlMessage(const TStrVec& fieldValues) const;
     bool handleControlMessage(const TStrVec& fieldValues);
     void addRowToDataFrame(const TStrVec& fieldValues);
+    void writeResultsOf(const CDataFrameAnalysisRunner& analysis) const;
 
 private:
     // This has values: -2 (unset), -1 (missing), >= 0 (control field index).

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 #ifndef INCLUDED_ml_api_CDataFrameAnalyzer_h
 #define INCLUDED_ml_api_CDataFrameAnalyzer_h
 

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -26,8 +26,11 @@ public:
     //! \sa CDataFrameAnalysisRunner::run.
     virtual std::size_t numberOfPartitions() const;
 
-    //! \return The number of columns of the output frame.
-    virtual std::size_t requiredFrameColumns() const;
+    //! \return The number of columns this adds to the data frame.
+    virtual std::size_t numberExtraColumns() const;
+
+    //! Write the extra columns of \p row added by outlier analysis to \p writer.
+    virtual void writeOneRow(TRowRef row, core::CRapidJsonConcurrentLineWriter& writer) const;
 
 private:
     using TOptionalSize = boost::optional<std::size_t>;

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -4,6 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#ifndef INCLUDED_ml_api_CDataFrameOutliersRunner_h
+#define INCLUDED_ml_api_CDataFrameOutliersRunner_h
+
 #include <api/CDataFrameAnalysisRunner.h>
 
 #include <api/ImportExport.h>
@@ -65,3 +68,5 @@ public:
 };
 }
 }
+
+#endif // INCLUDED_ml_api_CDataFrameOutliersRunner_h

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -207,9 +207,10 @@ public:
                EReadWriteToStorage readAndWriteToStoreSyncStrategy,
                const TWriteSliceToStoreFunc& writeSliceToStore);
 
+    ~CDataFrame();
+
     CDataFrame(const CDataFrame&) = delete;
     CDataFrame& operator=(const CDataFrame&) = delete;
-
     CDataFrame(CDataFrame&&) = default;
     CDataFrame& operator=(CDataFrame&&) = default;
 
@@ -415,10 +416,11 @@ private:
 //! \param[in] readWriteToStoreSyncStrategy Controls whether reads and writes
 //! from slice storage are synchronous or asynchronous.
 CORE_EXPORT
-CDataFrame makeMainStorageDataFrame(std::size_t numberColumns,
-                                    boost::optional<std::size_t> sliceCapacity = boost::none,
-                                    CDataFrame::EReadWriteToStorage readWriteToStoreSyncStrategy =
-                                        CDataFrame::EReadWriteToStorage::E_Sync);
+std::unique_ptr<CDataFrame>
+makeMainStorageDataFrame(std::size_t numberColumns,
+                         boost::optional<std::size_t> sliceCapacity = boost::none,
+                         CDataFrame::EReadWriteToStorage readWriteToStoreSyncStrategy =
+                             CDataFrame::EReadWriteToStorage::E_Sync);
 
 //! Make a data frame which uses disk storage for its slices.
 //!
@@ -431,12 +433,13 @@ CDataFrame makeMainStorageDataFrame(std::size_t numberColumns,
 //! \param[in] readWriteToStoreSyncStrategy Controls whether reads and writes
 //! from slice storage are synchronous or asynchronous.
 CORE_EXPORT
-CDataFrame makeDiskStorageDataFrame(const std::string& rootDirectory,
-                                    std::size_t numberColumns,
-                                    std::size_t numberRows,
-                                    boost::optional<std::size_t> sliceCapacity = boost::none,
-                                    CDataFrame::EReadWriteToStorage readWriteToStoreSyncStrategy =
-                                        CDataFrame::EReadWriteToStorage::E_Async);
+std::unique_ptr<CDataFrame>
+makeDiskStorageDataFrame(const std::string& rootDirectory,
+                         std::size_t numberColumns,
+                         std::size_t numberRows,
+                         boost::optional<std::size_t> sliceCapacity = boost::none,
+                         CDataFrame::EReadWriteToStorage readWriteToStoreSyncStrategy =
+                             CDataFrame::EReadWriteToStorage::E_Async);
 }
 }
 

--- a/include/core/CRapidJsonConcurrentLineWriter.h
+++ b/include/core/CRapidJsonConcurrentLineWriter.h
@@ -49,10 +49,11 @@ public:
     std::size_t memoryUsage() const;
 
     //! Write JSON document to outputstream
-    //! Note this non-virtual overwrite is needed to avoid slicing of the writer
-    //! and hence ensure the correct EndObject is called
-    //! \p doc reference to rapidjson document value
-    void write(rapidjson::Value& doc) { doc.Accept(*this); }
+    //! \note This overwrite is needed because the members of rapidjson::Writer
+    //! are not virtual and we need to avoid "slicing" the writer to ensure that
+    //! that the correct StartObject/EndObject functions are called when this is
+    //! passed to \p doc Accept.
+    void write(const rapidjson::Value& doc) { doc.Accept(*this); }
 
 private:
     //! The stream object

--- a/include/core/CRapidJsonLineWriter.h
+++ b/include/core/CRapidJsonLineWriter.h
@@ -55,10 +55,11 @@ public:
     }
 
     //! Write JSON document to outputstream
-    //! Note this non-virtual overwrite is needed to avoid slicing of the writer
-    //! and hence ensure the correct StartObject/EndObject functions are called
-    //! \p doc reference to rapidjson document value
-    void write(rapidjson::Value& doc) { doc.Accept(*this); }
+    //! \note This overwrite is needed because the members of rapidjson::Writer
+    //! are not virtual and we need to avoid "slicing" the writer to ensure that
+    //! that the correct StartObject/EndObject functions are called when this is
+    //! passed to \p doc Accept.
+    void write(const rapidjson::Value& doc) { doc.Accept(*this); }
 
 private:
     size_t m_ObjectCount = 0;

--- a/include/core/CRapidJsonWriterBase.h
+++ b/include/core/CRapidJsonWriterBase.h
@@ -218,7 +218,7 @@ public:
 
     //! write the rapidjson value document to the output stream
     //! \p[in] doc rapidjson document value to write out
-    virtual void write(TValue& doc) { doc.Accept(*this); }
+    virtual void write(const TValue& doc) { doc.Accept(*this); }
 
     //! Return a new rapidjson document
     TDocument makeDoc() const {

--- a/include/core/CStaticThreadPool.h
+++ b/include/core/CStaticThreadPool.h
@@ -71,8 +71,9 @@ private:
     void worker(std::size_t id);
 
 private:
-    // This doesn't have to be atomic because it is always only set to true and
-    // always set straight before it is checked on each worker in the pool.
+    // This doesn't have to be atomic because it is always only set to true,
+    // always set straight before it is checked on each worker in the pool
+    // and tearing can't happen for single byte writes.
     bool m_Done = false;
     std::atomic_bool m_Busy;
     std::atomic<std::uint64_t> m_Cursor;

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -6,13 +6,14 @@
 
 #include <api/CDataFrameAnalysisSpecification.h>
 
+#include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
+#include <core/CRapidJsonLineWriter.h>
 
 #include <api/CDataFrameOutliersRunner.h>
 
 #include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+#include <rapidjson/ostreamwrapper.h>
 
 #include <boost/make_unique.hpp>
 
@@ -52,10 +53,11 @@ bool isValidMember(const MEMBER& member) {
 }
 
 std::string toString(const rapidjson::Value& value) {
-    rapidjson::StringBuffer valueAsString;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(valueAsString);
-    value.Accept(writer);
-    return valueAsString.GetString();
+    std::ostringstream valueAsString;
+    rapidjson::OStreamWrapper shim{valueAsString};
+    ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> writer{shim};
+    writer.write(value);
+    return valueAsString.str();
 }
 }
 

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -85,12 +85,12 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         };
 
         if (document.HasMember(ROWS) && isPositiveInteger(document[ROWS])) {
-            m_Rows = document[ROWS].GetUint();
+            m_NumberRows = document[ROWS].GetUint();
         } else {
             registerFailure(ROWS);
         }
         if (document.HasMember(COLS) && isPositiveInteger(document[COLS])) {
-            m_Cols = document[COLS].GetUint();
+            m_NumberColumns = document[COLS].GetUint();
         } else {
             registerFailure(COLS);
         }
@@ -100,7 +100,7 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
             registerFailure(MEMORY_LIMIT);
         }
         if (document.HasMember(THREADS) && isPositiveInteger(document[THREADS])) {
-            m_Threads = document[THREADS].GetUint();
+            m_NumberThreads = document[THREADS].GetUint();
         } else {
             registerFailure(THREADS);
         }
@@ -130,20 +130,24 @@ bool CDataFrameAnalysisSpecification::bad() const {
     return m_Bad || m_Runner->bad();
 }
 
-std::size_t CDataFrameAnalysisSpecification::rows() const {
-    return m_Rows;
+std::size_t CDataFrameAnalysisSpecification::numberRows() const {
+    return m_NumberRows;
 }
 
-std::size_t CDataFrameAnalysisSpecification::cols() const {
-    return m_Cols;
+std::size_t CDataFrameAnalysisSpecification::numberColumns() const {
+    return m_NumberColumns;
+}
+
+std::size_t CDataFrameAnalysisSpecification::numberExtraColumns() const {
+    return m_Runner != nullptr ? m_Runner->numberExtraColumns() : 0;
 }
 
 std::size_t CDataFrameAnalysisSpecification::memoryLimit() const {
     return m_MemoryLimit;
 }
 
-std::size_t CDataFrameAnalysisSpecification::threads() const {
-    return m_Threads;
+std::size_t CDataFrameAnalysisSpecification::numberThreads() const {
+    return m_NumberThreads;
 }
 
 CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame& frame) const {

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -63,6 +63,8 @@ bool CDataFrameAnalyzer::handleRecord(const TStrVec& fieldNames, const TStrVec& 
     // be triggered to run by calling run explicitly.
 
     if (m_AnalysisSpecification == nullptr || m_AnalysisSpecification->bad()) {
+        // TODO We need to communicate an error but don't want one for each row.
+        // Revisit this when we have finalized our monitoring strategy.
         LOG_TRACE(<< "Specification is bad");
         return false;
     }
@@ -73,6 +75,8 @@ bool CDataFrameAnalyzer::handleRecord(const TStrVec& fieldNames, const TStrVec& 
     }
 
     if (this->sufficientFieldValues(fieldValues) == false) {
+        // TODO We need to communicate an error but don't want one for each row.
+        // Revisit this when we have finalized our monitoring strategy.
         LOG_TRACE(<< "Expected " << m_AnalysisSpecification->numberColumns()
                   << " field values and got " << fieldValues.size());
         return false;
@@ -88,7 +92,7 @@ bool CDataFrameAnalyzer::handleRecord(const TStrVec& fieldNames, const TStrVec& 
 
 void CDataFrameAnalyzer::receivedAllRows() {
     m_DataFrame->finishWritingRows();
-    LOG_TRACE(<< "Received " << m_DataFrame->numberRows() << " rows");
+    LOG_DEBUG(<< "Received " << m_DataFrame->numberRows() << " rows");
 }
 
 void CDataFrameAnalyzer::run() {

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -209,6 +209,7 @@ void CDataFrameAnalyzer::addRowToDataFrame(const TStrVec& fieldValues) {
 
 void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis) const {
     // TODO Revisit this can probably be core::CRapidJsonLineWriter.
+    // TODO This should probably be a member variable so it is only created once.
     auto outStream = m_OutStreamSupplier();
     core::CRapidJsonConcurrentLineWriter outputWriter{*outStream};
 

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -46,6 +46,7 @@ CDataFrameAnalyzer::CDataFrameAnalyzer(TDataFrameAnalysisSpecificationUPtr analy
                                  m_AnalysisSpecification->numberExtraColumns());
     }
 }
+
 CDataFrameAnalyzer::~CDataFrameAnalyzer() = default;
 
 bool CDataFrameAnalyzer::usingControlMessages() const {

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -29,7 +29,6 @@ double truncateToFloatRange(double value) {
 const std::string CONTROL_MESSAGE_FIELD_NAME{"."};
 // Control message types:
 const char FINISHED_DATA_CONTROL_MESSAGE_FIELD_VALUE{'$'};
-const char RUN_ANALYSIS_CONTROL_MESSAGE_FIELD_VALUE{'r'};
 
 const std::string ID_HASH{"id_hash"};
 const std::string RESULTS{"results"};
@@ -178,8 +177,6 @@ bool CDataFrameAnalyzer::handleControlMessage(const TStrVec& fieldValues) {
         return true;
     case FINISHED_DATA_CONTROL_MESSAGE_FIELD_VALUE:
         this->receivedAllRows();
-        break;
-    case RUN_ANALYSIS_CONTROL_MESSAGE_FIELD_VALUE:
         this->run();
         break;
     default:

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -222,9 +222,9 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
     m_DataFrame->readRows(numberThreads, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             outputWriter.StartObject();
-            outputWriter.String(ID_HASH);
+            outputWriter.Key(ID_HASH);
             outputWriter.String(ID_HASH); // TODO this should be the actual hash
-            outputWriter.String(RESULTS);
+            outputWriter.Key(RESULTS);
             analysis.writeOneRow(*row, outputWriter);
             outputWriter.EndObject();
         }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -111,7 +111,7 @@ void CDataFrameOutliersRunner::writeOneRow(TRowRef row,
                                            core::CRapidJsonConcurrentLineWriter& outputWriter) const {
     std::size_t lastColumn{row.numberColumns() - 1};
     outputWriter.StartObject();
-    outputWriter.String(OUTLIER_SCORE);
+    outputWriter.Key(OUTLIER_SCORE);
     outputWriter.Double(row[lastColumn]);
     outputWriter.EndObject();
 }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -6,12 +6,13 @@
 
 #include <api/CDataFrameOutliersRunner.h>
 
+#include <core/CDataFrame.h>
 #include <core/CLogger.h>
+#include <core/CRapidJsonConcurrentLineWriter.h>
 
 #include <maths/CLocalOutlierFactors.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
-
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
@@ -25,14 +26,17 @@
 namespace ml {
 namespace api {
 namespace {
+// Configuration
 const char* NUMBER_NEIGHBOURS{"number_neighbours"};
 const char* METHOD{"method"};
 const char* LOF{"lof"};
 const char* LDOF{"ldof"};
 const char* DISTANCE_KTH_NN{"distance_kth_nn"};
 const char* DISTANCE_KNN{"distance_knn"};
-
 const char* VALID_MEMBER_NAMES[]{NUMBER_NEIGHBOURS, METHOD};
+
+// Output
+const std::string OUTLIER_SCORE{"outlier_score"};
 
 template<typename MEMBER>
 bool isValidMember(const MEMBER& member) {
@@ -98,13 +102,22 @@ std::size_t CDataFrameOutliersRunner::numberOfPartitions() const {
     return m_NumberPartitions;
 }
 
-std::size_t CDataFrameOutliersRunner::requiredFrameColumns() const {
-    // This is number of columns + outlier score + explaining features TBD.
-    return this->spec().cols() + 1;
+std::size_t CDataFrameOutliersRunner::numberExtraColumns() const {
+    // Column for outlier score + explaining features TBD.
+    return 1;
 }
 
-void CDataFrameOutliersRunner::runImpl(core::CDataFrame& /*frame*/) {
-    // TODO
+void CDataFrameOutliersRunner::writeOneRow(TRowRef row,
+                                           core::CRapidJsonConcurrentLineWriter& outputWriter) const {
+    std::size_t lastColumn{row.numberColumns() - 1};
+    outputWriter.StartObject();
+    outputWriter.String(OUTLIER_SCORE);
+    outputWriter.Double(row[lastColumn]);
+    outputWriter.EndObject();
+}
+
+void CDataFrameOutliersRunner::runImpl(core::CDataFrame& frame) {
+    maths::computeOutliers(this->spec().numberThreads(), frame);
 }
 
 const char* CDataFrameOutliersRunnerFactory::name() const {

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -137,7 +137,6 @@ void CDataFrameAnalyzerTest::testRunOutlierDetection() {
     addTestData(fieldNames, fieldValues, analyzer, expectedScores);
 
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "$"});
-    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "r"});
 
     rapidjson::Document results;
     rapidjson::ParseResult ok(results.Parse(output.str().c_str()));

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -1,0 +1,229 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CDataFrameAnalyzerTest.h"
+
+#include <core/CContainerPrinter.h>
+#include <core/CJsonOutputStreamWrapper.h>
+
+#include <maths/CLocalOutlierFactors.h>
+
+#include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalyzer.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/error/en.h>
+
+#include <memory>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace ml;
+
+namespace {
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TStrVec = std::vector<std::string>;
+using TPoint = maths::CDenseVector<maths::CFloatStorage>;
+using TPointVec = std::vector<TPoint>;
+
+std::unique_ptr<api::CDataFrameAnalysisSpecification> outlierSpec() {
+    std::string spec{"{\n"
+                     "  \"rows\": 100,\n"
+                     "  \"cols\": 5,\n"
+                     "  \"memory_limit\": 100000,\n"
+                     "  \"threads\": 1,\n"
+                     "  \"analysis\": {\n"
+                     "    \"name\": \"outliers\""
+                     "  }"
+                     "}"};
+    return std::make_unique<api::CDataFrameAnalysisSpecification>(spec);
+}
+
+void addTestData(TStrVec fieldNames,
+                 TStrVec fieldValues,
+                 api::CDataFrameAnalyzer& analyzer,
+                 TDoubleVec& expectedScores) {
+
+    std::size_t numberInliers{100};
+    std::size_t numberOutliers{10};
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec mean{1.0, 10.0, 4.0, 8.0, 3.0};
+    TDoubleVecVec covariance{{1.0, 0.1, -0.1, 0.3, 0.2},
+                             {0.1, 1.3, -0.3, 0.1, 0.1},
+                             {-0.1, -0.3, 2.1, 0.1, 0.2},
+                             {0.3, 0.1, 0.1, 0.8, 0.2},
+                             {0.2, 0.1, 0.2, 0.2, 2.2}};
+
+    TDoubleVecVec inliers;
+    rng.generateMultivariateNormalSamples(mean, covariance, numberInliers, inliers);
+
+    TDoubleVec outliers;
+    rng.generateUniformSamples(0.0, 10.0, numberOutliers * 5, outliers);
+
+    TPointVec points(numberInliers + numberOutliers, TPoint(5));
+    for (std::size_t i = 0; i < inliers.size(); ++i) {
+        for (std::size_t j = 0; j < 5; ++j) {
+            fieldValues[j] = std::to_string(inliers[i][j]);
+            points[i](j) = inliers[i][j];
+        }
+        analyzer.handleRecord(fieldNames, fieldValues);
+    }
+    for (std::size_t i = 0, j = numberInliers; i < outliers.size(); ++j) {
+        for (std::size_t k = 0; k < 5; ++i, ++k) {
+            fieldValues[k] = std::to_string(outliers[i]);
+            points[j](k) = outliers[i];
+        }
+        analyzer.handleRecord(fieldNames, fieldValues);
+    }
+
+    maths::CLocalOutlierFactors::ensemble(points, expectedScores);
+}
+}
+
+void CDataFrameAnalyzerTest::testWithoutControlMessages() {
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+
+    TDoubleVec expectedScores;
+
+    TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5"};
+    TStrVec fieldValues(fieldNames.size());
+    addTestData(fieldNames, fieldValues, analyzer, expectedScores);
+
+    analyzer.receivedAllRows();
+    analyzer.run();
+
+    rapidjson::Document results;
+    rapidjson::ParseResult ok(results.Parse(output.str().c_str()));
+    CPPUNIT_ASSERT(static_cast<bool>(ok) == true);
+
+    auto expectedScore = expectedScores.begin();
+    for (const auto& result : results.GetArray()) {
+        CPPUNIT_ASSERT(expectedScore != expectedScores.end());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(*(expectedScore++),
+                                     result["results"]["outlier_score"].GetDouble(),
+                                     1e-6);
+    }
+    CPPUNIT_ASSERT(expectedScore == expectedScores.end());
+}
+
+void CDataFrameAnalyzerTest::testRunOutlierDetection() {
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+
+    TDoubleVec expectedScores;
+
+    TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", "."};
+    TStrVec fieldValues(fieldNames.size());
+    addTestData(fieldNames, fieldValues, analyzer, expectedScores);
+
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "$"});
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "r"});
+
+    rapidjson::Document results;
+    rapidjson::ParseResult ok(results.Parse(output.str().c_str()));
+    CPPUNIT_ASSERT(static_cast<bool>(ok) == true);
+
+    auto expectedScore = expectedScores.begin();
+    for (const auto& result : results.GetArray()) {
+        CPPUNIT_ASSERT(expectedScore != expectedScores.end());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(*(expectedScore++),
+                                     result["results"]["outlier_score"].GetDouble(),
+                                     1e-6);
+    }
+    CPPUNIT_ASSERT(expectedScore == expectedScores.end());
+}
+
+void CDataFrameAnalyzerTest::testFlushMessage() {
+
+    // Test that white space is just ignored.
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+    CPPUNIT_ASSERT_EQUAL(
+        true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", "."},
+                                    {"", "", "", "", "", "           "}));
+}
+
+void CDataFrameAnalyzerTest::testErrors() {
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    // Test with bad analysis specification.
+    {
+        api::CDataFrameAnalyzer analyzer{
+            std::make_unique<api::CDataFrameAnalysisSpecification>(std::string{"junk"}),
+            outputWriterFactory};
+        CPPUNIT_ASSERT_EQUAL(false,
+                             analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5"},
+                                                   {"10", "10", "10", "10", "10"}));
+    }
+
+    // Test control message in the wrong position
+    {
+        api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+        CPPUNIT_ASSERT_EQUAL(
+            false, analyzer.handleRecord({"c1", "c2", "c3", ".", "c4", "c5"},
+                                         {"10", "10", "10", "", "10", "10"}));
+    }
+
+    // Test bad control message
+    {
+        api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+        CPPUNIT_ASSERT_EQUAL(
+            false, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", "."},
+                                         {"10", "10", "10", "10", "10", "foo"}));
+    }
+
+    // Test bad input
+    {
+        api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+        CPPUNIT_ASSERT_EQUAL(
+            false, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", "."},
+                                         {"10", "10", "10", "10", "10"}));
+    }
+}
+
+CppUnit::Test* CDataFrameAnalyzerTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CDataFrameAnalyzerTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
+        "CDataFrameAnalyzerTest::testWithoutControlMessages",
+        &CDataFrameAnalyzerTest::testWithoutControlMessages));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
+        "CDataFrameAnalyzerTest::testRunOutlierDetection",
+        &CDataFrameAnalyzerTest::testRunOutlierDetection));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
+        "CDataFrameAnalyzerTest::testFlushMessage", &CDataFrameAnalyzerTest::testFlushMessage));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
+        "CDataFrameAnalyzerTest::testErrors", &CDataFrameAnalyzerTest::testErrors));
+
+    return suiteOfTests;
+}

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -19,8 +19,8 @@
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 
-#include <memory>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -115,9 +115,8 @@ void CDataFrameAnalyzerTest::testWithoutControlMessages() {
     auto expectedScore = expectedScores.begin();
     for (const auto& result : results.GetArray()) {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(*(expectedScore++),
-                                     result["results"]["outlier_score"].GetDouble(),
-                                     1e-6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(
+            *(expectedScore++), result["results"]["outlier_score"].GetDouble(), 1e-6);
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
 }
@@ -147,9 +146,8 @@ void CDataFrameAnalyzerTest::testRunOutlierDetection() {
     auto expectedScore = expectedScores.begin();
     for (const auto& result : results.GetArray()) {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(*(expectedScore++),
-                                     result["results"]["outlier_score"].GetDouble(),
-                                     1e-6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(
+            *(expectedScore++), result["results"]["outlier_score"].GetDouble(), 1e-6);
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CDataFrameAnalyzerTest_h
+#define INCLUDED_CDataFrameAnalyzerTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CDataFrameAnalyzerTest : public CppUnit::TestFixture {
+public:
+    void testWithoutControlMessages();
+    void testRunOutlierDetection();
+    void testFlushMessage();
+    void testErrors();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CDataFrameAnalyzerTest_h

--- a/lib/api/unittest/Main.cc
+++ b/lib/api/unittest/Main.cc
@@ -14,6 +14,7 @@
 #include "CCsvInputParserTest.h"
 #include "CCsvOutputWriterTest.h"
 #include "CDataFrameAnalysisSpecificationTest.h"
+#include "CDataFrameAnalyzerTest.h"
 #include "CDetectionRulesJsonParserTest.h"
 #include "CFieldConfigTest.h"
 #include "CFieldDataTyperTest.h"
@@ -47,6 +48,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CCsvInputParserTest::suite());
     runner.addTest(CCsvOutputWriterTest::suite());
     runner.addTest(CDataFrameAnalysisSpecificationTest::suite());
+    runner.addTest(CDataFrameAnalyzerTest::suite());
     runner.addTest(CDetectionRulesJsonParserTest::suite());
     runner.addTest(CFieldConfigTest::suite());
     runner.addTest(CFieldDataTyperTest::suite());

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -28,6 +28,7 @@ SRCS=\
 	CCsvInputParserTest.cc \
 	CCsvOutputWriterTest.cc \
 	CDataFrameAnalysisSpecificationTest.cc \
+	CDataFrameAnalyzerTest.cc \
 	CDetectionRulesJsonParserTest.cc \
 	CFieldConfigTest.cc \
 	CFieldDataTyperTest.cc \

--- a/lib/core/CStaticThreadPool.cc
+++ b/lib/core/CStaticThreadPool.cc
@@ -73,8 +73,12 @@ void CStaticThreadPool::shutdown() {
         }});
     }
     for (auto& thread : m_Pool) {
-        thread.join();
+        if (thread.joinable()) {
+            thread.join();
+        }
     }
+    m_TaskQueues.clear();
+    m_Pool.clear();
 }
 
 void CStaticThreadPool::worker(std::size_t id) {

--- a/lib/maths/CLocalOutlierFactors.cc
+++ b/lib/maths/CLocalOutlierFactors.cc
@@ -75,8 +75,7 @@ bool computeOutliersNoPartitions(std::size_t numberThreads, core::CDataFrame& fr
     // value is not important. This is presized so that rowsToPoints only
     // needs to access and write to each element. Since it does this once
     // per element it is thread safe.
-    CFloatStorage initial;
-    TVectorVec points(frame.numberRows(), TVector{&initial, 1});
+    TVectorVec points(frame.numberRows(), TVector{nullptr, 1});
 
     auto rowsToPoints = [&points](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {

--- a/lib/maths/CLocalOutlierFactors.cc
+++ b/lib/maths/CLocalOutlierFactors.cc
@@ -80,7 +80,7 @@ bool computeOutliersNoPartitions(std::size_t numberThreads, core::CDataFrame& fr
 
     auto rowsToPoints = [&points](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            points[row->index()] = TVector{row->data(), row->numberColumns()};
+            new (&points[row->index()]) TVector{row->data(), row->numberColumns()};
         }
     };
 
@@ -104,7 +104,7 @@ bool computeOutliersNoPartitions(std::size_t numberThreads, core::CDataFrame& fr
     frame.resizeColumns(numberThreads, frame.numberColumns() + 1);
     successful = frame.writeColumns(numberThreads, writeScores);
     if (successful == false) {
-        LOG_ERROR(<< "Failed to write scores");
+        LOG_ERROR(<< "Failed to write scores to the data frame");
         return false;
     }
     return true;


### PR DESCRIPTION
This finishes up the implementation of `CDataFrameAnalyzer`: wiring in outlier detection and writing results to the output stream.

It also fixes a couple of bugs discovered while testing and renames some functions to be consistent across all functionality related to a data frame.