### PR TITLE
[ML] Check the data frame row count is consistent with the analysis configuration

### DIFF
--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -113,6 +113,14 @@ void CDataFrameAnalyzer::run() {
         return;
     }
 
+    if (m_DataFrame->numberRows() != m_AnalysisSpecification->numberRows()) {
+        HANDLE_FATAL(<< "Input error: expected '"
+                     << m_AnalysisSpecification->numberRows() << "' rows "
+                     << "but got '" << m_DataFrame->numberRows() << "' rows"
+                     << ". Please report this problem.");
+        return;
+    }
+
     LOG_TRACE(<< "Running analysis...");
 
     CDataFrameAnalysisRunner* analysis{m_AnalysisSpecification->run(*m_DataFrame)};
@@ -164,8 +172,8 @@ bool CDataFrameAnalyzer::prepareToReceiveControlMessages(const TStrVec& fieldNam
     } else if (fieldNames.size() < 2 || posDocHash != fieldNames.end() - 2 ||
                posControlMessage != fieldNames.end() - 1) {
 
-        HANDLE_FATAL(<< "Input error: expected exacly two special "
-                     << "fields in last two positions, got '"
+        HANDLE_FATAL(<< "Input error: expected exactly two special "
+                     << "fields in last two positions but got '"
                      << core::CContainerPrinter::print(fieldNames)
                      << "'. Please report this problem.");
         return false;

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -502,7 +502,7 @@ void CDataFrameAnalyzerTest::testRoundTripDocHashes() {
         return std::make_unique<core::CJsonOutputStreamWrapper>(output);
     };
 
-    api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+    api::CDataFrameAnalyzer analyzer{outlierSpec(9), outputWriterFactory};
     for (auto i : {"1", "2", "3", "4", "5", "6", "7", "8", "9"}) {
         analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
                               {i, i, i, i, i, i, ""});

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -479,6 +479,20 @@ void CDataFrameAnalyzerTest::testErrors() {
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
+
+    // Test inconsistent number of rows
+    {
+        api::CDataFrameAnalyzer analyzer{outlierSpec(2), outputWriterFactory};
+        errors.clear();
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"10", "10", "10", "10", "10", "0", ""}));
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"", "", "", "", "", "", "$"}));
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        CPPUNIT_ASSERT(errors.size() > 0);
+    }
 }
 
 void CDataFrameAnalyzerTest::testRoundTripDocHashes() {


### PR DESCRIPTION
Whilst investigating #511, I noticed that the data_frame_analyzer will happily run an analysis on a frame with fewer rows than specified in the configuration object. Currently, there is no reason that this should happen and it would indicate a problem with the calling Java code if it did. This change adds a consistency check and fails if the values are inconsistent.