### PR TITLE
[ML] Add a docker image to perform clang-format in a correct version

### DIFF
--- a/dev-tools/docker/clang-format/Dockerfile
+++ b/dev-tools/docker/clang-format/Dockerfile
@@ -11,9 +11,7 @@ FROM alpine:3.8
 MAINTAINER Valeriy Khakhutskyy <valeriy.khakhutskyy@elastic.co>
 
 RUN apk update && \
-    apk add clang bash git
+    apk add --no-cache clang bash git
 
 WORKDIR /ml-cpp
 ENV CPP_SRC_HOME=/ml-cpp
-    
-ENTRYPOINT ["/ml-cpp/dev-tools/clang-format.sh"]

--- a/dev-tools/docker/clang-format/Dockerfile
+++ b/dev-tools/docker/clang-format/Dockerfile
@@ -1,0 +1,19 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+FROM alpine:3.8
+
+# Docker image containing the correct clang-format for check-style.sh
+
+MAINTAINER Valeriy Khakhutskyy <valeriy.khakhutskyy@elastic.co>
+
+RUN apk update && \
+    apk add clang bash git
+
+WORKDIR /ml-cpp
+ENV CPP_SRC_HOME=/ml-cpp
+    
+ENTRYPOINT ["/ml-cpp/dev-tools/clang-format.sh"]

--- a/dev-tools/docker/clang-format/Dockerfile
+++ b/dev-tools/docker/clang-format/Dockerfile
@@ -15,3 +15,5 @@ RUN apk update && \
 
 WORKDIR /ml-cpp
 ENV CPP_SRC_HOME=/ml-cpp
+    
+ENTRYPOINT ["/ml-cpp/dev-tools/clang-format.sh"]

--- a/dev-tools/docker/clang-format/build-docker-clang-format.sh
+++ b/dev-tools/docker/clang-format/build-docker-clang-format.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build . -t alpine:clang-format

--- a/dev-tools/docker/clang-format/build-docker-clang-format.sh
+++ b/dev-tools/docker/clang-format/build-docker-clang-format.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License;

--- a/dev-tools/docker/clang-format/build-docker-clang-format.sh
+++ b/dev-tools/docker/clang-format/build-docker-clang-format.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
 docker build . -t alpine:clang-format

--- a/dev-tools/docker/clang-format/run-docker-clang-format.sh
+++ b/dev-tools/docker/clang-format/run-docker-clang-format.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License;

--- a/dev-tools/docker/clang-format/run-docker-clang-format.sh
+++ b/dev-tools/docker/clang-format/run-docker-clang-format.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -v $CPP_SRC_HOME:/ml-cpp -u $(id -u):$(id -g) alpine:clang-format

--- a/dev-tools/docker/clang-format/run-docker-clang-format.sh
+++ b/dev-tools/docker/clang-format/run-docker-clang-format.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
 docker run --rm -v $CPP_SRC_HOME:/ml-cpp -u $(id -u):$(id -g) alpine:clang-format


### PR DESCRIPTION
I based the image on `alpine:3.8` as it comes with `clang` in version 5.0.1 out of the box and the base image is only 4.4mb. Having this docker image resolves the problem of needing to track down and install the correct clang version and dependencies (which is impossible on some modern Linux distributions). 

Running docker with `-u` option should solve file ownership issues on the mounted directories. I did not test it on macOS though. 