### PR TITLE
[FEATURE][ML] Store and retrieve doc id (32 bit hashes) for data frame analyses

### DIFF
--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -54,8 +54,8 @@ private:
     using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
 
 private:
-    static const std::ptrdiff_t CONTROL_FIELD_UNSET{-2};
-    static const std::ptrdiff_t CONTROL_FIELD_MISSING{-1};
+    static const std::ptrdiff_t FIELD_UNSET{-2};
+    static const std::ptrdiff_t FIELD_MISSING{-1};
 
 private:
     bool sufficientFieldValues(const TStrVec& fieldNames) const;
@@ -68,10 +68,12 @@ private:
 
 private:
     // This has values: -2 (unset), -1 (missing), >= 0 (control field index).
-    std::ptrdiff_t m_ControlFieldIndex = CONTROL_FIELD_UNSET;
-    std::ptrdiff_t m_BeginDataFieldValues = -1;
-    std::ptrdiff_t m_EndDataFieldValues = -1;
+    std::ptrdiff_t m_ControlFieldIndex = FIELD_UNSET;
+    std::ptrdiff_t m_BeginDataFieldValues = FIELD_UNSET;
+    std::ptrdiff_t m_EndDataFieldValues = FIELD_UNSET;
+    std::ptrdiff_t m_DocIdFieldIndex = FIELD_UNSET;
     std::uint64_t m_BadValueCount;
+    std::uint64_t m_BadDocIdCount;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
     TDataFrameUPtr m_DataFrame;
     TJsonOutputStreamWrapperUPtrSupplier m_OutStreamSupplier;

--- a/include/core/CDataFrameRowSlice.h
+++ b/include/core/CDataFrameRowSlice.h
@@ -25,12 +25,14 @@ namespace data_frame_row_slice_detail {
 class CORE_EXPORT CDataFrameRowSliceHandleImpl {
 public:
     using TFloatVec = std::vector<CFloatStorage>;
+    using TInt32Vec = std::vector<std::int32_t>;
     using TImplPtr = std::unique_ptr<CDataFrameRowSliceHandleImpl>;
 
 public:
     virtual ~CDataFrameRowSliceHandleImpl() = default;
     virtual TImplPtr clone() const = 0;
-    virtual TFloatVec& values() const = 0;
+    virtual TFloatVec& rows() const = 0;
+    virtual const TInt32Vec& docIds() const = 0;
     virtual bool bad() const = 0;
 };
 }
