### PR TITLE
[ML] do not exit the worker after warning about failed cleanup

### DIFF
--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -225,7 +225,6 @@ void CForecastRunner::forecastWorker() {
                     LOG_WARN(<< "Failed to cleanup temporary data from: "
                              << forecastJob.s_TemporaryFolder << " error "
                              << errorCode.message());
-                    return;
                 }
             }
         }


### PR DESCRIPTION
fix a race condition if a forecast job requires overflowing to disk but cleanup of temporary storage fails. This can cause the autodetect process to hang on exit, if more forecast requests are in the queue

relates to #350

6.x #353
6.6.0 #357 
6.5.5 #356 
