### PR TITLE
[ML] Fix the debug build on Windows

### DIFF
--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -14,6 +14,19 @@
 
 #include <cstring>
 
+#ifdef Windows
+// rapidjson::Writer<rapidjson::StringBuffer> gets instantiated in the core
+// library, and on Windows it gets exported too, because
+// CRapidJsonConcurrentLineWriter inherits from it and is also exported.
+// To avoid breaching the one-definition rule we must reuse this exported
+// instantiation, as deduplication of template instantiations doesn't work
+// across DLLs.  To make this even more confusing, this is only strictly
+// necessary when building without optimisation, because with optimisation
+// enabled the instantiation in this library gets inlined to the extent that
+// there are no clashing symbols.
+template class CORE_EXPORT rapidjson::Writer<rapidjson::StringBuffer>;
+#endif
+
 namespace ml {
 namespace api {
 namespace {


### PR DESCRIPTION
`rapidjson::Writer<rapidjson::StringBuffer>` is exported from
the core library (implicitly rather than explicitly, because
`CRapidJsonConcurrentLineWriter` inherits from it and is exported).

To avoid violating the one-definition rule, other libraries
that link to the core library (i.e. all of them) and use
`rapidjson::Writer<rapidjson::StringBuffer>` must import the
instantiation in the core library rather than reinstantiating
the template themselves.

This change is basically working around item 2 in
http://developercommunity.visualstudio.com/solutions/228892/view.html

It's only strictly necessary to do this at the moment when
building with debug as in an optimised build the clashing methods
get inlined, so don't generate clashing symbols.  However, future
code changes could cause the compiler to inline different methods,
so it's best to always import the instantiation exported from the
core library.