### PR TITLE
[FEATURE][ML] Per column standardisation prior to outlier detection

### DIFF
--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -155,6 +155,7 @@ int main(int argc, char** argv) {
     if (dataFrameAnalyzer.usingControlMessages() == false) {
         // To make running from the command line easy, we'll run the analysis
         // after closing the input pipe if control messages are not in use.
+        dataFrameAnalyzer.receivedAllRows();
         dataFrameAnalyzer.run();
     }
 

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -184,6 +184,7 @@ public:
     using TFloatVec = std::vector<CFloatStorage>;
     using TFloatVecItr = TFloatVec::iterator;
     using TInt32Vec = std::vector<std::int32_t>;
+    using TRowRef = data_frame_detail::CRowRef;
     using TRowItr = data_frame_detail::CRowIterator;
     using TRowFunc = std::function<void(TRowItr, TRowItr)>;
     using TRowFuncVec = std::vector<TRowFunc>;

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -32,7 +32,7 @@ struct SRowTo<CMemoryMappedDenseVector<T>> {
 template<typename T>
 struct SRowTo<CDenseVector<T>> {
     static CDenseVector<T> dispatch(const core::CDataFrame::TRowRef& row) {
-        std::size_t n{n = row.numberColumns()};
+        std::size_t n{row.numberColumns()};
         CDenseVector<T> result{n};
         for (std::size_t i = 0; i < n; ++i) {
             result(i) = row[i];

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CDataFrameUtils_h
+#define INCLUDED_ml_maths_CDataFrameUtils_h
+
+#include <core/CDataFrame.h>
+#include <core/CNonInstantiatable.h>
+
+#include <maths/CLinearAlgebraEigen.h>
+
+#include <maths/ImportExport.h>
+
+namespace ml {
+namespace maths {
+namespace data_frame_utils_detail {
+template<typename T>
+struct SRowTo {
+    static_assert(sizeof(T) < 0, "Vector type not supported");
+};
+
+template<typename T>
+struct SRowTo<CMemoryMappedDenseVector<T>> {
+    static CMemoryMappedDenseVector<T> dispatch(const core::CDataFrame::TRowRef& row) {
+        return {row.data(), static_cast<long>(row.numberColumns())};
+    }
+};
+
+template<typename T>
+struct SRowTo<CDenseVector<T>> {
+    static CDenseVector<T> dispatch(const core::CDataFrame::TRowRef& row) {
+        std::size_t n{n = row.numberColumns()};
+        CDenseVector<T> result{n};
+        for (std::size_t i = 0; i < n; ++i) {
+            result(i) = row[i];
+        }
+        return result;
+    }
+};
+}
+
+//! \brief A collection of basic utilities applied to a data frame.
+class MATHS_EXPORT CDataFrameUtils : private core::CNonInstantiatable {
+public:
+    //! Convert a row of the data frame to a specified vector type.
+    template<typename VECTOR>
+    static VECTOR rowTo(const core::CDataFrame::TRowRef& row) {
+        return data_frame_utils_detail::SRowTo<VECTOR>::dispatch(row);
+    }
+
+    //! Subtract the mean and divide each column value by its standard deviation.
+    static bool standardizeColumns(std::size_t numberThreads, core::CDataFrame& frame);
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CDataFrameUtils_h

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -135,9 +135,9 @@ void CDataFrameAnalyzerTest::testWithoutControlMessages() {
     auto expectedScore = expectedScores.begin();
     for (const auto& result : results.GetArray()) {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(*expectedScore,
-                                     result["row_results"]["results"]["outlier_score"].GetDouble(),
-                                     1e-5 * *expectedScore);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(
+            *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
+            1e-5 * *expectedScore);
         ++expectedScore;
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
@@ -167,9 +167,9 @@ void CDataFrameAnalyzerTest::testRunOutlierDetection() {
     auto expectedScore = expectedScores.begin();
     for (const auto& result : results.GetArray()) {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(*expectedScore,
-                                     result["row_results"]["results"]["outlier_score"].GetDouble(),
-                                     1e-5 * *expectedScore);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(
+            *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
+            1e-5 * *expectedScore);
         ++expectedScore;
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CDataFrameUtils.h>
+
+#include <core/CContainerPrinter.h>
+#include <core/CLogger.h>
+#include <core/Concurrency.h>
+
+#include <maths/CBasicStatistics.h>
+#include <maths/CMathsFuncs.h>
+
+#include <vector>
+
+namespace ml {
+namespace maths {
+
+bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataFrame& frame) {
+    using TDoubleVec = std::vector<double>;
+    using TRowItr = core::CDataFrame::TRowItr;
+    using TMeanVarAccumulatorVec =
+        std::vector<CBasicStatistics::SSampleMeanVar<double>::TAccumulator>;
+
+    if (frame.numberRows() == 0 || frame.numberColumns() == 0) {
+        return true;
+    }
+
+    auto computeColumnMoments = core::bindRetrievableState(
+        [](TMeanVarAccumulatorVec& moments, TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                for (std::size_t i = 0; i < row->numberColumns(); ++i) {
+                    if (CMathsFuncs::isFinite((*row)[i])) {
+                        moments[i].add((*row)[i]);
+                    }
+                }
+            }
+        },
+        TMeanVarAccumulatorVec{frame.numberColumns()});
+
+    auto results = frame.readRows(numberThreads, computeColumnMoments);
+    if (results.second == false) {
+        LOG_ERROR(<< "Failed to standardise columns");
+        return false;
+    }
+
+    TMeanVarAccumulatorVec moments{frame.numberColumns()};
+    for (const auto& result : results.first) {
+        for (std::size_t i = 0; i < moments.size(); ++i) {
+            moments[i] += result.s_FunctionState[i];
+        }
+    }
+
+    TDoubleVec mean(moments.size());
+    TDoubleVec scale(moments.size());
+    for (std::size_t i = 0; i < moments.size(); ++i) {
+        double variance{CBasicStatistics::variance(moments[i])};
+        mean[i] = CBasicStatistics::mean(moments[i]);
+        scale[i] = variance == 0.0 ? 1.0 : 1.0 / std::sqrt(variance);
+    }
+
+    LOG_TRACE(<< "means = " << core::CContainerPrinter::print(mean));
+    LOG_TRACE(<< "scales = " << core::CContainerPrinter::print(scale));
+
+    auto standardiseColumns = [&mean, &scale](TRowItr beginRows, TRowItr endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            for (std::size_t i = 0; i < row->numberColumns(); ++i) {
+                row->writeColumn(i, scale[i] * ((*row)[i] - mean[i]));
+            }
+        }
+    };
+
+    return frame.writeColumns(numberThreads, standardiseColumns);
+}
+}
+}

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -8,6 +8,7 @@
 
 #include <core/CDataFrame.h>
 
+#include <maths/CDataFrameUtils.h>
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CTools.h>
 
@@ -88,8 +89,7 @@ bool computeOutliersNoPartitions(std::size_t numberThreads,
 
     auto rowsToPoints = [&points](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            points[row->index()] =
-                TVector{row->data(), static_cast<long>(row->numberColumns())};
+            points[row->index()] = CDataFrameUtils::rowTo<TVector>(*row);
         }
     };
 
@@ -138,6 +138,8 @@ bool computeOutliers(std::size_t numberThreads,
                      core::CDataFrame& frame) {
     // TODO memory monitoring.
     // TODO different analysis types.
+
+    CDataFrameUtils::standardizeColumns(numberThreads, frame);
 
     if (frame.inMainMemory()) {
         if (computeOutliersNoPartitions(numberThreads, recordProgress, frame) == false) {

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -31,6 +31,7 @@ CClustererStateSerialiser.cc \
 CConstantPrior.cc \
 CCooccurrences.cc \
 CCountMinSketch.cc \
+CDataFrameUtils.cc \
 CDecayRateController.cc \
 CDecompositionComponent.cc \
 CEntropySketch.cc \

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CDataFrameUtilsTest.h"
+
+#include <maths/CBasicStatistics.h>
+#include <maths/CDataFrameUtils.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <boost/filesystem.hpp>
+
+#include <vector>
+
+using namespace ml;
+
+void CDataFrameUtilsTest::testStandardizeColumns() {
+
+    using TDoubleVec = std::vector<double>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TMeanVarAccumulatorVec =
+        std::vector<maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator>;
+    using TFactoryFunc = std::function<std::unique_ptr<core::CDataFrame>()>;
+
+    test::CRandomNumbers rng;
+
+    std::size_t rows{2000};
+    std::size_t cols{4};
+    std::size_t capacity{500};
+
+    TDoubleVecVec values(4);
+    TMeanVarAccumulatorVec moments(4);
+    {
+        std::size_t i = 0;
+        for (auto a : {-10.0, 0.0}) {
+            for (auto b : {5.0, 30.0}) {
+                rng.generateUniformSamples(a, b, rows, values[i++]);
+            }
+        }
+        for (i = 0; i < cols; ++i) {
+            moments[i].add(values[i]);
+        }
+    }
+
+    TFactoryFunc makeOnDisk{[=] {
+        return core::makeDiskStorageDataFrame(
+                   boost::filesystem::current_path().string(), cols, rows, capacity)
+            .first;
+    }};
+    TFactoryFunc makeMainMemory{
+        [=] { return core::makeMainStorageDataFrame(cols, capacity).first; }};
+
+    core::stopDefaultAsyncExecutor();
+
+    for (auto threads : {1, 4}) {
+
+        for (const auto& factory : {makeOnDisk, makeMainMemory}) {
+
+            auto frame = factory();
+
+            for (std::size_t i = 0; i < rows; ++i) {
+                frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column,
+                                                   std::int32_t&) {
+                    for (std::size_t j = 0; j < cols; ++j, ++column) {
+                        *column = values[j][i];
+                    }
+                });
+            }
+            frame->finishWritingRows();
+
+            CPPUNIT_ASSERT(maths::CDataFrameUtils::standardizeColumns(threads, *frame));
+
+            bool passed{true};
+            frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
+                                   core::CDataFrame::TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    for (std::size_t j = 0; j < row->numberColumns(); ++j) {
+                        double mean{maths::CBasicStatistics::mean(moments[j])};
+                        double sd{std::sqrt(maths::CBasicStatistics::variance(moments[j]))};
+                        double expected{(values[j][row->index()] - mean) / sd};
+                        if (std::fabs((*row)[j] - expected) > 1e-6) {
+                            LOG_ERROR(<< "Expected " << expected << " got " << (*row)[j]);
+                            passed = false;
+                        }
+                    }
+                }
+            });
+
+            CPPUNIT_ASSERT(passed);
+        }
+
+        core::startDefaultAsyncExecutor();
+    }
+
+    core::stopDefaultAsyncExecutor();
+}
+
+CppUnit::Test* CDataFrameUtilsTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CDataFrameUtilsTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameUtilsTest>(
+        "CDataFrameUtilsTest::testStandardizeColumns",
+        &CDataFrameUtilsTest::testStandardizeColumns));
+
+    return suiteOfTests;
+}

--- a/lib/maths/unittest/CDataFrameUtilsTest.h
+++ b/lib/maths/unittest/CDataFrameUtilsTest.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CDataFrameUtilsTest_h
+#define INCLUDED_CDataFrameUtilsTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CDataFrameUtilsTest : public CppUnit::TestFixture {
+public:
+    void testStandardizeColumns();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CDataFrameUtilsTest_h

--- a/lib/maths/unittest/Main.cc
+++ b/lib/maths/unittest/Main.cc
@@ -20,6 +20,7 @@
 #include "CClusterEvaluationTest.h"
 #include "CClustererTest.h"
 #include "CCountMinSketchTest.h"
+#include "CDataFrameUtilsTest.h"
 #include "CDecayRateControllerTest.h"
 #include "CEntropySketchTest.h"
 #include "CEqualWithToleranceTest.h"
@@ -106,6 +107,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CClustererTest::suite());
     runner.addTest(CClusterEvaluationTest::suite());
     runner.addTest(CCountMinSketchTest::suite());
+    runner.addTest(CDataFrameUtilsTest::suite());
     runner.addTest(CDecayRateControllerTest::suite());
     runner.addTest(CEqualWithToleranceTest::suite());
     runner.addTest(CEntropySketchTest::suite());

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -8,6 +8,7 @@ include $(CPP_SRC_HOME)/mk/defines.mk
 TARGET=ml_test$(EXE_EXT)
 
 USE_BOOST=1
+USE_BOOST_FILESYSTEM_LIBS=1
 USE_RAPIDJSON=1
 USE_EIGEN=1
 
@@ -31,6 +32,7 @@ SRCS=\
 	CClustererTest.cc \
 	CClusterEvaluationTest.cc \
 	CCountMinSketchTest.cc \
+	CDataFrameUtilsTest.cc \
 	CDecayRateControllerTest.cc \
 	CEntropySketchTest.cc \
 	CEqualWithToleranceTest.cc \


### PR DESCRIPTION
This adds in standardisation of column(feature) values prior to outlier detection (we prefer standardisation to min-max normalisation because it is more resilient to extreme outliers). This will be configurable for the power user (that change will be made in a separate PR focusing on user configuration).

The default behaviour will be to standardise since it guards against obvious misuse when mixing features with very different value ranges.