### PR TITLE
[FEATURE][ML] Boosted regression tree (initial commit)

### DIFF
--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -60,7 +60,7 @@ public:
 };
 
 //! \brief Finds the leaf node value which minimises the MSE.
-class MATHS_EXPORT CArgMinMse : public CArgMinLoss {
+class MATHS_EXPORT CArgMinMse final : public CArgMinLoss {
 public:
     double value() const override;
 

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CBoostedTree_h
+#define INCLUDED_ml_maths_CBoostedTree_h
+
+#include <core/CDataFrame.h>
+
+#include <maths/CBasicStatistics.h>
+#include <maths/CDataFrameRegressionModel.h>
+#include <maths/ImportExport.h>
+
+#include <cstddef>
+#include <memory>
+#include <thread>
+
+namespace ml {
+namespace maths {
+namespace boosted_tree {
+//! \brief Computes the leaf value which minimizes the loss function.
+class MATHS_EXPORT CArgMinLoss {
+public:
+    virtual ~CArgMinLoss() = default;
+
+    //! Update with a point prediction and actual value.
+    void add(double prediction, double actual);
+
+    //! Returns the value at the node which minimises the loss for the
+    //! at the predictions added.
+    //!
+    //! Formally, returns \f$x^* = arg\min_x\{\sum_i{L(p_i + x, a_i)}\}\f$
+    //! for predictions and actuals \f$p_i\f$ and \f$a_i\f$, respectively.
+    virtual double value() const = 0;
+
+private:
+    virtual void addImpl(double prediction, double actual) = 0;
+
+private:
+    std::mutex m_Mutex;
+};
+
+//! \brief Defines the loss function for the regression problem.
+class MATHS_EXPORT CLoss {
+public:
+    using TArgMinLossUPtr = std::unique_ptr<CArgMinLoss>;
+
+public:
+    virtual ~CLoss() = default;
+    //! The value of the loss function.
+    virtual double value(double prediction, double actual) const = 0;
+    //! The slope of the loss function.
+    virtual double gradient(double prediction, double actual) const = 0;
+    //! The curvature of the loss function.
+    virtual double curvature(double prediction, double actual) const = 0;
+    //! Get an object which computes the leaf value that minimises loss.
+    virtual TArgMinLossUPtr minimizer() const = 0;
+};
+
+//! \brief Finds the leaf node value which minimises the MSE.
+class MATHS_EXPORT CArgMinMse : public CArgMinLoss {
+public:
+    double value() const override;
+
+private:
+    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+private:
+    void addImpl(double prediction, double actual) override;
+
+private:
+    TMeanAccumulator m_MeanError;
+};
+
+//! \brief The MSE loss function.
+class MATHS_EXPORT CMse final : public CLoss {
+public:
+public:
+    double value(double prediction, double actual) const override;
+    double gradient(double prediction, double actual) const override;
+    double curvature(double prediction, double actual) const override;
+    TArgMinLossUPtr minimizer() const override;
+};
+}
+
+//! \brief A boosted regression tree model.
+//!
+//! DESCRIPTION:\n
+//! This is strongly based on xgboost. We deviate in two important respect: we have
+//! hyperparameters which control the chance of selecting a feature in the feature
+//! bag for a tree, we have different handling of categorical fields.
+//!
+//! The probability of selecting a feature behave like a feature weight, allowing us
+//! to:
+//!   1. Incorporate some estimate of strength of relationship between a feature and
+//!      the target variable upfront,
+//!   2. Use optimisation techniques suited for smooth cost functions to fine tune
+//!      the features used during training.
+//! All in all this gives us improved resilience to nuisance variables and allows
+//! us to perform feature selection by imposing a hard cutoff on the minimum probability
+//! of a feature we will accept in the final model.
+//!
+//! The original xgboost paper doesn't explicitly deal with categorical data, it assumes
+//! there is a well ordering on each feature and looks for binary splits subject to this
+//! ordering. This leaves two choices for categorical fields a) use some predefined order
+//! knowing that only splits of the form \f$\{\{1,2,...,i\},\{i+1,i+2,...,m\}\}\f$ will
+//! be considered or b) use hot-one-encoding knowing splits of the form \f$\{\{0\},\{1\}\}\f$
+//! will then be considered for each category. The first choice will rule out good splits
+//! because they aren't consistent with the ordering and the second choice will behave
+//! poorly for fields with high cardinality because it will be impossible to accurately
+//! estimate the change in loss corresponding to the splits.
+// TODO
+class MATHS_EXPORT CBoostedTree final : public CDataFrameRegressionModel {
+public:
+    using TProgressCallback = std::function<void(double)>;
+    using TRowRef = core::CDataFrame::TRowRef;
+    using TLossFunctionUPtr = std::unique_ptr<boosted_tree::CLoss>;
+
+public:
+    CBoostedTree(std::size_t numberThreads, std::size_t dependentVariable, TLossFunctionUPtr loss);
+    ~CBoostedTree() override;
+
+    //! \name Parameter Setters
+    //@{
+    //! Set the maximum number of trees in the ensemble.
+    CBoostedTree& maximumNumberTrees(std::size_t maximumNumberTrees);
+    //! Set the fraction of features we'll use in the bag to build a tree.
+    CBoostedTree& featureBagFraction(double featureBagFraction);
+    //! Set the amount we'll shrink the weights on each each iteration.
+    CBoostedTree& shrinkageFactor(double shrinkageFactor);
+    //@}
+
+    //! Train the model on the values in \p frame.
+    void train(core::CDataFrame& frame, TProgressCallback recordProgress = noop) override;
+
+    //! Write the predictions of this model to \p frame.
+    void predict(core::CDataFrame& frame, TProgressCallback recordProgress = noop) const override;
+
+    //! Write this model to \p writer.
+    void write(core::CRapidJsonConcurrentLineWriter& writer) const override;
+
+private:
+    class CImpl;
+    using TImplUPtr = std::unique_ptr<CImpl>;
+
+private:
+    TImplUPtr m_Impl;
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CBoostedTree_h

--- a/include/maths/CDataFrameRegressionModel.h
+++ b/include/maths/CDataFrameRegressionModel.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CDataFrameRegressionModel_h
+#define INCLUDED_ml_maths_CDataFrameRegressionModel_h
+
+#include <maths/ImportExport.h>
+
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace ml {
+namespace core {
+class CDataFrame;
+class CRapidJsonConcurrentLineWriter;
+}
+namespace maths {
+
+//! \brief Defines the interface for fitting and evaluating a regression model
+//! on a data frame.
+class MATHS_EXPORT CDataFrameRegressionModel {
+public:
+    using TProgressCallback = std::function<void(double)>;
+    using TMemoryUsageCallback = std::function<void(std::uint64_t)>;
+
+public:
+    virtual ~CDataFrameRegressionModel() = default;
+
+    //! Train the model on the values in \p frame.
+    virtual void train(core::CDataFrame& frame,
+                       TProgressCallback recordProgress = noop) = 0;
+
+    //! Write the predictions of this model to \p frame.
+    virtual void predict(core::CDataFrame& frame,
+                         TProgressCallback recordProgress = noop) const = 0;
+
+    //! Write this model to \p writer.
+    virtual void write(core::CRapidJsonConcurrentLineWriter& writer) const = 0;
+
+protected:
+    static void noop(double);
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CDataFrameRegressionModel_h

--- a/include/maths/CDataFrameRegressionModel.h
+++ b/include/maths/CDataFrameRegressionModel.h
@@ -31,8 +31,7 @@ public:
     virtual ~CDataFrameRegressionModel() = default;
 
     //! Train the model on the values in \p frame.
-    virtual void train(core::CDataFrame& frame,
-                       TProgressCallback recordProgress = noop) = 0;
+    virtual void train(core::CDataFrame& frame, TProgressCallback recordProgress = noop) = 0;
 
     //! Write the predictions of this model to \p frame.
     virtual void predict(core::CDataFrame& frame,

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -18,6 +18,9 @@
 #include <vector>
 
 namespace ml {
+namespace core {
+class CPackedBitVector;
+}
 namespace maths {
 class CQuantileSketch;
 
@@ -54,6 +57,7 @@ public:
     using TRowRef = core::CDataFrame::TRowRef;
     using TWeightFunction = std::function<double(TRowRef)>;
     using TQuantileSketchVec = std::vector<CQuantileSketch>;
+    using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
 public:
     //! Convert a row of the data frame to a specified vector type.
@@ -72,20 +76,25 @@ public:
     //!
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute the column quantiles.
+    //! \param[in] rowMask A mask of the rows from which to compute quantiles.
     //! \param[in] columnMask A mask of the columns for which to compute quantiles.
-    //! \param[in,out] result This must be initialised with the sketches which will
-    //! be used for estimating the column quantiles. It is filled in with the result.
+    //! \param[in] sketch The sketch to be used to estimate column quantiles.
+    //! \param[out] result Filled in with the column quantile estimates.
     //! \param[in] weight The weight to assign each row. The default is unity for
     //! all rows.
     static bool columnQuantiles(std::size_t numberThreads,
                                 const core::CDataFrame& frame,
+                                const core::CPackedBitVector& rowMask,
                                 const TSizeVec& columnMask,
+                                const CQuantileSketch& sketch,
                                 TQuantileSketchVec& result,
                                 TWeightFunction weight = unitWeight);
 
+    //! Check if a data frame value is missing.
+    static bool isMissing(double value);
+
 private:
     static double unitWeight(const TRowRef&);
-    static bool isMissing(double value);
 };
 }
 }

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -1,0 +1,1023 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CBoostedTree.h>
+
+#include <core/CConcurrentQueue.h>
+#include <core/CDataFrame.h>
+#include <core/CPackedBitVector.h>
+
+#include <maths/CBasicStatistics.h>
+#include <maths/CDataFrameUtils.h>
+#include <maths/CQuantileSketch.h>
+#include <maths/CSampling.h>
+#include <maths/CTools.h>
+
+#include <boost/optional.hpp>
+
+#include <numeric>
+#include <utility>
+#include <vector>
+
+namespace ml {
+namespace maths {
+namespace {
+using namespace boosted_tree;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TDoubleDoubleDoubleTr = std::tuple<double, double, double>;
+using TRowItr = core::CDataFrame::TRowItr;
+using TRowRef = core::CDataFrame::TRowRef;
+using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+
+const double INF{std::numeric_limits<double>::max()};
+
+std::size_t predictionColumn(std::size_t numberColumns) {
+    return numberColumns - 3;
+}
+
+std::size_t lossGradientColumn(std::size_t numberColumns) {
+    return numberColumns - 2;
+}
+
+std::size_t lossCurvatureColumn(std::size_t numberColumns) {
+    return numberColumns - 1;
+}
+
+std::size_t numberFeatures(const core::CDataFrame& frame) {
+    return frame.numberColumns() - 3;
+}
+
+class CNode;
+using TNodeVec = std::vector<CNode>;
+using TNodeVecVec = std::vector<TNodeVec>;
+
+//! \brief A node of a regression tree.
+//!
+//! DESCRIPTION:\n
+//! This defines a tree structure on a vector of nodes (maintaining the parent
+//! child relationships as indexes into the vector). It holds the (binary)
+//! splitting criterion (feature and value) and the tree's prediction at each
+//! leaf. The intervals are open above so the left node contains feature vectors
+//! for which the feature value is _strictly_ less than the split value.
+//!
+//! During training row masks are maintained for each node (so the data can be
+//! efficiently traversed). This supports extracting the left and right child
+//! node bit masks from the node's bit mask.
+class CNode {
+public:
+    //! Check if this is a leaf node.
+    bool isLeaf() const { return m_LeftChild < 0; }
+
+    //! Get the leaf index for \p row.
+    std::size_t leafIndex(const TRowRef& row, const TNodeVec& tree, std::int32_t index = 0) const {
+        if (this->isLeaf()) {
+            return index;
+        }
+        return row[m_SplitFeature] < m_SplitValue
+                   ? tree[m_LeftChild].leafIndex(row, tree, m_LeftChild)
+                   : tree[m_RightChild].leafIndex(row, tree, m_RightChild);
+    }
+
+    //! Get the value predicted by \p tree for the feature vector \p row.
+    double value(const TRowRef& row, const TNodeVec& tree) const {
+        return tree[this->leafIndex(row, tree)].m_NodeValue;
+    }
+
+    //! Get the value of this node.
+    double value() const { return m_NodeValue; }
+
+    //! Set the node value to \p value.
+    void value(double value) { m_NodeValue = value; }
+
+    //! Split this node and add its child nodes to \p tree.
+    std::pair<std::size_t, std::size_t>
+    split(std::size_t splitFeature, double splitValue, TNodeVec& tree) {
+        m_SplitValue = splitFeature;
+        m_SplitValue = splitValue;
+        m_LeftChild = static_cast<std::int32_t>(tree.size());
+        m_RightChild = static_cast<std::int32_t>(tree.size() + 1);
+        tree.resize(tree.size() + 2);
+        return {m_LeftChild, m_RightChild};
+    }
+
+    //! Get the row masks of the left and right children of this node.
+    auto rowMasks(std::size_t numberThreads,
+                  const core::CDataFrame& frame,
+                  core::CPackedBitVector rowMask,
+                  bool assignMissingToLeft) const {
+
+        auto result = frame.readRows(
+            numberThreads, 0, frame.numberRows(),
+            core::bindRetrievableState(
+                [&](core::CPackedBitVector& leftRowMask, TRowItr beginRows, TRowItr endRows) {
+                    for (auto row = beginRows; row != endRows; ++row) {
+                        std::size_t index{row->index()};
+                        double value{(*row)[m_SplitFeature]};
+                        bool missing{CDataFrameUtils::isMissing(value)};
+                        if ((missing && assignMissingToLeft) ||
+                            (missing == false && value < m_SplitValue)) {
+                            leftRowMask.extend(false, index - leftRowMask.size());
+                            leftRowMask.extend(true);
+                        } else {
+                            leftRowMask.extend(false, index + 1 - leftRowMask.size());
+                        }
+                    }
+                },
+                core::CPackedBitVector{}),
+            &rowMask);
+
+        core::CPackedBitVector leftRowMask{std::move(result.first[0].s_FunctionState)};
+        for (std::size_t i = 1; i < result.first.size(); ++i) {
+            leftRowMask |= result.first[i].s_FunctionState;
+        }
+
+        core::CPackedBitVector rightRowMask{std::move(rowMask)};
+        rightRowMask ^= leftRowMask;
+
+        return std::make_pair(std::move(leftRowMask), std::move(rightRowMask));
+    }
+
+private:
+    std::size_t m_SplitFeature = 0;
+    double m_SplitValue = 0.0;
+    std::int32_t m_LeftChild = -1;
+    std::int32_t m_RightChild = -1;
+    double m_NodeValue = 0.0;
+};
+
+//! \brief Maintains a collection of statistics about a leaf of the regression
+//! tree as it is built.
+//!
+//! DESCRIPTION:\N
+//! The regression tree is grown top down by greedily selecting the split with
+//! the maximum gain (in the loss). This finds and scores the maximum gain split
+//! of a single leaf of the tree.
+class CLeafNodeStatistics {
+public:
+    CLeafNodeStatistics(std::size_t id,
+                        std::size_t numberThreads,
+                        const core::CDataFrame& frame,
+                        double lambda,
+                        double gamma,
+                        const TDoubleVecVec& candidateSplits,
+                        TSizeVec featureBag,
+                        core::CPackedBitVector rowMask)
+        : m_Id{id}, m_Lambda{lambda}, m_Gamma{gamma}, m_CandidateSplits{candidateSplits},
+          m_FeatureBag{std::move(featureBag)}, m_RowMask{std::move(rowMask)} {
+
+        this->computeAggregateGradientsAndCurvatures(numberThreads, frame);
+    }
+
+    CLeafNodeStatistics(const CLeafNodeStatistics&) = delete;
+    CLeafNodeStatistics& operator=(const CLeafNodeStatistics&) = delete;
+    CLeafNodeStatistics(CLeafNodeStatistics&&) = default;
+    CLeafNodeStatistics& operator=(CLeafNodeStatistics&&) = default;
+
+    //! Order two leaves by decreasing loss.
+    bool operator<(const CLeafNodeStatistics& rhs) const {
+        return this->bestSplitStatistics() < rhs.bestSplitStatistics();
+    }
+
+    //! Get the gain in loss of the best split.
+    double gain() const { return this->bestSplitStatistics().s_Gain; }
+
+    //! Get the best (feature, feature value) split.
+    TSizeDoublePr bestSplit() const {
+        const auto& split = this->bestSplitStatistics();
+        return {split.s_Feature, split.s_SplitAt};
+    }
+
+    //! Check if we should assign the missing feature rows to the left child
+    //! of the split.
+    bool assignMissingToLeft() const {
+        return this->bestSplitStatistics().s_AssignMissingToLeft;
+    }
+
+    //! Get the node's identifier.
+    std::size_t id() const { return m_Id; }
+
+    //! Get the row mask for this leaf node.
+    core::CPackedBitVector& rowMask() { return m_RowMask; }
+
+private:
+    //! \brief Statistics relating to a split of the node.
+    struct SSplitStatistics {
+        bool operator<(const SSplitStatistics& rhs) const {
+            return COrderings::lexicographical_compare(s_Gain, s_Feature,
+                                                       rhs.s_Gain, rhs.s_Feature);
+        }
+
+        double s_Gain;
+        std::size_t s_Feature;
+        double s_SplitAt;
+        bool s_AssignMissingToLeft;
+    };
+
+    //! \brief A collection aggregate derivatives.
+    struct SDerivatives {
+        SDerivatives(const TSizeVec& featureBag, const TDoubleVecVec& candidateSplits)
+            : s_Gradients(featureBag.size()), s_Curvatures(featureBag.size()),
+              s_MissingGradients(featureBag.size(), 0.0),
+              s_MissingCurvatures(featureBag.size(), 0.0) {
+
+            for (std::size_t i = 0; i < featureBag.size(); ++i) {
+                s_Gradients[i].resize(candidateSplits[featureBag[i]].size() + 1);
+                s_Curvatures[i].resize(candidateSplits[featureBag[i]].size() + 1);
+            }
+        }
+
+        TDoubleVecVec s_Gradients;
+        TDoubleVecVec s_Curvatures;
+        TDoubleVec s_MissingGradients;
+        TDoubleVec s_MissingCurvatures;
+    };
+
+private:
+    void computeAggregateGradientsAndCurvatures(std::size_t numberThreads,
+                                                const core::CDataFrame& frame) {
+
+        auto result = frame.readRows(
+            numberThreads, 0, frame.numberRows(),
+            core::bindRetrievableState(
+                [&](SDerivatives& state, TRowItr beginRows, TRowItr endRows) {
+                    for (auto row = beginRows; row != endRows; ++row) {
+                        this->addRowDerivatives(*row, state);
+                    }
+                },
+                SDerivatives{m_FeatureBag, m_CandidateSplits}),
+            &m_RowMask);
+
+        auto& results = result.first;
+
+        m_Gradients = std::move(results[0].s_FunctionState.s_Gradients);
+        m_Curvatures = std::move(results[0].s_FunctionState.s_Curvatures);
+        m_MissingGradients = std::move(results[0].s_FunctionState.s_MissingGradients);
+        m_MissingCurvatures = std::move(results[0].s_FunctionState.s_MissingCurvatures);
+
+        for (std::size_t k = 1; k < results.size(); ++k) {
+            const auto& derivatives = results[k].s_FunctionState;
+            for (std::size_t i = 0; i < m_FeatureBag.size(); ++i) {
+                std::size_t numberSplits{m_CandidateSplits[m_FeatureBag[i]].size()};
+                for (std::size_t j = 0; j <= numberSplits; ++j) {
+                    m_Gradients[i][j] += derivatives.s_Gradients[i][j];
+                    m_Curvatures[i][j] += derivatives.s_Curvatures[i][j];
+                }
+                m_MissingGradients[i] += derivatives.s_MissingGradients[i];
+                m_MissingCurvatures[i] += derivatives.s_MissingCurvatures[i];
+            }
+        }
+    }
+
+    void addRowDerivatives(const TRowRef& row, SDerivatives& derivatives) const {
+
+        std::size_t numberColumns{row.numberColumns()};
+        std::size_t derivativeColumn{lossGradientColumn(numberColumns)};
+        std::size_t curvatureColumn{lossCurvatureColumn(numberColumns)};
+
+        for (std::size_t i = 0; i < m_FeatureBag.size(); ++i) {
+            std::size_t column{m_FeatureBag[i]};
+            if (CDataFrameUtils::isMissing(row[column])) {
+                derivatives.s_MissingGradients[i] += row[derivativeColumn];
+                derivatives.s_MissingCurvatures[i] += row[curvatureColumn];
+            } else {
+                auto j = std::lower_bound(m_CandidateSplits[column].begin(),
+                                          m_CandidateSplits[column].end(), row[column]) -
+                         m_CandidateSplits[column].begin();
+                derivatives.s_Gradients[i][j] += row[derivativeColumn];
+                derivatives.s_Curvatures[i][j] += row[curvatureColumn];
+            }
+        }
+    }
+
+    const SSplitStatistics& bestSplitStatistics() const {
+        if (m_BestSplit == boost::none) {
+            m_BestSplit = this->computeBestSplitStatistics();
+        }
+        return *m_BestSplit;
+    }
+
+    SSplitStatistics computeBestSplitStatistics() const {
+
+        static const std::size_t ASSIGN_MISSING_TO_LEFT{0};
+        static const std::size_t ASSIGN_MISSING_TO_RIGHT{1};
+
+        SSplitStatistics result{INF, m_FeatureBag.size(), INF, true};
+
+        for (std::size_t i = 0; i < m_FeatureBag.size(); ++i) {
+            double g{std::accumulate(m_Gradients[i].begin(), m_Gradients[i].end(), 0.0) +
+                     m_MissingGradients[i]};
+            double h{std::accumulate(m_Curvatures[i].begin(), m_Curvatures[i].end(), 0.0) +
+                     m_MissingCurvatures[i]};
+            double gl[]{m_MissingGradients[i], 0.0};
+            double hl[]{m_MissingCurvatures[i], 0.0};
+
+            std::size_t split{m_FeatureBag.size()};
+            double maximumGain{INF};
+            std::size_t assignMissingTo{ASSIGN_MISSING_TO_LEFT};
+
+            for (std::size_t j = 0; j + 1 < m_Gradients[i].size(); ++j) {
+                gl[ASSIGN_MISSING_TO_LEFT] += m_Gradients[i][j];
+                hl[ASSIGN_MISSING_TO_LEFT] += m_Curvatures[i][j];
+                gl[ASSIGN_MISSING_TO_RIGHT] += m_Gradients[i][j];
+                hl[ASSIGN_MISSING_TO_RIGHT] += m_Curvatures[i][j];
+
+                double gain[]{CTools::pow2(gl[ASSIGN_MISSING_TO_LEFT]) /
+                                      (hl[ASSIGN_MISSING_TO_LEFT] + m_Lambda) +
+                                  CTools::pow2(g - gl[ASSIGN_MISSING_TO_LEFT]) /
+                                      (h - hl[ASSIGN_MISSING_TO_LEFT] + m_Lambda),
+                              CTools::pow2(gl[ASSIGN_MISSING_TO_RIGHT]) /
+                                      (hl[ASSIGN_MISSING_TO_RIGHT] + m_Lambda) +
+                                  CTools::pow2(g - gl[ASSIGN_MISSING_TO_RIGHT]) /
+                                      (h - hl[ASSIGN_MISSING_TO_RIGHT] + m_Lambda)};
+
+                if (gain[ASSIGN_MISSING_TO_LEFT] > maximumGain) {
+                    split = j;
+                    maximumGain = gain[ASSIGN_MISSING_TO_LEFT];
+                    assignMissingTo = ASSIGN_MISSING_TO_LEFT;
+                }
+                if (gain[ASSIGN_MISSING_TO_RIGHT] > maximumGain) {
+                    split = j;
+                    maximumGain = gain[ASSIGN_MISSING_TO_RIGHT];
+                    assignMissingTo = ASSIGN_MISSING_TO_RIGHT;
+                }
+            }
+
+            double gain{0.5 * (maximumGain - CTools::pow2(g) / (h + m_Lambda)) - m_Gamma};
+
+            SSplitStatistics candidate{gain, m_FeatureBag[i],
+                                       m_CandidateSplits[m_FeatureBag[i]][split],
+                                       assignMissingTo == ASSIGN_MISSING_TO_LEFT};
+            if (candidate < *m_BestSplit) {
+                *m_BestSplit = candidate;
+            }
+        }
+
+        return result;
+    }
+
+private:
+    std::size_t m_Id;
+    double m_Lambda;
+    double m_Gamma;
+    const TDoubleVecVec& m_CandidateSplits;
+    TSizeVec m_FeatureBag;
+    core::CPackedBitVector m_RowMask;
+    TDoubleVecVec m_Gradients;
+    TDoubleVecVec m_Curvatures;
+    TDoubleVec m_MissingGradients;
+    TDoubleVec m_MissingCurvatures;
+    mutable boost::optional<SSplitStatistics> m_BestSplit;
+};
+}
+
+namespace boosted_tree {
+
+void CArgMinLoss::add(double prediction, double actual) {
+    std::unique_lock<std::mutex> lock{m_Mutex};
+    this->addImpl(prediction, actual);
+}
+
+double CMse::value(double prediction, double actual) const {
+    return CTools::pow2(prediction - actual);
+}
+
+double CMse::gradient(double prediction, double actual) const {
+    return prediction - actual;
+}
+
+double CMse::curvature(double /*prediction*/, double /*actual*/) const {
+    return 2.0;
+}
+
+void CArgMinMse::addImpl(double prediction, double actual) {
+    m_MeanError.add(prediction - actual);
+}
+
+CMse::TArgMinLossUPtr CMse::minimizer() const {
+    return std::make_unique<CArgMinMse>();
+}
+
+double CArgMinMse::value() const {
+    return CBasicStatistics::mean(m_MeanError);
+}
+}
+
+class CBoostedTree::CImpl {
+public:
+    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+public:
+    CImpl(std::size_t numberThreads, std::size_t dependentVariable, TLossFunctionUPtr loss)
+        : m_NumberThreads{numberThreads},
+          m_DependentVariable{dependentVariable}, m_Loss{std::move(loss)} {}
+
+    //! Set the loss function.
+    //!
+    //! Set the number of folds to use for estimating the generalisation error.
+    void numberFolds(std::size_t k) { m_NumberFolds = k; }
+
+    //! Set the maximum number of trees to use in the forest.
+    void maximumNumberTrees(std::size_t maximumNumberTrees) {
+        m_MaximumNumberTrees = maximumNumberTrees;
+    }
+
+    //! Set the fraction of features which are used in each bag.
+    void featureBagFraction(double featureBagFraction) {
+        m_FeatureBagFraction = featureBagFraction;
+    }
+
+    //! Set the amount by which to shrink the node values for each successive tree
+    //! in the forest.
+    void shrinkageFactor(double shrinkageFactor) {
+        m_ShrinkageFactor = shrinkageFactor;
+    }
+
+    //! Train the model on the values in \p frame.
+    void train(core::CDataFrame& frame, TProgressCallback recordProgress) {
+
+        if (m_Loss == nullptr) {
+            HANDLE_FATAL(<< "Internal error: no loss function defined for regression."
+                         << " Please report this problem.");
+            return;
+        }
+
+        this->initializeMissingFeatureMasks(frame);
+
+        // We store the gradient and curvature of the loss function and the predicted
+        // value for the dependent variable of the regression.
+
+        frame.resizeColumns(m_NumberThreads, frame.numberColumns() + 3);
+
+        TPackedBitVectorVec trainingRowMasks;
+        TPackedBitVectorVec testingRowMasks;
+        std::tie(trainingRowMasks, testingRowMasks) = this->crossValidationRowMasks();
+
+        this->initializeFeatureSampleDistribution(frame);
+
+        this->initializeRegularisation(frame, trainingRowMasks, recordProgress);
+
+        // TODO Hyperparameter optimisation...
+        // Get next parameters to test, compute generalisation error, record if best, repeat.
+
+        TMeanAccumulator error;
+        for (std::size_t fold = 0; fold < m_NumberFolds; ++fold) {
+            TNodeVecVec forest(this->trainForest(frame, trainingRowMasks[fold], recordProgress));
+            error.add(this->meanLoss(frame, testingRowMasks[fold], forest));
+        }
+
+        if (CBasicStatistics::mean(error) < m_BestForestTestError) {
+            // TODO remember hyperparameters, rng seed, etc and train on full data set at end.
+        }
+    }
+
+    //! Write the predictions of this model to \p frame.
+    void predict(core::CDataFrame& /*frame*/, TProgressCallback /*recordProgress*/) const {
+        // TODO
+    }
+
+    //! Write this model to \p writer.
+    void write(core::CRapidJsonConcurrentLineWriter& /*writer*/) const {
+        // TODO
+    }
+
+private:
+    //! Setup the missing feature row masks.
+    void initializeMissingFeatureMasks(const core::CDataFrame& frame) {
+
+        m_MissingFeatureRowMasks.resize(frame.numberColumns());
+
+        auto result = frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                for (std::size_t i = 0; i < row->numberColumns(); ++i) {
+                    double value{(*row)[i]};
+                    if (CDataFrameUtils::isMissing(value)) {
+                        m_MissingFeatureRowMasks[i].extend(
+                            false, row->index() - m_MissingFeatureRowMasks[i].size());
+                        m_MissingFeatureRowMasks[i].extend(true);
+                    }
+                }
+            }
+        });
+
+        for (auto& mask : m_MissingFeatureRowMasks) {
+            mask.extend(false, frame.numberRows() - mask.size());
+        }
+    }
+
+    //! Get the row masks to use for the training and testing sets for k-fold
+    //! cross validation estimates of the generalisation error.
+    std::pair<TPackedBitVectorVec, TPackedBitVectorVec> crossValidationRowMasks() const {
+
+        const core::CPackedBitVector& mask{m_MissingFeatureRowMasks[m_DependentVariable]};
+
+        TPackedBitVectorVec trainingRowMasks(m_NumberFolds);
+
+        for (auto row = mask.beginOneBits(); row != mask.endOneBits(); ++row) {
+            std::size_t fold{CSampling::uniformSample(m_Rng, 0, m_NumberFolds)};
+            trainingRowMasks[fold].extend(true, *row - trainingRowMasks[fold].size());
+            trainingRowMasks[fold].extend(false);
+        }
+
+        for (auto& fold : trainingRowMasks) {
+            fold.extend(true, mask.size() - fold.size());
+        }
+
+        TPackedBitVectorVec testingRowMasks(
+            m_NumberFolds, core::CPackedBitVector{mask.size(), true});
+        for (std::size_t i = 0; i < m_NumberFolds; ++i) {
+            testingRowMasks[i] ^= trainingRowMasks[i];
+        }
+
+        return std::make_pair(trainingRowMasks, testingRowMasks);
+    }
+
+    //! Initialize the regressors sample distribution.
+    void initializeFeatureSampleDistribution(const core::CDataFrame& frame) {
+
+        // Exclude all constant features by zeroing their probabilities.
+
+        std::size_t n{numberFeatures(frame)};
+
+        TSizeVec regressors(n);
+        std::iota(regressors.begin(), regressors.end(), 0);
+        regressors.erase(regressors.begin() + m_DependentVariable);
+
+        TDoubleVecVec distinct(n);
+        frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                for (std::size_t i = 0; i < regressors.size(); ++i) {
+                    double value{(*row)[regressors[i]]};
+                    if (distinct[i].size() == 2) {
+                        continue;
+                    }
+                    if (distinct[i].empty()) {
+                        distinct[i].push_back(value);
+                    }
+                    if (value != distinct[i][0]) {
+                        distinct[i].push_back(value);
+                    }
+                }
+            }
+        });
+
+        regressors.erase(
+            std::remove_if(regressors.begin(), regressors.end(),
+                           [&](std::size_t i) { return distinct[i].size() < 2; }),
+            regressors.end());
+
+        // TODO consider "correlation" with target variable(s).
+
+        m_FeatureSampleProbabilities.assign(n, 0.0);
+
+        if (regressors.empty()) {
+            HANDLE_FATAL(<< "Input error: all features constant.");
+        } else {
+            double p{1.0 / static_cast<double>(regressors.size())};
+            for (auto feature : regressors) {
+                m_FeatureSampleProbabilities[feature] = p;
+            }
+        }
+    }
+
+    //! Estimate the values of \f$\lambda\f$ and \f$\gamma\f$ which match the
+    //! gain from a small tree.
+    //!
+    //! We'll use this as a starting point for hyperparameter tuning.
+    void initializeRegularisation(core::CDataFrame& frame,
+                                  const TPackedBitVectorVec& trainingRowMasks,
+                                  TProgressCallback recordProgress) {
+
+        bool computeLambda{m_Lambda == boost::none};
+        bool computeGamma{m_Gamma == boost::none};
+
+        if (computeLambda == false && computeGamma == false) {
+            return;
+        }
+
+        core::CPackedBitVector trainingRowMask{trainingRowMasks[0]};
+        for (std::size_t i = 1; i < trainingRowMasks.size(); ++i) {
+            trainingRowMask |= trainingRowMasks[i];
+        }
+
+        m_Lambda = m_Lambda.value_or(0.0);
+        m_Gamma = m_Gamma.value_or(0.0);
+
+        auto tree = this->initializePredictionsGradientsAndCurvatures(frame, trainingRowMask);
+
+        double L[2];
+        double T[2];
+        double W[2];
+
+        std::tie(L[0], T[0], W[0]) =
+            this->regularisedLoss(frame, trainingRowMask, {std::move(tree)});
+
+        auto forest = this->trainForest(frame, trainingRowMask, recordProgress);
+
+        std::tie(L[1], T[1], W[1]) = this->regularisedLoss(frame, trainingRowMask, forest);
+
+        if (computeLambda && computeGamma) {
+            m_Lambda = 0.5 * (L[1] - L[0]) / (W[1] - W[0]);
+            m_Gamma = 0.5 * (L[1] - L[0]) / (T[1] - T[0]);
+        } else if (computeLambda) {
+            m_Lambda = (L[1] - L[0]) / (W[1] - W[0]);
+        } else if (computeGamma) {
+            m_Gamma = (L[1] - L[0]) / (T[1] - T[0]);
+        }
+    }
+
+    //! Compute the sum loss for the predictions from \p frame and the leaf
+    //! count and squared weight sum from \p forest.
+    TDoubleDoubleDoubleTr regularisedLoss(const core::CDataFrame& frame,
+                                          const core::CPackedBitVector& trainingRowMask,
+                                          const TNodeVecVec& forest) const {
+
+        auto results = frame.readRows(
+            m_NumberThreads, 0, frame.numberRows(),
+            core::bindRetrievableState(
+                [&](double& loss, TRowItr beginRows, TRowItr endRows) {
+                    for (auto row = beginRows; row != endRows; ++row) {
+                        std::size_t numberColumns{row->numberColumns()};
+                        loss += m_Loss->value((*row)[predictionColumn(numberColumns)],
+                                              (*row)[m_DependentVariable]);
+                    }
+                },
+                0.0),
+            &trainingRowMask);
+
+        double loss{0.0};
+        for (const auto& result : results.first) {
+            loss += result.s_FunctionState;
+        }
+
+        double leafCount{0.0};
+        double sumSquareLeafWeights{0.0};
+        for (const auto& tree : forest) {
+            for (const auto& node : tree) {
+                if (node.isLeaf()) {
+                    leafCount += 1.0;
+                    sumSquareLeafWeights += CTools::pow2(node.value());
+                }
+            }
+        }
+
+        return {loss, leafCount, sumSquareLeafWeights};
+    }
+
+    //! Train one forest on the rows of \p frame in the mask \p trainingRowMask.
+    TNodeVecVec trainForest(core::CDataFrame& frame,
+                            const core::CPackedBitVector& trainingRowMask,
+                            TProgressCallback /*recordProgress*/) const {
+
+        this->initializePredictionsGradientsAndCurvatures(frame, trainingRowMask);
+
+        TNodeVecVec forest;
+        forest.reserve(m_MaximumNumberTrees);
+
+        // For each iteration:
+        //  1. Compute loss gradient and curvature and write to data frame
+        //  2. Compute weighted quantiles for features F
+        //  3. Compute candidate split set S from quantiles of F
+        //  4. Build one tree on (F, S)
+        //  5. Shrink weights and update predictions and loss derivatives
+
+        double shrinkage{1.0};
+
+        for (std::size_t retries = 0; forest.size() < m_MaximumNumberTrees; /**/) {
+
+            TDoubleVecVec candidateSplits(this->candidateSplits(frame, trainingRowMask));
+
+            auto tree = this->trainTree(frame, trainingRowMask, candidateSplits);
+
+            retries = tree.size() == 1 ? retries + 1 : 0;
+
+            if (retries == m_MaximumAttemptsToAddTree) {
+                break;
+            } else if (retries == 0) {
+                shrinkage *= m_ShrinkageFactor;
+                this->refreshPredictionsGradientsAndCurvatures(frame, trainingRowMask,
+                                                               shrinkage, tree);
+                forest.push_back(std::move(tree));
+            }
+        }
+
+        return forest;
+    }
+
+    //! Get the candidate splits values for each feature.
+    TDoubleVecVec candidateSplits(const core::CDataFrame& frame,
+                                  const core::CPackedBitVector& trainingRowMask) const {
+
+        using TQuantileSketchVec = std::vector<CQuantileSketch>;
+
+        TSizeVec features{this->candidateFeatures()};
+
+        TQuantileSketchVec columnQuantiles;
+        CDataFrameUtils::columnQuantiles(
+            m_NumberThreads, frame, trainingRowMask, features,
+            CQuantileSketch{CQuantileSketch::E_Linear, 100}, columnQuantiles,
+            [](const TRowRef& row) {
+                return row[lossCurvatureColumn(row.numberColumns())];
+            });
+
+        TDoubleVecVec result(numberFeatures(frame));
+
+        for (std::size_t i = 0; i < features.size(); ++i) {
+
+            TDoubleVec columnSplits;
+            columnSplits.reserve(m_NumberSplitsPerFeature - 1);
+
+            for (std::size_t j = 1; j < m_NumberSplitsPerFeature; ++j) {
+                double rank{static_cast<double>(j) /
+                            static_cast<double>(m_NumberSplitsPerFeature)};
+                double q;
+                if (columnQuantiles[i].quantile(rank, q) == false) {
+                    columnSplits.push_back(q);
+                } else {
+                    LOG_WARN(<< "Failed to compute quantile " << rank << ": ignoring split");
+                }
+            }
+
+            columnSplits.erase(std::unique(columnSplits.begin(), columnSplits.end()),
+                               columnSplits.end());
+            result[features[i]] = std::move(columnSplits);
+        }
+
+        return result;
+    }
+
+    //! Get the maximum number of nodes to use in a tree.
+    //!
+    //! \note This number will only be used if the regularisation says its a
+    //! good idea.
+    std::size_t maximumTreeSize(const core::CDataFrame& frame) const {
+        return static_cast<std::size_t>(
+            std::ceil(m_MaximumTreeSizeFraction *
+                      std::sqrt(static_cast<double>(frame.numberRows()))));
+    }
+
+    //! Train one tree on the rows of \p frame in the mask \p trainingRowMask.
+    TNodeVec trainTree(core::CDataFrame& frame,
+                       const core::CPackedBitVector& trainingRowMask,
+                       const TDoubleVecVec& candidateSplits) const {
+
+        // For each iteration we:
+        //   1. Find the leaf with the greatest decrease in loss
+        //   2. If no split reduced the loss we terminate
+        //   3. Otherwise we split that leaf
+
+        // TODO improve categorical regressor treatment
+
+        using TLeafNodeStatisticsPtr = std::shared_ptr<CLeafNodeStatistics>;
+        using TLeafNodeStatisticsPtrQueue =
+            std::priority_queue<TLeafNodeStatisticsPtr, std::vector<TLeafNodeStatisticsPtr>, COrderings::SLess>;
+
+        std::size_t maximumTreeSize{this->maximumTreeSize(frame)};
+
+        TNodeVec tree(1);
+        tree.reserve(maximumTreeSize);
+
+        TLeafNodeStatisticsPtrQueue leaves;
+        leaves.push(std::make_shared<CLeafNodeStatistics>(
+            0 /*root*/, m_NumberThreads, frame, *m_Lambda, *m_Gamma,
+            candidateSplits, this->featureBag(frame), trainingRowMask));
+
+        for (std::size_t i = 0; i < maximumTreeSize; ++i) {
+
+            auto split = leaves.top();
+            leaves.pop();
+
+            if (split->gain() < 0.0) {
+                break;
+            }
+
+            std::size_t splitFeature;
+            double splitValue;
+            std::tie(splitFeature, splitValue) = split->bestSplit();
+
+            bool assignMissingToLeft{split->assignMissingToLeft()};
+
+            std::size_t leftChildId, rightChildId;
+            std::tie(leftChildId, rightChildId) =
+                tree[split->id()].split(splitFeature, splitValue, tree);
+
+            TSizeVec featureBag{this->featureBag(frame)};
+
+            core::CPackedBitVector leftChildRowMask;
+            core::CPackedBitVector rightChildRowMask;
+            std::tie(leftChildRowMask, rightChildRowMask) = tree[split->id()].rowMasks(
+                m_NumberThreads, frame, std::move(split->rowMask()), assignMissingToLeft);
+
+            leaves.push(std::make_shared<CLeafNodeStatistics>(
+                leftChildId, m_NumberThreads, frame, *m_Lambda, *m_Gamma,
+                candidateSplits, featureBag, std::move(leftChildRowMask)));
+            leaves.push(std::make_shared<CLeafNodeStatistics>(
+                rightChildId, m_NumberThreads, frame, *m_Lambda, *m_Gamma,
+                candidateSplits, featureBag, std::move(rightChildRowMask)));
+        }
+
+        return tree;
+    }
+
+    //! Get the number of features to consider splitting on.
+    std::size_t featureBagSize(const core::CDataFrame& frame) const {
+        return static_cast<std::size_t>(std::ceil(
+            m_FeatureBagFraction * static_cast<double>(numberFeatures(frame))));
+    }
+
+    //! Sample the features according to their categorical distribution.
+    TSizeVec featureBag(const core::CDataFrame& frame) const {
+
+        std::size_t size{this->featureBagSize(frame)};
+
+        TSizeVec features{this->candidateFeatures()};
+        if (size >= features.size()) {
+            return features;
+        }
+
+        TSizeVec sample;
+        TDoubleVec probabilities(m_FeatureSampleProbabilities);
+        CSampling::categoricalSampleWithoutReplacement(m_Rng, probabilities, size, sample);
+
+        return sample;
+    }
+
+    TNodeVec initializePredictionsGradientsAndCurvatures(core::CDataFrame& frame,
+                                                         const core::CPackedBitVector& trainingRowMask) const {
+
+        frame.writeColumns(m_NumberThreads, 0, frame.numberRows(),
+                           [](TRowItr beginRows, TRowItr endRows) {
+                               for (auto row = beginRows; row != endRows; ++row) {
+                                   std::size_t numberColumns{row->numberColumns()};
+                                   (*row)[predictionColumn(numberColumns)] = 0.0;
+                                   (*row)[lossGradientColumn(numberColumns)] = 0.0;
+                                   (*row)[lossCurvatureColumn(numberColumns)] = 0.0;
+                               }
+                           },
+                           &trainingRowMask);
+
+        TNodeVec tree(1);
+        this->refreshPredictionsGradientsAndCurvatures(frame, trainingRowMask, 1.0, tree);
+
+        return tree;
+    }
+
+    //! Refresh the loss function gradient and curvatures.
+    void refreshPredictionsGradientsAndCurvatures(core::CDataFrame& frame,
+                                                  const core::CPackedBitVector& trainingRowMask,
+                                                  double shrinkage,
+                                                  TNodeVec& tree) const {
+
+        using TArgMinLossUPtrVec = std::vector<CLoss::TArgMinLossUPtr>;
+
+        TArgMinLossUPtrVec leafValues;
+        leafValues.reserve(tree.size());
+        for (std::size_t i = 0; i < tree.size(); ++i) {
+            leafValues.push_back(m_Loss->minimizer());
+        }
+
+        frame.readRows(m_NumberThreads, 0, frame.numberRows(),
+                       [&](TRowItr beginRows, TRowItr endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               std::size_t numberColumns{row->numberColumns()};
+                               double prediction{(*row)[predictionColumn(numberColumns)]};
+                               double actual{(*row)[m_DependentVariable]};
+                               leafValues[leaf(*row, tree)]->add(prediction, actual);
+                           }
+                       },
+                       &trainingRowMask);
+
+        for (std::size_t i = 0; i < tree.size(); ++i) {
+            tree[i].value(leafValues[i]->value());
+        }
+
+        frame.writeColumns(
+            m_NumberThreads, 0, frame.numberRows(),
+            [&](TRowItr beginRows, TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    std::size_t numberColumns{row->numberColumns()};
+                    double actual{(*row)[m_DependentVariable]};
+                    double prediction{(*row)[predictionColumn(numberColumns)]};
+
+                    prediction += shrinkage * predict(*row, tree);
+
+                    row->writeColumn(predictionColumn(numberColumns), prediction);
+                    row->writeColumn(lossGradientColumn(numberColumns),
+                                     m_Loss->gradient(prediction, actual));
+                    row->writeColumn(lossCurvatureColumn(numberColumns),
+                                     m_Loss->curvature(prediction, actual));
+                }
+            },
+            &trainingRowMask);
+    }
+
+    //! Compute the loss function on the masked rows.
+    double meanLoss(const core::CDataFrame& frame,
+                    const core::CPackedBitVector& rowMask,
+                    const TNodeVecVec& forest) const {
+
+        auto results = frame.readRows(
+            m_NumberThreads, 0, frame.numberRows(),
+            core::bindRetrievableState(
+                [&](TMeanAccumulator& loss, TRowItr beginRows, TRowItr endRows) {
+                    for (auto row = beginRows; row != endRows; ++row) {
+                        for (const auto& tree : forest) {
+                            double prediction{predict(*row, tree)};
+                            double actual{(*row)[m_DependentVariable]};
+                            loss.add(m_Loss->value(prediction, actual));
+                        }
+                    }
+                },
+                TMeanAccumulator{}),
+            &rowMask);
+
+        TMeanAccumulator loss;
+        for (const auto& result : results.first) {
+            loss += result.s_FunctionState;
+        }
+
+        return CBasicStatistics::mean(loss);
+    }
+
+    //! Get a column mask of the suitable regressor features.
+    TSizeVec candidateFeatures() const {
+        TSizeVec result;
+        result.reserve(m_FeatureSampleProbabilities.size());
+        for (std::size_t i = 0; i < m_FeatureSampleProbabilities.size(); ++i) {
+            if (m_FeatureSampleProbabilities[i] > 0.0) {
+                result.push_back(i);
+            }
+        }
+        return result;
+    }
+
+    //! Get the prediction of \p tree for \p row.
+    static double predict(const TRowRef& row, const TNodeVec& tree) {
+        return tree[0].value(row, tree);
+    }
+
+    //! Get the leaf index of \p row in \p tree.
+    static std::size_t leaf(const TRowRef& row, const TNodeVec& tree) {
+        return tree[0].leafIndex(row, tree);
+    }
+
+private:
+    mutable CPRNG::CXorOShiro128Plus m_Rng;
+    std::size_t m_NumberThreads;
+    std::size_t m_DependentVariable;
+    TLossFunctionUPtr m_Loss;
+    boost::optional<double> m_Lambda;
+    boost::optional<double> m_Gamma;
+    std::size_t m_NumberFolds = 3;
+    std::size_t m_MaximumNumberTrees = 10;
+    std::size_t m_MaximumAttemptsToAddTree = 3;
+    std::size_t m_NumberSplitsPerFeature = 40;
+    double m_FeatureBagFraction = 0.5;
+    double m_MaximumTreeSizeFraction = 1.0;
+    double m_ShrinkageFactor = 0.98;
+    TDoubleVec m_FeatureSampleProbabilities;
+    TPackedBitVectorVec m_MissingFeatureRowMasks;
+    double m_BestForestTestError = INF;
+    TNodeVecVec m_BestForest;
+};
+
+CBoostedTree::CBoostedTree(std::size_t numberThreads, std::size_t dependentVariable, TLossFunctionUPtr loss)
+    : m_Impl{std::make_unique<CImpl>(numberThreads, dependentVariable, std::move(loss))} {
+}
+
+CBoostedTree::~CBoostedTree() {
+}
+
+CBoostedTree& CBoostedTree::maximumNumberTrees(std::size_t maximumNumberTrees) {
+    m_Impl->maximumNumberTrees(maximumNumberTrees);
+    return *this;
+}
+
+CBoostedTree& CBoostedTree::featureBagFraction(double featureBagFraction) {
+    m_Impl->featureBagFraction(featureBagFraction);
+    return *this;
+}
+
+CBoostedTree& CBoostedTree::shrinkageFactor(double shrinkageFactor) {
+    m_Impl->shrinkageFactor(shrinkageFactor);
+    return *this;
+}
+
+void CBoostedTree::train(core::CDataFrame& frame, TProgressCallback recordProgress) {
+    m_Impl->train(frame, recordProgress);
+}
+
+void CBoostedTree::predict(core::CDataFrame& frame, TProgressCallback recordProgress) const {
+    m_Impl->predict(frame, recordProgress);
+}
+
+void CBoostedTree::write(core::CRapidJsonConcurrentLineWriter& writer) const {
+    m_Impl->write(writer);
+}
+}
+}

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -136,7 +136,8 @@ public:
             &rowMask);
 
         for (auto& mask : result.first) {
-            mask.s_FunctionState.extend(false, rowMask.size() - mask.s_FunctionState.size());
+            mask.s_FunctionState.extend(false, rowMask.size() -
+                                                   mask.s_FunctionState.size());
         }
 
         core::CPackedBitVector leftRowMask{std::move(result.first[0].s_FunctionState)};
