### PR TITLE
[ML] Temporary directory must be set if disk usage is allowed

### DIFF
--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -122,6 +122,9 @@ public:
         }
 
         //! Get the parameter called \p name.
+        CParameter operator[](const std::string& name) const;
+
+        //! Get the parameter called \p name.
         CParameter operator[](const char* name) const;
 
     private:
@@ -135,6 +138,15 @@ public:
     //! \param[in] requirement Is the parameter required or optional.
     //! \param[in] permittedValues The permitted values for an enumeration.
     void addParameter(const char* name,
+                      ERequirement requirement,
+                      TStrIntMap permittedValues = TStrIntMap{});
+
+    //! Register a parameter.
+    //!
+    //! \param[in] name The parameter name.
+    //! \param[in] requirement Is the parameter required or optional.
+    //! \param[in] permittedValues The permitted values for an enumeration.
+    void addParameter(const std::string& name,
                       ERequirement requirement,
                       TStrIntMap permittedValues = TStrIntMap{});
 

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -50,6 +50,18 @@ public:
     using TRunnerFactoryUPtrVec = std::vector<TRunnerFactoryUPtr>;
 
 public:
+    static const std::string ROWS;
+    static const std::string COLS;
+    static const std::string MEMORY_LIMIT;
+    static const std::string THREADS;
+    static const std::string TEMPORARY_DIRECTORY;
+    static const std::string RESULTS_FIELD;
+    static const std::string ANALYSIS;
+    static const std::string NAME;
+    static const std::string PARAMETERS;
+    static const std::string DISK_USAGE_ALLOWED;
+
+public:
     //! Initialize from a JSON object.
     //!
     //! The specification has the following expected form:

--- a/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
+++ b/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
@@ -10,7 +10,7 @@
 #include <core/CNonInstantiatable.h>
 #include <core/CRapidJsonConcurrentLineWriter.h>
 
-#include <api/ImportExport.h
+#include <api/ImportExport.h>
 
 #include <string>
 

--- a/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
+++ b/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
@@ -10,6 +10,8 @@
 #include <core/CNonInstantiatable.h>
 #include <core/CRapidJsonConcurrentLineWriter.h>
 
+#include <api/ImportExport.h
+
 #include <string>
 
 namespace ml {
@@ -17,7 +19,7 @@ namespace api {
 
 //! \brief
 //! A static utility for writing data frame analysis specification in JSON.
-class CDataFrameAnalysisSpecificationJsonWriter : private core::CNonInstantiatable {
+class API_EXPORT CDataFrameAnalysisSpecificationJsonWriter : private core::CNonInstantiatable {
 public:
     using TRapidJsonLineWriter = core::CRapidJsonLineWriter<rapidjson::StringBuffer>;
 
@@ -34,6 +36,7 @@ public:
                       const rapidjson::Document& analysisParametersDocument,
                       TRapidJsonLineWriter& writer);
 
+    //! Writes the data frame analysis specification in JSON format.
     static void write(std::size_t rows,
                       std::size_t cols,
                       std::size_t memoryLimit,
@@ -45,6 +48,7 @@ public:
                       const std::string& analysisParameters,
                       TRapidJsonLineWriter& writer);
 
+    //! Returns a string with the data frame analysis specification in JSON format.
     static std::string jsonString(size_t rows,
                                   size_t cols,
                                   size_t memoryLimit,

--- a/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
+++ b/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
@@ -30,8 +30,19 @@ public:
                       const std::string& temporaryDirectory,
                       const std::string& resultsField,
                       bool diskUsageAllowed,
-                      const std::string& analysis_name,
-                      const std::string& analysis_parameters,
+                      const std::string& analysisName,
+                      const rapidjson::Document& analysisParametersDocument,
+                      TRapidJsonLineWriter& writer);
+
+    static void write(std::size_t rows,
+                      std::size_t cols,
+                      std::size_t memoryLimit,
+                      std::size_t numberThreads,
+                      const std::string& temporaryDirectory,
+                      const std::string& resultsField,
+                      bool diskUsageAllowed,
+                      const std::string& analysisName,
+                      const std::string& analysisParameters,
                       TRapidJsonLineWriter& writer);
 
     static std::string jsonString(size_t rows,
@@ -44,7 +55,6 @@ public:
                                   const std::string& analysis_name,
                                   const std::string& analysis_parameters);
 };
-
 }
 }
 #endif //INCLUDED_ml_api_CDataFrameAnalysisSpecificationJsonWriter_h

