### PR TITLE
[ML] Improve behaviour of outlier detection with when nearly all points are duplicates

### DIFF
--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -276,11 +276,10 @@ private:
             min += result.s_FunctionState;
         }
         if (min.count() > 0) {
-            // Use twice times the maximum "density" at any other point if there
-            // are k-fold duplicates. Note it is possible that all reference
-            // points are duplicates, in which case we need to set their local
-            // reachability density in this loop too. The overwritten densities
-            // are reset in setup.
+            // Use twice the maximum "density" at any other point if there are
+            // k-fold duplicates. Note it is possible that all lookup points are
+            // duplicates, in which case we need to set their local reachability
+            // density in this loop. The overwritten densities are reset in setup.
             for (std::size_t i = 0; i < m_EndAddresses; ++i) {
                 if (m_Lrd[i] == UNSET_DISTANCE) {
                     m_Lrd[i] = 2.0 / min[0];

--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -212,6 +212,8 @@ private:
         m_KDistances.resize(k * m_EndAddresses, {0, UNSET_DISTANCE});
         m_Lrd.resize(m_StartAddresses, UNSET_DISTANCE);
         m_Lrd.resize(m_EndAddresses, UNSET_DISTANCE);
+        std::copy(m_LrdOfLookupPoints.begin(), m_LrdOfLookupPoints.end(), m_Lrd.begin());
+        m_LrdOfLookupPoints.assign(m_Lrd.begin(), m_Lrd.begin() + m_StartAddresses);
 
         if (this->computeFeatureInfluence()) {
             m_CoordinateLrd.resize(m_Dimension * m_StartAddresses, UNSET_DISTANCE);
@@ -274,9 +276,12 @@ private:
             min += result.s_FunctionState;
         }
         if (min.count() > 0) {
-            // Use twice the maximum "density" at any other point if there
-            // are k-fold duplicates.
-            for (std::size_t i = m_StartAddresses; i < m_EndAddresses; ++i) {
+            // Use twice times the maximum "density" at any other point if there
+            // are k-fold duplicates. Note it is possible that all reference
+            // points are duplicates, in which case we need to set their local
+            // reachability density in this loop too. The overwritten densities
+            // are reset in setup.
+            for (std::size_t i = 0; i < m_EndAddresses; ++i) {
                 if (m_Lrd[i] == UNSET_DISTANCE) {
                     m_Lrd[i] = 2.0 / min[0];
                 }
@@ -402,6 +407,7 @@ private:
     // flattened: [neighbours of 0, neighbours of 1,...].
     TUInt32CoordinatePrVec m_KDistances;
     TCoordinateVec m_Lrd;
+    TCoordinateVec m_LrdOfLookupPoints;
     // The coordinate local reachability distances are stored flattened:
     // [coordinates of 0, coordinates of 2, ...].
     TCoordinateVec m_CoordinateLrd;

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -556,23 +556,26 @@ void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulator2Vec& logScoreMomen
     // of benchmark sets to make this effective a priori. We also account for the
     // fact that the scores will be somewhat correlated.
 
+    // We lower bound the coefficient of variation (to 1e-4) of the log-normal we
+    // use to compute the score c.d.f.
+    static const double MINIMUM_VARIANCE{CTools::fastLog(1.0 + 1e-8)};
+
     auto scoreCdfComplement = [&](std::size_t i, std::size_t j) {
         double location{CBasicStatistics::mean(logScoreMoments[i])};
-        double scale{std::sqrt(CBasicStatistics::variance(logScoreMoments[i]))};
-        if (scale > 0.0) {
-            try {
-                boost::math::lognormal lognormal{location, scale};
-                return CTools::safeCdfComplement(lognormal, shift(scores[i][j]));
-            } catch (const std::exception& e) {
-                // In this case, we use the initial value of 0.5 for the cdfComplement
-                // which means P(outlier | score) = P(inlier | score) = 0.5. The outcome
-                // is the score conveys no information about whether or not a point is
-                // an outlier, it is effectively ignored. The rationale for keeping going
-                // therefore is that this handling is good enough that the results may
-                // still be useful.
-                LOG_WARN(<< "Failed to normalise scores: '" << e.what()
-                         << "'. Results maybe compromised.");
-            }
+        double scale{std::sqrt(std::max(
+            CBasicStatistics::variance(logScoreMoments[i]), MINIMUM_VARIANCE))};
+        try {
+            boost::math::lognormal lognormal{location, scale};
+            return CTools::safeCdfComplement(lognormal, shift(scores[i][j]));
+        } catch (const std::exception& e) {
+            // In this case, we use the initial value of 0.5 for the cdfComplement
+            // which means P(outlier | score) = P(inlier | score) = 0.5. The outcome
+            // is the score conveys no information about whether or not a point is
+            // an outlier, it is effectively ignored. The rationale for keeping going
+            // therefore is that this handling is good enough that the results may
+            // still be useful.
+            LOG_WARN(<< "Failed to normalise scores: '" << e.what()
+                     << "'. Results maybe compromised.");
         }
         return 0.5;
     };
@@ -717,7 +720,6 @@ CEnsemble<POINT>::CModel::CModel(const TMethodFactoryVec& methodFactories,
     TProgressCallback noop{[](double) {}};
 
     for (auto& method : methods) {
-
         method->progressRecorder().swap(noop);
         TDouble1VecVec2Vec scores(method->run(sample, sample.size()));
         method->progressRecorder().swap(noop);

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -557,8 +557,9 @@ void CEnsemble<POINT>::CScorer::add(const TMeanVarAccumulator2Vec& logScoreMomen
     // fact that the scores will be somewhat correlated.
 
     // We lower bound the coefficient of variation (to 1e-4) of the log-normal we
-    // use to compute the score c.d.f.
-    static const double MINIMUM_VARIANCE{CTools::fastLog(1.0 + 1e-8)};
+    // use to compute the score c.d.f. This is log(1 + CV^2) which for small CV is
+    // very nearly CV^2.
+    static const double MINIMUM_VARIANCE{1e-8};
 
     auto scoreCdfComplement = [&](std::size_t i, std::size_t j) {
         double location{CBasicStatistics::mean(logScoreMoments[i])};

--- a/lib/maths/unittest/COutliersTest.h
+++ b/lib/maths/unittest/COutliersTest.h
@@ -19,6 +19,7 @@ public:
     void testFeatureInfluences();
     void testEstimateMemoryUsedByCompute();
     void testProgressMonitoring();
+    void testMostlyDuplicate();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
We were hitting issues when the sample of points used for computing nearest neighbours contained only duplicates. In particular, we weren't initialising the local reachability density (lrd) for LOF properly and we weren't computing the cumulative density function (cdf) value for the scores properly when aggregating. This fixes both these problems by using the usual lower bound for lrd and lower bounding the scores' coefficient of variation used to compute the cdf.