### PR TITLE
[7.4][ML] Temporary directory must be set if disk usage is allowed (#534)

### DIFF
--- a/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
+++ b/include/api/CDataFrameAnalysisSpecificationJsonWriter.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_api_CDataFrameAnalysisSpecificationJsonWriter_h
+#define INCLUDED_ml_api_CDataFrameAnalysisSpecificationJsonWriter_h
+
+#include <core/CNonInstantiatable.h>
+#include <core/CRapidJsonConcurrentLineWriter.h>
+
+#include <api/ImportExport.h>
+
+#include <string>
+
+namespace ml {
+namespace api {
+
+//! \brief
+//! A static utility for writing data frame analysis specification in JSON.
+class API_EXPORT CDataFrameAnalysisSpecificationJsonWriter : private core::CNonInstantiatable {
+public:
+    using TRapidJsonLineWriter = core::CRapidJsonLineWriter<rapidjson::StringBuffer>;
+
+public:
+    //! Writes the data frame analysis specification in JSON format.
+    static void write(std::size_t rows,
+                      std::size_t cols,
+                      std::size_t memoryLimit,
+                      std::size_t numberThreads,
+                      const std::string& temporaryDirectory,
+                      const std::string& resultsField,
+                      bool diskUsageAllowed,
+                      const std::string& analysisName,
+                      const rapidjson::Document& analysisParametersDocument,
+                      TRapidJsonLineWriter& writer);
+
+    //! Writes the data frame analysis specification in JSON format.
+    static void write(std::size_t rows,
+                      std::size_t cols,
+                      std::size_t memoryLimit,
+                      std::size_t numberThreads,
+                      const std::string& temporaryDirectory,
+                      const std::string& resultsField,
+                      bool diskUsageAllowed,
+                      const std::string& analysisName,
+                      const std::string& analysisParameters,
+                      TRapidJsonLineWriter& writer);
+
+    //! Returns a string with the data frame analysis specification in JSON format.
+    static std::string jsonString(size_t rows,
+                                  size_t cols,
+                                  size_t memoryLimit,
+                                  size_t numberThreads,
+                                  bool diskUsageAllowed,
+                                  const std::string& tempDir,
+                                  const std::string& resultField,
+                                  const std::string& analysisName,
+                                  const std::string& analysisParameters);
+};
+}
+}
+#endif //INCLUDED_ml_api_CDataFrameAnalysisSpecificationJsonWriter_h

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -64,7 +64,7 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
             break;
         }
         // if we are not allowed to spill over to disk then only one partition is possible
