### PR TITLE
[FEATURE][ML] Shallow copy memory mapped vector and matrix types

### DIFF
--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -320,6 +320,9 @@ public:
     //! Get the memory used by the data frame.
     std::size_t memoryUsage() const;
 
+    //! Get a checksum of all the data stored in the data frame.
+    std::uint64_t checksum() const;
+
     // TODO Better error case diagnostics.
 
     // TODO We may want an architecture agnostic check pointing mechanism for long

--- a/include/core/CDataFrameRowSlice.h
+++ b/include/core/CDataFrameRowSlice.h
@@ -75,6 +75,7 @@ public:
     virtual void write(const TFloatVec& values) = 0;
     virtual std::size_t staticSize() const = 0;
     virtual std::size_t memoryUsage() const = 0;
+    virtual std::uint64_t checksum() const = 0;
 };
 
 //! \brief In main memory CDataFrame slice storage.
@@ -95,6 +96,7 @@ public:
     virtual void write(const TFloatVec& values);
     virtual std::size_t staticSize() const;
     virtual std::size_t memoryUsage() const;
+    virtual std::uint64_t checksum() const;
 
 private:
     std::size_t m_FirstRow;
@@ -155,6 +157,7 @@ public:
     virtual void write(const TFloatVec& values);
     virtual std::size_t staticSize() const;
     virtual std::size_t memoryUsage() const;
+    virtual std::uint64_t checksum() const;
 
 private:
     void writeToDisk(const TFloatVec& state);

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -312,19 +312,31 @@ public:
         : CMemoryMappedDenseMatrix{static_cast<const CMemoryMappedDenseMatrix&>(other)} {}
     CMemoryMappedDenseMatrix(const CMemoryMappedDenseMatrix& other)
         : TBase{nullptr, 1, 1} {
-        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+        this->reseat(other);
     }
     CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix&& other)
         : TBase{nullptr, 1, 1} {
-        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+        this->reseat(other);
     }
     CMemoryMappedDenseMatrix& operator=(const CMemoryMappedDenseMatrix& other) {
-        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+        if (this != &other) {
+            this->reseat(other);
+        }
+        return *this;
     }
     CMemoryMappedDenseMatrix& operator=(CMemoryMappedDenseMatrix&& other) {
-        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+        if (this != &other) {
+            this->reseat(other);
+        }
+        return *this;
     }
     //@}
+
+private:
+    void reseat(const CMemoryMappedDenseMatrix& other) {
+        TBase *base{static_cast<TBase*>(this)};
+        new (base) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+    }
 };
 
 //! \brief Gets a constant square dense matrix with specified dimension or with
@@ -393,21 +405,21 @@ public:
         : CMemoryMappedDenseVector{static_cast<const CMemoryMappedDenseVector&>(other)} {}
     CMemoryMappedDenseVector(const CMemoryMappedDenseVector& other)
         : TBase{nullptr, 1} {
-        new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+        this->reseat(other);
     }
     CMemoryMappedDenseVector(CMemoryMappedDenseVector&& other)
         : TBase{nullptr, 1} {
-        new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+        this->reseat(other);
     }
     CMemoryMappedDenseVector& operator=(const CMemoryMappedDenseVector& other) {
         if (this != &other) {
-            new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+            this->reseat(other);
         }
         return *this;
     }
     CMemoryMappedDenseVector& operator=(CMemoryMappedDenseVector&& other) {
         if (this != &other) {
-            new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+            this->reseat(other);
         }
         return *this;
     }
@@ -419,6 +431,12 @@ public:
             seed = CChecksum::calculate(seed, this->coeff(i));
         }
         return seed;
+    }
+
+private:
+    void reseat(const CMemoryMappedDenseVector& other) {
+        TBase *base{static_cast<TBase*>(this)};
+        new (base) TBase{const_cast<SCALAR*>(other.data()), other.size()};
     }
 };
 

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -334,7 +334,7 @@ public:
 
 private:
     void reseat(const CMemoryMappedDenseMatrix& other) {
-        TBase *base{static_cast<TBase*>(this)};
+        TBase* base{static_cast<TBase*>(this)};
         new (base) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
     }
 };
@@ -435,7 +435,7 @@ public:
 
 private:
     void reseat(const CMemoryMappedDenseVector& other) {
-        TBase *base{static_cast<TBase*>(this)};
+        TBase* base{static_cast<TBase*>(this)};
         new (base) TBase{const_cast<SCALAR*>(other.data()), other.size()};
     }
 };

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -281,7 +281,16 @@ struct SConstant<CDenseVector<SCALAR>> {
     }
 };
 
