### PR TITLE
[FEATURE][ML] Tools for auto encoding categorical fields

### DIFF
--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -97,7 +97,6 @@ public:
 
     //! Get the relative frequency of each category in \p frame.
     //!
-    //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute category frequencies.
     //! \param[in] columnMask A mask of the columns to include.
     //! \return The frequency of each category. The collection is indexed by column
@@ -176,6 +175,8 @@ private:
                                                    const TSizeVec& columnMask,
                                                    std::size_t targetColumn,
                                                    std::size_t numberSamples);
+    static void removeMetricColumns(const core::CDataFrame& frame, TSizeVec& columnMask);
+    static void removeCategoricalColumns(const core::CDataFrame& frame, TSizeVec& columnMask);
     static double unitWeight(const TRowRef&);
 };
 }

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -54,7 +54,11 @@ struct SRowTo<CDenseVector<T>> {
 class MATHS_EXPORT CDataFrameUtils : private core::CNonInstantiatable {
 public:
     using TDoubleVec = std::vector<double>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
     using TSizeVec = std::vector<std::size_t>;
+    using TSizeDoublePr = std::pair<std::size_t, double>;
+    using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
+    using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
     using TRowRef = core::CDataFrame::TRowRef;
     using TWeightFunction = std::function<double(TRowRef)>;
     using TQuantileSketchVec = std::vector<CQuantileSketch>;
@@ -70,7 +74,7 @@ public:
     //! Subtract the mean and divide each column value by its standard deviation.
     //!
     //! \param[in] numberThreads The number of threads available.
-    //! \param[in] frame The data frame whose columns are to be standardized.
+    //! \param[in,out] frame The data frame whose columns are to be standardized.
     static bool standardizeColumns(std::size_t numberThreads, core::CDataFrame& frame);
 
     //! Get a quantile sketch of each column's values.
@@ -91,30 +95,86 @@ public:
                                 TQuantileSketchVec& result,
                                 TWeightFunction weight = unitWeight);
 
+    //! Get the relative frequency of each category in \p frame.
+    //!
+    //! \param[in] numberThreads The number of threads available.
+    //! \param[in] frame The data frame for which to compute category frequencies.
+    //! \param[in] columnMask A mask of the columns to include.
+    //! \return The frequencies of each category indexed by column and then stored
+    //! category identifier.
+    static TDoubleVecVec categoryFrequencies(std::size_t numberThreads,
+                                             const core::CDataFrame& frame,
+                                             TSizeVec columnMask);
+
+    //! Compute the mean value of \p targetColumn on the restriction to the rows
+    //! labelled by each distinct category of the categorical columns.
+    //!
+    //! \param[in] numberThreads The number of threads available.
+    //! \param[in] frame The data frame for which to compute mean values.
+    //! \param[in] columnMask A mask of the columns to include.
+    //! \param[in] targetColumn The column whose mean values are computed.
+    //! \return The mean values of \p targetColumn indexed by column and then stored
+    //! category identifier.
+    static TDoubleVecVec meanValueOfTargetForCategories(std::size_t numberThreads,
+                                                        const core::CDataFrame& frame,
+                                                        TSizeVec columnMask,
+                                                        std::size_t targetColumn);
+
+    //! Assess the strength of the relationship for each distinct category with
+    //! \p targetColumn by computing the maximum information coefficient (MIC).
+    //!
+    //! \param[in] numberThreads The number of threads available.
+    //! \param[in] frame The data frame for which to compute the column MICs.
+    //! \param[in] columnMask A mask of the columns to include.
+    //! \param[in] targetColumn The column with which to compute MIC.
+    //! \param[in] minimumFrequency The minimum frequency of the category in the
+    //! data set for which to compute MIC.
+    //! \return A collection containing (category identifier, MIC with \p targetColumn)
+    //! pairs for the frequent categorical fields indexed by column index.
+    static TSizeDoublePrVecVec categoryMicWithColumn(std::size_t numberThreads,
+                                                     const core::CDataFrame& frame,
+                                                     TSizeVec columnMask,
+                                                     std::size_t targetColumn,
+                                                     double minimumFrequency = 0.01);
+
     //! Assess the strength of the relationship for each column with \p targetColumn
     //! by computing the maximum information coefficient (MIC).
     //!
     //! \param[in] frame The data frame for which to compute the column MICs.
-    //! \param[in] columnMask A mask of the columns for which to compute MIC.
+    //! \param[in] columnMask A mask of the columns to include.
     //! \param[in] targetColumn The column with which to compute MIC.
     //! \return A collection containing the MIC of each column with \p targetColumn
     //! indexed by column index.
     static TDoubleVec micWithColumn(const core::CDataFrame& frame,
-                                    const TSizeVec& columnMask,
+                                    TSizeVec columnMask,
                                     std::size_t targetColumn);
 
     //! Check if a data frame value is missing.
     static bool isMissing(double value);
 
 private:
-    static TDoubleVec micWithColumnDataFrameInMainMemory(std::size_t numberSamples,
-                                                         const core::CDataFrame& frame,
-                                                         const TSizeVec& columnMask,
-                                                         std::size_t targetColumn);
-    static TDoubleVec micWithColumnDataFrameOnDisk(std::size_t numberSamples,
-                                                   const core::CDataFrame& frame,
+    static TSizeDoublePrVecVec
+    categoryMicWithColumnDataFrameInMemory(std::size_t numberThreads,
+                                           const core::CDataFrame& frame,
+                                           const TSizeVec& columnMask,
+                                           std::size_t targetColumn,
+                                           std::size_t numberSamples,
+                                           double minimumFrequency);
+    static TSizeDoublePrVecVec
+    categoryMicWithColumnDataFrameOnDisk(std::size_t numberThreads,
+                                         const core::CDataFrame& frame,
+                                         const TSizeVec& columnMask,
+                                         std::size_t targetColumn,
+                                         std::size_t numberSamples,
+                                         double minimumFrequency);
+    static TDoubleVec micWithColumnDataFrameInMemory(const core::CDataFrame& frame,
+                                                     const TSizeVec& columnMask,
+                                                     std::size_t targetColumn,
+                                                     std::size_t numberSamples);
+    static TDoubleVec micWithColumnDataFrameOnDisk(const core::CDataFrame& frame,
                                                    const TSizeVec& columnMask,
-                                                   std::size_t targetColumn);
+                                                   std::size_t targetColumn,
+                                                   std::size_t numberSamples);
     static double unitWeight(const TRowRef&);
 };
 }

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -100,8 +100,8 @@ public:
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute category frequencies.
     //! \param[in] columnMask A mask of the columns to include.
