### PR TITLE
[ML] Improve hyperparameter optimisation stability

### DIFF
--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -66,6 +66,9 @@ public:
     //! variance in the error in \p fx w.r.t. the true value is \p vx.
     void add(TVector x, double fx, double vx);
 
+    //! Get the bounding box (in the function domain) in which we're minimizing.
+    std::pair<TVector, TVector> boundingBox() const;
+
     //! Compute the location which maximizes the expected improvement given the
     //! function evaluations added so far.
     TVector maximumExpectedImprovement();

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -62,6 +62,11 @@ void CBayesianOptimisation::add(TVector x, double fx, double vx) {
     m_ErrorVariances.push_back(CTools::pow2(m_RangeScale) * vx);
 }
 
+std::pair<CBayesianOptimisation::TVector, CBayesianOptimisation::TVector>
+CBayesianOptimisation::boundingBox() const {
+    return {m_MinBoundary, m_MaxBoundary};
+}
+
 CBayesianOptimisation::TVector CBayesianOptimisation::maximumExpectedImprovement() {
 
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -235,7 +235,7 @@ CBoostedTreeImpl::regularisedLoss(const core::CDataFrame& frame,
         }
     }
 
-    return {loss, leafCount, sumSquareLeafWeights};
+    return {loss, leafCount, 0.5 * sumSquareLeafWeights};
 }
 
 CBoostedTreeImpl::TMeanVarAccumulator
@@ -615,7 +615,17 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     double lossVariance{CBasicStatistics::variance(lossMoments)};
 
     bopt.add(parameters, meanLoss, lossVariance);
-    parameters = bopt.maximumExpectedImprovement();
+    if (3 * m_CurrentRound < m_NumberRounds) {
+        std::generate_n(parameters.data(), parameters.size(), [&]() {
+            return CSampling::uniformSample(m_Rng, 0.0, 1.0);
+        });
+        TVector minBoundary;
+        TVector maxBoundary;
+        std::tie(minBoundary, maxBoundary) = bopt.boundingBox();
+        parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
+    } else {
+        parameters = bopt.maximumExpectedImprovement();
+    }
 
     // Write parameters for next round.
     i = 0;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -197,14 +197,14 @@ void CBoostedTreeTest::testPiecewiseConstant() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.9);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.93);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.92);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.93);
 }
 
 void CBoostedTreeTest::testLinear() {
@@ -252,14 +252,14 @@ void CBoostedTreeTest::testLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.96);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.96);
 }
 
 void CBoostedTreeTest::testNonLinear() {
@@ -319,14 +319,14 @@ void CBoostedTreeTest::testNonLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.92);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.94);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.95);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.96);
 }
 
 void CBoostedTreeTest::testThreading() {
@@ -602,8 +602,8 @@ void CBoostedTreeTest::testCategoricalRegressors() {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.1);
-    CPPUNIT_ASSERT(modelRSquared > 0.9);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.01);
+    CPPUNIT_ASSERT(modelRSquared > 0.92);
 }
 
 void CBoostedTreeTest::testProgressMonitoring() {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -602,8 +602,8 @@ void CBoostedTreeTest::testCategoricalRegressors() {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.01);
-    CPPUNIT_ASSERT(modelRSquared > 0.92);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.1);
+    CPPUNIT_ASSERT(modelRSquared > 0.91);
 }
 
 void CBoostedTreeTest::testProgressMonitoring() {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -319,7 +319,7 @@ void CBoostedTreeTest::testNonLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.93);
 


### PR DESCRIPTION
We're getting stability issues in hyperparameter optimisation. This is shows up because we don't ensure a stable order for the rows in the data frame passed to the data_frame_analyzer command. Seeding Bayesian Optimisation (BO) with several rounds of random search (RS) greatly improves stability (and is in any case considered best practice). We allocate 1/3, 2/3 split between RS and BO.