@@ -41,6 +43,8 @@ class CORE_EXPORT CDataFrameRowSliceHandle {
 public:
     using TFloatVec = std::vector<CFloatStorage>;
     using TFloatVecItr = TFloatVec::iterator;
+    using TInt32Vec = std::vector<std::int32_t>;
+    using TInt32VecCItr = TInt32Vec::const_iterator;
     using TImplPtr = std::unique_ptr<data_frame_row_slice_detail::CDataFrameRowSliceHandleImpl>;
 
 public:
@@ -53,9 +57,12 @@ public:
     CDataFrameRowSliceHandle& operator=(CDataFrameRowSliceHandle&& other);
 
     std::size_t size() const;
-    TFloatVecItr begin() const;
-    TFloatVecItr end() const;
-    const TFloatVec& values() const;
+    TFloatVecItr beginRows() const;
+    TFloatVecItr endRows() const;
+    TInt32VecCItr beginDocIds() const;
+    TInt32VecCItr endDocIds() const;
+    const TFloatVec& rows() const;
+    const TInt32Vec& docIds() const;
     bool bad() const;
 
 private:
@@ -67,12 +74,13 @@ class CORE_EXPORT CDataFrameRowSlice {
 public:
     using TFloatVec = std::vector<CFloatStorage>;
     using TSizeHandlePr = std::pair<std::size_t, CDataFrameRowSliceHandle>;
+    using TInt32Vec = std::vector<std::int32_t>;
 
 public:
     virtual ~CDataFrameRowSlice() = default;
     virtual bool reserve(std::size_t numberColumns, std::size_t extraColumns) = 0;
     virtual TSizeHandlePr read() = 0;
-    virtual void write(const TFloatVec& values) = 0;
+    virtual void write(const TFloatVec& rows, const TInt32Vec& docIds) = 0;
     virtual std::size_t staticSize() const = 0;
     virtual std::size_t memoryUsage() const = 0;
     virtual std::uint64_t checksum() const = 0;
@@ -90,17 +98,18 @@ public:
 //! rows to adapt it for use by the data frame.
 class CORE_EXPORT CMainMemoryDataFrameRowSlice final : public CDataFrameRowSlice {
 public:
-    CMainMemoryDataFrameRowSlice(std::size_t firstRow, TFloatVec state);
+    CMainMemoryDataFrameRowSlice(std::size_t firstRow, TFloatVec rows, TInt32Vec docIds);
     virtual bool reserve(std::size_t numberColumns, std::size_t extraColumns);
     virtual TSizeHandlePr read();
-    virtual void write(const TFloatVec& values);
+    virtual void write(const TFloatVec& rows, const TInt32Vec& docIds);
     virtual std::size_t staticSize() const;
     virtual std::size_t memoryUsage() const;
     virtual std::uint64_t checksum() const;
 
 private:
     std::size_t m_FirstRow;
-    TFloatVec m_State;
+    TFloatVec m_Rows;
+    TInt32Vec m_DocIds;
 };
 
 //! \brief On disk CDataFrame slice storage.
@@ -151,17 +160,18 @@ public:
 public:
     COnDiskDataFrameRowSlice(const TTemporaryDirectoryPtr& directory,
                              std::size_t firstRow,
-                             TFloatVec state);
+                             TFloatVec rows,
+                             TInt32Vec docIds);
     virtual bool reserve(std::size_t numberColumns, std::size_t extraColumns);
     virtual TSizeHandlePr read();
-    virtual void write(const TFloatVec& values);
+    virtual void write(const TFloatVec& rows, const TInt32Vec& docIds);
     virtual std::size_t staticSize() const;
     virtual std::size_t memoryUsage() const;
     virtual std::uint64_t checksum() const;
 
 private:
-    void writeToDisk(const TFloatVec& state);
-    bool readFromDisk(TFloatVec& result) const;
+    void writeToDisk(const TFloatVec& rows, const TInt32Vec& docIds);
+    bool readFromDisk(TFloatVec& rows, TInt32Vec& docIds) const;
 
 private:
     using TByteVec = CCompressUtil::TByteVec;
@@ -169,10 +179,11 @@ private:
 private:
     mutable bool m_StateIsBad = false;
     std::size_t m_FirstRow;
-    std::size_t m_Capacity;
+    std::size_t m_RowsCapacity;
+    std::size_t m_DocIdsCapacity;
     TTemporaryDirectoryPtr m_Directory;
     boost::filesystem::path m_FileName;
-    uint64_t m_Checksum;
+    std::uint64_t m_Checksum;
 };
 }
 }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -172,9 +172,11 @@ CDataFrameAnalysisSpecification::makeDataFrame() const {
     }
 
     // TODO Remove hack when passing directory in config.
+    ////
     if (m_Runner->storeDataFrameInMainMemory() == false) {
         return {};
     }