-    //! \return The frequencies of each category indexed by column and then stored
-    //! category identifier.
+    //! \return The frequency of each category. The collection is indexed by column
+    //! and then category identifier.
     static TDoubleVecVec categoryFrequencies(std::size_t numberThreads,
                                              const core::CDataFrame& frame,
                                              TSizeVec columnMask);
@@ -113,8 +113,8 @@ public:
     //! \param[in] frame The data frame for which to compute mean values.
     //! \param[in] columnMask A mask of the columns to include.
     //! \param[in] targetColumn The column whose mean values are computed.
-    //! \return The mean values of \p targetColumn indexed by column and then stored
-    //! category identifier.
+    //! \return The mean values of \p targetColumn for each category. The collection
+    //! is indexed by column and then category identifier.
     static TDoubleVecVec meanValueOfTargetForCategories(std::size_t numberThreads,
                                                         const core::CDataFrame& frame,
                                                         TSizeVec columnMask,
@@ -124,27 +124,28 @@ public:
     //! \p targetColumn by computing the maximum information coefficient (MIC).
     //!
     //! \param[in] numberThreads The number of threads available.
-    //! \param[in] frame The data frame for which to compute the column MICs.
+    //! \param[in] frame The data frame for which to compute the category MICs.
     //! \param[in] columnMask A mask of the columns to include.
     //! \param[in] targetColumn The column with which to compute MIC.
     //! \param[in] minimumFrequency The minimum frequency of the category in the
     //! data set for which to compute MIC.
-    //! \return A collection containing (category identifier, MIC with \p targetColumn)
-    //! pairs for the frequent categorical fields indexed by column index.
+    //! \return A collection containing (category, MIC with \p targetColumn) pairs
+    //! for each category whose frequency in \p frame is greater than \p minimumFrequency
+    //! and each categorical column. The collection is indexed by column.
     static TSizeDoublePrVecVec categoryMicWithColumn(std::size_t numberThreads,
                                                      const core::CDataFrame& frame,
                                                      TSizeVec columnMask,
                                                      std::size_t targetColumn,
                                                      double minimumFrequency = 0.01);
 
-    //! Assess the strength of the relationship for each column with \p targetColumn
-    //! by computing the maximum information coefficient (MIC).
+    //! Assess the strength of the relationship for each metric valued column with
+    //! \p targetColumn by computing the maximum information coefficient (MIC).
     //!
     //! \param[in] frame The data frame for which to compute the column MICs.
     //! \param[in] columnMask A mask of the columns to include.
     //! \param[in] targetColumn The column with which to compute MIC.
-    //! \return A collection containing the MIC of each column with \p targetColumn
-    //! indexed by column index.
+    //! \return A collection containing the MIC of each metric valued column with
+    //! \p targetColumn. The collectionis indexed by column.
     static TDoubleVec micWithColumn(const core::CDataFrame& frame,
                                     TSizeVec columnMask,
                                     std::size_t targetColumn);

--- a/include/maths/CMic.h
+++ b/include/maths/CMic.h
@@ -12,6 +12,7 @@
 
 #include <boost/operators.hpp>
 
+#include <array>
 #include <vector>
 
 class CMicTest;
@@ -35,6 +36,9 @@ public:
     //! Reserve space for the number of samples if this known in advance.
     void reserve(std::size_t n);
 
+    //! Clear all state.
+    void clear();
+
     //! Merge this and \p other.
     const CMic& operator+=(const CMic& other);
 
@@ -47,6 +51,7 @@ public:
 private:
     using TDoubleVec = std::vector<double>;
     using TSizeVec = std::vector<std::size_t>;
+    using TSizeVec2Ary = std::array<TSizeVec, 2>;
     using TVector2d = CVectorNx1<double, 2>;
     using TVector2dVec = std::vector<TVector2d>;
     using TVectorXd = CVector<double>;
@@ -62,7 +67,7 @@ private:
 
 private:
     TVector2dVec m_Samples;
-    TSizeVec m_Order[2];
+    TSizeVec2Ary m_Order;
 
     friend class ::CMicTest;
 };

