### PR TITLE
[ML] Fix a SIGSEGV in outlier detection

### DIFF
--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -271,7 +271,7 @@ public:
             for (const auto& neighbour : neighbours) {
                 result.push_back(neighbour.second);
             }
-        } else if (n > m_Nodes.size()) {
+        } else if (n >= m_Nodes.size()) {
             TDoubleVec distances;
             distances.reserve(m_Nodes.size());
             result.reserve(m_Nodes.size());

--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -224,6 +224,9 @@ private:
     void add(const POINT& point, const TPointVec& neighbours, TDouble1VecVec&) override {
         // This is called exactly once for each point therefore an element
         // of m_KDistances is only ever written by one thread.
+        if (neighbours.empty()) {
+            return;
+        }
         std::size_t i{point.annotation()};
         std::size_t a(point == neighbours[0] ? 1 : 0);
         std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
@@ -430,6 +433,14 @@ public:
 private:
     void add(const POINT& point, const std::vector<POINT>& neighbours, TDouble1VecVec& scores) override {
 
+        std::size_t dimension{las::dimension(point)};
+        auto& score = scores[point.annotation()];
+        score.resize(this->computeFeatureInfluence() ? dimension + 1 : 1, 0.0);
+
+        if (neighbours.empty()) {
+            return;
+        }
+
         auto ldof = [](const TMeanAccumulator& d, const TMeanAccumulator& D) {
             return CBasicStatistics::mean(D) > 0.0
                        ? CBasicStatistics::mean(d) / CBasicStatistics::mean(D)
@@ -438,10 +449,6 @@ private:
 
         std::size_t a(point == neighbours[0] ? 1 : 0);
         std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
-        std::size_t dimension{las::dimension(point)};
-
-        auto& score = scores[point.annotation()];
-        score.resize(this->computeFeatureInfluence() ? dimension + 1 : 1);
 
         TMeanAccumulator D;
         {
@@ -495,12 +502,16 @@ public:
 private:
     void add(const POINT& point, const std::vector<POINT>& neighbours, TDouble1VecVec& scores) override {
 
+        auto& score = scores[point.annotation()];
+        score.resize(this->computeFeatureInfluence() ? las::dimension(point) + 1 : 1, 0.0);
+
+        if (neighbours.empty()) {
+            return;
+        }
+
         std::size_t k{std::min(this->k() + 1, neighbours.size() - 1) -
                       (point == neighbours[0] ? 0 : 1)};
         const auto& kthNeighbour = neighbours[k];
-
-        auto& score = scores[point.annotation()];
-        score.resize(this->computeFeatureInfluence() ? las::dimension(point) + 1 : 1);
 
         double d{las::distance(point, kthNeighbour)};
         score[0] = d;
@@ -529,11 +540,15 @@ public:
 private:
     void add(const POINT& point, const std::vector<POINT>& neighbours, TDouble1VecVec& scores) override {
 
-        std::size_t a(point == neighbours[0] ? 1 : 0);
-        std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
-
         auto& score = scores[point.annotation()];
         score.assign(this->computeFeatureInfluence() ? las::dimension(point) + 1 : 1, 0.0);
+
+        if (neighbours.empty()) {
+            return;
+        }
+
+        std::size_t a(point == neighbours[0] ? 1 : 0);
+        std::size_t b{std::min(this->k() + a - 1, neighbours.size() + a - 2)};
 
         for (std::size_t i = a; i <= b; ++i) {
             double d{las::distance(point, neighbours[i])};

--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -224,7 +224,7 @@ private:
     void add(const POINT& point, const TPointVec& neighbours, TDouble1VecVec&) override {
         // This is called exactly once for each point therefore an element
         // of m_KDistances is only ever written by one thread.
-        if (neighbours.empty()) {
+        if (neighbours.size() < 2) {
             return;
         }
         std::size_t i{point.annotation()};
@@ -435,9 +435,9 @@ private:
 
         std::size_t dimension{las::dimension(point)};
         auto& score = scores[point.annotation()];
-        score.resize(this->computeFeatureInfluence() ? dimension + 1 : 1, 0.0);
+        score.assign(this->computeFeatureInfluence() ? dimension + 1 : 1, 0.0);
 
-        if (neighbours.empty()) {
+        if (neighbours.size() < 2) {
             return;
         }
 
@@ -503,9 +503,9 @@ private:
     void add(const POINT& point, const std::vector<POINT>& neighbours, TDouble1VecVec& scores) override {
 
         auto& score = scores[point.annotation()];
-        score.resize(this->computeFeatureInfluence() ? las::dimension(point) + 1 : 1, 0.0);
+        score.assign(this->computeFeatureInfluence() ? las::dimension(point) + 1 : 1, 0.0);
 
-        if (neighbours.empty()) {
+        if (neighbours.size() < 2) {
             return;
         }
 
@@ -543,7 +543,7 @@ private:
         auto& score = scores[point.annotation()];
         score.assign(this->computeFeatureInfluence() ? las::dimension(point) + 1 : 1, 0.0);
 
-        if (neighbours.empty()) {
+        if (neighbours.size() < 2) {
             return;
         }
 

--- a/lib/maths/unittest/CKdTreeTest.cc
+++ b/lib/maths/unittest/CKdTreeTest.cc
@@ -89,7 +89,8 @@ std::string print(const POINT& t) {
 }
 
 void CKdTreeTest::testBuild() {
-    const std::size_t numberTests = 200;
+
+    const std::size_t numberTests{200};
 
     test::CRandomNumbers rng;
 
@@ -123,6 +124,7 @@ void CKdTreeTest::testBuild() {
 }
 
 void CKdTreeTest::testBuildWithMove() {
+
     test::CRandomNumbers rng;
 
     TDoubleVec samples;
@@ -157,7 +159,8 @@ void CKdTreeTest::testBuildWithMove() {
 }
 
 void CKdTreeTest::testNearestNeighbour() {
-    const std::size_t numberTests = 200u;
+
+    const std::size_t numberTests{200};
 
     test::CRandomNumbers rng;
 
@@ -202,7 +205,8 @@ void CKdTreeTest::testNearestNeighbour() {
 }
 
 void CKdTreeTest::testNearestNeighbours() {
-    const std::size_t numberTests = 200u;
+
+    const std::size_t numberTests{200};
 
     test::CRandomNumbers rng;
 
@@ -251,6 +255,32 @@ void CKdTreeTest::testNearestNeighbours() {
     }
 }
 
+void CKdTreeTest::testRequestingEveryPoint() {
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec samples;
+    rng.generateUniformSamples(-100.0, 100.0, 5 * 5, samples);
+
+    TVector5Vec points;
+    for (std::size_t j = 0u; j < samples.size(); j += 5) {
+        points.emplace_back(&samples[j], &samples[j + 5]);
+    }
+    std::stable_sort(points.begin(), points.end());
+    std::string expected{core::CContainerPrinter::print(points)};
+
+    maths::CKdTree<TVector5> kdTree;
+    kdTree.build(points);
+    CPPUNIT_ASSERT(kdTree.checkInvariants());
+
+    TVector5Vec neighbours;
+    kdTree.nearestNeighbours(5, TVector5{0.0}, neighbours);
+    std::stable_sort(neighbours.begin(), neighbours.end());
+
+    CPPUNIT_ASSERT_EQUAL(kdTree.size(), neighbours.size());
+    CPPUNIT_ASSERT_EQUAL(expected, core::CContainerPrinter::print(neighbours));
+}
+
 CppUnit::Test* CKdTreeTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CKdTreeTest");
 
@@ -262,6 +292,8 @@ CppUnit::Test* CKdTreeTest::suite() {
         "CKdTreeTest::testNearestNeighbour", &CKdTreeTest::testNearestNeighbour));
     suiteOfTests->addTest(new CppUnit::TestCaller<CKdTreeTest>(
         "CKdTreeTest::testNearestNeighbours", &CKdTreeTest::testNearestNeighbours));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CKdTreeTest>(
+        "CKdTreeTest::testRequestingEveryPoint", &CKdTreeTest::testRequestingEveryPoint));
 
     return suiteOfTests;
 }

--- a/lib/maths/unittest/CKdTreeTest.h
+++ b/lib/maths/unittest/CKdTreeTest.h
@@ -15,6 +15,7 @@ public:
     void testBuildWithMove();
     void testNearestNeighbour();
     void testNearestNeighbours();
+    void testRequestingEveryPoint();
 
     static CppUnit::Test* suite();
 };

--- a/lib/maths/unittest/COutliersTest.h
+++ b/lib/maths/unittest/COutliersTest.h
@@ -20,6 +20,7 @@ public:
     void testEstimateMemoryUsedByCompute();
     void testProgressMonitoring();
     void testMostlyDuplicate();
+    void testFewPoints();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
The special case handling for when the requested number of neighbours *exactly* equals the number of points in the k-d tree was broken: it wasn't returning any points. This could cause an invalid read in outlier detection.

This PR fixes the bug in the k-d tree and makes the outlier code defensive if the neighbour set is ever ~~empty~~ too small.

The code isn't released so marking as a non-issue.