### PR TITLE
[ML] Add some instrumentation of outlier detection

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -130,6 +130,9 @@ public:
 protected:
     const CDataFrameAnalysisSpecification& spec() const;
     TProgressRecorder progressRecorder();
+    std::size_t estimateMemoryUsage(std::size_t totalNumberRows,
+                                    std::size_t partitionNumberRows,
+                                    std::size_t numberColumns) const;
 
 private:
     virtual void runImpl(core::CDataFrame& frame) = 0;
@@ -137,9 +140,6 @@ private:
                                                        std::size_t totalNumberRows,
                                                        std::size_t partitionNumberRows,
                                                        std::size_t numberColumns) const = 0;
-    std::size_t estimateMemoryUsage(std::size_t totalNumberRows,
-                                    std::size_t partitionNumberRows,
-                                    std::size_t numberColumns) const;
 
     //! This adds \p fractionalProgess to the current progress.
     //!

--- a/include/core/CProgramCounters.h
+++ b/include/core/CProgramCounters.h
@@ -86,10 +86,25 @@ enum ECounterTypes {
     //! The number of times partial memory estimates have been carried out
     E_TSADNumberMemoryUsageEstimates = 18,
 
+    //! The estimated peak memory usage for outlier detection
+    E_DFOEstimatedPeakMemoryUsage = 19,
+
+    //! The peak memory usage of outlier detection in bytes
+    E_DFOPeakMemoryUsage = 20,
+
+    //! The time in ms to create the ensemble for outlier detection
+    E_DFOTimeToCreateEnsemble = 21,
+
+    //! The time in ms to compute the outlier scores
+    E_DFOTimeToComputeScores = 22,
+
+    //! The number of partitions used
+    E_DFONumberPartitions = 23,
+
     // Add any new values here
 
     //! This MUST be last, increment the value for every new enum added
-    E_LastEnumCounter = 19
+    E_LastEnumCounter = 24
 };
 
 static constexpr size_t NUM_COUNTERS = static_cast<size_t>(E_LastEnumCounter);
@@ -165,6 +180,13 @@ private:
         CCounter& operator+=(std::uint64_t counter) {
             m_Counter += counter;
             return *this;
+        }
+
+        void max(std::uint64_t counter) {
+            std::uint64_t previousCounter{m_Counter.load(std::memory_order_relaxed)};
+            while (previousCounter < counter &&
+                   m_Counter.compare_exchange_weak(previousCounter, counter) == false) {
+            }
         }
 
         operator std::uint64_t() const { return m_Counter; }
@@ -272,7 +294,16 @@ private:
          {counter_t::E_TSADNumberMemoryLimitModelCreationFailures, "E_TSADNumberMemoryLimitModelCreationFailures",
           "The number of model creation failures from being over memory limit"},
          {counter_t::E_TSADNumberPrunedItems, "E_TSADNumberPrunedItems",
-          "The number of old people or attributes pruned from the models"}}};
+          "The number of old people or attributes pruned from the models"},
+         {counter_t::E_DFOEstimatedPeakMemoryUsage, "E_DFOEstimatedPeakMemoryUsage",
+          "The estimate of the peak memory outlier detection will use"},
+         {counter_t::E_DFOPeakMemoryUsage, "E_DFOPeakMemoryUsage", "The peak memory outlier detection used"},
+         {counter_t::E_DFOTimeToCreateEnsemble, "E_DFOTimeToCreateEnsemble",
+          "The time it takes to create the ensemble used for outlier detection"},
+         {counter_t::E_DFOTimeToComputeScores, "E_DFOTimeToComputeScores",
+          "The time it takes to compute outlier scores"},
+         {counter_t::E_DFONumberPartitions, "E_DFONumberPartitions",
+          "The number of partitions outlier detection used"}}};
 
     //! Enabling printing out the current counters.
     friend CORE_EXPORT std::ostream& operator<<(std::ostream& o,

--- a/lib/core/unittest/CProgramCountersTest.cc
+++ b/lib/core/unittest/CProgramCountersTest.cc
@@ -13,7 +13,10 @@
 #include <core/CRegex.h>
 #include <core/CSleep.h>
 
-#include <stdint.h>
+#include <test/CRandomNumbers.h>
+
+#include <cstdint>
+#include <thread>
 
 CppUnit::Test* CProgramCountersTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CProgramCountersTest");
@@ -28,6 +31,8 @@ CppUnit::Test* CProgramCountersTest::suite() {
         "CProgramCountersTest::testUnknownCounter", &CProgramCountersTest::testUnknownCounter));
     suiteOfTests->addTest(new CppUnit::TestCaller<CProgramCountersTest>(
         "CProgramCountersTest::testMissingCounter", &CProgramCountersTest::testMissingCounter));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CProgramCountersTest>(
+        "CProgramCountersTest::testMax", &CProgramCountersTest::testMax));
     return suiteOfTests;
 }
 
