### PR TITLE
[ML] Persistence for boosted trees (#568)

### DIFF
--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -16,6 +16,7 @@
 
 #include <boost/array.hpp>
 #include <boost/iterator/indirect_iterator.hpp>
+#include <boost/optional.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -251,6 +252,15 @@ public:
             return value.toString();
         }
 
+        template<typename OPTIONAL_TYPE>
+        std::string operator()(const boost::optional<OPTIONAL_TYPE>& state) const {
+            if (state) {
+                return this->operator()(std::make_pair(true, state.get()));
+            } else {
+                return this->operator()(std::make_pair(false, OPTIONAL_TYPE()));
+            }
+        }
+
         template<typename U, typename V>
         std::string operator()(const std::pair<U, V>& value) const {
             return this->operator()(value.first) + m_PairDelimiter +
@@ -313,6 +323,20 @@ public:
 
         bool operator()(const std::string& token, CFloatStorage& value) const {
             return value.fromString(token);
+        }
+
+        template<typename OPTIONAL_TYPE>
+        bool operator()(const std::string& token, boost::optional<OPTIONAL_TYPE>& value) const {
+            std::pair<bool, OPTIONAL_TYPE> pairValue;
+            if (this->operator()(token, pairValue)) {
+                if (pairValue.first) {
+                    value = boost::optional<OPTIONAL_TYPE>(pairValue.second);
+                } else {
+                    value = boost::optional<OPTIONAL_TYPE>();
+                }
+                return true;
+            }
+            return false;
         }
 
         template<typename U, typename V>

--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -61,6 +61,10 @@ public:
 public:
     CBayesianOptimisation(TDoubleDoublePrVec parameterBounds);
 
+    CBayesianOptimisation() = default;
+
+    CBayesianOptimisation(core::CStateRestoreTraverser& traverser);
+
     //! Add the result of evaluating the function to be \p fx at \p x where the
     //! variance in the error in \p fx w.r.t. the true value is \p vx.
     void add(TVector x, double fx, double vx);

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -8,6 +8,8 @@
 #define INCLUDED_ml_maths_CBoostedTree_h
 
 #include <core/CDataFrame.h>
+#include <core/CStatePersistInserter.h>
+#include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CDataFrameRegressionModel.h>
@@ -57,6 +59,8 @@ public:
     virtual double curvature(double prediction, double actual) const = 0;
     //! Get an object which computes the leaf value that minimises loss.
     virtual TArgMinLossUPtr minimizer() const = 0;
+    //! Get the name of the loss function
+    virtual const std::string& name() const = 0;
 };
 
 //! \brief Finds the leaf node value which minimises the MSE.
@@ -81,6 +85,10 @@ public:
     double gradient(double prediction, double actual) const override;
     double curvature(double prediction, double actual) const override;
     TArgMinLossUPtr minimizer() const override;
+    const std::string& name() const override;
+
+public:
+    static const std::string NAME;
 };
 }
 
@@ -142,11 +150,18 @@ public:
     //! Get the column containing the model's prediction for the dependent variable.
     std::size_t columnHoldingPrediction(std::size_t numberColumns) const override;
 
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
 private:
     using TImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
 
 private:
     CBoostedTree(core::CDataFrame& frame, TImplUPtr& impl);
+    CBoostedTree(core::CDataFrame& frame, TImplUPtr&& impl);
 
 private:
     TImplUPtr m_Impl;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -32,10 +32,14 @@ public:
     using TBoostedTreeUPtr = std::unique_ptr<CBoostedTree>;
 
 public:
-    //! Construct a boosted tree object from parameters
+    //! Construct a boosted tree object from parameters.
     static CBoostedTreeFactory constructFromParameters(std::size_t numberThreads,
                                                        std::size_t dependentVariable,
                                                        CBoostedTree::TLossFunctionUPtr loss);
