### PR TITLE
[7.3][ML] Workaround a bug with std::bind by changing to lambda (#514)

### DIFF
--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -128,9 +128,11 @@ bool CForecastModelPersist::CRestore::nextModel(TMathsModelPtr& model,
                         m_ModelParams.distributionRestoreParams(dataType)},
                     m_ModelParams.distributionRestoreParams(dataType)};
 
-                if (traverser.traverseSubLevel(std::bind<bool>(
-                        maths::CModelStateSerialiser(), std::cref(params),
-                        std::ref(model_), std::placeholders::_1)) == false) {
+                auto serialiserOperator =
+                    [&params, &model_](core::CStateRestoreTraverser& traverser_) {
+                        return maths::CModelStateSerialiser()(params, model_, traverser_);
+                    };
+                if (traverser.traverseSubLevel(serialiserOperator) == false) {
                     LOG_ERROR(<< "Failed to restore forecast model, model missing");
                     return false;
                 }


### PR DESCRIPTION
For some reason, if code is compiled with -g -O0 using g++ 7.3, then several fields within the const reference to params get modified to random values. This problem does not occur when using boost::bind or replacing std::bind with an equivalent lambda expression. I could not find any relevant reference to an official bug report in stdlib.