### PR TITLE
[ML] Introduction disk usage parameter for data frames

### DIFF
--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -50,7 +50,7 @@ public:
     using TRunnerFactoryUPtrVec = std::vector<TRunnerFactoryUPtr>;
 
 public:
-    //! Inititialize from a JSON object.
+    //! Initialize from a JSON object.
     //!
     //! The specification has the following expected form:
     //! <CODE>
@@ -61,6 +61,7 @@ public:
     //!   "threads": <integer>,
     //!   "temp_dir": <string>,
     //!   "results_field": <string>,
+    //!   "disk_usage_allowed": <boolean>,
     //!   "analysis": {
     //!     "name": <string>,
     //!     "parameters": <object>
@@ -109,6 +110,10 @@ public:
     //! \return The name of the results field.
     const std::string& resultsField() const;
 
+    //! \return If it is allowed to overflow data frame to the disk if it doesn't
+    //! fit in memory.
+    bool diskUsageAllowed() const;
+
     //! Make a data frame suitable for this analysis specification.
     //!
     //! This chooses the storage strategy based on the analysis constraints and
@@ -139,6 +144,7 @@ private:
     std::size_t m_NumberThreads = 0;
     std::string m_TemporaryDirectory;
     std::string m_ResultsField;
+    bool m_DiskUsageAllowed;
     // TODO Sparse table support
     // double m_TableLoadFactor = 0.0;
     TRunnerFactoryUPtrVec m_RunnerFactories;

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -64,7 +64,7 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
             break;
         }
         // if we are not allowed to spill over to disk then only one partition is possible
