### PR TITLE
[ML][7.3] Upgrade the Apache Portable Runtime libraries

### DIFF
--- a/3rd_party/3rd_party.sh
+++ b/3rd_party/3rd_party.sh
@@ -64,9 +64,8 @@ case `uname` in
                 LOG4CXX_EXTENSION=.so.10
                 XML_LOCATION=/usr/local/gcc73/lib
                 XML_EXTENSION=.so.2
-                # Ship the version of expat that came with the apr-util library
                 EXPAT_LOCATION=/usr/local/gcc73/lib
-                EXPAT_EXTENSION=.so.0
+                EXPAT_EXTENSION=.so.1
                 GCC_RT_LOCATION=/usr/local/gcc73/lib64
                 GCC_RT_EXTENSION=.so.1
                 STL_LOCATION=/usr/local/gcc73/lib64
@@ -85,9 +84,8 @@ case `uname` in
                 LOG4CXX_EXTENSION=.so.10
                 XML_LOCATION=/usr/local/lib
                 XML_EXTENSION=.so.2
-                # Ship the version of expat that came with the apr-util library
                 EXPAT_LOCATION=/usr/local/lib
-                EXPAT_EXTENSION=.so.0
+                EXPAT_EXTENSION=.so.1
                 GCC_RT_LOCATION=
                 STL_LOCATION=
                 ATOMIC_LOCATION=

--- a/3rd_party/licenses/apr-INFO.csv
+++ b/3rd_party/licenses/apr-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright
-Apache Portable Runtime Library,1.5.2,,https://apr.apache.org,Apache-2.0,Copyright (c) 2000-2015 The Apache Software Foundation
+Apache Portable Runtime Library,1.7.0,,https://apr.apache.org,Apache-2.0,Copyright (c) 2000-2019 The Apache Software Foundation

--- a/3rd_party/licenses/apr-NOTICE.txt
+++ b/3rd_party/licenses/apr-NOTICE.txt
@@ -1,7 +1,7 @@
 Apache Portable Runtime
-Copyright (c) 2009 The Apache Software Foundation.
+Copyright (c) 2000-2019 The Apache Software Foundation.
 
-This product includes software developed by
+This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 Portions of this software were developed at the National Center

--- a/3rd_party/licenses/apr-iconv-INFO.csv
+++ b/3rd_party/licenses/apr-iconv-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright
-Apache Portable Runtime Iconv Library,1.2.1,,https://apr.apache.org,Apache-2.0,Copyright (c) 2000 Konstantin Chuguev
+Apache Portable Runtime Iconv Library,1.2.2,,https://apr.apache.org,Apache-2.0,Copyright (c) 2000-2017 The Apache Software Foundation

--- a/3rd_party/licenses/apr-iconv-NOTICE.txt
+++ b/3rd_party/licenses/apr-iconv-NOTICE.txt
@@ -1,2 +1,5 @@
-This product includes software developed by
+Apache Portable Runtime ICONV Charset Conversion Library
+Copyright (c) 2000-2017 The Apache Software Foundation.
+
+This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/3rd_party/licenses/apr-util-INFO.csv
+++ b/3rd_party/licenses/apr-util-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright
-Apache Portable Runtime Utility Library,1.5.4,,https://apr.apache.org,Apache-2.0,Copyright (c) 2000-2014 The Apache Software Foundation
+Apache Portable Runtime Utility Library,1.6.1,,https://apr.apache.org,Apache-2.0,Copyright (c) 2000-2016 The Apache Software Foundation

--- a/3rd_party/licenses/apr-util-NOTICE.txt
+++ b/3rd_party/licenses/apr-util-NOTICE.txt
@@ -1,7 +1,7 @@
 Apache Portable Runtime Utility Library
-Copyright (c) 2009 The Apache Software Foundation.
+Copyright (c) 2000-2016 The Apache Software Foundation.
 
-This product includes software developed by
+This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 Portions of this software were developed at the National Center

--- a/3rd_party/licenses/expat-INFO.csv
+++ b/3rd_party/licenses/expat-INFO.csv
@@ -1,0 +1,2 @@
+name,version,revision,url,license,copyright
+Expat,2.2.6,39e487da353b20bb3a724311d179ba0fddffc65b,https://github.com/libexpat/libexpat,MIT,Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper and Copyright (c) 2001-2017 Expat maintainers

--- a/3rd_party/licenses/expat-LICENSE.txt
+++ b/3rd_party/licenses/expat-LICENSE.txt
@@ -1,0 +1,21 @@
+Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
+Copyright (c) 2001-2017 Expat maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -150,14 +150,32 @@ sudo make install
 
 to install.
 
