### PR TITLE
[FEATURE][ML] Progress monitoring

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -132,7 +132,17 @@ protected:
 
     void setToBad();
     void setToFinished();
-    void updateProgress(double fractionalProgress);
+
+    //! This adds \p fractionalProgess to the current progress.
+    //!
+    //! \note The caller should try to ensure that the sum of the values added
+    //! at the end of the analysis is equal to one.
+    //! \note This is converted to an integer - so we can atomically add - by
+    //! scaling by 1024. Therefore, this shouldn't be called with values less
+    //! than 0.001. In fact, it is unlikely that such high resolution is needed
+    //! and typically this would be called significantly less frequently.
+    void recordProgress(double fractionalProgress);
+
     void addError(const std::string& error);
 
 private:
@@ -150,7 +160,7 @@ private:
 
     bool m_Bad = false;
     std::atomic_bool m_Finished;
-    std::atomic<double> m_FractionalProgress;
+    std::atomic_int m_FractionalProgress;
     TStrVec m_Errors;
 
     std::thread m_Runner;

--- a/include/core/CLoopProgress.h
+++ b/include/core/CLoopProgress.h
@@ -62,7 +62,7 @@ private:
     std::size_t m_Steps;
     double m_StepProgress;
     std::size_t m_Pos = 0;
-    std::size_t m_LastProgress = 1;
+    std::size_t m_LastProgress = 0;
     const TProgressCallback* m_RecordProgress;
 };
 }

--- a/include/core/CLoopProgress.h
+++ b/include/core/CLoopProgress.h
@@ -63,7 +63,7 @@ private:
     double m_StepProgress;
     std::size_t m_Pos = 0;
     std::size_t m_LastProgress = 0;
-    const TProgressCallback* m_RecordProgress;
+    TProgressCallback m_RecordProgress;
 };
 }
 }

--- a/include/core/CLoopProgress.h
+++ b/include/core/CLoopProgress.h
@@ -55,9 +55,6 @@ public:
     void increment(std::size_t i = 1);
 
 private:
-    static const std::size_t STEPS = 16;
-
-private:
     std::size_t m_Size;
     std::size_t m_Steps;
     double m_StepProgress;

