### PR TITLE
[ML] Only check that the supplied rows don't exceed the specified for data frame analyses

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,16 @@
 
 //=== Regressions
 
+== {es} version 7.3.1
+
+=== Bug Fixes
+
+* Only trap the case that more rows are supplied to outlier detection than expected.
+Previously, if rows were excluded from the data frame after supplying the row count
+in the configuration then we detected the inconsistency and failed outlier detection.
+However, this legitimately happens in case where the field values are non-numeric or
+array valued. (See {ml-pull}569[#569].)
+
 == {es} version 7.3.0
 
 === Enhancements

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -122,8 +122,12 @@ void CDataFrameAnalyzer::run() {
         return;
     }
 
-    if (m_DataFrame->numberRows() != m_AnalysisSpecification->numberRows()) {
-        HANDLE_FATAL(<< "Input error: expected '"
+    // The main condition to care about is if the analysis is going to use more
+    // memory than was budgeted for. There are circumstances in which rows are
+    // excluded after the search filter is applied so this can't trap the case
+    // that the row counts are not equal.
+    if (m_DataFrame->numberRows() > m_AnalysisSpecification->numberRows()) {
+        HANDLE_FATAL(<< "Input error: expected no more than '"
                      << m_AnalysisSpecification->numberRows() << "' rows "
                      << "but got '" << m_DataFrame->numberRows() << "' rows"
                      << ". Please report this problem.");

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -706,6 +706,24 @@ void CDataFrameAnalyzerTest::testErrors() {
             true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
                                         {"", "", "", "", "", "", "$"}));
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        CPPUNIT_ASSERT(errors.empty());
+    }
+    {
+        api::CDataFrameAnalyzer analyzer{outlierSpec(2), outputWriterFactory};
+        errors.clear();
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"10", "10", "10", "10", "10", "0", ""}));
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"10", "10", "10", "10", "10", "0", ""}));
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"10", "10", "10", "10", "10", "0", ""}));
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"", "", "", "", "", "", "$"}));
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -697,6 +697,7 @@ void CDataFrameAnalyzerTest::testErrors() {
 
     // Test inconsistent number of rows
     {
+        // Fewer rows than expected is ignored.
         api::CDataFrameAnalyzer analyzer{outlierSpec(2), outputWriterFactory};
         errors.clear();
         CPPUNIT_ASSERT_EQUAL(


### PR DESCRIPTION
This catches the main case we need to care about: that we'll use more resources than were budgeted for. We can't check for equality because the Java currently excludes rows for reasons other than the search filter and these aren't considered when it passes the expected row count.