### PR TITLE
Introduce memory usage estimation mode in data_frame_analyzer

### DIFF
--- a/bin/data_frame_analyzer/CCmdLineParser.cc
+++ b/bin/data_frame_analyzer/CCmdLineParser.cc
@@ -20,6 +20,7 @@ const std::string CCmdLineParser::DESCRIPTION = "Usage: data_frame_analyzer [opt
 bool CCmdLineParser::parse(int argc,
                            const char* const* argv,
                            std::string& configFile,
+                           bool& memoryUsageEstimationOnly,
                            std::string& logProperties,
                            std::string& logPipe,
                            bool& lengthEncodedInput,
@@ -35,6 +36,7 @@ bool CCmdLineParser::parse(int argc,
             ("version", "Display version information and exit")
             ("config", boost::program_options::value<std::string>(),
                     "The configuration file")
+            ("memoryUsageEstimationOnly", "Whether to perform memory usage estimation only")
             ("logProperties", boost::program_options::value<std::string>(),
                     "Optional logger properties file")
             ("logPipe", boost::program_options::value<std::string>(),
@@ -65,6 +67,9 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("config") > 0) {
             configFile = vm["config"].as<std::string>();
+        }
+        if (vm.count("memoryUsageEstimationOnly") > 0) {
+            memoryUsageEstimationOnly = true;
         }
         if (vm.count("logProperties") > 0) {
             logProperties = vm["logProperties"].as<std::string>();

--- a/bin/data_frame_analyzer/CCmdLineParser.h
+++ b/bin/data_frame_analyzer/CCmdLineParser.h
@@ -27,6 +27,7 @@ public:
     static bool parse(int argc,
                       const char* const* argv,
                       std::string& configFile,
+                      bool& memoryUsageEstimationOnly,
                       std::string& logProperties,
                       std::string& logPipe,
                       bool& lengthEncodedInput,

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -142,12 +142,11 @@ int main(int argc, char** argv) {
         std::make_unique<ml::api::CDataFrameAnalysisSpecification>(analysisSpecificationJson);
 
     if (memoryUsageEstimationOnly) {
-        const auto result = analysisSpecification->estimateMemoryUsage();
         auto outStream = [&ioMgr]() {
             return std::make_unique<ml::core::CJsonOutputStreamWrapper>(ioMgr.outputStream());
         }();
-        ml::api::CMemoryUsageEstimationResultJsonWriter jsonWriter(*outStream);
-        jsonWriter.write(result);
+        ml::api::CMemoryUsageEstimationResultJsonWriter writer(*outStream);
+        analysisSpecification->estimateMemoryUsage(writer);
         return EXIT_SUCCESS;
     }
 

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -96,8 +96,9 @@ int main(int argc, char** argv) {
     std::string outputFileName;
     bool isOutputFileNamedPipe(false);
     if (ml::data_frame_analyzer::CCmdLineParser::parse(
-            argc, argv, configFile, memoryUsageEstimationOnly, logProperties, logPipe, lengthEncodedInput, inputFileName,
-            isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe) == false) {
+            argc, argv, configFile, memoryUsageEstimationOnly, logProperties,
+            logPipe, lengthEncodedInput, inputFileName, isInputFileNamedPipe,
+            outputFileName, isOutputFileNamedPipe) == false) {
         return EXIT_FAILURE;
     }
 

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -78,7 +78,7 @@ public:
 
     //! Estimates memory usage in two cases: one partition (the whole data frame
     //! fits in main memory) and maximum tolerable number of partitions (only
-    //! one partition needs to be loaded to main memory.
+    //! one partition needs to be loaded to main memory).
     void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const;
 
     //! Check if the data frame for this analysis should use in or out of core

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -31,7 +31,7 @@ class CRowRef;
 }
 namespace api {
 class CDataFrameAnalysisSpecification;
-struct SMemoryUsageEstimationResult;
+class CMemoryUsageEstimationResultJsonWriter;
 
 //! \brief Hierarchy for running a specific core::CDataFrame analyses.
 //!
@@ -79,7 +79,7 @@ public:
     //! Estimates memory usage in two cases: one partition (the whole data frame
     //! fits in main memory) and maximum tolerable number of partitions (only
     //! one partition needs to be loaded to main memory.
-    SMemoryUsageEstimationResult estimateMemoryUsage() const;
+    void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const;
 
     //! Check if the data frame for this analysis should use in or out of core
     //! storage.

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -31,6 +31,7 @@ class CRowRef;
 }
 namespace api {
 class CDataFrameAnalysisSpecification;
+struct SMemoryUsageEstimationResult;
 
 //! \brief Hierarchy for running a specific core::CDataFrame analyses.
 //!
@@ -74,6 +75,11 @@ public:
     //! the data frame will be stored, the size of the partition and the maximum
     //! number of rows per subset.
     void computeAndSaveExecutionStrategy();
+
+    //! Estimates memory usage in two cases: one partition (the whole data frame
+    //! fits in main memory) and maximum tolerable number of partitions (only
+    //! one partition needs to be loaded to main memory.
+    SMemoryUsageEstimationResult estimateMemoryUsage() const;
 
     //! Check if the data frame for this analysis should use in or out of core
     //! storage.

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -154,7 +154,7 @@ public:
     //! Estimates memory usage in two cases: one partition (the whole data frame
     //! fits in main memory) and maximum tolerable number of partitions (only
     //! one partition needs to be loaded to main memory.
-    SMemoryUsageEstimationResult estimateMemoryUsage() const;
+    void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& resultWriter) const;
 
 private:
     void initializeRunner(const rapidjson::Value& jsonAnalysis);

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -151,6 +151,11 @@ public:
     //! calling thread until the runner has finished.
     CDataFrameAnalysisRunner* run(core::CDataFrame& frame) const;
 
+    //! Estimates memory usage in two cases: one partition (the whole data frame
+    //! fits in main memory) and maximum tolerable number of partitions (only
+    //! one partition needs to be loaded to main memory.
+    SMemoryUsageEstimationResult estimateMemoryUsage() const;
+
 private:
     void initializeRunner(const rapidjson::Value& jsonAnalysis);
 

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -153,8 +153,8 @@ public:
 
     //! Estimates memory usage in two cases: one partition (the whole data frame
     //! fits in main memory) and maximum tolerable number of partitions (only
-    //! one partition needs to be loaded to main memory.
-    void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& resultWriter) const;
+    //! one partition needs to be loaded to main memory).
+    void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const;
 
 private:
     void initializeRunner(const rapidjson::Value& jsonAnalysis);

--- a/include/api/CMemoryUsageEstimationResultJsonWriter.h
+++ b/include/api/CMemoryUsageEstimationResultJsonWriter.h
@@ -25,7 +25,7 @@ namespace api {
 //!
 class API_EXPORT CMemoryUsageEstimationResultJsonWriter : private core::CNonCopyable {
 public:
-    //! Constructor that causes output to be written to the specified wrapped stream
+    //! \param[in] strmOut The wrapped stream to which to write output.
     CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut);
 
     //! Writes the given memory usage estimation result in JSON format.

--- a/include/api/CMemoryUsageEstimationResultJsonWriter.h
+++ b/include/api/CMemoryUsageEstimationResultJsonWriter.h
@@ -30,7 +30,7 @@ public:
 
     //! Writes the given memory usage estimation result in JSON format.
     void write(size_t expectedMemoryUsageWithOnePartition,
-    	       size_t expectedMemoryUsageWithMaxPartitions);
+               size_t expectedMemoryUsageWithMaxPartitions);
 
 private:
     //! JSON line writer

--- a/include/api/CMemoryUsageEstimationResultJsonWriter.h
+++ b/include/api/CMemoryUsageEstimationResultJsonWriter.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CMemoryUsageEstimationResultJsonWriter_h
+#define INCLUDED_ml_api_CMemoryUsageEstimationResultJsonWriter_h
+
+#include <core/CJsonOutputStreamWrapper.h>
+#include <core/CNonCopyable.h>
+#include <core/CRapidJsonConcurrentLineWriter.h>
+
+#include <api/ImportExport.h>
+
+#include <string>
+
+namespace ml {
+namespace api {
+
+//! Structure to store the memory usage estimation result
+struct API_EXPORT SMemoryUsageEstimationResult {
+    SMemoryUsageEstimationResult(size_t memoryUsageWithOnePartition, size_t memoryUsageWithMaxPartitions);
+    SMemoryUsageEstimationResult(const SMemoryUsageEstimationResult& result);
+
+    const size_t s_MemoryUsageWithOnePartition;
+    const size_t s_MemoryUsageWithMaxPartitions;
+};
+
+//! \brief
+//! Write memory usage estimation result in JSON format
+//!
+//! DESCRIPTION:\n
+//! Outputs the memory usage estimation result.
+//!
+class API_EXPORT CMemoryUsageEstimationResultJsonWriter : private core::CNonCopyable {
+public:
+    //! Constructor that causes output to be written to the specified wrapped stream
+    CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut);
+
+    //! Writes the given memory usage estimation result in JSON format.
+    void write(const SMemoryUsageEstimationResult& result);
+
+private:
+    //! JSON line writer
+    core::CRapidJsonConcurrentLineWriter m_Writer;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CMemoryUsageEstimationResultJsonWriter_h

--- a/include/api/CMemoryUsageEstimationResultJsonWriter.h
+++ b/include/api/CMemoryUsageEstimationResultJsonWriter.h
@@ -29,8 +29,8 @@ public:
     CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut);
 
     //! Writes the given memory usage estimation result in JSON format.
-    void write(size_t expectedMemoryUsageWithOnePartition,
-               size_t expectedMemoryUsageWithMaxPartitions);
+    void write(const std::string& expectedMemoryUsageWithOnePartition,
+               const std::string& expectedMemoryUsageWithMaxPartitions);
 
 private:
     //! JSON line writer

--- a/include/api/CMemoryUsageEstimationResultJsonWriter.h
+++ b/include/api/CMemoryUsageEstimationResultJsonWriter.h
@@ -17,15 +17,6 @@
 namespace ml {
 namespace api {
 
-//! Structure to store the memory usage estimation result
-struct API_EXPORT SMemoryUsageEstimationResult {
-    SMemoryUsageEstimationResult(size_t memoryUsageWithOnePartition, size_t memoryUsageWithMaxPartitions);
-    SMemoryUsageEstimationResult(const SMemoryUsageEstimationResult& result);
-
-    const size_t s_MemoryUsageWithOnePartition;
-    const size_t s_MemoryUsageWithMaxPartitions;
-};
-
 //! \brief
 //! Write memory usage estimation result in JSON format
 //!
@@ -38,7 +29,8 @@ public:
     CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut);
 
     //! Writes the given memory usage estimation result in JSON format.
-    void write(const SMemoryUsageEstimationResult& result);
+    void write(size_t expectedMemoryUsageWithOnePartition,
+    	       size_t expectedMemoryUsageWithMaxPartitions);
 
 private:
     //! JSON line writer

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -56,7 +56,11 @@ void CDataFrameAnalysisRunner::estimateMemoryUsage(CMemoryUsageEstimationResultJ
         this->estimateMemoryUsage(numberRows, numberRows, numberColumns)};
     std::size_t expectedMemoryUsageWithMaxPartitions{this->estimateMemoryUsage(
         numberRows, numberRows / maxNumberPartitions, numberColumns)};
-    writer.write(expectedMemoryUsageWithOnePartition, expectedMemoryUsageWithMaxPartitions);
+    auto roundUpToNearestKilobyte = [](std::size_t bytes) {
+        return 1024 * ((bytes + 1024 - 1) / 1024);
+    };
+    writer.write(roundUpToNearestKilobyte(expectedMemoryUsageWithOnePartition),
+                 roundUpToNearestKilobyte(expectedMemoryUsageWithMaxPartitions));
 }
 
 void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -54,8 +54,8 @@ void CDataFrameAnalysisRunner::estimateMemoryUsage(CMemoryUsageEstimationResultJ
     }
     std::size_t expectedMemoryUsageWithOnePartition{
         this->estimateMemoryUsage(numberRows, numberRows, numberColumns)};
-    std::size_t expectedMemoryUsageWithMaxPartitions{
-        this->estimateMemoryUsage(numberRows, numberRows / maxNumberPartitions, numberColumns)};
+    std::size_t expectedMemoryUsageWithMaxPartitions{this->estimateMemoryUsage(
+        numberRows, numberRows / maxNumberPartitions, numberColumns)};
     writer.write(expectedMemoryUsageWithOnePartition, expectedMemoryUsageWithMaxPartitions);
 }
 
@@ -73,8 +73,7 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
     std::size_t maxNumberPartitions{maximumNumberPartitions(m_Spec)};
     std::size_t memoryUsage{0};
 
-    for (m_NumberPartitions = 1; m_NumberPartitions < maxNumberPartitions;
-         ++m_NumberPartitions) {
+    for (m_NumberPartitions = 1; m_NumberPartitions < maxNumberPartitions; ++m_NumberPartitions) {
         std::size_t partitionNumberRows{numberRows / m_NumberPartitions};
         memoryUsage = this->estimateMemoryUsage(numberRows, partitionNumberRows, numberColumns);
         LOG_TRACE(<< "partition number rows = " << partitionNumberRows);

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -49,7 +49,7 @@ void CDataFrameAnalysisRunner::estimateMemoryUsage(CMemoryUsageEstimationResultJ
     std::size_t numberColumns{m_Spec.numberColumns() + this->numberExtraColumns()};
     std::size_t maxNumberPartitions{maximumNumberPartitions(m_Spec)};
     if (maxNumberPartitions == 0) {
-        writer.write(0, 0);
+        writer.write("0", "0");
         return;
     }
     std::size_t expectedMemoryUsageWithOnePartition{
@@ -57,7 +57,7 @@ void CDataFrameAnalysisRunner::estimateMemoryUsage(CMemoryUsageEstimationResultJ
     std::size_t expectedMemoryUsageWithMaxPartitions{this->estimateMemoryUsage(
         numberRows, numberRows / maxNumberPartitions, numberColumns)};
     auto roundUpToNearestKilobyte = [](std::size_t bytes) {
-        return 1024 * ((bytes + 1024 - 1) / 1024);
+        return std::to_string((bytes + 1024 - 1) / 1024) + "kB";
     };
     writer.write(roundUpToNearestKilobyte(expectedMemoryUsageWithOnePartition),
                  roundUpToNearestKilobyte(expectedMemoryUsageWithMaxPartitions));

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -184,9 +184,12 @@ CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame&
     return nullptr;
 }
 
-void CDataFrameAnalysisSpecification::estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& resultWriter) const {
-    // TODO: What to do if m_Runner is nullptr?
-    m_Runner->estimateMemoryUsage(resultWriter);
+void CDataFrameAnalysisSpecification::estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const {
+    if (m_Runner == nullptr) {
+        HANDLE_FATAL(<< "Internal error: no runner available so can't estimate memory. Please report this problem.");
+        return;
+    }
+    m_Runner->estimateMemoryUsage(writer);
 }
 
 void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& jsonAnalysis) {

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -184,9 +184,9 @@ CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame&
     return nullptr;
 }
 
-SMemoryUsageEstimationResult CDataFrameAnalysisSpecification::estimateMemoryUsage() const {
+void CDataFrameAnalysisSpecification::estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& resultWriter) const {
     // TODO: What to do if m_Runner is nullptr?
-    return m_Runner->estimateMemoryUsage();
+    m_Runner->estimateMemoryUsage(resultWriter);
 }
 
 void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& jsonAnalysis) {

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -12,6 +12,7 @@
 #include <api/CDataFrameAnalysisConfigReader.h>
 #include <api/CDataFrameBoostedTreeRunner.h>
 #include <api/CDataFrameOutliersRunner.h>
+#include <api/CMemoryUsageEstimationResultJsonWriter.h>
 
 #include <rapidjson/document.h>
 #include <rapidjson/ostreamwrapper.h>
@@ -181,6 +182,11 @@ CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame&
         return m_Runner.get();
     }
     return nullptr;
+}
+
+SMemoryUsageEstimationResult CDataFrameAnalysisSpecification::estimateMemoryUsage() const {
+    // TODO: What to do if m_Runner is nullptr?
+    return m_Runner->estimateMemoryUsage();
 }
 
 void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& jsonAnalysis) {

--- a/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
+++ b/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
@@ -11,29 +11,23 @@ namespace api {
 namespace {
 
 // JSON field names
-const std::string MEMORY_USAGE_WITH_ONE_PARTITION("memory_usage_with_one_partition");
-const std::string MEMORY_USAGE_WITH_MAX_PARTITIONS("memory_usage_with_max_partitions");
+const std::string EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION("expected_memory_usage_with_one_partition");
+const std::string EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS("expected_memory_usage_with_max_partitions");
 }
 
-SMemoryUsageEstimationResult::SMemoryUsageEstimationResult(
-    std::size_t memoryUsageWithOnePartition, std::size_t memoryUsageWithMaxPartitions):
-s_MemoryUsageWithOnePartition(memoryUsageWithOnePartition), s_MemoryUsageWithMaxPartitions(memoryUsageWithMaxPartitions) {}
-
-SMemoryUsageEstimationResult::SMemoryUsageEstimationResult(
-    const SMemoryUsageEstimationResult& result):
-SMemoryUsageEstimationResult(result.s_MemoryUsageWithOnePartition, result.s_MemoryUsageWithMaxPartitions) {}
-
-CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut) : m_Writer(strmOut) {
+CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(
+        core::CJsonOutputStreamWrapper& strmOut) : m_Writer(strmOut) {
     // Don't write any output in the constructor because, the way things work at
     // the moment, the output stream might be redirected after construction
 }
 
-void CMemoryUsageEstimationResultJsonWriter::write(const SMemoryUsageEstimationResult& result) {
+void CMemoryUsageEstimationResultJsonWriter::write(std::size_t expectedMemoryUsageWithOnePartition,
+                                                   std::size_t expectedMemoryUsageWithMaxPartitions) {
     m_Writer.StartObject();
-    m_Writer.Key(MEMORY_USAGE_WITH_ONE_PARTITION);
-    m_Writer.Uint64(result.s_MemoryUsageWithOnePartition);
-    m_Writer.Key(MEMORY_USAGE_WITH_MAX_PARTITIONS);
-    m_Writer.Uint64(result.s_MemoryUsageWithMaxPartitions);
+    m_Writer.Key(EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION);
+    m_Writer.Uint64(expectedMemoryUsageWithOnePartition);
+    m_Writer.Key(EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS);
+    m_Writer.Uint64(expectedMemoryUsageWithMaxPartitions);
     m_Writer.EndObject();
     m_Writer.flush();
 }

--- a/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
+++ b/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CMemoryUsageEstimationResultJsonWriter.h>
+
+namespace ml {
+namespace api {
+namespace {
+
+// JSON field names
+const std::string MEMORY_USAGE_WITH_ONE_PARTITION("memory_usage_with_one_partition");
+const std::string MEMORY_USAGE_WITH_MAX_PARTITIONS("memory_usage_with_max_partitions");
+}
+
+SMemoryUsageEstimationResult::SMemoryUsageEstimationResult(
+    std::size_t memoryUsageWithOnePartition, std::size_t memoryUsageWithMaxPartitions):
+s_MemoryUsageWithOnePartition(memoryUsageWithOnePartition), s_MemoryUsageWithMaxPartitions(memoryUsageWithMaxPartitions) {}
+
+SMemoryUsageEstimationResult::SMemoryUsageEstimationResult(
+    const SMemoryUsageEstimationResult& result):
+SMemoryUsageEstimationResult(result.s_MemoryUsageWithOnePartition, result.s_MemoryUsageWithMaxPartitions) {}
+
+CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut) : m_Writer(strmOut) {
+    // Don't write any output in the constructor because, the way things work at
+    // the moment, the output stream might be redirected after construction
+}
+
+void CMemoryUsageEstimationResultJsonWriter::write(const SMemoryUsageEstimationResult& result) {
+    m_Writer.StartObject();
+    m_Writer.Key(MEMORY_USAGE_WITH_ONE_PARTITION);
+    m_Writer.Uint64(result.s_MemoryUsageWithOnePartition);
+    m_Writer.Key(MEMORY_USAGE_WITH_MAX_PARTITIONS);
+    m_Writer.Uint64(result.s_MemoryUsageWithMaxPartitions);
+    m_Writer.EndObject();
+    m_Writer.flush();
+}
+}
+}

--- a/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
+++ b/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
@@ -15,8 +15,8 @@ const std::string EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION("expected_memory_usag
 const std::string EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS("expected_memory_usage_with_max_partitions");
 }
 
-CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(
-        core::CJsonOutputStreamWrapper& strmOut) : m_Writer(strmOut) {
+CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut)
+    : m_Writer(strmOut) {
     // Don't write any output in the constructor because, the way things work at
     // the moment, the output stream might be redirected after construction
 }

--- a/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
+++ b/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
@@ -21,13 +21,13 @@ CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(c
     // the moment, the output stream might be redirected after construction
 }
 
-void CMemoryUsageEstimationResultJsonWriter::write(std::size_t expectedMemoryUsageWithOnePartition,
-                                                   std::size_t expectedMemoryUsageWithMaxPartitions) {
+void CMemoryUsageEstimationResultJsonWriter::write(const std::string& expectedMemoryUsageWithOnePartition,
+                                                   const std::string& expectedMemoryUsageWithMaxPartitions) {
     m_Writer.StartObject();
     m_Writer.Key(EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION);
-    m_Writer.Uint64(expectedMemoryUsageWithOnePartition);
+    m_Writer.String(expectedMemoryUsageWithOnePartition);
     m_Writer.Key(EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS);
-    m_Writer.Uint64(expectedMemoryUsageWithMaxPartitions);
+    m_Writer.String(expectedMemoryUsageWithMaxPartitions);
     m_Writer.EndObject();
     m_Writer.flush();
 }

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -43,6 +43,7 @@ CInputParser.cc \
 CIoManager.cc \
 CJsonOutputWriter.cc \
 CLengthEncodedInputParser.cc \
+CMemoryUsageEstimationResultJsonWriter.cc \
 CModelPlotDataJsonWriter.cc \
 CModelSizeStatsJsonWriter.cc \
 CModelSnapshotJsonWriter.cc \

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -174,19 +174,19 @@ void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_0() {
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1() {
-    testEstimateMemoryUsage(1, 6050, 6050, 0);
+    testEstimateMemoryUsage(1, 6144, 6144, 0);
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_10() {
-    testEstimateMemoryUsage(10, 15128, 13112, 0);
+    testEstimateMemoryUsage(10, 15360, 13312, 0);
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_100() {
-    testEstimateMemoryUsage(100, 63056, 35516, 0);
+    testEstimateMemoryUsage(100, 63488, 35840, 0);
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1000() {
-    testEstimateMemoryUsage(1000, 460328, 146372, 0);
+    testEstimateMemoryUsage(1000, 460800, 146432, 0);
 }
 
 CppUnit::Test* CDataFrameAnalysisRunnerTest::suite() {

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -123,7 +123,7 @@ void CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageF
 }
 
 void testEstimateMemoryUsage(int64_t numberRows,
-                             int64_t expected_expected_memory_usage_with_one_partition, 
+                             int64_t expected_expected_memory_usage_with_one_partition,
                              int64_t expected_expected_memory_usage_with_max_partitions,
                              int expected_number_errors) {
 
@@ -140,7 +140,8 @@ void testEstimateMemoryUsage(int64_t numberRows,
     // The output writer won't close the JSON structures until is is destroyed
     {
         std::string jsonSpec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
-            numberRows, 5, 100000000, 1, {}, true, test::CTestTmpDir::tmpDir(), "", "outlier_detection", "")};
+            numberRows, 5, 100000000, 1, {}, true, test::CTestTmpDir::tmpDir(),
+            "", "outlier_detection", "")};
         api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
         core::CJsonOutputStreamWrapper wrappedOutStream(sstream);
@@ -162,7 +163,7 @@ void testEstimateMemoryUsage(int64_t numberRows,
     CPPUNIT_ASSERT_EQUAL(expected_expected_memory_usage_with_one_partition,
                          result["expected_memory_usage_with_one_partition"].GetInt64());
     CPPUNIT_ASSERT(result.HasMember("expected_memory_usage_with_max_partitions"));
-    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_usage_with_max_partitions, 
+    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_usage_with_max_partitions,
                          result["expected_memory_usage_with_max_partitions"].GetInt64());
 
     CPPUNIT_ASSERT_EQUAL(expected_number_errors, static_cast<int>(errors.size()));

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -123,8 +123,8 @@ void CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageF
 }
 
 void testEstimateMemoryUsage(int64_t numberRows,
-                             int64_t expected_expected_memory_usage_with_one_partition,
-                             int64_t expected_expected_memory_usage_with_max_partitions,
+                             const std::string& expected_expected_memory_usage_with_one_partition,
+                             const std::string& expected_expected_memory_usage_with_max_partitions,
                              int expected_number_errors) {
 
     std::ostringstream sstream;
@@ -160,33 +160,35 @@ void testEstimateMemoryUsage(int64_t numberRows,
     CPPUNIT_ASSERT(result.IsObject());
 
     CPPUNIT_ASSERT(result.HasMember("expected_memory_usage_with_one_partition"));
-    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_usage_with_one_partition,
-                         result["expected_memory_usage_with_one_partition"].GetInt64());
+    CPPUNIT_ASSERT_EQUAL(
+        expected_expected_memory_usage_with_one_partition,
+        std::string(result["expected_memory_usage_with_one_partition"].GetString()));
     CPPUNIT_ASSERT(result.HasMember("expected_memory_usage_with_max_partitions"));
-    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_usage_with_max_partitions,
-                         result["expected_memory_usage_with_max_partitions"].GetInt64());
+    CPPUNIT_ASSERT_EQUAL(
+        expected_expected_memory_usage_with_max_partitions,
+        std::string(result["expected_memory_usage_with_max_partitions"].GetString()));
 
     CPPUNIT_ASSERT_EQUAL(expected_number_errors, static_cast<int>(errors.size()));
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_0() {
-    testEstimateMemoryUsage(0, 0, 0, 1);
+    testEstimateMemoryUsage(0, "0", "0", 1);
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1() {
-    testEstimateMemoryUsage(1, 6144, 6144, 0);
+    testEstimateMemoryUsage(1, "6kB", "6kB", 0);
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_10() {
-    testEstimateMemoryUsage(10, 15360, 13312, 0);
+    testEstimateMemoryUsage(10, "15kB", "13kB", 0);
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_100() {
-    testEstimateMemoryUsage(100, 63488, 35840, 0);
+    testEstimateMemoryUsage(100, "62kB", "35kB", 0);
 }
 
 void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1000() {
-    testEstimateMemoryUsage(1000, 460800, 146432, 0);
+    testEstimateMemoryUsage(1000, "450kB", "143kB", 0);
 }
 
 CppUnit::Test* CDataFrameAnalysisRunnerTest::suite() {

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -122,8 +122,12 @@ void CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageF
     }
 }
 
-void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage() {
+void testEstimateMemoryUsage(int64_t numberRows,
+                             int64_t expected_expected_memory_usage_with_one_partition, 
+                             int64_t expected_expected_memory_usage_with_max_partitions,
+                             int expected_number_errors) {
 
+    std::ostringstream sstream;
     std::vector<std::string> errors;
     std::mutex errorsMutex;
     auto errorHandler = [&errors, &errorsMutex](std::string error) {
@@ -132,55 +136,56 @@ void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage() {
     };
 
     core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
-    api::CDataFrameOutliersRunnerFactory factory;
 
-    // Test estimation for empty data frame
+    // The output writer won't close the JSON structures until is is destroyed
     {
-        errors.clear();
         std::string jsonSpec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
-            0, 5, 100000000, 1, {}, true, test::CTestTmpDir::tmpDir(), "", "outlier_detection", "")};
+            numberRows, 5, 100000000, 1, {}, true, test::CTestTmpDir::tmpDir(), "", "outlier_detection", "")};
         api::CDataFrameAnalysisSpecification spec{jsonSpec};
 
-        // Check memory estimation result
-        api::SMemoryUsageEstimationResult result = spec.estimateMemoryUsage();
-        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(result.s_MemoryUsageWithOnePartition));
-        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(result.s_MemoryUsageWithMaxPartitions));
+        core::CJsonOutputStreamWrapper wrappedOutStream(sstream);
+        api::CMemoryUsageEstimationResultJsonWriter writer(wrappedOutStream);
 
-        // no error should be registered
-        CPPUNIT_ASSERT_EQUAL(1, static_cast<int>(errors.size()));
+        spec.estimateMemoryUsage(writer);
     }
 
-    // Test estimation for data frame with 1 row
-    {
-        errors.clear();
-        std::string jsonSpec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
-            1, 5, 100000000, 1, {}, true, test::CTestTmpDir::tmpDir(), "", "outlier_detection", "")};
-        api::CDataFrameAnalysisSpecification spec{jsonSpec};
+    rapidjson::Document arrayDoc;
+    arrayDoc.Parse<rapidjson::kParseDefaultFlags>(sstream.str().c_str());
 
-        // Check memory estimation result
-        api::SMemoryUsageEstimationResult result = spec.estimateMemoryUsage();
-        CPPUNIT_ASSERT_EQUAL(6050, static_cast<int>(result.s_MemoryUsageWithOnePartition));
-        CPPUNIT_ASSERT_EQUAL(6050, static_cast<int>(result.s_MemoryUsageWithMaxPartitions));
+    CPPUNIT_ASSERT(arrayDoc.IsArray());
+    CPPUNIT_ASSERT_EQUAL(rapidjson::SizeType(1), arrayDoc.Size());
 
-        // no error should be registered
-        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(errors.size()));
-    }
+    const rapidjson::Value& result = arrayDoc[rapidjson::SizeType(0)];
+    CPPUNIT_ASSERT(result.IsObject());
 
-    // Test estimation for data frame with 4 rows
-    {
-        errors.clear();
-        std::string jsonSpec{api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
-            4, 5, 100000000, 1, {}, true, test::CTestTmpDir::tmpDir(), "", "outlier_detection", "")};
-        api::CDataFrameAnalysisSpecification spec{jsonSpec};
+    CPPUNIT_ASSERT(result.HasMember("expected_memory_usage_with_one_partition"));
+    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_usage_with_one_partition,
+                         result["expected_memory_usage_with_one_partition"].GetInt64());
+    CPPUNIT_ASSERT(result.HasMember("expected_memory_usage_with_max_partitions"));
+    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_usage_with_max_partitions, 
+                         result["expected_memory_usage_with_max_partitions"].GetInt64());
 
-        // Check memory estimation result
-        api::SMemoryUsageEstimationResult result = spec.estimateMemoryUsage();
-        CPPUNIT_ASSERT_EQUAL(9104, static_cast<int>(result.s_MemoryUsageWithOnePartition));
-        CPPUNIT_ASSERT_EQUAL(8528, static_cast<int>(result.s_MemoryUsageWithMaxPartitions));
+    CPPUNIT_ASSERT_EQUAL(expected_number_errors, static_cast<int>(errors.size()));
+}
 
-        // no error should be registered
-        CPPUNIT_ASSERT_EQUAL(0, static_cast<int>(errors.size()));
-    }
+void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_0() {
+    testEstimateMemoryUsage(0, 0, 0, 1);
+}
+
+void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1() {
+    testEstimateMemoryUsage(1, 6050, 6050, 0);
+}
+
+void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_10() {
+    testEstimateMemoryUsage(10, 15128, 13112, 0);
+}
+
+void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_100() {
+    testEstimateMemoryUsage(100, 63056, 35516, 0);
+}
+
+void CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1000() {
+    testEstimateMemoryUsage(1000, 460328, 146372, 0);
 }
 
 CppUnit::Test* CDataFrameAnalysisRunnerTest::suite() {
@@ -193,8 +198,20 @@ CppUnit::Test* CDataFrameAnalysisRunnerTest::suite() {
         "CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag",
         &CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageFlag));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisRunnerTest>(
-        "CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage",
-        &CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage));
+        "CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_0",
+        &CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_0));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisRunnerTest>(
+        "CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1",
+        &CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisRunnerTest>(
+        "CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_10",
+        &CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_10));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisRunnerTest>(
+        "CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_100",
+        &CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_100));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalysisRunnerTest>(
+        "CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1000",
+        &CDataFrameAnalysisRunnerTest::testEstimateMemoryUsage_1000));
 
     return suiteOfTests;
 }

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
@@ -13,6 +13,7 @@ class CDataFrameAnalysisRunnerTest : public CppUnit::TestFixture {
 public:
     void testComputeExecutionStrategyForOutliers();
     void testComputeAndSaveExecutionStrategyDiskUsageFlag();
+    void testEstimateMemoryUsage();
 
     static CppUnit::Test* suite();
 

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.h
@@ -13,7 +13,11 @@ class CDataFrameAnalysisRunnerTest : public CppUnit::TestFixture {
 public:
     void testComputeExecutionStrategyForOutliers();
     void testComputeAndSaveExecutionStrategyDiskUsageFlag();
-    void testEstimateMemoryUsage();
+    void testEstimateMemoryUsage_0();
+    void testEstimateMemoryUsage_1();
+    void testEstimateMemoryUsage_10();
+    void testEstimateMemoryUsage_100();
+    void testEstimateMemoryUsage_1000();
 
     static CppUnit::Test* suite();
 

--- a/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
+++ b/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
@@ -35,7 +35,7 @@ void CMemoryUsageEstimationResultJsonWriterTest::testWrite() {
     {
         core::CJsonOutputStreamWrapper wrappedOutStream(sstream);
         CMemoryUsageEstimationResultJsonWriter writer(wrappedOutStream);
-        writer.write(static_cast<std::size_t>(2000), static_cast<std::size_t>(1000));
+        writer.write("16kB", "8kB");
     }
 
     rapidjson::Document arrayDoc;
@@ -48,9 +48,11 @@ void CMemoryUsageEstimationResultJsonWriterTest::testWrite() {
     CPPUNIT_ASSERT(object.IsObject());
 
     CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_one_partition"));
-    CPPUNIT_ASSERT_EQUAL(int64_t(2000),
-                         object["expected_memory_usage_with_one_partition"].GetInt64());
+    CPPUNIT_ASSERT_EQUAL(
+        std::string("16kB"),
+        std::string(object["expected_memory_usage_with_one_partition"].GetString()));
     CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_max_partitions"));
-    CPPUNIT_ASSERT_EQUAL(int64_t(1000),
-                         object["expected_memory_usage_with_max_partitions"].GetInt64());
+    CPPUNIT_ASSERT_EQUAL(
+        std::string("8kB"),
+        std::string(object["expected_memory_usage_with_max_partitions"].GetString()));
 }

--- a/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
+++ b/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
@@ -22,7 +22,8 @@ using namespace api;
 CppUnit::Test* CMemoryUsageEstimationResultJsonWriterTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CMemoryUsageEstimationResultJsonWriterTest");
     suiteOfTests->addTest(new CppUnit::TestCaller<CMemoryUsageEstimationResultJsonWriterTest>(
-        "CMemoryUsageEstimationResultJsonWriterTest::testWrite", &CMemoryUsageEstimationResultJsonWriterTest::testWrite));
+        "CMemoryUsageEstimationResultJsonWriterTest::testWrite",
+        &CMemoryUsageEstimationResultJsonWriterTest::testWrite));
     return suiteOfTests;
 }
 
