### PR TITLE
[7.4][ML] Add option to persist in foreground (#550)

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -196,6 +196,7 @@ The use of the words SHOULD, MUST etc., comply with RFC 2119.
 1.  Lambdas SHOULD be used in preference to any form of `bind`
 1.  Default lambda capture modes SHOULD be avoided
 1.  The `override` keyword SHOULD be used consistently within a source file
+1.  The `virtual` keyword SHOULD NOT be used in conjunction with `override`
 1.  Type aliases MUST be used in preference to typedefs - use `using` to create a type alias not `typedef`
 1.  Rvalue references SHOULD only be used in the following cases
     1.  For implementing move semantics

--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -48,6 +48,7 @@ bool CCmdLineParser::parse(int argc,
                            bool& isRestoreFileNamedPipe,
                            std::string& persistFileName,
                            bool& isPersistFileNamedPipe,
+                           bool& isPersistInForeground,
                            size_t& maxAnomalyRecords,
                            bool& memoryUsage,
                            bool& multivariateByFields,
@@ -104,6 +105,7 @@ bool CCmdLineParser::parse(int argc,
             ("persistIsPipe", "Specified persist file is a named pipe")
             ("persistInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically persist model state - if not specified then models will only be persisted at program exit")
+            ("persistInForeground", "Persistence occurs in the foreground. Defaults to background persistence.")
             ("maxQuantileInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically output quantiles if they have not been output due to an anomaly - if not specified then quantiles will only be output following a big anomaly")
             ("maxAnomalyRecords", boost::program_options::value<size_t>(),
@@ -212,6 +214,9 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("persistIsPipe") > 0) {
             isPersistFileNamedPipe = true;
+        }
+        if (vm.count("persistInForeground") > 0) {
+            isPersistInForeground = true;
         }
         if (vm.count("maxAnomalyRecords") > 0) {
             maxAnomalyRecords = vm["maxAnomalyRecords"].as<size_t>();

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -60,6 +60,7 @@ public:
                       bool& isRestoreFileNamedPipe,
                       std::string& persistFileName,
                       bool& isPersistFileNamedPipe,
+                      bool& isPersistInForeground,
                       size_t& maxAnomalyRecords,
                       bool& memoryUsage,
                       bool& multivariateByFields,

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -28,7 +28,6 @@
 #include <model/ModelTypes.h>
 
 #include <api/CAnomalyJob.h>
-#include <api/CBackgroundPersister.h>
 #include <api/CCmdSkeleton.h>
 #include <api/CCsvInputParser.h>
 #include <api/CFieldConfig.h>
@@ -38,6 +37,7 @@
 #include <api/CLengthEncodedInputParser.h>
 #include <api/CModelSnapshotJsonWriter.h>
 #include <api/COutputChainer.h>
+#include <api/CPersistenceManager.h>
 #include <api/CSingleStreamDataAdder.h>
 #include <api/CSingleStreamSearcher.h>
 #include <api/CStateRestoreStreamFilter.h>
@@ -108,6 +108,7 @@ int main(int argc, char** argv) {
     bool isRestoreFileNamedPipe(false);
     std::string persistFileName;
     bool isPersistFileNamedPipe(false);
+    bool isPersistInForeground(false);
     size_t maxAnomalyRecords(100u);
     bool memoryUsage(false);
     bool multivariateByFields(false);
@@ -118,8 +119,8 @@ int main(int argc, char** argv) {
             summaryCountFieldName, delimiter, lengthEncodedInput, timeField,
             timeFormat, quantilesStateFile, deleteStateFiles, persistInterval,
             maxQuantileInterval, inputFileName, isInputFileNamedPipe, outputFileName,
-            isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe,
-            persistFileName, isPersistFileNamedPipe, maxAnomalyRecords,
+            isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe, persistFileName,
+            isPersistFileNamedPipe, isPersistInForeground, maxAnomalyRecords,
             memoryUsage, multivariateByFields, clauseTokens) == false) {
         return EXIT_FAILURE;
     }
@@ -154,7 +155,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    ml::model::CLimits limits;
+    ml::model::CLimits limits(isPersistInForeground);
     if (!limitConfigFile.empty() && limits.init(limitConfigFile) == false) {
         LOG_FATAL(<< "Ml limit config file '" << limitConfigFile << "' could not be loaded");
         return EXIT_FAILURE;
@@ -215,13 +216,15 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    using TBackgroundPersisterUPtr = std::unique_ptr<ml::api::CBackgroundPersister>;
-    const TBackgroundPersisterUPtr periodicPersister{[persistInterval, &persister]() -> TBackgroundPersisterUPtr {
-        if (persistInterval >= 0) {
-            return std::make_unique<ml::api::CBackgroundPersister>(persistInterval, *persister);
-        }
-        return nullptr;
-    }()};
+    using TPersistenceManagerUPtr = std::unique_ptr<ml::api::CPersistenceManager>;
+    const TPersistenceManagerUPtr periodicPersister{
+        [persistInterval, isPersistInForeground, &persister]() -> TPersistenceManagerUPtr {
+            if (persistInterval >= 0) {
+                return std::make_unique<ml::api::CPersistenceManager>(
+                    persistInterval, isPersistInForeground, *persister);
+            }
+            return nullptr;
+        }()};
 
     using InputParserCUPtr = std::unique_ptr<ml::api::CInputParser>;
     const InputParserCUPtr inputParser{[lengthEncodedInput, &ioMgr, delimiter]() -> InputParserCUPtr {
@@ -273,9 +276,11 @@ int main(int argc, char** argv) {
     }
 
     if (periodicPersister != nullptr) {
-        periodicPersister->firstProcessorPeriodicPersistFunc(
-            std::bind(&ml::api::CDataProcessor::periodicPersistState,
-                      firstProcessor, std::placeholders::_1));
+        periodicPersister->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
+            &ml::api::CDataProcessor::periodicPersistStateInBackground, firstProcessor));
+
+        periodicPersister->firstProcessorForegroundPeriodicPersistFunc(std::bind(
+            &ml::api::CDataProcessor::periodicPersistStateInForeground, firstProcessor));
     }
 
     // The skeleton avoids the need to duplicate a lot of boilerplate code

--- a/bin/categorize/CCmdLineParser.cc
+++ b/bin/categorize/CCmdLineParser.cc
@@ -34,6 +34,7 @@ bool CCmdLineParser::parse(int argc,
                            bool& isRestoreFileNamedPipe,
                            std::string& persistFileName,
                            bool& isPersistFileNamedPipe,
+                           bool& isPersistInForeground,
                            std::string& categorizationFieldName) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
@@ -67,6 +68,7 @@ bool CCmdLineParser::parse(int argc,
             ("persistIsPipe", "Specified persist file is a named pipe")
             ("persistInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically persist model state - if not specified then models will only be persisted at program exit")
+            ("persistInForeground", "Persistence occurs in the foreground. Defaults to background persistence.")
             ("categorizationfield", boost::program_options::value<std::string>(),
                         "Field to compute mlcategory from")
         ;
@@ -129,6 +131,9 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("persistIsPipe") > 0) {
             isPersistFileNamedPipe = true;
+        }
+        if (vm.count("persistInForeground") > 0) {
+            isPersistInForeground = true;
         }
         if (vm.count("categorizationfield") > 0) {
             categorizationFieldName = vm["categorizationfield"].as<std::string>();

--- a/bin/categorize/CCmdLineParser.h
+++ b/bin/categorize/CCmdLineParser.h
@@ -45,6 +45,7 @@ public:
                       bool& isRestoreFileNamedPipe,
                       std::string& persistFileName,
                       bool& isPersistFileNamedPipe,
+                      bool& isPersistInForeground,
                       std::string& categorizationFieldName);
 
 private:

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 
-class CBackgroundPersisterTest;
+class CPersistenceManagerTest;
 class CAnomalyJobTest;
 
 namespace ml {
@@ -50,7 +50,7 @@ class CHierarchicalResults;
 class CLimits;
 }
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 class CModelPlotDataJsonWriter;
 class CFieldConfig;
 
@@ -148,42 +148,42 @@ public:
                 model::CAnomalyDetectorModelConfig& modelConfig,
                 core::CJsonOutputStreamWrapper& outputBuffer,
                 const TPersistCompleteFunc& persistCompleteFunc = TPersistCompleteFunc(),
-                CBackgroundPersister* periodicPersister = nullptr,
+                CPersistenceManager* periodicPersister = nullptr,
                 core_t::TTime maxQuantileInterval = -1,
                 const std::string& timeFieldName = DEFAULT_TIME_FIELD_NAME,
                 const std::string& timeFieldFormat = EMPTY_STRING,
                 size_t maxAnomalyRecords = 0u);
 
-    virtual ~CAnomalyJob();
+    ~CAnomalyJob() override;
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream();
+    void newOutputStream() override;
 
     //! Access the output handler
-    virtual COutputHandler& outputHandler();
+    COutputHandler& outputHandler() override;
 
     //! Receive a single record to be processed, and produce output
     //! with any required modifications
-    virtual bool handleRecord(const TStrStrUMap& dataRowFields);
+    bool handleRecord(const TStrStrUMap& dataRowFields) override;
 
     //! Perform any final processing once all input data has been seen.
-    virtual void finalise();
+    void finalise() override;
 
     //! Restore previously saved state
-    virtual bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime);
+    bool restoreState(core::CDataSearcher& restoreSearcher,
+                      core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
 
     //! Initialise normalizer from quantiles state
     virtual bool initNormalizer(const std::string& quantilesStateFile);
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const;
+    uint64_t numRecordsHandled() const override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Log a list of the detectors and keys
     void description() const;
@@ -243,26 +243,30 @@ private:
                               core::CStateRestoreTraverser& traverser);
 
     //! Persist current state in the background
-    bool backgroundPersistState(CBackgroundPersister& backgroundPersister);
+    bool backgroundPersistState();
 
     //! This is the function that is called in a different thread to the
     //! main processing when background persistence is triggered.
     bool runBackgroundPersist(TBackgroundPersistArgsPtr args, core::CDataAdder& persister);
 
+    //! This function is called from the persistence manager when foreground persistence is triggered
+    bool runForegroundPersist(core::CDataAdder& persister);
+
     //! Persist the detectors to a stream.
-    bool persistState(const std::string& descriptionPrefix,
-                      core_t::TTime time,
-                      const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
-                      const model::CResourceMonitor::SResults& modelSizeStats,
-                      const model::CInterimBucketCorrector& interimBucketCorrector,
-                      const model::CHierarchicalResultsAggregator& aggregator,
-                      const std::string& normalizerState,
-                      core_t::TTime latestRecordTime,
-                      core_t::TTime lastResultsTime,
-                      core::CDataAdder& persister);
+    bool persistCopiedState(const std::string& descriptionPrefix,
+                            core_t::TTime time,
+                            const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
+                            const model::CResourceMonitor::SResults& modelSizeStats,
+                            const model::CInterimBucketCorrector& interimBucketCorrector,
+                            const model::CHierarchicalResultsAggregator& aggregator,
+                            const std::string& normalizerState,
+                            core_t::TTime latestRecordTime,
+                            core_t::TTime lastResultsTime,
+                            core::CDataAdder& persister);
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    bool periodicPersistStateInBackground() override;
+    bool periodicPersistStateInForeground() override;
 
     //! Acknowledge a flush request
     void acknowledgeFlush(const std::string& flushId);
@@ -429,7 +433,7 @@ private:
     //! Pointer to periodic persister that works in the background.  May be
     //! nullptr if this object is not responsible for starting periodic
     //! persistence.
-    CBackgroundPersister* m_PeriodicPersister;
+    CPersistenceManager* m_PeriodicPersister;
 
     //! If we haven't output quantiles for this long due to a big anomaly
     //! we'll output them to reflect decay.  Non-positive values mean never.
@@ -460,7 +464,7 @@ private:
     //! Flag indicating whether or not time has been advanced.
     bool m_TimeAdvanced{false};
 
-    friend class ::CBackgroundPersisterTest;
+    friend class ::CPersistenceManagerTest;
     friend class ::CAnomalyJobTest;
 };
 }

--- a/include/api/CDataProcessor.h
+++ b/include/api/CDataProcessor.h
@@ -25,7 +25,7 @@ class CDataSearcher;
 }
 
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 class COutputHandler;
 
 //! \brief
