### PR TITLE
[ML] Fix race condition in test assertion

### DIFF
--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -229,7 +229,7 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
         CPPUNIT_ASSERT(runner != nullptr);
 
         double lastProgress{runner->progress()};
-        while (runner->finished()) {
+        while (runner->finished() == false) {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
             LOG_TRACE(<< "progress = " << lastProgress);
             CPPUNIT_ASSERT(runner->progress() >= lastProgress);

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -229,16 +229,12 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
         CPPUNIT_ASSERT(runner != nullptr);
 
         double lastProgress{runner->progress()};
-        for (;;) {
+        while (runner->finished()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
-
             LOG_TRACE(<< "progress = " << lastProgress);
             CPPUNIT_ASSERT(runner->progress() >= lastProgress);
             lastProgress = runner->progress();
-            if (runner->finished()) {
-                break;
-            }
-            CPPUNIT_ASSERT(runner->progress() < 1.0);
+            CPPUNIT_ASSERT(runner->progress() <= 1.0);
         }
 
         LOG_DEBUG(<< "progress = " << lastProgress);


### PR DESCRIPTION
We could conceivably set the task to finished between checking the loop exit condition and checking the progress is less than one. This would cause the assertion to trigger. This has been observed in CI.