### PR TITLE
[ML] Enhancements to outlier detection ensemble

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -132,9 +132,12 @@ protected:
 private:
     virtual void runImpl(core::CDataFrame& frame) = 0;
     virtual std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
-                                                       std::size_t numberRows,
+                                                       std::size_t totalNumberRows,
+                                                       std::size_t partitionNumberRows,
                                                        std::size_t numberColumns) const = 0;
-    std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
+    std::size_t estimateMemoryUsage(std::size_t totalNumberRows,
+                                    std::size_t partitionNumberRows,
+                                    std::size_t numberColumns) const;
 
     //! This adds \p fractionalProgess to the current progress.
     //!

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -29,20 +29,20 @@ public:
     CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec);
 
     //! \return The number of columns this adds to the data frame.
-    virtual std::size_t numberExtraColumns() const;
+    std::size_t numberExtraColumns() const override;
 
     //! Write the extra columns of \p row added by outlier analysis to \p writer.
-    virtual void writeOneRow(TRowRef row, core::CRapidJsonConcurrentLineWriter& writer) const;
+    void writeOneRow(TRowRef row, core::CRapidJsonConcurrentLineWriter& writer) const override;
 
 private:
     using TOptionalSize = boost::optional<std::size_t>;
 
 private:
-    virtual void runImpl(core::CDataFrame& frame);
-    virtual std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
-                                                       std::size_t totalNumberRows,
-                                                       std::size_t partitionNumberRows,
-                                                       std::size_t numberColumns) const;
+    void runImpl(core::CDataFrame& frame) override;
+    std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
+                                               std::size_t totalNumberRows,
+                                               std::size_t partitionNumberRows,
+                                               std::size_t numberColumns) const override;
     template<typename POINT>
     std::size_t estimateMemoryUsage(std::size_t totalNumberRows,
                                     std::size_t partitionNumberRows,
@@ -64,14 +64,14 @@ private:
 };
 
 //! \brief Makes a core::CDataFrame outlier analysis runner.
-class API_EXPORT CDataFrameOutliersRunnerFactory : public CDataFrameAnalysisRunnerFactory {
+class API_EXPORT CDataFrameOutliersRunnerFactory final : public CDataFrameAnalysisRunnerFactory {
 public:
-    virtual const char* name() const;
+    const char* name() const override;
 
 private:
-    virtual TRunnerUPtr makeImpl(const CDataFrameAnalysisSpecification& spec) const;
-    virtual TRunnerUPtr makeImpl(const CDataFrameAnalysisSpecification& spec,
-                                 const rapidjson::Value& params) const;
+    TRunnerUPtr makeImpl(const CDataFrameAnalysisSpecification& spec) const override;
+    TRunnerUPtr makeImpl(const CDataFrameAnalysisSpecification& spec,
+                         const rapidjson::Value& params) const override;
 };
 }
 }

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -40,10 +40,13 @@ private:
 private:
     virtual void runImpl(core::CDataFrame& frame);
     virtual std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
-                                                       std::size_t numberRows,
+                                                       std::size_t totalNumberRows,
+                                                       std::size_t partitionNumberRows,
                                                        std::size_t numberColumns) const;
     template<typename POINT>
-    std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
+    std::size_t estimateMemoryUsage(std::size_t totalNumberRows,
+                                    std::size_t partitionNumberRows,
+                                    std::size_t numberColumns) const;
 
 private:
     //! \name Custom config

--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -17,6 +17,8 @@
 #include <maths/COrderings.h>
 #include <maths/CTypeTraits.h>
 
+#include <boost/operators.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -147,23 +149,39 @@ public:
     using TNodeVecCItr = typename TNodeVec::const_iterator;
 
     //! \brief Iterates points in the tree.