@@ -71,10 +71,14 @@ public:
                               core_t::TTime& completeToTime) = 0;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister) = 0;
+    virtual bool persistState(core::CDataAdder& persister,
+                              const std::string& descriptionPrefix) = 0;
 
-    //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    //! Persist current state in the background due to the periodic persistence being triggered.
+    virtual bool periodicPersistStateInBackground();
+
+    //! Persist current state in the foreground due to the periodic persistence being triggered.
+    virtual bool periodicPersistStateInForeground();
 
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const = 0;

--- a/include/api/CFieldDataTyper.h
+++ b/include/api/CFieldDataTyper.h
@@ -31,10 +31,10 @@ namespace model {
 class CLimits;
 }
 namespace api {
-class CBackgroundPersister;
 class CFieldConfig;
 class CJsonOutputWriter;
 class COutputHandler;
+class CPersistenceManager;
 
 //! \brief
 //! Assign categorisation fields to input records
@@ -80,38 +80,39 @@ public:
                     const model::CLimits& limits,
                     COutputHandler& outputHandler,
                     CJsonOutputWriter& jsonOutputWriter,
-                    CBackgroundPersister* periodicPersister = nullptr);
+                    CPersistenceManager* periodicPersister = nullptr);
 
-    virtual ~CFieldDataTyper();
+    ~CFieldDataTyper() override;
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream();
+    void newOutputStream() override;
 
     //! Receive a single record to be typed, and output that record to
     //! STDOUT with its type field added
-    virtual bool handleRecord(const TStrStrUMap& dataRowFields);
+    bool handleRecord(const TStrStrUMap& dataRowFields) override;
 
     //! Perform any final processing once all input data has been seen.
-    virtual void finalise();
+    void finalise() override;
 
     //! Restore previously saved state
-    virtual bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime);
+    bool restoreState(core::CDataSearcher& restoreSearcher,
+                      core_t::TTime& completeToTime) override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    bool periodicPersistStateInBackground() override;
+    bool periodicPersistStateInForeground() override;
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const;
+    uint64_t numRecordsHandled() const override;
 
     //! Access the output handler
-    virtual COutputHandler& outputHandler();
+    COutputHandler& outputHandler() override;
 
 private:
     //! Create the typer to operate on the categorization field
@@ -199,7 +200,7 @@ private:
     //! Pointer to periodic persister that works in the background.  May be
     //! nullptr if this object is not responsible for starting periodic
     //! persistence.
-    CBackgroundPersister* m_PeriodicPersister;
+    CPersistenceManager* m_PeriodicPersister;
 };
 }
 }

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -18,7 +18,7 @@ class CDataAdder;
 class CDataSearcher;
 }
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 class CDataProcessor;
 
 //! \brief
@@ -41,14 +41,14 @@ public:
     COutputChainer(CDataProcessor& dataProcessor);
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream();
+    void newOutputStream() override;
 
     // Bring the other overload of fieldNames() into scope
     using COutputHandler::fieldNames;
 
     //! Set field names, adding extra field names if they're not already
     //! present - this is only allowed once
-    virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames);
+    bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
     // Bring the other overload of writeRow() into scope
     using COutputHandler::writeRow;
@@ -57,32 +57,32 @@ public:
     //! values, optionally overriding some of the original field values.
     //! Where the same field is present in both overrideDataRowFields and
     //! dataRowFields, the value in overrideDataRowFields will be written.
