### PR TITLE
[ML] Defend against data frame spec not being an object

### DIFF
--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -79,7 +79,8 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
     } else {
 
         if (document.IsObject() == false) {
-            HANDLE_FATAL(<< "Input error: expected object but input was '" << jsonSpecification << "'");
+            HANDLE_FATAL(<< "Input error: expected object but input was '"
+                         << jsonSpecification << "'");
             return;
         }
 

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -77,6 +77,12 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         HANDLE_FATAL(<< "Input error: failed to parse analysis specification '"
                      << jsonSpecification << "'. Please report this problem.");
     } else {
+
+        if (document.IsObject() == false) {
+            HANDLE_FATAL(<< "Input error: expected object but input was '" << jsonSpecification << "'");
+            return;
+        }
+
         auto isPositiveInteger = [](const rapidjson::Value& value) {
             return value.IsUint() && value.GetUint() > 0;
         };

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -262,7 +262,7 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
     m_DataFrame->readRows(numberThreads, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             outputWriter.StartObject();
-            outputWriter.String(ROW_RESULTS);
+            outputWriter.Key(ROW_RESULTS);
             outputWriter.StartObject();
             outputWriter.Key(CHECKSUM);
             outputWriter.Int(row->docHash());


### PR DESCRIPTION
There is a test that passes input to the data frame
specification that is not a JSON object. The constructor
is not guarding against that and proceeds into calling
`HasMember` which then triggers the assertion that the
document is not an object.