### PR TITLE
[7.x] Rename expected_memory_usage_with_one_partition to expected_memory_without_disk (#601)

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -76,9 +76,9 @@ public:
     //! number of rows per subset.
     void computeAndSaveExecutionStrategy();
 
-    //! Estimates memory usage in two cases: one partition (the whole data frame
-    //! fits in main memory) and maximum tolerable number of partitions (only
-    //! one partition needs to be loaded to main memory).
+    //! Estimates memory usage in two cases:
+    //!   1. disk is not used (the whole data frame fits in main memory)
+    //!   2. disk is used (only one partition needs to be loaded to main memory)
     void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const;
 
     //! Check if the data frame for this analysis should use in or out of core

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -151,9 +151,9 @@ public:
     //! calling thread until the runner has finished.
     CDataFrameAnalysisRunner* run(const TStrVec& featureNames, core::CDataFrame& frame) const;
 
-    //! Estimates memory usage in two cases: one partition (the whole data frame
-    //! fits in main memory) and maximum tolerable number of partitions (only
-    //! one partition needs to be loaded to main memory).
+    //! Estimates memory usage in two cases:
+    //!   1. disk is not used (the whole data frame fits in main memory)
+    //!   2. disk is used (only one partition needs to be loaded to main memory)
     void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const;
 
 private:

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -52,15 +52,15 @@ void CDataFrameAnalysisRunner::estimateMemoryUsage(CMemoryUsageEstimationResultJ
         writer.write("0", "0");
         return;
     }
-    std::size_t expectedMemoryUsageWithOnePartition{
+    std::size_t expectedMemoryWithoutDisk{
         this->estimateMemoryUsage(numberRows, numberRows, numberColumns)};
-    std::size_t expectedMemoryUsageWithMaxPartitions{this->estimateMemoryUsage(
+    std::size_t expectedMemoryWithDisk{this->estimateMemoryUsage(
         numberRows, numberRows / maxNumberPartitions, numberColumns)};
     auto roundUpToNearestKilobyte = [](std::size_t bytes) {
         return std::to_string((bytes + 1024 - 1) / 1024) + "kB";
     };
-    writer.write(roundUpToNearestKilobyte(expectedMemoryUsageWithOnePartition),
-                 roundUpToNearestKilobyte(expectedMemoryUsageWithMaxPartitions));
+    writer.write(roundUpToNearestKilobyte(expectedMemoryWithoutDisk),
+                 roundUpToNearestKilobyte(expectedMemoryWithDisk));
 }
 
 void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {

--- a/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
+++ b/lib/api/CMemoryUsageEstimationResultJsonWriter.cc
@@ -11,8 +11,8 @@ namespace api {
 namespace {
 
 // JSON field names
-const std::string EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION("expected_memory_usage_with_one_partition");
-const std::string EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS("expected_memory_usage_with_max_partitions");
+const std::string EXPECTED_MEMORY_WITHOUT_DISK("expected_memory_without_disk");
+const std::string EXPECTED_MEMORY_WITH_DISK("expected_memory_with_disk");
 }
 
 CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(core::CJsonOutputStreamWrapper& strmOut)
@@ -21,13 +21,13 @@ CMemoryUsageEstimationResultJsonWriter::CMemoryUsageEstimationResultJsonWriter(c
     // the moment, the output stream might be redirected after construction
 }
 
-void CMemoryUsageEstimationResultJsonWriter::write(const std::string& expectedMemoryUsageWithOnePartition,
-                                                   const std::string& expectedMemoryUsageWithMaxPartitions) {
+void CMemoryUsageEstimationResultJsonWriter::write(const std::string& expectedMemoryWithoutDisk,
+                                                   const std::string& expectedMemoryWithDisk) {
     m_Writer.StartObject();
-    m_Writer.Key(EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION);
-    m_Writer.String(expectedMemoryUsageWithOnePartition);
-    m_Writer.Key(EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS);
-    m_Writer.String(expectedMemoryUsageWithMaxPartitions);
+    m_Writer.Key(EXPECTED_MEMORY_WITHOUT_DISK);
+    m_Writer.String(expectedMemoryWithoutDisk);
+    m_Writer.Key(EXPECTED_MEMORY_WITH_DISK);
+    m_Writer.String(expectedMemoryWithDisk);
     m_Writer.EndObject();
     m_Writer.flush();
 }

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -123,8 +123,8 @@ void CDataFrameAnalysisRunnerTest::testComputeAndSaveExecutionStrategyDiskUsageF
 }
 
 void testEstimateMemoryUsage(int64_t numberRows,
-                             const std::string& expected_expected_memory_usage_with_one_partition,
-                             const std::string& expected_expected_memory_usage_with_max_partitions,
+                             const std::string& expected_expected_memory_without_disk,
+                             const std::string& expected_expected_memory_with_disk,
                              int expected_number_errors) {
 
     std::ostringstream sstream;
@@ -159,14 +159,12 @@ void testEstimateMemoryUsage(int64_t numberRows,
     const rapidjson::Value& result = arrayDoc[rapidjson::SizeType(0)];
     CPPUNIT_ASSERT(result.IsObject());
 
-    CPPUNIT_ASSERT(result.HasMember("expected_memory_usage_with_one_partition"));
-    CPPUNIT_ASSERT_EQUAL(
-        expected_expected_memory_usage_with_one_partition,
-        std::string(result["expected_memory_usage_with_one_partition"].GetString()));
-    CPPUNIT_ASSERT(result.HasMember("expected_memory_usage_with_max_partitions"));
-    CPPUNIT_ASSERT_EQUAL(
-        expected_expected_memory_usage_with_max_partitions,
-        std::string(result["expected_memory_usage_with_max_partitions"].GetString()));
+    CPPUNIT_ASSERT(result.HasMember("expected_memory_without_disk"));
+    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_without_disk,
+                         std::string(result["expected_memory_without_disk"].GetString()));
+    CPPUNIT_ASSERT(result.HasMember("expected_memory_with_disk"));
+    CPPUNIT_ASSERT_EQUAL(expected_expected_memory_with_disk,
+                         std::string(result["expected_memory_with_disk"].GetString()));
 
     CPPUNIT_ASSERT_EQUAL(expected_number_errors, static_cast<int>(errors.size()));
 }

--- a/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
+++ b/lib/api/unittest/CMemoryUsageEstimationResultJsonWriterTest.cc
@@ -47,12 +47,10 @@ void CMemoryUsageEstimationResultJsonWriterTest::testWrite() {
     const rapidjson::Value& object = arrayDoc[rapidjson::SizeType(0)];
     CPPUNIT_ASSERT(object.IsObject());
 
-    CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_one_partition"));
-    CPPUNIT_ASSERT_EQUAL(
-        std::string("16kB"),
-        std::string(object["expected_memory_usage_with_one_partition"].GetString()));
-    CPPUNIT_ASSERT(object.HasMember("expected_memory_usage_with_max_partitions"));
-    CPPUNIT_ASSERT_EQUAL(
-        std::string("8kB"),
-        std::string(object["expected_memory_usage_with_max_partitions"].GetString()));
+    CPPUNIT_ASSERT(object.HasMember("expected_memory_without_disk"));
+    CPPUNIT_ASSERT_EQUAL(std::string("16kB"),
+                         std::string(object["expected_memory_without_disk"].GetString()));
+    CPPUNIT_ASSERT(object.HasMember("expected_memory_with_disk"));
+    CPPUNIT_ASSERT_EQUAL(std::string("8kB"),
+                         std::string(object["expected_memory_with_disk"].GetString()));
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Rename expected_memory_usage_with_one_partition to expected_memory_without_disk  (#601)