### PR TITLE
[ML] Features influencing outliers

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -103,9 +103,11 @@ public:
     //! </pre>
     //! with one named member for each column added.
     //!
+    //! \param[in] featureNames The names of the analysis features.
     //! \param[in] row The row to write the columns added by this analysis.
     //! \param[in,out] writer The stream to which to write the extra columns.
-    virtual void writeOneRow(TRowRef row,
+    virtual void writeOneRow(const TStrVec& featureNames,
+                             TRowRef row,
                              core::CRapidJsonConcurrentLineWriter& writer) const = 0;
 
     //! Checks whether the analysis is already running and if not launches it

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -70,6 +70,7 @@ private:
     bool prepareToReceiveControlMessages(const TStrVec& fieldNames);
     bool isControlMessage(const TStrVec& fieldValues) const;
     bool handleControlMessage(const TStrVec& fieldValues);
+    void captureFieldNames(const TStrVec& fieldNames);
     void addRowToDataFrame(const TStrVec& fieldValues);
     void monitorProgress(const CDataFrameAnalysisRunner& analysis,
                          core::CRapidJsonConcurrentLineWriter& writer) const;
@@ -87,6 +88,7 @@ private:
     std::uint64_t m_BadDocHashCount;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
     TDataFrameUPtr m_DataFrame;
+    TStrVec m_FieldNames;
     TTemporaryDirectoryPtr m_DataFrameDirectory;
     TJsonOutputStreamWrapperUPtrSupplier m_OutStreamSupplier;
 };

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -60,6 +60,12 @@ private:
     //!
     //! \see maths::COutliers for more details.
     std::size_t m_Method;
+
+    //! Compute the significance of features responsible for each point being outlying.
+    bool m_FeatureSignificances = false;
+
+    //! The prior probability that a point is an outlier.
+    double m_ProbabilityOutlier = 0.05;
     //@}
 };
 

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -63,11 +63,11 @@ private:
     //! \see maths::COutliers for more details.
     std::size_t m_Method;
 
-    //! Compute the significance of features responsible for each point being outlying.
-    bool m_FeatureSignificances = false;
+    //! Compute the relative influence of each feature on each point being outlying.
+    bool m_ComputeFeatureInfluence = false;
 
-    //! The minimum outlier score for which we'll write output feature significances.
-    double m_WriteFeatureSignificancesMinimumScore = 0.1;
+    //! The minimum outlier score for which we'll write out feature influence.
+    double m_WriteFeatureInfluenceMinimumScore = 0.1;
 
     //! The prior probability that a point is an outlier.
     double m_ProbabilityOutlier = 0.05;

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -32,7 +32,9 @@ public:
     std::size_t numberExtraColumns() const override;
 
     //! Write the extra columns of \p row added by outlier analysis to \p writer.
-    void writeOneRow(TRowRef row, core::CRapidJsonConcurrentLineWriter& writer) const override;
+    void writeOneRow(const TStrVec& featureNames,
+                     TRowRef row,
+                     core::CRapidJsonConcurrentLineWriter& writer) const override;
 
 private:
     using TOptionalSize = boost::optional<std::size_t>;
@@ -63,6 +65,9 @@ private:
 
     //! Compute the significance of features responsible for each point being outlying.
     bool m_FeatureSignificances = false;
+
+    //! The minimum outlier score for which we'll write output feature significances.
+    double m_WriteFeatureSignificancesMinimumScore = 0.1;
 
     //! The prior probability that a point is an outlier.
     double m_ProbabilityOutlier = 0.05;

