### PR TITLE
[ML] Make predictions for rows missing the dependent variable value

### DIFF
--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -96,8 +96,9 @@ private:
     std::ptrdiff_t m_BeginDataFieldValues = FIELD_UNSET;
     std::ptrdiff_t m_EndDataFieldValues = FIELD_UNSET;
     std::ptrdiff_t m_DocHashFieldIndex = FIELD_UNSET;
-    std::uint64_t m_BadValueCount;
-    std::uint64_t m_BadDocHashCount;
+    std::uint64_t m_MissingValueCount = 0;
+    std::uint64_t m_BadValueCount = 0;
+    std::uint64_t m_BadDocHashCount = 0;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
     TStrVec m_CategoricalFieldNames;
     TStrSizeUMapVec m_CategoricalFieldValues;

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -307,15 +307,17 @@ void CDataFrameAnalyzer::addRowToDataFrame(const TStrVec& fieldValues) {
             return core::CFloatStorage{static_cast<double>(id)};
         }
 
-        double value;
-        if (core::CStringUtils::stringToTypeSilent(fieldValue, value) == false) {
-            ++m_BadValueCount;
+        // Use NaN to indicate missing or bad values in the data frame. This
+        // needs handling with care from an analysis perspective. If analyses
+        // can deal with missing values they need to treat NaNs as missing
+        // otherwise we must impute or exit with failure.
 
-            // TODO this is a can of worms we can deal with later.
-            // Use NaN to indicate missing in the data frame, but this needs
-            // handling with care from an analysis perspective. If analyses
-            // can deal with missing values they need to treat NaNs as missing
-            // otherwise we must impute or exit with failure.
+        double value;
+        if (fieldValue.empty()) {
+            ++m_MissingValueCount;
+            return core::CFloatStorage{std::numeric_limits<float>::quiet_NaN()};
+        } else if (core::CStringUtils::stringToTypeSilent(fieldValue, value) == false) {
+            ++m_BadValueCount;
             return core::CFloatStorage{std::numeric_limits<float>::quiet_NaN()};
         }
 

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -132,11 +132,13 @@ void CDataFrameBoostedTreeRunner::runImpl(const TStrVec& featureNames,
                      << m_DependentVariable << "' is missing from training data "
                      << core::CContainerPrinter::print(featureNames)
                      << ". Please report this problem.");
-    } else {
-        m_BoostedTree = m_BoostedTreeFactory->buildFor(
-            frame, dependentVariableColumn - featureNames.begin());
-        m_BoostedTree->train(this->progressRecorder());
+        return;
     }
+
+    m_BoostedTree = m_BoostedTreeFactory->buildFor(
+        frame, dependentVariableColumn - featureNames.begin());
+    m_BoostedTree->train(this->progressRecorder());
+    m_BoostedTree->predict(this->progressRecorder());
 }
 
 std::size_t CDataFrameBoostedTreeRunner::estimateBookkeepingMemoryUsage(

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -654,7 +654,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValu
         if (result.HasMember("row_results")) {
             double expected{target(feature[result["row_results"]["checksum"].GetUint64()])};
             CPPUNIT_ASSERT_DOUBLES_EQUAL(
-                expected, result["row_results"]["results"]["ml"]["prediction"].GetDouble(),
+                expected,
+                result["row_results"]["results"]["ml"]["target_prediction"].GetDouble(),
                 0.15 * expected);
             ++numberResults;
         }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -609,7 +609,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithParams() {
     CPPUNIT_ASSERT(progressCompleted);
 }
 
-void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithTestData() {
+void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValue() {
 
     // Test we are able to predict value rows for which the dependent variable
     // is missing.
@@ -931,8 +931,8 @@ CppUnit::Test* CDataFrameAnalyzerTest::suite() {
         "CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithParams",
         &CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithParams));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
-        "CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithTestData",
-        &CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithTestData));
+        "CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValue",
+        &CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValue));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(
         "CDataFrameAnalyzerTest::testFlushMessage", &CDataFrameAnalyzerTest::testFlushMessage));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameAnalyzerTest>(

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -18,6 +18,7 @@ public:
     void testRunOutlierDetectionWithParams();
     void testRunBoostedTreeTraining();
     void testRunBoostedTreeTrainingWithParams();
+    void testRunBoostedTreeTrainingWithTestData();
     void testFlushMessage();
     void testErrors();
     void testRoundTripDocHashes();

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -18,7 +18,7 @@ public:
     void testRunOutlierDetectionWithParams();
     void testRunBoostedTreeTraining();
     void testRunBoostedTreeTrainingWithParams();
-    void testRunBoostedTreeTrainingWithTestData();
+    void testRunBoostedTreeTrainingWithRowsMissingTargetValue();
     void testFlushMessage();
     void testErrors();
     void testRoundTripDocHashes();


### PR DESCRIPTION
We must call predict explicitly to ensure that rows missing the dependent variable get predictions after training a regression model.

This also corrects the initialisation of bad data counters and splits out the case that a metric value is missing, i.e. field value is empty, and the case it is non-numeric.