### PR TITLE
[ML] Wire category encoding into random forest training

### DIFF
--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -113,7 +113,7 @@ private:
     std::size_t numberHyperparameterTuningRounds() const;
 
 private:
-    double m_MinimumFrequencyToOneHotEncode = 0.05;
+    double m_MinimumFrequencyToOneHotEncode;
     TBoostedTreeImplUPtr m_TreeImpl;
     CBoostedTree::TProgressCallback m_ProgressCallback;
 };

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -46,6 +46,8 @@ public:
     CBoostedTreeFactory(CBoostedTreeFactory&&);
     CBoostedTreeFactory& operator=(CBoostedTreeFactory&&);
 
+    //! Set the minimum fraction with a category value to one-hot encode.
+    CBoostedTreeFactory& minimumFrequencyToOneHotEncode(double frequency);
     //! Set the number of folds to use for estimating the generalisation error.
     CBoostedTreeFactory& numberFolds(std::size_t numberFolds);
     //! Set the lambda regularisation parameter.
@@ -91,8 +93,10 @@ private:
     //! Get the (train, test) row masks for performing cross validation.
     std::pair<TPackedBitVectorVec, TPackedBitVectorVec> crossValidationRowMasks() const;
 
+    void selectFeaturesAndEncodeCategories(const core::CDataFrame& frame) const;
+
     //! Initialize the regressors sample distribution.
-    bool initializeFeatureSampleDistribution(const core::CDataFrame& frame) const;
+    bool initializeFeatureSampleDistribution() const;
 
     //! Read overrides for hyperparameters and if necessary estimate the initial
     //! values for \f$\lambda\f$ and \f$\gamma\f$ which match the gain from an
@@ -107,6 +111,7 @@ private:
     std::size_t numberHyperparameterTuningRounds() const;
 
 private:
+    double m_MinimumFrequencyToOneHotEncode = 0.05;
     TBoostedTreeImplUPtr m_TreeImpl;
     CBoostedTree::TProgressCallback m_ProgressCallback;
 };

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -93,6 +93,8 @@ private:
     //! Get the (train, test) row masks for performing cross validation.
     std::pair<TPackedBitVectorVec, TPackedBitVectorVec> crossValidationRowMasks() const;
 
+    //! Encode categorical fields and at the same time select the features to use
+    //! as regressors.
     void selectFeaturesAndEncodeCategories(const core::CDataFrame& frame) const;
 
     //! Initialize the regressors sample distribution.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -15,10 +15,11 @@
 #include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBasicStatistics.h>
-#include <maths/CBayesianOptimisation.h>
 #include <maths/CBoostedTree.h>
+#include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CDataFrameUtils.h>
 #include <maths/CLinearAlgebraEigen.h>
+#include <maths/CPRNG.h>
 #include <maths/CTools.h>
 #include <maths/ImportExport.h>
 
