### PR TITLE
[ML] Rework user overrides for data frame analytics plus support overriding additional parameters for outlier detection

### DIFF
--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -88,7 +88,7 @@ public:
         //! Get an enum point parameter.
         template<typename ENUM>
         ENUM fallback(ENUM value) const {
-            static_assert(std::is_enum<ENUM>::value, "Type must be an enumeration");
+            static_assert(std::is_enum<ENUM>::value, "ENUM must be an enumeration");
             if (m_Value == nullptr) {
                 return value;
             }

--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_api_CDataFrameAnalysisConfigReader_h
+#define INCLUDED_ml_api_CDataFrameAnalysisConfigReader_h
+
+#include <core/CLogger.h>
+
+#include <api/ImportExport.h>
+
+#include <rapidjson/document.h>
+
+#include <map>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace ml {
+namespace api {
+
+//! \brief Reads and validates parameters for a data frame analysis.
+//!
+//! DESCRIPTION:\n
+//! This wraps up extracting parameter values from a JSON configuration object.
+//! It supports predefining a set of expected parameters. It is expected that
+//! there will be one static reader object per analysis type.
+//!
+//! The read method extracts all the parameters the JSON contains and returns
+//! a collection to get them by name.
+//!
+//! Expected usage is:
+//! \code
+//! static const CDataFrameAnalysisConfigReader reader{[] {
+//!     CDataFrameAnalysisConfigReader theReader;
+//!     theReader.addParameter("foo", CDataFrameAnalysisConfigReader::E_OptionalParameter);
+//!     theReader.addParameter("bar", CDataFrameAnalysisConfigReader::E_RequiredParameter);
+//! }()};
+//!
+//! auto parameters = reader.read(json);
+//! bool foo{parameters["foo"].fallback(true)};
+//! double bar{parameters["bar"].as<double>()};
+//! \endcode
+//!
+//! IMPLEMENTATION:\n
+//! Not understanding a parameter is likely to result in the wrong analysis being
+//! performed so any errors are treated as fatal causing the process to terminate
+//! immediately. For the same reason this treats unexpected parameters as an error.
+//! It is the calling code's responsibility to ask for the right type for a parameter.
+//! If a parameter is known to exist, i.e. it is required, then it can be accessed
+//! from the read value by calling as<T>(), for type T, otherwise use the fallback
+//! method and provide the default value for the case it is missing.
+class API_EXPORT CDataFrameAnalysisConfigReader {
+public:
+    using TStrIntMap = std::map<std::string, int>;
+
+    enum ERequirement { E_OptionalParameter, E_RequiredParameter };
+
+    //! \brief A single parameter which has been read.
+    class API_EXPORT CParameter {
+    public:
+        CParameter(const char* name) : m_Name{name} {}
+        CParameter(const char* name, const rapidjson::Value& value, const TStrIntMap& permittedValues);
+
+        //! Get the name of the parameter.
+        const char* name() const { return m_Name; }
+        //! Get the parameter of type T.
+        template<typename T>
+        T as() const {
+            if (m_Value == nullptr) {
+                HANDLE_FATAL(<< "Input error: expected value for '" << m_Name
+                             << "'. Please report this problem.");
+            }
+            return this->fallback(T{});
+        }
+        //! Get the JSON object.
+        const rapidjson::Value* jsonObject() { return m_Value; }
+        //! Get a boolean parameter.
+        bool fallback(bool value) const;
+        //! Get an unsigned integer parameter.
+        std::size_t fallback(std::size_t fallback) const;
+        //! Get a floating point parameter.
+        double fallback(double fallback) const;
+        //! Get a string parameter.
+        std::string fallback(const std::string& fallback) const;
+        //! Get an enum point parameter.
+        template<typename ENUM>
+        ENUM fallback(ENUM value) const {
+            static_assert(std::is_enum<ENUM>::value, "Type must be an enumeration");
+            if (m_Value == nullptr) {
+                return value;
+            }
+            if (m_Value->IsString() == false) {
+                this->handleFatal();
+            }
+            auto pos = m_PermittedValues->find(std::string{m_Value->GetString()});
+            if (pos == m_PermittedValues->end()) {
+                this->handleFatal();
+            }
+            return static_cast<ENUM>(pos->second);
+        }
+
+    private:
+        void handleFatal() const;
+
+    private:
+        const char* m_Name = nullptr;
+        const rapidjson::Value* m_Value = nullptr;
+        const TStrIntMap* m_PermittedValues = nullptr;
+    };
+
+    //! \brief A collection of all parameters which have been read.
+    class API_EXPORT CParameters {
+    public:
+        //! Add \p parameter.
+        void add(const CParameter& parameter) {
+            m_ParameterValues.push_back(parameter);
+        }
+
+        //! Get the parameter called \p name.
+        CParameter operator[](const char* name) const;
+
+    private:
+        std::vector<CParameter> m_ParameterValues;
+    };
+
+public:
+    //! Register a parameter.
+    //!
+    //! \param[in] name The parameter name.
+    //! \param[in] requirement Is the parameter required or optional.
+    //! \param[in] permittedValues The permitted values for an enumeration.
+    void addParameter(const char* name,
+                      ERequirement requirement,
+                      TStrIntMap permittedValues = TStrIntMap{});
+
+    //! Extract the parameters from a JSON object.
+    CParameters read(const rapidjson::Value& json) const;
+
+private:
+    //! Reads a parameter from the JSON configuration object.
+    class API_EXPORT CParameterReader {
+    public:
+        CParameterReader(const char* name, ERequirement requirement, TStrIntMap permittedValues);
+
+        const char* name() const { return m_Name; }
+        bool required() const { return m_Requirement == E_RequiredParameter; }
+        CParameter readFrom(const rapidjson::Value& json) const {
+            return {m_Name, json[m_Name], m_PermittedValues};
+        }
+
+    private:
+        const char* m_Name;
+        ERequirement m_Requirement;
+        TStrIntMap m_PermittedValues;
+    };
+
+private:
+    std::vector<CParameterReader> m_ParameterReaders;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CDataFrameAnalysisConfigReader_h

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -126,7 +126,7 @@ public:
     CDataFrameAnalysisRunner* run(core::CDataFrame& frame) const;
 
 private:
-    void initializeRunner(const char* name, const rapidjson::Value& analysis);
+    void initializeRunner(const rapidjson::Value& jsonAnalysis);
 
 private:
     std::size_t m_NumberRows = 0;

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -23,7 +23,7 @@ class API_EXPORT CDataFrameOutliersRunner final : public CDataFrameAnalysisRunne
 public:
     //! This is not intended to be called directly: use CDataFrameOutliersRunnerFactory.
     CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec,
-                             const rapidjson::Value& params);
+                             const rapidjson::Value& jsonParameters);
 
     //! This is not intended to be called directly: use CDataFrameOutliersRunnerFactory.
     CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec);