+    ////
 
     TDataFrameUPtr result{m_Runner->storeDataFrameInMainMemory()
                               ? core::makeMainStorageDataFrame(m_NumberColumns)

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -26,7 +26,8 @@ double truncateToFloatRange(double value) {
     return maths::CTools::truncate(value, -largest, largest);
 }
 
-const std::string CONTROL_MESSAGE_FIELD_NAME{"."};
+const std::string SPECIAL_COLUMN_FIELD_NAME{"."};
+
 // Control message types:
 const char FINISHED_DATA_CONTROL_MESSAGE_FIELD_VALUE{'$'};
 
@@ -61,20 +62,19 @@ bool CDataFrameAnalyzer::handleRecord(const TStrVec& fieldNames, const TStrVec& 
     if (m_AnalysisSpecification == nullptr || m_AnalysisSpecification->bad()) {
         // TODO We need to communicate an error but don't want one for each row.
         // Revisit this when we have finalized our monitoring strategy.
-        LOG_TRACE(<< "Specification is bad");
+        LOG_ERROR(<< "Specification is bad");
         return false;
     }
 
     if (this->readyToReceiveControlMessages() == false &&
         this->prepareToReceiveControlMessages(fieldNames) == false) {
+        // Logging handled below.
         return false;
     }
 
     if (this->sufficientFieldValues(fieldValues) == false) {
         // TODO We need to communicate an error but don't want one for each row.
         // Revisit this when we have finalized our monitoring strategy.
-        LOG_TRACE(<< "Expected " << m_AnalysisSpecification->numberColumns()
-                  << " field values and got " << fieldValues.size());
         return false;
     }
 
@@ -116,24 +116,43 @@ void CDataFrameAnalyzer::run() {
 }
 
 bool CDataFrameAnalyzer::readyToReceiveControlMessages() const {
-    return m_ControlFieldIndex != CONTROL_FIELD_UNSET;
+    return m_ControlFieldIndex != FIELD_UNSET;
 }
 
 bool CDataFrameAnalyzer::prepareToReceiveControlMessages(const TStrVec& fieldNames) {
-    if (fieldNames.empty() || fieldNames.back() != CONTROL_MESSAGE_FIELD_NAME) {
-        m_ControlFieldIndex = CONTROL_FIELD_MISSING;
+    // If this is being called by the Java API we'll use the last two columns for
+    // special purposes:
+    //   - penultimate contains a 32 bit hash of the document identifier.
+    //   - last contains the control message.
+    //
+    // These will both be called . to avoid collision with any real field name.
+
+    auto posDocId = std::find(fieldNames.begin(), fieldNames.end(), SPECIAL_COLUMN_FIELD_NAME);
+    auto posControlMessage = posDocId == fieldNames.end()
+                                 ? fieldNames.end()
+                                 : std::find(posDocId + 1, fieldNames.end(),
+                                             SPECIAL_COLUMN_FIELD_NAME);
+
+    if (posDocId == fieldNames.end() && posControlMessage == fieldNames.end()) {
+        m_ControlFieldIndex = FIELD_MISSING;
         m_BeginDataFieldValues = 0;
         m_EndDataFieldValues = static_cast<std::ptrdiff_t>(fieldNames.size());
+        m_DocIdFieldIndex = FIELD_MISSING;
+
+    } else if (fieldNames.size() < 2 || posDocId != fieldNames.end() - 2 ||
+               posControlMessage != fieldNames.end() - 1) {
+
+        LOG_ERROR(<< "Expected exacly two special fields in last two positions, got "
+                  << core::CContainerPrinter::print(fieldNames));
+        return false;
+
     } else {
-        m_ControlFieldIndex = static_cast<std::ptrdiff_t>(fieldNames.size() - 1);
+        m_ControlFieldIndex = posControlMessage - fieldNames.begin();
         m_BeginDataFieldValues = 0;
-        m_EndDataFieldValues = m_ControlFieldIndex;
-        auto pos = std::find(fieldNames.begin(), fieldNames.end(), CONTROL_MESSAGE_FIELD_NAME);
-        if (pos != fieldNames.end() - 1) {
-            LOG_ERROR(<< "Unexpected possible control field: ignoring");
-            return false;
-        }
+        m_EndDataFieldValues = posDocId - fieldNames.begin();
+        m_DocIdFieldIndex = m_ControlFieldIndex - 1;
     }
+
     return true;
 }
 
@@ -142,10 +161,14 @@ bool CDataFrameAnalyzer::isControlMessage(const TStrVec& fieldValues) const {
 }
 
 bool CDataFrameAnalyzer::sufficientFieldValues(const TStrVec& fieldValues) const {
-    if (m_ControlFieldIndex >= 0) {
-        return fieldValues.size() == m_AnalysisSpecification->numberColumns() + 1;
+    std::size_t expectedNumberFieldValues{m_AnalysisSpecification->numberColumns() +
+                                          (m_ControlFieldIndex >= 0 ? 2 : 0)};
+    if (fieldValues.size() != expectedNumberFieldValues) {
+        LOG_ERROR(<< "Expected " << expectedNumberFieldValues
+                  << " field values and got " << fieldValues.size());
+        return false;
     }
-    return fieldValues.size() == m_AnalysisSpecification->numberColumns();
+    return true;
 }
 
 bool CDataFrameAnalyzer::handleControlMessage(const TStrVec& fieldValues) {
@@ -202,8 +225,11 @@ void CDataFrameAnalyzer::addRowToDataFrame(const TStrVec& fieldValues) {
                 *columns = truncateToFloatRange(value);
             }
         }
-        // TODO write stub until passed.
-        docId = 0xdeadbeef;
+        docId = 0;
+        if (m_DocIdFieldIndex != FIELD_MISSING &&
+            core::CStringUtils::stringToType(fieldValues[m_DocIdFieldIndex], docId) == false) {
+            ++m_BadDocIdCount;
+        }
     });
 }
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -15,6 +15,7 @@ public:
     void testRunOutlierDetection();
     void testFlushMessage();
     void testErrors();
+    void testRoundTripDocIds();
 
     static CppUnit::Test* suite();
 };

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -12,8 +12,6 @@
 #include <core/CMemory.h>
 #include <core/Concurrency.h>
 
