### PR TITLE
[7.0][ML] Improve autodetect logic for persistence (#437)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,17 @@
 
 * Ensure statics are persisted in a consistent manner {ml-pull}360[#360]
 
+* Improve autodetect logic for persistence. {ml-pull}437[#437]
+
+== {es} version 7.1.0
+
+* Remove hard limit for maximum forecast interval and limit based on the time interval of data added
+to the model. (See {pull}214[#214].)
+
+* Handle NaNs when detrending seasonal components. {ml-pull}408[#408]
+
+* Improve autodetect logic for persistence. {ml-pull}437[#437]
+
 == {es} version 7.0.0-alpha1
 
 == {es} version 6.7.0

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -182,6 +182,9 @@ public:
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const;
 
+    //! Is persistence needed?
+    virtual bool isPersistenceNeeded(const std::string& description) const;
+
     //! Log a list of the detectors and keys
     void description() const;
 
@@ -453,6 +456,9 @@ private:
 
     //! The hierarchical results normalizer.
     model::CHierarchicalResultsNormalizer m_Normalizer;
+
+    //! Flag indicating whether or not time has been advanced.
+    bool m_TimeAdvanced{false};
 
     friend class ::CBackgroundPersisterTest;
     friend class ::CAnomalyJobTest;

--- a/include/api/CDataProcessor.h
+++ b/include/api/CDataProcessor.h
@@ -82,6 +82,9 @@ public:
     //! Access the output handler
     virtual COutputHandler& outputHandler() = 0;
 
+    //! Is persistence needed?
+    virtual bool isPersistenceNeeded(const std::string& description) const = 0;
+
     //! Create debug for a record.  This is expensive so should NOT be
     //! called for every record as a matter of course.
     static std::string debugPrintRecord(const TStrStrUMap& dataRowFields);

--- a/include/api/CFieldDataTyper.h
+++ b/include/api/CFieldDataTyper.h
@@ -98,6 +98,9 @@ public:
     virtual bool restoreState(core::CDataSearcher& restoreSearcher,
                               core_t::TTime& completeToTime);
 
+    //! Is persistence needed?
+    virtual bool isPersistenceNeeded(const std::string& description) const;
+
     //! Persist current state
     virtual bool persistState(core::CDataAdder& persister);
 

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -81,6 +81,9 @@ public:
     //! Persist current state due to the periodic persistence being triggered.
     virtual bool periodicPersistState(CBackgroundPersister& persister);
 
+    //! Is persistence needed?
+    virtual bool isPersistenceNeeded(const std::string& description) const;
+
     //! The chainer does consume control messages, because it passes them on
     //! to whatever processor it's chained to.
     virtual bool consumesControlMessages();

--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -97,6 +97,9 @@ public:
     //! Persist current state due to the periodic persistence being triggered.
     virtual bool periodicPersistState(CBackgroundPersister& persister);
 
+    //! Is persistence needed?
+    virtual bool isPersistenceNeeded(const std::string& description) const;
+
     //! Does this handler deal with control messages?
     virtual bool consumesControlMessages();
 

--- a/include/config/CAutoconfigurer.h
+++ b/include/config/CAutoconfigurer.h
@@ -46,6 +46,9 @@ public:
     //! Generate the report.
     virtual void finalise();
 
+    //! Is persistence needed?
+    virtual bool isPersistenceNeeded(const std::string& description) const;
+
     //! No-op.
     virtual bool restoreState(core::CDataSearcher& restoreSearcher,
                               core_t::TTime& completeToTime);

--- a/lib/api/CCmdSkeleton.cc
+++ b/lib/api/CCmdSkeleton.cc
@@ -56,8 +56,7 @@ bool CCmdSkeleton::persistState() {
         return true;
     }
 
-    if (m_Processor.numRecordsHandled() == 0) {
-        LOG_DEBUG(<< "Zero records were handled - will not attempt to persist state");
+    if (m_Processor.isPersistenceNeeded("state") == false) {
         return true;
     }
 

--- a/lib/api/CFieldDataTyper.cc
+++ b/lib/api/CFieldDataTyper.cc
@@ -335,6 +335,20 @@ bool CFieldDataTyper::persistState(core::CDataAdder& persister) {
     return this->doPersistState(m_DataTyper->makePersistFunc(), m_ExamplesCollector, persister);
 }
 
+bool CFieldDataTyper::isPersistenceNeeded(const std::string& description) const {
+    // Pass on the request in case we're chained
+    if (m_OutputHandler.isPersistenceNeeded(description)) {
+        return true;
+    }
+
+    if (m_NumRecordsHandled == 0) {
+        LOG_DEBUG(<< "Zero records were handled - will not attempt to persist "
+                  << description << ".");
+        return false;
+    }
+    return true;
+}
+
 bool CFieldDataTyper::doPersistState(const CDataTyper::TPersistFunc& dataTyperPersistFunc,
                                      const CCategoryExamplesCollector& examplesCollector,
                                      core::CDataAdder& persister) {

--- a/lib/api/COutputChainer.cc
+++ b/lib/api/COutputChainer.cc
@@ -117,6 +117,10 @@ bool COutputChainer::periodicPersistState(CBackgroundPersister& persister) {
     return m_DataProcessor.periodicPersistState(persister);
 }
 
+bool COutputChainer::isPersistenceNeeded(const std::string& description) const {
+    return m_DataProcessor.isPersistenceNeeded(description);
+}
+
 bool COutputChainer::consumesControlMessages() {
     return true;
 }

--- a/lib/api/COutputHandler.cc
+++ b/lib/api/COutputHandler.cc
@@ -52,6 +52,11 @@ bool COutputHandler::periodicPersistState(CBackgroundPersister& /* persister */)
     return true;
 }
 
+bool COutputHandler::isPersistenceNeeded(const std::string& /*description*/) const {
+    // NOOP unless overridden
+    return false;
+}
+
 COutputHandler::CPreComputedHash::CPreComputedHash(size_t hash) : m_Hash(hash) {
 }
 

--- a/lib/api/unittest/CAnomalyJobTest.h
+++ b/lib/api/unittest/CAnomalyJobTest.h
@@ -17,6 +17,7 @@ public:
     void testOutOfSequence();
     void testControlMessages();
     void testSkipTimeControlMessage();
+    void testIsPersistenceNeeded();
     void testModelPlot();
     void testInterimResultEdgeCases();
     void testRestoreFailsWithEmptyStream();

--- a/lib/api/unittest/CMockDataProcessor.cc
+++ b/lib/api/unittest/CMockDataProcessor.cc
@@ -47,6 +47,15 @@ bool CMockDataProcessor::handleRecord(const TStrStrUMap& dataRowFields) {
 void CMockDataProcessor::finalise() {
 }
 
+bool CMockDataProcessor::isPersistenceNeeded(const std::string& description) const {
+    if (m_NumRecordsHandled == 0) {
+        LOG_DEBUG(<< "Zero records were handled - will not attempt to persist "
+                  << description << ".");
+        return false;
+    }
+    return true;
+}
+
 bool CMockDataProcessor::restoreState(ml::core::CDataSearcher& restoreSearcher,
                                       ml::core_t::TTime& completeToTime) {
     // Pass on the request in case we're chained

--- a/lib/api/unittest/CMockDataProcessor.h
+++ b/lib/api/unittest/CMockDataProcessor.h
@@ -40,6 +40,8 @@ public:
 
     virtual void finalise();
 
+    virtual bool isPersistenceNeeded(const std::string& description) const;
+
     //! Restore previously saved state
     virtual bool restoreState(ml::core::CDataSearcher& restoreSearcher,
                               ml::core_t::TTime& completeToTime);

--- a/lib/config/CAutoconfigurer.cc
+++ b/lib/config/CAutoconfigurer.cc
@@ -165,6 +165,10 @@ void CAutoconfigurer::finalise() {
     m_Impl->finalise();
 }
 
+bool CAutoconfigurer::isPersistenceNeeded(const std::string& /*description*/) const {
+    return false;
+}
+
 bool CAutoconfigurer::restoreState(core::CDataSearcher& /*restoreSearcher*/,
                                    core_t::TTime& /*completeToTime*/) {
     return true;


### PR DESCRIPTION
Changed the logic surrounding persistence of both state and quantiles on
graceful shutdown so that persistence only occurs if and only if at
least one input record has been processed or time has been advanced.

Backports #437 