--- a/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
+++ b/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_api_CDataFrameAnalysisSpecificationJsonWriter_h
+#define INCLUDED_ml_api_CDataFrameAnalysisSpecificationJsonWriter_h
+
+#include <core/CNonInstantiatable.h>
+#include <core/CRapidJsonConcurrentLineWriter.h>
+
+#include <string>
+
+namespace ml {
+namespace api {
+
+//! \brief
+//! A static utility for writing data frame analysis specification in JSON.
+class CDataFrameAnalysisSpecificationJsonWriter : private core::CNonInstantiatable {
+public:
+    using TRapidJsonLineWriter = core::CRapidJsonLineWriter<rapidjson::StringBuffer>;
+
+public:
+    //! Writes the data frame analysis specification in JSON format.
+    static void write(std::size_t rows,
+                      std::size_t cols,
+                      std::size_t memoryLimit,
+                      std::size_t numberThreads,
+                      const std::string& temporaryDirectory,
+                      const std::string& resultsField,
+                      bool diskUsageAllowed,
+                      const std::string& analysis_name,
+                      const std::string& analysis_parameters,
+                      TRapidJsonLineWriter& writer);
+
+    static std::string jsonString(size_t rows,
+                                  size_t cols,
+                                  size_t memoryLimit,
+                                  size_t numberThreads,
+                                  bool diskUsageAllowed,
+                                  const std::string& tempDir,
+                                  const std::string& resultField,
+                                  const std::string& analysis_name,
+                                  const std::string& analysis_parameters);
+};
+
+}
+}
+#endif //INCLUDED_ml_api_CDataFrameAnalysisSpecificationJsonWriter_h

--- a/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
+++ b/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
@@ -56,8 +56,8 @@ public:
                                   bool diskUsageAllowed,
                                   const std::string& tempDir,
                                   const std::string& resultField,
-                                  const std::string& analysis_name,
-                                  const std::string& analysis_parameters);
+                                  const std::string& analysisName,
+                                  const std::string& analysisParameters);
 };
 }
 }

--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -44,6 +44,12 @@ void CDataFrameAnalysisConfigReader::addParameter(const char* name,
     m_ParameterReaders.emplace_back(name, requirement, std::move(permittedValues));
 }
 
+void CDataFrameAnalysisConfigReader::addParameter(const std::string& name,
+                                                  ERequirement requirement,
+                                                  TStrIntMap permittedValues) {
+    addParameter(name.c_str(), requirement, std::move(permittedValues));
+}
+
 CDataFrameAnalysisConfigReader::CParameters
 CDataFrameAnalysisConfigReader::read(const rapidjson::Value& json) const {
 
@@ -150,6 +156,11 @@ CDataFrameAnalysisConfigReader::CParameter
         }
     }
     return {name};
+}
+
+CDataFrameAnalysisConfigReader::CParameter CDataFrameAnalysisConfigReader::CParameters::
+operator[](const std::string& name) const {
+    return this->operator[](name.c_str());
 }
 
 CDataFrameAnalysisConfigReader::CParameterReader::CParameterReader(const char* name,

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -64,7 +64,7 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
             break;
         }
         // if we are not allowed to spill over to disk then only one partition is possible
