### PR TITLE
[7.x][ML] Fix return type of L-BFGS lambdas

### DIFF
--- a/include/maths/CLbfgs.h
+++ b/include/maths/CLbfgs.h
@@ -143,10 +143,16 @@ public:
             VECTOR r2{x_ + z2 + w2 - b};
             double n1{las::norm(r1)};
             double n2{las::norm(r2)};
-            return f(x_) + 0.5 * rho * (n1 * n1 + n2 * n2);
+            // Explicitly construct the return type before returning from the lambda,
+            // otherwise the auto return type may be an Eigen closure type which
+            // references temporaries
+            return double{f(x_) + 0.5 * rho * (n1 * n1 + n2 * n2)};
         };
         auto gal = [&](const VECTOR& x_) {
-            return g(x_) + rho * (2 * x_ - z1 + z2 - a - b + w1 + w2);
+            // Explicitly construct the return type before returning from the lambda,
+            // otherwise the auto return type may be an Eigen closure type which
+            // references temporaries
+            return VECTOR{g(x_) + rho * (2 * x_ - z1 + z2 - a - b + w1 + w2)};
         };
 
         VECTOR xmin;


### PR DESCRIPTION
Test failures in the debug build show that a couple
of lambdas in the CLbfgs class were returning Eigen
closure types referencing temporaries that could lead
to invalid memory accesses.

This change makes the lambdas construct self-contained
types before returning to avoid accesses to out-of-scope
temporaries.

(We believe that with optimization enabled the invalid
memory accesses were not occurring as the lambdas were
optimized away.)

Backport of #579