### PR TITLE
[ML] Add option to persist in foreground

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -196,6 +196,7 @@ The use of the words SHOULD, MUST etc., comply with RFC 2119.
 1.  Lambdas SHOULD be used in preference to any form of `bind`
 1.  Default lambda capture modes SHOULD be avoided
 1.  The `override` keyword SHOULD be used consistently within a source file
+1.  The `virtual` keyword SHOULD NOT be used in conjunction with `override`
 1.  Type aliases MUST be used in preference to typedefs - use `using` to create a type alias not `typedef`
 1.  Rvalue references SHOULD only be used in the following cases
     1.  For implementing move semantics

--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -48,6 +48,7 @@ bool CCmdLineParser::parse(int argc,
                            bool& isRestoreFileNamedPipe,
                            std::string& persistFileName,
                            bool& isPersistFileNamedPipe,
+                           bool& isPersistInForeground,
                            size_t& maxAnomalyRecords,
                            bool& memoryUsage,
                            bool& multivariateByFields,
@@ -104,6 +105,7 @@ bool CCmdLineParser::parse(int argc,
             ("persistIsPipe", "Specified persist file is a named pipe")
             ("persistInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically persist model state - if not specified then models will only be persisted at program exit")
+            ("persistInForeground", "Persistence occurs in the foreground. Defaults to background persistence.")
             ("maxQuantileInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically output quantiles if they have not been output due to an anomaly - if not specified then quantiles will only be output following a big anomaly")
             ("maxAnomalyRecords", boost::program_options::value<size_t>(),
@@ -212,6 +214,9 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("persistIsPipe") > 0) {
             isPersistFileNamedPipe = true;
+        }
+        if (vm.count("persistInForeground") > 0) {
+            isPersistInForeground = true;
         }
         if (vm.count("maxAnomalyRecords") > 0) {
             maxAnomalyRecords = vm["maxAnomalyRecords"].as<size_t>();

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -60,6 +60,7 @@ public:
                       bool& isRestoreFileNamedPipe,
                       std::string& persistFileName,
                       bool& isPersistFileNamedPipe,
+                      bool& isPersistInForeground,
                       size_t& maxAnomalyRecords,
                       bool& memoryUsage,
                       bool& multivariateByFields,

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -277,12 +277,10 @@ int main(int argc, char** argv) {
 
     if (periodicPersister != nullptr) {
         periodicPersister->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
-            &ml::api::CDataProcessor::periodicPersistStateInBackground,
-            firstProcessor));
+            &ml::api::CDataProcessor::periodicPersistStateInBackground, firstProcessor));
 
         periodicPersister->firstProcessorForegroundPeriodicPersistFunc(std::bind(
-            &ml::api::CDataProcessor::periodicPersistStateInForeground,
-            firstProcessor));
+            &ml::api::CDataProcessor::periodicPersistStateInForeground, firstProcessor));
     }
 
     // The skeleton avoids the need to duplicate a lot of boilerplate code

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -276,10 +276,13 @@ int main(int argc, char** argv) {
     }
 
     if (periodicPersister != nullptr) {
-        periodicPersister->firstProcessorPeriodicPersistFunc(std::bind(
-            isPersistInForeground ? &ml::api::CDataProcessor::periodicPersistStateInForeground
-                                  : &ml::api::CDataProcessor::periodicPersistStateInBackground,
-            firstProcessor, std::placeholders::_1));
+        periodicPersister->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
+            &ml::api::CDataProcessor::periodicPersistStateInBackground,
+            firstProcessor));
+
+        periodicPersister->firstProcessorForegroundPeriodicPersistFunc(std::bind(
+            &ml::api::CDataProcessor::periodicPersistStateInForeground,
+            firstProcessor));
     }
 
     // The skeleton avoids the need to duplicate a lot of boilerplate code

--- a/bin/categorize/CCmdLineParser.cc
+++ b/bin/categorize/CCmdLineParser.cc
@@ -68,9 +68,9 @@ bool CCmdLineParser::parse(int argc,
             ("persistIsPipe", "Specified persist file is a named pipe")
             ("persistInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically persist model state - if not specified then models will only be persisted at program exit")
-                        ("persistInForeground", "Persistence occurs in the foreground. Defaults to background persistence.")
+            ("persistInForeground", "Persistence occurs in the foreground. Defaults to background persistence.")
             ("categorizationfield", boost::program_options::value<std::string>(),
-                    "Field to compute mlcategory from")
+                        "Field to compute mlcategory from")
         ;
         // clang-format on
 

--- a/bin/categorize/CCmdLineParser.cc
+++ b/bin/categorize/CCmdLineParser.cc
@@ -34,6 +34,7 @@ bool CCmdLineParser::parse(int argc,
                            bool& isRestoreFileNamedPipe,
                            std::string& persistFileName,
                            bool& isPersistFileNamedPipe,
+                           bool& isPersistInForeground,
                            std::string& categorizationFieldName) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
@@ -67,8 +68,9 @@ bool CCmdLineParser::parse(int argc,
             ("persistIsPipe", "Specified persist file is a named pipe")
             ("persistInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically persist model state - if not specified then models will only be persisted at program exit")
+                        ("persistInForeground", "Persistence occurs in the foreground. Defaults to background persistence.")
             ("categorizationfield", boost::program_options::value<std::string>(),
-                        "Field to compute mlcategory from")
+                    "Field to compute mlcategory from")
         ;
         // clang-format on
 
@@ -129,6 +131,9 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("persistIsPipe") > 0) {
             isPersistFileNamedPipe = true;
+        }
+        if (vm.count("persistInForeground") > 0) {
+            isPersistInForeground = true;
         }
         if (vm.count("categorizationfield") > 0) {
             categorizationFieldName = vm["categorizationfield"].as<std::string>();

--- a/bin/categorize/CCmdLineParser.h
+++ b/bin/categorize/CCmdLineParser.h
@@ -45,6 +45,7 @@ public:
                       bool& isRestoreFileNamedPipe,
                       std::string& persistFileName,
                       bool& isPersistFileNamedPipe,
+                      bool& isPersistInForeground,
                       std::string& categorizationFieldName);
 
 private:

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -24,7 +24,6 @@
 
 #include <model/CLimits.h>
 
-#include <api/CBackgroundPersister.h>
 #include <api/CCmdSkeleton.h>
 #include <api/CCsvInputParser.h>
 #include <api/CFieldConfig.h>
@@ -34,6 +33,7 @@
 #include <api/CLengthEncodedInputParser.h>
 #include <api/CNullOutput.h>
 #include <api/COutputChainer.h>
+#include <api/CPersistenceManager.h>
 #include <api/CSingleStreamDataAdder.h>
 #include <api/CSingleStreamSearcher.h>
 #include <api/CStateRestoreStreamFilter.h>
@@ -65,12 +65,14 @@ int main(int argc, char** argv) {
     bool isRestoreFileNamedPipe(false);
     std::string persistFileName;
     bool isPersistFileNamedPipe(false);
+    bool isPersistInForeground(false);
     std::string categorizationFieldName;
     if (ml::categorize::CCmdLineParser::parse(
             argc, argv, limitConfigFile, jobId, logProperties, logPipe, delimiter,
             lengthEncodedInput, persistInterval, inputFileName, isInputFileNamedPipe,
-            outputFileName, isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe,
-            persistFileName, isPersistFileNamedPipe, categorizationFieldName) == false) {
+            outputFileName, isOutputFileNamedPipe, restoreFileName,
+            isRestoreFileNamedPipe, persistFileName, isPersistFileNamedPipe,
+            isPersistInForeground, categorizationFieldName) == false) {
         return EXIT_FAILURE;
     }
 
@@ -104,7 +106,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    ml::model::CLimits limits;
+    ml::model::CLimits limits(isPersistInForeground);
     if (!limitConfigFile.empty() && limits.init(limitConfigFile) == false) {
         LOG_FATAL(<< "Ml limit config file '" << limitConfigFile << "' could not be loaded");
         return EXIT_FAILURE;
@@ -146,13 +148,15 @@ int main(int argc, char** argv) {
                      "unless a place to persist to has been specified using the 'persist' argument");
         return EXIT_FAILURE;
     }
-    using TBackgroundPersisterUPtr = std::unique_ptr<ml::api::CBackgroundPersister>;
-    const TBackgroundPersisterUPtr periodicPersister{[persistInterval, &persister]() -> TBackgroundPersisterUPtr {
-        if (persistInterval >= 0) {
-            return std::make_unique<ml::api::CBackgroundPersister>(persistInterval, *persister);
-        }
-        return nullptr;
-    }()};
+    using TBackgroundPersisterUPtr = std::unique_ptr<ml::api::CPersistenceManager>;
+    const TBackgroundPersisterUPtr periodicPersister{
+        [persistInterval, isPersistInForeground, &persister]() -> TBackgroundPersisterUPtr {
+            if (persistInterval >= 0) {
+                return std::make_unique<ml::api::CPersistenceManager>(
+                    persistInterval, isPersistInForeground, *persister);
+            }
+            return nullptr;
+        }()};
 
     using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
     const TInputParserUPtr inputParser{[lengthEncodedInput, &ioMgr, delimiter]() -> TInputParserUPtr {
@@ -177,7 +181,9 @@ int main(int argc, char** argv) {
 
     if (periodicPersister != nullptr) {
         periodicPersister->firstProcessorPeriodicPersistFunc(std::bind(
-            &ml::api::CFieldDataTyper::periodicPersistState, &typer, std::placeholders::_1));
+            isPersistInForeground ? &ml::api::CFieldDataTyper::periodicPersistStateInForeground
+                                  : &ml::api::CFieldDataTyper::periodicPersistStateInBackground,
+            &typer, std::placeholders::_1));
     }
 
     // The skeleton avoids the need to duplicate a lot of boilerplate code

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -181,12 +181,10 @@ int main(int argc, char** argv) {
 
     if (periodicPersister != nullptr) {
         periodicPersister->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
-            &ml::api::CFieldDataTyper::periodicPersistStateInBackground,
-            &typer));
+            &ml::api::CFieldDataTyper::periodicPersistStateInBackground, &typer));
 
         periodicPersister->firstProcessorForegroundPeriodicPersistFunc(std::bind(
-            &ml::api::CFieldDataTyper::periodicPersistStateInForeground,
-            &typer));
+            &ml::api::CFieldDataTyper::periodicPersistStateInForeground, &typer));
     }
 
     // The skeleton avoids the need to duplicate a lot of boilerplate code

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -171,11 +171,10 @@ public:
 
     //! Restore previously saved state
     bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime) override;
