### PR TITLE
[7.1][ML] Use hardening options for gcc 7.3 build

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -43,6 +43,7 @@ export CFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
 export CXX='g++ -std=gnu++14'
 export CXXFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
 export LDFLAGS='-Wl,-z,relro -Wl,-z,now'
+export LDFLAGS_FOR_TARGET='-Wl,-z,relro -Wl,-z,now'
 unset LIBRARY_PATH
 ```
 
@@ -60,6 +61,7 @@ Unlike most automake-based tools, gcc must be built in a directory adjacent to t
 tar zxvf gcc-7.3.0.tar.gz
 cd gcc-7.3.0
 contrib/download_prerequisites
+sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
 cd ..
 mkdir gcc-7.3.0-build
 cd gcc-7.3.0-build

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -17,7 +17,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=6
+VERSION=7
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:6
+FROM docker.elastic.co/ml-dev/ml-linux-build:7
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -15,11 +15,18 @@ RUN \
   rm /var/lib/rpm/__db.* && \
   yum install -y gcc gcc-c++ git unzip wget zip zlib-devel
 
+# For compiling with hardening and optimisation
+ENV CFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
+ENV CXXFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
+ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now"
+ENV LDFLAGS_FOR_TARGET "-Wl,-z,relro -Wl,-z,now"
+
 # Build gcc 7.3
 RUN \
   wget --quiet -O - http://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.gz | tar zxf - && \
   cd gcc-7.3.0 && \
   contrib/download_prerequisites && \
+  sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc && \
   cd .. && \
   mkdir gcc-7.3.0-build && \
   cd gcc-7.3.0-build && \
@@ -29,15 +36,10 @@ RUN \
   cd .. && \
   rm -rf gcc-7.3.0 gcc-7.3.0-build
 
-# Update paths to use the newly built compiler
+# Update paths to use the newly built compiler in C++14 mode
 ENV LD_LIBRARY_PATH /usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
 ENV PATH /usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin
-
-# For compiling in C++14 mode with hardening and optimisation
-ENV CFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
 ENV CXX "g++ -std=gnu++14"
-ENV CXXFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
-ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now"
 
 # Build libxml2
 RUN \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:6
+FROM docker.elastic.co/ml-dev/ml-linux-build:7
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/vagrant/linux/provision.sh
+++ b/dev-tools/vagrant/linux/provision.sh
@@ -31,6 +31,14 @@ if [ ! -f java.state ]; then
   touch java.state
 fi
 
+# Env variables for hardening and optimisation
+echo "Setting env variables..."
+export CFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
+export CXXFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
+export LDFLAGS='-Wl,-z,relro -Wl,-z,now'
+export LDFLAGS_FOR_TARGET='-Wl,-z,relro -Wl,-z,now'
+unset LIBRARY_PATH
+
 # ----------------- Compile gcc 7.3 -------------------------
 if [ ! -f gcc.state ]; then
   echo "Compiling GCC 7.3..."
@@ -41,6 +49,7 @@ if [ ! -f gcc.state ]; then
   tar xfz gcc-7.3.0.tar.gz -C gcc-source --strip-components=1
   cd gcc-source
   contrib/download_prerequisites
+  sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
   cd ..
   mkdir gcc-build
   cd gcc-build
@@ -54,17 +63,10 @@ if [ ! -f gcc.state ]; then
   touch gcc.state
 fi
 
-# Update paths to use the newly built compiler
+# Update paths to use the newly built compiler in C++14 mode
 export LD_LIBRARY_PATH=/usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
 export PATH=/usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
-
-# Various env variables
-echo "Setting env variables..."
-export CFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
 export CXX='g++ -std=gnu++14'
-export CXXFLAGS='-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2'
-export LDFLAGS='-Wl,-z,relro -Wl,-z,now'
-unset LIBRARY_PATH
 
 # ----------------- Compile libxml2 -------------------------
 if [ ! -f libxml2.state ]; then


### PR DESCRIPTION
This is a follow on to #453

The stack protector, relro and fortify source options
need to be used when building gcc, because we redistribute
two libraries that are built as part of it, namely
libgcc_s.so.1 and libstdc++.so.6.

Backport of #470