@@ -34,13 +35,14 @@
 
 namespace ml {
 namespace maths {
+class CBayesianOptimisation;
+
 namespace boosted_tree_detail {
 inline std::size_t predictionColumn(std::size_t numberColumns) {
     return numberColumns - 3;
 }
-
-inline std::size_t numberFeatures(const core::CDataFrame& frame) {
-    return frame.numberColumns() - 3;
+inline std::size_t numberColumnsAddedToDataFrame() {
+    return 3;
 }
 }
 
@@ -56,6 +58,11 @@ public:
 
 public:
     CBoostedTreeImpl(std::size_t numberThreads, CBoostedTree::TLossFunctionUPtr loss);
+
+    ~CBoostedTreeImpl();
+
+    CBoostedTreeImpl& operator=(const CBoostedTreeImpl&) = delete;
+    CBoostedTreeImpl& operator=(CBoostedTreeImpl&&);
 
     //! Train the model on the values in \p frame.
     void train(core::CDataFrame& frame, CBoostedTree::TProgressCallback recordProgress);
@@ -95,8 +102,8 @@ private:
     using TSizeDoublePr = std::pair<std::size_t, double>;
     using TDoubleDoubleDoubleTr = std::tuple<double, double, double>;
     using TRowItr = core::CDataFrame::TRowItr;
-    using TRowRef = core::CDataFrame::TRowRef;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+    using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
 
     class CNode;
     using TNodeVec = std::vector<CNode>;
@@ -136,8 +143,9 @@ private:
         bool isLeaf() const { return m_LeftChild < 0; }
 
         //! Get the leaf index for \p row.
-        std::size_t
-        leafIndex(const TRowRef& row, const TNodeVec& tree, std::int32_t index = 0) const {
+        std::size_t leafIndex(const CEncodedDataFrameRowRef& row,
+                              const TNodeVec& tree,
+                              std::int32_t index = 0) const {
             if (this->isLeaf()) {
                 return index;
             }
@@ -150,7 +158,7 @@ private:
         }
 
         //! Get the value predicted by \p tree for the feature vector \p row.
-        double value(const TRowRef& row, const TNodeVec& tree) const {
+        double value(const CEncodedDataFrameRowRef& row, const TNodeVec& tree) const {
             return tree[this->leafIndex(row, tree)].m_NodeValue;
         }
 
@@ -177,6 +185,7 @@ private:
         //! Get the row masks of the left and right children of this node.
         auto rowMasks(std::size_t numberThreads,
                       const core::CDataFrame& frame,
+                      const CDataFrameCategoryEncoder& encoder,
                       core::CPackedBitVector rowMask) const {
 
             LOG_TRACE(<< "Splitting feature '" << m_SplitFeature << "' @ " << m_SplitValue);
@@ -189,7 +198,7 @@ private:
                     [&](core::CPackedBitVector& leftRowMask, TRowItr beginRows, TRowItr endRows) {
                         for (auto row = beginRows; row != endRows; ++row) {
                             std::size_t index{row->index()};
-                            double value{(*row)[m_SplitFeature]};
+                            double value{encoder.encode(*row)[m_SplitFeature]};
                             bool missing{CDataFrameUtils::isMissing(value)};
                             if ((missing && m_AssignMissingToLeft) ||
                                 (missing == false && value < m_SplitValue)) {
@@ -268,6 +277,7 @@ private:
         CLeafNodeStatistics(std::size_t id,
                             std::size_t numberThreads,
                             const core::CDataFrame& frame,
+                            const CDataFrameCategoryEncoder& encoder,
                             double lambda,
                             double gamma,
                             const TDoubleVecVec& candidateSplits,
@@ -280,7 +290,7 @@ private:
             LOG_TRACE(<< "row mask = " << m_RowMask);
             LOG_TRACE(<< "feature bag = " << core::CContainerPrinter::print(m_FeatureBag));
 
-            this->computeAggregateLossDerivatives(numberThreads, frame);
+            this->computeAggregateLossDerivatives(numberThreads, frame, encoder);
         }
 
         //! This should only called by split but is public so it's accessible to make_shared.
@@ -337,6 +347,7 @@ private:
                    std::size_t rightChildId,
                    std::size_t numberThreads,
                    const core::CDataFrame& frame,
+                   const CDataFrameCategoryEncoder& encoder,
                    double lambda,
                    double gamma,
                    const TDoubleVecVec& candidateSplits,
@@ -346,7 +357,7 @@ private:
 
             if (leftChildRowMask.manhattan() < rightChildRowMask.manhattan()) {
                 auto leftChild = std::make_shared<CLeafNodeStatistics>(
-                    leftChildId, numberThreads, frame, lambda, gamma,
+                    leftChildId, numberThreads, frame, encoder, lambda, gamma,
                     candidateSplits, featureBag, std::move(leftChildRowMask));
                 auto rightChild = std::make_shared<CLeafNodeStatistics>(
                     rightChildId, *this, *leftChild, std::move(rightChildRowMask));
@@ -355,7 +366,7 @@ private:
             }
 
             auto rightChild = std::make_shared<CLeafNodeStatistics>(
-                rightChildId, numberThreads, frame, lambda, gamma,
+                rightChildId, numberThreads, frame, encoder, lambda, gamma,
                 candidateSplits, featureBag, std::move(rightChildRowMask));
             auto leftChild = std::make_shared<CLeafNodeStatistics>(
                 leftChildId, *this, *rightChild, std::move(leftChildRowMask));
@@ -457,14 +468,15 @@ private:
 
     private:
         void computeAggregateLossDerivatives(std::size_t numberThreads,
-                                             const core::CDataFrame& frame) {
+                                             const core::CDataFrame& frame,
+                                             const CDataFrameCategoryEncoder& encoder) {
 
             auto result = frame.readRows(
                 numberThreads, 0, frame.numberRows(),
                 core::bindRetrievableState(
                     [&](SDerivatives& state, TRowItr beginRows, TRowItr endRows) {
                         for (auto row = beginRows; row != endRows; ++row) {
-                            this->addRowDerivatives(*row, state);
+                            this->addRowDerivatives(encoder.encode(*row), state);
                         }
                     },
                     SDerivatives{m_CandidateSplits}),
@@ -498,7 +510,8 @@ private:
                       << core::CContainerPrinter::print(m_MissingCurvatures));
         }
 
-        void addRowDerivatives(const TRowRef& row, SDerivatives& derivatives) const;
+        void addRowDerivatives(const CEncodedDataFrameRowRef& row,
+                               SDerivatives& derivatives) const;
 
         const SSplitStatistics& bestSplitStatistics() const {
             if (m_BestSplit == boost::none) {
@@ -623,11 +636,14 @@ private:
                        const core::CPackedBitVector& trainingRowMask,
                        const TDoubleVecVec& candidateSplits) const;
 
+    //! Get the number of features including category encoding.
+    std::size_t numberFeatures() const;
+
     //! Get the number of features to consider splitting on.
-    std::size_t featureBagSize(const core::CDataFrame& frame) const;
+    std::size_t featureBagSize() const;
 
     //! Sample the features according to their categorical distribution.
-    TSizeVec featureBag(const core::CDataFrame& frame) const;
+    TSizeVec featureBag() const;
 
     //! Refresh the predictions and loss function derivatives for the masked
     //! rows in \p frame with predictions of \p tree.
@@ -642,13 +658,13 @@ private:
                     const TNodeVecVec& forest) const;
 
     //! Get a column mask of the suitable regressor features.
-    TSizeVec candidateFeatures() const;
+    TSizeVec candidateRegressorFeatures() const;
 
     //! Get the root node of \p tree.
     static const CNode& root(const TNodeVec& tree);
 
     //! Get the forest's prediction for \p row.
-    static double predictRow(const TRowRef& row, const TNodeVecVec& forest);
+    static double predictRow(const CEncodedDataFrameRowRef& row, const TNodeVecVec& forest);
 
     //! Select the next hyperparameters for which to train a model.
     bool selectNextHyperparameters(const TMeanVarAccumulator& lossMoments,
@@ -704,6 +720,7 @@ private:
     std::size_t m_RowsPerFeature = 50;
     double m_FeatureBagFraction = 0.5;
     double m_MaximumTreeSizeFraction = 1.0;
+    TDataFrameCategoryEncoderUPtr m_Encoder;
     TDoubleVec m_FeatureSampleProbabilities;
     TPackedBitVectorVec m_MissingFeatureRowMasks;
     TPackedBitVectorVec m_TrainingRowMasks;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -595,7 +595,7 @@ private:
     };
 
 private:
-    CBoostedTreeImpl() = default;
+    CBoostedTreeImpl();
 
     //! Check if we can train a model.
     bool canTrain() const;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -41,9 +41,6 @@ namespace boosted_tree_detail {
 inline std::size_t predictionColumn(std::size_t numberColumns) {
     return numberColumns - 3;
 }
-inline std::size_t numberColumnsAddedToDataFrame() {
-    return 3;
-}
 }
 
 class MATHS_EXPORT CBoostedTreeImpl final {

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -148,6 +148,9 @@ public:
     //! Get the number of one-hot encoded categories for \p feature.
     std::size_t numberOneHotEncodedCategories(std::size_t feature) const;
 
+    //! Check if \p category of \p feature uses one-hot encoding.
+    bool usesOneHotEncoding(std::size_t feature, std::size_t category) const;
+
     //! Check if feature with encoding \p encoding is one for \p category of \p feature.
     bool isHot(std::size_t encoding, std::size_t feature, std::size_t category) const;
 

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -9,13 +9,20 @@
 
 #include <core/CDataFrame.h>
 
+#include <maths/CDataFrameUtils.h>
 #include <maths/ImportExport.h>
 #include <maths/MathsTypes.h>
 
+#include <boost/unordered_set.hpp>
+
+#include <cstdint>
 #include <utility>
 #include <vector>
 
 namespace ml {
+namespace core {
+class CPackedBitVector;
+}
 namespace maths {
 class CDataFrameCategoryEncoder;
 
@@ -53,6 +60,9 @@ public:
         }
     }
 
+    //! Get the underlying row reference.
+    const TRowRef& unencodedRow() const;
+
 private:
     TRowRef m_Row;
     const CDataFrameCategoryEncoder* m_Encoder;
@@ -81,6 +91,7 @@ public:
 public:
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute the encoding.
+    //! \param[in] rowMask A mask of the rows to use to determine the encoding.
     //! \param[in] columnMask A mask of the columns to include.
     //! \param[in] targetColumn The regression target variable.
     //! \param[in] minimumRowsPerFeature The minimum number of rows needed per dimension
@@ -93,26 +104,21 @@ public:
     //! features already selected.
     CDataFrameCategoryEncoder(std::size_t numberThreads,
                               const core::CDataFrame& frame,
+                              const core::CPackedBitVector& rowMask,
                               const TSizeVec& columnMask,
                               std::size_t targetColumn,
                               std::size_t minimumRowsPerFeature,
-                              double minimumFrequencyToOneHotEncode = 0.01,
+                              double minimumFrequencyToOneHotEncode = 0.05,
                               double redundancyWeight = 0.5);
 
     //! Get a row reference which encodes the categories in \p row.
-    CEncodedDataFrameRowRef encode(TRowRef row);
+    CEncodedDataFrameRowRef encode(TRowRef row) const;
 
     //! Check if \p feature is categorical.
     bool columnIsCategorical(std::size_t feature) const;
 
-    //! Get the selected metric features.
-    const TSizeVec& selectedMetricFeatures() const;
-
-    //! Get the selected metric features' MICs.
-    const TDoubleVec& selectedMetricFeatureMics() const;
-
-    //! Get the selected categorical features.
-    const TSizeVec& selectedCategoricalFeatures() const;
+    //! Get the MICs of the selected features.
+    const TDoubleVec& featureMics() const;
 
     //! Get the total number of dimensions in the feature vector.
     std::size_t numberFeatures() const;
@@ -123,66 +129,78 @@ public:
     //! Get the data frame column of \p index into the feature vector.
     std::size_t column(std::size_t index) const;
 
+    //! Check if \p index is a binary encoded feature.
+    bool isBinary(std::size_t index) const;
+
     //! Get the number of one-hot encoded categories for \p feature.
     std::size_t numberOneHotEncodedCategories(std::size_t feature) const;
 
-    //! Check if \p encoding is one for category \p category of \p feature.
-    bool isOne(std::size_t encoding, std::size_t feature, std::size_t category) const;
+    //! Check if feature with encoding \p encoding is one for \p category of \p feature.
+    bool isHot(std::size_t encoding, std::size_t feature, std::size_t category) const;
 
-    //! Check if \p feature has rare categories.
-    bool hasRareCategories(std::size_t feature) const;
+    //! Check if \p feature uses frequency encoding.
+    bool usesFrequencyEncoding(std::size_t feature) const;
 
-    //! Check if \p category of \p feature is rare.
+    //! Check if \p category of \p feature is a rare category.
     bool isRareCategory(std::size_t feature, std::size_t category) const;
+
+    //! Get the frequency of \p category of \p feature.
+    double frequency(std::size_t feature, std::size_t category) const;
 
     //! Get the mean value of the target variable for \p category of \p feature.
     double targetMeanValue(std::size_t feature, std::size_t category) const;
+
+    //! Get a checksum of the state of this object seeded with \p seed.
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
 private:
     using TSizeDoublePr = std::pair<std::size_t, double>;
     using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
     using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+    using TSizeSizePrDoubleMap = std::map<TSizeSizePr, double>;
+    using TSizeUSet = boost::unordered_set<std::size_t>;
+    using TSizeUSetVec = std::vector<TSizeUSet>;
 
 private:
-    std::pair<TDoubleVec, TSizeDoublePrVecVec>
-    mics(std::size_t numberThreads,
-         const core::CDataFrame& frame,
-         std::size_t feature,
-         std::size_t category,
-         const TSizeVec& metricColumnMask,
-         const TSizeVec& categoricalColumnMask,
-         double minimumFrequencyToOneHotEncode) const;
-    void isRareEncode(std::size_t numberThreads,
-                      const core::CDataFrame& frame,
-                      const TSizeVec& categoricalColumnMask,
-                      std::size_t minimumRowsPerFeature);
-    void oneHotEncode(std::size_t numberThreads,
-                      const core::CDataFrame& frame,
-                      TSizeVec metricColumnMask,
-                      TSizeVec categoricalColumnMask,
-                      std::size_t targetColumn,
-                      std::size_t minimumRowsPerFeature,
-                      double minimumFrequencyToOneHotEncode);
-    void oneHotEncodeAll(const TDoubleVec& metricMics, const TSizeDoublePrVecVec& categoricalMics);
-    void targetMeanValueEncode(std::size_t numberThreads,
-                               const core::CDataFrame& frame,
-                               const TSizeVec& categoricalColumnMask,
-                               std::size_t targetColumn);
-    void setupEncodingMaps(const core::CDataFrame& frame);
-    std::size_t numberAvailableFeatures(const TDoubleVec& metricMics,
-                                        const TSizeDoublePrVecVec& categoricalMics) const;
+    TSizeDoublePrVecVec mics(std::size_t numberThreads,
+                             const core::CDataFrame& frame,
+                             const CDataFrameUtils::CColumnValue& target,
+                             const core::CPackedBitVector& rowMask,
+                             const TSizeVec& metricColumnMask,
+                             const TSizeVec& categoricalColumnMask) const;
+    void setupFrequencyEncoding(std::size_t numberThreads,
+                                const core::CDataFrame& frame,
+                                const core::CPackedBitVector& rowMask,
+                                const TSizeVec& categoricalColumnMask);
+    void setupTargetMeanValueEncoding(std::size_t numberThreads,
+                                      const core::CDataFrame& frame,
+                                      const core::CPackedBitVector& rowMask,
+                                      const TSizeVec& categoricalColumnMask,
+                                      std::size_t targetColumn);
+    TSizeSizePrDoubleMap selectFeatures(std::size_t numberThreads,
+                                        const core::CDataFrame& frame,
+                                        const core::CPackedBitVector& rowMask,
+                                        TSizeVec metricColumnMask,
+                                        TSizeVec categoricalColumnMask,
+                                        std::size_t targetColumn);
+    TSizeSizePrDoubleMap selectAllFeatures(const TSizeDoublePrVecVec& mics);
+    void finishEncoding(std::size_t targetColumn, TSizeSizePrDoubleMap selectedFeatureMics);
+    std::size_t numberAvailableFeatures(const TSizeDoublePrVecVec& mics) const;
 
 private:
+    std::size_t m_MinimumRowsPerFeature;
+    double m_MinimumFrequencyToOneHotEncode;
     double m_RedundancyWeight;
     TBoolVec m_ColumnIsCategorical;
-    TSizeVec m_SelectedMetricFeatures;
-    TDoubleVec m_SelectedMetricFeatureMics;
-    TSizeVec m_SelectedCategoricalFeatures;
+    TBoolVec m_ColumnUsesFrequencyEncoding;
+    TSizeVecVec m_OneHotEncodedCategories;
+    TSizeUSetVec m_RareCategories;
+    TDoubleVecVec m_CategoryFrequencies;
+    TDoubleVecVec m_TargetMeanValues;
+    TDoubleVec m_FeatureVectorMics;
     TSizeVec m_FeatureVectorColumnMap;
     TSizeVec m_FeatureVectorEncodingMap;
-    TDoubleVecVec m_TargetMeanValues;
-    TSizeVecVec m_RareCategories;
-    TSizeVecVec m_OneHotEncodedCategories;
 };
 }
 }

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -111,6 +111,9 @@ public:
                               double minimumFrequencyToOneHotEncode = 0.05,
                               double redundancyWeight = 0.5);
 
+    //! Initialize from serialized data.
+    CDataFrameCategoryEncoder(core::CStateRestoreTraverser& traverser);
+
     //! Get a row reference which encodes the categories in \p row.
     CEncodedDataFrameRowRef encode(TRowRef row) const;
 
@@ -152,6 +155,12 @@ public:
 
     //! Get a checksum of the state of this object seeded with \p seed.
     std::uint64_t checksum(std::uint64_t seed = 0) const;
+
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
 private:
     using TSizeDoublePr = std::pair<std::size_t, double>;

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -89,6 +89,16 @@ public:
     using TRowRef = core::CDataFrame::TRowRef;
 
 public:
+    //! This ensures we don't try and one-hot encode too many categories and thus
+    //! overfit. This represents a reasonable default, but this is likely better
+    //! estimated from the data characteristics.
+    static constexpr double MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE{0.05};
+
+    //! By default assign roughly twice the importance to maximising relevance vs
+    //! minimising redundancy when choosing the encoding and selecting features.
+    static constexpr double REDUNDANCY_WEIGHT{0.5};
+
+public:
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute the encoding.
     //! \param[in] rowMask A mask of the rows to use to determine the encoding.
@@ -108,8 +118,8 @@ public:
                               const TSizeVec& columnMask,
                               std::size_t targetColumn,
                               std::size_t minimumRowsPerFeature,
-                              double minimumFrequencyToOneHotEncode = 0.05,
-                              double redundancyWeight = 0.5);
+                              double minimumFrequencyToOneHotEncode = MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE,
+                              double redundancyWeight = REDUNDANCY_WEIGHT);
 
     //! Initialize from serialized data.
     CDataFrameCategoryEncoder(core::CStateRestoreTraverser& traverser);

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -75,7 +75,7 @@ public:
         virtual ~CColumnValue() = default;
         virtual double operator()(const TRowRef& row) const = 0;
         virtual double operator()(const TFloatVec& row) const = 0;
-        virtual std::size_t id() const = 0;
+        virtual std::size_t hash() const = 0;
 
     protected:
         std::size_t column() const { return m_Column; }
@@ -94,7 +94,7 @@ public:
         double operator()(const TFloatVec& row) const override {
             return row[this->column()];
         }
-        std::size_t id() const override { return 0; }
+        std::size_t hash() const override { return 0; }
     };
 
     //! \brief Used to extract the value from a one-hot encoded categorical column
@@ -109,7 +109,7 @@ public:
         double operator()(const TFloatVec& row) const override {
             return static_cast<std::size_t>(row[this->column()]) == m_Category ? 1.0 : 0.0;
         }
-        std::size_t id() const override { return m_Category; }
+        std::size_t hash() const override { return m_Category; }
 
     private:
         std::size_t m_Category;
@@ -129,7 +129,7 @@ public:
             std::size_t category{static_cast<std::size_t>(row[this->column()])};
             return (*m_Frequencies)[category];
         }
-        std::size_t id() const override { return 0; }
+        std::size_t hash() const override { return 0; }
 
     private:
         const TDoubleVec* m_Frequencies;
@@ -155,7 +155,7 @@ public:
             std::size_t category{static_cast<std::size_t>(row[this->column()])};
             return this->isRare(category) ? 0.0 : (*m_TargetMeanValues)[category];
         }
-        std::size_t id() const override { return 0; }
+        std::size_t hash() const override { return 0; }
 
     private:
         bool isRare(std::size_t category) const {
@@ -277,19 +277,19 @@ public:
 private:
     static TSizeDoublePrVecVecVec
     categoricalMicWithColumnDataFrameInMemory(const CColumnValue& target,
-                                              std::size_t numberThreads,
                                               const core::CDataFrame& frame,
                                               const core::CPackedBitVector& rowMask,
                                               const TSizeVec& columnMask,
                                               const TEncoderFactoryVec& encoderFactories,
+                                              const TDoubleVecVec& frequencies,
                                               std::size_t numberSamples);
     static TSizeDoublePrVecVecVec
     categoricalMicWithColumnDataFrameOnDisk(const CColumnValue& target,
-                                            std::size_t numberThreads,
                                             const core::CDataFrame& frame,
                                             const core::CPackedBitVector& rowMask,
                                             const TSizeVec& columnMask,
                                             const TEncoderFactoryVec& encoderFactories,
+                                            const TDoubleVecVec& frequencies,
                                             std::size_t numberSamples);
     static TDoubleVec
     metricMicWithColumnDataFrameInMemory(const CColumnValue& target,

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -13,6 +13,8 @@
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/ImportExport.h>
 
+#include <boost/unordered_set.hpp>
+
 #include <functional>
 #include <vector>
 
@@ -21,6 +23,7 @@ namespace core {
 class CPackedBitVector;
 }
 namespace maths {
+class CDataFrameCategoryEncoder;
 class CQuantileSketch;
 
 namespace data_frame_utils_detail {
@@ -59,51 +62,114 @@ public:
     using TSizeDoublePr = std::pair<std::size_t, double>;
     using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
     using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
+    using TSizeDoublePrVecVecVec = std::vector<TSizeDoublePrVecVec>;
     using TRowRef = core::CDataFrame::TRowRef;
     using TWeightFunction = std::function<double(TRowRef)>;
     using TQuantileSketchVec = std::vector<CQuantileSketch>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
     //! \brief Used to extract the value from a specific column of the data frame.
-    class CColumnValue {
+    class MATHS_EXPORT CColumnValue {
     public:
+        CColumnValue(std::size_t column) : m_Column{column} {}
         virtual ~CColumnValue() = default;
         virtual double operator()(const TRowRef& row) const = 0;
         virtual double operator()(const TFloatVec& row) const = 0;
-    };
+        virtual std::size_t id() const = 0;
 
-    //! \brief Used to extract the value from a metric column of the data frame.
-    class CMetricColumnValue final : public CColumnValue {
-    public:
-        CMetricColumnValue(std::size_t column) : m_Column{column} {}
-        double operator()(const TRowRef& row) const override {
-            return row[m_Column];
-        }
-        double operator()(const TFloatVec& row) const override {
-            return row[m_Column];
-        }
+    protected:
+        std::size_t column() const { return m_Column; }
 
     private:
         std::size_t m_Column;
+    };
+
+    //! \brief Used to extract the value from a metric column of the data frame.
+    class MATHS_EXPORT CMetricColumnValue final : public CColumnValue {
+    public:
+        CMetricColumnValue(std::size_t column) : CColumnValue{column} {}
+        double operator()(const TRowRef& row) const override {
+            return row[this->column()];
+        }
+        double operator()(const TFloatVec& row) const override {
+            return row[this->column()];
+        }
+        std::size_t id() const override { return 0; }
     };
 
     //! \brief Used to extract the value from a one-hot encoded categorical column
     //! of the data frame.
-    class COneHotCategoricalColumnValue final : public CColumnValue {
+    class MATHS_EXPORT COneHotCategoricalColumnValue final : public CColumnValue {
     public:
         COneHotCategoricalColumnValue(std::size_t column, std::size_t category)
-            : m_Column{column}, m_Category{category} {}
+            : CColumnValue{column}, m_Category{category} {}
         double operator()(const TRowRef& row) const override {
-            return static_cast<std::size_t>(row[m_Column]) == m_Category ? 1.0 : 0.0;
+            return static_cast<std::size_t>(row[this->column()]) == m_Category ? 1.0 : 0.0;
         }
         double operator()(const TFloatVec& row) const override {
-            return static_cast<std::size_t>(row[m_Column]) == m_Category ? 1.0 : 0.0;
+            return static_cast<std::size_t>(row[this->column()]) == m_Category ? 1.0 : 0.0;
+        }
+        std::size_t id() const override { return m_Category; }
+
+    private:
+        std::size_t m_Category;
+    };
+
+    //! \brief Used to extract the value from a "is rare" encoded categorical column
+    //! of the data frame.
+    class MATHS_EXPORT CFrequencyCategoricalColumnValue final : public CColumnValue {
+    public:
+        CFrequencyCategoricalColumnValue(std::size_t column, const TDoubleVec& frequencies)
+            : CColumnValue{column}, m_Frequencies{&frequencies} {}
+        double operator()(const TRowRef& row) const override {
+            std::size_t category{static_cast<std::size_t>(row[this->column()])};
+            return (*m_Frequencies)[category];
+        }
+        double operator()(const TFloatVec& row) const override {
+            std::size_t category{static_cast<std::size_t>(row[this->column()])};
+            return (*m_Frequencies)[category];
+        }
+        std::size_t id() const override { return 0; }
+
+    private:
+        const TDoubleVec* m_Frequencies;
+    };
+
+    //! \brief Used to extract the value from a mean target encoded categorical
+    //! column of the data frame.
+    class MATHS_EXPORT CTargetMeanCategoricalColumnValue final : public CColumnValue {
+    public:
+        using TSizeUSet = boost::unordered_set<std::size_t>;
+
+    public:
+        CTargetMeanCategoricalColumnValue(std::size_t column,
+                                          const TSizeUSet& rareCategories,
+                                          const TDoubleVec& targetMeanValues)
+            : CColumnValue{column}, m_RareCategories{&rareCategories}, m_TargetMeanValues{&targetMeanValues} {
+        }
+        double operator()(const TRowRef& row) const override {
+            std::size_t category{static_cast<std::size_t>(row[this->column()])};
+            return this->isRare(category) ? 0.0 : (*m_TargetMeanValues)[category];
+        }
+        double operator()(const TFloatVec& row) const override {
+            std::size_t category{static_cast<std::size_t>(row[this->column()])};
+            return this->isRare(category) ? 0.0 : (*m_TargetMeanValues)[category];
+        }
+        std::size_t id() const override { return 0; }
+
+    private:
+        bool isRare(std::size_t category) const {
+            return m_RareCategories->find(category) != m_RareCategories->end();
         }
 
     private:
-        std::size_t m_Column;
-        std::size_t m_Category;
+        const TSizeUSet* m_RareCategories;
+        const TDoubleVec* m_TargetMeanValues;
     };
+
+    using TEncoderFactory =
+        std::function<std::unique_ptr<CColumnValue>(std::size_t, std::size_t, std::size_t)>;
+    using TEncoderFactoryVec = std::vector<std::pair<TEncoderFactory, double>>;
 
 public:
     //! Convert a row of the data frame to a specified vector type.
@@ -126,6 +192,8 @@ public:
     //! \param[in] columnMask A mask of the columns for which to compute quantiles.
     //! \param[in] sketch The sketch to be used to estimate column quantiles.
     //! \param[out] result Filled in with the column quantile estimates.
+    //! \param[in] encoder If non-null used to encode the rows for which to compute
+    //! quantiles.
     //! \param[in] weight The weight to assign each row. The default is unity for
     //! all rows.
     static bool columnQuantiles(std::size_t numberThreads,
@@ -134,31 +202,36 @@ public:
                                 const TSizeVec& columnMask,
                                 const CQuantileSketch& sketch,
                                 TQuantileSketchVec& result,
+                                const CDataFrameCategoryEncoder* encoder = nullptr,
                                 TWeightFunction weight = unitWeight);
 
     //! Get the relative frequency of each category in \p frame.
     //!
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute category frequencies.
+    //! \param[in] rowMask A mask of the rows from which to compute category frequencies.
     //! \param[in] columnMask A mask of the columns to include.
     //! \return The frequency of each category. The collection is indexed by column
     //! and then category identifier.
     static TDoubleVecVec categoryFrequencies(std::size_t numberThreads,
                                              const core::CDataFrame& frame,
+                                             const core::CPackedBitVector& rowMask,
                                              TSizeVec columnMask);
 
     //! Compute the mean value of \p target on the restriction to the rows labelled
     //! by each distinct category of the categorical columns.
     //!
-    //! \param[in] target Extracts the column value with which to compute MIC.
+    //! \param[in] target The column value for which to compute the mean value.
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute mean values.
+    //! \param[in] rowMask A mask of the rows from which to compute mean values.
     //! \param[in] columnMask A mask of the columns to include.
     //! \return The mean values of \p target for each category. The collection
     //! is indexed by column and then category identifier.
     static TDoubleVecVec meanValueOfTargetForCategories(const CColumnValue& target,
                                                         std::size_t numberThreads,
                                                         const core::CDataFrame& frame,
+                                                        const core::CPackedBitVector& rowMask,
                                                         TSizeVec columnMask);
 
     //! Assess the strength of the relationship for each distinct category with
@@ -167,56 +240,69 @@ public:
     //! \param[in] target Extracts the column value with which to compute MIC.
     //! \param[in] numberThreads The number of threads available.
     //! \param[in] frame The data frame for which to compute the category MICs.
+    //! \param[in] rowMask A mask of the rows from which to compute MIC.
     //! \param[in] columnMask A mask of the columns to include.
-    //! \param[in] minimumFrequency The minimum frequency of the category in the
-    //! data set for which to compute MIC.
+    //! \param[in] encoderFactories A collection of (factory, minimum frequency)
+    //! pairs, with the factory making the encoder for distinct category values
+    //! and the minimum frequency being the minimum frequency for a category in
+    //! the frame to use the corresponding encoding.
     //! \return A collection containing (category, MIC with \p target) pairs
     //! for each category whose frequency in \p frame is greater than \p minimumFrequency
     //! and each categorical column. The collection is indexed by column.
-    static TSizeDoublePrVecVec categoryMicWithColumn(const CColumnValue& target,
-                                                     std::size_t numberThreads,
-                                                     const core::CDataFrame& frame,
-                                                     TSizeVec columnMask,
-                                                     double minimumFrequency = 0.01);
+    static TSizeDoublePrVecVecVec
+    categoricalMicWithColumn(const CColumnValue& target,
+                             std::size_t numberThreads,
+                             const core::CDataFrame& frame,
+                             const core::CPackedBitVector& rowMask,
+                             TSizeVec columnMask,
+                             const TEncoderFactoryVec& encoderFactories);
 
     //! Assess the strength of the relationship for each metric valued column with
     //! \p target by computing the maximum information coefficient (MIC).
     //!
     //! \param[in] target Extracts the column value with which to compute MIC.
     //! \param[in] frame The data frame for which to compute the column MICs.
+    //! \param[in] rowMask A mask of the rows from which to compute MIC.
     //! \param[in] columnMask A mask of the columns to include.
     //! \return A collection containing the MIC of each metric valued column with
     //! \p target. The collectionis indexed by column.
-    static TDoubleVec micWithColumn(const CColumnValue& target,
-                                    const core::CDataFrame& frame,
-                                    TSizeVec columnMask);
+    static TDoubleVec metricMicWithColumn(const CColumnValue& target,
+                                          const core::CDataFrame& frame,
+                                          const core::CPackedBitVector& rowMask,
+                                          TSizeVec columnMask);
 
     //! Check if a data frame value is missing.
     static bool isMissing(double value);
 
 private:
-    static TSizeDoublePrVecVec
-    categoryMicWithColumnDataFrameInMemory(const CColumnValue& target,
-                                           std::size_t numberThreads,
-                                           const core::CDataFrame& frame,
-                                           const TSizeVec& columnMask,
-                                           std::size_t numberSamples,
-                                           double minimumFrequency);
-    static TSizeDoublePrVecVec
-    categoryMicWithColumnDataFrameOnDisk(const CColumnValue& target,
-                                         std::size_t numberThreads,
+    static TSizeDoublePrVecVecVec
+    categoricalMicWithColumnDataFrameInMemory(const CColumnValue& target,
+                                              std::size_t numberThreads,
+                                              const core::CDataFrame& frame,
+                                              const core::CPackedBitVector& rowMask,
+                                              const TSizeVec& columnMask,
+                                              const TEncoderFactoryVec& encoderFactories,
+                                              std::size_t numberSamples);
+    static TSizeDoublePrVecVecVec
+    categoricalMicWithColumnDataFrameOnDisk(const CColumnValue& target,
+                                            std::size_t numberThreads,
+                                            const core::CDataFrame& frame,
+                                            const core::CPackedBitVector& rowMask,
+                                            const TSizeVec& columnMask,
+                                            const TEncoderFactoryVec& encoderFactories,
+                                            std::size_t numberSamples);
+    static TDoubleVec
+    metricMicWithColumnDataFrameInMemory(const CColumnValue& target,
                                          const core::CDataFrame& frame,
+                                         const core::CPackedBitVector& rowMask,
                                          const TSizeVec& columnMask,
-                                         std::size_t numberSamples,
-                                         double minimumFrequency);
-    static TDoubleVec micWithColumnDataFrameInMemory(const CColumnValue& target,
-                                                     const core::CDataFrame& frame,
-                                                     const TSizeVec& columnMask,
-                                                     std::size_t numberSamples);
-    static TDoubleVec micWithColumnDataFrameOnDisk(const CColumnValue& target,
-                                                   const core::CDataFrame& frame,
-                                                   const TSizeVec& columnMask,
-                                                   std::size_t numberSamples);
+                                         std::size_t numberSamples);
+    static TDoubleVec
+    metricMicWithColumnDataFrameOnDisk(const CColumnValue& target,
+                                       const core::CDataFrame& frame,
+                                       const core::CPackedBitVector& rowMask,
+                                       const TSizeVec& columnMask,
+                                       std::size_t numberSamples);
     static void removeMetricColumns(const core::CDataFrame& frame, TSizeVec& columnMask);
     static void removeCategoricalColumns(const core::CDataFrame& frame, TSizeVec& columnMask);
     static double unitWeight(const TRowRef&);

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -58,7 +58,7 @@ double CArgMinMse::value() const {
 }
 
 CBoostedTree::CBoostedTree(core::CDataFrame& frame, TImplUPtr&& impl)
-    : CDataFrameRegressionModel(frame), m_Impl{std::move(impl)} {
+    : CDataFrameRegressionModel{frame}, m_Impl{std::move(impl)} {
 }
 
 CBoostedTree::~CBoostedTree() = default;

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -289,7 +289,8 @@ CBoostedTreeFactory::constructFromString(std::stringstream& jsonStringStream,
 
 CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads,
                                          CBoostedTree::TLossFunctionUPtr loss)
-    : m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))} {
+    : m_MinimumFrequencyToOneHotEncode{CDataFrameCategoryEncoder::MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE},
+      m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))} {
 }
 
 CBoostedTreeFactory::CBoostedTreeFactory(CBoostedTreeFactory&&) = default;

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -10,6 +10,7 @@
 
 #include <maths/CBayesianOptimisation.h>
 #include <maths/CBoostedTreeImpl.h>
+#include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CSampling.h>
 
 namespace ml {
@@ -30,10 +31,12 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
 
     // We store the gradient and curvature of the loss function and the predicted
     // value for the dependent variable of the regression.
-    frame.resizeColumns(m_TreeImpl->m_NumberThreads, frame.numberColumns() + 3);
+    frame.resizeColumns(m_TreeImpl->m_NumberThreads,
+                        frame.numberColumns() + this->numberExtraColumnsForTrain());
 
-    // TODO we should do feature selection per fold.
-    if (this->initializeFeatureSampleDistribution(frame)) {
+    this->selectFeaturesAndEncodeCategories(frame);
+
+    if (this->initializeFeatureSampleDistribution()) {
         this->initializeHyperparameters(frame, m_ProgressCallback);
         this->initializeHyperparameterOptimisation();
     }
@@ -140,44 +143,36 @@ CBoostedTreeFactory::crossValidationRowMasks() const {
     return {trainingRowMasks, testingRowMasks};
 }
 
-bool CBoostedTreeFactory::initializeFeatureSampleDistribution(const core::CDataFrame& frame) const {
+void CBoostedTreeFactory::selectFeaturesAndEncodeCategories(const core::CDataFrame& frame) const {
 
-    // Exclude all constant features by zeroing their probabilities.
+    // TODO we should do feature selection per fold.
 
-    std::size_t n{numberFeatures(frame)};
-
-    TSizeVec regressors(n);
+    TSizeVec regressors(frame.numberColumns() - this->numberExtraColumnsForTrain());
     std::iota(regressors.begin(), regressors.end(), 0);
     regressors.erase(regressors.begin() + m_TreeImpl->m_DependentVariable);
-
-    TDoubleVec mics(CDataFrameUtils::micWithColumn(
-        CDataFrameUtils::CMetricColumnValue{m_TreeImpl->m_DependentVariable}, frame, regressors));
-
-    regressors.erase(std::remove_if(regressors.begin(), regressors.end(),
-                                    [&](std::size_t i) { return mics[i] == 0.0; }),
-                     regressors.end());
     LOG_TRACE(<< "candidate regressors = " << core::CContainerPrinter::print(regressors));
 
-    m_TreeImpl->m_FeatureSampleProbabilities.assign(n, 0.0);
-    if (regressors.size() > 0) {
-        std::stable_sort(regressors.begin(), regressors.end(),
-                         [&mics](std::size_t lhs, std::size_t rhs) {
-                             return mics[lhs] > mics[rhs];
-                         });
+    m_TreeImpl->m_Encoder = std::make_unique<CDataFrameCategoryEncoder>(
+        m_TreeImpl->m_NumberThreads, frame, m_TreeImpl->allTrainingRowsMask(),
+        regressors, m_TreeImpl->m_DependentVariable,
+        m_TreeImpl->m_RowsPerFeature, m_MinimumFrequencyToOneHotEncode);
+}
 
-        std::size_t maximumNumberFeatures{frame.numberRows() / m_TreeImpl->m_RowsPerFeature};
-        LOG_TRACE(<< "Using up to " << maximumNumberFeatures << " out of "
-                  << regressors.size() << " features");
+bool CBoostedTreeFactory::initializeFeatureSampleDistribution() const {
 
-        regressors.resize(std::min(maximumNumberFeatures, regressors.size()));
+    // Compute feature sample probabilities.
 
-        double Z{std::accumulate(
-            regressors.begin(), regressors.end(), 0.0,
-            [&mics](double z, std::size_t i) { return z + mics[i]; })};
+    TDoubleVec mics(m_TreeImpl->m_Encoder->featureMics());
+    LOG_TRACE(<< "candidate regressors MICe = " << core::CContainerPrinter::print(mics));
+
+    if (mics.size() > 0) {
+        double Z{std::accumulate(mics.begin(), mics.end(), 0.0,
+                                 [](double z, double mic) { return z + mic; })};
         LOG_TRACE(<< "Z = " << Z);
-        for (auto i : regressors) {
-            m_TreeImpl->m_FeatureSampleProbabilities[i] = mics[i] / Z;
+        for (auto& mic : mics) {
+            mic /= Z;
         }
+        m_TreeImpl->m_FeatureSampleProbabilities = std::move(mics);
         LOG_TRACE(<< "P(sample) = "
                   << core::CContainerPrinter::print(m_TreeImpl->m_FeatureSampleProbabilities));
         return true;
@@ -302,6 +297,15 @@ CBoostedTreeFactory::CBoostedTreeFactory(CBoostedTreeFactory&&) = default;
 CBoostedTreeFactory& CBoostedTreeFactory::operator=(CBoostedTreeFactory&&) = default;
 
 CBoostedTreeFactory::~CBoostedTreeFactory() = default;
+
+CBoostedTreeFactory& CBoostedTreeFactory::minimumFrequencyToOneHotEncode(double frequency) {
+    if (frequency >= 1.0) {
+        LOG_WARN(<< "Frequency to one-hot encode must be less than one");
+        frequency = 1.0 - std::numeric_limits<double>::epsilon();
+    }
+    m_MinimumFrequencyToOneHotEncode = frequency;
+    return *this;
+}
 
 CBoostedTreeFactory& CBoostedTreeFactory::numberFolds(std::size_t numberFolds) {
     if (numberFolds < 2) {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -71,7 +71,8 @@ CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads, CBoostedTree::TLos
     : m_NumberThreads{numberThreads}, m_Loss{std::move(loss)} {
 }
 
-CBoostedTreeImpl::~CBoostedTreeImpl() = default;
+CBoostedTreeImpl::~CBoostedTreeImpl() {
+}
 
 CBoostedTreeImpl& CBoostedTreeImpl::operator=(CBoostedTreeImpl&&) = default;
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -676,6 +676,7 @@ const std::string ETA_OVERRIDE_TAG{"eta_override"};
 const std::string ETA_TAG{"eta"};
 const std::string FEATURE_BAG_FRACTION_OVERRIDE_TAG{"feature_bag_fraction_override"};
 const std::string FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
+const std::string ENCODER_TAG{"encoder_tag"};
 const std::string FEATURE_SAMPLE_PROBABILITIES_TAG{"feature_sample_probabilities"};
 const std::string GAMMA_OVERRIDE_TAG{"gamma_override"};
 const std::string GAMMA_TAG{"gamma"};
@@ -721,6 +722,7 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
                                  m_EtaGrowthRatePerTree, inserter);
     core::CPersistUtils::persist(ETA_TAG, m_Eta, inserter);
     core::CPersistUtils::persist(FEATURE_BAG_FRACTION_TAG, m_FeatureBagFraction, inserter);
+    core::CPersistUtils::persist(ENCODER_TAG, *m_Encoder, inserter);
     core::CPersistUtils::persist(FEATURE_SAMPLE_PROBABILITIES_TAG,
                                  m_FeatureSampleProbabilities, inserter);
     core::CPersistUtils::persist(GAMMA_TAG, m_Gamma, inserter);
@@ -850,6 +852,8 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
         RESTORE(FEATURE_BAG_FRACTION_TAG,
                 core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
                                              m_FeatureBagFraction, traverser))
+        RESTORE_NO_ERROR(ENCODER_TAG,
+                         m_Encoder = std::make_unique<CDataFrameCategoryEncoder>(traverser))
         RESTORE(FEATURE_SAMPLE_PROBABILITIES_TAG,
                 core::CPersistUtils::restore(FEATURE_SAMPLE_PROBABILITIES_TAG,
                                              m_FeatureSampleProbabilities, traverser))

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -71,8 +71,9 @@ CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads, CBoostedTree::TLos
     : m_NumberThreads{numberThreads}, m_Loss{std::move(loss)} {
 }
 
-CBoostedTreeImpl::~CBoostedTreeImpl() {
-}
+CBoostedTreeImpl::CBoostedTreeImpl() = default;
+
+CBoostedTreeImpl::~CBoostedTreeImpl() = default;
 
 CBoostedTreeImpl& CBoostedTreeImpl::operator=(CBoostedTreeImpl&&) = default;
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -8,8 +8,11 @@
 
 #include <core/CPersistUtils.h>
 
+#include <maths/CBayesianOptimisation.h>
+#include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CQuantileSketch.h>
 #include <maths/CSampling.h>
+#include <maths/CSetTools.h>
 
 namespace ml {
 namespace maths {
@@ -17,6 +20,8 @@ using namespace boosted_tree;
 using namespace boosted_tree_detail;
 
 namespace {
+using TRowRef = core::CDataFrame::TRowRef;
+
 std::size_t lossGradientColumn(std::size_t numberColumns) {
     return numberColumns - 2;
 }
@@ -24,26 +29,40 @@ std::size_t lossGradientColumn(std::size_t numberColumns) {
 std::size_t lossCurvatureColumn(std::size_t numberColumns) {
     return numberColumns - 1;
 }
+
+double readPrediction(const TRowRef& row) {
+    return row[predictionColumn(row.numberColumns())];
 }
 
-void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(const TRowRef& row,
+double readLossGradient(const TRowRef& row) {
+    return row[lossGradientColumn(row.numberColumns())];
+}
+
+double readLossCurvature(const TRowRef& row) {
+    return row[lossCurvatureColumn(row.numberColumns())];
+}
+
+double readActual(const TRowRef& row, std::size_t dependentVariable) {
+    return row[dependentVariable];
+}
+}
+
+void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(const CEncodedDataFrameRowRef& row,
                                                               SDerivatives& derivatives) const {
 
-    std::size_t numberColumns{row.numberColumns()};
-    std::size_t gradientColumn{lossGradientColumn(numberColumns)};
-    std::size_t curvatureColumn{lossCurvatureColumn(numberColumns)};
+    const TRowRef& unencodedRow{row.unencodedRow()};
 
     for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
         double featureValue{row[i]};
         if (CDataFrameUtils::isMissing(featureValue)) {
-            derivatives.s_MissingGradients[i] += row[gradientColumn];
-            derivatives.s_MissingCurvatures[i] += row[curvatureColumn];
+            derivatives.s_MissingGradients[i] += readLossGradient(unencodedRow);
+            derivatives.s_MissingCurvatures[i] += readLossCurvature(unencodedRow);
         } else {
             auto j = std::upper_bound(m_CandidateSplits[i].begin(),
                                       m_CandidateSplits[i].end(), featureValue) -
                      m_CandidateSplits[i].begin();
-            derivatives.s_Gradients[i][j] += row[gradientColumn];
-            derivatives.s_Curvatures[i][j] += row[curvatureColumn];
+            derivatives.s_Gradients[i][j] += readLossGradient(unencodedRow);
+            derivatives.s_Curvatures[i][j] += readLossCurvature(unencodedRow);
         }
     }
 }
@@ -51,6 +70,10 @@ void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(const TRowRef& row
 CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads, CBoostedTree::TLossFunctionUPtr loss)
     : m_NumberThreads{numberThreads}, m_Loss{std::move(loss)} {
 }
+
+CBoostedTreeImpl::~CBoostedTreeImpl() = default;
+
+CBoostedTreeImpl& CBoostedTreeImpl::operator=(CBoostedTreeImpl&&) = default;
 
 void CBoostedTreeImpl::train(core::CDataFrame& frame,
                              CBoostedTree::TProgressCallback recordProgress) {
@@ -117,7 +140,7 @@ void CBoostedTreeImpl::predict(core::CDataFrame& frame,
         m_NumberThreads, 0, frame.numberRows(), [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 row->writeColumn(predictionColumn(row->numberColumns()),
-                                 predictRow(*row, m_BestForest));
+                                 predictRow(m_Encoder->encode(*row), m_BestForest));
             }
         });
     if (successful == false) {
@@ -173,9 +196,8 @@ CBoostedTreeImpl::regularisedLoss(const core::CDataFrame& frame,
         core::bindRetrievableState(
             [&](double& loss, TRowItr beginRows, TRowItr endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
-                    std::size_t numberColumns{row->numberColumns()};
-                    loss += m_Loss->value((*row)[predictionColumn(numberColumns)],
-                                          (*row)[m_DependentVariable]);
+                    loss += m_Loss->value(readPrediction(*row),
+                                          readActual(*row, m_DependentVariable));
                 }
             },
             0.0),
@@ -288,19 +310,32 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
 
     using TQuantileSketchVec = std::vector<CQuantileSketch>;
 
-    TSizeVec features{this->candidateFeatures()};
+    TSizeVec features{this->candidateRegressorFeatures()};
     LOG_TRACE(<< "candidate features = " << core::CContainerPrinter::print(features));
 
+    TSizeVec binaryFeatures(features);
+    binaryFeatures.erase(std::remove_if(binaryFeatures.begin(), binaryFeatures.end(),
+                                        [this](std::size_t index) {
+                                            return m_Encoder->isBinary(index) == false;
+                                        }),
+                         binaryFeatures.end());
+    CSetTools::inplace_set_difference(features, binaryFeatures.begin(),
+                                      binaryFeatures.end());
+    LOG_TRACE(<< "binary features = " << core::CContainerPrinter::print(binaryFeatures)
+              << " other features = " << core::CContainerPrinter::print(features));
+
     TQuantileSketchVec columnQuantiles;
-    CDataFrameUtils::columnQuantiles(
-        m_NumberThreads, frame, trainingRowMask, features,
-        CQuantileSketch{CQuantileSketch::E_Linear, 100}, columnQuantiles,
-        [](const TRowRef& row) {
-            return row[lossCurvatureColumn(row.numberColumns())];
-        });
+    CDataFrameUtils::columnQuantiles(m_NumberThreads, frame, trainingRowMask, features,
+                                     CQuantileSketch{CQuantileSketch::E_Linear, 100},
+                                     columnQuantiles, m_Encoder.get(), readLossCurvature);
 
-    TDoubleVecVec result(numberFeatures(frame));
+    TDoubleVecVec candidateSplits(this->numberFeatures());
 
+    for (std::size_t i : binaryFeatures) {
+        candidateSplits[i] = TDoubleVec{0.5};
+        LOG_TRACE(<< "feature '" << i << "' splits = "
+                  << core::CContainerPrinter::print(candidateSplits[i]));
+    }
     for (std::size_t i = 0; i < features.size(); ++i) {
 
         TDoubleVec columnSplits;
@@ -319,21 +354,21 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
 
         columnSplits.erase(std::unique(columnSplits.begin(), columnSplits.end()),
                            columnSplits.end());
-        result[features[i]] = std::move(columnSplits);
+        candidateSplits[features[i]] = std::move(columnSplits);
 
         LOG_TRACE(<< "feature '" << features[i] << "' splits = "
-                  << core::CContainerPrinter::print(result[features[i]]));
+                  << core::CContainerPrinter::print(candidateSplits[features[i]]));
     }
 
-    return result;
+    LOG_TRACE(<< "candidate splits = " << core::CContainerPrinter::print(candidateSplits));
+
+    return candidateSplits;
 }
 
 CBoostedTreeImpl::TNodeVec
 CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
                             const TDoubleVecVec& candidateSplits) const {
-
-    // TODO improve categorical regressor treatment
 
     LOG_TRACE(<< "Training one tree...");
 
@@ -348,8 +383,8 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
     TLeafNodeStatisticsPtrQueue leaves;
     leaves.push(std::make_shared<CLeafNodeStatistics>(
-        0 /*root*/, m_NumberThreads, frame, m_Lambda, m_Gamma, candidateSplits,
-        this->featureBag(frame), trainingRowMask));
+        0 /*root*/, m_NumberThreads, frame, *m_Encoder, m_Lambda, m_Gamma,
+        candidateSplits, this->featureBag(), trainingRowMask));
 
     // For each iteration we:
     //   1. Find the leaf with the greatest decrease in loss
@@ -380,19 +415,19 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         std::tie(leftChildId, rightChildId) = tree[leaf->id()].split(
             splitFeature, splitValue, assignMissingToLeft, tree);
 
-        TSizeVec featureBag{this->featureBag(frame)};
+        TSizeVec featureBag{this->featureBag()};
 
         core::CPackedBitVector leftChildRowMask;
         core::CPackedBitVector rightChildRowMask;
         std::tie(leftChildRowMask, rightChildRowMask) = tree[leaf->id()].rowMasks(
-            m_NumberThreads, frame, std::move(leaf->rowMask()));
+            m_NumberThreads, frame, *m_Encoder, std::move(leaf->rowMask()));
 
         TLeafNodeStatisticsPtr leftChild;
         TLeafNodeStatisticsPtr rightChild;
-        std::tie(leftChild, rightChild) =
-            leaf->split(leftChildId, rightChildId, m_NumberThreads, frame,
-                        m_Lambda, m_Gamma, candidateSplits, std::move(featureBag),
-                        std::move(leftChildRowMask), std::move(rightChildRowMask));
+        std::tie(leftChild, rightChild) = leaf->split(
+            leftChildId, rightChildId, m_NumberThreads, frame, *m_Encoder,
+            m_Lambda, m_Gamma, candidateSplits, std::move(featureBag),
+            std::move(leftChildRowMask), std::move(rightChildRowMask));
 
         leaves.push(std::move(leftChild));
         leaves.push(std::move(rightChild));
@@ -403,16 +438,20 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
     return tree;
 }
 
-std::size_t CBoostedTreeImpl::featureBagSize(const core::CDataFrame& frame) const {
-    return static_cast<std::size_t>(std::max(
-        std::ceil(m_FeatureBagFraction * static_cast<double>(numberFeatures(frame))), 1.0));
+std::size_t CBoostedTreeImpl::numberFeatures() const {
+    return m_Encoder->numberFeatures();
 }
 
-CBoostedTreeImpl::TSizeVec CBoostedTreeImpl::featureBag(const core::CDataFrame& frame) const {
+std::size_t CBoostedTreeImpl::featureBagSize() const {
+    return static_cast<std::size_t>(std::max(
+        std::ceil(m_FeatureBagFraction * static_cast<double>(this->numberFeatures())), 1.0));
+}
 
-    std::size_t size{this->featureBagSize(frame)};
+CBoostedTreeImpl::TSizeVec CBoostedTreeImpl::featureBag() const {
 
-    TSizeVec features{this->candidateFeatures()};
+    std::size_t size{this->featureBagSize()};
+
+    TSizeVec features{this->candidateRegressorFeatures()};
     if (size >= features.size()) {
         return features;
     }
@@ -437,16 +476,17 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
         leafValues.push_back(m_Loss->minimizer());
     }
 
-    frame.readRows(1, 0, frame.numberRows(),
-                   [&](TRowItr beginRows, TRowItr endRows) {
-                       for (auto row = beginRows; row != endRows; ++row) {
-                           std::size_t numberColumns{row->numberColumns()};
-                           double prediction{(*row)[predictionColumn(numberColumns)]};
-                           double actual{(*row)[m_DependentVariable]};
-                           leafValues[root(tree).leafIndex(*row, tree)]->add(prediction, actual);
-                       }
-                   },
-                   &trainingRowMask);
+    frame.readRows(
+        1, 0, frame.numberRows(),
+        [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                double prediction{readPrediction(*row)};
+                double actual{readActual(*row, m_DependentVariable)};
+                leafValues[root(tree).leafIndex(m_Encoder->encode(*row), tree)]->add(
+                    prediction, actual);
+            }
+        },
+        &trainingRowMask);
 
     for (std::size_t i = 0; i < tree.size(); ++i) {
         tree[i].value(eta * leafValues[i]->value());
@@ -459,12 +499,11 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
         core::bindRetrievableState(
             [&](double& loss, TRowItr beginRows, TRowItr endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
+                    double prediction{readPrediction(*row) +
+                                      root(tree).value(m_Encoder->encode(*row), tree)};
+                    double actual{readActual(*row, m_DependentVariable)};
+
                     std::size_t numberColumns{row->numberColumns()};
-                    double actual{(*row)[m_DependentVariable]};
-                    double prediction{(*row)[predictionColumn(numberColumns)]};
-
-                    prediction += root(tree).value(*row, tree);
-
                     row->writeColumn(predictionColumn(numberColumns), prediction);
                     row->writeColumn(lossGradientColumn(numberColumns),
                                      m_Loss->gradient(prediction, actual));
@@ -493,8 +532,8 @@ double CBoostedTreeImpl::meanLoss(const core::CDataFrame& frame,
         core::bindRetrievableState(
             [&](TMeanAccumulator& loss, TRowItr beginRows, TRowItr endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
-                    double prediction{predictRow(*row, forest)};
-                    double actual{(*row)[m_DependentVariable]};
+                    double prediction{predictRow(m_Encoder->encode(*row), forest)};
+                    double actual{readActual(*row, m_DependentVariable)};
                     loss.add(m_Loss->value(prediction, actual));
                 }
             },
@@ -511,7 +550,7 @@ double CBoostedTreeImpl::meanLoss(const core::CDataFrame& frame,
     return CBasicStatistics::mean(loss);
 }
 
-CBoostedTreeImpl::TSizeVec CBoostedTreeImpl::candidateFeatures() const {
+CBoostedTreeImpl::TSizeVec CBoostedTreeImpl::candidateRegressorFeatures() const {
     TSizeVec result;
     result.reserve(m_FeatureSampleProbabilities.size());
     for (std::size_t i = 0; i < m_FeatureSampleProbabilities.size(); ++i) {
@@ -522,12 +561,12 @@ CBoostedTreeImpl::TSizeVec CBoostedTreeImpl::candidateFeatures() const {
     return result;
 }
 
-const CBoostedTreeImpl::CNode& CBoostedTreeImpl::root(const CBoostedTreeImpl::TNodeVec& tree) {
+const CBoostedTreeImpl::CNode& CBoostedTreeImpl::root(const TNodeVec& tree) {
     return tree[0];
 }
 
-double CBoostedTreeImpl::predictRow(const CBoostedTreeImpl::TRowRef& row,
-                                    const CBoostedTreeImpl::TNodeVecVec& forest) {
+double CBoostedTreeImpl::predictRow(const CEncodedDataFrameRowRef& row,
+                                    const TNodeVecVec& forest) {
     double result{0.0};
     for (const auto& tree : forest) {
         result += root(tree).value(row, tree);

--- a/lib/maths/CChecksum.cc
+++ b/lib/maths/CChecksum.cc
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CChecksum.h>
+
+namespace ml {
+namespace maths {
+namespace checksum_detail {
+const std::hash<std::vector<bool>> CChecksumImpl<ContainerChecksum>::ms_VectorBoolHasher{};
+}
+}
+}

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -379,7 +379,7 @@ bool CDataFrameCategoryEncoder::isRareCategory(std::size_t feature, std::size_t 
 
 double CDataFrameCategoryEncoder::targetMeanValue(std::size_t feature,
                                                   std::size_t category) const {
-    // TODO make this better
+    // TODO combine rare categories and use one mapping for collections.
     return this->isRareCategory(feature, category)
                ? 0.0
                : m_TargetMeanValues[feature][category];

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -11,6 +11,7 @@
 #include <core/CTriple.h>
 
 #include <maths/CBasicStatistics.h>
+#include <maths/CChecksum.h>
 #include <maths/CDataFrameUtils.h>
 #include <maths/COrderings.h>
 
@@ -24,6 +25,37 @@ using TDoubleVec = std::vector<double>;
 using TSizeDoublePr = std::pair<std::size_t, double>;
 using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
 using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
+using TSizeUSet = boost::unordered_set<std::size_t>;
+
+const std::size_t METRIC_CATEGORY{std::numeric_limits<std::size_t>::max()};
+const std::size_t RARE_CATEGORY{METRIC_CATEGORY - 1};
+const std::size_t TARGET_MEAN_CATEGORY{RARE_CATEGORY - 1};
+const std::size_t TARGET_CATEGORY{TARGET_MEAN_CATEGORY - 1};
+
+bool isMetric(std::size_t category) {
+    return category == METRIC_CATEGORY;
+}
+bool isRare(std::size_t category) {
+    return category == RARE_CATEGORY;
+}
+bool isTargetMean(std::size_t category) {
+    return category == TARGET_MEAN_CATEGORY;
+}
+bool isCategory(std::size_t category) {
+    return (isMetric(category) || isRare(category) || isTargetMean(category)) == false;
+}
+std::string print(std::size_t category) {
+    if (isMetric(category)) {
+        return "metric";
+    }
+    if (isRare(category)) {
+        return "rare";
+    }
+    if (isTargetMean(category)) {
+        return "target mean";
+    }
+    return std::to_string(category);
+}
 
 //! \brief Maintains the state for a single feature in a greedy search for the
 //! minimum redundancy maximum relevance feature selection.
@@ -32,14 +64,14 @@ public:
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 public:
-    CFeatureRelevanceMinusRedundancy(std::size_t feature,
-                                     std::size_t category,
-                                     bool isCategorical,
-                                     double micWithDependentVariable)
-        : m_Feature{feature}, m_Category{category}, m_IsCategorical{isCategorical},
-          m_MicWithDependentVariable{micWithDependentVariable} {}
+    CFeatureRelevanceMinusRedundancy(std::size_t feature, std::size_t category, double micWithDependentVariable)
+        : m_Feature{feature}, m_Category{category}, m_MicWithDependentVariable{
+                                                        micWithDependentVariable} {}
 
-    bool isCategorical() const { return m_IsCategorical; }
+    bool isMetric() const { return maths::isMetric(m_Category); }
+    bool isRare() const { return maths::isRare(m_Category); }
+    bool isTargetMean() const { return maths::isTargetMean(m_Category); }
+    bool isCategory() const { return maths::isCategory(m_Category); }
     std::size_t feature() const { return m_Feature; }
     std::size_t category() const { return m_Category; }
 
@@ -52,18 +84,31 @@ public:
                redundancyWeight * this->micWithSelectedVariables();
     }
 
-    void update(const TDoubleVec& metricMics, const TSizeDoublePrVecVec& categoricalMics) {
-        if (m_IsCategorical) {
-            auto i = std::find_if(categoricalMics[m_Feature].begin(),
-                                  categoricalMics[m_Feature].end(),
-                                  [this](const TSizeDoublePr& categoryMic) {
-                                      return categoryMic.first == m_Category;
-                                  });
-            if (i != categoricalMics[m_Feature].end()) {
-                m_MicWithSelectedVariables.add(i->second);
-            }
-        } else {
-            m_MicWithSelectedVariables.add(metricMics[m_Feature]);
+    std::unique_ptr<CDataFrameUtils::CColumnValue>
+    columnValue(const TSizeUSet& rareCategories,
+                const TDoubleVec& frequencies,
+                const TDoubleVec& targetMeanValues) const {
+        if (this->isMetric()) {
+            return std::make_unique<CDataFrameUtils::CMetricColumnValue>(m_Feature);
+        }
+        if (this->isRare()) {
+            return std::make_unique<CDataFrameUtils::CFrequencyCategoricalColumnValue>(
+                m_Feature, frequencies);
+        }
+        if (this->isTargetMean()) {
+            return std::make_unique<CDataFrameUtils::CTargetMeanCategoricalColumnValue>(
+                m_Feature, rareCategories, targetMeanValues);
+        }
+        return std::make_unique<CDataFrameUtils::COneHotCategoricalColumnValue>(
+            m_Feature, m_Category);
+    }
+
+    void update(const TSizeDoublePrVecVec& mics) {
+        auto i = std::find_if(
+            mics[m_Feature].begin(), mics[m_Feature].end(),
+            [this](const TSizeDoublePr& mic) { return mic.first == m_Category; });
+        if (i != mics[m_Feature].end()) {
+            m_MicWithSelectedVariables.add(i->second);
         }
     }
 
@@ -75,7 +120,6 @@ private:
 private:
     std::size_t m_Feature = 0;
     std::size_t m_Category = 0;
-    bool m_IsCategorical;
     double m_MicWithDependentVariable = 0.0;
     TMeanAccumulator m_MicWithSelectedVariables;
 };
@@ -99,21 +143,15 @@ private:
 class CMinRedundancyMaxRelevancyGreedySearch {
 public:
     CMinRedundancyMaxRelevancyGreedySearch(double redundancyWeight,
-                                           const TDoubleVec& metricMics,
-                                           const TSizeDoublePrVecVec& categoricalMics)
+                                           const TSizeDoublePrVecVec& mics)
         : m_RedundancyWeight{redundancyWeight} {
-        for (std::size_t i = 0; i < metricMics.size(); ++i) {
-            if (metricMics[i] > 0.0) {
-                m_Features.emplace_back(i, 0, false, metricMics[i]);
-            }
-        }
-        for (std::size_t i = 0; i < categoricalMics.size(); ++i) {
-            for (std::size_t j = 0; j < categoricalMics[i].size(); ++j) {
+        for (std::size_t i = 0; i < mics.size(); ++i) {
+            for (std::size_t j = 0; j < mics[i].size(); ++j) {
                 std::size_t category;
                 double mic;
-                std::tie(category, mic) = categoricalMics[i][j];
+                std::tie(category, mic) = mics[i][j];
                 if (mic > 0.0) {
-                    m_Features.emplace_back(i, category, true, mic);
+                    m_Features.emplace_back(i, category, mic);
                 }
             }
         }
@@ -132,9 +170,9 @@ public:
         return result;
     }
 
-    void update(const TDoubleVec& metricMics, const TSizeDoublePrVecVec& categoricalMics) {
+    void update(const TSizeDoublePrVecVec& mics) {
         for (auto& feature : m_Features) {
-            feature.update(metricMics, categoricalMics);
+            feature.update(mics);
         }
     }
 
@@ -168,11 +206,12 @@ CFloatStorage CEncodedDataFrameRowRef::operator[](std::size_t i) const {
         m_Encoder->numberOneHotEncodedCategories(feature)};
 
     if (encoding < numberOneHotEncodedCategories) {
-        return m_Encoder->isOne(encoding, feature, category) ? 1.0 : 0.0;
+        return m_Encoder->isHot(encoding, feature, category) ? 1.0 : 0.0;
     }
 
-    if (encoding == numberOneHotEncodedCategories && m_Encoder->hasRareCategories(feature)) {
-        return m_Encoder->isRareCategory(feature, category) ? 1.0 : 0.0;
+    if (encoding == numberOneHotEncodedCategories &&
+        m_Encoder->usesFrequencyEncoding(feature)) {
+        return m_Encoder->frequency(feature, category);
     }
 
     return m_Encoder->targetMeanValue(feature, category);
@@ -186,14 +225,20 @@ std::size_t CEncodedDataFrameRowRef::numberColumns() const {
     return m_Encoder->numberFeatures();
 }
 
+const CEncodedDataFrameRowRef::TRowRef& CEncodedDataFrameRowRef::unencodedRow() const {
+    return m_Row;
+}
+
 CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(std::size_t numberThreads,
                                                      const core::CDataFrame& frame,
+                                                     const core::CPackedBitVector& rowMask,
                                                      const TSizeVec& columnMask,
                                                      std::size_t targetColumn,
                                                      std::size_t minimumRowsPerFeature,
                                                      double minimumFrequencyToOneHotEncode,
                                                      double redundancyWeight)
-    : m_RedundancyWeight{redundancyWeight},
+    : m_MinimumRowsPerFeature{minimumRowsPerFeature},
+      m_MinimumFrequencyToOneHotEncode{minimumFrequencyToOneHotEncode}, m_RedundancyWeight{redundancyWeight},
       m_ColumnIsCategorical(frame.columnIsCategorical()) {
 
     TSizeVec metricColumnMask(columnMask);
@@ -221,21 +266,19 @@ CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(std::size_t numberThreads,
     // to the permitted overall feature count.
     // We mean value encode the remaining features where we have a representative
     // sample size.
-    // We use one indicator dimension in the feature vector for encoding all rare
-    // categories of a categorical column.
+    // We frequency encode all rare categories of a categorical feature.
 
-    this->isRareEncode(numberThreads, frame, categoricalColumnMask, minimumRowsPerFeature);
+    this->setupFrequencyEncoding(numberThreads, frame, rowMask, categoricalColumnMask);
 
-    this->targetMeanValueEncode(numberThreads, frame, categoricalColumnMask, targetColumn);
+    this->setupTargetMeanValueEncoding(numberThreads, frame, rowMask,
+                                       categoricalColumnMask, targetColumn);
 
-    this->oneHotEncode(numberThreads, frame, metricColumnMask,
-                       categoricalColumnMask, targetColumn,
-                       minimumRowsPerFeature, minimumFrequencyToOneHotEncode);
-
-    this->setupEncodingMaps(frame);
+    this->finishEncoding(
+        targetColumn, this->selectFeatures(numberThreads, frame, rowMask, metricColumnMask,
+                                           categoricalColumnMask, targetColumn));
 }
 
-CEncodedDataFrameRowRef CDataFrameCategoryEncoder::encode(TRowRef row) {
+CEncodedDataFrameRowRef CDataFrameCategoryEncoder::encode(TRowRef row) const {
     return {std::move(row), *this};
 }
 
@@ -243,23 +286,12 @@ bool CDataFrameCategoryEncoder::columnIsCategorical(std::size_t feature) const {
     return m_ColumnIsCategorical[feature];
 }
 
-const CDataFrameCategoryEncoder::TSizeVec&
-CDataFrameCategoryEncoder::selectedMetricFeatures() const {
-    return m_SelectedMetricFeatures;
-}
-
-const CDataFrameCategoryEncoder::TDoubleVec&
-CDataFrameCategoryEncoder::selectedMetricFeatureMics() const {
-    return m_SelectedMetricFeatureMics;
-}
-
-const CDataFrameCategoryEncoder::TSizeVec&
-CDataFrameCategoryEncoder::selectedCategoricalFeatures() const {
-    return m_SelectedCategoricalFeatures;
+const CDataFrameCategoryEncoder::TDoubleVec& CDataFrameCategoryEncoder::featureMics() const {
+    return m_FeatureVectorMics;
 }
 
 std::size_t CDataFrameCategoryEncoder::numberFeatures() const {
-    return m_FeatureVectorColumnMap.size();
+    return m_FeatureVectorMics.size();
 }
 
 std::size_t CDataFrameCategoryEncoder::encoding(std::size_t index) const {
@@ -270,18 +302,24 @@ std::size_t CDataFrameCategoryEncoder::column(std::size_t index) const {
     return m_FeatureVectorColumnMap[index];
 }
 
+bool CDataFrameCategoryEncoder::isBinary(std::size_t index) const {
+    std::size_t encoding{this->encoding(index)};
+    std::size_t feature{this->column(index)};
+    return encoding < m_OneHotEncodedCategories[feature].size();
+}
+
 std::size_t CDataFrameCategoryEncoder::numberOneHotEncodedCategories(std::size_t feature) const {
     return m_OneHotEncodedCategories[feature].size();
 }
 
-bool CDataFrameCategoryEncoder::isOne(std::size_t encoding,
+bool CDataFrameCategoryEncoder::isHot(std::size_t encoding,
                                       std::size_t feature,
                                       std::size_t category) const {
 
     // The most important categories are one-hot encode. In the encoded row the
     // layout of the encoding dimensions, for each categorical feature, is as
     // follows:
-    //   (...| one-hot | mean target | is rare |...)
+    //   (...| one-hot | mean target | frequency |...)
     //
     // The ones are in the order the categories appear in m_OneHotEncodedCategories.
     // For example, if m_OneHotEncodedCategories[feature] = (2, 5, 7) for any other
@@ -301,74 +339,167 @@ bool CDataFrameCategoryEncoder::isOne(std::size_t encoding,
                one - m_OneHotEncodedCategories[feature].begin();
 }
 
-bool CDataFrameCategoryEncoder::hasRareCategories(std::size_t feature) const {
-    return m_RareCategories[feature].size() > 0;
+bool CDataFrameCategoryEncoder::usesFrequencyEncoding(std::size_t feature) const {
+    return m_ColumnUsesFrequencyEncoding[feature];
+}
+
+double CDataFrameCategoryEncoder::frequency(std::size_t feature, std::size_t category) const {
+    return m_CategoryFrequencies[feature][category];
 }
 
 bool CDataFrameCategoryEncoder::isRareCategory(std::size_t feature, std::size_t category) const {
-    return std::binary_search(m_RareCategories[feature].begin(),
-                              m_RareCategories[feature].end(), category);
+    return m_RareCategories[feature].find(category) != m_RareCategories[feature].end();
 }
 
 double CDataFrameCategoryEncoder::targetMeanValue(std::size_t feature,
                                                   std::size_t category) const {
-    return m_TargetMeanValues[feature][category];
+    // TODO make this better
+    return this->isRareCategory(feature, category)
+               ? 0.0
+               : m_TargetMeanValues[feature][category];
 }
 
-std::pair<TDoubleVec, TSizeDoublePrVecVec>
+std::uint64_t CDataFrameCategoryEncoder::checksum(std::uint64_t seed) const {
+    seed = CChecksum::calculate(seed, m_MinimumRowsPerFeature);
+    seed = CChecksum::calculate(seed, m_MinimumFrequencyToOneHotEncode);
+    seed = CChecksum::calculate(seed, m_RedundancyWeight);
+    seed = CChecksum::calculate(seed, m_ColumnIsCategorical);
+    seed = CChecksum::calculate(seed, m_ColumnUsesFrequencyEncoding);
+    seed = CChecksum::calculate(seed, m_OneHotEncodedCategories);
+    seed = CChecksum::calculate(seed, m_RareCategories);
+    seed = CChecksum::calculate(seed, m_CategoryFrequencies);
+    seed = CChecksum::calculate(seed, m_TargetMeanValues);
+    seed = CChecksum::calculate(seed, m_FeatureVectorMics);
+    seed = CChecksum::calculate(seed, m_FeatureVectorColumnMap);
+    return CChecksum::calculate(seed, m_FeatureVectorEncodingMap);
+}
+
+CDataFrameCategoryEncoder::TSizeDoublePrVecVec
 CDataFrameCategoryEncoder::mics(std::size_t numberThreads,
                                 const core::CDataFrame& frame,
-                                std::size_t feature,
-                                std::size_t category,
+                                const CDataFrameUtils::CColumnValue& target,
+                                const core::CPackedBitVector& rowMask,
                                 const TSizeVec& metricColumnMask,
-                                const TSizeVec& categoricalColumnMask,
-                                double minimumFrequencyToOneHotEncode) const {
-    if (m_ColumnIsCategorical[feature]) {
-        return {CDataFrameUtils::micWithColumn(
-                    CDataFrameUtils::COneHotCategoricalColumnValue{feature, category},
-                    frame, metricColumnMask),
-                CDataFrameUtils::categoryMicWithColumn(
-                    CDataFrameUtils::COneHotCategoricalColumnValue{feature, category}, numberThreads,
-                    frame, categoricalColumnMask, minimumFrequencyToOneHotEncode)};
+                                const TSizeVec& categoricalColumnMask) const {
+
+    CDataFrameUtils::TEncoderFactoryVec encoderFactories{
+        {[](std::size_t, std::size_t sampleColumn, std::size_t category) {
+             return std::make_unique<CDataFrameUtils::COneHotCategoricalColumnValue>(
+                 sampleColumn, category);
+         },
+         m_MinimumFrequencyToOneHotEncode},
+        {[this](std::size_t column, std::size_t sampleColumn, std::size_t) {
+             return std::make_unique<CDataFrameUtils::CTargetMeanCategoricalColumnValue>(
+                 sampleColumn, m_RareCategories[column], m_TargetMeanValues[column]);
+         },
+         0.0},
+        {[this](std::size_t column, std::size_t sampleColumn, std::size_t) {
+             return std::make_unique<CDataFrameUtils::CFrequencyCategoricalColumnValue>(
+                 sampleColumn, m_CategoryFrequencies[column]);
+         },
+         0.0}};
+
+    auto metricMics = CDataFrameUtils::metricMicWithColumn(target, frame, rowMask,
+                                                           metricColumnMask);
+    auto categoricalMics = CDataFrameUtils::categoricalMicWithColumn(
+        target, numberThreads, frame, rowMask, categoricalColumnMask, encoderFactories);
+
+    TSizeDoublePrVecVec mics(std::move(categoricalMics[0]));
+    for (std::size_t i = 0; i < categoricalMics[1].size(); ++i) {
+        if (categoricalMics[1][i].size() > 0) {
+            mics[i].emplace_back(TARGET_MEAN_CATEGORY, categoricalMics[1][i][0].second);
+        }
     }
-    return {CDataFrameUtils::micWithColumn(CDataFrameUtils::CMetricColumnValue{feature},
-                                           frame, metricColumnMask),
-            CDataFrameUtils::categoryMicWithColumn(
-                CDataFrameUtils::CMetricColumnValue{feature}, numberThreads,
-                frame, categoricalColumnMask, minimumFrequencyToOneHotEncode)};
+    for (std::size_t i = 0; i < categoricalMics[2].size(); ++i) {
+        if (categoricalMics[2][i].size() > 0) {
+            mics[i].emplace_back(RARE_CATEGORY, categoricalMics[2][i][0].second);
+        }
+    }
+    for (std::size_t i = 0; i < metricMics.size(); ++i) {
+        if (metricMics[i] > 0.0) {
+            mics[i].emplace_back(METRIC_CATEGORY, metricMics[i]);
+        }
+    }
+    LOG_TRACE(<< "MICe = " << core::CContainerPrinter::print(mics));
+
+    return mics;
 }
 
-void CDataFrameCategoryEncoder::isRareEncode(std::size_t numberThreads,
-                                             const core::CDataFrame& frame,
-                                             const TSizeVec& categoricalColumnMask,
-                                             std::size_t minimumRowsPerFeature) {
+void CDataFrameCategoryEncoder::setupFrequencyEncoding(std::size_t numberThreads,
+                                                       const core::CDataFrame& frame,
+                                                       const core::CPackedBitVector& rowMask,
+                                                       const TSizeVec& categoricalColumnMask) {
 
-    TDoubleVecVec categoryFrequencies(CDataFrameUtils::categoryFrequencies(
-        numberThreads, frame, categoricalColumnMask));
+    m_CategoryFrequencies = CDataFrameUtils::categoryFrequencies(
+        numberThreads, frame, rowMask, categoricalColumnMask);
     LOG_TRACE(<< "category frequencies = "
-              << core::CContainerPrinter::print(categoryFrequencies));
+              << core::CContainerPrinter::print(m_CategoryFrequencies));
 
     m_RareCategories.resize(frame.numberColumns());
-    for (std::size_t i = 0; i < categoryFrequencies.size(); ++i) {
-        for (std::size_t j = 0; j < categoryFrequencies[i].size(); ++j) {
+    for (std::size_t i = 0; i < m_CategoryFrequencies.size(); ++i) {
+        for (std::size_t j = 0; j < m_CategoryFrequencies[i].size(); ++j) {
             std::size_t count{static_cast<std::size_t>(
-                categoryFrequencies[i][j] * static_cast<double>(frame.numberRows()) + 0.5)};
-            if (count < minimumRowsPerFeature) {
-                m_RareCategories[i].push_back(j);
+                m_CategoryFrequencies[i][j] * static_cast<double>(frame.numberRows()) + 0.5)};
+            if (count < m_MinimumRowsPerFeature) {
+                m_RareCategories[i].insert(j);
             }
         }
-        m_RareCategories[i].shrink_to_fit();
     }
     LOG_TRACE(<< "rare categories = " << core::CContainerPrinter::print(m_RareCategories));
 }
 
-void CDataFrameCategoryEncoder::oneHotEncode(std::size_t numberThreads,
-                                             const core::CDataFrame& frame,
-                                             TSizeVec metricColumnMask,
-                                             TSizeVec categoricalColumnMask,
-                                             std::size_t targetColumn,
-                                             std::size_t minimumRowsPerFeature,
-                                             double minimumFrequencyToOneHotEncode) {
+void CDataFrameCategoryEncoder::setupTargetMeanValueEncoding(std::size_t numberThreads,
+                                                             const core::CDataFrame& frame,
+                                                             const core::CPackedBitVector& rowMask,
+                                                             const TSizeVec& categoricalColumnMask,
+                                                             std::size_t targetColumn) {
+
+    m_TargetMeanValues = CDataFrameUtils::meanValueOfTargetForCategories(
+        CDataFrameUtils::CMetricColumnValue{targetColumn}, numberThreads, frame,
+        rowMask, categoricalColumnMask);
+    LOG_TRACE(<< "target mean values = "
+              << core::CContainerPrinter::print(m_TargetMeanValues));
+}
+
+CDataFrameCategoryEncoder::TSizeSizePrDoubleMap
+CDataFrameCategoryEncoder::selectAllFeatures(const TSizeDoublePrVecVec& mics) {
+
+    TSizeSizePrDoubleMap selectedFeatureMics;
+
+    for (std::size_t feature = 0; feature < mics.size(); ++feature) {
+        for (std::size_t i = 0; i < mics[feature].size(); ++i) {
+            std::size_t category;
+            double mic;
+            std::tie(category, mic) = mics[feature][i];
+            if (mic == 0.0) {
+                continue;
+            }
+            LOG_TRACE(<< "Selected feature = " << feature << ", category = "
+                      << print(category) << ", mic with target = " << mic);
+
+            selectedFeatureMics[{feature, category}] = mic;
+
+            if (isCategory(category)) {
+                m_OneHotEncodedCategories[feature].push_back(category);
+            } else if (isRare(category)) {
+                m_ColumnUsesFrequencyEncoding[feature] = true;
+            }
+        }
+    }
+
+    LOG_TRACE(<< "one-hot encoded = "
+              << core::CContainerPrinter::print(m_OneHotEncodedCategories));
+
+    return selectedFeatureMics;
+}
+
+CDataFrameCategoryEncoder::TSizeSizePrDoubleMap
+CDataFrameCategoryEncoder::selectFeatures(std::size_t numberThreads,
+                                          const core::CDataFrame& frame,
+                                          const core::CPackedBitVector& rowMask,
+                                          TSizeVec metricColumnMask,
+                                          TSizeVec categoricalColumnMask,
+                                          std::size_t targetColumn) {
 
     // We want to choose features which provide independent information about the
     // target variable. Ideally, we'd recompute MICe w.r.t. target - f(x) with x
@@ -376,35 +507,34 @@ void CDataFrameCategoryEncoder::oneHotEncode(std::size_t numberThreads,
     // since it requires training a model f(.) on a subset of the features after
     // each decision. Instead, we use the average MICe between the unselected and
     // selected features as a useful proxy. This is essentially the mRMR approach
-    // of Peng et al. albeit with MICe rather than MI. We also support a parameter
-    // redundancy weight, which should be non-negative, controls the relative weight
-    // of MICe with the target vs the selected variables. A value of zero means
-    // exclusively maximise MICe with the target and as redundancy weight -> infinity
-    // means exclusively minimise MICe with the selected variables.
+    // of Peng et al. albeit with MICe rather than mutual information. We also
+    // a redundancy weight, which should be non-negative, is used to control the
+    // relative weight of MICe with the target vs the selected variables. A value
+    // of zero means exclusively maximise MICe with the target and as redundancy
+    // weight -> infinity means exclusively minimise MICe with the selected variables.
 
-    TDoubleVec metricMics;
-    TSizeDoublePrVecVec categoricalMics;
-    std::tie(metricMics, categoricalMics) =
-        this->mics(numberThreads, frame, targetColumn, 0, metricColumnMask,
-                   categoricalColumnMask, minimumFrequencyToOneHotEncode);
-    LOG_TRACE(<< "metric MICe = " << core::CContainerPrinter::print(metricMics));
-    LOG_TRACE(<< "categorical MICe = " << core::CContainerPrinter::print(categoricalMics));
+    TSizeDoublePrVecVec mics(this->mics(
+        numberThreads, frame, CDataFrameUtils::CMetricColumnValue{targetColumn},
+        rowMask, metricColumnMask, categoricalColumnMask));
+    LOG_TRACE(<< "features MICe = " << core::CContainerPrinter::print(mics));
 
-    std::size_t numberAvailableFeatures{
-        this->numberAvailableFeatures(metricMics, categoricalMics)};
+    std::size_t numberAvailableFeatures{this->numberAvailableFeatures(mics)};
     std::size_t maximumNumberFeatures{
-        (frame.numberRows() + minimumRowsPerFeature / 2) / minimumRowsPerFeature};
+        (frame.numberRows() + m_MinimumRowsPerFeature / 2) / m_MinimumRowsPerFeature};
     LOG_TRACE(<< "number possible features = " << numberAvailableFeatures
               << " maximum permitted features = " << maximumNumberFeatures);
 
+    m_ColumnUsesFrequencyEncoding.resize(frame.numberColumns(), false);
     m_OneHotEncodedCategories.resize(frame.numberColumns());
 
-    if (maximumNumberFeatures >= numberAvailableFeatures) {
-        this->oneHotEncodeAll(metricMics, categoricalMics);
+    TSizeSizePrDoubleMap selectedFeatureMics;
 
+    if (maximumNumberFeatures >= numberAvailableFeatures) {
+
+        selectedFeatureMics = this->selectAllFeatures(mics);
     } else {
-        CMinRedundancyMaxRelevancyGreedySearch search{m_RedundancyWeight,
-                                                      metricMics, categoricalMics};
+
+        CMinRedundancyMaxRelevancyGreedySearch search{m_RedundancyWeight, mics};
 
         for (std::size_t i = 0; i < maximumNumberFeatures; ++i) {
 
@@ -413,138 +543,83 @@ void CDataFrameCategoryEncoder::oneHotEncode(std::size_t numberThreads,
             double mic{selected.micWithDependentVariable()};
             std::size_t feature{selected.feature()};
             std::size_t category{selected.category()};
+            LOG_TRACE(<< "Selected feature = " << feature << ", category = "
+                      << print(category) << ", mic with target = " << mic);
 
-            if (selected.isCategorical()) {
-                m_SelectedCategoricalFeatures.push_back(feature);
+            selectedFeatureMics[{feature, category}] = mic;
+
+            if (selected.isCategory()) {
                 m_OneHotEncodedCategories[feature].push_back(category);
-
-                if (m_OneHotEncodedCategories[feature].size() == 1) {
-                    i += 1 + (this->hasRareCategories(feature) ? 1 : 0);
-                }
-                if (m_OneHotEncodedCategories[feature].size() ==
-                    categoricalMics[feature].size()) {
-                    categoricalColumnMask.erase(std::find(
-                        categoricalColumnMask.begin(), categoricalColumnMask.end(), feature));
-                }
-            } else {
-                m_SelectedMetricFeatures.push_back(feature);
-                m_SelectedMetricFeatureMics.push_back(mic);
+            } else if (selected.isRare()) {
+                m_ColumnUsesFrequencyEncoding[feature] = true;
+            } else if (selected.isMetric()) {
                 metricColumnMask.erase(std::find(metricColumnMask.begin(),
                                                  metricColumnMask.end(), feature));
             }
 
-            std::tie(metricMics, categoricalMics) =
-                this->mics(numberThreads, frame, feature, category, metricColumnMask,
-                           categoricalColumnMask, minimumFrequencyToOneHotEncode);
-            search.update(metricMics, categoricalMics);
+            auto columnValue = selected.columnValue(m_RareCategories[feature],
+                                                    m_CategoryFrequencies[feature],
+                                                    m_TargetMeanValues[feature]);
+            mics = this->mics(numberThreads, frame, *columnValue, rowMask,
+                              metricColumnMask, categoricalColumnMask);
+            search.update(mics);
         }
     }
-
-    COrderings::simultaneousSort(m_SelectedMetricFeatures, m_SelectedMetricFeatureMics);
-    std::sort(m_SelectedCategoricalFeatures.begin(),
-              m_SelectedCategoricalFeatures.end());
-    m_SelectedCategoricalFeatures.erase(
-        std::unique(m_SelectedCategoricalFeatures.begin(),
-                    m_SelectedCategoricalFeatures.end()),
-        m_SelectedCategoricalFeatures.end());
-    m_SelectedCategoricalFeatures.shrink_to_fit();
 
     for (auto& categories : m_OneHotEncodedCategories) {
         categories.shrink_to_fit();
         std::sort(categories.begin(), categories.end());
     }
 
-    LOG_TRACE(<< "selected metrics = "
-              << core::CContainerPrinter::print(m_SelectedMetricFeatures));
     LOG_TRACE(<< "one-hot encoded = "
               << core::CContainerPrinter::print(m_OneHotEncodedCategories));
+    LOG_TRACE(<< "selected features MICe = "
+              << core::CContainerPrinter::print(selectedFeatureMics));
+
+    return selectedFeatureMics;
 }
 
-void CDataFrameCategoryEncoder::oneHotEncodeAll(const TDoubleVec& metricMics,
-                                                const TSizeDoublePrVecVec& categoricalMics) {
-
-    for (std::size_t i = 0; i < metricMics.size(); ++i) {
-        if (metricMics[i] > 0.0) {
-            m_SelectedMetricFeatures.push_back(i);
-            m_SelectedMetricFeatureMics.push_back(metricMics[i]);
-        }
-    }
-
-    for (std::size_t i = 0; i < categoricalMics.size(); ++i) {
-        for (std::size_t j = 0; j < categoricalMics[i].size(); ++j) {
-            std::size_t category;
-            double mic;
-            std::tie(category, mic) = categoricalMics[i][j];
-            if (mic > 0.0) {
-                m_SelectedCategoricalFeatures.push_back(i);
-                m_OneHotEncodedCategories[i].push_back(category);
-            }
-        }
-    }
-}
-
-void CDataFrameCategoryEncoder::targetMeanValueEncode(std::size_t numberThreads,
-                                                      const core::CDataFrame& frame,
-                                                      const TSizeVec& categoricalColumnMask,
-                                                      std::size_t targetColumn) {
-
-    m_TargetMeanValues = CDataFrameUtils::meanValueOfTargetForCategories(
-        CDataFrameUtils::CMetricColumnValue{targetColumn}, numberThreads, frame,
-        categoricalColumnMask);
-    LOG_TRACE(<< "target mean values = "
-              << core::CContainerPrinter::print(m_TargetMeanValues));
-}
-
-void CDataFrameCategoryEncoder::setupEncodingMaps(const core::CDataFrame& frame) {
+void CDataFrameCategoryEncoder::finishEncoding(std::size_t targetColumn,
+                                               TSizeSizePrDoubleMap selectedFeatureMics) {
 
     // Fill in a mapping from encoded column indices to raw column indices.
 
-    for (std::size_t i = 0; i < frame.numberColumns(); ++i) {
+    selectedFeatureMics[{targetColumn, TARGET_CATEGORY}] = 0.0;
 
-        if (m_ColumnIsCategorical[i]) {
-            std::size_t numberOneHot{m_OneHotEncodedCategories[i].size()};
-            std::size_t numberRare{m_RareCategories[i].size()};
-            std::size_t numberCategories{m_TargetMeanValues[i].size()};
+    m_FeatureVectorMics.reserve(selectedFeatureMics.size());
+    m_FeatureVectorColumnMap.reserve(selectedFeatureMics.size());
+    m_FeatureVectorEncodingMap.reserve(selectedFeatureMics.size());
 
-            std::size_t offset{m_FeatureVectorColumnMap.size()};
-            std::size_t extra{numberOneHot + (numberRare > 0 ? 1 : 0) +
-                              (numberCategories > numberOneHot + numberRare ? 1 : 0)};
-
-            m_FeatureVectorColumnMap.resize(offset + extra, i);
-            m_FeatureVectorEncodingMap.resize(offset + extra);
-            std::iota(m_FeatureVectorEncodingMap.begin() + offset,
-                      m_FeatureVectorEncodingMap.end(), 0);
-
-        } else {
-            m_FeatureVectorColumnMap.push_back(i);
-            m_FeatureVectorEncodingMap.push_back(0);
+    auto i = selectedFeatureMics.begin();
+    auto end = selectedFeatureMics.end();
+    std::size_t encoding{0};
+    for (;;) {
+        std::size_t feature{i->first.first};
+        double mic{i->second};
+        m_FeatureVectorMics.push_back(mic);
+        m_FeatureVectorColumnMap.push_back(feature);
+        m_FeatureVectorEncodingMap.push_back(encoding);
+        if (++i == end) {
+            break;
         }
+        encoding = i->first.first == feature ? encoding + 1 : 0;
     }
-    m_FeatureVectorColumnMap.shrink_to_fit();
-    m_FeatureVectorEncodingMap.shrink_to_fit();
+
+    LOG_TRACE(<< "feature vector MICe = "
+              << core::CContainerPrinter::print(m_FeatureVectorMics));
     LOG_TRACE(<< "feature vector index to column map = "
               << core::CContainerPrinter::print(m_FeatureVectorColumnMap));
     LOG_TRACE(<< "feature vector index to encoding map = "
               << core::CContainerPrinter::print(m_FeatureVectorEncodingMap));
 }
 
-std::size_t
-CDataFrameCategoryEncoder::numberAvailableFeatures(const TDoubleVec& metricMics,
-                                                   const TSizeDoublePrVecVec& categoricalMics) const {
-    std::size_t numberFeatures(std::count_if(metricMics.begin(), metricMics.end(),
-                                             [](double mic) { return mic > 0.0; }));
-    for (std::size_t i = 0; i < categoricalMics.size(); ++i) {
-        numberFeatures += std::count_if(categoricalMics[i].begin(),
-                                        categoricalMics[i].end(),
-                                        [&](auto categoryMic) {
-                                            std::size_t category;
-                                            double mic;
-                                            std::tie(category, mic) = categoryMic;
-                                            return mic > 0.0;
-                                        }) +
-                          (this->hasRareCategories(i) ? 1 : 0);
+std::size_t CDataFrameCategoryEncoder::numberAvailableFeatures(const TSizeDoublePrVecVec& mics) const {
+    std::size_t count{0};
+    for (const auto& featureMics : mics) {
+        count += std::count_if(featureMics.begin(), featureMics.end(),
+                               [](const auto& mic) { return mic.second > 0.0; });
     }
-    return numberFeatures;
+    return count;
 }
 }
 }

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -12,14 +12,16 @@
 #include <core/Concurrency.h>
 
 #include <maths/CBasicStatistics.h>
+#include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CMathsFuncs.h>
 #include <maths/CMic.h>
 #include <maths/COrderings.h>
 #include <maths/CQuantileSketch.h>
 #include <maths/CSampling.h>
 
-#include <boost/unordered_set.hpp>
+#include <boost/unordered_map.hpp>
 
+#include <memory>
 #include <vector>
 
 namespace ml {
@@ -27,12 +29,11 @@ namespace maths {
 namespace {
 using TFloatVec = std::vector<CFloatStorage>;
 using TFloatVecVec = std::vector<TFloatVec>;
-using TFloatFloatPr = std::pair<CFloatStorage, CFloatStorage>;
-using TFloatFloatPrVec = std::vector<TFloatFloatPr>;
-using TFloatUSet = boost::unordered_set<CFloatStorage, std::hash<double>>;
 using TRowItr = core::CDataFrame::TRowItr;
 using TRowRef = core::CDataFrame::TRowRef;
 using TRowSampler = CSampling::CRandomStreamSampler<TRowRef>;
+using TSizeEncoderPtrUMap =
+    boost::unordered_map<std::size_t, std::unique_ptr<CDataFrameUtils::CColumnValue>>;
 
 //! Reduce the results of a call to core::CDataFrame::readRows using \p reduceFirst
 //! for the first and \p reduce for the rest and writing the result \p reduction.
@@ -56,13 +57,13 @@ bool doReduce(std::pair<std::vector<READER>, bool> readResults,
 
 //! Get a row feature sampler.
 template<typename TARGET>
-auto rowFeatureSampler(std::size_t i, const TARGET& target, TFloatFloatPrVec& samples) {
+auto rowFeatureSampler(std::size_t i, const TARGET& target, TFloatVecVec& samples) {
     return [i, &target, &samples](std::size_t slot, const TRowRef& row) {
         if (slot >= samples.size()) {
             samples.resize(slot + 1, {0.0, 0.0});
         }
-        samples[slot].first = row[i];
-        samples[slot].second = target(row);
+        samples[slot][0] = row[i];
+        samples[slot][1] = target(row);
     };
 }
 
@@ -145,14 +146,26 @@ bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
                                       const TSizeVec& columnMask,
                                       const CQuantileSketch& sketch,
                                       TQuantileSketchVec& result,
+                                      const CDataFrameCategoryEncoder* encoder,
                                       TWeightFunction weight) {
 
     auto readQuantiles = core::bindRetrievableState(
         [&](TQuantileSketchVec& quantiles, TRowItr beginRows, TRowItr endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                for (std::size_t i = 0; i < columnMask.size(); ++i) {
-                    if (isMissing((*row)[columnMask[i]]) == false) {
-                        quantiles[i].add((*row)[columnMask[i]], weight(*row));
+            if (encoder != nullptr) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    CEncodedDataFrameRowRef encodedRow{encoder->encode(*row)};
+                    for (std::size_t i = 0; i < columnMask.size(); ++i) {
+                        if (isMissing(encodedRow[columnMask[i]]) == false) {
+                            quantiles[i].add(encodedRow[columnMask[i]], weight(*row));
+                        }
+                    }
+                }
+            } else {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    for (std::size_t i = 0; i < columnMask.size(); ++i) {
+                        if (isMissing((*row)[columnMask[i]]) == false) {
+                            quantiles[i].add((*row)[columnMask[i]], weight(*row));
+                        }
                     }
                 }
             }
@@ -179,6 +192,7 @@ bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
 CDataFrameUtils::TDoubleVecVec
 CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
                                      const core::CDataFrame& frame,
+                                     const core::CPackedBitVector& rowMask,
                                      TSizeVec columnMask) {
 
     removeMetricColumns(frame, columnMask);
@@ -186,13 +200,14 @@ CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
         return TDoubleVecVec(frame.numberColumns());
     }
 
+    // Note this can throw a length_error in resize hence the try block around read.
     auto readCategoryCounts = core::bindRetrievableState(
         [&](TDoubleVecVec& counts, TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t i : columnMask) {
-                    std::size_t id{static_cast<std::size_t>((*row)[i])};
-                    counts[i].resize(std::max(counts[i].size(), id + 1), 0.0);
-                    counts[i][id] += 1.0;
+                    std::size_t category{static_cast<std::size_t>((*row)[i])};
+                    counts[i].resize(std::max(counts[i].size(), category + 1), 0.0);
+                    counts[i][category] += 1.0;
                 }
             }
         },
@@ -202,6 +217,7 @@ CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
     };
     auto reduceCategoryCounts = [](TDoubleVecVec counts, TDoubleVecVec& result) {
         for (std::size_t i = 0; i < counts.size(); ++i) {
+            result[i].resize(std::max(result[i].size(), counts[i].size()), 0.0);
             for (std::size_t j = 0; j < counts[i].size(); ++j) {
                 result[i][j] += counts[i][j];
             }
@@ -209,11 +225,17 @@ CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
     };
 
     TDoubleVecVec result;
-    if (doReduce(frame.readRows(numberThreads, readCategoryCounts),
-                 copyCategoryCounts, reduceCategoryCounts, result) == false) {
-        HANDLE_FATAL(<< "Internal error: failed to calculate category"
-                     << " frequencies. Please report this problem.");
-        return result;
+    try {
+        if (doReduce(frame.readRows(numberThreads, 0, frame.numberRows(),
+                                    readCategoryCounts, &rowMask),
+                     copyCategoryCounts, reduceCategoryCounts, result) == false) {
+            HANDLE_FATAL(<< "Internal error: failed to calculate category"
+                         << " frequencies. Please report this problem.");
+            return result;
+        }
+    } catch (const std::exception& e) {
+        HANDLE_FATAL(<< "Internal error: '" << e.what() << "' exception calculating"
+                     << " category frequencies. Please report this problem.");
     }
     for (std::size_t i = 0; i < result.size(); ++i) {
         for (std::size_t j = 0; j < result[i].size(); ++j) {
@@ -228,6 +250,7 @@ CDataFrameUtils::TDoubleVecVec
 CDataFrameUtils::meanValueOfTargetForCategories(const CColumnValue& target,
                                                 std::size_t numberThreads,
                                                 const core::CDataFrame& frame,
+                                                const core::CPackedBitVector& rowMask,
                                                 TSizeVec columnMask) {
 
     TDoubleVecVec result(frame.numberColumns());
@@ -240,13 +263,14 @@ CDataFrameUtils::meanValueOfTargetForCategories(const CColumnValue& target,
     using TMeanAccumulatorVec = std::vector<CBasicStatistics::SSampleMean<double>::TAccumulator>;
     using TMeanAccumulatorVecVec = std::vector<TMeanAccumulatorVec>;
 
+    // Note this can throw a length_error in resize hence the try block around read.
     auto readColumnMeans = core::bindRetrievableState(
         [&](TMeanAccumulatorVecVec& means_, TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t i : columnMask) {
-                    std::size_t id{static_cast<std::size_t>((*row)[i])};
-                    means_[i].resize(std::max(means_[i].size(), id + 1));
-                    means_[i][id].add(target(*row));
+                    std::size_t category{static_cast<std::size_t>((*row)[i])};
+                    means_[i].resize(std::max(means_[i].size(), category + 1));
+                    means_[i][category].add(target(*row));
                 }
             }
         },
@@ -256,6 +280,7 @@ CDataFrameUtils::meanValueOfTargetForCategories(const CColumnValue& target,
     };
     auto reduceColumnMeans = [](TMeanAccumulatorVecVec means_, TMeanAccumulatorVecVec& means) {
         for (std::size_t i = 0; i < means_.size(); ++i) {
+            means[i].resize(std::max(means[i].size(), means_[i].size()));
             for (std::size_t j = 0; j < means_[i].size(); ++j) {
                 means[i][j] += means_[i][j];
             }
@@ -263,10 +288,16 @@ CDataFrameUtils::meanValueOfTargetForCategories(const CColumnValue& target,
     };
 
     TMeanAccumulatorVecVec means;
-    if (doReduce(frame.readRows(numberThreads, readColumnMeans),
-                 copyColumnMeans, reduceColumnMeans, means) == false) {
-        HANDLE_FATAL(<< "Internal error: failed to calculate mean target value"
-                     << " for categories. Please report this problem.");
+    try {
+        if (doReduce(frame.readRows(numberThreads, 0, frame.numberRows(), readColumnMeans, &rowMask),
+                     copyColumnMeans, reduceColumnMeans, means) == false) {
+            HANDLE_FATAL(<< "Internal error: failed to calculate mean target values"
+                         << " for categories. Please report this problem.");
+            return result;
+        }
+    } catch (const std::exception& e) {
+        HANDLE_FATAL(<< "Internal error: '" << e.what() << "' exception calculating"
+                     << " mean target values for categories. Please report this problem.");
         return result;
     }
     for (std::size_t i = 0; i < result.size(); ++i) {
@@ -279,41 +310,47 @@ CDataFrameUtils::meanValueOfTargetForCategories(const CColumnValue& target,
     return result;
 }
 
-CDataFrameUtils::TSizeDoublePrVecVec
-CDataFrameUtils::categoryMicWithColumn(const CColumnValue& target,
-                                       std::size_t numberThreads,
-                                       const core::CDataFrame& frame,
-                                       TSizeVec columnMask,
-                                       double minimumFrequency) {
+CDataFrameUtils::TSizeDoublePrVecVecVec
+CDataFrameUtils::categoricalMicWithColumn(const CColumnValue& target,
+                                          std::size_t numberThreads,
+                                          const core::CDataFrame& frame,
+                                          const core::CPackedBitVector& rowMask,
+                                          TSizeVec columnMask,
+                                          const TEncoderFactoryVec& encoderFactories) {
 
-    TSizeDoublePrVecVec none(frame.numberColumns());
+    TSizeDoublePrVecVecVec none(encoderFactories.size(),
+                                TSizeDoublePrVecVec(frame.numberColumns()));
 
     removeMetricColumns(frame, columnMask);
     if (frame.numberRows() == 0 || columnMask.empty()) {
         return none;
     }
 
-    auto method = frame.inMainMemory() ? categoryMicWithColumnDataFrameInMemory
-                                       : categoryMicWithColumnDataFrameOnDisk;
+    auto method = frame.inMainMemory() ? categoricalMicWithColumnDataFrameInMemory
+                                       : categoricalMicWithColumnDataFrameOnDisk;
 
-    TSizeDoublePrVecVec mics(method(
-        target, numberThreads, frame, columnMask,
-        std::min(NUMBER_SAMPLES_TO_COMPUTE_MIC, frame.numberRows()), minimumFrequency));
+    TSizeDoublePrVecVecVec mics(
+        method(target, numberThreads, frame, rowMask, columnMask, encoderFactories,
+               std::min(NUMBER_SAMPLES_TO_COMPUTE_MIC, frame.numberRows())));
 
-    for (auto& categoryMics : mics) {
-        std::sort(categoryMics.begin(), categoryMics.end(),
-                  [](const TSizeDoublePr& lhs, const TSizeDoublePr& rhs) {
-                      return COrderings::lexicographical_compare(
-                          -lhs.second, lhs.first, -rhs.second, rhs.first);
-                  });
+    for (auto& encoderMics : mics) {
+        for (auto& categoryMics : encoderMics) {
+            std::sort(categoryMics.begin(), categoryMics.end(),
+                      [](const TSizeDoublePr& lhs, const TSizeDoublePr& rhs) {
+                          return COrderings::lexicographical_compare(
+                              -lhs.second, lhs.first, -rhs.second, rhs.first);
+                      });
+        }
     }
 
     return mics;
 }
 
-CDataFrameUtils::TDoubleVec CDataFrameUtils::micWithColumn(const CColumnValue& target,
-                                                           const core::CDataFrame& frame,
-                                                           TSizeVec columnMask) {
+CDataFrameUtils::TDoubleVec
+CDataFrameUtils::metricMicWithColumn(const CColumnValue& target,
+                                     const core::CDataFrame& frame,
+                                     const core::CPackedBitVector& rowMask,
+                                     TSizeVec columnMask) {
 
     TDoubleVec zeros(frame.numberColumns(), 0.0);
 
@@ -322,10 +359,10 @@ CDataFrameUtils::TDoubleVec CDataFrameUtils::micWithColumn(const CColumnValue& t
         return zeros;
     }
 
-    auto method = frame.inMainMemory() ? micWithColumnDataFrameInMemory
-                                       : micWithColumnDataFrameOnDisk;
+    auto method = frame.inMainMemory() ? metricMicWithColumnDataFrameInMemory
+                                       : metricMicWithColumnDataFrameOnDisk;
 
-    return method(target, frame, columnMask,
+    return method(target, frame, rowMask, columnMask,
                   std::min(NUMBER_SAMPLES_TO_COMPUTE_MIC, frame.numberRows()));
 }
 
@@ -333,138 +370,177 @@ bool CDataFrameUtils::isMissing(double x) {
     return CMathsFuncs::isFinite(x) == false;
 }
 
-CDataFrameUtils::TSizeDoublePrVecVec
-CDataFrameUtils::categoryMicWithColumnDataFrameInMemory(const CColumnValue& target,
-                                                        std::size_t numberThreads,
-                                                        const core::CDataFrame& frame,
-                                                        const TSizeVec& columnMask,
-                                                        std::size_t numberSamples,
-                                                        double minimumFrequency) {
+CDataFrameUtils::TSizeDoublePrVecVecVec CDataFrameUtils::categoricalMicWithColumnDataFrameInMemory(
+    const CColumnValue& target,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const core::CPackedBitVector& rowMask,
+    const TSizeVec& columnMask,
+    const TEncoderFactoryVec& encoderFactories,
+    std::size_t numberSamples) {
 
-    TSizeDoublePrVecVec mics(frame.numberColumns());
+    TSizeDoublePrVecVecVec encoderMics;
+    encoderMics.reserve(encoderFactories.size());
 
-    TDoubleVecVec frequencies(categoryFrequencies(numberThreads, frame, columnMask));
-    LOG_TRACE(<< "frequencies = " << core::CContainerPrinter::print(frequencies));
+    for (const auto& encoderFactory_ : encoderFactories) {
 
-    TFloatFloatPrVec samples;
-    TFloatUSet categories;
-    CMic mic;
+        TEncoderFactory encoderFactory;
+        double minimumFrequency;
+        std::tie(encoderFactory, minimumFrequency) = encoderFactory_;
 
-    samples.reserve(numberSamples);
-    mic.reserve(numberSamples);
+        TSizeDoublePrVecVec mics(frame.numberColumns());
 
-    for (auto i : columnMask) {
+        TDoubleVecVec frequencies(categoryFrequencies(numberThreads, frame, rowMask, columnMask));
+        LOG_TRACE(<< "frequencies = " << core::CContainerPrinter::print(frequencies));
 
-        // Sample
+        TFloatVecVec samples;
+        TSizeEncoderPtrUMap encoders;
+        CMic mic;
 
-        TRowSampler sampler{numberSamples, rowFeatureSampler(i, target, samples)};
-        frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                std::size_t j{static_cast<std::size_t>((*row)[i])};
-                if (frequencies[i][j] >= minimumFrequency && isMissing(target(*row)) == false) {
-                    sampler.sample(*row);
-                }
-            }
-        });
-        LOG_TRACE(<< "# samples = " << samples.size());
+        samples.reserve(numberSamples);
+        mic.reserve(numberSamples);
 
-        // Compute MICe
+        for (auto i : columnMask) {
 
-        categories.clear();
-        for (const auto& sample : samples) {
-            categories.insert(std::floor(sample.first));
-        }
-        LOG_TRACE(<< "feature = " << i
-                  << " categories = " << core::CContainerPrinter::print(categories));
+            // Sample
 
-        TSizeDoublePrVec categoryMics;
-        categoryMics.reserve(categories.size());
-        for (auto category : categories) {
-            mic.clear();
+            TRowSampler sampler{numberSamples, rowFeatureSampler(i, target, samples)};
+            frame.readRows(1, 0, frame.numberRows(),
+                           [&](TRowItr beginRows, TRowItr endRows) {
+                               for (auto row = beginRows; row != endRows; ++row) {
+                                   std::size_t j{static_cast<std::size_t>((*row)[i])};
+                                   if (frequencies[i][j] >= minimumFrequency &&
+                                       isMissing(target(*row)) == false) {
+                                       sampler.sample(*row);
+                                   }
+                               }
+                           },
+                           &rowMask);
+            LOG_TRACE(<< "# samples = " << samples.size());
+
+            // Compute MICe
+
+            encoders.clear();
             for (const auto& sample : samples) {
-                mic.add(std::floor(sample.first) != category ? 0.0 : 1.0, sample.second);
+                std::size_t category{static_cast<std::size_t>(std::floor(sample[0]))};
+                auto encoder = encoderFactory(i, 0, category);
+                std::size_t id{encoder->id()};
+                encoders.emplace(id, std::move(encoder));
             }
-            categoryMics.emplace_back(static_cast<std::size_t>(category), mic.compute());
-        }
-        mics[i] = std::move(categoryMics);
 
-        samples.clear();
+            TSizeDoublePrVec categoryMics;
+            categoryMics.reserve(encoders.size());
+            for (const auto& encoder : encoders) {
+                std::size_t category{encoder.first};
+                const auto& encode = *encoder.second;
+                mic.clear();
+                for (const auto& sample : samples) {
+                    mic.add(encode(sample), sample[1]);
+                }
+                categoryMics.emplace_back(category, mic.compute());
+            }
+            mics[i] = std::move(categoryMics);
+
+            samples.clear();
+        }
+
+        encoderMics.push_back(std::move(mics));
     }
 
-    return mics;
+    return encoderMics;
 }
 
-CDataFrameUtils::TSizeDoublePrVecVec
-CDataFrameUtils::categoryMicWithColumnDataFrameOnDisk(const CColumnValue& target,
-                                                      std::size_t numberThreads,
-                                                      const core::CDataFrame& frame,
-                                                      const TSizeVec& columnMask,
-                                                      std::size_t numberSamples,
-                                                      double minimumFrequency) {
+CDataFrameUtils::TSizeDoublePrVecVecVec CDataFrameUtils::categoricalMicWithColumnDataFrameOnDisk(
+    const CColumnValue& target,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const core::CPackedBitVector& rowMask,
+    const TSizeVec& columnMask,
+    const TEncoderFactoryVec& encoderFactories,
+    std::size_t numberSamples) {
 
-    TSizeDoublePrVecVec mics(frame.numberColumns());
+    TSizeDoublePrVecVecVec encoderMics;
+    encoderMics.reserve(encoderFactories.size());
 
-    TDoubleVecVec frequencies(categoryFrequencies(numberThreads, frame, columnMask));
-    LOG_TRACE(<< "frequencies = " << core::CContainerPrinter::print(frequencies));
+    for (const auto& encoderFactory_ : encoderFactories) {
 
-    TFloatVecVec samples;
-    TFloatUSet categories;
-    CMic mic;
+        TEncoderFactory encoderFactory;
+        double minimumFrequency;
+        std::tie(encoderFactory, minimumFrequency) = encoderFactory_;
 
-    samples.reserve(numberSamples);
-    mic.reserve(numberSamples);
+        TSizeDoublePrVecVec mics(frame.numberColumns());
 
-    // Sample
-    //
-    // The law of large numbers means we have a high probability of sampling
-    // each category provided minimumFrequency * NUMBER_SAMPLES_TO_COMPUTE_MIC
-    // is large (which we ensure it is).
+        TDoubleVecVec frequencies(categoryFrequencies(numberThreads, frame, rowMask, columnMask));
+        LOG_TRACE(<< "frequencies = " << core::CContainerPrinter::print(frequencies));
 
-    TRowSampler sampler{numberSamples, rowSampler(samples)};
-    frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
-        for (auto row = beginRows; row != endRows; ++row) {
-            if (isMissing(target(*row)) == false) {
-                sampler.sample(*row);
-            }
-        }
-    });
-    LOG_TRACE(<< "# samples = " << samples.size());
+        TFloatVecVec samples;
+        TSizeEncoderPtrUMap encoders;
+        CMic mic;
 
-    for (auto i : columnMask) {
-        categories.clear();
-        for (const auto& sample : samples) {
-            std::size_t category{static_cast<std::size_t>(sample[i])};
-            if (frequencies[i][category] >= minimumFrequency) {
-                categories.insert(std::floor(sample[i]));
-            }
-        }
-        LOG_TRACE(<< "feature = " << i
-                  << " categories = " << core::CContainerPrinter::print(categories));
+        samples.reserve(numberSamples);
+        mic.reserve(numberSamples);
 
-        TSizeDoublePrVec categoryMics;
-        categoryMics.reserve(categories.size());
-        for (auto category : categories) {
-            mic.clear();
+        // Sample
+        //
+        // The law of large numbers means we have a high probability of sampling
+        // each category provided minimumFrequency * NUMBER_SAMPLES_TO_COMPUTE_MIC
+        // is large (which we ensure it is).
+
+        TRowSampler sampler{numberSamples, rowSampler(samples)};
+        frame.readRows(1, 0, frame.numberRows(),
+                       [&](TRowItr beginRows, TRowItr endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               if (isMissing(target(*row)) == false) {
+                                   sampler.sample(*row);
+                               }
+                           }
+                       },
+                       &rowMask);
+        LOG_TRACE(<< "# samples = " << samples.size());
+
+        for (auto i : columnMask) {
+
+            encoders.clear();
             for (const auto& sample : samples) {
-                mic.add(std::floor(sample[i]) != category ? 0.0 : 1.0, target(sample));
+                std::size_t category{static_cast<std::size_t>(sample[i])};
+                if (frequencies[i][category] >= minimumFrequency) {
+                    auto encoder = encoderFactory(i, i, category);
+                    std::size_t id{encoder->id()};
+                    encoders.emplace(id, std::move(encoder));
+                }
             }
-            categoryMics.emplace_back(static_cast<std::size_t>(category), mic.compute());
+
+            TSizeDoublePrVec categoryMics;
+            categoryMics.reserve(encoders.size());
+            for (const auto& encoder : encoders) {
+                std::size_t category{encoder.first};
+                const auto& encode = *encoder.second;
+                mic.clear();
+                for (const auto& sample : samples) {
+                    mic.add(encode(sample), target(sample));
+                }
+                categoryMics.emplace_back(static_cast<std::size_t>(category),
+                                          mic.compute());
+            }
+            mics[i] = std::move(categoryMics);
         }
-        mics[i] = std::move(categoryMics);
+
+        encoderMics.push_back(std::move(mics));
     }
 
-    return mics;
+    return encoderMics;
 }
 
 CDataFrameUtils::TDoubleVec
-CDataFrameUtils::micWithColumnDataFrameInMemory(const CColumnValue& target,
-                                                const core::CDataFrame& frame,
-                                                const TSizeVec& columnMask,
-                                                std::size_t numberSamples) {
+CDataFrameUtils::metricMicWithColumnDataFrameInMemory(const CColumnValue& target,
+                                                      const core::CDataFrame& frame,
+                                                      const core::CPackedBitVector& rowMask,
+                                                      const TSizeVec& columnMask,
+                                                      std::size_t numberSamples) {
 
     TDoubleVec mics(frame.numberColumns(), 0.0);
 
-    TFloatFloatPrVec samples;
+    TFloatVecVec samples;
     samples.reserve(numberSamples);
 
     for (auto i : columnMask) {
@@ -473,17 +549,19 @@ CDataFrameUtils::micWithColumnDataFrameInMemory(const CColumnValue& target,
 
         TRowSampler sampler{numberSamples, rowFeatureSampler(i, target, samples)};
         auto missingCount = frame.readRows(
-            1, core::bindRetrievableState(
-                   [&](std::size_t& missing, TRowItr beginRows, TRowItr endRows) {
-                       for (auto row = beginRows; row != endRows; ++row) {
-                           if (isMissing((*row)[i])) {
-                               ++missing;
-                           } else if (isMissing(target(*row)) == false) {
-                               sampler.sample(*row);
-                           }
-                       }
-                   },
-                   std::size_t{0}));
+            1, 0, frame.numberRows(),
+            core::bindRetrievableState(
+                [&](std::size_t& missing, TRowItr beginRows, TRowItr endRows) {
+                    for (auto row = beginRows; row != endRows; ++row) {
+                        if (isMissing((*row)[i])) {
+                            ++missing;
+                        } else if (isMissing(target(*row)) == false) {
+                            sampler.sample(*row);
+                        }
+                    }
+                },
+                std::size_t{0}),
+            &rowMask);
         LOG_TRACE(<< "# samples = " << samples.size());
 
         double fractionMissing{static_cast<double>(missingCount.first[0].s_FunctionState) /
@@ -495,7 +573,7 @@ CDataFrameUtils::micWithColumnDataFrameInMemory(const CColumnValue& target,
         CMic mic;
         mic.reserve(samples.size());
         for (const auto& sample : samples) {
-            mic.add(sample.first, sample.second);
+            mic.add(sample[0], sample[1]);
         }
 
         mics[i] = (1.0 - fractionMissing) * mic.compute();
@@ -506,10 +584,11 @@ CDataFrameUtils::micWithColumnDataFrameInMemory(const CColumnValue& target,
 }
 
 CDataFrameUtils::TDoubleVec
-CDataFrameUtils::micWithColumnDataFrameOnDisk(const CColumnValue& target,
-                                              const core::CDataFrame& frame,
-                                              const TSizeVec& columnMask,
-                                              std::size_t numberSamples) {
+CDataFrameUtils::metricMicWithColumnDataFrameOnDisk(const CColumnValue& target,
+                                                    const core::CDataFrame& frame,
+                                                    const core::CPackedBitVector& rowMask,
+                                                    const TSizeVec& columnMask,
+                                                    std::size_t numberSamples) {
 
     TDoubleVec mics(frame.numberColumns(), 0.0);
 
@@ -520,18 +599,20 @@ CDataFrameUtils::micWithColumnDataFrameOnDisk(const CColumnValue& target,
 
     TRowSampler sampler{numberSamples, rowSampler(samples)};
     auto missingCounts = frame.readRows(
-        1, core::bindRetrievableState(
-               [&](TSizeVec& missing, TRowItr beginRows, TRowItr endRows) {
-                   for (auto row = beginRows; row != endRows; ++row) {
-                       for (std::size_t i = 0; i < row->numberColumns(); ++i) {
-                           missing[i] += isMissing((*row)[i]) ? 1 : 0;
-                       }
-                       if (isMissing(target(*row)) == false) {
-                           sampler.sample(*row);
-                       }
-                   }
-               },
-               TSizeVec(frame.numberColumns(), 0)));
+        1, 0, frame.numberRows(),
+        core::bindRetrievableState(
+            [&](TSizeVec& missing, TRowItr beginRows, TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    for (std::size_t i = 0; i < row->numberColumns(); ++i) {
+                        missing[i] += isMissing((*row)[i]) ? 1 : 0;
+                    }
+                    if (isMissing(target(*row)) == false) {
+                        sampler.sample(*row);
+                    }
+                }
+            },
+            TSizeVec(frame.numberColumns(), 0)),
+        &rowMask);
     LOG_TRACE(<< "# samples = " << samples.size());
 
     TDoubleVec fractionMissing(frame.numberColumns());

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -31,6 +31,7 @@ CCalendarComponentAdaptiveBucketing.cc \
 CCalendarComponent.cc \
 CCalendarFeature.cc \
 CCategoricalTools.cc \
+CChecksum.cc \
 CClusterer.cc \
 CClustererStateSerialiser.cc \
 CConstantPrior.cc \

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -600,7 +600,7 @@ void CBoostedTreeTest::testCategoricalRegressors() {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.06);
     CPPUNIT_ASSERT(modelRSquared > 0.97);
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -586,8 +586,8 @@ void CBoostedTreeTest::testCategoricalRegressors() {
     });
 
     auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, cols - 1, std::make_unique<maths::boosted_tree::CMse>())
-                          .buildFor(*frame);
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .buildFor(*frame, cols - 1);
 
     regression->train();
     regression->predict();

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -17,14 +17,12 @@ public:
     void testThreading();
     void testConstantFeatures();
     void testConstantObjective();
+    void testCategoricalRegressors();
     void testMissingData();
-    void testErrors();
-    // TODO void testCategoricalRegressors();
     // TODO void testFeatureWeights();
     // TODO void testNuisanceFeatures();
-    // TODO void testCheckpointing();
     void testPersistRestore();
-    void testPersistRestoreErrorHandling();
+    void testRestoreErrorHandling();
 
     static CppUnit::Test* suite();
 };

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -152,7 +152,7 @@ void CDataFrameCategoryEncoderTest::testMeanValueEncoding() {
 
         for (std::size_t i = 0; i < expectedTargetMeanValues.size(); ++i) {
             CPPUNIT_ASSERT_EQUAL(
-                encoder.isRareCategory(0, i)
+                encoder.usesOneHotEncoding(0, i) || encoder.isRareCategory(0, i)
                     ? 0.0
                     : maths::CBasicStatistics::mean(expectedTargetMeanValues[i]),
                 encoder.targetMeanValue(0, i));
@@ -164,7 +164,7 @@ void CDataFrameCategoryEncoderTest::testMeanValueEncoding() {
     core::stopDefaultAsyncExecutor();
 }
 
-void CDataFrameCategoryEncoderTest::testFrequencyEncoding() {
+void CDataFrameCategoryEncoderTest::testRareCategories() {
 
     // Test we get the rare features we expect given the frequency threshold.
 
@@ -440,10 +440,13 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
             return categories[0] == expectedOneHot[0][encoder.encoding(i)] ? 1.0 : 0.0; // one-hot
         }
         if (i < expectedOneHot[0].size() + 1) {
-            return expectedFrequencies[0][categories[0]]; // frequency
+            return encoder.usesOneHotEncoding(0, categories[0])
+                       ? 0.0
+                       : expectedFrequencies[0][categories[0]]; // frequency
         }
         if (i < expectedOneHot[0].size() + 2) {
-            return encoder.isRareCategory(0, categories[0])
+            return encoder.usesOneHotEncoding(0, categories[0]) ||
+                           encoder.isRareCategory(0, categories[0])
                        ? 0.0
                        : maths::CBasicStatistics::mean(
                              expectedTargetMeanValues[0][categories[0]]); // target mean
@@ -455,7 +458,8 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
             return categories[1] == expectedOneHot[2][encoder.encoding(i)] ? 1.0 : 0.0; // one-hot
         }
         if (i < expectedOneHot[0].size() + 4 + expectedOneHot[2].size() + 1) {
-            return encoder.isRareCategory(0, categories[1])
+            return encoder.usesOneHotEncoding(3, categories[1]) ||
+                           encoder.isRareCategory(3, categories[1])
                        ? 0.0
                        : maths::CBasicStatistics::mean(
                              expectedTargetMeanValues[1][categories[1]]); // target mean
@@ -557,8 +561,8 @@ CppUnit::Test* CDataFrameCategoryEncoderTest::suite() {
         "CDataFrameCategoryEncoderTest::testMeanValueEncoding",
         &CDataFrameCategoryEncoderTest::testMeanValueEncoding));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
-        "CDataFrameCategoryEncoderTest::testFrequencyEncoding",
-        &CDataFrameCategoryEncoderTest::testFrequencyEncoding));
+        "CDataFrameCategoryEncoderTest::testRareCategories",
+        &CDataFrameCategoryEncoderTest::testRareCategories));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
         "CDataFrameCategoryEncoderTest::testCorrelatedFeatures",
         &CDataFrameCategoryEncoderTest::testCorrelatedFeatures));

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -7,6 +7,7 @@
 #include "CDataFrameCategoryEncoderTest.h"
 
 #include <core/CDataFrame.h>
+#include <core/CPackedBitVector.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CDataFrameCategoryEncoder.h>
@@ -66,30 +67,28 @@ void CDataFrameCategoryEncoderTest::testOneHotEncoding() {
         }
         frame->finishWritingRows();
 
-        maths::CDataFrameCategoryEncoder encoder{threads, *frame, {0, 1, 2}, 3, 50};
+        maths::CDataFrameCategoryEncoder encoder{
+            threads,   *frame, core::CPackedBitVector{rows, true},
+            {0, 1, 2}, 3,      50};
 
         for (std::size_t i = 0; i < cols; ++i) {
             CPPUNIT_ASSERT_EQUAL(bool{frame->columnIsCategorical()[i]},
                                  encoder.columnIsCategorical(i));
         }
 
-        CPPUNIT_ASSERT_EQUAL(
-            std::string{"[1, 2]"},
-            core::CContainerPrinter::print(encoder.selectedMetricFeatures()));
-
         TSizeVec expectedColumns{0, 0, 0, 0, 1, 2, 3};
+        TSizeVec expectedEncoding{0, 1, 2, 3, 0, 0, 0};
         CPPUNIT_ASSERT_EQUAL(expectedColumns.size(), encoder.numberFeatures());
         for (std::size_t i = 0; i < expectedColumns.size(); ++i) {
             CPPUNIT_ASSERT_EQUAL(expectedColumns[i], encoder.column(i));
+            CPPUNIT_ASSERT_EQUAL(expectedEncoding[i], encoder.encoding(i));
         }
 
         TSizeVecVec expectedOneHotEncodedCategories{{0, 1}, {}, {}, {}};
         for (std::size_t i = 0; i < cols; ++i) {
-            CPPUNIT_ASSERT_EQUAL(expectedOneHotEncodedCategories[i].size(),
-                                 encoder.numberOneHotEncodedCategories(i));
             if (encoder.columnIsCategorical(i)) {
                 for (auto j : expectedOneHotEncodedCategories[i]) {
-                    CPPUNIT_ASSERT_EQUAL(true, encoder.isOne(j, i, j));
+                    CPPUNIT_ASSERT_EQUAL(true, encoder.isHot(j, i, j));
                 }
             }
         }
@@ -144,11 +143,16 @@ void CDataFrameCategoryEncoderTest::testMeanValueEncoding() {
         }
         frame->finishWritingRows();
 
-        maths::CDataFrameCategoryEncoder encoder{threads, *frame, {0, 1, 2}, 3, 50};
+        maths::CDataFrameCategoryEncoder encoder{
+            threads,   *frame, core::CPackedBitVector{rows, true},
+            {0, 1, 2}, 3,      50};
 
         for (std::size_t i = 0; i < expectedTargetMeanValues.size(); ++i) {
-            CPPUNIT_ASSERT_EQUAL(maths::CBasicStatistics::mean(expectedTargetMeanValues[i]),
-                                 encoder.targetMeanValue(0, i));
+            CPPUNIT_ASSERT_EQUAL(
+                encoder.isRareCategory(0, i)
+                    ? 0.0
+                    : maths::CBasicStatistics::mean(expectedTargetMeanValues[i]),
+                encoder.targetMeanValue(0, i));
         }
 
         core::startDefaultAsyncExecutor();
@@ -157,7 +161,7 @@ void CDataFrameCategoryEncoderTest::testMeanValueEncoding() {
     core::stopDefaultAsyncExecutor();
 }
 
-void CDataFrameCategoryEncoderTest::testEncodingRare() {
+void CDataFrameCategoryEncoderTest::testFrequencyEncoding() {
 
     // Test we get the rare features we expect given the frequency threshold.
 
@@ -193,9 +197,10 @@ void CDataFrameCategoryEncoderTest::testEncodingRare() {
     }
     frame->finishWritingRows();
 
-    maths::CDataFrameCategoryEncoder encoder{1, *frame, {0, 1, 2}, 3, 50, 0.1};
+    maths::CDataFrameCategoryEncoder encoder{
+        1, *frame, core::CPackedBitVector{rows, true}, {0, 1, 2}, 3, 50, 0.1};
 
-    CPPUNIT_ASSERT(encoder.hasRareCategories(2));
+    CPPUNIT_ASSERT(encoder.usesFrequencyEncoding(2));
     for (std::size_t i = 0; i < categoryCounts.size(); ++i) {
         CPPUNIT_ASSERT_EQUAL(categoryCounts[i] < 50, encoder.isRareCategory(2, i));
     }
@@ -208,7 +213,7 @@ void CDataFrameCategoryEncoderTest::testCorrelatedFeatures() {
 
     test::CRandomNumbers rng;
 
-    // Two correlated metrics + 4 independent metrics.
+    // Two correlated + 4 independent metrics.
     {
         auto target = [&](const TDoubleVecVec& features, std::size_t row) {
             return 5.3 * features[0][row] + 4.8 * features[1][row] +
@@ -247,34 +252,43 @@ void CDataFrameCategoryEncoderTest::testCorrelatedFeatures() {
         }
         frame->finishWritingRows();
 
-        maths::CDataFrameCategoryEncoder encoder{1, *frame, {0, 1, 2, 3, 4, 5}, 6, 50};
+        maths::CDataFrameCategoryEncoder encoder{
+            1, *frame, core::CPackedBitVector{rows, true}, {0, 1, 2, 3, 4, 5},
+            6, 50};
 
         // Dispite both carrying a lot of information about the target nearly
         // the same information is carried by columns 0 and 1 so we should
-        // choose columns 0 or 1 and column 5.
+        // choose feature 0 or 1 and feature 5.
 
-        CPPUNIT_ASSERT_EQUAL(
-            std::string{"[1, 5]"},
-            core::CContainerPrinter::print(encoder.selectedMetricFeatures()));
+        TSizeVec expectedColumns{1, 5, 6};
+        CPPUNIT_ASSERT_EQUAL(expectedColumns.size(), encoder.numberFeatures());
+        for (std::size_t i = 0; i < encoder.numberFeatures(); ++i) {
+            CPPUNIT_ASSERT_EQUAL(expectedColumns[i], encoder.column(i));
+        }
     }
 
-    // Two correlated categorical fields.
+    // Two correlated + two independent categorical fields.
     {
         auto target = [&](const TDoubleVecVec& features, std::size_t row) {
-            return std::floor(features[0][row]) + std::floor(features[1][row]);
+            return std::floor(features[0][row]) + std::floor(features[1][row]) +
+                   2.0 * (std::floor(features[2][row]) + std::floor(features[3][row]));
         };
 
         std::size_t rows{200};
-        std::size_t cols{3};
-        double numberCategories{3.0};
+        std::size_t cols{5};
+        double numberCategories{4.0};
 
         TDoubleVecVec features(cols - 1);
         rng.generateUniformSamples(0.0, numberCategories, rows, features[0]);
         features[1] = features[0];
+        rng.discard(100000);
+        rng.generateUniformSamples(0.0, numberCategories, rows, features[2]);
+        rng.discard(100000);
+        rng.generateUniformSamples(0.0, numberCategories, rows, features[3]);
 
         auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
 
-        frame->categoricalColumns({true, true, false});
+        frame->categoricalColumns({true, true, true, true, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 for (std::size_t j = 0; j + 1 < cols; ++j, ++column) {
@@ -285,14 +299,70 @@ void CDataFrameCategoryEncoderTest::testCorrelatedFeatures() {
         }
         frame->finishWritingRows();
 
-        maths::CDataFrameCategoryEncoder encoder{1, *frame, {0, 1}, 6, 50};
+        maths::CDataFrameCategoryEncoder encoder{
+            1, *frame, core::CPackedBitVector{rows, true}, {0, 1, 2, 3}, 4, 50};
 
-        CPPUNIT_ASSERT_EQUAL(
-            std::string{"[0]"},
-            core::CContainerPrinter::print(encoder.selectedCategoricalFeatures()));
-        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(numberCategories),
-                             encoder.numberOneHotEncodedCategories(0));
+        // Dispite both carrying a lot of information about the target nearly
+        // the same information is carried by columns 0 and 1 so we should
+        // choose feature 0 or 1 and features 2 and 3.
+
+        TSizeVec expectedColumns{0, 0, 2, 3, 4};
+        CPPUNIT_ASSERT_EQUAL(expectedColumns.size(), encoder.numberFeatures());
+        for (std::size_t i = 0; i < encoder.numberFeatures(); ++i) {
+            CPPUNIT_ASSERT_EQUAL(expectedColumns[i], encoder.column(i));
+        }
     }
+}
+
+void CDataFrameCategoryEncoderTest::testWithRowMask() {
+
+    // Test the invariant that the encoding for the row mask equals the
+    // encoding on a reduced frame containing only the masked rows.
+
+    test::CRandomNumbers rng;
+
+    auto target = [&](const TDoubleVecVec& features, std::size_t row) {
+        return features[0][row] + features[1][row] + features[2][row];
+    };
+
+    std::size_t rows{500};
+    std::size_t cols{4};
+
+    core::CPackedBitVector rowMask;
+    TDoubleVec uniform01;
+    rng.generateUniformSamples(0.0, 1.0, rows, uniform01);
+    for (auto u : uniform01) {
+        rowMask.extend(u < 0.5);
+    }
+
+    TDoubleVecVec features(cols - 1);
+    rng.generateNormalSamples(-1.0, 2.0, rows, features[0]);
+    rng.generateNormalSamples(0.0, 4.0, rows, features[1]);
+    rng.generateNormalSamples(2.0, 2.0, rows, features[2]);
+
+    auto frame = core::makeMainStorageDataFrame(cols).first;
+    auto maskedFrame = core::makeMainStorageDataFrame(cols).first;
+
+    for (std::size_t i = 0; i < rows; ++i) {
+        auto writeOneRow = [&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            for (std::size_t j = 0; j + 1 < cols; ++j, ++column) {
+                *column = features[j][i];
+            }
+            *column = target(features, i);
+        };
+
+        frame->writeRow(writeOneRow);
+        if (rowMask[i]) {
+            maskedFrame->writeRow(writeOneRow);
+        }
+    }
+
+    maths::CDataFrameCategoryEncoder encoder{1,         *frame, rowMask,
+                                             {0, 1, 2}, 3,      50};
+    maths::CDataFrameCategoryEncoder maskedEncoder{
+        1, *maskedFrame, core::CPackedBitVector{rows, true}, {0, 1, 2}, 3, 50};
+
+    CPPUNIT_ASSERT_EQUAL(encoder.checksum(), maskedEncoder.checksum());
 }
 
 void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
@@ -349,41 +419,47 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
     }
     frame->finishWritingRows();
 
-    maths::CDataFrameCategoryEncoder encoder{1, *frame, {0, 1, 2, 3}, 4, 50};
+    auto expectedFrequencies = maths::CDataFrameUtils::categoryFrequencies(
+        1, *frame, core::CPackedBitVector{rows, true}, {0, 2});
+    TSizeVecVec expectedOneHot{{0, 1, 2}, {}, {0, 1}, {}};
+    TSizeVecVec expectedRare{{4}, {}, {4}, {}};
+
+    maths::CDataFrameCategoryEncoder encoder{
+        1, *frame, core::CPackedBitVector{rows, true}, {0, 1, 2, 3}, 4, 50};
+    LOG_DEBUG(<< "# features = " << encoder.numberFeatures());
 
     auto expectedEncoded = [&](const core::CDataFrame::TRowRef& row, std::size_t i) {
 
-        // We should have one-hot encoded categories 0 and 1 for each categorical
-        // feature, category 4 should be rare and 2 and 3 should be mean target
-        // encoded.
+        TSizeVec encoding{0, 1, 2, 3, 4, 0, 0, 0, 1, 2, 0};
 
         std::size_t categories[]{static_cast<std::size_t>(row[0]),
                                  static_cast<std::size_t>(row[3])};
 
-        if (i < 2) {
-            return categories[0] == i ? 1.0 : 0.0; // one-hot
+        if (i < expectedOneHot[0].size()) {
+            return categories[0] == expectedOneHot[0][encoder.encoding(i)] ? 1.0 : 0.0; // one-hot
         }
-        if (i == 2) {
-            return categories[0] == 4 ? 1.0 : 0.0; // rare
+        if (i < expectedOneHot[0].size() + 1) {
+            return expectedFrequencies[0][categories[0]]; // frequency
         }
-        if (i == 3) {
-            return maths::CBasicStatistics::mean(
-                expectedTargetMeanValues[0][categories[0]]); // mean target
+        if (i < expectedOneHot[0].size() + 2) {
+            return encoder.isRareCategory(0, categories[0])
+                       ? 0.0
+                       : maths::CBasicStatistics::mean(
+                             expectedTargetMeanValues[0][categories[0]]); // target mean
         }
-        if (i < 6) {
-            return static_cast<double>(row[i - 3]); // metrics
+        if (i < expectedOneHot[0].size() + 4) {
+            return static_cast<double>(row[encoder.column(i)]); // metrics
         }
-        if (i < 8) {
-            return categories[1] == i - 6 ? 1.0 : 0.0; // one-hot
+        if (i < expectedOneHot[0].size() + 4 + expectedOneHot[2].size()) {
+            return categories[1] == expectedOneHot[2][encoder.encoding(i)] ? 1.0 : 0.0; // one-hot
         }
-        if (i == 8) {
-            return categories[1] == 4 ? 1.0 : 0.0; // rare
+        if (i < expectedOneHot[0].size() + 4 + expectedOneHot[2].size() + 1) {
+            return encoder.isRareCategory(0, categories[1])
+                       ? 0.0
+                       : maths::CBasicStatistics::mean(
+                             expectedTargetMeanValues[1][categories[1]]); // target mean
         }
-        if (i == 9) {
-            return maths::CBasicStatistics::mean(
-                expectedTargetMeanValues[1][categories[1]]); // mean target
-        }
-        return static_cast<double>(row[4]); // target
+        return static_cast<double>(row[encoder.column(i)]); // target
     };
 
     bool passed{true};
@@ -398,7 +474,7 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
                     passed = passed &&
                              std::fabs(encoded[i] - expectedEncoded(*row, i)) < 1e-6;
                     if (passed == false) {
-                        LOG_DEBUG(<< i << " " << encoded[i] << " "
+                        LOG_DEBUG(<< i << " got " << encoded[i] << " expected "
                                   << expectedEncoded(*row, i));
                     }
                 }
@@ -419,11 +495,14 @@ CppUnit::Test* CDataFrameCategoryEncoderTest::suite() {
         "CDataFrameCategoryEncoderTest::testMeanValueEncoding",
         &CDataFrameCategoryEncoderTest::testMeanValueEncoding));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
-        "CDataFrameCategoryEncoderTest::testEncodingRare",
-        &CDataFrameCategoryEncoderTest::testEncodingRare));
+        "CDataFrameCategoryEncoderTest::testFrequencyEncoding",
+        &CDataFrameCategoryEncoderTest::testFrequencyEncoding));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
         "CDataFrameCategoryEncoderTest::testCorrelatedFeatures",
         &CDataFrameCategoryEncoderTest::testCorrelatedFeatures));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
+        "CDataFrameCategoryEncoderTest::testWithRowMask",
+        &CDataFrameCategoryEncoderTest::testWithRowMask));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameCategoryEncoderTest>(
         "CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef",
         &CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef));

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
@@ -13,7 +13,7 @@ class CDataFrameCategoryEncoderTest : public CppUnit::TestFixture {
 public:
     void testOneHotEncoding();
     void testMeanValueEncoding();
-    void testFrequencyEncoding();
+    void testRareCategories();
     void testCorrelatedFeatures();
     void testWithRowMask();
     void testEncodedDataFrameRowRef();

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
@@ -17,6 +17,7 @@ public:
     void testCorrelatedFeatures();
     void testWithRowMask();
     void testEncodedDataFrameRowRef();
+    void testPersistRestore();
 
     static CppUnit::Test* suite();
 };

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
@@ -13,8 +13,9 @@ class CDataFrameCategoryEncoderTest : public CppUnit::TestFixture {
 public:
     void testOneHotEncoding();
     void testMeanValueEncoding();
-    void testEncodingRare();
+    void testFrequencyEncoding();
     void testCorrelatedFeatures();
+    void testWithRowMask();
     void testEncodedDataFrameRowRef();
 
     static CppUnit::Test* suite();

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -228,7 +228,7 @@ void CDataFrameUtilsTest::testColumnQuantiles() {
                     CPPUNIT_ASSERT(expectedQuantiles[feature].quantile(x, qe));
                     CPPUNIT_ASSERT(actualQuantiles[feature].quantile(x, qa));
                     CPPUNIT_ASSERT_DOUBLES_EQUAL(
-                        qe, qa, 0.01 * std::max(std::fabs(qa), 1.5));
+                        qe, qa, 0.02 * std::max(std::fabs(qa), 1.5));
                     columnsMae[feature].add(std::fabs(qa - qe));
                 }
             }
@@ -237,11 +237,11 @@ void CDataFrameUtilsTest::testColumnQuantiles() {
             for (std::size_t i = 0; i < columnsMae.size(); ++i) {
                 LOG_DEBUG(<< "Column MAE = "
                           << maths::CBasicStatistics::mean(columnsMae[i]));
-                CPPUNIT_ASSERT(maths::CBasicStatistics::mean(columnsMae[i]) < 0.01);
+                CPPUNIT_ASSERT(maths::CBasicStatistics::mean(columnsMae[i]) < 0.03);
                 mae += columnsMae[i];
             }
             LOG_DEBUG(<< "MAE = " << maths::CBasicStatistics::mean(mae));
-            CPPUNIT_ASSERT(maths::CBasicStatistics::mean(mae) < 0.005);
+            CPPUNIT_ASSERT(maths::CBasicStatistics::mean(mae) < 0.015);
         }
 
         core::startDefaultAsyncExecutor();
@@ -640,7 +640,7 @@ void CDataFrameUtilsTest::testCategoryMicWithColumn() {
                       return std::make_unique<maths::CDataFrameUtils::COneHotCategoricalColumnValue>(
                           sampleColumn, category);
                   },
-                  0.05}})[0];
+                  0.01}})[0];
 
             LOG_DEBUG(<< "mics[0] = " << core::CContainerPrinter::print(mics[0]));
             LOG_DEBUG(<< "mics[2] = " << core::CContainerPrinter::print(mics[2]));

--- a/lib/maths/unittest/CDataFrameUtilsTest.h
+++ b/lib/maths/unittest/CDataFrameUtilsTest.h
@@ -13,6 +13,7 @@ class CDataFrameUtilsTest : public CppUnit::TestFixture {
 public:
     void testStandardizeColumns();
     void testColumnQuantiles();
+    void testColumnQuantilesWithEncoding();
     void testMicWithColumn();
     void testCategoryFrequencies();
     void testMeanValueOfTargetForCategories();


### PR DESCRIPTION
This also makes some further refinements to category encoding. In particular, including frequency and target mean encoding explicitly in the feature selection loop. This also requires us to generalise the MICe calculations on `CDataFrameUtils` to support callbacks to define column values.