### PR TITLE
[ML] Trap the case that no data are sent to data_frame_analyzer explicitly

### DIFF
--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -133,6 +133,10 @@ void CDataFrameAnalyzer::run() {
                      << ". Please report this problem.");
         return;
     }
+    if (m_DataFrame->numberRows() == 0) {
+        HANDLE_FATAL(<< "Input error: no data sent.");
+        return;
+    }
 
     LOG_TRACE(<< "Running analysis...");
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -729,6 +729,18 @@ void CDataFrameAnalyzerTest::testErrors() {
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         CPPUNIT_ASSERT(errors.size() > 0);
     }
+
+    // No data.
+    {
+        api::CDataFrameAnalyzer analyzer{outlierSpec(2), outputWriterFactory};
+        errors.clear();
+        CPPUNIT_ASSERT_EQUAL(
+            true, analyzer.handleRecord({"c1", "c2", "c3", "c4", "c5", ".", "."},
+                                        {"", "", "", "", "", "", "$"}));
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        CPPUNIT_ASSERT(errors.size() > 0);
+        CPPUNIT_ASSERT_EQUAL(std::string{"Input error: no data sent."}, errors[0]);
+    }
 }
 
 void CDataFrameAnalyzerTest::testRoundTripDocHashes() {


### PR DESCRIPTION
This came up while we were debugging the new Java API: currently the error message is cryptic.