### PR TITLE
[FEATURE][ML] Template reducing results read from a data frame

### DIFF
--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -34,6 +34,27 @@ using TRowItr = core::CDataFrame::TRowItr;
 using TRowRef = core::CDataFrame::TRowRef;
 using TRowSampler = CSampling::CRandomStreamSampler<TRowRef>;
 
+//! Reduce the results of core::CDataFrame::readRows.
+template<typename READER, typename REDUCER, typename FIRST_REDUCER>
+bool doReduce(std::pair<std::vector<READER>, bool> readResults,
+              FIRST_REDUCER reduceFirst,
+              REDUCER reduce) {
+    if (readResults.second == false) {
+        return false;
+    }
+    reduceFirst(std::move(readResults.first[0].s_FunctionState));
+    for (std::size_t i = 1; i < readResults.first.size(); ++i) {
+        reduce(std::move(readResults.first[i].s_FunctionState));
+    }
+    return true;
+}
+
+//! Reduce the results of core::CDataFrame::readRows.
+template<typename READER, typename REDUCER>
+bool doReduce(std::pair<std::vector<READER>, bool> readResults, REDUCER reduce) {
+    return doReduce(std::move(readResults), reduce, reduce);
+}
+
 //! Get a row feature sampler.
 auto rowFeatureSampler(std::size_t i, std::size_t targetColumn, TFloatFloatPrVec& samples) {
     return [i, targetColumn, &samples](std::size_t slot, const TRowRef& row) {
@@ -67,29 +88,28 @@ bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataF
         return true;
     }
 
-    auto computeColumnMoments = core::bindRetrievableState(
-        [](TMeanVarAccumulatorVec& moments, TRowItr beginRows, TRowItr endRows) {
+    TMeanVarAccumulatorVec moments(frame.numberColumns());
+
+    auto readColumnMoments = core::bindRetrievableState(
+        [](TMeanVarAccumulatorVec& moments_, TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t i = 0; i < row->numberColumns(); ++i) {
                     if (isMissing((*row)[i]) == false) {
-                        moments[i].add((*row)[i]);
+                        moments_[i].add((*row)[i]);
                     }
                 }
             }
         },
         TMeanVarAccumulatorVec(frame.numberColumns()));
+    auto reduceColumnMoments = [&moments](TMeanVarAccumulatorVec moments_) {
+        for (std::size_t i = 0; i < moments.size(); ++i) {
+            moments[i] += moments_[i];
+        }
+    };
 
-    auto results = frame.readRows(numberThreads, computeColumnMoments);
-    if (results.second == false) {
+    if (doReduce(frame.readRows(numberThreads, readColumnMoments), reduceColumnMoments) == false) {
         LOG_ERROR(<< "Failed to standardise columns");
         return false;
-    }
-
-    TMeanVarAccumulatorVec moments(frame.numberColumns());
-    for (const auto& result : results.first) {
-        for (std::size_t i = 0; i < moments.size(); ++i) {
-            moments[i] += result.s_FunctionState[i];
-        }
     }
 
     TDoubleVec mean(moments.size());
@@ -124,31 +144,30 @@ bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
 
     result.assign(columnMask.size(), sketch);
 
-    auto quantiles = frame.readRows(
-        numberThreads, 0, frame.numberRows(),
-        core::bindRetrievableState(
-            [&](TQuantileSketchVec& quantiles_, TRowItr beginRows, TRowItr endRows) {
-                for (auto row = beginRows; row != endRows; ++row) {
-                    for (std::size_t i = 0; i < columnMask.size(); ++i) {
-                        if (isMissing((*row)[columnMask[i]]) == false) {
-                            quantiles_[i].add((*row)[columnMask[i]], weight(*row));
-                        }
+    auto readQuantiles = core::bindRetrievableState(
+        [&](TQuantileSketchVec& quantiles, TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                for (std::size_t i = 0; i < columnMask.size(); ++i) {
+                    if (isMissing((*row)[columnMask[i]]) == false) {
+                        quantiles[i].add((*row)[columnMask[i]], weight(*row));
                     }
                 }
-            },
-            std::move(result)),
-        &rowMask);
+            }
+        },
+        std::move(result));
+    auto copyQuantiles = [&result](TQuantileSketchVec quantiles) {
+        result = std::move(quantiles);
+    };
+    auto reduceQuantiles = [&](TQuantileSketchVec quantiles) {
+        for (std::size_t i = 0; i < columnMask.size(); ++i) {
+            result[i] += quantiles[i];
+        }
+    };
 
-    if (quantiles.second == false) {
+    if (doReduce(frame.readRows(numberThreads, 0, frame.numberRows(), readQuantiles, &rowMask),
+                 copyQuantiles, reduceQuantiles) == false) {
         LOG_ERROR(<< "Failed to compute column quantiles");
         return false;
-    }
-
-    result = std::move(quantiles.first[0].s_FunctionState);
-    for (std::size_t i = 1; i < quantiles.first.size(); ++i) {
-        for (std::size_t j = 0; j < columnMask.size(); ++j) {
-            result[j] += quantiles.first[i].s_FunctionState[j];
-        }
     }
 
     return true;
@@ -166,34 +185,30 @@ CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
         return result;
     }
 
-    auto categoryCounts = frame.readRows(
-        numberThreads,
-        core::bindRetrievableState(
-            [&](TDoubleVecVec& counts, TRowItr beginRows, TRowItr endRows) {
-                for (auto row = beginRows; row != endRows; ++row) {
-                    for (std::size_t i : columnMask) {
-                        std::size_t id{static_cast<std::size_t>((*row)[i])};
-                        counts[i].resize(std::max(counts[i].size(), id + 1), 0.0);
-                        counts[i][id] += 1.0;
-                    }
+    auto readCategoryCounts = core::bindRetrievableState(
+        [&](TDoubleVecVec& counts, TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                for (std::size_t i : columnMask) {
+                    std::size_t id{static_cast<std::size_t>((*row)[i])};
+                    counts[i].resize(std::max(counts[i].size(), id + 1), 0.0);
+                    counts[i][id] += 1.0;
                 }
-            },
-            TDoubleVecVec(frame.numberColumns())));
-
-    if (categoryCounts.second == false) {
-        HANDLE_FATAL(<< "Internal error: failed to calculate category"
-                     << " frequencies. Please report this problem.");
-        return result;
-    }
-
-    for (const auto& counts_ : categoryCounts.first) {
-        for (std::size_t i = 0; i < counts_.s_FunctionState.size(); ++i) {
-            result[i].resize(counts_.s_FunctionState[i].size(), 0.0);
-            for (std::size_t j = 0; j < counts_.s_FunctionState[i].size(); ++j) {
-                result[i][j] += counts_.s_FunctionState[i][j] /
-                                static_cast<double>(frame.numberRows());
+            }
+        },
+        TDoubleVecVec(frame.numberColumns()));
+    auto computeCategoryFrequencies = [&result, &frame](TDoubleVecVec counts) {
+        for (std::size_t i = 0; i < counts.size(); ++i) {
+            result[i].resize(counts[i].size(), 0.0);
+            for (std::size_t j = 0; j < counts[i].size(); ++j) {
+                result[i][j] += counts[i][j] / static_cast<double>(frame.numberRows());
             }
         }
+    };
+
+    if (doReduce(frame.readRows(numberThreads, readCategoryCounts),
+                 computeCategoryFrequencies) == false) {
+        HANDLE_FATAL(<< "Internal error: failed to calculate category"
+                     << " frequencies. Please report this problem.");
     }
 
     return result;
@@ -222,35 +237,34 @@ CDataFrameUtils::meanValueOfTargetForCategories(std::size_t numberThreads,
     using TMeanAccumulatorVec = std::vector<CBasicStatistics::SSampleMean<double>::TAccumulator>;
     using TMeanAccumulatorVecVec = std::vector<TMeanAccumulatorVec>;
 
-    auto categoryMeanValues = frame.readRows(
-        numberThreads,
-        core::bindRetrievableState(
-            [&](TMeanAccumulatorVecVec& means, TRowItr beginRows, TRowItr endRows) {
-                for (auto row = beginRows; row != endRows; ++row) {
-                    for (std::size_t i : columnMask) {
-                        std::size_t id{static_cast<std::size_t>((*row)[i])};
-                        means[i].resize(std::max(means[i].size(), id + 1));
-                        means[i][id].add((*row)[targetColumn]);
-                    }
-                }
-            },
-            TMeanAccumulatorVecVec(frame.numberColumns())));
+    TMeanAccumulatorVecVec means(frame.numberColumns());
 
-    if (categoryMeanValues.second == false) {
+    auto readColumnMeans = core::bindRetrievableState(
+        [&](TMeanAccumulatorVecVec& means_, TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                for (std::size_t i : columnMask) {
+                    std::size_t id{static_cast<std::size_t>((*row)[i])};
+                    means_[i].resize(std::max(means_[i].size(), id + 1));
+                    means_[i][id].add((*row)[targetColumn]);
+                }
+            }
+        },
+        TMeanAccumulatorVecVec(frame.numberColumns()));
+    auto reduceColumnMeans = [&means](TMeanAccumulatorVecVec means_) {
+        for (std::size_t i = 0; i < means_.size(); ++i) {
+            means[i].resize(means_[i].size());
+            for (std::size_t j = 0; j < means_[i].size(); ++j) {
+                means[i][j] += means_[i][j];
+            }
+        }
+    };
+
+    if (doReduce(frame.readRows(numberThreads, readColumnMeans), reduceColumnMeans) == false) {
         HANDLE_FATAL(<< "Internal error: failed to calculate mean target value"
                      << " for categories. Please report this problem.");
         return result;
     }
 
-    TMeanAccumulatorVecVec means(frame.numberColumns());
-    for (const auto& means_ : categoryMeanValues.first) {
-        for (std::size_t i = 0; i < means_.s_FunctionState.size(); ++i) {
-            means[i].resize(means_.s_FunctionState[i].size());
-            for (std::size_t j = 0; j < means_.s_FunctionState[i].size(); ++j) {
-                means[i][j] += means_.s_FunctionState[i][j];
-            }
-        }
-    }
     for (std::size_t i = 0; i < result.size(); ++i) {
         result[i].resize(means[i].size());
         for (std::size_t j = 0; j < means[i].size(); ++j) {


### PR DESCRIPTION
Following on from the suggestion of @valeriy42 in #539, this PR implements a generic reduce operation over the results of reading `core::CDataFrame` rows. Although this is slightly more verbose, despite sharing some code, I feel like it does better separate out logical concerns in the functions which use it.

I considered rolling reading the rows into this function and also moving to `core::CDataFrame`. I decided against this for the following reasons:
1. I then have to duplicate the various versions taking different parameters
2. Passing the state from the read to the reduce step via `core::bindRetrievableState` was all then hidden and I felt this made the resulting code more opaque
3. There aren't that many other places in the code which benefit from this yet

I'd be happy to revisit this down-the-line, but I think this represents a reasonable first step.