@@ -161,9 +162,8 @@ public:
     }
 
 private:
-    std::ostringstream& doPrint(std::string pad,
-                 const TNodeVec& tree,
-                 std::ostringstream& result) const {
+    std::ostringstream&
+    doPrint(std::string pad, const TNodeVec& tree, std::ostringstream& result) const {
         result << "\n" << pad;
         if (this->isLeaf()) {
             result << m_NodeValue;
@@ -956,16 +956,17 @@ private:
             leafValues.push_back(m_Loss->minimizer());
         }
 
-        frame.readRows(m_NumberThreads, 0, frame.numberRows(),
-                       [&](TRowItr beginRows, TRowItr endRows) {
-                           for (auto row = beginRows; row != endRows; ++row) {
-                               std::size_t numberColumns{row->numberColumns()};
-                               double prediction{(*row)[predictionColumn(numberColumns)]};
-                               double actual{(*row)[m_DependentVariable]};
-                               leafValues[root(tree).leafIndex(*row, tree)]->add(prediction, actual);
-                           }
-                       },
-                       &trainingRowMask);
+        frame.readRows(
+            m_NumberThreads, 0, frame.numberRows(),
+            [&](TRowItr beginRows, TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    std::size_t numberColumns{row->numberColumns()};
+                    double prediction{(*row)[predictionColumn(numberColumns)]};
+                    double actual{(*row)[m_DependentVariable]};
+                    leafValues[root(tree).leafIndex(*row, tree)]->add(prediction, actual);
+                }
+            },
+            &trainingRowMask);
 
         for (std::size_t i = 0; i < tree.size(); ++i) {
             tree[i].value(shrinkage * leafValues[i]->value());
@@ -1036,9 +1037,7 @@ private:
     }
 
     //! Get the root node of \p tree.
-    static const CNode& root(const TNodeVec& tree) {
-        return tree[0];
-    }
+    static const CNode& root(const TNodeVec& tree) { return tree[0]; }
 
 private:
     mutable CPRNG::CXorOShiro128Plus m_Rng;

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -516,17 +516,17 @@ public:
 
         LOG_TRACE(<< "Starting training");
 
-        TMeanAccumulator error;
+        TMeanAccumulator meanLoss;
         for (std::size_t i = 0; i < m_NumberFolds; ++i) {
             LOG_TRACE(<< "fold = " << i);
             TNodeVecVec forest(this->trainForest(frame, trainingRowMasks[i], recordProgress));
             double loss{this->meanLoss(frame, testingRowMasks[i], forest)};
-            error.add(loss);
+            meanLoss.add(loss);
             LOG_TRACE(<< "test set loss = " << loss);
         }
-        LOG_TRACE(<< "mean test set loss = " << CBasicStatistics::mean(error));
+        LOG_TRACE(<< "mean test set loss = " << CBasicStatistics::mean(meanLoss));
 
-        if (CBasicStatistics::mean(error) < m_BestForestTestError) {
+        if (CBasicStatistics::mean(meanLoss) < m_BestForestTestLoss) {
             // TODO remember hyperparameters, rng seed, etc and train on full data set at end.
         }
     }
@@ -1066,7 +1066,7 @@ private:
     double m_ShrinkageFactor = 0.98;
     TDoubleVec m_FeatureSampleProbabilities;
     TPackedBitVectorVec m_MissingFeatureRowMasks;
-    double m_BestForestTestError = INF;
+    double m_BestForestTestLoss = INF;
     TNodeVecVec m_BestForest;
 };
 

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -215,12 +215,12 @@ public:
     CLeafNodeStatistics(CLeafNodeStatistics&&) = default;
     CLeafNodeStatistics& operator=(CLeafNodeStatistics&&) = default;
 