-        if (!m_Spec.diskUsageAllowed()) {
+        if (m_Spec.diskUsageAllowed() == false) {
             LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
             break;
         }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -109,8 +109,9 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         m_ResultsField = parameters[RESULTS_FIELD].fallback(DEFAULT_RESULT_FIELD);
         m_DiskUsageAllowed = parameters[DISK_USAGE_ALLOWED].fallback(DEFAULT_DISK_USAGE_ALLOWED);
 
-        if (m_DiskUsageAllowed and m_TemporaryDirectory.empty()) {
-            HANDLE_FATAL(<< "Temporary directory path should be explicitly set if disk usage is allowed!");
+        if (m_DiskUsageAllowed && m_TemporaryDirectory.empty()) {
+            HANDLE_FATAL(<< "Input error: temporary directory path should be explicitly set if disk"
+                            " usage is allowed! Please report this problem.");
         }
 
         auto jsonAnalysis = parameters[ANALYSIS].jsonObject();

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -7,9 +7,7 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 
 #include <core/CDataFrame.h>
-#include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
-#include <core/CRapidJsonLineWriter.h>
 
 #include <api/CDataFrameAnalysisConfigReader.h>
 #include <api/CDataFrameOutliersRunner.h>
@@ -22,10 +20,22 @@
 #include <cstring>
 #include <iterator>
 #include <memory>
-#include <thread>
 
 namespace ml {
 namespace api {
+
+// These must be consistent with Java names.
+const std::string CDataFrameAnalysisSpecification::ROWS("rows");
+const std::string CDataFrameAnalysisSpecification::COLS("cols");
+const std::string CDataFrameAnalysisSpecification::MEMORY_LIMIT("memory_limit");
+const std::string CDataFrameAnalysisSpecification::THREADS("threads");
+const std::string CDataFrameAnalysisSpecification::TEMPORARY_DIRECTORY("temp_dir");
+const std::string CDataFrameAnalysisSpecification::RESULTS_FIELD("results_field");
+const std::string CDataFrameAnalysisSpecification::ANALYSIS("analysis");
+const std::string CDataFrameAnalysisSpecification::NAME("name");
+const std::string CDataFrameAnalysisSpecification::PARAMETERS("parameters");
+const std::string CDataFrameAnalysisSpecification::DISK_USAGE_ALLOWED("disk_usage_allowed");
+
 namespace {
 using TRunnerFactoryUPtrVec = ml::api::CDataFrameAnalysisSpecification::TRunnerFactoryUPtrVec;
 
@@ -36,41 +46,36 @@ TRunnerFactoryUPtrVec analysisFactories() {
     return factories;
 }
 
-// These must be consistent with Java names.
-const char* const ROWS{"rows"};
-const char* const COLS{"cols"};
-const char* const MEMORY_LIMIT{"memory_limit"};
-const char* const THREADS{"threads"};
-const char* const TEMPORARY_DIRECTORY{"temp_dir"};
-const char* const RESULTS_FIELD{"results_field"};
-const char* const ANALYSIS{"analysis"};
-const char* const NAME{"name"};
-const char* const PARAMETERS{"parameters"};
-const char* const DISK_USAGE_ALLOWED{"disk_usage_allowed"};
-
 const std::string DEFAULT_RESULT_FIELD("ml");
 const bool DEFAULT_DISK_USAGE_ALLOWED(false);
 
 const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
     CDataFrameAnalysisConfigReader theReader;
-    theReader.addParameter(ROWS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(COLS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(MEMORY_LIMIT, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(THREADS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    // TODO required
-    theReader.addParameter(TEMPORARY_DIRECTORY,
+    theReader.addParameter(CDataFrameAnalysisSpecification::ROWS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::COLS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::MEMORY_LIMIT,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::THREADS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::TEMPORARY_DIRECTORY,
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
-    theReader.addParameter(RESULTS_FIELD, CDataFrameAnalysisConfigReader::E_OptionalParameter);
-    theReader.addParameter(ANALYSIS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(DISK_USAGE_ALLOWED,
+    theReader.addParameter(CDataFrameAnalysisSpecification::RESULTS_FIELD,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::ANALYSIS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::DISK_USAGE_ALLOWED,
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 
 const CDataFrameAnalysisConfigReader ANALYSIS_READER{[] {
     CDataFrameAnalysisConfigReader theReader;
-    theReader.addParameter(NAME, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(PARAMETERS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::NAME,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::PARAMETERS,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -105,10 +105,13 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         m_NumberColumns = parameters[COLS].as<std::size_t>();
         m_MemoryLimit = parameters[MEMORY_LIMIT].as<std::size_t>();
         m_NumberThreads = parameters[THREADS].as<std::size_t>();
-        m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(
-            boost::filesystem::current_path().string());
+        m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(std::string{});
         m_ResultsField = parameters[RESULTS_FIELD].fallback(DEFAULT_RESULT_FIELD);
         m_DiskUsageAllowed = parameters[DISK_USAGE_ALLOWED].fallback(DEFAULT_DISK_USAGE_ALLOWED);
+
+        if (m_DiskUsageAllowed and m_TemporaryDirectory.empty()) {
+            HANDLE_FATAL(<< "Temporary directory path should be explicitly set if disk usage is allowed!");
+        }
 
         auto jsonAnalysis = parameters[ANALYSIS].jsonObject();
         if (jsonAnalysis != nullptr) {

--- a/lib/api/CDataFrameAnalysisSpecificationJsonWriter.cc
+++ b/lib/api/CDataFrameAnalysisSpecificationJsonWriter.cc
@@ -4,13 +4,15 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
+
+#include <api/CDataFrameAnalysisSpecification.h>
+
+#include <iostream>
 
 namespace ml {
 namespace api {
 
-// TODO (valeriy) analysis parameter is missing
 void CDataFrameAnalysisSpecificationJsonWriter::write(std::size_t rows,
                                                       std::size_t cols,
                                                       std::size_t memoryLimit,
@@ -18,9 +20,26 @@ void CDataFrameAnalysisSpecificationJsonWriter::write(std::size_t rows,
                                                       const std::string& temporaryDirectory,
                                                       const std::string& resultsField,
                                                       bool diskUsageAllowed,
-                                                      const std::string& analysis_name,
-                                                      const std::string& analysis_parameters,
+                                                      const std::string& analysisName,
+                                                      const std::string& analysisParameters,
                                                       TRapidJsonLineWriter& writer) {
+    rapidjson::Document analysisParametersDoc;
+    analysisParametersDoc.Parse(analysisParameters);
+    write(rows, cols, memoryLimit, numberThreads, temporaryDirectory, resultsField,
+          diskUsageAllowed, analysisName, analysisParametersDoc, writer);
+}
+
+void CDataFrameAnalysisSpecificationJsonWriter::write(std::size_t rows,
+                                                      std::size_t cols,
+                                                      std::size_t memoryLimit,
+                                                      std::size_t numberThreads,
+                                                      const std::string& temporaryDirectory,
+                                                      const std::string& resultsField,
+                                                      bool diskUsageAllowed,
+                                                      const std::string& analysisName,
+                                                      const rapidjson::Document& analysisParametersDocument,
+                                                      TRapidJsonLineWriter& writer) {
+
     writer.StartObject();
 
     writer.String(CDataFrameAnalysisSpecification::ROWS);
@@ -47,13 +66,13 @@ void CDataFrameAnalysisSpecificationJsonWriter::write(std::size_t rows,
     writer.String(CDataFrameAnalysisSpecification::ANALYSIS);
     writer.StartObject();
     writer.String(CDataFrameAnalysisSpecification::NAME);
-    writer.String(analysis_name);
-    if (analysis_parameters.empty() == false) {
+    writer.String(analysisName);
+    if (analysisParametersDocument.IsObject()) {
         writer.String(CDataFrameAnalysisSpecification::PARAMETERS);
-        writer.String(analysis_parameters);
+        writer.write(analysisParametersDocument);
     }
-    writer.EndObject();
 
+    writer.EndObject();
     writer.EndObject();
     writer.Flush();
 }

--- a/lib/api/CDataFrameAnalysisSpecificationJsonWriter.cc
+++ b/lib/api/CDataFrameAnalysisSpecificationJsonWriter.cc
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
+
+namespace ml {
+namespace api {
+
+// TODO (valeriy) analysis parameter is missing
+void CDataFrameAnalysisSpecificationJsonWriter::write(std::size_t rows,
+                                                      std::size_t cols,
+                                                      std::size_t memoryLimit,
+                                                      std::size_t numberThreads,
+                                                      const std::string& temporaryDirectory,
+                                                      const std::string& resultsField,
+                                                      bool diskUsageAllowed,
+                                                      const std::string& analysis_name,
+                                                      const std::string& analysis_parameters,
+                                                      TRapidJsonLineWriter& writer) {
+    writer.StartObject();
+
+    writer.String(CDataFrameAnalysisSpecification::ROWS);
+    writer.Uint64(rows);
+
+    writer.String(CDataFrameAnalysisSpecification::COLS);
+    writer.Uint64(cols);
+
+    writer.String(CDataFrameAnalysisSpecification::MEMORY_LIMIT);
+    writer.Uint64(memoryLimit);
+
+    writer.String(CDataFrameAnalysisSpecification::THREADS);
+    writer.Uint64(numberThreads);
+
+    writer.String(CDataFrameAnalysisSpecification::TEMPORARY_DIRECTORY);
+    writer.String(temporaryDirectory);
+
+    writer.String(CDataFrameAnalysisSpecification::RESULTS_FIELD);
+    writer.String(resultsField);
+
+    writer.String(CDataFrameAnalysisSpecification::DISK_USAGE_ALLOWED);
+    writer.Bool(diskUsageAllowed);
+
+    writer.String(CDataFrameAnalysisSpecification::ANALYSIS);
+    writer.StartObject();
+    writer.String(CDataFrameAnalysisSpecification::NAME);
+    writer.String(analysis_name);
+    if (analysis_parameters.empty() == false) {
+        writer.String(CDataFrameAnalysisSpecification::PARAMETERS);
+        writer.String(analysis_parameters);
+    }
+    writer.EndObject();
+
+    writer.EndObject();
+    writer.Flush();
+}
+
+std::string
+CDataFrameAnalysisSpecificationJsonWriter::jsonString(size_t rows,
+                                                      size_t cols,
+                                                      size_t memoryLimit,
+                                                      size_t numberThreads,
+                                                      bool diskUsageAllowed,
+                                                      const std::string& tempDir,
+                                                      const std::string& resultField,
+                                                      const std::string& analysis_name,
+                                                      const std::string& analysis_parameters) {
+    rapidjson::StringBuffer stringBuffer;
+    api::CDataFrameAnalysisSpecificationJsonWriter::TRapidJsonLineWriter writer;
+    writer.Reset(stringBuffer);
+
+    write(rows, cols, memoryLimit, numberThreads, tempDir, resultField,
+          diskUsageAllowed, analysis_name, analysis_parameters, writer);
+
+    return stringBuffer.GetString();
+}
+}
+}

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -113,6 +113,14 @@ void CDataFrameAnalyzer::run() {
         return;
     }
 
+    if (m_DataFrame->numberRows() != m_AnalysisSpecification->numberRows()) {
+        HANDLE_FATAL(<< "Input error: expected '"
+                     << m_AnalysisSpecification->numberRows() << "' rows "
+                     << "but got '" << m_DataFrame->numberRows() << "' rows"
+                     << ". Please report this problem.");
+        return;
+    }
+
     LOG_TRACE(<< "Running analysis...");
 
     CDataFrameAnalysisRunner* analysis{m_AnalysisSpecification->run(*m_DataFrame)};
@@ -164,8 +172,8 @@ bool CDataFrameAnalyzer::prepareToReceiveControlMessages(const TStrVec& fieldNam
     } else if (fieldNames.size() < 2 || posDocHash != fieldNames.end() - 2 ||
                posControlMessage != fieldNames.end() - 1) {
 
-        HANDLE_FATAL(<< "Input error: expected exacly two special "
-                     << "fields in last two positions, got '"
+        HANDLE_FATAL(<< "Input error: expected exactly two special "
+                     << "fields in last two positions but got '"
                      << core::CContainerPrinter::print(fieldNames)
                      << "'. Please report this problem.");
         return false;

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -29,6 +29,7 @@ CCsvOutputWriter.cc \
 CDataFrameAnalysisConfigReader.cc \
 CDataFrameAnalysisRunner.cc \
 CDataFrameAnalysisSpecification.cc \
+CDataFrameAnalysisSpecificationJsonWriter.cc \
 CDataFrameAnalyzer.cc \
 CDataFrameOutliersRunner.cc \
 CDataProcessor.cc \

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -6,11 +6,12 @@
 
 #include "CDataFrameAnalysisRunnerTest.h"
 
-#include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameOutliersRunner.h>
+
+#include <test/CTestTmpDir.h>
 
 #include <mutex>
 #include <string>
@@ -85,6 +86,7 @@ CDataFrameAnalysisRunnerTest::createSpecJsonForDiskUsageTest(std::size_t numberR
                          std::to_string(numberCols) +
                          ",\n"
                          "  \"memory_limit\": 500000,\n"
+                         "  \"temp_dir\": \"" + test::CTestTmpDir::tmpDir() + "\",\n"
                          "  \"disk_usage_allowed\": " +
                          (diskUsageAllowed ? "true" : "false") +
                          ",\n"

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -86,7 +86,9 @@ CDataFrameAnalysisRunnerTest::createSpecJsonForDiskUsageTest(std::size_t numberR
                          std::to_string(numberCols) +
                          ",\n"
                          "  \"memory_limit\": 500000,\n"
-                         "  \"temp_dir\": \"" + test::CTestTmpDir::tmpDir() + "\",\n"
+                         "  \"temp_dir\": \"" +
+                         test::CTestTmpDir::tmpDir() +
+                         "\",\n"
                          "  \"disk_usage_allowed\": " +
                          (diskUsageAllowed ? "true" : "false") +
                          ",\n"

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -38,6 +38,9 @@ void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
                                  "  \"cols\": " +
                                  std::to_string(numberCols) +
                                  ",\n"
+                                 "  \"temp_dir\": \"" +
+                                 test::CTestTmpDir::tmpDir() +
+                                 "\",\n"
                                  "  \"memory_limit\": 100000000,\n"
                                  "  \"disk_usage_allowed\": true,\n"
                                  "  \"threads\": 1,\n"

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -9,6 +9,7 @@
 #include <core/CLogger.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameOutliersRunner.h>
 
 #include <test/CTestTmpDir.h>
@@ -30,24 +31,9 @@ void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
             LOG_DEBUG(<< "# rows = " << numberRows << ", # cols = " << numberCols);
 
             // Give the process approximately 100MB.
-
-            std::string jsonSpec{"{\n"
-                                 "  \"rows\": " +
-                                 std::to_string(numberRows) +
-                                 ",\n"
-                                 "  \"cols\": " +
-                                 std::to_string(numberCols) +
-                                 ",\n"
-                                 "  \"temp_dir\": \"" +
-                                 test::CTestTmpDir::tmpDir() +
-                                 "\",\n"
-                                 "  \"memory_limit\": 100000000,\n"
-                                 "  \"disk_usage_allowed\": true,\n"
-                                 "  \"threads\": 1,\n"
-                                 "  \"analysis\": {\n"
-                                 "    \"name\": \"outlier_detection\""
-                                 "  }"
-                                 "}"};
+            std::string jsonSpec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+                numberRows, numberCols, 100000000, 1, true,
+                test::CTestTmpDir::tmpDir(), "", "outlier_detection", "")};
 
             api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
@@ -81,26 +67,9 @@ std::string
 CDataFrameAnalysisRunnerTest::createSpecJsonForDiskUsageTest(std::size_t numberRows,
                                                              std::size_t numberCols,
                                                              bool diskUsageAllowed) {
-    std::string jsonSpec{"{\n"
-                         "  \"rows\": " +
-                         std::to_string(numberRows) +
-                         ",\n"
-                         "  \"cols\": " +
-                         std::to_string(numberCols) +
-                         ",\n"
-                         "  \"memory_limit\": 500000,\n"
-                         "  \"temp_dir\": \"" +
-                         test::CTestTmpDir::tmpDir() +
-                         "\",\n"
-                         "  \"disk_usage_allowed\": " +
-                         (diskUsageAllowed ? "true" : "false") +
-                         ",\n"
-                         "  \"threads\": 1,\n"
-                         "  \"analysis\": {\n"
-                         "    \"name\": \"outlier_detection\""
-                         "  }"
-                         "}"};
-    return jsonSpec;
+    return api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        numberRows, numberCols, 500000, 1, diskUsageAllowed,
+        test::CTestTmpDir::tmpDir(), "", "outlier_detection", "");
 }
 
 void CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag() {

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -291,7 +291,7 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
 
 std::string
 CDataFrameAnalysisSpecificationTest::createSpecJsonForTempDirDiskUsageTest(bool tempDirPathSet,
-                                                             bool diskUsageAllowed) {
+                                                                           bool diskUsageAllowed) {
 
     std::string tempDirParameter = tempDirPathSet ? "  \"temp_dir\": \"/tmp\",\n" : "";
     std::string diskUsageParameter = diskUsageAllowed ? "true" : "false";
@@ -299,8 +299,8 @@ CDataFrameAnalysisSpecificationTest::createSpecJsonForTempDirDiskUsageTest(bool 
                          "  \"rows\": 100,\n"
                          "  \"cols\": 3,\n"
                          "  \"memory_limit\": 500000,\n" +
-                         tempDirParameter +
-                         "  \"disk_usage_allowed\": " + diskUsageParameter + ",\n"
+                         tempDirParameter + "  \"disk_usage_allowed\": " + diskUsageParameter +
+                         ",\n"
                          "  \"threads\": 1,\n"
                          "  \"analysis\": {\n"
                          "    \"name\": \"outlier_detection\""
@@ -308,7 +308,6 @@ CDataFrameAnalysisSpecificationTest::createSpecJsonForTempDirDiskUsageTest(bool 
                          "}"};
     return jsonSpec;
 }
-
 
 void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {
 
@@ -365,8 +364,8 @@ CppUnit::Test* CDataFrameAnalysisSpecificationTest::suite() {
         "CDataFrameAnalysisSpecificationTest::testRunAnalysis",
         &CDataFrameAnalysisSpecificationTest::testRunAnalysis));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisSpecificationTest>(
-            "CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage",
-            &CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage));
+        "CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage",
+        &CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage));
 
     return suiteOfTests;
 }

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -308,7 +308,7 @@ void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {
         api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
         // single error is registered that temp dir is empty
-        CPPUNIT_ASSERT_EQUAL(1, static_cast<int>(errors.size()));
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), errors.size());
         CPPUNIT_ASSERT(errors[0].find("Input error: temporary directory path should be explicitly set if disk usage is allowed!") !=
                        std::string::npos);
     }
@@ -320,7 +320,7 @@ void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {
         api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
         // no error should be registered
-        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(errors.size()));
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), errors.size());
     }
 
     // Temp dir given and disk usage allowed
@@ -330,7 +330,7 @@ void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {
         api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
         // no error should be registered
-        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(errors.size()));
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), errors.size());
     }
 }
 

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -326,7 +326,7 @@ void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {
         std::string jsonSpec{createSpecJsonForTempDirDiskUsageTest(false, true)};
         api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
-        // single error is registered that the memory limit is to low
+        // single error is registered that temp dir is empty
         CPPUNIT_ASSERT_EQUAL(1, static_cast<int>(errors.size()));
         CPPUNIT_ASSERT(errors[0].find("Temporary directory path should be explicitly set") !=
                        std::string::npos);

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -12,6 +12,7 @@
 
 #include <api/CDataFrameAnalysisRunner.h>
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameOutliersRunner.h>
 
 #include <test/CTestTmpDir.h>
@@ -254,19 +255,19 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
         return factories;
     };
 
-    std::string jsonSpec{"{\n"
-                         "  \"rows\": 100,\n"
-                         "  \"cols\": 10,\n"
-                         "  \"memory_limit\": 1000,\n"
-                         "  \"threads\": 1,\n"
-                         "  \"temp_dir\": \"" +
-                         test::CTestTmpDir::tmpDir() +
-                         "\",\n"
-                         "  \"disk_usage_allowed\": true,\n"
-                         "  \"analysis\": {\n"
-                         "    \"name\": \"test\""
-                         "  }"
-                         "}"};
+    std::size_t rows = 100;
+    std::size_t cols = 10;
+    std::size_t memoryLimit = 1000;
+    std::size_t numberThreads = 1;
+    std::string tempDir = test::CTestTmpDir::tmpDir();
+    std::string resultField = "";
+    bool diskUsageAllowed = true;
+    std::string analysis_name = "test";
+    std::string analysis_parameters = "";
+
+    std::string jsonSpec = api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        rows, cols, memoryLimit, numberThreads, diskUsageAllowed, tempDir,
+        resultField, analysis_name, analysis_parameters);
 
     for (std::size_t i = 0; i < 10; ++i) {
         api::CDataFrameAnalysisSpecification spec{testFactory(), jsonSpec};
@@ -295,20 +296,9 @@ std::string
 CDataFrameAnalysisSpecificationTest::createSpecJsonForTempDirDiskUsageTest(bool tempDirPathSet,
                                                                            bool diskUsageAllowed) {
 
-    std::string tempDirParameter = tempDirPathSet ? "  \"temp_dir\": \"/tmp\",\n" : "";
-    std::string diskUsageParameter = diskUsageAllowed ? "true" : "false";
-    std::string jsonSpec{"{\n"
-                         "  \"rows\": 100,\n"
-                         "  \"cols\": 3,\n"
-                         "  \"memory_limit\": 500000,\n" +
-                         tempDirParameter + "  \"disk_usage_allowed\": " + diskUsageParameter +
-                         ",\n"
-                         "  \"threads\": 1,\n"
-                         "  \"analysis\": {\n"
-                         "    \"name\": \"outlier_detection\""
-                         "  }"
-                         "}"};
-    return jsonSpec;
+    std::string tempDir = tempDirPathSet ? test::CTestTmpDir::tmpDir() : "";
+    return api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        100, 3, 500000, 1, diskUsageAllowed, tempDir, "", "outlier_detection", "");
 }
 
 void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -9,13 +9,12 @@
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
-#include <core/CStopWatch.h>
 
 #include <api/CDataFrameAnalysisRunner.h>
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameOutliersRunner.h>
 
-#include <test/CRandomNumbers.h>
+#include <test/CTestTmpDir.h>
 
 #include "CDataFrameMockAnalysisRunner.h"
 
@@ -260,6 +259,7 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
                          "  \"cols\": 10,\n"
                          "  \"memory_limit\": 1000,\n"
                          "  \"threads\": 1,\n"
+                         "  \"temp_dir\": \"" + test::CTestTmpDir::tmpDir() + "\",\n"
                          "  \"disk_usage_allowed\": true,\n"
                          "  \"analysis\": {\n"
                          "    \"name\": \"test\""

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -255,19 +255,8 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
         return factories;
     };
 
-    std::size_t rows = 100;
-    std::size_t cols = 10;
-    std::size_t memoryLimit = 1000;
-    std::size_t numberThreads = 1;
-    std::string tempDir = test::CTestTmpDir::tmpDir();
-    std::string resultField = "";
-    bool diskUsageAllowed = true;
-    std::string analysis_name = "test";
-    std::string analysis_parameters = "";
-
     std::string jsonSpec = api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
-        rows, cols, memoryLimit, numberThreads, diskUsageAllowed, tempDir,
-        resultField, analysis_name, analysis_parameters);
+        100, 10, 1000, 1, true, test::CTestTmpDir::tmpDir(), "", "test", "");
 
     for (std::size_t i = 0; i < 10; ++i) {
         api::CDataFrameAnalysisSpecification spec{testFactory(), jsonSpec};

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -330,7 +330,7 @@ void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {
 
         // single error is registered that temp dir is empty
         CPPUNIT_ASSERT_EQUAL(1, static_cast<int>(errors.size()));
-        CPPUNIT_ASSERT(errors[0].find("Temporary directory path should be explicitly set") !=
+        CPPUNIT_ASSERT(errors[0].find("Input error: temporary directory path should be explicitly set if disk usage is allowed!") !=
                        std::string::npos);
     }
 

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -259,7 +259,9 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
                          "  \"cols\": 10,\n"
                          "  \"memory_limit\": 1000,\n"
                          "  \"threads\": 1,\n"
-                         "  \"temp_dir\": \"" + test::CTestTmpDir::tmpDir() + "\",\n"
+                         "  \"temp_dir\": \"" +
+                         test::CTestTmpDir::tmpDir() +
+                         "\",\n"
                          "  \"disk_usage_allowed\": true,\n"
                          "  \"analysis\": {\n"
                          "    \"name\": \"test\""

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.h
@@ -13,8 +13,12 @@ class CDataFrameAnalysisSpecificationTest : public CppUnit::TestFixture {
 public:
     void testCreate();
     void testRunAnalysis();
+    void testTempDirDiskUsage();
 
     static CppUnit::Test* suite();
+
+private:
+    std::string createSpecJsonForTempDirDiskUsageTest(bool, bool);
 };
 
 #endif // INCLUDED_CDataFrameAnalysisSpecificationTest_h

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.h
@@ -19,6 +19,15 @@ public:
 
 private:
     std::string createSpecJsonForTempDirDiskUsageTest(bool, bool);
+    std::string jsonString(size_t rows,
+                           size_t cols,
+                           size_t memoryLimit,
+                           size_t numberThreads,
+                           bool diskUsageAllowed,
+                           const std::string& tempDir,
+                           const std::string& resultField,
+                           const std::string& analysis_name,
+                           const std::string& analysis_parameters) const;
 };
 
 #endif // INCLUDED_CDataFrameAnalysisSpecificationTest_h

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -479,6 +479,20 @@ void CDataFrameAnalyzerTest::testErrors() {
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
+
+    // Test inconsistent number of rows
+    {
+        api::CDataFrameAnalyzer analyzer{outlierSpec(2), outputWriterFactory};
+        errors.clear();
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"10", "10", "10", "10", "10", "0", ""}));
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"", "", "", "", "", "", "$"}));
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        CPPUNIT_ASSERT(errors.size() > 0);
+    }
 }
 
 void CDataFrameAnalyzerTest::testRoundTripDocHashes() {
@@ -488,7 +502,7 @@ void CDataFrameAnalyzerTest::testRoundTripDocHashes() {
         return std::make_unique<core::CJsonOutputStreamWrapper>(output);
     };
 
-    api::CDataFrameAnalyzer analyzer{outlierSpec(), outputWriterFactory};
+    api::CDataFrameAnalyzer analyzer{outlierSpec(9), outputWriterFactory};
     for (auto i : {"1", "2", "3", "4", "5", "6", "7", "8", "9"}) {
         analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
                               {i, i, i, i, i, i, ""});

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -15,6 +15,7 @@
 #include <maths/COutliers.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameAnalyzer.h>
 
 #include <test/CDataFrameTestUtils.h>
@@ -46,45 +47,33 @@ outlierSpec(std::size_t rows = 110,
             std::size_t numberNeighbours = 0,
             bool computeFeatureInfluence = false) {
 
-    std::string spec{"{\n"
-                     "  \"rows\": " +
-                     std::to_string(rows) +
-                     ",\n"
-                     "  \"cols\": 5,\n"
-                     "  \"memory_limit\": " +
-                     std::to_string(memoryLimit) +
-                     ",\n"
-                     "  \"threads\": 1,\n"
-                     "  \"temp_dir\": \"" +
-                     test::CTestTmpDir::tmpDir() +
-                     "\",\n"
-                     "  \"disk_usage_allowed\": true,\n"
-                     "  \"analysis\": {\n"
-                     "    \"name\": \"outlier_detection\""};
-    spec += ",\n    \"parameters\": {\n";
+    std::string parameters = "{\n";
     bool hasTrailingParameter{false};
     if (method != "") {
-        spec += "      \"method\": \"" + method + "\"";
+        parameters += "      \"method\": \"" + method + "\"";
         hasTrailingParameter = true;
     }
     if (numberNeighbours > 0) {
-        spec += (hasTrailingParameter ? ",\n" : "");
-        spec += "      \"n_neighbors\": " + core::CStringUtils::typeToString(numberNeighbours);
+        parameters += (hasTrailingParameter ? ",\n" : "");
+        parameters += "      \"n_neighbors\": " +
+                      core::CStringUtils::typeToString(numberNeighbours);
         hasTrailingParameter = true;
     }
     if (computeFeatureInfluence == false) {
-        spec += (hasTrailingParameter ? ",\n" : "");
-        spec += "      \"compute_feature_influence\": false";
+        parameters += (hasTrailingParameter ? ",\n" : "");
+        parameters += "      \"compute_feature_influence\": false";
         hasTrailingParameter = true;
     } else {
-        spec += (hasTrailingParameter ? ",\n" : "");
-        spec += "      \"feature_influence_threshold\": 0.0";
+        parameters += (hasTrailingParameter ? ",\n" : "");
+        parameters += "      \"feature_influence_threshold\": 0.0";
         hasTrailingParameter = true;
     }
-    spec += (hasTrailingParameter ? "\n" : "");
-    spec += "    }\n";
-    spec += "  }\n"
-            "}";
+    parameters += (hasTrailingParameter ? "\n" : "");
+    parameters += "    }\n";
+
+    std::string spec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        rows, 5, memoryLimit, 1, true, test::CTestTmpDir::tmpDir(), "ml",
+        "outlier_detection", parameters)};
 
     LOG_TRACE(<< "spec =\n" << spec);
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -55,7 +55,9 @@ outlierSpec(std::size_t rows = 110,
                      std::to_string(memoryLimit) +
                      ",\n"
                      "  \"threads\": 1,\n"
-                     "  \"temp_dir\": \"" + test::CTestTmpDir::tmpDir() + "\",\n"
+                     "  \"temp_dir\": \"" +
+                     test::CTestTmpDir::tmpDir() +
+                     "\",\n"
                      "  \"disk_usage_allowed\": true,\n"
                      "  \"analysis\": {\n"
                      "    \"name\": \"outlier_detection\""};

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -19,6 +19,7 @@
 
 #include <test/CDataFrameTestUtils.h>
 #include <test/CRandomNumbers.h>
+#include <test/CTestTmpDir.h>
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
@@ -54,6 +55,7 @@ outlierSpec(std::size_t rows = 110,
                      std::to_string(memoryLimit) +
                      ",\n"
                      "  \"threads\": 1,\n"
+                     "  \"temp_dir\": \"" + test::CTestTmpDir::tmpDir() + "\",\n"
                      "  \"disk_usage_allowed\": true,\n"
                      "  \"analysis\": {\n"
                      "    \"name\": \"outlier_detection\""};


### PR DESCRIPTION
If the json specification parameter `temp_dir` is not set, but `disk_usage_allowed` is `true`, the specification is in inconsistent state. This PR adds an error message informing user about the misconfiguration.