### PR TITLE
[FEATURE][ML] Ensure progress is less than one for unfinished data frame analysis tasks

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -127,8 +127,6 @@ public:
 
 protected:
     const CDataFrameAnalysisSpecification& spec() const;
-
-    void setToFinished();
     TProgressRecorder progressRecorder();
 
 private:
@@ -147,6 +145,7 @@ private:
     //! than 0.001. In fact, it is unlikely that such high resolution is needed
     //! and typically this would be called significantly less frequently.
     void recordProgress(double fractionalProgress);
+    void setToFinished();
 
 private:
     const CDataFrameAnalysisSpecification& m_Spec;
@@ -155,7 +154,7 @@ private:
     std::size_t m_MaximumNumberRowsPerPartition = 0;
 
     std::atomic_bool m_Finished;
-    std::atomic_int m_FractionalProgress;
+    std::atomic_size_t m_FractionalProgress;
 
     std::thread m_Runner;
 };

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -48,7 +48,6 @@ public:
     using TRunnerUPtr = std::unique_ptr<CDataFrameAnalysisRunner>;
     using TRunnerFactoryUPtr = std::unique_ptr<CDataFrameAnalysisRunnerFactory>;
     using TRunnerFactoryUPtrVec = std::vector<TRunnerFactoryUPtr>;
-    using TFatalErrorHandler = std::function<void(std::string)>;
 
 public:
     //! Inititialize from a JSON object.
@@ -128,7 +127,6 @@ public:
 
 private:
     void initializeRunner(const char* name, const rapidjson::Value& analysis);
-    static TFatalErrorHandler defaultFatalErrorHandler();
 
 private:
     std::size_t m_NumberRows = 0;

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -24,7 +24,8 @@ std::size_t memoryLimitWithSafetyMargin(const CDataFrameAnalysisSpecification& s
     return static_cast<std::size_t>(0.9 * static_cast<double>(spec.memoryLimit()) + 0.5);
 }
 
-const std::size_t MAXIMUM_FRACTIONAL_PROGRESS{1ull << ((sizeof(std::size_t) - 2) * 8)};
+const std::size_t MAXIMUM_FRACTIONAL_PROGRESS{std::size_t{1}
+                                              << ((sizeof(std::size_t) - 2) * 8)};
 }
 
 CDataFrameAnalysisRunner::CDataFrameAnalysisRunner(const CDataFrameAnalysisSpecification& spec)

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -15,6 +15,7 @@
 #include <boost/iterator/counting_iterator.hpp>
 
 #include <algorithm>
+#include <cstddef>
 
 namespace ml {
 namespace api {
@@ -23,7 +24,7 @@ std::size_t memoryLimitWithSafetyMargin(const CDataFrameAnalysisSpecification& s
     return static_cast<std::size_t>(0.9 * static_cast<double>(spec.memoryLimit()) + 0.5);
 }
 
-const double MAXIMUM_FRACTIONAL_PROGRESS{1024.0};
+const std::size_t MAXIMUM_FRACTIONAL_PROGRESS{1ull << ((sizeof(std::size_t) - 2) * 8)};
 }
 
 CDataFrameAnalysisRunner::CDataFrameAnalysisRunner(const CDataFrameAnalysisSpecification& spec)
@@ -94,7 +95,10 @@ void CDataFrameAnalysisRunner::run(core::CDataFrame& frame) {
     } else {
         m_FractionalProgress.store(0.0);
         m_Finished.store(false);
-        m_Runner = std::thread([this, &frame]() { this->runImpl(frame); });
+        m_Runner = std::thread([this, &frame]() {
+            this->runImpl(frame);
+            this->setToFinished();
+        });
     }
 }
 