-### APR
+### expat
 
-For Linux, before building log4cxx you must download the Apache Portable Runtime (APR) from <http://archive.apache.org/dist/apr/apr-1.5.2.tar.bz2>.
+Download expat from <https://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2>.
 
 Extract the tarball to a temporary directory:
 
 ```
-tar jxvf apr-1.5.2.tar.bz2
+tar jxvf expat-2.2.6.tar.bz2
+```
+
+Then build using:
+
+```
+./configure --prefix=/usr/local/gcc73 --without-docbook
+make
+sudo make install
+```
+
+### APR
+
+For Linux, before building log4cxx you must download the Apache Portable Runtime (APR) from <http://archive.apache.org/dist/apr/apr-1.7.0.tar.bz2>.
+
+Extract the tarball to a temporary directory:
+
+```
+tar jxvf apr-1.7.0.tar.bz2
 ```
 
 We want to avoid a dependency on the operating system `libcrypt`, as this may not be available in all Linux distributions.  Therefore, before building, in `configure` change:
@@ -194,12 +212,12 @@ sudo make install
 
 ### APR utilities
 
-For Linux, before building log4cxx you must download the Apache Portable Runtime (APR) utilities from <http://archive.apache.org/dist/apr/apr-util-1.5.4.tar.bz2>.
+For Linux, before building log4cxx you must download the Apache Portable Runtime (APR) utilities from <http://archive.apache.org/dist/apr/apr-util-1.6.1.tar.bz2>.
 
 Extract the tarball to a temporary directory:
 
 ```
-tar jxvf apr-util-1.5.4.tar.bz2
+tar jxvf apr-util-1.6.1.tar.bz2
 ```
 
 We want to avoid a dependency on the operating system `libcrypt`, as this may not be available in all Linux distributions.  Therefore, before building, in `configure` change:
@@ -229,7 +247,7 @@ to:
 Then build using:
 
 ```
-./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=builtin
+./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=/usr/local/gcc73
 make
 sudo make install
 ```

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -159,22 +159,47 @@ nmake
 nmake install
 ```
 
+### expat
+
+Download expat from <https://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2>.
+
+Extract it in a Git bash shell using the GNU tar that comes with Git for Windows, e.g.:
+
+```
+cd /c/tools
+tar jxvf /z/cpp_src/expat-2.2.6.tar.bz2
+```
+
+Double click `C:\tools\expat-2.2.6\expat.sln`. Visual Studio 2017 should load.
+
+Select "Release" in the "Solution Configurations" dropdown and "x64" in the "Solution Platforms" dropdown.
+
+Right click on "expat_static" on the right hand side of the screen and choose "Properties...".  Then in the dialog box, go to Configuration Properties -&gt; C/C++ -&gt; Code Generation and change "Runtime Library" to "Multi-threaded DLL (/MD)".  Also go to Configuration Properties -&gt; Librarian -&gt; General and change "Output File" from "..\win32\bin\Release\libexpatMT.lib" to "..\x64\bin\Release\libexpatMD.lib".  Then click "OK".
+
+Build the static library by right clicking "expat_static" again and choosing "Build".
+
+Then from `C:\tools\expat-2.2.6\x64\bin\Release` manually copy `libexpatMD.lib` into `C:\usr\local\lib`, and from `C:\tools\expat-2.2.6\lib` manually copy `expat.h` and `expat_external.h` into `C:\usr\local\include`.
+
 ### APR
 
-Download the Windows source for version 1.5.2 of the Apache Portable Runtime (APR) from <http://archive.apache.org/dist/apr/apr-1.5.2-win32-src.zip>.
+Download the Windows source for version 1.7.0 of the Apache Portable Runtime (APR) from <http://archive.apache.org/dist/apr/apr-1.7.0-win32-src.zip>.
 
-Unzip the file into `C:\tools`. You should end up with a subdirectory called `apr-1.5.2`. Rename this to simply `apr`.
+Unzip the file into `C:\tools`. You should end up with a subdirectory called `apr-1.7.0`. Rename this to simply `apr`.
 
-Within the files `C:\tools\apr\apr.mak` and `C:\tools\apr\libapr.mak`, globally replace:
-
-```
-/D "WIN32"
-```
-
-with:
+Edit `C:\tools\apr\include\apr.hw` and change lines 87-89 from:
 
 ```
