### PR TITLE
[ML] Threading optimisations

### DIFF
--- a/include/core/CConcurrentQueue.h
+++ b/include/core/CConcurrentQueue.h
@@ -132,14 +132,11 @@ public:
 
 private:
     void waitWhileEmpty(std::unique_lock<std::mutex>& lock) {
-        while (m_Queue.empty()) {
-            m_ConsumerCondition.wait(lock);
-        }
+        m_ConsumerCondition.wait(lock, [this] { return m_Queue.size() > 0; });
     }
     void waitWhileFull(std::unique_lock<std::mutex>& lock) {
-        while (m_Queue.size() >= QUEUE_CAPACITY) {
-            m_ProducerCondition.wait(lock);
-        }
+        m_ProducerCondition.wait(
+            lock, [this] { return m_Queue.size() < QUEUE_CAPACITY; });
     }
 
     void notifyIfNoLongerFull(std::unique_lock<std::mutex>& lock, std::size_t oldSize) {

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -403,7 +403,7 @@ private:
         TWriteSliceToStoreFunc m_WriteSliceToStore;
         TFloatVec m_RowsOfSliceBeingWritten;
         TInt32Vec m_DocHashesOfSliceBeingWritten;
-        future<TRowSlicePtr> m_SliceWrittenAsyncToStore;
+        std::future<TRowSlicePtr> m_SliceWrittenAsyncToStore;
         TRowSlicePtrVec m_SlicesWrittenToStore;
     };
     using TRowSliceWriterPtr = std::unique_ptr<CDataFrameRowSliceWriter>;

--- a/include/core/CStaticThreadPool.h
+++ b/include/core/CStaticThreadPool.h
@@ -10,7 +10,6 @@
 #include <core/Concurrency.h>
 #include <core/ImportExport.h>
 
-#include <boost/any.hpp>
 #include <boost/optional.hpp>
 
 #include <atomic>
@@ -26,11 +25,11 @@ namespace core {
 //!
 //! IMPLEMENTATION:\n
 //! This purposely has very limited interface and is intended to mainly support
-//! CThreadPoolExecutor. This provides the mechanism by which we expose the thread
+//! CThreadPoolExecutor which provides the mechanism by which we expose the thread
 //! pool to the rest of the code via calls core::async.
 class CORE_EXPORT CStaticThreadPool {
 public:
-    using TTask = std::packaged_task<boost::any()>;
+    using TTask = std::function<void()>;
 
 public:
     explicit CStaticThreadPool(std::size_t size);
@@ -49,10 +48,7 @@ public:
     //! and is suitable for our use case where we don't need to guaranty that this
     //! always returns immediately and instead want to exert back pressure on the
     //! thread scheduling tasks if the pool can't keep up.
-    void schedule(std::packaged_task<boost::any()>&& task);
-
-    //! Executes the specified function in the thread pool.
-    void schedule(std::function<void()>&& f);
+    void schedule(TTask&& task);
 
     //! Check if the thread pool has been marked as busy.
     bool busy() const;

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -141,16 +141,16 @@ async(CExecutor& executor, FUNCTION&& f, ARGS&&... args) {
     auto promise = std::make_shared<std::promise<R>>();
     auto result = promise->get_future();
 
-    std::function<void()> task{[g_ = std::move(g), promise_ = std::move(promise)]() mutable {
-        concurrency_detail::invokeAndWriteResultToPromise(g_, promise_,
-                                                          std::is_same<R, void>{});
-}
-};
+    std::function<void()> task(
+        [ g_ = std::move(g), promise_ = std::move(promise) ]() mutable {
+            concurrency_detail::invokeAndWriteResultToPromise(
+                g_, promise_, std::is_same<R, void>{});
+        });
 
-// Schedule the task to compute the result.
-executor.schedule(std::move(task));
+    // Schedule the task to compute the result.
+    executor.schedule(std::move(task));
 
-return std::move(result);
+    return std::move(result);
 }
 
 //! Wait for all \p futures to be available.

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -291,7 +291,7 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::sequentialApplyToAllRows(std::size_t b
         // function each slice is then concurrently read by the callback
         // on a worker thread.
 
-        future<void> backgroundApply;
+        std::future<void> backgroundApply;
 
         // We need to wait and this isn't guaranteed by the future destructor.
         CWaitIfValidWhenExitingScope<void> waitFor(backgroundApply);

--- a/lib/core/Concurrency.cc
+++ b/lib/core/Concurrency.cc
@@ -19,9 +19,9 @@ namespace {
 //! \brief Executes a function immediately (on the calling thread).
 class CImmediateExecutor final : public CExecutor {
 public:
-    virtual void schedule(std::packaged_task<boost::any()>&& f) { f(); }
-    virtual bool busy() const { return false; }
-    virtual void busy(bool) {}
+    void schedule(std::function<void()>&& f) override { f(); }
+    bool busy() const override { return false; }
+    void busy(bool) override {}
 };
 
 //! \brief Executes a function in a thread pool.
@@ -29,11 +29,11 @@ class CThreadPoolExecutor final : public CExecutor {
 public:
     explicit CThreadPoolExecutor(std::size_t size) : m_ThreadPool{size} {}
 
-    virtual void schedule(std::packaged_task<boost::any()>&& f) {
-        m_ThreadPool.schedule(std::forward<std::packaged_task<boost::any()>>(f));
+    void schedule(std::function<void()>&& f) override {
+        m_ThreadPool.schedule(std::forward<std::function<void()>>(f));
     }
-    virtual bool busy() const { return m_ThreadPool.busy(); }
-    virtual void busy(bool value) { return m_ThreadPool.busy(value); }
+    bool busy() const override { return m_ThreadPool.busy(); }
+    void busy(bool value) override { return m_ThreadPool.busy(value); }
 
 private:
     CStaticThreadPool m_ThreadPool;
@@ -115,7 +115,7 @@ CExecutor& defaultAsyncExecutor() {
     return singletonExecutor.get();
 }
 
-bool get_conjunction_of_all(std::vector<future<bool>>& futures) {
+bool get_conjunction_of_all(std::vector<std::future<bool>>& futures) {
 
     // This waits until results are present. If we get an exception we still want
     // to wait until all results are ready in case continuing destroys state access

--- a/lib/core/Concurrency.cc
+++ b/lib/core/Concurrency.cc
@@ -122,7 +122,7 @@ bool get_conjunction_of_all(std::vector<std::future<bool>>& futures) {
     // which a worker thread reads. We just rethrow the _last_ exception we received.
     std::exception_ptr e;
     bool result{std::accumulate(futures.begin(), futures.end(), true,
-                                [&e](bool conjunction, future<bool>& future) {
+                                [&e](bool conjunction, std::future<bool>& future) {
                                     try {
                                         // Don't shortcircuit
                                         bool value = future.get();


### PR DESCRIPTION
Wrapping function calls in a `std::packaged_task` was slightly more than doubling the runtime overhead per task in the thread pool. This moves to using a standard function pointer which can (optionally) hold the promise to which results are written. A nice side effect is we don't actually need a custom wrapper around std::future to unpack the result of function passed to the thread pool, so the code is slightly cleaner.