@@ -33,8 +34,7 @@ void CMemoryUsageEstimationResultJsonWriterTest::testWrite() {
     {
         core::CJsonOutputStreamWrapper wrappedOutStream(sstream);
         CMemoryUsageEstimationResultJsonWriter writer(wrappedOutStream);
-        SMemoryUsageEstimationResult result(2000, 1000);
-        writer.write(result);
+        writer.write(static_cast<std::size_t>(2000), static_cast<std::size_t>(1000));
     }
 
     rapidjson::Document arrayDoc;
@@ -46,8 +46,8 @@ void CMemoryUsageEstimationResultJsonWriterTest::testWrite() {
     const rapidjson::Value& object = arrayDoc[rapidjson::SizeType(0)];
     CPPUNIT_ASSERT(object.IsObject());
 
-    CPPUNIT_ASSERT(object.HasMember("memory_usage_with_one_partition"));
-    CPPUNIT_ASSERT_EQUAL(int64_t(2000), object["memory_usage_with_one_partition"].GetInt64());
-    CPPUNIT_ASSERT(object.HasMember("memory_usage_with_max_partitions"));
-    CPPUNIT_ASSERT_EQUAL(int64_t(1000), object["memory_usage_with_max_partitions"].GetInt64());
+    CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_one_partition"));
+    CPPUNIT_ASSERT_EQUAL(int64_t(2000), object["expected_memory_usage_with_one_partition"].GetInt64());
+    CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_max_partitions"));
+    CPPUNIT_ASSERT_EQUAL(int64_t(1000), object["expected_memory_usage_with_max_partitions"].GetInt64());
 }

--- a/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
+++ b/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include "CMemoryUsageEstimationResultJsonWriterTest.h"
+
+#include <core/CJsonOutputStreamWrapper.h>
+#include <core/CoreTypes.h>
+
+#include <model/CResourceMonitor.h>
+
+#include <api/CMemoryUsageEstimationResultJsonWriter.h>
+
+#include <rapidjson/document.h>
+
+#include <string>
+
+using namespace ml;
+using namespace api;
+
+CppUnit::Test* CMemoryUsageEstimationResultJsonWriterTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CMemoryUsageEstimationResultJsonWriterTest");
+    suiteOfTests->addTest(new CppUnit::TestCaller<CMemoryUsageEstimationResultJsonWriterTest>(
+        "CMemoryUsageEstimationResultJsonWriterTest::testWrite", &CMemoryUsageEstimationResultJsonWriterTest::testWrite));
+    return suiteOfTests;
+}
+
+void CMemoryUsageEstimationResultJsonWriterTest::testWrite() {
+    std::ostringstream sstream;
+
+    // The output writer won't close the JSON structures until is is destroyed
+    {
+        core::CJsonOutputStreamWrapper wrappedOutStream(sstream);
+        CMemoryUsageEstimationResultJsonWriter writer(wrappedOutStream);
+        SMemoryUsageEstimationResult result(2000, 1000);
+        writer.write(result);
+    }
+
+    rapidjson::Document arrayDoc;
+    arrayDoc.Parse<rapidjson::kParseDefaultFlags>(sstream.str().c_str());
+
+    CPPUNIT_ASSERT(arrayDoc.IsArray());
+    CPPUNIT_ASSERT_EQUAL(rapidjson::SizeType(1), arrayDoc.Size());
+
+    const rapidjson::Value& object = arrayDoc[rapidjson::SizeType(0)];
+    CPPUNIT_ASSERT(object.IsObject());
+
+    CPPUNIT_ASSERT(object.HasMember("memory_usage_with_one_partition"));
+    CPPUNIT_ASSERT_EQUAL(int64_t(2000), object["memory_usage_with_one_partition"].GetInt64());
+    CPPUNIT_ASSERT(object.HasMember("memory_usage_with_max_partitions"));
+    CPPUNIT_ASSERT_EQUAL(int64_t(1000), object["memory_usage_with_max_partitions"].GetInt64());
+}

