### PR TITLE
[7.1][ML] Use hardened compiler options to build 3rd party libraries

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -36,14 +36,17 @@ On other Linux distributions the package names are generally the same and you ju
 
 ### General settings for building the tools
 
-Most of the tools are built via a GNU "configure" script. There are some environment variables that affect the behaviour of this. Therefore, when building ANY tool on Linux, set the following environment variable:
+Most of the tools are built via a GNU "configure" script. There are some environment variables that affect the behaviour of this. Therefore, when building ANY tool on Linux, set the following environment variables:
 
 ```
+export CFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
 export CXX='g++ -std=gnu++14'
+export CXXFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
+export LDFLAGS='-Wl,-z,relro -Wl,-z,now'
 unset LIBRARY_PATH
 ```
 
-The `CXX` environment variable only needs to be set when building tools on Linux. It should NOT be set when compiling the Machine Learning source code (as this should pick up all settings from our Makefiles).
+These environment variables only need to be set when building tools on Linux. They should NOT be set when compiling the Machine Learning source code (as this should pick up all settings from our Makefiles).
 
 ### gcc
 
@@ -290,7 +293,7 @@ bzip2 -cd boost_1_65_1.tar.bz2 | tar xvf -
 In the resulting `boost_1_65_1` directory, run:
 
 ```
-./bootstrap.sh cxxflags=-std=gnu++14 --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=log --without-libraries=mpi --without-libraries=python --without-icu
+./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=log --without-libraries=mpi --without-libraries=python --without-icu
 ```
 
 This should build the `b2` program, which in turn is used to build Boost.
@@ -322,8 +325,8 @@ to:
 Finally, run:
 
 ```
-./b2 -j6 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-sudo env PATH="$PATH" ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+./b2 -j6 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now
+sudo env PATH="$PATH" ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now
 ```
 
 to install the Boost headers and libraries.  (Note the `env PATH="$PATH"` bit in the install command - this is because `sudo` usually resets `PATH` and that will cause Boost to rebuild everything again with the default compiler as part of the install!)

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -17,7 +17,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=5
+VERSION=6
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:5
+FROM docker.elastic.co/ml-dev/ml-linux-build:6
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -33,8 +33,11 @@ RUN \
 ENV LD_LIBRARY_PATH /usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
 ENV PATH /usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin
 
-# For compiling in C++14 mode
+# For compiling in C++14 mode with hardening and optimisation
+ENV CFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
 ENV CXX "g++ -std=gnu++14"
+ENV CXXFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
+ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now"
 
 # Build libxml2
 RUN \
@@ -90,11 +93,11 @@ RUN \
 RUN \
   wget --quiet -O - http://sourceforge.mirrorservice.org/b/bo/boost/boost/1.65.1/boost_1_65_1.tar.bz2 | tar jxf - && \
   cd boost_1_65_1 && \
-  ./bootstrap.sh cxxflags=-std=gnu++14 --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=log --without-libraries=mpi --without-libraries=python --without-icu && \
+  ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=log --without-libraries=mpi --without-libraries=python --without-icu && \
   sed -i -e 's/(17ul)(29ul)(37ul)(53ul)(67ul)(79ul) \\/(3ul)(17ul)(29ul)(37ul)(53ul)(67ul)(79ul) \\/' boost/unordered/detail/implementation.hpp && \
   sed -i -e 's%#if ((defined(__linux__) \&\& !defined(__UCLIBC__) \&\& !defined(BOOST_MATH_HAVE_FIXED_GLIBC)) || defined(__QNX__) || defined(__IBMCPP__)) \&\& !defined(BOOST_NO_FENV_H)%#if ((!defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS) \&\& defined(__linux__) \&\& !defined(__UCLIBC__) \&\& !defined(BOOST_MATH_HAVE_FIXED_GLIBC)) || defined(__QNX__) || defined(__IBMCPP__)) \&\& !defined(BOOST_NO_FENV_H)%g' boost/math/tools/config.hpp && \
