### PR TITLE
[ML] Persistence for boosted trees

### DIFF
--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -255,9 +255,9 @@ public:
         template<typename OPTIONAL_TYPE>
         std::string operator()(const boost::optional<OPTIONAL_TYPE>& state) const {
             if (state) {
-                return operator()(std::make_pair(true, state.get()));
+                return this->operator()(std::make_pair(true, state.get()));
             } else {
-                return operator()(std::make_pair(false, OPTIONAL_TYPE()));
+                return this->operator()(std::make_pair(false, OPTIONAL_TYPE()));
             }
         }
 
@@ -328,7 +328,7 @@ public:
         template<typename OPTIONAL_TYPE>
         bool operator()(const std::string& token, boost::optional<OPTIONAL_TYPE>& value) const {
             std::pair<bool, OPTIONAL_TYPE> pairValue;
-            if (operator()(token, pairValue)) {
+            if (this->operator()(token, pairValue)) {
                 if (pairValue.first) {
                     value = boost::optional<OPTIONAL_TYPE>(pairValue.second);
                 } else {

--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -16,6 +16,7 @@
 
 #include <boost/array.hpp>
 #include <boost/iterator/indirect_iterator.hpp>
+#include <boost/optional.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -251,6 +252,15 @@ public:
             return value.toString();
         }
 
+        template<typename OPTIONAL_TYPE>
+        std::string operator()(const boost::optional<OPTIONAL_TYPE>& state) const {
+            if (state) {
+                return operator()(std::make_pair(true, state.get()));
+            } else {
+                return operator()(std::make_pair(false, OPTIONAL_TYPE()));
+            }
+        }
+
         template<typename U, typename V>
         std::string operator()(const std::pair<U, V>& value) const {
             return this->operator()(value.first) + m_PairDelimiter +
@@ -313,6 +323,20 @@ public:
 
         bool operator()(const std::string& token, CFloatStorage& value) const {
             return value.fromString(token);
+        }
+
+        template<typename OPTIONAL_TYPE>
+        bool operator()(const std::string& token, boost::optional<OPTIONAL_TYPE>& value) const {
+            std::pair<bool, OPTIONAL_TYPE> pairValue;
+            if (operator()(token, pairValue)) {
+                if (pairValue.first) {
+                    value = boost::optional<OPTIONAL_TYPE>(pairValue.second);
+                } else {
+                    value = boost::optional<OPTIONAL_TYPE>();
+                }
+                return true;
+            }
+            return false;
         }
 
         template<typename U, typename V>

--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -61,6 +61,10 @@ public:
 public:
     CBayesianOptimisation(TDoubleDoublePrVec parameterBounds);
 
+    CBayesianOptimisation() = default;
+
+    CBayesianOptimisation(core::CStateRestoreTraverser& traverser);
+
     //! Add the result of evaluating the function to be \p fx at \p x where the
     //! variance in the error in \p fx w.r.t. the true value is \p vx.
     void add(TVector x, double fx, double vx);

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -60,7 +60,7 @@ public:
     //! Get an object which computes the leaf value that minimises loss.
     virtual TArgMinLossUPtr minimizer() const = 0;
     //! Get the name of the loss function
-    virtual std::string name() const = 0;
+    virtual const std::string& name() const = 0;
 };
 
 //! \brief Finds the leaf node value which minimises the MSE.
@@ -85,7 +85,7 @@ public:
     double gradient(double prediction, double actual) const override;
     double curvature(double prediction, double actual) const override;
     TArgMinLossUPtr minimizer() const override;
-    std::string name() const override;
+    const std::string& name() const override;
 
 public:
     static const std::string NAME;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -8,6 +8,8 @@
 #define INCLUDED_ml_maths_CBoostedTree_h
 
 #include <core/CDataFrame.h>
+#include <core/CStatePersistInserter.h>
+#include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CDataFrameRegressionModel.h>
@@ -57,6 +59,8 @@ public:
     virtual double curvature(double prediction, double actual) const = 0;
     //! Get an object which computes the leaf value that minimises loss.
     virtual TArgMinLossUPtr minimizer() const = 0;
+    //! Get the name of the loss function
+    virtual std::string name() const = 0;
 };
 
 //! \brief Finds the leaf node value which minimises the MSE.
@@ -81,6 +85,10 @@ public:
     double gradient(double prediction, double actual) const override;
     double curvature(double prediction, double actual) const override;
     TArgMinLossUPtr minimizer() const override;
+    std::string name() const override;
+
+public:
+    static const std::string NAME;
 };
 }
 