-    //! Order two leaves by decreasing loss.
+    //! Order two leaves by decreasing gain in splitting them.
     bool operator<(const CLeafNodeStatistics& rhs) const {
         return this->bestSplitStatistics() < rhs.bestSplitStatistics();
     }
 
-    //! Get the gain in loss of the best split.
+    //! Get the gain in loss of the best split of this leaf.
     double gain() const { return this->bestSplitStatistics().s_Gain; }
 
     //! Get the best (feature, feature value) split.
@@ -266,7 +266,7 @@ private:
         bool s_AssignMissingToLeft;
     };
 
-    //! \brief A collection aggregate derivatives.
+    //! \brief A collection of aggregate derivatives.
     struct SDerivatives {
         SDerivatives(const TSizeVec& featureBag, const TDoubleVecVec& candidateSplits)
             : s_Gradients(featureBag.size()), s_Curvatures(featureBag.size()),
@@ -832,8 +832,8 @@ private:
 
     //! Get the maximum number of nodes to use in a tree.
     //!
-    //! \note This number will only be used if the regularisation says its a
-    //! good idea.
+    //! \note This number will only be used if the regularised loss says its
+    //! a good idea.
     std::size_t maximumTreeSize(const core::CDataFrame& frame) const {
         return static_cast<std::size_t>(
             std::ceil(m_MaximumTreeSizeFraction *

--- a/lib/maths/CDataFrameRegressionModel.cc
+++ b/lib/maths/CDataFrameRegressionModel.cc
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CDataFrameRegressionModel.h>
+
+namespace ml {
+namespace maths {
+
+void CDataFrameRegressionModel::noop(double) {
+}
+}
+}

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -20,6 +20,7 @@ CAdaptiveBucketing.cc \
 CAgglomerativeClusterer.cc \
 CAssignment.cc \
 CBasicStatistics.cc \
+CBoostedTree.cc \
 CBjkstUniqueValues.cc \
 CCalendarCyclicTest.cc \
 CCalendarComponentAdaptiveBucketing.cc \
@@ -31,6 +32,7 @@ CClustererStateSerialiser.cc \
 CConstantPrior.cc \
 CCooccurrences.cc \
 CCountMinSketch.cc \
+CDataFrameRegressionModel.cc \
 CDataFrameUtils.cc \
 CDecayRateController.cc \
 CDecompositionComponent.cc \

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CBoostedTreeTest.h"
+
+#include <core/CDataFrame.h>
+
+#include <maths/CBoostedTree.h>
+
+#include <boost/filesystem.hpp>
+
+#include <test/CRandomNumbers.h>
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+using namespace ml;
+
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TFactoryFunc = std::function<std::unique_ptr<core::CDataFrame>()>;
+using TRowRef = core::CDataFrame::TRowRef;
+using TRowItr = core::CDataFrame::TRowItr;
+
+void CBoostedTreeTest::testPiecewiseConstant() {
+
+    test::CRandomNumbers rng;
+
+    std::size_t rows{500};
+    std::size_t cols{6};
+    std::size_t capacity{500};
+
+    TFactoryFunc makeOnDisk{[=] {
+        return core::makeDiskStorageDataFrame(
+                   boost::filesystem::current_path().string(), cols, rows, capacity)
+            .first;
+    }};
+    TFactoryFunc makeMainMemory{
+        [=] { return core::makeMainStorageDataFrame(cols, capacity).first; }};
+
+    for (std::size_t test = 0; test < 1; ++test) {
+        TDoubleVec p;
+        TDoubleVec v;
+        rng.generateUniformSamples(0.0, 10.0, 2 * cols - 2, p);
+        rng.generateUniformSamples(-10.0, 10.0, cols - 1, v);
+        for (std::size_t i = 0; i < p.size(); i += 2) {
+            std::sort(p.begin() + i, p.begin() + i + 2);
+        }
+
+        auto f = [&p, &v, cols](const TRowRef& row) {
+            double result{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                if (row[i] >= p[2 * i] && row[i] < p[2 * i + 1]) {
+                    result += v[i];
+                }
+            }
+            return result;
+        };
+
+        TDoubleVecVec x(cols - 1);
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+        }
+
+        TDoubleVec noise;
+        rng.generateUniformSamples(-0.2, 0.2, rows, noise);
+
+        for (const auto& factory : {makeOnDisk, makeMainMemory}) {
+
+            auto frame = factory();
+
+            for (std::size_t i = 0; i < rows; ++i) {
+                frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                    for (std::size_t j = 0; j < cols - 1; ++j, ++column) {
+                        *column = x[j][i];
+                    }
+                });
+            }
+            frame->finishWritingRows();
+            frame->writeColumns(1, [&](TRowItr beginRows, TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    row->writeColumn(cols - 1, f(*row) + noise[row->index()]);
+                }
+            });
+
+            maths::CBoostedTree regression{
+                1, cols - 1, std::make_unique<maths::boosted_tree::CMse>()};
+
+            regression.train(*frame);
+        }
+    }
+}
+
+void CBoostedTreeTest::testLinear() {
+}
+
+void CBoostedTreeTest::testNonLinear() {
+}
+
+void CBoostedTreeTest::testConstantFeatures() {
+}
+
+void CBoostedTreeTest::testConstantObjective() {
+}
+
+void CBoostedTreeTest::testMissingData() {
+}
+
+void CBoostedTreeTest::testErrors() {
+}
+
+CppUnit::Test* CBoostedTreeTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CBoostedTreeTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testPiecewiseConstant", &CBoostedTreeTest::testPiecewiseConstant));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testLinear", &CBoostedTreeTest::testLinear));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testNonLinear", &CBoostedTreeTest::testNonLinear));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testConstantFeatures", &CBoostedTreeTest::testConstantFeatures));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testMissingData", &CBoostedTreeTest::testMissingData));
+
+    return suiteOfTests;
+}

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CBoostedTreeTest_h
+#define INCLUDED_CBoostedTreeTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CBoostedTreeTest : public CppUnit::TestFixture {
+public:
+    void testPiecewiseConstant();
+    void testLinear();
+    void testNonLinear();
+    void testConstantFeatures();
+    void testConstantObjective();
+    void testMissingData();
+    // TODO void testCategoricalRegressors();
+    // TODO void testFeatureWeights();
+    // TODO void testNuisanceFeatures();
+    // TODO void testModelReflection();
+    void testErrors();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CBoostedTreeTest_h

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -16,6 +16,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <functional>
 #include <numeric>
 #include <vector>
 

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -6,6 +6,8 @@
 
 #include "CDataFrameUtilsTest.h"
 
