### PR TITLE
[ML] Stop linking to libcrypt on Linux

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -160,7 +160,31 @@ Extract the tarball to a temporary directory:
 tar jxvf apr-1.5.2.tar.bz2
 ```
 
-Build using:
+We want to avoid a dependency on the operating system `libcrypt`, as this may not be available in all Linux distributions.  Therefore, before building, in `configure` change:
+
+```
+for ac_lib in '' crypt ufc; do
+```
+
+to:
+
+```
+for ac_lib in ''; do
+```
+
+And in `include/apr.h.in` change:
+
+```
+#define APR_HAVE_CRYPT_H         @crypth@
+```
+
+to:
+
+```
+#define APR_HAVE_CRYPT_H         0
+```
+
+Then build using:
 
 ```
 ./configure --prefix=/usr/local/gcc73
@@ -178,7 +202,31 @@ Extract the tarball to a temporary directory:
 tar jxvf apr-util-1.5.4.tar.bz2
 ```
 
-Build using:
+We want to avoid a dependency on the operating system `libcrypt`, as this may not be available in all Linux distributions.  Therefore, before building, in `configure` change:
+
+```
+for ac_lib in '' crypt ufc; do
+```
+
+to:
+
+```
+for ac_lib in ''; do
+```
+
+And in `crypto/apr_passwd.c` change:
+
+```
+#define CRYPT_MISSING 0
+```
+
+to:
+
+```
+#define CRYPT_MISSING 1
+```
+
+Then build using:
 
 ```
 ./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=builtin

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -17,7 +17,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=7
+VERSION=8
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:7
+FROM docker.elastic.co/ml-dev/ml-linux-build:8
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -55,6 +55,8 @@ RUN \
 RUN \
   wget --quiet -O - http://archive.apache.org/dist/apr/apr-1.5.2.tar.bz2 | tar jxf - && \
   cd apr-1.5.2 && \
+  sed -i -e "s/for ac_lib in '' crypt ufc; do/for ac_lib in ''; do/" configure && \
+  sed -i -e 's/#define APR_HAVE_CRYPT_H         @crypth@/#define APR_HAVE_CRYPT_H         0/' include/apr.h.in && \
   ./configure --prefix=/usr/local/gcc73 && \
   make -j`grep -c '^processor' /proc/cpuinfo` && \
   make install && \
@@ -65,6 +67,8 @@ RUN \
 RUN \
   wget --quiet -O - http://archive.apache.org/dist/apr/apr-util-1.5.4.tar.bz2 | tar jxf - && \
   cd apr-util-1.5.4 && \
+  sed -i -e "s/for ac_lib in '' crypt ufc; do/for ac_lib in ''; do/" configure && \
+  sed -i -e 's/#define CRYPT_MISSING 0/#define CRYPT_MISSING 1/' crypto/apr_passwd.c && \
   ./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=builtin && \
   make -j`grep -c '^processor' /proc/cpuinfo` && \
   make install && \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:7
+FROM docker.elastic.co/ml-dev/ml-linux-build:8
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/vagrant/linux/provision.sh
+++ b/dev-tools/vagrant/linux/provision.sh
@@ -95,6 +95,10 @@ if [ ! -f apr.state ]; then
   tar xfz apr-1.5.2.tar.gz -C apr --strip-components=1
   cd apr
   echo "  Configuring..."
+
+  sed -i -e "s/for ac_lib in '' crypt ufc; do/for ac_lib in ''; do/" configure
+  sed -i -e 's/#define APR_HAVE_CRYPT_H         @crypth@/#define APR_HAVE_CRYPT_H         0/' include/apr.h.in
+
   ./configure --prefix=/usr/local/gcc73 > configure.log 2>&1
   echo "  Making..."
   make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
@@ -113,6 +117,10 @@ if [ ! -f apr-util.state ]; then
   tar xfz apr-util-1.5.4.tar.gz -C apr-util --strip-components=1
   cd apr-util
   echo "  Configuring..."
+
+  sed -i -e "s/for ac_lib in '' crypt ufc; do/for ac_lib in ''; do/" configure
+  sed -i -e 's/#define CRYPT_MISSING 0/#define CRYPT_MISSING 1/' crypto/apr_passwd.c
+
   ./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=builtin > configure.log 2>&1
   echo "  Making..."
   make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,7 +28,7 @@
 
 //=== Regressions
 
-== {es} version 7.1.0
+== {es} version 7.2.0
 
 === Enhancements
 
@@ -41,6 +41,8 @@ to the model. (See {ml-pull}214[#214].)
 (See {ml-pull}463[#463].)
 
 * Improve residual model selection. (See {ml-pull}468[#468].)
+
+* Stop linking to libcrypt on Linux. (See {ml-pull}480[#480].)
 
 === Bug Fixes
 


### PR DESCRIPTION
Recent Linux distributions do not install libcrypt as a
system library by default.  We do not use any functionality
from this library, so it is better to build our other
dependencies in such a way that they don't link to libcrypt.
This avoids the need to install extra OS packages before
Elasticsearch.

Closes #478