-        if (not m_Spec.diskUsageAllowed()) {
+        if (!m_Spec.diskUsageAllowed()) {
             LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
             break;
         }

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -63,7 +63,7 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
         if (memoryUsage <= memoryLimit) {
             break;
         }
-        // if we are not allowed to spill over to disk than only one partition is possible
+        // if we are not allowed to spill over to disk then only one partition is possible
         if (not m_Spec.diskUsageAllowed()) {
             LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
             break;

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -63,6 +63,11 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
         if (memoryUsage <= memoryLimit) {
             break;
         }
+        // if we are not allowed to spill over to disk than only one partition is possible
+        if (not m_Spec.diskUsageAllowed()) {
+        	LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
+        	break;
+        }
     }
 
     LOG_TRACE(<< "number partitions = " << m_NumberPartitions);

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -65,8 +65,8 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
         }
         // if we are not allowed to spill over to disk than only one partition is possible
         if (not m_Spec.diskUsageAllowed()) {
-        	LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
-        	break;
+            LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
+            break;
         }
     }
 

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -62,7 +62,8 @@ const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(RESULTS_FIELD, CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(ANALYSIS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(DISK_USAGE_ALLOWED, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(DISK_USAGE_ALLOWED,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 
@@ -136,7 +137,7 @@ const std::string& CDataFrameAnalysisSpecification::resultsField() const {
 }
 
 bool CDataFrameAnalysisSpecification::diskUsageAllowed() const {
-	return m_DiskUsageAllowed;
+    return m_DiskUsageAllowed;
 }
 
 CDataFrameAnalysisSpecification::TDataFrameUPtrTemporaryDirectoryPtrPr
@@ -161,8 +162,6 @@ CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame&
     }
     return nullptr;
 }
-
-
 
 void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& jsonAnalysis) {
     // We pass of the interpretation of the parameters object to the appropriate

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -46,8 +46,10 @@ const char* const RESULTS_FIELD{"results_field"};
 const char* const ANALYSIS{"analysis"};
 const char* const NAME{"name"};
 const char* const PARAMETERS{"parameters"};
+const char* const DISK_USAGE_ALLOWED{"disk_usage_allowed"};
 
 const std::string DEFAULT_RESULT_FIELD("ml");
+const bool DEFAULT_DISK_USAGE_ALLOWED(false);
 
 const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
     CDataFrameAnalysisConfigReader theReader;
@@ -60,6 +62,7 @@ const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(RESULTS_FIELD, CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(ANALYSIS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(DISK_USAGE_ALLOWED, CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 
@@ -99,6 +102,7 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(
             boost::filesystem::current_path().string());
         m_ResultsField = parameters[RESULTS_FIELD].fallback(DEFAULT_RESULT_FIELD);
+        m_DiskUsageAllowed = parameters[DISK_USAGE_ALLOWED].fallback(DEFAULT_DISK_USAGE_ALLOWED);
 
         auto jsonAnalysis = parameters[ANALYSIS].jsonObject();
         if (jsonAnalysis != nullptr) {
@@ -131,6 +135,10 @@ const std::string& CDataFrameAnalysisSpecification::resultsField() const {
     return m_ResultsField;
 }
 
+bool CDataFrameAnalysisSpecification::diskUsageAllowed() const {
+	return m_DiskUsageAllowed;
+}
+
 CDataFrameAnalysisSpecification::TDataFrameUPtrTemporaryDirectoryPtrPr
 CDataFrameAnalysisSpecification::makeDataFrame() {
     if (m_Runner == nullptr) {
@@ -153,6 +161,8 @@ CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame&
     }
     return nullptr;
 }
+
+
 
 void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& jsonAnalysis) {
     // We pass of the interpretation of the parameters object to the appropriate

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -6,11 +6,13 @@
 
 #include "CDataFrameAnalysisRunnerTest.h"
 
+#include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameOutliersRunner.h>
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -36,7 +38,7 @@ void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
                                  std::to_string(numberCols) +
                                  ",\n"
                                  "  \"memory_limit\": 100000000,\n"
-								 "  \"disk_usage_allowed\": true,\n"
+                                 "  \"disk_usage_allowed\": true,\n"
                                  "  \"threads\": 1,\n"
                                  "  \"analysis\": {\n"
                                  "    \"name\": \"outlier_detection\""
@@ -71,55 +73,72 @@ void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
     // TODO test running memory is in acceptable range.
 }
 
-std::string CDataFrameAnalysisRunnerTest::createSpecJsonForDiskUsageTest(
-		std::size_t numberRows, std::size_t numberCols, bool diskUsageAllowed) {
-	std::string jsonSpec{"{\n"
-							 "  \"rows\": " +
-							 std::to_string(numberRows) +
-							 ",\n"
-							 "  \"cols\": " +
-							 std::to_string(numberCols) +
-							 ",\n"
-							 "  \"memory_limit\": 100,\n"
-							 "  \"disk_usage_allowed\": " +
-							 (diskUsageAllowed ? "true" : "false") +
-							 ",\n"
-							 "  \"threads\": 1,\n"
-							 "}"};
-	return jsonSpec;
+std::string
+CDataFrameAnalysisRunnerTest::createSpecJsonForDiskUsageTest(std::size_t numberRows,
+                                                             std::size_t numberCols,
+                                                             bool diskUsageAllowed) {
+    std::string jsonSpec{"{\n"
+                         "  \"rows\": " +
+                         std::to_string(numberRows) +
+                         ",\n"
+                         "  \"cols\": " +
+                         std::to_string(numberCols) +
+                         ",\n"
+                         "  \"memory_limit\": 500000,\n"
+                         "  \"disk_usage_allowed\": " +
+                         (diskUsageAllowed ? "true" : "false") +
+                         ",\n"
+                         "  \"threads\": 1,\n"
+                         "  \"analysis\": {\n"
+                         "    \"name\": \"outlier_detection\""
+                         "  }"
+                         "}"};
+    return jsonSpec;
 }
 
 void CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag() {
 
-	std::vector<std::string> errors;
-	std::mutex errorsMutex;
-	auto errorHandler = [&errors, &errorsMutex](std::string error) {
-		std::lock_guard<std::mutex> lock {errorsMutex};
-		errors.push_back(error);
-	};
+    std::vector<std::string> errors;
+    std::mutex errorsMutex;
+    auto errorHandler = [&errors, &errorsMutex](std::string error) {
+        std::lock_guard<std::mutex> lock{errorsMutex};
+        errors.push_back(error);
+    };
 
-	core::CLogger::CScopeSetFatalErrorHandler scope { errorHandler };
+    core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
+    api::CDataFrameOutliersRunnerFactory factory;
 
-	// Test with bad analysis specification.
-	{
-		errors.clear();
-		api::CDataFrameAnalyzer analyzer { std::make_unique<
-				api::CDataFrameAnalysisSpecification>(std::string { "junk" }),
-				outputWriterFactory };
-		LOG_DEBUG(<< core::CContainerPrinter::print(errors));
-		CPPUNIT_ASSERT(errors.size() > 0);
-		CPPUNIT_ASSERT_EQUAL(false, analyzer.handleRecord( { "c1", "c2", "c3",
-				"c4", "c5" }, { "10", "10", "10", "10", "10" }));
-	}
+    // Test large memory requirement without disk usage
+    {
+        errors.clear();
+        std::string jsonSpec{createSpecJsonForDiskUsageTest(1000, 100, false)};
+        api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
-	std::string jsonSpec { createSpecJsonForDiskUsageTest(1000000, 100, false) };
-	try {
-		new api::CDataFrameAnalysisSpecification(jsonSpec);
-	} catch (const std::exception& ex) {
-		std::cout << ex.what() << std::endl;
-	}
-//	CPPUNIT_ASSERT_THROW(new api::CDataFrameAnalysisSpecification(jsonSpec), CppUnit::Exception);
+        // single error is registered that the memory limit is to low
+        CPPUNIT_ASSERT_EQUAL(1, static_cast<int>(errors.size()));
+        CPPUNIT_ASSERT(errors[0].find("Input error: memory limit is too low to perform analysis.") !=
+                       std::string::npos);
+    }
 
+    // Test large memory requirement with disk usage
+    {
+        errors.clear();
+        std::string jsonSpec{createSpecJsonForDiskUsageTest(1000, 100, true)};
+        api::CDataFrameAnalysisSpecification spec{jsonSpec};
+
+        // no error should be registered
+        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(errors.size()));
+    }
+
+    // Test low memory requirement without disk usage
+    {
+        errors.clear();
+        std::string jsonSpec{createSpecJsonForDiskUsageTest(10, 10, false)};
+        api::CDataFrameAnalysisSpecification spec{jsonSpec};
+
+        // no error should be registered
+        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(errors.size()));
+    }
 }
 
 CppUnit::Test* CDataFrameAnalysisRunnerTest::suite() {
@@ -130,10 +149,8 @@ CppUnit::Test* CDataFrameAnalysisRunnerTest::suite() {
         &CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers));
 
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisRunnerTest>(
-		"CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag",
-		&CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag));
+        "CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag",
+        &CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag));
 
     return suiteOfTests;
 }