+
+    //! Construct a boosted tree object from its serialized version.
+    static TBoostedTreeUPtr constructFromString(std::stringstream& jsonStringStream,
+                                                core::CDataFrame& frame);
 
     ~CBoostedTreeFactory();
     CBoostedTreeFactory(CBoostedTreeFactory&) = delete;
@@ -60,6 +64,8 @@ public:
     CBoostedTreeFactory& maximumOptimisationRoundsPerHyperparameter(std::size_t rounds);
     //! Set the callback function for progress monitoring.
     CBoostedTreeFactory& progressCallback(CBoostedTree::TProgressCallback callback);
+    //! Set the number of rows required to support a feature.
+    CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
 
     //! Estimate the maximum booking memory that training the boosted tree on a data
     //! frame with \p numberRows row and \p numberColumns columns will use.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -11,6 +11,8 @@
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
 #include <core/CPackedBitVector.h>
+#include <core/CStatePersistInserter.h>
+#include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBayesianOptimisation.h>
@@ -36,6 +38,7 @@ namespace boosted_tree_detail {
 inline std::size_t predictionColumn(std::size_t numberColumns) {
     return numberColumns - 3;
 }
+
 inline std::size_t numberFeatures(const core::CDataFrame& frame) {
     return frame.numberColumns() - 3;
 }
@@ -61,19 +64,26 @@ public:
     // TODO move all these methods factory since it is a friend anyway.
     //! Set the number of folds to use for estimating the generalisation error.
     void numberFolds(std::size_t numberFolds);
+
     //! Set the lambda regularisation parameter.
     void lambda(double lambda);
+
     //! Set the gamma regularisation parameter.
     void gamma(double gamma);
+
     //! Set the amount we'll shrink the weights on each each iteration.
     void eta(double eta);
+
     //! Set the maximum number of trees in the ensemble.
     void maximumNumberTrees(std::size_t maximumNumberTrees);
+
     //! Set the fraction of features we'll use in the bag to build a tree.
     void featureBagFraction(double featureBagFraction);
+
     //! Set the maximum number of optimisation rounds we'll use for hyperparameter
     //! optimisation per parameter.
     void maximumOptimisationRoundsPerHyperparameter(std::size_t rounds);
+
     //! The number of training examples we need per feature we'll include.
     void rowsPerFeature(std::size_t rowsPerFeature);
 
@@ -99,6 +109,12 @@ public:
     //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
 
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
 private:
     using TDoubleDoublePrVec = std::vector<std::pair<double, double>>;
     using TOptionalDouble = boost::optional<double>;
@@ -111,6 +127,7 @@ private:
     using TRowItr = core::CDataFrame::TRowItr;
     using TRowRef = core::CDataFrame::TRowRef;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+
     class CNode;
     using TNodeVec = std::vector<CNode>;
     using TNodeVecVec = std::vector<TNodeVec>;
@@ -123,6 +140,12 @@ private:
         double s_EtaGrowthRatePerTree;
         double s_FeatureBagFraction;
         TDoubleVec s_FeatureSampleProbabilities;
+
+        //! Persist by passing information to \p inserter.
+        void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+        //! Populate the object from serialized data.
+        bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
     };
 
     //! \brief A node of a regression tree.
@@ -234,6 +257,12 @@ private:
             return this->doPrint("", tree, result).str();
         }
 
+        //! Persist by passing information to \p inserter.
+        void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+        //! Populate the object from serialized data.
+        bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
     private:
         std::ostringstream&
         doPrint(std::string pad, const TNodeVec& tree, std::ostringstream& result) const {
@@ -326,8 +355,11 @@ private:
         }
 
         CLeafNodeStatistics(const CLeafNodeStatistics&) = delete;
+
         CLeafNodeStatistics& operator=(const CLeafNodeStatistics&) = delete;
+
         CLeafNodeStatistics(CLeafNodeStatistics&&) = default;
+
         CLeafNodeStatistics& operator=(CLeafNodeStatistics&&) = default;
 
         //! Apply the split defined by (\p leftChildRowMask, \p rightChildRowMask).