--- a/include/maths/CLinearAlgebraShims.h
+++ b/include/maths/CLinearAlgebraShims.h
@@ -65,7 +65,7 @@ CSymmetricMatrix<T> conformableZeroMatrix(const CVector<T>& x) {
 //! Get the conformable zero initialized matrix for the Eigen dense vector.
 template<typename SCALAR>
 CDenseMatrix<SCALAR> conformableZeroMatrix(const CDenseVector<SCALAR>& x) {
-    return SConstant<CDenseMatrix<SCALAR>>::get(x.size(), 0);
+    return SConstant<CDenseMatrix<SCALAR>>::get(dimension(x), 0);
 }
 
 //! Get the conformable zero initialized matrix for the Eigen memory mapped vector.

--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -34,9 +34,22 @@ namespace ml {
 namespace maths {
 namespace outliers_detail {
 using TDoubleVec = std::vector<double>;
-using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TDouble2Vec = core::CSmallVector<double, 2>;
+using TDouble1VecVec = std::vector<TDouble1Vec>;
+using TDouble1VecVec2Vec = core::CSmallVector<TDouble1VecVec, 2>;
+using TDouble1Vec2Vec = core::CSmallVector<TDouble1Vec, 2>;
 using TProgressCallback = std::function<void(double)>;
 using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+//! Get the distance in the complement space of the projection.
+//!
+//! We use Euclidean distances so this is just \f$\sqrt{d^2 - x^2}\f$ for
+//! \f$d\f$ the total distance and \f$x\f$ is the distance in the projection
+//! space.
+inline double complementDistance(double distance, double projectionDistance) {
+    return std::sqrt(std::max(CTools::pow2(distance) - CTools::pow2(projectionDistance), 0.0));
+}
 
 //! \brief The interface for a nearest neighbour outlier calculation method.
 template<typename POINT, typename NEAREST_NEIGHBOURS>
@@ -45,9 +58,16 @@ public:
     using TPointVec = std::vector<POINT>;
 
 public:
-    CNearestNeighbourMethod(std::size_t k, NEAREST_NEIGHBOURS lookup, TProgressCallback recordProgress)
-        : m_K{k}, m_Lookup{std::move(lookup)}, m_RecordProgress{std::move(recordProgress)} {}
+    CNearestNeighbourMethod(bool featureSignificances,
+                            std::size_t k,
+                            NEAREST_NEIGHBOURS lookup,
+                            TProgressCallback recordProgress)
+        : m_FeatureSignificances{featureSignificances}, m_K{k}, m_Lookup{std::move(lookup)},
+          m_RecordProgress{std::move(recordProgress)} {}
     virtual ~CNearestNeighbourMethod() = default;
+
+    //! Check whether to compute coordinate scores.
+    bool featureSignificances() const { return m_FeatureSignificances; }
 
     //! The number of points.
     std::size_t n() const { return m_Lookup.size(); }
@@ -55,14 +75,17 @@ public:
     //! The number of nearest neighbours.
     std::size_t k() const { return m_K; }
 
+    //! Get the nearest neighbours lookup.
+    const NEAREST_NEIGHBOURS& lookup() const { return m_Lookup; }
+
     //! Compute the outlier scores for \p points.
-    void run(const TPointVec& points, std::size_t numberScores, TDoubleVecVec& scores) {
+    TDouble1VecVec2Vec run(const TPointVec& points, std::size_t numberScores) {
 
         this->setup(points);
 
         // We call add exactly once for each point. Scores is presized
         // so any writes to it are safe.
-        scores = TDoubleVecVec(this->numberMethods(), TDoubleVec(numberScores, 0.0));
+        TDouble1VecVec2Vec scores(this->numberMethods(), TDouble1VecVec(numberScores));
         core::parallel_for_each(points.begin(), points.end(),
                                 [&, neighbours = TPointVec{} ](const POINT& point) mutable {
                                     m_Lookup.nearestNeighbours(m_K + 1, point, neighbours);
@@ -73,7 +96,12 @@ public:
                                 });
 
         this->compute(points, scores);
+
+        return scores;
     }
+
+    //! Recover any temporary memory used by run.
+    virtual void recoverMemory() {}
 
     //! \name Progress Monitoring
     //@{
@@ -85,26 +113,28 @@ public:
     }
     //@}
 
+    //! Get a human readable description of the outlier detection method.
     virtual std::string print() const {
         return this->name() + "(n = " + std::to_string(this->n()) +
                ", k = " + std::to_string(m_K) + ")";
     }
 
     virtual void setup(const TPointVec&) {}
-    virtual void add(const POINT&, const TPointVec&, TDoubleVec&) {}
-    virtual void compute(const TPointVec&, TDoubleVec&) {}
+    virtual void add(const POINT&, const TPointVec&, TDouble1VecVec&) {}
+    virtual void compute(const TPointVec&, TDouble1VecVec&) {}
 
 private:
-    virtual void add(const POINT& point, const TPointVec& neighbours, TDoubleVecVec& scores) {
+    virtual void add(const POINT& point, const TPointVec& neighbours, TDouble1VecVec2Vec& scores) {
         this->add(point, neighbours, scores[0]);
     }
-    virtual void compute(const TPointVec& points, TDoubleVecVec& scores) {
+    virtual void compute(const TPointVec& points, TDouble1VecVec2Vec& scores) {
         this->compute(points, scores[0]);
     }
     virtual std::size_t numberMethods() const { return 1; }
     virtual std::string name() const = 0;
 
 private:
+    bool m_FeatureSignificances;
     std::size_t m_K;
     NEAREST_NEIGHBOURS m_Lookup;
     TProgressCallback m_RecordProgress;
@@ -122,63 +152,95 @@ public:
     static const TCoordinate UNSET_DISTANCE;
 
 public:
-    CLof(std::size_t k,
+    CLof(bool featureSignificances,
+         std::size_t k,
          TProgressCallback recordProgress,
          NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
         : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
-              k, std::move(lookup), std::move(recordProgress)} {}
+              featureSignificances, k, std::move(lookup), std::move(recordProgress)} {}
 
-    //! Estimate the additional bookkeeping memory used explicitly by the
-    //! local outlier factors calculation.
-    static std::size_t estimateOwnMemoryOverhead(std::size_t k, std::size_t numberPoints) {
-        return numberPoints * (k * sizeof(TUInt32CoordinatePr) + sizeof(TCoordinate));
+    void recoverMemory() override {
+        m_KDistances.resize(this->k() * m_StartAddresses);
+        m_Lrd.resize(m_StartAddresses);
+        m_CoordinateLrd.resize(m_Dimension * m_StartAddresses);
+        m_KDistances.shrink_to_fit();
+        m_Lrd.shrink_to_fit();
+        m_CoordinateLrd.shrink_to_fit();
+    }
+
+    static std::size_t estimateOwnMemoryOverhead(bool featureSignificances,
+                                                 std::size_t k,
+                                                 std::size_t numberPoints,
+                                                 std::size_t dimension) {
+        return numberPoints *
+               (k * sizeof(TUInt32CoordinatePr) +
+                (featureSignificances ? dimension + 1 : 1) * sizeof(TCoordinate));
     }
 
 private:
     void setup(const TPointVec& points) override {
-        std::size_t addressSpace{
-            std::max_element(points.begin(), points.end(),
-                             [](const POINT& lhs, const POINT& rhs) {
-                                 return lhs.annotation() < rhs.annotation();
-                             })
-                ->annotation() +
-            1};
-        m_KDistances.resize(this->k() * addressSpace, {0, UNSET_DISTANCE});
-        m_Lrd.resize(addressSpace, UNSET_DISTANCE);
-    }
 
-    void add(const POINT& point, const TPointVec& neighbours, TDoubleVec&) override {
-        // This is called exactly once for each point therefore an element
-        // of m_KDistances is only ever written by one thread.
-        std::size_t i{point.annotation() * this->k()};
-        std::size_t a(point == neighbours[0] ? 1 : 0);
-        std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
-        for (std::size_t j = a; j <= b; ++j) {
-            m_KDistances[i + j - a].first =
-                static_cast<uint32_t>(neighbours[j].annotation());
-            m_KDistances[i + j - a].second = las::distance(point, neighbours[j]);
+        m_Dimension = las::dimension(points[0]);
+
+        auto minmax = std::minmax_element(
+            points.begin(), points.end(), [](const POINT& lhs, const POINT& rhs) {
+                return lhs.annotation() < rhs.annotation();
+            });
+        m_StartAddresses = minmax.first->annotation();
+        m_EndAddresses = minmax.second->annotation() + 1;
+
+        std::size_t k{this->k()};
+        m_KDistances.resize(k * m_StartAddresses, {0, UNSET_DISTANCE});
+        m_KDistances.resize(k * m_EndAddresses, {0, UNSET_DISTANCE});
+        m_Lrd.resize(m_StartAddresses, UNSET_DISTANCE);
+        m_Lrd.resize(m_EndAddresses, UNSET_DISTANCE);
+
+        if (this->featureSignificances()) {
+            m_CoordinateLrd.resize(m_Dimension * m_StartAddresses, UNSET_DISTANCE);
+            m_CoordinateLrd.resize(m_Dimension * m_EndAddresses, UNSET_DISTANCE);
         }
     }
 
-    void compute(const TPointVec& points, TDoubleVec& scores) override {
-        using TMinAccumulator = CBasicStatistics::SMin<double>::TAccumulator;
+    void add(const POINT& point, const TPointVec& neighbours, TDouble1VecVec&) override {
+        // This is called exactly once for each point therefore an element
+        // of m_KDistances is only ever written by one thread.
+        std::size_t i{point.annotation()};
+        std::size_t a(point == neighbours[0] ? 1 : 0);
+        std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
+        for (std::size_t j = a; j <= b; ++j) {
+            std::size_t index{this->kDistanceIndex(i, j - a)};
+            m_KDistances[index].first =
+                static_cast<std::uint32_t>(neighbours[j].annotation());
+            m_KDistances[index].second = las::distance(point, neighbours[j]);
+        }
+    }
 
-        std::size_t k{this->k()};
+    void compute(const TPointVec& points, TDouble1VecVec& scores) override {
+        this->computeLocalReachabilityDistances(points);
+        this->computeLocalOutlierFactors(points, scores);
+    }
 
-        // We bind a minimum accumulator (by value) to each lambda (since
+    std::string name() const override { return "lof"; }
+
+    void computeLocalReachabilityDistances(const TPointVec& points) {
+
+        // We bind minimum accumulators (by value) to each lambda (since
         // one copy is then accessed by each thread) and take the minimum
         // of these at the end.
+
+        using TMinAccumulator = CBasicStatistics::SMin<double>::TAccumulator;
+
         auto results = core::parallel_for_each(
             points.begin(), points.end(),
             core::bindRetrievableState(
-                [&](TMinAccumulator& min, const POINT& point) {
+                [this](TMinAccumulator& min, const POINT& point) mutable {
+
                     std::size_t i{point.annotation()};
                     TMeanAccumulator reachability_;
-                    for (std::size_t j = i * k; j < (i + 1) * k; ++j) {
-                        const auto& neighbour = m_KDistances[j];
+                    for (std::size_t j = 0; j < this->k(); ++j) {
+                        const auto& neighbour = m_KDistances[this->kDistanceIndex(i, j)];
                         if (distance(neighbour) != UNSET_DISTANCE) {
-                            reachability_.add(std::max(kdistance(index(neighbour)),
-                                                       distance(neighbour)));
+                            reachability_.add(this->reachabilityDistance(neighbour));
                         }
                     }
                     double reachability{CBasicStatistics::mean(reachability_)};
@@ -193,30 +255,104 @@ private:
         for (const auto& result : results) {
             min += result.s_FunctionState;
         }
-
         if (min.count() > 0) {
             // Use twice the maximum "density" at any other point if there
             // are k-fold duplicates.
-            for (auto& lrd : m_Lrd) {
-                if (lrd < 0.0) {
-                    lrd = 2.0 / min[0];
+            for (std::size_t i = m_StartAddresses; i < m_EndAddresses; ++i) {
+                if (m_Lrd[i] == UNSET_DISTANCE) {
+                    m_Lrd[i] = 2.0 / min[0];
                 }
             }
-            core::parallel_for_each(points.begin(), points.end(), [&](const POINT& point) {
-                std::size_t i{point.annotation()};
-                TMeanAccumulator score;
-                for (std::size_t j = i * k; j < (i + 1) * k; ++j) {
-                    const auto& neighbour = m_KDistances[j];
-                    if (distance(neighbour) != UNSET_DISTANCE) {
-                        score.add(m_Lrd[index(neighbour)]);
+        }
+
+        if (this->featureSignificances()) {
+            // The idea is to compute the score placing each point p at the
+            // locations which minimise the lof on each axis aligned line
+            // passing through p. If we let p'(x) denote the point obtained
+            // by replacing the i'th coordinate of p with x then this is p'(y)
+            // where
+            //   y = argmin_{x}{sum_{i in neighbours of p}{rd(p'(x))}}
+            // and rd(.) denotes the reachability distance. Unfortunately,
+            // we need to look up nearest neighbours again.
+
+            core::parallel_for_each(
+                points.begin(), points.end(),
+                [&, neighbours = TPointVec{} ](const POINT& point) mutable {
+
+                    std::size_t i{point.annotation()};
+
+                    this->lookup().nearestNeighbours(this->k() + 1, point, neighbours);
+                    std::size_t a(point == neighbours[0] ? 1 : 0);
+                    std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
+
+                    POINT point_;
+                    for (std::size_t j = 0; j < m_Dimension; ++j) {
+                        // p'(y) can be found by an iterative scheme which moves
+                        // it as close as possible to the current point on the
+                        // hypersphere with radius equal to the k-distance of the
+                        // neighbour. Initializing with the p after two iterations
+                        // we end up very close.
+                        point_ = point;
+                        for (std::size_t round = 0; round < 2; ++round) {
+                            TMeanAccumulator centroid;
+                            for (std::size_t k = a; k <= b; ++k) {
+                                const POINT& neighbour{neighbours[k]};
+                                double kdistance{this->kdistance(neighbour.annotation())};
+                                double distance{las::distance(point_, neighbour)};
+                                double step{std::min(kdistance / distance, 1.0)};
+                                centroid.add((neighbour + (point_ - neighbour) * step)(j));
+                            }
+                            point_(j) = CBasicStatistics::mean(centroid);
+                        }
+
+                        TMeanAccumulator reachability_;
+                        for (std::size_t k = a; k <= b; ++k) {
+                            POINT& neighbour{neighbours[k]};
+                            double kdistance{this->kdistance(neighbour.annotation())};
+                            double distance{las::distance(point_, neighbour)};
+                            reachability_.add(std::max(kdistance, distance));
+                        }
+                        double reachability{
+                            std::max(CBasicStatistics::mean(reachability_), min[0])};
+                        m_CoordinateLrd[this->coordinateLrdIndex(i, j)] = 1.0 / reachability;
                     }
-                }
-                scores[i] = CBasicStatistics::mean(score) / m_Lrd[i];
-            });
+                });
         }
     }
 
-    std::string name() const override { return "lof"; }
+    void computeLocalOutlierFactors(const TPointVec& points, TDouble1VecVec& scores) {
+
+        core::parallel_for_each(points.begin(), points.end(), [&](const POINT& point) mutable {
+
+            std::size_t i{point.annotation()};
+
+            TMeanAccumulator neighbourhoodLrd;
+            for (std::size_t j = 0; j < this->k(); ++j) {
+                const auto& neighbour = m_KDistances[this->kDistanceIndex(i, j)];
+                if (distance(neighbour) != UNSET_DISTANCE) {
+                    neighbourhoodLrd.add(m_Lrd[index(neighbour)]);
+                }
+            }
+
+            scores[i].resize(this->featureSignificances() ? m_Dimension + 1 : 1);
+            scores[i][0] = CBasicStatistics::mean(neighbourhoodLrd) / m_Lrd[i];
+
+            // We choose to ignore the impact of moving the point on its
+            // neighbours' local reachability distances when computing
+            // scores for each coordinate.
+            for (std::size_t j = 1; j < scores[i].size(); ++j) {
+                scores[i][j] = CBasicStatistics::mean(neighbourhoodLrd) /
+                               m_CoordinateLrd[this->coordinateLrdIndex(i, j - 1)];
+            }
+        });
+    }
+
+    std::size_t kDistanceIndex(std::size_t index, std::size_t neighbourIndex) const {
+        return index * this->k() + neighbourIndex;
+    }
+    std::size_t coordinateLrdIndex(std::size_t index, std::size_t coordinate) const {
+        return index * m_Dimension + coordinate;
+    }
 
     static std::size_t index(const TUInt32CoordinatePr& neighbour) {
         return neighbour.first;
@@ -224,20 +360,31 @@ private:
     static double distance(const TUInt32CoordinatePr& neighbour) {
         return neighbour.second;
     }
-    double kdistance(std::size_t index) const {
-        for (std::size_t k{this->k()}, j = (index + 1) * k; j > index * k; --j) {
-            if (distance(m_KDistances[j - 1]) != UNSET_DISTANCE) {
-                return distance(m_KDistances[j - 1]);
+
+    double reachabilityDistance(const TUInt32CoordinatePr& neighbour) const {
+        return std::max(this->kdistance(index(neighbour)), distance(neighbour));
+    }
+    double kdistance(std::size_t i) const {
+        for (std::size_t j = this->k(); j > 0; --j) {
+            double dist{distance(m_KDistances[this->kDistanceIndex(i, j - 1)])};
+            if (dist != UNSET_DISTANCE) {
+                return dist;
             }
         }
         return UNSET_DISTANCE;
     }
 
 private:
-    // The k distances to the neighbouring points of each point are
-    // stored flattened: [neighbours of 0, neighbours of 1,...].
+    std::size_t m_Dimension;
+    std::size_t m_StartAddresses;
+    std::size_t m_EndAddresses;
+    // The k distances to the neighbouring points of each point are stored
+    // flattened: [neighbours of 0, neighbours of 1,...].
     TUInt32CoordinatePrVec m_KDistances;
     TCoordinateVec m_Lrd;
+    // The coordinate local reachability distances are stored flattened:
+    // [coordinates of 0, coordinates of 2, ...].
+    TCoordinateVec m_CoordinateLrd;
 };
 
 template<typename POINT, typename NEAREST_NEIGHBOURS>
@@ -248,27 +395,56 @@ const typename CLof<POINT, NEAREST_NEIGHBOURS>::TCoordinate
 template<typename POINT, typename NEAREST_NEIGHBOURS>
 class CLdof final : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
 public:
-    CLdof(std::size_t k,
+    CLdof(bool featureSignificances,
+          std::size_t k,
           TProgressCallback recordProgress,
           NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
         : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
-              k, std::move(lookup), std::move(recordProgress)} {}
+              featureSignificances, k, std::move(lookup), std::move(recordProgress)} {}
 
 private:
-    void add(const POINT& point, const std::vector<POINT>& neighbours, TDoubleVec& scores) override {
-        TMeanAccumulator d, D;
+    void add(const POINT& point, const std::vector<POINT>& neighbours, TDouble1VecVec& scores) override {
+
+        using TPointMeanAccumulator = typename CBasicStatistics::SSampleMean<POINT>::TAccumulator;
+
+        auto ldof = [](const TMeanAccumulator& d, const TMeanAccumulator& D) {
+            return CBasicStatistics::mean(D) > 0.0
+                       ? CBasicStatistics::mean(d) / CBasicStatistics::mean(D)
+                       : 0.0;
+        };
+
         std::size_t a(point == neighbours[0] ? 1 : 0);
         std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
+
+        auto& score = scores[point.annotation()];
+        score.resize(this->featureSignificances() ? las::dimension(point) + 1 : 1);
+
+        TMeanAccumulator d, D;
         for (std::size_t i = a; i <= b; ++i) {
             d.add(las::distance(point, neighbours[i]));
             for (std::size_t j = 1; j < i; ++j) {
                 D.add(las::distance(neighbours[i], neighbours[j]));
             }
         }
-        scores[point.annotation()] = CBasicStatistics::mean(D) > 0.0
-                                         ? CBasicStatistics::mean(d) /
-                                               CBasicStatistics::mean(D)
-                                         : 0.0;
+        score[0] = ldof(d, D);
+
+        if (score.size() > 1) {
+            // The idea is to compute the score placing the point at the
+            // locations which minimise the ldof on each axis aligned line
+            // passing through the point. These are just the neighbours
+            // coordinate centroids.
+            TPointMeanAccumulator centroid{las::zero(point)};
+            centroid.add(neighbours);
+            POINT point_{point};
+            for (std::size_t i = 1; i < score.size(); ++i) {
+                d = TMeanAccumulator{};
+                point_(i - 1) = CBasicStatistics::mean(centroid)(i - 1);
+                for (std::size_t j = a; j <= b; ++j) {
+                    d.add(las::distance(point_, neighbours[j]));
+                }
+                score[i] = ldof(d, D);
+            }
+        }
     }
 
     std::string name() const override { return "ldof"; }
@@ -278,17 +454,30 @@ private:
 template<typename POINT, typename NEAREST_NEIGHBOURS>
 class CDistancekNN final : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
 public:
-    CDistancekNN(std::size_t k,
+    CDistancekNN(bool featureSignificances,
+                 std::size_t k,
                  TProgressCallback recordProgress,
                  NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
         : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
-              k, std::move(lookup), std::move(recordProgress)} {}
+              featureSignificances, k, std::move(lookup), std::move(recordProgress)} {}
 
 private:
-    void add(const POINT& point, const std::vector<POINT>& neighbours, TDoubleVec& scores) override {
+    void add(const POINT& point, const std::vector<POINT>& neighbours, TDouble1VecVec& scores) override {
+
         std::size_t k{std::min(this->k() + 1, neighbours.size() - 1) -
                       (point == neighbours[0] ? 0 : 1)};
-        scores[point.annotation()] = las::distance(point, neighbours[k]);
+        const auto& kthNeighbour = neighbours[k];
+
+        auto& score = scores[point.annotation()];
+        score.resize(this->featureSignificances() ? las::dimension(point) + 1 : 1);
+
+        double d{las::distance(point, kthNeighbour)};
+        score[0] = d;
+        for (std::size_t i = 1; i < score.size(); ++i) {
+            // The idea here is to compute the score for the complement
+            // space of each coordinate projection.
+            score[i] = complementDistance(d, kthNeighbour(i - 1) - point(i - 1));
+        }
     }
 
     std::string name() const override { return "knn"; }
@@ -299,21 +488,34 @@ template<typename POINT, typename NEAREST_NEIGHBOURS>
 class CTotalDistancekNN final
     : public CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS> {
 public:
-    CTotalDistancekNN(std::size_t k,
+    CTotalDistancekNN(bool featureSignificances,
+                      std::size_t k,
                       TProgressCallback recordProgress,
                       NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
         : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{
-              k, std::move(lookup), std::move(recordProgress)} {}
+              featureSignificances, k, std::move(lookup), std::move(recordProgress)} {}
 
 private:
-    void add(const POINT& point, const std::vector<POINT>& neighbours, TDoubleVec& scores) override {
-        std::size_t i{point.annotation()};
+    void add(const POINT& point, const std::vector<POINT>& neighbours, TDouble1VecVec& scores) override {
+
         std::size_t a(point == neighbours[0] ? 1 : 0);
         std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
-        for (std::size_t j = a; j <= b; ++j) {
-            scores[i] += las::distance(point, neighbours[j]);
+
+        auto& score = scores[point.annotation()];
+        score.assign(this->featureSignificances() ? las::dimension(point) + 1 : 1, 0.0);
+
+        for (std::size_t i = a; i <= b; ++i) {
+            double d{las::distance(point, neighbours[i])};
+            score[0] += d;
+            // The idea here is to compute the score for the complement
+            // space of each coordinate projection.
+            for (std::size_t j = 1; j < score.size(); ++j) {
+                score[j] += complementDistance(d, neighbours[i](j - 1) - point(j - 1));
+            }
         }
-        scores[i] /= static_cast<double>(this->k());
+        for (std::size_t i = 0; i < score.size(); ++i) {
+            score[i] /= static_cast<double>(this->k());
+        }
     }
 
     std::string name() const override { return "tnn"; }
@@ -336,9 +538,16 @@ public:
     CMultipleMethods(std::size_t k,
                      TMethodUPtrVec methods,
                      NEAREST_NEIGHBOURS lookup = NEAREST_NEIGHBOURS())
-        : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{k, std::move(lookup),
+        : CNearestNeighbourMethod<POINT, NEAREST_NEIGHBOURS>{methods[0]->featureSignificances(),
+                                                             k, std::move(lookup),
                                                              methods[0]->progressRecorder()},
           m_Methods{std::move(methods)} {}
+
+    void recoverMemory() override {
+        for (auto& model : m_Methods) {
+            model->recoverMemory();
+        }
+    }
 
     std::string print() const override {
         std::string result;
@@ -359,13 +568,13 @@ private:
         }
     }
 
-    void add(const POINT& point, const TPointVec& neighbours, TDoubleVecVec& scores) override {
+    void add(const POINT& point, const TPointVec& neighbours, TDouble1VecVec2Vec& scores) override {
         for (std::size_t i = 0; i < m_Methods.size(); ++i) {
             m_Methods[i]->add(point, neighbours, scores[i]);
         }
     }
 
-    void compute(const TPointVec& points, TDoubleVecVec& scores) override {
+    void compute(const TPointVec& points, TDouble1VecVec2Vec& scores) override {
         for (std::size_t i = 0; i < m_Methods.size(); ++i) {
             m_Methods[i]->compute(points, scores[i]);
         }
@@ -398,15 +607,19 @@ public:
     using TSizeVecVec = std::vector<TSizeVec>;
     using TSizeSizePr = std::pair<std::size_t, std::size_t>;
     using TSizeSizePrVec = std::vector<TSizeSizePr>;
+    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using TMeanVarAccumulator2Vec = core::CSmallVector<TMeanVarAccumulator, 2>;
     using TPoint = CAnnotatedVector<decltype(SConstant<POINT>::get(0, 0)), std::size_t>;
     using TPointVec = std::vector<TPoint>;
     using TPointVecVec = std::vector<TPointVec>;
     using TKdTree = CKdTree<TPoint>;
+    using TMatrix = typename SConformableMatrix<TPoint>::Type;
+    using TMatrixVec = std::vector<TMatrix>;
     using TMethodUPtr = std::unique_ptr<CNearestNeighbourMethod<TPoint, const TKdTree&>>;
     using TMethodUPtrVec = std::vector<TMethodUPtr>;
     using TMethodFactory = std::function<TMethodUPtr(std::size_t, const TKdTree&)>;
     using TMethodFactoryVec = std::vector<TMethodFactory>;
-    using TMethodSize = std::function<std::size_t(std::size_t)>;
+    using TMethodSize = std::function<std::size_t(std::size_t, std::size_t, std::size_t)>;
 
     //! \brief Builds (online) one model of the points for the ensemble.
     class CModelBuilder {
@@ -417,7 +630,7 @@ public:
         CModelBuilder(CPRNG::CXorOShiro128Plus& rng,
                       TSizeSizePrVec&& methodAndNumberNeighbours,
                       std::size_t sampleSize,
-                      TPointVec&& projection);
+                      TMatrix&& projection);
 
         //! Maybe sample the point.
         void addPoint(const TRowRef& point) { m_Sampler.sample(point); }
@@ -435,19 +648,57 @@ public:
         TSizeSizePrVec m_MethodsAndNumberNeighbours;
         std::size_t m_SampleSize;
         TSampler m_Sampler;
-        TPointVec m_Projection;
+        TMatrix m_Projection;
         TPointVec m_SampledProjectedPoints;
     };
     using TModelBuilderVec = std::vector<CModelBuilder>;
+
+    //! \brief Manages computing the probability that a point is an outlier
+    //! given its scores from a collection of ensemble models.
+    class CScorer {
+    public:
+        void add(const TMeanVarAccumulator2Vec& logScoreMoments,
+                 const TMatrix& columnNormalizedProjection,
+                 const TDouble1Vec2Vec& scores);
+
+        //! Compute the posterior probability that the point is an outlier
+        //! and optionally the feature significances.
+        TDouble1Vec compute(double pOutlier) const;
+
+        static std::size_t estimateMemoryUsage(std::size_t dimension) {
+            return (dimension + 2) * sizeof(CFloatStorage);
+        }
+
+    private:
+        using TFloat2Vec = core::CSmallVector<CFloatStorage, 2>;
+
+    private:
+        double ensembleSize() const { return m_State[0]; }
+        CFloatStorage& ensembleSize() { return m_State[0]; }
+
+        double logLikelihoodOutlier() const { return m_State[1]; }
+        CFloatStorage& logLikelihoodOutlier() { return m_State[1]; }
+
+        double significance(std::size_t index) const {
+            return m_State[index + 2];
+        }
+        CFloatStorage& significance(std::size_t index) {
+            return m_State[index + 2];
+        }
+
+        std::size_t numberSignificances() const { return m_State.size() - 2; }
+
+    private:
+        TFloat2Vec m_State;
+    };
+    using TScorerVec = std::vector<CScorer>;
 
 public:
     static const double SAMPLE_SIZE_SCALE;
     static const double NEIGHBOURHOOD_FRACTION;
 
 public:
-    CEnsemble(const TMethodFactoryVec& methodFactories,
-              TModelBuilderVec modelBuilders,
-              double priorProbabilityOutlier = 0.05);
+    CEnsemble(const TMethodFactoryVec& methodFactories, TModelBuilderVec modelBuilders);
     CEnsemble(const CEnsemble&) = delete;
     CEnsemble& operator=(const CEnsemble&) = delete;
     CEnsemble(CEnsemble&&) = default;
@@ -461,54 +712,54 @@ public:
                  CPRNG::CXorOShiro128Plus rng = CPRNG::CXorOShiro128Plus{});
 
     //! Compute the outlier scores for \p points.
-    void computeOutlierScores(const std::vector<POINT>& points, TDoubleVec& scores) const;
+    TScorerVec computeOutlierScores(const std::vector<POINT>& points) const;
 
     //! Estimate the amount of memory that will be used by the ensemble.
     static std::size_t
     estimateMemoryUsedToComputeOutlierScores(TMethodSize methodSize,
-                                             std::size_t numberMethods,
+                                             std::size_t numberMethodsPerModel,
+                                             bool featureSignificances,
                                              std::size_t totalNumberPoints,
                                              std::size_t partitionNumberPoints,
                                              std::size_t dimension) {
-        std::size_t ensembleSize{
-            computeEnsembleSize(numberMethods, totalNumberPoints, dimension)};
+        std::size_t ensembleSize{computeEnsembleSize(numberMethodsPerModel,
+                                                     totalNumberPoints, dimension)};
         std::size_t sampleSize{computeSampleSize(totalNumberPoints)};
-        std::size_t numberModels{(ensembleSize + numberMethods - 1) / numberMethods};
+        std::size_t numberModels{(ensembleSize + numberMethodsPerModel - 1) / numberMethodsPerModel};
         std::size_t maxNumberNeighbours{computeNumberNeighbours(sampleSize)};
         std::size_t projectionDimension{computeProjectionDimension(sampleSize, dimension)};
         std::size_t averageNumberNeighbours{(3 + maxNumberNeighbours) / 2};
-        // This is "own size" + "method scores size" + "scorers size" +
-        // "projected points size" + "models size".
-        return sizeof(CEnsemble) +
-               partitionNumberPoints *
-                   (sizeof(double) + sizeof(CScorer) +
-                    las::estimateMemoryUsage<TPoint>(projectionDimension)) +
-               numberModels * CModel::estimateMemoryUsage(methodSize, sampleSize,
-                                                          averageNumberNeighbours,
-                                                          projectionDimension, dimension);
+
+        auto projectedPointsSize = [&] {
+            return partitionNumberPoints * las::estimateMemoryUsage<TPoint>(projectionDimension);
+        };
+        auto scorersSize = [&] {
+            return partitionNumberPoints *
+                   (sizeof(CScorer) + CScorer::estimateMemoryUsage(
+                                          featureSignificances ? dimension : 0));
+        };
+        auto modelSize = [&] {
+            return CModel::estimateMemoryUsage(methodSize, sampleSize, averageNumberNeighbours,
+                                               projectionDimension, dimension);
+        };
+        auto perPartitionOverhead = [&] {
+            // The scores for a single method plus bookkeeping overhead
+            // for a single partition.
+            return numberMethodsPerModel * partitionNumberPoints *
+                       (sizeof(TDouble1Vec) +
+                        (featureSignificances ? projectionDimension * sizeof(double) : 0)) +
+                   methodSize(averageNumberNeighbours, partitionNumberPoints, projectionDimension);
+        };
+
+        return projectedPointsSize() + scorersSize() +
+               numberModels * modelSize() + perPartitionOverhead();
     }
 
     //! Get a human readable description of the ensemble.
     std::string print() const;
 
 private:
-    using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
-    using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
     using TKdTreeUPtr = std::unique_ptr<TKdTree>;
-
-    //! \brief Manages computing the probability that a point is an outlier
-    //! given its scores from a collection of ensemble models.
-    class CScorer {
-    public:
-        void add(const TMeanVarAccumulatorVec& logScoreMoments, const TDoubleVec& scores);
-        double compute(double pOutlier) const;
-
-    private:
-        double m_EnsembleSize = 0.0;
-        double m_LogLikelihoodOutlierGivenScores = 0.0;
-        double m_LogLikelihoodInlierGivenScores = 0.0;
-    };
-    using TScorerVec = std::vector<CScorer>;
 
     //! \brief A model of the points used as part of the ensemble.
     class CModel {
@@ -516,7 +767,7 @@ private:
         CModel(const TMethodFactoryVec& methodFactories,
                TSizeSizePrVec methodAndNumberNeighbours,
                TPointVec samples,
-               TPointVec projection);
+               TMatrix projection);
 
         std::size_t numberPoints() const { return m_Lookup->size(); }
 
@@ -529,19 +780,26 @@ private:
                                                std::size_t averageNumberNeighbours,
                                                std::size_t projectionDimension,
                                                std::size_t dimension) {
-            return sizeof(CModel) +
-                   TKdTree::estimateMemoryUsage(sampleSize, projectionDimension) +
-                   projectionDimension * las::estimateMemoryUsage<TPoint>(dimension) +
-                   methodSize(averageNumberNeighbours);
+            auto lookupSize = [&] {
+                return TKdTree::estimateMemoryUsage(sampleSize, projectionDimension);
+            };
+            auto projectionSize = [&] {
+                return projectionDimension * dimension *
+                       sizeof(typename SCoordinate<TPoint>::Type);
+            };
+
+            return lookupSize() + 2 * projectionSize() +
+                   methodSize(averageNumberNeighbours, sampleSize, projectionDimension);
         }
 
         std::string print() const;
 
     private:
         TKdTreeUPtr m_Lookup;
-        TPointVec m_Projection;
+        TMatrix m_Projection;
+        TMatrix m_RowNormalizedProjection;
         TMethodUPtr m_Method;
-        TMeanVarAccumulatorVec m_LogScoreMoments;
+        TMeanVarAccumulator2Vec m_LogScoreMoments;
     };
     using TModelVec = std::vector<CModel>;
 
@@ -594,15 +852,12 @@ private:
         return static_cast<std::size_t>(std::min(std::max(target, 2.0), 10.0) + 0.5);
     }
 
-    static TPointVecVec createProjections(CPRNG::CXorOShiro128Plus& rng,
-                                          std::size_t numberProjections,
-                                          std::size_t projectionDimension,
-                                          std::size_t dimension);
-
-    static TPoint project(const TPointVec& projection, const POINT& point);
+    static TMatrixVec createProjections(CPRNG::CXorOShiro128Plus& rng,
+                                        std::size_t numberProjections,
+                                        std::size_t projectionDimension,
+                                        std::size_t dimension);
 
 private:
-    double m_PriorProbabilityOutlier;
     TModelVec m_Models;
 };
 
@@ -616,7 +871,6 @@ const double CEnsemble<POINT>::NEIGHBOURHOOD_FRACTION{0.01};
 class MATHS_EXPORT COutliers : private core::CNonInstantiatable {
 public:
     using TDoubleVec = outliers_detail::TDoubleVec;
-    using TDoubleVecVec = outliers_detail::TDoubleVecVec;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TProgressCallback = outliers_detail::TProgressCallback;
     template<typename POINT>
@@ -636,10 +890,27 @@ public:
         E_Ensemble
     };
 
+    //! \brief The parameters for compute.
+    struct SComputeParameters {
+        //! The number of threads available.
+        std::size_t s_NumberThreads;
+        //! The number of partitions to use.
+        std::size_t s_NumberPartitions;
+        //! If true also compute the feature significances.
+        bool s_FeatureSignificances;
+        //! The prior probability that a point is an outlier.
+        double s_ProbabilityOutlier;
+    };
+
 public:
     //! Compute outliers for \p frame and write to a new column.
-    static void compute(std::size_t numberThreads,
-                        std::size_t numberPartitions,
+    //!
+    //! \param[in] params The calculation parameters.
+    //! \param[in] frame The data frame whose rows hold the coordinated of
+    //! the points for which to compute outliers.
+    //! \param[in] recordProgress A function to which fractional progress
+    //! is written.
+    static void compute(const SComputeParameters& params,
                         core::CDataFrame& frame,
                         TProgressCallback recordProgress = noop);
 
@@ -648,6 +919,8 @@ public:
     //!
     //! \param[in] method The method that will be used.
     //! \param[in] k The number of nearest neighbours which will be used.
+    //! \param[in] featureSignificances If true the feature significances
+    //! will also be computed.
     //! \param[in] totalNumberPoints The total number of points for which
     //! outlier scores will be computed.
     //! \param[in] partitionNumberPoints The number of points per partition
@@ -655,31 +928,40 @@ public:
     //! \param[in] dimension The dimension of the points for which outliers
     //! will be computed.
     template<typename POINT>
-    static std::size_t estimateComputeMemoryUsage(EMethod method,
-                                                  std::size_t k,
-                                                  std::size_t totalNumberPoints,
-                                                  std::size_t partitionNumberPoints,
-                                                  std::size_t dimension) {
-        auto methodSize = [method, k, partitionNumberPoints](std::size_t) {
+    static std::size_t estimateMemoryUsedByCompute(EMethod method,
+                                                   std::size_t k,
+                                                   bool featureSignificances,
+                                                   std::size_t totalNumberPoints,
+                                                   std::size_t partitionNumberPoints,
+                                                   std::size_t dimension) {
+        auto methodSize = [=](std::size_t, std::size_t numberPoints,
+                              std::size_t projectionDimension) {
             return method == E_Lof
-                       ? TLof<POINT>::estimateOwnMemoryOverhead(k, partitionNumberPoints)
+                       ? TLof<POINT>::estimateOwnMemoryOverhead(
+                             featureSignificances, k, numberPoints, projectionDimension)
                        : 0;
         };
         return TEnsemble<POINT>::estimateMemoryUsedToComputeOutlierScores(
-            methodSize, 1, totalNumberPoints, partitionNumberPoints, dimension);
+            methodSize, 1 /*number methods*/, featureSignificances,
+            totalNumberPoints, partitionNumberPoints, dimension);
     }
 
-    //! Overload of estimateComputeMemoryUsage for default behaviour.
+    //! Overload of estimateMemoryUsedByCompute for default behaviour.
     template<typename POINT>
-    static std::size_t estimateComputeMemoryUsage(std::size_t totalNumberPoints,
-                                                  std::size_t partitionNumberPoints,
-                                                  std::size_t dimension) {
-        auto methodSize = [partitionNumberPoints](std::size_t k_) {
+    static std::size_t estimateMemoryUsedByCompute(bool featureSignificances,
+                                                   std::size_t totalNumberPoints,
+                                                   std::size_t partitionNumberPoints,
+                                                   std::size_t dimension) {
+        auto methodSize = [=](std::size_t k, std::size_t numberPoints,
+                              std::size_t projectionDimension) {
             // On average half of models use CLof.
-            return TLof<POINT>::estimateOwnMemoryOverhead(k_, partitionNumberPoints) / 2;
+            return TLof<POINT>::estimateOwnMemoryOverhead(
+                       featureSignificances, k, numberPoints, projectionDimension) /
+                   2;
         };
         return TEnsemble<POINT>::estimateMemoryUsedToComputeOutlierScores(
-            methodSize, 2, totalNumberPoints, partitionNumberPoints, dimension);
+            methodSize, 2 /*number methods*/, featureSignificances,
+            totalNumberPoints, partitionNumberPoints, dimension);
     }
 
     //! \name Test Interface
@@ -742,12 +1024,13 @@ private:
             lookup.build(annotatedPoints);
 
             METHOD<TAnnotatedPoint<POINT>, CKdTree<TAnnotatedPoint<POINT>>> scorer{
-                k, noop, std::move(lookup)};
+                false, k, noop, std::move(lookup)};
+            auto scores_ = scorer.run(annotatedPoints, annotatedPoints.size());
 
-            TDoubleVecVec scores_;
-            scorer.run(annotatedPoints, annotatedPoints.size(), scores_);
-
-            scores = std::move(scores_[0]);
+            scores.resize(scores_[0].size());
+            for (std::size_t i = 0; i < scores.size(); ++i) {
+                scores[i] = scores_[0][i][0];
+            }
         }
     }
 

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -70,8 +70,8 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(const std::stri
 
 CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryUPtrVec runnerFactories,
                                                                  const std::string& jsonSpecification)
-    : m_RunnerFactories{std::move(runnerFactories)},
-      m_TemporaryDirectory{boost::filesystem::current_path().string()} {
+    : m_TemporaryDirectory{boost::filesystem::current_path().string()},
+      m_RunnerFactories{std::move(runnerFactories)} {
 
     rapidjson::Document document;
     if (document.Parse(jsonSpecification.c_str()) == false) {

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -225,14 +225,13 @@ void CDataFrameAnalyzer::addRowToDataFrame(const TStrVec& fieldValues) {
         return;
     }
 
-    using TFloatVec = std::vector<core::CFloatStorage>;
-    using TFloatVecItr = TFloatVec::iterator;
+    using TFloatVecItr = core::CDataFrame::TFloatVecItr;
 
     m_DataFrame->writeRow([&](TFloatVecItr columns, std::int32_t& docHash) {
         for (std::ptrdiff_t i = m_BeginDataFieldValues;
              i != m_EndDataFieldValues; ++i, ++columns) {
             double value;
-            if (core::CStringUtils::stringToType(fieldValues[i], value) == false) {
+            if (core::CStringUtils::stringToTypeSilent(fieldValues[i], value) == false) {
                 ++m_BadValueCount;
 
                 // TODO this is a can of worms we can deal with later.
@@ -249,7 +248,8 @@ void CDataFrameAnalyzer::addRowToDataFrame(const TStrVec& fieldValues) {
         }
         docHash = 0;
         if (m_DocHashFieldIndex != FIELD_MISSING &&
-            core::CStringUtils::stringToType(fieldValues[m_DocHashFieldIndex], docHash) == false) {
+            core::CStringUtils::stringToTypeSilent(fieldValues[m_DocHashFieldIndex],
+                                                   docHash) == false) {
             ++m_BadDocHashCount;
         }
     });

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -94,7 +94,9 @@ bool CDataFrameAnalyzer::handleRecord(const TStrVec& fieldNames, const TStrVec& 
         return this->handleControlMessage(fieldValues);
     }
 
+    this->captureFieldNames(fieldNames);
     this->addRowToDataFrame(fieldValues);
+
     return true;
 }
 
@@ -220,6 +222,13 @@ bool CDataFrameAnalyzer::handleControlMessage(const TStrVec& fieldValues) {
     return true;
 }
 
+void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
+    if (m_FieldNames.empty()) {
+        m_FieldNames.assign(fieldNames.begin() + m_BeginDataFieldValues,
+                            fieldNames.begin() + m_EndDataFieldValues);
+    }
+}
+
 void CDataFrameAnalyzer::addRowToDataFrame(const TStrVec& fieldValues) {
     if (m_DataFrame == nullptr) {
         return;
@@ -294,7 +303,7 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
             writer.Key(CHECKSUM);
             writer.Int(row->docHash());
             writer.Key(RESULTS);
-            analysis.writeOneRow(*row, writer);
+            analysis.writeOneRow(m_FieldNames, *row, writer);
             writer.EndObject();
             writer.EndObject();
         }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -37,7 +37,7 @@ const char* VALID_MEMBER_NAMES[]{NUMBER_NEIGHBOURS, METHOD};
 
 // Output
 const char* OUTLIER_SCORE{"outlier_score"};
-const char* FEATURE_SIGNIFICANCE_PREFIX{"feature_significance."};
+const char* FEATURE_INFLUENCE_PREFIX{"feature_influence."};
 
 template<typename MEMBER>
 bool isValidMember(const MEMBER& member) {
@@ -115,7 +115,7 @@ void CDataFrameOutliersRunner::writeOneRow(const TStrVec& featureNames,
     writer.Double(row[scoreColumn]);
     if (row[scoreColumn] > m_WriteFeatureInfluenceMinimumScore) {
         for (std::size_t i = 0; i < numberFeatureScoreColumns; ++i) {
-            writer.Key(FEATURE_SIGNIFICANCE_PREFIX + featureNames[i]);
+            writer.Key(FEATURE_INFLUENCE_PREFIX + featureNames[i]);
             writer.Double(row[beginFeatureScoreColumns + i]);
         }
     }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -101,7 +101,7 @@ CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpeci
 }
 
 std::size_t CDataFrameOutliersRunner::numberExtraColumns() const {
-    return m_FeatureSignificances ? this->spec().numberColumns() + 1 : 1;
+    return m_ComputeFeatureInfluence ? this->spec().numberColumns() + 1 : 1;
 }
 
 void CDataFrameOutliersRunner::writeOneRow(const TStrVec& featureNames,
@@ -113,7 +113,7 @@ void CDataFrameOutliersRunner::writeOneRow(const TStrVec& featureNames,
     writer.StartObject();
     writer.Key(OUTLIER_SCORE);
     writer.Double(row[scoreColumn]);
-    if (row[scoreColumn] > m_WriteFeatureSignificancesMinimumScore) {
+    if (row[scoreColumn] > m_WriteFeatureInfluenceMinimumScore) {
         for (std::size_t i = 0; i < numberFeatureScoreColumns; ++i) {
             writer.Key(FEATURE_SIGNIFICANCE_PREFIX + featureNames[i]);
             writer.Double(row[beginFeatureScoreColumns + i]);
@@ -125,7 +125,7 @@ void CDataFrameOutliersRunner::writeOneRow(const TStrVec& featureNames,
 void CDataFrameOutliersRunner::runImpl(core::CDataFrame& frame) {
     maths::COutliers::SComputeParameters params{
         this->spec().numberThreads(), this->numberPartitions(),
-        m_FeatureSignificances, m_ProbabilityOutlier};
+        m_ComputeFeatureInfluence, m_ProbabilityOutlier};
 
     maths::COutliers::compute(params, frame, this->progressRecorder());
 }
@@ -157,10 +157,11 @@ CDataFrameOutliersRunner::estimateMemoryUsage(std::size_t totalNumberRows,
     maths::COutliers::EMethod method{static_cast<maths::COutliers::EMethod>(m_Method)};
     return m_NumberNeighbours != boost::none
                ? maths::COutliers::estimateMemoryUsedByCompute<POINT>(
-                     method, *m_NumberNeighbours, m_FeatureSignificances,
+                     method, *m_NumberNeighbours, m_ComputeFeatureInfluence,
                      totalNumberRows, partitionNumberRows, numberColumns)
                : maths::COutliers::estimateMemoryUsedByCompute<POINT>(
-                     m_FeatureSignificances, totalNumberRows, partitionNumberRows, numberColumns);
+                     m_ComputeFeatureInfluence, totalNumberRows,
+                     partitionNumberRows, numberColumns);
 }
 
 const char* CDataFrameOutliersRunnerFactory::name() const {

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -248,41 +248,6 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
 }
 
-void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
-
-    // Test the case we have to overflow to disk to compute outliers subject
-    // to the memory constraints.
-
-    std::stringstream output;
-    auto outputWriterFactory = [&output]() {
-        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
-    };
-
-    api::CDataFrameAnalyzer analyzer{outlierSpec(1000, 100000), outputWriterFactory};
-
-    TDoubleVec expectedScores;
-
-    TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", ".", "."};
-    TStrVec fieldValues{"", "", "", "", "", "0", ""};
-    addTestData(fieldNames, fieldValues, analyzer, expectedScores, 990, 10);
-
-    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
-
-    rapidjson::Document results;
-    rapidjson::ParseResult ok(results.Parse(output.str().c_str()));
-    CPPUNIT_ASSERT(static_cast<bool>(ok) == true);
-
-    auto expectedScore = expectedScores.begin();
-    for (const auto& result : results.GetArray()) {
-        CPPUNIT_ASSERT(expectedScore != expectedScores.end());
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(
-            *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
-            1e-4 * *expectedScore);
-        ++expectedScore;
-    }
-    CPPUNIT_ASSERT(expectedScore == expectedScores.end());
-}
-
 void CDataFrameAnalyzerTest::testFlushMessage() {
 
     // Test that white space is just ignored.

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -248,6 +248,41 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
 }
 
+void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
+
+    // Test the case we have to overflow to disk to compute outliers subject
+    // to the memory constraints.
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    api::CDataFrameAnalyzer analyzer{outlierSpec(1000, 100000), outputWriterFactory};
+
+    TDoubleVec expectedScores;
+
+    TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    addTestData(fieldNames, fieldValues, analyzer, expectedScores, 990, 10);
+
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    rapidjson::Document results;
+    rapidjson::ParseResult ok(results.Parse(output.str().c_str()));
+    CPPUNIT_ASSERT(static_cast<bool>(ok) == true);
+
+    auto expectedScore = expectedScores.begin();
+    for (const auto& result : results.GetArray()) {
+        CPPUNIT_ASSERT(expectedScore != expectedScores.end());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(
+            *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
+            1e-4 * *expectedScore);
+        ++expectedScore;
+    }
+    CPPUNIT_ASSERT(expectedScore == expectedScores.end());
+}
+
 void CDataFrameAnalyzerTest::testFlushMessage() {
 
     // Test that white space is just ignored.

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -236,11 +236,14 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
 
     auto expectedScore = expectedScores.begin();
     for (const auto& result : results.GetArray()) {
-        CPPUNIT_ASSERT(expectedScore != expectedScores.end());
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(
-            *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
-            1e-4 * *expectedScore);
-        ++expectedScore;
+        if (result.HasMember("row_results")) {
+            CPPUNIT_ASSERT(expectedScore != expectedScores.end());
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(
+                *expectedScore,
+                result["row_results"]["results"]["outlier_score"].GetDouble(),
+                1e-4 * *expectedScore);
+            ++expectedScore;
+        }
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -112,7 +112,7 @@ void addTestData(TStrVec fieldNames,
 
     auto frame = test::CDataFrameTestUtils::toMainMemoryDataFrame(points);
 
-    maths::COutliers::compute(1, 1, *frame);
+    maths::COutliers::compute({1, 1, false, 0.05}, *frame);
 
     expectedScores.resize(points.size());
     frame->readRows(1, [&expectedScores](core::CDataFrame::TRowItr beginRows,

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -17,7 +17,9 @@ std::size_t CDataFrameMockAnalysisRunner::numberExtraColumns() const {
     return 2;
 }
 
-void CDataFrameMockAnalysisRunner::writeOneRow(TRowRef, ml::core::CRapidJsonConcurrentLineWriter&) const {
+void CDataFrameMockAnalysisRunner::writeOneRow(const TStrVec&,
+                                               TRowRef,
+                                               ml::core::CRapidJsonConcurrentLineWriter&) const {
 }
 
 void CDataFrameMockAnalysisRunner::runImpl(ml::core::CDataFrame&) {

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -19,7 +19,9 @@ public:
     CDataFrameMockAnalysisRunner(const ml::api::CDataFrameAnalysisSpecification& spec);
 
     std::size_t numberExtraColumns() const override;
-    void writeOneRow(TRowRef, ml::core::CRapidJsonConcurrentLineWriter&) const override;
+    void writeOneRow(const TStrVec& featureNames,
+                     TRowRef,
+                     ml::core::CRapidJsonConcurrentLineWriter&) const override;
 
 private:
     void runImpl(ml::core::CDataFrame&) override;

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -65,7 +65,7 @@ CEnsemble<POINT>::makeBuilders(const TSizeVecVec& methods,
     TModelBuilderVec result;
     result.reserve(numberModels);
 
-    TMatrixVec projections{createProjections(rng, numberModels, projectionDimension, dimension)};
+    TMatrixVec projections(createProjections(rng, numberModels, projectionDimension, dimension));
 
     for (std::size_t i = 0; i < projections.size(); ++i) {
         // Multiple algorithms are used for the same model which therefore share
@@ -404,7 +404,7 @@ CEnsemble<POINT>::CModel::CModel(const TMethodFactoryVec& methodFactories,
     for (auto& method : methods) {
 
         method->progressRecorder().swap(noop);
-        TDouble1VecVec2Vec scores{method->run(sample, sample.size())};
+        TDouble1VecVec2Vec scores(method->run(sample, sample.size()));
         method->progressRecorder().swap(noop);
 
         m_LogScoreMoments.emplace_back();

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -322,15 +322,17 @@ void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulator2Vec& logScoreMomen
             double fi0{scoreCdfComplement(i, 0)};
             for (std::size_t j = 1; j < numberScores; ++j) {
                 double fij{scoreCdfComplement(i, j)};
-                influences(j - 1) += weights[i] * std::max(fij - fi0, 0.0);
+                influences(j - 1) +=
+                    weights[i] *
+                    std::max(CTools::fastLog(fij) - CTools::fastLog(fi0), 0.0);
             }
         }
         influences = rowNormalizedProjection * influences;
         std::size_t numberInfluences{las::dimension(influences)};
 
-        m_State.resize(numberInfluences + 2);
+        m_State.resize(numberInfluences + 2, 0.0);
         for (std::size_t i = 0; i < numberInfluences; ++i) {
-            this->influence(i) += influence(i);
+            this->influence(i) += influences(i);
         }
     }
 }

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -30,10 +30,7 @@ double shift(double score) {
 }
 
 template<typename POINT>
-CEnsemble<POINT>::CEnsemble(const TMethodFactoryVec& methodFactories,
-                            TModelBuilderVec builders,
-                            double priorProbabilityOutlier)
-    : m_PriorProbabilityOutlier{priorProbabilityOutlier} {
+CEnsemble<POINT>::CEnsemble(const TMethodFactoryVec& methodFactories, TModelBuilderVec builders) {
 
     m_Models.reserve(builders.size());
     for (auto& builder : builders) {
@@ -68,13 +65,9 @@ CEnsemble<POINT>::makeBuilders(const TSizeVecVec& methods,
     TModelBuilderVec result;
     result.reserve(numberModels);
 
-    TPointVecVec projections{
-        createProjections(rng, numberModels, projectionDimension, dimension)};
+    TMatrixVec projections{createProjections(rng, numberModels, projectionDimension, dimension)};
 
-    // If we didn't find suitable projections this can be less than the target.
-    numberModels = projections.size();
-
-    for (std::size_t model = 0; model < numberModels; ++model) {
+    for (std::size_t i = 0; i < projections.size(); ++i) {
         // Multiple algorithms are used for the same model which therefore share
         // the sampled points. This allows us to save on both memory and runtime
         // (because we can share the nearest neighbour lookup for the different
@@ -88,7 +81,7 @@ CEnsemble<POINT>::makeBuilders(const TSizeVecVec& methods,
         }
 
         result.emplace_back(rng, std::move(methodsAndNumberNeighbours),
-                            sampleSize, std::move(projections[model]));
+                            sampleSize, std::move(projections[i]));
 
         rng.discard(1ull < 63);
     }
@@ -97,37 +90,34 @@ CEnsemble<POINT>::makeBuilders(const TSizeVecVec& methods,
 }
 
 template<typename POINT>
-void CEnsemble<POINT>::computeOutlierScores(const std::vector<POINT>& points,
-                                            TDoubleVec& scores) const {
+typename CEnsemble<POINT>::TScorerVec
+CEnsemble<POINT>::computeOutlierScores(const std::vector<POINT>& points) const {
     if (points.empty()) {
-        return;
+        return {};
     }
 
     LOG_TRACE(<< "Computing outlier scores");
 
-    TScorerVec scores_(points.size());
+    TScorerVec scores(points.size());
     for (const auto& model : m_Models) {
-        model.addOutlierScores(points, scores_);
+        model.addOutlierScores(points, scores);
     }
-
-    scores.resize(points.size());
-    for (std::size_t i = 0; i < scores_.size(); ++i) {
-        scores[i] = scores_[i].compute(m_PriorProbabilityOutlier);
-    }
+    return scores;
 }
 
 template<typename POINT>
 std::string CEnsemble<POINT>::print() const {
     std::ostringstream result;
-    result << "prior probability outlier = " << m_PriorProbabilityOutlier;
+    result << "ensemble: {";
     for (const auto& model : m_Models) {
-        result << "\n" << model.print();
+        result << "\n  " << model.print();
     }
+    result << "\n}";
     return result.str();
 }
 
 template<typename POINT>
-typename CEnsemble<POINT>::TPointVecVec
+typename CEnsemble<POINT>::TMatrixVec
 CEnsemble<POINT>::createProjections(CPRNG::CXorOShiro128Plus& rng,
                                     std::size_t numberProjections,
                                     std::size_t projectionDimension,
@@ -136,7 +126,7 @@ CEnsemble<POINT>::createProjections(CPRNG::CXorOShiro128Plus& rng,
     LOG_TRACE(<< "# projections = " << numberProjections << ", dimension = " << dimension
               << ", projection dimension = " << projectionDimension);
 
-    TPointVecVec result;
+    TMatrixVec result;
     result.reserve(numberProjections);
 
     if (projectionDimension < dimension) {
@@ -175,35 +165,19 @@ CEnsemble<POINT>::createProjections(CPRNG::CXorOShiro128Plus& rng,
                                        projection.size() / projectionDimension)};
 
                 for (std::size_t i = 0; i < n; ++i) {
-                    result.push_back({});
+                    result.emplace_back(projectionDimension, dimension);
                     for (std::size_t j = 0; j < projectionDimension; ++j) {
                         std::size_t index{projectionDimension * i + j};
-                        result.back().push_back(std::move(projection[index]));
+                        result.back().row(j) = std::move(projection[index]);
                     }
                 }
             }
         }
     } else {
-        // Identity.
-        result.resize(numberProjections);
-        for (std::size_t p = 0; p < numberProjections; ++p) {
-            result[p].resize(projectionDimension, SConstant<TPoint>::get(dimension, 0));
-            for (std::size_t d = 0; d < dimension; ++d) {
-                result[p][d](d) = 1.0;
-            }
-        }
+        // Identity matices.
+        result.resize(numberProjections, TMatrix::Identity(dimension, dimension));
     }
 
-    return result;
-}
-
-template<typename POINT>
-typename CEnsemble<POINT>::TPoint
-CEnsemble<POINT>::project(const TPointVec& projection, const POINT& point) {
-    auto result = SConstant<TPoint>::get(projection.size(), 0);
-    for (std::size_t pd = 0; pd < projection.size(); ++pd) {
-        result(pd) = las::inner(projection[pd], point);
-    }
     return result;
 }
 
@@ -211,10 +185,10 @@ template<typename POINT>
 CEnsemble<POINT>::CModelBuilder::CModelBuilder(CPRNG::CXorOShiro128Plus& rng,
                                                TSizeSizePrVec&& methodsAndNumberNeighbours,
                                                std::size_t sampleSize,
-                                               TPointVec&& projection)
+                                               TMatrix&& projection)
     : m_MethodsAndNumberNeighbours{std::forward<TSizeSizePrVec>(methodsAndNumberNeighbours)},
       m_SampleSize{sampleSize}, m_Sampler{makeSampler(rng, sampleSize)},
-      m_Projection(std::forward<TPointVec>(projection)) {
+      m_Projection{std::forward<TMatrix>(projection)} {
 
     m_SampledProjectedPoints.reserve(m_Sampler.targetSampleSize());
 }
@@ -245,19 +219,20 @@ CEnsemble<POINT>::CModelBuilder::makeSampler(CPRNG::CXorOShiro128Plus& rng,
                                              std::size_t sampleSize) {
     auto onSample = [this](std::size_t index, const TRowRef& row) {
         if (index >= m_SampledProjectedPoints.size()) {
-            m_SampledProjectedPoints.push_back(
-                project(m_Projection, CDataFrameUtils::rowTo<POINT>(row)));
+            m_SampledProjectedPoints.emplace_back(
+                m_Projection * CDataFrameUtils::rowTo<POINT>(row));
         } else {
-            m_SampledProjectedPoints[index] =
-                project(m_Projection, CDataFrameUtils::rowTo<POINT>(row));
+            m_SampledProjectedPoints[index] = m_Projection *
+                                              CDataFrameUtils::rowTo<POINT>(row);
         }
     };
     return {sampleSize, onSample, rng};
 }
 
 template<typename POINT>
-void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulatorVec& logScoreMoments,
-                                    const TDoubleVec& scores) {
+void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulator2Vec& logScoreMoments,
+                                    const TMatrix& rowNormalizedProjection,
+                                    const TDouble1Vec2Vec& scores) {
 
     // The basic idea is to map score percentile to a probability that the data
     // point is an outlier. We use a monotonic function for this which is flat
@@ -268,48 +243,13 @@ void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulatorVec& logScoreMoment
     // of benchmark sets to make this effective a priori. We also account for the
     // fact that the scores will be somewhat correlated.
 
-    auto pOutlier = [](double cdfComplement) {
-        static const double LOG_KNOTS[]{
-            CTools::fastLog(1e-5), CTools::fastLog(1e-3), CTools::fastLog(0.01),
-            CTools::fastLog(0.1),  CTools::fastLog(0.2),  CTools::fastLog(0.4),
-            CTools::fastLog(0.5),  CTools::fastLog(0.6),  CTools::fastLog(0.8),
-            CTools::fastLog(1.0)};
-        static const double KNOT_PROBABILITIES[]{0.98, 0.87, 0.76, 0.65, 0.6,
-                                                 0.5,  0.5,  0.5,  0.3,  0.3};
-
-        double logCdfComplement{CTools::fastLog(std::max(cdfComplement, 1e-5))};
-        auto k = std::upper_bound(std::begin(LOG_KNOTS), std::end(LOG_KNOTS), logCdfComplement);
-        return CTools::linearlyInterpolate(
-            *(k - 1), *k, KNOT_PROBABILITIES[k - std::begin(LOG_KNOTS) - 1],
-            KNOT_PROBABILITIES[k - std::begin(LOG_KNOTS)], logCdfComplement);
-    };
-
-    static const double EXPECTED_PROBABILITY{[pOutlier] {
-        double result{0.0};
-        for (double x = 0.0; x < 0.99; x += 0.1) {
-            double interval;
-            CIntegration::gaussLegendre<CIntegration::OrderTwo>(
-                [pOutlier](double x_, double& r) {
-                    r = pOutlier(x_);
-                    return true;
-                },
-                x, x + 0.1, interval);
-            result += interval;
-        }
-        return result;
-    }()};
-
-    double logLikelihoodOutlierGivenScores{0.0};
-    double logLikelihoodInlierGivenScores{0.0};
-
-    for (std::size_t i = 0; i < scores.size(); ++i) {
+    auto scoreCdfComplement = [&](std::size_t i, std::size_t j) {
         double location{CBasicStatistics::mean(logScoreMoments[i])};
         double scale{std::sqrt(CBasicStatistics::variance(logScoreMoments[i]))};
-        double cdfComplement{0.5};
         if (scale > 0.0) {
             try {
                 boost::math::lognormal lognormal{location, scale};
-                cdfComplement = CTools::safeCdfComplement(lognormal, shift(scores[i]));
+                return CTools::safeCdfComplement(lognormal, shift(scores[i][j]));
             } catch (const std::exception& e) {
                 // In this case, we use the initial value of 0.5 for the cdfComplement
                 // which means P(outlier | score) = P(inlier | score) = 0.5. The outcome
@@ -321,55 +261,126 @@ void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulatorVec& logScoreMoment
                          << "'. Results maybe compromised.");
             }
         }
+        return 0.5;
+    };
 
-        double pOutlierGivenScore{pOutlier(cdfComplement) * 0.5 / EXPECTED_PROBABILITY};
+    auto pOutlierGiven = [](double cdfComplement) {
 
-        logLikelihoodOutlierGivenScores += CTools::fastLog(pOutlierGivenScore);
-        logLikelihoodInlierGivenScores += CTools::fastLog(1.0 - pOutlierGivenScore);
+        static const TDoubleVec LOG_KNOTS{
+            CTools::fastLog(1e-5), CTools::fastLog(1e-3), CTools::fastLog(0.01),
+            CTools::fastLog(0.1),  CTools::fastLog(0.2),  CTools::fastLog(0.4),
+            CTools::fastLog(0.5),  CTools::fastLog(0.6),  CTools::fastLog(0.8),
+            CTools::fastLog(1.0)};
+        static const TDoubleVec KNOTS_P_OUTLIER{0.98, 0.87, 0.76, 0.65, 0.6,
+                                                0.5,  0.5,  0.5,  0.3,  0.3};
+
+        double logCdfComplement{CTools::fastLog(std::max(cdfComplement, 1e-5))};
+        auto k = std::upper_bound(LOG_KNOTS.begin(), LOG_KNOTS.end(), logCdfComplement);
+
+        return CTools::linearlyInterpolate(
+            *(k - 1), *k, KNOTS_P_OUTLIER[k - LOG_KNOTS.begin() - 1],
+            KNOTS_P_OUTLIER[k - LOG_KNOTS.begin()], logCdfComplement);
+    };
+
+    static const double EXPECTED_P_OUTLIER{[=] {
+        double result{0.0};
+        for (double x = 0.0; x < 0.99; x += 0.1) {
+            double interval;
+            CIntegration::gaussLegendre<CIntegration::OrderTwo>(
+                [=](double x_, double& r) {
+                    r = pOutlierGiven(x_);
+                    return true;
+                },
+                x, x + 0.1, interval);
+            result += interval;
+        }
+        return result;
+    }()};
+
+    double logLikelihoodOutlier{0.0};
+    double logLikelihoodInlier{0.0};
+    TDouble2Vec weights(scores.size(), 0.0);
+    for (std::size_t i = 0; i < scores.size(); ++i) {
+        double pOutlier{0.5 / EXPECTED_P_OUTLIER * pOutlierGiven(scoreCdfComplement(i, 0))};
+        logLikelihoodOutlier += CTools::fastLog(pOutlier);
+        logLikelihoodInlier += CTools::fastLog(1.0 - pOutlier);
+        weights[i] = pOutlier;
     }
+    double likelihoodOutlier{std::exp(logLikelihoodOutlier)};
+    double likelihoodInlier{std::exp(logLikelihoodInlier)};
+    double pOutlier{likelihoodOutlier / (likelihoodInlier + likelihoodOutlier)};
+    double pInlier{1.0 - pOutlier};
 
-    double pOutlierGivenScores{std::exp(logLikelihoodOutlierGivenScores)};
-    double pInlierGivenScores{std::exp(logLikelihoodInlierGivenScores)};
-    double Z{pInlierGivenScores + pOutlierGivenScores};
+    m_State.resize(2);
+    this->ensembleSize() += 1.0;
+    this->logLikelihoodOutlier() += CTools::fastLog(pOutlier) - CTools::fastLog(pInlier);
 
-    m_EnsembleSize += 1.0;
-    m_LogLikelihoodOutlierGivenScores += CTools::fastLog(pOutlierGivenScores / Z);
-    m_LogLikelihoodInlierGivenScores += CTools::fastLog(pInlierGivenScores / Z);
+    std::size_t numberScores{scores[0].size()};
+    if (numberScores > 1) {
+        TPoint significances{SConstant<TPoint>::get(numberScores - 1, 0)};
+        for (std::size_t i = 0; i < scores.size(); ++i) {
+            double fi0{scoreCdfComplement(i, 0)};
+            for (std::size_t j = 1; j < numberScores; ++j) {
+                double fij{scoreCdfComplement(i, j)};
+                significances(j - 1) += weights[i] * std::max(fij - fi0, 0.0);
+            }
+        }
+        significances = rowNormalizedProjection * significances;
+        std::size_t numberSignificances{las::dimension(significances)};
+
+        m_State.resize(numberSignificances + 2);
+        for (std::size_t i = 0; i < numberSignificances; ++i) {
+            this->significance(i) += significances(i);
+        }
+    }
 }
 
 template<typename POINT>
-double CEnsemble<POINT>::CScorer::compute(double pOutlier) const {
-
-    double pInlier{1.0 - pOutlier};
-
-    double logLikelihoodOutlier{m_LogLikelihoodOutlierGivenScores};
-    double logLikelihoodInlier{m_LogLikelihoodInlierGivenScores};
-
-    double renorm{std::max(logLikelihoodOutlier, logLikelihoodInlier)};
-    logLikelihoodOutlier -= renorm;
-    logLikelihoodInlier -= renorm;
+TDouble1Vec CEnsemble<POINT>::CScorer::compute(double pOutlier) const {
 
     // For large ensemble sizes, the classification becomes unrealistically
     // confident. For a high degree of confidence we instead require that the
     // point has a significant chance of being an outlier for a significant
-    // fraction of the ensemble models, i.e. 4 out of 5. In the following, we
-    // use the fact that max(P(outlier), P(inlier)) is zero after renormalisation.
-
-    (logLikelihoodInlier < logLikelihoodOutlier ? logLikelihoodInlier
-                                                : logLikelihoodOutlier) /= 0.8 * m_EnsembleSize;
+    // fraction of the ensemble models, i.e. 4 out of 5.
+    double logLikelihoodOutlier{this->logLikelihoodOutlier() / (0.8 * this->ensembleSize())};
 
     // The conditional probability follows from Bayes rule.
     double likelihoodOutlier{std::exp(logLikelihoodOutlier + CTools::fastLog(pOutlier))};
-    double likelihoodInlier{std::exp(logLikelihoodInlier + CTools::fastLog(pInlier))};
-    return likelihoodOutlier / (likelihoodOutlier + likelihoodInlier);
+    double likelihoodInlier{std::exp(CTools::fastLog(1.0 - pOutlier))};
+
+    TDouble1Vec result{likelihoodOutlier / (likelihoodOutlier + likelihoodInlier)};
+
+    // The normalised feature significances.
+    result.resize(this->numberSignificances() + 1);
+    double Z{0.0};
+    for (std::size_t i = 1; i < result.size(); ++i) {
+        Z += result[i] = this->significance(i - 1);
+    }
+    for (std::size_t i = 1; Z > 0.0 && i < result.size(); ++i) {
+        result[i] /= Z;
+    }
+
+    return result;
 }
 
 template<typename POINT>
 CEnsemble<POINT>::CModel::CModel(const TMethodFactoryVec& methodFactories,
                                  TSizeSizePrVec methodsAndNumberNeighbours,
                                  TPointVec sample,
-                                 TPointVec projection)
-    : m_Lookup{std::make_unique<TKdTree>()}, m_Projection{std::move(projection)} {
+                                 TMatrix projection)
+    : m_Lookup{std::make_unique<TKdTree>()}, m_Projection{std::move(projection)},
+      m_RowNormalizedProjection(m_Projection.cols(), m_Projection.rows()) {
+
+    // Column normalized absolute projection values.
+    for (std::ptrdiff_t i = 0; i < m_Projection.rows(); ++i) {
+        double Z{0.0};
+        for (std::ptrdiff_t j = 0; j < m_Projection.cols(); ++j) {
+            Z += std::fabs(m_Projection(i, j));
+        }
+        for (std::ptrdiff_t j = 0; j < m_Projection.cols(); ++j) {
+            m_RowNormalizedProjection(j, i) = std::fabs(m_Projection(i, j)) / Z;
+        }
+    }
 
     m_Lookup->reserve(sample.size());
     m_Lookup->build(sample);
@@ -388,23 +399,18 @@ CEnsemble<POINT>::CModel::CModel(const TMethodFactoryVec& methodFactories,
 
     m_LogScoreMoments.reserve(methods.size());
 
-    TDoubleVec scores;
     TProgressCallback noop{[](double) {}};
+
     for (auto& method : methods) {
-        method->progressRecorder().swap(noop);
-
-        TDoubleVecVec scores_;
-        method->run(sample, sample.size(), scores_);
-        scores = std::move(scores_[0]);
 
         method->progressRecorder().swap(noop);
-
-        for (auto& score : scores) {
-            score = CTools::fastLog(shift(score));
-        }
+        TDouble1VecVec2Vec scores{method->run(sample, sample.size())};
+        method->progressRecorder().swap(noop);
 
         m_LogScoreMoments.emplace_back();
-        m_LogScoreMoments.back().add(scores);
+        for (std::size_t i = 0; i < scores[0].size(); ++i) {
+            m_LogScoreMoments.back().add(CTools::fastLog(shift(scores[0][i][0])));
+        }
     }
     m_Method = std::make_unique<CMultipleMethods<TPoint, const TKdTree&>>(
         maxk, std::move(methods), *m_Lookup);
@@ -429,27 +435,26 @@ void CEnsemble<POINT>::CModel::addOutlierScores(const std::vector<POINT>& points
     TPointVec points_;
     points_.reserve(points.size());
     for (std::size_t i = 0; i < points.size(); ++i, ++index) {
-        points_.emplace_back(project(m_Projection, points[i]), index);
+        points_.emplace_back(m_Projection * points[i], index);
     }
 
-    TDoubleVecVec methodScores;
-    m_Method->run(points_, index, methodScores);
+    TDouble1VecVec2Vec methodScores{m_Method->run(points_, index)};
+    m_Method->recoverMemory();
 
-    TDoubleVec pointScores(methodScores.size());
+    TDouble1Vec2Vec pointScores(methodScores.size());
     for (std::size_t i = 0; i < points_.size(); ++i) {
         index = points_[i].annotation();
         for (std::size_t j = 0; j < methodScores.size(); ++j) {
-            pointScores[j] = methodScores[j][index];
+            pointScores[j] = std::move(methodScores[j][index]);
         }
-        scores[i].add(m_LogScoreMoments, pointScores);
+        scores[i].add(m_LogScoreMoments, m_RowNormalizedProjection, pointScores);
     }
 }
 
 template<typename POINT>
 std::string CEnsemble<POINT>::CModel::print() const {
-    return "projection = " + std::to_string(m_Projection.size()) + " x " +
-           std::to_string(las::dimension(m_Projection[0])) +
-           " method = " + m_Method->print() +
+    return "projection = " + std::to_string(m_Projection.rows()) + " x " +
+           std::to_string(m_Projection.cols()) + " method = " + m_Method->print() +
            " score moments = " + core::CContainerPrinter::print(m_LogScoreMoments);
 }
 }
@@ -460,32 +465,39 @@ namespace {
 using TRowItr = core::CDataFrame::TRowItr;
 
 template<typename POINT>
-typename CEnsemble<POINT>::TMethodFactoryVec methodFactories(TProgressCallback recordProgress) {
+typename CEnsemble<POINT>::TMethodFactoryVec
+methodFactories(bool featureSignificances, TProgressCallback recordProgress) {
+
     using TPoint = typename CEnsemble<POINT>::TPoint;
     using TKdTree = typename CEnsemble<POINT>::TKdTree;
 
     typename CEnsemble<POINT>::TMethodFactoryVec result;
     result.reserve(4);
 
-    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
-        return std::make_unique<CLof<TPoint, const TKdTree&>>(k, recordProgress, lookup);
+    result.emplace_back([=](std::size_t k, const TKdTree& lookup) {
+        return std::make_unique<CLof<TPoint, const TKdTree&>>(
+            featureSignificances, k, recordProgress, lookup);
     });
-    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
-        return std::make_unique<CLdof<TPoint, const TKdTree&>>(k, recordProgress, lookup);
+    result.emplace_back([=](std::size_t k, const TKdTree& lookup) {
+        return std::make_unique<CLdof<TPoint, const TKdTree&>>(
+            featureSignificances, k, recordProgress, lookup);
     });
-    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
-        return std::make_unique<CDistancekNN<TPoint, const TKdTree&>>(k, recordProgress, lookup);
+    result.emplace_back([=](std::size_t k, const TKdTree& lookup) {
+        return std::make_unique<CDistancekNN<TPoint, const TKdTree&>>(
+            featureSignificances, k, recordProgress, lookup);
     });
-    result.emplace_back([recordProgress](std::size_t k, const TKdTree& lookup) {
+    result.emplace_back([=](std::size_t k, const TKdTree& lookup) {
         return std::make_unique<CTotalDistancekNN<TPoint, const TKdTree&>>(
-            k, recordProgress, lookup);
+            featureSignificances, k, recordProgress, lookup);
     });
 
     return result;
 }
 
 template<typename POINT>
-CEnsemble<POINT> buildEnsemble(core::CDataFrame& frame, TProgressCallback recordProgress) {
+CEnsemble<POINT> buildEnsemble(bool featureSignificances,
+                               core::CDataFrame& frame,
+                               TProgressCallback recordProgress) {
 
     using TSizeVec = typename CEnsemble<POINT>::TSizeVec;
     using TSizeVecVec = typename CEnsemble<POINT>::TSizeVecVec;
@@ -505,18 +517,22 @@ CEnsemble<POINT> buildEnsemble(core::CDataFrame& frame, TProgressCallback record
         }
     });
 
-    return {methodFactories<POINT>(recordProgress), std::move(builders)};
+    return {methodFactories<POINT>(featureSignificances, std::move(recordProgress)),
+            std::move(builders)};
 }
 
-bool computeOutliersNoPartitions(std::size_t numberThreads,
+bool computeOutliersNoPartitions(const COutliers::SComputeParameters& params,
                                  core::CDataFrame& frame,
                                  TProgressCallback recordProgress) {
 
     using TPoint = CMemoryMappedDenseVector<CFloatStorage>;
     using TPointVec = std::vector<TPoint>;
 
-    CEnsemble<TPoint> ensemble{buildEnsemble<TPoint>(frame, recordProgress)};
+    CEnsemble<TPoint> ensemble{buildEnsemble<TPoint>(params.s_FeatureSignificances,
+                                                     frame, recordProgress)};
     LOG_TRACE(<< "Ensemble = " << ensemble.print());
+
+    std::size_t dimension{frame.numberColumns()};
 
     // The points will be entirely overwritten by readRows so the initial value
     // is not important. This is presized so that rowsToPoints only needs to
@@ -533,15 +549,14 @@ bool computeOutliersNoPartitions(std::size_t numberThreads,
     std::uint64_t checksum{frame.checksum()};
 
     bool successful;
-    std::tie(std::ignore, successful) = frame.readRows(numberThreads, rowsToPoints);
+    std::tie(std::ignore, successful) = frame.readRows(params.s_NumberThreads, rowsToPoints);
 
     if (successful == false) {
         LOG_ERROR(<< "Failed to read the data frame");
         return false;
     }
 
-    TDoubleVec scores;
-    ensemble.computeOutlierScores(points, scores);
+    auto scores = ensemble.computeOutlierScores(points);
 
     // This is a sanity check against CEnsemble accidentally writing to the data
     // frame via one of the memory mapped vectors. All bets are off as to whether
@@ -551,39 +566,45 @@ bool computeOutliersNoPartitions(std::size_t numberThreads,
         return false;
     }
 
-    auto writeScores = [&scores](TRowItr beginRows, TRowItr endRows) {
+    auto writeScores = [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            row->writeColumn(row->numberColumns() - 1, scores[row->index()]);
+            std::size_t index{dimension};
+            for (auto value : scores[row->index()].compute(params.s_ProbabilityOutlier)) {
+                row->writeColumn(index++, value);
+            }
         }
     };
 
-    frame.resizeColumns(numberThreads, frame.numberColumns() + 1);
+    frame.resizeColumns(params.s_NumberThreads,
+                        (params.s_FeatureSignificances ? 2 : 1) * dimension + 1);
 
-    if (frame.writeColumns(numberThreads, writeScores) == false) {
+    if (frame.writeColumns(params.s_NumberThreads, writeScores) == false) {
         LOG_ERROR(<< "Failed to write scores to the data frame");
         return false;
     }
     return true;
 }
 
-bool computeOutliersPartitioned(std::size_t numberThreads,
-                                std::size_t numberPartitions,
+bool computeOutliersPartitioned(const COutliers::SComputeParameters& params,
                                 core::CDataFrame& frame,
                                 TProgressCallback recordProgress) {
 
     using TPoint = CDenseVector<CFloatStorage>;
     using TPointVec = std::vector<TPoint>;
 
-    CEnsemble<TPoint> ensemble{buildEnsemble<TPoint>(frame, [=](double progress) {
-        recordProgress(progress / static_cast<double>(numberPartitions));
-    })};
+    CEnsemble<TPoint> ensemble{buildEnsemble<TPoint>(
+        params.s_FeatureSignificances, frame, [=](double progress) {
+            recordProgress(progress / static_cast<double>(params.s_NumberPartitions));
+        })};
     LOG_TRACE(<< "Ensemble = " << ensemble.print());
 
     std::size_t dimension{frame.numberColumns()};
 
-    frame.resizeColumns(numberThreads, dimension + 1);
+    frame.resizeColumns(params.s_NumberThreads,
+                        (params.s_FeatureSignificances ? 2 : 1) * dimension + 1);
 
-    std::size_t rowsPerPartition{(frame.numberRows() + numberPartitions - 1) / numberPartitions};
+    std::size_t rowsPerPartition{(frame.numberRows() + params.s_NumberPartitions - 1) /
+                                 params.s_NumberPartitions};
     LOG_TRACE(<< "# rows = " << frame.numberRows() << ", # partitions = " << numberPartitions
               << ", # rows per partition = " << rowsPerPartition);
 
@@ -591,7 +612,7 @@ bool computeOutliersPartitioned(std::size_t numberThreads,
     // each element. Since it does this once per element it is thread safe.
     TPointVec points(rowsPerPartition, SConstant<TPoint>::get(dimension, 0.0));
 
-    for (std::size_t i = 0, beginPartitionRows = 0; i < numberPartitions;
+    for (std::size_t i = 0, beginPartitionRows = 0; i < params.s_NumberPartitions;
          ++i, beginPartitionRows += rowsPerPartition) {
 
         std::size_t endPartitionRows{beginPartitionRows + rowsPerPartition};
@@ -609,24 +630,26 @@ bool computeOutliersPartitioned(std::size_t numberThreads,
 
         bool successful;
         std::tie(std::ignore, successful) = frame.readRows(
-            numberThreads, beginPartitionRows, endPartitionRows, rowsToPoints);
+            params.s_NumberThreads, beginPartitionRows, endPartitionRows, rowsToPoints);
 
         if (successful == false) {
             LOG_ERROR(<< "Failed to read the data frame");
             return false;
         }
 
-        TDoubleVec scores;
-        ensemble.computeOutlierScores(points, scores);
+        auto scores = ensemble.computeOutlierScores(points);
 
-        auto writeScores = [beginPartitionRows, dimension,
-                            &scores](TRowItr beginRows, TRowItr endRows) {
+        auto writeScores = [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                row->writeColumn(dimension, scores[row->index() - beginPartitionRows]);
+                std::size_t offset{row->index() - beginPartitionRows};
+                std::size_t index{dimension};
+                for (auto value : scores[offset].compute(params.s_ProbabilityOutlier)) {
+                    row->writeColumn(index++, value);
+                }
             }
         };
 
-        if (frame.writeColumns(numberThreads, beginPartitionRows,
+        if (frame.writeColumns(params.s_NumberThreads, beginPartitionRows,
                                endPartitionRows, writeScores) == false) {
             LOG_ERROR(<< "Failed to write scores to the data frame");
             return false;
@@ -637,19 +660,17 @@ bool computeOutliersPartitioned(std::size_t numberThreads,
 }
 }
 
-void COutliers::compute(std::size_t numberThreads,
-                        std::size_t numberPartitions,
+void COutliers::compute(const SComputeParameters& params,
                         core::CDataFrame& frame,
                         TProgressCallback recordProgress) {
     // TODO memory monitoring.
-    // TODO different analysis types.
+    // TODO user overrides.
 
-    CDataFrameUtils::standardizeColumns(numberThreads, frame);
+    CDataFrameUtils::standardizeColumns(params.s_NumberThreads, frame);
 
-    bool successful{frame.inMainMemory() && numberPartitions == 1
-                        ? computeOutliersNoPartitions(numberThreads, frame, recordProgress)
-                        : computeOutliersPartitioned(numberThreads, numberPartitions,
-                                                     frame, recordProgress)};
+    bool successful{frame.inMainMemory() && params.s_NumberPartitions == 1
+                        ? computeOutliersNoPartitions(params, frame, recordProgress)
+                        : computeOutliersPartitioned(params, frame, recordProgress)};
 
     if (successful == false) {
         HANDLE_FATAL(<< "Internal error: computing outliers for data frame. There "

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -438,7 +438,7 @@ void CEnsemble<POINT>::CModel::addOutlierScores(const std::vector<POINT>& points
         points_.emplace_back(m_Projection * points[i], index);
     }
 
-    TDouble1VecVec2Vec methodScores{m_Method->run(points_, index)};
+    TDouble1VecVec2Vec methodScores(m_Method->run(points_, index));
     m_Method->recoverMemory();
 
     TDouble1Vec2Vec pointScores(methodScores.size());

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -116,7 +116,9 @@ void outlierErrorStatisticsForEnsemble(std::size_t numberThreads,
 
         auto dataFrame = pointsToDataFrame(points);
 
-        maths::COutliers::compute(numberThreads, numberPartitions, *dataFrame);
+        maths::COutliers::SComputeParameters params{numberThreads,
+                                                    numberPartitions, false, 0.05};
+        maths::COutliers::compute(params, *dataFrame);
 
         dataFrame->readRows(1, [&scores](core::CDataFrame::TRowItr beginRows,
                                          core::CDataFrame::TRowItr endRows) {
@@ -427,7 +429,8 @@ void COutliersTest::testProgressMonitoring() {
         std::atomic_bool finished{false};
 
         std::thread worker{[&]() {
-            maths::COutliers::compute(2, numberPartitions[i], *dataFrame, reportProgress);
+            maths::COutliers::SComputeParameters params{2, numberPartitions[i], false, 0.05};
+            maths::COutliers::compute(params, *dataFrame, reportProgress);
             finished.store(true);
         }};
 

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -392,7 +392,7 @@ void COutliersTest::testEnsemble() {
     }
 }
 
-void COutliersTest::testSignificantFeatures() {
+void COutliersTest::testFeatureInfluences() {
 
     // Test calculation of outlier significant features.
 
@@ -463,17 +463,17 @@ void COutliersTest::testSignificantFeatures() {
                     if (row->index() == outlierIndexes[0]) {
                         LOG_DEBUG(<< "x-significance = " << (*row)[3]
                                   << ", y-significance = " << (*row)[4]);
-                        passed &= (1.0 - (*row)[4] < 0.001);
+                        passed &= (1.0 - (*row)[4] < 0.005);
                     }
                     if (row->index() == outlierIndexes[1]) {
                         LOG_DEBUG(<< "x-significance = " << (*row)[3]
                                   << ", y-significance = " << (*row)[4]);
-                        passed &= (1.0 - (*row)[3] < 0.001);
+                        passed &= (1.0 - (*row)[3] < 0.005);
                     }
                     if (row->index() == outlierIndexes[2]) {
                         LOG_DEBUG(<< "x-significance = " << (*row)[3]
                                   << ", y-significance = " << (*row)[4]);
-                        passed &= (std::fabs((*row)[4] - (*row)[3]) < 0.5);
+                        passed &= (std::fabs((*row)[4] - (*row)[3]) < 0.2);
                     }
                 }
             });
@@ -566,7 +566,7 @@ CppUnit::Test* COutliersTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<COutliersTest>(
         "COutliersTest::testEnsemble", &COutliersTest::testEnsemble));
     suiteOfTests->addTest(new CppUnit::TestCaller<COutliersTest>(
-        "COutliersTest::testSignificantFeatures", &COutliersTest::testSignificantFeatures));
+        "COutliersTest::testFeatureInfluences", &COutliersTest::testFeatureInfluences));
     suiteOfTests->addTest(new CppUnit::TestCaller<COutliersTest>(
         "COutliersTest::testProgressMonitoring", &COutliersTest::testProgressMonitoring));
 

--- a/lib/maths/unittest/COutliersTest.h
+++ b/lib/maths/unittest/COutliersTest.h
@@ -16,6 +16,7 @@ public:
     void testDistancekNN();
     void testTotalDistancekNN();
     void testEnsemble();
+    void testSignificantFeatures();
     void testProgressMonitoring();
 
     static CppUnit::Test* suite();

--- a/lib/maths/unittest/COutliersTest.h
+++ b/lib/maths/unittest/COutliersTest.h
@@ -16,7 +16,7 @@ public:
     void testDistancekNN();
     void testTotalDistancekNN();
     void testEnsemble();
-    void testSignificantFeatures();
+    void testFeatureInfluences();
     void testProgressMonitoring();
 
     static CppUnit::Test* suite();


### PR DESCRIPTION
This wires in a calculation of which features are most responsible for a point being an outlier. Very briefly, this is based on understanding how the outlier score changes as we change each feature value independently. The greater the change in the score the greater the feature's influence. I'll prepare some separate detailed documentation.

The extra values are written with the label `feature_influence.<feature_name>` in the result document.

Although this wires it through to result writing it is default disabled and not currently possible to enable. I need to finish up supporting user configuration and will make the change to allow it to be optionally enabled and unit test the result writing in a separate PR. 