### PR TITLE
[ML] Partitioned outlier detection

### DIFF
--- a/include/core/CDataFrameRowSlice.h
+++ b/include/core/CDataFrameRowSlice.h
@@ -31,6 +31,7 @@ public:
 public:
     virtual ~CDataFrameRowSliceHandleImpl() = default;
     virtual TImplPtr clone() const = 0;
+    virtual std::size_t indexOfFirstRow() const = 0;
     virtual TFloatVec& rows() const = 0;
     virtual const TInt32Vec& docHashes() const = 0;
     virtual bool bad() const = 0;
@@ -57,6 +58,7 @@ public:
     CDataFrameRowSliceHandle& operator=(CDataFrameRowSliceHandle&& other);
 
     std::size_t size() const;
+    std::size_t indexOfFirstRow() const;
     TFloatVecItr beginRows() const;
     TFloatVecItr endRows() const;
     TInt32VecCItr beginDocHashes() const;
@@ -73,13 +75,13 @@ private:
 class CORE_EXPORT CDataFrameRowSlice {
 public:
     using TFloatVec = std::vector<CFloatStorage>;
-    using TSizeHandlePr = std::pair<std::size_t, CDataFrameRowSliceHandle>;
     using TInt32Vec = std::vector<std::int32_t>;
 
 public:
     virtual ~CDataFrameRowSlice() = default;
     virtual void reserve(std::size_t numberColumns, std::size_t extraColumns) = 0;
-    virtual TSizeHandlePr read() = 0;
+    virtual std::size_t indexOfFirstRow() const = 0;
+    virtual CDataFrameRowSliceHandle read() = 0;
     virtual void write(const TFloatVec& rows, const TInt32Vec& docHashes) = 0;
     virtual std::size_t staticSize() const = 0;
     virtual std::size_t memoryUsage() const = 0;
@@ -100,12 +102,13 @@ class CORE_EXPORT CMainMemoryDataFrameRowSlice final : public CDataFrameRowSlice
 public:
     CMainMemoryDataFrameRowSlice(std::size_t firstRow, TFloatVec rows, TInt32Vec docHashes);
 
-    virtual void reserve(std::size_t numberColumns, std::size_t extraColumns);
-    virtual TSizeHandlePr read();
-    virtual void write(const TFloatVec& rows, const TInt32Vec& docHashes);
-    virtual std::size_t staticSize() const;
-    virtual std::size_t memoryUsage() const;
-    virtual std::uint64_t checksum() const;
+    void reserve(std::size_t numberColumns, std::size_t extraColumns) override;
+    std::size_t indexOfFirstRow() const override;
+    CDataFrameRowSliceHandle read() override;
+    void write(const TFloatVec& rows, const TInt32Vec& docHashes) override;
+    std::size_t staticSize() const override;
+    std::size_t memoryUsage() const override;
+    std::uint64_t checksum() const override;
 
 private:
     std::size_t m_FirstRow;
@@ -163,12 +166,13 @@ public:
                              TFloatVec rows,
                              TInt32Vec docHashes);
 
-    virtual void reserve(std::size_t numberColumns, std::size_t extraColumns);
-    virtual TSizeHandlePr read();
-    virtual void write(const TFloatVec& rows, const TInt32Vec& docHashes);
-    virtual std::size_t staticSize() const;
-    virtual std::size_t memoryUsage() const;
-    virtual std::uint64_t checksum() const;
+    void reserve(std::size_t numberColumns, std::size_t extraColumns) override;
+    std::size_t indexOfFirstRow() const override;
+    CDataFrameRowSliceHandle read() override;
+    void write(const TFloatVec& rows, const TInt32Vec& docHashes) override;
+    std::size_t staticSize() const override;
+    std::size_t memoryUsage() const override;
+    std::uint64_t checksum() const override;
 
 private:
     void writeToDisk(const TFloatVec& rows, const TInt32Vec& docHashes);

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -33,7 +33,7 @@ template<typename T>
 struct SRowTo<CDenseVector<T>> {
     static CDenseVector<T> dispatch(const core::CDataFrame::TRowRef& row) {
         std::size_t n{row.numberColumns()};
-        CDenseVector<T> result{n};
+        CDenseVector<T> result{SConstant<CDenseVector<T>>::get(n, 0)};
         for (std::size_t i = 0; i < n; ++i) {
             result(i) = row[i];
         }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -114,7 +114,8 @@ void CDataFrameOutliersRunner::writeOneRow(TRowRef row,
 }
 
 void CDataFrameOutliersRunner::runImpl(core::CDataFrame& frame) {
-    maths::COutliers::compute(this->spec().numberThreads(), frame, this->progressRecorder());
+    maths::COutliers::compute(this->spec().numberThreads(), this->numberPartitions(),
+                              frame, this->progressRecorder());
 }
 
 std::size_t

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -13,6 +13,7 @@ class CDataFrameAnalyzerTest : public CppUnit::TestFixture {
 public:
     void testWithoutControlMessages();
     void testRunOutlierDetection();
+    void testRunOutlierDetectionPartitioned();
     void testFlushMessage();
     void testErrors();
     void testRoundTripDocHashes();

--- a/lib/core/unittest/CDataFrameTest.h
+++ b/lib/core/unittest/CDataFrameTest.h
@@ -17,6 +17,8 @@ public:
     void testInMainMemoryParallelRead();
     void testOnDiskBasicReadWrite();
     void testOnDiskParallelRead();
+    void testReadRange();
+    void testWriteRange();
     void testMemoryUsage();
     void testReserve();
     void testResizeColumns();


### PR DESCRIPTION
This fills in the missing functionality to perform out-of-core outlier detection paging in only as many points as will fit given the main memory constraint.

The bulk of this change is to add efficient read/write row range methods to a data frame.

I also slightly tightened up the constraint on minimum row count to trigger a failure. This is now proportional to (number rows)^(1/2) since it should still allow us to process very large data sets subject to a reasonable memory constraint. If the partition count gets too high there are significant runtime overheads so I think it makes sense to just request the user allots more memory in these cases.