@@ -53,9 +53,9 @@ private:
 private:
     //! \name Custom config
     //@{
-    //! If non-null this overrides default number of neighbours to use when computing
+    //! If non-zero this overrides default number of neighbours to use when computing
     //! outlier factors.
-    TOptionalSize m_NumberNeighbours;
+    std::size_t m_NumberNeighbours = 0;
 
     //! Selects the method to use to compute outlier factors; the default is an ensemble
     //! of all supported types.
@@ -63,11 +63,14 @@ private:
     //! \see maths::COutliers for more details.
     std::size_t m_Method;
 
-    //! Compute the relative influence of each feature on each point being outlying.
-    bool m_ComputeFeatureInfluence = false;
+    //! If true then standardise the feature values.
+    bool m_StandardizeColumns = true;
+
+    //! Compute the significance of features responsible for each point being outlying.
+    bool m_ComputeFeatureInfluence = true;
 
     //! The minimum outlier score for which we'll write out feature influence.
-    double m_WriteFeatureInfluenceMinimumScore = 0.1;
+    double m_MinimumScoreToWriteFeatureInfluence = 0.1;
 
     //! The prior probability that a point is an outlier.
     double m_ProbabilityOutlier = 0.05;

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -72,8 +72,8 @@ private:
     //! The minimum outlier score for which we'll write out feature influence.
     double m_MinimumScoreToWriteFeatureInfluence = 0.1;
 
-    //! The prior probability that a point is an outlier.
-    double m_ProbabilityOutlier = 0.05;
+    //! The fraction of true outliers amoung the points.
+    double m_OutlierFraction = 0.05;
     //@}
 };
 

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -42,7 +42,7 @@ struct SRowTo<CDenseVector<T>> {
 };
 }
 
-//! \brief A collection of basic utilities applied to a data frame.
+//! \brief A collection of basic utilities for analyses on a data frame.
 class MATHS_EXPORT CDataFrameUtils : private core::CNonInstantiatable {
 public:
     //! Convert a row of the data frame to a specified vector type.

--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -715,6 +715,7 @@ public:
     makeBuilders(const TSizeVecVec& algorithms,
                  std::size_t numberPoints,
                  std::size_t dimension,
+                 std::size_t numberNeighbours,
                  CPRNG::CXorOShiro128Plus rng = CPRNG::CXorOShiro128Plus{});
 
     //! Compute the outlier scores for \p points.
@@ -902,10 +903,16 @@ public:
         std::size_t s_NumberThreads;
         //! The number of partitions to use.
         std::size_t s_NumberPartitions;
+        //! Standardize the column values before computing outlier scores.
+        bool s_StandardizeColumns;
+        //! The methods to use.
+        EMethod s_Method;
+        //! The number of neighbours to use if non-zero.
+        std::size_t s_NumberNeighbours;
         //! If true also compute the feature influence.
         bool s_ComputeFeatureInfluence;
-        //! The prior probability that a point is an outlier.
-        double s_ProbabilityOutlier;
+        //! The fraction of true outliers amoung the points.
+        double s_OutlierFraction;
     };
 
 public:

--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -71,7 +71,7 @@ CDataFrameAnalysisConfigReader::read(const rapidjson::Value& json) const {
     return result;
 }
 
