### PR TITLE
[ML] Fully migrate data frame analysis parameter reader to use std::string

### DIFF
--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -61,11 +61,17 @@ public:
     //! \brief A single parameter which has been read.
     class API_EXPORT CParameter {
     public:
-        CParameter(const char* name) : m_Name{name} {}
-        CParameter(const char* name, const rapidjson::Value& value, const TStrIntMap& permittedValues);
+        //! \warning The \p name string is stored by reference so must outlive use
+        //! of this object.
+        explicit CParameter(const std::string& name) : m_Name{name} {}
+        //! \warning The \p name string is stored by reference so must outlive use
+        //! of this object.
+        CParameter(const std::string& name,
+                   const rapidjson::Value& value,
+                   const TStrIntMap& permittedValues);
 
         //! Get the name of the parameter.
-        const char* name() const { return m_Name; }
+        const std::string& name() const { return m_Name; }
         //! Get the parameter of type T.
         template<typename T>
         T as() const {
@@ -108,7 +114,7 @@ public:
         void handleFatal() const;
 
     private:
-        const char* m_Name = nullptr;
+        std::string m_Name;
         const rapidjson::Value* m_Value = nullptr;
         const TStrIntMap* m_PermittedValues = nullptr;
     };
@@ -124,23 +130,11 @@ public:
         //! Get the parameter called \p name.
         CParameter operator[](const std::string& name) const;
 
-        //! Get the parameter called \p name.
-        CParameter operator[](const char* name) const;
-
     private:
         std::vector<CParameter> m_ParameterValues;
     };
 
 public:
-    //! Register a parameter.
-    //!
-    //! \param[in] name The parameter name.
-    //! \param[in] requirement Is the parameter required or optional.
-    //! \param[in] permittedValues The permitted values for an enumeration.
-    void addParameter(const char* name,
-                      ERequirement requirement,
-                      TStrIntMap permittedValues = TStrIntMap{});
-
     //! Register a parameter.
     //!
     //! \param[in] name The parameter name.
@@ -157,16 +151,16 @@ private:
     //! Reads a parameter from the JSON configuration object.
     class API_EXPORT CParameterReader {
     public:
-        CParameterReader(const char* name, ERequirement requirement, TStrIntMap permittedValues);
+        CParameterReader(const std::string& name, ERequirement requirement, TStrIntMap permittedValues);
 
-        const char* name() const { return m_Name; }
+        const std::string& name() const { return m_Name; }
         bool required() const { return m_Requirement == E_RequiredParameter; }
         CParameter readFrom(const rapidjson::Value& json) const {
             return {m_Name, json[m_Name], m_PermittedValues};
         }
 
     private:
-        const char* m_Name;
+        std::string m_Name;
         ERequirement m_Requirement;
         TStrIntMap m_PermittedValues;
     };

