### PR TITLE
[FEATURE][ML] Speed up computing node statistics after split during boosted tree training

### DIFF
--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -1118,8 +1118,8 @@ private:
             bool assignMissingToLeft{leaf->assignMissingToLeft()};
 
             std::size_t leftChildId, rightChildId;
-            std::tie(leftChildId, rightChildId) =
-                tree[leaf->id()].split(splitFeature, splitValue, assignMissingToLeft, tree);
+            std::tie(leftChildId, rightChildId) = tree[leaf->id()].split(
+                splitFeature, splitValue, assignMissingToLeft, tree);
 
             TSizeVec featureBag{this->featureBag(frame)};
 


### PR DESCRIPTION
We only need to visit rows for the child with fewest rows when refreshing leaf statistics after a split and can compute the others from the parent and sibling values.

This gets us around a 10% speed up in the unit tests, but the gain should be significantly larger for large data sets when we've overflowed to disk.