### PR TITLE
[7.3][ML] Introduction disk usage parameter for data frames (#522)

### DIFF
--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -50,7 +50,7 @@ public:
     using TRunnerFactoryUPtrVec = std::vector<TRunnerFactoryUPtr>;
 
 public:
-    //! Inititialize from a JSON object.
+    //! Initialize from a JSON object.
     //!
     //! The specification has the following expected form:
     //! <CODE>
@@ -61,6 +61,7 @@ public:
     //!   "threads": <integer>,
     //!   "temp_dir": <string>,
     //!   "results_field": <string>,
+    //!   "disk_usage_allowed": <boolean>,
     //!   "analysis": {
     //!     "name": <string>,
     //!     "parameters": <object>
@@ -109,6 +110,10 @@ public:
     //! \return The name of the results field.
     const std::string& resultsField() const;
 
+    //! \return If it is allowed to overflow data frame to the disk if it doesn't
+    //! fit in memory.
+    bool diskUsageAllowed() const;
+
     //! Make a data frame suitable for this analysis specification.
     //!
     //! This chooses the storage strategy based on the analysis constraints and
@@ -139,6 +144,7 @@ private:
     std::size_t m_NumberThreads = 0;
     std::string m_TemporaryDirectory;
     std::string m_ResultsField;
+    bool m_DiskUsageAllowed;
     // TODO Sparse table support
     // double m_TableLoadFactor = 0.0;
     TRunnerFactoryUPtrVec m_RunnerFactories;

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -63,6 +63,11 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
         if (memoryUsage <= memoryLimit) {
             break;
         }
+        // if we are not allowed to spill over to disk then only one partition is possible
+        if (!m_Spec.diskUsageAllowed()) {
+            LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
+            break;
+        }
     }
 
     LOG_TRACE(<< "number partitions = " << m_NumberPartitions);

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -46,8 +46,10 @@ const char* const RESULTS_FIELD{"results_field"};
 const char* const ANALYSIS{"analysis"};
 const char* const NAME{"name"};
 const char* const PARAMETERS{"parameters"};
+const char* const DISK_USAGE_ALLOWED{"disk_usage_allowed"};
 
 const std::string DEFAULT_RESULT_FIELD("ml");
+const bool DEFAULT_DISK_USAGE_ALLOWED(false);
 
 const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
     CDataFrameAnalysisConfigReader theReader;
@@ -60,6 +62,8 @@ const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(RESULTS_FIELD, CDataFrameAnalysisConfigReader::E_OptionalParameter);
     theReader.addParameter(ANALYSIS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(DISK_USAGE_ALLOWED,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 
@@ -99,6 +103,7 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(
             boost::filesystem::current_path().string());
         m_ResultsField = parameters[RESULTS_FIELD].fallback(DEFAULT_RESULT_FIELD);
+        m_DiskUsageAllowed = parameters[DISK_USAGE_ALLOWED].fallback(DEFAULT_DISK_USAGE_ALLOWED);
 
         auto jsonAnalysis = parameters[ANALYSIS].jsonObject();
         if (jsonAnalysis != nullptr) {
@@ -129,6 +134,10 @@ std::size_t CDataFrameAnalysisSpecification::numberThreads() const {
 
 const std::string& CDataFrameAnalysisSpecification::resultsField() const {
     return m_ResultsField;
+}
+
+bool CDataFrameAnalysisSpecification::diskUsageAllowed() const {
+    return m_DiskUsageAllowed;
 }
 
 CDataFrameAnalysisSpecification::TDataFrameUPtrTemporaryDirectoryPtrPr

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
@@ -12,8 +12,12 @@
 class CDataFrameAnalysisRunnerTest : public CppUnit::TestFixture {
 public:
     void testComputeExecutionStrategyForOutliers();
+    void testComputeAndSaveExecutionStrategyDiskUsageFlag();
 
     static CppUnit::Test* suite();
+
+private:
+    std::string createSpecJsonForDiskUsageTest(std::size_t rows, std::size_t cols, bool diskUsageAllowed);
 };
 
 #endif // INCLUDED_CDataFrameAnalysisRunnerTest_h

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -77,11 +77,11 @@ void CDataFrameAnalysisSpecificationTest::testCreate() {
             result << "     \"name\": \"" << name << "\"";
         }
         if (parameters.size() > 0) {
-            result << ",\n     \"parameters\": " << parameters << "\n";
+            result << ",\n     \"parameters\": " << parameters << ",\n";
         } else {
-            result << "\n";
+            result << ",\n";
         }
-        result << "   }\n}";
+        result << "     \"disk_usage_allowed\": true \n}\n}";
         return result.str();
     };
 
@@ -260,6 +260,7 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
                          "  \"cols\": 10,\n"
                          "  \"memory_limit\": 1000,\n"
                          "  \"threads\": 1,\n"
+                         "  \"disk_usage_allowed\": true,\n"
                          "  \"analysis\": {\n"
                          "    \"name\": \"test\""
                          "  }"

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -54,6 +54,7 @@ outlierSpec(std::size_t rows = 110,
                      std::to_string(memoryLimit) +
                      ",\n"
                      "  \"threads\": 1,\n"
+                     "  \"disk_usage_allowed\": true,\n"
                      "  \"analysis\": {\n"
                      "    \"name\": \"outlier_detection\""};
     spec += ",\n    \"parameters\": {\n";


### PR DESCRIPTION
This PR introduces an optional json specification parameter disk_usage_allowed, which is false by default. This parameter controls whether or not the system can overflow data frame to disk.

Relates elastic/ml-team#168