-
-

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
@@ -12,8 +12,12 @@
 class CDataFrameAnalysisRunnerTest : public CppUnit::TestFixture {
 public:
     void testComputeExecutionStrategyForOutliers();
+    void testComputeAndSaveExecutionStrategyDiskUsageFlag();
 
     static CppUnit::Test* suite();
+
+private:
+    std::string createSpecJsonForDiskUsageTest(std::size_t rows, std::size_t cols, bool diskUsageAllowed);
 };
 
 #endif // INCLUDED_CDataFrameAnalysisRunnerTest_h

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -77,11 +77,11 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
             result << "     \"name\": \"" << name << "\"";
         }
         if (parameters.size() > 0) {
-            result << ",\n     \"parameters\": " << parameters << "\n";
+            result << ",\n     \"parameters\": " << parameters << ",\n";
         } else {
-            result << "\n";
+            result << ",\n";
         }
-        result << "   }\n}";
+        result << "     \"disk_usage_allowed\": true \n}\n}";
         return result.str();
     };
 
@@ -260,6 +260,7 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
                          "  \"cols\": 10,\n"
                          "  \"memory_limit\": 1000,\n"
                          "  \"threads\": 1,\n"
+                         "  \"disk_usage_allowed\": true,\n"
                          "  \"analysis\": {\n"
                          "    \"name\": \"test\""
                          "  }"

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -54,6 +54,7 @@ outlierSpec(std::size_t rows = 110,
                      std::to_string(memoryLimit) +
                      ",\n"
                      "  \"threads\": 1,\n"
+                     "  \"disk_usage_allowed\": true,\n"
                      "  \"analysis\": {\n"
                      "    \"name\": \"outlier_detection\""};
     spec += ",\n    \"parameters\": {\n";


### PR DESCRIPTION
This PR introduces an optional json specification parameter `disk_usage_allowed`, which is `false` by default. This parameter controls whether or not the system can overflow data frame to disk. 

Relates elastic/ml-team#168