--- a/include/core/CLoopProgress.h
+++ b/include/core/CLoopProgress.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_core_CLoopProgress_h
+#define INCLUDED_ml_core_CLoopProgress_h
+
+#include <core/ImportExport.h>
+
+#include <cstddef>
+#include <functional>
+
+namespace ml {
+namespace core {
+
+//! \brief Manages recording the progress of a loop.
+//!
+//! DESCRIPTION:\n
+//! It is generally bad practice to record progress every iteration of a loop since:
+//!   -# This level of granularity of progress reporting is not needed
+//!   -# In parallel code this can cause a lot of contention on some shared resource.
+//!
+//! This class manages breaking the progress reporting of a loop into a fixed number
+//! of steps.
+//!
+//! Example:
+//! \code{cpp}
+//! double progress{0.0};
+//! CLoopProgess loopProgess{n, [&progess](double p) { progress += p}};
+//! for (std::size_t i = 0; i < n; ++i, loopProgess.increment()) {
+//!   ...
+//! }
+//! std::cout << progress << std::endl;
+//! \endcode
+//!
+//! Output: 1
+//!
+//! IMPLEMENTATION:\N
+//! The number of steps chosen to be a power of 2 so that the progress per step is
+//! exactly representable as an IEEE floating point type. This means in normal usage
+//! the total progress will be exactly 1.0 at the end of a loop.
+class CORE_EXPORT CLoopProgress {
+public:
+    using TProgressCallback = std::function<void(double)>;
+
+public:
+    template<typename ITR>
+    CLoopProgress(ITR begin, ITR end, const TProgressCallback& recordProgress, double scale = 1.0)
+        : CLoopProgress(std::distance(begin, end), recordProgress, scale) {}
+    CLoopProgress(std::size_t size, const TProgressCallback& recordProgress, double scale = 1.0);
+
+    //! Increment the progress by \p i.
+    void increment(std::size_t i = 1);
+
+private:
+    static const std::size_t STEPS = 16;
+
+private:
+    std::size_t m_Size;
+    std::size_t m_Steps;
+    double m_StepProgress;
+    std::size_t m_Pos = 0;
+    std::size_t m_LastProgress = 1;
+    const TProgressCallback* m_RecordProgress;
+};
+}
+}
+
+#endif // INCLUDED_ml_core_CLoopProgress_h

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -373,7 +373,6 @@ parallel_for_each(std::size_t partitions,
 
     std::vector<future<bool>> tasks;
 
-
     for (std::size_t offset = 0; offset < partitions; ++offset, ++start) {
         // Note there is one copy of g for each thread so capture by reference
         // is thread safe provided f is thread safe.

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -377,7 +377,8 @@ parallel_for_each(std::size_t partitions,
         // Note there is one copy of g for each thread so capture by reference
         // is thread safe provided f is thread safe.
 
-        CLoopProgress progress{size - offset, recordProgress, 1.0 / static_cast<double>(partitions)};
+        CLoopProgress progress{size - offset, recordProgress,
+                               1.0 / static_cast<double>(partitions)};
 
         auto& g = functions[offset];
         tasks.emplace_back(async(

--- a/include/maths/CRegressionDetail.h
+++ b/include/maths/CRegressionDetail.h
@@ -189,8 +189,8 @@ bool CRegression::CLeastSquaresOnline<N, T>::parameters(std::size_t n,
         return false;
     }
 
-    // Don't bother checking the solution since we check
-    // the matrix condition above.
+    // Don't bother checking the solution since we check the matrix
+    // condition above.
     VECTOR r = svd.solve(y);
     for (std::size_t i = 0u; i < n; ++i) {
         result[i] = r(i);

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -114,7 +114,11 @@ void CDataFrameOutliersRunner::writeOneRow(TRowRef row,
 }
 
 void CDataFrameOutliersRunner::runImpl(core::CDataFrame& frame) {
-    maths::computeOutliers(this->spec().numberThreads(), frame);
+    maths::computeOutliers(this->spec().numberThreads(),
+                           [this](double fractionalProgress) {
+                               this->recordProgress(fractionalProgress);
+                           },
+                           frame);
 }
 
 std::size_t

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -48,7 +48,7 @@ protected:
 
             std::this_thread::sleep_for(std::chrono::milliseconds(wait[0]));
 
-            this->updateProgress(static_cast<double>(i) / 30.0);
+            this->recordProgress(1.0 / 30.0);
             if (i % 10 == 0) {
                 this->addError("error " + std::to_string(i));
             }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -89,7 +89,8 @@ void addTestData(TStrVec fieldNames,
         analyzer.handleRecord(fieldNames, fieldValues);
     }
 
-    maths::CLocalOutlierFactors::ensemble(points, expectedScores);
+    maths::CLocalOutlierFactors lofs;
+    lofs.ensemble(points, expectedScores);
 }
 }
 

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -12,15 +12,19 @@ namespace ml {
 namespace core {
 
 CLoopProgress::CLoopProgress(std::size_t size, const TProgressCallback& recordProgress, double scale)
-    : m_Size{size < STEPS ? 1 : size}, m_Steps{std::min(size, STEPS)},
+    : m_Size{size}, m_Steps{std::min(size, STEPS)},
       m_StepProgress{scale / static_cast<double>(m_Steps)}, m_RecordProgress{&recordProgress} {
 }
 
 void CLoopProgress::increment(std::size_t i) {
     m_Pos += i;
-    if (m_Steps * m_Pos + 1 > m_LastProgress * m_Size) {
-        (*m_RecordProgress)(m_StepProgress);
-        ++m_LastProgress;
+
+    if (m_Steps * m_Pos + 1 > (m_LastProgress + 1) * m_Size) {
+        // Account for the fact that if i is large we may have jumped several steps.
+        std::size_t stride{m_Steps * std::min(m_Pos, m_Size) / m_Size - m_LastProgress};
+
+        (*m_RecordProgress)(static_cast<double>(stride) * m_StepProgress);
+        m_LastProgress += stride;
     }
 }
 }

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -13,7 +13,7 @@ namespace core {
 
 CLoopProgress::CLoopProgress(std::size_t size, const TProgressCallback& recordProgress, double scale)
     : m_Size{size}, m_Steps{std::min(size, STEPS)},
-      m_StepProgress{scale / static_cast<double>(m_Steps)}, m_RecordProgress{&recordProgress} {
+      m_StepProgress{scale / static_cast<double>(m_Steps)}, m_RecordProgress{recordProgress} {
 }
 
 void CLoopProgress::increment(std::size_t i) {
@@ -23,7 +23,7 @@ void CLoopProgress::increment(std::size_t i) {
         // Account for the fact that if i is large we may have jumped several steps.
         std::size_t stride{m_Steps * std::min(m_Pos, m_Size) / m_Size - m_LastProgress};
 
-        (*m_RecordProgress)(static_cast<double>(stride) * m_StepProgress);
+        m_RecordProgress(static_cast<double>(stride) * m_StepProgress);
         m_LastProgress += stride;
     }
 }

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CLoopProgress.h>
+
+#include <algorithm>
+
+namespace ml {
+namespace core {
+
+CLoopProgress::CLoopProgress(std::size_t size, const TProgressCallback& recordProgress, double scale)
+    : m_Size{size < STEPS ? 1 : size}, m_Steps{std::min(size, STEPS)},
+      m_StepProgress{scale / static_cast<double>(m_Steps)}, m_RecordProgress{&recordProgress} {
+}
+
+void CLoopProgress::increment(std::size_t i) {
+    m_Pos += i;
+    if (m_Steps * m_Pos + 1 > m_LastProgress * m_Size) {
+        (*m_RecordProgress)(m_StepProgress);
+        ++m_LastProgress;
+    }
+}
+}
+}

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -10,6 +10,9 @@
 
 namespace ml {
 namespace core {
+namespace {
+const std::size_t STEPS{16};
+}
 
 CLoopProgress::CLoopProgress(std::size_t size, const TProgressCallback& recordProgress, double scale)
     : m_Size{size}, m_Steps{std::min(size, STEPS)},

--- a/lib/core/Concurrency.cc
+++ b/lib/core/Concurrency.cc
@@ -141,6 +141,9 @@ CDefaultAsyncExecutorBusyForScope::~CDefaultAsyncExecutorBusyForScope() {
 bool CDefaultAsyncExecutorBusyForScope::wasBusy() const {
     return m_WasBusy;
 }
+
+void noop(double) {
+}
 }
 }
 }

--- a/lib/core/Makefile
+++ b/lib/core/Makefile
@@ -87,6 +87,7 @@ CJsonOutputStreamWrapper.cc \
 CJsonStatePersistInserter.cc \
 CJsonStateRestoreTraverser.cc \
 CLogger.cc \
+CLoopProgress.cc \
 CMemory.cc \
 CMemoryUsage.cc \
 CMemoryUsageJsonWriter.cc \

--- a/lib/core/unittest/CConcurrencyTest.cc
+++ b/lib/core/unittest/CConcurrencyTest.cc
@@ -264,7 +264,7 @@ void CConcurrencyTest::testProgressMonitoring() {
         LOG_DEBUG(<< "Testing " << tag << " indices");
 
         std::thread worker{[&reportProgress]() {
-            core::parallel_for_each(std::size_t{0}, std::size_t{1000},
+            core::parallel_for_each(4, std::size_t{0}, std::size_t{1000},
                                     [](std::size_t) {
                                         std::chrono::microseconds pause{500};
                                         std::this_thread::sleep_for(pause);
@@ -297,7 +297,7 @@ void CConcurrencyTest::testProgressMonitoring() {
         LOG_DEBUG(<< "Testing " << tag << " iterators");
 
         std::thread worker{[&reportProgress, &values]() {
-            core::parallel_for_each(values.begin(), values.end(),
+            core::parallel_for_each(4, values.begin(), values.end(),
                                     [](int) {
                                         std::chrono::microseconds pause{500};
                                         std::this_thread::sleep_for(pause);

--- a/lib/core/unittest/CConcurrencyTest.h
+++ b/lib/core/unittest/CConcurrencyTest.h
@@ -17,6 +17,7 @@ public:
     void testParallelForEach();
     void testParallelForEachWithExceptions();
     void testParallelForEachReentry();
+    void testProgressMonitoring();
 
     static CppUnit::Test* suite();
 };

--- a/lib/core/unittest/CLoopProgressTest.cc
+++ b/lib/core/unittest/CLoopProgressTest.cc
@@ -19,7 +19,6 @@ void CLoopProgressTest::testShort() {
 
     double progress{0.0};
 
-    LOG_DEBUG(<< "Test short loops");
     for (std::size_t n = 1; n < 16; ++n) {
 
         LOG_DEBUG(<< "Testing " << n);
@@ -33,6 +32,21 @@ void CLoopProgressTest::testShort() {
         }
 
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, progress, 1e-15);
+    }
+
+    LOG_DEBUG(<< "Test with stride > 1");
+
+    for (std::size_t n = 2; n < 16; ++n) {
+
+        LOG_DEBUG(<< "Testing " << n);
+
+        progress = 0.0;
+        core::CLoopProgress loopProgress{n,
+                                         [&progress](double p) { progress += p; }};
+
+        for (std::size_t i = 0; i < n; i += 2, loopProgress.increment(2)) {
+            // Empty
+        }
     }
 }
 
@@ -55,6 +69,28 @@ void CLoopProgressTest::testRandom() {
                                          [&progress](double p) { progress += p; }};
 
         for (std::size_t i = 0; i < size[0]; ++i, loopProgress.increment()) {
+            // Empty
+        }
+
+        CPPUNIT_ASSERT_EQUAL(1.0, progress);
+    }
+
+    LOG_DEBUG(<< "Test with stride > 1");
+
+    for (std::size_t t = 0; t < 100; ++t) {
+
+        TSizeVec size;
+        rng.generateUniformSamples(30, 100, 1, size);
+
+        if (t % 10 == 0) {
+            LOG_DEBUG(<< "Loop length = " << size[0]);
+        }
+
+        progress = 0.0;
+        core::CLoopProgress loopProgress{size[0],
+                                         [&progress](double p) { progress += p; }};
+
+        for (std::size_t i = 0; i < size[0]; i += 20, loopProgress.increment(20)) {
             // Empty
         }
 

--- a/lib/core/unittest/CLoopProgressTest.cc
+++ b/lib/core/unittest/CLoopProgressTest.cc
@@ -18,17 +18,20 @@ using TSizeVec = std::vector<std::size_t>;
 void CLoopProgressTest::testShort() {
 
     double progress{0.0};
+    auto recordProgress = [&progress](double p) { progress += p; };
+
+    LOG_DEBUG(<< "Test with stride == 1");
 
     for (std::size_t n = 1; n < 16; ++n) {
 
         LOG_DEBUG(<< "Testing " << n);
 
         progress = 0.0;
-        core::CLoopProgress loopProgress{n,
-                                         [&progress](double p) { progress += p; }};
+        core::CLoopProgress loopProgress{n, recordProgress};
 
         for (std::size_t i = 0; i < n; ++i, loopProgress.increment()) {
-            // Empty
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(
+                static_cast<double>(i) / static_cast<double>(n), progress, 1e-15);
         }
 
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, progress, 1e-15);
@@ -41,11 +44,11 @@ void CLoopProgressTest::testShort() {
         LOG_DEBUG(<< "Testing " << n);
 
         progress = 0.0;
-        core::CLoopProgress loopProgress{n,
-                                         [&progress](double p) { progress += p; }};
+        core::CLoopProgress loopProgress{n, recordProgress};
 
         for (std::size_t i = 0; i < n; i += 2, loopProgress.increment(2)) {
-            // Empty
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(
+                static_cast<double>(i) / static_cast<double>(n), progress, 1e-15);
         }
     }
 }
@@ -53,7 +56,11 @@ void CLoopProgressTest::testShort() {
 void CLoopProgressTest::testRandom() {
 
     double progress{0.0};
+    auto recordProgress = [&progress](double p) { progress += p; };
+
     test::CRandomNumbers rng;
+
+    LOG_DEBUG(<< "Test with stride == 1");
 
     for (std::size_t t = 0; t < 100; ++t) {
 
@@ -65,11 +72,10 @@ void CLoopProgressTest::testRandom() {
         }
 
         progress = 0.0;
-        core::CLoopProgress loopProgress{size[0],
-                                         [&progress](double p) { progress += p; }};
+        core::CLoopProgress loopProgress{size[0], recordProgress};
 
         for (std::size_t i = 0; i < size[0]; ++i, loopProgress.increment()) {
-            // Empty
+            CPPUNIT_ASSERT_EQUAL(static_cast<double>(16 * i / size[0]) / 16.0, progress);
         }
 
         CPPUNIT_ASSERT_EQUAL(1.0, progress);
@@ -87,11 +93,10 @@ void CLoopProgressTest::testRandom() {
         }
 
         progress = 0.0;
-        core::CLoopProgress loopProgress{size[0],
-                                         [&progress](double p) { progress += p; }};
+        core::CLoopProgress loopProgress{size[0], recordProgress};
 
         for (std::size_t i = 0; i < size[0]; i += 20, loopProgress.increment(20)) {
-            // Empty
+            CPPUNIT_ASSERT_EQUAL(static_cast<double>(16 * i / size[0]) / 16.0, progress);
         }
 
         CPPUNIT_ASSERT_EQUAL(1.0, progress);
@@ -101,6 +106,8 @@ void CLoopProgressTest::testRandom() {
 void CLoopProgressTest::testScaled() {
 
     double progress{0.0};
+    auto recordProgress = [&progress](double p) { progress += p; };
+
     test::CRandomNumbers rng;
 
     for (std::size_t t = 0; t < 100; ++t) {
@@ -115,13 +122,12 @@ void CLoopProgressTest::testScaled() {
         }
 
         progress = 0.0;
-        core::CLoopProgress loopProgress{size[0],
-                                         [&progress](double p) { progress += p; },
+        core::CLoopProgress loopProgress{size[0], recordProgress,
                                          1.0 / static_cast<double>(step[0])};
 
         for (std::size_t i = 0; i < size[0];
              i += step[0], loopProgress.increment(step[0])) {
-            // Empty
+            // We're only interested in checking the progress at the end.
         }
 
         CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0 / static_cast<double>(step[0]), progress, 1e-15);

--- a/lib/core/unittest/CLoopProgressTest.cc
+++ b/lib/core/unittest/CLoopProgressTest.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CLoopProgressTest.h"
+
+#include <core/CLogger.h>
+#include <core/CLoopProgress.h>
+
+#include <test/CRandomNumbers.h>
+
+using namespace ml;
+
+using TSizeVec = std::vector<std::size_t>;
+
+void CLoopProgressTest::testShort() {
+
+    double progress{0.0};
+
+    LOG_DEBUG(<< "Test short loops");
+    for (std::size_t n = 1; n < 16; ++n) {
+
+        LOG_DEBUG(<< "Testing " << n);
+
+        progress = 0.0;
+        core::CLoopProgress loopProgress{n,
+                                         [&progress](double p) { progress += p; }};
+
+        for (std::size_t i = 0; i < n; ++i, loopProgress.increment()) {
+            // Empty
+        }
+
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, progress, 1e-15);
+    }
+}
+
+void CLoopProgressTest::testRandom() {
+
+    double progress{0.0};
+    test::CRandomNumbers rng;
+
+    for (std::size_t t = 0; t < 100; ++t) {
+
+        TSizeVec size;
+        rng.generateUniformSamples(16, 10000, 1, size);
+
+        if (t % 10 == 0) {
+            LOG_DEBUG(<< "Loop length = " << size[0]);
+        }
+
+        progress = 0.0;
+        core::CLoopProgress loopProgress{size[0],
+                                         [&progress](double p) { progress += p; }};
+
+        for (std::size_t i = 0; i < size[0]; ++i, loopProgress.increment()) {
+            // Empty
+        }
+
+        CPPUNIT_ASSERT_EQUAL(1.0, progress);
+    }
+}
+
+void CLoopProgressTest::testScaled() {
+
+    double progress{0.0};
+    test::CRandomNumbers rng;
+
+    for (std::size_t t = 0; t < 100; ++t) {
+
+        TSizeVec step;
+        rng.generateUniformSamples(1, 10, 1, step);
+        TSizeVec size;
+        rng.generateUniformSamples(16 * step[0], 10000, 1, size);
+
+        if (t % 10 == 0) {
+            LOG_DEBUG(<< "Loop length = " << size[0]);
+        }
+
+        progress = 0.0;
+        core::CLoopProgress loopProgress{size[0],
+                                         [&progress](double p) { progress += p; },
+                                         1.0 / static_cast<double>(step[0])};
+
+        for (std::size_t i = 0; i < size[0];
+             i += step[0], loopProgress.increment(step[0])) {
+            // Empty
+        }
+
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0 / static_cast<double>(step[0]), progress, 1e-15);
+    }
+}
+
+CppUnit::Test* CLoopProgressTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CLoopProgressTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CLoopProgressTest>(
+        "CLoopProgressTest::testShort", &CLoopProgressTest::testShort));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CLoopProgressTest>(
+        "CLoopProgressTest::testRandom", &CLoopProgressTest::testRandom));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CLoopProgressTest>(
+        "CLoopProgressTest::testScaled", &CLoopProgressTest::testScaled));
+
+    return suiteOfTests;
+}

--- a/lib/core/unittest/CLoopProgressTest.h
+++ b/lib/core/unittest/CLoopProgressTest.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CLoopProgressTest_h
+#define INCLUDED_CLoopProgressTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CLoopProgressTest : public CppUnit::TestFixture {
+public:
+    void testShort();
+    void testRandom();
+    void testScaled();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CLoopProgressTest_h

--- a/lib/core/unittest/Main.cc
+++ b/lib/core/unittest/Main.cc
@@ -30,6 +30,7 @@
 #include "CJsonStatePersistInserterTest.h"
 #include "CJsonStateRestoreTraverserTest.h"
 #include "CLoggerTest.h"
+#include "CLoopProgressTest.h"
 #include "CMapPopulationTest.h"
 #include "CMemoryUsageJsonWriterTest.h"
 #include "CMemoryUsageTest.h"
@@ -106,6 +107,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CJsonStatePersistInserterTest::suite());
     runner.addTest(CJsonStateRestoreTraverserTest::suite());
     runner.addTest(CLoggerTest::suite());
+    runner.addTest(CLoopProgressTest::suite());
     runner.addTest(CMapPopulationTest::suite());
     runner.addTest(CMemoryUsageJsonWriterTest::suite());
     runner.addTest(CMemoryUsageTest::suite());

--- a/lib/core/unittest/Makefile
+++ b/lib/core/unittest/Makefile
@@ -50,6 +50,7 @@ CJsonOutputStreamWrapperTest.cc \
 CJsonStatePersistInserterTest.cc \
 CJsonStateRestoreTraverserTest.cc \
 CLoggerTest.cc \
+CLoopProgressTest.cc \
 CMemoryUsageJsonWriterTest.cc \
 CMemoryUsageTest.cc \
 CMessageBufferTest.cc \

--- a/lib/maths/unittest/CLocalOutlierFactorsTest.cc
+++ b/lib/maths/unittest/CLocalOutlierFactorsTest.cc
@@ -118,8 +118,10 @@ void outlierErrorStatisticsForEnsemble(test::CRandomNumbers& rng,
     for (std::size_t t = 0; t < 100; ++t) {
         gaussianWithUniformNoiseForPresizedPoints(rng, numberInliers, numberOutliers, points);
 
+        maths::CLocalOutlierFactors lofs;
+
         TDoubleVec scores;
-        maths::CLocalOutlierFactors::ensemble(points, scores);
+        lofs.ensemble(points, scores);
 
         TSizeVec outliers[3];
         for (std::size_t i = 0; i < scores.size(); ++i) {
@@ -198,8 +200,10 @@ void CLocalOutlierFactorsTest::testLof() {
                            "-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, "
                            "-1, -1, -1, -1, -1]"};
     for (auto k : {5, 10, 15}) {
+        maths::CLocalOutlierFactors lofs;
+
         TDoubleVec scores;
-        maths::CLocalOutlierFactors::normalizedLof(k, false, points, scores);
+        lofs.normalizedLof(k, false, points, scores);
 
         TMaxAccumulator outliers_(numberOutliers);
         for (std::size_t i = 0u; i < scores.size(); ++i) {
@@ -227,9 +231,11 @@ void CLocalOutlierFactorsTest::testDlof() {
     TVectorVec points;
     gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
+    maths::CLocalOutlierFactors lofs;
+
     TDoubleVec scores;
     std::size_t k{10};
-    maths::CLocalOutlierFactors::normalizedLdof(k, false, points, scores);
+    lofs.normalizedLdof(k, false, points, scores);
     LOG_DEBUG(<< "scores = " << core::CContainerPrinter::print(scores));
 
     TMaxAccumulator outlierScoresWithoutProjecting(numberOutliers);
@@ -259,7 +265,7 @@ void CLocalOutlierFactorsTest::testDlof() {
 
     // Compare outliers when projecting (should be similar).
 
-    maths::CLocalOutlierFactors::normalizedLdof(k, true, points, scores);
+    lofs.normalizedLdof(k, true, points, scores);
 
     TMaxAccumulator outlierScoresProjecting(numberOutliers);
     for (std::size_t i = 0; i < scores.size(); ++i) {
@@ -296,9 +302,11 @@ void CLocalOutlierFactorsTest::testDistancekNN() {
     TVectorVec points;
     gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
+    maths::CLocalOutlierFactors lofs;
+
     TDoubleVec scores;
     std::size_t k{10};
-    maths::CLocalOutlierFactors::normalizedDistancekNN(k, false, points, scores);
+    lofs.normalizedDistancekNN(k, false, points, scores);
     LOG_DEBUG(<< "scores = " << core::CContainerPrinter::print(scores));
 
     TMaxAccumulator outlierScoresWithoutProjecting(numberOutliers);
@@ -321,7 +329,7 @@ void CLocalOutlierFactorsTest::testDistancekNN() {
 
     // Compare outliers when projecting (should be similar).
 
-    maths::CLocalOutlierFactors::normalizedDistancekNN(k, true, points, scores);
+    lofs.normalizedDistancekNN(k, true, points, scores);
 
     TMaxAccumulator outlierScoresProjecting(numberOutliers);
     for (std::size_t i = 0; i < scores.size(); ++i) {
@@ -357,9 +365,11 @@ void CLocalOutlierFactorsTest::testTotalDistancekNN() {
     TVectorVec points;
     gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
+    maths::CLocalOutlierFactors lofs;
+
     TDoubleVec scores;
     std::size_t k{10};
-    maths::CLocalOutlierFactors::normalizedTotalDistancekNN(k, false, points, scores);
+    lofs.normalizedTotalDistancekNN(k, false, points, scores);
     LOG_DEBUG(<< "scores = " << core::CContainerPrinter::print(scores));
 
     TMaxAccumulator outlierScoresWithoutProjecting(numberOutliers);
@@ -386,7 +396,7 @@ void CLocalOutlierFactorsTest::testTotalDistancekNN() {
 
     // Compare outliers when projecting (should be similar).
 
-    maths::CLocalOutlierFactors::normalizedTotalDistancekNN(k, true, points, scores);
+    lofs.normalizedTotalDistancekNN(k, true, points, scores);
 
     TMaxAccumulator outlierScoresProjecting(numberOutliers);
     for (std::size_t i = 0; i < scores.size(); ++i) {

--- a/lib/maths/unittest/CLocalOutlierFactorsTest.cc
+++ b/lib/maths/unittest/CLocalOutlierFactorsTest.cc
@@ -533,18 +533,19 @@ void CLocalOutlierFactorsTest::testProgressMonitoring() {
     int lastTotalFractionalProgress{0};
     int lastProgressReport{0};
 
+    bool monotonic{true};
     while (finished.load() == false) {
         if (totalFractionalProgress.load() > lastProgressReport) {
             LOG_DEBUG(<< (static_cast<double>(lastProgressReport) / 10) << "% complete");
             lastProgressReport += 100;
         }
-        CPPUNIT_ASSERT(totalFractionalProgress.load() >= lastTotalFractionalProgress);
+        monotonic &= (totalFractionalProgress.load() >= lastTotalFractionalProgress);
         lastTotalFractionalProgress = totalFractionalProgress.load();
     }
-
-    CPPUNIT_ASSERT_EQUAL(1024, totalFractionalProgress.load());
-
     worker.join();
+
+    CPPUNIT_ASSERT(monotonic);
+    CPPUNIT_ASSERT_EQUAL(1024, totalFractionalProgress.load());
 }
 
 CppUnit::Test* CLocalOutlierFactorsTest::suite() {

--- a/lib/maths/unittest/CLocalOutlierFactorsTest.h
+++ b/lib/maths/unittest/CLocalOutlierFactorsTest.h
@@ -16,6 +16,7 @@ public:
     void testDistancekNN();
     void testTotalDistancekNN();
     void testEnsemble();
+    void testProgressMonitoring();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
This wires in progress monitoring to the data frame analysis framework. I've discretised the progress so I can efficiently update atomically. The actual progress is updated via a callback to maximally decouple the "observer" from the algorithms whose progress is being observed. This also makes it trivial to stub out progress monitoring.

Note I haven't yet done anything to pass this back during a long running analysis, because the Java side isn't expecting anything yet.