### PR TITLE
[FEATURE][ML] change artifactname in order to create a CI build job

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=false
 
 elasticsearchVersion=7.0.0
 
-artifactName=ml-cpp
+artifactName=ml-cpp-df


### PR DESCRIPTION
changes the artifact name to  `ml-cpp-df` in order setup a CI build that uploads builds without clashing with master builds

Before the feature branch is merged, this change must be reverted.

@dimitris-athanasiou 