### PR TITLE
[ML] Improve seasonal component lifecycle for time series modelling

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,6 +30,10 @@
 
 == {es} version 7.3.0
 
+=== Enhancements
+
+* Improve stability of modelling around change points. (See {ml-pull}496[#496].)
+
 === Bug Fixes
 
 * Reduce false positives associated with the multi-bucket feature. (See {ml-pull}491[#491].)

--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -25,13 +25,29 @@ namespace ml {
 namespace maths {
 class CSeasonalTime;
 
-//! \brief Represents the result of running the periodicity
-//! hypothesis tests.
-class MATHS_EXPORT CPeriodicityHypothesisTestsResult
+//! \brief Represents the different trend hypotheses.
+class MATHS_EXPORT CTrendHypothesis final {
+public:
+    enum EType { E_None, E_Linear, E_PiecewiseLinear };
+
+public:
+    explicit CTrendHypothesis(std::size_t segments = 0);
+
+    EType type() const;
+    std::size_t segments() const;
+
+private:
+    std::size_t m_Segments;
+};
+
+//! \brief Represents the result of running the periodicity tests.
+class MATHS_EXPORT CPeriodicityHypothesisTestsResult final
     : boost::equality_comparable<CPeriodicityHypothesisTestsResult> {
 public:
     using TTimeTimePr = std::pair<core_t::TTime, core_t::TTime>;
     using TSizeVec = std::vector<std::size_t>;
+    using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
+    using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
 
     //! \brief Component data.
     struct MATHS_EXPORT SComponent {
@@ -89,11 +105,14 @@ public:
     //! Remove the component with \p description.
     void remove(const TRemoveCondition& condition);
 
-    //! Set if this is a piecewise linear trend.
-    void piecewiseLinearTrend(bool value);
+    //! Set the type of trend the hypothesis assumes.
+    void trend(CTrendHypothesis value);
 
-    //! Check if this is a piecewise linear trend.
-    bool piecewiseLinearTrend() const;
+    //! Fit and remove the appropriate trend from \p values.
+    void removeTrend(TFloatMeanAccumulatorVec& values) const;
+
+    //! Remove any discontinuities in \p values.
+    void removeDiscontinuities(TFloatMeanAccumulatorVec& values) const;
 
     //! Check if there are any periodic components.
     bool periodic() const;
@@ -105,18 +124,16 @@ public:
     std::string print() const;
 
 private:
-    //! If true then the hypothesis used a piecewise linear trend.
-    bool m_PiecewiseLinearTrend = false;
+    //! The trend used for the hypothesis.
+    CTrendHypothesis m_Trend;
 
     //! The periodic components.
     TComponent5Vec m_Components;
 };
 
 //! \brief Configures the periodicity testing.
-class MATHS_EXPORT CPeriodicityHypothesisTestsConfig {
+class MATHS_EXPORT CPeriodicityHypothesisTestsConfig final {
 public:
-    CPeriodicityHypothesisTestsConfig();
-
     //! Disable diurnal periodicity tests.
     void disableDiurnal();
     //! Test given we know there is daily periodic component.
@@ -141,15 +158,15 @@ public:
 
 private:
     //! True if we should test for diurnal periodicity.
-    bool m_TestForDiurnal;
+    bool m_TestForDiurnal = true;
     //! True if we know there is a daily component.
-    bool m_HasDaily;
+    bool m_HasDaily = false;
     //! True if we know there is a weekend.
-    bool m_HasWeekend;
+    bool m_HasWeekend = false;
     //! True if we know there is a weekly component.
-    bool m_HasWeekly;
+    bool m_HasWeekly = false;
     //! The start of the week.
-    core_t::TTime m_StartOfWeek;
+    core_t::TTime m_StartOfWeek = 0;
 };
 
 //! \brief Implements a set of hypothesis tests to discover the
@@ -164,7 +181,7 @@ private:
 //! of the amplitude. It also compares these possibilities with a
 //! specified period (typically found by examining the cyclic
 //! autocorrelation).
-class MATHS_EXPORT CPeriodicityHypothesisTests {
+class MATHS_EXPORT CPeriodicityHypothesisTests final {
 public:
     using TDouble2Vec = core::CSmallVector<double, 2>;
     using TTimeTimePr = std::pair<core_t::TTime, core_t::TTime>;
@@ -256,7 +273,7 @@ private:
     };
 
     //! \brief Manages the testing of a set of nested hypotheses.
-    class CNestedHypotheses {
+    class CNestedHypotheses final {
     public:
         using TTestFunc = std::function<CPeriodicityHypothesisTestsResult(STestStats&)>;
 
@@ -285,8 +302,8 @@ private:
         CNestedHypotheses& addNested(TTestFunc test);
         //! Test the hypotheses.
         CPeriodicityHypothesisTestsResult test(STestStats& stats) const;
-        //! Set if the hypothesis uses a piecewise linear trend.
-        void trendSegments(std::size_t segments);
+        //! Set if the type of trend the hypothesis is using.
+        void trend(CTrendHypothesis trend);
         //! Check if the hypothesis uses a piecewise linear trend.
         std::size_t trendSegments() const;
 
@@ -296,8 +313,8 @@ private:
     private:
         //! The test.
         TTestFunc m_Test;
-        //! The number of segments in the trend.
-        std::size_t m_TrendSegments;
+        //! The type of trend the hypothesis is using.
+        CTrendHypothesis m_Trend;
         //! If true always test the nested hypotheses.
         bool m_AlwaysTestNested;
         //! The nested hypotheses to test.

--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -124,10 +124,10 @@ public:
     std::string print() const;
 
 private:
-    //! The trend used for the hypothesis.
+    //! The trend hypothesis for the test.
     CTrendHypothesis m_Trend;
 
-    //! The periodic components.
+    //! The periodic components found.
     TComponent5Vec m_Components;
 };
 

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -51,9 +51,6 @@ struct STimeSeriesDecompositionRestoreParams;
 class MATHS_EXPORT CTimeSeriesDecomposition : public CTimeSeriesDecompositionInterface,
                                               private CTimeSeriesDecompositionDetail {
 public:
-    using TSizeVec = std::vector<std::size_t>;
-
-public:
     //! \param[in] decayRate The rate at which information is lost.
     //! \param[in] bucketLength The data bucketing length.
     //! \param[in] seasonalComponentSize The number of buckets to
@@ -99,16 +96,17 @@ public:
 
     //! Adds a time series point \f$(t, f(t))\f$.
     //!
-    //! \param[in] time The time of the function point.
-    //! \param[in] value The function value at \p time.
+    //! \param[in] time The time of the data point.
+    //! \param[in] value The value of the data point.
     //! \param[in] weights The weights of \p value. The smaller
     //! the count weight the less influence \p value has on the trend
     //! and it's local variance.
-    //! \return True if number of estimated components changed
-    //! and false otherwise.
-    virtual bool addPoint(core_t::TTime time,
+    //! \param[in] componentChangeCallback Called if the components
+    //! change as a result of adding the data point.
+    virtual void addPoint(core_t::TTime time,
                           double value,
-                          const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT);
+                          const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT,
+                          const TComponentChangeCallback& componentChangeCallback = noop);
 
     //! Apply \p change at \p time.
     //!
@@ -172,11 +170,8 @@ public:
     virtual maths_t::TDoubleDoublePr
     scale(core_t::TTime time, double variance, double confidence, bool smooth = true) const;
 
-    //! Check if this might add components between now and \p time.
-    virtual bool mightAddComponents(core_t::TTime time) const;
-
     //! Get the values in a recent time window.
-    virtual TTimeFloatMeanAccumulatorPrVec windowValues() const;
+    virtual TFloatMeanAccumulatorVec windowValues(const TPredictor& predictor) const;
 
     //! Roll time forwards by \p skipInterval.
     virtual void skipTime(core_t::TTime skipInterval);

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -262,7 +262,7 @@ public:
         //! Account for memory that is not allocated by initialisation.
         std::size_t extraMemoryOnInitialization() const;
 
-        //! Get the accounting for linear scales in the test window. 
+        //! Get the accounting for linear scales in the test window.
         TPredictor scaledPredictor(const TPredictor& predictor) const;
 
         //! Remove any linear scale events outside the test windows.

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -36,11 +36,9 @@ class CExpandingWindow;
 class CTimeSeriesDecomposition;
 
 //! \brief Utilities for computing the decomposition.
-class MATHS_EXPORT CTimeSeriesDecompositionDetail {
+class MATHS_EXPORT CTimeSeriesDecompositionDetail : private CTimeSeriesDecompositionTypes {
 public:
-    using TPredictor = std::function<double(core_t::TTime)>;
     using TDoubleVec = std::vector<double>;
-    using TTimeVec = std::vector<core_t::TTime>;
     class CMediator;
 
     //! \brief The base message passed.
@@ -63,7 +61,8 @@ public:
                   double seasonal,
                   double calendar,
                   const TPredictor& predictor,
-                  const CPeriodicityHypothesisTestsConfig& periodicityTestConfig);
+                  const CPeriodicityHypothesisTestsConfig& periodicityTestConfig,
+                  TComponentChangeCallback componentChangeCallback);
         SAddValue(const SAddValue&) = delete;
         SAddValue& operator=(const SAddValue&) = delete;
 
@@ -81,6 +80,8 @@ public:
         TPredictor s_Predictor;
         //! The periodicity test configuration.
         CPeriodicityHypothesisTestsConfig s_PeriodicityTestConfig;
+        //! Called if the components change.
+        TComponentChangeCallback s_ComponentChangeCallback;
     };
 
     //! \brief The message passed to indicate periodic components have
@@ -189,10 +190,6 @@ public:
     //! diurnal and any other large amplitude seasonal components.
     class MATHS_EXPORT CPeriodicityTest : public CHandler {
     public:
-        using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
-        using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
-        using TTimeFloatMeanAccumulatorPrVec = std::vector<TTimeFloatMeanAccumulatorPr>;
-
         //! Test types (categorised as short and long period tests).
         enum ETest { E_Short, E_Long };
 
@@ -216,9 +213,6 @@ public:
         //! Reset the test.
         virtual void handle(const SNewComponents& message);
 
-        //! Check if we should run the periodicity test on \p window.
-        bool shouldTest(ETest test, core_t::TTime time) const;
-
         //! Test to see whether any seasonal components are present.
         void test(const SAddValue& message);
 
@@ -230,7 +224,7 @@ public:
         void propagateForwards(core_t::TTime start, core_t::TTime end);
 
         //! Get the values in the window if we're going to test at \p time.
-        TTimeFloatMeanAccumulatorPrVec windowValues() const;
+        TFloatMeanAccumulatorVec windowValues(const TPredictor& predictor) const;
 
         //! Get a checksum for this object.
         uint64_t checksum(uint64_t seed = 0) const;
@@ -242,7 +236,6 @@ public:
         std::size_t memoryUsage() const;
 
     private:
-        using TTimeAry = boost::array<core_t::TTime, 2>;
         using TExpandingWindowPtr = std::unique_ptr<CExpandingWindow>;
         using TExpandingWindowPtrAry = boost::array<TExpandingWindowPtr, 2>;
 
@@ -254,6 +247,9 @@ public:
     private:
         //! Handle \p symbol.
         void apply(std::size_t symbol, const SMessage& message);
+
+        //! Check if we should run the periodicity test on \p window.
+        bool shouldTest(ETest test, core_t::TTime time) const;
 
         //! Get a new \p test. (Warning: this is owned by the caller.)
         CExpandingWindow* newWindow(ETest test, bool deflate = true) const;
@@ -375,13 +371,6 @@ public:
         //! Set whether or not we're testing for a change.
         void testingForChange(bool value);
 
-        //! Start observing for modifications to the components.
-        void observeComponentsModified();
-
-        //! Check if any components were added or removed since observeComponentsModified
-        //! was last called.
-        bool componentsModified();
-
         //! Apply \p shift to the level at \p time and \p value.
         void shiftLevel(core_t::TTime time, double value, double shift);
 
@@ -444,12 +433,9 @@ public:
         std::size_t memoryUsage() const;
 
     private:
-        using TOptionalDouble = boost::optional<double>;
         using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
         using TSeasonalComponentPtrVec = std::vector<CSeasonalComponent*>;
         using TCalendarComponentPtrVec = std::vector<CCalendarComponent*>;
-        using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
-        using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
 
         //! \brief Manages the setting of the error gain when updating
         //! the components with a value.
@@ -851,14 +837,14 @@ public:
         //! The moments of the error in the predictions including the trend.
         TMeanVarAccumulator m_PredictionErrorWithTrend;
 
+        //! Called if the components change.
+        TComponentChangeCallback m_ComponentChangeCallback;
+
         //! Set to true when testing for a change.
         bool m_TestingForChange = false;
 
         //! Set to true if the trend model should be used for prediction.
         bool m_UsingTrendForPrediction = false;
-
-        //! Set to true when new components are added or removed
-        bool m_ComponentsModified = false;
 
         //! Befriend a helper class used by the unit tests
         friend class ::CNanInjector;

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -216,6 +216,9 @@ public:
         //! Test to see whether any seasonal components are present.
         void test(const SAddValue& message);
 
+        //! Record a linear scale of \p scale at \p time.
+        void linearScale(core_t::TTime time, double scale);
+
         //! Shift the start of the tests' expanding windows by \p dt.
         void shiftTime(core_t::TTime dt);
 
@@ -236,6 +239,8 @@ public:
         std::size_t memoryUsage() const;
 
     private:
+        using TTimeDoublePr = std::pair<core_t::TTime, double>;
+        using TTimeDoublePrVec = std::vector<std::pair<core_t::TTime, double>>;
         using TExpandingWindowPtr = std::unique_ptr<CExpandingWindow>;
         using TExpandingWindowPtrAry = boost::array<TExpandingWindowPtr, 2>;
 
@@ -254,9 +259,14 @@ public:
         //! Get a new \p test. (Warning: this is owned by the caller.)
         CExpandingWindow* newWindow(ETest test, bool deflate = true) const;
 
-        //! Account for memory that is not yet allocated
-        //! during the initial state
+        //! Account for memory that is not allocated by initialisation.
         std::size_t extraMemoryOnInitialization() const;
+
+        //! Get the accounting for linear scales in the test window. 
+        TPredictor scaledPredictor(const TPredictor& predictor) const;
+
+        //! Remove any linear scale events outside the test windows.
+        void pruneLinearScales();
 
     private:
         //! The state machine.
@@ -270,6 +280,9 @@ public:
 
         //! Expanding windows on the "recent" time series values.
         TExpandingWindowPtrAry m_Windows;
+
+        //! The times of linear scales in the window range.
+        TTimeDoublePrVec m_LinearScales;
     };
 
     //! \brief Tests for cyclic calendar components explaining large prediction

--- a/include/maths/CTimeSeriesDecompositionStub.h
+++ b/include/maths/CTimeSeriesDecompositionStub.h
@@ -41,9 +41,10 @@ public:
     virtual void testingForChange(bool value);
 
     //! No-op returning false.
-    virtual bool addPoint(core_t::TTime time,
+    virtual void addPoint(core_t::TTime time,
                           double value,
-                          const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT);
+                          const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT,
+                          const TComponentChangeCallback& componentChangeCallback = noop);
 
     //! No-op returning false.
     virtual bool applyChange(core_t::TTime time, double value, const SChangeDescription& change);
@@ -82,11 +83,8 @@ public:
     virtual maths_t::TDoubleDoublePr
     scale(core_t::TTime time, double variance, double confidence, bool smooth = true) const;
 
-    //! Returns false.
-    virtual bool mightAddComponents(core_t::TTime time) const;
-
     //! Returns an empty vector.
-    virtual TTimeFloatMeanAccumulatorPrVec windowValues() const;
+    virtual TFloatMeanAccumulatorVec windowValues(const TPredictor& predictor) const;
 
     //! No-op.
     virtual void skipTime(core_t::TTime skipInterval);

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -55,8 +55,7 @@ double weight(const CMultivariatePrior& prior,
 class MATHS_EXPORT CUnivariateTimeSeriesModel : public CModel {
 public:
     using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
-    using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
-    using TTimeFloatMeanAccumulatorPrVec = std::vector<TTimeFloatMeanAccumulatorPr>;
+    using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
     using TDoubleWeightsAry = maths_t::TDoubleWeightsAry;
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
     using TDecayRateController2Ary = boost::array<CDecayRateController, 2>;
@@ -206,8 +205,6 @@ private:
     using TSizeVec = std::vector<std::size_t>;
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TDouble1VecVec = std::vector<TDouble1Vec>;
-    using TDouble1VecDoubleWeightsAry1VecPr =
-        std::pair<TDouble1Vec, maths_t::TDoubleWeightsAry1Vec>;
     using TDouble2VecWeightsAryVec = std::vector<TDouble2VecWeightsAry>;
     using TMultibucketFeaturePtr = std::unique_ptr<TMultibucketFeature>;
     using TDecayRateController2AryPtr = std::unique_ptr<TDecayRateController2Ary>;
@@ -247,7 +244,7 @@ private:
 
     //! Reinitialize state after detecting a new component of the trend
     //! decomposition.
-    void reinitializeStateGivenNewComponent(const TTimeFloatMeanAccumulatorPrVec& initialValues);
+    void reinitializeStateGivenNewComponent(TFloatMeanAccumulatorVec residuals);
 
     //! Compute the probability for uncorrelated series.
     bool uncorrelatedProbability(const CModelProbabilityParams& params,
@@ -527,10 +524,8 @@ public:
     using TDouble10Vec = core::CSmallVector<double, 10>;
     using TDouble10Vec1Vec = core::CSmallVector<TDouble10Vec, 1>;
     using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
-    using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
-    using TTimeFloatMeanAccumulatorPrVec = std::vector<TTimeFloatMeanAccumulatorPr>;
-    using TTimeFloatMeanAccumulatorPrVec10Vec =
-        core::CSmallVector<TTimeFloatMeanAccumulatorPrVec, 10>;
+    using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
+    using TFloatMeanAccumulatorVec10Vec = core::CSmallVector<TFloatMeanAccumulatorVec, 10>;
     using TDouble10VecWeightsAry = maths_t::TDouble10VecWeightsAry;
     using TDouble10VecWeightsAry1Vec = core::CSmallVector<TDouble10VecWeightsAry, 1>;
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
@@ -677,12 +672,8 @@ private:
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TDouble1VecVec = std::vector<TDouble1Vec>;
     using TDouble2VecWeightsAryVec = std::vector<TDouble2VecWeightsAry>;
-    using TDouble10Vec1VecDouble10VecWeightsAry1VecPr =
-        std::pair<TDouble10Vec1Vec, TDouble10VecWeightsAry1Vec>;
     using TVector = CVector<CFloatStorage>;
     using TVectorMeanAccumulator = CBasicStatistics::SSampleMean<TVector>::TAccumulator;
-    using TTimeVectorMeanAccumulatorPr = std::pair<core_t::TTime, TVectorMeanAccumulator>;
-    using TTimeVectorMeanAccumulatorPrCBuf = boost::circular_buffer<TTimeVectorMeanAccumulatorPr>;
     using TMultibucketFeaturePtr = std::unique_ptr<TMultibucketFeature>;
     using TDecayRateController2AryPtr = std::unique_ptr<TDecayRateController2Ary>;
     using TMultivariatePriorPtr = std::unique_ptr<CMultivariatePrior>;
@@ -706,7 +697,7 @@ private:
 
     //! Reinitialize state after detecting a new component of the trend
     //! decomposition.
-    void reinitializeStateGivenNewComponent(const TTimeFloatMeanAccumulatorPrVec10Vec& initialValues);
+    void reinitializeStateGivenNewComponent(TFloatMeanAccumulatorVec10Vec residuals);
 
     //! Get the model dimension.
     std::size_t dimension() const;

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -354,7 +354,7 @@ void CAnomalyJobLimitTest::testModelledEntityCountForFixedMemoryLimit() {
         std::size_t s_ExpectedOverUsageRelativeErrorDivisor;
     } testParams[]{{600, 550, 6000, 300, 33, 40, 40},
                    {3600, 550, 5500, 300, 27, 25, 20},
-                   {172800, 150, 850, 120, 6, 6, 3}};
+                   {172800, 150, 850, 110, 6, 6, 3}};
 
     for (const auto& testParam : testParams) {
         TGeneratorVec generators{periodic, tradingDays, level, ramp, sparse};

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -169,6 +169,19 @@ const std::string DIURNAL_COMPONENT_NAMES[] = {
     "weekend daily",  "weekend weekly", "weekday daily",
     "weekday weekly", "daily",          "weekly"};
 
+//! Fit and remove a constant from \p values.
+void removeLevel(TFloatMeanAccumulatorVec& values) {
+    TMeanAccumulator level;
+    for (const auto& value : values) {
+        level.add(CBasicStatistics::mean(value), CBasicStatistics::count(value));
+    }
+    for (auto& value : values) {
+        if (CBasicStatistics::count(value) > 0.0) {
+            CBasicStatistics::moment<0>(value) -= CBasicStatistics::mean(level);
+        }
+    }
+}
+
 //! Fit and remove a linear trend from \p values.
 void removeLinearTrend(TFloatMeanAccumulatorVec& values) {
     using TRegression = CLeastSquaresOnlineRegression<1, double>;
@@ -488,17 +501,21 @@ R residualVariance(const CONTAINER& trend, double scale) {
 }
 }
 
+CTrendHypothesis::CTrendHypothesis(std::size_t segments)
+    : m_Segments{segments} {
+}
+
+CTrendHypothesis::EType CTrendHypothesis::type() const {
+    return m_Segments == 0 ? E_None : (m_Segments == 1 ? E_Linear : E_PiecewiseLinear);
+}
+
+std::size_t CTrendHypothesis::segments() const {
+    return m_Segments;
+}
+
 bool CPeriodicityHypothesisTestsResult::
 operator==(const CPeriodicityHypothesisTestsResult& other) const {
     return m_Components == other.m_Components;
-}
-
-void CPeriodicityHypothesisTestsResult::piecewiseLinearTrend(bool value) {
-    m_PiecewiseLinearTrend = value;
-}
-
-bool CPeriodicityHypothesisTestsResult::piecewiseLinearTrend() const {
-    return m_PiecewiseLinearTrend;
 }
 
 void CPeriodicityHypothesisTestsResult::add(const std::string& description,
@@ -515,6 +532,32 @@ void CPeriodicityHypothesisTestsResult::add(const std::string& description,
 void CPeriodicityHypothesisTestsResult::remove(const TRemoveCondition& condition) {
     m_Components.erase(std::remove_if(m_Components.begin(), m_Components.end(), condition),
                        m_Components.end());
+}
+
+void CPeriodicityHypothesisTestsResult::trend(CTrendHypothesis value) {
+    m_Trend = value;
+}
+
+void CPeriodicityHypothesisTestsResult::removeTrend(TFloatMeanAccumulatorVec& values) const {
+    switch (m_Trend.type()) {
+    case CTrendHypothesis::E_None:
+        removeLevel(values);
+        break;
+    case CTrendHypothesis::E_Linear:
+        removeLinearTrend(values);
+        break;
+    case CTrendHypothesis::E_PiecewiseLinear:
+        values = CTimeSeriesSegmentation::removePiecewiseLinear(
+            values, CTimeSeriesSegmentation::piecewiseLinear(values));
+        break;
+    }
+}
+
+void CPeriodicityHypothesisTestsResult::removeDiscontinuities(TFloatMeanAccumulatorVec& values) const {
+    if (m_Trend.type() == CTrendHypothesis::E_PiecewiseLinear) {
+        values = CTimeSeriesSegmentation::removePiecewiseLinearDiscontinuities(
+            values, CTimeSeriesSegmentation::piecewiseLinear(values));
+    }
 }
 
 bool CPeriodicityHypothesisTestsResult::periodic() const {
@@ -557,11 +600,6 @@ CSeasonalTime* CPeriodicityHypothesisTestsResult::SComponent::seasonalTime() con
                                 s_Window.second, s_Period, s_Precedence);
     }
     return new CGeneralPeriodTime(s_Period, s_Precedence);
-}
-
-CPeriodicityHypothesisTestsConfig::CPeriodicityHypothesisTestsConfig()
-    : m_TestForDiurnal(true), m_HasDaily(false), m_HasWeekend(false),
-      m_HasWeekly(false), m_StartOfWeek(0) {
 }
 
 void CPeriodicityHypothesisTestsConfig::disableDiurnal() {
@@ -679,6 +717,9 @@ CPeriodicityHypothesisTestsResult CPeriodicityHypothesisTests::test() const {
 
     std::size_t numberHypotheses(segmentation.size() > 2 ? 3 : 2);
 
+    CTrendHypothesis trendHypotheses[]{CTrendHypothesis{0}, CTrendHypothesis{1},
+                                       CTrendHypothesis{segmentation.size()}};
+
     TTimeTimePr2Vec windowForTestingDaily(window(DAY));
     TTimeTimePr2Vec windowForTestingWeekly(window(WEEK));
     TTimeTimePr2Vec windowForTestingPeriod(window(m_Period));
@@ -720,9 +761,11 @@ CPeriodicityHypothesisTestsResult CPeriodicityHypothesisTests::test() const {
             this->hypothesesForPeriod(windowForTestingPeriod,
                                       bucketsForTestingPeriod[i], hypotheses_);
         }
+
+        CTrendHypothesis trendHypothesis{trendHypotheses[i]};
         std::for_each(hypotheses_.begin(), hypotheses_.end(),
-                      [&segmentation, i](CNestedHypotheses& hypothesis) {
-                          hypothesis.trendSegments(i < 2 ? 1 : segmentation.size() - 1);
+                      [&trendHypothesis](CNestedHypotheses& hypothesis) {
+                          hypothesis.trend(trendHypothesis);
                       });
 
         LOG_TRACE(<< "# hypotheses = " << hypotheses_.size());
@@ -2232,7 +2275,7 @@ bool CPeriodicityHypothesisTests::STestStats::nullHypothesisGoodEnough() const {
 }
 
 CPeriodicityHypothesisTests::CNestedHypotheses::CNestedHypotheses(TTestFunc test)
-    : m_Test(test), m_TrendSegments(1), m_AlwaysTestNested(false) {
+    : m_Test(test), m_AlwaysTestNested(false) {
 }
 
 CPeriodicityHypothesisTests::CNestedHypotheses::CBuilder
@@ -2256,21 +2299,21 @@ CPeriodicityHypothesisTests::CNestedHypotheses::test(STestStats& stats) const {
         for (const auto& child : m_Nested) {
             CPeriodicityHypothesisTestsResult childResult{child.test(stats)};
             if (result != childResult) {
-                childResult.piecewiseLinearTrend(m_TrendSegments > 1);
+                childResult.trend(m_Trend);
                 return childResult;
             }
         }
     }
-    result.piecewiseLinearTrend(m_TrendSegments > 1);
+    result.trend(m_Trend);
     return result;
 }
 
-void CPeriodicityHypothesisTests::CNestedHypotheses::trendSegments(std::size_t segments) {
-    m_TrendSegments = segments;
+void CPeriodicityHypothesisTests::CNestedHypotheses::trend(CTrendHypothesis value) {
+    m_Trend = value;
 }
 
 std::size_t CPeriodicityHypothesisTests::CNestedHypotheses::trendSegments() const {
-    return m_TrendSegments;
+    return m_Trend.segments();
 }
 
 CPeriodicityHypothesisTests::CNestedHypotheses::CBuilder::CBuilder(CNestedHypotheses& hypothesis) {

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -220,6 +220,7 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                                         double value,
                                         const maths_t::TDoubleWeightsAry& weights,
                                         const TComponentChangeCallback& componentChangeCallback) {
+
     if (CMathsFuncs::isFinite(value) == false) {
         LOG_ERROR("Discarding invalid value.");
         return;
@@ -262,6 +263,7 @@ bool CTimeSeriesDecomposition::applyChange(core_t::TTime time,
         m_Components.shiftLevel(time, value, change.s_Value[0]);
         break;
     case SChangeDescription::E_LinearScale:
+        m_PeriodicityTest.linearScale(time, change.s_Value[0]);
         m_Components.linearScale(time, change.s_Value[0]);
         break;
     case SChangeDescription::E_TimeShift: {

--- a/lib/maths/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/CTimeSeriesDecompositionStub.cc
@@ -36,10 +36,10 @@ bool CTimeSeriesDecompositionStub::initialized() const {
 void CTimeSeriesDecompositionStub::testingForChange(bool /*value*/) {
 }
 
-bool CTimeSeriesDecompositionStub::addPoint(core_t::TTime /*time*/,
+void CTimeSeriesDecompositionStub::addPoint(core_t::TTime /*time*/,
                                             double /*value*/,
-                                            const maths_t::TDoubleWeightsAry& /*weights*/) {
-    return false;
+                                            const maths_t::TDoubleWeightsAry& /*weights*/,
+                                            const TComponentChangeCallback& /*componentChangeCallback*/) {
 }
 
 bool CTimeSeriesDecompositionStub::applyChange(core_t::TTime /*time*/,
@@ -92,12 +92,8 @@ maths_t::TDoubleDoublePr CTimeSeriesDecompositionStub::scale(core_t::TTime /*tim
     return {1.0, 1.0};
 }
 
-bool CTimeSeriesDecompositionStub::mightAddComponents(core_t::TTime /*time*/) const {
-    return false;
-}
-
-CTimeSeriesDecompositionStub::TTimeFloatMeanAccumulatorPrVec
-CTimeSeriesDecompositionStub::windowValues() const {
+CTimeSeriesDecompositionStub::TFloatMeanAccumulatorVec
+CTimeSeriesDecompositionStub::windowValues(const TPredictor& /*predictor*/) const {
     return {};
 }
 

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1486,14 +1486,17 @@ CUnivariateTimeSeriesModel::applyChange(const SChangeDescription& change) {
     newTrendModel->decayRate(m_TrendModel->decayRate());
     newResidualModel->decayRate(m_ResidualModel->decayRate());
 
-    TTimeFloatMeanAccumulatorPrVec window(m_TrendModel->windowValues());
-
-    m_TrendModel = newTrendModel;
-    if (m_TrendModel->applyChange(timeOfChangePoint, valueAtChangePoint, change)) {
-        this->reinitializeStateGivenNewComponent(window);
+    if (newTrendModel->applyChange(timeOfChangePoint, valueAtChangePoint, change)) {
+        TFloatMeanAccumulatorVec window(m_TrendModel->windowValues([this](core_t::TTime time) {
+            return CBasicStatistics::mean(m_TrendModel->value(time, 0.0));
+        }));
+        TSizeVec segmentation{CTimeSeriesSegmentation::piecewiseLinear(window)};
+        this->reinitializeStateGivenNewComponent(
+            CTimeSeriesSegmentation::removePiecewiseLinear(std::move(window), segmentation));
     } else {
         m_ResidualModel = newResidualModel;
     }
+    m_TrendModel = newTrendModel;
 
     return E_Success;
 }
@@ -1521,32 +1524,27 @@ CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
                              samples[rhs].first, samples[rhs].second);
                      });
 
-    // Maybe get a window of historical values with which to reinitialize
-    // the residual model if new components of the time series decomposition
-    // are identified.
-    TTimeFloatMeanAccumulatorPrVec window;
-    for (auto i : timeorder) {
-        if (m_TrendModel->mightAddComponents(samples[i].first)) {
-            window = m_TrendModel->windowValues();
-            break;
-        }
-    }
-
     // Do the update.
+
+    TFloatMeanAccumulatorVec window;
+    auto componentChangeCallback = [&window, &result](TFloatMeanAccumulatorVec window_) {
+        window = std::move(window_);
+        result = E_Reset;
+    };
     for (auto i : timeorder) {
         core_t::TTime time{samples[i].first};
         double value{samples[i].second[0]};
         TDoubleWeightsAry weight{unpack(weights[i])};
-        if (m_TrendModel->addPoint(time, value, weight)) {
-            result = E_Reset;
-        }
+        m_TrendModel->addPoint(time, value, weight, componentChangeCallback);
     }
 
     if (result == E_Reset) {
         if (window.empty()) {
-            window = m_TrendModel->windowValues();
+            window = m_TrendModel->windowValues([this](core_t::TTime time) {
+                return CBasicStatistics::mean(m_TrendModel->value(time, 0.0));
+            });
         }
-        this->reinitializeStateGivenNewComponent(window);
+        this->reinitializeStateGivenNewComponent(std::move(window));
     }
 
     return result;
@@ -1610,9 +1608,7 @@ void CUnivariateTimeSeriesModel::appendPredictionErrors(double interval,
     }
 }
 
-void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(
-    const TTimeFloatMeanAccumulatorPrVec& initialValues) {
-    using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
+void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAccumulatorVec residuals) {
 
     // Reinitialize the residual model with any values we've been given. We
     // remove any trend we can fit accounting for step discontinuities and
@@ -1621,25 +1617,14 @@ void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(
 
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
 
-    if (initialValues.size() > 0) {
-        TFloatMeanAccumulatorVec samples;
-        samples.reserve(initialValues.size());
-        double totalWeight{0.0};
-
-        for (const auto& value : initialValues) {
-            CFloatStorage weight(CBasicStatistics::count(value.second));
-            samples.push_back(CBasicStatistics::momentsAccumulator(
-                weight, CFloatStorage(m_TrendModel->detrend(
-                            value.first, CBasicStatistics::mean(value.second), 0.0))));
-            totalWeight += weight;
-        }
-
-        TSizeVec segmentation{CTimeSeriesSegmentation::piecewiseLinear(samples)};
-        samples = CTimeSeriesSegmentation::removePiecewiseLinear(std::move(samples), segmentation);
-
+    if (residuals.size() > 0) {
+        double Z{std::accumulate(residuals.begin(), residuals.end(), 0.0,
+                                 [](double weight, const TFloatMeanAccumulator& sample) {
+                                     return weight + CBasicStatistics::count(sample);
+                                 })};
+        double weightScale{10.0 * std::max(this->params().learnRate(), 1.0) / Z};
         maths_t::TDoubleWeightsAry1Vec weights(1);
-        double weightScale{10.0 * std::max(this->params().learnRate(), 1.0) / totalWeight};
-        for (const auto& sample : samples) {
+        for (const auto& sample : residuals) {
             double weight(CBasicStatistics::count(sample));
             if (weight > 0.0) {
                 weights[0] = maths_t::countWeight(weightScale * weight);
@@ -2837,25 +2822,13 @@ CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& sample
                              samples[rhs].first, samples[rhs].second);
                      });
 
-    // Maybe get a window of historical values with which to reinitialize
-    // the residual model if new components of the time series decomposition
-    // are identified.
-    EUpdateResult result{E_Success};
-    TTimeFloatMeanAccumulatorPrVec10Vec window;
-    for (auto i : timeorder) {
-        core_t::TTime time{samples[i].first};
-        if (std::any_of(m_TrendModel.begin(), m_TrendModel.end(),
-                        [time](const TDecompositionPtr& model) {
-                            return model->mightAddComponents(time);
-                        })) {
-            for (std::size_t d = 0; d < dimension; ++d) {
-                window.push_back(m_TrendModel[d]->windowValues());
-            }
-            break;
-        }
-    }
-
     // Do the update.
+
+    EUpdateResult result;
+    auto componentChangeCallback = [&result](TFloatMeanAccumulatorVec) {
+        result = E_Reset;
+    };
+
     maths_t::TDoubleWeightsAry weight;
     for (auto i : timeorder) {
         core_t::TTime time{samples[i].first};
@@ -2864,19 +2837,18 @@ CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& sample
             for (std::size_t j = 0; j < maths_t::NUMBER_WEIGHT_STYLES; ++j) {
                 weight[j] = weights[i][j][d];
             }
-            if (m_TrendModel[d]->addPoint(time, value[d], weight)) {
-                result = E_Reset;
-            }
+            m_TrendModel[d]->addPoint(time, value[d], weight, componentChangeCallback);
         }
     }
 
     if (result == E_Reset) {
-        if (window.empty()) {
-            for (std::size_t d = 0; d < dimension; ++d) {
-                window.push_back(m_TrendModel[d]->windowValues());
-            }
+        TFloatMeanAccumulatorVec10Vec window(dimension);
+        for (std::size_t d = 0; d < dimension; ++d) {
+            window[d] = m_TrendModel[d]->windowValues([this, d](core_t::TTime time) {
+                return CBasicStatistics::mean(m_TrendModel[d]->value(time));
+            });
         }
-        this->reinitializeStateGivenNewComponent(window);
+        this->reinitializeStateGivenNewComponent(std::move(window));
     }
 
     return result;
@@ -2933,10 +2905,10 @@ void CMultivariateTimeSeriesModel::appendPredictionErrors(double interval,
     }
 }
 
-void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(
-    const TTimeFloatMeanAccumulatorPrVec10Vec& initialValues) {
+void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAccumulatorVec10Vec residuals) {
+
+    using TDoubleVec = std::vector<double>;
     using TDouble10VecVec = std::vector<TDouble10Vec>;
-    using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
 
     // Reinitialize the residual model with any values we've been given. We
     // remove any trend we can fit accounting for step discontinuities and
@@ -2945,45 +2917,34 @@ void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(
 
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
 
-    if (initialValues.size() > 0) {
+    if (residuals.size() > 0) {
         std::size_t dimension{this->dimension()};
 
         TDouble10VecVec samples;
-
+        TDoubleVec weights;
         for (std::size_t d = 0; d < dimension; ++d) {
-            TFloatMeanAccumulatorVec samplesForDimension;
-            samplesForDimension.reserve(initialValues[d].size());
+            TSizeVec segmentation{CTimeSeriesSegmentation::piecewiseLinear(residuals[d])};
+            residuals[d] = CTimeSeriesSegmentation::removePiecewiseLinear(
+                std::move(residuals[d]), segmentation);
 
-            for (const auto& value : initialValues[d]) {
-                samplesForDimension.push_back(CBasicStatistics::momentsAccumulator(
-                    CBasicStatistics::count(value.second),
-                    CFloatStorage(m_TrendModel[d]->detrend(
-                        value.first, CBasicStatistics::mean(value.second), 0.0))));
-            }
-
-            TSizeVec segmentation{CTimeSeriesSegmentation::piecewiseLinear(samplesForDimension)};
-            samplesForDimension = CTimeSeriesSegmentation::removePiecewiseLinear(
-                std::move(samplesForDimension), segmentation);
-
-            samplesForDimension.erase(
-                std::remove_if(samplesForDimension.begin(), samplesForDimension.end(),
-                               [](const TFloatMeanAccumulator& sample) {
-                                   return CBasicStatistics::count(sample) == 0.0;
-                               }),
-                samplesForDimension.end());
-
-            samples.resize(samplesForDimension.size(), TDouble10Vec(dimension));
-            for (std::size_t i = 0; i < samplesForDimension.size(); ++i) {
-                samples[i][d] = CBasicStatistics::mean(samplesForDimension[i]);
+            samples.resize(residuals[d].size(), TDouble10Vec(dimension));
+            weights.resize(residuals[d].size(), std::numeric_limits<double>::max());
+            for (std::size_t i = 0; i < residuals[d].size(); ++i) {
+                samples[i][d] = CBasicStatistics::mean(residuals[d][i]);
+                weights[i] = std::min(
+                    weights[i],
+                    static_cast<double>(CBasicStatistics::count(residuals[d][i])));
             }
         }
 
-        maths_t::TDouble10VecWeightsAry1Vec weight{
-            maths_t::countWeight(10.0 * std::max(this->params().learnRate(), 1.0) /
-                                     static_cast<double>(samples.size()),
-                                 dimension)};
-        for (const auto& sample : samples) {
-            m_ResidualModel->addSamples({sample}, weight);
+        double Z{std::accumulate(weights.begin(), weights.end(), 0.0)};
+        double weightScale{10.0 * std::max(this->params().learnRate(), 1.0) / Z};
+        maths_t::TDouble10VecWeightsAry1Vec weight(1);
+        for (std::size_t i = 0; i < samples.size(); ++i) {
+            if (weights[i] > 0.0) {
+                weight[0] = maths_t::countWeight(weightScale * weights[i], dimension);
+                m_ResidualModel->addSamples({samples[i]}, weight);
+            }
         }
     }
 

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1611,7 +1611,6 @@ void CUnivariateTimeSeriesModel::appendPredictionErrors(double interval,
 void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAccumulatorVec residuals) {
 
     // Reinitialize the residual model with any values we've been given. We
-    // remove any trend we can fit accounting for step discontinuities and
     // re-weight so that the total sample weight corresponds to the sample
     // weight the model receives from a fixed (shortish) time interval.
 
@@ -1629,11 +1628,11 @@ void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAc
                                  })};
         double weightScale{10.0 * std::max(this->params().learnRate(), 1.0) / Z};
         maths_t::TDoubleWeightsAry1Vec weights(1);
-        for (const auto& sample : residuals) {
-            double weight(CBasicStatistics::count(sample));
+        for (const auto& residual : residuals) {
+            double weight(CBasicStatistics::count(residual));
             if (weight > 0.0) {
                 weights[0] = maths_t::countWeight(weightScale * weight);
-                m_ResidualModel->addSamples({CBasicStatistics::mean(sample)}, weights);
+                m_ResidualModel->addSamples({CBasicStatistics::mean(residual)}, weights);
             }
         }
     }
@@ -2918,7 +2917,6 @@ void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMean
     using TDouble10VecVec = std::vector<TDouble10Vec>;
 
     // Reinitialize the residual model with any values we've been given. We
-    // remove any trend we can fit accounting for step discontinuities and
     // re-weight so that the total sample weight corresponds to the sample
     // weight the model receives from a fixed (shortish) time interval.
 

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -167,7 +167,7 @@ void CForecastTest::testDailyConstantLongTermTrend() {
                y[i] + noise;
     };
 
-    this->test(trend, bucketLength, 63, 64.0, 11.0, 0.02);
+    this->test(trend, bucketLength, 63, 64.0, 10.0, 0.016);
 }
 
 void CForecastTest::testDailyVaryingLongTermTrend() {
@@ -192,7 +192,7 @@ void CForecastTest::testDailyVaryingLongTermTrend() {
                8.0 * std::sin(boost::math::double_constants::two_pi * time_ / 43200.0) + noise;
     };
 
-    this->test(trend, bucketLength, 98, 9.0, 9.0, 0.04);
+    this->test(trend, bucketLength, 98, 9.0, 7.0, 0.043);
 }
 
 void CForecastTest::testComplexNoLongTermTrend() {
@@ -208,7 +208,7 @@ void CForecastTest::testComplexNoLongTermTrend() {
         return scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 24.0, 6.0, 0.13);
+    this->test(trend, bucketLength, 63, 24.0, 5.0, 0.14);
 }
 
 void CForecastTest::testComplexConstantLongTermTrend() {
@@ -225,7 +225,7 @@ void CForecastTest::testComplexConstantLongTermTrend() {
                scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 24.0, 4.0, 0.01);
+    this->test(trend, bucketLength, 63, 24.0, 5.0, 0.01);
 }
 
 void CForecastTest::testComplexVaryingLongTermTrend() {
@@ -255,7 +255,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 4.0, 15.0, 0.03);
+    this->test(trend, bucketLength, 63, 4.0, 15.0, 0.04);
 }
 
 void CForecastTest::testNonNegative() {

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -1831,10 +1831,10 @@ void CTimeSeriesDecompositionTest::testYearly() {
         meanError.add(error);
         debug.addValue(time, trend);
         debug.addPrediction(time, prediction, trend - prediction);
-        if (time / HOUR % 40 == 0 || error > 0.18) {
+        if (time / HOUR % 40 == 0 || error > 0.19) {
             LOG_DEBUG(<< "error = " << error);
         }
-        CPPUNIT_ASSERT(error < 0.18);
+        CPPUNIT_ASSERT(error < 0.19);
     }
 
     LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -59,9 +59,6 @@ using TMeanAccumulator2Vec = core::CSmallVector<TMeanAccumulator, 2>;
 using TFloatMeanAccumulator =
     maths::CBasicStatistics::SSampleMean<maths::CFloatStorage>::TAccumulator;
 using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
-using TTimeFloatMeanAccumulatorPrVec =
-    std::vector<std::pair<core_t::TTime, TFloatMeanAccumulator>>;
-using TTimeFloatMeanAccumulatorPrVecVec = std::vector<TTimeFloatMeanAccumulatorPrVec>;
 using TDecompositionPtr = std::shared_ptr<maths::CTimeSeriesDecompositionInterface>;
 using TDecompositionPtr10Vec = core::CSmallVector<TDecompositionPtr, 10>;
 using TDecayRateController2Ary = maths::CUnivariateTimeSeriesModel::TDecayRateController2Ary;
@@ -174,96 +171,82 @@ decayRateControllers(std::size_t dimension) {
                                          dimension)}};
 }
 
-void reinitialize(const TTimeFloatMeanAccumulatorPrVec& window,
-                  maths::CTimeSeriesDecomposition& trend,
-                  maths::CPrior& prior,
-                  TDecayRateController2Ary* controllers = nullptr) {
+auto makeComponentDetectedCallback(maths::CPrior& prior,
+                                   TDecayRateController2Ary* controllers = nullptr) {
 
-    prior.setToNonInformative(0.0, prior.decayRate());
+    return [&prior, controllers](TFloatMeanAccumulatorVec residuals) {
 
-    double totalWeight{0.0};
-    TFloatMeanAccumulatorVec samples;
-    samples.reserve(window.size());
+        prior.setToNonInformative(0.0, prior.decayRate());
 
-    for (const auto& value : window) {
-        double weight(maths::CBasicStatistics::count(value.second));
-        samples.push_back(maths::CBasicStatistics::momentsAccumulator(
-            maths::CFloatStorage(weight),
-            maths::CFloatStorage(trend.detrend(
-                value.first, maths::CBasicStatistics::mean(value.second), 0.0))));
-        totalWeight += weight;
-    }
-
-    TSizeVec segmentation{maths::CTimeSeriesSegmentation::piecewiseLinear(samples)};
-    samples = maths::CTimeSeriesSegmentation::removePiecewiseLinear(
-        std::move(samples), segmentation);
-
-    maths_t::TDoubleWeightsAry1Vec weight(1);
-    for (const auto& sample : samples) {
-        weight[0] = maths_t::countWeight(10.0 / totalWeight *
-                                         maths::CBasicStatistics::count(sample));
-        prior.addSamples({maths::CBasicStatistics::mean(sample)}, weight);
-    }
-    if (controllers) {
-        prior.decayRate(prior.decayRate() / (*controllers)[1].multiplier());
-        (*controllers)[0].reset();
-        (*controllers)[1].reset();
-    }
+        if (residuals.size() > 0) {
+            double Z{std::accumulate(
+                residuals.begin(), residuals.end(), 0.0,
+                [](double weight, const TFloatMeanAccumulator& sample) {
+                    return weight + maths::CBasicStatistics::count(sample);
+                })};
+            double weightScale{10.0 / Z};
+            maths_t::TDoubleWeightsAry1Vec weights(1);
+            for (const auto& residual : residuals) {
+                double weight(maths::CBasicStatistics::count(residual));
+                if (weight > 0.0) {
+                    weights[0] = maths_t::countWeight(weightScale * weight);
+                    prior.addSamples({maths::CBasicStatistics::mean(residual)}, weights);
+                }
+            }
+        }
+        if (controllers != nullptr) {
+            prior.decayRate(prior.decayRate() / (*controllers)[1].multiplier());
+            (*controllers)[0].reset();
+            (*controllers)[1].reset();
+        }
+    };
 }
 
-TTimeFloatMeanAccumulatorPrVecVec
-reinitializationWindow(core_t::TTime time, const TDecompositionPtr10Vec& trends) {
-    TTimeFloatMeanAccumulatorPrVecVec window;
-    for (std::size_t d = 0; d < trends.size(); ++d) {
-        window.push_back(trends[d]->mightAddComponents(time)
-                             ? trends[d]->windowValues()
-                             : TTimeFloatMeanAccumulatorPrVec{});
-    }
-    return window;
-}
+void reinitializeResidualModel(TDecompositionPtr10Vec& trends,
+                               maths::CMultivariatePrior& prior,
+                               TDecayRateController2Ary* controllers = nullptr) {
 
-void reinitialize(const TTimeFloatMeanAccumulatorPrVecVec& window,
-                  TDecompositionPtr10Vec& trends,
-                  maths::CMultivariatePrior& prior,
-                  TDecayRateController2Ary* controllers = nullptr) {
+    using TFloatMeanAccumulatorVecVec = std::vector<TFloatMeanAccumulatorVec>;
 
     std::size_t dimension{prior.dimension()};
-    prior.setToNonInformative(0.0, prior.decayRate());
 
-    TDouble10Vec1Vec samples;
-
+    TFloatMeanAccumulatorVecVec residuals(dimension);
     for (std::size_t d = 0; d < dimension; ++d) {
-        TFloatMeanAccumulatorVec samplesForDimension;
-        samplesForDimension.reserve(window[d].size());
-
-        for (const auto& value : window[d]) {
-            samplesForDimension.push_back(maths::CBasicStatistics::momentsAccumulator(
-                maths::CBasicStatistics::count(value.second),
-                maths::CFloatStorage(trends[d]->detrend(
-                    value.first, maths::CBasicStatistics::mean(value.second), 0.0))));
-        }
-
-        TSizeVec segmentation{maths::CTimeSeriesSegmentation::piecewiseLinear(samplesForDimension)};
-        samplesForDimension = maths::CTimeSeriesSegmentation::removePiecewiseLinear(
-            std::move(samplesForDimension), segmentation);
-
-        samplesForDimension.erase(
-            std::remove_if(samplesForDimension.begin(), samplesForDimension.end(),
-                           [](const TFloatMeanAccumulator& sample) {
-                               return maths::CBasicStatistics::count(sample) == 0.0;
-                           }),
-            samplesForDimension.end());
-
-        samples.resize(samplesForDimension.size(), TDouble10Vec(dimension));
-        for (std::size_t i = 0; i < samplesForDimension.size(); ++i) {
-            samples[i][d] = maths::CBasicStatistics::mean(samplesForDimension[i]);
-        }
+        residuals[d] = trends[d]->windowValues([&trends, d](core_t::TTime time) {
+            return maths::CBasicStatistics::mean(trends[d]->value(time));
+        });
     }
 
-    maths_t::TDouble10VecWeightsAry1Vec weight{
-        maths_t::countWeight(10.0 / static_cast<double>(samples.size()), dimension)};
-    for (const auto& sample : samples) {
-        prior.addSamples({sample}, weight);
+    prior.setToNonInformative(0.0, prior.decayRate());
+
+    if (residuals.size() > 0) {
+        TDouble10Vec1Vec samples;
+        TDoubleVec weights;
+        for (std::size_t d = 0; d < dimension; ++d) {
+            TSizeVec segmentation{
+                maths::CTimeSeriesSegmentation::piecewiseLinear(residuals[d])};
+            residuals[d] = maths::CTimeSeriesSegmentation::removePiecewiseLinear(
+                std::move(residuals[d]), segmentation);
+
+            samples.resize(residuals[d].size(), TDouble10Vec(dimension));
+            weights.resize(residuals[d].size(), std::numeric_limits<double>::max());
+            for (std::size_t i = 0; i < residuals[d].size(); ++i) {
+                samples[i][d] = maths::CBasicStatistics::mean(residuals[d][i]);
+                weights[i] = std::min(
+                    weights[i],
+                    static_cast<double>(maths::CBasicStatistics::count(residuals[d][i])));
+            }
+        }
+
+        double Z{std::accumulate(weights.begin(), weights.end(), 0.0)};
+        double weightScale{10.0 / Z};
+        maths_t::TDouble10VecWeightsAry1Vec weight(1);
+        for (std::size_t i = 0; i < samples.size(); ++i) {
+            if (weights[i] > 0.0) {
+                weight[0] = maths_t::countWeight(weightScale * weights[i], dimension);
+                prior.addSamples({samples[i]}, weight);
+            }
+        }
     }
 
     if (controllers) {
@@ -462,12 +445,8 @@ void CTimeSeriesModelTest::testMode() {
             model.addSamples(addSampleParams(unit),
                              {core::make_triple(time, TDouble2Vec{sample}, TAG)});
 
-            auto window = trend.mightAddComponents(time)
-                              ? trend.windowValues()
-                              : TTimeFloatMeanAccumulatorPrVec{};
-            if (trend.addPoint(time, sample)) {
-                reinitialize(window, trend, prior);
-            }
+            trend.addPoint(time, sample, maths_t::CUnitWeights::UNIT,
+                           makeComponentDetectedCallback(prior));
 
             prior.addSamples({trend.detrend(time, sample, 0.0)},
                              maths_t::CUnitWeights::SINGLE_UNIT);
@@ -567,16 +546,18 @@ void CTimeSeriesModelTest::testMode() {
             model.addSamples(addSampleParams(weights),
                              {core::make_triple(time, TDouble2Vec(sample), TAG)});
 
-            auto window = reinitializationWindow(time, trends);
+            bool reinitialize{false};
 
-            bool shouldReinitialize{false};
             TDouble10Vec1Vec detrended{TDouble10Vec(3)};
-            for (std::size_t i = 0u; i < sample.size(); ++i) {
-                shouldReinitialize |= trends[i]->addPoint(time, sample[i]);
+            for (std::size_t i = 0; i < sample.size(); ++i) {
+                trends[i]->addPoint(time, sample[i], maths_t::CUnitWeights::UNIT,
+                                    [&reinitialize](TFloatMeanAccumulatorVec) {
+                                        reinitialize = true;
+                                    });
                 detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0);
             }
-            if (shouldReinitialize) {
-                reinitialize(window, trends, prior);
+            if (reinitialize) {
+                reinitializeResidualModel(trends, prior);
             }
 
             prior.addSamples(detrended,
@@ -830,13 +811,8 @@ void CTimeSeriesModelTest::testAddSamples() {
 
             model.addSamples(addSampleParams(weights), sample_);
 
-            auto window = trend.mightAddComponents(time)
-                              ? trend.windowValues()
-                              : TTimeFloatMeanAccumulatorPrVec{};
-            if (trend.addPoint(time, sample)) {
-                trend.decayRate(trend.decayRate() / controllers[0].multiplier());
-                reinitialize(window, trend, prior, &controllers);
-            }
+            trend.addPoint(time, sample, maths_t::CUnitWeights::UNIT,
+                           makeComponentDetectedCallback(prior, &controllers));
 
             double detrended{trend.detrend(time, sample, 0.0)};
             prior.addSamples({detrended}, maths_t::CUnitWeights::SINGLE_UNIT);
@@ -904,20 +880,21 @@ void CTimeSeriesModelTest::testAddSamples() {
             model.addSamples(addSampleParams(weights),
                              {core::make_triple(time, TDouble2Vec(sample), TAG)});
 
-            auto window = reinitializationWindow(time, trends);
-
             bool hasTrend{false};
-            bool shouldReinitialize{false};
+            bool reinitialize{false};
 
             for (std::size_t i = 0u; i < sample.size(); ++i) {
-                shouldReinitialize |= trends[i]->addPoint(time, sample[i]);
+                trends[i]->addPoint(time, sample[i], maths_t::CUnitWeights::UNIT,
+                                    [&reinitialize](TFloatMeanAccumulatorVec) {
+                                        reinitialize = true;
+                                    });
                 detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0);
                 mean[i] = trends[i]->meanValue(time);
                 hasTrend |= true;
             }
 
-            if (shouldReinitialize) {
-                reinitialize(window, trends, prior, &controllers);
+            if (reinitialize) {
+                reinitializeResidualModel(trends, prior, &controllers);
             }
 
             prior.addSamples(detrended,
@@ -983,12 +960,8 @@ void CTimeSeriesModelTest::testPredict() {
             model.addSamples(addSampleParams(weights),
                              {core::make_triple(time, TDouble2Vec{sample}, TAG)});
 
-            auto window = trend.mightAddComponents(time)
-                              ? trend.windowValues()
-                              : TTimeFloatMeanAccumulatorPrVec{};
-            if (trend.addPoint(time, sample)) {
-                reinitialize(window, trend, prior);
-            }
+            trend.addPoint(time, sample, maths_t::CUnitWeights::UNIT,
+                           makeComponentDetectedCallback(prior));
 
             prior.addSamples({trend.detrend(time, sample, 0.0)},
                              maths_t::CUnitWeights::SINGLE_UNIT);
@@ -1081,16 +1054,18 @@ void CTimeSeriesModelTest::testPredict() {
             model.addSamples(addSampleParams(weights),
                              {core::make_triple(time, TDouble2Vec(sample), TAG)});
 
-            auto window = reinitializationWindow(time, trends);
+            bool reinitialize{false};
 
-            bool shouldReinitialize{false};
             TDouble10Vec detrended;
-            for (std::size_t i = 0u; i < sample.size(); ++i) {
-                shouldReinitialize |= trends[i]->addPoint(time, sample[i]);
+            for (std::size_t i = 0; i < sample.size(); ++i) {
+                trends[i]->addPoint(time, sample[i], maths_t::CUnitWeights::UNIT,
+                                    [&reinitialize](TFloatMeanAccumulatorVec) {
+                                        reinitialize = true;
+                                    });
                 detrended.push_back(trends[i]->detrend(time, sample[i], 0.0));
             }
-            if (shouldReinitialize) {
-                reinitialize(window, trends, prior);
+            if (reinitialize) {
+                reinitializeResidualModel(trends, prior);
             }
 
             prior.addSamples({detrended},

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2281,7 +2281,7 @@ void CMetricModelTest::testDecayRateControl() {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanPredictionError) <
-                       0.7 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                       0.72 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 


### PR DESCRIPTION
Following on from #489, the same data set showed up some improvements we can make to the detection and initialisation of new seasonal components, the seeding of the residual model when new components are detected and instabilities associated with ageing out old data. To that end, this PR makes the following changes:
1. Improve the handling of linear scaling events when testing for new seasonal components and
2. Preprocess the window values to match correctly match the best trend hypothesis from the test,
3. Use a callback to correctly seed the residual model from the test window.
4. Avoid an instability associated with allowing the seasonal component decay rate to become too large with respect to its period.