### PR TITLE
[ML] Ignore "persist now" control message if no prior input

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -85,6 +85,7 @@ to the model. (See {ml-pull}214[#214].)
 === Bug Fixes
 
 * Don't write model size stats when job is closed without any input {ml-pull}512[#512] (issue: {ml-issue}394[#394])
+* Don't persist model state at the end of lookback if the lookback did not generate any input {ml-pull}521[#521] (issue: {ml-issue}519[#519])
 
 == {es} version 6.7.2
 

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -345,11 +345,11 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
     case 'p':
         this->doForecast(controlMessage);
         break;
-    case 'w': {
-        if (m_PeriodicPersister != nullptr) {
+    case 'w':
+        if (m_PeriodicPersister != nullptr && this->isPersistenceNeeded("state")) {
             m_PeriodicPersister->startBackgroundPersist();
         }
-    } break;
+        break;
     default:
         LOG_WARN(<< "Ignoring unknown control message of length "
                  << controlMessage.length() << " beginning with '"


### PR DESCRIPTION
Persisting state when there has been no input data:

1. Is a waste of time
2. Causes the model snapshot document to embed an invalid
   model size stats document which causes an error in Elasticsearch

So we should not do this.

Fixes #519