+                      core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    bool persistState(core::CDataAdder& persister,
-                              const std::string& descriptionPrefix) override;
+    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
 
     //! Initialise normalizer from quantiles state
     virtual bool initNormalizer(const std::string& quantilesStateFile);

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -255,14 +255,14 @@ private:
     //! Persist the detectors to a stream.
     bool persistCopiedState(const std::string& descriptionPrefix,
                             core_t::TTime time,
-                      const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
-                      const model::CResourceMonitor::SResults& modelSizeStats,
-                      const model::CInterimBucketCorrector& interimBucketCorrector,
-                      const model::CHierarchicalResultsAggregator& aggregator,
-                      const std::string& normalizerState,
-                      core_t::TTime latestRecordTime,
-                      core_t::TTime lastResultsTime,
-                      core::CDataAdder& persister);
+                            const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
+                            const model::CResourceMonitor::SResults& modelSizeStats,
+                            const model::CInterimBucketCorrector& interimBucketCorrector,
+                            const model::CHierarchicalResultsAggregator& aggregator,
+                            const std::string& normalizerState,
+                            core_t::TTime latestRecordTime,
+                            core_t::TTime lastResultsTime,
+                            core::CDataAdder& persister);
 
     //! Persist current state due to the periodic persistence being triggered.
     bool periodicPersistStateInBackground() override;

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 
-class CBackgroundPersisterTest;
+class CPersistenceManagerTest;
 class CAnomalyJobTest;
 
 namespace ml {
@@ -50,7 +50,7 @@ class CHierarchicalResults;
 class CLimits;
 }
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 class CModelPlotDataJsonWriter;
 class CFieldConfig;
 
@@ -148,42 +148,43 @@ public:
                 model::CAnomalyDetectorModelConfig& modelConfig,
                 core::CJsonOutputStreamWrapper& outputBuffer,
                 const TPersistCompleteFunc& persistCompleteFunc = TPersistCompleteFunc(),
-                CBackgroundPersister* periodicPersister = nullptr,
+                CPersistenceManager* periodicPersister = nullptr,
                 core_t::TTime maxQuantileInterval = -1,
                 const std::string& timeFieldName = DEFAULT_TIME_FIELD_NAME,
                 const std::string& timeFieldFormat = EMPTY_STRING,
                 size_t maxAnomalyRecords = 0u);
 
-    virtual ~CAnomalyJob();
+    virtual ~CAnomalyJob() override;
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream();
+    virtual void newOutputStream() override;
 
     //! Access the output handler
-    virtual COutputHandler& outputHandler();
+    virtual COutputHandler& outputHandler() override;
 
     //! Receive a single record to be processed, and produce output
     //! with any required modifications
-    virtual bool handleRecord(const TStrStrUMap& dataRowFields);
+    virtual bool handleRecord(const TStrStrUMap& dataRowFields) override;
 
     //! Perform any final processing once all input data has been seen.
-    virtual void finalise();
+    virtual void finalise() override;
 
     //! Restore previously saved state
     virtual bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime);
+                              core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    virtual bool persistState(core::CDataAdder& persister,
+                              const std::string& descriptionPrefix) override;
 
     //! Initialise normalizer from quantiles state
     virtual bool initNormalizer(const std::string& quantilesStateFile);
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const;
+    virtual uint64_t numRecordsHandled() const override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    virtual bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Log a list of the detectors and keys
     void description() const;
@@ -243,11 +244,13 @@ private:
                               core::CStateRestoreTraverser& traverser);
 
     //! Persist current state in the background
-    bool backgroundPersistState(CBackgroundPersister& backgroundPersister);
+    bool backgroundPersistState(CPersistenceManager& backgroundPersister);
 
     //! This is the function that is called in a different thread to the
     //! main processing when background persistence is triggered.
     bool runBackgroundPersist(TBackgroundPersistArgsPtr args, core::CDataAdder& persister);
+
+    bool runForegroundPersist(core::CDataAdder& persister);
 
     //! Persist the detectors to a stream.
     bool persistState(const std::string& descriptionPrefix,
@@ -262,7 +265,8 @@ private:
                       core::CDataAdder& persister);
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    virtual bool periodicPersistStateInBackground(CPersistenceManager& persistenceManager) override;
+    virtual bool periodicPersistStateInForeground(CPersistenceManager& persistenceManager) override;
 
     //! Acknowledge a flush request
     void acknowledgeFlush(const std::string& flushId);
@@ -429,7 +433,7 @@ private:
     //! Pointer to periodic persister that works in the background.  May be
     //! nullptr if this object is not responsible for starting periodic
     //! persistence.
-    CBackgroundPersister* m_PeriodicPersister;
+    CPersistenceManager* m_PeriodicPersister;
 
     //! If we haven't output quantiles for this long due to a big anomaly
     //! we'll output them to reflect decay.  Non-positive values mean never.
@@ -460,7 +464,7 @@ private:
     //! Flag indicating whether or not time has been advanced.
     bool m_TimeAdvanced{false};
 
-    friend class ::CBackgroundPersisterTest;
+    friend class ::CPersistenceManagerTest;
     friend class ::CAnomalyJobTest;
 };
 }

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -154,37 +154,37 @@ public:
                 const std::string& timeFieldFormat = EMPTY_STRING,
                 size_t maxAnomalyRecords = 0u);
 
-    virtual ~CAnomalyJob() override;
+    ~CAnomalyJob() override;
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream() override;
+    void newOutputStream() override;
 
     //! Access the output handler
-    virtual COutputHandler& outputHandler() override;
+    COutputHandler& outputHandler() override;
 
     //! Receive a single record to be processed, and produce output
     //! with any required modifications
-    virtual bool handleRecord(const TStrStrUMap& dataRowFields) override;
+    bool handleRecord(const TStrStrUMap& dataRowFields) override;
 
     //! Perform any final processing once all input data has been seen.
-    virtual void finalise() override;
+    void finalise() override;
 
     //! Restore previously saved state
-    virtual bool restoreState(core::CDataSearcher& restoreSearcher,
+    bool restoreState(core::CDataSearcher& restoreSearcher,
                               core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister,
+    bool persistState(core::CDataAdder& persister,
                               const std::string& descriptionPrefix) override;
 
     //! Initialise normalizer from quantiles state
     virtual bool initNormalizer(const std::string& quantilesStateFile);
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const override;
+    uint64_t numRecordsHandled() const override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const override;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Log a list of the detectors and keys
     void description() const;
@@ -244,7 +244,7 @@ private:
                               core::CStateRestoreTraverser& traverser);
 
     //! Persist current state in the background
-    bool backgroundPersistState(CPersistenceManager& backgroundPersister);
+    bool backgroundPersistState();
 
     //! This is the function that is called in a different thread to the
     //! main processing when background persistence is triggered.
@@ -265,8 +265,8 @@ private:
                       core::CDataAdder& persister);
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistStateInBackground(CPersistenceManager& persistenceManager) override;
-    virtual bool periodicPersistStateInForeground(CPersistenceManager& persistenceManager) override;
+    bool periodicPersistStateInBackground() override;
+    bool periodicPersistStateInForeground() override;
 
     //! Acknowledge a flush request
     void acknowledgeFlush(const std::string& flushId);

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -249,11 +249,12 @@ private:
     //! main processing when background persistence is triggered.
     bool runBackgroundPersist(TBackgroundPersistArgsPtr args, core::CDataAdder& persister);
 
+    //! This function is called from the persistence manager when foreground persistence is triggered
     bool runForegroundPersist(core::CDataAdder& persister);
 
     //! Persist the detectors to a stream.
-    bool persistState(const std::string& descriptionPrefix,
-                      core_t::TTime time,
+    bool persistCopiedState(const std::string& descriptionPrefix,
+                            core_t::TTime time,
                       const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
                       const model::CResourceMonitor::SResults& modelSizeStats,
                       const model::CInterimBucketCorrector& interimBucketCorrector,

--- a/include/api/CDataProcessor.h
+++ b/include/api/CDataProcessor.h
@@ -72,7 +72,7 @@ public:
 
     //! Persist current state
     virtual bool persistState(core::CDataAdder& persister,
-                              const std::string& descriptionPrefix = "") = 0;
+                              const std::string& descriptionPrefix) = 0;
 
     //! Persist current state n the background due to the periodic persistence being triggered.
     virtual bool periodicPersistStateInBackground(CPersistenceManager& persistenceManager);

--- a/include/api/CDataProcessor.h
+++ b/include/api/CDataProcessor.h
@@ -25,7 +25,7 @@ class CDataSearcher;
 }
 
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 class COutputHandler;
 
 //! \brief
@@ -71,10 +71,14 @@ public:
                               core_t::TTime& completeToTime) = 0;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister) = 0;
+    virtual bool persistState(core::CDataAdder& persister,
+                              const std::string& descriptionPrefix = "") = 0;
 
-    //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    //! Persist current state n the background due to the periodic persistence being triggered.
+    virtual bool periodicPersistStateInBackground(CPersistenceManager& persistenceManager);
+
+    //! Persist current state in the foreground due to the periodic persistence being triggered.
+    virtual bool periodicPersistStateInForeground(CPersistenceManager& persistenceManager);
 
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const = 0;

--- a/include/api/CDataProcessor.h
+++ b/include/api/CDataProcessor.h
@@ -74,11 +74,11 @@ public:
     virtual bool persistState(core::CDataAdder& persister,
                               const std::string& descriptionPrefix) = 0;
 
-    //! Persist current state n the background due to the periodic persistence being triggered.
-    virtual bool periodicPersistStateInBackground(CPersistenceManager& persistenceManager);
+    //! Persist current state in the background due to the periodic persistence being triggered.
+    virtual bool periodicPersistStateInBackground();
 
     //! Persist current state in the foreground due to the periodic persistence being triggered.
-    virtual bool periodicPersistStateInForeground(CPersistenceManager& persistenceManager);
+    virtual bool periodicPersistStateInForeground();
 
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const = 0;

--- a/include/api/CFieldDataTyper.h
+++ b/include/api/CFieldDataTyper.h
@@ -31,10 +31,10 @@ namespace model {
 class CLimits;
 }
 namespace api {
-class CPersistenceManager;
 class CFieldConfig;
 class CJsonOutputWriter;
 class COutputHandler;
+class CPersistenceManager;
 
 //! \brief
 //! Assign categorisation fields to input records

--- a/include/api/CFieldDataTyper.h
+++ b/include/api/CFieldDataTyper.h
@@ -31,7 +31,7 @@ namespace model {
 class CLimits;
 }
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 class CFieldConfig;
 class CJsonOutputWriter;
 class COutputHandler;
@@ -80,38 +80,40 @@ public:
                     const model::CLimits& limits,
                     COutputHandler& outputHandler,
                     CJsonOutputWriter& jsonOutputWriter,
-                    CBackgroundPersister* periodicPersister = nullptr);
+                    CPersistenceManager* periodicPersister = nullptr);
 
