### PR TITLE
[FEATURE][ML] Groundwork for partitioning data frame analyses

### DIFF
--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -39,6 +39,7 @@ namespace api {
 class API_EXPORT CDataFrameAnalysisSpecification {
 public:
     using TStrVec = std::vector<std::string>;
+    using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
     using TRunnerUPtr = std::unique_ptr<CDataFrameAnalysisRunner>;
     using TRunnerFactoryUPtr = std::unique_ptr<CDataFrameAnalysisRunnerFactory>;
     using TRunnerFactoryUPtrVec = std::vector<TRunnerFactoryUPtr>;
@@ -53,6 +54,7 @@ public:
     //!   "cols": <integer>,
     //!   "memory_limit": <integer>,
     //!   "threads": <integer>,
+    //!   "temp_dir": <string>,
     //!   "analysis": {
     //!     "name": <string>,
     //!     "parameters": <object>
@@ -65,6 +67,9 @@ public:
     //! \note All constraints must be positive.
     //! \note The parameters, if any, must be consistent for the analysis type.
     //! \note If this fails the state is set to bad and the analysis will not run.
+    //! \note temp_dir Is a directory which can be used to store the data frame
+    //! out-of-core if we can't meet the memory constraint for the analysis without
+    //! partitioning.
     CDataFrameAnalysisSpecification(const std::string& jsonSpecification);
 
     //! This construtor provides support for custom analysis types and is mainly
@@ -98,6 +103,13 @@ public:
     //! \return The number of threads the analysis can use.
     std::size_t numberThreads() const;
 
+    //! Make a data frame suitable for this analysis specification.
+    //!
+    //! This chooses the storage strategy based on the analysis constraints and
+    //! the number of rows and target number of columns and reserves capacity as
+    //! appropriate.
+    TDataFrameUPtr makeDataFrame() const;
+
     //! Run the analysis in a background thread.
     //!
     //! This returns a handle to the object responsible for running the analysis.
@@ -120,6 +132,7 @@ private:
     std::size_t m_NumberColumns = 0;
     std::size_t m_MemoryLimit = 0;
     std::size_t m_NumberThreads = 0;
+    std::string m_TemporaryDirectory;
     // TODO Sparse table support
     // double m_TableLoadFactor = 0.0;
     TRunnerFactoryUPtrVec m_RunnerFactories;

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -92,7 +92,7 @@ public:
     //! to the data frame.
     std::size_t numberExtraColumns() const;
 
-    //! \return The memory limit for the process.
+    //! \return The memory usage limit for the process.
     std::size_t memoryLimit() const;
 
     //! \return The number of threads the analysis can use.

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -19,15 +19,11 @@ namespace ml {
 namespace api {
 
 //! \brief Runs outlier detection on a core::CDataFrame.
-class API_EXPORT CDataFrameOutliersRunner : public CDataFrameAnalysisRunner {
+class API_EXPORT CDataFrameOutliersRunner final : public CDataFrameAnalysisRunner {
 public:
     CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec,
                              const rapidjson::Value& params);
     CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec);
-
-    //! \return The number of partitions to use when computing outliers for the frame.
-    //! \sa CDataFrameAnalysisRunner::run.
-    virtual std::size_t numberOfPartitions() const;
 
     //! \return The number of columns this adds to the data frame.
     virtual std::size_t numberExtraColumns() const;
@@ -40,6 +36,11 @@ private:
 
 private:
     virtual void runImpl(core::CDataFrame& frame);
+    virtual std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
+                                                       std::size_t numberRows,
+                                                       std::size_t numberColumns) const;
+    template<typename POINT>
+    std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
 
 private:
     //! \name Custom config
@@ -54,8 +55,6 @@ private:
     //! \see maths::CLocalOutlierFactors for more details.
     TOptionalSize m_Method;
     //@}
-
-    std::size_t m_NumberPartitions;
 };
 
 //! \brief Makes a core::CDataFrame outlier analysis runner.

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -21,8 +21,11 @@ namespace api {
 //! \brief Runs outlier detection on a core::CDataFrame.
 class API_EXPORT CDataFrameOutliersRunner final : public CDataFrameAnalysisRunner {
 public:
+    //! This is not intended to be called directly: use CDataFrameOutliersRunnerFactory.
     CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec,
                              const rapidjson::Value& params);
+
+    //! This is not intended to be called directly: use CDataFrameOutliersRunnerFactory.
     CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec);
 
     //! \return The number of columns this adds to the data frame.
@@ -61,9 +64,11 @@ private:
 class API_EXPORT CDataFrameOutliersRunnerFactory : public CDataFrameAnalysisRunnerFactory {
 public:
     virtual const char* name() const;
-    virtual TRunnerUPtr make(const CDataFrameAnalysisSpecification& spec) const;
-    virtual TRunnerUPtr make(const CDataFrameAnalysisSpecification& spec,
-                             const rapidjson::Value& params) const;
+
+private:
+    virtual TRunnerUPtr makeImpl(const CDataFrameAnalysisSpecification& spec) const;
+    virtual TRunnerUPtr makeImpl(const CDataFrameAnalysisSpecification& spec,
+                                 const rapidjson::Value& params) const;
 };
 }
 }

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -52,11 +52,11 @@ private:
     //! outlier factors.
     TOptionalSize m_NumberNeighbours;
 
