### PR TITLE
[FEATURE][ML] Add results_field to data frame analytics specification

### DIFF
--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -60,6 +60,7 @@ public:
     //!   "memory_limit": <integer>,
     //!   "threads": <integer>,
     //!   "temp_dir": <string>,
+    //!   "results_field": <string>,
     //!   "analysis": {
     //!     "name": <string>,
     //!     "parameters": <object>
@@ -105,6 +106,9 @@ public:
     //! \return The number of threads the analysis can use.
     std::size_t numberThreads() const;
 
+    //! \return The name of the results field.
+    const std::string &resultsField() const;
+
     //! Make a data frame suitable for this analysis specification.
     //!
     //! This chooses the storage strategy based on the analysis constraints and
@@ -134,6 +138,7 @@ private:
     std::size_t m_MemoryLimit = 0;
     std::size_t m_NumberThreads = 0;
     std::string m_TemporaryDirectory;
+    std::string m_ResultsField;
     // TODO Sparse table support
     // double m_TableLoadFactor = 0.0;
     TRunnerFactoryUPtrVec m_RunnerFactories;

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -107,7 +107,7 @@ public:
     std::size_t numberThreads() const;
 
     //! \return The name of the results field.
-    const std::string &resultsField() const;
+    const std::string& resultsField() const;
 
     //! Make a data frame suitable for this analysis specification.
     //!

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -127,7 +127,7 @@ std::size_t CDataFrameAnalysisSpecification::numberThreads() const {
     return m_NumberThreads;
 }
 
-const std::string &CDataFrameAnalysisSpecification::resultsField() const {
+const std::string& CDataFrameAnalysisSpecification::resultsField() const {
     return m_ResultsField;
 }
 

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -42,9 +42,12 @@ const char* const COLS{"cols"};
 const char* const MEMORY_LIMIT{"memory_limit"};
 const char* const THREADS{"threads"};
 const char* const TEMPORARY_DIRECTORY{"temp_dir"};
+const char* const RESULTS_FIELD{"results_field"};
 const char* const ANALYSIS{"analysis"};
 const char* const NAME{"name"};
 const char* const PARAMETERS{"parameters"};
+
+const std::string DEFAULT_RESULT_FIELD("ml");
 
 const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
     CDataFrameAnalysisConfigReader theReader;
@@ -55,6 +58,7 @@ const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
     // TODO required
     theReader.addParameter(TEMPORARY_DIRECTORY,
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(RESULTS_FIELD, CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(ANALYSIS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
     return theReader;
 }()};
@@ -94,6 +98,7 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         m_NumberThreads = parameters[THREADS].as<std::size_t>();
         m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(
             boost::filesystem::current_path().string());
+        m_ResultsField = parameters[RESULTS_FIELD].fallback(DEFAULT_RESULT_FIELD);
 
         auto jsonAnalysis = parameters[ANALYSIS].jsonObject();
         if (jsonAnalysis != nullptr) {
@@ -120,6 +125,10 @@ std::size_t CDataFrameAnalysisSpecification::memoryLimit() const {
 
 std::size_t CDataFrameAnalysisSpecification::numberThreads() const {
     return m_NumberThreads;
+}
+
+const std::string &CDataFrameAnalysisSpecification::resultsField() const {
+    return m_ResultsField;
 }
 
 CDataFrameAnalysisSpecification::TDataFrameUPtrTemporaryDirectoryPtrPr

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -303,7 +303,12 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
             writer.Key(CHECKSUM);
             writer.Int(row->docHash());
             writer.Key(RESULTS);
+
+            writer.StartObject();
+            writer.Key(m_AnalysisSpecification->resultsField());
             analysis.writeOneRow(m_FieldNames, *row, writer);
+            writer.EndObject();
+
             writer.EndObject();
             writer.EndObject();
         }

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -50,8 +50,8 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
     };
     auto jsonSpec = [](const std::string& rows, const std::string& cols,
                        const std::string& memory, const std::string& threads,
-                       const std::string& name, const std::string& parameters = "",
-                       const std::string& junk = "") {
+                       const std::string& resultsField, const std::string& name,
+                       const std::string& parameters = "", const std::string& junk = "") {
         std::ostringstream result;
         result << "{\n";
         if (rows.size() > 0) {
@@ -65,6 +65,9 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
         }
         if (threads.size() > 0) {
             result << "   \"threads\": " << threads << ",\n";
+        }
+        if (resultsField.size() > 0) {
+            result << "   \"results_field\": \"" << resultsField << "\",\n";
         }
         if (junk.size() > 0) {
             result << "   \"" << junk << "\": 4,\n";
@@ -84,103 +87,104 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Valid input");
     {
-        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "2", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "2", "custom_ml", "outlier_detection"));
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "100000", "2", "outlier_detection")};
+            outliersFactory(), jsonSpec("1000", "20", "100000", "2", "custom_ml", "outlier_detection")};
         CPPUNIT_ASSERT_EQUAL(std::size_t{1000}, spec.numberRows());
         CPPUNIT_ASSERT_EQUAL(std::size_t{20}, spec.numberColumns());
         CPPUNIT_ASSERT_EQUAL(std::size_t{100000}, spec.memoryLimit());
         CPPUNIT_ASSERT_EQUAL(std::size_t{2}, spec.numberThreads());
