### PR TITLE
[ML] Workaround a bug with std::bind by changing to lambda

### DIFF
--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -128,10 +128,10 @@ bool CForecastModelPersist::CRestore::nextModel(TMathsModelPtr& model,
                         m_ModelParams.distributionRestoreParams(dataType)},
                     m_ModelParams.distributionRestoreParams(dataType)};
 
-                auto serialiser_operator = [&params = static_cast<const maths::SModelRestoreParams&>(params), &model_]
-											(core::CStateRestoreTraverser& traverser){
-                    return maths::CModelStateSerialiser()(params, model_, traverser);
-                };
+                auto serialiser_operator =
+                    [&params, &model_](core::CStateRestoreTraverser& traverser_) {
+                        return maths::CModelStateSerialiser()(params, model_, traverser_);
+                    };
                 if (traverser.traverseSubLevel(serialiser_operator) == false) {
                     LOG_ERROR(<< "Failed to restore forecast model, model missing");
                     return false;

--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -128,11 +128,11 @@ bool CForecastModelPersist::CRestore::nextModel(TMathsModelPtr& model,
                         m_ModelParams.distributionRestoreParams(dataType)},
                     m_ModelParams.distributionRestoreParams(dataType)};
 
-                auto serialiser_operator =
+                auto serialiserOperator =
                     [&params, &model_](core::CStateRestoreTraverser& traverser_) {
                         return maths::CModelStateSerialiser()(params, model_, traverser_);
                     };
-                if (traverser.traverseSubLevel(serialiser_operator) == false) {
+                if (traverser.traverseSubLevel(serialiserOperator) == false) {
                     LOG_ERROR(<< "Failed to restore forecast model, model missing");
                     return false;
                 }

--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -16,8 +16,6 @@
 
 #include <model/CAnomalyDetectorModelConfig.h>
 
-#include <boost/bind.hpp>
-
 namespace ml {
 namespace model {
 
@@ -53,8 +51,9 @@ void CForecastModelPersist::CPersist::addModel(const maths::CModel* model,
         inserter.insertValue(BY_FIELD_VALUE_TAG, byFieldValue);
         inserter.insertValue(FIRST_DATA_TIME_TAG, firstDataTime);
         inserter.insertValue(LAST_DATA_TIME_TAG, lastDataTime);
-        inserter.insertLevel(MODEL_TAG, std::bind<void>(maths::CModelStateSerialiser(),
-                                                          std::cref(*model), std::placeholders::_1));
+        inserter.insertLevel(
+            MODEL_TAG, std::bind<void>(maths::CModelStateSerialiser(),
+                                       std::cref(*model), std::placeholders::_1));
     };
 
     core::CJsonStatePersistInserter inserter(m_OutStream);

--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -128,8 +128,10 @@ bool CForecastModelPersist::CRestore::nextModel(TMathsModelPtr& model,
                         m_ModelParams.distributionRestoreParams(dataType)},
                     m_ModelParams.distributionRestoreParams(dataType)};
 
-                auto serialiser_operator = [&params = static_cast<const maths::SModelRestoreParams&>(params), &model_](core::CStateRestoreTraverser& traverser){
-                	return maths::CModelStateSerialiser()(params, model_, traverser);};
+                auto serialiser_operator = [&params = static_cast<const maths::SModelRestoreParams&>(params), &model_]
+											(core::CStateRestoreTraverser& traverser){
+                    return maths::CModelStateSerialiser()(params, model_, traverser);
+                };
                 if (traverser.traverseSubLevel(serialiser_operator) == false) {
                     LOG_ERROR(<< "Failed to restore forecast model, model missing");
                     return false;


### PR DESCRIPTION
For some reason, if code is compiled with `-g -O0` using g++ 7.3, then several fields within the const reference to `params` get modified to random values. This problem does not occur when using `boost::bind` or replacing `std::bind` with an equivalent lambda expression.  I could not find any relevant reference to an official bug report in `stdlib`.