-        if (!m_Spec.diskUsageAllowed()) {
+        if (m_Spec.diskUsageAllowed() == false) {
             LOG_TRACE(<< "stop partition number computation since disk usage is turned off");
             break;
         }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -105,10 +105,14 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryU
         m_NumberColumns = parameters[COLS].as<std::size_t>();
         m_MemoryLimit = parameters[MEMORY_LIMIT].as<std::size_t>();
         m_NumberThreads = parameters[THREADS].as<std::size_t>();
-        m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(
-            boost::filesystem::current_path().string());
+        m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(std::string{});
         m_ResultsField = parameters[RESULTS_FIELD].fallback(DEFAULT_RESULT_FIELD);
         m_DiskUsageAllowed = parameters[DISK_USAGE_ALLOWED].fallback(DEFAULT_DISK_USAGE_ALLOWED);
+
+        if (m_DiskUsageAllowed && m_TemporaryDirectory.empty()) {
+            HANDLE_FATAL(<< "Input error: temporary directory path should be explicitly set if disk"
+                            " usage is allowed! Please report this problem.");
+        }
 
         auto jsonAnalysis = parameters[ANALYSIS].jsonObject();
         if (jsonAnalysis != nullptr) {

--- a/lib/api/CDataFrameAnalysisSpecificationJsonWriter.cc
+++ b/lib/api/CDataFrameAnalysisSpecificationJsonWriter.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
+
+#include <api/CDataFrameAnalysisSpecification.h>
+
+#include <iostream>
+
+namespace ml {
+namespace api {
+
+void CDataFrameAnalysisSpecificationJsonWriter::write(std::size_t rows,
+                                                      std::size_t cols,
+                                                      std::size_t memoryLimit,
+                                                      std::size_t numberThreads,
+                                                      const std::string& temporaryDirectory,
+                                                      const std::string& resultsField,
+                                                      bool diskUsageAllowed,
+                                                      const std::string& analysisName,
+                                                      const std::string& analysisParameters,
+                                                      TRapidJsonLineWriter& writer) {
+    rapidjson::Document analysisParametersDoc;
+    if (analysisParameters.empty() == false) {
+        analysisParametersDoc.Parse(analysisParameters);
+        if (analysisParametersDoc.GetParseError()) {
+            HANDLE_FATAL(<< "Input error: analysis parameters " << analysisParameters
+                         << " cannot be parsed as json. Please report this problem.")
+        }
+    }
+    write(rows, cols, memoryLimit, numberThreads, temporaryDirectory, resultsField,
+          diskUsageAllowed, analysisName, analysisParametersDoc, writer);
+}
+
+void CDataFrameAnalysisSpecificationJsonWriter::write(std::size_t rows,
+                                                      std::size_t cols,
+                                                      std::size_t memoryLimit,
+                                                      std::size_t numberThreads,
+                                                      const std::string& temporaryDirectory,
+                                                      const std::string& resultsField,
+                                                      bool diskUsageAllowed,
+                                                      const std::string& analysisName,
+                                                      const rapidjson::Document& analysisParametersDocument,
+                                                      TRapidJsonLineWriter& writer) {
+
+    writer.StartObject();
+
+    writer.String(CDataFrameAnalysisSpecification::ROWS);
+    writer.Uint64(rows);
+
+    writer.String(CDataFrameAnalysisSpecification::COLS);
+    writer.Uint64(cols);
+
+    writer.String(CDataFrameAnalysisSpecification::MEMORY_LIMIT);
+    writer.Uint64(memoryLimit);
+
+    writer.String(CDataFrameAnalysisSpecification::THREADS);
+    writer.Uint64(numberThreads);
+
+    writer.String(CDataFrameAnalysisSpecification::TEMPORARY_DIRECTORY);
+    writer.String(temporaryDirectory);
+
+    writer.String(CDataFrameAnalysisSpecification::RESULTS_FIELD);
+    writer.String(resultsField);
+
+    writer.String(CDataFrameAnalysisSpecification::DISK_USAGE_ALLOWED);
+    writer.Bool(diskUsageAllowed);
+
+    writer.String(CDataFrameAnalysisSpecification::ANALYSIS);
+    writer.StartObject();
+    writer.String(CDataFrameAnalysisSpecification::NAME);
+    writer.String(analysisName);
+
+    // if no parameters are specified, parameters document has Null as its root element
+    if (analysisParametersDocument.IsNull() == false) {
+        if (analysisParametersDocument.IsObject()) {
+            writer.String(CDataFrameAnalysisSpecification::PARAMETERS);
+            writer.write(analysisParametersDocument);
+        } else {
+            HANDLE_FATAL(<< "Input error: analysis parameters suppose to "
+                         << "contain an object as root node.")
+        }
+    }
+
+    writer.EndObject();
+    writer.EndObject();
+    writer.Flush();
+}
+
+std::string
+CDataFrameAnalysisSpecificationJsonWriter::jsonString(size_t rows,
+                                                      size_t cols,
+                                                      size_t memoryLimit,
+                                                      size_t numberThreads,
+                                                      bool diskUsageAllowed,
+                                                      const std::string& tempDir,
+                                                      const std::string& resultField,
+                                                      const std::string& analysisName,
+                                                      const std::string& analysisParameters) {
+    rapidjson::StringBuffer stringBuffer;
+    api::CDataFrameAnalysisSpecificationJsonWriter::TRapidJsonLineWriter writer;
+    writer.Reset(stringBuffer);
+
+    write(rows, cols, memoryLimit, numberThreads, tempDir, resultField,
+          diskUsageAllowed, analysisName, analysisParameters, writer);
+
+    return stringBuffer.GetString();
+}
+}
+}

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -29,6 +29,7 @@ CCsvOutputWriter.cc \
 CDataFrameAnalysisConfigReader.cc \
 CDataFrameAnalysisRunner.cc \
 CDataFrameAnalysisSpecification.cc \
+CDataFrameAnalysisSpecificationJsonWriter.cc \
 CDataFrameAnalyzer.cc \
 CDataFrameOutliersRunner.cc \
 CDataProcessor.cc \

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -6,11 +6,13 @@
 
 #include "CDataFrameAnalysisRunnerTest.h"
 
-#include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameOutliersRunner.h>
+
+#include <test/CTestTmpDir.h>
 
 #include <mutex>
 #include <string>
@@ -29,21 +31,9 @@ void CDataFrameAnalysisRunnerTest::testComputeExecutionStrategyForOutliers() {
             LOG_DEBUG(<< "# rows = " << numberRows << ", # cols = " << numberCols);
 
             // Give the process approximately 100MB.
-
-            std::string jsonSpec{"{\n"
-                                 "  \"rows\": " +
-                                 std::to_string(numberRows) +
-                                 ",\n"
-                                 "  \"cols\": " +
-                                 std::to_string(numberCols) +
-                                 ",\n"
-                                 "  \"memory_limit\": 100000000,\n"
-                                 "  \"disk_usage_allowed\": true,\n"
-                                 "  \"threads\": 1,\n"
-                                 "  \"analysis\": {\n"
-                                 "    \"name\": \"outlier_detection\""
-                                 "  }"
-                                 "}"};
+            std::string jsonSpec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+                numberRows, numberCols, 100000000, 1, true,
+                test::CTestTmpDir::tmpDir(), "", "outlier_detection", "")};
 
             api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
@@ -77,23 +67,9 @@ std::string
 CDataFrameAnalysisRunnerTest::createSpecJsonForDiskUsageTest(std::size_t numberRows,
                                                              std::size_t numberCols,
                                                              bool diskUsageAllowed) {
-    std::string jsonSpec{"{\n"
-                         "  \"rows\": " +
-                         std::to_string(numberRows) +
-                         ",\n"
-                         "  \"cols\": " +
-                         std::to_string(numberCols) +
-                         ",\n"
-                         "  \"memory_limit\": 500000,\n"
-                         "  \"disk_usage_allowed\": " +
-                         (diskUsageAllowed ? "true" : "false") +
-                         ",\n"
-                         "  \"threads\": 1,\n"
-                         "  \"analysis\": {\n"
-                         "    \"name\": \"outlier_detection\""
-                         "  }"
-                         "}"};
-    return jsonSpec;
+    return api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        numberRows, numberCols, 500000, 1, diskUsageAllowed,
+        test::CTestTmpDir::tmpDir(), "", "outlier_detection", "");
 }
 
 void CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag() {

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -9,13 +9,13 @@
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
-#include <core/CStopWatch.h>
 
 #include <api/CDataFrameAnalysisRunner.h>
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameOutliersRunner.h>
 
-#include <test/CRandomNumbers.h>
+#include <test/CTestTmpDir.h>
 
 #include "CDataFrameMockAnalysisRunner.h"
 
@@ -255,16 +255,8 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
         return factories;
     };
 
