### PR TITLE
Persist static statistics in a consistent manner

### DIFF
--- a/include/core/CStatistics.h
+++ b/include/core/CStatistics.h
@@ -13,9 +13,11 @@
 #include <boost/array.hpp>
 
 #include <iosfwd>
-#include <map>
+#include <vector>
 
 #include <stdint.h>
+
+class CStatisticsTest;
 
 namespace ml {
 namespace stat_t {
@@ -109,12 +111,25 @@ class CStatePersistInserter;
 //! A singleton class: there should only be one collection of global stats
 //!
 class CORE_EXPORT CStatistics : private CNonCopyable {
+private:
+    class CStatsCache;
+
+private:
+    using TStatArray = boost::array<CStat, stat_t::E_LastEnumStat>;
+    using TStatsCacheUPtr = std::unique_ptr<CStatsCache>;
+
 public:
     //! Singleton pattern
     static CStatistics& instance();
 
     //! Provide access to the relevant stat from the collection
     static CStat& stat(int index);
+
+    //! copy the collection of live statistics to a cache
+    static void cacheStats();
+
+    //! Transfer ownership of the cached statistics to the caller
+    static TStatsCacheUPtr transferCachedStats();
 
     //! \name Persistence
     //@{
@@ -126,9 +141,6 @@ public:
     //@}
 
 private:
-    using TStatArray = boost::array<CStat, stat_t::E_LastEnumStat>;
-
-private:
     //! Constructor of a Singleton is private
     CStatistics();
 
@@ -138,8 +150,40 @@ private:
     //! Collection of statistics
     TStatArray m_Stats;
 
+    //! cache of stats for use in persistence
+    TStatsCacheUPtr m_Cache;
+
     //! Enabling printing out the current statistics.
     friend CORE_EXPORT std::ostream& operator<<(std::ostream& o, const CStatistics& stats);
+
+    //! Helper class for storing a snapshot of statistics prior to persisting them
+    friend class CStatsCache;
+
+    //! Befriend the test suite
+    friend class ::CStatisticsTest;
+
+private:
+    //! Maintains a snapshot of statistics to be used for persistence
+    //!
+    //! IMPLEMENTATION DECISIONS:\n
+    //! Only used by CStatistics so nested within that class definition
+    //! Instances of this class exist only transitorily, ownership is transferred by move semantics only.
+    class CStatsCache : private CNonCopyable {
+    public:
+        CStatsCache();
+
+        //! populate the cache with current live values
+        void populate(const CStatistics::TStatArray& statArray);
+
+        //! Provide access to the relevant stat from the collection
+        uint64_t stat(int index) const;
+
+    private:
+        using TUInt64Vec = std::vector<uint64_t>;
+
+    private:
+        TUInt64Vec m_Stats;
+    };
 };
 
 } // core

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -988,6 +988,11 @@ bool CAnomalyJob::persistState(core::CDataAdder& persister) {
     std::string normaliserState;
     m_Normalizer.toJson(m_LastResultsTime, "api", normaliserState, true);
 
+    // Persistence operates on a cached collection of statistics rather than on the live statistics directly.
+    // This is in order that background persistence operates on a consistent set of statistics however we
+    // also must ensure that foreground persistence has access to an up-to-date cache of statistics as well.
+    core::CStatistics::cacheStats();
+
     return this->persistState(
         "State persisted due to job close at ", m_LastFinalisedBucketEndTime, detectors,
         m_Limits.resourceMonitor().createMemoryUsageReport(

--- a/lib/api/CBackgroundPersister.cc
+++ b/lib/api/CBackgroundPersister.cc
@@ -7,6 +7,7 @@
 
 #include <core/CLogger.h>
 #include <core/CScopedFastLock.h>
+#include <core/CStatistics.h>
 #include <core/CTimeUtils.h>
 
 #include <string>
@@ -109,6 +110,9 @@ bool CBackgroundPersister::startPersist() {
         }
     }
 
+    // create a cache of the statistics, to ensure persistence operates
+    // on a consistent collection of statistics
+    core::CStatistics::cacheStats();
     m_IsShutdown = false;
     m_IsBusy = m_BackgroundThread.start();
 

--- a/lib/api/unittest/CBackgroundPersisterTest.cc
+++ b/lib/api/unittest/CBackgroundPersisterTest.cc
@@ -7,6 +7,7 @@
 
 #include <core/CJsonOutputStreamWrapper.h>
 #include <core/COsFileFuncs.h>
+#include <core/CStatistics.h>
 #include <core/CStringUtils.h>
 #include <core/CoreTypes.h>
 
@@ -58,6 +59,9 @@ CppUnit::Test* CBackgroundPersisterTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CBackgroundPersisterTest>(
         "CBackgroundPersisterTest::testCategorizationOnlyPersist",
         &CBackgroundPersisterTest::testCategorizationOnlyPersist));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBackgroundPersisterTest>(
+        "CBackgroundPersisterTest::testDetectorBackgroundPersistStaticsConsistency",
+        &CBackgroundPersisterTest::testDetectorBackgroundPersistStaticsConsistency));
 
     return suiteOfTests;
 }