@@ -583,6 +615,8 @@ private:
     };
 
 private:
+    CBoostedTreeImpl() = default;
+
     //! Check if we can train a model.
     bool canTrain() const;
 
@@ -670,6 +704,10 @@ private:
     //! \note This number will only be used if the regularised loss says its
     //! a good idea.
     std::size_t maximumTreeSize(std::size_t numberRows) const;
+
+    //! Restore \p loss function pointer from the \p traverser.
+    static bool restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
+                            core::CStateRestoreTraverser& traverser);
 
 private:
     static const double INF;

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -47,6 +47,30 @@ CBayesianOptimisation::CBayesianOptimisation(TDoubleDoublePrVec parameterBounds)
     }
 }
 
+CBayesianOptimisation::CBayesianOptimisation(core::CStateRestoreTraverser& traverser)
+    : CBayesianOptimisation() {
+    do {
+        auto name = traverser.name();
+        RESTORE_NO_ERROR(MIN_BOUNDARY_TAG,
+                         core::CPersistUtils::restore(MIN_BOUNDARY_TAG, m_MinBoundary, traverser))
+        RESTORE_NO_ERROR(MAX_BOUNDARY_TAG,
+                         core::CPersistUtils::restore(MAX_BOUNDARY_TAG, m_MaxBoundary, traverser))
+        RESTORE_NO_ERROR(ERROR_VARIANCES_TAG,
+                         core::CPersistUtils::restore(ERROR_VARIANCES_TAG,
+                                                      m_ErrorVariances, traverser))
+        RESTORE_NO_ERROR(KERNEL_PARAMETERS_TAG,
+                         core::CPersistUtils::restore(KERNEL_PARAMETERS_TAG,
+                                                      m_KernelParameters, traverser))
+        RESTORE_NO_ERROR(MIN_KERNEL_COORDINATE_DISTANCE_SCALES_TAG,
+                         core::CPersistUtils::restore(
+                             MIN_KERNEL_COORDINATE_DISTANCE_SCALES_TAG,
+                             m_MinimumKernelCoordinateDistanceScale, traverser))
+        RESTORE_NO_ERROR(FUNCTION_MEAN_VALUES_TAG,
+                         core::CPersistUtils::restore(FUNCTION_MEAN_VALUES_TAG,
+                                                      m_FunctionMeanValues, traverser))
+    } while (traverser.next());
+}
+
 void CBayesianOptimisation::add(TVector x, double fx, double vx) {
     m_FunctionMeanValues.emplace_back(x.cwiseQuotient(m_MaxBoundary - m_MinBoundary),
                                       m_RangeScale * (fx - m_RangeShift));

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -6,6 +6,8 @@
 
 #include <maths/CBoostedTreeFactory.h>
 
+#include <core/CJsonStateRestoreTraverser.h>
+
 #include <maths/CBayesianOptimisation.h>
 #include <maths/CBoostedTreeImpl.h>
 #include <maths/CSampling.h>
@@ -270,7 +272,9 @@ CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads,
 }
 
 CBoostedTreeFactory::~CBoostedTreeFactory() = default;
+
 CBoostedTreeFactory::CBoostedTreeFactory(CBoostedTreeFactory&&) = default;
+
 CBoostedTreeFactory& CBoostedTreeFactory::operator=(CBoostedTreeFactory&&) = default;
 
 CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads,
@@ -328,6 +332,21 @@ std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
 
 std::size_t CBoostedTreeFactory::numberExtraColumnsForTrain() const {
     return m_TreeImpl->numberExtraColumnsForTrain();
+}
+
+CBoostedTreeFactory& CBoostedTreeFactory::rowsPerFeature(std::size_t rowsPerFeature) {
+    this->m_TreeImpl->rowsPerFeature(rowsPerFeature);
+    return *this;
+}
+
+CBoostedTreeFactory::TBoostedTreeUPtr
+CBoostedTreeFactory::constructFromString(std::stringstream& jsonStringStream,
+                                         core::CDataFrame& frame) {
+    TBoostedTreeUPtr treePtr(new CBoostedTree(
+        frame, std::unique_ptr<CBoostedTreeImpl>(new CBoostedTreeImpl())));
+    core::CJsonStateRestoreTraverser traverser(jsonStringStream);
+    treePtr->acceptRestoreTraverser(traverser);
+    return treePtr;
 }
 }
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -6,6 +6,8 @@
 
 #include <maths/CBoostedTreeImpl.h>
 
