### PR TITLE
[ML] Fix race to assert and process all messages in CConcurrentWrapperTest

### DIFF
--- a/lib/core/unittest/CConcurrentWrapperTest.cc
+++ b/lib/core/unittest/CConcurrentWrapperTest.cc
@@ -162,13 +162,16 @@ void CConcurrentWrapperTest::testThreadsLowCapacity() {
     std::ostringstream stringStream;
     static const size_t MESSAGES(2500);
 
-    TOStringStreamLowCapacityConcurrentWrapper wrappedStringStream(stringStream);
     {
-        core::CStaticThreadPool tp(8);
-        for (size_t i = 0; i < MESSAGES; ++i) {
-            tp.schedule([&wrappedStringStream, i] {
-                taskLowCapacityQueue(wrappedStringStream, i, std::chrono::microseconds(0));
-            });
+        TOStringStreamLowCapacityConcurrentWrapper wrappedStringStream(stringStream);
+        {
+            core::CStaticThreadPool tp(8);
+            for (size_t i = 0; i < MESSAGES; ++i) {
+                tp.schedule([&wrappedStringStream, i] {
+                    taskLowCapacityQueue(wrappedStringStream, i,
+                                         std::chrono::microseconds(0));
+                });
+            }
         }
     }
 


### PR DESCRIPTION
There is a race to the assert in the main thread and for the worker thread in the `CConcurrentWrapper` to process every message it has been passed. We should make sure the worker thread has joined before asserting that all messages have been processed.

Closes #398.