### PR TITLE
[7.2][ML] Switch to use temporary test directory for data frame storage in tests

### DIFF
--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -12,6 +12,7 @@
 #include <core/Concurrency.h>
 
 #include <test/CRandomNumbers.h>
+#include <test/CTestTmpDir.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/unordered_map.hpp>
@@ -198,7 +199,7 @@ void CDataFrameTest::testOnDiskBasicReadWrite() {
     TFloatVec components{testData(rows, cols)};
 
     auto frameAndDirectory = core::makeDiskStorageDataFrame(
-        boost::filesystem::current_path().string(), cols, rows, capacity);
+        test::CTestTmpDir::tmpDir(), cols, rows, capacity);
     auto frame = std::move(frameAndDirectory.first);
 
     for (std::size_t i = 0; i < components.size(); i += cols) {
@@ -227,7 +228,7 @@ void CDataFrameTest::testOnDiskParallelRead() {
     TFloatVec components{testData(rows, cols)};
 
     auto frameAndDirectory = core::makeDiskStorageDataFrame(
-        boost::filesystem::current_path().string(), cols, rows, capacity);
+        test::CTestTmpDir::tmpDir(), cols, rows, capacity);
     auto frame = std::move(frameAndDirectory.first);
 
     for (std::size_t i = 0; i < components.size(); i += cols) {
@@ -267,8 +268,7 @@ void CDataFrameTest::testReadRange() {
     TFloatVec components{testData(rows, cols)};
 
     TFactoryFunc makeOnDisk = [=] {
-        return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows, capacity)
+        return core::makeDiskStorageDataFrame(test::CTestTmpDir::tmpDir(), cols, rows, capacity)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {
@@ -335,8 +335,7 @@ void CDataFrameTest::testWriteRange() {
     TFloatVec components{testData(rows, cols)};
 
     TFactoryFunc makeOnDisk = [=] {
-        return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows, capacity)
+        return core::makeDiskStorageDataFrame(test::CTestTmpDir::tmpDir(), cols, rows, capacity)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {
@@ -412,8 +411,8 @@ void CDataFrameTest::testMemoryUsage() {
 
     TFactoryFunc makeOnDisk = [=] {
         return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows,
-                   capacity, core::CDataFrame::EReadWriteToStorage::E_Async)
+                   test::CTestTmpDir::tmpDir(), cols, rows, capacity,
+                   core::CDataFrame::EReadWriteToStorage::E_Async)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {
@@ -456,8 +455,8 @@ void CDataFrameTest::testReserve() {
 
     TFactoryFunc makeOnDisk = [=] {
         return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows,
-                   capacity, core::CDataFrame::EReadWriteToStorage::E_Async)
+                   test::CTestTmpDir::tmpDir(), cols, rows, capacity,
+                   core::CDataFrame::EReadWriteToStorage::E_Async)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {
@@ -529,8 +528,8 @@ void CDataFrameTest::testResizeColumns() {
 
     TFactoryFunc makeOnDisk = [=] {
         return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows,
-                   capacity, core::CDataFrame::EReadWriteToStorage::E_Async)
+                   test::CTestTmpDir::tmpDir(), cols, rows, capacity,
+                   core::CDataFrame::EReadWriteToStorage::E_Async)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {
@@ -588,8 +587,8 @@ void CDataFrameTest::testWriteColumns() {
 
     TFactoryFunc makeOnDisk = [=] {
         return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows,
-                   capacity, core::CDataFrame::EReadWriteToStorage::E_Async)
+                   test::CTestTmpDir::tmpDir(), cols, rows, capacity,
+                   core::CDataFrame::EReadWriteToStorage::E_Async)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {
@@ -643,8 +642,8 @@ void CDataFrameTest::testDocHashes() {
 
     TFactoryFunc makeOnDisk = [=] {
         return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows,
-                   capacity, core::CDataFrame::EReadWriteToStorage::E_Async)
+                   test::CTestTmpDir::tmpDir(), cols, rows, capacity,
+                   core::CDataFrame::EReadWriteToStorage::E_Async)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -10,6 +10,7 @@
 #include <maths/CDataFrameUtils.h>
 
 #include <test/CRandomNumbers.h>
+#include <test/CTestTmpDir.h>
 
 #include <boost/filesystem.hpp>
 
@@ -46,8 +47,7 @@ void CDataFrameUtilsTest::testStandardizeColumns() {
     }
 
     TFactoryFunc makeOnDisk{[=] {
-        return core::makeDiskStorageDataFrame(
-                   boost::filesystem::current_path().string(), cols, rows, capacity)
+        return core::makeDiskStorageDataFrame(test::CTestTmpDir::tmpDir(), cols, rows, capacity)
             .first;
     }};
     TFactoryFunc makeMainMemory{

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -17,6 +17,7 @@
 
 #include <test/CDataFrameTestUtils.h>
 #include <test/CRandomNumbers.h>
+#include <test/CTestTmpDir.h>
 
 #include <boost/filesystem.hpp>
 
@@ -350,7 +351,7 @@ void COutliersTest::testEnsemble() {
     }};
     TFactoryFunc toOnDiskDataFrame{[](const TPointVec& points) {
         return test::CDataFrameTestUtils::toOnDiskDataFrame(
-            boost::filesystem::current_path().string(), points);
+            test::CTestTmpDir::tmpDir(), points);
     }};
     TFactoryFunc factories[]{toMainMemoryDataFrame, toOnDiskDataFrame};
     std::size_t numberPartitions[]{1, 3};
@@ -413,7 +414,7 @@ void COutliersTest::testFeatureInfluences() {
     }};
     TFactoryFunc toOnDiskDataFrame{[](const TPointVec& points) {
         return test::CDataFrameTestUtils::toOnDiskDataFrame(
-            boost::filesystem::current_path().string(), points);
+            test::CTestTmpDir::tmpDir(), points);
     }};
     TFactoryFunc factories[]{toMainMemoryDataFrame, toOnDiskDataFrame};
     std::size_t numberPartitions[]{1, 3};
@@ -514,7 +515,7 @@ void COutliersTest::testEstimateMemoryUsedByCompute() {
     }};
     TFactoryFunc toOnDiskDataFrame{[](const TPointVec& points) {
         return test::CDataFrameTestUtils::toOnDiskDataFrame(
-            boost::filesystem::current_path().string(), points);
+            test::CTestTmpDir::tmpDir(), points);
     }};
     TFactoryFunc factories[]{toMainMemoryDataFrame, toOnDiskDataFrame};
 
@@ -588,7 +589,7 @@ void COutliersTest::testProgressMonitoring() {
     }};
     TFactoryFunc toOnDiskDataFrame{[](const TPointVec& points) {
         return test::CDataFrameTestUtils::toOnDiskDataFrame(
-            boost::filesystem::current_path().string(), points);
+            test::CTestTmpDir::tmpDir(), points);
     }};
     TFactoryFunc factories[]{toMainMemoryDataFrame, toOnDiskDataFrame};
     std::size_t numberPartitions[]{1, 3};


### PR DESCRIPTION
Backport #479.