### PR TITLE
[DOCS] Edits 6.5.4 release notes entries

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -32,10 +32,10 @@
 
 === Bug Fixes
 
-Corrects query times for model bounds and forecasts in the bucket to match the
-times assigned to the samples that are added to the model for each bucket. For
-long bucket lengths, this fix could result in apparently shifted model bounds
-with respect to the data and increased errors in forecasts. (See {ml-pull}327[#327].)
+Fixes a problem that could result in shifted model bounds and increased forecast
+errors with long bucket spans. The solution was to correct query times for model
+bounds and forecasts in the bucket to match the times assigned to the samples
+that are added to the model for each bucket. (See {ml-pull}327[#327].)
 
  == {es} version 6.5.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -32,9 +32,10 @@
 
 === Bug Fixes
 
-Correct query times for model plot and forecast in the bucket to match the times we assign
-the samples we add to the model for each bucket. For long bucket lengths, this could result
-in apparently shifted model plot with respect to the data and increased errors in forecasts. 
+Corrects query times for model bounds and forecasts in the bucket to match the
+times assigned to the samples that are added to the model for each bucket. For
+long bucket lengths, this fix could result in apparently shifted model bounds
+with respect to the data and increased errors in forecasts. (See {ml-pull}327[#327].)
 
  == {es} version 6.5.0
 


### PR DESCRIPTION
This PR edits the ml-cpp entries for inclusion in the Elasticsearch 6.5.4 release notes.  In particular, it references the following PR: https://github.com/elastic/ml-cpp/pull/327