### PR TITLE
[FEATURE][ML] Fix possible deadlock in thread pool shutdown

### DIFF
--- a/lib/core/CStaticThreadPool.cc
+++ b/lib/core/CStaticThreadPool.cc
@@ -69,7 +69,7 @@ void CStaticThreadPool::busy(bool value) {
 
 void CStaticThreadPool::shutdown() {
 
-    // Drain before starting to shutting down to maximise through put.
+    // Drain the queues before starting to shut down in order to maximise throughput.
     this->drainQueuesWithoutBlocking();
 
     // Signal to each thread that it is finished. We bind each task to a thread so

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -147,7 +147,26 @@ void CStaticThreadPoolTest::testManyTasksThroughput() {
     //CPPUNIT_ASSERT(totalTime <= 780);
 }
 
-void CStaticThreadPoolTest::testExceptions() {
+void CStaticThreadPoolTest::testSchedulingOverhead() {
+
+    // Test the overhead per task is less than 1.6 microseconds.
+
+    core::CStaticThreadPool pool{4};
+
+    core::CStopWatch watch{true};
+    for (std::size_t i = 0; i < 1000000; ++i) {
+        if (i % 100000 == 0) {
+            LOG_DEBUG(<< i);
+        }
+        pool.schedule([]() {});
+    }
+
+    double overhead{static_cast<double>(watch.stop()) / 1000.0};
+    LOG_DEBUG(<< "Total time = " << overhead);
+    //CPPUNIT_ASSERT(overhead < 1.6);
+}
+
+void CStaticThreadPoolTest::testWithExceptions() {
 
     // Check we don't deadlock we don't kill worker threads if we do stupid things.
 
@@ -182,7 +201,10 @@ CppUnit::Test* CStaticThreadPoolTest::suite() {
         "CStaticThreadPoolTest::testManyTasksThroughput",
         &CStaticThreadPoolTest::testManyTasksThroughput));
     suiteOfTests->addTest(new CppUnit::TestCaller<CStaticThreadPoolTest>(
-        "CStaticThreadPoolTest::testExceptions", &CStaticThreadPoolTest::testExceptions));
+        "CStaticThreadPoolTest::testSchedulingOverhead",
+        &CStaticThreadPoolTest::testSchedulingOverhead));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CStaticThreadPoolTest>(
+        "CStaticThreadPoolTest::testWithExceptions", &CStaticThreadPoolTest::testWithExceptions));
 
     return suiteOfTests;
 }

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -105,12 +105,10 @@ void CStaticThreadPoolTest::testThroughputStability() {
 
     CPPUNIT_ASSERT_EQUAL(2000u, counter.load());
 
-    // The best we can achieve is 2000ms ignoring all overheads. In fact, there will
-    // be imbalance in the queues when the pool shuts down which is then performed
-    // single threaded. Also there are other overheads.
+    // The best we can achieve is 2000ms ignoring all overheads.
     std::uint64_t totalTime{totalTimeWatch.stop()};
     LOG_DEBUG(<< "Total time = " << totalTime);
-    //CPPUNIT_ASSERT(totalTime <= 2600);
+    //CPPUNIT_ASSERT(totalTime <= 2400);
 }
 
 void CStaticThreadPoolTest::testManyTasksThroughput() {

--- a/lib/core/unittest/CStaticThreadPoolTest.h
+++ b/lib/core/unittest/CStaticThreadPoolTest.h
@@ -14,7 +14,8 @@ public:
     void testScheduleDelayMinimisation();
     void testThroughputStability();
     void testManyTasksThroughput();
-    void testExceptions();
+    void testSchedulingOverhead();
+    void testWithExceptions();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
There was an error in the shutdown of the thread pool. In particular, although threads process tasks in their queue by preference, if there is a context switch whilst the main thread is adding shutdown messages to another thread which isn't waiting to pop its queue and hasn't yet had its shutdown message added then it could steal another queue's shutdown task. The thread whose shutdown task is stolen will then deadlock waiting for its last message iff its queue was already empty.

~~This PR changes shutdown to wait until all tasks have been processed before enqueuing shutdown tasks. This ensures that every task is blocked waiting to pop its own queue and will process only its own shutdown message and exit. This also means we get better concurrency draining the queues while shutting down and I tightened up one of the test thresholds as a result.~~ See below.

This issue is difficult to test without inserting waits into both the add shutdown task loop and steal task loop, but I reproduced manually and it has been occurring intermittently in integration tests.