@@ -73,6 +77,10 @@ void CBackgroundPersisterTest::testDetectorPersistOver() {
 void CBackgroundPersisterTest::testDetectorPersistPartition() {
     this->foregroundBackgroundCompCategorizationAndAnomalyDetection(
         "testfiles/new_mlfields_partition.conf");
+}
+
+void CBackgroundPersisterTest::testDetectorBackgroundPersistStaticsConsistency() {
+    this->foregroundBackgroundCompAnomalyDetectionAfterStaticsUpdate("testfiles/new_mlfields_over.conf");
 }
 
 void CBackgroundPersisterTest::testCategorizationOnlyPersist() {
@@ -225,6 +233,102 @@ void CBackgroundPersisterTest::foregroundBackgroundCompCategorizationAndAnomalyD
         ml::api::CSingleStreamDataAdder foregroundDataAdder(foregroundStreamPtr);
         CPPUNIT_ASSERT(firstProcessor->persistState(foregroundDataAdder));
         foregroundSnapshotId = snapshotId;
+    }
+
+    std::string backgroundState = backgroundStream->str();
+    std::string foregroundState = foregroundStream->str();
+
+    // The snapshot ID can be different between the two persists, so replace the
+    // first occurrence of it (which is in the bulk metadata)
+    CPPUNIT_ASSERT_EQUAL(size_t(1), ml::core::CStringUtils::replaceFirst(
+                                        backgroundSnapshotId, "snap", backgroundState));
+    CPPUNIT_ASSERT_EQUAL(size_t(1), ml::core::CStringUtils::replaceFirst(
+                                        foregroundSnapshotId, "snap", foregroundState));
+
+    // Replace the zero byte separators so the expected/actual strings don't get
+    // truncated by CppUnit if the test fails
+    std::replace(backgroundState.begin(), backgroundState.end(), '\0', ',');
+    std::replace(foregroundState.begin(), foregroundState.end(), '\0', ',');
+
+    CPPUNIT_ASSERT_EQUAL(backgroundState, foregroundState);
+}
+
+void CBackgroundPersisterTest::foregroundBackgroundCompAnomalyDetectionAfterStaticsUpdate(
+    const std::string& configFileName) {
+    // Start by creating processors with non-trivial state
+
+    static const ml::core_t::TTime BUCKET_SIZE(3600);
+    static const std::string JOB_ID("job");
+
+    std::string inputFilename("testfiles/big_ascending.txt");
+
+    // Open the input and output files
+    std::ifstream inputStrm(inputFilename.c_str());
+    CPPUNIT_ASSERT(inputStrm.is_open());
+
+    std::ofstream outputStrm(ml::core::COsFileFuncs::NULL_FILENAME);
+    CPPUNIT_ASSERT(outputStrm.is_open());
+
+    ml::model::CLimits limits;
+    ml::api::CFieldConfig fieldConfig;
+    CPPUNIT_ASSERT(fieldConfig.initFromFile(configFileName));
+
+    ml::model::CAnomalyDetectorModelConfig modelConfig =
+        ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
+
+    std::ostringstream* backgroundStream(nullptr);
+    ml::api::CSingleStreamDataAdder::TOStreamP backgroundStreamPtr(
+        backgroundStream = new std::ostringstream());
+    ml::api::CSingleStreamDataAdder backgroundDataAdder(backgroundStreamPtr);
+    // The 300 second persist interval is irrelevant here - we bypass the timer
+    // in this test and kick off the background persistence chain explicitly
+    ml::api::CBackgroundPersister backgroundPersister(300, backgroundDataAdder);
+
+    std::string snapshotId;
+    std::size_t numDocs(0);
+
+    std::string backgroundSnapshotId;
+    std::string foregroundSnapshotId;
+
+    std::ostringstream* foregroundStream(nullptr);
+    ml::api::CSingleStreamDataAdder::TOStreamP foregroundStreamPtr(
+        foregroundStream = new std::ostringstream());
+    {
+        ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
+        ml::api::CJsonOutputWriter outputWriter(JOB_ID, wrappedOutputStream);
+
+        ml::api::CAnomalyJob job(
+            JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
+            boost::bind(&reportPersistComplete, _1, boost::ref(snapshotId),
+                        boost::ref(numDocs)),
+            &backgroundPersister, -1, "time", "%d/%b/%Y:%T %z");
+
+        ml::api::CDataProcessor* firstProcessor(&job);
+
+        ml::api::CLineifiedJsonInputParser parser(inputStrm);
+
+        CPPUNIT_ASSERT(parser.readStream(boost::bind(
+            &ml::api::CDataProcessor::handleRecord, firstProcessor, _1)));
+
+        // Ensure the model size stats are up to date
+        job.finalise();
+
+        // Persist the processors' state in the foreground
+        ml::api::CSingleStreamDataAdder foregroundDataAdder(foregroundStreamPtr);
+        CPPUNIT_ASSERT(firstProcessor->persistState(foregroundDataAdder));
+        foregroundSnapshotId = snapshotId;
+
+        // Now persist the processors' state in the background
+        CPPUNIT_ASSERT(firstProcessor->periodicPersistState(backgroundPersister));
+        CPPUNIT_ASSERT(backgroundPersister.startPersist());
+
+        //Increment one of the statistics values
+        ml::core::CStatistics::stat(ml::stat_t::E_MemoryUsage).increment();
+
+        LOG_DEBUG(<< "Before waiting for the background persister to be idle");
+        CPPUNIT_ASSERT(backgroundPersister.waitForIdle());
+        LOG_DEBUG(<< "After waiting for the background persister to be idle");
+        backgroundSnapshotId = snapshotId;
     }
 
     std::string backgroundState = backgroundStream->str();

--- a/lib/api/unittest/CBackgroundPersisterTest.h
+++ b/lib/api/unittest/CBackgroundPersisterTest.h
@@ -16,11 +16,13 @@ public:
     void testDetectorPersistOver();
     void testDetectorPersistPartition();
     void testCategorizationOnlyPersist();
+    void testDetectorBackgroundPersistStaticsConsistency();
 
     static CppUnit::Test* suite();
 
 private:
     void foregroundBackgroundCompCategorizationAndAnomalyDetection(const std::string& configFileName);
+    void foregroundBackgroundCompAnomalyDetectionAfterStaticsUpdate(const std::string& configFileName);
 };
 
 #endif // INCLUDED_CBackgroundPersisterTest_h