-/D "WIN32" /D_WIN32_WINNT=0x0601
+/* Restrict the server to a subset of Windows XP header files by default
+ */
+#define _WIN32_WINNT 0x0501
+```
+
+to:
+
+```
+/* Restrict the server to a subset of Windows 7 header files by default
+ */
+#define _WIN32_WINNT 0x0601
 ```
 
 Start a command prompt using Start Menu -&gt; Apps -&gt; Visual Studio 2017 -&gt; x64 Native Tools Command Prompt for VS 2017, then in it type:
@@ -183,69 +208,25 @@ Start a command prompt using Start Menu -&gt; Apps -&gt; Visual Studio 2017 -&gt
 cd C:\tools\apr
 copy include\apr.hw include\apr.h
 copy include\apr.hw apr.h
-nmake -f Makefile.win ARCH="x64 Release"
+nmake -f Makefile.win ARCH="x64 Release" buildall
 nmake -f Makefile.win PREFIX=C:\usr\local ARCH="x64 Release" install
 ```
 
 ### APR iconv
 
-Download the Windows source for version 1.2.1 of the Apache Portable Runtime (APR) version of iconv from <http://archive.apache.org/dist/apr/apr-iconv-1.2.1-win32-src.zip>.
+Download the Windows source for version 1.2.2 of the Apache Portable Runtime (APR) version of iconv from <http://archive.apache.org/dist/apr/apr-iconv-1.2.2-win32-src.zip>.
 
-Unzip the file into `C:\tools`. You should end up with a subdirectory called `apr-iconv-1.2.1`. Rename this to simply `apr-iconv`.
+Unzip the file into `C:\tools`. You should end up with a subdirectory called `apr-iconv-1.2.2`. Rename this to simply `apr-iconv`.
 
-Within the files `C:\tools\apr-iconv\apriconv.mak` and `C:\tools\apr-iconv\libapriconv.mak`, globally replace:
-
-```
-/D "WIN32"
-```
-
-with:
-
-```
-/D "WIN32" /D_WIN32_WINNT=0x0601
-```
-
-Also, from the same two `.mak` files completely remove the following options:
-
-- `/Fp"$(INTDIR)\apriconv.pch" /Yc"iconv.h"`
-- `/Fp"$(INTDIR)\apriconv.pch" /Yu"iconv.h"`
-- `/Fp"$(INTDIR)\libapriconv.pch" /Yc"iconv.h"`
-- `/Fp"$(INTDIR)\libapriconv.pch" /Yu"iconv.h"`
-
-Finally, completely remove the following options from `C:\tools\apr-iconv\build\modules.mk.win`:
-
-- `/Fp$(MODRES).pch`
-- `/Yciconv.h`
-- `/Yuiconv.h`
-
-Start a command prompt using Start Menu -&gt; Apps -&gt; Visual Studio 2017 -&gt; x64 Native Tools Command Prompt for VS 2017, then in it type:
-
-```
-cd C:\tools\apr-iconv
-nmake -f apriconv.mak CFG="apriconv - x64 Release"
-```
-
-Note that this does not install all the iconv utilities - this will be done when you build the APR utility library, which you must do next.
+Note that this does not install the iconv utilities - this will be done when you build the APR utility library, which you must do next.
 
 ### APR util
 
-Download the Windows source for version 1.5.4 of the Apache Portable Runtime (APR) utilities from <http://archive.apache.org/dist/apr/apr-util-1.5.4-win32-src.zip>.
+Download the Windows source for version 1.6.1 of the Apache Portable Runtime (APR) utilities from <http://archive.apache.org/dist/apr/apr-util-1.6.1-win32-src.zip>.
 
-Unzip the file into `C:\tools`. You should end up with a subdirectory called `apr-util-1.5.4`. Rename this to simply `apr-util`.
+Unzip the file into `C:\tools`. You should end up with a subdirectory called `apr-util-1.6.1`. Rename this to simply `apr-util`.
 
-Within the files `C:\tools\apr-util\aprutil.mak` and `C:\tools\apr-util\libaprutil.mak`, globally replace:
-
-```
-/D "WIN32"
-```
-
-with:
-
-```
-/D "WIN32" /D_WIN32_WINNT=0x0601
-```
-
-Right-click on the directory `C:\tools\apr-util\xml`, go to Properties -&gt; Security -&gt; CREATOR OWNER -&gt; Edit..., check Full Control -&gt; Allow and then OK all the open dialog boxes.
+In both `C:\tools\apr-util\apr-util.mak` and `C:\tools\apr-util\libaprutil.mak` globally replace `./xml/expat/lib` with `../expat-2.2.6/lib`.
 
 Start a command prompt using Start Menu -&gt; Apps -&gt; Visual Studio 2017 -&gt; x64 Native Tools Command Prompt for VS 2017, then in it type:
 
