### PR TITLE
[ML] Some corrections to error handling on fail to restore boosted tree training state

### DIFF
--- a/include/core/RestoreMacros.h
+++ b/include/core/RestoreMacros.h
@@ -10,44 +10,60 @@
 namespace ml {
 namespace core {
 
-#define RESTORE(tag, restore)                                                      \
-    if (name == tag) {                                                             \
-        if ((restore) == false) {                                                  \
-            LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
-            return false;                                                          \
-        }                                                                          \
-        continue;                                                                  \
+#define RESTORE(tag, restore)                                                          \
+    if (name == tag) {                                                                 \
+        if ((restore) == false) {                                                      \
+            if (traverser.value().empty()) {                                           \
+                LOG_ERROR(<< "Failed to restore " #tag);                               \
+            } else {                                                                   \
+                LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
+            }                                                                          \
+            return false;                                                              \
+        }                                                                              \
+        continue;                                                                      \
     }
 
-#define RESTORE_BUILT_IN(tag, target)                                               \
-    if (name == tag) {                                                              \
-        if (core::CStringUtils::stringToType(traverser.value(), target) == false) { \
-            LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value());  \
-            return false;                                                           \
-        }                                                                           \
-        continue;                                                                   \
+#define RESTORE_BUILT_IN(tag, target)                                                  \
+    if (name == tag) {                                                                 \
+        if (core::CStringUtils::stringToType(traverser.value(), target) == false) {    \
+            if (traverser.value().empty()) {                                           \
+                LOG_ERROR(<< "Failed to restore " #tag);                               \
+            } else {                                                                   \
+                LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
+            }                                                                          \
+            return false;                                                              \
+        }                                                                              \
+        continue;                                                                      \
     }
 
-#define RESTORE_BOOL(tag, target)                                                  \
-    if (name == tag) {                                                             \
-        int value;                                                                 \
-        if (core::CStringUtils::stringToType(traverser.value(), value) == false) { \
-            LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
-            return false;                                                          \
-        }                                                                          \
-        target = (value != 0);                                                     \
-        continue;                                                                  \
+#define RESTORE_BOOL(tag, target)                                                      \
+    if (name == tag) {                                                                 \
+        int value;                                                                     \
+        if (core::CStringUtils::stringToType(traverser.value(), value) == false) {     \
+            if (traverser.value().empty()) {                                           \
+                LOG_ERROR(<< "Failed to restore " #tag);                               \
+            } else {                                                                   \
+                LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
+            }                                                                          \
+            return false;                                                              \
+        }                                                                              \
+        target = (value != 0);                                                         \
+        continue;                                                                      \
     }
 
-#define RESTORE_ENUM(tag, target, enumtype)                                        \
-    if (name == tag) {                                                             \
-        int value;                                                                 \
-        if (core::CStringUtils::stringToType(traverser.value(), value) == false) { \
-            LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
-            return false;                                                          \
-        }                                                                          \
-        target = enumtype(value);                                                  \
-        continue;                                                                  \
+#define RESTORE_ENUM(tag, target, enumtype)                                            \
+    if (name == tag) {                                                                 \
+        int value;                                                                     \
+        if (core::CStringUtils::stringToType(traverser.value(), value) == false) {     \
+            if (traverser.value().empty()) {                                           \
+                LOG_ERROR(<< "Failed to restore " #tag);                               \
+            } else {                                                                   \
+                LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
+            }                                                                          \
+            return false;                                                              \
+        }                                                                              \
+        target = enumtype(value);                                                      \
+        continue;                                                                      \
     }
 
 #define RESTORE_ENUM_CHECKED(tag, target, enumtype, restoreSuccess)            \
@@ -56,15 +72,19 @@ namespace core {
         RESTORE_ENUM(tag, target, enumtype)                                    \
     }
 
-#define RESTORE_SETUP_TEARDOWN(tag, setup, restore, teardown)                      \
-    if (name == tag) {                                                             \
-        setup;                                                                     \
-        if ((restore) == false) {                                                  \
-            LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
-            return false;                                                          \
-        }                                                                          \
-        teardown;                                                                  \
-        continue;                                                                  \
+#define RESTORE_SETUP_TEARDOWN(tag, setup, restore, teardown)                          \
+    if (name == tag) {                                                                 \
+        setup;                                                                         \
+        if ((restore) == false) {                                                      \
+            if (traverser.value().empty()) {                                           \
+                LOG_ERROR(<< "Failed to restore " #tag);                               \
+            } else {                                                                   \
+                LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
+            }                                                                          \
+            return false;                                                              \
+        }                                                                              \
+        teardown;                                                                      \
+        continue;                                                                      \
     }
 
 #define RESTORE_NO_ERROR(tag, restore)                                         \

--- a/include/core/UnwrapRef.h
+++ b/include/core/UnwrapRef.h
@@ -9,8 +9,8 @@
 //! file do not conform to the coding style to ease the eventual transition
 //! to std::unwrap_ref.
 
-#ifndef INCLUDED_ml_core_UNWRAPREF_H_
-#define INCLUDED_ml_core_UNWRAPREF_H_
+#ifndef INCLUDED_ml_core_UnwrapRef_h
+#define INCLUDED_ml_core_UnwrapRef_h
 
 #include <functional>
 
@@ -44,4 +44,4 @@ typename unwrap_reference<T>::type& unwrap_ref(T& t) {
 }
 }
 
-#endif /* INCLUDED_ml_core_UNWRAPREF_H_ */
+#endif // INCLUDED_ml_core_UnwrapRef_h

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -20,6 +20,8 @@
 
 #include <boost/math/distributions/normal.hpp>
 
+#include <exception>
+
 namespace ml {
 namespace maths {
 
@@ -48,8 +50,10 @@ CBayesianOptimisation::CBayesianOptimisation(TDoubleDoublePrVec parameterBounds)
 }
 
 CBayesianOptimisation::CBayesianOptimisation(core::CStateRestoreTraverser& traverser) {
-    traverser.traverseSubLevel(std::bind(&CBayesianOptimisation::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CBayesianOptimisation::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        throw std::runtime_error{"failed to restore Bayesian optimisation"};
+    }
 }
 
 void CBayesianOptimisation::add(TVector x, double fx, double vx) {

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -88,17 +88,11 @@ const std::string BOOSTED_TREE_IMPL_TAG{"boosted_tree_impl"};
 }
 
 bool CBoostedTree::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    try {
-        do {
-            const std::string& name = traverser.name();
-            RESTORE(BOOSTED_TREE_IMPL_TAG,
-                    core::CPersistUtils::restore(BOOSTED_TREE_IMPL_TAG, *m_Impl, traverser))
-        } while (traverser.next());
-    } catch (std::exception& e) {
-        LOG_ERROR(<< "Failed to restore state! " << e.what());
-        return false;
-    }
-
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(BOOSTED_TREE_IMPL_TAG,
+                core::CPersistUtils::restore(BOOSTED_TREE_IMPL_TAG, *m_Impl, traverser))
+    } while (traverser.next());
     return true;
 }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -276,24 +276,31 @@ CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads,
 CBoostedTreeFactory::TBoostedTreeUPtr
 CBoostedTreeFactory::constructFromString(std::stringstream& jsonStringStream,
                                          core::CDataFrame& frame) {
-    TBoostedTreeUPtr treePtr{
-        new CBoostedTree{frame, TBoostedTreeImplUPtr{new CBoostedTreeImpl{}}}};
-    core::CJsonStateRestoreTraverser traverser(jsonStringStream);
-    treePtr->acceptRestoreTraverser(traverser);
-    return treePtr;
+    try {
+        TBoostedTreeUPtr treePtr{
+            new CBoostedTree{frame, TBoostedTreeImplUPtr{new CBoostedTreeImpl{}}}};
+        core::CJsonStateRestoreTraverser traverser(jsonStringStream);
+        if (treePtr->acceptRestoreTraverser(traverser) == false) {
+            throw std::runtime_error{"failed to restore boosted tree"};
+        }
+        return treePtr;
+    } catch (const std::exception& e) {
+        HANDLE_FATAL(<< "Input error: '" << e.what() << "'. Check logs for more details.");
+    }
+    return nullptr;
 }
-
-CBoostedTreeFactory::~CBoostedTreeFactory() = default;
-
-CBoostedTreeFactory::CBoostedTreeFactory(CBoostedTreeFactory&&) = default;
-
-CBoostedTreeFactory& CBoostedTreeFactory::operator=(CBoostedTreeFactory&&) = default;
 
 CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads,
                                          std::size_t dependentVariable,
                                          CBoostedTree::TLossFunctionUPtr loss)
     : m_TreeImpl{new CBoostedTreeImpl{numberThreads, dependentVariable, std::move(loss)}} {
 }
+
+CBoostedTreeFactory::CBoostedTreeFactory(CBoostedTreeFactory&&) = default;
+
+CBoostedTreeFactory& CBoostedTreeFactory::operator=(CBoostedTreeFactory&&) = default;
+
+CBoostedTreeFactory::~CBoostedTreeFactory() = default;
 
 CBoostedTreeFactory& CBoostedTreeFactory::numberFolds(std::size_t numberFolds) {
     if (numberFolds < 2) {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -280,7 +280,7 @@ CBoostedTreeFactory::constructFromString(std::stringstream& jsonStringStream,
         TBoostedTreeUPtr treePtr{
             new CBoostedTree{frame, TBoostedTreeImplUPtr{new CBoostedTreeImpl{}}}};
         core::CJsonStateRestoreTraverser traverser(jsonStringStream);
-        if (treePtr->acceptRestoreTraverser(traverser) == false) {
+        if (treePtr->acceptRestoreTraverser(traverser) == false || traverser.haveBadState()) {
             throw std::runtime_error{"failed to restore boosted tree"};
         }
         return treePtr;

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -730,56 +730,44 @@ void CBoostedTreeImpl::SHyperparameters::acceptPersistInserter(core::CStatePersi
 }
 
 bool CBoostedTreeImpl::SHyperparameters::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    try {
-        do {
-            const std::string& name = traverser.name();
-            RESTORE(HYPERPARAM_LAMBDA_TAG,
-                    core::CPersistUtils::restore(HYPERPARAM_LAMBDA_TAG, s_Lambda, traverser))
-            RESTORE(HYPERPARAM_GAMMA_TAG,
-                    core::CPersistUtils::restore(HYPERPARAM_GAMMA_TAG, s_Gamma, traverser))
-            RESTORE(HYPERPARAM_ETA_TAG,
-                    core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, s_Eta, traverser))
-            RESTORE(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
-                    core::CPersistUtils::restore(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
-                                                 s_EtaGrowthRatePerTree, traverser))
-            RESTORE(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                    core::CPersistUtils::restore(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                                                 s_FeatureBagFraction, traverser))
-            RESTORE(HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG,
-                    core::CPersistUtils::restore(HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG,
-                                                 s_FeatureSampleProbabilities, traverser))
-        } while (traverser.next());
-    } catch (std::exception& e) {
-        LOG_ERROR(<< "Failed to restore state! " << e.what());
-        return false;
-    }
-
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(HYPERPARAM_LAMBDA_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_LAMBDA_TAG, s_Lambda, traverser))
+        RESTORE(HYPERPARAM_GAMMA_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_GAMMA_TAG, s_Gamma, traverser))
+        RESTORE(HYPERPARAM_ETA_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, s_Eta, traverser))
+        RESTORE(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                                             s_EtaGrowthRatePerTree, traverser))
+        RESTORE(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                                             s_FeatureBagFraction, traverser))
+        RESTORE(HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_FEATURE_SAMPLE_PROBABILITIES_TAG,
+                                             s_FeatureSampleProbabilities, traverser))
+    } while (traverser.next());
     return true;
 }
 
 bool CBoostedTreeImpl::CNode::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    try {
-        do {
-            const std::string& name = traverser.name();
-            RESTORE(LEFT_CHILD_TAG,
-                    core::CPersistUtils::restore(LEFT_CHILD_TAG, m_LeftChild, traverser))
-            RESTORE(RIGHT_CHILD_TAG,
-                    core::CPersistUtils::restore(RIGHT_CHILD_TAG, m_RightChild, traverser))
-            RESTORE(SPLIT_FEATURE_TAG,
-                    core::CPersistUtils::restore(SPLIT_FEATURE_TAG, m_SplitFeature, traverser))
-            RESTORE(ASSIGN_MISSING_TO_LEFT_TAG,
-                    core::CPersistUtils::restore(ASSIGN_MISSING_TO_LEFT_TAG,
-                                                 m_AssignMissingToLeft, traverser))
-            RESTORE(NODE_VALUE_TAG,
-                    core::CPersistUtils::restore(NODE_VALUE_TAG, m_NodeValue, traverser))
-            RESTORE(SPLIT_VALUE_TAG,
-                    core::CPersistUtils::restore(SPLIT_VALUE_TAG, m_SplitValue, traverser))
-        } while (traverser.next());
-    } catch (std::exception& e) {
-        LOG_ERROR(<< "Failed to restore state! " << e.what());
-        return false;
-    }
-
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(LEFT_CHILD_TAG,
+                core::CPersistUtils::restore(LEFT_CHILD_TAG, m_LeftChild, traverser))
+        RESTORE(RIGHT_CHILD_TAG,
+                core::CPersistUtils::restore(RIGHT_CHILD_TAG, m_RightChild, traverser))
+        RESTORE(SPLIT_FEATURE_TAG,
+                core::CPersistUtils::restore(SPLIT_FEATURE_TAG, m_SplitFeature, traverser))
+        RESTORE(ASSIGN_MISSING_TO_LEFT_TAG,
+                core::CPersistUtils::restore(ASSIGN_MISSING_TO_LEFT_TAG,
+                                             m_AssignMissingToLeft, traverser))
+        RESTORE(NODE_VALUE_TAG,
+                core::CPersistUtils::restore(NODE_VALUE_TAG, m_NodeValue, traverser))
+        RESTORE(SPLIT_VALUE_TAG,
+                core::CPersistUtils::restore(SPLIT_VALUE_TAG, m_SplitValue, traverser))
+    } while (traverser.next());
     return true;
 }
 
@@ -796,89 +784,81 @@ bool CBoostedTreeImpl::restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
 }
 
 bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    try {
-        do {
-            const std::string& name = traverser.name();
-            RESTORE_NO_ERROR(BAYESIAN_OPTIMIZATION_TAG,
-                             m_BayesianOptimization =
-                                 std::make_unique<CBayesianOptimisation>(traverser))
-            RESTORE(BEST_FOREST_TEST_LOSS_TAG,
-                    core::CPersistUtils::restore(BEST_FOREST_TEST_LOSS_TAG,
-                                                 m_BestForestTestLoss, traverser))
-            RESTORE(CURRENT_ROUND_TAG,
-                    core::CPersistUtils::restore(CURRENT_ROUND_TAG, m_CurrentRound, traverser))
-            RESTORE(DEPENDENT_VARIABLE_TAG,
-                    core::CPersistUtils::restore(DEPENDENT_VARIABLE_TAG,
-                                                 m_DependentVariable, traverser))
-            RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
-                    core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
-                                                 m_EtaGrowthRatePerTree, traverser))
-            RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
-            RESTORE(FEATURE_BAG_FRACTION_TAG,
-                    core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
-                                                 m_FeatureBagFraction, traverser))
-            RESTORE(FEATURE_SAMPLE_PROBABILITIES_TAG,
-                    core::CPersistUtils::restore(FEATURE_SAMPLE_PROBABILITIES_TAG,
-                                                 m_FeatureSampleProbabilities, traverser))
-            RESTORE(GAMMA_TAG, core::CPersistUtils::restore(GAMMA_TAG, m_Gamma, traverser))
-            RESTORE(LAMBDA_TAG, core::CPersistUtils::restore(LAMBDA_TAG, m_Lambda, traverser))
-            RESTORE(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
-                    core::CPersistUtils::restore(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
-                                                 m_MaximumAttemptsToAddTree, traverser))
-            RESTORE(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
-                    core::CPersistUtils::restore(
-                        MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
-                        m_MaximumOptimisationRoundsPerHyperparameter, traverser))
-            RESTORE(MAXIMUM_TREE_SIZE_FRACTION_TAG,
-                    core::CPersistUtils::restore(MAXIMUM_TREE_SIZE_FRACTION_TAG,
-                                                 m_MaximumTreeSizeFraction, traverser))
-            RESTORE(MISSING_FEATURE_ROW_MASKS_TAG,
-                    core::CPersistUtils::restore(MISSING_FEATURE_ROW_MASKS_TAG,
-                                                 m_MissingFeatureRowMasks, traverser))
-            RESTORE(NUMBER_FOLDS_TAG,
-                    core::CPersistUtils::restore(NUMBER_FOLDS_TAG, m_NumberFolds, traverser))
-            RESTORE(NUMBER_ROUNDS_TAG,
-                    core::CPersistUtils::restore(NUMBER_ROUNDS_TAG, m_NumberRounds, traverser))
-            RESTORE(NUMBER_SPLITS_PER_FEATURE_TAG,
-                    core::CPersistUtils::restore(NUMBER_SPLITS_PER_FEATURE_TAG,
-                                                 m_NumberSplitsPerFeature, traverser))
-            RESTORE(NUMBER_THREADS_TAG,
-                    core::CPersistUtils::restore(NUMBER_THREADS_TAG, m_NumberThreads, traverser))
-            RESTORE(ROWS_PER_FEATURE_TAG,
-                    core::CPersistUtils::restore(ROWS_PER_FEATURE_TAG, m_RowsPerFeature, traverser))
-            RESTORE(TESTING_ROW_MASKS_TAG,
-                    core::CPersistUtils::restore(TESTING_ROW_MASKS_TAG,
-                                                 m_TestingRowMasks, traverser))
-            RESTORE(MAXIMUM_NUMBER_TREES_TAG,
-                    core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_TAG,
-                                                 m_MaximumNumberTrees, traverser))
-            RESTORE(TRAINING_ROW_MASKS_TAG,
-                    core::CPersistUtils::restore(TRAINING_ROW_MASKS_TAG,
-                                                 m_TrainingRowMasks, traverser))
-            RESTORE(BEST_FOREST_TAG,
-                    core::CPersistUtils::restore(BEST_FOREST_TAG, m_BestForest, traverser))
-            RESTORE(BEST_HYPERPARAMETERS_TAG,
-                    core::CPersistUtils::restore(BEST_HYPERPARAMETERS_TAG,
-                                                 m_BestHyperparameters, traverser))
-            RESTORE(ETA_OVERRIDE_TAG,
-                    core::CPersistUtils::restore(ETA_OVERRIDE_TAG, m_EtaOverride, traverser))
-            RESTORE(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
-                    core::CPersistUtils::restore(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
-                                                 m_FeatureBagFractionOverride, traverser))
-            RESTORE(GAMMA_OVERRIDE_TAG,
-                    core::CPersistUtils::restore(GAMMA_OVERRIDE_TAG, m_GammaOverride, traverser))
-            RESTORE(LAMBDA_OVERRIDE_TAG,
-                    core::CPersistUtils::restore(LAMBDA_OVERRIDE_TAG, m_LambdaOverride, traverser))
-            RESTORE(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
-                    core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
-                                                 m_MaximumNumberTreesOverride, traverser))
-            RESTORE(LOSS_TAG, restoreLoss(m_Loss, traverser))
-        } while (traverser.next());
-    } catch (std::exception& e) {
-        LOG_ERROR(<< "Failed to restore state! " << e.what());
-        return false;
-    }
-
+    do {
+        const std::string& name = traverser.name();
+        RESTORE_NO_ERROR(BAYESIAN_OPTIMIZATION_TAG,
+                         m_BayesianOptimization =
+                             std::make_unique<CBayesianOptimisation>(traverser))
+        RESTORE(BEST_FOREST_TEST_LOSS_TAG,
+                core::CPersistUtils::restore(BEST_FOREST_TEST_LOSS_TAG,
+                                             m_BestForestTestLoss, traverser))
+        RESTORE(CURRENT_ROUND_TAG,
+                core::CPersistUtils::restore(CURRENT_ROUND_TAG, m_CurrentRound, traverser))
+        RESTORE(DEPENDENT_VARIABLE_TAG,
+                core::CPersistUtils::restore(DEPENDENT_VARIABLE_TAG,
+                                             m_DependentVariable, traverser))
+        RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
+                core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
+                                             m_EtaGrowthRatePerTree, traverser))
+        RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
+        RESTORE(FEATURE_BAG_FRACTION_TAG,
+                core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
+                                             m_FeatureBagFraction, traverser))
+        RESTORE(FEATURE_SAMPLE_PROBABILITIES_TAG,
+                core::CPersistUtils::restore(FEATURE_SAMPLE_PROBABILITIES_TAG,
+                                             m_FeatureSampleProbabilities, traverser))
+        RESTORE(GAMMA_TAG, core::CPersistUtils::restore(GAMMA_TAG, m_Gamma, traverser))
+        RESTORE(LAMBDA_TAG, core::CPersistUtils::restore(LAMBDA_TAG, m_Lambda, traverser))
+        RESTORE(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
+                core::CPersistUtils::restore(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
+                                             m_MaximumAttemptsToAddTree, traverser))
+        RESTORE(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                core::CPersistUtils::restore(
+                    MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                    m_MaximumOptimisationRoundsPerHyperparameter, traverser))
+        RESTORE(MAXIMUM_TREE_SIZE_FRACTION_TAG,
+                core::CPersistUtils::restore(MAXIMUM_TREE_SIZE_FRACTION_TAG,
+                                             m_MaximumTreeSizeFraction, traverser))
+        RESTORE(MISSING_FEATURE_ROW_MASKS_TAG,
+                core::CPersistUtils::restore(MISSING_FEATURE_ROW_MASKS_TAG,
+                                             m_MissingFeatureRowMasks, traverser))
+        RESTORE(NUMBER_FOLDS_TAG,
+                core::CPersistUtils::restore(NUMBER_FOLDS_TAG, m_NumberFolds, traverser))
+        RESTORE(NUMBER_ROUNDS_TAG,
+                core::CPersistUtils::restore(NUMBER_ROUNDS_TAG, m_NumberRounds, traverser))
+        RESTORE(NUMBER_SPLITS_PER_FEATURE_TAG,
+                core::CPersistUtils::restore(NUMBER_SPLITS_PER_FEATURE_TAG,
+                                             m_NumberSplitsPerFeature, traverser))
+        RESTORE(NUMBER_THREADS_TAG,
+                core::CPersistUtils::restore(NUMBER_THREADS_TAG, m_NumberThreads, traverser))
+        RESTORE(ROWS_PER_FEATURE_TAG,
+                core::CPersistUtils::restore(ROWS_PER_FEATURE_TAG, m_RowsPerFeature, traverser))
+        RESTORE(TESTING_ROW_MASKS_TAG,
+                core::CPersistUtils::restore(TESTING_ROW_MASKS_TAG, m_TestingRowMasks, traverser))
+        RESTORE(MAXIMUM_NUMBER_TREES_TAG,
+                core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_TAG,
+                                             m_MaximumNumberTrees, traverser))
+        RESTORE(TRAINING_ROW_MASKS_TAG,
+                core::CPersistUtils::restore(TRAINING_ROW_MASKS_TAG, m_TrainingRowMasks, traverser))
+        RESTORE(BEST_FOREST_TAG,
+                core::CPersistUtils::restore(BEST_FOREST_TAG, m_BestForest, traverser))
+        RESTORE(BEST_HYPERPARAMETERS_TAG,
+                core::CPersistUtils::restore(BEST_HYPERPARAMETERS_TAG,
+                                             m_BestHyperparameters, traverser))
+        RESTORE(ETA_OVERRIDE_TAG,
+                core::CPersistUtils::restore(ETA_OVERRIDE_TAG, m_EtaOverride, traverser))
+        RESTORE(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+                core::CPersistUtils::restore(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+                                             m_FeatureBagFractionOverride, traverser))
+        RESTORE(GAMMA_OVERRIDE_TAG,
+                core::CPersistUtils::restore(GAMMA_OVERRIDE_TAG, m_GammaOverride, traverser))
+        RESTORE(LAMBDA_OVERRIDE_TAG,
+                core::CPersistUtils::restore(LAMBDA_OVERRIDE_TAG, m_LambdaOverride, traverser))
+        RESTORE(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
+                core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
+                                             m_MaximumNumberTreesOverride, traverser))
+        RESTORE(LOSS_TAG, restoreLoss(m_Loss, traverser))
+    } while (traverser.next());
     return true;
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -8,6 +8,8 @@
 
 #include <core/CDataFrame.h>
 #include <core/CJsonStatePersistInserter.h>