+#include <core/CPackedBitVector.h>
+
 #include <maths/CBasicStatistics.h>
 #include <maths/CDataFrameUtils.h>
 #include <maths/CQuantileSketch.h>
@@ -161,6 +163,7 @@ void CDataFrameUtilsTest::testColumnQuantiles() {
     TFactoryFunc makeMainMemory{
         [=] { return core::makeMainStorageDataFrame(cols, capacity).first; }};
 
+    core::CPackedBitVector rowMask{rows, true};
     TSizeVec columnMask(cols);
     std::iota(columnMask.begin(), columnMask.end(), 0);
 
@@ -182,9 +185,10 @@ void CDataFrameUtilsTest::testColumnQuantiles() {
             }
             frame->finishWritingRows();
 
-            TQuantileSketchVec actualQuantiles(4, {maths::CQuantileSketch::E_Linear, 100});
+            maths::CQuantileSketch sketch{maths::CQuantileSketch::E_Linear, 100};
+            TQuantileSketchVec actualQuantiles;
             CPPUNIT_ASSERT(maths::CDataFrameUtils::columnQuantiles(
-                threads, *frame, columnMask, actualQuantiles));
+                threads, *frame, rowMask, columnMask, sketch, actualQuantiles));
 
             // Check the quantile sketches match.
 

