### PR TITLE
[ML] Correctly write field names for data frame analytics results

### DIFF
--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -264,9 +264,9 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
             outputWriter.StartObject();
             outputWriter.String(ROW_RESULTS);
             outputWriter.StartObject();
-            outputWriter.Key(CHECKSUM);
+            outputWriter.String(CHECKSUM);
             outputWriter.Int(row->docHash());
-            outputWriter.Key(RESULTS);
+            outputWriter.String(RESULTS);
             analysis.writeOneRow(*row, outputWriter);
             outputWriter.EndObject();
             outputWriter.EndObject();


### PR DESCRIPTION
The function `Key()` was used accidentally on the JSON writer when
`String()` should be used for field names. This was causing an
assertion to trigger.