-    std::string jsonSpec{"{\n"
-                         "  \"rows\": 100,\n"
-                         "  \"cols\": 10,\n"
-                         "  \"memory_limit\": 1000,\n"
-                         "  \"threads\": 1,\n"
-                         "  \"disk_usage_allowed\": true,\n"
-                         "  \"analysis\": {\n"
-                         "    \"name\": \"test\""
-                         "  }"
-                         "}"};
+    std::string jsonSpec = api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        100, 10, 1000, 1, true, test::CTestTmpDir::tmpDir(), "", "test", "");
 
     for (std::size_t i = 0; i < 10; ++i) {
         api::CDataFrameAnalysisSpecification spec{testFactory(), jsonSpec};
@@ -289,6 +281,59 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
     }
 }
 
+std::string
+CDataFrameAnalysisSpecificationTest::createSpecJsonForTempDirDiskUsageTest(bool tempDirPathSet,
+                                                                           bool diskUsageAllowed) {
+
+    std::string tempDir = tempDirPathSet ? test::CTestTmpDir::tmpDir() : "";
+    return api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        100, 3, 500000, 1, diskUsageAllowed, tempDir, "", "outlier_detection", "");
+}
+
+void CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage() {
+
+    std::vector<std::string> errors;
+    std::mutex errorsMutex;
+    auto errorHandler = [&errors, &errorsMutex](std::string error) {
+        std::lock_guard<std::mutex> lock{errorsMutex};
+        errors.push_back(error);
+    };
+
+    core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
+
+    // No temp dir given, disk usage allowed
+    {
+        errors.clear();
+        std::string jsonSpec{createSpecJsonForTempDirDiskUsageTest(false, true)};
+        api::CDataFrameAnalysisSpecification spec{jsonSpec};
+
+        // single error is registered that temp dir is empty
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), errors.size());
+        CPPUNIT_ASSERT(errors[0].find("Input error: temporary directory path should be explicitly set if disk usage is allowed!") !=
+                       std::string::npos);
+    }
+
+    // No temp dir given, no disk usage allowed
+    {
+        errors.clear();
+        std::string jsonSpec{createSpecJsonForTempDirDiskUsageTest(false, false)};
+        api::CDataFrameAnalysisSpecification spec{jsonSpec};
+
+        // no error should be registered
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), errors.size());
+    }
+
+    // Temp dir given and disk usage allowed
+    {
+        errors.clear();
+        std::string jsonSpec{createSpecJsonForTempDirDiskUsageTest(true, true)};
+        api::CDataFrameAnalysisSpecification spec{jsonSpec};
+
+        // no error should be registered
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), errors.size());
+    }
+}
+
 CppUnit::Test* CDataFrameAnalysisSpecificationTest::suite() {
     CppUnit::TestSuite* suiteOfTests =
         new CppUnit::TestSuite("CDataFrameAnalysisSpecificationTest");
@@ -299,6 +344,9 @@ CppUnit::Test* CDataFrameAnalysisSpecificationTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisSpecificationTest>(
         "CDataFrameAnalysisSpecificationTest::testRunAnalysis",
         &CDataFrameAnalysisSpecificationTest::testRunAnalysis));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisSpecificationTest>(
+        "CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage",
+        &CDataFrameAnalysisSpecificationTest::testTempDirDiskUsage));
 
     return suiteOfTests;
 }

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.h
@@ -13,8 +13,21 @@ class CDataFrameAnalysisSpecificationTest : public CppUnit::TestFixture {
 public:
     void testCreate();
     void testRunAnalysis();
+    void testTempDirDiskUsage();
 
     static CppUnit::Test* suite();
+
+private:
+    std::string createSpecJsonForTempDirDiskUsageTest(bool, bool);
+    std::string jsonString(size_t rows,
+                           size_t cols,
+                           size_t memoryLimit,
+                           size_t numberThreads,
+                           bool diskUsageAllowed,
+                           const std::string& tempDir,
+                           const std::string& resultField,
+                           const std::string& analysis_name,
+                           const std::string& analysis_parameters) const;
 };
 
 #endif // INCLUDED_CDataFrameAnalysisSpecificationTest_h

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -15,10 +15,12 @@
 #include <maths/COutliers.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameAnalyzer.h>
 
 #include <test/CDataFrameTestUtils.h>
 #include <test/CRandomNumbers.h>