--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -61,11 +61,7 @@ public:
     //! \brief A single parameter which has been read.
     class API_EXPORT CParameter {
     public:
-        //! \warning The \p name string is stored by reference so must outlive use
-        //! of this object.
         explicit CParameter(const std::string& name) : m_Name{name} {}
-        //! \warning The \p name string is stored by reference so must outlive use
-        //! of this object.
         CParameter(const std::string& name,
                    const rapidjson::Value& value,
                    const TStrIntMap& permittedValues);

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -171,7 +171,7 @@ public:
 
 public:
     virtual ~CDataFrameAnalysisRunnerFactory() = default;
-    virtual const char* name() const = 0;
+    virtual const std::string& name() const = 0;
 
     TRunnerUPtr make(const CDataFrameAnalysisSpecification& spec) const;
     TRunnerUPtr make(const CDataFrameAnalysisSpecification& spec,

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -71,7 +71,10 @@ private:
 //! \brief Makes a core::CDataFrame outlier analysis runner.
 class API_EXPORT CDataFrameOutliersRunnerFactory final : public CDataFrameAnalysisRunnerFactory {
 public:
-    const char* name() const override;
+    const std::string& name() const override;
+
+private:
+    static const std::string NAME;
 
 private:
     TRunnerUPtr makeImpl(const CDataFrameAnalysisSpecification& spec) const override;

--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -38,16 +38,10 @@ std::string toString(const rapidjson::Value& value) {
 }
 }
 
-void CDataFrameAnalysisConfigReader::addParameter(const char* name,
-                                                  ERequirement requirement,
-                                                  TStrIntMap permittedValues) {
-    m_ParameterReaders.emplace_back(name, requirement, std::move(permittedValues));
-}
-
 void CDataFrameAnalysisConfigReader::addParameter(const std::string& name,
                                                   ERequirement requirement,
                                                   TStrIntMap permittedValues) {
-    addParameter(name.c_str(), requirement, std::move(permittedValues));
+    m_ParameterReaders.emplace_back(name, requirement, std::move(permittedValues));
 }
 
 CDataFrameAnalysisConfigReader::CParameters
@@ -68,7 +62,7 @@ CDataFrameAnalysisConfigReader::read(const rapidjson::Value& json) const {
             HANDLE_FATAL(<< "Input error: missing required parameter '"
                          << reader.name() << "'. Please report this problem.");
         } else {
-            result.add(reader.name());
+            result.add(CParameter{reader.name()});
         }
     }
 
@@ -76,7 +70,7 @@ CDataFrameAnalysisConfigReader::read(const rapidjson::Value& json) const {
     for (auto i = json.MemberBegin(); i != json.MemberEnd(); ++i) {
         bool found{false};
         for (const auto& param : m_ParameterReaders) {
-            if (std::strcmp(i->name.GetString(), param.name()) == 0) {
+            if (i->name.GetString() == param.name()) {
                 found = true;
                 break;
             }
@@ -90,7 +84,7 @@ CDataFrameAnalysisConfigReader::read(const rapidjson::Value& json) const {
     return result;
 }
 
-CDataFrameAnalysisConfigReader::CParameter::CParameter(const char* name,
+CDataFrameAnalysisConfigReader::CParameter::CParameter(const std::string& name,
                                                        const rapidjson::Value& value,
                                                        const TStrIntMap& permittedValues)
     : m_Name{name}, m_Value{&value}, m_PermittedValues{&permittedValues} {
@@ -148,22 +142,17 @@ void CDataFrameAnalysisConfigReader::CParameter::handleFatal() const {
                  << "' for '" << m_Name << "'.");
 }
 
-CDataFrameAnalysisConfigReader::CParameter
-    CDataFrameAnalysisConfigReader::CParameters::operator[](const char* name) const {
+CDataFrameAnalysisConfigReader::CParameter CDataFrameAnalysisConfigReader::CParameters::
+operator[](const std::string& name) const {
     for (const auto& value : m_ParameterValues) {
-        if (std::strcmp(name, value.name()) == 0) {
+        if (name == value.name()) {
             return value;
         }
     }
-    return {name};
+    return CParameter{name};
 }
 
-CDataFrameAnalysisConfigReader::CParameter CDataFrameAnalysisConfigReader::CParameters::
-operator[](const std::string& name) const {
-    return this->operator[](name.c_str());
-}
-
-CDataFrameAnalysisConfigReader::CParameterReader::CParameterReader(const char* name,
+CDataFrameAnalysisConfigReader::CParameterReader::CParameterReader(const std::string& name,
                                                                    ERequirement requirement,
                                                                    TStrIntMap permittedValues)
     : m_Name{name}, m_Requirement{requirement}, m_PermittedValues{std::move(permittedValues)} {

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -27,12 +27,12 @@ namespace ml {
 namespace api {
 namespace {
 // Configuration
-const char* const STANDARDIZE_COLUMNS{"standardize_columns"};
-const char* const N_NEIGHBORS{"n_neighbors"};
-const char* const METHOD{"method"};
-const char* const COMPUTE_FEATURE_INFLUENCE{"compute_feature_influence"};
-const char* const FEATURE_INFLUENCE_THRESHOLD{"feature_influence_threshold"};
-const char* const OUTLIER_FRACTION{"outlier_fraction"};
+const std::string STANDARDIZE_COLUMNS{"standardize_columns"};
+const std::string N_NEIGHBORS{"n_neighbors"};
+const std::string METHOD{"method"};
+const std::string COMPUTE_FEATURE_INFLUENCE{"compute_feature_influence"};
+const std::string FEATURE_INFLUENCE_THRESHOLD{"feature_influence_threshold"};
+const std::string OUTLIER_FRACTION{"outlier_fraction"};
 
 const CDataFrameAnalysisConfigReader PARAMETER_READER{[] {
     const std::string lof{"lof"};
@@ -57,8 +57,8 @@ const CDataFrameAnalysisConfigReader PARAMETER_READER{[] {
 }()};
 
 // Output
-const char* const OUTLIER_SCORE{"outlier_score"};
-const char* const FEATURE_INFLUENCE_PREFIX{"feature_influence."};
+const std::string OUTLIER_SCORE{"outlier_score"};
+const std::string FEATURE_INFLUENCE_PREFIX{"feature_influence."};
 }
 
 CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec,

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -141,8 +141,8 @@ CDataFrameOutliersRunner::estimateBookkeepingMemoryUsage(std::size_t numberParti
         params, totalNumberRows, partitionNumberRows, numberColumns);
 }
 
-const char* CDataFrameOutliersRunnerFactory::name() const {
-    return "outlier_detection";
+const std::string& CDataFrameOutliersRunnerFactory::name() const {
+    return NAME;
 }
 
 CDataFrameOutliersRunnerFactory::TRunnerUPtr
@@ -155,5 +155,7 @@ CDataFrameOutliersRunnerFactory::makeImpl(const CDataFrameAnalysisSpecification&
                                           const rapidjson::Value& params) const {
     return std::make_unique<CDataFrameOutliersRunner>(spec, params);
 }
+
+const std::string CDataFrameOutliersRunnerFactory::NAME{"outlier_detection"};
 }
 }

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -41,8 +41,8 @@ std::size_t CDataFrameMockAnalysisRunner::estimateBookkeepingMemoryUsage(std::si
 
 ml::test::CRandomNumbers CDataFrameMockAnalysisRunner::ms_Rng;
 
-const char* CDataFrameMockAnalysisRunnerFactory::name() const {
-    return "test";
+const std::string& CDataFrameMockAnalysisRunnerFactory::name() const {
+    return NAME;
 }
 
 CDataFrameMockAnalysisRunnerFactory::TRunnerUPtr
@@ -55,3 +55,5 @@ CDataFrameMockAnalysisRunnerFactory::makeImpl(const ml::api::CDataFrameAnalysisS
                                               const rapidjson::Value&) const {
     return std::make_unique<CDataFrameMockAnalysisRunner>(spec);
 }
+
+const std::string CDataFrameMockAnalysisRunnerFactory::NAME{"test"};

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -36,7 +36,10 @@ private:
 
 class CDataFrameMockAnalysisRunnerFactory final : public ml::api::CDataFrameAnalysisRunnerFactory {
 public:
-    const char* name() const override;
+    const std::string& name() const override;
+
+private:
+    static const std::string NAME;
 
 private:
     TRunnerUPtr makeImpl(const ml::api::CDataFrameAnalysisSpecification& spec) const override;


### PR DESCRIPTION
Following on from #536, this tidies up the remaining uses of c-style strings in `CDataFrameAnalysisConfigReader` and `CDataFrameAnalysisRunnerFactory`.