### PR TITLE
[FEATURE][ML] Migrate data frame background write to storage to use thread pool

### DIFF
--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -250,10 +250,10 @@ parallel_for_each(std::size_t partitions, std::size_t start, std::size_t end, FU
     //      in priority order. Then we can assign these tasks "highest priority in
     //      queue" + 1.
     //
-    // In the first instance I'm going to implement 1) because in practice we probably
-    // don't actually need to nest parallel_for_each and we are just interested in
-    // guarding against accidental deadlock in the case someone inadvertantly calls
-    // parallelised code and it is significantly simpler.
+    // This implements 1) because it is significantly simpler to and in practice we
+    // probably don't actually need to nest parallel_for_each. We're just interested
+    // in guarding against accidental deadlock in the case someone inadvertantly calls
+    // parallelised code in the function to execute.
 
     concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
 

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -33,9 +33,9 @@ void slowTask(std::atomic_uint& counter) {
 }
 
 // ASSERTIONS BASED ON TIMINGS ARE NOT RELIABLE IN OUR VIRTUALISED TEST ENVIRONMENT
-// SO I'VE COMMENTED OUT. THESE VALUES CONSISTENTLY PASSED AT ONE POINT ON BARE METAL.
-// IF YOU MAKE CHANGES TO THE THREAD POOL COMMENT THEM BACK IN AND CHECK LOCALLY THAT
-// YOU HAVEN'T DEGRADED PERFORMANCE.
+// SO ARE COMMENTED OUT. THESE VALUES CONSISTENTLY PASSED AT ONE POINT ON BARE METAL.
+// IF YOU MAKE CHANGES TO THE THREAD POOL COMMENT THEM BACK IN AND CHECK THAT YOU
+// HAVEN'T DEGRADED PERFORMANCE.
 
 void CStaticThreadPoolTest::testScheduleDelayMinimisation() {
 
@@ -105,9 +105,10 @@ void CStaticThreadPoolTest::testThroughputStability() {
 
     CPPUNIT_ASSERT_EQUAL(2000u, counter.load());
 
-    // The best we can achieve is 2000ms ignoring all overheads. In fact, there will
-    // be imbalance in the queues when the pool shuts down which is then performed
-    // single threaded. Also there are other overheads.
+    // The best we can achieve is 2000ms ignoring all overheads. There will be
+    // imbalance in the queues when the pool shuts down and we must wait for
+    // the queue with the longest delay to drain on its worker thread. There
+    // will also be overheads.
     std::uint64_t totalTime{totalTimeWatch.stop()};
     LOG_DEBUG(<< "Total time = " << totalTime);
     //CPPUNIT_ASSERT(totalTime <= 2600);
@@ -151,7 +152,8 @@ void CStaticThreadPoolTest::testManyTasksThroughput() {
 
 void CStaticThreadPoolTest::testExceptions() {
 
-    // Check we don't deadlock we don't kill worker threads if we do stupid things.
+    // Check we don't deadlock because we don't kill worker threads if we do stupid
+    // things.
 
     std::atomic_uint counter{0};
     {
@@ -167,7 +169,7 @@ void CStaticThreadPoolTest::testExceptions() {
         }
     }
 
-    // We limped on without killing any of the worker threads.
+    // We didn't lose any real tasks.
     CPPUNIT_ASSERT_EQUAL(200u, counter.load());
 }
 


### PR DESCRIPTION
This reworks the data frame writer to use the thread pool rather than launching its own threads to write to storage in the background. Aside from simplifying the code, this also means that we properly enforce the number of threads constraint supplied to the data_frame_analyzer command. I also improved a couple of comments from #322.