-#include <boost/make_unique.hpp>
-
 #include <algorithm>
 #include <future>
 #include <memory>
@@ -22,8 +20,8 @@ namespace ml {
 namespace core {
 namespace data_frame_detail {
 
-CRowRef::CRowRef(std::size_t index, TFloatVecItr beginColumns, TFloatVecItr endColumns)
-    : m_Index{index}, m_BeginColumns{beginColumns}, m_EndColumns{endColumns} {
+CRowRef::CRowRef(std::size_t index, TFloatVecItr beginColumns, TFloatVecItr endColumns, std::int32_t docId)
+    : m_Index{index}, m_BeginColumns{beginColumns}, m_EndColumns{endColumns}, m_DocId{docId} {
 }
 
 CFloatStorage CRowRef::operator[](std::size_t i) const {
@@ -46,44 +44,48 @@ CFloatStorage* CRowRef::data() const {
     return &(*m_BeginColumns);
 }
 
+std::int32_t CRowRef::docId() const {
+    return m_DocId;
+}
+
 CRowIterator::CRowIterator(std::size_t numberColumns,
                            std::size_t rowCapacity,
                            std::size_t index,
-                           TFloatVecItr base)
-    : m_NumberColumns{numberColumns}, m_RowCapacity{rowCapacity}, m_Index{index}, m_Base{base} {
+                           TFloatVecItr rowItr,
+                           TInt32VecCItr docIdItr)
+    : m_NumberColumns{numberColumns},
+      m_RowCapacity{rowCapacity}, m_Index{index}, m_RowItr{rowItr}, m_DocIdItr{docIdItr} {
 }
 
 bool CRowIterator::operator==(const CRowIterator& rhs) const {
-    return m_Base == rhs.m_Base;
+    return m_RowItr == rhs.m_RowItr && m_DocIdItr == rhs.m_DocIdItr;
 }
 
 bool CRowIterator::operator!=(const CRowIterator& rhs) const {
-    return m_Base != rhs.m_Base;
+    return m_RowItr != rhs.m_RowItr || m_DocIdItr != rhs.m_DocIdItr;
 }
 
 CRowRef CRowIterator::operator*() const {
-    return CRowRef{m_Index, m_Base, m_Base + m_NumberColumns};
+    return CRowRef{m_Index, m_RowItr, m_RowItr + m_NumberColumns, *m_DocIdItr};
 }
 
 CRowPtr CRowIterator::operator->() const {
-    return CRowPtr{m_Index, m_Base, m_Base + m_NumberColumns};
+    return CRowPtr{m_Index, m_RowItr, m_RowItr + m_NumberColumns, *m_DocIdItr};
 }
 
 CRowIterator& CRowIterator::operator++() {
     ++m_Index;
-    m_Base += m_RowCapacity;
+    m_RowItr += m_RowCapacity;
+    ++m_DocIdItr;
     return *this;
 }
 
 CRowIterator CRowIterator::operator++(int) {
     CRowIterator result{*this};
     ++m_Index;
-    m_Base += m_RowCapacity;
+    m_RowItr += m_RowCapacity;
+    ++m_DocIdItr;
     return result;
-}
-
-TFloatVecItr CRowIterator::base() const {
-    return m_Base;
 }
 }
 using namespace data_frame_detail;
@@ -182,7 +184,7 @@ bool CDataFrame::writeColumns(std::size_t numberThreads, TRowFunc writer) {
 
 void CDataFrame::writeRow(const TWriteFunc& writeRow) {
     if (m_Writer == nullptr) {
-        m_Writer = boost::make_unique<CDataFrameRowSliceWriter>(
+        m_Writer = std::make_unique<CDataFrameRowSliceWriter>(
             m_NumberRows, m_RowCapacity, m_SliceCapacityInRows,
             m_ReadAndWriteToStoreSyncStrategy, m_WriteSliceToStore);
     }
@@ -257,7 +259,7 @@ CDataFrame::parallelApplyToAllRows(std::size_t numberThreads, TRowFunc func, boo
                 this->applyToRowsOfOneSlice(func_, firstRow, readRow);
 
                 if (commitResult) {
-                    slice->write(readRow.values());
+                    slice->write(readRow.rows(), readRow.docIds());
                 }
             },
             std::move(func)));
@@ -302,7 +304,7 @@ CDataFrame::sequentialApplyToAllRows(TRowFunc func, bool commitResult) const {
             ] {
                 this->applyToRowsOfOneSlice(func, firstRow, readSlice_);
                 if (commitResult) {
-                    slice->write(readSlice_.values());
+                    slice->write(readSlice_.rows(), readSlice_.docIds());
                 }
             });
         }
@@ -316,7 +318,7 @@ CDataFrame::sequentialApplyToAllRows(TRowFunc func, bool commitResult) const {
             }
             this->applyToRowsOfOneSlice(func, firstRow, readSlice);
             if (commitResult) {
-                slice->write(readSlice.values());
+                slice->write(readSlice.rows(), readSlice.docIds());
             }
         }
         break;
@@ -331,8 +333,10 @@ void CDataFrame::applyToRowsOfOneSlice(TRowFunc& func,
     LOG_TRACE(<< "Applying function to slice starting at row " << firstRow);
     std::size_t rows{slice.size() / m_RowCapacity};
     std::size_t lastRow{firstRow + rows};
-    func(CRowIterator{m_NumberColumns, m_RowCapacity, firstRow, slice.begin()},
-         CRowIterator{m_NumberColumns, m_RowCapacity, lastRow, slice.end()});
+    func(CRowIterator{m_NumberColumns, m_RowCapacity, firstRow,
+                      slice.beginRows(), slice.beginDocIds()},
+         CRowIterator{m_NumberColumns, m_RowCapacity, lastRow, slice.endRows(),
+                      slice.endDocIds()});
 }
 
 CDataFrame::CDataFrameRowSliceWriter::CDataFrameRowSliceWriter(
@@ -343,20 +347,23 @@ CDataFrame::CDataFrameRowSliceWriter::CDataFrameRowSliceWriter(
     TWriteSliceToStoreFunc writeSliceToStore)
     : m_NumberRows{numberRows}, m_RowCapacity{rowCapacity}, m_SliceCapacityInRows{sliceCapacityInRows},
       m_WriteToStoreSyncStrategy{writeToStoreSyncStrategy}, m_WriteSliceToStore{writeSliceToStore} {
-    m_SliceBeingWritten.reserve(m_SliceCapacityInRows * m_RowCapacity);
+    m_RowsOfSliceBeingWritten.reserve(m_SliceCapacityInRows * m_RowCapacity);
+    m_DocIdsOfSliceBeingWritten.reserve(m_SliceCapacityInRows);
 }
 
 void CDataFrame::CDataFrameRowSliceWriter::operator()(const TWriteFunc& writeRow) {
     // Write the next row at the end of the current slice being written
     // and if the slice is full pass to the thread storing slices.
 
-    std::size_t end{m_SliceBeingWritten.size()};
+    std::size_t end{m_RowsOfSliceBeingWritten.size()};
 
-    m_SliceBeingWritten.resize(end + m_RowCapacity);
-    writeRow(m_SliceBeingWritten.begin() + end);
+    m_RowsOfSliceBeingWritten.resize(end + m_RowCapacity);
+    m_DocIdsOfSliceBeingWritten.emplace_back();
+    writeRow(m_RowsOfSliceBeingWritten.begin() + end,
+             m_DocIdsOfSliceBeingWritten.back());
     ++m_NumberRows;
 
-    if (m_SliceBeingWritten.size() == m_SliceCapacityInRows * m_RowCapacity) {
+    if (m_DocIdsOfSliceBeingWritten.size() == m_SliceCapacityInRows) {
         std::size_t firstRow{m_NumberRows - m_SliceCapacityInRows};
         LOG_TRACE(<< "Storing slice [" << firstRow << "," << m_NumberRows << ")");
 
@@ -365,18 +372,22 @@ void CDataFrame::CDataFrameRowSliceWriter::operator()(const TWriteFunc& writeRow
             if (m_SliceWrittenAsyncToStore.valid()) {
                 m_SlicesWrittenToStore.push_back(m_SliceWrittenAsyncToStore.get());
             }
-            m_SliceWrittenAsyncToStore = async(defaultAsyncExecutor(),
-                                               m_WriteSliceToStore, firstRow,
-                                               std::move(m_SliceBeingWritten));
+            m_SliceWrittenAsyncToStore =
+                async(defaultAsyncExecutor(), m_WriteSliceToStore, firstRow,
+                      std::move(m_RowsOfSliceBeingWritten),
+                      std::move(m_DocIdsOfSliceBeingWritten));
             break;
         }
         case EReadWriteToStorage::E_Sync:
             m_SlicesWrittenToStore.push_back(
-                m_WriteSliceToStore(firstRow, std::move(m_SliceBeingWritten)));
+                m_WriteSliceToStore(firstRow, std::move(m_RowsOfSliceBeingWritten),
+                                    std::move(m_DocIdsOfSliceBeingWritten)));
             break;
         }
-        m_SliceBeingWritten.clear();
-        m_SliceBeingWritten.reserve(m_SliceCapacityInRows * m_RowCapacity);
+        m_RowsOfSliceBeingWritten.clear();
+        m_DocIdsOfSliceBeingWritten.clear();
+        m_RowsOfSliceBeingWritten.reserve(m_SliceCapacityInRows * m_RowCapacity);
+        m_DocIdsOfSliceBeingWritten.reserve(m_SliceCapacityInRows);
     }
 }
 
@@ -386,12 +397,13 @@ CDataFrame::CDataFrameRowSliceWriter::finishWritingRows() {
         m_SlicesWrittenToStore.push_back(m_SliceWrittenAsyncToStore.get());
     }
 
-    if (m_SliceBeingWritten.size() > 0) {
-        std::size_t firstRow{m_NumberRows - m_SliceBeingWritten.size() / m_RowCapacity};
+    if (m_DocIdsOfSliceBeingWritten.size() > 0) {
+        std::size_t firstRow{m_NumberRows - m_RowsOfSliceBeingWritten.size() / m_RowCapacity};
         LOG_TRACE(<< "Last slice [" << std::to_string(firstRow) << ","
                   << std::to_string(m_NumberRows) + ")");
         m_SlicesWrittenToStore.push_back(
-            m_WriteSliceToStore(firstRow, std::move(m_SliceBeingWritten)));
+            m_WriteSliceToStore(firstRow, std::move(m_RowsOfSliceBeingWritten),
+                                std::move(m_DocIdsOfSliceBeingWritten)));
     }
 
     return {m_NumberRows, std::move(m_SlicesWrittenToStore)};
@@ -401,8 +413,9 @@ std::unique_ptr<CDataFrame>
 makeMainStorageDataFrame(std::size_t numberColumns,
                          boost::optional<std::size_t> sliceCapacity,
                          CDataFrame::EReadWriteToStorage readWriteToStoreSyncStrategy) {
-    auto writer = [](std::size_t firstRow, TFloatVec slice) {
-        return std::make_unique<CMainMemoryDataFrameRowSlice>(firstRow, std::move(slice));
+    auto writer = [](std::size_t firstRow, TFloatVec rows, TInt32Vec docIds) {
+        return std::make_unique<CMainMemoryDataFrameRowSlice>(
+            firstRow, std::move(rows), std::move(docIds));
     };
 
     if (sliceCapacity != boost::none) {
@@ -430,9 +443,9 @@ makeDiskStorageDataFrame(const std::string& rootDirectory,
     // pointer is copied to the data frame. So this isn't destroyed, and
     // the folder cleaned up, until the data frame itself is destroyed.
 
-    auto writer = [directory](std::size_t firstRow, TFloatVec slice) {
-        return std::make_unique<COnDiskDataFrameRowSlice>(directory, firstRow,
-                                                          std::move(slice));
+    auto writer = [directory](std::size_t firstRow, TFloatVec rows, TInt32Vec docIds) {
+        return std::make_unique<COnDiskDataFrameRowSlice>(
+            directory, firstRow, std::move(rows), std::move(docIds));
     };
 
     if (sliceCapacity != boost::none) {

--- a/lib/core/unittest/CDataFrameTest.h
+++ b/lib/core/unittest/CDataFrameTest.h
@@ -21,6 +21,7 @@ public:
     void testReserve();
     void testResizeColumns();
     void testWriteColumns();
+    void testDocIds();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
We're going to round trip hashes of the Elasticsearch document identifiers to sanity check the join of analysis results with existing data frame row documents. This makes the necessary changes for doing this in the data_frame_analyzer command.