-CDataFrameAnalysisConfigReader::CParameter::CParameter(const char* name, 
+CDataFrameAnalysisConfigReader::CParameter::CParameter(const char* name,
                                                        const rapidjson::Value& value,
                                                        const TStrIntMap& permittedValues)
     : m_Name{name}, m_Value{&value}, m_PermittedValues{&permittedValues} {
@@ -91,15 +91,18 @@ std::size_t CDataFrameAnalysisConfigReader::CParameter::fallback(std::size_t val
     if (m_Value == nullptr) {
         return value;
     }
-    if (m_Value->IsUint() == false) {
+    if (m_Value->IsUint64() == false) {
         this->handleFatal();
     }
-    return m_Value->GetUint();
+    return m_Value->GetUint64();
 }
 
 double CDataFrameAnalysisConfigReader::CParameter::fallback(double value) const {
     if (m_Value == nullptr) {
         return value;
+    }
+    if (m_Value->IsInt64()) {
+        return static_cast<double>(m_Value->GetInt64());
     }
     if (m_Value->IsDouble() == false) {
         this->handleFatal();
@@ -133,8 +136,8 @@ CDataFrameAnalysisConfigReader::CParameter
 }
 
 CDataFrameAnalysisConfigReader::CParameterReader::CParameterReader(const char* name,
-                                                       ERequirement requirement,
-                                                       TStrIntMap permittedValues)
+                                                                   ERequirement requirement,
+                                                                   TStrIntMap permittedValues)
     : m_Name{name}, m_Requirement{requirement}, m_PermittedValues{std::move(permittedValues)} {
 }
 }

--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CDataFrameAnalysisConfigReader.h>
+
+#include <core/CLogger.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <cstring>
+
+namespace ml {
+namespace api {
+namespace {
+std::string toString(const rapidjson::Value& value) {
+    rapidjson::StringBuffer valueAsString;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(valueAsString);
+    value.Accept(writer);
+    return valueAsString.GetString();
+}
+}
+
+void CDataFrameAnalysisConfigReader::addParameter(const char* name,
+                                                  ERequirement requirement,
+                                                  TStrIntMap permittedValues) {
+    m_ParameterReaders.emplace_back(name, requirement, std::move(permittedValues));
+}
+
+CDataFrameAnalysisConfigReader::CParameters
+CDataFrameAnalysisConfigReader::read(const rapidjson::Value& json) const {
+
+    CParameters result;
+
+    if (json.IsObject() == false) {
+        HANDLE_FATAL(<< "Input error: expected JSON object but input was '"
+                     << toString(json) << "'. Please report this problem.");
+        return result;
+    }
+
+    for (const auto& reader : m_ParameterReaders) {
+        if (json.HasMember(reader.name())) {
+            result.add(reader.readFrom(json));
+        } else if (reader.required()) {
+            HANDLE_FATAL(<< "Input error: missing required parameter '"
+                         << reader.name() << "'. Please report this problem.");
+        } else {
+            result.add(reader.name());
+        }
+    }
+
+    // Check for any unrecognised fields: these might be typos.
+    for (auto i = json.MemberBegin(); i != json.MemberEnd(); ++i) {
+        bool found{false};
+        for (const auto& param : m_ParameterReaders) {
+            if (std::strcmp(i->name.GetString(), param.name()) == 0) {
+                found = true;
+                break;
+            }
+        }
+        if (found == false) {
+            HANDLE_FATAL(<< "Input error: unexpected parameter '"
+                         << i->name.GetString() << "'. Please report this problem.")
+        }
+    }
+
+    return result;
+}
+
+CDataFrameAnalysisConfigReader::CParameter::CParameter(const char* name, 
+                                                       const rapidjson::Value& value,
+                                                       const TStrIntMap& permittedValues)
+    : m_Name{name}, m_Value{&value}, m_PermittedValues{&permittedValues} {
+}
+
+bool CDataFrameAnalysisConfigReader::CParameter::fallback(bool value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsBool() == false) {
+        this->handleFatal();
+    }
+    return m_Value->GetBool();
+}
+
+std::size_t CDataFrameAnalysisConfigReader::CParameter::fallback(std::size_t value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsUint() == false) {
+        this->handleFatal();
+    }
+    return m_Value->GetUint();
+}
+
+double CDataFrameAnalysisConfigReader::CParameter::fallback(double value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsDouble() == false) {
+        this->handleFatal();
+    }
+    return m_Value->GetDouble();
+}
+
+std::string CDataFrameAnalysisConfigReader::CParameter::fallback(const std::string& value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsString() == false) {
+        this->handleFatal();
+    }
+    return m_Value->GetString();
+}
+
+void CDataFrameAnalysisConfigReader::CParameter::handleFatal() const {
+    HANDLE_FATAL(<< "Input error: bad value '" << toString(*m_Value)
+                 << "' for '" << m_Name << "'.");
+}
+
+CDataFrameAnalysisConfigReader::CParameter
+    CDataFrameAnalysisConfigReader::CParameters::operator[](const char* name) const {
+    for (const auto& value : m_ParameterValues) {
+        if (std::strcmp(name, value.name()) == 0) {
+            return value;
+        }
+    }
+    return {name};
+}
+
+CDataFrameAnalysisConfigReader::CParameterReader::CParameterReader(const char* name,
+                                                       ERequirement requirement,
+                                                       TStrIntMap permittedValues)
+    : m_Name{name}, m_Requirement{requirement}, m_PermittedValues{std::move(permittedValues)} {
+}
+}
+}

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -11,6 +11,7 @@
 #include <core/CLogger.h>
 #include <core/CRapidJsonLineWriter.h>
 
