### PR TITLE
[7.x][ML] Do not write model size stats after autodetect no-op

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -80,6 +80,12 @@ to the model. (See {ml-pull}214[#214].)
 
 == {es} version 7.0.0-alpha1
 
+== {es} version 6.8.2
+
+=== Bug Fixes
+
+* Don't write model size stats when job is closed without any input {ml-pull}512[#512] (issue: {ml-issue}394[#394])
+
 == {es} version 6.7.2
 
 === Enhancements


### PR DESCRIPTION
Similar to the fix for state and quantiles in #437,
if no input is received and time is not advanced then
there is no need to write model size stats when the
autodetect process exits. Doing this can actually
cause a problem for a job that has never ever seen
any input, as the unnecessary model size stats were
written with a negative timestamp. This change also
adds an extra defensive check to prevent that ever
happening, although the only situation when it is
thought to be possible should be prevented by the
first change.

Backport of #512