-    class TPointIterator : public std::iterator<std::forward_iterator_tag, const POINT> {
+    class TPointIterator
+        : public boost::random_access_iterator_helper<TPointIterator, POINT, std::ptrdiff_t, const POINT*, const POINT&> {
     public:
         TPointIterator() = default;
         TPointIterator(TNodeVecCItr itr) : m_Itr(itr) {}
         const POINT& operator*() const { return m_Itr->s_Point; }
         const POINT* operator->() const { return &m_Itr->s_Point; }
+        const POINT& operator[](std::ptrdiff_t n) { return m_Itr[n].s_Point; }
         bool operator==(const TPointIterator& rhs) const {
             return m_Itr == rhs.m_Itr;
         }
-        bool operator!=(const TPointIterator& rhs) const {
-            return m_Itr != rhs.m_Itr;
+        bool operator<(const TPointIterator& rhs) const {
+            return m_Itr < rhs.m_Itr;
         }
         TPointIterator& operator++() {
             ++m_Itr;
             return *this;
         }
-        TPointIterator operator++(int) { return m_Itr++; }
+        TPointIterator& operator--() {
+            --m_Itr;
+            return *this;
+        }
+        TPointIterator& operator+=(std::ptrdiff_t n) {
+            m_Itr += n;
+            return *this;
+        }
+        TPointIterator& operator-=(std::ptrdiff_t n) {
+            m_Itr -= n;
+            return *this;
+        }
+        std::ptrdiff_t operator-(const TPointIterator& rhs) const {
+            return m_Itr - rhs.m_Itr;
+        }
 
     private:
         TNodeVecCItr m_Itr;

--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -8,6 +8,7 @@
 #define INCLUDED_ml_maths_COutliers_h
 
 #include <core/CHashing.h>
+#include <core/CNonInstantiatable.h>
 #include <core/Concurrency.h>
 
 #include <maths/CBasicStatistics.h>
@@ -25,6 +26,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace ml {
@@ -32,21 +34,576 @@ namespace core {
 class CDataFrame;
 }
 namespace maths {
+namespace outliers_detail {
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TProgressCallback = std::function<void(double)>;
+using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
-//! \brief Utilities for computing outlier scores for collections
-//! of points.
-class MATHS_EXPORT COutliers {
-private:
-    template<typename POINT>
-    using TKdTree = CKdTree<CAnnotatedVector<POINT, std::size_t>>;
+//! \brief The interface for a nearest neighbour outlier calculation method.
+template<typename POINT, typename NEAREST_NEIGHBOURS>
+class CNearestNeighbourMethod {
+public:
+    using TPointVec = std::vector<POINT>;
+    using TScoreReader = std::function<void(TDoubleVecVec)>;
 
 public:
-    using TDoubleVec = std::vector<double>;
-    using TDoubleVecVec = std::vector<TDoubleVec>;
-    using TProgressCallback = std::function<void(double)>;
+    CNearestNeighbourMethod(std::size_t k, NEAREST_NEIGHBOURS lookup, TProgressCallback recordProgress)
+        : m_K{k}, m_Lookup{std::move(lookup)}, m_RecordProgress{std::move(recordProgress)} {}
+    virtual ~CNearestNeighbourMethod() = default;
 
-    //! The available algorithms.
-    enum EAlgorithm {
+    //! The number of points.
+    std::size_t n() const { return m_Lookup.size(); }
+
+    //! The number of nearest neighbours.
+    std::size_t k() const { return m_K; }
+
+    //! Compute the outlier scores for \p points.
+    void run(const TPointVec& points, std::size_t numberScores, TScoreReader scoreReader) {
+
+        this->setup(points);
+
+        // We call add exactly once for each point. Scores is presized
+        // so any writes to it are safe.
+        TDoubleVecVec scores{this->numberMethods(), TDoubleVec(numberScores, 0.0)};
+        core::parallel_for_each(points.begin(), points.end(),
+                                [&, neighbours = TPointVec{} ](const POINT& point) mutable {
+                                    m_Lookup.nearestNeighbours(m_K + 1, point, neighbours);
+                                    this->add(point, neighbours, scores);
+                                },
+                                [this](double fractionalProgress) {
+                                    this->recordProgress(fractionalProgress);
+                                });
+        this->compute(points, scores);
+
+        scoreReader(std::move(scores));
+    }
+
+    //! \name Progress Monitoring
+    //@{
+    //! Get the progress recorder.
+    TProgressCallback& progressRecorder() { return m_RecordProgress; }
+    //! Record \p fractionalProgress.
+    void recordProgress(double fractionalProgress) {
+        m_RecordProgress(fractionalProgress);
+    }
+    //@}
+
+    virtual std::string print() const {
+        return this->name() + "(n = " + std::to_string(this->n()) +
+               ", k = " + std::to_string(m_K) + ")";
+    }
+
+    virtual void setup(const TPointVec&) {}
+    virtual void add(const POINT&, const TPointVec&, TDoubleVec&) {}
+    virtual void compute(const TPointVec&, TDoubleVec&) {}
+
+private:
+    virtual void add(const POINT& point, const TPointVec& neighbours, TDoubleVecVec& scores) {
+        this->add(point, neighbours, scores[0]);
+    }
+    virtual void compute(const TPointVec& points, TDoubleVecVec& scores) {
+        this->compute(points, scores[0]);
+    }
+    virtual std::size_t numberMethods() const { return 1; }
+    virtual std::string name() const = 0;
+
+private:
+    std::size_t m_K;
+    NEAREST_NEIGHBOURS m_Lookup;
+    TProgressCallback m_RecordProgress;
+};
+
+//! \brief Computes the local outlier factor score.
+template<typename POINT, typename NEAREST_NEIGHBOURS>
+class CLof final : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
+public:
+    using TPointVec = std::vector<POINT>;
+    using TCoordinate = typename SCoordinate<POINT>::Type;
+    using TCoordinateVec = std::vector<TCoordinate>;
+    using TUInt32CoordinatePr = std::pair<uint32_t, TCoordinate>;
+    using TUInt32CoordinatePrVec = std::vector<TUInt32CoordinatePr>;
+    static const TCoordinate UNSET_DISTANCE;
+
+public:
+    CLof(std::size_t k,
+         TProgressCallback recordProgress,
+         NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
+        : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
+              k, std::move(lookup), std::move(recordProgress)} {}
+
+    //! Estimate the additional bookkeeping memory used explicitly by the
+    //! local outlier factors calculation.
+    static std::size_t estimateOwnMemoryOverhead(std::size_t k, std::size_t numberPoints) {
+        return numberPoints * (k * sizeof(TUInt32CoordinatePr) + sizeof(TCoordinate));
+    }
+
+private:
+    void setup(const TPointVec& points) override {
+        std::size_t addressSpace{
+            std::max_element(points.begin(), points.end(),
+                             [](const POINT& lhs, const POINT& rhs) {
+                                 return lhs.annotation() < rhs.annotation();
+                             })
+                ->annotation() +
+            1};
+        m_KDistances.resize(this->k() * addressSpace, {0, UNSET_DISTANCE});
+        m_Lrd.resize(addressSpace, UNSET_DISTANCE);
+    }
+
+    void add(const POINT& point, const TPointVec& neighbours, TDoubleVec&) override {
+        // This is called exactly once for each point therefore an element
+        // of m_KDistances is only ever written by one thread.
+        std::size_t i{point.annotation() * this->k()};
+        std::size_t a(point == neighbours[0] ? 1 : 0);
+        std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
+        for (std::size_t j = a; j <= b; ++j) {
+            m_KDistances[i + j - a].first =
+                static_cast<uint32_t>(neighbours[j].annotation());
+            m_KDistances[i + j - a].second = las::distance(point, neighbours[j]);
+        }
+    }
+
+    void compute(const TPointVec& points, TDoubleVec& scores) override {
+        using TMinAccumulator = CBasicStatistics::SMin<double>::TAccumulator;
+
+        std::size_t k{this->k()};
+
+        // We bind a minimum accumulator (by value) to each lambda (since
+        // one copy is then accessed by each thread) and take the minimum
+        // of these at the end.
+        auto results = core::parallel_for_each(
+            points.begin(), points.end(),
+            core::bindRetrievableState(
+                [&](TMinAccumulator& min, const POINT& point) {
+                    std::size_t i{point.annotation()};
+                    TMeanAccumulator reachability_;
+                    for (std::size_t j = i * k; j < (i + 1) * k; ++j) {
+                        const auto& neighbour = m_KDistances[j];
+                        if (distance(neighbour) != UNSET_DISTANCE) {
+                            reachability_.add(std::max(kdistance(index(neighbour)),
+                                                       distance(neighbour)));
+                        }
+                    }
+                    double reachability{CBasicStatistics::mean(reachability_)};
+                    if (reachability > 0.0) {
+                        m_Lrd[i] = 1.0 / reachability;
+                        min.add(reachability);
+                    }
+                },
+                TMinAccumulator{}));
+
+        TMinAccumulator min;
+        for (const auto& result : results) {
+            min += result.s_FunctionState;
+        }
+
+        if (min.count() > 0) {
+            // Use twice the maximum "density" at any other point if there
+            // are k-fold duplicates.
+            for (auto& lrd : m_Lrd) {
+                if (lrd < 0.0) {
+                    lrd = 2.0 / min[0];
+                }
+            }
+            core::parallel_for_each(points.begin(), points.end(), [&](const POINT& point) {
+                std::size_t i{point.annotation()};
+                TMeanAccumulator score;
+                for (std::size_t j = i * k; j < (i + 1) * k; ++j) {
+                    const auto& neighbour = m_KDistances[j];
+                    if (distance(neighbour) != UNSET_DISTANCE) {
+                        score.add(m_Lrd[index(neighbour)]);
+                    }
+                }
+                scores[i] = CBasicStatistics::mean(score) / m_Lrd[i];
+            });
+        }
+    }
+
+    std::string name() const override { return "lof"; }
+
+    static std::size_t index(const TUInt32CoordinatePr& neighbour) {
+        return neighbour.first;
+    }
+    static double distance(const TUInt32CoordinatePr& neighbour) {
+        return neighbour.second;
+    }
+    double kdistance(std::size_t index) const {
+        for (std::size_t k{this->k()}, j = (index + 1) * k; j > index * k; --j) {
+            if (distance(m_KDistances[j - 1]) != UNSET_DISTANCE) {
+                return distance(m_KDistances[j - 1]);
+            }
+        }
+        return UNSET_DISTANCE;
+    }
+
+private:
+    // The k distances to the neighbouring points of each point are
+    // stored flattened: [neighbours of 0, neighbours of 1,...].
+    TUInt32CoordinatePrVec m_KDistances;
+    TCoordinateVec m_Lrd;
+};
+
+template<typename POINT, typename NEAREST_NEIGHBOURS>
+const typename CLof<POINT, NEAREST_NEIGHBOURS>::TCoordinate
+    CLof<POINT, NEAREST_NEIGHBOURS>::UNSET_DISTANCE(-1.0);
+
+//! \brief Computes the local distance based outlier score.
+template<typename POINT, typename NEAREST_NEIGHBOURS>
+class CLdof final : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
+public:
+    CLdof(std::size_t k,
+          TProgressCallback recordProgress,
+          NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
+        : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
+              k, std::move(lookup), std::move(recordProgress)} {}
+
+private:
+    void add(const POINT& point, const std::vector<POINT>& neighbours, TDoubleVec& scores) override {
+        TMeanAccumulator d, D;
+        std::size_t a(point == neighbours[0] ? 1 : 0);
+        std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
+        for (std::size_t i = a; i <= b; ++i) {
+            d.add(las::distance(point, neighbours[i]));
+            for (std::size_t j = 1; j < i; ++j) {
+                D.add(las::distance(neighbours[i], neighbours[j]));
+            }
+        }
+        scores[point.annotation()] = CBasicStatistics::mean(D) > 0.0
+                                         ? CBasicStatistics::mean(d) /
+                                               CBasicStatistics::mean(D)
+                                         : 0.0;
+    }
+
+    std::string name() const override { return "ldof"; }
+};
+
+//! \brief Computes the distance to the k'th nearest neighbour score.
+template<typename POINT, typename NEAREST_NEIGHBOURS>
+class CDistancekNN final : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
+public:
+    CDistancekNN(std::size_t k,
+                 TProgressCallback recordProgress,
+                 NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
+        : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
+              k, std::move(lookup), std::move(recordProgress)} {}
+
+private:
+    void add(const POINT& point, const std::vector<POINT>& neighbours, TDoubleVec& scores) override {
+        std::size_t k{std::min(this->k() + 1, neighbours.size() - 1) -
+                      (point == neighbours[0] ? 0 : 1)};
+        scores[point.annotation()] = las::distance(point, neighbours[k]);
+    }
+
+    std::string name() const override { return "knn"; }
+};
+
+//! \brief Computes the total distance to the k nearest neighbours score.
+template<typename POINT, typename NEAREST_NEIGHBOURS>
+class CTotalDistancekNN final
+    : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
+public:
+    CTotalDistancekNN(std::size_t k,
+                      TProgressCallback recordProgress,
+                      NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
+        : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
+              k, std::move(lookup), std::move(recordProgress)} {}
+
+private:
+    void add(const POINT& point, const std::vector<POINT>& neighbours, TDoubleVec& scores) override {
+        std::size_t i{point.annotation()};
+        std::size_t a(point == neighbours[0] ? 1 : 0);
+        std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
+        for (std::size_t j = a; j <= b; ++j) {
+            scores[i] += las::distance(point, neighbours[j]);
+        }
+        scores[i] /= static_cast<double>(this->k());
+    }
+
+    std::string name() const override { return "tnn"; }
+};
+
+//! \brief A composite method.
+//!
+//! IMPLEMENTATION:\n
+//! This is used in conjunction with CEnsemble so we can share nearest
+//! neighbour lookups for all methods in an ensemble model.
+template<typename POINT, typename NEAREST_NEIGHBOURS>
+class CMultipleMethods final
+    : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
+public:
+    using TPointVec = std::vector<POINT>;
+    using TMethodUPtr = std::unique_ptr<CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>>;
+    using TMethodUPtrVec = std::vector<TMethodUPtr>;
+
+public:
+    CMultipleMethods(std::size_t k,
+                     TMethodUPtrVec methods,
+                     NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
+        : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{k, std::move(lookup),
+                                                             methods[0]->progressRecorder()},
+          m_Methods{std::move(methods)} {}
+
+    std::string print() const override {
+        std::string result;
+        result += "{";
+        for (const auto& method : m_Methods) {
+            result += " " + method->print();
+        }
+        result += " }";
+        return result;
+    }
+
+private:
+    std::size_t numberMethods() const override { return m_Methods.size(); }
+
+    void setup(const TPointVec& points) override {
+        for (auto& method : m_Methods) {
+            method->setup(points);
+        }
+    }
+
+    void add(const POINT& point, const TPointVec& neighbours, TDoubleVecVec& scores) override {
+        for (std::size_t i = 0; i < m_Methods.size(); ++i) {
+            m_Methods[i]->add(point, neighbours, scores[i]);
+        }
+    }
+
+    void compute(const TPointVec& points, TDoubleVecVec& scores) override {
+        for (std::size_t i = 0; i < m_Methods.size(); ++i) {
+            m_Methods[i]->compute(points, scores[i]);
+        }
+    }
+
+    std::string name() const override { return ""; }
+
+private:
+    TMethodUPtrVec m_Methods;
+};
+
+//! \brief This encapsulates creating a collection of models used for outlier
+//! detection.
+//!
+//! DESCRIPTION:\n
+//! A model is defined as one or more algorithm for computing outlier scores,
+//! the number of nearest neighbours used to compute the score and a sample of
+//! the original data points (possibly) projected onto a random subspace which
+//! is searched for neighbours.
+//!
+//! The models can be built from a data stream by repeatedly calling addPoint.
+//! The evaluation of the outlier score for a point is delagated.
+template<typename POINT>
+class CEnsemble {
+private:
+    class CModel;
+
+public:
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+    using TSizeSizePrVec = std::vector<TSizeSizePr>;
+    using TPoint = CAnnotatedVector<decltype(SConstant<POINT>::get(0, 0)), std::size_t>;
+    using TPointVec = std::vector<TPoint>;
+    using TPointVecVec = std::vector<TPointVec>;
+    using TKdTree = CKdTree<TPoint>;
+    using TMethodUPtr = std::unique_ptr<CNearestNeighbourMethod<TPoint, const TKdTree&>>;
+    using TMethodUPtrVec = std::vector<TMethodUPtr>;
+    using TMethodFactory = std::function<TMethodUPtr(std::size_t, const TKdTree&)>;
+    using TMethodFactoryVec = std::vector<TMethodFactory>;
+    using TMethodSize = std::function<std::size_t(std::size_t)>;
+
+    //! \brief Builds (online) one model of the points for the ensemble.
+    class CModelBuilder {
+    public:
+        CModelBuilder(CPRNG::CXorOShiro128Plus& rng,
+                      TSizeSizePrVec&& methodAndNumberNeighbours,
+                      std::size_t sampleSize,
+                      TPointVec&& projection);
+
+        //! Maybe sample the point.
+        void addPoint(const POINT& point) { m_Sampler.sample(point); }
+
+        //! \note Only call once: this moves state into place.
+        CModel make(const TMethodFactoryVec& methodFactories);
+
+    private:
+        using TSampler = CSampling::CRandomStreamSampler<POINT>;
+
+    private:
+        TSampler makeSampler(CPRNG::CXorOShiro128Plus& rng, std::size_t sampleSize);
+
+    private:
+        TSizeSizePrVec m_MethodsAndNumberNeighbours;
+        std::size_t m_SampleSize;
+        TSampler m_Sampler;
+        TPointVec m_Projection;
+        TPointVec m_SampledProjectedPoints;
+    };
+    using TModelBuilderVec = std::vector<CModelBuilder>;
+
+public:
+    static const double SAMPLE_SIZE_SCALE;
+    static const double NEIGHBOURHOOD_FRACTION;
+
+public:
+    CEnsemble(const TMethodFactoryVec& methodFactories,
+              TModelBuilderVec modelBuilders,
+              double priorProbabilityOutlier = 0.05);
+    CEnsemble(const CEnsemble&) = delete;
+    CEnsemble& operator=(const CEnsemble&) = delete;
+    CEnsemble(CEnsemble&&) = default;
+    CEnsemble& operator=(CEnsemble&&) = default;
+
+    //! Make the builders for the ensemble models.
+    static TModelBuilderVec
+    makeBuilders(const TSizeVecVec& algorithms,
+                 std::size_t numberPoints,
+                 std::size_t dimension,
+                 CPRNG::CXorOShiro128Plus rng = CPRNG::CXorOShiro128Plus{});
+
+    //! Compute the outlier scores for \p points.
+    void computeOutlierScores(const std::vector<POINT>& points, TDoubleVec& scores);
+
+    //! Estimate the amount of memory that will be used by the ensemble.
+    static std::size_t
+    estimateMemoryUsedToComputeOutlierScores(TMethodSize methodSize,
+                                             std::size_t numberMethods,
+                                             std::size_t totalNumberPoints,
+                                             std::size_t partitionNumberPoints,
+                                             std::size_t dimension) {
+        std::size_t ensembleSize{
+            computeEnsembleSize(numberMethods, totalNumberPoints, dimension)};
+        std::size_t sampleSize{computeSampleSize(totalNumberPoints)};
+        std::size_t numberModels{(ensembleSize + numberMethods - 1) / numberMethods};
+        std::size_t maxNumberNeighbours{computeNumberNeighbours(sampleSize)};
+        std::size_t projectionDimension{computeProjectionDimension(sampleSize, dimension)};
+        std::size_t averageNumberNeighbours{(3 + maxNumberNeighbours) / 2};
+        // This is "own size" + "method scores size" + "scorers size" +
+        // "projected points size" + "models size".
+        return sizeof(CEnsemble) +
+               partitionNumberPoints *
+                   (sizeof(double) + sizeof(CScorer) +
+                    las::estimateMemoryUsage<TPoint>(projectionDimension)) +
+               numberModels * CModel::estimateMemoryUsage(methodSize, sampleSize,
+                                                          averageNumberNeighbours,
+                                                          projectionDimension, dimension);
+    }
+
+    //! Get a human readable description of the ensemble.
+    std::string print() const;
+
+private:
+    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
+    using TKdTreeUPtr = std::unique_ptr<TKdTree>;
+
+    //! \brief Manages computing the probability that a point is an outlier
+    //! given its scores from a collection of ensemble models.
+    class CScorer {
+    public:
+        void add(const TMeanVarAccumulatorVec& logScoreMoments, const TDoubleVec& scores);
+        double compute(double pOutlier) const;
+
+    private:
+        double m_LogLikelihoodOutlierGivenScores;
+        double m_LogLikelihoodInlierGivenScores;
+    };
+    using TScorerVec = std::vector<CScorer>;
+
+    //! \brief A model of the points used as part of the ensemble.
+    class CModel {
+    public:
+        CModel(CPRNG::CXorOShiro128Plus& rng,
+               const TMethodFactoryVec& methodFactories,
+               TSizeSizePrVec methodAndNumberNeighbours,
+               TPointVec samples,
+               TPointVec projection);
+
+        std::size_t numberPoints() const { return m_Lookup->size(); }
+
+        void proportionOfRuntimePerMethod(double proportion);
+
+        void addOutlierScores(const std::vector<POINT>& points, TScorerVec& scores) const;
+
+        static std::size_t estimateMemoryUsage(TMethodSize methodSize,
+                                               std::size_t sampleSize,
+                                               std::size_t averageNumberNeighbours,
+                                               std::size_t projectionDimension,
+                                               std::size_t dimension) {
+            return sizeof(CModel) +
+                   TKdTree::estimateMemoryUsage(sampleSize, projectionDimension) +
+                   projectionDimension * las::estimateMemoryUsage<TPoint>(dimension) +
+                   methodSize(averageNumberNeighbours);
+        }
+
+        std::string print() const;
+
+    private:
+        TKdTreeUPtr m_Lookup;
+        TPointVec m_Projection;
+        TMethodUPtr m_Method;
+        TMeanVarAccumulatorVec m_LogScoreMoments;
+    };
+    using TModelVec = std::vector<CModel>;
+
+private:
+    static std::size_t computeEnsembleSize(std::size_t numberMethods,
+                                           std::size_t numberPoints,
+                                           std::size_t dimension) {
+        std::size_t projectionDimension{
+            computeProjectionDimension(computeSampleSize(numberPoints), dimension)};
+        std::size_t requiredNumberModels{(dimension + projectionDimension - 1) / projectionDimension};
+        double target{std::max(static_cast<double>(numberMethods * requiredNumberModels),
+                               std::sqrt(static_cast<double>(numberPoints)) / SAMPLE_SIZE_SCALE)};
+        return static_cast<std::size_t>(std::min(std::max(target, 6.0), 20.0) + 0.5);
+    }
+    static std::size_t computeSampleSize(std::size_t numberPoints) {
+        double target{2.0 * SAMPLE_SIZE_SCALE * std::sqrt(static_cast<double>(numberPoints))};
+        return static_cast<std::size_t>(target + 0.5);
+    }
+    static std::size_t computeNumberNeighbours(std::size_t sampleSize) {
+        double target{NEIGHBOURHOOD_FRACTION * static_cast<double>(sampleSize)};
+        return static_cast<std::size_t>(std::min(std::max(target, 5.0), 100.0) + 0.5);
+    }
+    static std::size_t computeProjectionDimension(std::size_t numberPoints,
+                                                  std::size_t dimension) {
+        double logNumberPoints{std::log(static_cast<double>(numberPoints)) / std::log(3.0)};
+        double target{std::min(static_cast<double>(dimension), logNumberPoints)};
+        return static_cast<std::size_t>(std::min(std::max(target, 2.0), 10.0) + 0.5);
+    }
+
+    static TPointVecVec createProjections(CPRNG::CXorOShiro128Plus& rng,
+                                          std::size_t numberProjections,
+                                          std::size_t projectionDimension,
+                                          std::size_t dimension);
+
+    static TPoint project(const TPointVec& projection, const POINT& point);
+
+private:
+    double m_PriorProbabilityOutlier;
+    TModelVec m_Models;
+};
+
+template<typename POINT>
+const double CEnsemble<POINT>::SAMPLE_SIZE_SCALE{5.0};
+template<typename POINT>
+const double CEnsemble<POINT>::NEIGHBOURHOOD_FRACTION{0.01};
+}
+
+//! \brief Utilities for computing outlier scores for collections of points.
+class MATHS_EXPORT COutliers : private core::CNonInstantiatable {
+public:
+    using TDoubleVec = outliers_detail::TDoubleVec;
+    using TDoubleVecVec = outliers_detail::TDoubleVecVec;
+    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using TProgressCallback = outliers_detail::TProgressCallback;
+    template<typename POINT>
+    using TEnsemble = outliers_detail::CEnsemble<POINT>;
+    template<typename POINT>
+    using TLof = outliers_detail::CLof<POINT, CKdTree<POINT>>;
+
+    //! The outlier detection methods which are available.
+    enum EMethod {
         E_Lof,
         E_Ldof,
         E_DistancekNN,
@@ -55,239 +612,120 @@ public:
     };
 
 public:
-    COutliers(TProgressCallback recordProgress = noop);
+    //! Compute outliers for \p frame and write to a new column.
+    static void compute(std::size_t numberThreads,
+                        core::CDataFrame& frame,
+                        TProgressCallback recordProgress = noop);
 
-    //! Compute the normalized LOF scores for \p points.
+    //! Estimate the amount of memory that will be used computing outliers
+    //! for a data frame.
     //!
-    //! \note This automatically chooses to project the data and
-    //! the number of nearest neighbours to use based on the data
-    //! characteristics.
+    //! \param[in] method The method that will be used.
+    //! \param[in] k The number of nearest neighbours which will be used.
+    //! \param[in] totalNumberPoints The total number of points for which
+    //! outlier scores will be computed.
+    //! \param[in] partitionNumberPoints The number of points per partition
+    //! for which outlier scores will be computed.
+    //! \param[in] dimension The dimension of the points for which outliers
+    //! will be computed.
     template<typename POINT>
-    void normalizedLof(std::vector<POINT> points, TDoubleVec& scores) {
-        std::size_t k{defaultNumberOfNeighbours(points)};
-        bool project{shouldProject(points)};
-        normalizedLof(k, project, std::move(points), scores);
+    static std::size_t estimateComputeMemoryUsage(EMethod method,
+                                                  std::size_t k,
+                                                  std::size_t totalNumberPoints,
+                                                  std::size_t partitionNumberPoints,
+                                                  std::size_t dimension) {
+        auto methodSize = [method, k, partitionNumberPoints](std::size_t) {
+            return method == E_Lof
+                       ? TLof<POINT>::estimateOwnMemoryOverhead(k, partitionNumberPoints)
+                       : 0;
+        };
+        return TEnsemble<POINT>::estimateMemoryUsedToComputeOutlierScores(
+            methodSize, 1, totalNumberPoints, partitionNumberPoints, dimension);
     }
 
+    //! Overload of estimateComputeMemoryUsage for default behaviour.
+    template<typename POINT>
+    static std::size_t estimateComputeMemoryUsage(std::size_t totalNumberPoints,
+                                                  std::size_t partitionNumberPoints,
+                                                  std::size_t dimension) {
+        auto methodSize = [partitionNumberPoints](std::size_t k_) {
+            // On average half of models use CLof.
+            return TLof<POINT>::estimateOwnMemoryOverhead(k_, partitionNumberPoints) / 2;
+        };
+        return TEnsemble<POINT>::estimateMemoryUsedToComputeOutlierScores(
+            methodSize, 2, totalNumberPoints, partitionNumberPoints, dimension);
+    }
+
+    //! \name Test Interface
+    //@{
     //! Compute the normalized LOF scores for \p points.
     //!
-    //! See https://en.wikipedia.org/wiki/Local_outlier_factor
-    //! for details.
+    //! See https://en.wikipedia.org/wiki/Local_outlier_factor for details.
     //!
     //! \param[in] k The number of nearest neighbours to use.
-    //! \param[in] project If true, compute geometric average scores
-    //! over multiple random projections of the data.
     //! \param[in] points The points for which to compute scores.
     //! \param[out] scores The scores of \p points.
     template<typename POINT>
-    void normalizedLof(std::size_t k, bool project, std::vector<POINT> points, TDoubleVec& scores) {
-        normalized<CLof>(k, project, std::move(points), scores);
+    static void normalizedLof(std::size_t k, std::vector<POINT> points, TDoubleVec& scores) {
+        normalized<outliers_detail::CLof>(k, std::move(points), scores);
     }
 
-    //! Compute the normalized local distance based outlier scores
-    //! for \p points.
-    //!
-    //! \note This automatically chooses to project the data and
-    //! the number of nearest neighbours to use based on the data
-    //! characteristics.
-    template<typename POINT>
-    void normalizedLdof(std::vector<POINT> points, TDoubleVec& scores) {
-        std::size_t k{defaultNumberOfNeighbours(points)};
-        bool project{shouldProject(points)};
-        normalizedLdof(k, project, std::move(points), scores);
-    }
-
-    //! Compute normalized local distance based outlier scores
-    //! for \p points.
+    //! Compute normalized local distance based outlier scores for \p points.
     //!
     //! See https://arxiv.org/pdf/0903.3257.pdf for details.
     //!
     //! \param[in] k The number of nearest neighbours to use.
-    //! \param[in] project If true compute geometric average scores
-    //! over multiple random projections of the data.
     //! \param[in] points The points for which to compute scores.
     //! \param[out] scores The scores of \p points.
     template<typename POINT>
-    void normalizedLdof(std::size_t k, bool project, std::vector<POINT> points, TDoubleVec& scores) {
-        normalized<CLdof>(k, project, std::move(points), scores);
-    }
-
-    //! Compute the normalized distance to the k-th nearest neighbour
-    //! outlier scores for \p points.
-    //!
-    //! \note This automatically chooses to project the data and
-    //! the number of nearest neighbours to use based on the data
-    //! characteristics.
-    template<typename POINT>
-    void normalizedDistancekNN(std::vector<POINT> points, TDoubleVec& scores) {
-        std::size_t k{defaultNumberOfNeighbours(points)};
-        bool project{shouldProject(points)};
-        normalizedDistancekNN(k, project, std::move(points), scores);
+    static void normalizedLdof(std::size_t k, std::vector<POINT> points, TDoubleVec& scores) {
+        normalized<outliers_detail::CLdof>(k, std::move(points), scores);
     }
 
     //! Compute the normalized distance to the k-th nearest neighbour
     //! outlier scores for \p points.
     //!
     //! \param[in] k The number of nearest neighbours to use.
-    //! \param[in] project If true compute geometric average scores
-    //! over multiple random projections of the data.
     //! \param[in] points The points for which to compute scores.
     //! \param[out] scores The scores of \p points.
     template<typename POINT>
-    void normalizedDistancekNN(std::size_t k, bool project, std::vector<POINT> points, TDoubleVec& scores) {
-        normalized<CDistancekNN>(k, project, std::move(points), scores);
+    static void
+    normalizedDistancekNN(std::size_t k, std::vector<POINT> points, TDoubleVec& scores) {
+        normalized<outliers_detail::CDistancekNN>(k, std::move(points), scores);
     }
 
-    //! Compute the normalized mean distance to the k nearest
-    //! neighbours outlier scores for \p points.
-    //!
-    //! \note This automatically chooses to project the data and
-    //! the number of nearest neighbours to use based on the data
-    //! characteristics.
-    template<typename POINT>
-    void normalizedTotalDistancekNN(std::vector<POINT> points, TDoubleVec& scores) {
-        std::size_t k{defaultNumberOfNeighbours(points)};
-        bool project{shouldProject(points)};
-        normalizedTotalDistancekNN(k, project, std::move(points), scores);
-    }
-
-    //! Compute the normalized mean distance to the k nearest
-    //! neighbours outlier scores for \p points.
+    //! Compute the normalized mean distance to the k nearest neighbours
+    //! outlier scores for \p points.
     //!
     //! \param[in] k The number of nearest neighbours to use.
-    //! \param[in] project If true compute geometric average scores
-    //! over multiple random projections of the data.
     //! \param[in] points The points for which to compute scores.
     //! \param[out] scores The scores of \p points.
     template<typename POINT>
-    void normalizedTotalDistancekNN(std::size_t k,
-                                    bool project,
-                                    std::vector<POINT> points,
-                                    TDoubleVec& scores) {
-        normalized<CTotalDistancekNN>(k, project, std::move(points), scores);
+    static void
+    normalizedTotalDistancekNN(std::size_t k, std::vector<POINT> points, TDoubleVec& scores) {
+        normalized<outliers_detail::CTotalDistancekNN>(k, std::move(points), scores);
     }
-
-    //! Compute the outlier scores using a mean ensemble of approaches.
-    //!
-    //! \note This automatically chooses to project the data and
-    //! the number of nearest neighbours to use based on the data
-    //! characteristics.
-    template<typename POINT>
-    void ensemble(std::vector<POINT> points, TDoubleVec& scores) {
-        if (points.empty()) {
-            return;
-        }
-
-        std::size_t k{defaultNumberOfNeighbours(points)};
-        if (shouldProject(points)) {
-            using TPoint = decltype(SConstant<POINT>::get(0, 0));
-            CEnsemble<TPoint, TKdTree<TPoint>> ensemble{k, m_RecordProgress};
-            ensemble.lof().ldof().knn().tnn();
-            computeForBagOfProjections(ensemble, points, scores);
-        } else {
-            CEnsemble<POINT, TKdTree<POINT>> ensemble{k, m_RecordProgress};
-            ensemble.lof().ldof().knn().tnn();
-            compute(ensemble, annotate(std::move(points)), scores);
-        }
-    }
-
-    //! Estimate the amount of memory that will be used computing outliers.
-    //!
-    //! \param[in] algorithm The algorithm that will be used.
-    //! \param[in] k The number of nearest neighbours which will be used.
-    //! \param[in] numberPoints The number of points for outliers will be
-    //! computed.
-    //! \param[in] dimension The dimension of the points for which outliers
-    //! will be computed.
-    template<typename POINT>
-    static std::size_t estimateMemoryUsage(EAlgorithm algorithm,
-                                           std::size_t k,
-                                           std::size_t numberPoints,
-                                           std::size_t dimension) {
-        // TODO handle the case we'll project the data properly.
-        std::size_t result{TKdTree<POINT>::estimateMemoryUsage(numberPoints, dimension)};
-        switch (algorithm) {
-        case E_Ensemble:
-            result += CLof<POINT, TKdTree<POINT>>::estimateOwnMemoryOverhead(k, numberPoints) +
-                      CEnsemble<POINT, TKdTree<POINT>>::estimateOwnMemoryOverhead(
-                          numberPoints, 4);
-            break;
-        case E_Lof:
-            result += CLof<POINT, TKdTree<POINT>>::estimateOwnMemoryOverhead(k, numberPoints);
-            break;
-        case E_Ldof:
-        case E_DistancekNN:
-        case E_TotalDistancekNN:
-            break;
-        }
-        return result;
-    }
-
-    //! Overload of estimateMemoryUsage which computes estimated usage
-    //! for the default method and number of nearest neighbours.
-    template<typename POINT>
-    static std::size_t
-    estimateMemoryUsage(EAlgorithm algorithm, std::size_t numberPoints, std::size_t dimension) {
-        return estimateMemoryUsage<POINT>(
-            algorithm, defaultNumberOfNeighbours(numberPoints, dimension),
-            numberPoints, dimension);
-    }
-
-protected:
-    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
-    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
-    using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
+    //@}
 
 protected:
     //! Compute normalised outlier scores for a specified method.
     template<template<typename, typename> class METHOD, typename POINT>
-    void normalized(std::size_t k, bool project, std::vector<POINT> points, TDoubleVec& scores) {
-        if (points.empty()) {
-            // Nothing to do
-        } else if (project) {
-            using TPoint = decltype(SConstant<POINT>::get(0, 0));
-            METHOD<TPoint, TKdTree<TPoint>> method(k, m_RecordProgress);
-            computeForBagOfProjections(method, points, scores);
-        } else {
-            METHOD<POINT, TKdTree<POINT>> method(k, m_RecordProgress);
-            compute(method, annotate(std::move(points)), scores);
+    static void normalized(std::size_t k, std::vector<POINT> points, TDoubleVec& scores) {
+        if (points.size() > 0) {
+            using TPoint = CAnnotatedVector<POINT, std::size_t>;
+
+            auto annotatedPoints = annotate(std::move(points));
+            CKdTree<TPoint> lookup;
+            lookup.reserve(points.size());
+            lookup.build(annotatedPoints);
+
+            METHOD<TPoint, CKdTree<TPoint>> scorer{k, noop, std::move(lookup)};
+
+            scorer.run(annotatedPoints, annotatedPoints.size(), [&scores](TDoubleVecVec scores_) {
+                scores = std::move(scores_[0]);
+            });
+            normalize(scores);
         }
-    }
-
-    //! Check whether to project the data.
-    template<typename POINT>
-    static bool shouldProject(const std::vector<POINT>& points) {
-        return shouldProject(points.size() > 0 ? las::dimension(points[0]) : 1);
-    }
-
-    //! Check whether to project the data.
-    static bool shouldProject(std::size_t dimension) { return dimension > 4; }
-
-    //! Get the number of nearest neighbours to use.
-    template<typename POINT>
-    static std::size_t defaultNumberOfNeighbours(const std::vector<POINT>& points) {
-        if (points.empty()) {
-            return 1;
-        }
-
-        std::size_t numberPoints{points.size()};
-        std::size_t dimension{las::dimension(points[0])};
-        if (shouldProject(points)) {
-            std::tie(std::ignore, dimension) = computeBagsAndProjectedDimension(points);
-        }
-
-        return defaultNumberOfNeighbours(numberPoints, dimension);
-    }
-
-    //! Get the number of nearest neighbours to use.
-    static std::size_t defaultNumberOfNeighbours(std::size_t numberPoints,
-                                                 std::size_t dimension) {
-        return static_cast<std::size_t>(
-            CTools::truncate(std::min(5.0 * static_cast<double>(dimension),
-                                      std::pow(static_cast<double>(numberPoints), 1.0 / 3.0)),
-                             10.0, 50.0) +
-            0.5);
     }
 
     //! Create points annotated with their index in \p points.
@@ -302,494 +740,21 @@ protected:
         return annotatedPoints;
     }
 
-    //! Compute the outlier scores of \p points using \p compute.
-    template<typename COMPUTE, typename POINT>
-    static void compute(COMPUTE& compute,
-                        std::vector<CAnnotatedVector<POINT, std::size_t>> points,
-                        TDoubleVec& scores) {
-        scores.assign(points.size(), 0.0);
-        compute(std::move(points), scores);
-    }
-
-    //! Compute the outlier scores of \p points using \p compute and
-    //! a bag of random projections.
-    template<typename COMPUTE, typename POINT>
-    static void computeForBagOfProjections(COMPUTE& compute,
-                                           const std::vector<POINT>& points,
-                                           TDoubleVec& scores) {
-        using TPoint = decltype(SConstant<POINT>::get(0, 0));
-        using TPointVec = std::vector<TPoint>;
-        using TAnnotatedPoint = CAnnotatedVector<TPoint, std::size_t>;
-        using TAnnotatedPointVec = std::vector<TAnnotatedPoint>;
-        using TMaxAccumulator = CBasicStatistics::SMax<double>::TAccumulator;
-        using TMaxAccumulatorVec = std::vector<TMaxAccumulator>;
-
-        std::size_t dimension{las::dimension(points[0])};
-        std::size_t bags, projectedDimension;
-        std::tie(bags, projectedDimension) = computeBagsAndProjectedDimension(points);
-        compute.numberRuns(bags);
-
-        // Use standard 2-stable Gaussian projections since we are
-        // interested in Euclidean distances.
-        TDoubleVec coordinates;
-        CPRNG::CXorOShiro128Plus rng;
-        CSampling::normalSample(rng, 0.0, 1.0, 2 * bags * projectedDimension * dimension,
-                                coordinates);
-
-        // Placeholder for projected points.
-        TAnnotatedPointVec projectedPoints;
-        projectedPoints.reserve(points.size());
-        for (std::size_t i = 0; i < points.size(); ++i) {
-            projectedPoints.emplace_back(SConstant<POINT>::get(projectedDimension, 0), i);
-        }
-
-        // We're interested if points are:
-        //   1) Outlying in any projection of the data,
-        //   2) Outlying in many projections of the data.
-        //
-        // We want to identify the former as outliers and the later as
-        // the most significant outliers. To this end we average the
-        // maximum score from any projection with the average score for
-        // all projections.
-        TMaxAccumulatorVec maxScores(points.size());
-        TMeanAccumulatorVec meanScores(points.size());
-
-        TPointVec projection(projectedDimension, las::zero(points[0]));
-        for (std::size_t bag = 0, i = 0; bag < bags && i < coordinates.size(); /**/) {
-            // Create an orthonormal basis for the bag.
-            for (std::size_t p = 0; p < projectedDimension; ++p) {
-                for (std::size_t d = 0; d < dimension; ++i, ++d) {
-                    projection[p](d) = coordinates[i];
-                }
-            }
-            if (COrthogonaliser::orthonormalBasis(projection) &&
-                projection.size() == projectedDimension) {
-
-                // Project onto the basis.
-                core::parallel_for_each(0, points.size(), [&](std::size_t j) {
-                    for (std::size_t d = 0; d < projectedDimension; ++d) {
-                        projectedPoints[j](d) = las::inner(projection[d], points[j]);
-                    }
-                });
-
-                // Compute the scores and update the overall score.
-                scores.assign(points.size(), 0.0);
-                compute(projectedPoints, scores);
-                core::parallel_for_each(0, scores.size(), [&](std::size_t j) {
-                    maxScores[j].add(scores[j]);
-                    meanScores[j].add(scores[j]);
-                });
-
-                ++bag;
-            }
-        }
-
-        core::parallel_for_each(0, meanScores.size(), [&](std::size_t i) {
-            scores[i] = (maxScores[i][0] + CBasicStatistics::mean(meanScores[i])) / 2.0;
-        });
-    }
-
-    //! Compute the number of bags and the projection dimension.
-    template<typename POINT>
-    static TSizeSizePr computeBagsAndProjectedDimension(const std::vector<POINT>& points) {
-        // Note because we get big wins in the lookup speed of the k-d
-        // tree by reducing the points' dimensions we still get a speed
-        // up if "number of projections" x "projection dimension" is
-        // O("dimension of the full space").
-
-        std::size_t dimension{las::dimension(points[0])};
-        double rootDimension{std::sqrt(std::min(static_cast<double>(dimension), 100.0))};
-        double logNumberPoints{std::log(static_cast<double>(points.size()))};
-        std::size_t projectedDimension{static_cast<std::size_t>(
-            std::max(std::min(rootDimension, logNumberPoints), 4.0) + 0.5)};
-        return {std::max(dimension / 2 / projectedDimension, std::size_t(2)), projectedDimension};
-    }
-
-    //! \brief The interface for an outlier calculation method.
-    template<typename POINT, typename NEAREST_NEIGHBOURS>
-    class CMethod {
-    public:
-        using TPoint = CAnnotatedVector<POINT, std::size_t>;
-        using TPointVec = std::vector<TPoint>;
-
-    public:
-        CMethod(NEAREST_NEIGHBOURS lookup, TProgressCallback recordProgress)
-            : m_Lookup{std::move(lookup)}, m_RecordProgress{recordProgress} {}
-        virtual ~CMethod() = default;
-
-        void run(std::size_t k, TPointVec points, TDoubleVec& scores) {
-            this->setup(points);
-            m_Lookup.build(std::move(points));
-            // We call add exactly once for each point. Scores is presized
-            // so writes are safe because these are happening for different
-            // elements in different threads.
-            core::parallel_for_each(
-                m_Lookup.begin(), m_Lookup.end(),
-                [&, neighbours = TPointVec{} ](const TPoint& point) mutable {
-                    m_Lookup.nearestNeighbours(k + 1, point, neighbours);
-                    this->add(point, neighbours, scores);
-                },
-                [this](double fractionalProgress) {
-                    this->recordProgress(fractionalProgress);
-                });
-            this->compute(scores);
-        }
-
-        const NEAREST_NEIGHBOURS& lookup() const { return m_Lookup; }
-
-        virtual void setup(const TPointVec& /*points*/) {}
-
-        virtual void
-        add(const TPoint& point, const TPointVec& neighbours, TDoubleVec& scores) = 0;
-
-        virtual void compute(TDoubleVec& scores) { normalize(scores); }
-
-        //! \name Progress Monitoring
-        //@{
-        void recordProgress(double fractionalProgress) {
-            m_RecordProgress(fractionalProgress / m_NumberRuns);
-        }
-
-        void numberRuns(std::size_t numberRuns) {
-            m_NumberRuns = static_cast<double>(numberRuns);
-        }
-        //@}
-
-    protected:
-        TProgressCallback progressCallback() const { return m_RecordProgress; }
-
-    private:
-        NEAREST_NEIGHBOURS m_Lookup;
-        double m_NumberRuns = 1.0;
-        TProgressCallback m_RecordProgress;
-    };
-
-    //! \brief Computes the normalized version of the local outlier
-    //! factor score.
-    template<typename POINT, typename NEAREST_NEIGHBOURS>
-    class CLof final : public CMethod<POINT, NEAREST_NEIGHBOURS> {
-    public:
-        using TPoint = CAnnotatedVector<POINT, std::size_t>;
-        using TPointVec = std::vector<TPoint>;
-        using TCoordinate = typename SCoordinate<POINT>::Type;
-        using TCoordinateVec = std::vector<TCoordinate>;
-        using TUInt32CoordinatePr = std::pair<uint32_t, TCoordinate>;
-        using TUInt32CoordinatePrVec = std::vector<TUInt32CoordinatePr>;
-        static const TCoordinate UNSET_DISTANCE;
-
-    public:
-        CLof(std::size_t k,
-             TProgressCallback recordProgress,
-             NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
-            : CMethod<POINT, NEAREST_NEIGHBOURS>{std::move(lookup), recordProgress}, m_K{k} {}
-
-        void operator()(TPointVec points, TDoubleVec& scores) {
-            this->run(m_K, std::move(points), scores);
-        }
-
-        virtual void setup(const TPointVec& points) {
-            m_KDistances.assign(m_K * points.size(), {0, UNSET_DISTANCE});
-            m_Lrd.assign(points.size(), UNSET_DISTANCE);
-        }
-
-        virtual void add(const TPoint& point, const TPointVec& neighbours, TDoubleVec&) {
-            // This is called exactly once for each point therefore an
-            // element of m_KDistances is only ever written by one thread.
-            std::size_t i{point.annotation() * m_K};
-            std::size_t k{std::min(m_K, neighbours.size() - 1)};
-            for (std::size_t j = 1; j <= k; ++j) {
-                m_KDistances[i + j - 1].first =
-                    static_cast<uint32_t>(neighbours[j].annotation());
-                m_KDistances[i + j - 1].second = las::distance(point, neighbours[j]);
-            }
-        }
-
-        virtual void compute(TDoubleVec& scores) {
-            using TMinAccumulator = CBasicStatistics::SMin<double>::TAccumulator;
-
-            // We bind a minimum accumulator (by value) to each lambda
-            // (since one copy is then accessed by each thread) and take
-            // the minimum of these at the end.
-
-            auto results = core::parallel_for_each(
-                this->lookup().begin(), this->lookup().end(),
-                core::bindRetrievableState(
-                    [&](TMinAccumulator& min, const TPoint& point) {
-                        std::size_t i{point.annotation()};
-                        TMeanAccumulator reachability_;
-                        for (std::size_t j = i * m_K; j < (i + 1) * m_K; ++j) {
-                            const auto& neighbour = m_KDistances[j];
-                            if (distance(neighbour) != UNSET_DISTANCE) {
-                                reachability_.add(std::max(kdistance(index(neighbour)),
-                                                           distance(neighbour)));
-                            }
-                        }
-                        double reachability{CBasicStatistics::mean(reachability_)};
-                        if (reachability > 0.0) {
-                            m_Lrd[i] = 1.0 / reachability;
-                            min.add(reachability);
-                        }
-                    },
-                    TMinAccumulator{}));
-
-            TMinAccumulator min;
-            for (const auto& result : results) {
-                min += result.s_FunctionState;
-            }
-
-            if (min.count() > 0) {
-                // Use twice the maximum "density" at any other point if there are
-                // k-fold duplicates.
-                for (auto& lrd : m_Lrd) {
-                    if (lrd < 0.0) {
-                        lrd = 2.0 / min[0];
-                    }
-                }
-                core::parallel_for_each(
-                    this->lookup().begin(), this->lookup().end(), [&](const TPoint& point) {
-                        std::size_t i{point.annotation()};
-                        TMeanAccumulator score;
-                        for (std::size_t j = i * m_K; j < (i + 1) * m_K; ++j) {
-                            const auto& neighbour = m_KDistances[j];
-                            if (distance(neighbour) != UNSET_DISTANCE) {
-                                score.add(m_Lrd[index(neighbour)]);
-                            }
-                        }
-                        scores[i] = CBasicStatistics::mean(score) / m_Lrd[i];
-                    });
-            }
-            normalize(scores);
-        }
-
-        static std::size_t estimateOwnMemoryOverhead(std::size_t k, std::size_t numberPoints) {
-            return numberPoints * (k * sizeof(TUInt32CoordinatePr) + sizeof(TCoordinate));
-        }
-
-    private:
-        static std::size_t index(const TUInt32CoordinatePr& neighbour) {
-            return neighbour.first;
-        }
-        static double distance(const TUInt32CoordinatePr& neighbour) {
-            return neighbour.second;
-        }
-        double kdistance(std::size_t index) const {
-            for (std::size_t j = (index + 1) * m_K; j > index * m_K; --j) {
-                if (distance(m_KDistances[j - 1]) != UNSET_DISTANCE) {
-                    return distance(m_KDistances[j - 1]);
-                }
-            }
-            return UNSET_DISTANCE;
-        }
-
-    private:
-        std::size_t m_K;
-        // The k distances to the neighbouring points of each point are
-        // stored flattened: [neighbours of 0, neighbours of 1,...].
-        TUInt32CoordinatePrVec m_KDistances;
-        TCoordinateVec m_Lrd;
-    };
-
-    //! \brief Computes the normalized version of the local distance
-    //! based outlier score.
-    template<typename POINT, typename NEAREST_NEIGHBOURS>
-    class CLdof final : public CMethod<POINT, NEAREST_NEIGHBOURS> {
-    public:
-        using TPoint = CAnnotatedVector<POINT, std::size_t>;
-        using TPointVec = std::vector<TPoint>;
-
-    public:
-        CLdof(std::size_t k,
-              TProgressCallback recordProgress,
-              NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
-            : CMethod<POINT, NEAREST_NEIGHBOURS>{std::move(lookup), recordProgress}, m_K{k} {}
-
-        void operator()(TPointVec points, TDoubleVec& scores) {
-            this->run(m_K, std::move(points), scores);
-        }
-
-        virtual void add(const TPoint& point, const TPointVec& neighbours, TDoubleVec& scores) {
-            TMeanAccumulator d, D;
-            std::size_t k{std::min(m_K, neighbours.size() - 1)};
-            for (std::size_t i = 1; i <= k; ++i) {
-                d.add(las::distance(point, neighbours[i]));
-                for (std::size_t j = 1; j < i; ++j) {
-                    D.add(las::distance(neighbours[i], neighbours[j]));
-                }
-            }
-            scores[point.annotation()] = CBasicStatistics::mean(D) > 0.0
-                                             ? CBasicStatistics::mean(d) /
-                                                   CBasicStatistics::mean(D)
-                                             : 0.0;
-        }
-
-    private:
-        std::size_t m_K;
-    };
-
-    //! \brief Computes the normalized version of the distance
-    //! to the k'th nearest neighbour score.
-    template<typename POINT, typename NEAREST_NEIGHBOURS>
-    class CDistancekNN final : public CMethod<POINT, NEAREST_NEIGHBOURS> {
-    public:
-        using TPoint = CAnnotatedVector<POINT, std::size_t>;
-        using TPointVec = std::vector<TPoint>;
-
-    public:
-        CDistancekNN(std::size_t k,
-                     TProgressCallback recordProgress,
-                     NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
-            : CMethod<POINT, NEAREST_NEIGHBOURS>{std::move(lookup), recordProgress}, m_K{k} {}
-
-        void operator()(TPointVec points, TDoubleVec& scores) {
-            this->run(m_K, std::move(points), scores);
-        }
-
-        virtual void add(const TPoint& point, const TPointVec& neighbours, TDoubleVec& scores) {
-            std::size_t k{std::min(m_K, neighbours.size() - 1)};
-            scores[point.annotation()] = las::distance(point, neighbours[k]);
-        }
-
-    private:
-        std::size_t m_K;
-    };
-
-    //! \brief Computes the normalized version of the total
-    //! distance to the k nearest neighbours.
-    template<typename POINT, typename NEAREST_NEIGHBOURS>
-    class CTotalDistancekNN final : public CMethod<POINT, NEAREST_NEIGHBOURS> {
-    public:
-        using TPoint = CAnnotatedVector<POINT, std::size_t>;
-        using TPointVec = std::vector<TPoint>;
-
-    public:
-        CTotalDistancekNN(std::size_t k,
-                          TProgressCallback recordProgress,
-                          NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
-            : CMethod<POINT, NEAREST_NEIGHBOURS>{std::move(lookup), recordProgress}, m_K{k} {}
-
-        void operator()(TPointVec points, TDoubleVec& scores) {
-            this->run(m_K, std::move(points), scores);
-        }
-
-        virtual void add(const TPoint& point, const TPointVec& neighbours, TDoubleVec& scores) {
-            std::size_t i{point.annotation()};
-            std::size_t k{std::min(m_K, neighbours.size() - 1)};
-            for (std::size_t j = 1; j <= k; ++j) {
-                scores[i] += las::distance(point, neighbours[j]);
-            }
-            scores[i] /= static_cast<double>(k);
-        }
-
-    private:
-        std::size_t m_K;
-    };
-
-    //! \brief Computes a mean ensemble of the other methods.
-    template<typename POINT, typename NEAREST_NEIGHBOURS>
-    class CEnsemble final : public CMethod<POINT, NEAREST_NEIGHBOURS> {
-    public:
-        using TPoint = CAnnotatedVector<POINT, std::size_t>;
-        using TPointVec = std::vector<TPoint>;
-        using TMethodUPtr = std::unique_ptr<CMethod<POINT, const NEAREST_NEIGHBOURS&>>;
-        using TMethodUPtrVec = std::vector<TMethodUPtr>;
-
-    public:
-        CEnsemble(std::size_t k,
-                  TProgressCallback recordProgress,
-                  NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
-            : CMethod<POINT, NEAREST_NEIGHBOURS>{lookup, recordProgress}, m_K{k} {}
-
-        CEnsemble& lof() {
-            m_Methods.push_back(std::make_unique<CLof<POINT, const NEAREST_NEIGHBOURS&>>(
-                m_K, this->progressCallback(), this->lookup()));
-            return *this;
-        }
-        CEnsemble& ldof() {
-            m_Methods.push_back(std::make_unique<CLdof<POINT, const NEAREST_NEIGHBOURS&>>(
-                m_K, this->progressCallback(), this->lookup()));
-            return *this;
-        }
-        CEnsemble& knn() {
-            m_Methods.push_back(std::make_unique<CDistancekNN<POINT, const NEAREST_NEIGHBOURS&>>(
-                m_K, this->progressCallback(), this->lookup()));
-            return *this;
-        }
-        CEnsemble& tnn() {
-            m_Methods.push_back(
-                std::make_unique<CTotalDistancekNN<POINT, const NEAREST_NEIGHBOURS&>>(
-                    m_K, this->progressCallback(), this->lookup()));
-            return *this;
-        }
-
-        void operator()(TPointVec points, TDoubleVec& scores) {
-            this->run(m_K, std::move(points), scores);
-        }
-
-        virtual void setup(const TPointVec& points) {
-            for (auto& method : m_Methods) {
-                method->setup(points);
-            }
-            m_Scores.assign(m_Methods.size(), TDoubleVec(points.size()));
-        }
-
-        virtual void add(const TPoint& point, const TPointVec& neighbours, TDoubleVec&) {
-            for (std::size_t i = 0; i < m_Methods.size(); ++i) {
-                m_Methods[i]->add(point, neighbours, m_Scores[i]);
-            }
-        }
-
-        virtual void compute(TDoubleVec& scores) {
-            for (std::size_t i = 0; i < m_Methods.size(); ++i) {
-                m_Methods[i]->compute(m_Scores[i]);
-            }
-            for (std::size_t i = 0; i < scores.size(); ++i) {
-                for (std::size_t j = 0; j < m_Scores.size(); ++j) {
-                    scores[i] += m_Scores[j][i];
-                }
-                scores[i] /= static_cast<double>(m_Scores.size());
-            }
-        }
-
-        static std::size_t estimateOwnMemoryOverhead(std::size_t numberPoints,
-                                                     std::size_t numberMethods) {
-            return numberMethods * (sizeof(TMethodUPtr) + sizeof(TDoubleVec) +
-                                    numberPoints * sizeof(double));
-        }
-
-    private:
-        std::size_t m_K = 0;
-        TMethodUPtrVec m_Methods;
-        TDoubleVecVec m_Scores;
-    };
-
-    //! The Gaussian normalization scheme proposed in "Interpreting
-    //! and Unifying Outlier Scores" by Kreigel et al.
+    //! This is based on the Gaussian normalization scheme proposed in
+    //! "Interpreting and Unifying Outlier Scores" by Kreigel et al.
     //!
-    //! This simply fits a Gaussian to a collection of scores for an
-    //! outlier method and computes the right tail probability.
-    static void normalize(TDoubleVec& scores);
+    //! The main departure is it compute a conditional probability that
+    //! a point is an outlier given a prior probability which can be user
+    //! defined.
+    static void normalize(TDoubleVec& scores, double pOutlier = 0.05);
 
-    //! Convert the c.d.f. complement of an outlier factor into a
-    //! score in the range [0,100] with the higher the score the
-    //! greater the outlier.
-    static double cdfComplementToScore(double cdfComplement);
+    //! Converts the score percentile into a conditional probability that
+    //! the point is an outlier.
+    static double probabilityOutlierGiven(double scorePercentile);
 
 private:
     static void noop(double);
-
-private:
-    TProgressCallback m_RecordProgress;
 };
-
-template<typename POINT, typename NEAREST_NEIGHBOURS>
-const typename COutliers::CLof<POINT, NEAREST_NEIGHBOURS>::TCoordinate
-    COutliers::CLof<POINT, NEAREST_NEIGHBOURS>::UNSET_DISTANCE = -1.0;
-
-//! Compute outliers for \p frame and write to a new column.
-MATHS_EXPORT
-bool computeOutliers(std::size_t numberThreads,
-                     std::function<void(double)> recordProgress,
-                     core::CDataFrame& frame);
 }
 }
 

--- a/include/maths/CSampling.h
+++ b/include/maths/CSampling.h
@@ -20,6 +20,7 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 
+#include <cstddef>
 #include <functional>
 #include <vector>
 

--- a/include/maths/CSampling.h
+++ b/include/maths/CSampling.h
@@ -82,7 +82,7 @@ public:
         using TOnSampleCallback = std::function<void(std::size_t, const T&)>;
 
     public:
-        static const std::size_t MINIMUM_TARGET_SAMPLE_SIZE{100};
+        static const std::size_t MINIMUM_TARGET_SAMPLE_SIZE;
 
     public:
         CRandomStreamSampler(std::size_t targetSampleSize,
@@ -518,6 +518,9 @@ private:
     //! The uniform random number generator.
     static CRandomNumberGenerator ms_Rng;
 };
+
+template<typename T>
+const std::size_t CSampling::CRandomStreamSampler<T>::MINIMUM_TARGET_SAMPLE_SIZE{100};
 }
 }
 

--- a/include/test/CDataFrameTestUtils.h
+++ b/include/test/CDataFrameTestUtils.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_test_CDataFrameTestUtils_h
+#define INCLUDED_ml_test_CDataFrameTestUtils_h
+
+#include <core/CDataFrame.h>
+
+#include <maths/CLinearAlgebraShims.h>
+
+#include <test/ImportExport.h>
+
+#include <vector>
+
+namespace ml {
+namespace test {
+
+//! \brief Utility functionality for writing tests for data frame analytics.
+class TEST_EXPORT CDataFrameTestUtils {
+public:
+    //! \brief Callable wrapper around toMainMemoryDataFrame.
+    struct TEST_EXPORT SToMainMemoryDataFrame {
+        template<typename POINT>
+        auto operator()(const std::vector<POINT>& points) {
+            return toMainMemoryDataFrame(points);
+        }
+    };
+
+public:
+    //! Create a data frame whose rows are initialized with \p points.
+    template<typename POINT>
+    static auto toMainMemoryDataFrame(const std::vector<POINT>& points) {
+
+        std::size_t dimension{maths::las::dimension(points[0])};
+
+        auto result = core::makeMainStorageDataFrame(dimension).first;
+
+        for (std::size_t i = 0; i < points.size(); ++i) {
+            result->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t& id) {
+                for (std::size_t d = 0; d < dimension; ++d, ++column) {
+                    *column = points[i](d);
+                }
+                id = static_cast<std::int32_t>(i);
+            });
+        }
+        result->finishWritingRows();
+
+        return result;
+    }
+};
+}
+}
+
+#endif // INCLUDED_ml_test_CDataFrameTestUtils_h

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -125,11 +125,11 @@ CDataFrameOutliersRunner::estimateBookkeepingMemoryUsage(std::size_t numberParti
     std::size_t result{0};
     switch (numberPartitions) {
     case 1:
-        result = estimateMemoryUsage<maths::CMemoryMappedDenseVector<float>>(
+        result = estimateMemoryUsage<maths::CMemoryMappedDenseVector<maths::CFloatStorage>>(
             totalNumberRows, partitionNumberRows, numberColumns);
         break;
     default:
-        result = estimateMemoryUsage<maths::CDenseVector<float>>(
+        result = estimateMemoryUsage<maths::CDenseVector<maths::CFloatStorage>>(
             totalNumberRows, partitionNumberRows, numberColumns);
         break;
     }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -114,34 +114,39 @@ void CDataFrameOutliersRunner::writeOneRow(TRowRef row,
 }
 
 void CDataFrameOutliersRunner::runImpl(core::CDataFrame& frame) {
-    maths::computeOutliers(this->spec().numberThreads(), this->progressRecorder(), frame);
+    maths::COutliers::compute(this->spec().numberThreads(), frame, this->progressRecorder());
 }
 
 std::size_t
 CDataFrameOutliersRunner::estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
-                                                         std::size_t numberRows,
+                                                         std::size_t totalNumberRows,
+                                                         std::size_t partitionNumberRows,
                                                          std::size_t numberColumns) const {
     std::size_t result{0};
     switch (numberPartitions) {
     case 1:
         result = estimateMemoryUsage<maths::CMemoryMappedDenseVector<float>>(
-            numberRows, numberColumns);
+            totalNumberRows, partitionNumberRows, numberColumns);
         break;
     default:
-        result = estimateMemoryUsage<maths::CDenseVector<float>>(numberRows, numberColumns);
+        result = estimateMemoryUsage<maths::CDenseVector<float>>(
+            totalNumberRows, partitionNumberRows, numberColumns);
         break;
     }
     return result;
 }
 
 template<typename POINT>
-std::size_t CDataFrameOutliersRunner::estimateMemoryUsage(std::size_t numberRows,
-                                                          std::size_t numberColumns) const {
-    maths::COutliers::EAlgorithm method{static_cast<maths::COutliers::EAlgorithm>(m_Method)};
+std::size_t
+CDataFrameOutliersRunner::estimateMemoryUsage(std::size_t totalNumberRows,
+                                              std::size_t partitionNumberRows,
+                                              std::size_t numberColumns) const {
+    maths::COutliers::EMethod method{static_cast<maths::COutliers::EMethod>(m_Method)};
     return m_NumberNeighbours != boost::none
-               ? maths::COutliers::estimateMemoryUsage<POINT>(
-                     method, *m_NumberNeighbours, numberRows, numberColumns)
-               : maths::COutliers::estimateMemoryUsage<POINT>(method, numberRows, numberColumns);
+               ? maths::COutliers::estimateComputeMemoryUsage<POINT>(
+                     method, *m_NumberNeighbours, totalNumberRows, partitionNumberRows, numberColumns)
+               : maths::COutliers::estimateComputeMemoryUsage<POINT>(
+                     totalNumberRows, partitionNumberRows, numberColumns);
 }
 
 const char* CDataFrameOutliersRunnerFactory::name() const {

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -147,7 +147,7 @@ void CDataFrameAnalyzerTest::testWithoutControlMessages() {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
-            1e-6 * *expectedScore);
+            1e-4 * *expectedScore);
         ++expectedScore;
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
@@ -179,7 +179,7 @@ void CDataFrameAnalyzerTest::testRunOutlierDetection() {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
-            1e-6 * *expectedScore);
+            1e-4 * *expectedScore);
         ++expectedScore;
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -16,6 +16,7 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameAnalyzer.h>
 
+#include <test/CDataFrameTestUtils.h>
 #include <test/CRandomNumbers.h>
 
 #include <rapidjson/document.h>
@@ -105,8 +106,17 @@ void addTestData(TStrVec fieldNames,
         }
     }
 
-    maths::COutliers lofs;
-    lofs.ensemble(points, expectedScores);
+    auto frame = test::CDataFrameTestUtils::toMainMemoryDataFrame(points);
+
+    maths::COutliers::compute(1, *frame);
+
+    expectedScores.resize(points.size());
+    frame->readRows(1, [&expectedScores](core::CDataFrame::TRowItr beginRows,
+                                         core::CDataFrame::TRowItr endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            expectedScores[row->index()] = (*row)[row->numberColumns() - 1];
+        }
+    });
 }
 }
 
@@ -137,7 +147,7 @@ void CDataFrameAnalyzerTest::testWithoutControlMessages() {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
-            1e-5 * *expectedScore);
+            1e-6 * *expectedScore);
         ++expectedScore;
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
@@ -169,7 +179,7 @@ void CDataFrameAnalyzerTest::testRunOutlierDetection() {
         CPPUNIT_ASSERT(expectedScore != expectedScores.end());
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
-            1e-5 * *expectedScore);
+            1e-6 * *expectedScore);
         ++expectedScore;
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -13,10 +13,6 @@ CDataFrameMockAnalysisRunner::CDataFrameMockAnalysisRunner(const ml::api::CDataF
     : ml::api::CDataFrameAnalysisRunner{spec} {
 }
 
-std::size_t CDataFrameMockAnalysisRunner::numberOfPartitions() const {
-    return 1;
-}
-
 std::size_t CDataFrameMockAnalysisRunner::numberExtraColumns() const {
     return 2;
 }
@@ -35,6 +31,7 @@ void CDataFrameMockAnalysisRunner::runImpl(ml::core::CDataFrame&) {
 }
 
 std::size_t CDataFrameMockAnalysisRunner::estimateBookkeepingMemoryUsage(std::size_t,
+                                                                         std::size_t,
                                                                          std::size_t,
                                                                          std::size_t) const {
     return 0;

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -14,33 +14,32 @@
 
 #include <functional>
 
-class CDataFrameMockAnalysisRunner : public ml::api::CDataFrameAnalysisRunner {
+class CDataFrameMockAnalysisRunner final : public ml::api::CDataFrameAnalysisRunner {
 public:
     CDataFrameMockAnalysisRunner(const ml::api::CDataFrameAnalysisSpecification& spec);
 
-    virtual std::size_t numberOfPartitions() const;
-    virtual std::size_t numberExtraColumns() const;
-    virtual void writeOneRow(TRowRef, ml::core::CRapidJsonConcurrentLineWriter&) const;
-
-protected:
-    void runImpl(ml::core::CDataFrame&);
+    std::size_t numberExtraColumns() const override;
+    void writeOneRow(TRowRef, ml::core::CRapidJsonConcurrentLineWriter&) const override;
 
 private:
-    virtual std::size_t
-        estimateBookkeepingMemoryUsage(std::size_t, std::size_t, std::size_t) const;
+    void runImpl(ml::core::CDataFrame&) override;
+    std::size_t estimateBookkeepingMemoryUsage(std::size_t,
+                                               std::size_t,
+                                               std::size_t,
+                                               std::size_t) const override;
 
 private:
     static ml::test::CRandomNumbers ms_Rng;
 };
 
-class CDataFrameMockAnalysisRunnerFactory : public ml::api::CDataFrameAnalysisRunnerFactory {
+class CDataFrameMockAnalysisRunnerFactory final : public ml::api::CDataFrameAnalysisRunnerFactory {
 public:
-    virtual const char* name() const;
+    const char* name() const override;
 
 private:
-    virtual TRunnerUPtr makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec) const;
-    virtual TRunnerUPtr makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec,
-                                 const rapidjson::Value&) const;
+    TRunnerUPtr makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec) const override;
+    TRunnerUPtr makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec,
+                         const rapidjson::Value&) const override;
 };
 
 #endif // INCLUDED_CDataFrameMockAnalysisRunner_h

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -13,7 +13,7 @@
 
 #include <test/CRandomNumbers.h>
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/unordered_map.hpp>
 
 #include <functional>

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -24,7 +24,7 @@ namespace maths {
 namespace outliers_detail {
 
 double shift(double score) {
-    return 1e-4 + score;
+    return std::exp(-2.0) + score;
 }
 
 template<typename POINT>
@@ -339,11 +339,14 @@ double CEnsemble<POINT>::CScorer::compute(double pOutlier) const {
     logLikelihoodOutlier -= renorm;
     logLikelihoodInlier -= renorm;
 
-    // We want improved sensitivity for high scores. In the following, we use
-    // the fact that max(P(outlier), P(inlier)) is zero after renormalisation.
+    // For large ensemble sizes, the classification becomes unrealistically
+    // confident. For a high degree of confidence we instead require that the
+    // point has a significant chance of being an outlier for a significant
+    // fraction of the ensemble models, i.e. 4 out of 5. In the following, we
+    // use the fact that max(P(outlier), P(inlier)) is zero after renormalisation.
 
     (logLikelihoodInlier < logLikelihoodOutlier ? logLikelihoodInlier
-                                                : logLikelihoodOutlier) /= m_EnsembleSize;
+                                                : logLikelihoodOutlier) /= 0.8 * m_EnsembleSize;
 
     // The conditional probability follows from Bayes rule.
     double likelihoodOutlier{std::exp(logLikelihoodOutlier + CTools::fastLog(pOutlier))};

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -90,7 +90,7 @@ CEnsemble<POINT>::makeBuilders(const TSizeVecVec& methods,
         }
 
         result.emplace_back(rng, std::move(methodsAndNumberNeighbours),
-                            (4 * sampleSize) * 3, std::move(projections[model]));
+                            (4 * sampleSize) / 3, std::move(projections[model]));
 
         rng.discard(1ull < 63);
     }

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -12,84 +12,502 @@
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CTools.h>
 
-#include <boost/math/distributions/normal.hpp>
+#include <boost/math/distributions/lognormal.hpp>
 
+#include <numeric>
+#include <sstream>
 #include <tuple>
-#include <vector>
 
 namespace ml {
 namespace maths {
-
-COutliers::COutliers(TProgressCallback recordProgress)
-    : m_RecordProgress{recordProgress} {
+namespace {
+double shrink(double scorePercentile, double shrinkage) {
+    // We treat the score "percentile" as a rough proxy to the chance that the
+    // point is from the outlier class. However, we shrink probabilities towards
+    // 0.5 to account for the fact that the scoring methodology is not perfect.
+    return 0.5 + shrinkage * (scorePercentile - 0.5);
+}
 }
 
-void COutliers::normalize(TDoubleVec& scores) {
-    using TMaxAccumulator =
-        CBasicStatistics::COrderStatisticsHeap<double, std::greater<double>>;
+namespace outliers_detail {
 
-    TMaxAccumulator max(std::max(scores.size() / 10, std::size_t(1)));
-    max.add(scores);
-    double cutoff{max.biggest()};
+template<typename POINT>
+CEnsemble<POINT>::CEnsemble(const TMethodFactoryVec& methodFactories,
+                            TModelBuilderVec builders,
+                            double priorProbabilityOutlier)
+    : m_PriorProbabilityOutlier{priorProbabilityOutlier} {
 
-    TMeanVarAccumulator moments;
-    for (auto score : scores) {
-        moments.add(std::min(score, cutoff));
+    m_Models.reserve(builders.size());
+    for (auto& builder : builders) {
+        m_Models.push_back(builder.make(methodFactories));
     }
 
-    try {
-        double mean{CBasicStatistics::mean(moments)};
-        double variance{CBasicStatistics::variance(moments)};
-        if (variance > 0.0) {
-            boost::math::normal normal(mean, std::sqrt(variance));
-            core::parallel_for_each(scores.begin(), scores.end(), [normal](double& score) {
-                score = cdfComplementToScore(CTools::safeCdfComplement(normal, score));
-            });
-        } else {
-            scores.assign(scores.size(), 0.0);
+    for (auto& model : m_Models) {
+        model.proportionOfRuntimePerMethod(1.0 / static_cast<double>(m_Models.size()));
+    }
+}
+
+template<typename POINT>
+typename CEnsemble<POINT>::TModelBuilderVec
+CEnsemble<POINT>::makeBuilders(const TSizeVecVec& methods,
+                               std::size_t numberPoints,
+                               std::size_t dimension,
+                               CPRNG::CXorOShiro128Plus rng) {
+    // Compute some constants of the ensemble:
+    //   - The number of ensemble models, which is proportional n^(1/2),
+    //   - The number of points which are sampled for each model, which is also
+    //     proportional to the n^(1/2),
+    //   - The maximum number of nearest neighbours, which is a fraction of the
+    //     model sample size and
+    //   - The dimension of the projected points, which is proportional to log(n)
+    //     (to ensure there is sufficient data) and d^(1/2)
+    std::size_t ensembleSize{computeEnsembleSize(methods.size(), numberPoints, dimension)};
+    std::size_t sampleSize{computeSampleSize(numberPoints)};
+    std::size_t numberModels{(ensembleSize + methods.size() - 1) / methods.size()};
+    std::size_t maxNumberNeighbours{computeNumberNeighbours(sampleSize)};
+    std::size_t projectionDimension{computeProjectionDimension(sampleSize, dimension)};
+
+    TModelBuilderVec result;
+    result.reserve(numberModels);
+
+    TPointVecVec projections{
+        createProjections(rng, numberModels, projectionDimension, dimension)};
+
+    // If we didn't find suitable projections this can be less than the target.
+    numberModels = projections.size();
+
+    for (std::size_t model = 0; model < numberModels; ++model) {
+        // Multiple algorithms are used for the same model which therefore share
+        // the sampled points. This allows us to save on both memory and runtime
+        // (because we can share the nearest neighbour lookup for the different
+        // algorithms).
+        TSizeSizePrVec methodsAndNumberNeighbours;
+        methodsAndNumberNeighbours.reserve(methods.size());
+        for (const auto& method : methods) {
+            methodsAndNumberNeighbours.emplace_back(
+                method[CSampling::uniformSample(rng, 0, methods.size())],
+                CSampling::uniformSample(rng, 3, maxNumberNeighbours + 1));
         }
-    } catch (const std::exception& e) {
-        LOG_ERROR(<< "Failed to normalise scores: " << e.what());
+
+        result.emplace_back(rng, std::move(methodsAndNumberNeighbours),
+                            (4 * sampleSize) * 3, std::move(projections[model]));
+
+        rng.discard(1ull < 63);
+    }
+
+    return result;
+}
+
+template<typename POINT>
+void CEnsemble<POINT>::computeOutlierScores(const std::vector<POINT>& points,
+                                            TDoubleVec& scores) {
+    if (points.empty()) {
+        return;
+    }
+
+    LOG_TRACE(<< "Computing outlier scores");
+
+    TScorerVec scores_(points.size());
+    for (const auto& model : m_Models) {
+        model.addOutlierScores(points, scores_);
+    }
+
+    scores.resize(points.size());
+    for (std::size_t i = 0; i < scores_.size(); ++i) {
+        scores[i] = scores_[i].compute(m_PriorProbabilityOutlier);
     }
 }
 
-double COutliers::cdfComplementToScore(double cdfComplement) {
-    auto logInterpolate = [](double xa, double fa, double xb, double fb, double x) {
-        x = CTools::truncate(x, std::min(xa, xb), std::max(xa, xb));
-        return CTools::linearlyInterpolate(CTools::fastLog(xa), CTools::fastLog(xb),
-                                           fa, fb, CTools::fastLog(x));
+template<typename POINT>
+std::string CEnsemble<POINT>::print() const {
+    std::ostringstream result;
+    result << "prior probability outlier = " << m_PriorProbabilityOutlier;
+    for (const auto& model : m_Models) {
+        result << "\n" << model.print();
+    }
+    return result.str();
+}
+
+template<typename POINT>
+typename CEnsemble<POINT>::TPointVecVec
+CEnsemble<POINT>::createProjections(CPRNG::CXorOShiro128Plus& rng,
+                                    std::size_t numberProjections,
+                                    std::size_t projectionDimension,
+                                    std::size_t dimension) {
+
+    LOG_TRACE(<< "# projections = " << numberProjections << ", dimension = " << dimension
+              << ", projection dimension = " << projectionDimension);
+
+    TPointVecVec result;
+    result.reserve(numberProjections);
+
+    if (projectionDimension < dimension) {
+
+        // We create bags of random projections that are orthogonalised together.
+        // This gives us much better diversity across the models in the ensemble.
+        std::size_t bag{dimension / projectionDimension};
+        bag = projectionDimension * std::min(bag, numberProjections);
+        LOG_TRACE(<< "# projections in bag = " << bag);
+
+        // Use standard 2-stable Gaussian projections since we are interested
+        // in Euclidean distances.
+        TDoubleVec coordinates;
+        std::size_t target{2 * numberProjections * projectionDimension * dimension};
+        CSampling::normalSample(rng, 0.0, 1.0, bag * ((target + bag - 1) / bag), coordinates);
+        LOG_TRACE(<< "# random samples = " << coordinates.size());
+
+        for (auto coordinate = coordinates.begin();
+             result.size() < numberProjections && coordinate != coordinates.end();
+             /**/) {
+
+            TPointVec projection{bag, SConstant<TPoint>::get(dimension, 0)};
+
+            for (std::size_t i = 0; i < bag; ++i) {
+                for (std::size_t j = 0; j < dimension; ++j, ++coordinate) {
+                    projection[i](j) = *coordinate;
+                }
+            }
+
+            // Orthogonalise the projection. This resizes the it if there are
+            // linear dependencies.
+            if (COrthogonaliser::orthonormalBasis(projection)) {
+
+                std::size_t n{std::min(numberProjections - result.size(),
+                                       projection.size() / projectionDimension)};
+
+                for (std::size_t i = 0; i < n; ++i) {
+                    result.push_back({});
+                    for (std::size_t j = 0; j < projectionDimension; ++j) {
+                        std::size_t index{projectionDimension * i + j};
+                        result.back().push_back(std::move(projection[index]));
+                    }
+                }
+            }
+        }
+    } else {
+        // Identity.
+        result.resize(numberProjections);
+        for (std::size_t p = 0; p < numberProjections; ++p) {
+            result[p].resize(projectionDimension, SConstant<TPoint>::get(dimension, 0));
+            for (std::size_t d = 0; d < dimension; ++d) {
+                result[p][d](d) = 1.0;
+            }
+        }
+    }
+
+    return result;
+}
+
+template<typename POINT>
+typename CEnsemble<POINT>::TPoint
+CEnsemble<POINT>::project(const TPointVec& projection, const POINT& point) {
+    auto result = SConstant<TPoint>::get(projection.size(), 0);
+    for (std::size_t pd = 0; pd < projection.size(); ++pd) {
+        result(pd) = las::inner(projection[pd], point);
+    }
+    return result;
+}
+
+template<typename POINT>
+CEnsemble<POINT>::CModelBuilder::CModelBuilder(CPRNG::CXorOShiro128Plus& rng,
+                                               TSizeSizePrVec&& methodsAndNumberNeighbours,
+                                               std::size_t sampleSize,
+                                               TPointVec&& projection)
+    : m_MethodsAndNumberNeighbours{std::forward<TSizeSizePrVec>(methodsAndNumberNeighbours)},
+      m_SampleSize{sampleSize}, m_Sampler{makeSampler(rng, sampleSize)},
+      m_Projection(std::forward<TPointVec>(projection)) {
+
+    m_SampledProjectedPoints.reserve(m_Sampler.targetSampleSize());
+}
+
+template<typename POINT>
+typename CEnsemble<POINT>::CModel
+CEnsemble<POINT>::CModelBuilder::make(const TMethodFactoryVec& methodFactories) {
+
+    if (m_SampledProjectedPoints.size() > m_SampleSize) {
+        // We want a random subset of size m_SampleSize. Randomly permute and grab
+        // the first m_SampleSize elements is equivalent.
+        CSampling::random_shuffle(m_Sampler.rng(), m_SampledProjectedPoints.begin(),
+                                  m_SampledProjectedPoints.end());
+        m_SampledProjectedPoints.resize(m_SampleSize);
+    }
+
+    for (std::size_t i = 0; i < m_SampledProjectedPoints.size(); ++i) {
+        m_SampledProjectedPoints[i].annotation() = i;
+    }
+
+    return {m_Sampler.rng(), methodFactories, std::move(m_MethodsAndNumberNeighbours),
+            std::move(m_SampledProjectedPoints), std::move(m_Projection)};
+}
+
+template<typename POINT>
+typename CEnsemble<POINT>::CModelBuilder::TSampler
+CEnsemble<POINT>::CModelBuilder::makeSampler(CPRNG::CXorOShiro128Plus& rng,
+                                             std::size_t sampleSize) {
+    auto onSample = [this](std::size_t index, const POINT& point) {
+        if (index >= m_SampledProjectedPoints.size()) {
+            m_SampledProjectedPoints.push_back(project(m_Projection, point));
+        } else {
+            m_SampledProjectedPoints[index] = project(m_Projection, point);
+        }
     };
-    if (cdfComplement > 1e-3) {
-        return 1e-3 / cdfComplement;
-    }
-    if (cdfComplement > 1e-10) {
-        return logInterpolate(1e-10, 50.0, 1e-3, 1.0, cdfComplement);
-    }
-    return logInterpolate(std::numeric_limits<double>::min(), 100.0, 1e-10, 50.0, cdfComplement);
+    return {sampleSize, onSample, rng};
 }
 
-void COutliers::noop(double) {
+template<typename POINT>
+void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulatorVec& logScoreMoments,
+                                    const TDoubleVec& scores) {
+
+    // The basic idea is to map score percentile to a probability that the data
+    // point is an outlier. We use a monotonic function for this which is flat
+    // near the median, doesn't become too small for low percentiles and is
+    // relatively sensitive for very high percentiles. Even then we don't become
+    // too confident based on a single score. This could be explicitly calibrated
+    // using the slope of the ROC curve, but one would need a very good collection
+    // of benchmark sets to make this effective a priori. We also account for the
+    // fact that the scores will be somewhat correlated.
+
+    static const double KNOTS[]{1e-5, 1e-3, 0.01, 0.1, 0.2,
+                                0.4,  0.5,  0.6,  0.7, 1.0};
+    static const double KNOT_PROBABILITIES[]{0.98, 0.87, 0.76, 0.65, 0.6,
+                                             0.5,  0.5,  0.5,  0.3,  0.3};
+
+    double logLikelihoodOutlierGivenScores{0.0};
+    double logLikelihoodInlierGivenScores{0.0};
+
+    for (std::size_t i = 0; i < scores.size(); ++i) {
+        double location{CBasicStatistics::mean(logScoreMoments[i])};
+        double scale{std::sqrt(CBasicStatistics::variance(logScoreMoments[i]))};
+        double cdfComplement{0.5};
+        if (scale > 0.0) {
+            try {
+                boost::math::lognormal lognormal{location, scale};
+                cdfComplement =
+                    std::max(CTools::safeCdfComplement(lognormal, scores[i]), 1e-6);
+            } catch (const std::exception& e) {
+                LOG_ERROR(<< "Failed to normalise scores: " << e.what());
+            }
+        }
+
+        auto k = std::upper_bound(std::begin(KNOTS), std::end(KNOTS), cdfComplement);
+        double pOutlierGivenScore{CTools::linearlyInterpolate(
+            CTools::fastLog(*(k - 1)), CTools::fastLog(*k),
+            KNOT_PROBABILITIES[k - std::begin(KNOTS) - 1],
+            KNOT_PROBABILITIES[k - std::begin(KNOTS)], CTools::fastLog(cdfComplement))};
+
+        logLikelihoodOutlierGivenScores += CTools::fastLog(pOutlierGivenScore);
+        logLikelihoodInlierGivenScores += CTools::fastLog(1.0 - pOutlierGivenScore);
+    }
+
+    double pOutlierGivenScores{std::exp(logLikelihoodOutlierGivenScores)};
+    double pInlierGivenScores{std::exp(logLikelihoodInlierGivenScores)};
+    double Z{pInlierGivenScores + pOutlierGivenScores};
+
+    m_LogLikelihoodOutlierGivenScores += CTools::fastLog(pOutlierGivenScores / Z);
+    m_LogLikelihoodInlierGivenScores += CTools::fastLog(pInlierGivenScores / Z);
 }
+
+template<typename POINT>
+double CEnsemble<POINT>::CScorer::compute(double pOutlier) const {
+
+    double pInlier{1.0 - pOutlier};
+    double logLikelihoodOutlierGivenScores{m_LogLikelihoodOutlierGivenScores +
+                                           CTools::fastLog(pOutlier)};
+    double logLikelihoodInlierGivenScores{m_LogLikelihoodInlierGivenScores +
+                                          CTools::fastLog(pInlier)};
+
+    double renorm{std::max(logLikelihoodOutlierGivenScores, logLikelihoodInlierGivenScores)};
+    logLikelihoodOutlierGivenScores -= renorm;
+    logLikelihoodInlierGivenScores -= renorm;
+
+    // We want improved sensitivity for high scores. In the following, we use
+    // the fact that if P(outlier) > P(inlier) it's zero after renormalisation.
+
+    if (m_LogLikelihoodOutlierGivenScores > m_LogLikelihoodInlierGivenScores) {
+        logLikelihoodInlierGivenScores *= 0.25;
+    }
+
+    // The conditional probability follows from Bayes rule.
+
+    double pOutlierGivenScores{std::exp(logLikelihoodOutlierGivenScores)};
+    double pInlierGivenScores{std::exp(logLikelihoodInlierGivenScores)};
+    return pOutlierGivenScores / (pOutlierGivenScores + pInlierGivenScores);
+}
+
+template<typename POINT>
+CEnsemble<POINT>::CModel::CModel(CPRNG::CXorOShiro128Plus& rng,
+                                 const TMethodFactoryVec& methodFactories,
+                                 TSizeSizePrVec methodsAndNumberNeighbours,
+                                 TPointVec sample,
+                                 TPointVec projection)
+    : m_Lookup{std::make_unique<TKdTree>()}, m_Projection{std::move(projection)} {
+
+    CSampling::random_shuffle(rng, sample.begin(), sample.end());
+
+    std::size_t n{3 * (sample.size() + 1) / 4};
+
+    TPointVec lookup;
+    lookup.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        lookup.push_back(sample[i]);
+    }
+
+    m_Lookup->reserve(lookup.size());
+    m_Lookup->build(std::move(lookup));
+
+    TMethodUPtrVec methods;
+    methods.reserve(methodsAndNumberNeighbours.size());
+    std::size_t maxk{0};
+
+    for (const auto& methodAndNumberNeighbours : methodsAndNumberNeighbours) {
+        std::size_t method;
+        std::size_t k;
+        std::tie(method, k) = methodAndNumberNeighbours;
+        methods.push_back(std::move(methodFactories[method](k, *m_Lookup)));
+        maxk = std::max(maxk, k);
+    }
+
+    m_LogScoreMoments.reserve(methods.size());
+
+    TDoubleVec scores;
+    TProgressCallback noop{[](double) {}};
+    for (auto& method : methods) {
+        method->progressRecorder().swap(noop);
+        method->run(sample, sample.size(), [&scores](TDoubleVecVec scores_) {
+            scores = std::move(scores_[0]);
+        });
+        method->progressRecorder().swap(noop);
+        for (auto& score : scores) {
+            score = CTools::fastLog(score);
+        }
+        TMeanVarAccumulator moments;
+        moments.add(scores);
+        m_LogScoreMoments.push_back(moments);
+    }
+    m_Method = std::make_unique<CMultipleMethods<TPoint, const TKdTree&>>(
+        maxk, std::move(methods), *m_Lookup);
+}
+
+template<typename POINT>
+void CEnsemble<POINT>::CModel::proportionOfRuntimePerMethod(double proportion) {
+    TProgressCallback recordProgress{m_Method->progressRecorder()};
+    m_Method->progressRecorder() = [proportion, recordProgress](double progress) {
+        recordProgress(proportion * progress);
+    };
+}
+
+template<typename POINT>
+void CEnsemble<POINT>::CModel::addOutlierScores(const std::vector<POINT>& points,
+                                                TScorerVec& scores) const {
+    // This index is used for addressing an array in the cache of nearest neighbour
+    // distances for the local outlier factor method. We simply need to ensure that
+    // it doesn't overlap the indices of any of the sampled model points.
+    std::size_t index{this->numberPoints()};
+
+    TPointVec points_;
+    points_.reserve(points.size());
+    for (std::size_t i = 0; i < points.size(); ++i, ++index) {
+        points_.emplace_back(project(m_Projection, points[i]), index);
+    }
+
+    TDoubleVecVec methodScores;
+    m_Method->run(points_, index, [&methodScores](TDoubleVecVec scores_) {
+        methodScores = std::move(scores_);
+    });
+
+    TDoubleVec pointScores(methodScores.size());
+    for (std::size_t i = 0; i < points_.size(); ++i) {
+        index = points_[i].annotation();
+        for (std::size_t j = 0; j < methodScores.size(); ++j) {
+            pointScores[j] = methodScores[j][index];
+        }
+        scores[i].add(m_LogScoreMoments, pointScores);
+    }
+}
+
+template<typename POINT>
+std::string CEnsemble<POINT>::CModel::print() const {
+    return "projection = " + std::to_string(m_Projection.size()) + " x " +
+           std::to_string(las::dimension(m_Projection[0])) +
+           " method = " + m_Method->print() +
+           " score moments = " + core::CContainerPrinter::print(m_LogScoreMoments);
+}
+}
+
+using namespace outliers_detail;
 
 namespace {
+using TRowItr = core::CDataFrame::TRowItr;
+
+template<typename POINT>
+typename CEnsemble<POINT>::TMethodFactoryVec methodFactories(TProgressCallback recordProgress) {
+    using TPoint = typename CEnsemble<POINT>::TPoint;
+    using TKdTree = typename CEnsemble<POINT>::TKdTree;
+
+    typename CEnsemble<POINT>::TMethodFactoryVec result;
+    result.reserve(4);
+
+    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
+        return std::make_unique<CLof<TPoint, const TKdTree&>>(k, recordProgress, lookup);
+    });
+    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
+        return std::make_unique<CLdof<TPoint, const TKdTree&>>(k, recordProgress, lookup);
+    });
+    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
+        return std::make_unique<CDistancekNN<TPoint, const TKdTree&>>(k, recordProgress, lookup);
+    });
+    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
+        return std::make_unique<CTotalDistancekNN<TPoint, const TKdTree&>>(
+            k, recordProgress, lookup);
+    });
+
+    return result;
+}
+
+template<typename POINT>
+CEnsemble<POINT> buildEnsemble(TProgressCallback recordProgress, core::CDataFrame& frame) {
+
+    using TSizeVec = typename CEnsemble<POINT>::TSizeVec;
+    using TSizeVecVec = typename CEnsemble<POINT>::TSizeVecVec;
+
+    TSizeVecVec methods(2);
+    methods[0] = TSizeVec{COutliers::E_Lof, COutliers::E_Ldof};
+    methods[1] = TSizeVec{COutliers::E_DistancekNN, COutliers::E_TotalDistancekNN};
+
+    auto builders = CEnsemble<POINT>::makeBuilders(methods, frame.numberRows(),
+                                                   frame.numberColumns());
+
+    frame.readRows(1, [&builders](TRowItr beginRows, TRowItr endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            for (auto& builder : builders) {
+                builder.addPoint(CDataFrameUtils::rowTo<POINT>(*row));
+            }
+        }
+    });
+
+    return {methodFactories<POINT>(recordProgress), std::move(builders)};
+}
+
 bool computeOutliersNoPartitions(std::size_t numberThreads,
-                                 std::function<void(double)> recordProgress,
+                                 TProgressCallback recordProgress,
                                  core::CDataFrame& frame) {
 
     using TDoubleVec = std::vector<double>;
-    using TVector = CMemoryMappedDenseVector<CFloatStorage>;
-    using TVectorVec = std::vector<TVector>;
-    using TRowItr = core::CDataFrame::TRowItr;
+    using TPoint = CMemoryMappedDenseVector<CFloatStorage>;
+    using TPointVec = std::vector<TPoint>;
+
+    CEnsemble<TPoint> ensemble{buildEnsemble<TPoint>(recordProgress, frame)};
+    LOG_TRACE(<< "Ensemble = " << ensemble.print());
 
     // The points will be entirely overwritten by readRows so the initial
     // value is not important. This is presized so that rowsToPoints only
     // needs to access and write to each element. Since it does this once
     // per element it is thread safe.
-    TVectorVec points(frame.numberRows(), TVector{nullptr, 1});
+    TPointVec points(frame.numberRows(), TPoint{nullptr, 1});
 
     auto rowsToPoints = [&points](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            points[row->index()] = CDataFrameUtils::rowTo<TVector>(*row);
+            points[row->index()] = CDataFrameUtils::rowTo<TPoint>(*row);
         }
     };
 
@@ -103,15 +521,13 @@ bool computeOutliersNoPartitions(std::size_t numberThreads,
         return false;
     }
 
-    COutliers outliers{recordProgress};
-
     TDoubleVec scores;
-    outliers.ensemble(std::move(points), scores);
+    ensemble.computeOutlierScores(points, scores);
 
     // This never happens now, but it is a sanity check against someone
-    // changing COutliers to accidentally write to the data frame via one
-    // of the memory mapped vectors. All bets are off as to if we generate
-    // anything meaningful if this happens.
+    // changing CLocalOutlierFactors to accidentally write to the data
+    // frame via one of the memory mapped vectors. All bets are off as to
+    // if we generate anything meaningful if this happens.
     if (checksum != frame.checksum()) {
         LOG_ERROR(<< "Accidentally modified the data frame");
         return false;
@@ -133,9 +549,9 @@ bool computeOutliersNoPartitions(std::size_t numberThreads,
 }
 }
 
-bool computeOutliers(std::size_t numberThreads,
-                     std::function<void(double)> recordProgress,
-                     core::CDataFrame& frame) {
+void COutliers::compute(std::size_t numberThreads,
+                        core::CDataFrame& frame,
+                        TProgressCallback recordProgress) {
     // TODO memory monitoring.
     // TODO different analysis types.
 
@@ -146,13 +562,47 @@ bool computeOutliers(std::size_t numberThreads,
             HANDLE_FATAL(<< "Internal error: computing outliers for data frame. There "
                          << "may be more details in the logs. Please report this problem.");
         }
-        return true;
+        return;
     }
 
     // TODO this needs to work out the partitioning and run outlier detection
     // one partition at a time.
+}
 
-    return false;
+void COutliers::normalize(TDoubleVec& scores, double pOutlier) {
+
+    TMeanVarAccumulator moments;
+    for (const auto& score : scores) {
+        moments.add(CTools::fastLog(score));
+    }
+    double location{CBasicStatistics::mean(moments)};
+    double scale{std::sqrt(CBasicStatistics::variance(moments))};
+
+    double pInlier{1.0 - pOutlier};
+
+    if (scale > 0.0) {
+        try {
+            boost::math::lognormal lognormal(location, scale);
+            for (auto& score : scores) {
+                // The conditional probability follows from Bayes rule.
+                double pOutlierGivenScore{
+                    probabilityOutlierGiven(CTools::safeCdf(lognormal, score))};
+                score = pOutlierGivenScore * pOutlier /
+                        (pOutlierGivenScore * pOutlier + (1.0 - pOutlierGivenScore) * pInlier);
+            }
+        } catch (const std::exception& e) {
+            LOG_ERROR(<< "Failed to normalise scores: " << e.what());
+        }
+    } else {
+        scores.assign(scores.size(), 0.0);
+    }
+}
+
+double COutliers::probabilityOutlierGiven(double scorePercentile) {
+    return shrink(scorePercentile, 0.99);
+}
+
+void COutliers::noop(double) {
 }
 }
 }

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -315,7 +315,8 @@ void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulatorVec& logScoreMoment
                 // an outlier, it is effectively ignored. The rationale for keeping going
                 // therefore is that this handling is good enough that the results may
                 // still be useful.
-                LOG_ERROR(<< "Failed to normalise scores: " << e.what());
+                LOG_WARN(<< "Failed to normalise scores: '" << e.what()
+                         << "'. Results maybe compromised.");
             }
         }
 

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -340,7 +340,7 @@ void COutliersTest::testEnsemble() {
     TDoubleVec TN;
     TDoubleVec FP;
     TDoubleVec FN;
-    double precisionLowerBounds[]{0.24, 0.85, 0.98};
+    double precisionLowerBounds[]{0.23, 0.85, 0.98};
     double recallLowerBounds[]{0.98, 0.92, 0.62};
 
     // Test sequential then parallel.

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -340,8 +340,8 @@ void COutliersTest::testEnsemble() {
     TDoubleVec TN;
     TDoubleVec FP;
     TDoubleVec FN;
-    double precisionLowerBounds[]{0.28, 0.94, 0.99};
-    double recallLowerBounds[]{0.98, 0.86, 0.33};
+    double precisionLowerBounds[]{0.24, 0.85, 0.98};
+    double recallLowerBounds[]{0.98, 0.92, 0.62};
 
     // Test sequential then parallel.
 

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -7,6 +7,7 @@
 #include "COutliersTest.h"
 
 #include <core/CContainerPrinter.h>
+#include <core/CDataFrame.h>
 #include <core/CLogger.h>
 
 #include <maths/CLinearAlgebraEigen.h>
@@ -31,6 +32,7 @@ using TMaxAccumulator =
     maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr, std::greater<TDoubleSizePr>>;
 using TVector = maths::CDenseVector<double>;
 using TVectorVec = std::vector<TVector>;
+using TFactoryFunc = std::function<std::unique_ptr<core::CDataFrame>(const TVectorVec&)>;
 
 class COutliersTestInternals : public maths::COutliers {
 public:
@@ -58,13 +60,11 @@ void nearestNeightbours(std::size_t k, const TVectorVec& points, const TVector& 
     }
 }
 
-template<typename VECTOR>
-void gaussianWithUniformNoiseForPresizedPoints(test::CRandomNumbers& rng,
-                                               std::size_t numberInliers,
-                                               std::size_t numberOutliers,
-                                               std::vector<VECTOR>& points) {
-
-    CPPUNIT_ASSERT_EQUAL(numberInliers + numberOutliers, points.size());
+void gaussianWithUniformNoise(test::CRandomNumbers& rng,
+                              std::size_t numberInliers,
+                              std::size_t numberOutliers,
+                              TVectorVec& points) {
+    points.assign(numberInliers + numberOutliers, TVector(6));
 
     TDoubleVec mean{1.0, 10.0, 4.0, 8.0, 3.0, 5.0};
     TDoubleVecVec covariance{
@@ -90,59 +90,76 @@ void gaussianWithUniformNoiseForPresizedPoints(test::CRandomNumbers& rng,
     }
 }
 
-void gaussianWithUniformNoise(test::CRandomNumbers& rng,
-                              std::size_t numberInliers,
-                              std::size_t numberOutliers,
-                              TVectorVec& points) {
-    points.assign(numberInliers + numberOutliers, TVector(6));
-    gaussianWithUniformNoiseForPresizedPoints(rng, numberInliers, numberOutliers, points);
+auto toMainMemoryDataFrame(const TVectorVec& points) {
+    CPPUNIT_ASSERT(points.size() > 0);
+
+    auto result =
+        core::makeMainStorageDataFrame(maths::las::dimension(points[0])).first;
+
+    for (const auto& point : points) {
+        result->writeRow([&point](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            for (std::size_t d = 0; d < maths::las::dimension(point); ++d, ++column) {
+                *column = point(d);
+            }
+        });
+    }
+    result->finishWritingRows();
+
+    return result;
 }
 
-template<typename VECTOR>
-void outlierErrorStatisticsForEnsemble(test::CRandomNumbers& rng,
+void outlierErrorStatisticsForEnsemble(TFactoryFunc pointsToDataFrame,
                                        std::size_t numberInliers,
                                        std::size_t numberOutliers,
-                                       std::vector<VECTOR>& points,
                                        TDoubleVec& TP,
                                        TDoubleVec& TN,
                                        TDoubleVec& FP,
                                        TDoubleVec& FN) {
+    test::CRandomNumbers rng;
 
     TP.assign(3, 0.0);
     TN.assign(3, 0.0);
     FP.assign(3, 0.0);
     FN.assign(3, 0.0);
-
     TSizeVec trueOutliers(numberOutliers, 0);
     std::iota(trueOutliers.begin(), trueOutliers.end(), numberInliers);
 
+    TVectorVec points;
+    TDoubleVec scores(numberInliers + numberOutliers);
+
     for (std::size_t t = 0; t < 100; ++t) {
-        gaussianWithUniformNoiseForPresizedPoints(rng, numberInliers, numberOutliers, points);
+        gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
-        maths::COutliers lofs;
+        auto dataFrame = pointsToDataFrame(points);
 
-        TDoubleVec scores;
-        lofs.ensemble(points, scores);
+        maths::COutliers::compute(1, *dataFrame);
+
+        dataFrame->readRows(1, [&scores](core::CDataFrame::TRowItr beginRows,
+                                         core::CDataFrame::TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                scores[row->index()] = (*row)[6];
+            }
+        });
 
         TSizeVec outliers[3];
         for (std::size_t i = 0; i < scores.size(); ++i) {
             if (scores[i] >= 0.1) {
                 outliers[0].push_back(i);
             }
-            if (scores[i] >= 1.0) {
+            if (scores[i] >= 0.5) {
                 outliers[1].push_back(i);
             }
-            if (scores[i] >= 10.0) {
+            if (scores[i] >= 0.9) {
                 outliers[2].push_back(i);
             }
         }
 
         if (t % 10 == 0) {
-            LOG_DEBUG(<< "outliers at 0.1  = "
+            LOG_DEBUG(<< "outliers at 0.1 = "
                       << core::CContainerPrinter::print(outliers[0]));
-            LOG_DEBUG(<< "outliers at 1.0  = "
+            LOG_DEBUG(<< "outliers at 0.5 = "
                       << core::CContainerPrinter::print(outliers[1]));
-            LOG_DEBUG(<< "outliers at 10.0 = "
+            LOG_DEBUG(<< "outliers at 0.9 = "
                       << core::CContainerPrinter::print(outliers[2]));
         }
 
@@ -158,11 +175,11 @@ void outlierErrorStatisticsForEnsemble(test::CRandomNumbers& rng,
         }
     }
 
-    LOG_DEBUG(<< "At 0.1:  TP = " << TP[0] << " TN = " << TN[0]
+    LOG_DEBUG(<< "At 0.1: TP = " << TP[0] << " TN = " << TN[0]
               << " FP = " << FP[0] << " FN = " << FN[0]);
-    LOG_DEBUG(<< "At 1.0:  TP = " << TP[1] << " TN = " << TN[1]
+    LOG_DEBUG(<< "At 0.5: TP = " << TP[1] << " TN = " << TN[1]
               << " FP = " << FP[1] << " FN = " << FN[1]);
-    LOG_DEBUG(<< "At 10.0: TP = " << TP[2] << " TN = " << TN[2]
+    LOG_DEBUG(<< "At 0.9: TP = " << TP[2] << " TN = " << TN[2]
               << " FP = " << FP[2] << " FN = " << FN[2]);
 }
 }
@@ -201,10 +218,8 @@ void COutliersTest::testLof() {
                            "-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, "
                            "-1, -1, -1, -1, -1]"};
     for (auto k : {5, 10, 15}) {
-        maths::COutliers lofs;
-
         TDoubleVec scores;
-        lofs.normalizedLof(k, false, points, scores);
+        maths::COutliers::normalizedLof(k, points, scores);
 
         TMaxAccumulator outliers_(numberOutliers);
         for (std::size_t i = 0u; i < scores.size(); ++i) {
@@ -232,11 +247,9 @@ void COutliersTest::testDlof() {
     TVectorVec points;
     gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
-    maths::COutliers lofs;
-
     TDoubleVec scores;
     std::size_t k{10};
-    lofs.normalizedLdof(k, false, points, scores);
+    maths::COutliers::normalizedLdof(k, points, scores);
     LOG_DEBUG(<< "scores = " << core::CContainerPrinter::print(scores));
 
     TMaxAccumulator outlierScoresWithoutProjecting(numberOutliers);
@@ -263,35 +276,6 @@ void COutliersTest::testDlof() {
     for (std::size_t i = 0; i < scores.size(); ++i) {
         CPPUNIT_ASSERT_DOUBLES_EQUAL(ldof[i], scores[i], 1e-6);
     }
-
-    // Compare outliers when projecting (should be similar).
-
-    lofs.normalizedLdof(k, true, points, scores);
-
-    TMaxAccumulator outlierScoresProjecting(numberOutliers);
-    for (std::size_t i = 0; i < scores.size(); ++i) {
-        outlierScoresProjecting.add({scores[i], i});
-    }
-
-    TSizeVec outliersWithoutProjecting;
-    TSizeVec outliersProjecting;
-    for (std::size_t i = 0; i < numberOutliers; ++i) {
-        outliersWithoutProjecting.push_back(outlierScoresWithoutProjecting[i].second);
-        outliersProjecting.push_back(outlierScoresProjecting[i].second);
-    }
-
-    std::sort(outliersWithoutProjecting.begin(), outliersWithoutProjecting.end());
-    std::sort(outliersProjecting.begin(), outliersProjecting.end());
-    LOG_DEBUG(<< "without projecting = "
-              << core::CContainerPrinter::print(outliersWithoutProjecting));
-    LOG_DEBUG(<< "projecting         = "
-              << core::CContainerPrinter::print(outliersProjecting));
-
-    double similarity{maths::CSetTools::jaccard(
-        outliersWithoutProjecting.begin(), outliersWithoutProjecting.end(),
-        outliersProjecting.begin(), outliersProjecting.end())};
-
-    CPPUNIT_ASSERT(similarity > 0.4);
 }
 
 void COutliersTest::testDistancekNN() {
@@ -303,11 +287,9 @@ void COutliersTest::testDistancekNN() {
     TVectorVec points;
     gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
-    maths::COutliers lofs;
-
     TDoubleVec scores;
     std::size_t k{10};
-    lofs.normalizedDistancekNN(k, false, points, scores);
+    maths::COutliers::normalizedDistancekNN(k, points, scores);
     LOG_DEBUG(<< "scores = " << core::CContainerPrinter::print(scores));
 
     TMaxAccumulator outlierScoresWithoutProjecting(numberOutliers);
@@ -327,34 +309,6 @@ void COutliersTest::testDistancekNN() {
     for (std::size_t i = 0; i < scores.size(); ++i) {
         CPPUNIT_ASSERT_DOUBLES_EQUAL(distances[i], scores[i], 1e-6);
     }
-
-    // Compare outliers when projecting (should be similar).
-
-    lofs.normalizedDistancekNN(k, true, points, scores);
-
-    TMaxAccumulator outlierScoresProjecting(numberOutliers);
-    for (std::size_t i = 0; i < scores.size(); ++i) {
-        outlierScoresProjecting.add({scores[i], i});
-    }
-
-    TSizeVec outliersWithoutProjecting;
-    TSizeVec outliersProjecting;
-    for (std::size_t i = 0; i < numberOutliers; ++i) {
-        outliersWithoutProjecting.push_back(outlierScoresWithoutProjecting[i].second);
-        outliersProjecting.push_back(outlierScoresProjecting[i].second);
-    }
-
-    std::sort(outliersWithoutProjecting.begin(), outliersWithoutProjecting.end());
-    std::sort(outliersProjecting.begin(), outliersProjecting.end());
-    LOG_DEBUG(<< "without projecting = "
-              << core::CContainerPrinter::print(outliersWithoutProjecting));
-    LOG_DEBUG(<< "projecting         = "
-              << core::CContainerPrinter::print(outliersProjecting));
-
-    double similarity{maths::CSetTools::jaccard(
-        outliersWithoutProjecting.begin(), outliersWithoutProjecting.end(),
-        outliersProjecting.begin(), outliersProjecting.end())};
-    CPPUNIT_ASSERT(similarity > 0.9);
 }
 
 void COutliersTest::testTotalDistancekNN() {
@@ -366,11 +320,9 @@ void COutliersTest::testTotalDistancekNN() {
     TVectorVec points;
     gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
-    maths::COutliers lofs;
-
     TDoubleVec scores;
     std::size_t k{10};
-    lofs.normalizedTotalDistancekNN(k, false, points, scores);
+    maths::COutliers::normalizedTotalDistancekNN(k, points, scores);
     LOG_DEBUG(<< "scores = " << core::CContainerPrinter::print(scores));
 
     TMaxAccumulator outlierScoresWithoutProjecting(numberOutliers);
@@ -394,43 +346,17 @@ void COutliersTest::testTotalDistancekNN() {
     for (std::size_t i = 0; i < scores.size(); ++i) {
         CPPUNIT_ASSERT_DOUBLES_EQUAL(distances[i], scores[i], 1e-6);
     }
-
-    // Compare outliers when projecting (should be similar).
-
-    lofs.normalizedTotalDistancekNN(k, true, points, scores);
-
-    TMaxAccumulator outlierScoresProjecting(numberOutliers);
-    for (std::size_t i = 0; i < scores.size(); ++i) {
-        outlierScoresProjecting.add({scores[i], i});
-    }
-
-    TSizeVec outliersWithoutProjecting;
-    TSizeVec outliersProjecting;
-    for (std::size_t i = 0; i < numberOutliers; ++i) {
-        outliersWithoutProjecting.push_back(outlierScoresWithoutProjecting[i].second);
-        outliersProjecting.push_back(outlierScoresProjecting[i].second);
-    }
-
-    std::sort(outliersWithoutProjecting.begin(), outliersWithoutProjecting.end());
-    std::sort(outliersProjecting.begin(), outliersProjecting.end());
-    LOG_DEBUG(<< "without projecting = "
-              << core::CContainerPrinter::print(outliersWithoutProjecting));
-    LOG_DEBUG(<< "projecting         = "
-              << core::CContainerPrinter::print(outliersProjecting));
-
-    double similarity{maths::CSetTools::jaccard(
-        outliersWithoutProjecting.begin(), outliersWithoutProjecting.end(),
-        outliersProjecting.begin(), outliersProjecting.end())};
-    CPPUNIT_ASSERT(similarity > 0.9);
 }
 
 void COutliersTest::testEnsemble() {
-    // Check error stats for scores, 0.1, 1.0 and 10.0. We should see precision increase
+    // Check error stats for scores, 0.1, 0.5 and 0.9. We should see precision increase
     // for higher scores but recall decrease.
     //
     // In practice, the samples are randomly generated so it isn't necessarily the case
     // that those generated from the different process are the outliers, they simply have
     // a much higher probability of this being the case.
+
+    // TODO test outlier detection with and without partitioning are equivalent.
 
     std::size_t numberInliers{100};
     std::size_t numberOutliers{20};
@@ -439,55 +365,21 @@ void COutliersTest::testEnsemble() {
     TDoubleVec TN;
     TDoubleVec FP;
     TDoubleVec FN;
-    double precisionLowerBounds[]{0.8, 0.85, 0.95};
-    double recallLowerBounds[]{0.86, 0.7, 0.21};
+    double precisionLowerBounds[]{0.66, 0.92, 1.0};
+    double recallLowerBounds[]{0.97, 0.94, 0.07};
 
     // Test sequential then parallel.
 
-    core::stopDefaultAsyncExecutor();
-
     std::string tags[]{"sequential", "parallel"};
 
-    for (std::size_t t = 0; t < 2; ++t) {
-        LOG_DEBUG(<< "Testing " << tags[t]);
-
-        test::CRandomNumbers rng;
-
-        TVectorVec points(numberInliers + numberOutliers, TVector(6));
-
-        outlierErrorStatisticsForEnsemble(rng, numberInliers, numberOutliers,
-                                          points, TP, TN, FP, FN);
-
-        for (std::size_t i = 0; i < 3; ++i) {
-            double precision{TP[i] / (TP[i] + FP[i])};
-            double recall{TP[i] / (TP[i] + FN[i])};
-            LOG_DEBUG(<< "precision = " << precision);
-            LOG_DEBUG(<< "recall = " << recall);
-            CPPUNIT_ASSERT(precision >= precisionLowerBounds[i]);
-            CPPUNIT_ASSERT(recall >= recallLowerBounds[i]);
-        }
-
-        core::startDefaultAsyncExecutor();
-    }
-
     core::stopDefaultAsyncExecutor();
 
     for (std::size_t t = 0; t < 2; ++t) {
         LOG_DEBUG(<< "Testing " << tags[t]);
 
-        using TMemoryMappedVector = maths::CMemoryMappedDenseVector<double>;
-        using TMemoryMappedVectorVec = std::vector<TMemoryMappedVector>;
+        outlierErrorStatisticsForEnsemble(toMainMemoryDataFrame, numberInliers,
+                                          numberOutliers, TP, TN, FP, FN);
 
-        test::CRandomNumbers rng;
-
-        TDoubleVec storage((numberInliers + numberOutliers) * 6);
-        TMemoryMappedVectorVec points;
-        for (std::size_t i = 0; i < numberInliers + numberOutliers; ++i) {
-            points.emplace_back(&storage[6 * i], 6);
-        }
-
-        outlierErrorStatisticsForEnsemble(rng, numberInliers, numberOutliers,
-                                          points, TP, TN, FP, FN);
         for (std::size_t i = 0; i < 3; ++i) {
             double precision{TP[i] / (TP[i] + FP[i])};
             double recall{TP[i] / (TP[i] + FN[i])};
@@ -507,37 +399,41 @@ void COutliersTest::testProgressMonitoring() {
 
     // Test progress monitoring invariants.
 
-    std::size_t numberInliers{100000};
+    // TODO test outlier detection with and without partitioning are equivalent.
+
+    std::size_t numberInliers{10000};
     std::size_t numberOutliers{500};
 
     test::CRandomNumbers rng;
 
     TVectorVec points(numberInliers + numberOutliers, TVector(6));
+    gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
+
+    auto dataFrame = toMainMemoryDataFrame(points);
 
     std::atomic_int totalFractionalProgress{0};
 
     auto reportProgress = [&totalFractionalProgress](double fractionalProgress) {
-        totalFractionalProgress.fetch_add(static_cast<int>(1024.0 * fractionalProgress + 0.5));
+        totalFractionalProgress.fetch_add(static_cast<int>(65536.0 * fractionalProgress + 0.5));
     };
 
     std::atomic_bool finished{false};
 
-    std::thread worker{[&](TVectorVec points_) {
-                           maths::COutliers lofs{reportProgress};
-                           TDoubleVec scores;
-                           lofs.ensemble(points_, scores);
-                           finished.store(true);
-                       },
-                       std::move(points)};
+    std::thread worker{[&]() {
+        maths::COutliers::compute(1, *dataFrame, reportProgress);
+        finished.store(true);
+    }};
 
     int lastTotalFractionalProgress{0};
     int lastProgressReport{0};
 
     bool monotonic{true};
+    std::size_t percentage{0};
     while (finished.load() == false) {
         if (totalFractionalProgress.load() > lastProgressReport) {
-            LOG_DEBUG(<< (static_cast<double>(lastProgressReport) / 10) << "% complete");
-            lastProgressReport += 100;
+            LOG_DEBUG(<< percentage << "% complete");
+            percentage += 10;
+            lastProgressReport += 6554;
         }
         monotonic &= (totalFractionalProgress.load() >= lastTotalFractionalProgress);
         lastTotalFractionalProgress = totalFractionalProgress.load();
@@ -545,7 +441,7 @@ void COutliersTest::testProgressMonitoring() {
     worker.join();
 
     CPPUNIT_ASSERT(monotonic);
-    CPPUNIT_ASSERT_EQUAL(1024, totalFractionalProgress.load());
+    CPPUNIT_ASSERT(std::fabs(65536 - totalFractionalProgress.load()) < 100);
 }
 
 CppUnit::Test* COutliersTest::suite() {

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -258,7 +258,7 @@ void COutliersTest::testDlof() {
     LOG_DEBUG(<< "normalized ldof = " << core::CContainerPrinter::print(ldof));
 
     for (std::size_t i = 0; i < scores.size(); ++i) {
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(ldof[i], scores[i], 1e-6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(ldof[i], scores[i], 1e-5);
     }
 }
 
@@ -291,7 +291,7 @@ void COutliersTest::testDistancekNN() {
     LOG_DEBUG(<< "normalized distances = " << core::CContainerPrinter::print(distances));
 
     for (std::size_t i = 0; i < scores.size(); ++i) {
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(distances[i], scores[i], 1e-6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(distances[i], scores[i], 1e-5);
     }
 }
 
@@ -328,7 +328,7 @@ void COutliersTest::testTotalDistancekNN() {
     LOG_DEBUG(<< "normalized distances = " << core::CContainerPrinter::print(distances));
 
     for (std::size_t i = 0; i < scores.size(); ++i) {
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(distances[i], scores[i], 1e-6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(distances[i], scores[i], 1e-5);
     }
 }
 


### PR DESCRIPTION
This reworks outlier detection to provide a more principled ensemble. We want a diverse ensemble (independent errors) and as such randomise ensemble members on various key parameters:
1. The method (I've stratified along general classes of method so we get equal numbers local and global methods),
2. The vector projections,
3. The point subset used for nearest neighbour queries and
4. The number of nearest neighbours.

I've also overhauled ensemble aggregation along Bayesian lines. We start off with a (potentially configurable) prior probability that a point is an outlier and update our conditional belief that the point is actually an outlier based on its outlier score for each ensemble member.

We already calculated a quantity which relates to the chance that the raw score (or larger) is drawn from population distribution of raw scores (in order to normalise it). However, I've reworked it to fit a log normal distribution to the scores since this tended to fit the observed distribution significantly better. (We could do model selection here and that is something to revisit.)

The normalised score isn't a bad proxy to the likelihood the point is an outlier (provided the method approximately matches the required definition). However, I introduced a mapping such that we learn a lot more from high than low normalised scores. The intuition here is that points typically aren't outlying in all projections/downsamples; this was also born out in empirically better results. (There is potential to calibrate this better based on methods' real ROC curve slopes across a diverse collection of data sets, but I haven't done this work yet.)

This also, incidentally, fixed the TODOs in the upfront memory requirements calculation.

This gave us pretty good wins across our evaluation set: mean AU(ROC)C improved by 5% and worst case 30%. That means over the 20 data sets in our eval set we're now within 8% on average of the best QoR with optimal parameters for any of KNN, KNNW, LOF, LoOP, ODIN, KDEOS, LDF, INFLO and COF. We also obtain state-of-the-art performance for the Annthyroid and SpamBase data sets.

This is a fairly large reworking of the outlier detection, although I haven't significantly altered the basic implementations of the individual methods. It is difficult to make these changes in isolation because I wanted to evaluate the result of the change as a whole.