@@ -142,11 +150,19 @@ public:
     //! Get the column containing the model's prediction for the dependent variable.
     std::size_t columnHoldingPrediction(std::size_t numberColumns) const override;
 
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
 private:
     using TImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
 
 private:
     CBoostedTree(core::CDataFrame& frame, TImplUPtr& impl);
+
+    bool restoreImpl(TImplUPtr& impl, core::CStateRestoreTraverser& traverser);
 
 private:
     TImplUPtr m_Impl;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -161,8 +161,7 @@ private:
 
 private:
     CBoostedTree(core::CDataFrame& frame, TImplUPtr& impl);
-
-    bool restoreImpl(TImplUPtr& impl, core::CStateRestoreTraverser& traverser);
+    CBoostedTree(core::CDataFrame& frame, TImplUPtr&& impl);
 
 private:
     TImplUPtr m_Impl;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -153,7 +153,7 @@ public:
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
-    //! Populate the object from serialized data
+    //! Populate the object from serialized data.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
 private:

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -32,10 +32,14 @@ public:
     using TBoostedTreeUPtr = std::unique_ptr<CBoostedTree>;
 
 public:
-    //! Construct a boosted tree object from parameters
+    //! Construct a boosted tree object from parameters.
     static CBoostedTreeFactory constructFromParameters(std::size_t numberThreads,
                                                        std::size_t dependentVariable,
                                                        CBoostedTree::TLossFunctionUPtr loss);
+
+    //! Construct a boosted tree object from its serialized version.
+    static TBoostedTreeUPtr constructFromString(std::stringstream& jsonStringStream,
+                                                core::CDataFrame& frame);
 
     ~CBoostedTreeFactory();
     CBoostedTreeFactory(CBoostedTreeFactory&) = delete;
@@ -62,6 +66,7 @@ public:
     CBoostedTreeFactory& progressCallback(CBoostedTree::TProgressCallback callback);
     //! Set the number of rows required to support a feature.
     CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
+
     //! Estimate the maximum booking memory that training the boosted tree on a data
     //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -60,7 +60,8 @@ public:
     CBoostedTreeFactory& maximumOptimisationRoundsPerHyperparameter(std::size_t rounds);
     //! Set the callback function for progress monitoring.
     CBoostedTreeFactory& progressCallback(CBoostedTree::TProgressCallback callback);
-
+    //! Set the number of rows required to support a feature.
+    CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
     //! Estimate the maximum booking memory that training the boosted tree on a data
     //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -38,6 +38,7 @@ namespace boosted_tree_detail {
 inline std::size_t predictionColumn(std::size_t numberColumns) {
     return numberColumns - 3;
 }
+
 inline std::size_t numberFeatures(const core::CDataFrame& frame) {
     return frame.numberColumns() - 3;
 }
@@ -63,19 +64,26 @@ public:
     // TODO move all these methods factory since it is a friend anyway.
     //! Set the number of folds to use for estimating the generalisation error.
     void numberFolds(std::size_t numberFolds);
+
     //! Set the lambda regularisation parameter.
     void lambda(double lambda);
+
     //! Set the gamma regularisation parameter.
     void gamma(double gamma);
+
     //! Set the amount we'll shrink the weights on each each iteration.
     void eta(double eta);
+
     //! Set the maximum number of trees in the ensemble.
     void maximumNumberTrees(std::size_t maximumNumberTrees);
+
     //! Set the fraction of features we'll use in the bag to build a tree.
     void featureBagFraction(double featureBagFraction);
+
     //! Set the maximum number of optimisation rounds we'll use for hyperparameter
     //! optimisation per parameter.
     void maximumOptimisationRoundsPerHyperparameter(std::size_t rounds);
+
     //! The number of training examples we need per feature we'll include.
     void rowsPerFeature(std::size_t rowsPerFeature);
 
@@ -119,7 +127,9 @@ private:
     using TRowItr = core::CDataFrame::TRowItr;
     using TRowRef = core::CDataFrame::TRowRef;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+
     class CNode;
+
     using TNodeVec = std::vector<CNode>;
     using TNodeVecVec = std::vector<TNodeVec>;
 
@@ -346,8 +356,11 @@ private:
         }
 
         CLeafNodeStatistics(const CLeafNodeStatistics&) = delete;
+
         CLeafNodeStatistics& operator=(const CLeafNodeStatistics&) = delete;
+
         CLeafNodeStatistics(CLeafNodeStatistics&&) = default;