-    //! If non-null selects the method to use to compute outlier factors; the default
-    //! is an ensemble of all supported types.
+    //! Selects the method to use to compute outlier factors; the default is an ensemble
+    //! of all supported types.
     //!
     //! \see maths::CLocalOutlierFactors for more details.
-    TOptionalSize m_Method;
+    std::size_t m_Method;
     //@}
 };
 

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -323,6 +323,12 @@ public:
     //! Get a checksum of all the data stored in the data frame.
     std::uint64_t checksum() const;
 
+    //! Get the estimated memory usage for a data frame with \p numberRows rows and
+    //! \p numberColumns columns.
+    static std::size_t estimateMemoryUsage(bool inMainMemory,
+                                           std::size_t numberRows,
+                                           std::size_t numberColumns);
+
     // TODO Better error case diagnostics.
 
     // TODO We may want an architecture agnostic check pointing mechanism for long

--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -126,6 +126,11 @@ public:
             return depth;
         }
 
+        //! Estimate the amount of memory this node will use.
+        static std::size_t estimateMemoryUsage(std::size_t dimension) {
+            return sizeof(SNode) + las::estimateMemoryUsage<POINT>(dimension);
+        }
+
         //! The parent.
         SNode* s_Parent;
         //! The left child if one exists.
@@ -289,6 +294,14 @@ public:
             }
         }
         return true;
+    }
+
+    //! Estimate the amount of memory the k-d tree will use.
+    //!
+    //! \param[in] numberPoints The number of points it will hold.
+    //! \param[in] dimension The dimension of points it will hold.
+    static std::size_t estimateMemoryUsage(std::size_t numberPoints, std::size_t dimension) {
+        return numberPoints * SNode::estimateMemoryUsage(dimension);
     }
 
 private:

--- a/include/maths/CLinearAlgebraShims.h
+++ b/include/maths/CLinearAlgebraShims.h
@@ -332,6 +332,41 @@ typename SConformableMatrix<VECTOR>::Type
 outer(const CAnnotatedVector<VECTOR, ANNOTATION>& x) {
     return outer(static_cast<const VECTOR&>(x));
 }