-    virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields);
+    bool writeRow(const TStrStrUMap& dataRowFields,
+                  const TStrStrUMap& overrideDataRowFields) override;
 
     //! Perform any final processing once all data for the current search
     //! has been seen.  Chained classes should NOT rely on this method being
     //! called - they should do the best they can on the assumption that
     //! this method will not be called, but may be able to improve their
     //! output if this method is called.
-    virtual void finalise();
+    void finalise() override;
 
     //! Restore previously saved state
-    virtual bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime);
+    bool restoreState(core::CDataSearcher& restoreSearcher,
+                      core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    bool periodicPersistStateInBackground() override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! The chainer does consume control messages, because it passes them on
     //! to whatever processor it's chained to.
-    virtual bool consumesControlMessages();
+    bool consumesControlMessages() override;
 
 private:
     //! The function that will be called for every record output via this

--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -25,7 +25,7 @@ class CDataAdder;
 class CDataSearcher;
 }
 namespace api {
-class CBackgroundPersister;
+class CPersistenceManager;
 
 //! \brief
 //! Interface for CDataProcessor output
@@ -86,10 +86,10 @@ public:
                               core_t::TTime& completeToTime);
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister);
+    virtual bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix);
 
     //! Persist current state due to the periodic persistence being triggered.
-    virtual bool periodicPersistState(CBackgroundPersister& persister);
+    virtual bool periodicPersistStateInBackground();
 
     //! Is persistence needed?
     virtual bool isPersistenceNeeded(const std::string& description) const;

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -3,8 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-#ifndef INCLUDED_ml_api_CBackgroundPersister_h
-#define INCLUDED_ml_api_CBackgroundPersister_h
+#ifndef INCLUDED_ml_api_CPersistenceManager_h
+#define INCLUDED_ml_api_CPersistenceManager_h
 
 #include <core/CDataAdder.h>
 #include <core/CFastMutex.h>
@@ -18,13 +18,14 @@
 #include <functional>
 #include <list>
 