+#include <api/CDataFrameAnalysisConfigReader.h>
 #include <api/CDataFrameOutliersRunner.h>
 
 #include <rapidjson/document.h>
@@ -45,23 +46,25 @@ const char* const ANALYSIS{"analysis"};
 const char* const NAME{"name"};
 const char* const PARAMETERS{"parameters"};
 
-const char* const VALID_MEMBER_NAMES[]{ROWS, COLS, MEMORY_LIMIT, THREADS, ANALYSIS};
+const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
+    CDataFrameAnalysisConfigReader theReader;
+    theReader.addParameter(ROWS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(COLS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(MEMORY_LIMIT, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(THREADS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    // TODO required
+    theReader.addParameter(TEMPORARY_DIRECTORY,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(ANALYSIS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    return theReader;
+}()};
 
-template<typename MEMBER>
-bool isValidMember(const MEMBER& member) {
-    return std::find_if(std::begin(VALID_MEMBER_NAMES),
-                        std::end(VALID_MEMBER_NAMES), [&member](const char* name) {
-                            return std::strcmp(name, member.name.GetString()) == 0;
-                        }) != std::end(VALID_MEMBER_NAMES);
-}
-
-std::string toString(const rapidjson::Value& value) {
-    std::ostringstream valueAsString;
-    rapidjson::OStreamWrapper shim{valueAsString};
-    ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> writer{shim};
-    writer.write(value);
-    return valueAsString.str();
-}
+const CDataFrameAnalysisConfigReader ANALYSIS_READER{[] {
+    CDataFrameAnalysisConfigReader theReader;
+    theReader.addParameter(NAME, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(PARAMETERS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    return theReader;
+}()};
 }
 
 CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(const std::string& jsonSpecification)
@@ -70,82 +73,30 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(const std::stri
 
 CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryUPtrVec runnerFactories,
                                                                  const std::string& jsonSpecification)
-    : m_TemporaryDirectory{boost::filesystem::current_path().string()},
-      m_RunnerFactories{std::move(runnerFactories)} {
+    : m_RunnerFactories{std::move(runnerFactories)} {
 
-    rapidjson::Document document;
-    if (document.Parse(jsonSpecification.c_str()) == false) {
+    rapidjson::Document specification;
+    if (specification.Parse(jsonSpecification.c_str()) == false) {
         HANDLE_FATAL(<< "Input error: failed to parse analysis specification '"
                      << jsonSpecification << "'. Please report this problem.");
     } else {
 
-        if (document.IsObject() == false) {
-            HANDLE_FATAL(<< "Input error: expected object but input was '"
-                         << jsonSpecification << "'");
-            return;
-        }
+        auto parameters = CONFIG_READER.read(specification);
 
-        auto isPositiveInteger = [](const rapidjson::Value& value) {
-            return value.IsUint() && value.GetUint() > 0;
-        };
-        auto registerFailure = [&document](const char* name) {
-            if (document.HasMember(name)) {
-                HANDLE_FATAL(<< "Input error: bad value '" << toString(document[name])
-                             << "' for '" << name << "' in analysis specification.");
-            } else {
-                HANDLE_FATAL(<< "Input error: missing '" << name << "' in analysis "
-                             << "specification. Please report this problem.");
-            }
-        };
-
-        if (document.HasMember(ROWS) && isPositiveInteger(document[ROWS])) {
-            m_NumberRows = document[ROWS].GetUint();
-        } else {
-            registerFailure(ROWS);
-        }
-        if (document.HasMember(COLS) && isPositiveInteger(document[COLS])) {
-            m_NumberColumns = document[COLS].GetUint();
-        } else {
-            registerFailure(COLS);
-        }
-        if (document.HasMember(MEMORY_LIMIT) && isPositiveInteger(document[MEMORY_LIMIT])) {
-            m_MemoryLimit = document[MEMORY_LIMIT].GetUint();
-        } else {
-            registerFailure(MEMORY_LIMIT);
-        }
-        if (document.HasMember(THREADS) && isPositiveInteger(document[THREADS])) {
-            m_NumberThreads = document[THREADS].GetUint();
-        } else {
-            registerFailure(THREADS);
-        }
-        // TODO Remove if (false) hack when being passed.
-        if (false) {
-            if (document.HasMember(TEMPORARY_DIRECTORY) &&
-                document[TEMPORARY_DIRECTORY].IsString() &&
-                boost::filesystem::portable_name(document[TEMPORARY_DIRECTORY].GetString())) {
-                m_TemporaryDirectory = document[TEMPORARY_DIRECTORY].GetString();
-            } else {
-                registerFailure(TEMPORARY_DIRECTORY);
+        for (auto name : {ROWS, COLS, MEMORY_LIMIT, THREADS}) {
+            if (parameters[name].as<std::size_t>() == 0) {
+                HANDLE_FATAL(<< "Input error: '" << name << "' must be non-zero");
             }
         }
+        m_NumberRows = parameters[ROWS].as<std::size_t>();
+        m_NumberColumns = parameters[COLS].as<std::size_t>();
+        m_MemoryLimit = parameters[MEMORY_LIMIT].as<std::size_t>();
+        m_NumberThreads = parameters[THREADS].as<std::size_t>();
+        m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(boost::filesystem::current_path().string());
 
-        if (document.HasMember(ANALYSIS) && document[ANALYSIS].IsObject()) {
-            const auto& analysis = document[ANALYSIS];
-            if (analysis.HasMember(NAME) && analysis[NAME].IsString()) {
-                this->initializeRunner(analysis[NAME].GetString(), analysis);
-            } else {
-                registerFailure(NAME);
-            }
-        } else {
-            registerFailure(ANALYSIS);
-        }
-
-        // Check for any unrecognised fields; these might be typos.
-        for (auto i = document.MemberBegin(); i != document.MemberEnd(); ++i) {
-            if (isValidMember(*i) == false) {
-                HANDLE_FATAL(<< "Input error: unexpected member '" << i->name.GetString()
-                             << "' of analysis specification. Please report this problem.");
-            }
+        auto jsonAnalysis = parameters[ANALYSIS].jsonObject();
+        if (jsonAnalysis != nullptr) {
+            this->initializeRunner(*jsonAnalysis);
         }
     }
 }
@@ -193,14 +144,19 @@ CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame&
     return nullptr;
 }
 
-void CDataFrameAnalysisSpecification::initializeRunner(const char* name,
-                                                       const rapidjson::Value& analysis) {
+void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& jsonAnalysis) {
     // We pass of the interpretation of the parameters object to the appropriate
     // analysis runner.
+
+    auto analysis = ANALYSIS_READER.read(jsonAnalysis);
+
+    std::string name{analysis[NAME].as<std::string>()};
+
     for (const auto& factory : m_RunnerFactories) {
-        if (std::strcmp(factory->name(), name) == 0) {
-            m_Runner = analysis.HasMember(PARAMETERS)
-                           ? factory->make(*this, analysis[PARAMETERS])
+        if (name == factory->name()) {
+            auto parameters = analysis[PARAMETERS].jsonObject();
+            m_Runner = parameters != nullptr
+                           ? factory->make(*this, *parameters)
                            : factory->make(*this);
             return;
         }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -92,7 +92,8 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         m_NumberColumns = parameters[COLS].as<std::size_t>();
         m_MemoryLimit = parameters[MEMORY_LIMIT].as<std::size_t>();
         m_NumberThreads = parameters[THREADS].as<std::size_t>();
-        m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(boost::filesystem::current_path().string());
+        m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(
+            boost::filesystem::current_path().string());
 
         auto jsonAnalysis = parameters[ANALYSIS].jsonObject();
         if (jsonAnalysis != nullptr) {
@@ -155,9 +156,8 @@ void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& j
     for (const auto& factory : m_RunnerFactories) {
         if (name == factory->name()) {
             auto parameters = analysis[PARAMETERS].jsonObject();
-            m_Runner = parameters != nullptr
-                           ? factory->make(*this, *parameters)
-                           : factory->make(*this);
+            m_Runner = parameters != nullptr ? factory->make(*this, *parameters)
+                                             : factory->make(*this);
             return;
         }
     }

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -31,6 +31,7 @@ const char* const NUMBER_NEIGHBOURS{"number_neighbours"};
 const char* const METHOD{"method"};
 const char* const COMPUTE_FEATURE_INFLUENCE{"compute_feature_influence"};
 const char* const MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE{"minimum_score_to_write_feature_influence"};
+const char* const OUTLIER_FRACTION{"outlier_fraction"};
 
 const CDataFrameAnalysisConfigReader PARAMETER_READER{[] {
     const std::string lof{"lof"};
@@ -50,6 +51,7 @@ const CDataFrameAnalysisConfigReader PARAMETER_READER{[] {
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE,
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(OUTLIER_FRACTION, CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 
@@ -69,6 +71,7 @@ CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpeci
     m_ComputeFeatureInfluence = parameters[COMPUTE_FEATURE_INFLUENCE].fallback(true);
     m_MinimumScoreToWriteFeatureInfluence =
         parameters[MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE].fallback(0.1);
+    m_OutlierFraction = parameters[OUTLIER_FRACTION].fallback(0.05);
 }
 
 CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec)
@@ -105,7 +108,7 @@ void CDataFrameOutliersRunner::runImpl(core::CDataFrame& frame) {
                                                 static_cast<maths::COutliers::EMethod>(m_Method),
                                                 m_NumberNeighbours,
                                                 m_ComputeFeatureInfluence,
-                                                m_ProbabilityOutlier};
+                                                m_OutlierFraction};
     maths::COutliers::compute(params, frame, this->progressRecorder());
 }
 

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -26,6 +26,7 @@ CCmdSkeleton.cc \
 CConfigUpdater.cc \
 CCsvInputParser.cc \
 CCsvOutputWriter.cc \
+CDataFrameAnalysisConfigReader.cc \
 CDataFrameAnalysisRunner.cc \
 CDataFrameAnalysisSpecification.cc \
 CDataFrameAnalyzer.cc \

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -67,7 +67,6 @@ void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
         }
     }
 
-    // TODO test with params.
     // TODO test running memory is in acceptable range.
 }
 

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -174,14 +174,50 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
         CPPUNIT_ASSERT(errors.size() > 0);
     }
 
-    LOG_DEBUG(<< "Invalid parameters");
+    LOG_DEBUG(<< "Invalid number neighbours");
     {
         LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
-                              "{\"number_neighbours\": 0}"));
+                              "{\"number_neighbours\": -1}"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
             outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
-                                        "{\"number_neighbours\": 0}")};
+                                        "{\"number_neighbours\": -1}")};
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        CPPUNIT_ASSERT(errors.size() > 0);
+    }
+
+    LOG_DEBUG(<< "Invalid method");
+    {
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
+                              "{\"method\": \"lofe\"}"));
+        errors.clear();
+        api::CDataFrameAnalysisSpecification spec{
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
+                                        "{\"method\": \"lofe\"}")};
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        CPPUNIT_ASSERT(errors.size() > 0);
+    }
+
+    LOG_DEBUG(<< "Invalid feature influence");
+    {
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
+                              "{\"compute_feature_influence\": 1}"));
+        errors.clear();
+        api::CDataFrameAnalysisSpecification spec{
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
+                                        "{\"compute_feature_influence\": 1}")};
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        CPPUNIT_ASSERT(errors.size() > 0);
+    }
+
+    LOG_DEBUG(<< "Invalid feature influence");
+    {
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
+                              "{\"compute_feature_influences\": true}"));
+        errors.clear();
+        api::CDataFrameAnalysisSpecification spec{
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
+                                        "{\"compute_feature_influences\": true}")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -38,7 +38,12 @@ using TPoint = maths::CDenseVector<maths::CFloatStorage>;
 using TPointVec = std::vector<TPoint>;
 
 std::unique_ptr<api::CDataFrameAnalysisSpecification>