+        CPPUNIT_ASSERT_EQUAL(std::string("custom_ml"), spec.resultsField());
     }
     LOG_DEBUG(<< "Bad input");
     {
-        LOG_TRACE(<< jsonSpec("", "20", "100000", "2", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("", "20", "100000", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("", "20", "100000", "2", "outlier_detection")};
+            outliersFactory(), jsonSpec("", "20", "100000", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("1000", "", "100000", "2", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("1000", "", "100000", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "", "100000", "2", "outlier_detection")};
+            outliersFactory(), jsonSpec("1000", "", "100000", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("1000", "20", "", "2", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("1000", "20", "", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "", "2", "outlier_detection")};
+            outliersFactory(), jsonSpec("1000", "20", "", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "100000", "", "outlier_detection")};
+            outliersFactory(), jsonSpec("1000", "20", "100000", "", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "2", ""));
+        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "2", "ml", ""));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "100000", "2", "")};
+            outliersFactory(), jsonSpec("1000", "20", "100000", "2", "ml", "")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("-3", "20", "100000", "2", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("-3", "20", "100000", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("-3", "20", "100000", "2", "outlier_detection")};
+            outliersFactory(), jsonSpec("-3", "20", "100000", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("1000", "0", "100000", "2", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("1000", "0", "100000", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "0", "100000", "2", "outlier_detection")};
+            outliersFactory(), jsonSpec("1000", "0", "100000", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("1000", "20", "ZZ", "2", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("1000", "20", "ZZ", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "\"ZZ\"", "2", "outlier_detection")};
+            outliersFactory(), jsonSpec("1000", "20", "\"ZZ\"", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "-1", "outlier_detection"));
+        LOG_TRACE(<< jsonSpec("1000", "20", "100000", "-1", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "100000", "-1", "outlier_detection")};
+            outliersFactory(), jsonSpec("1000", "20", "100000", "-1", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
     {
-        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outl1ers"));
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml", "outl1ers"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outl1ers")};
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml", "outl1ers")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
 
     LOG_DEBUG(<< "Invalid number neighbours");
     {
-        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                               "{\"number_neighbours\": -1}"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                                         "{\"number_neighbours\": -1}")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
@@ -188,11 +192,11 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Invalid method");
     {
-        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                               "{\"method\": \"lofe\"}"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                                         "{\"method\": \"lofe\"}")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
@@ -200,11 +204,11 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Invalid feature influence");
     {
-        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                               "{\"compute_feature_influence\": 1}"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                                         "{\"compute_feature_influence\": 1}")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
@@ -212,11 +216,11 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Invalid feature influence");
     {
-        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "outlier_detection",
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                               "{\"compute_feature_influences\": true}"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("100", "20", "100000", "2", "outlier_detection",
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
                                         "{\"compute_feature_influences\": true}")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
@@ -224,11 +228,11 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Extra junk");
     {
-        LOG_TRACE(<< jsonSpec("1000", "2", "100000", "2", "outlier_detection", "", "threeds"));
+        LOG_TRACE(<< jsonSpec("1000", "2", "100000", "2", "ml", "outlier_detection", "", "threeds"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
             outliersFactory(),
-            jsonSpec("1000", "2", "100000", "2", "outlier_detection", "", "threeds")};
+            jsonSpec("1000", "2", "100000", "2", "ml", "outlier_detection", "", "threeds")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -89,7 +89,8 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
     {
         LOG_TRACE(<< jsonSpec("1000", "20", "100000", "2", "custom_ml", "outlier_detection"));
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "100000", "2", "custom_ml", "outlier_detection")};
+            outliersFactory(),
+            jsonSpec("1000", "20", "100000", "2", "custom_ml", "outlier_detection")};
         CPPUNIT_ASSERT_EQUAL(std::size_t{1000}, spec.numberRows());
         CPPUNIT_ASSERT_EQUAL(std::size_t{20}, spec.numberColumns());
         CPPUNIT_ASSERT_EQUAL(std::size_t{100000}, spec.memoryLimit());
@@ -125,7 +126,8 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
         LOG_TRACE(<< jsonSpec("1000", "20", "100000", "", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "100000", "", "ml", "outlier_detection")};
+            outliersFactory(),
+            jsonSpec("1000", "20", "100000", "", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
@@ -149,7 +151,8 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
         LOG_TRACE(<< jsonSpec("1000", "0", "100000", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "0", "100000", "2", "ml", "outlier_detection")};
+            outliersFactory(),
+            jsonSpec("1000", "0", "100000", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
@@ -157,7 +160,8 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
         LOG_TRACE(<< jsonSpec("1000", "20", "ZZ", "2", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "\"ZZ\"", "2", "ml", "outlier_detection")};
+            outliersFactory(),
+            jsonSpec("1000", "20", "\"ZZ\"", "2", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
@@ -165,7 +169,8 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
         LOG_TRACE(<< jsonSpec("1000", "20", "100000", "-1", "ml", "outlier_detection"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("1000", "20", "100000", "-1", "ml", "outlier_detection")};
+            outliersFactory(),
+            jsonSpec("1000", "20", "100000", "-1", "ml", "outlier_detection")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
@@ -180,8 +185,8 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Invalid number neighbours");
     {
-        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
-                              "{\"number_neighbours\": -1}"));
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml",
+                              "outlier_detection", "{\"number_neighbours\": -1}"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
             outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
@@ -192,12 +197,12 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Invalid method");
     {
-        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
-                              "{\"method\": \"lofe\"}"));
+        LOG_TRACE(<< jsonSpec("100", "20", "100000", "2", "ml",
+                              "outlier_detection", "{\"method\": \"lofe\"}"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml", "outlier_detection",
-                                        "{\"method\": \"lofe\"}")};
+            outliersFactory(), jsonSpec("100", "20", "100000", "2", "ml",
+                                        "outlier_detection", "{\"method\": \"lofe\"}")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
@@ -228,11 +233,12 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
 
     LOG_DEBUG(<< "Extra junk");
     {
-        LOG_TRACE(<< jsonSpec("1000", "2", "100000", "2", "ml", "outlier_detection", "", "threeds"));
+        LOG_TRACE(<< jsonSpec("1000", "2", "100000", "2", "ml",
+                              "outlier_detection", "", "threeds"));
         errors.clear();
         api::CDataFrameAnalysisSpecification spec{
-            outliersFactory(),
-            jsonSpec("1000", "2", "100000", "2", "ml", "outlier_detection", "", "threeds")};
+            outliersFactory(), jsonSpec("1000", "2", "100000", "2", "ml",
+                                        "outlier_detection", "", "threeds")};
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -188,7 +188,7 @@ void CDataFrameAnalyzerTest::testWithoutControlMessages() {
             CPPUNIT_ASSERT(expectedScore != expectedScores.end());
             CPPUNIT_ASSERT_DOUBLES_EQUAL(
                 *expectedScore,
-                result["row_results"]["results"]["outlier_score"].GetDouble(),
+                result["row_results"]["results"]["ml"]["outlier_score"].GetDouble(),
                 1e-4 * *expectedScore);
             CPPUNIT_ASSERT(result.HasMember("progress_percent") == false);
             ++expectedScore;
@@ -230,7 +230,7 @@ void CDataFrameAnalyzerTest::testRunOutlierDetection() {
             CPPUNIT_ASSERT(expectedScore != expectedScores.end());
             CPPUNIT_ASSERT_DOUBLES_EQUAL(
                 *expectedScore,
-                result["row_results"]["results"]["outlier_score"].GetDouble(),
+                result["row_results"]["results"]["ml"]["outlier_score"].GetDouble(),
                 1e-4 * *expectedScore);
             ++expectedScore;
             CPPUNIT_ASSERT(result.HasMember("progress_percent") == false);
@@ -276,7 +276,7 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
             CPPUNIT_ASSERT(expectedScore != expectedScores.end());
             CPPUNIT_ASSERT_DOUBLES_EQUAL(
                 *expectedScore,
-                result["row_results"]["results"]["outlier_score"].GetDouble(),
+                result["row_results"]["results"]["ml"]["outlier_score"].GetDouble(),
                 1e-4 * *expectedScore);
             ++expectedScore;
         }
@@ -317,7 +317,7 @@ void CDataFrameAnalyzerTest::testRunOutlierFeatureInfluences() {
             for (std::size_t i = 0; i < 5; ++i) {
                 CPPUNIT_ASSERT_DOUBLES_EQUAL(
                     (*expectedFeatureInfluence)[i],
-                    result["row_results"]["results"][expectedNames[i]].GetDouble(),
+                    result["row_results"]["results"]["ml"][expectedNames[i]].GetDouble(),
                     1e-4 * (*expectedFeatureInfluence)[i]);
             }
             ++expectedFeatureInfluence;
@@ -367,7 +367,7 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionWithParams() {
                     CPPUNIT_ASSERT(expectedScore != expectedScores.end());
                     CPPUNIT_ASSERT_DOUBLES_EQUAL(
                         *expectedScore,
-                        result["row_results"]["results"]["outlier_score"].GetDouble(),
+                        result["row_results"]["results"]["ml"]["outlier_score"].GetDouble(),
                         1e-6 * *expectedScore);
                     ++expectedScore;
                 }


### PR DESCRIPTION
This adds `results_field` to the data frame analytics specification.
Results are now written in an object that is named after the value
of this setting.