-//! \brief Decorates an Eigen::Map of a dense matrix with some useful methods.
+//! \brief Decorates an Eigen::Map of a dense matrix with some useful methods
+//! and changes default copy semantics to shallow copy.
+//!
+//! IMPLEMENTATION:\n
+//! This effectively acts like a std::reference_wrapper of an Eigen::Map for
+//! an Eigen matrix. In particular, all copying is shallow unlike Eigen::Map
+//! that acts directly on the referenced memory. This is to match the behaviour
+//! of CMemoryMappedDenseVector.
+//!
+//! \sa CMemoryMappedDenseVector for more information.
 template<typename SCALAR>
 class CMemoryMappedDenseMatrix
     : public Eigen::Map<typename CDenseMatrix<SCALAR>::TBase> {
@@ -302,10 +311,19 @@ public:
     CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix& other)
         : CMemoryMappedDenseMatrix{static_cast<const CMemoryMappedDenseMatrix&>(other)} {}
     CMemoryMappedDenseMatrix(const CMemoryMappedDenseMatrix& other)
-        : TBase{static_cast<const TBase&>(other)} {}
-    CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix&& other) = default;
-    CMemoryMappedDenseMatrix& operator=(const CMemoryMappedDenseMatrix& other) = default;
-    CMemoryMappedDenseMatrix& operator=(CMemoryMappedDenseMatrix&& other) = default;
+        : TBase{nullptr, 1, 1} {
+        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+    }
+    CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix&& other)
+        : TBase{nullptr, 1, 1} {
+        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+    }
+    CMemoryMappedDenseMatrix& operator=(const CMemoryMappedDenseMatrix& other) {
+        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+    }
+    CMemoryMappedDenseMatrix& operator=(CMemoryMappedDenseMatrix&& other) {
+        new (this) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
+    }
     //@}
 };
 
@@ -323,7 +341,37 @@ struct SConstant<CMemoryMappedDenseMatrix<SCALAR>> {
     }
 };
 