+
         CLeafNodeStatistics& operator=(CLeafNodeStatistics&&) = default;
 
         //! Apply the split defined by (\p leftChildRowMask, \p rightChildRowMask).
@@ -603,6 +616,8 @@ private:
     };
 
 private:
+    CBoostedTreeImpl() = default;
+
     //! Check if we can train a model.
     bool canTrain() const;
 
@@ -628,7 +643,7 @@ private:
     //! Train one forest on the rows of \p frame in the mask \p trainingRowMask.
     TNodeVecVec trainForest(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
-                            CBoostedTree::TProgressCallback /*recordProgress*/) const;
+                            const CBoostedTree::TProgressCallback& /*recordProgress*/) const;
 
     //! Get the candidate splits values for each feature.
     TDoubleVecVec candidateSplits(const core::CDataFrame& frame,

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -642,7 +642,7 @@ private:
     //! Train one forest on the rows of \p frame in the mask \p trainingRowMask.
     TNodeVecVec trainForest(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
-                            CBoostedTree::TProgressCallback  /*recordProgress*/) const;
+                            CBoostedTree::TProgressCallback /*recordProgress*/) const;
 
     //! Get the candidate splits values for each feature.
     TDoubleVecVec candidateSplits(const core::CDataFrame& frame,

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -112,7 +112,7 @@ public:
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
-    //! Populate the object from serialized data
+    //! Populate the object from serialized data.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
 private:
@@ -129,7 +129,6 @@ private:
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
     class CNode;
-
     using TNodeVec = std::vector<CNode>;
     using TNodeVecVec = std::vector<TNodeVec>;
 
@@ -643,7 +642,7 @@ private:
     //! Train one forest on the rows of \p frame in the mask \p trainingRowMask.
     TNodeVecVec trainForest(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
-                            const CBoostedTree::TProgressCallback& /*recordProgress*/) const;
+                            CBoostedTree::TProgressCallback  /*recordProgress*/) const;
 
     //! Get the candidate splits values for each feature.
     TDoubleVecVec candidateSplits(const core::CDataFrame& frame,

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -144,7 +144,7 @@ private:
         //! Persist by passing information to \p inserter.
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
-        //! Populate the object from serialized data
+        //! Populate the object from serialized data.
         bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
     };
 
@@ -260,7 +260,7 @@ private:
         //! Persist by passing information to \p inserter.
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
-        //! Populate the object from serialized data
+        //! Populate the object from serialized data.
         bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     private:
@@ -706,8 +706,8 @@ private:
     std::size_t maximumTreeSize(std::size_t numberRows) const;
 
     //! Restore \p loss function pointer from the \p traverser.
-    bool restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
-                     core::CStateRestoreTraverser& traverser);
+    static bool restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
+                            core::CStateRestoreTraverser& traverser);
 
 private:
     static const double INF;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -11,6 +11,8 @@
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
 #include <core/CPackedBitVector.h>
+#include <core/CStatePersistInserter.h>
+#include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBayesianOptimisation.h>
@@ -99,6 +101,12 @@ public:
     //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
 
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
 private:
     using TDoubleDoublePrVec = std::vector<std::pair<double, double>>;
     using TOptionalDouble = boost::optional<double>;
@@ -123,6 +131,12 @@ private:
         double s_EtaGrowthRatePerTree;
         double s_FeatureBagFraction;
         TDoubleVec s_FeatureSampleProbabilities;
+
+        //! Persist by passing information to \p inserter.
+        void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+        //! Populate the object from serialized data
+        bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
     };
 
     //! \brief A node of a regression tree.
@@ -233,6 +247,12 @@ private:
             std::ostringstream result;
             return this->doPrint("", tree, result).str();
         }
+
+        //! Persist by passing information to \p inserter.
+        void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+        //! Populate the object from serialized data
+        bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     private:
         std::ostringstream&
@@ -670,6 +690,10 @@ private:
     //! \note This number will only be used if the regularised loss says its
     //! a good idea.
     std::size_t maximumTreeSize(std::size_t numberRows) const;
+
+    //! Restore \p loss function pointer from the \p traverser.
+    bool restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
+                     core::CStateRestoreTraverser& traverser);
 
 private:
     static const double INF;

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -47,6 +47,30 @@ CBayesianOptimisation::CBayesianOptimisation(TDoubleDoublePrVec parameterBounds)
     }
 }
 
