### PR TITLE
[FEATURE][ML] Fix a bug in bit vector line scan

### DIFF
--- a/lib/core/CPackedBitVector.cc
+++ b/lib/core/CPackedBitVector.cc
@@ -345,6 +345,8 @@ bool CPackedBitVector::lineScan(const CPackedBitVector& covector, RUN_ACTION act
         } else {
             if (length != MAX_RUN_LENGTH) {
                 value = 1 - value;
+            }
+            if (colength != MAX_RUN_LENGTH) {
                 covalue = 1 - covalue;
             }
             length = static_cast<std::size_t>(m_RunLengths[++i]);

--- a/lib/core/unittest/CPackedBitVectorTest.cc
+++ b/lib/core/unittest/CPackedBitVectorTest.cc
@@ -515,6 +515,68 @@ void CPackedBitVectorTest::testInnerProductBitwiseOr() {
     }
 }
 
+void CPackedBitVectorTest::testProblemCases() {
+
+    // Test a problem case with line scan. We were accidentally inverting the bits
+    // of the covector in bitwise operations if a run in both vectors stopped at the
+    // same position but one of them was encoding a run of length greater than 255.
+    // In this test the one bits of rhs are a subset of lhs and so we can assert that
+    // the intersection should be equal to rhs and the exclusive or contains the one
+    // bits of lhs which aren't the one bits of rhs.
+
+    TBoolVec lhs_{
+        0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0,
+        0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+        0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+        0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1,
+        0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+        0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0,
+        1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0,
+        1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0,
+        0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1,
+        1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0,
+        1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0,
+        0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1,
+        0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 1,
+        1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0,
+        0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0,
+        1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0};
+
+    TBoolVec rhs_{
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0};
+
+    core::CPackedBitVector lhs{lhs_};
+    core::CPackedBitVector rhs{rhs_};
+
+    CPPUNIT_ASSERT_EQUAL(rhs.manhattan(), (lhs & rhs).manhattan());
+    CPPUNIT_ASSERT_EQUAL(lhs.manhattan() - rhs.manhattan(), (lhs ^ rhs).manhattan());
+}
+
 void CPackedBitVectorTest::testPersist() {
     TBoolVec bits{true,  true,  false, false, true,
                   false, false, false, true,  true};
@@ -557,6 +619,8 @@ CppUnit::Test* CPackedBitVectorTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CPackedBitVectorTest>(
         "CPackedBitVectorTest::testInnerProductBitwiseOr",
         &CPackedBitVectorTest::testInnerProductBitwiseOr));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CPackedBitVectorTest>(
+        "CPackedBitVectorTest::testProblemCases", &CPackedBitVectorTest::testProblemCases));
     suiteOfTests->addTest(new CppUnit::TestCaller<CPackedBitVectorTest>(
         "CPackedBitVectorTest::testPersist", &CPackedBitVectorTest::testPersist));
 

--- a/lib/core/unittest/CPackedBitVectorTest.h
+++ b/lib/core/unittest/CPackedBitVectorTest.h
@@ -20,6 +20,7 @@ public:
     void testOneBitIterators();
     void testInnerProductBitwiseAnd();
     void testInnerProductBitwiseOr();
+    void testProblemCases();
     void testPersist();
 
     static CppUnit::Test* suite();


### PR DESCRIPTION
We were incorrectly inverting the bits of one of the vectors when performing a line scan on our packed bit vector in an edge case. This is a fix and unit test.