-outlierSpec(std::size_t rows = 110, std::size_t memoryLimit = 100000) {
+outlierSpec(std::size_t rows = 110,
+            std::size_t memoryLimit = 100000,
+            std::string method = "",
+            std::size_t numberNeighbours = 0,
+            bool computeFeatureInfluence = false) {
+
     std::string spec{"{\n"
                      "  \"rows\": " +
                      std::to_string(rows) +
@@ -49,9 +54,35 @@ outlierSpec(std::size_t rows = 110, std::size_t memoryLimit = 100000) {
                      ",\n"
                      "  \"threads\": 1,\n"
                      "  \"analysis\": {\n"
-                     "    \"name\": \"outlier_detection\""
-                     "  }"
-                     "}"};
+                     "    \"name\": \"outlier_detection\""};
+    spec += ",\n    \"parameters\": {\n";
+    bool hasTrailingParameter{false};
+    if (method != "") {
+        spec += "      \"method\": \"" + method + "\"";
+        hasTrailingParameter = true;
+    }
+    if (numberNeighbours > 0) {
+        spec += (hasTrailingParameter ? ",\n" : "");
+        spec += "      \"number_neighbours\": " +
+                core::CStringUtils::typeToString(numberNeighbours);
+        hasTrailingParameter = true;
+    }
+    if (computeFeatureInfluence == false) {
+        spec += (hasTrailingParameter ? ",\n" : "");
+        spec += "      \"compute_feature_influence\": false";
+        hasTrailingParameter = true;
+    } else {
+        spec += (hasTrailingParameter ? ",\n" : "");
+        spec += "      \"minimum_score_to_write_feature_influence\": 0.0";
+        hasTrailingParameter = true;
+    }
+    spec += (hasTrailingParameter ? "\n" : "");
+    spec += "    }\n";
+    spec += "  }\n"
+            "}";
+
+    LOG_TRACE(<< "spec =\n" << spec);
+
     return std::make_unique<api::CDataFrameAnalysisSpecification>(spec);
 }
 
@@ -59,8 +90,12 @@ void addTestData(TStrVec fieldNames,
                  TStrVec fieldValues,
                  api::CDataFrameAnalyzer& analyzer,
                  TDoubleVec& expectedScores,
+                 TDoubleVecVec& expectedFeatureInfluences,
                  std::size_t numberInliers = 100,
-                 std::size_t numberOutliers = 10) {
+                 std::size_t numberOutliers = 10,
+                 maths::COutliers::EMethod method = maths::COutliers::E_Ensemble,
+                 std::size_t numberNeighbours = 0,
+                 bool computeFeatureInfluence = false) {
 
     using TMeanVarAccumulatorVec =
         std::vector<maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator>;
@@ -102,23 +137,23 @@ void addTestData(TStrVec fieldNames,
         analyzer.handleRecord(fieldNames, fieldValues);
     }
 
-    for (std::size_t j = 0; j < 5; ++j) {
-        double shift{maths::CBasicStatistics::mean(columnMoments[j])};
-        double scale{1.0 / std::sqrt(maths::CBasicStatistics::variance(columnMoments[j]))};
-        for (auto& point : points) {
-            point(j) = scale * (point(j) - shift);
-        }
-    }
-
     auto frame = test::CDataFrameTestUtils::toMainMemoryDataFrame(points);
 
-    maths::COutliers::compute({1, 1, false, 0.05}, *frame);
+    maths::COutliers::compute(
+        {1, 1, true, method, numberNeighbours, computeFeatureInfluence, 0.05}, *frame);
 
     expectedScores.resize(points.size());
-    frame->readRows(1, [&expectedScores](core::CDataFrame::TRowItr beginRows,
-                                         core::CDataFrame::TRowItr endRows) {
+    expectedFeatureInfluences.resize(points.size(), TDoubleVec(5));
+
+    frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
+                           core::CDataFrame::TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            expectedScores[row->index()] = (*row)[row->numberColumns() - 1];
+            expectedScores[row->index()] = (*row)[5];
+            if (computeFeatureInfluence) {
+                for (std::size_t i = 6; i < 11; ++i) {
+                    expectedFeatureInfluences[row->index()][i - 6] = (*row)[i];
+                }
+            }
         }
     });
 }