--- a/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
+++ b/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
@@ -20,7 +20,8 @@ using namespace ml;
 using namespace api;
 
 CppUnit::Test* CMemoryUsageEstimationResultJsonWriterTest::suite() {
-    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CMemoryUsageEstimationResultJsonWriterTest");
+    CppUnit::TestSuite* suiteOfTests =
+        new CppUnit::TestSuite("CMemoryUsageEstimationResultJsonWriterTest");
     suiteOfTests->addTest(new CppUnit::TestCaller<CMemoryUsageEstimationResultJsonWriterTest>(
         "CMemoryUsageEstimationResultJsonWriterTest::testWrite",
         &CMemoryUsageEstimationResultJsonWriterTest::testWrite));
@@ -47,7 +48,9 @@ void CMemoryUsageEstimationResultJsonWriterTest::testWrite() {
     CPPUNIT_ASSERT(object.IsObject());
 
     CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_one_partition"));
-    CPPUNIT_ASSERT_EQUAL(int64_t(2000), object["expected_memory_usage_with_one_partition"].GetInt64());
+    CPPUNIT_ASSERT_EQUAL(int64_t(2000),
+                         object["expected_memory_usage_with_one_partition"].GetInt64());
     CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_max_partitions"));
-    CPPUNIT_ASSERT_EQUAL(int64_t(1000), object["expected_memory_usage_with_max_partitions"].GetInt64());
+    CPPUNIT_ASSERT_EQUAL(int64_t(1000),
+                         object["expected_memory_usage_with_max_partitions"].GetInt64());
 }

--- a/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.h
+++ b/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_CMemoryUsageEstimationResultJsonWriterTest_h
+#define INCLUDED_CMemoryUsageEstimationResultJsonWriterTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CMemoryUsageEstimationResultJsonWriterTest : public CppUnit::TestFixture {
+public:
+    void testWrite();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CMemoryUsageEstimationResultJsonWriterTest_h

--- a/lib/api/unittest/Main.cc
+++ b/lib/api/unittest/Main.cc
@@ -22,6 +22,7 @@
 #include "CIoManagerTest.h"
 #include "CJsonOutputWriterTest.h"
 #include "CLengthEncodedInputParserTest.h"
+#include "CMemoryUsageEstimationResultJsonWriterTest.h"
 #include "CModelPlotDataJsonWriterTest.h"
 #include "CModelSnapshotJsonWriterTest.h"
 #include "CMultiFileDataAdderTest.h"
@@ -57,11 +58,12 @@ int main(int argc, const char** argv) {
     runner.addTest(CIoManagerTest::suite());
     runner.addTest(CJsonOutputWriterTest::suite());
     runner.addTest(CLengthEncodedInputParserTest::suite());
-    runner.addTest(CNdJsonInputParserTest::suite());
-    runner.addTest(CNdJsonOutputWriterTest::suite());
+    runner.addTest(CMemoryUsageEstimationResultJsonWriterTest::suite());
     runner.addTest(CModelPlotDataJsonWriterTest::suite());
     runner.addTest(CModelSnapshotJsonWriterTest::suite());
     runner.addTest(CMultiFileDataAdderTest::suite());
+    runner.addTest(CNdJsonInputParserTest::suite());
+    runner.addTest(CNdJsonOutputWriterTest::suite());
     runner.addTest(COutputChainerTest::suite());
     runner.addTest(CPersistenceManagerTest::suite());
     runner.addTest(CRestorePreviousStateTest::suite());

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -37,6 +37,7 @@ SRCS=\
 	CIoManagerTest.cc \
 	CJsonOutputWriterTest.cc \
 	CLengthEncodedInputParserTest.cc \
+	CMemoryUsageEstimationResultJsonWriterTest.cc \
 	CMockDataAdder.cc \
 	CMockDataProcessor.cc \
 	CMockSearcher.cc \


### PR DESCRIPTION
Introduce a mode in which data_frame_analyzer binary only outputs memory usage estimations but does not perform any analysis. This mode will be used by the new endpoint in Java server.

Relates https://github.com/elastic/elasticsearch/issues/44699