### PR TITLE
[ML] Fix occasional test failure

### DIFF
--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -819,17 +819,16 @@ void CTimeSeriesDecompositionTest::testSeasonalOnset() {
 
             const TSeasonalComponentVec& components = decomposition.seasonalComponents();
             if (time > 12 * WEEK) {
-                // Check that both components have been initialized.
+                // Check that there are at two least components.
                 CPPUNIT_ASSERT(components.size() >= 2);
                 CPPUNIT_ASSERT(components[0].initialized());
                 CPPUNIT_ASSERT(components[1].initialized());
-                CPPUNIT_ASSERT(components[2].initialized());
             } else if (time > 11 * WEEK) {
-                // Check that both components have been initialized.
+                // Check that there is at least one component.
                 CPPUNIT_ASSERT_EQUAL(std::size_t(1), components.size());
                 CPPUNIT_ASSERT(components[0].initialized());
             } else {
-                // Check that neither component has been initialized.
+                // Check that there are no components.
                 CPPUNIT_ASSERT(components.empty());
             }
             lastWeek += WEEK;


### PR DESCRIPTION
It is not guaranteed that the model will use 3 seasonal components in `CTimeSeriesDecompositionTest::testSeasonalOnset`. This test should only check that at least two components have been initialised. This showed up as a sporadic test failure on Windows.