@@ -162,9 +167,9 @@ void CProgramCountersTest::testCacheCounters() {
 
     // check that the cached and live counters match and that the values are as expected
     for (size_t i = 0; i < ml::counter_t::NUM_COUNTERS; ++i) {
-        CPPUNIT_ASSERT_EQUAL(static_cast<uint64_t>(counters.counter(i)),
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::uint64_t>(counters.counter(i)),
                              counters.m_Cache[i]);
-        CPPUNIT_ASSERT_EQUAL(uint64_t(i + 1), counters.m_Cache[i]);
+        CPPUNIT_ASSERT_EQUAL(std::uint64_t(i + 1), counters.m_Cache[i]);
     }
 
     // Take a local copy of the cached counters
@@ -177,7 +182,7 @@ void CProgramCountersTest::testCacheCounters() {
 
     // compare with the cached values, they should have not changed
     for (size_t i = 0; i < ml::counter_t::NUM_COUNTERS; ++i) {
-        CPPUNIT_ASSERT_EQUAL(uint64_t(1), counters.counter(i) - counters.m_Cache[i]);
+        CPPUNIT_ASSERT_EQUAL(std::uint64_t(1), counters.counter(i) - counters.m_Cache[i]);
         CPPUNIT_ASSERT_EQUAL(origCache[i], counters.m_Cache[i]);
     }
 
@@ -235,8 +240,8 @@ void CProgramCountersTest::testPersist() {
     ml::core::CRegex regex;
     // Look for "name":"E.*"value": 0}
     regex.init(".*\"name\":\"E.*\"value\":.*");
-    for (ml::core::CRegex::TStrVecCItr i = tokens.begin(); i != (tokens.end() - 1); ++i) {
-        CPPUNIT_ASSERT(regex.matches(*i));
+    for (size_t i = 0; i < ml::counter_t::NUM_COUNTERS; ++i) {
+        CPPUNIT_ASSERT(regex.matches(tokens[i]));
     }
 
     LOG_DEBUG(<< output);
@@ -327,6 +332,37 @@ void CProgramCountersTest::testPersist() {
 
     // check that the order in which the counters are given doesn't affect the order in which they are printed
     CPPUNIT_ASSERT_EQUAL(outputOrder1, outputOrder2);
+}
+
+void CProgramCountersTest::testMax() {
+    ml::test::CRandomNumbers rng;
+    std::size_t m1, m2;
+    std::thread thread1{[&m1, &rng] {
+        std::vector<std::size_t> samples;
+        rng.generateUniformSamples(0, 100000, 1000, samples);
+        for (auto sample : samples) {
+            ml::core::CProgramCounters::counter(ml::counter_t::E_DFOEstimatedPeakMemoryUsage)
+                .max(sample);
+            m1 = std::max(m1, sample);
+        }
+    }};
+    std::thread thread2{[&m2, &rng] {
+        std::vector<std::size_t> samples;
+        rng.generateUniformSamples(0, 100000, 1000, samples);
+        for (auto sample : samples) {
+            ml::core::CProgramCounters::counter(ml::counter_t::E_DFOEstimatedPeakMemoryUsage)
+                .max(sample);
+            m2 = std::max(m2, sample);
+        }
+    }};
+
+    thread1.join();
+    thread2.join();
+
+    std::size_t expected{std::max(m1, m2)};
+    std::size_t actual{ml::core::CProgramCounters::counter(
+        ml::counter_t::E_DFOEstimatedPeakMemoryUsage)};
+    CPPUNIT_ASSERT_EQUAL(expected, actual);
 }
 
 std::string CProgramCountersTest::persist(bool doCacheCounters) {

--- a/lib/core/unittest/CProgramCountersTest.cc
+++ b/lib/core/unittest/CProgramCountersTest.cc
@@ -336,7 +336,7 @@ void CProgramCountersTest::testPersist() {
 
 void CProgramCountersTest::testMax() {
     ml::test::CRandomNumbers rng;
-    std::size_t m1, m2;
+    std::size_t m1{0}, m2{0};
     std::thread thread1{[&m1, &rng] {
         std::vector<std::size_t> samples;
         rng.generateUniformSamples(0, 100000, 1000, samples);

--- a/lib/core/unittest/CProgramCountersTest.h
+++ b/lib/core/unittest/CProgramCountersTest.h
@@ -18,6 +18,7 @@ public:
     void testCacheCounters();
     void testUnknownCounter();
     void testMissingCounter();
+    void testMax();
 
     static CppUnit::Test* suite();
 


### PR DESCRIPTION
This adds some basic performance counters; specifically, (actual and estimated) peak memory usage, run time and the number of partitions used. We will likely add to this over time, but this is a useful first set.