@@ -109,18 +113,15 @@ bool CDataFrameAnalysisRunner::finished() const {
 }
 
 double CDataFrameAnalysisRunner::progress() const {
-    return static_cast<double>(std::min(m_FractionalProgress.load(),
-                                        static_cast<int>(MAXIMUM_FRACTIONAL_PROGRESS))) /
-           MAXIMUM_FRACTIONAL_PROGRESS;
+    return this->finished()
+               ? 1.0
+               : static_cast<double>(std::min(m_FractionalProgress.load(),
+                                              MAXIMUM_FRACTIONAL_PROGRESS - 1)) /
+                     static_cast<double>(MAXIMUM_FRACTIONAL_PROGRESS);
 }
 
 const CDataFrameAnalysisSpecification& CDataFrameAnalysisRunner::spec() const {
     return m_Spec;
-}
-
-void CDataFrameAnalysisRunner::setToFinished() {
-    m_Finished.store(true);
-    m_FractionalProgress.store(static_cast<int>(MAXIMUM_FRACTIONAL_PROGRESS));
 }
 
 CDataFrameAnalysisRunner::TProgressRecorder CDataFrameAnalysisRunner::progressRecorder() {
@@ -137,8 +138,13 @@ std::size_t CDataFrameAnalysisRunner::estimateMemoryUsage(std::size_t numberRows
 }
 
 void CDataFrameAnalysisRunner::recordProgress(double fractionalProgress) {
-    m_FractionalProgress.fetch_add(std::max(
-        static_cast<int>(MAXIMUM_FRACTIONAL_PROGRESS * fractionalProgress + 0.5), 1));
+    m_FractionalProgress.fetch_add(static_cast<std::size_t>(std::max(
+        static_cast<double>(MAXIMUM_FRACTIONAL_PROGRESS) * fractionalProgress + 0.5, 1.0)));
+}
+
+void CDataFrameAnalysisRunner::setToFinished() {
+    m_Finished.store(true);
+    m_FractionalProgress.store(MAXIMUM_FRACTIONAL_PROGRESS);
 }
 
 CDataFrameAnalysisRunnerFactory::TRunnerUPtr

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -80,7 +80,7 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         auto isPositiveInteger = [](const rapidjson::Value& value) {
             return value.IsUint() && value.GetUint() > 0;
         };
-        auto registerFailure = [this, &document](const char* name) {
+        auto registerFailure = [&document](const char* name) {
             if (document.HasMember(name)) {
                 HANDLE_FATAL(<< "Input error: bad value '" << toString(document[name])
                              << "' for '" << name << "' in analysis specification.");

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -58,7 +58,7 @@ CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpeci
                                                    const rapidjson::Value& params)
     : CDataFrameOutliersRunner{spec} {
 
-    auto registerFailure = [this, &params](const char* name) {
+    auto registerFailure = [&params](const char* name) {
         HANDLE_FATAL(<< "Input error: bad value '" << toString(params[name])
                      << "' for '" << name << "'.");
     };

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CDataFrameMockAnalysisRunner.h"
+
+#include <core/CDataFrame.h>
+#include <core/CLoopProgress.h>
+
+CDataFrameMockAnalysisRunner::CDataFrameMockAnalysisRunner(const ml::api::CDataFrameAnalysisSpecification& spec)
+    : ml::api::CDataFrameAnalysisRunner{spec} {
+}
+
+std::size_t CDataFrameMockAnalysisRunner::numberOfPartitions() const {
+    return 1;
+}
+
+std::size_t CDataFrameMockAnalysisRunner::numberExtraColumns() const {
+    return 2;
+}
+
+void CDataFrameMockAnalysisRunner::writeOneRow(TRowRef, ml::core::CRapidJsonConcurrentLineWriter&) const {
+}
+
+void CDataFrameMockAnalysisRunner::runImpl(ml::core::CDataFrame&) {
+    ml::core::CLoopProgress progress{31, this->progressRecorder()};
+    for (std::size_t i = 0; i < 31; ++i, progress.increment()) {
+
+        std::vector<std::size_t> wait;
+        ms_Rng.generateUniformSamples(1, 20, 1, wait);
+        std::this_thread::sleep_for(std::chrono::milliseconds(wait[0]));
+    }
+}
+
+std::size_t CDataFrameMockAnalysisRunner::estimateBookkeepingMemoryUsage(std::size_t,
+                                                                         std::size_t,
+                                                                         std::size_t) const {
+    return 0;
+}
+
+ml::test::CRandomNumbers CDataFrameMockAnalysisRunner::ms_Rng;
+
+const char* CDataFrameMockAnalysisRunnerFactory::name() const {
+    return "test";
+}
+
+CDataFrameMockAnalysisRunnerFactory::TRunnerUPtr
+CDataFrameMockAnalysisRunnerFactory::makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec) const {
+    return std::make_unique<CDataFrameMockAnalysisRunner>(spec);
+}
+
+CDataFrameMockAnalysisRunnerFactory::TRunnerUPtr
+CDataFrameMockAnalysisRunnerFactory::makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec,
+                                              const rapidjson::Value&) const {
+    return std::make_unique<CDataFrameMockAnalysisRunner>(spec);
+}

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CDataFrameMockAnalysisRunner_h
+#define INCLUDED_CDataFrameMockAnalysisRunner_h
+
+#include <api/CDataFrameAnalysisRunner.h>
+#include <api/CDataFrameAnalysisSpecification.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <functional>
+
+class CDataFrameMockAnalysisRunner : public ml::api::CDataFrameAnalysisRunner {
+public:
+    CDataFrameMockAnalysisRunner(const ml::api::CDataFrameAnalysisSpecification& spec);
+
+    virtual std::size_t numberOfPartitions() const;
+    virtual std::size_t numberExtraColumns() const;
+    virtual void writeOneRow(TRowRef, ml::core::CRapidJsonConcurrentLineWriter&) const;
+
+protected:
+    void runImpl(ml::core::CDataFrame&);
+
+private:
+    virtual std::size_t
+        estimateBookkeepingMemoryUsage(std::size_t, std::size_t, std::size_t) const;
+
+private:
+    static ml::test::CRandomNumbers ms_Rng;
+};
+
+class CDataFrameMockAnalysisRunnerFactory : public ml::api::CDataFrameAnalysisRunnerFactory {
+public:
+    virtual const char* name() const;
+
+private:
+    virtual TRunnerUPtr makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec) const;
+    virtual TRunnerUPtr makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec,
+                                 const rapidjson::Value&) const;
+};
+
+#endif // INCLUDED_CDataFrameMockAnalysisRunner_h

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -30,6 +30,7 @@ SRCS=\
 	CDataFrameAnalysisRunnerTest.cc \
 	CDataFrameAnalysisSpecificationTest.cc \
 	CDataFrameAnalyzerTest.cc \
+	CDataFrameMockAnalysisRunner.cc \
 	CDetectionRulesJsonParserTest.cc \
 	CFieldConfigTest.cc \
 	CFieldDataTyperTest.cc \

--- a/lib/test/CTestRunner.cc
+++ b/lib/test/CTestRunner.cc
@@ -55,9 +55,8 @@ const std::string CTestRunner::SKIP_FILE_NAME("unit_test_skip_dirs.csv");
 const std::string CTestRunner::XML_RESULT_FILE_NAME("cppunit_results.xml");
 
 CTestRunner::CTestRunner(int argc, const char** argv) {
-    ml::core::CLogger::instance().fatalErrorHandler([](std::string message) {
-        CPPUNIT_FAIL(message);
-    });
+    ml::core::CLogger::instance().fatalErrorHandler(
+        [](std::string message) { CPPUNIT_FAIL(message); });
     this->processCmdLine(argc, argv);
 }
 


### PR DESCRIPTION
This ensures the data_frame_analyzer command never reports progress as greater than or equal to one until the analysis task is complete. It also uses much greater precision for progress monitoring since (provided the sum of values added is close to one as it should be) this won't overflow the integer representation.

I also factored out the mock data frame. I had planned to use this in `CDataFrameAnalysisRunnerTest` but decided the existing test coverage of progress monitoring was good enough. However, I think it is useful to have this in its own file for reusability.

@droberts195 this address your comment in #367.