-//! \brief Decorates an Eigen::Map of a dense vector with some useful methods.
+//! \brief Decorates an Eigen::Map of a dense vector with some useful methods
+//! and changes default copy semantics to shallow.
+//!
+//! IMPLEMENTATION:\n
+//! This effectively acts like a std::reference_wrapper of an Eigen::Map for
+//! an Eigen vector. In particular, all copying is shallow unlike Eigen::Map
+//! that acts directly on the referenced memory, i.e.
+//! \code{.cpp}
+//! double values1[]{1.0, 1.0};
+//! double values2[]{2.0, 2.0};
+//!
+//! CMemoryMappedDenseVector<double> mm1{values1, 2};
+//! CMemoryMappedDenseVector<double> mm2{values2, 2};
+//!
+//! mm1 = mm2;
+//! std::cout << mm1(0) << "," << mm1(1) << "," << values1[0] << "," << values1[1] << std::endl;
+//!
+//! Eigen::Map<Eigen::VectorXd> map1{values1, 2};
+//! Eigen::Map<Eigen::VectorXd> map2{values2, 2};
+//!
+//! map1 = map2;
+//! std::cout << map1(0) << "," << map1(1) << "," << values1[0] << "," << values1[1] << std::endl;
+//! \endcode
+//!
+//! Outputs:\n
+//! 2,2,1,1\n
+//! 2,2,2,2
+//!
+//! This better fits our needs with data frames where we want to reference the
+//! memory stored in the data frame rows, but never modify it directly through
+//! this vector type.
 template<typename SCALAR>
 class CMemoryMappedDenseVector
     : public Eigen::Map<typename CDenseVector<SCALAR>::TBase> {
@@ -337,17 +385,32 @@ public:
     //! Forwarding constructor.
     template<typename... ARGS>
     CMemoryMappedDenseVector(ARGS&&... args)
-        : TBase(std::forward<ARGS>(args)...) {}
+        : TBase{std::forward<ARGS>(args)...} {}
 
     //! \name Copy and Move Semantics
     //@{
     CMemoryMappedDenseVector(CMemoryMappedDenseVector& other)
         : CMemoryMappedDenseVector{static_cast<const CMemoryMappedDenseVector&>(other)} {}
     CMemoryMappedDenseVector(const CMemoryMappedDenseVector& other)
-        : TBase{static_cast<const TBase&>(other)} {}
-    CMemoryMappedDenseVector(CMemoryMappedDenseVector&& other) = default;
-    CMemoryMappedDenseVector& operator=(const CMemoryMappedDenseVector& other) = default;
-    CMemoryMappedDenseVector& operator=(CMemoryMappedDenseVector&& other) = default;
+        : TBase{nullptr, 1} {
+        new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+    }
+    CMemoryMappedDenseVector(CMemoryMappedDenseVector&& other)
+        : TBase{nullptr, 1} {
+        new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+    }
+    CMemoryMappedDenseVector& operator=(const CMemoryMappedDenseVector& other) {
+        if (this != &other) {
+            new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+        }
+        return *this;
+    }
+    CMemoryMappedDenseVector& operator=(CMemoryMappedDenseVector&& other) {
+        if (this != &other) {
+            new (this) TBase{const_cast<SCALAR*>(other.data()), other.size()};
+        }
+        return *this;
+    }
     //@}
 
     //! Get a checksum of this object.

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -87,7 +87,7 @@ bool CDataFrameAnalyzer::handleRecord(const TStrVec& fieldNames, const TStrVec& 
     }
 
     this->addRowToDataFrame(fieldValues);
-    return false;
+    return true;
 }
 
 void CDataFrameAnalyzer::receivedAllRows() {
@@ -158,7 +158,7 @@ bool CDataFrameAnalyzer::handleControlMessage(const TStrVec& fieldValues) {
     case ' ':
         // Spaces are just used to fill the buffers and force prior messages
         // through the system - we don't need to do anything else.
-        LOG_TRACE(<< "Received pad of length " << controlMessage.length());
+        LOG_TRACE(<< "Received pad of length " << fieldValues[m_ControlFieldIndex]);
         return true;
     case FINISHED_DATA_CONTROL_MESSAGE_FIELD_VALUE:
         this->receivedAllRows();

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -158,7 +158,7 @@ bool CDataFrameAnalyzer::handleControlMessage(const TStrVec& fieldValues) {
     case ' ':
         // Spaces are just used to fill the buffers and force prior messages
         // through the system - we don't need to do anything else.
-        LOG_TRACE(<< "Received pad of length " << fieldValues[m_ControlFieldIndex]);
+        LOG_TRACE(<< "Received pad of length " << fieldValues[m_ControlFieldIndex].length());
         return true;
     case FINISHED_DATA_CONTROL_MESSAGE_FIELD_VALUE:
         this->receivedAllRows();

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -158,7 +158,8 @@ bool CDataFrameAnalyzer::handleControlMessage(const TStrVec& fieldValues) {
     case ' ':
         // Spaces are just used to fill the buffers and force prior messages
         // through the system - we don't need to do anything else.
-        LOG_TRACE(<< "Received pad of length " << fieldValues[m_ControlFieldIndex].length());
+        LOG_TRACE(<< "Received pad of length "
+                  << fieldValues[m_ControlFieldIndex].length());
         return true;
     case FINISHED_DATA_CONTROL_MESSAGE_FIELD_VALUE:
         this->receivedAllRows();

--- a/lib/maths/CLocalOutlierFactors.cc
+++ b/lib/maths/CLocalOutlierFactors.cc
@@ -79,7 +79,8 @@ bool computeOutliersNoPartitions(std::size_t numberThreads, core::CDataFrame& fr
 
     auto rowsToPoints = [&points](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            new (&points[row->index()]) TVector{row->data(), row->numberColumns()};
+            points[row->index()] =
+                TVector{row->data(), static_cast<long>(row->numberColumns())};
         }
     };
 


### PR DESCRIPTION
We have a problem with the copy semantics of memory mapped matrix and vector types (which they inherit from Eigen::Map) for our usage. Basically, copy and move overwrite the values in the referenced memory, whereas for our purposes we'd like to treat these as immutable and simply copy the reference.

This causes a real problem in our current implementation of outlier detection on a data frame when using memory mapped types, because for example, building k-d tree reorders a `std::vector` of memory mapped vectors and in doing so copies values between the rows of the data frame.

We could wrap everything in a `std::reference_wrapper`, but 1) we then still need to create an immutable vector of mapped types that is referenced (which is wasteful) and 2) have to adapt all code to unwrap any vector type before it is used (which is annoying).

The ideal solution would be to be able to inherit from `Eigen::Map<const Eigen::VectorXd>` and then if this is used as a write destination it would fail to compile. Annoyingly, `Eigen::Map` doesn't support this so we subvert const correctness knowing that we don't break it in any actual uses. (Another strategy would be to turn `CMemoryMappedDenseVector` into a custom reference wrapper around `Eigen::Map<const Eigen::VectorXd>`. This works around problem 1) above. However, we'd have to access the underlying Eigen type as a const reference whenever we used it and so it still suffers from problem 2).)

I've added a checksum to CDataFrame, and we check in code that uses the memory mapped vectors that it doesn't modify the checksum. This at least verifies at run time that nothing is inadvertently writing the data frame via a memory mapped vector.