### PR TITLE
[ML] Guard calls to Get* in config parser in the case the fatal error handler is overridden

### DIFF
--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -94,10 +94,12 @@ public:
             }
             if (m_Value->IsString() == false) {
                 this->handleFatal();
+                return value;
             }
             auto pos = m_PermittedValues->find(std::string{m_Value->GetString()});
             if (pos == m_PermittedValues->end()) {
                 this->handleFatal();
+                return value;
             }
             return static_cast<ENUM>(pos->second);
         }

--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -83,6 +83,7 @@ bool CDataFrameAnalysisConfigReader::CParameter::fallback(bool value) const {
     }
     if (m_Value->IsBool() == false) {
         this->handleFatal();
+        return value;
     }
     return m_Value->GetBool();
 }
@@ -93,6 +94,7 @@ std::size_t CDataFrameAnalysisConfigReader::CParameter::fallback(std::size_t val
     }
     if (m_Value->IsUint64() == false) {
         this->handleFatal();
+        return value;
     }
     return m_Value->GetUint64();
 }
@@ -106,6 +108,7 @@ double CDataFrameAnalysisConfigReader::CParameter::fallback(double value) const 
     }
     if (m_Value->IsDouble() == false) {
         this->handleFatal();
+        return value;
     }
     return m_Value->GetDouble();
 }
@@ -116,6 +119,7 @@ std::string CDataFrameAnalysisConfigReader::CParameter::fallback(const std::stri
     }
     if (m_Value->IsString() == false) {
         this->handleFatal();
+        return value;
     }
     return m_Value->GetString();
 }


### PR DESCRIPTION
Some unit tests override the fatal error handling to not terminate the process in order to check error messages on bad input. We need to guard calls to Get* on rapidjson::Value in these cases or the tests hit an assertion in a debug build.