### PR TITLE
[ML] Reduce false positives associated with the multi-bucket feature

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@
 
 * Fix an edge case causing spurious anomalies (false positives) if the variance in the count of events
 changed significantly throughout the period of a seasonal quantity. (See {ml-pull}489[#489].)
+* Reduce false positives associated with the multi-bucket feature. (See {ml-pull}491[#491].)
 
 == {es} version 7.2.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,13 +28,18 @@
 
 //=== Regressions
 
+== {es} version 7.3.0
+
+=== Bug Fixes
+
+* Reduce false positives associated with the multi-bucket feature. (See {ml-pull}491[#491].)
+
 == {es} version 7.2.1
 
 === Bug Fixes
 
 * Fix an edge case causing spurious anomalies (false positives) if the variance in the count of events
 changed significantly throughout the period of a seasonal quantity. (See {ml-pull}489[#489].)
-* Reduce false positives associated with the multi-bucket feature. (See {ml-pull}491[#491].)
 
 == {es} version 7.2.0
 

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -579,6 +579,10 @@ bool CTimeSeriesAnomalyModel::acceptRestoreTraverser(const SModelRestoreParams& 
         std::size_t index{0};
         while (traverser.next()) {
             const std::string& name{traverser.name()};
+            RESTORE_SETUP_TEARDOWN(ANOMALY_6_5_TAG, CAnomaly restored,
+                                   traverser.traverseSubLevel(boost::bind(
+                                       &CAnomaly::acceptRestoreTraverser, &restored, _1)),
+                                   m_Anomaly.reset(restored))
             RESTORE(ANOMALY_FEATURE_MODEL_6_5_TAG,
                     traverser.traverseSubLevel(boost::bind(
                         &TMultivariateNormalConjugate::acceptRestoreTraverser,
@@ -588,10 +592,6 @@ bool CTimeSeriesAnomalyModel::acceptRestoreTraverser(const SModelRestoreParams& 
         std::size_t index{0};
         while (traverser.next()) {
             const std::string& name{traverser.name()};
-            RESTORE_SETUP_TEARDOWN(ANOMALY_6_5_TAG, CAnomaly restored,
-                                   traverser.traverseSubLevel(boost::bind(
-                                       &CAnomaly::acceptRestoreTraverser, &restored, _1)),
-                                   m_Anomaly.reset(restored))
             RESTORE(ANOMALY_FEATURE_MODEL_6_5_TAG,
                     traverser.traverseSubLevel(boost::bind(
                         &TMultivariateNormalConjugate::acceptRestoreTraverser,

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -320,7 +320,7 @@ private:
     public:
         CAnomaly() = default;
         explicit CAnomaly(core_t::TTime time)
-            : m_FirstAnomalousBucketTime(time) {}
+            : m_FirstAnomalousBucketTime(time), m_LastAnomalousBucketTime(time) {}
 
         //! Add a result to the anomaly.
         void update(core_t::TTime time, double predictionError) {

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -112,7 +112,7 @@ double aggregateFeatureProbabilities(const TDouble4Vec& probabilities, double co
 
 const std::string VERSION_6_3_TAG("6.3");
 const std::string VERSION_6_5_TAG("6.5");
-const std::string VERSION_7_2_TAG("7.2");
+const std::string VERSION_7_3_TAG("7.3");
 
 // Models
 // Version >= 6.3
@@ -140,8 +140,8 @@ const std::string IS_NON_NEGATIVE_OLD_TAG{"g"};
 const std::string IS_FORECASTABLE_OLD_TAG{"h"};
 
 // Anomaly model
-// Version >= 7.2
-const std::string LAST_ANOMALOUS_BUCKET_TIME_7_2_TAG{"d"};
+// Version >= 7.3
+const std::string LAST_ANOMALOUS_BUCKET_TIME_7_3_TAG{"d"};
 // Version >= 6.5
 const std::string ANOMALY_6_5_TAG{"e"};
 const std::string ANOMALY_FEATURE_MODEL_6_5_TAG{"f"};
@@ -357,7 +357,7 @@ private:
             do {
                 const std::string& name{traverser.name()};
                 RESTORE_BUILT_IN(FIRST_ANOMALOUS_BUCKET_TIME_6_5_TAG, m_FirstAnomalousBucketTime)
-                RESTORE_BUILT_IN(LAST_ANOMALOUS_BUCKET_TIME_7_2_TAG, m_LastAnomalousBucketTime)
+                RESTORE_BUILT_IN(LAST_ANOMALOUS_BUCKET_TIME_7_3_TAG, m_LastAnomalousBucketTime)
                 RESTORE_BUILT_IN(SUM_PREDICTION_ERROR_6_5_TAG, m_SumPredictionError)
                 RESTORE(MEAN_ABS_PREDICTION_ERROR_6_5_TAG,
                         m_MeanAbsPredictionError.fromDelimited(traverser.value()))
@@ -368,7 +368,7 @@ private:
         //! Persist by passing information to \p inserter.
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
             inserter.insertValue(FIRST_ANOMALOUS_BUCKET_TIME_6_5_TAG, m_FirstAnomalousBucketTime);
-            inserter.insertValue(LAST_ANOMALOUS_BUCKET_TIME_7_2_TAG, m_LastAnomalousBucketTime);
+            inserter.insertValue(LAST_ANOMALOUS_BUCKET_TIME_7_3_TAG, m_LastAnomalousBucketTime);
             inserter.insertValue(SUM_PREDICTION_ERROR_6_5_TAG, m_SumPredictionError,
                                  core::CIEEE754::E_SinglePrecision);
             inserter.insertValue(MEAN_ABS_PREDICTION_ERROR_6_5_TAG,
@@ -575,7 +575,7 @@ std::size_t CTimeSeriesAnomalyModel::memoryUsage() const {
 bool CTimeSeriesAnomalyModel::acceptRestoreTraverser(const SModelRestoreParams& params,
                                                      core::CStateRestoreTraverser& traverser) {
     m_BucketLength = boost::unwrap_ref(params.s_Params).bucketLength();
-    if (traverser.name() == VERSION_7_2_TAG) {
+    if (traverser.name() == VERSION_7_3_TAG) {
         std::size_t index{0};
         while (traverser.next()) {
             const std::string& name{traverser.name()};
@@ -604,7 +604,7 @@ bool CTimeSeriesAnomalyModel::acceptRestoreTraverser(const SModelRestoreParams& 
 }
 
 void CTimeSeriesAnomalyModel::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    inserter.insertValue(VERSION_7_2_TAG, "");
+    inserter.insertValue(VERSION_7_3_TAG, "");
     if (m_Anomaly) {
         inserter.insertLevel(ANOMALY_6_5_TAG, boost::bind(&CAnomaly::acceptPersistInserter,
                                                           m_Anomaly.get(), _1));

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -176,8 +176,8 @@ void CEventRateAnomalyDetectorTest::testAnomalies() {
     // We have 11 instances of correlated 503s and rare SQL statements
     // and one extended drop in status 200s, which are the principal
     // anomalies to find in this data set.
-    static const double HIGH_ANOMALY_SCORE(0.002);
-    static const size_t EXPECTED_ANOMALOUS_HOURS(12);
+    static const double HIGH_ANOMALY_SCORE(0.005);
+    static const size_t EXPECTED_ANOMALOUS_HOURS(13);
 
     static const ml::core_t::TTime FIRST_TIME(1346713620);
     static const ml::core_t::TTime LAST_TIME(1347317974);


### PR DESCRIPTION
This improves the interaction between multi-bucket feature and the model we maintain attending specifically to periods flagged as anomalous. In particular, we were suppressing updates of this anomaly model if the bucket probability was high but continuing to adjust the overall probability if the multi-bucket feature probability was low. The upshot our scores were inappropriately high.

This change pegs the time used to compute the anomaly duration to the last update time for the anomaly model and also smoothly reduces the impact on our overall result if the bucket value itself is normal.

This should help with #477.