+
+namespace las_detail {
+template<typename VECTOR>
+struct SEstimateMemoryUsage {
+    static std::size_t value(std::size_t) { return 0; }
+};
+template<typename T>
+struct SEstimateMemoryUsage<CVector<T>> {
+    static std::size_t value(std::size_t dimension) {
+        return dimension * sizeof(T);
+    }
+};
+template<typename SCALAR>
+struct SEstimateMemoryUsage<CDenseVector<SCALAR>> {
+    static std::size_t value(std::size_t dimension) {
+        // Ignore pad for alignment.
+        return dimension * sizeof(SCALAR);
+    }
+};
+template<typename VECTOR, typename ANNOTATION>
+struct SEstimateMemoryUsage<CAnnotatedVector<VECTOR, ANNOTATION>> {
+    static std::size_t value(std::size_t dimension) {
+        // Ignore any dynamic memory used by the annotation: we don't know how to
+        // compute this here. It will be up to the calling code to estimate this
+        // correctly.
+        return SEstimateMemoryUsage<VECTOR>::value(dimension);
+    }
+};
+}
+
+//! Estimate the amount of memory a point of type VECTOR and \p dimension will use.
+template<typename VECTOR>
+std::size_t estimateMemoryUsage(std::size_t dimension) {
+    return las_detail::SEstimateMemoryUsage<VECTOR>::value(dimension);
+}
 }
 }
 }

--- a/include/maths/CLocalOutlierFactors.h
+++ b/include/maths/CLocalOutlierFactors.h
@@ -513,7 +513,7 @@ protected:
             normalize(scores);
         }
 
-        static std::size_t estimateOwnMemoryOverheads(std::size_t k, std::size_t numberPoints) {
+        static std::size_t estimateOwnMemoryOverhead(std::size_t k, std::size_t numberPoints) {
             return numberPoints * (sizeof(TSizeDoublePrVec) +
                                    k * sizeof(TSizeDoublePr) + sizeof(double));
         }
@@ -697,8 +697,8 @@ protected:
             }
         }
 
-        static std::size_t estimateOwnMemoryOverheads(std::size_t numberPoints,
-                                                      std::size_t numberMethods) {
+        static std::size_t estimateOwnMemoryOverhead(std::size_t numberPoints,
+                                                     std::size_t numberMethods) {
             return numberMethods * (sizeof(TDoubleVec) + numberPoints * sizeof(double));
         }
 

--- a/include/maths/CLocalOutlierFactors.h
+++ b/include/maths/CLocalOutlierFactors.h
@@ -203,15 +203,16 @@ public:
                                            std::size_t k,
                                            std::size_t numberPoints,
                                            std::size_t dimension) {
+        // TODO handle the case we'll project the data properly.
         std::size_t result{TKdTree<POINT>::estimateMemoryUsage(numberPoints, dimension)};
         switch (algorithm) {
         case E_Ensemble:
-            result += CLof<POINT, TKdTree<POINT>>::estimateMemoryUsage(k, numberPoints) +
-                      CEnsemble<POINT, TKdTree<POINT>>::estimateMemoryUsage(
-                          numberPoints, dimension);
+            result += CLof<POINT, TKdTree<POINT>>::estimateOwnMemoryOverhead(k, numberPoints) +
+                      CEnsemble<POINT, TKdTree<POINT>>::estimateOwnMemoryOverhead(
+                          numberPoints, 4);
             break;
         case E_Lof:
-            result += CLof<POINT, TKdTree<POINT>>::estimateMemoryUsage(numberPoints, dimension);
+            result += CLof<POINT, TKdTree<POINT>>::estimateOwnMemoryOverhead(k, numberPoints);
             break;
         case E_Ldof:
         case E_DistancekNN:
@@ -512,7 +513,7 @@ protected:
             normalize(scores);
         }
 
-        static std::size_t estimateMemoryUsage(std::size_t numberPoints, std::size_t k) {
+        static std::size_t estimateOwnMemoryOverheads(std::size_t k, std::size_t numberPoints) {
             return numberPoints * (sizeof(TSizeDoublePrVec) +
                                    k * sizeof(TSizeDoublePr) + sizeof(double));
         }
@@ -696,8 +697,8 @@ protected:
             }
         }
 
