### PR TITLE
[DOCS] Updates changelog for 7.0.0-rc1

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,16 @@
 
 //=== Regressions
 
+== {es} version 7.0.0-rc1
+
+//None
+
+//=== Regressions
+
+== {es} version 7.0.0-beta1
+
+//None
+
 == {es} version 7.0.0-alpha2
 
 === Bug Fixes
@@ -39,24 +49,6 @@
 
 * Improve autodetect logic for persistence. {ml-pull}437[#437]
 
-== {es} version 7.1.0
-
-* Remove hard limit for maximum forecast interval and limit based on the time interval of data added
-to the model. (See {pull}214[#214].)
-
-* Handle NaNs when detrending seasonal components. {ml-pull}408[#408]
-
-* Improve autodetect logic for persistence. {ml-pull}437[#437]
-
 == {es} version 7.0.0-alpha1
 
-== {es} version 6.7.0
-
-== {es} version 6.6.2
-
-* Fixes an issue where interim results would be calculated after advancing time into an empty bucket. {ml-pull}416[#416]
-
-=== Enhancements
-
-* Adjust seccomp filter for Fedora 29. {ml-pull}354[#354]
-
+//None


### PR DESCRIPTION
This PR updates the changelog for 7.0.0-rc1 and removes information about 6.x and 7.1.x.