-    virtual ~CFieldDataTyper();
+    virtual ~CFieldDataTyper() override;
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream();
+    virtual void newOutputStream() override;
 
     //! Receive a single record to be typed, and output that record to
     //! STDOUT with its type field added
-    virtual bool handleRecord(const TStrStrUMap& dataRowFields);
+    virtual bool handleRecord(const TStrStrUMap& dataRowFields) override;
 
     //! Perform any final processing once all input data has been seen.
-    virtual void finalise();
+    virtual void finalise() override;
 
     //! Restore previously saved state
     virtual bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime);
+                              core_t::TTime& completeToTime) override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    virtual bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    virtual bool persistState(core::CDataAdder& persister,
+                              const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    virtual bool periodicPersistStateInBackground(CPersistenceManager& persister) override;
+    virtual bool periodicPersistStateInForeground(CPersistenceManager& persister) override;
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const;
+    virtual uint64_t numRecordsHandled() const override;
 
     //! Access the output handler
-    virtual COutputHandler& outputHandler();
+    virtual COutputHandler& outputHandler() override;
 
 private:
     //! Create the typer to operate on the categorization field
@@ -199,7 +201,7 @@ private:
     //! Pointer to periodic persister that works in the background.  May be
     //! nullptr if this object is not responsible for starting periodic
     //! persistence.
-    CBackgroundPersister* m_PeriodicPersister;
+    CPersistenceManager* m_PeriodicPersister;
 };
 }
 }

--- a/include/api/CFieldDataTyper.h
+++ b/include/api/CFieldDataTyper.h
@@ -82,38 +82,38 @@ public:
                     CJsonOutputWriter& jsonOutputWriter,
                     CPersistenceManager* periodicPersister = nullptr);
 
-    virtual ~CFieldDataTyper() override;
+    ~CFieldDataTyper() override;
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream() override;
+    void newOutputStream() override;
 
     //! Receive a single record to be typed, and output that record to
     //! STDOUT with its type field added
-    virtual bool handleRecord(const TStrStrUMap& dataRowFields) override;
+    bool handleRecord(const TStrStrUMap& dataRowFields) override;
 
     //! Perform any final processing once all input data has been seen.
-    virtual void finalise() override;
+    void finalise() override;
 
     //! Restore previously saved state
-    virtual bool restoreState(core::CDataSearcher& restoreSearcher,
+    bool restoreState(core::CDataSearcher& restoreSearcher,
                               core_t::TTime& completeToTime) override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const override;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister,
+    bool persistState(core::CDataAdder& persister,
                               const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistStateInBackground(CPersistenceManager& persister) override;
-    virtual bool periodicPersistStateInForeground(CPersistenceManager& persister) override;
+    bool periodicPersistStateInBackground() override;
+    bool periodicPersistStateInForeground() override;
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const override;
+    uint64_t numRecordsHandled() const override;
 
     //! Access the output handler
-    virtual COutputHandler& outputHandler() override;
+    COutputHandler& outputHandler() override;
 
 private:
     //! Create the typer to operate on the categorization field

--- a/include/api/CFieldDataTyper.h
+++ b/include/api/CFieldDataTyper.h
@@ -96,14 +96,13 @@ public:
 
     //! Restore previously saved state
     bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime) override;
+                      core_t::TTime& completeToTime) override;
 
     //! Is persistence needed?
     bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Persist current state
-    bool persistState(core::CDataAdder& persister,
-                              const std::string& descriptionPrefix) override;
+    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
     bool periodicPersistStateInBackground() override;

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -41,14 +41,14 @@ public:
     COutputChainer(CDataProcessor& dataProcessor);
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream() override;
+    void newOutputStream() override;
 
     // Bring the other overload of fieldNames() into scope
     using COutputHandler::fieldNames;
 
     //! Set field names, adding extra field names if they're not already
     //! present - this is only allowed once
-    virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
+    bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
     // Bring the other overload of writeRow() into scope
     using COutputHandler::writeRow;
@@ -57,7 +57,7 @@ public:
     //! values, optionally overriding some of the original field values.
     //! Where the same field is present in both overrideDataRowFields and
     //! dataRowFields, the value in overrideDataRowFields will be written.
-    virtual bool writeRow(const TStrStrUMap& dataRowFields,
+    bool writeRow(const TStrStrUMap& dataRowFields,
                           const TStrStrUMap& overrideDataRowFields) override;
 
     //! Perform any final processing once all data for the current search
@@ -65,25 +65,25 @@ public:
     //! called - they should do the best they can on the assumption that
     //! this method will not be called, but may be able to improve their
     //! output if this method is called.
-    virtual void finalise() override;
+    void finalise() override;
 
     //! Restore previously saved state
-    virtual bool restoreState(core::CDataSearcher& restoreSearcher,
+    bool restoreState(core::CDataSearcher& restoreSearcher,
                               core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister,
+    bool persistState(core::CDataAdder& persister,
                               const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistStateInBackground(CPersistenceManager& persistenceManager) override;
+    bool periodicPersistStateInBackground() override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const override;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! The chainer does consume control messages, because it passes them on
     //! to whatever processor it's chained to.
-    virtual bool consumesControlMessages() override;
+    bool consumesControlMessages() override;
 
 private:
     //! The function that will be called for every record output via this

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -58,7 +58,7 @@ public:
     //! Where the same field is present in both overrideDataRowFields and
     //! dataRowFields, the value in overrideDataRowFields will be written.
     bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields) override;
+                  const TStrStrUMap& overrideDataRowFields) override;
 
     //! Perform any final processing once all data for the current search
     //! has been seen.  Chained classes should NOT rely on this method being
@@ -69,11 +69,10 @@ public:
 
     //! Restore previously saved state
     bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime) override;
+                      core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    bool persistState(core::CDataAdder& persister,
-                              const std::string& descriptionPrefix) override;
+    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
     bool periodicPersistStateInBackground() override;

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -18,7 +18,7 @@ class CDataAdder;
 class CDataSearcher;
 }
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 class CDataProcessor;
 
 //! \brief
@@ -41,14 +41,14 @@ public:
     COutputChainer(CDataProcessor& dataProcessor);
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream();
+    virtual void newOutputStream() override;
 
     // Bring the other overload of fieldNames() into scope
     using COutputHandler::fieldNames;
 
     //! Set field names, adding extra field names if they're not already
     //! present - this is only allowed once
-    virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames);
+    virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
     // Bring the other overload of writeRow() into scope
     using COutputHandler::writeRow;
@@ -58,31 +58,32 @@ public:
     //! Where the same field is present in both overrideDataRowFields and
     //! dataRowFields, the value in overrideDataRowFields will be written.
     virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields);
+                          const TStrStrUMap& overrideDataRowFields) override;
 
     //! Perform any final processing once all data for the current search
     //! has been seen.  Chained classes should NOT rely on this method being
     //! called - they should do the best they can on the assumption that
     //! this method will not be called, but may be able to improve their
     //! output if this method is called.
-    virtual void finalise();
+    virtual void finalise() override;
 
     //! Restore previously saved state
     virtual bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime);
+                              core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    virtual bool persistState(core::CDataAdder& persister,
+                              const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    virtual bool periodicPersistStateInBackground(CPersistenceManager& persistenceManager) override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    virtual bool isPersistenceNeeded(const std::string& description) const override;
 
     //! The chainer does consume control messages, because it passes them on
     //! to whatever processor it's chained to.
-    virtual bool consumesControlMessages();
+    virtual bool consumesControlMessages() override;
 
 private:
     //! The function that will be called for every record output via this

--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -25,7 +25,7 @@ class CDataAdder;
 class CDataSearcher;
 }
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 
 //! \brief
 //! Interface for CDataProcessor output
@@ -86,10 +86,10 @@ public:
                               core_t::TTime& completeToTime);
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    virtual bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix);
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    virtual bool periodicPersistStateInBackground(CPersistenceManager& persister);
 
     //! Is persistence needed?
     virtual bool isPersistenceNeeded(const std::string& description) const;

--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -89,7 +89,7 @@ public:
     virtual bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix);
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistStateInBackground(CPersistenceManager& persister);
+    virtual bool periodicPersistStateInBackground();
 
     //! Is persistence needed?
     virtual bool isPersistenceNeeded(const std::string& description) const;

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -157,10 +157,10 @@ private:
     bool clear();
 
 private:
-    //! How frequently should  persistence be attempted?
+    //! How frequently should persistence be attempted?
     core_t::TTime m_PeriodicPersistInterval;
 
-    //! Should  persistence occur in the foreground?
+    //! Should persistence occur in the foreground?
     const bool m_PersistInForeground;
 
     //! What was the wall clock time when we started our last periodic

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -106,10 +106,11 @@ public:
     //! background persistence is currently in progress.
     //! This should be set once before startBackgroundPersistIfAppropriate is
     //! called.
