### PR TITLE
[7.0][ML] Ensure simple count detector is updated first in interim result …

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -41,6 +41,10 @@
 
 == {es} version 6.7.0
 
+== {es} version 6.6.2
+
+* Fixes an issue where interim results would be calculated after advancing time into an empty bucket. {ml-pull}416[#416]
+
 === Enhancements
 
 * Adjust seccomp filter for Fedora 29. {ml-pull}354[#354]

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -540,9 +540,6 @@ void CAnomalyJob::doForecast(const std::string& controlMessage) {
 }
 
 void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
-    using TKeyAnomalyDetectorPtrUMapCItr = TKeyAnomalyDetectorPtrUMap::const_iterator;
-    using TKeyAnomalyDetectorPtrUMapCItrVec = std::vector<TKeyAnomalyDetectorPtrUMapCItr>;
-
     core::CStopWatch timer(true);
 
     core_t::TTime bucketLength = m_ModelConfig.bucketLength();
@@ -550,20 +547,14 @@ void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
     model::CHierarchicalResults results;
     TModelPlotDataVec modelPlotData;
 
-    TKeyAnomalyDetectorPtrUMapCItrVec iterators;
-    iterators.reserve(m_Detectors.size());
-    for (TKeyAnomalyDetectorPtrUMapCItr itr = m_Detectors.begin();
-         itr != m_Detectors.end(); ++itr) {
-        iterators.push_back(itr);
-    }
-    std::sort(iterators.begin(), iterators.end(),
-              core::CFunctional::SDereference<maths::COrderings::SFirstLess>());
+    TKeyCRefAnomalyDetectorPtrPrVec detectors;
+    this->sortedDetectors(detectors);
 
-    for (std::size_t i = 0u; i < iterators.size(); ++i) {
-        model::CAnomalyDetector* detector(iterators[i]->second.get());
+    for (const auto& detector_ : detectors) {
+        model::CAnomalyDetector* detector(detector_.second.get());
         if (detector == nullptr) {
             LOG_ERROR(<< "Unexpected NULL pointer for key '"
-                      << pairDebug(iterators[i]->first) << '\'');
+                      << pairDebug(detector_.first) << '\'');
             continue;
         }
         detector->buildResults(bucketStartTime, bucketStartTime + bucketLength, results);
@@ -608,7 +599,10 @@ void CAnomalyJob::outputInterimResults(core_t::TTime bucketStartTime) {
     model::CHierarchicalResults results;
     results.setInterim();
 
-    for (const auto& detector_ : m_Detectors) {
+    TKeyCRefAnomalyDetectorPtrPrVec detectors;
+    this->sortedDetectors(detectors);
+
+    for (const auto& detector_ : detectors) {
         model::CAnomalyDetector* detector(detector_.second.get());
         if (detector == nullptr) {
             LOG_ERROR(<< "Unexpected NULL pointer for key '"

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -174,6 +174,11 @@ bool CSearchKey::operator==(const CSearchKey& rhs) const {
 }
 
 bool CSearchKey::operator<(const CSearchKey& rhs) const {
+    // We rely on simple count to come before other detectors when we sort
+    if (this->isSimpleCount() != rhs.isSimpleCount()) {
+        return this->isSimpleCount() ? true : false;
+    }
+
     if (this->hash() == rhs.hash()) {
         if (m_Identifier == rhs.m_Identifier) {
             if (m_Function == rhs.m_Function) {

--- a/lib/model/unittest/CSearchKeyTest.cc
+++ b/lib/model/unittest/CSearchKeyTest.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CSearchKeyTest.h"
+
+#include <model/CSearchKey.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <string>
+#include <vector>
+
+using namespace ml;
+using namespace model;
+
+void CSearchKeyTest::testSimpleCountComesFirst() {
+    using TStrVec = std::vector<std::string>;
+    using TExcludeFrequentVec = std::vector<model_t::EExcludeFrequent>;
+    using TFunctionVec = std::vector<function_t::EFunction>;
+    test::CRandomNumbers rng;
+    TExcludeFrequentVec excludeFrequents{model_t::E_XF_None, model_t::E_XF_By,
+                                         model_t::E_XF_Over, model_t::E_XF_Both};
+    TFunctionVec functions{function_t::E_IndividualCount, function_t::E_IndividualMetric,
+                           function_t::E_PopulationMetricMean, function_t::E_PopulationRare};
+
+    for (std::size_t i = 0; i < 100; ++i) {
+        function_t::EFunction function{functions[i % functions.size()]};
+        bool useNull{i % 2 == 0};
+        model_t::EExcludeFrequent excludeFrequent{
+            excludeFrequents[i % excludeFrequents.size()]};
+        TStrVec fields;
+        rng.generateWords(10, 3, fields);
+        CSearchKey key{static_cast<int>(i + 1),
+                       function,
+                       useNull,
+                       excludeFrequent,
+                       fields[0],
+                       fields[1],
+                       fields[2]};
+        CPPUNIT_ASSERT(CSearchKey::simpleCountKey() < key);
+    }
+}
+
+CppUnit::Test* CSearchKeyTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CSearchKeyTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CSearchKeyTest>(
+        "CSearchKeyTest::testSimpleCountComesFirst", &CSearchKeyTest::testSimpleCountComesFirst));
+
+    return suiteOfTests;
+}

--- a/lib/model/unittest/CSearchKeyTest.h
+++ b/lib/model/unittest/CSearchKeyTest.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CSearchKeyTest_h
+#define INCLUDED_CSearchKeyTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CSearchKeyTest : public CppUnit::TestFixture {
+public:
+    void testSimpleCountComesFirst();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CSearchKeyTest_h

--- a/lib/model/unittest/Main.cc
+++ b/lib/model/unittest/Main.cc
@@ -40,6 +40,7 @@
 #include "CResourceMonitorTest.h"
 #include "CRuleConditionTest.h"
 #include "CSampleQueueTest.h"
+#include "CSearchKeyTest.h"
 #include "CStringStoreTest.h"
 #include "CToolsTest.h"
 
@@ -80,6 +81,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CResourceMonitorTest::suite());
     runner.addTest(CRuleConditionTest::suite());
     runner.addTest(CSampleQueueTest::suite());
+    runner.addTest(CSearchKeyTest::suite());
     runner.addTest(CStringStoreTest::suite());
     runner.addTest(CToolsTest::suite());
 

--- a/lib/model/unittest/Makefile
+++ b/lib/model/unittest/Makefile
@@ -53,6 +53,7 @@ SRCS=\
 	CResourceMonitorTest.cc \
 	CRuleConditionTest.cc \
 	CSampleQueueTest.cc \
+	CSearchKeyTest.cc \
 	CStringStoreTest.cc \
 	CToolsTest.cc \
 	Mocks.cc


### PR DESCRIPTION
…… (#416)

This commit sorts detectors before caclulating interim results making sure
that the simple count detector goes first. We rely on that being the case
as the simple count model updates the interim results corrector with the
current bucket count. If it does not get updated first, then the bucket
completeness will be thought to be full and interim results may be
created when they should not.

Closes #324