### PR TITLE
[7.4][ML] Move json constants to CDataFrameAnalysisSpecification definition

### DIFF
--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -122,6 +122,9 @@ public:
         }
 
         //! Get the parameter called \p name.
+        CParameter operator[](const std::string& name) const;
+
+        //! Get the parameter called \p name.
         CParameter operator[](const char* name) const;
 
     private:
@@ -135,6 +138,15 @@ public:
     //! \param[in] requirement Is the parameter required or optional.
     //! \param[in] permittedValues The permitted values for an enumeration.
     void addParameter(const char* name,
+                      ERequirement requirement,
+                      TStrIntMap permittedValues = TStrIntMap{});
+
+    //! Register a parameter.
+    //!
+    //! \param[in] name The parameter name.
+    //! \param[in] requirement Is the parameter required or optional.
+    //! \param[in] permittedValues The permitted values for an enumeration.
+    void addParameter(const std::string& name,
                       ERequirement requirement,
                       TStrIntMap permittedValues = TStrIntMap{});
 

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -50,6 +50,18 @@ public:
     using TRunnerFactoryUPtrVec = std::vector<TRunnerFactoryUPtr>;
 
 public:
+    static const std::string ROWS;
+    static const std::string COLS;
+    static const std::string MEMORY_LIMIT;
+    static const std::string THREADS;
+    static const std::string TEMPORARY_DIRECTORY;
+    static const std::string RESULTS_FIELD;
+    static const std::string ANALYSIS;
+    static const std::string NAME;
+    static const std::string PARAMETERS;
+    static const std::string DISK_USAGE_ALLOWED;
+
+public:
     //! Initialize from a JSON object.
     //!
     //! The specification has the following expected form:

--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -44,6 +44,12 @@ void CDataFrameAnalysisConfigReader::addParameter(const char* name,
     m_ParameterReaders.emplace_back(name, requirement, std::move(permittedValues));
 }
 
+void CDataFrameAnalysisConfigReader::addParameter(const std::string& name,
+                                                  ERequirement requirement,
+                                                  TStrIntMap permittedValues) {
+    addParameter(name.c_str(), requirement, std::move(permittedValues));
+}
+
 CDataFrameAnalysisConfigReader::CParameters
 CDataFrameAnalysisConfigReader::read(const rapidjson::Value& json) const {
 
@@ -150,6 +156,11 @@ CDataFrameAnalysisConfigReader::CParameter
         }
     }
     return {name};
+}
+
+CDataFrameAnalysisConfigReader::CParameter CDataFrameAnalysisConfigReader::CParameters::
+operator[](const std::string& name) const {
+    return this->operator[](name.c_str());
 }
 
 CDataFrameAnalysisConfigReader::CParameterReader::CParameterReader(const char* name,

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -7,9 +7,7 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 
 #include <core/CDataFrame.h>
-#include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
-#include <core/CRapidJsonLineWriter.h>
 
 #include <api/CDataFrameAnalysisConfigReader.h>
 #include <api/CDataFrameOutliersRunner.h>
@@ -22,10 +20,22 @@
 #include <cstring>
 #include <iterator>
 #include <memory>
-#include <thread>
 
 namespace ml {
 namespace api {
+
+// These must be consistent with Java names.
+const std::string CDataFrameAnalysisSpecification::ROWS("rows");
+const std::string CDataFrameAnalysisSpecification::COLS("cols");
+const std::string CDataFrameAnalysisSpecification::MEMORY_LIMIT("memory_limit");
+const std::string CDataFrameAnalysisSpecification::THREADS("threads");
+const std::string CDataFrameAnalysisSpecification::TEMPORARY_DIRECTORY("temp_dir");
+const std::string CDataFrameAnalysisSpecification::RESULTS_FIELD("results_field");
+const std::string CDataFrameAnalysisSpecification::ANALYSIS("analysis");
+const std::string CDataFrameAnalysisSpecification::NAME("name");
+const std::string CDataFrameAnalysisSpecification::PARAMETERS("parameters");
+const std::string CDataFrameAnalysisSpecification::DISK_USAGE_ALLOWED("disk_usage_allowed");
+
 namespace {
 using TRunnerFactoryUPtrVec = ml::api::CDataFrameAnalysisSpecification::TRunnerFactoryUPtrVec;
 
@@ -36,41 +46,36 @@ TRunnerFactoryUPtrVec analysisFactories() {
     return factories;
 }
 
-// These must be consistent with Java names.
-const char* const ROWS{"rows"};
-const char* const COLS{"cols"};
-const char* const MEMORY_LIMIT{"memory_limit"};
-const char* const THREADS{"threads"};
-const char* const TEMPORARY_DIRECTORY{"temp_dir"};
-const char* const RESULTS_FIELD{"results_field"};
-const char* const ANALYSIS{"analysis"};
-const char* const NAME{"name"};
-const char* const PARAMETERS{"parameters"};
-const char* const DISK_USAGE_ALLOWED{"disk_usage_allowed"};
-
 const std::string DEFAULT_RESULT_FIELD("ml");
 const bool DEFAULT_DISK_USAGE_ALLOWED(false);
 
 const CDataFrameAnalysisConfigReader CONFIG_READER{[] {
     CDataFrameAnalysisConfigReader theReader;
-    theReader.addParameter(ROWS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(COLS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(MEMORY_LIMIT, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(THREADS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    // TODO required
-    theReader.addParameter(TEMPORARY_DIRECTORY,
+    theReader.addParameter(CDataFrameAnalysisSpecification::ROWS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::COLS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::MEMORY_LIMIT,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::THREADS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::TEMPORARY_DIRECTORY,
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
-    theReader.addParameter(RESULTS_FIELD, CDataFrameAnalysisConfigReader::E_OptionalParameter);
-    theReader.addParameter(ANALYSIS, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(DISK_USAGE_ALLOWED,
+    theReader.addParameter(CDataFrameAnalysisSpecification::RESULTS_FIELD,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::ANALYSIS,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::DISK_USAGE_ALLOWED,
                            CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 
 const CDataFrameAnalysisConfigReader ANALYSIS_READER{[] {
     CDataFrameAnalysisConfigReader theReader;
-    theReader.addParameter(NAME, CDataFrameAnalysisConfigReader::E_RequiredParameter);
-    theReader.addParameter(PARAMETERS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::NAME,
+                           CDataFrameAnalysisConfigReader::E_RequiredParameter);
+    theReader.addParameter(CDataFrameAnalysisSpecification::PARAMETERS,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }()};
 }


### PR DESCRIPTION
This PR moves the definitions of the constants for json specification parameter names into the class `CDataFrameAnalysisSpecification`. The type of the constants is changed from `const char* const` to `static const std::string`. This makes them consistent with definitions of other constants elsewhere in the code and adhere to the practices of the modern C++ development.