--- a/lib/maths/unittest/Main.cc
+++ b/lib/maths/unittest/Main.cc
@@ -10,6 +10,7 @@
 #include "CAssignmentTest.h"
 #include "CBasicStatisticsTest.h"
 #include "CBjkstUniqueValuesTest.h"
+#include "CBoostedTreeTest.h"
 #include "CBootstrapClustererTest.h"
 #include "CBoundingBoxTest.h"
 #include "CCalendarComponentAdaptiveBucketingTest.h"
@@ -93,6 +94,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CAssignmentTest::suite());
     runner.addTest(CBasicStatisticsTest::suite());
     runner.addTest(CBjkstUniqueValuesTest::suite());
+    runner.addTest(CBoostedTreeTest::suite());
     runner.addTest(CBootstrapClustererTest::suite());
     runner.addTest(CBoundingBoxTest::suite());
     runner.addTest(CCategoricalToolsTest::suite());

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -22,6 +22,7 @@ SRCS=\
 	CAssignmentTest.cc \
 	CBasicStatisticsTest.cc \
 	CBjkstUniqueValuesTest.cc \
+	CBoostedTreeTest.cc \
 	CBootstrapClustererTest.cc \
 	CBoundingBoxTest.cc \
 	CCalendarComponentAdaptiveBucketingTest.cc \


### PR DESCRIPTION
This implements a boosted regression tree. This is still very much work in progress and largely untested, but it is a first pass implementation of nearly the full train functionality and defines the API for other tasks. As such, I think this represents a point where we can review without the change becoming too large.

The biggest missing piece is hyperparameter optimisation. This will build on some standalone functionality, so I'm leaving it for the time being. I also have some plans for custom treatment of categorical regressors, but this depends on adding a column data type and I'm going to delay this until later.