--- a/lib/core/unittest/CStatisticsTest.cc
+++ b/lib/core/unittest/CStatisticsTest.cc
@@ -53,6 +53,8 @@ CppUnit::Test* CStatisticsTest::suite() {
         "CStatisticsTest::testStatistics", &CStatisticsTest::testStatistics));
     suiteOfTests->addTest(new CppUnit::TestCaller<CStatisticsTest>(
         "CStatisticsTest::testPersist", &CStatisticsTest::testPersist));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CStatisticsTest>(
+        "CStatisticsTest::testCacheStatistics", &CStatisticsTest::testCacheStatistics));
 
     return suiteOfTests;
 }
@@ -97,6 +99,55 @@ void CStatisticsTest::testStatistics() {
     CPPUNIT_ASSERT_EQUAL(uint64_t(0x1000000), stats.stat(TEST_STAT).value());
 }
 
+void CStatisticsTest::testCacheStatistics() {
+    ml::core::CStatistics& stats = ml::core::CStatistics::instance();
+
+    {
+        //! obtain ownership of the stats cache
+        ml::core::CStatistics::TStatsCacheUPtr statsCache =
+            ml::core::CStatistics::transferCachedStats();
+
+        // confirm that initially the cache is non-existent
+        CPPUNIT_ASSERT(statsCache == nullptr);
+    }
+
+    // populate non-zero live stats
+    for (int i = 0; i < ml::stat_t::E_LastEnumStat; i++) {
+        stats.stat(i).set(i + 1);
+    }
+
+    // copy the live values to the cache
+    stats.cacheStats();
+
+    //! obtain ownership of the stats cache
+    ml::core::CStatistics::TStatsCacheUPtr statsCache =
+        ml::core::CStatistics::transferCachedStats();
+    CPPUNIT_ASSERT(statsCache != nullptr);
+
+    // check that the cached and live stats match and that the values are as expected
+    for (int i = 0; i < ml::stat_t::E_LastEnumStat; i++) {
+        CPPUNIT_ASSERT_EQUAL(stats.stat(i).value(), statsCache->stat(i));
+        CPPUNIT_ASSERT_EQUAL(uint64_t(i + 1), statsCache->stat(i));
+    }
+
+    // Take a local copy of the cached stats
+    std::vector<uint64_t> origCache;
+    for (int i = 0; i < ml::stat_t::E_LastEnumStat; i++) {
+        origCache.push_back(statsCache->stat(i));
+    }
+
+    // increment the live stats
+    for (int i = 0; i < ml::stat_t::E_LastEnumStat; i++) {
+        stats.stat(i).increment();
+    }
+
+    // compare with the cached values, they should have not changed
+    for (int i = 0; i < ml::stat_t::E_LastEnumStat; i++) {
+        CPPUNIT_ASSERT_EQUAL(uint64_t(1), stats.stat(i).value() - statsCache->stat(i));
+        CPPUNIT_ASSERT_EQUAL(origCache[i], statsCache->stat(i));
+    }
+}
+
 void CStatisticsTest::testPersist() {
     ml::core::CStatistics& stats = ml::core::CStatistics::instance();
 
@@ -107,6 +158,7 @@ void CStatisticsTest::testPersist() {
 
     std::string origStaticsXml;
     {
+        stats.cacheStats();
         ml::core::CRapidXmlStatePersistInserter inserter("root");
         stats.staticsAcceptPersistInserter(inserter);
         inserter.toXml(origStaticsXml);
@@ -132,9 +184,22 @@ void CStatisticsTest::testPersist() {
         CPPUNIT_ASSERT_EQUAL(uint64_t(567 + (i * 3)), stats.stat(i).value());
     }
 
-    // Save this state
+    // Save this state, without first caching the live values
+    std::string newStaticsXmlNoCaching;
+    {
+        ml::core::CRapidXmlStatePersistInserter inserter("root");
+        stats.staticsAcceptPersistInserter(inserter);
+        inserter.toXml(newStaticsXmlNoCaching);
+    }
+
+    // we expect the persisted statistics to be all zeros,
+    // as persistence operates on the cached values and these haven't been updated yet
+    CPPUNIT_ASSERT_EQUAL(origStaticsXml, newStaticsXmlNoCaching);
+
+    // Save the state after updating the cache
     std::string newStaticsXml;
     {
+        stats.cacheStats();
         ml::core::CRapidXmlStatePersistInserter inserter("root");
         stats.staticsAcceptPersistInserter(inserter);
         inserter.toXml(newStaticsXml);
@@ -174,6 +239,11 @@ void CStatisticsTest::testPersist() {
         CPPUNIT_ASSERT(traverser.traverseSubLevel(
             &ml::core::CStatistics::staticsAcceptRestoreTraverser));
     }
+
+    // Check that the cache is automatically cleaned up
+    ml::core::CStatistics::TStatsCacheUPtr statsCache =
+        ml::core::CStatistics::transferCachedStats();
+    CPPUNIT_ASSERT(statsCache == nullptr);
 
     for (int i = 0; i < ml::stat_t::E_LastEnumStat; i++) {
         CPPUNIT_ASSERT_EQUAL(uint64_t(0), stats.stat(i).value());

--- a/lib/core/unittest/CStatisticsTest.h
+++ b/lib/core/unittest/CStatisticsTest.h
@@ -12,8 +12,7 @@ class CStatisticsTest : public CppUnit::TestFixture {
 public:
     void testStatistics();
     void testPersist();
-
-    void threadRunner(int i);
+    void testCacheStatistics();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
Uses a transient cache that is cleaned up after persistence occurs