### PR TITLE
Log if lstat fails for a reason other than missing file

### DIFF
--- a/lib/core/CNamedPipeFactory.cc
+++ b/lib/core/CNamedPipeFactory.cc
@@ -201,8 +201,7 @@ CNamedPipeFactory::initPipeHandle(const std::string& fileName, bool forWrite) {
     } else {
         if (errno != ENOENT) {
             LOG_WARN(<< "lstat of named pipe " << fileName
-                     << " failed with unexpected error "
-                     << ::strerror(errno));
+                     << " failed with unexpected error " << ::strerror(errno));
         }
 
         // The file didn't exist, so create a new FIFO for it, with permissions

--- a/lib/core/CNamedPipeFactory.cc
+++ b/lib/core/CNamedPipeFactory.cc
@@ -199,6 +199,12 @@ CNamedPipeFactory::initPipeHandle(const std::string& fileName, bool forWrite) {
             return -1;
         }
     } else {
+        if (errno != ENOENT) {
+            LOG_WARN(<< "lstat of named pipe " << fileName
+                     << " failed with unexpected error "
+                     << ::strerror(errno));
+        }
+
         // The file didn't exist, so create a new FIFO for it, with permissions
         // for the current user only
         if (::mkfifo(fileName.c_str(), S_IRUSR | S_IWUSR) == -1) {


### PR DESCRIPTION
In `CNamedPipeFactory::initPipeHandle` the named pipe file name is stat-ed to check it does not exist. Failure of `lstat` is considered a successful outcome in that the file does not exist and can now be created but `lstat` may fail for a number of reasons. 

The motivation for the change is the following log message spotted in the wild. The message can only occur if `lstat` return a non-zero value and the following called to `mkfifo` failed because the file exists. 

```org.elasticsearch.ElasticsearchException: Unable to create named pipe /tmp/elasticsearch-XXX/normalize_some_ml_job: File exists```

relates to elastic/elasticsearch#43830