-    bool firstProcessorBackgroundPeriodicPersistFunc(const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
+    bool firstProcessorBackgroundPeriodicPersistFunc(
+        const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
 
-    bool firstProcessorForegroundPeriodicPersistFunc(const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
-
+    bool firstProcessorForegroundPeriodicPersistFunc(
+        const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
 
     //! If the periodic persist interval has passed since the last persist
     //! then it is appropriate to persist now.  Start it by calling the
@@ -167,7 +168,6 @@ private:
     //! persistence.
     TFirstProcessorPeriodicPersistFunc m_FirstProcessorBackgroundPeriodicPersistFunc;
     TFirstProcessorPeriodicPersistFunc m_FirstProcessorForegroundPeriodicPersistFunc;
-
 
     //! Reference to the data adder to be used by the background thread.
     //! The data adder referred to must outlive this object. If the data

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -3,8 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-#ifndef INCLUDED_ml_api_CBackgroundPersister_h
-#define INCLUDED_ml_api_CBackgroundPersister_h
+#ifndef INCLUDED_ml_api_CPersistenceManager_h
+#define INCLUDED_ml_api_CPersistenceManager_h
 
 #include <core/CDataAdder.h>
 #include <core/CFastMutex.h>
@@ -18,13 +18,14 @@
 #include <functional>
 #include <list>
 
-class CBackgroundPersisterTest;
+class CPersistenceManagerTest;
 
 namespace ml {
 namespace api {
 
 //! \brief
-//! Enables a data adder to run in a different thread.
+//! Manages the details of persisting data where the data adder may
+//! optionally run in a different thread.
 //!
 //! DESCRIPTION:\n
 //! A wrapper around core::CThread to hide the gory details of
@@ -36,11 +37,11 @@ namespace api {
 //! are that a lot of memory is being used by the temporary
 //! copy of the data to be persisted.
 //!
-//! Persistence happens in a background thread and further
-//! persistence requests via the startBackgroundPersist*() methods
+//! Persistence may happen in a background thread and if so further
+//! persistence requests via the startPersist*() methods
 //! will be rejected if the background thread is executing.
-//! However, calls to startBackgroundPersist() and
-//! startBackgroundPersistIfAppropriate() are not thread safe and
+//! However, calls to startPersist() and
+//! startPersistIfAppropriate() are not thread safe and
 //! must not be made concurrently.
 //!
 //! IMPLEMENTATION DECISIONS:\n
@@ -52,16 +53,18 @@ namespace api {
 //! thread.  However, note that a couple of copies are made, so
 //! if the bound data is very large then binding a
 //! std::shared_ptr may be more appropriate than binding
-//! values.
+//! values. Alternatively, if foreground persistence is preferred,
+//! the data is not required to be copied and the bound function can
+//! safely be passed its arguments by reference.
 //!
 //! A data adder must be supplied to the constructor, and, since
 //! this is held by reference it must outlive this object.  If
 //! the data adder is not thread safe then it may not be used by
 //! any other object until after this object is destroyed.
 //!
-class API_EXPORT CBackgroundPersister : private core::CNonCopyable {
+class API_EXPORT CPersistenceManager : private core::CNonCopyable {
 public:
-    using TFirstProcessorPeriodicPersistFunc = std::function<bool(CBackgroundPersister&)>;
+    using TFirstProcessorPeriodicPersistFunc = std::function<bool(CPersistenceManager&)>;
 
 public:
     //! The supplied data adder must outlive this object.  If the data
@@ -69,15 +72,18 @@ public:
     //! object until after this object is destroyed.  When using this
     //! constructor the first processor persistence function must be
     //! set before the object is used.
-    CBackgroundPersister(core_t::TTime periodicPersistInterval, core::CDataAdder& dataAdder);
+    CPersistenceManager(core_t::TTime periodicPersistInterval,
+                        bool persistInForeground,
+                        core::CDataAdder& dataAdder);
 
     //! As above, but also supply the first processor persistence
     //! function at construction time.
-    CBackgroundPersister(core_t::TTime periodicPersistInterval,
-                         const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc,
-                         core::CDataAdder& dataAdder);
+    CPersistenceManager(core_t::TTime periodicPersistInterval,
+                        bool persistInForeground,
+                        const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc,
+                        core::CDataAdder& dataAdder);
 
-    ~CBackgroundPersister();
+    ~CPersistenceManager();
 
     //! Is background persistence currently in progress?
     bool isBusy() const;
@@ -86,7 +92,7 @@ public:
     //! complete
     bool waitForIdle();
 
-    //! Add a function to be called when the background persist is started.
+    //! Add a function to be called when persistence is started.
     //! This will be rejected if a background persistence is currently in
     //! progress.  It is likely that the supplied \p persistFunc will have
     //! data bound into it that will be used by the function it calls, i.e. the
@@ -101,22 +107,22 @@ public:
     //! called.
     bool firstProcessorPeriodicPersistFunc(const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
 
-    //! Start a background persist is one is not running.
-    //! Calls the first processor periodic persist function first.
-    //! Concurrent calls to this method are not threadsafe.
-    bool startBackgroundPersist();
-
     //! If the periodic persist interval has passed since the last persist
     //! then it is appropriate to persist now.  Start it by calling the
     //! first processor periodic persist function.
     //! Concurrent calls to this method are not threadsafe.
-    bool startBackgroundPersistIfAppropriate();
+    bool startPersistIfAppropriate();
+
+    //! Start a  persist if a background one is not running.
+    //! Calls the first processor periodic persist function first.
+    //! Concurrent calls to this method are not threadsafe.
+    bool startPersist(core_t::TTime timeOfPersistence);
 
 private:
     //! Implementation of the background thread
     class CBackgroundThread : public core::CThread {
     public:
-        CBackgroundThread(CBackgroundPersister& owner);
+        CBackgroundThread(CPersistenceManager& owner);
 
     protected:
         //! Inherited virtual interface
@@ -125,7 +131,7 @@ private:
 
     private:
         //! Reference to the owning background persister
-        CBackgroundPersister& m_Owner;
+        CPersistenceManager& m_Owner;
     };
 
 private:
@@ -133,9 +139,16 @@ private:
     //! to timeOfPersistence
     bool startBackgroundPersist(core_t::TTime timeOfPersistence);
 
+    //! Persist in the foreground setting the last persist time
+    //! to timeOfPersistence
+    bool startForegroundPersist(core_t::TTime timeOfPersistence);
+
     //! When this function is called a background persistence will be
     //! triggered unless there is already one in progress.
-    bool startPersist();
+    bool startPersistInBackground();
+
+    //! Execute the registered persistence functions now
+    void startPersist();
 
     //! Clear any persistence functions that have been added but not yet
     //! invoked.  This will be rejected if a background persistence is
@@ -144,14 +157,17 @@ private:
     bool clear();
 
 private:
-    //! How frequently should background persistence be attempted?
+    //! How frequently should  persistence be attempted?
     core_t::TTime m_PeriodicPersistInterval;
+
+    //! Should  persistence occur in the foreground?
+    const bool m_PersistInForeground;
 
     //! What was the wall clock time when we started our last periodic
     //! persistence?
     core_t::TTime m_LastPeriodicPersistTime;
 
-    //! The function that will be called to start the chain of background
+    //! The function that will be called to start the chain of
     //! persistence.
     TFirstProcessorPeriodicPersistFunc m_FirstProcessorPeriodicPersistFunc;
 
@@ -172,7 +188,7 @@ private:
 
     using TPersistFuncList = std::list<core::CDataAdder::TPersistFunc>;
 
-    //! Function to call in the background thread to do persistence.
+    //! Functions to call to do persistence.
     TPersistFuncList m_PersistFuncs;
 
     //! Thread used to do the background work
@@ -183,9 +199,9 @@ private:
     friend class CBackgroundThread;
 
     // For testing
-    friend class ::CBackgroundPersisterTest;
+    friend class ::CPersistenceManagerTest;
 };
 }
 }
 
-#endif // INCLUDED_ml_api_CBackgroundPersister_h
+#endif // INCLUDED_ml_api_CPersistenceManager_h

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -91,7 +91,11 @@ public:
     //! complete
     bool waitForIdle();
 
-    void persistInForeground(bool persistInForeground);
+    //! Configure persistence to be performed in the background
+    void useBackgroundPersistence();
+
+    //! Configure persistence to be performed in the foreground
+    void useForegroundPersistence();
 
     //! Add a function to be called when persistence is started.
     //! This will be rejected if a background persistence is currently in

--- a/include/config/CAutoconfigurer.h
+++ b/include/config/CAutoconfigurer.h
@@ -54,7 +54,7 @@ public:
                               core_t::TTime& completeToTime);
 
     //! No-op.
-    virtual bool persistState(core::CDataAdder& persister);
+    virtual bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix);
 
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const;

--- a/include/model/CLimits.h
+++ b/include/model/CLimits.h
@@ -64,7 +64,8 @@ public:
 
 public:
     //! Default constructor
-    explicit CLimits(double byteLimitMargin = CResourceMonitor::DEFAULT_BYTE_LIMIT_MARGIN);
+    explicit CLimits(bool persistenceInForeground = false,
+                     double byteLimitMargin = CResourceMonitor::DEFAULT_BYTE_LIMIT_MARGIN);
 
     //! Initialise from a config file.  This overwrites current settings
     //! with any found in the config file.  Settings that are not present

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -169,6 +169,9 @@ private:
     //! of background persistence.
     std::size_t adjustedUsage(std::size_t usage) const;
 
+    //! Returns the amount by which reported memory usage is scaled depending on the type of persistence in use
+    std::size_t persistenceMemoryIncreaseFactor() const;
+
 private:
     //! The registered collection of components
     TDetectorPtrSizeUMap m_Detectors;

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -62,7 +62,8 @@ public:
 
 public:
     //! Default constructor
-    explicit CResourceMonitor(double byteLimitMargin = DEFAULT_BYTE_LIMIT_MARGIN);
+    explicit CResourceMonitor(bool persistenceInForeground = false,
+                              double byteLimitMargin = DEFAULT_BYTE_LIMIT_MARGIN);
 
     //! Query the resource monitor to find out if the models are
     //! taking up too much memory and further allocations should be banned
@@ -232,6 +233,9 @@ private:
 
     //! The number of bytes over the high limit for memory usage at the last allocation failure
     std::size_t m_CurrentBytesExceeded;
+
+    //! Is persistence occurring in the foreground?
+    bool m_PersistenceInForeground;
 
     //! Test friends
     friend class ::CResourceMonitorTest;

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1063,8 +1063,8 @@ bool CAnomalyJob::backgroundPersistState(CPersistenceManager& backgroundPersiste
 bool CAnomalyJob::runForegroundPersist(core::CDataAdder& persister) {
     LOG_INFO(<< "Foreground persist commencing...");
 
-    // Finalise the processor so it gets a chance to write any remaining results
-    this->finalise();
+    // Prune the models so that the persisted state is as neat as possible
+    this->pruneAllModels();
 
     return this->persistState(persister, "Periodic foreground persist at ");
 }

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1090,15 +1090,15 @@ bool CAnomalyJob::runBackgroundPersist(TBackgroundPersistArgsPtr args,
 }
 
 bool CAnomalyJob::persistCopiedState(const std::string& descriptionPrefix,
-                               core_t::TTime time,
-                               const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
-                               const model::CResourceMonitor::SResults& modelSizeStats,
-                               const model::CInterimBucketCorrector& interimBucketCorrector,
-                               const model::CHierarchicalResultsAggregator& aggregator,
-                               const std::string& normalizerState,
-                               core_t::TTime latestRecordTime,
-                               core_t::TTime lastResultsTime,
-                               core::CDataAdder& persister) {
+                                     core_t::TTime time,
+                                     const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
+                                     const model::CResourceMonitor::SResults& modelSizeStats,
+                                     const model::CInterimBucketCorrector& interimBucketCorrector,
+                                     const model::CHierarchicalResultsAggregator& aggregator,
+                                     const std::string& normalizerState,
+                                     core_t::TTime latestRecordTime,
+                                     core_t::TTime lastResultsTime,
+                                     core::CDataAdder& persister) {
     // Persist state for each detector separately by streaming
     try {
         core::CStateCompressor compressor(persister);

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1061,7 +1061,7 @@ bool CAnomalyJob::backgroundPersistState() {
         return false;
     }
 
-    m_PeriodicPersister->persistInForeground(false);
+    m_PeriodicPersister->useBackgroundPersistence();
 
     return true;
 }
@@ -1210,7 +1210,7 @@ bool CAnomalyJob::periodicPersistStateInForeground() {
         return false;
     }
 
-    m_PeriodicPersister->persistInForeground(true);
+    m_PeriodicPersister->useForegroundPersistence();
 
     return true;
 }

--- a/lib/api/CCmdSkeleton.cc
+++ b/lib/api/CCmdSkeleton.cc
@@ -61,7 +61,7 @@ bool CCmdSkeleton::persistState() {
     }
 
     // Attempt to persist state
-    if (m_Processor.persistState(*m_Persister) == false) {
+    if (m_Processor.persistState(*m_Persister, "State persisted due to job close at ") == false) {
         LOG_FATAL(<< "Failed to persist state");
         return false;
     }

--- a/lib/api/CDataProcessor.cc
+++ b/lib/api/CDataProcessor.cc
@@ -49,12 +49,12 @@ std::string CDataProcessor::debugPrintRecord(const TStrStrUMap& dataRowFields) {
     return result.str();
 }
 
-bool CDataProcessor::periodicPersistStateInBackground(CPersistenceManager& /*persister*/) {
+bool CDataProcessor::periodicPersistStateInBackground() {
     // No-op
     return true;
 }
 
-bool CDataProcessor::periodicPersistStateInForeground(CPersistenceManager& /*persister*/) {
+bool CDataProcessor::periodicPersistStateInForeground() {
     // No-op
     return true;
 }

--- a/lib/api/CDataProcessor.cc
+++ b/lib/api/CDataProcessor.cc
@@ -49,7 +49,12 @@ std::string CDataProcessor::debugPrintRecord(const TStrStrUMap& dataRowFields) {
     return result.str();
 }
 
-bool CDataProcessor::periodicPersistState(CBackgroundPersister& /*persister*/) {
+bool CDataProcessor::periodicPersistStateInBackground(CPersistenceManager& /*persister*/) {
+    // No-op
+    return true;
+}
+
+bool CDataProcessor::periodicPersistStateInForeground(CPersistenceManager& /*persister*/) {
     // No-op
     return true;
 }

--- a/lib/api/CFieldDataTyper.cc
+++ b/lib/api/CFieldDataTyper.cc
@@ -426,7 +426,7 @@ bool CFieldDataTyper::periodicPersistStateInBackground() {
         return false;
     }
 
-    m_PeriodicPersister->persistInForeground(false);
+    m_PeriodicPersister->useBackgroundPersistence();
 
     return true;
 }
@@ -446,7 +446,7 @@ bool CFieldDataTyper::periodicPersistStateInForeground() {
         return false;
     }
 
-    m_PeriodicPersister->persistInForeground(true);
+    m_PeriodicPersister->useForegroundPersistence();
 
     return true;
 }

--- a/lib/api/CFieldDataTyper.cc
+++ b/lib/api/CFieldDataTyper.cc
@@ -15,10 +15,10 @@
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
 
-#include <api/CBackgroundPersister.h>
 #include <api/CFieldConfig.h>
 #include <api/CJsonOutputWriter.h>
 #include <api/COutputHandler.h>
+#include <api/CPersistenceManager.h>
 #include <api/CTokenListReverseSearchCreator.h>
 
 #include <sstream>
@@ -45,7 +45,7 @@ CFieldDataTyper::CFieldDataTyper(const std::string& jobId,
                                  const model::CLimits& limits,
                                  COutputHandler& outputHandler,
                                  CJsonOutputWriter& jsonOutputWriter,
-                                 CBackgroundPersister* periodicPersister)
+                                 CPersistenceManager* periodicPersister)
     : m_JobId(jobId), m_OutputHandler(outputHandler),
       m_ExtraFieldNames(1, MLCATEGORY_NAME), m_WriteFieldNames(true),
       m_NumRecordsHandled(0), m_OutputFieldCategory(m_Overrides[MLCATEGORY_NAME]),
@@ -168,7 +168,7 @@ int CFieldDataTyper::computeType(const TStrStrUMap& dataRowFields) {
 
     // Check if a periodic persist is due.
     if (m_PeriodicPersister != nullptr) {
-        m_PeriodicPersister->startBackgroundPersistIfAppropriate();
+        m_PeriodicPersister->startPersistIfAppropriate();
     }
 
     return type;
@@ -313,7 +313,8 @@ bool CFieldDataTyper::acceptRestoreTraverser(core::CStateRestoreTraverser& trave
     return true;
 }
 
-bool CFieldDataTyper::persistState(core::CDataAdder& persister) {
+bool CFieldDataTyper::persistState(core::CDataAdder& persister,
+                                   const std::string& descriptionPrefix) {
     if (m_PeriodicPersister != nullptr) {
         // This will not happen if finalise() was called before persisting state
         if (m_PeriodicPersister->isBusy()) {
@@ -324,7 +325,7 @@ bool CFieldDataTyper::persistState(core::CDataAdder& persister) {
     }
 
     // Pass on the request in case we're chained
-    if (m_OutputHandler.persistState(persister) == false) {
+    if (m_OutputHandler.persistState(persister, descriptionPrefix) == false) {
         return false;
     }
 
@@ -369,7 +370,7 @@ bool CFieldDataTyper::doPersistState(const CDataTyper::TPersistFunc& dataTyperPe
 
         {
             // Keep the JSON inserter scoped as it only finishes the stream
-            // when it is desctructed
+            // when it is destructed
             core::CJsonStatePersistInserter inserter(*strm);
             this->acceptPersistInserter(dataTyperPersistFunc, examplesCollector, inserter);
         }
@@ -401,11 +402,11 @@ void CFieldDataTyper::acceptPersistInserter(const CDataTyper::TPersistFunc& data
                                    &examplesCollector, std::placeholders::_1));
 }
 
-bool CFieldDataTyper::periodicPersistState(CBackgroundPersister& persister) {
+bool CFieldDataTyper::periodicPersistStateInBackground(CPersistenceManager& persister) {
     LOG_DEBUG(<< "Periodic persist typer state");
 
     // Pass on the request in case we're chained
-    if (m_OutputHandler.periodicPersistState(persister) == false) {
+    if (m_OutputHandler.periodicPersistStateInBackground(persister) == false) {
         return false;
     }
 
@@ -416,6 +417,19 @@ bool CFieldDataTyper::periodicPersistState(CBackgroundPersister& persister) {
                                            m_DataTyper->makePersistFunc(), m_ExamplesCollector,
                                            std::placeholders::_1)) == false) {
         LOG_ERROR(<< "Failed to add categorizer background persistence function");
+        return false;
+    }
+
+    return true;
+}
+
+bool CFieldDataTyper::periodicPersistStateInForeground(CPersistenceManager& persistenceManager) {
+    LOG_DEBUG(<< "Periodic persist typer state");
+
+    if (persistenceManager.addPersistFunc([&](core::CDataAdder& persister) {
+            return this->persistState(persister, "Periodic foreground persist at ");
+        }) == false) {
+        LOG_ERROR(<< "Failed to add categorizer foreground persistence function");
         return false;
     }
 

--- a/lib/api/CFieldDataTyper.cc
+++ b/lib/api/CFieldDataTyper.cc
@@ -415,12 +415,13 @@ bool CFieldDataTyper::periodicPersistStateInBackground() {
         return false;
     }
 
-    if (m_PeriodicPersister->addPersistFunc(std::bind(&CFieldDataTyper::doPersistState, this,
-                                           // Do NOT add std::ref wrappers
-                                           // around these arguments - they
-                                           // MUST be copied for thread safety
-                                           m_DataTyper->makePersistFunc(), m_ExamplesCollector,
-                                           std::placeholders::_1)) == false) {
+    if (m_PeriodicPersister->addPersistFunc(
+            std::bind(&CFieldDataTyper::doPersistState, this,
+                      // Do NOT add std::ref wrappers
+                      // around these arguments - they
+                      // MUST be copied for thread safety
+                      m_DataTyper->makePersistFunc(), m_ExamplesCollector,
+                      std::placeholders::_1)) == false) {
         LOG_ERROR(<< "Failed to add categorizer background persistence function");
         return false;
     }

--- a/lib/api/COutputChainer.cc
+++ b/lib/api/COutputChainer.cc
@@ -112,8 +112,8 @@ bool COutputChainer::persistState(core::CDataAdder& persister,
     return m_DataProcessor.persistState(persister, descriptionPrefix);
 }
 
-bool COutputChainer::periodicPersistStateInBackground(CPersistenceManager& persistenceManager) {
-    return m_DataProcessor.periodicPersistStateInBackground(persistenceManager);
+bool COutputChainer::periodicPersistStateInBackground() {
+    return m_DataProcessor.periodicPersistStateInBackground();
 }
 
 bool COutputChainer::isPersistenceNeeded(const std::string& description) const {

--- a/lib/api/COutputChainer.cc
+++ b/lib/api/COutputChainer.cc
@@ -107,12 +107,13 @@ bool COutputChainer::restoreState(core::CDataSearcher& restoreSearcher,
     return m_DataProcessor.restoreState(restoreSearcher, completeToTime);
 }
 
-bool COutputChainer::persistState(core::CDataAdder& persister) {
-    return m_DataProcessor.persistState(persister);
+bool COutputChainer::persistState(core::CDataAdder& persister,
+                                  const std::string& descriptionPrefix) {
+    return m_DataProcessor.persistState(persister, descriptionPrefix);
 }
 
-bool COutputChainer::periodicPersistState(CBackgroundPersister& persister) {
-    return m_DataProcessor.periodicPersistState(persister);
+bool COutputChainer::periodicPersistStateInBackground(CPersistenceManager& persistenceManager) {
+    return m_DataProcessor.periodicPersistStateInBackground(persistenceManager);
 }
 
 bool COutputChainer::isPersistenceNeeded(const std::string& description) const {

--- a/lib/api/COutputHandler.cc
+++ b/lib/api/COutputHandler.cc
@@ -42,7 +42,7 @@ bool COutputHandler::persistState(core::CDataAdder& /* persister */,
     return true;
 }
 
-bool COutputHandler::periodicPersistStateInBackground(CPersistenceManager& /* persister */) {
+bool COutputHandler::periodicPersistStateInBackground() {
     // NOOP unless overridden
     return true;
 }

--- a/lib/api/COutputHandler.cc
+++ b/lib/api/COutputHandler.cc
@@ -36,12 +36,13 @@ bool COutputHandler::restoreState(core::CDataSearcher& /* restoreSearcher */,
     return true;
 }
 
-bool COutputHandler::persistState(core::CDataAdder& /* persister */) {
+bool COutputHandler::persistState(core::CDataAdder& /* persister */,
+                                  const std::string& /*descriptionPrefix*/) {
     // NOOP unless overridden
     return true;
 }
 
-bool COutputHandler::periodicPersistState(CBackgroundPersister& /* persister */) {
+bool COutputHandler::periodicPersistStateInBackground(CPersistenceManager& /* persister */) {
     // NOOP unless overridden
     return true;
 }

--- a/lib/api/CPersistenceManager.cc
+++ b/lib/api/CPersistenceManager.cc
@@ -188,12 +188,11 @@ bool CPersistenceManager::startPersist(core_t::TTime timeOfPersistence) {
         return false;
     }
 
-    auto firstProcessorPeriodicPersistFunc = [&]() {
-        return m_PersistInForeground ? m_FirstProcessorForegroundPeriodicPersistFunc
-                                     : m_FirstProcessorBackgroundPeriodicPersistFunc;
-    };
+    const auto& firstProcessorPeriodicPersistFunc =
+        m_PersistInForeground ? m_FirstProcessorForegroundPeriodicPersistFunc
+                              : m_FirstProcessorBackgroundPeriodicPersistFunc;
 
-    bool persistSetupOk = firstProcessorPeriodicPersistFunc()(*this);
+    bool persistSetupOk = firstProcessorPeriodicPersistFunc(*this);
     if (!persistSetupOk) {
         LOG_ERROR(<< "Failed to create persistence functions");
         // It's possible that some functions were added before the failure, so

--- a/lib/api/CPersistenceManager.cc
+++ b/lib/api/CPersistenceManager.cc
@@ -32,8 +32,8 @@ CPersistenceManager::CPersistenceManager(core_t::TTime periodicPersistInterval,
     : m_PeriodicPersistInterval(periodicPersistInterval),
       m_PersistInForeground(persistInForeground),
       m_LastPeriodicPersistTime(core::CTimeUtils::now()),
-      m_BgDataAdder(bgDataAdder), m_FgDataAdder(fgDataAdder), m_IsBusy(false), m_IsShutdown(false),
-      m_BackgroundThread(*this)  {
+      m_BgDataAdder(bgDataAdder), m_FgDataAdder(fgDataAdder), m_IsBusy(false),
+      m_IsShutdown(false), m_BackgroundThread(*this) {
     if (m_PeriodicPersistInterval < PERSIST_INTERVAL_INCREMENT) {
         // This may be dynamically increased further depending on how long
         // persistence takes

--- a/lib/api/CPersistenceManager.cc
+++ b/lib/api/CPersistenceManager.cc
@@ -61,8 +61,12 @@ bool CPersistenceManager::waitForIdle() {
     return m_BackgroundThread.waitForFinish();
 }
 
-void CPersistenceManager::persistInForeground(bool persistInForeground) {
-    m_PersistInForeground = persistInForeground;
+void CPersistenceManager::useBackgroundPersistence() {
+    m_PersistInForeground = false;
+}
+
+void CPersistenceManager::useForegroundPersistence() {
+    m_PersistInForeground = true;
 }
 
 bool CPersistenceManager::addPersistFunc(core::CDataAdder::TPersistFunc persistFunc) {

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -18,7 +18,6 @@ all: build
 
 SRCS= \
 CAnomalyJob.cc \
-CBackgroundPersister.cc \
 CBaseTokenListDataTyper.cc \
 CBenchMarker.cc \
 CCategoryExamplesCollector.cc \
@@ -52,6 +51,7 @@ CNdJsonOutputWriter.cc \
 CNullOutput.cc \
 COutputChainer.cc \
 COutputHandler.cc \
+CPersistenceManager.cc \
 CResultNormalizer.cc \
 CSingleStreamDataAdder.cc \
 CSingleStreamSearcher.cc \

--- a/lib/api/dump_state/Main.cc
+++ b/lib/api/dump_state/Main.cc
@@ -124,7 +124,7 @@ bool writeNormalizerState(const std::string& outputFileName) {
 }
 
 bool persistCategorizerStateToFile(const std::string& outputFileName) {
-    ml::model::CLimits limits;
+    ml::model::CLimits limits(true);
     ml::api::CFieldConfig config("count", "mlcategory");
 
     std::ofstream outStream(ml::core::COsFileFuncs::NULL_FILENAME);
@@ -149,7 +149,7 @@ bool persistCategorizerStateToFile(const std::string& outputFileName) {
         }
 
         ml::api::CSingleStreamDataAdder persister(ptr);
-        if (!typer.persistState(persister)) {
+        if (!typer.persistState(persister, "State persisted due to job close at ")) {
             LOG_ERROR(<< "Error persisting state to " << outputFileName);
             return false;
         }
@@ -174,7 +174,7 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
 
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-    ml::model::CLimits limits;
+    ml::model::CLimits limits(true);
     ml::api::CFieldConfig fieldConfig;
     if (!fieldConfig.initFromFile(configFileName)) {
         LOG_ERROR(<< "Failed to init field config from " << configFileName);
@@ -215,7 +215,7 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
         }
 
         ml::api::CSingleStreamDataAdder persister(ptr);
-        if (!origJob.persistState(persister)) {
+        if (!origJob.persistState(persister, "State persisted due to job close at ")) {
             LOG_ERROR(<< "Error persisting state to " << outputFileName);
             return false;
         }

--- a/lib/api/unittest/CFieldDataTyperTest.cc
+++ b/lib/api/unittest/CFieldDataTyperTest.cc
@@ -153,7 +153,7 @@ void CFieldDataTyperTest::testAll() {
     std::string origJson;
     {
         CTestDataAdder adder;
-        typer.persistState(adder);
+        typer.persistState(adder, "");
         std::ostringstream& ss = dynamic_cast<std::ostringstream&>(*adder.getStream());
         origJson = ss.str();
     }
@@ -174,7 +174,7 @@ void CFieldDataTyperTest::testAll() {
         newTyper.restoreState(restorer, time);
 
         CTestDataAdder adder;
-        newTyper.persistState(adder);
+        newTyper.persistState(adder, "");
         std::ostringstream& ss = dynamic_cast<std::ostringstream&>(*adder.getStream());
         newJson = ss.str();
     }

--- a/lib/api/unittest/CMockDataProcessor.cc
+++ b/lib/api/unittest/CMockDataProcessor.cc
@@ -66,9 +66,10 @@ bool CMockDataProcessor::restoreState(ml::core::CDataSearcher& restoreSearcher,
     return true;
 }
 
-bool CMockDataProcessor::persistState(ml::core::CDataAdder& persister) {
+bool CMockDataProcessor::persistState(ml::core::CDataAdder& persister,
+                                      const std::string& descriptionPrefix) {
     // Pass on the request in case we're chained
-    if (m_OutputHandler.persistState(persister) == false) {
+    if (m_OutputHandler.persistState(persister, descriptionPrefix) == false) {
         return false;
     }
 

--- a/lib/api/unittest/CMockDataProcessor.h
+++ b/lib/api/unittest/CMockDataProcessor.h
@@ -47,7 +47,8 @@ public:
                               ml::core_t::TTime& completeToTime);
 
     //! Persist current state
-    virtual bool persistState(ml::core::CDataAdder& persister);
+    virtual bool persistState(ml::core::CDataAdder& persister,
+                              const std::string& descriptionPrefix);
 
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const;

--- a/lib/api/unittest/CMultiFileDataAdderTest.cc
+++ b/lib/api/unittest/CMultiFileDataAdderTest.cc
@@ -208,7 +208,7 @@ void CMultiFileDataAdderTest::detectorPersistHelper(const std::string& configFil
         CPPUNIT_ASSERT_NO_THROW(boost::filesystem::remove_all(origDir));
 
         ml::test::CMultiFileDataAdder persister(baseOrigOutputFilename);
-        CPPUNIT_ASSERT(origJob.persistState(persister));
+        CPPUNIT_ASSERT(origJob.persistState(persister, ""));
     }
 
     std::string origBaseDocId(JOB_ID + '_' + ml::api::CAnomalyJob::STATE_TYPE +
@@ -263,7 +263,7 @@ void CMultiFileDataAdderTest::detectorPersistHelper(const std::string& configFil
         CPPUNIT_ASSERT_NO_THROW(boost::filesystem::remove_all(restoredDir));
 
         ml::test::CMultiFileDataAdder persister(baseRestoredOutputFilename);
-        CPPUNIT_ASSERT(restoredJob.persistState(persister));
+        CPPUNIT_ASSERT(restoredJob.persistState(persister, ""));
     }
 
     std::string restoredBaseDocId(JOB_ID + '_' + ml::api::CAnomalyJob::STATE_TYPE +

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -3,7 +3,6 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-#include "../../../include/api/CPersistenceManager.h"
 #include "CPersistenceManagerTest.h"
 
 #include <core/CJsonOutputStreamWrapper.h>
@@ -24,6 +23,7 @@
 #include <api/CNdJsonInputParser.h>
 #include <api/CNullOutput.h>
 #include <api/COutputChainer.h>
+#include <api/CPersistenceManager.h>
 #include <api/CSingleStreamDataAdder.h>
 
 #include <algorithm>

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -245,7 +245,7 @@ void CPersistenceManagerTest::foregroundBackgroundCompCategorizationAndAnomalyDe
         persistenceManager.startPersist();
         foregroundSnapshotId = snapshotId;
 
-        // ... persist in foreground againi by directly calling persistState
+        // ... persist in foreground again by directly calling persistState
         ml::api::CSingleStreamDataAdder foregroundDataAdder2(foregroundStreamPtr2);
         CPPUNIT_ASSERT(firstProcessor->persistState(
             foregroundDataAdder2, "Periodic foreground persistence at "));

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -109,7 +109,8 @@ void CPersistenceManagerTest::testCategorizationOnlyPersist() {
 
     // The 300 second persist interval is irrelevant here - we bypass the timer
     // in this test and kick off the background persistence chain explicitly
-    ml::api::CPersistenceManager persistenceManager(300, false, backgroundDataAdder, foregroundDataAdder);
+    ml::api::CPersistenceManager persistenceManager(300, false, backgroundDataAdder,
+                                                    foregroundDataAdder);
 
     {
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
@@ -187,7 +188,8 @@ void CPersistenceManagerTest::foregroundBackgroundCompCategorizationAndAnomalyDe
 
     // The 300 second persist interval is irrelevant here - we bypass the timer
     // in this test and kick off the background persistence chain explicitly
-    ml::api::CPersistenceManager persistenceManager(300, false, backgroundDataAdder, foregroundDataAdder);
+    ml::api::CPersistenceManager persistenceManager(300, false, backgroundDataAdder,
+                                                    foregroundDataAdder);
 
     std::string snapshotId;
     std::size_t numDocs(0);
@@ -195,7 +197,6 @@ void CPersistenceManagerTest::foregroundBackgroundCompCategorizationAndAnomalyDe
     std::string backgroundSnapshotId;
     std::string foregroundSnapshotId;
     std::string foregroundSnapshotId2;
-
 
     std::ostringstream* foregroundStream2(nullptr);
     ml::api::CSingleStreamDataAdder::TOStreamP foregroundStreamPtr2(
@@ -216,7 +217,8 @@ void CPersistenceManagerTest::foregroundBackgroundCompCategorizationAndAnomalyDe
         ml::api::COutputChainer outputChainer(job);
 
         // The typer knows how to assign categories to records
-        ml::api::CFieldDataTyper typer(JOB_ID, fieldConfig, limits, outputChainer, outputWriter, &persistenceManager);
+        ml::api::CFieldDataTyper typer(JOB_ID, fieldConfig, limits, outputChainer,
+                                       outputWriter, &persistenceManager);
 
         if (fieldConfig.fieldNameSuperset().count(ml::api::CFieldDataTyper::MLCATEGORY_NAME) > 0) {
             LOG_DEBUG(<< "Applying the categorization typer for anomaly detection");
@@ -311,7 +313,8 @@ void CPersistenceManagerTest::foregroundBackgroundCompAnomalyDetectionAfterStati
 
     // The 300 second persist interval is irrelevant here - we bypass the timer
     // in this test and kick off the background persistence chain explicitly
-    ml::api::CPersistenceManager persistenceManager(300, false, backgroundDataAdder, foregroundDataAdder);
+    ml::api::CPersistenceManager persistenceManager(300, false, backgroundDataAdder,
+                                                    foregroundDataAdder);
 
     std::string snapshotId;
     std::size_t numDocs(0);

--- a/lib/api/unittest/CPersistenceManagerTest.h
+++ b/lib/api/unittest/CPersistenceManagerTest.h
@@ -3,14 +3,14 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-#ifndef INCLUDED_CBackgroundPersisterTest_h
-#define INCLUDED_CBackgroundPersisterTest_h
+#ifndef INCLUDED_CPersistenceManagerTest_h
+#define INCLUDED_CPersistenceManagerTest_h
 
 #include <cppunit/extensions/HelperMacros.h>
 
 #include <string>
 
-class CBackgroundPersisterTest : public CppUnit::TestFixture {
+class CPersistenceManagerTest : public CppUnit::TestFixture {
 public:
     void testDetectorPersistBy();
     void testDetectorPersistOver();
@@ -25,4 +25,4 @@ private:
     void foregroundBackgroundCompAnomalyDetectionAfterStaticsUpdate(const std::string& configFileName);
 };
 
-#endif // INCLUDED_CBackgroundPersisterTest_h
+#endif // INCLUDED_CPersistenceManagerTest_h

--- a/lib/api/unittest/CRestorePreviousStateTest.cc
+++ b/lib/api/unittest/CRestorePreviousStateTest.cc
@@ -179,7 +179,7 @@ void CRestorePreviousStateTest::categorizerRestoreHelper(const std::string& stat
             std::ostringstream* strm(nullptr);
             ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
             ml::api::CSingleStreamDataAdder persister(ptr);
-            CPPUNIT_ASSERT(restoredTyper.persistState(persister));
+            CPPUNIT_ASSERT(restoredTyper.persistState(persister, ""));
             newPersistedState = strm->str();
         }
         CPPUNIT_ASSERT_EQUAL(this->stripDocIds(origPersistedState),
@@ -249,7 +249,7 @@ void CRestorePreviousStateTest::anomalyDetectorRestoreHelper(const std::string& 
             std::ostringstream* strm(nullptr);
             ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
             ml::api::CSingleStreamDataAdder persister(ptr);
-            CPPUNIT_ASSERT(restoredJob.persistState(persister));
+            CPPUNIT_ASSERT(restoredJob.persistState(persister, ""));
             newPersistedState = strm->str();
         }
 

--- a/lib/api/unittest/CSingleStreamDataAdderTest.cc
+++ b/lib/api/unittest/CSingleStreamDataAdderTest.cc
@@ -162,7 +162,7 @@ void CSingleStreamDataAdderTest::detectorPersistHelper(const std::string& config
         std::ostringstream* strm(nullptr);
         ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
         ml::api::CSingleStreamDataAdder persister(ptr);
-        CPPUNIT_ASSERT(firstProcessor->persistState(persister));
+        CPPUNIT_ASSERT(firstProcessor->persistState(persister, ""));
         origPersistedState = strm->str();
     }
 
@@ -215,7 +215,7 @@ void CSingleStreamDataAdderTest::detectorPersistHelper(const std::string& config
         std::ostringstream* strm(nullptr);
         ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
         ml::api::CSingleStreamDataAdder persister(ptr);
-        CPPUNIT_ASSERT(restoredFirstProcessor->persistState(persister));
+        CPPUNIT_ASSERT(restoredFirstProcessor->persistState(persister, ""));
         newPersistedState = strm->str();
     }
 

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -178,7 +178,7 @@ void CStringStoreTest::testPersonStringPruning() {
         time += BUCKET_SPAN * 100;
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
 
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
         wrappedOutputStream.syncFlush();
 
         CPPUNIT_ASSERT_EQUAL(std::size_t(1),
@@ -224,7 +224,7 @@ void CStringStoreTest::testPersonStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 3, 1, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring job again");
     {
@@ -266,7 +266,7 @@ void CStringStoreTest::testPersonStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 2, 2, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring yet again");
     {
@@ -368,7 +368,7 @@ void CStringStoreTest::testAttributeStringPruning() {
         time += BUCKET_SPAN * 100;
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
 
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
         wrappedOutputStream.syncFlush();
         CPPUNIT_ASSERT_EQUAL(std::size_t(1),
                              countBuckets("records", outputStrm.str() + "]"));
@@ -413,7 +413,7 @@ void CStringStoreTest::testAttributeStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 3, 1, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring job again");
     {
@@ -456,7 +456,7 @@ void CStringStoreTest::testAttributeStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 2, 2, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring yet again");
     {

--- a/lib/api/unittest/Main.cc
+++ b/lib/api/unittest/Main.cc
@@ -7,7 +7,6 @@
 
 #include "CAnomalyJobLimitTest.h"
 #include "CAnomalyJobTest.h"
-#include "CBackgroundPersisterTest.h"
 #include "CBaseTokenListDataTyperTest.h"
 #include "CCategoryExamplesCollectorTest.h"
 #include "CConfigUpdaterTest.h"
@@ -29,6 +28,7 @@
 #include "CNdJsonInputParserTest.h"
 #include "CNdJsonOutputWriterTest.h"
 #include "COutputChainerTest.h"
+#include "CPersistenceManagerTest.h"
 #include "CRestorePreviousStateTest.h"
 #include "CResultNormalizerTest.h"
 #include "CSingleStreamDataAdderTest.h"
@@ -42,7 +42,6 @@ int main(int argc, const char** argv) {
 
     runner.addTest(CAnomalyJobLimitTest::suite());
     runner.addTest(CAnomalyJobTest::suite());
-    runner.addTest(CBackgroundPersisterTest::suite());
     runner.addTest(CBaseTokenListDataTyperTest::suite());
     runner.addTest(CCategoryExamplesCollectorTest::suite());
     runner.addTest(CConfigUpdaterTest::suite());
@@ -64,6 +63,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CModelSnapshotJsonWriterTest::suite());
     runner.addTest(CMultiFileDataAdderTest::suite());
     runner.addTest(COutputChainerTest::suite());
+    runner.addTest(CPersistenceManagerTest::suite());
     runner.addTest(CRestorePreviousStateTest::suite());
     runner.addTest(CResultNormalizerTest::suite());
     runner.addTest(CSingleStreamDataAdderTest::suite());

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -21,7 +21,6 @@ SRCS=\
 	Main.cc \
 	CAnomalyJobLimitTest.cc \
 	CAnomalyJobTest.cc \
-	CBackgroundPersisterTest.cc \
 	CBaseTokenListDataTyperTest.cc \
 	CCategoryExamplesCollectorTest.cc \
 	CConfigUpdaterTest.cc \
@@ -47,6 +46,7 @@ SRCS=\
 	CNdJsonInputParserTest.cc \
 	CNdJsonOutputWriterTest.cc \
 	COutputChainerTest.cc \
+	CPersistenceManagerTest.cc \
 	CRestorePreviousStateTest.cc \
 	CResultNormalizerTest.cc \
 	CSingleStreamDataAdderTest.cc \

--- a/lib/config/CAutoconfigurer.cc
+++ b/lib/config/CAutoconfigurer.cc
@@ -174,7 +174,7 @@ bool CAutoconfigurer::restoreState(core::CDataSearcher& /*restoreSearcher*/,
     return true;
 }
 
-bool CAutoconfigurer::persistState(core::CDataAdder& /*persister*/) {
+bool CAutoconfigurer::persistState(core::CDataAdder&, const std::string&) {
     return true;
 }
 

--- a/lib/model/CLimits.cc
+++ b/lib/model/CLimits.cc
@@ -24,13 +24,13 @@ const size_t CLimits::DEFAULT_RESULTS_MAX_EXAMPLES(4);
 // The probability threshold is stored as a percentage in the config file
 const double CLimits::DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD(3.5);
 
-CLimits::CLimits(double byteLimitMargin)
+CLimits::CLimits(bool persistenceInForeground, double byteLimitMargin)
     : m_AutoConfigEvents(DEFAULT_AUTOCONFIG_EVENTS),
       m_AnomalyMaxTimeBuckets(DEFAULT_ANOMALY_MAX_TIME_BUCKETS),
       m_MaxExamples(DEFAULT_RESULTS_MAX_EXAMPLES),
       m_UnusualProbabilityThreshold(DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD),
       m_MemoryLimitMB(CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB),
-      m_ResourceMonitor(byteLimitMargin) {
+      m_ResourceMonitor(persistenceInForeground, byteLimitMargin) {
 }
 
 bool CLimits::init(const std::string& configFile) {

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -275,7 +275,7 @@ CResourceMonitor::SResults CResourceMonitor::createMemoryUsageReport(core_t::TTi
 }
 
 std::size_t CResourceMonitor::adjustedUsage(std::size_t usage) const {
-    // We  scale the reported memory usage by the inverse of the byte limit margin.
+    // We scale the reported memory usage by the inverse of the byte limit margin.
     // This gives the user a fairer indication of how close the job is to hitting
     // the model memory limit in a concise manner (as the limit is scaled down by
     // the margin during the beginning period of the job's existence).

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -302,7 +302,7 @@ std::size_t CResourceMonitor::adjustedUsage(std::size_t usage) const {
         // If that gets implemented, we should only double when background
         // persist is configured.
 
-        adjustedUsage = static_cast<std::size_t>(2 * adjustedUsage);
+        adjustedUsage *= 2;
     }
 
     return adjustedUsage;

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -27,7 +27,7 @@ const double CResourceMonitor::DEFAULT_BYTE_LIMIT_MARGIN(0.7);
 const core_t::TTime
     CResourceMonitor::MAXIMUM_BYTE_LIMIT_MARGIN_PERIOD(2 * core::constants::HOUR);
 
-CResourceMonitor::CResourceMonitor(double byteLimitMargin)
+CResourceMonitor::CResourceMonitor(bool persistenceInForeground, double byteLimitMargin)
     : m_AllowAllocations(true), m_ByteLimitMargin{byteLimitMargin},
       m_ByteLimitHigh(0), m_ByteLimitLow(0), m_CurrentAnomalyDetectorMemory(0),
       m_ExtraMemory(0), m_PreviousTotal(this->totalMemory()), m_Peak(m_PreviousTotal),
@@ -36,7 +36,8 @@ CResourceMonitor::CResourceMonitor(double byteLimitMargin)
       m_PruneWindow(std::numeric_limits<std::size_t>::max()),
       m_PruneWindowMaximum(std::numeric_limits<std::size_t>::max()),
       m_PruneWindowMinimum(std::numeric_limits<std::size_t>::max()),
-      m_NoLimit(false), m_CurrentBytesExceeded(0) {
+      m_NoLimit(false), m_CurrentBytesExceeded(0),
+      m_PersistenceInForeground(persistenceInForeground) {
     this->updateMemoryLimitsAndPruneThreshold(DEFAULT_MEMORY_LIMIT_MB);
 }
 
@@ -80,7 +81,7 @@ void CResourceMonitor::updateMemoryLimitsAndPruneThreshold(std::size_t limitMBs)
         // number, such as "what would total memory usage be if we allocated 10
         // more models?", and it causes problems if these calculations overflow.
         m_ByteLimitHigh = std::numeric_limits<std::size_t>::max() / 2 + 1;
-    } else {
+    } else if (m_PersistenceInForeground == false) {
         // Background persist causes the memory size to double due to copying
         // the models. On top of that, after the persist is done we may not
         // be able to retrieve that memory back. Thus, we halve the requested
@@ -91,6 +92,8 @@ void CResourceMonitor::updateMemoryLimitsAndPruneThreshold(std::size_t limitMBs)
         // If that gets implemented, we should only halve when background
         // persist is configured.
         m_ByteLimitHigh = static_cast<std::size_t>((limitMBs * 1024 * 1024) / 2);
+    } else {
+        m_ByteLimitHigh = static_cast<std::size_t>((limitMBs * 1024 * 1024));
     }
     m_ByteLimitLow = (m_ByteLimitHigh * 49) / 50;
     m_PruneThreshold = (m_ByteLimitHigh * 3) / 5;
@@ -282,21 +285,26 @@ CResourceMonitor::SResults CResourceMonitor::createMemoryUsageReport(core_t::TTi
 }
 
 std::size_t CResourceMonitor::adjustedUsage(std::size_t usage) const {
-    // Background persist causes the memory size to double due to copying
-    // the models. On top of that, after the persist is done we may not
-    // be able to retrieve that memory back. Thus, we report twice the
-    // memory usage in order to allow for that.
-    // See https://github.com/elastic/x-pack-elasticsearch/issues/1020.
-    // Issue https://github.com/elastic/x-pack-elasticsearch/issues/857
-    // discusses adding an option to perform only foreground persist.
-    // If that gets implemented, we should only double when background
-    // persist is configured.
-
-    // We also scale the reported memory usage by the inverse of the byte limit margin.
+    // We  scale the reported memory usage by the inverse of the byte limit margin.
     // This gives the user a fairer indication of how close the job is to hitting
     // the model memory limit in a concise manner (as the limit is scaled down by
     // the margin during the beginning period of the job's existence).
-    size_t adjustedUsage = static_cast<std::size_t>(2 * usage / m_ByteLimitMargin);
+    size_t adjustedUsage{static_cast<std::size_t>(usage / m_ByteLimitMargin)};
+
+    if (m_PersistenceInForeground == false) {
+        // Background persist causes the memory size to double due to copying
+        // the models. On top of that, after the persist is done we may not
+        // be able to retrieve that memory back. Thus, we report twice the
+        // memory usage in order to allow for that.
+        // See https://github.com/elastic/x-pack-elasticsearch/issues/1020.
+        // Issue https://github.com/elastic/x-pack-elasticsearch/issues/857
+        // discusses adding an option to perform only foreground persist.
+        // If that gets implemented, we should only double when background
+        // persist is configured.
+
+        adjustedUsage = static_cast<std::size_t>(2 * adjustedUsage);
+    }
+
     return adjustedUsage;
 }
 

--- a/lib/model/unittest/CResourceLimitTest.cc
+++ b/lib/model/unittest/CResourceLimitTest.cc
@@ -537,7 +537,6 @@ void doTestLargeAllocations(SLargeAllocationTestParams& param) {
     CPPUNIT_ASSERT_EQUAL(std::size_t(0), model->getNewAttributes());
     CPPUNIT_ASSERT_EQUAL(model->getNewPeople(), gatherer->numberActivePeople());
 }
-
 }
 
 void CResourceLimitTest::testLargeAllocations() {

--- a/lib/model/unittest/CResourceLimitTest.h
+++ b/lib/model/unittest/CResourceLimitTest.h
@@ -19,9 +19,6 @@ class CResourceMonitor;
 
 class CResultWriter;
 
-
-
-
 class CResourceLimitTest : public CppUnit::TestFixture {
 public:
     void testLimitBy();
@@ -31,8 +28,6 @@ public:
     static CppUnit::Test* suite();
 
 private:
-
-
     void importCsvDataWithLimiter(ml::core_t::TTime firstTime,
                                   ml::core_t::TTime bucketLength,
                                   CResultWriter& outputResults,

--- a/lib/model/unittest/CResourceLimitTest.h
+++ b/lib/model/unittest/CResourceLimitTest.h
@@ -19,6 +19,9 @@ class CResourceMonitor;
 
 class CResultWriter;
 
+
+
+
 class CResourceLimitTest : public CppUnit::TestFixture {
 public:
     void testLimitBy();
@@ -28,6 +31,8 @@ public:
     static CppUnit::Test* suite();
 
 private:
+
+
     void importCsvDataWithLimiter(ml::core_t::TTime firstTime,
                                   ml::core_t::TTime bucketLength,
                                   CResultWriter& outputResults,

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -83,6 +83,25 @@ void CResourceMonitorTest::testMonitor() {
         }
     }
     {
+        // Test foreground persistence constructor
+        CResourceMonitor mon(true);
+        CPPUNIT_ASSERT(mon.m_ByteLimitHigh > 0);
+        CPPUNIT_ASSERT_EQUAL((49 * mon.m_ByteLimitHigh) / 50, mon.m_ByteLimitLow);
+        CPPUNIT_ASSERT(mon.m_ByteLimitHigh > mon.m_ByteLimitLow);
+        CPPUNIT_ASSERT(mon.m_AllowAllocations);
+        LOG_DEBUG(<< "Resource limit is: " << mon.m_ByteLimitHigh);
+        if (sizeof(std::size_t) == 4) {
+            // 32-bit platform
+            CPPUNIT_ASSERT_EQUAL(std::size_t(1024ull * 1024 * 1024 / 2), mon.m_ByteLimitHigh);
+        } else if (sizeof(std::size_t) == 8) {
+            // 64-bit platform
+            CPPUNIT_ASSERT_EQUAL(std::size_t(4096ull * 1024 * 1024), mon.m_ByteLimitHigh);
+        } else {
+            // Unexpected platform
+            CPPUNIT_ASSERT(false);
+        }
+    }
+    {
         // Test size constructor
         CResourceMonitor mon;
         mon.memoryLimit(543);
@@ -123,7 +142,7 @@ void CResourceMonitorTest::testMonitor() {
     }
     {
         // Check that High limit can be breached and then gone back
-        CResourceMonitor mon(1.0);
+        CResourceMonitor mon(false, 1.0);
         CPPUNIT_ASSERT(mem > 5); // This SHOULD be OK
 
         // Let's go above the low but below the high limit
@@ -309,7 +328,7 @@ void CResourceMonitorTest::testPruning() {
 
     CAnomalyDetectorModelConfig modelConfig =
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
-    CLimits limits(1.0);
+    CLimits limits(false, 1.0);
 
     CSearchKey key(1, // identifier
                    function_t::E_IndividualMetric, false, model_t::E_XF_None,

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -71,10 +71,7 @@ void CResourceMonitorTest::testMonitor() {
         CPPUNIT_ASSERT(mon.m_ByteLimitHigh > mon.m_ByteLimitLow);
         CPPUNIT_ASSERT(mon.m_AllowAllocations);
         LOG_DEBUG(<< "Resource limit is: " << mon.m_ByteLimitHigh);
-        if (sizeof(std::size_t) == 4) {
-            // 32-bit platform
-            CPPUNIT_ASSERT_EQUAL(std::size_t(1024ull * 1024 * 1024 / 2), mon.m_ByteLimitHigh);
-        } else if (sizeof(std::size_t) == 8) {
+        if (sizeof(std::size_t) == 8) {
             // 64-bit platform
             CPPUNIT_ASSERT_EQUAL(std::size_t(4096ull * 1024 * 1024 / 2), mon.m_ByteLimitHigh);
         } else {
@@ -90,10 +87,7 @@ void CResourceMonitorTest::testMonitor() {
         CPPUNIT_ASSERT(mon.m_ByteLimitHigh > mon.m_ByteLimitLow);
         CPPUNIT_ASSERT(mon.m_AllowAllocations);
         LOG_DEBUG(<< "Resource limit is: " << mon.m_ByteLimitHigh);
-        if (sizeof(std::size_t) == 4) {
-            // 32-bit platform
-            CPPUNIT_ASSERT_EQUAL(std::size_t(1024ull * 1024 * 1024 / 2), mon.m_ByteLimitHigh);
-        } else if (sizeof(std::size_t) == 8) {
+        if (sizeof(std::size_t) == 8) {
             // 64-bit platform
             CPPUNIT_ASSERT_EQUAL(std::size_t(4096ull * 1024 * 1024), mon.m_ByteLimitHigh);
         } else {

--- a/lib/model/unittest/CSampleQueueTest.h
+++ b/lib/model/unittest/CSampleQueueTest.h
@@ -8,7 +8,7 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
-#include "../../../include/model/CSampleQueue.h"
+#include <model/CSampleQueue.h>
 
 class CSampleQueueTest : public CppUnit::TestFixture {
 public:


### PR DESCRIPTION
Added command line option to both `autodetect` and `categorizer`
indicating that persistence should be performed in the foreground.
Default behaviour remains to perform persistence in a background thread.

Foreground persistence has the advantage that it does not require data
to be copied and hence the memory requirements are half that of background
persistence. This is accounted for in the resource manager.

Relates to elastic/elasticsearch#29770