### PR TITLE
[FEATURE][ML] Automatic categorical field encoding

### DIFF
--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -88,7 +88,7 @@ private:
 };
 
 //! \brief Decorates CRowCRef to give it pointer semantics.
-class CORE_EXPORT CRowPtr : public CRowRef {
+class CORE_EXPORT CRowPtr final : public CRowRef {
 public:
     template<typename... ARGS>
     CRowPtr(ARGS&&... args) : CRowRef{std::forward<ARGS>(args)...} {}
@@ -102,7 +102,7 @@ public:
 //! DESCRIPTION:\n
 //! This is a helper class used to read rows of a CDataFrame object which
 //! dereferences to CRowRef objects.
-class CORE_EXPORT CRowIterator
+class CORE_EXPORT CRowIterator final
     : public std::iterator<std::forward_iterator_tag, CRowRef, std::ptrdiff_t, CRowPtr, CRowRef> {
 public:
     CRowIterator() = default;

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -406,7 +406,7 @@ public:
     void writeRow(const TWriteFunc& writeRow);
 
     //! Write which columns contain categorical data.
-    void writeCategoricalColumns(TBoolVec columnIsCategorical);
+    void categoricalColumns(TBoolVec columnIsCategorical);
 
     //! This retrieves the asynchronous work from writing the rows to the store
     //! and updates the stored rows.

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -106,7 +106,7 @@ public:
 //! there is a well ordering on each feature and looks for binary splits subject to this
 //! ordering. This leaves two choices for categorical fields a) use some predefined order
 //! knowing that only splits of the form \f$\{\{1,2,...,i\},\{i+1,i+2,...,m\}\}\f$ will
-//! be considered or b) use hot-one-encoding knowing splits of the form \f$\{\{0\},\{1\}\}\f$
+//! be considered or b) use one-hot-encoding knowing splits of the form \f$\{\{0\},\{1\}\}\f$
 //! will then be considered for each category. The first choice will rule out good splits
 //! because they aren't consistent with the ordering and the second choice will behave
 //! poorly for fields with high cardinality because it will be impossible to accurately

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -69,7 +69,7 @@ private:
 //! reasonable sample set and a catch all indicator feature for all rare categories.
 //!
 //! This also selects the independent metric features to use at the same time controlling
-//! the total number of features we use in total based on the quantity of training data.
+//! the number of features we use in total based on the quantity of training data.
 class MATHS_EXPORT CDataFrameCategoryEncoder final {
 public:
     using TBoolVec = std::vector<bool>;
@@ -83,15 +83,16 @@ public:
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute the encoding.
     //! \param[in] columnMask A mask of the columns to include.
-    //! \param[in] targetColumn The column whose mean values are computed.
+    //! \param[in] targetColumn The regression target variable.
     //! \param[in] minimumRowsPerFeature The minimum number of rows needed per dimension
     //! of the feature vector.
     //! \param[in] minimumFrequencyToHotOneEncode The minimum relative frequency of a
     //! category in \p frame to consider hot-one encoding it.
-    //! \param[in] lambda Controls the weight between category MICe and the count of
+    //! \param[in] lambda Controls the weight between category MIC and the count of
     //! categories already hot-one encoded for a feature when selecting features. This
-    //! should be positive and the higher the value the more it will prefer to choose
-    //! all the metrics and equal numbers from each category to hot-one encode.
+    //! should be non-negative and the higher the value the more this will prefer to
+    //! choose all the metrics and equal numbers of categories from each categorical
+    //! column to hot-one encode.
     CDataFrameCategoryEncoder(std::size_t numberThreads,
                               const core::CDataFrame& frame,
                               const TSizeVec& columnMask,
@@ -103,7 +104,7 @@ public:
     //! Get a row reference which encodes the categories in \p row.
     CEncodedDataFrameRowRef encode(TRowRef row);
 
-    //! Get an indicator vector of categorical columns.
+    //! Check if \p feature is categorical.
     bool columnIsCategorical(std::size_t feature) const;
 
     //! Get the selected metric features.
@@ -115,28 +116,28 @@ public:
     //! Get the selected categorical features.
     const TSizeVec& selectedCategoricalFeatures() const;
 
-    //! Get the number of dimensions in the feature vector.
+    //! Get the total number of dimensions in the feature vector.
     std::size_t numberFeatures() const;
 
     //! Get the encoding offset in feature vector of \p index.
     std::size_t encoding(std::size_t index) const;
 
-    //! Get the data frame column of the feature vector \p index.
+    //! Get the data frame column of \p index into the feature vector.
     std::size_t column(std::size_t index) const;
 
     //! Get the number of hot-one encoded categories for \p feature.
     std::size_t numberHotOneEncodedCategories(std::size_t feature) const;
 
-    //! Check if \p index is the hot-one for category \p category.
+    //! Check if \p index is the hot-one for category \p category of \p feature.
     bool isHotOne(std::size_t index, std::size_t feature, std::size_t category) const;
 
     //! Check if \p feature has rare categories.
     bool hasRareCategories(std::size_t feature) const;
 
-    //! Check if \p category is rare.
+    //! Check if \p category of \p feature is rare.
     bool isRareCategory(std::size_t feature, std::size_t category) const;
 
-    //! Get the mean value of the target variable for \p category.
+    //! Get the mean value of the target variable for \p category of \p feature.
     double targetMeanValue(std::size_t feature, std::size_t category) const;
 
 private:

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -23,7 +23,7 @@ class CDataFrameCategoryEncoder;
 //!
 //! DESCRIPTION:\n
 //! This implements a subset of the core::CDataFrame::TRowRef interface dealing with
-//! the extra dimensions introduced by hot-one encoded categories, extracting the mean
+//! the extra dimensions introduced by one-hot encoded categories, extracting the mean
 //! target variable value for other categories and so on. The intention is it provides
 //! a drop in replacement for core::CDataFrame::TRowRef when a data frame contains
 //! categorical columns.
@@ -64,7 +64,7 @@ private:
 //! DESCRIPTION:\n
 //! We select appropriate encodings for categorical values based on their cardinality,
 //! the information they carry about the regression target variable and so on. We use
-//! a mixture of hot-one encoding for the categories which carry the most information
+//! a mixture of one-hot encoding for the categories which carry the most information
 //! (because this is lossless), mean target encoding for categories where we have a
 //! reasonable sample set and a catch all indicator feature for all rare categories.
 //!
@@ -86,19 +86,19 @@ public:
     //! \param[in] targetColumn The regression target variable.
     //! \param[in] minimumRowsPerFeature The minimum number of rows needed per dimension
     //! of the feature vector.
-    //! \param[in] minimumFrequencyToHotOneEncode The minimum relative frequency of a
-    //! category in \p frame to consider hot-one encoding it.
+    //! \param[in] minimumFrequencyToOneHotEncode The minimum relative frequency of a
+    //! category in \p frame to consider one-hot encoding it.
     //! \param[in] lambda Controls the weight between category MIC and the count of
-    //! categories already hot-one encoded for a feature when selecting features. This
+    //! categories already one-hot encoded for a feature when selecting features. This
     //! should be non-negative and the higher the value the more this will prefer to
     //! choose all the metrics and equal numbers of categories from each categorical
-    //! column to hot-one encode.
+    //! column to one-hot encode.
     CDataFrameCategoryEncoder(std::size_t numberThreads,
                               const core::CDataFrame& frame,
                               const TSizeVec& columnMask,
                               std::size_t targetColumn,
                               std::size_t minimumRowsPerFeature,
-                              double minimumFrequencyToHotOneEncode = 0.01,
+                              double minimumFrequencyToOneHotEncode = 0.01,
                               double lambda = 0.2 * std::log(2.0));
 
     //! Get a row reference which encodes the categories in \p row.
@@ -125,11 +125,11 @@ public:
     //! Get the data frame column of \p index into the feature vector.
     std::size_t column(std::size_t index) const;
 
-    //! Get the number of hot-one encoded categories for \p feature.
-    std::size_t numberHotOneEncodedCategories(std::size_t feature) const;
+    //! Get the number of one-hot encoded categories for \p feature.
+    std::size_t numberOneHotEncodedCategories(std::size_t feature) const;
 
-    //! Check if \p index is the hot-one for category \p category of \p feature.
-    bool isHotOne(std::size_t index, std::size_t feature, std::size_t category) const;
+    //! Check if \p index is the one-hot for category \p category of \p feature.
+    bool isOneHot(std::size_t index, std::size_t feature, std::size_t category) const;
 
     //! Check if \p feature has rare categories.
     bool hasRareCategories(std::size_t feature) const;
@@ -156,7 +156,7 @@ private:
                       const TSizeVec& categoricalColumnMask,
                       std::size_t targetColumn,
                       std::size_t minimumRowsPerFeature,
-                      double minimumFrequencyToHotOneEncode);
+                      double minimumFrequencyToOneHotEncode);
     void targetMeanValueEncode(std::size_t numberThreads,
                                const core::CDataFrame& frame,
                                const TSizeVec& categoricalColumnMask,
@@ -173,7 +173,7 @@ private:
     TSizeVec m_FeatureVectorEncodingMap;
     TDoubleVecVec m_TargetMeanValues;
     TSizeVecVec m_RareCategories;
-    TSizeVecVec m_HotOneEncodedCategories;
+    TSizeVecVec m_OneHotEncodedCategories;
 };
 }
 }

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CDataFrameCategoryEncoder_h
+#define INCLUDED_ml_maths_CDataFrameCategoryEncoder_h
+
+#include <core/CDataFrame.h>
+
+#include <maths/ImportExport.h>
+#include <maths/MathsTypes.h>
+
+#include <utility>
+#include <vector>
+
+namespace ml {
+namespace maths {
+class CDataFrameCategoryEncoder;
+
+//! \brief A wrapper of a data frame row reference which handles encoding categories.
+//!
+//! DESCRIPTION:\n
+//! This implements a subset of the core::CDataFrame::TRowRef interface dealing with
+//! the extra dimensions introduced by hot-one encoded categories, extracting the mean
+//! target variable value for other categories and so on. The intention is it provides
+//! a drop in replacement for core::CDataFrame::TRowRef when a data frame contains
+//! categorical columns.
+class MATHS_EXPORT CEncodedDataFrameRowRef final {
+public:
+    using TRowRef = core::CDataFrame::TRowRef;
+
+public:
+    CEncodedDataFrameRowRef(TRowRef row, const CDataFrameCategoryEncoder& encoder);
+
+    //! Get column \p i value.
+    CFloatStorage operator[](std::size_t i) const;
+
+    //! Get the row's index.
+    std::size_t index() const;
+
+    //! Get the number of columns.
+    std::size_t numberColumns() const;
+
+    //! Copy the range to \p output iterator.
+    //!
+    //! \warning The output iterator that must be able to receive numberColumns
+    //! values.
+    template<typename ITR>
+    void copyTo(ITR output) const {
+        for (std::size_t i = 0; i < this->numberColumns(); ++i, ++output) {
+            *output = this->operator[](i);
+        }
+    }
+
+private:
+    TRowRef m_Row;
+    const CDataFrameCategoryEncoder* m_Encoder;
+};
+
+//! \brief Performs encoding of the categorical columns in a data frame.
+//!
+//! DESCRIPTION:\n
+//! We select appropriate encodings for categorical values based on their cardinality,
+//! the information they carry about the regression target variable and so on. We use
+//! a mixture of hot-one encoding for the categories which carry the most information
+//! (because this is lossless), mean target encoding for categories where we have a
+//! reasonable sample set and a catch all indicator feature for all rare categories.
+//!
+//! This also selects the independent metric features to use at the same time controlling
+//! the total number of features we use in total based on the quantity of training data.
+class MATHS_EXPORT CDataFrameCategoryEncoder final {
+public:
+    using TBoolVec = std::vector<bool>;
+    using TDoubleVec = std::vector<double>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TRowRef = core::CDataFrame::TRowRef;
+
+public:
+    //! \param[in] numberThreads The number of threads available.
+    //! \param[in] frame The data frame for which to compute the encoding.
+    //! \param[in] columnMask A mask of the columns to include.
+    //! \param[in] targetColumn The column whose mean values are computed.
+    //! \param[in] minimumRowsPerFeature The minimum number of rows needed per dimension
+    //! of the feature vector.
+    //! \param[in] minimumFrequencyToHotOneEncode The minimum relative frequency of a
+    //! category in \p frame to consider hot-one encoding it.
+    //! \param[in] lambda Controls the weight between category MICe and the count of
+    //! categories already hot-one encoded for a feature when selecting features. This
+    //! should be positive and the higher the value the more it will prefer to choose
+    //! all the metrics and equal numbers from each category to hot-one encode.
+    CDataFrameCategoryEncoder(std::size_t numberThreads,
+                              const core::CDataFrame& frame,
+                              const TSizeVec& columnMask,
+                              std::size_t targetColumn,
+                              std::size_t minimumRowsPerFeature,
+                              double minimumFrequencyToHotOneEncode = 0.01,
+                              double lambda = 0.2 * std::log(2.0));
+
+    //! Get a row reference which encodes the categories in \p row.
+    CEncodedDataFrameRowRef encode(TRowRef row);
+
+    //! Get an indicator vector of categorical columns.
+    bool columnIsCategorical(std::size_t feature) const;
+
+    //! Get the selected metric features.
+    const TSizeVec& selectedMetricFeatures() const;
+
+    //! Get the selected metric features' MICs.
+    const TDoubleVec& selectedMetricFeatureMics() const;
+
+    //! Get the selected categorical features.
+    const TSizeVec& selectedCategoricalFeatures() const;
+
+    //! Get the number of dimensions in the feature vector.
+    std::size_t numberFeatures() const;
+
+    //! Get the encoding offset in feature vector of \p index.
+    std::size_t encoding(std::size_t index) const;
+
+    //! Get the data frame column of the feature vector \p index.
+    std::size_t column(std::size_t index) const;
+
+    //! Get the number of hot-one encoded categories for \p feature.
+    std::size_t numberHotOneEncodedCategories(std::size_t feature) const;
+
+    //! Check if \p index is the hot-one for category \p category.
+    bool isHotOne(std::size_t index, std::size_t feature, std::size_t category) const;
+
+    //! Check if \p feature has rare categories.
+    bool hasRareCategories(std::size_t feature) const;
+
+    //! Check if \p category is rare.
+    bool isRareCategory(std::size_t feature, std::size_t category) const;
+
+    //! Get the mean value of the target variable for \p category.
+    double targetMeanValue(std::size_t feature, std::size_t category) const;
+
+private:
+    using TSizeDoublePr = std::pair<std::size_t, double>;
+    using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
+    using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
+
+private:
+    void isRareEncode(std::size_t numberThreads,
+                      const core::CDataFrame& frame,
+                      const TSizeVec& categoricalColumnMask,
+                      std::size_t minimumRowsPerFeature);
+    void hotOneEncode(std::size_t numberThreads,
+                      const core::CDataFrame& frame,
+                      const TSizeVec& metricColumnMask,
+                      const TSizeVec& categoricalColumnMask,
+                      std::size_t targetColumn,
+                      std::size_t minimumRowsPerFeature,
+                      double minimumFrequencyToHotOneEncode);
+    void targetMeanValueEncode(std::size_t numberThreads,
+                               const core::CDataFrame& frame,
+                               const TSizeVec& categoricalColumnMask,
+                               std::size_t targetColumn);
+    void setupEncodingMaps(const core::CDataFrame& frame);
+
+private:
+    double m_Lambda;
+    TBoolVec m_ColumnIsCategorical;
+    TSizeVec m_SelectedMetricFeatures;
+    TDoubleVec m_SelectedMetricFeatureMics;
+    TSizeVec m_SelectedCategoricalFeatures;
+    TSizeVec m_FeatureVectorColumnMap;
+    TSizeVec m_FeatureVectorEncodingMap;
+    TDoubleVecVec m_TargetMeanValues;
+    TSizeVecVec m_RareCategories;
+    TSizeVecVec m_HotOneEncodedCategories;
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CDataFrameCategoryEncoder_h

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -128,8 +128,8 @@ public:
     //! Get the number of one-hot encoded categories for \p feature.
     std::size_t numberOneHotEncodedCategories(std::size_t feature) const;
 
-    //! Check if \p index is the one-hot for category \p category of \p feature.
-    bool isOneHot(std::size_t index, std::size_t feature, std::size_t category) const;
+    //! Check if \p index is one for category \p category of \p feature.
+    bool isOne(std::size_t index, std::size_t feature, std::size_t category) const;
 
     //! Check if \p feature has rare categories.
     bool hasRareCategories(std::size_t feature) const;

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -11,7 +11,6 @@
 #include <core/CNonInstantiatable.h>
 
 #include <maths/CLinearAlgebraEigen.h>
-
 #include <maths/ImportExport.h>
 
 #include <functional>

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -207,7 +207,7 @@ bool CDataFrameAnalyzer::prepareToReceiveControlMessages(const TStrVec& fieldNam
     }
 
     if (m_DataFrame != nullptr) {
-        m_DataFrame->writeCategoricalColumns(std::move(isCategorical));
+        m_DataFrame->categoricalColumns(std::move(isCategorical));
     }
 
     return true;

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -6,6 +6,7 @@
 
 #include <core/CDataFrame.h>
 
+#include <core/CContainerPrinter.h>
 #include <core/CDataFrameRowSlice.h>
 #include <core/CHashing.h>
 #include <core/CLogger.h>
@@ -208,7 +209,13 @@ void CDataFrame::writeRow(const TWriteFunc& writeRow) {
 }
 
 void CDataFrame::writeCategoricalColumns(TBoolVec columnIsCategorical) {
-    m_ColumnIsCategorical = std::move(columnIsCategorical);
+    if (columnIsCategorical.size() != m_NumberColumns) {
+        HANDLE_FATAL(<< "Internal error: expected '" << m_NumberColumns << "' is"
+                     << "categorical column values but got "
+                     << CContainerPrinter::print(columnIsCategorical));
+    } else {
+        m_ColumnIsCategorical = std::move(columnIsCategorical);
+    }
 }
 
 void CDataFrame::finishWritingRows() {

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -208,7 +208,7 @@ void CDataFrame::writeRow(const TWriteFunc& writeRow) {
     (*m_Writer)(writeRow);
 }
 
-void CDataFrame::writeCategoricalColumns(TBoolVec columnIsCategorical) {
+void CDataFrame::categoricalColumns(TBoolVec columnIsCategorical) {
     if (columnIsCategorical.size() != m_NumberColumns) {
         HANDLE_FATAL(<< "Internal error: expected '" << m_NumberColumns << "' is"
                      << "categorical column values but got "

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -209,11 +209,13 @@ void CDataFrameCategoryEncoder::hotOneEncode(std::size_t numberThreads,
     // selected so far. This would be very expensive since it requires training
     // a model on a subset of the features for each decision. Instead, we introduce
     // a single non-negative parameter lambda and the category MICe for each feature
-    // is scale by exp(-lambda x "count of categories one-hot encoded for feature").
+    // is scaled by exp(-lambda x "count of categories one-hot encoded for feature").
     // In the limit lambda is zero this amounts to simply choosing the metrics
-    // and categories to one-hot encode with highest MICe. In the limit lambda is
-    // large this amounts to choosing all metrics then the same count of categories
-    // (with the highest MICe) to one-hot encode for each categorical feature.
+    // and categories to one-hot encode that carry the most information about, i.e.
+    // have the highest MICe with, the target variable. In the limit lambda is large
+    // this amounts to choosing all the metrics and the same count of categories to
+    // one-hot encode for each categorical feature. In this case the MICe with the
+    // target is maximised independently for each categorical feature.
 
     using TDoubleSizeSizeTr = core::CTriple<double, std::size_t, std::size_t>;
     using TDoubleSizeSizeTrList = std::list<TDoubleSizeSizeTr>;

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -159,7 +159,7 @@ bool CDataFrameCategoryEncoder::isOne(std::size_t index,
     // The ones are in the order the categories appear in m_OneHotEncodedCategories.
     // For example, if m_OneHotEncodedCategories[feature] = (2, 5, 7) for any other
     // category the encoded row will contain (...| 0 0 0 | ...). For 2, 5 and 7 it
-    // will contain (...| 1 0 0 | ...), (...| 0 1 0 | ...) and (...| 0 0 1 | ...),
+    // will contain (...| 1 0 0 |...), (...| 0 1 0 |...) and (...| 0 0 1 |...),
     // respectively.
     //
     // In the following we therefore 1) check to see if the category is being

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -1,0 +1,373 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CDataFrameCategoryEncoder.h>
+
+#include <core/CContainerPrinter.h>
+#include <core/CLogger.h>
+#include <core/CTriple.h>
+
+#include <maths/CDataFrameUtils.h>
+#include <maths/COrderings.h>
+
+#include <algorithm>
+#include <numeric>
+
+namespace ml {
+namespace maths {
+
+CEncodedDataFrameRowRef::CEncodedDataFrameRowRef(TRowRef row, const CDataFrameCategoryEncoder& encoder)
+    : m_Row{std::move(row)}, m_Encoder{&encoder} {
+}
+
+CFloatStorage CEncodedDataFrameRowRef::operator[](std::size_t i) const {
+
+    std::size_t feature{m_Encoder->column(i)};
+
+    CFloatStorage value{m_Row[feature]};
+
+    if (m_Encoder->columnIsCategorical(feature) == false) {
+        return value;
+    }
+
+    std::size_t encoding{m_Encoder->encoding(i)};
+    std::size_t category{static_cast<std::size_t>(value)};
+
+    std::size_t numberHotOneEncodedCategories{
+        m_Encoder->numberHotOneEncodedCategories(feature)};
+
+    if (encoding < numberHotOneEncodedCategories) {
+        return m_Encoder->isHotOne(encoding, feature, category) ? 1.0 : 0.0;
+    }
+
+    if (encoding == numberHotOneEncodedCategories && m_Encoder->hasRareCategories(feature)) {
+        return m_Encoder->isRareCategory(feature, category) ? 1.0 : 0.0;
+    }
+
+    return m_Encoder->targetMeanValue(feature, category);
+}
+
+std::size_t CEncodedDataFrameRowRef::index() const {
+    return m_Row.index();
+}
+
+std::size_t CEncodedDataFrameRowRef::numberColumns() const {
+    return m_Encoder->numberFeatures();
+}
+
+CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(std::size_t numberThreads,
+                                                     const core::CDataFrame& frame,
+                                                     const TSizeVec& columnMask,
+                                                     std::size_t targetColumn,
+                                                     std::size_t minimumRowsPerFeature,
+                                                     double minimumFrequencyToHotOneEncode,
+                                                     double lambda)
+    : m_Lambda{lambda}, m_ColumnIsCategorical(frame.columnIsCategorical()) {
+
+    TSizeVec metricColumnMask(columnMask);
+    std::iota(metricColumnMask.begin(), metricColumnMask.end(), 0);
+    metricColumnMask.erase(
+        std::remove_if(metricColumnMask.begin(), metricColumnMask.end(),
+                       [targetColumn, this](std::size_t i) {
+                           return i == targetColumn || m_ColumnIsCategorical[i];
+                       }),
+        metricColumnMask.end());
+    LOG_TRACE(<< "metric column mask = " << core::CContainerPrinter::print(metricColumnMask));
+
+    TSizeVec categoricalColumnMask(columnMask);
+    std::iota(categoricalColumnMask.begin(), categoricalColumnMask.end(), 0);
+    categoricalColumnMask.erase(
+        std::remove_if(categoricalColumnMask.begin(), categoricalColumnMask.end(),
+                       [targetColumn, this](std::size_t i) {
+                           return i == targetColumn || m_ColumnIsCategorical[i] == false;
+                       }),
+        categoricalColumnMask.end());
+    LOG_TRACE(<< "categorical column mask = "
+              << core::CContainerPrinter::print(categoricalColumnMask));
+
+    // The top-level strategy is as follows:
+    //
+    // We hot-one encode the frequent categories with the highest non-zero MICe up
+    // to the permitted overall feature count.
+    // We mean value encode the remaining features where we have a representative
+    // sample size.
+    // We use one indicator dimension in the feature vector for encoding all rare
+    // categories of a categorical column.
+
+    this->isRareEncode(numberThreads, frame, categoricalColumnMask, minimumRowsPerFeature);
+
+    this->targetMeanValueEncode(numberThreads, frame, categoricalColumnMask, targetColumn);
+
+    this->hotOneEncode(numberThreads, frame, metricColumnMask,
+                       categoricalColumnMask, targetColumn,
+                       minimumRowsPerFeature, minimumFrequencyToHotOneEncode);
+
+    this->setupEncodingMaps(frame);
+}
+
+CEncodedDataFrameRowRef CDataFrameCategoryEncoder::encode(TRowRef row) {
+    return {std::move(row), *this};
+}
+
+bool CDataFrameCategoryEncoder::columnIsCategorical(std::size_t feature) const {
+    return m_ColumnIsCategorical[feature];
+}
+
+const CDataFrameCategoryEncoder::TSizeVec&
+CDataFrameCategoryEncoder::selectedMetricFeatures() const {
+    return m_SelectedMetricFeatures;
+}
+
+const CDataFrameCategoryEncoder::TDoubleVec&
+CDataFrameCategoryEncoder::selectedMetricFeatureMics() const {
+    return m_SelectedMetricFeatureMics;
+}
+
+const CDataFrameCategoryEncoder::TSizeVec&
+CDataFrameCategoryEncoder::selectedCategoricalFeatures() const {
+    return m_SelectedCategoricalFeatures;
+}
+
+std::size_t CDataFrameCategoryEncoder::numberFeatures() const {
+    return m_FeatureVectorColumnMap.size();
+}
+
+std::size_t CDataFrameCategoryEncoder::encoding(std::size_t index) const {
+    return m_FeatureVectorEncodingMap[index];
+}
+
+std::size_t CDataFrameCategoryEncoder::column(std::size_t index) const {
+    return m_FeatureVectorColumnMap[index];
+}
+
+std::size_t CDataFrameCategoryEncoder::numberHotOneEncodedCategories(std::size_t feature) const {
+    return m_HotOneEncodedCategories[feature].size();
+}
+
+bool CDataFrameCategoryEncoder::isHotOne(std::size_t index,
+                                         std::size_t feature,
+                                         std::size_t category) const {
+    auto one = std::lower_bound(m_HotOneEncodedCategories[feature].begin(),
+                                m_HotOneEncodedCategories[feature].end(), category);
+    return one != m_HotOneEncodedCategories[feature].end() && category == *one &&
+           static_cast<std::ptrdiff_t>(index) ==
+               one - m_HotOneEncodedCategories[feature].begin();
+}
+
+bool CDataFrameCategoryEncoder::hasRareCategories(std::size_t feature) const {
+    return m_RareCategories[feature].size() > 0;
+}
+
+bool CDataFrameCategoryEncoder::isRareCategory(std::size_t feature, std::size_t category) const {
+    return std::binary_search(m_RareCategories[feature].begin(),
+                              m_RareCategories[feature].end(), category);
+}
+
+double CDataFrameCategoryEncoder::targetMeanValue(std::size_t feature,
+                                                  std::size_t category) const {
+    return m_TargetMeanValues[feature][category];
+}
+
+void CDataFrameCategoryEncoder::isRareEncode(std::size_t numberThreads,
+                                             const core::CDataFrame& frame,
+                                             const TSizeVec& categoricalColumnMask,
+                                             std::size_t minimumRowsPerFeature) {
+
+    TDoubleVecVec categoryFrequencies(CDataFrameUtils::categoryFrequencies(
+        numberThreads, frame, categoricalColumnMask));
+    LOG_TRACE(<< "category frequencies = "
+              << core::CContainerPrinter::print(categoryFrequencies));
+
+    m_RareCategories.resize(frame.numberColumns());
+    for (std::size_t i = 0; i < categoryFrequencies.size(); ++i) {
+        for (std::size_t j = 0; j < categoryFrequencies[i].size(); ++j) {
+            std::size_t count{static_cast<std::size_t>(
+                categoryFrequencies[i][j] * static_cast<double>(frame.numberRows()) + 0.5)};
+            if (count < minimumRowsPerFeature) {
+                m_RareCategories[i].push_back(j);
+            }
+        }
+        m_RareCategories[i].shrink_to_fit();
+    }
+    LOG_TRACE(<< "rare categories = " << core::CContainerPrinter::print(m_RareCategories));
+}
+
+void CDataFrameCategoryEncoder::hotOneEncode(std::size_t numberThreads,
+                                             const core::CDataFrame& frame,
+                                             const TSizeVec& metricColumnMask,
+                                             const TSizeVec& categoricalColumnMask,
+                                             std::size_t targetColumn,
+                                             std::size_t minimumRowsPerFeature,
+                                             double minimumFrequencyToHotOneEncode) {
+
+    // We expect information carried by distinct features to be less correlated
+    // so want to prefer choosing distinct features if the decision is marginal.
+    // Ideally we'd recompute MICe w.r.t. target - prediction given the features
+    // selected so far. This would be very expensive since it requires training
+    // a model on a subset of the features for each decision. Instead, we introduce
+    // a single non-negative parameter lambda and the category MICe for each feature
+    // is scale by exp(-lambda x "count of categories hot-one encoded for feature").
+    // In the limit lambda is zero this amounts to simply choosing the metrics
+    // and categories to hot-one encode with highest MICe. In the limit lambda is
+    // large this amounts to choosing all metrics then the same count of categories
+    // (with the highest MICe) to hot-one encode for each categorical feature.
+
+    using TDoubleSizeSizeTr = core::CTriple<double, std::size_t, std::size_t>;
+    using TDoubleSizeSizeTrList = std::list<TDoubleSizeSizeTr>;
+
+    LOG_TRACE(<< "target column = " << targetColumn);
+
+    auto metricMics = CDataFrameUtils::micWithColumn(frame, metricColumnMask, targetColumn);
+    auto categoricalMics = CDataFrameUtils::categoryMicWithColumn(
+        numberThreads, frame, categoricalColumnMask, targetColumn, minimumFrequencyToHotOneEncode);
+    LOG_TRACE(<< "metric MICe = " << core::CContainerPrinter::print(metricMics));
+    LOG_TRACE(<< "categorical MICe = " << core::CContainerPrinter::print(categoricalMics));
+
+    std::size_t numberFeatures(std::count_if(metricMics.begin(), metricMics.end(),
+                                             [](double mic) { return mic > 0.0; }));
+    for (std::size_t i = 0; i < categoricalMics.size(); ++i) {
+        numberFeatures += std::count_if(categoricalMics[i].begin(),
+                                        categoricalMics[i].end(),
+                                        [&](auto categoryMic) {
+                                            std::size_t category;
+                                            double mic;
+                                            std::tie(category, mic) = categoryMic;
+                                            return mic > 0.0;
+                                        }) +
+                          (this->hasRareCategories(i) ? 1 : 0);
+    }
+
+    std::size_t maximumNumberFeatures{
+        (frame.numberRows() + minimumRowsPerFeature / 2) / minimumRowsPerFeature};
+    LOG_TRACE(<< "number possible features = " << numberFeatures
+              << " maximum permitted features = " << maximumNumberFeatures);
+
+    m_HotOneEncodedCategories.resize(frame.numberColumns());
+
+    if (maximumNumberFeatures >= numberFeatures) {
+        for (std::size_t i = 0; i < metricMics.size(); ++i) {
+            if (metricMics[i] > 0.0) {
+                m_SelectedMetricFeatures.push_back(i);
+                m_SelectedMetricFeatureMics.push_back(metricMics[i]);
+            }
+        }
+        for (std::size_t i = 0; i < categoricalMics.size(); ++i) {
+            for (std::size_t j = 0; j < categoricalMics[i].size(); ++j) {
+                std::size_t category;
+                double mic;
+                std::tie(category, mic) = categoricalMics[i][j];
+                if (mic > 0.0) {
+                    m_HotOneEncodedCategories[i].push_back(category);
+                }
+            }
+        }
+
+    } else {
+        TDoubleSizeSizeTrList mics;
+        for (std::size_t i = 0; i < metricMics.size(); ++i) {
+            if (metricMics[i] > 0.0) {
+                mics.emplace_back(metricMics[i], i, 0);
+            }
+        }
+        for (std::size_t i = 0; i < categoricalMics.size(); ++i) {
+            for (std::size_t j = 0; j < categoricalMics[i].size(); ++j) {
+                std::size_t category;
+                double mic;
+                std::tie(category, mic) = categoricalMics[i][j];
+                if (mic > 0.0) {
+                    mics.emplace_back(mic, i, category);
+                }
+            }
+        }
+        LOG_TRACE(<< "MICe = " << core::CContainerPrinter::print(mics));
+
+        TDoubleVec hotOneEncodedCounts(frame.numberColumns(), 0.0);
+
+        for (std::size_t i = 0; i < maximumNumberFeatures; ++i) {
+
+            auto next = std::max_element(
+                mics.begin(), mics.end(),
+                [&](const TDoubleSizeSizeTr& lhs, const TDoubleSizeSizeTr& rhs) {
+                    return std::exp(-m_Lambda * hotOneEncodedCounts[lhs.second]) * lhs.first <
+                           std::exp(-m_Lambda * hotOneEncodedCounts[rhs.second]) * rhs.first;
+                });
+
+            double mic{next->first};
+            std::size_t feature{next->second};
+            std::size_t category{next->third};
+
+            if (m_ColumnIsCategorical[feature]) {
+                m_SelectedCategoricalFeatures.push_back(feature);
+                m_HotOneEncodedCategories[feature].push_back(category);
+                hotOneEncodedCounts[feature] += 1.0;
+                if (hotOneEncodedCounts[feature] == 1.0) {
+                    i += 1 + (this->hasRareCategories(feature) ? 1 : 0);
+                }
+            } else {
+                m_SelectedMetricFeatures.push_back(feature);
+                m_SelectedMetricFeatureMics.push_back(mic);
+            }
+
+            mics.erase(next);
+        }
+    }
+
+    for (auto& categories : m_HotOneEncodedCategories) {
+        categories.shrink_to_fit();
+        std::sort(categories.begin(), categories.end());
+    }
+    COrderings::simultaneousSort(m_SelectedMetricFeatures, m_SelectedMetricFeatureMics);
+    LOG_TRACE(<< "selected metrics = "
+              << core::CContainerPrinter::print(m_SelectedMetricFeatures));
+    LOG_TRACE(<< "hot-one encoded = "
+              << core::CContainerPrinter::print(m_HotOneEncodedCategories));
+}
+
+void CDataFrameCategoryEncoder::targetMeanValueEncode(std::size_t numberThreads,
+                                                      const core::CDataFrame& frame,
+                                                      const TSizeVec& categoricalColumnMask,
+                                                      std::size_t targetColumn) {
+
+    m_TargetMeanValues = CDataFrameUtils::meanValueOfTargetForCategories(
+        numberThreads, frame, categoricalColumnMask, targetColumn);
+    LOG_TRACE(<< "target mean values = "
+              << core::CContainerPrinter::print(m_TargetMeanValues));
+}
+
+void CDataFrameCategoryEncoder::setupEncodingMaps(const core::CDataFrame& frame) {
+
+    // Fill in a mapping from encoded column indices to raw column indices.
+
+    for (std::size_t i = 0; i < frame.numberColumns(); ++i) {
+
+        if (m_ColumnIsCategorical[i]) {
+            std::size_t numberHotOne{m_HotOneEncodedCategories[i].size()};
+            std::size_t numberRare{m_RareCategories[i].size()};
+            std::size_t numberCategories{m_TargetMeanValues[i].size()};
+
+            std::size_t offset{m_FeatureVectorColumnMap.size()};
+            std::size_t extra{numberHotOne + (numberRare > 0 ? 1 : 0) +
+                              (numberCategories > numberHotOne + numberRare ? 1 : 0)};
+
+            m_FeatureVectorColumnMap.resize(offset + extra, i);
+            m_FeatureVectorEncodingMap.resize(offset + extra);
+            std::iota(m_FeatureVectorEncodingMap.begin() + offset,
+                      m_FeatureVectorEncodingMap.end(), 0);
+
+        } else {
+            m_FeatureVectorColumnMap.push_back(i);
+            m_FeatureVectorEncodingMap.push_back(0);
+        }
+    }
+    m_FeatureVectorColumnMap.shrink_to_fit();
+    m_FeatureVectorEncodingMap.shrink_to_fit();
+    LOG_TRACE(<< "feature vector index to column map = "
+              << core::CContainerPrinter::print(m_FeatureVectorColumnMap));
+    LOG_TRACE(<< "feature vector index to encoding map = "
+              << core::CContainerPrinter::print(m_FeatureVectorEncodingMap));
+}
+}
+}

--- a/lib/maths/CMic.cc
+++ b/lib/maths/CMic.cc
@@ -207,7 +207,7 @@ CMic::TDoubleVec CMic::equipartitionAxis(std::size_t variable, std::size_t l) co
         std::unique(partitionBoundaries.begin(), partitionBoundaries.end()),
         partitionBoundaries.end());
     double max{m_Samples[m_Order[variable].back()](variable)};
-    partitionBoundaries.push_back((1.0 + std::copysign(EPS, max)) * max);
+    partitionBoundaries.push_back(max == 0.0 ? EPS : (1.0 + std::copysign(EPS, max)) * max);
 
     return partitionBoundaries;
 }

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -34,6 +34,7 @@ CClustererStateSerialiser.cc \
 CConstantPrior.cc \
 CCooccurrences.cc \
 CCountMinSketch.cc \
+CDataFrameCategoryEncoder.cc \
 CDataFrameRegressionModel.cc \
 CDataFrameUtils.cc \
 CDecayRateController.cc \

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -89,7 +89,7 @@ void CDataFrameCategoryEncoderTest::testOneHotEncoding() {
                                  encoder.numberOneHotEncodedCategories(i));
             if (encoder.columnIsCategorical(i)) {
                 for (auto j : expectedOneHotEncodedCategories[i]) {
-                    CPPUNIT_ASSERT_EQUAL(true, encoder.isOneHot(j, i, j));
+                    CPPUNIT_ASSERT_EQUAL(true, encoder.isOne(j, i, j));
                 }
             }
         }

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -54,7 +54,7 @@ void CDataFrameCategoryEncoderTest::testOneHotEncoding() {
 
         auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
 
-        frame->writeCategoricalColumns({true, false, false, false});
+        frame->categoricalColumns({true, false, false, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 *(column++) = std::floor(features[0][i]);
@@ -130,7 +130,7 @@ void CDataFrameCategoryEncoderTest::testMeanValueEncoding() {
 
         TMeanAccumulatorVec expectedTargetMeanValues(static_cast<std::size_t>(numberCategories));
 
-        frame->writeCategoricalColumns({true, false, false, false});
+        frame->categoricalColumns({true, false, false, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 *(column++) = std::floor(features[0][i]);
@@ -180,7 +180,7 @@ void CDataFrameCategoryEncoderTest::testEncodingRare() {
 
     TSizeVec categoryCounts(static_cast<std::size_t>(numberCategories), 0);
 
-    frame->writeCategoricalColumns({false, false, true, false});
+    frame->categoricalColumns({false, false, true, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             for (std::size_t j = 0; j + 2 < cols; ++j, ++column) {
@@ -238,7 +238,7 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
         TMeanAccumulatorVec(static_cast<std::size_t>(std::ceil(numberCategories))),
         TMeanAccumulatorVec(static_cast<std::size_t>(std::ceil(numberCategories)))};
 
-    frame->writeCategoricalColumns({true, false, false, true, false});
+    frame->categoricalColumns({true, false, false, true, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             *(column++) = std::floor(features[0][i]);

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -25,9 +25,9 @@ using TSizeVecVec = std::vector<TSizeVec>;
 using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
 
-void CDataFrameCategoryEncoderTest::testHotOneEncoding() {
+void CDataFrameCategoryEncoderTest::testOneHotEncoding() {
 
-    // Test hot-one encoding of two categories carrying a lot of information
+    // Test one-hot encoding of two categories carrying a lot of information
     // about the target.
 
     TDoubleVec categoryValue{-15.0, 20.0, 0.0};
@@ -83,13 +83,13 @@ void CDataFrameCategoryEncoderTest::testHotOneEncoding() {
             CPPUNIT_ASSERT_EQUAL(expectedColumns[i], encoder.column(i));
         }
 
-        TSizeVecVec expectedHotOneEncodedCategories{{0, 1}, {}, {}, {}};
+        TSizeVecVec expectedOneHotEncodedCategories{{0, 1}, {}, {}, {}};
         for (std::size_t i = 0; i < cols; ++i) {
-            CPPUNIT_ASSERT_EQUAL(expectedHotOneEncodedCategories[i].size(),
-                                 encoder.numberHotOneEncodedCategories(i));
+            CPPUNIT_ASSERT_EQUAL(expectedOneHotEncodedCategories[i].size(),
+                                 encoder.numberOneHotEncodedCategories(i));
             if (encoder.columnIsCategorical(i)) {
-                for (auto j : expectedHotOneEncodedCategories[i]) {
-                    CPPUNIT_ASSERT_EQUAL(true, encoder.isHotOne(j, i, j));
+                for (auto j : expectedOneHotEncodedCategories[i]) {
+                    CPPUNIT_ASSERT_EQUAL(true, encoder.isOneHot(j, i, j));
                 }
             }
         }
@@ -206,7 +206,7 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
     // Test we get the feature vectors we expect after encoding.
 
     // The feature vector layout for each encoded category is as follows:
-    // | hot-one | is rare | mean target value |
+    // | one-hot | is rare | mean target value |
 
     TDoubleVec categoryValue[2]{{-15.0, 20.0, 0.0}, {10.0, -10.0, 0.0}};
 
@@ -259,7 +259,7 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
 
     auto expectedEncoded = [&](const core::CDataFrame::TRowRef& row, std::size_t i) {
 
-        // We should have hot-one encoded categories 0 and 1 for each categorical
+        // We should have one-hot encoded categories 0 and 1 for each categorical
         // feature, category 4 should be rare and 2 and 3 should be mean target
         // encoded.
 
@@ -267,7 +267,7 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
                                  static_cast<std::size_t>(row[3])};
 
         if (i < 2) {
-            return categories[0] == i ? 1.0 : 0.0; // hot-one
+            return categories[0] == i ? 1.0 : 0.0; // one-hot
         }
         if (i == 2) {
             return categories[0] == 4 ? 1.0 : 0.0; // rare
@@ -280,7 +280,7 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
             return static_cast<double>(row[i - 3]); // metrics
         }
         if (i < 8) {
-            return categories[1] == i - 6 ? 1.0 : 0.0; // hot-one
+            return categories[1] == i - 6 ? 1.0 : 0.0; // one-hot
         }
         if (i == 8) {
             return categories[1] == 4 ? 1.0 : 0.0; // rare
@@ -319,8 +319,8 @@ CppUnit::Test* CDataFrameCategoryEncoderTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CDataFrameCategoryEncoderTest");
 
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
-        "CDataFrameCategoryEncoderTest::testHotOneEncoding",
-        &CDataFrameCategoryEncoderTest::testHotOneEncoding));
+        "CDataFrameCategoryEncoderTest::testOneHotEncoding",
+        &CDataFrameCategoryEncoderTest::testOneHotEncoding));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
         "CDataFrameCategoryEncoderTest::testMeanValueEncoding",
         &CDataFrameCategoryEncoderTest::testMeanValueEncoding));

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -1,0 +1,335 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CDataFrameCategoryEncoderTest.h"
+
+#include <core/CDataFrame.h>
+
+#include <maths/CBasicStatistics.h>
+#include <maths/CDataFrameCategoryEncoder.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <numeric>
+#include <vector>
+
+using namespace ml;
+
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
+
+void CDataFrameCategoryEncoderTest::testHotOneEncoding() {
+
+    // Test hot-one encoding of two categories carrying a lot of information
+    // about the target.
+
+    TDoubleVec categoryValue{-15.0, 20.0, 0.0};
+
+    auto target = [&](const TDoubleVecVec& features, std::size_t row) {
+        return categoryValue[static_cast<std::size_t>(std::min(features[0][row], 2.0))] +
+               1.5 * features[1][row] - 5.3 * features[2][row];
+    };
+
+    test::CRandomNumbers rng;
+
+    core::stopDefaultAsyncExecutor();
+
+    for (std::size_t threads : {1, 2}) {
+
+        std::size_t rows{300};
+        std::size_t cols{4};
+        double numberCategories{5.0};
+
+        TDoubleVecVec features(cols - 1);
+        rng.generateUniformSamples(0.0, numberCategories, rows, features[0]);
+        rng.generateNormalSamples(0.0, 4.0, rows, features[1]);
+        rng.generateNormalSamples(2.0, 2.0, rows, features[2]);
+
+        auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
+
+        frame->writeCategoricalColumns({true, false, false, false});
+        for (std::size_t i = 0; i < rows; ++i) {
+            frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                *(column++) = std::floor(features[0][i]);
+                for (std::size_t j = 1; j + 1 < cols; ++j, ++column) {
+                    *column = features[j][i];
+                }
+                *column = target(features, i);
+            });
+        }
+        frame->finishWritingRows();
+
+        maths::CDataFrameCategoryEncoder encoder{threads, *frame, {0, 1, 2}, 3, 50};
+
+        for (std::size_t i = 0; i < cols; ++i) {
+            CPPUNIT_ASSERT_EQUAL(bool{frame->columnIsCategorical()[i]},
+                                 encoder.columnIsCategorical(i));
+        }
+
+        CPPUNIT_ASSERT_EQUAL(
+            std::string{"[1, 2]"},
+            core::CContainerPrinter::print(encoder.selectedMetricFeatures()));
+
+        TSizeVec expectedColumns{0, 0, 0, 0, 1, 2, 3};
+        CPPUNIT_ASSERT_EQUAL(expectedColumns.size(), encoder.numberFeatures());
+        for (std::size_t i = 0; i < expectedColumns.size(); ++i) {
+            CPPUNIT_ASSERT_EQUAL(expectedColumns[i], encoder.column(i));
+        }
+
+        TSizeVecVec expectedHotOneEncodedCategories{{0, 1}, {}, {}, {}};
+        for (std::size_t i = 0; i < cols; ++i) {
+            CPPUNIT_ASSERT_EQUAL(expectedHotOneEncodedCategories[i].size(),
+                                 encoder.numberHotOneEncodedCategories(i));
+            if (encoder.columnIsCategorical(i)) {
+                for (auto j : expectedHotOneEncodedCategories[i]) {
+                    CPPUNIT_ASSERT_EQUAL(true, encoder.isHotOne(j, i, j));
+                }
+            }
+        }
+
+        core::startDefaultAsyncExecutor();
+    }
+
+    core::stopDefaultAsyncExecutor();
+}
+
+void CDataFrameCategoryEncoderTest::testMeanValueEncoding() {
+
+    // Test common features are mean value encoded and that we get the right
+    // mean target values.
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec categoryValue{-15.0, 20.0, 0.0};
+    auto target = [&](const TDoubleVecVec& features, std::size_t row) {
+        std::size_t category{static_cast<std::size_t>(std::min(features[0][row], 2.0))};
+        return categoryValue[category] + 1.5 * features[1][row] - 5.3 * features[2][row];
+    };
+
+    std::size_t rows{500};
+    std::size_t cols{4};
+    double numberCategories{10.0};
+
+    TDoubleVecVec features(cols - 1);
+    rng.generateUniformSamples(0.0, numberCategories, rows, features[0]);
+    rng.generateNormalSamples(0.0, 4.0, rows, features[1]);
+    rng.generateNormalSamples(2.0, 2.0, rows, features[2]);
+
+    core::stopDefaultAsyncExecutor();
+
+    for (std::size_t threads : {1, 2}) {
+
+        auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
+
+        TMeanAccumulatorVec expectedTargetMeanValues(static_cast<std::size_t>(numberCategories));
+
+        frame->writeCategoricalColumns({true, false, false, false});
+        for (std::size_t i = 0; i < rows; ++i) {
+            frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                *(column++) = std::floor(features[0][i]);
+                for (std::size_t j = 1; j + 1 < cols; ++j, ++column) {
+                    *column = features[j][i];
+                }
+                *column = target(features, i);
+                std::size_t category{static_cast<std::size_t>(features[0][i])};
+                expectedTargetMeanValues[category].add(*column);
+            });
+        }
+        frame->finishWritingRows();
+
+        maths::CDataFrameCategoryEncoder encoder{threads, *frame, {0, 1, 2}, 3, 50};
+
+        for (std::size_t i = 0; i < expectedTargetMeanValues.size(); ++i) {
+            CPPUNIT_ASSERT_EQUAL(maths::CBasicStatistics::mean(expectedTargetMeanValues[i]),
+                                 encoder.targetMeanValue(0, i));
+        }
+
+        core::startDefaultAsyncExecutor();
+    }
+
+    core::stopDefaultAsyncExecutor();
+}
+
+void CDataFrameCategoryEncoderTest::testEncodingRare() {
+
+    // Test we get the rare features we expect given the frequency threshold.
+
+    test::CRandomNumbers rng;
+
+    auto target = [&](const TDoubleVecVec& features, std::size_t row) {
+        return features[0][row] + 1.5 * features[1][row] - 5.3 * features[2][row];
+    };
+
+    std::size_t rows{1000};
+    std::size_t cols{4};
+    double numberCategories{25.0};
+
+    TDoubleVecVec features(cols - 1);
+    rng.generateNormalSamples(0.0, 4.0, rows, features[0]);
+    rng.generateNormalSamples(2.0, 2.0, rows, features[1]);
+    rng.generateUniformSamples(0.0, numberCategories, rows, features[2]);
+
+    auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
+
+    TSizeVec categoryCounts(static_cast<std::size_t>(numberCategories), 0);
+
+    frame->writeCategoricalColumns({false, false, true, false});
+    for (std::size_t i = 0; i < rows; ++i) {
+        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            for (std::size_t j = 0; j + 2 < cols; ++j, ++column) {
+                *column = features[j][i];
+            }
+            *(column++) = std::floor(features[2][i]);
+            *column = target(features, i);
+            ++categoryCounts[static_cast<std::size_t>(features[2][i])];
+        });
+    }
+    frame->finishWritingRows();
+
+    maths::CDataFrameCategoryEncoder encoder{1, *frame, {0, 1, 2}, 3, 50, 0.1};
+
+    CPPUNIT_ASSERT(encoder.hasRareCategories(2));
+    for (std::size_t i = 0; i < categoryCounts.size(); ++i) {
+        CPPUNIT_ASSERT_EQUAL(categoryCounts[i] < 50, encoder.isRareCategory(2, i));
+    }
+}
+
+void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
+
+    // Test we get the feature vectors we expect after encoding.
+
+    // The feature vector layout for each encoded category is as follows:
+    // | hot-one | is rare | mean target value |
+
+    TDoubleVec categoryValue[2]{{-15.0, 20.0, 0.0}, {10.0, -10.0, 0.0}};
+
+    auto target = [&](const TDoubleVecVec& features, std::size_t row) {
+        std::size_t categories[]{
+            static_cast<std::size_t>(std::min(features[0][row], 2.0)),
+            static_cast<std::size_t>(std::min(features[3][row], 2.0))};
+        return categoryValue[0][categories[0]] + categoryValue[1][categories[1]] +
+               1.5 * features[1][row] - 5.3 * features[2][row];
+    };
+
+    test::CRandomNumbers rng;
+
+    core::stopDefaultAsyncExecutor();
+
+    std::size_t rows{500};
+    std::size_t cols{5};
+    double numberCategories{4.1};
+
+    TDoubleVecVec features(cols - 1);
+    rng.generateUniformSamples(0.0, numberCategories, rows, features[0]);
+    rng.generateNormalSamples(0.0, 4.0, rows, features[1]);
+    rng.generateNormalSamples(2.0, 2.0, rows, features[2]);
+    rng.generateUniformSamples(0.0, numberCategories, rows, features[3]);
+
+    auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
+
+    TMeanAccumulatorVec expectedTargetMeanValues[2]{
+        TMeanAccumulatorVec(static_cast<std::size_t>(std::ceil(numberCategories))),
+        TMeanAccumulatorVec(static_cast<std::size_t>(std::ceil(numberCategories)))};
+
+    frame->writeCategoricalColumns({true, false, false, true, false});
+    for (std::size_t i = 0; i < rows; ++i) {
+        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            *(column++) = std::floor(features[0][i]);
+            for (std::size_t j = 1; j + 2 < cols; ++j, ++column) {
+                *column = features[j][i];
+            }
+            *(column++) = std::floor(features[3][i]);
+            *column = target(features, i);
+            std::size_t categories[]{static_cast<std::size_t>(features[0][i]),
+                                     static_cast<std::size_t>(features[3][i])};
+            expectedTargetMeanValues[0][categories[0]].add(*column);
+            expectedTargetMeanValues[1][categories[1]].add(*column);
+        });
+    }
+    frame->finishWritingRows();
+
+    maths::CDataFrameCategoryEncoder encoder{1, *frame, {0, 1, 2, 3}, 4, 50};
+
+    auto expectedEncoded = [&](const core::CDataFrame::TRowRef& row, std::size_t i) {
+
+        // We should have hot-one encoded categories 0 and 1 for each categorical
+        // feature, category 4 should be rare and 2 and 3 should be mean target
+        // encoded.
+
+        std::size_t categories[]{static_cast<std::size_t>(row[0]),
+                                 static_cast<std::size_t>(row[3])};
+
+        if (i < 2) {
+            return categories[0] == i ? 1.0 : 0.0; // hot-one
+        }
+        if (i == 2) {
+            return categories[0] == 4 ? 1.0 : 0.0; // rare
+        }
+        if (i == 3) {
+            return maths::CBasicStatistics::mean(
+                expectedTargetMeanValues[0][categories[0]]); // mean target
+        }
+        if (i < 6) {
+            return static_cast<double>(row[i - 3]); // metrics
+        }
+        if (i < 8) {
+            return categories[1] == i - 6 ? 1.0 : 0.0; // hot-one
+        }
+        if (i == 8) {
+            return categories[1] == 4 ? 1.0 : 0.0; // rare
+        }
+        if (i == 9) {
+            return maths::CBasicStatistics::mean(
+                expectedTargetMeanValues[1][categories[1]]); // mean target
+        }
+        return static_cast<double>(row[4]); // target
+    };
+
+    bool passed{true};
+
+    frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows, core::CDataFrame::TRowItr endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            if (passed) {
+                auto encoded = encoder.encode(*row);
+                passed = passed && encoded.index() == row->index();
+                passed = passed && encoded.numberColumns() == 11;
+                for (std::size_t i = 0; i < encoded.numberColumns(); ++i) {
+                    passed = passed &&
+                             std::fabs(encoded[i] - expectedEncoded(*row, i)) < 1e-6;
+                    if (passed == false) {
+                        LOG_DEBUG(<< i << " " << encoded[i] << " "
+                                  << expectedEncoded(*row, i));
+                    }
+                }
+            }
+        }
+    });
+
+    CPPUNIT_ASSERT(passed);
+}
+
+CppUnit::Test* CDataFrameCategoryEncoderTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CDataFrameCategoryEncoderTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
+        "CDataFrameCategoryEncoderTest::testHotOneEncoding",
+        &CDataFrameCategoryEncoderTest::testHotOneEncoding));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
+        "CDataFrameCategoryEncoderTest::testMeanValueEncoding",
+        &CDataFrameCategoryEncoderTest::testMeanValueEncoding));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
+        "CDataFrameCategoryEncoderTest::testEncodingRare",
+        &CDataFrameCategoryEncoderTest::testEncodingRare));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
+        "CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef",
+        &CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef));
+
+    return suiteOfTests;
+}

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
@@ -11,7 +11,7 @@
 
 class CDataFrameCategoryEncoderTest : public CppUnit::TestFixture {
 public:
-    void testHotOneEncoding();
+    void testOneHotEncoding();
     void testMeanValueEncoding();
     void testEncodingRare();
     void testEncodedDataFrameRowRef();

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CDataFrameCategoryEncoderTest_h
+#define INCLUDED_CDataFrameCategoryEncoderTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CDataFrameCategoryEncoderTest : public CppUnit::TestFixture {
+public:
+    void testHotOneEncoding();
+    void testMeanValueEncoding();
+    void testEncodingRare();
+    void testEncodedDataFrameRowRef();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CDataFrameCategoryEncoderTest_h

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -392,7 +392,7 @@ void CDataFrameUtilsTest::testCategoryFrequencies() {
 
             auto frame = factory();
 
-            frame->writeCategoricalColumns({true, false, true, false});
+            frame->categoricalColumns({true, false, true, false});
             for (std::size_t i = 0; i < rows; ++i) {
                 frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column,
                                                    std::int32_t&) {
@@ -468,7 +468,7 @@ void CDataFrameUtilsTest::testMeanValueOfTargetForCategories() {
 
             auto frame = factory();
 
-            frame->writeCategoricalColumns({true, false, true, false});
+            frame->categoricalColumns({true, false, true, false});
             for (std::size_t i = 0; i < rows; ++i) {
                 frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column,
                                                    std::int32_t&) {
@@ -536,7 +536,7 @@ void CDataFrameUtilsTest::testCategoryMicWithColumn() {
 
             auto frame = factory();
 
-            frame->writeCategoricalColumns({true, false, true, false});
+            frame->categoricalColumns({true, false, true, false});
             for (std::size_t i = 0; i < rows; ++i) {
                 frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column,
                                                    std::int32_t&) {

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -17,8 +17,6 @@
 #include <test/CRandomNumbers.h>
 #include <test/CTestTmpDir.h>
 
-#include <boost/filesystem.hpp>
-
 #include <functional>
 #include <limits>
 #include <numeric>

--- a/lib/maths/unittest/Main.cc
+++ b/lib/maths/unittest/Main.cc
@@ -21,6 +21,7 @@
 #include "CChecksumTest.h"
 #include "CClustererTest.h"
 #include "CCountMinSketchTest.h"
+#include "CDataFrameCategoryEncoderTest.h"
 #include "CDataFrameUtilsTest.h"
 #include "CDecayRateControllerTest.h"
 #include "CEntropySketchTest.h"
@@ -108,6 +109,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CChecksumTest::suite());
     runner.addTest(CClustererTest::suite());
     runner.addTest(CCountMinSketchTest::suite());
+    runner.addTest(CDataFrameCategoryEncoderTest::suite());
     runner.addTest(CDataFrameUtilsTest::suite());
     runner.addTest(CDecayRateControllerTest::suite());
     runner.addTest(CEqualWithToleranceTest::suite());

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -33,6 +33,7 @@ SRCS=\
 	CChecksumTest.cc \
 	CClustererTest.cc \
 	CCountMinSketchTest.cc \
+	CDataFrameCategoryEncoderTest.cc \
 	CDataFrameUtilsTest.cc \
 	CDecayRateControllerTest.cc \
 	CEntropySketchTest.cc \


### PR DESCRIPTION
This change also provides a data frame row reference wrapper which allows one to access encoded feature values as though they were stored in the data frame.
 
We use MICe to decide which categories to one-hot encode (which is a lossless scheme) when there are sufficient data, mean target encoding when there are sufficient samples for a category and one catch all indicator variable for rare categories of a categorical column.

All one-hot encoded categories and metrics are chosen together. We have a single parameter which controls whether we prefer choosing distinct metrics and categories from different categorical columns or whether we just consider MICe with the target variable. This accounts for the fact that we typically expect more correlation between errors from distinct categories of the same categorical field.

I'm leaving wiring this into `CBoostedTree` to a follow up PR to keep the size down.