+#include <core/CLogger.h>
+#include <core/CRegex.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
@@ -514,6 +516,7 @@ void CBoostedTreeTest::testErrors() {
 }
 
 void CBoostedTreeTest::testPersistRestore() {
+
     std::size_t rows{50};
     std::size_t cols{3};
     std::size_t capacity{50};
@@ -522,16 +525,13 @@ void CBoostedTreeTest::testPersistRestore() {
     std::stringstream persistOnceSStream;
     std::stringstream persistTwiceSStream;
 
-    TFactoryFunc makeMainMemory{
-        [=] { return core::makeMainStorageDataFrame(cols, capacity).first; }};
-
+    // generate completely random data
     TDoubleVecVec x(cols);
     for (std::size_t i = 0; i < cols; ++i) {
         rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
     }
-    auto frame = makeMainMemory();
 
-    // generate completely random data
+    auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             for (std::size_t j = 0; j < cols; ++j, ++column) {
@@ -568,6 +568,99 @@ void CBoostedTreeTest::testPersistRestore() {
     // and even run
     CPPUNIT_ASSERT_NO_THROW(boostedTree->train());
     CPPUNIT_ASSERT_NO_THROW(boostedTree->predict());
+
+    // TODO test persist and restore produces same train result.
+}
+
+void CBoostedTreeTest::testPersistRestoreErrorHandling() {
+
+    auto errorHandler = [](std::string error) {
+        throw std::runtime_error{error};
+    };
+    core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
+
+    std::size_t cols{3};
+    std::size_t capacity{50};
+
+    auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+
+    std::stringstream errorInBayesianOptimisationState;
+    errorInBayesianOptimisationState
+        << "{\"boosted_tree_impl\":{\"bayesian_optimization\":"
+           "{\"min_boundary\":{\"dense_vector\":\"-9.191737e-1:-2.041179:-3.506558:1.025:2e-1\"},"
+           "\"max_boundary\":{\"dense_vector\":\"3.685997:2.563991:-1.203973:a:8e-1\"},"
+           "\"error_variances\":\"\",\"kernel_parameters\":{\"dense_vector\":\"1:1:1:1:1:1\"},"
+           "\"min_kernel_coordinate_distance_scales\":{\"dense_vector\":\"1e-3:1e-3:1e-3:1e-3:1e-3\"},"
+           "\"function_mean_values\":{\"d\":\"0\"}},\"best_forest_test_loss\":\"1.797693e308\","
+           "\"current_round\":\"0\",\"dependent_variable\":\"2\",\"eta_growth_rate_per_tree\":\"1.05\","
+           "\"eta\":\"1e-1\",\"feature_bag_fraction\":\"5e-1\",\"feature_sample_probabilities\":\"1:0:0\","
+           "\"gamma\":\"1.298755\",\"lambda\":\"3.988485\",\"maximum_attempts_to_add_tree\":\"3\","
+           "\"maximum_optimisation_rounds_per_hyperparameter\":\"3\",\"maximum_tree_size_fraction\":\"10\","
+           "\"missing_feature_row_masks\":{\"d\":\"3\",\"a\":\"50:0:1:50\",\"a\":\"50:0:1:50\",\"a\":\"50:0:1:50\"},"
+           "\"number_folds\":\"2\",\"number_rounds\":\"15\",\"number_splits_per_feature\":\"40\","
+           "\"number_threads\":\"1\",\"rows_per_feature\":\"50\","
+           "\"testing_row_masks\":{\"d\":\"2\",\"a\":\"50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\","
+           "\"a\":\"50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\"},\"maximum_number_trees\":\"2\","
+           "\"training_row_masks\":{\"d\":\"2\",\"a\":\"50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\","
+           "\"a\":\"50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\"},\"best_forest\":{\"d\":\"0\"},"
+           "\"best_hyperparameters\":{\"hyperparam_lambda\":\"0\",\"hyperparam_gamma\":\"0\","
+           "\"hyperparam_eta\":\"0\",\"hyperparam_eta_growth_rate_per_tree\":\"0\","
+           "\"hyperparam_feature_bag_fraction\":\"0\",\"hyperparam_feature_sample_probabilities\":\"\"},"
+           "\"eta_override\":\"false;0\",\"feature_bag_fraction_override\":\"false;0\",\"gamma_override\":\"false;0\","
+           "\"lambda_override\":\"false;0\",\"maximum_number_trees_override\":\"true;2\",\"loss\":\"mse\"}}";
+    errorInBayesianOptimisationState.flush();
+
+    bool throwsExceptions{false};
+    try {
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(
+            errorInBayesianOptimisationState, *frame);
+    } catch (const std::exception& e) {
+        LOG_DEBUG(<< "got = " << e.what());
+        throwsExceptions = true;
+        core::CRegex re;
+        re.init("Input error:.*");
+        CPPUNIT_ASSERT(re.matches(e.what()));
+    }
+    CPPUNIT_ASSERT(throwsExceptions);
+
+    std::stringstream errorInBoostedTreeImplState;
+    errorInBoostedTreeImplState
+        << "{\"boosted_tree_impl\":{\"bayesian_optimization\":"
+           "{\"min_boundary\":{\"dense_vector\":\"-9.191737e-1:-2.041179:-3.506558:1.025:2e-1\"},"
+           "\"max_boundary\":{\"dense_vector\":\"3.685997:2.563991:-1.203973:0.1:8e-1\"},"
+           "\"error_variances\":\"\",\"kernel_parameters\":{\"dense_vector\":\"1:1:1:1:1:1\"},"
+           "\"min_kernel_coordinate_distance_scales\":{\"dense_vector\":\"1e-3:1e-3:1e-3:1e-3:1e-3\"},"
+           "\"function_mean_values\":{\"d\":\"0\"}},\"best_forest_test_loss\":\"1.797693e308\","
+           "\"current_round\":\"0\",\"dependent_variable\":\"2\",\"eta_growth_rate_per_tree\":\"1.05\","
+           "\"eta\":\"1e-1\",\"feature_bag_fraction\":\"5e-1\",\"feature_sample_probabilities\":\"1:0:0\","
+           "\"gamma\":\"1.298755\",\"lambda\":\"3.988485\",\"maximum_attempts_to_add_tree\":\"3\","
+           "\"maximum_optimisation_rounds_per_hyperparameter\":\"3\",\"maximum_tree_size_fraction\":\"10\","
+           "\"missing_feature_row_masks\":{\"d\":\"3\",\"a\":\"50:0:1:50\",\"a\":\"50:0:1:50\",\"a\":\"50:0:1:50\"},"
+           "\"number_folds\":\"\",\"number_rounds\":\"15\",\"number_splits_per_feature\":\"40\","
+           "\"number_threads\":\"1\",\"rows_per_feature\":\"50\","
+           "\"testing_row_masks\":{\"d\":\"2\",\"a\":\"50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\","
+           "\"a\":\"50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\"},\"maximum_number_trees\":\"2\","
+           "\"training_row_masks\":{\"d\":\"2\",\"a\":\"50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\","
+           "\"a\":\"50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2\"},\"best_forest\":{\"d\":\"0\"},"
+           "\"best_hyperparameters\":{\"hyperparam_lambda\":\"0\",\"hyperparam_gamma\":\"0\","
+           "\"hyperparam_eta\":\"0\",\"hyperparam_eta_growth_rate_per_tree\":\"0\","
+           "\"hyperparam_feature_bag_fraction\":\"0\",\"hyperparam_feature_sample_probabilities\":\"\"},"
+           "\"eta_override\":\"false;0\",\"feature_bag_fraction_override\":\"false;0\",\"gamma_override\":\"false;0\","
+           "\"lambda_override\":\"false;0\",\"maximum_number_trees_override\":\"true;2\",\"loss\":\"mse\"}}";
+    errorInBoostedTreeImplState.flush();
+
+    throwsExceptions = false;
+    try {
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(
+            errorInBoostedTreeImplState, *frame);
+    } catch (const std::exception& e) {
+        LOG_DEBUG(<< "got = " << e.what());
+        throwsExceptions = true;
+        core::CRegex re;
+        re.init("Input error:.*");
+        CPPUNIT_ASSERT(re.matches(e.what()));
+    }
+    CPPUNIT_ASSERT(throwsExceptions);
 }
 
 CppUnit::Test* CBoostedTreeTest::suite() {
@@ -591,6 +684,9 @@ CppUnit::Test* CBoostedTreeTest::suite() {
         "CBoostedTreeTest::testErrors", &CBoostedTreeTest::testErrors));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testPersistRestore", &CBoostedTreeTest::testPersistRestore));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testPersistRestoreErrorHandling",
+        &CBoostedTreeTest::testPersistRestoreErrorHandling));
 
     return suiteOfTests;
 }

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -18,12 +18,13 @@ public:
     void testConstantFeatures();
     void testConstantObjective();
     void testMissingData();
-    void testPersistRestore();
+    void testErrors();
     // TODO void testCategoricalRegressors();
     // TODO void testFeatureWeights();
     // TODO void testNuisanceFeatures();
     // TODO void testCheckpointing();
-    void testErrors();
+    void testPersistRestore();
+    void testPersistRestoreErrorHandling();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
Previously, we absorbed any errors emitted restoring boosted tree training state and just returned the bad object. We were also silently swallowing errors in `CBayesianOptimisation` constructor from a state traverser. Finally, we were unnecessarily wrapping individual restore loops in try blocks (this was already done in the `traverseSubLevel` function).

We now ensure all errors are propagated to `CBoostedTreeFactory::constructFromString` where we then propagate errors back to the Java via the usual `HANDLE_FATAL` mechanism. (We need to revisit whether a restore issue should be a fatal error, since we can just resume training from scratch in this case, but I'll defer that decision until it is fully wired in.)

This change also adds some bad state restore unit tests.