-  ./b2 -j`grep -c '^processor' /proc/cpuinfo` --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS && \
-  ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS && \
+  ./b2 -j`grep -c '^processor' /proc/cpuinfo` --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now && \
+  ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now && \
   cd .. && \
   rm -rf boost_1_65_1
 

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:5
+FROM docker.elastic.co/ml-dev/ml-linux-build:6
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/vagrant/linux/provision.sh
+++ b/dev-tools/vagrant/linux/provision.sh
@@ -60,7 +60,11 @@ export PATH=/usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
 
 # Various env variables
 echo "Setting env variables..."
+export CFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
 export CXX='g++ -std=gnu++14'
+export CXXFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
+export LDFLAGS='-Wl,-z,relro -Wl,-z,now'
+unset LIBRARY_PATH
 
 # ----------------- Compile libxml2 -------------------------
 if [ ! -f libxml2.state ]; then
@@ -70,7 +74,6 @@ if [ ! -f libxml2.state ]; then
   mkdir libxml
   tar xfz LATEST_LIBXML2.tar.gz -C libxml --strip-components=1
   cd libxml
-  sed -i -e 's/-O2/-O3/g' configure
   echo "  Configuring..."
   ./configure --prefix=/usr/local/gcc73 --without-python --without-readline > configure.log 2>&1
   echo "  Making..."
@@ -161,7 +164,7 @@ if [ ! -f boost.state ]; then
 
   cd boost
   echo "  Bootstrapping..."
-  ./bootstrap.sh cxxflags=-std=gnu++14 --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=log --without-libraries=mpi --without-libraries=python --without-icu > bootstrap.log 2>&1
+  ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=log --without-libraries=mpi --without-libraries=python --without-icu > bootstrap.log 2>&1
 
   echo "  Configuring..."
 
@@ -169,8 +172,8 @@ if [ ! -f boost.state ]; then
   sed -i -e 's%#if ((defined(__linux__) \&\& !defined(__UCLIBC__) \&\& !defined(BOOST_MATH_HAVE_FIXED_GLIBC)) || defined(__QNX__) || defined(__IBMCPP__)) \&\& !defined(BOOST_NO_FENV_H)%#if ((!defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS) \&\& defined(__linux__) \&\& !defined(__UCLIBC__) \&\& !defined(BOOST_MATH_HAVE_FIXED_GLIBC)) || defined(__QNX__) || defined(__IBMCPP__)) \&\& !defined(BOOST_NO_FENV_H)%g' boost/math/tools/config.hpp
 
   echo "  Building..."
-  ./b2 -j$NUMCPUS --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS > b2_make.log 2>&1
-  ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS > b2_make_install.log 2>&1
+  ./b2 -j$NUMCPUS --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now > b2_make.log 2>&1
+  ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now > b2_make_install.log 2>&1
 
   cd ..
   rm boost_1_65_1.tar.gz

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,9 +30,41 @@
 
 == {es} version 7.1.0
 
+=== Enhancements
+
 * Remove hard limit for maximum forecast interval and limit based on the time interval of data added
-to the model. (See {pull}214[#214].)
+to the model. (See {ml-pull}214[#214].)
+
+* Use hardened compiler options to build 3rd party libraries. (See {ml-pull}453[#453].)
+
+=== Bug Fixes
 
 * Handle NaNs when detrending seasonal components. {ml-pull}408[#408]
 
+== {es} version 7.0.0-alpha2
+
+=== Bug Fixes
+
+* Fixes CPoissonMeanConjugate sampling error. {ml-pull}335[#335]
+//NOTE: Remove from final 7.0.0 release notes if already in 6.x
+
+* Ensure statics are persisted in a consistent manner {ml-pull}360[#360]
+
+== {es} version 7.0.0-alpha1
+
+== {es} version 6.7.0
+
+=== Bug Fixes
+
 * Improve autodetect logic for persistence. {ml-pull}437[#437]
+
+== {es} version 6.6.2
+
+=== Enhancements
+
+* Adjust seccomp filter for Fedora 29. {ml-pull}354[#354]
+
+=== Bug Fixes
+
+* Fixes an issue where interim results would be calculated after advancing time into an empty bucket. {ml-pull}416[#416]
+


### PR DESCRIPTION
This change adds the stack protector, relro and fortify source
options to the commands used to build the 3rd party libraries
we use on Linux.

(We already used these options when building our own code.)

Backport of #453