### PR TITLE
[FEATURE][ML] Fix CDenseVector::fromStdVector

### DIFF
--- a/lib/maths/unittest/CLinearAlgebraTest.cc
+++ b/lib/maths/unittest/CLinearAlgebraTest.cc
@@ -1507,17 +1507,16 @@ void CLinearAlgebraTest::testPersist() {
 
         LOG_DEBUG(<< "vector XML representation:\n" << origXml);
 
-        // Restore the XML into a new regression.
+        // Restore the XML into a new vector.
         core::CRapidXmlParser parser;
         CPPUNIT_ASSERT(parser.parseStringIgnoreCdata(origXml));
         core::CRapidXmlStateRestoreTraverser traverser(parser);
-
         maths::CDenseVector<double> restoredVector;
         CPPUNIT_ASSERT(traverser.traverseSubLevel(
             std::bind(&maths::CDenseVector<double>::acceptRestoreTraverser,
                       &restoredVector, std::placeholders::_1)));
 
-        CPPUNIT_ASSERT_EQUAL(origVector.checksum(0), restoredVector.checksum(0));
+        CPPUNIT_ASSERT_EQUAL(origVector.checksum(), restoredVector.checksum());
     }
 }
 


### PR DESCRIPTION
[This](https://github.com/elastic/ml-cpp/pull/544/files/64cdffd6576bb0ab40b86555635877824a901337#r303851555) comment intrigued me. It turns out the underlying reason is the Eigen operator<< doesn't behave like one might expect: it works by overwriting the elements from the start of the array representation with the comma separated list supplied. Therefore, as it stood `fromStdVector` wrote all the values into the first element of the vector and left the remaining ones uninitialised.

This change also makes a couple of tweaks to conform to coding standards (public static members first, etc) and makes the to and from std vector methods private for the time being since they're only used by persistence.