### PR TITLE
[7.3][ML] Add a docker image to perform clang-format in a correct version …

### DIFF
--- a/dev-tools/docker/build_check_style_image.sh
+++ b/dev-tools/docker/build_check_style_image.sh
@@ -15,7 +15,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-check-style
-VERSION=1
+VERSION=2
 
 set -e
 

--- a/dev-tools/docker/check_style_image/Dockerfile
+++ b/dev-tools/docker/check_style_image/Dockerfile
@@ -4,21 +4,15 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-FROM ubuntu:16.04
+FROM alpine:3.8
 
 # Docker image containing the correct clang-format for check-style.sh
 
-MAINTAINER David Roberts <dave.roberts@elastic.co>
+MAINTAINER Valeriy Khakhutskyy <valeriy.khakhutskyy@elastic.co>
 
-# Make sure apt-get is up to date and required packages are installed
-RUN \
-  apt-get update && \
-  apt-get install --no-install-recommends -y git wget xz-utils
+RUN apk update && \
+    apk add --no-cache clang bash git
 
-# Install the version of LLVM mandated for code formatting
-RUN \
-  wget --quiet -O - http://releases.llvm.org/5.0.1/clang+llvm-5.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz | tar Jxf -
-
-# Update path to find clang-format
-ENV PATH /clang+llvm-5.0.1-x86_64-linux-gnu-ubuntu-16.04/bin:/usr/bin:/bin:/usr/sbin:/sbin
+WORKDIR /ml-cpp
+ENV CPP_SRC_HOME=/ml-cpp
 

--- a/dev-tools/docker/run_docker_clang_format.sh
+++ b/dev-tools/docker/run_docker_clang_format.sh
@@ -1,14 +1,8 @@
+#!/bin/bash
 #
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 #
 
-# Increment the version here when a new check style image is built
-FROM docker.elastic.co/ml-dev/ml-check-style:2
-
-MAINTAINER David Roberts <dave.roberts@elastic.co>
-
-# Copy the current Git repository into the container
-COPY . /ml-cpp/
-
+docker run --rm -v $CPP_SRC_HOME:/ml-cpp -u $(id -u):$(id -g) docker.elastic.co/ml-dev/ml-check-style:2 /ml-cpp/dev-tools/clang-format.sh


### PR DESCRIPTION
…(#525)

This PR changes the base of the ml-check-style docker image from ubuntu:16.04 to alpine:3.8, which already comes with clang in version 5.0.1 out of the box. This reduces the image size from 1.56GB to 214MB. The version of ml-check-style is bumped from 1 to 2.

PR also introduce the script run_docker_clang_format which mounts the $CPP_SRC_HOME director into the container and performs formatting. Running docker with -u option should solve file ownership issues on the mounted directories. I did not test it on macOS though.