### PR TITLE
[ML] Improve performance of k-d tree nearest neighbour search

### DIFF
--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -372,8 +372,8 @@ private:
             nearest = &node.s_Point;
         }
 
-        SNode* primary{node.s_LeftChild};
-        SNode* secondary{node.s_RightChild};
+        const SNode* primary{node.s_LeftChild};
+        const SNode* secondary{node.s_RightChild};
 
         if (primary != nullptr && secondary != nullptr) {
             TCoordinatePrecise distanceToHyperplane{point(coordinate) -
@@ -422,8 +422,8 @@ private:
             std::push_heap(nearest.begin(), nearest.end(), less);
         }
 
-        SNode* primary{node.s_LeftChild};
-        SNode* secondary{node.s_RightChild};
+        const SNode* primary{node.s_LeftChild};
+        const SNode* secondary{node.s_RightChild};
 
         if (primary != nullptr && secondary != nullptr) {
             TCoordinatePrecise distanceToHyperplane{point(coordinate) -

--- a/include/maths/COrderings.h
+++ b/include/maths/COrderings.h
@@ -341,7 +341,6 @@ public:
             return lexicographical_compare(lhs.first, lhs.second, rhs.first,
                                            rhs.second, *this);
         }
-        SReferenceLess s_Less;
     };
 
     //! \brief Wrapper around various less than comparisons.
@@ -387,8 +386,6 @@ public:
             return lexicographical_compare(lhs.first, lhs.second, rhs.first,
                                            rhs.second, *this);
         }
-
-        SReferenceGreater s_Greater;
     };
 
     //! Lexicographical comparison of various common types.

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -70,8 +70,8 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(const std::stri
 
 CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryUPtrVec runnerFactories,
                                                                  const std::string& jsonSpecification)
-    : m_RunnerFactories{std::move(runnerFactories)},
-      m_TemporaryDirectory{boost::filesystem::current_path().string()} {
+    : m_TemporaryDirectory{boost::filesystem::current_path().string()},
+      m_RunnerFactories{std::move(runnerFactories)} {
 
     rapidjson::Document document;
     if (document.Parse(jsonSpecification.c_str()) == false) {

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -411,6 +411,8 @@ void COutliersTest::testProgressMonitoring() {
     TPointVec points(numberInliers + numberOutliers, TPoint(6));
     gaussianWithUniformNoise(rng, numberInliers, numberOutliers, points);
 
+    core::startDefaultAsyncExecutor(2);
+
     for (std::size_t i = 0; i < 2; ++i) {
 
         LOG_DEBUG(<< "# partitions = " << numberPartitions[i]);
@@ -450,8 +452,10 @@ void COutliersTest::testProgressMonitoring() {
         CPPUNIT_ASSERT(monotonic);
 
         LOG_DEBUG(<< "total fractional progress = " << totalFractionalProgress.load());
-        CPPUNIT_ASSERT(std::fabs(65536 - totalFractionalProgress.load()) < 250);
+        CPPUNIT_ASSERT(std::fabs(65536 - totalFractionalProgress.load()) < 300);
     }
+
+    core::startDefaultAsyncExecutor();
 }
 
 CppUnit::Test* COutliersTest::suite() {


### PR DESCRIPTION
There was a silly copy of the point class into a temporary in the `CKdTree::nearestNeighbours`. After fixing that creating temporary pairs to (maybe) push onto the heap still added 25% to its runtime so I've refactored to avoid this. Improving the lower bound on the search (to be the distance to point at the intersection of all hyperplanes above the current node in the recursion) gets a further 20% improvement. Finally, the modulo turned out much slower than a (predictable) branch for getting the next coordinate on which to compare and I've made some tweaks to take a few operations off the critical path. All-in-all this gives us around a 6x performance improvement of outlier detection.