### PR TITLE
[7.1][ML] Syntax-check log trace even when optimised out

### DIFF
--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -21,9 +21,12 @@
 #define LOG_TRACE(message)                                                     \
     LOG4CXX_INFO(ml::core::CLogger::instance().logger(), "" message)
 #elif defined(EXCLUDE_TRACE_LOGGING)
-// When this option is set TRACE logging is expanded to nothing - this avoids
-// the overhead of checking the logging level at all for this low level logging
-#define LOG_TRACE(message)
+// When this option is set TRACE logging is expanded to dummy code that can be
+// eliminated from the compiled program (certainly when optimisation is
+// enabled) - this avoids the overhead of checking the logging level at all for
+// this low level logging
+#define LOG_TRACE(message)                                                     \
+    static_cast<void>([&]() { std::ostringstream() << "" message; })
 #else
 #define LOG_TRACE(message)                                                     \
     LOG4CXX_TRACE(ml::core::CLogger::instance().logger(), "" message)

--- a/include/maths/CSolvers.h
+++ b/include/maths/CSolvers.h
@@ -173,7 +173,7 @@ private:
 
             double u = x + s;
             double fu = f(u);
-            LOG_TRACE(<< "s = " << s << ", u = " << u)
+            LOG_TRACE(<< "s = " << s << ", u = " << u);
             LOG_TRACE(<< "f(u) = " << fu << ", f(x) = " << fx);
 
             if (fu <= fx) {

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1331,7 +1331,7 @@ CAnomalyJob::detectorForKey(bool isRestoring,
 
         LOG_TRACE(<< "Creating new detector for key '" << key.debug() << '/'
                   << partition << '\'' << ", time " << time);
-        LOG_TRACE(<< "Detector count " << m_Detectors.size())
+        LOG_TRACE(<< "Detector count " << m_Detectors.size());
 
         detector = this->makeDetector(key.identifier(), m_ModelConfig, m_Limits,
                                       partition, time, m_ModelConfig.factory(key));

--- a/lib/maths/CLinearAlgebraTools.cc
+++ b/lib/maths/CLinearAlgebraTools.cc
@@ -157,14 +157,14 @@ public:
             LOG_TRACE(<< "# intervals = " << numberIntervals);
             result.reserve(rank * numberIntervals);
             double scale = std::sqrt(static_cast<double>(rank));
-            LOG_TRACE(<< "scale = " << scale)
+            LOG_TRACE(<< "scale = " << scale);
 
             for (std::size_t i = 0u; i < rank; ++i) {
                 VECTOR_PRECISE u(fromDenseVector(covariance.matrixU().col(i)));
                 try {
                     double variance = covariance.singularValues()(i);
                     boost::math::normal normal(0.0, std::sqrt(variance));
-                    LOG_TRACE(<< "[U]_{.i} = " << covariance.matrixU().col(i).transpose())
+                    LOG_TRACE(<< "[U]_{.i} = " << covariance.matrixU().col(i).transpose());
                     LOG_TRACE(<< "variance = " << variance);
                     LOG_TRACE(<< "u = " << u);
 

--- a/lib/maths/CMultinomialConjugate.cc
+++ b/lib/maths/CMultinomialConjugate.cc
@@ -589,7 +589,7 @@ CMultinomialConjugate::marginalLikelihoodConfidenceInterval(double percentage,
                      static_cast<ptrdiff_t>(quantiles.size()) - 1);
         x2 = m_Categories[i2];
     }
-    LOG_TRACE(<< "x1 = " << x1 << ", x2 = " << x2)
+    LOG_TRACE(<< "x1 = " << x1 << ", x2 = " << x2);
     LOG_TRACE(<< "quantiles = " << core::CContainerPrinter::print(quantiles));
     LOG_TRACE(<< "            " << core::CContainerPrinter::print(m_Categories));
 

--- a/lib/maths/CNaturalBreaksClassifier.cc
+++ b/lib/maths/CNaturalBreaksClassifier.cc
@@ -121,7 +121,7 @@ double CNaturalBreaksClassifier::percentile(double p) const {
                            ? boost::math::quantile(normal, q)
                            : (2.0 * q - 1.0) * boost::numeric::bounds<double>::highest();
             LOG_TRACE(<< "N(" << mean << "," << deviation << ")"
-                      << ", q = " << q << ", x = " << x)
+                      << ", q = " << q << ", x = " << x);
 
             if (i > 0) {
                 // Left truncate by the assignment boundary between

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -607,7 +607,8 @@ bool computeOutliersPartitioned(const COutliers::SComputeParameters& params,
 
     std::size_t rowsPerPartition{(frame.numberRows() + params.s_NumberPartitions - 1) /
                                  params.s_NumberPartitions};
-    LOG_TRACE(<< "# rows = " << frame.numberRows() << ", # partitions = " << numberPartitions
+    LOG_TRACE(<< "# rows = " << frame.numberRows()
+              << ", # partitions = " << params.s_NumberPartitions
               << ", # rows per partition = " << rowsPerPartition);
 
     // This is presized so that rowsToPoints only needs to access and write to

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -414,7 +414,7 @@ void CTrendComponent::forecast(core_t::TTime startTime,
         model.s_Regression.covariances(n * CTools::pow2(bias) + variance,
                                        modelCovariances[i], MAX_CONDITION);
         LOG_TRACE(<< "params      = " << core::CContainerPrinter::print(models[i]));
-        LOG_TRACE(<< "covariances = " << modelCovariances[i].toDelimited())
+        LOG_TRACE(<< "covariances = " << modelCovariances[i].toDelimited());
         LOG_TRACE(<< "variances   = " << residualVariances[i]);
     }
     LOG_TRACE(<< "long time variance = " << CBasicStatistics::variance(m_ValueMoments));


### PR DESCRIPTION
We have had a few situations where LOG_TRACE macros
contained syntax errors which were only found by the
nightly debug build because most builds optimise
away these trace macros.

This commit changes the approach for optimising away
LOG_TRACE.  Instead of completly ignoring the contents
of the macro it is used within an anonymous lambda
that is immediately discarded.  The hope then is that
the compiler's dead-code elimination optimisation will
completely remove any generated code from the final
program, leading to the same shipped product we had
before but without the pain of having to fix syntax
errors when building debug binaries.

Backport of #417