+#include <test/CTestTmpDir.h>
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
@@ -45,42 +47,33 @@ outlierSpec(std::size_t rows = 110,
             std::size_t numberNeighbours = 0,
             bool computeFeatureInfluence = false) {
 
-    std::string spec{"{\n"
-                     "  \"rows\": " +
-                     std::to_string(rows) +
-                     ",\n"
-                     "  \"cols\": 5,\n"
-                     "  \"memory_limit\": " +
-                     std::to_string(memoryLimit) +
-                     ",\n"
-                     "  \"threads\": 1,\n"
-                     "  \"disk_usage_allowed\": true,\n"
-                     "  \"analysis\": {\n"
-                     "    \"name\": \"outlier_detection\""};
-    spec += ",\n    \"parameters\": {\n";
+    std::string parameters = "{\n";
     bool hasTrailingParameter{false};
     if (method != "") {
-        spec += "      \"method\": \"" + method + "\"";
+        parameters += "      \"method\": \"" + method + "\"";
         hasTrailingParameter = true;
     }
     if (numberNeighbours > 0) {
-        spec += (hasTrailingParameter ? ",\n" : "");
-        spec += "      \"n_neighbors\": " + core::CStringUtils::typeToString(numberNeighbours);
+        parameters += (hasTrailingParameter ? ",\n" : "");
+        parameters += "      \"n_neighbors\": " +
+                      core::CStringUtils::typeToString(numberNeighbours);
         hasTrailingParameter = true;
     }
     if (computeFeatureInfluence == false) {
-        spec += (hasTrailingParameter ? ",\n" : "");
-        spec += "      \"compute_feature_influence\": false";
+        parameters += (hasTrailingParameter ? ",\n" : "");
+        parameters += "      \"compute_feature_influence\": false";
         hasTrailingParameter = true;
     } else {
-        spec += (hasTrailingParameter ? ",\n" : "");
-        spec += "      \"feature_influence_threshold\": 0.0";
+        parameters += (hasTrailingParameter ? ",\n" : "");
+        parameters += "      \"feature_influence_threshold\": 0.0";
         hasTrailingParameter = true;
     }
-    spec += (hasTrailingParameter ? "\n" : "");
-    spec += "    }\n";
-    spec += "  }\n"
-            "}";
+    parameters += (hasTrailingParameter ? "\n" : "");
+    parameters += "    }\n";
+
+    std::string spec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
+        rows, 5, memoryLimit, 1, true, test::CTestTmpDir::tmpDir(), "ml",
+        "outlier_detection", parameters)};
 
     LOG_TRACE(<< "spec =\n" << spec);
 


### PR DESCRIPTION
If the json specification parameter temp_dir is not set, but disk_usage_allowed is true, the specification is in inconsistent state. This PR adds an error message informing user about the misconfiguration.