-class CBackgroundPersisterTest;
+class CPersistenceManagerTest;
 
 namespace ml {
 namespace api {
 
 //! \brief
-//! Enables a data adder to run in a different thread.
+//! Manages the details of persisting data where the data adder may
+//! optionally run in a different thread.
 //!
 //! DESCRIPTION:\n
 //! A wrapper around core::CThread to hide the gory details of
@@ -36,11 +37,11 @@ namespace api {
 //! are that a lot of memory is being used by the temporary
 //! copy of the data to be persisted.
 //!
-//! Persistence happens in a background thread and further
-//! persistence requests via the startBackgroundPersist*() methods
+//! Persistence may happen in a background thread and if so further
+//! persistence requests via the startPersist*() methods
 //! will be rejected if the background thread is executing.
-//! However, calls to startBackgroundPersist() and
-//! startBackgroundPersistIfAppropriate() are not thread safe and
+//! However, calls to startPersist() and
+//! startPersistIfAppropriate() are not thread safe and
 //! must not be made concurrently.
 //!
 //! IMPLEMENTATION DECISIONS:\n
@@ -52,32 +53,36 @@ namespace api {
 //! thread.  However, note that a couple of copies are made, so
 //! if the bound data is very large then binding a
 //! std::shared_ptr may be more appropriate than binding
-//! values.
+//! values. Alternatively, if foreground persistence is preferred,
+//! the data is not required to be copied and the bound function can
+//! safely be passed its arguments by reference.
 //!
 //! A data adder must be supplied to the constructor, and, since
 //! this is held by reference it must outlive this object.  If
 //! the data adder is not thread safe then it may not be used by
 //! any other object until after this object is destroyed.
 //!
-class API_EXPORT CBackgroundPersister : private core::CNonCopyable {
+class API_EXPORT CPersistenceManager : private core::CNonCopyable {
 public:
-    using TFirstProcessorPeriodicPersistFunc = std::function<bool(CBackgroundPersister&)>;
+    using TFirstProcessorPeriodicPersistFunc = std::function<bool(CPersistenceManager&)>;
 
 public:
-    //! The supplied data adder must outlive this object.  If the data
-    //! adder is not thread safe then it may not be used by any other
+    //! The supplied data adders must outlive this object.  If the data
+    //! adders are not thread safe then they may not be used by any other
     //! object until after this object is destroyed.  When using this
     //! constructor the first processor persistence function must be
     //! set before the object is used.
-    CBackgroundPersister(core_t::TTime periodicPersistInterval, core::CDataAdder& dataAdder);
+    CPersistenceManager(core_t::TTime periodicPersistInterval,
+                        bool persistInForeground,
+                        core::CDataAdder& bgDataAdder,
+                        core::CDataAdder& fgDataAdder);
 
-    //! As above, but also supply the first processor persistence
-    //! function at construction time.
-    CBackgroundPersister(core_t::TTime periodicPersistInterval,
-                         const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc,
-                         core::CDataAdder& dataAdder);
+    //! As above, but using the same data adder for both foreground and background persistence.
+    CPersistenceManager(core_t::TTime periodicPersistInterval,
+                        bool persistInForeground,
+                        core::CDataAdder& dataAdder);
 
-    ~CBackgroundPersister();
+    ~CPersistenceManager();
 
     //! Is background persistence currently in progress?
     bool isBusy() const;
@@ -86,7 +91,13 @@ public:
     //! complete
     bool waitForIdle();
 
-    //! Add a function to be called when the background persist is started.
+    //! Configure persistence to be performed in the background
+    void useBackgroundPersistence();
+
+    //! Configure persistence to be performed in the foreground
+    void useForegroundPersistence();
+
+    //! Add a function to be called when persistence is started.
     //! This will be rejected if a background persistence is currently in
     //! progress.  It is likely that the supplied \p persistFunc will have
     //! data bound into it that will be used by the function it calls, i.e. the
@@ -99,24 +110,28 @@ public:
     //! background persistence is currently in progress.
     //! This should be set once before startBackgroundPersistIfAppropriate is
     //! called.
-    bool firstProcessorPeriodicPersistFunc(const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
+    bool firstProcessorBackgroundPeriodicPersistFunc(
+        const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
 
-    //! Start a background persist is one is not running.
-    //! Calls the first processor periodic persist function first.
-    //! Concurrent calls to this method are not threadsafe.
-    bool startBackgroundPersist();
+    bool firstProcessorForegroundPeriodicPersistFunc(
+        const TFirstProcessorPeriodicPersistFunc& firstProcessorPeriodicPersistFunc);
 
     //! If the periodic persist interval has passed since the last persist
     //! then it is appropriate to persist now.  Start it by calling the
     //! first processor periodic persist function.
     //! Concurrent calls to this method are not threadsafe.
-    bool startBackgroundPersistIfAppropriate();
+    bool startPersistIfAppropriate();
+
+    //! Start a persist if a background one is not running.
+    //! Calls the first processor periodic persist function first.
+    //! Concurrent calls to this method are not threadsafe.
+    bool startPersist(core_t::TTime timeOfPersistence);
 
 private:
     //! Implementation of the background thread
     class CBackgroundThread : public core::CThread {
     public:
-        CBackgroundThread(CBackgroundPersister& owner);
+        CBackgroundThread(CPersistenceManager& owner);
 
     protected:
         //! Inherited virtual interface
@@ -125,17 +140,16 @@ private:
 
     private:
         //! Reference to the owning background persister
-        CBackgroundPersister& m_Owner;
+        CPersistenceManager& m_Owner;
     };
 
 private:
-    //! Persist in the background setting the last persist time
-    //! to timeOfPersistence
-    bool startBackgroundPersist(core_t::TTime timeOfPersistence);
-
     //! When this function is called a background persistence will be
     //! triggered unless there is already one in progress.
-    bool startPersist();
+    bool startPersistInBackground();
+
+    //! Execute the registered persistence functions now
+    void startPersist();
 
     //! Clear any persistence functions that have been added but not yet
     //! invoked.  This will be rejected if a background persistence is
@@ -144,22 +158,30 @@ private:
     bool clear();
 
 private:
-    //! How frequently should background persistence be attempted?
+    //! How frequently should persistence be attempted?
     core_t::TTime m_PeriodicPersistInterval;
+
+    //! Should persistence occur in the foreground?
+    bool m_PersistInForeground;
 
     //! What was the wall clock time when we started our last periodic
     //! persistence?
     core_t::TTime m_LastPeriodicPersistTime;
 
-    //! The function that will be called to start the chain of background
+    //! The function that will be called to start the chain of
     //! persistence.
-    TFirstProcessorPeriodicPersistFunc m_FirstProcessorPeriodicPersistFunc;
+    TFirstProcessorPeriodicPersistFunc m_FirstProcessorBackgroundPeriodicPersistFunc;
+    TFirstProcessorPeriodicPersistFunc m_FirstProcessorForegroundPeriodicPersistFunc;
 
     //! Reference to the data adder to be used by the background thread.
-    //! The data adder refered to must outlive this object.  If the data
+    //! The data adder referred to must outlive this object. If the data
     //! adder is not thread safe then it may not be used by any other
     //! object until after this object is destroyed.
-    core::CDataAdder& m_DataAdder;
+    core::CDataAdder& m_BgDataAdder;
+
+    //! Reference to the data adder to be used for foreground persistence.
+    //! The data adder referred to must outlive this object.
+    core::CDataAdder& m_FgDataAdder;
 
     //! Mutex to ensure atomicity of operations where required.
     core::CFastMutex m_Mutex;
@@ -172,7 +194,7 @@ private:
 
     using TPersistFuncList = std::list<core::CDataAdder::TPersistFunc>;
 
-    //! Function to call in the background thread to do persistence.
+    //! Functions to call to do persistence.
     TPersistFuncList m_PersistFuncs;
 
     //! Thread used to do the background work
@@ -183,9 +205,9 @@ private:
     friend class CBackgroundThread;
 
     // For testing
-    friend class ::CBackgroundPersisterTest;
+    friend class ::CPersistenceManagerTest;
 };
 }
 }
 
-#endif // INCLUDED_ml_api_CBackgroundPersister_h
+#endif // INCLUDED_ml_api_CPersistenceManager_h

--- a/include/config/CAutoconfigurer.h
+++ b/include/config/CAutoconfigurer.h
@@ -54,7 +54,7 @@ public:
                               core_t::TTime& completeToTime);
 
     //! No-op.
-    virtual bool persistState(core::CDataAdder& persister);
+    virtual bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix);
 
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const;

--- a/include/model/CLimits.h
+++ b/include/model/CLimits.h
@@ -64,7 +64,8 @@ public:
 
 public:
     //! Default constructor
-    explicit CLimits(double byteLimitMargin = CResourceMonitor::DEFAULT_BYTE_LIMIT_MARGIN);
+    explicit CLimits(bool persistenceInForeground = false,
+                     double byteLimitMargin = CResourceMonitor::DEFAULT_BYTE_LIMIT_MARGIN);
 
     //! Initialise from a config file.  This overwrites current settings
     //! with any found in the config file.  Settings that are not present

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -62,7 +62,8 @@ public:
 
 public:
     //! Default constructor
-    explicit CResourceMonitor(double byteLimitMargin = DEFAULT_BYTE_LIMIT_MARGIN);
+    explicit CResourceMonitor(bool persistenceInForeground = false,
+                              double byteLimitMargin = DEFAULT_BYTE_LIMIT_MARGIN);
 
     //! Query the resource monitor to find out if the models are
     //! taking up too much memory and further allocations should be banned
@@ -168,6 +169,9 @@ private:
     //! of background persistence.
     std::size_t adjustedUsage(std::size_t usage) const;
 
+    //! Returns the amount by which reported memory usage is scaled depending on the type of persistence in use
+    std::size_t persistenceMemoryIncreaseFactor() const;
+
 private:
     //! The registered collection of components
     TDetectorPtrSizeUMap m_Detectors;
@@ -232,6 +236,9 @@ private:
 
     //! The number of bytes over the high limit for memory usage at the last allocation failure
     std::size_t m_CurrentBytesExceeded;
+
+    //! Is persistence occurring in the foreground?
+    bool m_PersistenceInForeground;
 
     //! Test friends
     friend class ::CResourceMonitorTest;

--- a/lib/api/CCmdSkeleton.cc
+++ b/lib/api/CCmdSkeleton.cc
@@ -61,7 +61,7 @@ bool CCmdSkeleton::persistState() {
     }
 
     // Attempt to persist state
-    if (m_Processor.persistState(*m_Persister) == false) {
+    if (m_Processor.persistState(*m_Persister, "State persisted due to job close at ") == false) {
         LOG_FATAL(<< "Failed to persist state");
         return false;
     }

--- a/lib/api/CDataProcessor.cc
+++ b/lib/api/CDataProcessor.cc
@@ -49,7 +49,12 @@ std::string CDataProcessor::debugPrintRecord(const TStrStrUMap& dataRowFields) {
     return result.str();
 }
 
-bool CDataProcessor::periodicPersistState(CBackgroundPersister& /*persister*/) {
+bool CDataProcessor::periodicPersistStateInBackground() {
+    // No-op
+    return true;
+}
+
+bool CDataProcessor::periodicPersistStateInForeground() {
     // No-op
     return true;
 }

--- a/lib/api/COutputChainer.cc
+++ b/lib/api/COutputChainer.cc
@@ -107,12 +107,13 @@ bool COutputChainer::restoreState(core::CDataSearcher& restoreSearcher,
     return m_DataProcessor.restoreState(restoreSearcher, completeToTime);
 }
 
-bool COutputChainer::persistState(core::CDataAdder& persister) {
-    return m_DataProcessor.persistState(persister);
+bool COutputChainer::persistState(core::CDataAdder& persister,
+                                  const std::string& descriptionPrefix) {
+    return m_DataProcessor.persistState(persister, descriptionPrefix);
 }
 
-bool COutputChainer::periodicPersistState(CBackgroundPersister& persister) {
-    return m_DataProcessor.periodicPersistState(persister);
+bool COutputChainer::periodicPersistStateInBackground() {
+    return m_DataProcessor.periodicPersistStateInBackground();
 }
 
 bool COutputChainer::isPersistenceNeeded(const std::string& description) const {

--- a/lib/api/COutputHandler.cc
+++ b/lib/api/COutputHandler.cc
@@ -36,12 +36,13 @@ bool COutputHandler::restoreState(core::CDataSearcher& /* restoreSearcher */,
     return true;
 }
 
-bool COutputHandler::persistState(core::CDataAdder& /* persister */) {
+bool COutputHandler::persistState(core::CDataAdder& /* persister */,
+                                  const std::string& /*descriptionPrefix*/) {
     // NOOP unless overridden
     return true;
 }
 
-bool COutputHandler::periodicPersistState(CBackgroundPersister& /* persister */) {
+bool COutputHandler::periodicPersistStateInBackground() {
     // NOOP unless overridden
     return true;
 }

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -18,7 +18,6 @@ all: build
 
 SRCS= \
 CAnomalyJob.cc \
-CBackgroundPersister.cc \
 CBaseTokenListDataTyper.cc \
 CBenchMarker.cc \
 CCategoryExamplesCollector.cc \
@@ -52,6 +51,7 @@ CNdJsonOutputWriter.cc \
 CNullOutput.cc \
 COutputChainer.cc \
 COutputHandler.cc \
+CPersistenceManager.cc \
 CResultNormalizer.cc \
 CSingleStreamDataAdder.cc \
 CSingleStreamSearcher.cc \

--- a/lib/api/dump_state/Main.cc
+++ b/lib/api/dump_state/Main.cc
@@ -124,7 +124,7 @@ bool writeNormalizerState(const std::string& outputFileName) {
 }
 
 bool persistCategorizerStateToFile(const std::string& outputFileName) {
-    ml::model::CLimits limits;
+    ml::model::CLimits limits(true);
     ml::api::CFieldConfig config("count", "mlcategory");
 
     std::ofstream outStream(ml::core::COsFileFuncs::NULL_FILENAME);
@@ -149,7 +149,7 @@ bool persistCategorizerStateToFile(const std::string& outputFileName) {
         }
 
         ml::api::CSingleStreamDataAdder persister(ptr);
-        if (!typer.persistState(persister)) {
+        if (!typer.persistState(persister, "State persisted due to job close at ")) {
             LOG_ERROR(<< "Error persisting state to " << outputFileName);
             return false;
         }
@@ -174,7 +174,7 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
 
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-    ml::model::CLimits limits;
+    ml::model::CLimits limits(true);
     ml::api::CFieldConfig fieldConfig;
     if (!fieldConfig.initFromFile(configFileName)) {
         LOG_ERROR(<< "Failed to init field config from " << configFileName);
@@ -215,7 +215,7 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
         }
 
         ml::api::CSingleStreamDataAdder persister(ptr);
-        if (!origJob.persistState(persister)) {
+        if (!origJob.persistState(persister, "State persisted due to job close at ")) {
             LOG_ERROR(<< "Error persisting state to " << outputFileName);
             return false;
         }

--- a/lib/api/unittest/CFieldDataTyperTest.cc
+++ b/lib/api/unittest/CFieldDataTyperTest.cc
@@ -153,7 +153,7 @@ void CFieldDataTyperTest::testAll() {
     std::string origJson;
     {
         CTestDataAdder adder;
-        typer.persistState(adder);
+        typer.persistState(adder, "");
         std::ostringstream& ss = dynamic_cast<std::ostringstream&>(*adder.getStream());
         origJson = ss.str();
     }
@@ -174,7 +174,7 @@ void CFieldDataTyperTest::testAll() {
         newTyper.restoreState(restorer, time);
 
         CTestDataAdder adder;
-        newTyper.persistState(adder);
+        newTyper.persistState(adder, "");
         std::ostringstream& ss = dynamic_cast<std::ostringstream&>(*adder.getStream());
         newJson = ss.str();
     }

--- a/lib/api/unittest/CMockDataProcessor.cc
+++ b/lib/api/unittest/CMockDataProcessor.cc
@@ -66,9 +66,10 @@ bool CMockDataProcessor::restoreState(ml::core::CDataSearcher& restoreSearcher,
     return true;
 }
 
-bool CMockDataProcessor::persistState(ml::core::CDataAdder& persister) {
+bool CMockDataProcessor::persistState(ml::core::CDataAdder& persister,
+                                      const std::string& descriptionPrefix) {
     // Pass on the request in case we're chained
-    if (m_OutputHandler.persistState(persister) == false) {
+    if (m_OutputHandler.persistState(persister, descriptionPrefix) == false) {
         return false;
     }
 

--- a/lib/api/unittest/CMockDataProcessor.h
+++ b/lib/api/unittest/CMockDataProcessor.h
@@ -47,7 +47,8 @@ public:
                               ml::core_t::TTime& completeToTime);
 
     //! Persist current state
-    virtual bool persistState(ml::core::CDataAdder& persister);
+    virtual bool persistState(ml::core::CDataAdder& persister,
+                              const std::string& descriptionPrefix);
 
     //! How many records did we handle?
     virtual uint64_t numRecordsHandled() const;

--- a/lib/api/unittest/CMultiFileDataAdderTest.cc
+++ b/lib/api/unittest/CMultiFileDataAdderTest.cc
@@ -208,7 +208,7 @@ void CMultiFileDataAdderTest::detectorPersistHelper(const std::string& configFil
         CPPUNIT_ASSERT_NO_THROW(boost::filesystem::remove_all(origDir));
 
         ml::test::CMultiFileDataAdder persister(baseOrigOutputFilename);
-        CPPUNIT_ASSERT(origJob.persistState(persister));
+        CPPUNIT_ASSERT(origJob.persistState(persister, ""));
     }
 
     std::string origBaseDocId(JOB_ID + '_' + ml::api::CAnomalyJob::STATE_TYPE +
@@ -263,7 +263,7 @@ void CMultiFileDataAdderTest::detectorPersistHelper(const std::string& configFil
         CPPUNIT_ASSERT_NO_THROW(boost::filesystem::remove_all(restoredDir));
 
         ml::test::CMultiFileDataAdder persister(baseRestoredOutputFilename);
-        CPPUNIT_ASSERT(restoredJob.persistState(persister));
+        CPPUNIT_ASSERT(restoredJob.persistState(persister, ""));
     }
 
     std::string restoredBaseDocId(JOB_ID + '_' + ml::api::CAnomalyJob::STATE_TYPE +

--- a/lib/api/unittest/CPersistenceManagerTest.h
+++ b/lib/api/unittest/CPersistenceManagerTest.h
@@ -3,14 +3,14 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-#ifndef INCLUDED_CBackgroundPersisterTest_h
-#define INCLUDED_CBackgroundPersisterTest_h
+#ifndef INCLUDED_CPersistenceManagerTest_h
+#define INCLUDED_CPersistenceManagerTest_h
 
 #include <cppunit/extensions/HelperMacros.h>
 
 #include <string>
 
-class CBackgroundPersisterTest : public CppUnit::TestFixture {
+class CPersistenceManagerTest : public CppUnit::TestFixture {
 public:
     void testDetectorPersistBy();
     void testDetectorPersistOver();
@@ -25,4 +25,4 @@ private:
     void foregroundBackgroundCompAnomalyDetectionAfterStaticsUpdate(const std::string& configFileName);
 };
 
-#endif // INCLUDED_CBackgroundPersisterTest_h
+#endif // INCLUDED_CPersistenceManagerTest_h

--- a/lib/api/unittest/CRestorePreviousStateTest.cc
+++ b/lib/api/unittest/CRestorePreviousStateTest.cc
@@ -179,7 +179,7 @@ void CRestorePreviousStateTest::categorizerRestoreHelper(const std::string& stat
             std::ostringstream* strm(nullptr);
             ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
             ml::api::CSingleStreamDataAdder persister(ptr);
-            CPPUNIT_ASSERT(restoredTyper.persistState(persister));
+            CPPUNIT_ASSERT(restoredTyper.persistState(persister, ""));
             newPersistedState = strm->str();
         }
         CPPUNIT_ASSERT_EQUAL(this->stripDocIds(origPersistedState),
@@ -249,7 +249,7 @@ void CRestorePreviousStateTest::anomalyDetectorRestoreHelper(const std::string& 
             std::ostringstream* strm(nullptr);
             ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
             ml::api::CSingleStreamDataAdder persister(ptr);
-            CPPUNIT_ASSERT(restoredJob.persistState(persister));
+            CPPUNIT_ASSERT(restoredJob.persistState(persister, ""));
             newPersistedState = strm->str();
         }
 

--- a/lib/api/unittest/CSingleStreamDataAdderTest.cc
+++ b/lib/api/unittest/CSingleStreamDataAdderTest.cc
@@ -162,7 +162,7 @@ void CSingleStreamDataAdderTest::detectorPersistHelper(const std::string& config
         std::ostringstream* strm(nullptr);
         ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
         ml::api::CSingleStreamDataAdder persister(ptr);
-        CPPUNIT_ASSERT(firstProcessor->persistState(persister));
+        CPPUNIT_ASSERT(firstProcessor->persistState(persister, ""));
         origPersistedState = strm->str();
     }
 
@@ -215,7 +215,7 @@ void CSingleStreamDataAdderTest::detectorPersistHelper(const std::string& config
         std::ostringstream* strm(nullptr);
         ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
         ml::api::CSingleStreamDataAdder persister(ptr);
-        CPPUNIT_ASSERT(restoredFirstProcessor->persistState(persister));
+        CPPUNIT_ASSERT(restoredFirstProcessor->persistState(persister, ""));
         newPersistedState = strm->str();
     }
 

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -178,7 +178,7 @@ void CStringStoreTest::testPersonStringPruning() {
         time += BUCKET_SPAN * 100;
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
 
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
         wrappedOutputStream.syncFlush();
 
         CPPUNIT_ASSERT_EQUAL(std::size_t(1),
@@ -224,7 +224,7 @@ void CStringStoreTest::testPersonStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 3, 1, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring job again");
     {
@@ -266,7 +266,7 @@ void CStringStoreTest::testPersonStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 2, 2, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring yet again");
     {
@@ -368,7 +368,7 @@ void CStringStoreTest::testAttributeStringPruning() {
         time += BUCKET_SPAN * 100;
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
 
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
         wrappedOutputStream.syncFlush();
         CPPUNIT_ASSERT_EQUAL(std::size_t(1),
                              countBuckets("records", outputStrm.str() + "]"));
@@ -413,7 +413,7 @@ void CStringStoreTest::testAttributeStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 3, 1, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring job again");
     {
@@ -456,7 +456,7 @@ void CStringStoreTest::testAttributeStringPruning() {
         time = playData(time, BUCKET_SPAN, 100, 2, 2, 101, job);
 
         job.finalise();
-        CPPUNIT_ASSERT(job.persistState(adder));
+        CPPUNIT_ASSERT(job.persistState(adder, ""));
     }
     LOG_DEBUG(<< "Restoring yet again");
     {

--- a/lib/api/unittest/Main.cc
+++ b/lib/api/unittest/Main.cc
@@ -7,7 +7,6 @@
 
 #include "CAnomalyJobLimitTest.h"
 #include "CAnomalyJobTest.h"
-#include "CBackgroundPersisterTest.h"
 #include "CBaseTokenListDataTyperTest.h"
 #include "CCategoryExamplesCollectorTest.h"
 #include "CConfigUpdaterTest.h"
@@ -29,6 +28,7 @@
 #include "CNdJsonInputParserTest.h"
 #include "CNdJsonOutputWriterTest.h"
 #include "COutputChainerTest.h"
+#include "CPersistenceManagerTest.h"
 #include "CRestorePreviousStateTest.h"
 #include "CResultNormalizerTest.h"
 #include "CSingleStreamDataAdderTest.h"
@@ -42,7 +42,6 @@ int main(int argc, const char** argv) {
 
     runner.addTest(CAnomalyJobLimitTest::suite());
     runner.addTest(CAnomalyJobTest::suite());
-    runner.addTest(CBackgroundPersisterTest::suite());
     runner.addTest(CBaseTokenListDataTyperTest::suite());
     runner.addTest(CCategoryExamplesCollectorTest::suite());
     runner.addTest(CConfigUpdaterTest::suite());
@@ -64,6 +63,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CModelSnapshotJsonWriterTest::suite());
     runner.addTest(CMultiFileDataAdderTest::suite());
     runner.addTest(COutputChainerTest::suite());
+    runner.addTest(CPersistenceManagerTest::suite());
     runner.addTest(CRestorePreviousStateTest::suite());
     runner.addTest(CResultNormalizerTest::suite());
     runner.addTest(CSingleStreamDataAdderTest::suite());

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -21,7 +21,6 @@ SRCS=\
 	Main.cc \
 	CAnomalyJobLimitTest.cc \
 	CAnomalyJobTest.cc \
-	CBackgroundPersisterTest.cc \
 	CBaseTokenListDataTyperTest.cc \
 	CCategoryExamplesCollectorTest.cc \
 	CConfigUpdaterTest.cc \
@@ -47,6 +46,7 @@ SRCS=\
 	CNdJsonInputParserTest.cc \
 	CNdJsonOutputWriterTest.cc \
 	COutputChainerTest.cc \
+	CPersistenceManagerTest.cc \
 	CRestorePreviousStateTest.cc \
 	CResultNormalizerTest.cc \
 	CSingleStreamDataAdderTest.cc \

--- a/lib/config/CAutoconfigurer.cc
+++ b/lib/config/CAutoconfigurer.cc
@@ -174,7 +174,7 @@ bool CAutoconfigurer::restoreState(core::CDataSearcher& /*restoreSearcher*/,
     return true;
 }
 
-bool CAutoconfigurer::persistState(core::CDataAdder& /*persister*/) {
+bool CAutoconfigurer::persistState(core::CDataAdder&, const std::string&) {
     return true;
 }
 

--- a/lib/model/CLimits.cc
+++ b/lib/model/CLimits.cc
@@ -24,13 +24,13 @@ const size_t CLimits::DEFAULT_RESULTS_MAX_EXAMPLES(4);
 // The probability threshold is stored as a percentage in the config file
 const double CLimits::DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD(3.5);
 
-CLimits::CLimits(double byteLimitMargin)
+CLimits::CLimits(bool persistenceInForeground, double byteLimitMargin)
     : m_AutoConfigEvents(DEFAULT_AUTOCONFIG_EVENTS),
       m_AnomalyMaxTimeBuckets(DEFAULT_ANOMALY_MAX_TIME_BUCKETS),
       m_MaxExamples(DEFAULT_RESULTS_MAX_EXAMPLES),
       m_UnusualProbabilityThreshold(DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD),
       m_MemoryLimitMB(CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB),
-      m_ResourceMonitor(byteLimitMargin) {
+      m_ResourceMonitor(persistenceInForeground, byteLimitMargin) {
 }
 
 bool CLimits::init(const std::string& configFile) {

--- a/lib/model/unittest/CResourceLimitTest.cc
+++ b/lib/model/unittest/CResourceLimitTest.cc
@@ -235,9 +235,23 @@ void CResourceLimitTest::testLimitByOver() {
 
 namespace {
 
+class CMockModelInterface {
+public:
+    CMockModelInterface() = default;
+    virtual ~CMockModelInterface() = default;
+
+    virtual void createNewModels(std::size_t n, std::size_t m) = 0;
+
+    virtual void test(core_t::TTime time) = 0;
+
+    virtual std::size_t getNewPeople() const = 0;
+
+    virtual std::size_t getNewAttributes() const = 0;
+};
+
 //! A test wrapper around a real model that tracks calls to createNewModels
 //! and simulates taking lots of memory
-class CMockEventRateModel : public ml::model::CEventRateModel {
+class CMockEventRateModel : public CEventRateModel, public CMockModelInterface {
 public:
     CMockEventRateModel(const SModelParams& params,
                         const TDataGathererPtr& dataGatherer,
@@ -282,7 +296,7 @@ private:
 
 //! A test wrapper around a real model that tracks calls to createNewModels
 //! and simulates taking lots of memory
-class CMockMetricModel : public ml::model::CMetricModel {
+class CMockMetricModel : public CMetricModel, public CMockModelInterface {
 public:
     CMockMetricModel(const SModelParams& params,
                      const TDataGathererPtr& dataGatherer,
@@ -371,152 +385,170 @@ void addPersonMetricData(std::size_t start,
         addMetricArrival(time, ssA.str(), gatherer, resourceMonitor);
     }
 }
-}
 
-void CResourceLimitTest::testLargeAllocations() {
-    {
+using TAddPersonDataFunc =
+    std::function<void(std::size_t, std::size_t, core_t::TTime, CDataGatherer&, CResourceMonitor&)>;
+using TMockModelInterfacePtr = std::shared_ptr<CMockModelInterface>;
+using TModelFactoryPtr = std::shared_ptr<CModelFactory>;
+
+TAddPersonDataFunc createModel(model_t::EModelType modelType,
+                               const std::string& emptyString,
+                               core_t::TTime firstTime,
+                               core_t::TTime bucketLength,
+                               CResourceMonitor& resourceMonitor,
+                               TMockModelInterfacePtr& model,
+                               CModelFactory::TDataGathererPtr& gatherer,
+                               TModelFactoryPtr& factory) {
+    switch (modelType) {
+    case model_t::E_EventRateOnline: {
         // Test CEventRateModel::createUpdateNewModels()
-        const std::string EMPTY_STRING("");
-        const core_t::TTime FIRST_TIME(358556400);
-        const core_t::TTime BUCKET_LENGTH(3600);
 
-        SModelParams params(BUCKET_LENGTH);
+        SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(BUCKET_LENGTH);
-        CEventRateModelFactory factory(params, interimBucketCorrector);
-        factory.identifier(1);
-        factory.fieldNames(EMPTY_STRING, EMPTY_STRING, "pers", EMPTY_STRING, TStrVec());
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+
+        factory = std::make_shared<CEventRateModelFactory>(params, interimBucketCorrector);
+        factory->identifier(1);
+        factory->fieldNames(emptyString, emptyString, "pers", emptyString, TStrVec());
         CModelFactory::TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        factory.features(features);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(FIRST_TIME));
+        factory->features(features);
 
-        CResourceMonitor resourceMonitor(1.0);
-        resourceMonitor.memoryLimit(std::size_t(70));
+        gatherer.reset(factory->makeDataGatherer(firstTime));
+
         const maths::CMultinomialConjugate conjugate;
-        ::CMockEventRateModel model(
-            factory.modelParams(), gatherer,
-            factory.defaultFeatureModels(features, BUCKET_LENGTH, 0.4, true), conjugate,
+        std::shared_ptr<::CMockEventRateModel> model_ = std::make_shared<::CMockEventRateModel>(
+            factory->modelParams(), gatherer,
+            factory->defaultFeatureModels(features, bucketLength, 0.4, true), conjugate,
             CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec(),
             resourceMonitor);
 
-        CPPUNIT_ASSERT_EQUAL(model_t::E_EventRateOnline, model.category());
-        CPPUNIT_ASSERT(model.isPopulation() == false);
-        core_t::TTime time = FIRST_TIME;
+        CPPUNIT_ASSERT_EQUAL(model_t::E_EventRateOnline, model_->category());
+        CPPUNIT_ASSERT(model_->isPopulation() == false);
 
-        CPPUNIT_ASSERT(resourceMonitor.areAllocationsAllowed());
+        model = model_;
 
-        // Add some people & attributes to the gatherer
-        // Run a sample
-        // Check that the models can create the right number of people/attributes
-        ::addPersonData(0, 400, time, *gatherer, resourceMonitor);
-
-        CPPUNIT_ASSERT_EQUAL(std::size_t(400), gatherer->numberActivePeople());
-
-        LOG_DEBUG(<< "Testing for 1st time");
-        model.test(time);
-        CPPUNIT_ASSERT_EQUAL(std::size_t(400), gatherer->numberActivePeople());
-        CPPUNIT_ASSERT_EQUAL(std::size_t(400), model.getNewPeople());
-        CPPUNIT_ASSERT_EQUAL(std::size_t(0), model.getNewAttributes());
-        time += BUCKET_LENGTH;
-
-        ::addPersonData(400, 1000, time, *gatherer, resourceMonitor);
-        model.test(time);
-
-        // This should add enough people to go over the memory limit
-        ::addPersonData(1000, 3000, time, *gatherer, resourceMonitor);
-
-        LOG_DEBUG(<< "Testing for 2nd time");
-        model.test(time);
-        LOG_DEBUG(<< "# new people = " << model.getNewPeople());
-        CPPUNIT_ASSERT(model.getNewPeople() > 2700 && model.getNewPeople() < 2900);
-        CPPUNIT_ASSERT_EQUAL(std::size_t(0), model.getNewAttributes());
-        CPPUNIT_ASSERT_EQUAL(model.getNewPeople(), gatherer->numberActivePeople());
-
-        // Adding a small number of new people should be fine though,
-        // as they're allowed in
-        time += BUCKET_LENGTH;
-        std::size_t oldNumberPeople{model.getNewPeople()};
-        ::addPersonData(3000, 3010, time, *gatherer, resourceMonitor);
-
-        LOG_DEBUG(<< "Testing for 3rd time");
-        model.test(time);
-        CPPUNIT_ASSERT_EQUAL(oldNumberPeople + 10, model.getNewPeople());
-        CPPUNIT_ASSERT_EQUAL(std::size_t(0), model.getNewAttributes());
-        CPPUNIT_ASSERT_EQUAL(model.getNewPeople(), gatherer->numberActivePeople());
+        return addPersonData;
     }
-    {
-        // Test CMetricModel::createUpdateNewModels()
-        const std::string EMPTY_STRING("");
-        const core_t::TTime FIRST_TIME(358556400);
-        const core_t::TTime BUCKET_LENGTH(3600);
 
-        SModelParams params(BUCKET_LENGTH);
+    case model_t::E_MetricOnline: {
+        SModelParams params(bucketLength);
         params.s_DecayRate = 0.001;
-        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(BUCKET_LENGTH);
-        CMetricModelFactory factory(params, interimBucketCorrector);
-        factory.identifier(1);
-        factory.fieldNames(EMPTY_STRING, EMPTY_STRING, "peep", "val", TStrVec());
-        factory.useNull(true);
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        factory = std::make_shared<CMetricModelFactory>(params, interimBucketCorrector);
+        factory->identifier(1);
+        factory->fieldNames(emptyString, emptyString, "peep", "val", TStrVec());
+        factory->useNull(true);
         CModelFactory::TFeatureVec features;
         features.push_back(model_t::E_IndividualMeanByPerson);
         features.push_back(model_t::E_IndividualMinByPerson);
         features.push_back(model_t::E_IndividualMaxByPerson);
-        factory.features(features);
-        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(FIRST_TIME));
+        factory->features(features);
 
-        CResourceMonitor resourceMonitor;
-        resourceMonitor.memoryLimit(std::size_t(100));
-        ::CMockMetricModel model(
-            factory.modelParams(), gatherer,
-            factory.defaultFeatureModels(features, BUCKET_LENGTH, 0.4, true),
+        gatherer.reset(factory->makeDataGatherer(firstTime));
+
+        std::shared_ptr<::CMockMetricModel> model_ = std::make_shared<::CMockMetricModel>(
+            factory->modelParams(), gatherer,
+            factory->defaultFeatureModels(features, bucketLength, 0.4, true),
             CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec(),
             resourceMonitor);
 
-        CPPUNIT_ASSERT_EQUAL(model_t::E_MetricOnline, model.category());
-        CPPUNIT_ASSERT(model.isPopulation() == false);
-        core_t::TTime time = FIRST_TIME;
+        CPPUNIT_ASSERT_EQUAL(model_t::E_MetricOnline, model_->category());
+        CPPUNIT_ASSERT(model_->isPopulation() == false);
 
-        CPPUNIT_ASSERT(resourceMonitor.areAllocationsAllowed());
+        model = model_;
+        return addPersonMetricData;
+    }
 
-        // Add some people & attributes to the gatherer
-        // Run a sample
-        // Check that the models can create the right number of people/attributes
-        ::addPersonMetricData(0, 400, time, *gatherer, resourceMonitor);
+    case model_t::E_Counting:
+        return nullptr;
+    }
 
-        CPPUNIT_ASSERT_EQUAL(std::size_t(400), gatherer->numberActivePeople());
+    return nullptr;
+}
 
-        LOG_DEBUG(<< "Testing for 1st time");
-        model.test(time);
-        CPPUNIT_ASSERT_EQUAL(std::size_t(400), gatherer->numberActivePeople());
-        CPPUNIT_ASSERT_EQUAL(std::size_t(400), model.getNewPeople());
-        CPPUNIT_ASSERT_EQUAL(std::size_t(0), model.getNewAttributes());
-        time += BUCKET_LENGTH;
+struct SLargeAllocationTestParams {
+    bool m_PersistInForeground;
+    std::size_t m_MemoryLimit;
+    std::size_t m_NumPeopleToBreachLimit;
+    std::size_t m_NewPeopleLowerBound;
+    std::size_t m_NewPeopleUpperBound;
+    model_t::EModelType m_ModelType;
+};
 
-        ::addPersonMetricData(400, 1000, time, *gatherer, resourceMonitor);
-        model.test(time);
+void doTestLargeAllocations(SLargeAllocationTestParams& param) {
 
-        // This should add enough people to go over the memory limit
-        ::addPersonMetricData(1000, 3000, time, *gatherer, resourceMonitor);
+    const std::string EMPTY_STRING("");
+    const core_t::TTime FIRST_TIME(358556400);
+    const core_t::TTime BUCKET_LENGTH(3600);
 
-        LOG_DEBUG(<< "Testing for 2nd time");
-        model.test(time);
-        LOG_DEBUG(<< "# new people = " << model.getNewPeople());
-        CPPUNIT_ASSERT(model.getNewPeople() > 2600 && model.getNewPeople() < 3000);
-        CPPUNIT_ASSERT_EQUAL(std::size_t(0), model.getNewAttributes());
-        CPPUNIT_ASSERT_EQUAL(model.getNewPeople(), gatherer->numberActivePeople());
+    CResourceMonitor resourceMonitor(param.m_PersistInForeground, 1.0);
+    resourceMonitor.memoryLimit(std::size_t(param.m_MemoryLimit));
 
-        // Adding a small number of new people should be fine though,
-        // as they are are allowed in
-        time += BUCKET_LENGTH;
-        std::size_t oldNumberPeople{model.getNewPeople()};
-        ::addPersonMetricData(3000, 3010, time, *gatherer, resourceMonitor);
+    TMockModelInterfacePtr model;
+    CModelFactory::TDataGathererPtr gatherer;
+    TModelFactoryPtr factory;
+    TAddPersonDataFunc personAdder =
+        createModel(param.m_ModelType, EMPTY_STRING, FIRST_TIME, BUCKET_LENGTH,
+                    resourceMonitor, model, gatherer, factory);
 
-        LOG_DEBUG(<< "Testing for 3rd time");
-        model.test(time);
-        CPPUNIT_ASSERT_EQUAL(oldNumberPeople + 10, model.getNewPeople());
-        CPPUNIT_ASSERT_EQUAL(std::size_t(0), model.getNewAttributes());
-        CPPUNIT_ASSERT_EQUAL(model.getNewPeople(), gatherer->numberActivePeople());
+    core_t::TTime time = FIRST_TIME;
+
+    CPPUNIT_ASSERT(resourceMonitor.areAllocationsAllowed());
+
+    // Add some people & attributes to the gatherer
+    // Run a sample
+    // Check that the models can create the right number of people/attributes
+    personAdder(0, 400, time, *gatherer, resourceMonitor);
+
+    CPPUNIT_ASSERT_EQUAL(std::size_t(400), gatherer->numberActivePeople());
+
+    LOG_DEBUG(<< "Testing for 1st time");
+    model->test(time);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(400), gatherer->numberActivePeople());
+    CPPUNIT_ASSERT_EQUAL(std::size_t(400), model->getNewPeople());
+    CPPUNIT_ASSERT_EQUAL(std::size_t(0), model->getNewAttributes());
+    time += BUCKET_LENGTH;
+
+    personAdder(400, 1000, time, *gatherer, resourceMonitor);
+    model->test(time);
+
+    // This should add enough people to go over the memory limit
+    personAdder(1000, param.m_NumPeopleToBreachLimit, time, *gatherer, resourceMonitor);
+
+    LOG_DEBUG(<< "Testing for 2nd time");
+    model->test(time);
+    LOG_DEBUG(<< "# new people = " << model->getNewPeople());
+    CPPUNIT_ASSERT(model->getNewPeople() > param.m_NewPeopleLowerBound &&
+                   model->getNewPeople() < param.m_NewPeopleUpperBound);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(0), model->getNewAttributes());
+    CPPUNIT_ASSERT_EQUAL(model->getNewPeople(), gatherer->numberActivePeople());
+
+    // Adding a small number of new people should be fine though,
+    // as they're allowed in
+    time += BUCKET_LENGTH;
+    std::size_t oldNumberPeople{model->getNewPeople()};
+    personAdder(param.m_NumPeopleToBreachLimit, param.m_NumPeopleToBreachLimit + 10,
+                time, *gatherer, resourceMonitor);
+
+    LOG_DEBUG(<< "Testing for 3rd time");
+    model->test(time);
+    CPPUNIT_ASSERT_EQUAL(oldNumberPeople + 10, model->getNewPeople());
+    CPPUNIT_ASSERT_EQUAL(std::size_t(0), model->getNewAttributes());
+    CPPUNIT_ASSERT_EQUAL(model->getNewPeople(), gatherer->numberActivePeople());
+}
+}
+
+void CResourceLimitTest::testLargeAllocations() {
+
+    SLargeAllocationTestParams params[] = {
+        {false, 70, 3000, 2700, 2900, model_t::E_EventRateOnline},
+        {true, 70, 5000, 4500, 4700, model_t::E_EventRateOnline},
+        {false, 100, 4000, 3500, 3700, model_t::E_MetricOnline},
+        {true, 100, 7000, 6100, 6300, model_t::E_MetricOnline}};
+
+    for (auto& param : params) {
+        doTestLargeAllocations(param);
     }
 }
 

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -71,12 +71,25 @@ void CResourceMonitorTest::testMonitor() {
         CPPUNIT_ASSERT(mon.m_ByteLimitHigh > mon.m_ByteLimitLow);
         CPPUNIT_ASSERT(mon.m_AllowAllocations);
         LOG_DEBUG(<< "Resource limit is: " << mon.m_ByteLimitHigh);
-        if (sizeof(std::size_t) == 4) {
-            // 32-bit platform
-            CPPUNIT_ASSERT_EQUAL(std::size_t(1024ull * 1024 * 1024 / 2), mon.m_ByteLimitHigh);
-        } else if (sizeof(std::size_t) == 8) {
+        if (sizeof(std::size_t) == 8) {
             // 64-bit platform
             CPPUNIT_ASSERT_EQUAL(std::size_t(4096ull * 1024 * 1024 / 2), mon.m_ByteLimitHigh);
+        } else {
+            // Unexpected platform
+            CPPUNIT_ASSERT(false);
+        }
+    }
+    {
+        // Test foreground persistence constructor
+        CResourceMonitor mon(true);
+        CPPUNIT_ASSERT(mon.m_ByteLimitHigh > 0);
+        CPPUNIT_ASSERT_EQUAL((49 * mon.m_ByteLimitHigh) / 50, mon.m_ByteLimitLow);
+        CPPUNIT_ASSERT(mon.m_ByteLimitHigh > mon.m_ByteLimitLow);
+        CPPUNIT_ASSERT(mon.m_AllowAllocations);
+        LOG_DEBUG(<< "Resource limit is: " << mon.m_ByteLimitHigh);
+        if (sizeof(std::size_t) == 8) {
+            // 64-bit platform
+            CPPUNIT_ASSERT_EQUAL(std::size_t(4096ull * 1024 * 1024), mon.m_ByteLimitHigh);
         } else {
             // Unexpected platform
             CPPUNIT_ASSERT(false);
@@ -123,7 +136,7 @@ void CResourceMonitorTest::testMonitor() {
     }
     {
         // Check that High limit can be breached and then gone back
-        CResourceMonitor mon(1.0);
+        CResourceMonitor mon(false, 1.0);
         CPPUNIT_ASSERT(mem > 5); // This SHOULD be OK
 
         // Let's go above the low but below the high limit
@@ -309,7 +322,7 @@ void CResourceMonitorTest::testPruning() {
 
     CAnomalyDetectorModelConfig modelConfig =
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
-    CLimits limits(1.0);
+    CLimits limits(false, 1.0);
 
     CSearchKey key(1, // identifier
                    function_t::E_IndividualMetric, false, model_t::E_XF_None,

--- a/lib/model/unittest/CSampleQueueTest.h
+++ b/lib/model/unittest/CSampleQueueTest.h
@@ -8,7 +8,7 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
-#include "../../../include/model/CSampleQueue.h"
+#include <model/CSampleQueue.h>
 
 class CSampleQueueTest : public CppUnit::TestFixture {
 public:


### PR DESCRIPTION
Added command line option to both autodetect and categorizer
indicating that persistence should be performed in the foreground.

Backport #550