@@ -254,8 +235,8 @@ cd C:\tools\apr-util
 copy include\apr_ldap.hw include\apr-ldap.h
 copy include\apu.hw include\apu.h
 copy include\apu_want.hw include\apr_want.h
-nmake -f Makefile.win ARCH="x64 Release"
-nmake -f Makefile.win PREFIX=C:\usr\local ARCH="x64 Release" install
+nmake -f Makefile.win XML_PARSER=..\expat-2.2.6\x64\bin\Release\libexpatMD ARCH="x64 Release" buildall
+nmake -f Makefile.win XML_PARSER=..\expat-2.2.6\x64\bin\Release\libexpatMD PREFIX=C:\usr\local ARCH="x64 Release" install
 ```
 
 It is extremely important with this library that it is NOT linked to all sorts of unnecessary 3rd party libraries that we don't need (some of which are GPL). Therefore, once the build is complete, use `dumpbin` to confirm that `libaprutil-1.dll` does NOT have dependencies like MySQL, PostgreSQL, Berkeley DB, GNU DB Manager, LDAP, SQLite or ODBC. If it does, do the build again having first researched why the extra databases were linked.

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -17,7 +17,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=8
+VERSION=9
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:8
+FROM docker.elastic.co/ml-dev/ml-linux-build:9
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -51,29 +51,39 @@ RUN \
   cd .. && \
   rm -rf libxml2-2.9.4
 
+# Build expat
+RUN \
+  wget --quiet -O - http://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2 | tar jxf - && \
+  cd expat-2.2.6 && \
+  ./configure --prefix=/usr/local/gcc73 && \
+  make -j`grep -c '^processor' /proc/cpuinfo` && \
+  make install && \
+  cd .. && \
+  rm -rf expat-2.2.6
+
 # Build APR
 RUN \
-  wget --quiet -O - http://archive.apache.org/dist/apr/apr-1.5.2.tar.bz2 | tar jxf - && \
-  cd apr-1.5.2 && \
+  wget --quiet -O - http://archive.apache.org/dist/apr/apr-1.7.0.tar.bz2 | tar jxf - && \
+  cd apr-1.7.0 && \
   sed -i -e "s/for ac_lib in '' crypt ufc; do/for ac_lib in ''; do/" configure && \
   sed -i -e 's/#define APR_HAVE_CRYPT_H         @crypth@/#define APR_HAVE_CRYPT_H         0/' include/apr.h.in && \
   ./configure --prefix=/usr/local/gcc73 && \
   make -j`grep -c '^processor' /proc/cpuinfo` && \
   make install && \
   cd .. && \
-  rm -rf apr-1.5.2
+  rm -rf apr-1.7.0
 
 # Build APR utilities
 RUN \
-  wget --quiet -O - http://archive.apache.org/dist/apr/apr-util-1.5.4.tar.bz2 | tar jxf - && \
-  cd apr-util-1.5.4 && \
+  wget --quiet -O - http://archive.apache.org/dist/apr/apr-util-1.6.1.tar.bz2 | tar jxf - && \
+  cd apr-util-1.6.1 && \
   sed -i -e "s/for ac_lib in '' crypt ufc; do/for ac_lib in ''; do/" configure && \
   sed -i -e 's/#define CRYPT_MISSING 0/#define CRYPT_MISSING 1/' crypto/apr_passwd.c && \
-  ./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=builtin && \
+  ./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=/usr/local/gcc73 && \
   make -j`grep -c '^processor' /proc/cpuinfo` && \
   make install && \
   cd .. && \
-  rm -rf apr-util-1.5.4
+  rm -rf apr-util-1.6.1
 
 # Build log4cxx
 RUN \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:8
+FROM docker.elastic.co/ml-dev/ml-linux-build:9
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -4,9 +4,9 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2012_r2-7.zip"
+$Archive="usr-x86_64-windows-2012_r2-8.zip"
 $Destination="C:\"
-if (!(Test-Path "$Destination\usr\local\lib\boost_unit_test_framework-vc141-mt-1_65_1.dll")) {
+if (!(Test-Path "$Destination\usr\local\lib\libexpatMD.lib")) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore
     $ZipSource="https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/$Archive"
     $ZipDestination="$Env:TEMP\$Archive"

--- a/dev-tools/vagrant/linux/provision.sh
+++ b/dev-tools/vagrant/linux/provision.sh
@@ -18,7 +18,7 @@ if [ ! -f package.state ]; then
   echo "Installing misc packages..."
   add-apt-repository -y ppa:webupd8team/java
   apt-get update
-  apt-get -qq -y install git wget build-essential maven unzip perl libbz2-1.0 libbz2-dev python-setuptools zlib1g-dev
+  apt-get -qq -y install git wget build-essential maven unzip perl libbz2-1.0 libbz2-dev bzip2 python-setuptools zlib1g-dev
   touch package.state
 fi
 
@@ -86,13 +86,32 @@ if [ ! -f libxml2.state ]; then
   touch libxml2.state
 fi
 
+# ----------------- Compile expat -------------------------
+if [ ! -f expat.state ]; then
+  echo "Compiling expat..."
+  echo "  Downloading..."
+  wget --quiet http://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2
+  mkdir expat
+  tar xfj expat-2.2.6.tar.bz2 -C expat --strip-components=1
+  cd expat
+  echo "  Configuring..."
+
+  ./configure --prefix=/usr/local/gcc73 --without-docbook > configure.log 2>&1
+  echo "  Making..."
+  make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
+  make install > make_install.log 2>&1
+  cd ..
+  rm expat-2.2.6.tar.bz2
+  touch expat.state
+fi
+
 # ----------------- Compile APR -------------------------
 if [ ! -f apr.state ]; then
   echo "Compiling APR..."
   echo "  Downloading..."
-  wget --quiet http://archive.apache.org/dist/apr/apr-1.5.2.tar.gz
+  wget --quiet http://archive.apache.org/dist/apr/apr-1.7.0.tar.gz
   mkdir apr
-  tar xfz apr-1.5.2.tar.gz -C apr --strip-components=1
+  tar xfz apr-1.7.0.tar.gz -C apr --strip-components=1
   cd apr
   echo "  Configuring..."
 
@@ -104,7 +123,7 @@ if [ ! -f apr.state ]; then
   make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
   make install > make_install.log 2>&1
   cd ..
-  rm apr-1.5.2.tar.gz
+  rm apr-1.7.0.tar.gz
   touch apr.state
 fi
 
@@ -112,21 +131,21 @@ fi
 if [ ! -f apr-util.state ]; then
   echo "Compiling APR-Utilities..."
   echo "  Downloading..."
-  wget --quiet http://archive.apache.org/dist/apr/apr-util-1.5.4.tar.gz
+  wget --quiet http://archive.apache.org/dist/apr/apr-util-1.6.1.tar.gz
   mkdir apr-util
-  tar xfz apr-util-1.5.4.tar.gz -C apr-util --strip-components=1
+  tar xfz apr-util-1.6.1.tar.gz -C apr-util --strip-components=1
   cd apr-util
   echo "  Configuring..."
 
   sed -i -e "s/for ac_lib in '' crypt ufc; do/for ac_lib in ''; do/" configure
   sed -i -e 's/#define CRYPT_MISSING 0/#define CRYPT_MISSING 1/' crypto/apr_passwd.c
 
-  ./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=builtin > configure.log 2>&1
+  ./configure --prefix=/usr/local/gcc73 --with-apr=/usr/local/gcc73/bin/apr-1-config --with-expat=/usr/local/gcc73 > configure.log 2>&1
   echo "  Making..."
   make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
   make install > make_install.log 2>&1
   cd ..
-  rm apr-util-1.5.4.tar.gz
+  rm apr-util-1.6.1.tar.gz
   touch apr-util.state
 fi
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,6 +30,10 @@
 
 == {es} version 7.3.0
 
+=== Enhancements
+
+* Upgrade to a newer version of the Apache Portable Runtime library. (See {ml-pull}495[#495].)
+
 === Bug Fixes
 
 * Reduce false positives associated with the multi-bucket feature. (See {ml-pull}491[#491].)


### PR DESCRIPTION
In this change:

- libapr is upgraded to version 1.7.0 from version 1.5.2
- libapriconv is upgraded to version 1.2.2 from version 1.2.1
- libaprutil is upgraded to version 1.6.1 from version 1.5.4
- libexpat is upgraded to version 2.2.6 from the (ancient) version
  that used to be embedded into libaprutil prior to version 1.6.0

libaprutil no longer embeds libexpat, so it has to be built separately.

Backport of #495