### PR TITLE
[6.5][ML] do not exit the worker after warning about failed cleanup

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,14 @@
 
 //=== Regressions
 
+ == {es} version 6.5.5
+
+=== Bug Fixes
+
+Fix a race condition if a forecast job requires overflowing to disk but cleanup of temporary
+storage fails. This can cause the autodetect process to hang on exit, if more forecast requests
+are in the queue. (See {ml-pull}352[352].)
+
  == {es} version 6.5.4
 
 === Bug Fixes

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -222,7 +222,6 @@ void CForecastRunner::forecastWorker() {
                     LOG_WARN(<< "Failed to cleanup temporary data from: "
                              << forecastJob.s_TemporaryFolder << " error "
                              << errorCode.message());
-                    return;
                 }
             }
         }


### PR DESCRIPTION
fix a race condition if a forecast job requires overflowing to disk but cleanup of temporary storage fails. This can cause the autodetect process to hang on exit, if more forecast requests are in the queue

backport of #352