+CBayesianOptimisation::CBayesianOptimisation(core::CStateRestoreTraverser& traverser)
+    : CBayesianOptimisation() {
+    do {
+        auto name = traverser.name();
+        RESTORE_NO_ERROR(MIN_BOUNDARY_TAG,
+                         core::CPersistUtils::restore(MIN_BOUNDARY_TAG, m_MinBoundary, traverser))
+        RESTORE_NO_ERROR(MAX_BOUNDARY_TAG,
+                         core::CPersistUtils::restore(MAX_BOUNDARY_TAG, m_MaxBoundary, traverser))
+        RESTORE_NO_ERROR(ERROR_VARIANCES_TAG,
+                         core::CPersistUtils::restore(ERROR_VARIANCES_TAG,
+                                                      m_ErrorVariances, traverser))
+        RESTORE_NO_ERROR(KERNEL_PARAMETERS_TAG,
+                         core::CPersistUtils::restore(KERNEL_PARAMETERS_TAG,
+                                                      m_KernelParameters, traverser))
+        RESTORE_NO_ERROR(MIN_KERNEL_COORDINATE_DISTANCE_SCALES_TAG,
+                         core::CPersistUtils::restore(
+                             MIN_KERNEL_COORDINATE_DISTANCE_SCALES_TAG,
+                             m_MinimumKernelCoordinateDistanceScale, traverser))
+        RESTORE_NO_ERROR(FUNCTION_MEAN_VALUES_TAG,
+                         core::CPersistUtils::restore(FUNCTION_MEAN_VALUES_TAG,
+                                                      m_FunctionMeanValues, traverser))
+    } while (traverser.next());
+}
+
 void CBayesianOptimisation::add(TVector x, double fx, double vx) {
     m_FunctionMeanValues.emplace_back(x.cwiseQuotient(m_MaxBoundary - m_MinBoundary),
                                       m_RangeScale * (fx - m_RangeShift));

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -61,6 +61,10 @@ CBoostedTree::CBoostedTree(core::CDataFrame& frame, TImplUPtr& impl)
     : CDataFrameRegressionModel(frame), m_Impl{std::move(impl)} {
 }
 
+CBoostedTree::CBoostedTree(core::CDataFrame& frame, TImplUPtr&& impl)
+    : CDataFrameRegressionModel(frame), m_Impl{std::move(impl)} {
+}
+
 CBoostedTree::~CBoostedTree() = default;
 
 void CBoostedTree::train(TProgressCallback recordProgress) {
@@ -87,20 +91,12 @@ namespace {
 const std::string BOOSTED_TREE_IMPL_TAG{"boosted_tree_impl"};
 }
 
-bool CBoostedTree::restoreImpl(TImplUPtr& implPtr, core::CStateRestoreTraverser& traverser) {
-    implPtr.reset(new CBoostedTreeImpl(0, 0, nullptr));
-    if (core::CPersistUtils::restore(BOOSTED_TREE_IMPL_TAG, *implPtr, traverser)) {
-        return true;
-    }
-    implPtr.release();
-    return false;
-}
-
 bool CBoostedTree::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     try {
         do {
             const std::string& name = traverser.name();
-            RESTORE(BOOSTED_TREE_IMPL_TAG, restoreImpl(m_Impl, traverser))
+            RESTORE(BOOSTED_TREE_IMPL_TAG,
+                    core::CPersistUtils::restore(BOOSTED_TREE_IMPL_TAG, *m_Impl, traverser))
         } while (traverser.next());
     } catch (std::exception& e) {
         LOG_ERROR(<< "Failed to restore state! " << e.what());

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -40,7 +40,7 @@ double CMse::curvature(double /*prediction*/, double /*actual*/) const {
 
 const std::string CMse::NAME{"mse"};
 
-std::string CMse::name() const {
+const std::string& CMse::name() const {
     return NAME;
 }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -6,6 +6,8 @@
 
 #include <maths/CBoostedTreeFactory.h>
 
+#include <core/CJsonStateRestoreTraverser.h>
+
 #include <maths/CBayesianOptimisation.h>
 #include <maths/CBoostedTreeImpl.h>
 #include <maths/CSampling.h>
@@ -270,7 +272,9 @@ CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads,
 }
 
 CBoostedTreeFactory::~CBoostedTreeFactory() = default;
+
 CBoostedTreeFactory::CBoostedTreeFactory(CBoostedTreeFactory&&) = default;
+
 CBoostedTreeFactory& CBoostedTreeFactory::operator=(CBoostedTreeFactory&&) = default;
 
 CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads,
@@ -329,9 +333,20 @@ std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
 std::size_t CBoostedTreeFactory::numberExtraColumnsForTrain() const {
     return m_TreeImpl->numberExtraColumnsForTrain();
 }
+
 CBoostedTreeFactory& CBoostedTreeFactory::rowsPerFeature(std::size_t rowsPerFeature) {
     this->m_TreeImpl->rowsPerFeature(rowsPerFeature);
     return *this;
+}
+
+CBoostedTreeFactory::TBoostedTreeUPtr
+CBoostedTreeFactory::constructFromString(std::stringstream& jsonStringStream,
+                                         core::CDataFrame& frame) {
+    TBoostedTreeUPtr treePtr(new CBoostedTree(
+        frame, std::unique_ptr<CBoostedTreeImpl>(new CBoostedTreeImpl())));
+    core::CJsonStateRestoreTraverser traverser(jsonStringStream);
+    treePtr->acceptRestoreTraverser(traverser);
+    return treePtr;
 }
 }
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -329,5 +329,9 @@ std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
 std::size_t CBoostedTreeFactory::numberExtraColumnsForTrain() const {
     return m_TreeImpl->numberExtraColumnsForTrain();
 }
+CBoostedTreeFactory& CBoostedTreeFactory::rowsPerFeature(std::size_t rowsPerFeature) {
+    this->m_TreeImpl->rowsPerFeature(rowsPerFeature);
+    return *this;
+}
 }
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -306,7 +306,7 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
 CBoostedTreeImpl::TNodeVecVec
 CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
                               const core::CPackedBitVector& trainingRowMask,
-                              CBoostedTree::TProgressCallback  /*recordProgress*/) const {
+                              CBoostedTree::TProgressCallback /*recordProgress*/) const {
 
     LOG_TRACE(<< "Training one forest...");
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -306,7 +306,7 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
 CBoostedTreeImpl::TNodeVecVec
 CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
                               const core::CPackedBitVector& trainingRowMask,
-                              const CBoostedTree::TProgressCallback& /*recordProgress*/) const {
+                              CBoostedTree::TProgressCallback  /*recordProgress*/) const {
 
     LOG_TRACE(<< "Training one forest...");
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -20,6 +20,7 @@ namespace {
 std::size_t lossGradientColumn(std::size_t numberColumns) {
     return numberColumns - 2;
 }
+
 std::size_t lossCurvatureColumn(std::size_t numberColumns) {
     return numberColumns - 1;
 }
@@ -305,7 +306,7 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
 CBoostedTreeImpl::TNodeVecVec
 CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
                               const core::CPackedBitVector& trainingRowMask,
-                              CBoostedTree::TProgressCallback /*recordProgress*/) const {
+                              const CBoostedTree::TProgressCallback& /*recordProgress*/) const {
 
     LOG_TRACE(<< "Training one forest...");
 
@@ -606,7 +607,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     TVector parameters{this->numberHyperparametersToTune()};
 
     // Read parameters for last round.
-    std::size_t i{0};
+    int i{0};
     if (m_LambdaOverride == boost::none) {
         parameters(i++) = std::log(m_Lambda);
     }
@@ -880,6 +881,7 @@ bool CBoostedTreeImpl::restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
 
 bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     try {
+        m_BayesianOptimization = std::make_unique<CBayesianOptimisation>();
         do {
             const std::string& name = traverser.name();
             RESTORE(BAYESIAN_OPTIMIZATION_TAG,

--- a/lib/maths/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/unittest/CBayesianOptimisationTest.cc
@@ -334,7 +334,7 @@ void CBayesianOptimisationTest::testPersistRestoreSubroutine(
     }
     // and restore
     {
-        maths::CBayesianOptimisation bayesianOptimisation({});
+        maths::CBayesianOptimisation bayesianOptimisation;
         core::CJsonStateRestoreTraverser traverser(persistOnceSStream);
         bayesianOptimisation.acceptRestoreTraverser(traverser);
 

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -18,6 +18,7 @@ public:
     void testConstantFeatures();
     void testConstantObjective();
     void testMissingData();
+    void testPersistRestore();
     // TODO void testCategoricalRegressors();
     // TODO void testFeatureWeights();
     // TODO void testNuisanceFeatures();


### PR DESCRIPTION
This PR implements the functionality for persistence and restoration of the boosted trees, e.g. to recover from failure. It also enables a creation of a `CBoostedTree` instance from a serialized string using factory.

As an additional minimal refactoring, I added `rowsPerFeature` to the `CBoostedTreeFactory` since it is present in `Impl` and was missing before here.