@@ -134,10 +169,11 @@ void CDataFrameAnalyzerTest::testWithoutControlMessages() {
     api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
 
     TDoubleVec expectedScores;
+    TDoubleVecVec expectedFeatureInfluences;
 
     TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5"};
     TStrVec fieldValues{"", "", "", "", ""};
-    addTestData(fieldNames, fieldValues, analyzer, expectedScores);
+    addTestData(fieldNames, fieldValues, analyzer, expectedScores, expectedFeatureInfluences);
 
     analyzer.receivedAllRows();
     analyzer.run();
@@ -177,11 +213,11 @@ void CDataFrameAnalyzerTest::testRunOutlierDetection() {
     api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
 
     TDoubleVec expectedScores;
+    TDoubleVecVec expectedFeatureInfluences;
 
     TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", ".", "."};
     TStrVec fieldValues{"", "", "", "", "", "0", ""};
-    addTestData(fieldNames, fieldValues, analyzer, expectedScores);
-
+    addTestData(fieldNames, fieldValues, analyzer, expectedScores, expectedFeatureInfluences);
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
     rapidjson::Document results;
@@ -220,14 +256,15 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
         return std::make_unique<core::CJsonOutputStreamWrapper>(output);
     };
 
-    api::CDataFrameAnalyzer analyzer{outlierSpec(1000, 100000), outputWriterFactory};
+    api::CDataFrameAnalyzer analyzer{outlierSpec(1000), outputWriterFactory};
 
     TDoubleVec expectedScores;
+    TDoubleVecVec expectedFeatureInfluences;
 
     TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", ".", "."};
     TStrVec fieldValues{"", "", "", "", "", "0", ""};
-    addTestData(fieldNames, fieldValues, analyzer, expectedScores, 990, 10);
-
+    addTestData(fieldNames, fieldValues, analyzer, expectedScores,
+                expectedFeatureInfluences, 990, 10);
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
     rapidjson::Document results;
@@ -246,6 +283,98 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
         }
     }
     CPPUNIT_ASSERT(expectedScore == expectedScores.end());