-        static std::size_t estimateMemoryUsage(std::size_t numberPoints,
-                                               std::size_t numberMethods) {
+        static std::size_t estimateOwnMemoryOverheads(std::size_t numberPoints,
+                                                      std::size_t numberMethods) {
             return numberMethods * (sizeof(TDoubleVec) + numberPoints * sizeof(double));
         }
 

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -19,7 +19,7 @@
 namespace ml {
 namespace api {
 namespace {
-std::size_t memoryLimitWithMargin(const CDataFrameAnalysisSpecification& spec) {
+std::size_t memoryLimitWithSafetyMargin(const CDataFrameAnalysisSpecification& spec) {
     return static_cast<std::size_t>(0.9 * static_cast<double>(spec.memoryLimit()) + 0.5);
 }
 }
@@ -36,7 +36,7 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
 
     std::size_t numberRows{m_Spec.numberRows()};
     std::size_t numberColumns{m_Spec.numberColumns() + this->numberExtraColumns()};
-    std::size_t memoryLimit{memoryLimitWithMargin(m_Spec)};
+    std::size_t memoryLimit{memoryLimitWithSafetyMargin(m_Spec)};
 
     LOG_TRACE(<< "memory limit = " << memoryLimit);
 
@@ -148,7 +148,7 @@ void CDataFrameAnalysisRunner::addError(const std::string& error) {
 
 std::size_t CDataFrameAnalysisRunner::estimateMemoryUsage(std::size_t numberRows,
                                                           std::size_t numberColumns) const {
-    return core::CDataFrame::estimateMemoryUsage(m_NumberPartitions == 1,
+    return core::CDataFrame::estimateMemoryUsage(this->storeDataFrameInMainMemory(),
                                                  numberRows, numberColumns) +
            this->estimateBookkeepingMemoryUsage(m_NumberPartitions, numberRows, numberColumns);
 }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -172,7 +172,7 @@ CDataFrameAnalysisSpecification::makeDataFrame() const {
     }
 
     // TODO Remove hack when passing directory in config.
-    if (m_Runner->storeDataFrameInMainMemory()) {
+    if (m_Runner->storeDataFrameInMainMemory() == false) {
         return {};
     }
 

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -6,6 +6,7 @@
 
 #include <api/CDataFrameAnalysisSpecification.h>
 
+#include <core/CDataFrame.h>
 #include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
 #include <core/CRapidJsonLineWriter.h>
@@ -15,6 +16,7 @@
 #include <rapidjson/document.h>
 #include <rapidjson/ostreamwrapper.h>
 
+#include <boost/filesystem/path.hpp>
 #include <boost/make_unique.hpp>
 
 #include <cstring>
@@ -38,6 +40,7 @@ const char* ROWS{"rows"};
 const char* COLS{"cols"};
 const char* MEMORY_LIMIT{"memory_limit"};
 const char* THREADS{"threads"};
+const char* TEMPORARY_DIRECTORY{"temp_dir"};
 const char* ANALYSIS{"analysis"};
 const char* NAME{"name"};
 const char* PARAMETERS{"parameters"};
@@ -106,6 +109,16 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         } else {
             registerFailure(THREADS);
         }
+        // TODO Remove hack when being passed.
+        if (false) {
+            if (document.HasMember(TEMPORARY_DIRECTORY) &&
+                document[TEMPORARY_DIRECTORY].IsString() &&
+                boost::filesystem::portable_name(document[TEMPORARY_DIRECTORY].GetString())) {
+                m_TemporaryDirectory = document[TEMPORARY_DIRECTORY].GetString();
+            } else {
+                registerFailure(TEMPORARY_DIRECTORY);
+            }
+        }
 
         if (document.HasMember(ANALYSIS) && document[ANALYSIS].IsObject()) {
             const auto& analysis = document[ANALYSIS];
@@ -150,6 +163,26 @@ std::size_t CDataFrameAnalysisSpecification::memoryLimit() const {
 
 std::size_t CDataFrameAnalysisSpecification::numberThreads() const {
     return m_NumberThreads;
+}
+
+CDataFrameAnalysisSpecification::TDataFrameUPtr
+CDataFrameAnalysisSpecification::makeDataFrame() const {
+    if (m_Bad) {
+        return {};
+    }
+
+    // TODO Remove hack when passing directory in config.
+    if (m_Runner->storeDataFrameInMainMemory()) {
+        return {};
+    }
+
+    TDataFrameUPtr result{m_Runner->storeDataFrameInMainMemory()
+                              ? core::makeMainStorageDataFrame(m_NumberColumns)
+                              : core::makeDiskStorageDataFrame(
+                                    m_TemporaryDirectory, m_NumberColumns, m_NumberRows)};
+    result->reserve(m_NumberThreads, m_NumberColumns + this->numberExtraColumns());
+
+    return result;
 }
 
 CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame& frame) const {

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -38,12 +38,8 @@ CDataFrameAnalyzer::CDataFrameAnalyzer(TDataFrameAnalysisSpecificationUPtr analy
                                        TJsonOutputStreamWrapperUPtrSupplier outStreamSupplier)
     : m_AnalysisSpecification{std::move(analysisSpecification)}, m_OutStreamSupplier{outStreamSupplier} {
 
-    // TODO memory calculations plus choose data frame storage strategy.
-    if (m_AnalysisSpecification != nullptr && m_AnalysisSpecification->bad() == false) {
-        m_DataFrame = core::makeMainStorageDataFrame(m_AnalysisSpecification->numberColumns());
-        m_DataFrame->reserve(m_AnalysisSpecification->numberThreads(),
-                             m_AnalysisSpecification->numberColumns() +
-                                 m_AnalysisSpecification->numberExtraColumns());
+    if (m_AnalysisSpecification != nullptr) {
+        m_DataFrame = m_AnalysisSpecification->makeDataFrame();
     }
 }
 

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -87,8 +87,10 @@ bool CDataFrameAnalyzer::handleRecord(const TStrVec& fieldNames, const TStrVec& 
 }
 
 void CDataFrameAnalyzer::receivedAllRows() {
-    m_DataFrame->finishWritingRows();
-    LOG_DEBUG(<< "Received " << m_DataFrame->numberRows() << " rows");
+    if (m_DataFrame != nullptr) {
+        m_DataFrame->finishWritingRows();
+        LOG_DEBUG(<< "Received " << m_DataFrame->numberRows() << " rows");
+    }
 }
 
 void CDataFrameAnalyzer::run() {

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -124,11 +124,12 @@ CDataFrameOutliersRunner::estimateBookkeepingMemoryUsage(std::size_t numberParti
     std::size_t result{0};
     switch (numberPartitions) {
     case 1:
-        result = estimateMemoryUsage<maths::CDenseVector<float>>(numberRows, numberColumns);
-        break;
-    default:
         result = estimateMemoryUsage<maths::CMemoryMappedDenseVector<float>>(
             numberRows, numberColumns);
+        break;
+    default:
+        result = estimateMemoryUsage<maths::CDenseVector<float>>(numberRows, numberColumns);
+        break;
     }
     return result;
 }
@@ -138,12 +139,11 @@ std::size_t CDataFrameOutliersRunner::estimateMemoryUsage(std::size_t numberRows
                                                           std::size_t numberColumns) const {
     maths::CLocalOutlierFactors::EAlgorithm method{
         static_cast<maths::CLocalOutlierFactors::EAlgorithm>(m_Method)};
-    if (m_NumberNeighbours != boost::none) {
-        return maths::CLocalOutlierFactors::estimateMemoryUsage<POINT>(
-            method, *m_NumberNeighbours, numberRows, numberColumns);
-    }
-    return maths::CLocalOutlierFactors::estimateMemoryUsage<POINT>(method, numberRows,
-                                                                   numberColumns);
+    return m_NumberNeighbours != boost::none
+               ? maths::CLocalOutlierFactors::estimateMemoryUsage<POINT>(
+                     method, *m_NumberNeighbours, numberRows, numberColumns)
+               : maths::CLocalOutlierFactors::estimateMemoryUsage<POINT>(
+                     method, numberRows, numberColumns);
 }
 
 const char* CDataFrameOutliersRunnerFactory::name() const {

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -99,7 +99,7 @@ CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpeci
 }
 
 std::size_t CDataFrameOutliersRunner::numberExtraColumns() const {
-    // Column for outlier score + explaining features TBD.
+    // Column for outlier score + explaining features TODO.
     return 1;
 }
 
@@ -152,14 +152,14 @@ const char* CDataFrameOutliersRunnerFactory::name() const {
 }
 
 CDataFrameOutliersRunnerFactory::TRunnerUPtr
-CDataFrameOutliersRunnerFactory::make(const CDataFrameAnalysisSpecification& spec) const {
-    return boost::make_unique<CDataFrameOutliersRunner>(spec);
+CDataFrameOutliersRunnerFactory::makeImpl(const CDataFrameAnalysisSpecification& spec) const {
+    return std::make_unique<CDataFrameOutliersRunner>(spec);
 }
 
 CDataFrameOutliersRunnerFactory::TRunnerUPtr
-CDataFrameOutliersRunnerFactory::make(const CDataFrameAnalysisSpecification& spec,
-                                      const rapidjson::Value& params) const {
-    return boost::make_unique<CDataFrameOutliersRunner>(spec, params);
+CDataFrameOutliersRunnerFactory::makeImpl(const CDataFrameAnalysisSpecification& spec,
+                                          const rapidjson::Value& params) const {
+    return std::make_unique<CDataFrameOutliersRunner>(spec, params);
 }
 }
 }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -73,13 +73,13 @@ CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpeci
 
     if (params.HasMember(METHOD)) {
         if (std::strcmp(LOF, params[METHOD].GetString()) == 0) {
-            m_Method.reset(static_cast<std::size_t>(maths::CLocalOutlierFactors::E_Lof));
+            m_Method = static_cast<std::size_t>(maths::CLocalOutlierFactors::E_Lof);
         } else if (std::strcmp(LDOF, params[METHOD].GetString()) == 0) {
-            m_Method.reset(static_cast<std::size_t>(maths::CLocalOutlierFactors::E_Ldof));
+            m_Method = static_cast<std::size_t>(maths::CLocalOutlierFactors::E_Ldof);
         } else if (std::strcmp(DISTANCE_KTH_NN, params[METHOD].GetString()) == 0) {
-            m_Method.reset(static_cast<std::size_t>(maths::CLocalOutlierFactors::E_DistancekNN));
+            m_Method = static_cast<std::size_t>(maths::CLocalOutlierFactors::E_DistancekNN);
         } else if (std::strcmp(DISTANCE_KNN, params[METHOD].GetString()) == 0) {
-            m_Method.reset(static_cast<std::size_t>(maths::CLocalOutlierFactors::E_TotalDistancekNN));
+            m_Method = static_cast<std::size_t>(maths::CLocalOutlierFactors::E_TotalDistancekNN);
         } else {
             registerFailure(METHOD);
         }
@@ -95,7 +95,8 @@ CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpeci
 }
 
 CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec)
-    : CDataFrameAnalysisRunner{spec} {
+    : CDataFrameAnalysisRunner{spec}, m_Method{static_cast<std::size_t>(
+                                          maths::CLocalOutlierFactors::E_Ensemble)} {
 }
 
 std::size_t CDataFrameOutliersRunner::numberExtraColumns() const {
@@ -136,9 +137,7 @@ template<typename POINT>
 std::size_t CDataFrameOutliersRunner::estimateMemoryUsage(std::size_t numberRows,
                                                           std::size_t numberColumns) const {
     maths::CLocalOutlierFactors::EAlgorithm method{
-        m_Method != boost::none
-            ? static_cast<maths::CLocalOutlierFactors::EAlgorithm>(*m_Method)
-            : maths::CLocalOutlierFactors::E_Ensemble};
+        static_cast<maths::CLocalOutlierFactors::EAlgorithm>(m_Method)};
     if (m_NumberNeighbours != boost::none) {
         return maths::CLocalOutlierFactors::estimateMemoryUsage<POINT>(
             method, *m_NumberNeighbours, numberRows, numberColumns);

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -56,8 +56,6 @@ void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
             //   1. strategy is in main memory iff the number of partitions is one,
             //   2. number partitions x maximum number rows >= number rows,
             //   3. (number partitions - 1) x maximum number rows <= number rows.
-            //   4. If the frame is stored out-of-core, maximum number of rows is a
-            //      function of number columns only.
 
             bool inMainMemory{runner->storeDataFrameInMainMemory()};
             std::size_t numberPartitions{runner->numberPartitions()};

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CDataFrameAnalysisRunnerTest.h"
+
+#include <core/CLogger.h>
+
+#include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameOutliersRunner.h>
+
+#include <string>
+#include <vector>
+
+using namespace ml;
+
+void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
+    using TSizeVec = std::vector<std::size_t>;
+
+    TSizeVec numbersRows{100, 100000, 1000000};
+    TSizeVec numbersCols{3, 10, 50};
+
+    for (auto numberRows : numbersRows) {
+        for (auto numberCols : numbersCols) {
+            LOG_DEBUG(<< "# rows = " << numberRows << ", # cols = " << numberCols);
+
+            // Give the process approximately 100MB.
+
+            std::string jsonSpec{"{\n"
+                                 "  \"rows\": " +
+                                 std::to_string(numberRows) +
+                                 ",\n"
+                                 "  \"cols\": " +
+                                 std::to_string(numberCols) +
+                                 ",\n"
+                                 "  \"memory_limit\": 100000000,\n"
+                                 "  \"threads\": 1,\n"
+                                 "  \"analysis\": {\n"
+                                 "    \"name\": \"outliers\""
+                                 "  }"
+                                 "}"};
+
+            api::CDataFrameAnalysisSpecification spec{jsonSpec};
+
+            api::CDataFrameOutliersRunnerFactory factory;
+            auto runner = factory.make(spec);
+
+            LOG_DEBUG(<< "  Use main memory = " << runner->storeDataFrameInMainMemory());
+            LOG_DEBUG(<< "  # partitions = " << runner->numberPartitions());
+            LOG_DEBUG(<< "  # rows per partition = "
+                      << runner->maximumNumberRowsPerPartition());
+
+            // Check some invariants:
+            //   1. strategy is in main memory iff the number of partitions is one,
+            //   2. number partitions x maximum number rows >= number rows,
+            //   3. (number partitions - 1) x maximum number rows <= number rows.
+            //   4. If the frame is stored out-of-core, maximum number of rows is a
+            //      function of number columns only.
+
+            bool inMainMemory{runner->storeDataFrameInMainMemory()};
+            std::size_t numberPartitions{runner->numberPartitions()};
+            std::size_t maxRowsPerPartition{runner->maximumNumberRowsPerPartition()};
+
+            CPPUNIT_ASSERT_EQUAL(numberPartitions == 1, inMainMemory);
+            CPPUNIT_ASSERT(numberPartitions * maxRowsPerPartition >= numberRows);
+            CPPUNIT_ASSERT((numberPartitions - 1) * maxRowsPerPartition <= numberRows);
+        }
+    }
+
+    // TODO test with params.
+    // TODO test running memory is in acceptable range.
+}
+
+CppUnit::Test* CDataFrameAnalysisRunnerTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CDataFrameAnalysisRunnerTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisRunnerTest>(
+        "CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers",
+        &CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers));
+
+    return suiteOfTests;
+}

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CDataFrameAnalysisRunnerTest_h
+#define INCLUDED_CDataFrameAnalysisRunnerTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CDataFrameAnalysisRunnerTest : public CppUnit::TestFixture {
+public:
+    void testComputeExecutionStrategyForOutliers();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CDataFrameAnalysisRunnerTest_h

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -57,6 +57,12 @@ protected:
     }
 
 private:
+    virtual std::size_t
+    estimateBookkeepingMemoryUsage(std::size_t, std::size_t, std::size_t) const {
+        return 0;
+    }
+
+private:
     static test::CRandomNumbers ms_Rng;
 };
 
@@ -66,13 +72,14 @@ class CDataFrameTestAnalysisRunnerFactory : public api::CDataFrameAnalysisRunner
 public:
     virtual const char* name() const { return "test"; }
 
-    virtual TRunnerUPtr make(const api::CDataFrameAnalysisSpecification& spec) const {
-        return boost::make_unique<CDataFrameTestAnalysisRunner>(spec);
+private:
+    virtual TRunnerUPtr makeImpl(const api::CDataFrameAnalysisSpecification& spec) const {
+        return std::make_unique<CDataFrameTestAnalysisRunner>(spec);
     }
 
-    virtual TRunnerUPtr make(const api::CDataFrameAnalysisSpecification& spec,
-                             const rapidjson::Value&) const {
-        return boost::make_unique<CDataFrameTestAnalysisRunner>(spec);
+    virtual TRunnerUPtr makeImpl(const api::CDataFrameAnalysisSpecification& spec,
+                                 const rapidjson::Value&) const {
+        return std::make_unique<CDataFrameTestAnalysisRunner>(spec);
     }
 };
 }

--- a/lib/api/unittest/Main.cc
+++ b/lib/api/unittest/Main.cc
@@ -13,6 +13,7 @@
 #include "CConfigUpdaterTest.h"
 #include "CCsvInputParserTest.h"
 #include "CCsvOutputWriterTest.h"
+#include "CDataFrameAnalysisRunnerTest.h"
 #include "CDataFrameAnalysisSpecificationTest.h"
 #include "CDataFrameAnalyzerTest.h"
 #include "CDetectionRulesJsonParserTest.h"
@@ -47,6 +48,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CConfigUpdaterTest::suite());
     runner.addTest(CCsvInputParserTest::suite());
     runner.addTest(CCsvOutputWriterTest::suite());
+    runner.addTest(CDataFrameAnalysisRunnerTest::suite());
     runner.addTest(CDataFrameAnalysisSpecificationTest::suite());
     runner.addTest(CDataFrameAnalyzerTest::suite());
     runner.addTest(CDetectionRulesJsonParserTest::suite());

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -27,6 +27,7 @@ SRCS=\
 	CConfigUpdaterTest.cc \
 	CCsvInputParserTest.cc \
 	CCsvOutputWriterTest.cc \
+	CDataFrameAnalysisRunnerTest.cc \
 	CDataFrameAnalysisSpecificationTest.cc \
 	CDataFrameAnalyzerTest.cc \
 	CDetectionRulesJsonParserTest.cc \

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -264,6 +264,12 @@ std::uint64_t CDataFrame::checksum() const {
     return result;
 }
 
+std::size_t CDataFrame::estimateMemoryUsage(bool inMainMemory,
+                                            std::size_t numberRows,
+                                            std::size_t numberColumns) {
+    return inMainMemory ? numberRows * numberColumns * sizeof(float) : 0;
+}
+
 CDataFrame::CDataFrameRowSliceWriter::CDataFrameRowSliceWriter(
     std::size_t numberRows,
     std::size_t rowCapacity,


### PR DESCRIPTION
This is some of the groundwork for partitioning data frame analyses in general and outlier detection in particular.

It adds functionality to compute the expected memory usage for a `CDataFrame` and for bookkeeping for the algorithms which run on it. This is used to estimate the size of the partition, the maximum number of rows per partition subset and whether to store the data frame in or out of main memory. I've also added a placeholder for passing the directory to use for out-of-core storage from Java.

It isn't fully testable yet because not all the associated functionality is implemented, so I've left some todos in the unit tests.