### PR TITLE
[FEATURE][ML] Reduce bookkeeping memory usage for outlier detection

### DIFF
--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -311,7 +311,7 @@ private:
         m_Nodes.emplace_back(parent, std::move(point));
     }
 
-    //! Append a node coping \p point into place.
+    //! Append a node copying \p point into place.
     void append(std::false_type, SNode* parent, const POINT& point) {
         m_Nodes.emplace_back(parent, point);
     }

--- a/include/maths/CLocalOutlierFactors.h
+++ b/include/maths/CLocalOutlierFactors.h
@@ -474,7 +474,8 @@ protected:
             std::size_t i{point.annotation() * m_K};
             std::size_t k{std::min(m_K, neighbours.size() - 1)};
             for (std::size_t j = 1; j <= k; ++j) {
-                m_KDistances[i + j - 1].first = static_cast<uint32_t>(neighbours[j].annotation());
+                m_KDistances[i + j - 1].first =
+                    static_cast<uint32_t>(neighbours[j].annotation());
                 m_KDistances[i + j - 1].second = las::distance(point, neighbours[j]);
             }
         }
@@ -482,7 +483,7 @@ protected:
         virtual void compute(TDoubleVec& scores) {
             using TMinAccumulator = CBasicStatistics::SMin<double>::TAccumulator;
 
-            // We bind a minimum accumulator (by value) to each lambda 
+            // We bind a minimum accumulator (by value) to each lambda
             // (since one copy is then accessed by each thread) and take
             // the minimum of these at the end.
 
@@ -537,8 +538,7 @@ protected:
         }
 
         static std::size_t estimateOwnMemoryOverhead(std::size_t k, std::size_t numberPoints) {
-            return numberPoints * (sizeof(TSizeDoublePrVec) +
-                                   k * sizeof(TSizeDoublePr) + sizeof(double));
+            return numberPoints * (k * sizeof(TUInt32CoordinatePr) + sizeof(TCoordinate));
         }
 
     private:
@@ -728,7 +728,8 @@ protected:
 
         static std::size_t estimateOwnMemoryOverhead(std::size_t numberPoints,
                                                      std::size_t numberMethods) {
-            return numberMethods * (sizeof(TDoubleVec) + numberPoints * sizeof(double));
+            return numberMethods * (sizeof(TMethodUPtr) + sizeof(TDoubleVec) +
+                                    numberPoints * sizeof(double));
         }
 
     private:
@@ -752,8 +753,7 @@ protected:
 
 template<typename POINT, typename NEAREST_NEIGHBOURS>
 const typename CLocalOutlierFactors::CLof<POINT, NEAREST_NEIGHBOURS>::TCoordinate
-CLocalOutlierFactors::CLof<POINT, NEAREST_NEIGHBOURS>::UNSET_DISTANCE = -1.0;
-
+    CLocalOutlierFactors::CLof<POINT, NEAREST_NEIGHBOURS>::UNSET_DISTANCE = -1.0;
 
 //! Compute outliers for \p frame and write to a new column.
 MATHS_EXPORT

--- a/lib/maths/unittest/CLocalOutlierFactorsTest.cc
+++ b/lib/maths/unittest/CLocalOutlierFactorsTest.cc
@@ -8,6 +8,7 @@
 
 #include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
+#include <core/CStopWatch.h>
 
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CLinearAlgebraShims.h>
@@ -82,7 +83,7 @@ void gaussianWithUniformNoiseForPresizedPoints(test::CRandomNumbers& rng,
             points[i](j) = inliers[i][j];
         }
     }
-    for (std::size_t i = 100, j = 0; j < outliers.size(); ++i) {
+    for (std::size_t i = inliers.size(), j = 0; j < outliers.size(); ++i) {
         for (std::size_t end = j + 6; j < end; ++j) {
             points[i](j % 6) = outliers[j];
         }
@@ -93,7 +94,7 @@ void gaussianWithUniformNoise(test::CRandomNumbers& rng,
                               std::size_t numberInliers,
                               std::size_t numberOutliers,
                               TVectorVec& points) {
-    points.assign(120, TVector(6));
+    points.assign(numberInliers + numberOutliers, TVector(6));
     gaussianWithUniformNoiseForPresizedPoints(rng, numberInliers, numberOutliers, points);
 }
 
@@ -112,8 +113,8 @@ void outlierErrorStatisticsForEnsemble(test::CRandomNumbers& rng,
     FP.assign(3, 0.0);
     FN.assign(3, 0.0);
 
-    TSizeVec trueOutliers{100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
-                          110, 111, 112, 113, 114, 115, 116, 117, 118, 119};
+    TSizeVec trueOutliers(numberOutliers, 0);
+    std::iota(trueOutliers.begin(), trueOutliers.end(), numberInliers);
 
     for (std::size_t t = 0; t < 100; ++t) {
         gaussianWithUniformNoiseForPresizedPoints(rng, numberInliers, numberOutliers, points);

--- a/lib/maths/unittest/CLocalOutlierFactorsTest.cc
+++ b/lib/maths/unittest/CLocalOutlierFactorsTest.cc
@@ -8,7 +8,6 @@
 
 #include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
-#include <core/CStopWatch.h>
 
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CLinearAlgebraShims.h>

--- a/lib/maths/unittest/CLocalOutlierFactorsTest.h
+++ b/lib/maths/unittest/CLocalOutlierFactorsTest.h
@@ -16,6 +16,7 @@ public:
     void testDistancekNN();
     void testTotalDistancekNN();
     void testEnsemble();
+    void testDataFrame();
 
     static CppUnit::Test* suite();
 };

--- a/lib/maths/unittest/CLocalOutlierFactorsTest.h
+++ b/lib/maths/unittest/CLocalOutlierFactorsTest.h
@@ -16,7 +16,6 @@ public:
     void testDistancekNN();
     void testTotalDistancekNN();
     void testEnsemble();
-    void testDataFrame();
     void testProgressMonitoring();
 
     static CppUnit::Test* suite();


### PR DESCRIPTION
This revisits the storage format for some bookkeeping state used during outlier detection. It also makes sure to reclaim memory allocated for the vector buffer which is moved into the k-d tree.

In particular, this will save us at least `# rows * sizeof(point type)` + `# rows * sizeof(std::vector)` + `# rows * 8 * k` bytes, for k nearest neighbours, during a run of ensemble or LOF outlier detection and `# rows * sizeof(point type)` for all other methods.