### PR TITLE
[7.1][ML] Handle NaNs when detrending seasonal components (#408)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,8 +39,10 @@
 
 == {es} version 7.1.0
 
-Remove hard limit for maximum forecast interval and limit based on the time interval of data added
+* Remove hard limit for maximum forecast interval and limit based on the time interval of data added
 to the model. (See {pull}214[#214].)
+
+* Handle NaNs when detrending seasonal components. {ml-pull}408[#408]
 
 == {es} version 7.0.0-alpha1
 

--- a/include/maths/CAdaptiveBucketing.h
+++ b/include/maths/CAdaptiveBucketing.h
@@ -133,6 +133,9 @@ public:
     //! Name of component
     virtual std::string name() const = 0;
 
+    //! Check that the state is valid.
+    virtual bool isBad() const = 0;
+
 protected:
     using TRestoreFunc = std::function<bool(core::CStateRestoreTraverser&)>;
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;

--- a/include/maths/CCalendarComponent.h
+++ b/include/maths/CCalendarComponent.h
@@ -140,6 +140,9 @@ public:
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;
 
+    //! Check that the state is valid.
+    bool isBad() const;
+
 private:
     //! Create by traversing a state document.
     bool acceptRestoreTraverser(double decayRate,

--- a/include/maths/CCalendarComponentAdaptiveBucketing.h
+++ b/include/maths/CCalendarComponentAdaptiveBucketing.h
@@ -100,6 +100,9 @@ public:
     //! Name of component
     std::string name() const override;
 
+    //! Check that the state is valid.
+    bool isBad() const override;
+
 private:
     using TFloatMeanVarVec = std::vector<TFloatMeanVarAccumulator>;
 

--- a/include/maths/CMathsFuncsDetail.h
+++ b/include/maths/CMathsFuncsDetail.h
@@ -68,16 +68,6 @@ bool CMathsFuncs::isNan(const CSymmetricMatrixNxN<double, N>& val) {
 }
 
 template<std::size_t N>
-bool CMathsFuncs::isNan(const core::CSmallVector<double, N>& val) {
-    for (std::size_t i = 0u; i < val.size(); ++i) {
-        if (isNan(val[i])) {
-            return true;
-        }
-    }
-    return false;
-}
-
-template<std::size_t N>
 bool CMathsFuncs::isInf(const CVectorNx1<double, N>& val) {
     return aComponent(static_cast<bool (*)(double)>(&isInf), val);
 }
@@ -88,16 +78,6 @@ bool CMathsFuncs::isInf(const CSymmetricMatrixNxN<double, N>& val) {
 }
 
 template<std::size_t N>
-bool CMathsFuncs::isInf(const core::CSmallVector<double, N>& val) {
-    for (std::size_t i = 0u; i < val.size(); ++i) {
-        if (isInf(val[i])) {
-            return true;
-        }
-    }
-    return false;
-}
-
-template<std::size_t N>
 bool CMathsFuncs::isFinite(const CVectorNx1<double, N>& val) {
     return everyComponent(static_cast<bool (*)(double)>(&isFinite), val);
 }
@@ -105,16 +85,6 @@ bool CMathsFuncs::isFinite(const CVectorNx1<double, N>& val) {
 template<std::size_t N>
 bool CMathsFuncs::isFinite(const CSymmetricMatrixNxN<double, N>& val) {
     return everyElement(static_cast<bool (*)(double)>(&isFinite), val);
-}
-
-template<std::size_t N>
-bool CMathsFuncs::isFinite(const core::CSmallVector<double, N>& val) {
-    for (std::size_t i = 0u; i < val.size(); ++i) {
-        if (!isFinite(val[i])) {
-            return false;
-        }
-    }
-    return true;
 }
 }
 }

--- a/include/maths/CRegression.h
+++ b/include/maths/CRegression.h
@@ -22,6 +22,8 @@
 #include <cstddef>
 #include <cstdint>
 
+class CNanInjector;
+
 namespace ml {
 namespace core {
 class CStatePersistInserter;
@@ -400,6 +402,9 @@ public:
         //! regression. There are 3N - 1 in total, for the distinct
         //! values in the design matrix and vector.
         TVectorMeanAccumulator m_S;
+
+        //! Befriend a helper class used by the unit tests
+        friend class ::CNanInjector;
     };
 
     //! Get the predicted value of \p r at \p x.

--- a/include/maths/CSeasonalComponent.h
+++ b/include/maths/CSeasonalComponent.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+class CNanInjector;
+
 namespace ml {
 namespace core {
 class CStatePersistInserter;
@@ -186,6 +188,9 @@ public:
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;
 
+    //! Check that the state is valid.
+    bool isBad() const { return m_Bucketing.isBad(); }
+
 private:
     //! Create by traversing a state document.
     bool acceptRestoreTraverser(double decayRate,
@@ -202,6 +207,9 @@ private:
 
     //! Regression models for a collection of buckets covering the period.
     CSeasonalComponentAdaptiveBucketing m_Bucketing;
+
+    //! Befriend a helper class used by the unit tests
+    friend class ::CNanInjector;
 };
 
 //! Create a free function which will be picked up in Koenig lookup.

--- a/include/maths/CSeasonalComponentAdaptiveBucketing.h
+++ b/include/maths/CSeasonalComponentAdaptiveBucketing.h
@@ -21,6 +21,8 @@
 
 #include <stdint.h>
 
+class CNanInjector;
+
 namespace ml {
 namespace core {
 class CStatePersistInserter;
@@ -133,6 +135,9 @@ public:
     //! Name of component
     std::string name() const override;
 
+    //! Check that the state is valid.
+    bool isBad() const override;
+
 private:
     using TSeasonalTimePtr = std::unique_ptr<CSeasonalTime>;
 
@@ -148,6 +153,9 @@ private:
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
         uint64_t checksum(uint64_t seed) const;
+
+        //! Check that the state is valid.
+        bool isBad() const;
 
         TRegression s_Regression;
         CFloatStorage s_Variance;
@@ -198,6 +206,9 @@ private:
 
     //! The buckets.
     TBucketVec m_Buckets;
+
+    //! Befriend a helper class used by the unit tests
+    friend class ::CNanInjector;
 };
 
 //! Create a free function which will be found by Koenig lookup.

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-class CTimeSeriesDecompositionTest;
+class CNanInjector;
 
 namespace ml {
 namespace core {
@@ -252,6 +252,9 @@ private:
 
     //! The state for modeling the components of the decomposition.
     CComponents m_Components;
+
+    //! Befriend a helper class used by the unit tests
+    friend class ::CNanInjector;
 };
 }
 }

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -28,6 +28,8 @@
 #include <memory>
 #include <vector>
 
+class CNanInjector;
+
 namespace ml {
 namespace maths {
 class CExpandingWindow;
@@ -373,12 +375,12 @@ public:
         //! Set whether or not we're testing for a change.
         void testingForChange(bool value);
 
-        //! Start observing for new components.
-        void observeComponentsAdded();
+        //! Start observing for modifications to the components.
+        void observeComponentsModified();
 
-        //! Check if any components were added since observeComponentsAdded
+        //! Check if any components were added or removed since observeComponentsModified
         //! was last called.
-        bool componentsAdded();
+        bool componentsModified();
 
         //! Apply \p shift to the level at \p time and \p value.
         void shiftLevel(core_t::TTime time, double value, double shift);
@@ -653,12 +655,18 @@ public:
             //! Get the memory used by this object.
             std::size_t memoryUsage() const;
 
+            //! Remove any components with invalid values
+            bool removeComponentsWithBadValues(core_t::TTime);
+
         private:
             //! The components.
             maths_t::TSeasonalComponentVec m_Components;
 
             //! The components' prediction errors.
             TComponentErrorsVec m_PredictionErrors;
+
+            //! Befriend a helper class used by the unit tests
+            friend class ::CNanInjector;
         };
 
         using TSeasonalPtr = std::unique_ptr<CSeasonal>;
@@ -727,6 +735,9 @@ public:
 
             //! Get the memory used by this object.
             std::size_t memoryUsage() const;
+
+            //! Remove any components with invalid values
+            bool removeComponentsWithBadValues(core_t::TTime time);
 
         private:
             //! The calendar components.
@@ -846,8 +857,11 @@ public:
         //! Set to true if the trend model should be used for prediction.
         bool m_UsingTrendForPrediction = false;
 
-        //! Set to true when new components are added.
-        bool m_ComponentsAdded = false;
+        //! Set to true when new components are added or removed
+        bool m_ComponentsModified = false;
+
+        //! Befriend a helper class used by the unit tests
+        friend class ::CNanInjector;
     };
 };
 

--- a/lib/maths/CCalendarComponent.cc
+++ b/lib/maths/CCalendarComponent.cc
@@ -181,5 +181,9 @@ std::size_t CCalendarComponent::memoryUsage() const {
     return core::CMemory::dynamicSize(m_Bucketing) +
            core::CMemory::dynamicSize(this->splines());
 }
+
+bool CCalendarComponent::isBad() const {
+    return m_Bucketing.isBad();
+}
 }
 }

--- a/lib/maths/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/CCalendarComponentAdaptiveBucketing.cc
@@ -15,6 +15,7 @@
 
 #include <maths/CBasicStatisticsPersist.h>
 #include <maths/CChecksum.h>
+#include <maths/CMathsFuncs.h>
 #include <maths/CTools.h>
 
 #include <boost/bind.hpp>
@@ -355,6 +356,14 @@ void CCalendarComponentAdaptiveBucketing::split(std::size_t bucket) {
 std::string CCalendarComponentAdaptiveBucketing::name() const {
     return "Calendar[" + std::to_string(this->decayRate()) + "," +
            std::to_string(this->minimumBucketLength()) + "]";
+}
+
+bool CCalendarComponentAdaptiveBucketing::isBad() const {
+    // check for bad values in both the means and the variances
+    return std::any_of(m_Values.begin(), m_Values.end(), [](const auto& value) {
+        return ((CMathsFuncs::isFinite(CBasicStatistics::mean(value)) == false) ||
+                (CMathsFuncs::isFinite(CBasicStatistics::variance(value))) == false);
+    });
 }
 }
 }

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -107,6 +107,7 @@ void CDecompositionComponent::interpolate(const TDoubleVec& knots,
                                           const TDoubleVec& values,
                                           const TDoubleVec& variances) {
     m_Splines.interpolate(knots, values, variances, m_BoundaryCondition);
+
     m_MeanValue = this->valueSpline().mean();
     m_MeanVariance = this->varianceSpline().mean();
 }
@@ -123,9 +124,9 @@ TDoubleDoublePr CDecompositionComponent::value(double offset, double n, double c
     // asymptotically normal with mean equal to the sample mean
     // and variance equal to the sample variance divided by root
     // of the number of samples.
-
     if (this->initialized()) {
         double m{this->valueSpline().value(offset)};
+
         if (confidence == 0.0) {
             return {m, m};
         }

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -1981,6 +1981,13 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
         return false;
     }
 
+    // It's possible that none of the candidates are <= 1.05 times the minimum,
+    // this would be the case if a NaN were present in the values say.
+    // NaNs are detected and purged elsewhere so we simply return false here.
+    if (best.count() == 0) {
+        return false;
+    }
+
     startOfPartition = (m_StartTime + best[0].second) % repeat;
     double v1{varianceAtPercentile(correction * minimum[0].first, df1,
                                    50.0 + CONFIDENCE_INTERVAL / 2.0)};

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -17,6 +17,7 @@
 #include <maths/CBasicStatisticsPersist.h>
 #include <maths/CChecksum.h>
 #include <maths/CIntegerTools.h>
+#include <maths/CMathsFuncs.h>
 #include <maths/CPrior.h>
 #include <maths/CRestoreParams.h>
 #include <maths/CSeasonalTime.h>
@@ -218,6 +219,11 @@ void CTimeSeriesDecomposition::testingForChange(bool value) {
 bool CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                                         double value,
                                         const maths_t::TDoubleWeightsAry& weights) {
+    if (CMathsFuncs::isFinite(value) == false) {
+        LOG_ERROR("Discarding invalid value.");
+        return false;
+    }
+
     time += m_TimeShift;
 
     core_t::TTime lastTime{std::max(m_LastValueTime, m_LastPropagationTime)};
@@ -238,13 +244,13 @@ bool CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                       },
                       m_Components.periodicityTestConfig()};
 
-    m_Components.observeComponentsAdded();
+    m_Components.observeComponentsModified();
 
     m_Components.handle(message);
     m_PeriodicityTest.handle(message);
     m_CalendarCyclicTest.handle(message);
 
-    return m_Components.componentsAdded();
+    return m_Components.componentsModified();
 }
 
 bool CTimeSeriesDecomposition::applyChange(core_t::TTime time,

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -16,6 +16,8 @@
 
 #include <maths/CDecayRateController.h>
 #include <maths/CIntegerTools.h>
+#include <maths/CLinearAlgebraFwd.h>
+#include <maths/CMathsFuncs.h>
 #include <maths/CNormalMeanPrecConjugate.h>
 #include <maths/CRestoreParams.h>
 #include <maths/CSeasonalTime.h>
@@ -108,6 +110,31 @@ const core_t::TTime DAY = core::constants::DAY;
 const core_t::TTime WEEK = core::constants::WEEK;
 const core_t::TTime YEAR = core::constants::YEAR;
 }
+
+class CNanInjector {
+public:
+    // insert a NaN into a seasonal component bucket
+    void injectNan(maths::CTimeSeriesDecomposition& decomposition, size_t bucketIndex) {
+        firstRegressionStatistic(seasonalComponent(decomposition), bucketIndex) =
+            std::numeric_limits<double>::quiet_NaN();
+    }
+
+private:
+    // helper methods to get access to the state of a seasonal component
+
+    // return the regression statistics from the provided seasonal component
+    static maths::CFloatStorage&
+    firstRegressionStatistic(maths::CSeasonalComponent& component, size_t bucketIndex) {
+        return maths::CBasicStatistics::moment<0>(
+            component.m_Bucketing.m_Buckets[bucketIndex].s_Regression.m_S)(0);
+    }
+
+    // return the first seasonal component from the provided decomposition
+    static maths::CSeasonalComponent&
+    seasonalComponent(maths::CTimeSeriesDecomposition& decomposition) {
+        return decomposition.m_Components.m_Seasonal->m_Components[0];
+    }
+};
 
 void CTimeSeriesDecompositionTest::testSuperpositionOfSines() {
     TTimeVec times;
@@ -552,6 +579,66 @@ void CTimeSeriesDecompositionTest::testWeekend() {
         CPPUNIT_ASSERT(totalMaxResidual < 0.055 * totalMaxValue);
         CPPUNIT_ASSERT(totalPercentileError < 0.01 * totalSumValue);
     }
+}
+
+void CTimeSeriesDecompositionTest::testNanHandling() {
+
+    TTimeVec times;
+    TDoubleVec trend;
+    for (core_t::TTime time = 0; time < 10 * WEEK + 1; time += HALF_HOUR) {
+        double daily = 100.0 + 100.0 * std::sin(boost::math::double_constants::two_pi *
+                                                static_cast<double>(time) /
+                                                static_cast<double>(DAY));
+        times.push_back(time);
+        trend.push_back(daily);
+    }
+
+    const double noiseMean = 20.0;
+    const double noiseVariance = 16.0;
+    test::CRandomNumbers rng;
+    TDoubleVec noise;
+    rng.generateNormalSamples(noiseMean, noiseVariance, times.size(), noise);
+
+    maths::CTimeSeriesDecomposition decomposition(0.01, HALF_HOUR);
+
+    // run through half of the periodic data
+    std::size_t i = 0u;
+    for (; i < times.size() / 2; ++i) {
+        core_t::TTime time = times[i];
+        double value = trend[i] + noise[i];
+
+        decomposition.addPoint(time, value);
+    }
+
+    // inject a NaN into one of the seasonal components
+    CNanInjector nanInjector;
+    nanInjector.injectNan(decomposition, 0L);
+
+    int componentsModified{0};
+    // run through the 2nd half of the periodic data set
+    for (++i; i < times.size(); ++i) {
+        core_t::TTime time = times[i];
+        auto value = decomposition.value(time);
+        CPPUNIT_ASSERT(maths::CMathsFuncs::isFinite(value.first));
+        CPPUNIT_ASSERT(maths::CMathsFuncs::isFinite(value.second));
+
+        if (decomposition.addPoint(time, trend[i] + noise[i])) {
+            ++componentsModified;
+        }
+    }
+
+    // The call to 'addPoint' that results in the removal of the component
+    // containing the NaN value also triggers an immediate re-detection of
+    // a daily seasonal component. Hence we only expect it to report that the
+    // components have been modified just the once even though two modification
+    // event have occurred.
+    CPPUNIT_ASSERT_EQUAL(1, componentsModified);
+
+    // Check that only the daily component has been initialized.
+    const TSeasonalComponentVec& components = decomposition.seasonalComponents();
+    CPPUNIT_ASSERT_EQUAL(std::size_t(1), components.size());
+    CPPUNIT_ASSERT_EQUAL(DAY, components[0].time().period());
+    CPPUNIT_ASSERT(components[0].initialized());
 }
 
 void CTimeSeriesDecompositionTest::testSinglePeriodicity() {
@@ -2295,6 +2382,9 @@ CppUnit::Test* CTimeSeriesDecompositionTest::suite() {
         &CTimeSeriesDecompositionTest::testMinimizeLongComponents));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
         "CTimeSeriesDecompositionTest::testWeekend", &CTimeSeriesDecompositionTest::testWeekend));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
+        "CTimeSeriesDecompositionTest::testNanHandling",
+        &CTimeSeriesDecompositionTest::testNanHandling));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTimeSeriesDecompositionTest>(
         "CTimeSeriesDecompositionTest::testSinglePeriodicity",
         &CTimeSeriesDecompositionTest::testSinglePeriodicity));

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.h
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.h
@@ -15,6 +15,7 @@ public:
     void testDistortedPeriodic();
     void testMinimizeLongComponents();
     void testWeekend();
+    void testNanHandling();
     void testSinglePeriodicity();
     void testSeasonalOnset();
     void testVarianceScale();


### PR DESCRIPTION
While it is as yet unknown how it can occur, NaN values have been
observed to be present in seasonal components when detrending, resulting
in a chain of errors in the logs as the NaN values percolate up the call
stack.

This PR attempts to detect the NaN values as close as possible to their
source and ensure that they do not unduly affect the analysis.

The approach is to check for bad values in seasonal and calendar
components from within
CTimeSeriesDecompositionDetail::CComponents::interpolate, which is
called periodically. If invalid values are detected in a component then
it is removed from the decomposition.