+}
+
+void CDataFrameAnalyzerTest::testRunOutlierFeatureInfluences() {
+
+    // Test we compute and write out the feature influences when requested.
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    api::CDataFrameAnalyzer analyzer{outlierSpec(110, 100000, "", 0, true), outputWriterFactory};
+
+    TDoubleVec expectedScores;
+    TDoubleVecVec expectedFeatureInfluences;
+    TStrVec expectedNames{"feature_influence.c1", "feature_influence.c2", "feature_influence.c3",
+                          "feature_influence.c4", "feature_influence.c5"};
+
+    TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    addTestData(fieldNames, fieldValues, analyzer, expectedScores, expectedFeatureInfluences,
+                100, 10, maths::COutliers::E_Ensemble, 0, true);
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    rapidjson::Document results;
+    rapidjson::ParseResult ok(results.Parse(output.str().c_str()));
+    CPPUNIT_ASSERT(static_cast<bool>(ok) == true);
+
+    auto expectedFeatureInfluence = expectedFeatureInfluences.begin();
+    for (const auto& result : results.GetArray()) {
+        if (result.HasMember("row_results")) {
+            CPPUNIT_ASSERT(expectedFeatureInfluence != expectedFeatureInfluences.end());
+            for (std::size_t i = 0; i < 5; ++i) {
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(
+                    (*expectedFeatureInfluence)[i],
+                    result["row_results"]["results"][expectedNames[i]].GetDouble(),
+                    1e-4 * (*expectedFeatureInfluence)[i]);
+            }
+            ++expectedFeatureInfluence;
+        }
+    }
+    CPPUNIT_ASSERT(expectedFeatureInfluence == expectedFeatureInfluences.end());
+}
+
+void CDataFrameAnalyzerTest::testRunOutlierDetectionWithParams() {
+
+    // Test the method and number of neighbours parameters are correctly
+    // propagated to the analysis runner.
+
+    TStrVec methods{"lof", "ldof", "knn", "tnn"};
+
+    for (const auto& method :
+         {maths::COutliers::E_Lof, maths::COutliers::E_Ldof,
+          maths::COutliers::E_DistancekNN, maths::COutliers::E_TotalDistancekNN}) {
+        for (const auto k : {5, 10}) {
+
+            LOG_DEBUG(<< "Testing '" << methods[method] << "' and '" << k << "'");
+
+            std::stringstream output;
+            auto outputWriterFactory = [&output]() {
+                return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+            };
+
+            api::CDataFrameAnalyzer analyzer{
+                outlierSpec(110, 1000000, methods[method], k), outputWriterFactory};
+
+            TDoubleVec expectedScores;
+            TDoubleVecVec expectedFeatureInfluences;
+
+            TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", ".", "."};
+            TStrVec fieldValues{"", "", "", "", "", "0", ""};
+            addTestData(fieldNames, fieldValues, analyzer, expectedScores,
+                        expectedFeatureInfluences, 100, 10, method, k);
+            analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+            rapidjson::Document results;
+            rapidjson::ParseResult ok(results.Parse(output.str().c_str()));
+            CPPUNIT_ASSERT(static_cast<bool>(ok) == true);
+
+            auto expectedScore = expectedScores.begin();
+            for (const auto& result : results.GetArray()) {
+                if (result.HasMember("row_results")) {
+                    CPPUNIT_ASSERT(expectedScore != expectedScores.end());
+                    CPPUNIT_ASSERT_DOUBLES_EQUAL(
+                        *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
+                        1e-6 * *expectedScore);
+                    ++expectedScore;
+                }
+            }
+            CPPUNIT_ASSERT(expectedScore == expectedScores.end());
+        }
+    }
 }
 
 void CDataFrameAnalyzerTest::testFlushMessage() {
@@ -379,6 +508,12 @@ CppUnit::Test* CDataFrameAnalyzerTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
         "CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned",
         &CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
+        "CDataFrameAnalyzerTest::testRunOutlierFeatureInfluences",
+        &CDataFrameAnalyzerTest::testRunOutlierFeatureInfluences));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
+        "CDataFrameAnalyzerTest::testRunOutlierDetectionWithParams",
+        &CDataFrameAnalyzerTest::testRunOutlierDetectionWithParams));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
         "CDataFrameAnalyzerTest::testFlushMessage", &CDataFrameAnalyzerTest::testFlushMessage));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -145,8 +145,7 @@ void addTestData(TStrVec fieldNames,
     expectedScores.resize(points.size());
     expectedFeatureInfluences.resize(points.size(), TDoubleVec(5));
 
-    frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
-                           core::CDataFrame::TRowItr endRows) {
+    frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows, core::CDataFrame::TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             expectedScores[row->index()] = (*row)[5];
             if (computeFeatureInfluence) {
@@ -367,7 +366,8 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionWithParams() {
                 if (result.HasMember("row_results")) {
                     CPPUNIT_ASSERT(expectedScore != expectedScores.end());
                     CPPUNIT_ASSERT_DOUBLES_EQUAL(
-                        *expectedScore, result["row_results"]["results"]["outlier_score"].GetDouble(),
+                        *expectedScore,
+                        result["row_results"]["results"]["outlier_score"].GetDouble(),
                         1e-6 * *expectedScore);
                     ++expectedScore;
                 }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -14,6 +14,8 @@ public:
     void testWithoutControlMessages();
     void testRunOutlierDetection();
     void testRunOutlierDetectionPartitioned();
+    void testRunOutlierFeatureInfluences();
+    void testRunOutlierDetectionWithParams();
     void testFlushMessage();
     void testErrors();
     void testRoundTripDocHashes();

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -510,10 +510,12 @@ CEnsemble<POINT> buildEnsemble(const COutliers::SComputeParameters& params,
     TSizeVecVec methods;
     methods.reserve(2);
     if (params.s_Method == COutliers::E_Ensemble) {
-        methods.push_back(TSizeVec{COutliers::E_Lof, COutliers::E_Ldof});
-        methods.push_back(TSizeVec{COutliers::E_DistancekNN, COutliers::E_TotalDistancekNN});
+        methods.push_back(TSizeVec{static_cast<std::size_t>(COutliers::E_Lof),
+                                   static_cast<std::size_t>(COutliers::E_Ldof)});
+        methods.push_back(TSizeVec{static_cast<std::size_t>(COutliers::E_DistancekNN),
+                                   static_cast<std::size_t>(COutliers::E_TotalDistancekNN)});
     } else {
-        methods.push_back(TSizeVec{params.s_Method});
+        methods.push_back(TSizeVec{static_cast<std::size_t>(params.s_Method)});
     }
 
     auto builders = CEnsemble<POINT>::makeBuilders(


### PR DESCRIPTION
This factors out the validation of the data_frame_analyzer command parameters into a standalone parameter reader class.

I've also added in some additional parameters for outlier detection, allowing the user to opt out of computing feature influences, adjust the minimum outlier score at which we'll write influences out and support disabling column standardisation as part of outlier detection.

As a result I've also been able to finish up unit testing the API with feature influence.