+#include <core/CPersistUtils.h>
+
 #include <maths/CQuantileSketch.h>
 #include <maths/CSampling.h>
 
@@ -18,6 +20,7 @@ namespace {
 std::size_t lossGradientColumn(std::size_t numberColumns) {
     return numberColumns - 2;
 }
+
 std::size_t lossCurvatureColumn(std::size_t numberColumns) {
     return numberColumns - 1;
 }
@@ -604,7 +607,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     TVector parameters{this->numberHyperparametersToTune()};
 
     // Read parameters for last round.
-    std::size_t i{0};
+    int i{0};
     if (m_LambdaOverride == boost::none) {
         parameters(i++) = std::log(m_Lambda);
     }
@@ -684,6 +687,289 @@ std::size_t CBoostedTreeImpl::maximumTreeSize(const core::CDataFrame& frame) con
 std::size_t CBoostedTreeImpl::maximumTreeSize(std::size_t numberRows) const {
     return static_cast<std::size_t>(std::ceil(
         m_MaximumTreeSizeFraction * std::sqrt(static_cast<double>(numberRows))));
+}
+
+namespace {
+const std::string BAYESIAN_OPTIMIZATION_TAG{"bayesian_optimization"};
+const std::string BEST_FOREST_TAG{"best_forest"};
+const std::string BEST_FOREST_TEST_LOSS_TAG{"best_forest_test_loss"};
+const std::string BEST_HYPERPARAMETERS_TAG{"best_hyperparameters"};
+const std::string CURRENT_ROUND_TAG{"current_round"};
+const std::string DEPENDENT_VARIABLE_TAG{"dependent_variable"};
+const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
+const std::string ETA_OVERRIDE_TAG{"eta_override"};
+const std::string ETA_TAG{"eta"};
+const std::string FEATURE_BAG_FRACTION_OVERRIDE_TAG{"feature_bag_fraction_override"};
+const std::string FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
+const std::string FEATURE_SAMPLE_PROBABILITIES_TAG{"feature_sample_probabilities"};
+const std::string GAMMA_OVERRIDE_TAG{"gamma_override"};
+const std::string GAMMA_TAG{"gamma"};
+const std::string LAMBDA_OVERRIDE_TAG{"lambda_override"};
+const std::string LAMBDA_TAG{"lambda"};
+const std::string LOSS_TAG{"loss"};
+const std::string MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG{"maximum_attempts_to_add_tree"};
+const std::string MAXIMUM_NUMBER_TREES_OVERRIDE_TAG{"maximum_number_trees_override"};
+const std::string MAXIMUM_NUMBER_TREES_TAG{"maximum_number_trees"};
+const std::string MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG{
+    "maximum_optimisation_rounds_per_hyperparameter"};
+const std::string MAXIMUM_TREE_SIZE_FRACTION_TAG{"maximum_tree_size_fraction"};
+const std::string MISSING_FEATURE_ROW_MASKS_TAG{"missing_feature_row_masks"};
+const std::string NUMBER_FOLDS_TAG{"number_folds"};
+const std::string NUMBER_ROUNDS_TAG{"number_rounds"};
+const std::string NUMBER_SPLITS_PER_FEATURE_TAG{"number_splits_per_feature"};
+const std::string NUMBER_THREADS_TAG{"number_threads"};
+const std::string ROWS_PER_FEATURE_TAG{"rows_per_feature"};
+const std::string TESTING_ROW_MASKS_TAG{"testing_row_masks"};
+const std::string TRAINING_ROW_MASKS_TAG{"training_row_masks"};
+
+const std::string LEFT_CHILD_TAG{"left_child"};
+const std::string RIGHT_CHILD_TAG{"right_child"};
+const std::string SPLIT_FEATURE_TAG{"split_feature"};
+const std::string ASSIGN_MISSING_TO_LEFT_TAG{"assign_missing_to_left "};
+const std::string NODE_VALUE_TAG{"node_value"};
+const std::string SPLIT_VALUE_TAG{"split_value"};
+
+const std::string HYPERPARAM_LAMBDA_TAG{"hyperparam_lambda"};
+const std::string HYPERPARAM_GAMMA_TAG{"hyperparam_gamma"};
+const std::string HYPERPARAM_ETA_TAG{"hyperparam_eta"};
+const std::string HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG{"hyperparam_eta_growth_rate_per_tree"};
+const std::string HYPERPARAM_FEATURE_BAG_FRACTION_TAG{"hyperparam_feature_bag_fraction"};
+const std::string HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG{"hyperparam_feature_sample_probabilities"};
+}
+
+void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(BAYESIAN_OPTIMIZATION_TAG, *m_BayesianOptimization, inserter);
+    core::CPersistUtils::persist(BEST_FOREST_TEST_LOSS_TAG, m_BestForestTestLoss, inserter);
+    core::CPersistUtils::persist(CURRENT_ROUND_TAG, m_CurrentRound, inserter);
+    core::CPersistUtils::persist(DEPENDENT_VARIABLE_TAG, m_DependentVariable, inserter);
+    core::CPersistUtils::persist(ETA_GROWTH_RATE_PER_TREE_TAG,
+                                 m_EtaGrowthRatePerTree, inserter);
+    core::CPersistUtils::persist(ETA_TAG, m_Eta, inserter);
+    core::CPersistUtils::persist(FEATURE_BAG_FRACTION_TAG, m_FeatureBagFraction, inserter);
+    core::CPersistUtils::persist(FEATURE_SAMPLE_PROBABILITIES_TAG,
+                                 m_FeatureSampleProbabilities, inserter);
+    core::CPersistUtils::persist(GAMMA_TAG, m_Gamma, inserter);
+    core::CPersistUtils::persist(LAMBDA_TAG, m_Lambda, inserter);
+    core::CPersistUtils::persist(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
+                                 m_MaximumAttemptsToAddTree, inserter);
+    core::CPersistUtils::persist(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                                 m_MaximumOptimisationRoundsPerHyperparameter, inserter);
+    core::CPersistUtils::persist(MAXIMUM_TREE_SIZE_FRACTION_TAG,
+                                 m_MaximumTreeSizeFraction, inserter);
+    core::CPersistUtils::persist(MISSING_FEATURE_ROW_MASKS_TAG,
+                                 m_MissingFeatureRowMasks, inserter);
+    core::CPersistUtils::persist(NUMBER_FOLDS_TAG, m_NumberFolds, inserter);
+    core::CPersistUtils::persist(NUMBER_ROUNDS_TAG, m_NumberRounds, inserter);
+    core::CPersistUtils::persist(NUMBER_SPLITS_PER_FEATURE_TAG,
+                                 m_NumberSplitsPerFeature, inserter);
+    core::CPersistUtils::persist(NUMBER_THREADS_TAG, m_NumberThreads, inserter);
+    core::CPersistUtils::persist(ROWS_PER_FEATURE_TAG, m_RowsPerFeature, inserter);
+    core::CPersistUtils::persist(TESTING_ROW_MASKS_TAG, m_TestingRowMasks, inserter);
+    core::CPersistUtils::persist(MAXIMUM_NUMBER_TREES_TAG, m_MaximumNumberTrees, inserter);
+    core::CPersistUtils::persist(TRAINING_ROW_MASKS_TAG, m_TrainingRowMasks, inserter);
+    core::CPersistUtils::persist(BEST_FOREST_TAG, m_BestForest, inserter);
+    core::CPersistUtils::persist(BEST_HYPERPARAMETERS_TAG, m_BestHyperparameters, inserter);
+    core::CPersistUtils::persist(ETA_OVERRIDE_TAG, m_EtaOverride, inserter);
+    core::CPersistUtils::persist(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+                                 m_FeatureBagFractionOverride, inserter);
+    core::CPersistUtils::persist(GAMMA_OVERRIDE_TAG, m_GammaOverride, inserter);
+    core::CPersistUtils::persist(LAMBDA_OVERRIDE_TAG, m_LambdaOverride, inserter);
+    core::CPersistUtils::persist(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
+                                 m_MaximumNumberTreesOverride, inserter);
+    core::CPersistUtils::persist(LOSS_TAG, m_Loss->name(), inserter);
+}
+
+void CBoostedTreeImpl::CNode::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(LEFT_CHILD_TAG, m_LeftChild, inserter);
+    core::CPersistUtils::persist(RIGHT_CHILD_TAG, m_RightChild, inserter);
+    core::CPersistUtils::persist(SPLIT_FEATURE_TAG, m_SplitFeature, inserter);
+    core::CPersistUtils::persist(ASSIGN_MISSING_TO_LEFT_TAG, m_AssignMissingToLeft, inserter);
+    core::CPersistUtils::persist(NODE_VALUE_TAG, m_NodeValue, inserter);
+    core::CPersistUtils::persist(SPLIT_VALUE_TAG, m_SplitValue, inserter);
+}
+
+void CBoostedTreeImpl::SHyperparameters::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(HYPERPARAM_LAMBDA_TAG, s_Lambda, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_GAMMA_TAG, s_Gamma, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_ETA_TAG, s_Eta, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                                 s_EtaGrowthRatePerTree, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                                 s_FeatureBagFraction, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG,
+                                 s_FeatureSampleProbabilities, inserter);
+}
+
+bool CBoostedTreeImpl::SHyperparameters::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    try {
+        do {
+            const std::string& name = traverser.name();
+            RESTORE(HYPERPARAM_LAMBDA_TAG,
+                    core::CPersistUtils::restore(HYPERPARAM_LAMBDA_TAG, s_Lambda, traverser))
+            RESTORE(HYPERPARAM_GAMMA_TAG,
+                    core::CPersistUtils::restore(HYPERPARAM_GAMMA_TAG, s_Gamma, traverser))
+            RESTORE(HYPERPARAM_ETA_TAG,
+                    core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, s_Eta, traverser))
+            RESTORE(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                    core::CPersistUtils::restore(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                                                 s_EtaGrowthRatePerTree, traverser))
+            RESTORE(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                    core::CPersistUtils::restore(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                                                 s_FeatureBagFraction, traverser))
+            RESTORE(HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG,
+                    core::CPersistUtils::restore(HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG,
+                                                 s_FeatureSampleProbabilities, traverser))
+            else {
+                LOG_ERROR(<< "Unexpected name for restoring hyperparameters: "
+                          << traverser.name());
+                return false;
+            }
+        } while (traverser.next());
+    } catch (std::exception& e) {
+        LOG_ERROR(<< "Failed to restore state! " << e.what());
+        return false;
+    }
+
+    return true;
+}
+
+bool CBoostedTreeImpl::CNode::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    try {
+        do {
+            const std::string& name = traverser.name();
+            RESTORE(LEFT_CHILD_TAG,
+                    core::CPersistUtils::restore(LEFT_CHILD_TAG, m_LeftChild, traverser))
+            RESTORE(RIGHT_CHILD_TAG,
+                    core::CPersistUtils::restore(RIGHT_CHILD_TAG, m_RightChild, traverser))
+            RESTORE(SPLIT_FEATURE_TAG,
+                    core::CPersistUtils::restore(SPLIT_FEATURE_TAG, m_SplitFeature, traverser))
+            RESTORE(ASSIGN_MISSING_TO_LEFT_TAG,
+                    core::CPersistUtils::restore(ASSIGN_MISSING_TO_LEFT_TAG,
+                                                 m_AssignMissingToLeft, traverser))
+            RESTORE(NODE_VALUE_TAG,
+                    core::CPersistUtils::restore(NODE_VALUE_TAG, m_NodeValue, traverser))
+            RESTORE(SPLIT_VALUE_TAG,
+                    core::CPersistUtils::restore(SPLIT_VALUE_TAG, m_SplitValue, traverser))
+            else {
+                LOG_ERROR(<< "Unexpected name for restoring node class: "
+                          << traverser.name());
+                return false;
+            }
+        } while (traverser.next());
+    } catch (std::exception& e) {
+        LOG_ERROR(<< "Failed to restore state! " << e.what());
+        return false;
+    }
+
+    return true;
+}
+
+bool CBoostedTreeImpl::restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
+                                   core::CStateRestoreTraverser& traverser) {
+    std::string lossFunctionName;
+    if (core::CPersistUtils::restore(LOSS_TAG, lossFunctionName, traverser)) {
+        if (lossFunctionName == CMse::NAME) {
+            loss = std::make_unique<CMse>();
+            return true;
+        } else {
+            LOG_ERROR(<< "Error restoring loss function. Unknown loss function type "
+                      << lossFunctionName);
+        }
+    }
+    return false;
+}
+
+bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    try {
+        m_BayesianOptimization = std::make_unique<CBayesianOptimisation>();
+        do {
+            const std::string& name = traverser.name();
+            RESTORE(BAYESIAN_OPTIMIZATION_TAG,
+                    core::CPersistUtils::restore(BAYESIAN_OPTIMIZATION_TAG,
+                                                 *m_BayesianOptimization, traverser))
+            RESTORE(BEST_FOREST_TEST_LOSS_TAG,
+                    core::CPersistUtils::restore(BEST_FOREST_TEST_LOSS_TAG,
+                                                 m_BestForestTestLoss, traverser))
+            RESTORE(CURRENT_ROUND_TAG,
+                    core::CPersistUtils::restore(CURRENT_ROUND_TAG, m_CurrentRound, traverser))
+            RESTORE(DEPENDENT_VARIABLE_TAG,
+                    core::CPersistUtils::restore(DEPENDENT_VARIABLE_TAG,
+                                                 m_DependentVariable, traverser))
+            RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
+                    core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
+                                                 m_EtaGrowthRatePerTree, traverser))
+            RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
+            RESTORE(FEATURE_BAG_FRACTION_TAG,
+                    core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
+                                                 m_FeatureBagFraction, traverser))
+            RESTORE(FEATURE_SAMPLE_PROBABILITIES_TAG,
+                    core::CPersistUtils::restore(FEATURE_SAMPLE_PROBABILITIES_TAG,
+                                                 m_FeatureSampleProbabilities, traverser))
+            RESTORE(GAMMA_TAG, core::CPersistUtils::restore(GAMMA_TAG, m_Gamma, traverser))
+            RESTORE(LAMBDA_TAG, core::CPersistUtils::restore(LAMBDA_TAG, m_Lambda, traverser))
+            RESTORE(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
+                                                 m_MaximumAttemptsToAddTree, traverser))
+            RESTORE(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                    core::CPersistUtils::restore(
+                        MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                        m_MaximumOptimisationRoundsPerHyperparameter, traverser))
+            RESTORE(MAXIMUM_TREE_SIZE_FRACTION_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_TREE_SIZE_FRACTION_TAG,
+                                                 m_MaximumTreeSizeFraction, traverser))
+            RESTORE(MISSING_FEATURE_ROW_MASKS_TAG,
+                    core::CPersistUtils::restore(MISSING_FEATURE_ROW_MASKS_TAG,
+                                                 m_MissingFeatureRowMasks, traverser))
+            RESTORE(NUMBER_FOLDS_TAG,
+                    core::CPersistUtils::restore(NUMBER_FOLDS_TAG, m_NumberFolds, traverser))
+            RESTORE(NUMBER_ROUNDS_TAG,
+                    core::CPersistUtils::restore(NUMBER_ROUNDS_TAG, m_NumberRounds, traverser))
+            RESTORE(NUMBER_SPLITS_PER_FEATURE_TAG,
+                    core::CPersistUtils::restore(NUMBER_SPLITS_PER_FEATURE_TAG,
+                                                 m_NumberSplitsPerFeature, traverser))
+            RESTORE(NUMBER_THREADS_TAG,
+                    core::CPersistUtils::restore(NUMBER_THREADS_TAG, m_NumberThreads, traverser))
+            RESTORE(ROWS_PER_FEATURE_TAG,
+                    core::CPersistUtils::restore(ROWS_PER_FEATURE_TAG, m_RowsPerFeature, traverser))
+            RESTORE(TESTING_ROW_MASKS_TAG,
+                    core::CPersistUtils::restore(TESTING_ROW_MASKS_TAG,
+                                                 m_TestingRowMasks, traverser))
+            RESTORE(MAXIMUM_NUMBER_TREES_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_TAG,
+                                                 m_MaximumNumberTrees, traverser))
+            RESTORE(TRAINING_ROW_MASKS_TAG,
+                    core::CPersistUtils::restore(TRAINING_ROW_MASKS_TAG,
+                                                 m_TrainingRowMasks, traverser))
+            RESTORE(BEST_FOREST_TAG,
+                    core::CPersistUtils::restore(BEST_FOREST_TAG, m_BestForest, traverser))
+            RESTORE(BEST_HYPERPARAMETERS_TAG,
+                    core::CPersistUtils::restore(BEST_HYPERPARAMETERS_TAG,
+                                                 m_BestHyperparameters, traverser))
+            RESTORE(ETA_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(ETA_OVERRIDE_TAG, m_EtaOverride, traverser))
+            RESTORE(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+                                                 m_FeatureBagFractionOverride, traverser))
+            RESTORE(GAMMA_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(GAMMA_OVERRIDE_TAG, m_GammaOverride, traverser))
+            RESTORE(LAMBDA_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(LAMBDA_OVERRIDE_TAG, m_LambdaOverride, traverser))
+            RESTORE(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
+                                                 m_MaximumNumberTreesOverride, traverser))
+            RESTORE(LOSS_TAG, restoreLoss(m_Loss, traverser))
+            else {
+                LOG_ERROR(<< "Unexpected name for restoring boosted tree implementation: "
+                          << traverser.name());
+                return false;
+            }
+        } while (traverser.next());
+    } catch (std::exception& e) {
+        LOG_ERROR(<< "Failed to restore state! " << e.what());
+        return false;
+    }
+
+    return true;
 }
 
 const double CBoostedTreeImpl::MINIMUM_ETA{1e-3};

--- a/lib/maths/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/unittest/CBayesianOptimisationTest.cc
@@ -334,7 +334,7 @@ void CBayesianOptimisationTest::testPersistRestoreSubroutine(
     }
     // and restore
     {
-        maths::CBayesianOptimisation bayesianOptimisation({});
+        maths::CBayesianOptimisation bayesianOptimisation;
         core::CJsonStateRestoreTraverser traverser(persistOnceSStream);
         bayesianOptimisation.acceptRestoreTraverser(traverser);
 

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -18,6 +18,7 @@ public:
     void testConstantFeatures();
     void testConstantObjective();
     void testMissingData();
+    void testPersistRestore();
     // TODO void testCategoricalRegressors();
     // TODO void testFeatureWeights();
     // TODO void testNuisanceFeatures();


### PR DESCRIPTION
This PR implements the functionality for persistence and restoration of the boosted trees, e.g. to recover from failure. It also enables a creation of a CBoostedTree instance from a serialized string using factory.

As an additional minimal refactoring, I added rowsPerFeature to the CBoostedTreeFactory since it is present in Impl and was missing before here.