--- a/include/test/CRandomNumbers.h
+++ b/include/test/CRandomNumbers.h
@@ -123,7 +123,7 @@ public:
                                     std::size_t numberSamples,
                                     TDoubleVec& samples);
 
-    //! Generate random samples from a Diriclet distribution with
+    //! Generate random samples from a Dirichlet distribution with
     //! concentration parameters \p concentrations.
     void generateDirichletSamples(const TDoubleVec& concentrations,
                                   std::size_t numberSamples,

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -154,6 +154,7 @@ void CDataFrame::reserve(std::size_t numberThreads, std::size_t rowCapacity) {
 
 void CDataFrame::resizeColumns(std::size_t numberThreads, std::size_t numberColumns) {
     this->reserve(numberThreads, numberColumns);
+    m_ColumnIsCategorical.resize(numberColumns, false);
     m_NumberColumns = numberColumns;
 }
 

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -15,7 +15,6 @@
 #include <maths/CMathsFuncs.h>
 #include <maths/CMic.h>
 #include <maths/COrderings.h>
-#include <maths/CPRNG.h>
 #include <maths/CQuantileSketch.h>
 #include <maths/CSampling.h>
 
@@ -526,7 +525,6 @@ CDataFrameUtils::micWithColumnDataFrameOnDisk(const core::CDataFrame& frame,
 
     // Do sampling
 
-    CPRNG::CXorOShiro128Plus rng;
     TFloatVecVec samples;
     samples.reserve(numberSamples);
 

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -145,7 +145,6 @@ bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
     }
 
     result = std::move(quantiles.first[0].s_FunctionState);
-
     for (std::size_t i = 1; i < quantiles.first.size(); ++i) {
         for (std::size_t j = 0; j < columnMask.size(); ++j) {
             result[j] += quantiles.first[i].s_FunctionState[j];
@@ -189,11 +188,7 @@ CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
 
     for (const auto& counts_ : categoryCounts.first) {
         for (std::size_t i = 0; i < counts_.s_FunctionState.size(); ++i) {
-            result[i].resize(counts_.s_FunctionState[i].size());
-        }
-    }
-    for (const auto& counts_ : categoryCounts.first) {
-        for (std::size_t i = 0; i < counts_.s_FunctionState.size(); ++i) {
+            result[i].resize(counts_.s_FunctionState[i].size(), 0.0);
             for (std::size_t j = 0; j < counts_.s_FunctionState[i].size(); ++j) {
                 result[i][j] += counts_.s_FunctionState[i][j] /
                                 static_cast<double>(frame.numberRows());
@@ -251,10 +246,6 @@ CDataFrameUtils::meanValueOfTargetForCategories(std::size_t numberThreads,
     for (const auto& means_ : categoryMeanValues.first) {
         for (std::size_t i = 0; i < means_.s_FunctionState.size(); ++i) {
             means[i].resize(means_.s_FunctionState[i].size());
-        }
-    }
-    for (const auto& means_ : categoryMeanValues.first) {
-        for (std::size_t i = 0; i < means_.s_FunctionState.size(); ++i) {
             for (std::size_t j = 0; j < means_.s_FunctionState[i].size(); ++j) {
                 means[i][j] += means_.s_FunctionState[i][j];
             }

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -14,20 +14,53 @@
 #include <maths/CBasicStatistics.h>
 #include <maths/CMathsFuncs.h>
 #include <maths/CMic.h>
+#include <maths/COrderings.h>
 #include <maths/CPRNG.h>
 #include <maths/CQuantileSketch.h>
 #include <maths/CSampling.h>
+
+#include <boost/unordered_set.hpp>
 
 #include <vector>
 
 namespace ml {
 namespace maths {
-using TRowItr = core::CDataFrame::TRowItr;
 namespace {
+using TFloatVec = std::vector<CFloatStorage>;
+using TFloatVecVec = std::vector<TFloatVec>;
+using TFloatFloatPr = std::pair<CFloatStorage, CFloatStorage>;
+using TFloatFloatPrVec = std::vector<TFloatFloatPr>;
+using TFloatUSet = boost::unordered_set<CFloatStorage, std::hash<double>>;
+using TRowItr = core::CDataFrame::TRowItr;
+using TRowRef = core::CDataFrame::TRowRef;
+using TRowSampler = CSampling::CRandomStreamSampler<TRowRef>;
+
+//! Get a row column sampler.
+auto onSample(std::size_t i, std::size_t targetColumn, TFloatFloatPrVec& samples) {
+    return [i, targetColumn, &samples](std::size_t slot, const TRowRef& row) {
+        if (slot >= samples.size()) {
+            samples.resize(slot + 1, {0.0, 0.0});
+        }
+        samples[slot].first = row[i];
+        samples[slot].second = row[targetColumn];
+    };
+}
+
+//! Get a row sampler.
+auto onSample(TFloatVecVec& samples) {
+    return [&samples](std::size_t slot, const TRowRef& row) {
+        if (slot >= samples.size()) {
+            samples.resize(slot + 1, TFloatVec(row.numberColumns()));
+        }
+        row.copyTo(samples[slot].begin());
+    };
+}
+
 const std::size_t NUMBER_SAMPLES_TO_COMPUTE_MIC{10000};
 }
 
 bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataFrame& frame) {
+
     using TMeanVarAccumulatorVec =
         std::vector<CBasicStatistics::SSampleMeanVar<double>::TAccumulator>;
 
@@ -45,7 +78,7 @@ bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataF
                 }
             }
         },
-        TMeanVarAccumulatorVec{frame.numberColumns()});
+        TMeanVarAccumulatorVec(frame.numberColumns()));
 
     auto results = frame.readRows(numberThreads, computeColumnMoments);
     if (results.second == false) {
@@ -53,7 +86,7 @@ bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataF
         return false;
     }
 
-    TMeanVarAccumulatorVec moments{frame.numberColumns()};
+    TMeanVarAccumulatorVec moments(frame.numberColumns());
     for (const auto& result : results.first) {
         for (std::size_t i = 0; i < moments.size(); ++i) {
             moments[i] += result.s_FunctionState[i];
@@ -89,6 +122,7 @@ bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
                                       const CQuantileSketch& sketch,
                                       TQuantileSketchVec& result,
                                       TWeightFunction weight) {
+
     result.assign(columnMask.size(), sketch);
 
     auto results = frame.readRows(
@@ -122,48 +156,334 @@ bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
     return true;
 }
 
-CDataFrameUtils::TDoubleVec CDataFrameUtils::micWithColumn(const core::CDataFrame& frame,
-                                                           const TSizeVec& columnMask,
-                                                           std::size_t targetColumn) {
+CDataFrameUtils::TDoubleVecVec
+CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
+                                     const core::CDataFrame& frame,
+                                     TSizeVec columnMask) {
+
+    TDoubleVecVec result(frame.numberColumns());
+
+    const auto& columnIsCategorical = frame.columnIsCategorical();
+    columnMask.erase(std::remove_if(columnMask.begin(), columnMask.end(),
+                                    [&columnIsCategorical](std::size_t i) {
+                                        return columnIsCategorical[i] == false;
+                                    }),
+                     columnMask.end());
+
+    if (frame.numberRows() == 0 || columnMask.empty()) {
+        return result;
+    }
+
+    auto results = frame.readRows(
+        numberThreads,
+        core::bindRetrievableState(
+            [&](TDoubleVecVec& counts, TRowItr beginRows, TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    for (std::size_t i : columnMask) {
+                        std::size_t id{static_cast<std::size_t>((*row)[i])};
+                        counts[i].resize(std::max(counts[i].size(), id + 1), 0.0);
+                        counts[i][id] += 1.0;
+                    }
+                }
+            },
+            TDoubleVecVec(frame.numberColumns())));
+
+    if (results.second == false) {
+        HANDLE_FATAL(<< "Internal error: failed to calculate category"
+                     << " frequencies. Please report this problem.");
+        return result;
+    }
+
+    for (const auto& counts_ : results.first) {
+        for (std::size_t i = 0; i < counts_.s_FunctionState.size(); ++i) {
+            result[i].resize(counts_.s_FunctionState[i].size());
+        }
+    }
+    for (const auto& counts_ : results.first) {
+        for (std::size_t i = 0; i < counts_.s_FunctionState.size(); ++i) {
+            for (std::size_t j = 0; j < counts_.s_FunctionState[i].size(); ++j) {
+                result[i][j] += counts_.s_FunctionState[i][j] /
+                                static_cast<double>(frame.numberRows());
+            }
+        }
+    }
+
+    return result;
+}
+
+CDataFrameUtils::TDoubleVecVec
+CDataFrameUtils::meanValueOfTargetForCategories(std::size_t numberThreads,
+                                                const core::CDataFrame& frame,
+                                                TSizeVec columnMask,
+                                                std::size_t targetColumn) {
+
+    TDoubleVecVec result(frame.numberColumns());
+
+    if (targetColumn >= frame.numberColumns()) {
+        HANDLE_FATAL(<< "Internal error: target column out of bounds '"
+                     << targetColumn << " >= " << frame.numberColumns()
+                     << "'. Please report this problem.");
+        return result;
+    }
+
+    const auto& columnIsCategorical = frame.columnIsCategorical();
+    columnMask.erase(std::remove_if(columnMask.begin(), columnMask.end(),
+                                    [&columnIsCategorical](std::size_t i) {
+                                        return columnIsCategorical[i] == false;
+                                    }),
+                     columnMask.end());
+
+    if (frame.numberRows() == 0 || columnMask.empty()) {
+        return result;
+    }
+
+    using TMeanAccumulatorVec = std::vector<CBasicStatistics::SSampleMean<double>::TAccumulator>;
+    using TMeanAccumulatorVecVec = std::vector<TMeanAccumulatorVec>;
+
+    auto results = frame.readRows(
+        numberThreads,
+        core::bindRetrievableState(
+            [&](TMeanAccumulatorVecVec& means, TRowItr beginRows, TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    for (std::size_t i : columnMask) {
+                        std::size_t id{static_cast<std::size_t>((*row)[i])};
+                        means[i].resize(std::max(means[i].size(), id + 1));
+                        means[i][id].add((*row)[targetColumn]);
+                    }
+                }
+            },
+            TMeanAccumulatorVecVec(frame.numberColumns())));
+
+    if (results.second == false) {
+        HANDLE_FATAL(<< "Internal error: failed to calculate mean target value"
+                     << " for categories. Please report this problem.");
+        return result;
+    }
+
+    TMeanAccumulatorVecVec means(frame.numberColumns());
+    for (const auto& means_ : results.first) {
+        for (std::size_t i = 0; i < means_.s_FunctionState.size(); ++i) {
+            means[i].resize(means_.s_FunctionState[i].size());
+        }
+    }
+    for (const auto& means_ : results.first) {
+        for (std::size_t i = 0; i < means_.s_FunctionState.size(); ++i) {
+            for (std::size_t j = 0; j < means_.s_FunctionState[i].size(); ++j) {
+                means[i][j] += means_.s_FunctionState[i][j];
+            }
+        }
+    }
+    for (std::size_t i = 0; i < result.size(); ++i) {
+        result[i].resize(means[i].size());
+        for (std::size_t j = 0; j < means[i].size(); ++j) {
+            result[i][j] = CBasicStatistics::mean(means[i][j]);
+        }
+    }
+
+    return result;
+}
+
+CDataFrameUtils::TSizeDoublePrVecVec
+CDataFrameUtils::categoryMicWithColumn(std::size_t numberThreads,
+                                       const core::CDataFrame& frame,
+                                       TSizeVec columnMask,
+                                       std::size_t targetColumn,
+                                       double minimumFrequency) {
+
+    if (targetColumn >= frame.numberColumns()) {
+        HANDLE_FATAL(<< "Internal error: target column out of bounds '"
+                     << targetColumn << " >= " << frame.numberColumns()
+                     << "'. Please report this problem.");
+        return TSizeDoublePrVecVec(frame.numberColumns());
+    }
+
+    const auto& columnIsCategorical = frame.columnIsCategorical();
+    columnMask.erase(std::remove_if(columnMask.begin(), columnMask.end(),
+                                    [&columnIsCategorical](std::size_t i) {
+                                        return columnIsCategorical[i] == false;
+                                    }),
+                     columnMask.end());
+    minimumFrequency = std::max(minimumFrequency,
+                                50.0 / static_cast<double>(frame.numberRows()));
 
     std::size_t numberSamples{std::min(NUMBER_SAMPLES_TO_COMPUTE_MIC, frame.numberRows())};
 
-    return frame.inMainMemory()
-               ? micWithColumnDataFrameInMainMemory(numberSamples, frame, columnMask, targetColumn)
-               : micWithColumnDataFrameOnDisk(numberSamples, frame, columnMask, targetColumn);
+    auto method = frame.inMainMemory() ? categoryMicWithColumnDataFrameInMemory
+                                       : categoryMicWithColumnDataFrameOnDisk;
+
+    TSizeDoublePrVecVec mics(method(numberThreads, frame, columnMask, targetColumn,
+                                    numberSamples, minimumFrequency));
+
+    for (auto& categoryMics : mics) {
+        std::sort(categoryMics.begin(), categoryMics.end(),
+                  [](const TSizeDoublePr& lhs, const TSizeDoublePr& rhs) {
+                      return COrderings::lexicographical_compare(
+                          -lhs.second, lhs.first, -rhs.second, rhs.first);
+                  });
+    }
+
+    return mics;
+}
+
+CDataFrameUtils::TDoubleVec CDataFrameUtils::micWithColumn(const core::CDataFrame& frame,
+                                                           TSizeVec columnMask,
+                                                           std::size_t targetColumn) {
+
+    if (targetColumn >= frame.numberColumns()) {
+        HANDLE_FATAL(<< "Internal error: target column out of bounds '"
+                     << targetColumn << " >= " << frame.numberColumns()
+                     << "'. Please report this problem.");
+        return TDoubleVec(frame.numberColumns(), 0.0);
+    }
+
+    const auto& columnIsCategorical = frame.columnIsCategorical();
+    columnMask.erase(std::remove_if(columnMask.begin(), columnMask.end(),
+                                    [&columnIsCategorical](std::size_t i) {
+                                        return columnIsCategorical[i];
+                                    }),
+                     columnMask.end());
+
+    std::size_t numberSamples{std::min(NUMBER_SAMPLES_TO_COMPUTE_MIC, frame.numberRows())};
+
+    auto method = frame.inMainMemory() ? micWithColumnDataFrameInMemory
+                                       : micWithColumnDataFrameOnDisk;
+
+    return method(frame, columnMask, targetColumn, numberSamples);
 }
 
 bool CDataFrameUtils::isMissing(double x) {
     return CMathsFuncs::isFinite(x) == false;
 }
 
-CDataFrameUtils::TDoubleVec
-CDataFrameUtils::micWithColumnDataFrameInMainMemory(std::size_t numberSamples,
-                                                    const core::CDataFrame& frame,
-                                                    const TSizeVec& columnMask,
-                                                    std::size_t targetColumn) {
+CDataFrameUtils::TSizeDoublePrVecVec
+CDataFrameUtils::categoryMicWithColumnDataFrameInMemory(std::size_t numberThreads,
+                                                        const core::CDataFrame& frame,
+                                                        const TSizeVec& columnMask,
+                                                        std::size_t targetColumn,
+                                                        std::size_t numberSamples,
+                                                        double minimumFrequency) {
 
-    using TFloatFloatPr = std::pair<CFloatStorage, CFloatStorage>;
-    using TFloatFloatPrVec = std::vector<TFloatFloatPr>;
-    using TRowSampler = CSampling::CRandomStreamSampler<TRowRef>;
+    TSizeDoublePrVecVec mics(frame.numberColumns());
+
+    TDoubleVecVec frequencies(categoryFrequencies(numberThreads, frame, columnMask));
+
+    TFloatFloatPrVec samples;
+    TFloatUSet categories;
+    CMic mic;
+    mic.reserve(numberSamples);
+
+    for (auto i : columnMask) {
+
+        // Sample
+
+        TRowSampler sampler{numberSamples, onSample(i, targetColumn, samples)};
+        frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                std::size_t j{static_cast<std::size_t>((*row)[i])};
+                if (frequencies[i][j] >= minimumFrequency &&
+                    isMissing((*row)[targetColumn]) == false) {
+                    sampler.sample(*row);
+                }
+            }
+        });
+        LOG_TRACE(<< "# samples = " << samples.size());
+
+        // Compute MICe
+
+        categories.clear();
+        for (const auto& sample : samples) {
+            categories.insert(sample.first);
+        }
+
+        TSizeDoublePrVec categoryMics;
+        categoryMics.reserve(categories.size());
+        for (auto category : categories) {
+            mic.clear();
+            for (const auto& sample : samples) {
+                mic.add(sample.first != category ? 0.0 : 1.0, sample.second);
+            }
+            categoryMics.emplace_back(static_cast<std::size_t>(category), mic.compute());
+        }
+        mics[i] = std::move(categoryMics);
+
+        samples.clear();
+    }
+
+    return mics;
+}
+
+CDataFrameUtils::TSizeDoublePrVecVec
+CDataFrameUtils::categoryMicWithColumnDataFrameOnDisk(std::size_t numberThreads,
+                                                      const core::CDataFrame& frame,
+                                                      const TSizeVec& columnMask,
+                                                      std::size_t targetColumn,
+                                                      std::size_t numberSamples,
+                                                      double minimumFrequency) {
+
+    TDoubleVecVec frequencies(categoryFrequencies(numberThreads, frame, columnMask));
+
+    // Sample
+    //
+    // The law of large numbers means we have a high probability of sampling
+    // each category provided minimumFrequency * NUMBER_SAMPLES_TO_COMPUTE_MIC
+    // is large (which we ensure it is).
+
+    TFloatVecVec samples;
+    TRowSampler sampler{numberSamples, onSample(samples)};
+    auto results = frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            if (isMissing((*row)[targetColumn]) == false) {
+                sampler.sample(*row);
+            }
+        }
+    });
+    LOG_TRACE(<< "# samples = " << samples.size());
+
+    TSizeDoublePrVecVec mics(frame.numberColumns());
+
+    TFloatUSet categories;
+    CMic mic;
+    mic.reserve(samples.size());
+
+    for (auto i : columnMask) {
+        categories.clear();
+        for (const auto& sample : samples) {
+            std::size_t category{static_cast<std::size_t>(sample[i])};
+            if (frequencies[i][category] >= minimumFrequency) {
+                categories.insert(sample[i]);
+            }
+        }
+
+        TSizeDoublePrVec categoryMics;
+        categoryMics.reserve(categories.size());
+        for (auto category : categories) {
+            mic.clear();
+            for (const auto& sample : samples) {
+                mic.add(sample[i] != category ? 0.0 : 1.0, sample[targetColumn]);
+            }
+            categoryMics.emplace_back(static_cast<std::size_t>(category), mic.compute());
+        }
+        mics[i] = std::move(categoryMics);
+    }
+
+    return mics;
+}
+
+CDataFrameUtils::TDoubleVec
+CDataFrameUtils::micWithColumnDataFrameInMemory(const core::CDataFrame& frame,
+                                                const TSizeVec& columnMask,
+                                                std::size_t targetColumn,
+                                                std::size_t numberSamples) {
 
     TDoubleVec mics(frame.numberColumns());
 
-    CPRNG::CXorOShiro128Plus rng;
     TFloatFloatPrVec samples;
 
     for (auto i : columnMask) {
 
         // Do sampling
 
-        auto onSample = [&](std::size_t slot, const TRowRef& row) {
-            if (slot >= samples.size()) {
-                samples.resize(slot + 1);
-            }
-            samples[slot].first = row[i];
-            samples[slot].second = row[targetColumn];
-        };
-        TRowSampler sampler{numberSamples, onSample};
+        TRowSampler sampler{numberSamples, onSample(i, targetColumn, samples)};
 
         auto result = frame.readRows(
             1, core::bindRetrievableState(
@@ -199,14 +519,10 @@ CDataFrameUtils::micWithColumnDataFrameInMainMemory(std::size_t numberSamples,
 }
 
 CDataFrameUtils::TDoubleVec
-CDataFrameUtils::micWithColumnDataFrameOnDisk(std::size_t numberSamples,
-                                              const core::CDataFrame& frame,
+CDataFrameUtils::micWithColumnDataFrameOnDisk(const core::CDataFrame& frame,
                                               const TSizeVec& columnMask,
-                                              std::size_t targetColumn) {
-
-    using TFloatVec = std::vector<CFloatStorage>;
-    using TFloatVecVec = std::vector<TFloatVec>;
-    using TRowSampler = CSampling::CRandomStreamSampler<TRowRef>;
+                                              std::size_t targetColumn,
+                                              std::size_t numberSamples) {
 
     // Do sampling
 

--- a/lib/maths/CMic.cc
+++ b/lib/maths/CMic.cc
@@ -26,7 +26,16 @@ const double EPS{std::numeric_limits<double>::epsilon()};
 }
 
 void CMic::reserve(std::size_t n) {
-    m_Samples.reserve(n);
+    if (n > 0) {
+        m_Samples.reserve(n);
+    }
+}
+
+void CMic::clear() {
+    m_Samples.clear();
+    for (auto& order : m_Order) {
+        order.clear();
+    }
 }
 
 const CMic& CMic::operator+=(const CMic& other) {

--- a/lib/maths/unittest/CDataFrameUtilsTest.h
+++ b/lib/maths/unittest/CDataFrameUtilsTest.h
@@ -14,6 +14,9 @@ public:
     void testStandardizeColumns();
     void testColumnQuantiles();
     void testMicWithColumn();
+    void testCategoryFrequencies();
+    void testMeanValueOfTargetForCategories();
+    void testCategoryMicWithColumn();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
This is helper functionality we'll use for choosing how to encode categorical fields. In particular, it is functionality to 1) compute category frequencies, 2) compute the mean target value for each category, and 3) to compute MICe for hot-one encoded categories and the target variable.

I've split this out to keep the PR smaller.