### PR TITLE
[ML] Instrument the regression code for memory usage and training run time

### DIFF
--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -75,14 +75,15 @@ CCleanUpOnExit::TTemporaryDirectoryPtr CCleanUpOnExit::m_DataFrameDirectory{};
 
 int main(int argc, char** argv) {
     // Register the set of counters in which this program is interested
-    // clang-format off
     const ml::counter_t::TCounterTypeSet counters{
         ml::counter_t::E_DFOEstimatedPeakMemoryUsage,
         ml::counter_t::E_DFOPeakMemoryUsage,
         ml::counter_t::E_DFOTimeToCreateEnsemble,
         ml::counter_t::E_DFOTimeToComputeScores,
-        ml::counter_t::E_DFONumberPartitions};
-    // clang-format on
+        ml::counter_t::E_DFONumberPartitions,
+        ml::counter_t::E_DFTPMEstimatedPeakMemoryUsage,
+        ml::counter_t::E_DFTPMPeakMemoryUsage,
+        ml::counter_t::E_DFTPMTimeToTrain};
     ml::core::CProgramCounters::registerProgramCounterTypes(counters);
 
     // Read command line options

--- a/include/api/CDataFrameBoostedTreeRunner.h
+++ b/include/api/CDataFrameBoostedTreeRunner.h
@@ -13,6 +13,8 @@
 
 #include <rapidjson/fwd.h>
 
+#include <atomic>
+
 namespace ml {
 namespace maths {
 class CBoostedTree;
@@ -58,6 +60,7 @@ private:
     std::string m_PredictionFieldName;
     TBoostedTreeFactoryUPtr m_BoostedTreeFactory;
     TBoostedTreeUPtr m_BoostedTree;
+    std::atomic<std::int64_t> m_Memory;
 };
 
 //! \brief Makes a core::CDataFrame boosted tree regression runner.

--- a/include/core/CProgramCounters.h
+++ b/include/core/CProgramCounters.h
@@ -27,6 +27,8 @@ namespace counter_t {
 //! The E_LastEnumCounter value must be bumped for every new enum added.
 //! Don't forget to also add a description of the new enum value to m_CounterDefinitions.
 enum ECounterTypes {
+    // Time Series Anomaly Detection
+
     //! The number of new people not created in the data gatherer
     //! because there wasn't enough free resource
     E_TSADNumberNewPeopleNotAllowed = 0,
@@ -86,7 +88,9 @@ enum ECounterTypes {
     //! The number of times partial memory estimates have been carried out
     E_TSADNumberMemoryUsageEstimates = 18,
 
-    //! The estimated peak memory usage for outlier detection
+    // Data Frame Outlier Detection
+
+    //! The estimated peak memory usage for outlier detection in bytes
     E_DFOEstimatedPeakMemoryUsage = 19,
 
     //! The peak memory usage of outlier detection in bytes
@@ -101,10 +105,21 @@ enum ECounterTypes {
     //! The number of partitions used
     E_DFONumberPartitions = 23,
 
+    // Data Frame Train Predictive Model
+
+    //! The estimated peak memory usage for training a predictive model
+    E_DFTPMEstimatedPeakMemoryUsage = 24,
+
+    //! The peak memory usage of outlier detection in bytes
+    E_DFTPMPeakMemoryUsage = 25,
+
+    //! The time in ms to train the model
+    E_DFTPMTimeToTrain = 26,
+
     // Add any new values here
 
     //! This MUST be last, increment the value for every new enum added
-    E_LastEnumCounter = 24
+    E_LastEnumCounter = 27
 };
 
 static constexpr size_t NUM_COUNTERS = static_cast<size_t>(E_LastEnumCounter);
@@ -296,14 +311,20 @@ private:
          {counter_t::E_TSADNumberPrunedItems, "E_TSADNumberPrunedItems",
           "The number of old people or attributes pruned from the models"},
          {counter_t::E_DFOEstimatedPeakMemoryUsage, "E_DFOEstimatedPeakMemoryUsage",
-          "The estimate of the peak memory outlier detection will use"},
+          "The upfront estimate of the peak memory outlier detection would use"},
          {counter_t::E_DFOPeakMemoryUsage, "E_DFOPeakMemoryUsage", "The peak memory outlier detection used"},
          {counter_t::E_DFOTimeToCreateEnsemble, "E_DFOTimeToCreateEnsemble",
-          "The time it takes to create the ensemble used for outlier detection"},
+          "The time it took to create the ensemble used for outlier detection"},
          {counter_t::E_DFOTimeToComputeScores, "E_DFOTimeToComputeScores",
-          "The time it takes to compute outlier scores"},
+          "The time it took to compute outlier scores"},
          {counter_t::E_DFONumberPartitions, "E_DFONumberPartitions",
-          "The number of partitions outlier detection used"}}};
+          "The number of partitions outlier detection used"},
+         {counter_t::E_DFTPMEstimatedPeakMemoryUsage, "E_DFTPMEstimatedPeakMemoryUsage",
+          "The upfront estimate of the peak memory training the predictive model would use"},
+         {counter_t::E_DFTPMPeakMemoryUsage, "E_DFTPMPeakMemoryUsage",
+          "The peak memory training the predictive model used"},
+         {counter_t::E_DFTPMTimeToTrain, "E_DFTPMTimeToTrain",
+          "The time it took to train the predictive model"}}};
 
     //! Enabling printing out the current counters.
     friend CORE_EXPORT std::ostream& operator<<(std::ostream& o,

--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -76,6 +76,9 @@ public:
     //! Populate the object from serialized data
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const;
+
     //! \name Test Interface
     //@{
     //! Get minus the data likelihood and its gradient as a function of the kernel

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -123,7 +123,6 @@ class CBoostedTreeImpl;
 // TODO
 class MATHS_EXPORT CBoostedTree final : public CDataFrameRegressionModel {
 public:
-    using TProgressCallback = std::function<void(double)>;
     using TRowRef = core::CDataFrame::TRowRef;
     using TLossFunctionUPtr = std::unique_ptr<boosted_tree::CLoss>;
     using TDataFramePtr = core::CDataFrame*;
@@ -160,7 +159,10 @@ private:
     using TImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
 
 private:
-    CBoostedTree(core::CDataFrame& frame, TProgressCallback recordProgress, TImplUPtr&& impl);
+    CBoostedTree(core::CDataFrame& frame,
+                 TProgressCallback recordProgress,
+                 TMemoryUsageCallback recordMemoryUsage,
+                 TImplUPtr&& impl);
 
 private:
     TImplUPtr m_Impl;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -434,6 +434,11 @@ private:
                 static_cast<std::size_t>(std::ceil(
                     featureBagFraction * static_cast<double>(numberCols - 1))) *
                 sizeof(std::size_t)};
+            // 256 is the number of rows encoded by a single byte in the packed bit
+            // vector assuming best compression. We will typically get this for most
+            // of the leaves when the set of splits becomes large, corresponding to
+            // the worst case for memory usage. This is because the masks will mainly
+            // contain 0 bits in this case.
             std::size_t rowMaskSize{numberRows / 256};
             std::size_t gradientsSize{(numberCols - 1) *
                                       numberSplitsPerFeature * sizeof(double)};

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -426,7 +426,8 @@ private:
                                                double featureBagFraction,
                                                std::size_t numberSplitsPerFeature) {
             std::size_t featureBagSize{
-                static_cast<std::size_t>(std::ceil(featureBagFraction * static_cast<double>(numberCols - 1))) *
+                static_cast<std::size_t>(std::ceil(
+                    featureBagFraction * static_cast<double>(numberCols - 1))) *
                 sizeof(std::size_t)};
             std::size_t rowMaskSize{numberRows / 256};
             std::size_t gradientsSize{(numberCols - 1) *

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -10,6 +10,7 @@
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
+#include <core/CMemory.h>
 #include <core/CPackedBitVector.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
@@ -48,6 +49,8 @@ public:
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TBayesinOptimizationUPtr = std::unique_ptr<maths::CBayesianOptimisation>;
+    using TProgressCallback = CBoostedTree::TProgressCallback;
+    using TMemoryUsageCallback = CBoostedTree::TMemoryUsageCallback;
     using TDoubleVec = std::vector<double>;
 
 public:
@@ -62,13 +65,14 @@ public:
     CBoostedTreeImpl& operator=(CBoostedTreeImpl&&);
 
     //! Train the model on the values in \p frame.
-    void train(core::CDataFrame& frame, CBoostedTree::TProgressCallback recordProgress);
+    void train(core::CDataFrame& frame,
+               const TProgressCallback& recordProgress,
+               const TMemoryUsageCallback& recordMemoryUsage);
 
     //! Write the predictions of the best trained model to \p frame.
     //!
     //! \note Must be called only if a trained model is available.
-    void predict(core::CDataFrame& frame,
-                 CBoostedTree::TProgressCallback /*recordProgress*/) const;
+    void predict(core::CDataFrame& frame, const TProgressCallback& /*recordProgress*/) const;
 
     //! Write this model to \p writer.
     void write(core::CRapidJsonConcurrentLineWriter& /*writer*/) const;
@@ -88,6 +92,9 @@ public:
 
     //! Populate the object from serialized data.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const;
 
 private:
     using TDoubleDoublePrVec = std::vector<std::pair<double, double>>;
@@ -136,6 +143,9 @@ private:
     //! node bit masks from the node's bit mask.
     class CNode final {
     public:
+        //! See core::CMemory.
+        static bool dynamicSizeAlwaysZero() { return true; }
+
         //! Check if this is a leaf node.
         bool isLeaf() const { return m_LeftChild < 0; }
 
@@ -397,13 +407,24 @@ private:
         //! Get the row mask for this leaf node.
         core::CPackedBitVector& rowMask() { return m_RowMask; }
 
+        //! Get the memory used by this object.
+        std::size_t memoryUsage() const {
+            std::size_t mem{core::CMemory::dynamicSize(m_FeatureBag)};
+            mem += core::CMemory::dynamicSize(m_RowMask);
+            mem += core::CMemory::dynamicSize(m_Gradients);
+            mem += core::CMemory::dynamicSize(m_Curvatures);
+            mem += core::CMemory::dynamicSize(m_MissingGradients);
+            mem += core::CMemory::dynamicSize(m_MissingCurvatures);
+            return mem;
+        }
+
         //! Estimate maximum leaf statistics bookkeeping memory for training
         //! boosted trees on data frames with \p numberRows rows, \p numberCols columns
         //! with specified settings for \p featureBagFraction and \p numberSplitsPerFeature
-        static size_t estimateMemoryUsage(std::size_t numberRows,
-                                          std::size_t numberCols,
-                                          double featureBagFraction,
-                                          std::size_t numberSplitsPerFeature) {
+        static std::size_t estimateMemoryUsage(std::size_t numberRows,
+                                               std::size_t numberCols,
+                                               double featureBagFraction,
+                                               std::size_t numberSplitsPerFeature) {
             std::size_t featureBagSize{
                 static_cast<std::size_t>(ceil(featureBagFraction) * (numberCols - 1)) *
                 sizeof(std::size_t)};
@@ -612,7 +633,7 @@ private:
 
     //! Train the forest and compute loss moments on each fold.
     TMeanVarAccumulator crossValidateForest(core::CDataFrame& frame,
-                                            CBoostedTree::TProgressCallback recordProgress) const;
+                                            const TMemoryUsageCallback& recordMemoryUsage) const;
 
     //! Initialize the predictions and loss function derivatives for the masked
     //! rows in \p frame.
@@ -622,7 +643,7 @@ private:
     //! Train one forest on the rows of \p frame in the mask \p trainingRowMask.
     TNodeVecVec trainForest(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
-                            CBoostedTree::TProgressCallback /*recordProgress*/) const;
+                            const TMemoryUsageCallback& recordMemoryUsage) const;
 
     //! Get the candidate splits values for each feature.
     TDoubleVecVec candidateSplits(const core::CDataFrame& frame,
@@ -631,7 +652,8 @@ private:
     //! Train one tree on the rows of \p frame in the mask \p trainingRowMask.
     TNodeVec trainTree(core::CDataFrame& frame,
                        const core::CPackedBitVector& trainingRowMask,
-                       const TDoubleVecVec& candidateSplits) const;
+                       const TDoubleVecVec& candidateSplits,
+                       const TMemoryUsageCallback& recordMemoryUsage) const;
 
     //! Get the number of features including category encoding.
     std::size_t numberFeatures() const;
@@ -716,7 +738,7 @@ private:
     std::size_t m_MaximumOptimisationRoundsPerHyperparameter = 5;
     std::size_t m_RowsPerFeature = 50;
     double m_FeatureBagFraction = 0.5;
-    double m_MaximumTreeSizeFraction = 1.0;
+    double m_MaximumTreeSizeMultiplier = 1.0;
     TDataFrameCategoryEncoderUPtr m_Encoder;
     TDoubleVec m_FeatureSampleProbabilities;
     TPackedBitVectorVec m_MissingFeatureRowMasks;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -426,9 +426,9 @@ private:
                                                double featureBagFraction,
                                                std::size_t numberSplitsPerFeature) {
             std::size_t featureBagSize{
-                static_cast<std::size_t>(ceil(featureBagFraction) * (numberCols - 1)) *
+                static_cast<std::size_t>(std::ceil(featureBagFraction * static_cast<double>(numberCols - 1))) *
                 sizeof(std::size_t)};
-            std::size_t rowMaskSize{numberRows / 32};
+            std::size_t rowMaskSize{numberRows / 256};
             std::size_t gradientsSize{(numberCols - 1) *
                                       numberSplitsPerFeature * sizeof(double)};
             std::size_t curvatureSize{gradientsSize};

--- a/include/maths/CDataFrameRegressionModel.h
+++ b/include/maths/CDataFrameRegressionModel.h
@@ -52,13 +52,17 @@ public:
     virtual std::size_t columnHoldingPrediction(std::size_t numberColumns) const = 0;
 
 protected:
-    CDataFrameRegressionModel(core::CDataFrame& frame, TProgressCallback recordProgress);
+    CDataFrameRegressionModel(core::CDataFrame& frame,
+                              TProgressCallback recordProgress,
+                              TMemoryUsageCallback recordMemoryUsage);
     core::CDataFrame& frame() const;
     const TProgressCallback& progressRecorder() const;
+    const TMemoryUsageCallback& memoryUsageRecorder() const;
 
 private:
     core::CDataFrame& m_Frame;
     TProgressCallback m_RecordProgress;
+    TMemoryUsageCallback m_RecordMemoryUsage;
 };
 }
 }

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -90,8 +90,12 @@ CDataFrameBoostedTreeRunner::CDataFrameBoostedTreeRunner(const CDataFrameAnalysi
 
     (*m_BoostedTreeFactory).progressCallback(this->progressRecorder()).memoryUsageCallback([this](std::int64_t delta) {
         std::int64_t memory{m_Memory.fetch_add(delta)};
-        if (memory > 0) {
+        if (memory >= 0) {
             core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage).max(memory);
+        } else {
+            // Something has gone wrong with memory estimation. Trap this case
+            // to avoid underflowing the peak memory usage statistic.
+            LOG_DEBUG(<< "Memory estimate " << memory << " is negative!");
         }
     });
     if (lambda >= 0.0) {

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -586,7 +586,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithParams() {
     };
 
     api::CDataFrameAnalyzer analyzer{
-        regressionSpec("c5", 100, 5, 100000, {}, lambda, gamma, eta,
+        regressionSpec("c5", 100, 5, 1000000, {}, lambda, gamma, eta,
                        maximumNumberTrees, featureBagFraction),
         outputWriterFactory};
 
@@ -638,7 +638,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValu
 
     auto target = [](double feature) { return 10.0 * feature; };
 
-    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 100000), outputWriterFactory};
+    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 1000000), outputWriterFactory};
 
     TDoubleVec feature;
     rng.generateUniformSamples(1.0, 3.0, 50, feature);
@@ -851,7 +851,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
 
     {
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", 1000, 5, 1000000, {"x1", "x2"}), outputWriterFactory};
+            regressionSpec("x5", 1000, 5, 10000000, {"x1", "x2"}), outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
                     {"x21", "x22", "x23", "x24", "x25", "x26", "x27"}};
@@ -890,7 +890,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
         std::size_t rows{api::CDataFrameAnalyzer::MAX_CATEGORICAL_CARDINALITY + 3};
 
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", rows, 5, 2800000000, {"x1"}), outputWriterFactory};
+            regressionSpec("x5", rows, 5, 3600000000, {"x1"}), outputWriterFactory};
 
         TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};
         TStrVec fieldValues{"", "", "", "", "", "", ""};

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -85,7 +85,7 @@ auto outlierSpec(std::size_t rows = 110,
 auto regressionSpec(std::string dependentVariable,
                     std::size_t rows = 100,
                     std::size_t cols = 5,
-                    std::size_t memoryLimit = 1000000,
+                    std::size_t memoryLimit = 1500000,
                     const TStrVec& categoricalFieldNames = TStrVec{},
                     double lambda = -1.0,
                     double gamma = -1.0,
@@ -563,8 +563,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTraining() {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 600000);
-    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 200000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 760000);
+    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 250000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -586,7 +586,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithParams() {
     };
 
     api::CDataFrameAnalyzer analyzer{
-        regressionSpec("c5", 100, 5, 1000000, {}, lambda, gamma, eta,
+        regressionSpec("c5", 100, 5, 1500000, {}, lambda, gamma, eta,
                        maximumNumberTrees, featureBagFraction),
         outputWriterFactory};
 
@@ -856,7 +856,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
 
     {
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", 1000, 5, 10000000, {"x1", "x2"}), outputWriterFactory};
+            regressionSpec("x5", 1000, 5, 4000000, {"x1", "x2"}), outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
                     {"x21", "x22", "x23", "x24", "x25", "x26", "x27"}};
@@ -895,7 +895,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
         std::size_t rows{api::CDataFrameAnalyzer::MAX_CATEGORICAL_CARDINALITY + 3};
 
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", rows, 5, 3600000000, {"x1"}), outputWriterFactory};
+            regressionSpec("x5", rows, 5, 4000000000, {"x1"}), outputWriterFactory};
 
         TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};
         TStrVec fieldValues{"", "", "", "", "", "", ""};

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -638,7 +638,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValu
 
     auto target = [](double feature) { return 10.0 * feature; };
 
-    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 1000000), outputWriterFactory};
+    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 1000000),
+                                     outputWriterFactory};
 
     TDoubleVec feature;
     rng.generateUniformSamples(1.0, 3.0, 50, feature);

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -8,6 +8,7 @@
 
 #include <core/CIEEE754.h>
 #include <core/CJsonStateRestoreTraverser.h>
+#include <core/CMemory.h>
 #include <core/CPersistUtils.h>
 #include <core/RestoreMacros.h>
 
@@ -394,6 +395,21 @@ double CBayesianOptimisation::kernel(const TVector& a, const TVector& x, const T
                                          (x - y));
 }
 
+void CBayesianOptimisation::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    try {
+        core::CPersistUtils::persist(MIN_BOUNDARY_TAG, m_MinBoundary, inserter);
+
+        core::CPersistUtils::persist(MAX_BOUNDARY_TAG, m_MaxBoundary, inserter);
+        core::CPersistUtils::persist(ERROR_VARIANCES_TAG, m_ErrorVariances, inserter);
+        core::CPersistUtils::persist(KERNEL_PARAMETERS_TAG, m_KernelParameters, inserter);
+        core::CPersistUtils::persist(MIN_KERNEL_COORDINATE_DISTANCE_SCALES_TAG,
+                                     m_MinimumKernelCoordinateDistanceScale, inserter);
+        core::CPersistUtils::persist(FUNCTION_MEAN_VALUES_TAG, m_FunctionMeanValues, inserter);
+    } catch (std::exception& e) {
+        LOG_ERROR(<< "Failed to persist state! " << e.what());
+    }
+}
+
 bool CBayesianOptimisation::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     try {
         do {
@@ -423,19 +439,14 @@ bool CBayesianOptimisation::acceptRestoreTraverser(core::CStateRestoreTraverser&
     return true;
 }
 
-void CBayesianOptimisation::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    try {
-        core::CPersistUtils::persist(MIN_BOUNDARY_TAG, m_MinBoundary, inserter);
-
-        core::CPersistUtils::persist(MAX_BOUNDARY_TAG, m_MaxBoundary, inserter);
-        core::CPersistUtils::persist(ERROR_VARIANCES_TAG, m_ErrorVariances, inserter);
-        core::CPersistUtils::persist(KERNEL_PARAMETERS_TAG, m_KernelParameters, inserter);
-        core::CPersistUtils::persist(MIN_KERNEL_COORDINATE_DISTANCE_SCALES_TAG,
-                                     m_MinimumKernelCoordinateDistanceScale, inserter);
-        core::CPersistUtils::persist(FUNCTION_MEAN_VALUES_TAG, m_FunctionMeanValues, inserter);
-    } catch (std::exception& e) {
-        LOG_ERROR(<< "Failed to persist state! " << e.what());
-    }
+std::size_t CBayesianOptimisation::memoryUsage() const {
+    std::size_t mem{core::CMemory::dynamicSize(m_MinBoundary)};
+    mem += core::CMemory::dynamicSize(m_MaxBoundary);
+    mem += core::CMemory::dynamicSize(m_FunctionMeanValues);
+    mem += core::CMemory::dynamicSize(m_ErrorVariances);
+    mem += core::CMemory::dynamicSize(m_KernelParameters);
+    mem += core::CMemory::dynamicSize(m_MinimumKernelCoordinateDistanceScale);
+    return mem;
 }
 
 const double CBayesianOptimisation::MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE{1e-3};

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -57,14 +57,19 @@ double CArgMinMse::value() const {
 }
 }
 
-CBoostedTree::CBoostedTree(core::CDataFrame& frame, TProgressCallback recordProgress, TImplUPtr&& impl)
-    : CDataFrameRegressionModel{frame, std::move(recordProgress)}, m_Impl{std::move(impl)} {
+CBoostedTree::CBoostedTree(core::CDataFrame& frame,
+                           TProgressCallback recordProgress,
+                           TMemoryUsageCallback recordMemoryUsage,
+                           TImplUPtr&& impl)
+    : CDataFrameRegressionModel{frame, std::move(recordProgress),
+                                std::move(recordMemoryUsage)},
+      m_Impl{std::move(impl)} {
 }
 
 CBoostedTree::~CBoostedTree() = default;
 
 void CBoostedTree::train() {
-    m_Impl->train(this->frame(), this->progressRecorder());
+    m_Impl->train(this->frame(), this->progressRecorder(), this->memoryUsageRecorder());
 }
 
 void CBoostedTree::predict() const {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -235,6 +235,7 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
         maximumNumberNodes * CLeafNodeStatistics::estimateMemoryUsage(
                                  numberRows, numberColumns, m_FeatureBagFraction,
                                  m_NumberSplitsPerFeature)};
+
     return forestMemoryUsage + extraColumnsMemoryUsage +
            hyperparametersMemoryUsage + leafNodeStatisticsMemoryUsage;
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -23,6 +23,41 @@ using namespace boosted_tree_detail;
 namespace {
 using TRowRef = core::CDataFrame::TRowRef;
 
+class CScopeRecordMemoryUsage {
+public:
+    using TMemoryUsageCallback = CBoostedTreeImpl::TMemoryUsageCallback;
+
+public:
+    template<typename T>
+    CScopeRecordMemoryUsage(const T& object, const TMemoryUsageCallback& recordMemoryUsage)
+        : m_RecordMemoryUsage{recordMemoryUsage},
+          m_MemoryUsage(core::CMemory::dynamicSize(object)) {
+        m_RecordMemoryUsage(m_MemoryUsage);
+    }
+    ~CScopeRecordMemoryUsage() { m_RecordMemoryUsage(-m_MemoryUsage); }
+
+    CScopeRecordMemoryUsage(const CScopeRecordMemoryUsage&) = delete;
+    CScopeRecordMemoryUsage& operator=(const CScopeRecordMemoryUsage&) = delete;
+
+    template<typename T>
+    void add(const T& object) {
+        std::int64_t memoryUsage(core::CMemory::dynamicSize(object));
+        m_MemoryUsage += memoryUsage;
+        m_RecordMemoryUsage(memoryUsage);
+    }
+
+    template<typename T>
+    void remove(const T& object) {
+        std::int64_t memoryUsage(core::CMemory::dynamicSize(object));
+        m_MemoryUsage -= memoryUsage;
+        m_RecordMemoryUsage(-memoryUsage);
+    }
+
+private:
+    const TMemoryUsageCallback& m_RecordMemoryUsage;
+    std::int64_t m_MemoryUsage;
+};
+
 std::size_t lossGradientColumn(std::size_t numberColumns) {
     return numberColumns - 2;
 }
@@ -79,7 +114,8 @@ CBoostedTreeImpl::~CBoostedTreeImpl() = default;
 CBoostedTreeImpl& CBoostedTreeImpl::operator=(CBoostedTreeImpl&&) = default;
 
 void CBoostedTreeImpl::train(core::CDataFrame& frame,
-                             CBoostedTree::TProgressCallback recordProgress) {
+                             const TProgressCallback& recordProgress,
+                             const TMemoryUsageCallback& recordMemoryUsage) {
 
     if (m_DependentVariable >= frame.numberColumns()) {
         HANDLE_FATAL(<< "Internal error: dependent variable '" << m_DependentVariable
@@ -94,6 +130,9 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
     // values is counted as one round. This gives a total of m_NumberRounds + 3.
     core::CLoopProgress progress{m_NumberRounds + 3, recordProgress};
     progress.increment();
+
+    std::uint64_t lastMemoryUsage(this->memoryUsage());
+    recordMemoryUsage(lastMemoryUsage);
 
     if (this->canTrain() == false) {
         // Fallback to using the constant predictor which minimises the loss.
@@ -114,7 +153,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
         do {
             LOG_TRACE(<< "Optimisation round = " << m_CurrentRound + 1);
 
-            TMeanVarAccumulator lossMoments{this->crossValidateForest(frame, recordProgress)};
+            TMeanVarAccumulator lossMoments{this->crossValidateForest(frame, recordMemoryUsage)};
 
             this->captureBestHyperparameters(lossMoments);
 
@@ -131,21 +170,28 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
             progress.increment();
 
+            std::int64_t memoryUsage(this->memoryUsage());
+            recordMemoryUsage(memoryUsage - lastMemoryUsage);
+            lastMemoryUsage = memoryUsage;
+
         } while (m_CurrentRound++ < m_NumberRounds);
 
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
         this->restoreBestHyperparameters();
-        m_BestForest = this->trainForest(frame, this->allTrainingRowsMask(), recordProgress);
+        m_BestForest = this->trainForest(frame, this->allTrainingRowsMask(), recordMemoryUsage);
     }
 
     // Force to at least one here because we can have early exit from loop or take
     // a different path.
     recordProgress(1.0);
+
+    std::int64_t memoryUsage(this->memoryUsage());
+    recordMemoryUsage(memoryUsage - lastMemoryUsage);
 }
 
 void CBoostedTreeImpl::predict(core::CDataFrame& frame,
-                               CBoostedTree::TProgressCallback /*recordProgress*/) const {
+                               const TProgressCallback& /*recordProgress*/) const {
     if (m_BestForestTestLoss == INF) {
         HANDLE_FATAL(<< "Internal error: no model available for prediction. "
                      << "Please report this problem.");
@@ -240,10 +286,10 @@ CBoostedTreeImpl::regularisedLoss(const core::CDataFrame& frame,
 
 CBoostedTreeImpl::TMeanVarAccumulator
 CBoostedTreeImpl::crossValidateForest(core::CDataFrame& frame,
-                                      CBoostedTree::TProgressCallback recordProgress) const {
+                                      const TMemoryUsageCallback& recordMemoryUsage) const {
     TMeanVarAccumulator lossMoments;
     for (std::size_t i = 0; i < m_NumberFolds; ++i) {
-        TNodeVecVec forest(this->trainForest(frame, m_TrainingRowMasks[i], recordProgress));
+        TNodeVecVec forest(this->trainForest(frame, m_TrainingRowMasks[i], recordMemoryUsage));
         double loss{this->meanLoss(frame, m_TestingRowMasks[i], forest)};
         lossMoments.add(loss);
         LOG_TRACE(<< "fold = " << i << " forest size = " << forest.size()
@@ -278,12 +324,14 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
 CBoostedTreeImpl::TNodeVecVec
 CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
                               const core::CPackedBitVector& trainingRowMask,
-                              CBoostedTree::TProgressCallback /*recordProgress*/) const {
+                              const TMemoryUsageCallback& recordMemoryUsage) const {
 
     LOG_TRACE(<< "Training one forest...");
 
     TNodeVecVec forest{this->initializePredictionsAndLossDerivatives(frame, trainingRowMask)};
     forest.reserve(m_MaximumNumberTrees);
+
+    CScopeRecordMemoryUsage scopeMemoryUsage{forest, recordMemoryUsage};
 
     // For each iteration:
     //  1. Compute weighted quantiles for features F
@@ -298,7 +346,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
 
         TDoubleVecVec candidateSplits(this->candidateSplits(frame, trainingRowMask));
 
-        auto tree = this->trainTree(frame, trainingRowMask, candidateSplits);
+        auto tree = this->trainTree(frame, trainingRowMask, candidateSplits, recordMemoryUsage);
 
         retries = tree.size() == 1 ? retries + 1 : 0;
 
@@ -307,6 +355,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
         }
 
         if (sumEta < 1.0 || retries == 0) {
+            scopeMemoryUsage.add(tree);
             this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask, eta, tree);
             forest.push_back(std::move(tree));
             eta = std::min(1.0, m_EtaGrowthRatePerTree * eta);
@@ -384,7 +433,8 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
 CBoostedTreeImpl::TNodeVec
 CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
-                            const TDoubleVecVec& candidateSplits) const {
+                            const TDoubleVecVec& candidateSplits,
+                            const TMemoryUsageCallback& recordMemoryUsage) const {
 
     LOG_TRACE(<< "Training one tree...");
 
@@ -402,54 +452,75 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         0 /*root*/, m_NumberThreads, frame, *m_Encoder, m_Lambda, m_Gamma,
         candidateSplits, this->featureBag(), trainingRowMask));
 
-    // For each iteration we:
-    //   1. Find the leaf with the greatest decrease in loss
-    //   2. If no split (significantly) reduced the loss we terminate
-    //   3. Otherwise we split that leaf
+    // We update local variables because the callback can be expensive if it
+    // requires accessing atomics.
+    std::int64_t memory{0};
+    std::int64_t maxMemory{0};
+    TMemoryUsageCallback localRecordMemoryUsage{[&](std::int64_t delta) {
+        memory += delta;
+        maxMemory = std::max(maxMemory, memory);
+    }};
+    {
+        CScopeRecordMemoryUsage scopeMemoryUsage{leaves, localRecordMemoryUsage};
 
-    double totalGain{0.0};
+        // For each iteration we:
+        //   1. Find the leaf with the greatest decrease in loss
+        //   2. If no split (significantly) reduced the loss we terminate
+        //   3. Otherwise we split that leaf
 
-    for (std::size_t i = 0; i < maximumTreeSize; ++i) {
+        double totalGain{0.0};
 
-        auto leaf = leaves.top();
-        leaves.pop();
+        for (std::size_t i = 0; i < maximumTreeSize; ++i) {
 
-        if (leaf->gain() < MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
-            break;
+            auto leaf = leaves.top();
+            leaves.pop();
+
+            scopeMemoryUsage.remove(leaf);
+
+            if (leaf->gain() < MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
+                break;
+            }
+
+            totalGain += leaf->gain();
+            LOG_TRACE(<< "splitting " << leaf->id() << " total gain = " << totalGain);
+
+            std::size_t splitFeature;
+            double splitValue;
+            std::tie(splitFeature, splitValue) = leaf->bestSplit();
+
+            bool assignMissingToLeft{leaf->assignMissingToLeft()};
+
+            std::size_t leftChildId, rightChildId;
+            std::tie(leftChildId, rightChildId) = tree[leaf->id()].split(
+                splitFeature, splitValue, assignMissingToLeft, tree);
+
+            TSizeVec featureBag{this->featureBag()};
+
+            core::CPackedBitVector leftChildRowMask;
+            core::CPackedBitVector rightChildRowMask;
+            std::tie(leftChildRowMask, rightChildRowMask) = tree[leaf->id()].rowMasks(
+                m_NumberThreads, frame, *m_Encoder, std::move(leaf->rowMask()));
+
+            TLeafNodeStatisticsPtr leftChild;
+            TLeafNodeStatisticsPtr rightChild;
+            std::tie(leftChild, rightChild) = leaf->split(
+                leftChildId, rightChildId, m_NumberThreads, frame, *m_Encoder,
+                m_Lambda, m_Gamma, candidateSplits, std::move(featureBag),
+                std::move(leftChildRowMask), std::move(rightChildRowMask));
+
+            scopeMemoryUsage.add(leftChild);
+            scopeMemoryUsage.add(rightChild);
+
+            leaves.push(std::move(leftChild));
+            leaves.push(std::move(rightChild));
         }
-
-        totalGain += leaf->gain();
-        LOG_TRACE(<< "splitting " << leaf->id() << " total gain = " << totalGain);
-
-        std::size_t splitFeature;
-        double splitValue;
-        std::tie(splitFeature, splitValue) = leaf->bestSplit();
-
-        bool assignMissingToLeft{leaf->assignMissingToLeft()};
-
-        std::size_t leftChildId, rightChildId;
-        std::tie(leftChildId, rightChildId) = tree[leaf->id()].split(
-            splitFeature, splitValue, assignMissingToLeft, tree);
-
-        TSizeVec featureBag{this->featureBag()};
-
-        core::CPackedBitVector leftChildRowMask;
-        core::CPackedBitVector rightChildRowMask;
-        std::tie(leftChildRowMask, rightChildRowMask) = tree[leaf->id()].rowMasks(
-            m_NumberThreads, frame, *m_Encoder, std::move(leaf->rowMask()));
-
-        TLeafNodeStatisticsPtr leftChild;
-        TLeafNodeStatisticsPtr rightChild;
-        std::tie(leftChild, rightChild) = leaf->split(
-            leftChildId, rightChildId, m_NumberThreads, frame, *m_Encoder,
-            m_Lambda, m_Gamma, candidateSplits, std::move(featureBag),
-            std::move(leftChildRowMask), std::move(rightChildRowMask));
-
-        leaves.push(std::move(leftChild));
-        leaves.push(std::move(rightChild));
     }
 
-    LOG_TRACE(<< "Trained one tree");
+    // Flush the maximum memory used by the leaf statistics to the callback.
+    recordMemoryUsage(maxMemory);
+    recordMemoryUsage(-maxMemory);
+
+    LOG_TRACE(<< "Trained one tree. # nodes = " << tree.size());
 
     return tree;
 }
@@ -675,7 +746,7 @@ std::size_t CBoostedTreeImpl::maximumTreeSize(const core::CDataFrame& frame) con
 
 std::size_t CBoostedTreeImpl::maximumTreeSize(std::size_t numberRows) const {
     return static_cast<std::size_t>(std::ceil(
-        m_MaximumTreeSizeFraction * std::sqrt(static_cast<double>(numberRows))));
+        m_MaximumTreeSizeMultiplier * std::sqrt(static_cast<double>(numberRows))));
 }
 
 namespace {
@@ -702,7 +773,7 @@ const std::string MAXIMUM_NUMBER_TREES_OVERRIDE_TAG{"maximum_number_trees_overri
 const std::string MAXIMUM_NUMBER_TREES_TAG{"maximum_number_trees"};
 const std::string MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG{
     "maximum_optimisation_rounds_per_hyperparameter"};
-const std::string MAXIMUM_TREE_SIZE_FRACTION_TAG{"maximum_tree_size_fraction"};
+const std::string MAXIMUM_TREE_SIZE_MULTIPLIER_TAG{"maximum_tree_size_multiplier"};
 const std::string MISSING_FEATURE_ROW_MASKS_TAG{"missing_feature_row_masks"};
 const std::string NUMBER_FOLDS_TAG{"number_folds"};
 const std::string NUMBER_ROUNDS_TAG{"number_rounds"};
@@ -745,8 +816,8 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
                                  m_MaximumAttemptsToAddTree, inserter);
     core::CPersistUtils::persist(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
                                  m_MaximumOptimisationRoundsPerHyperparameter, inserter);
-    core::CPersistUtils::persist(MAXIMUM_TREE_SIZE_FRACTION_TAG,
-                                 m_MaximumTreeSizeFraction, inserter);
+    core::CPersistUtils::persist(MAXIMUM_TREE_SIZE_MULTIPLIER_TAG,
+                                 m_MaximumTreeSizeMultiplier, inserter);
     core::CPersistUtils::persist(MISSING_FEATURE_ROW_MASKS_TAG,
                                  m_MissingFeatureRowMasks, inserter);
     core::CPersistUtils::persist(NUMBER_FOLDS_TAG, m_NumberFolds, inserter);
@@ -880,9 +951,9 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
                 core::CPersistUtils::restore(
                     MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
                     m_MaximumOptimisationRoundsPerHyperparameter, traverser))
-        RESTORE(MAXIMUM_TREE_SIZE_FRACTION_TAG,
-                core::CPersistUtils::restore(MAXIMUM_TREE_SIZE_FRACTION_TAG,
-                                             m_MaximumTreeSizeFraction, traverser))
+        RESTORE(MAXIMUM_TREE_SIZE_MULTIPLIER_TAG,
+                core::CPersistUtils::restore(MAXIMUM_TREE_SIZE_MULTIPLIER_TAG,
+                                             m_MaximumTreeSizeMultiplier, traverser))
         RESTORE(MISSING_FEATURE_ROW_MASKS_TAG,
                 core::CPersistUtils::restore(MISSING_FEATURE_ROW_MASKS_TAG,
                                              m_MissingFeatureRowMasks, traverser))
@@ -924,6 +995,18 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
         RESTORE(LOSS_TAG, restoreLoss(m_Loss, traverser))
     } while (traverser.next());
     return true;
+}
+
+std::size_t CBoostedTreeImpl::memoryUsage() const {
+    std::size_t mem{core::CMemory::dynamicSize(m_Loss)};
+    mem += core::CMemory::dynamicSize(m_Encoder);
+    mem += core::CMemory::dynamicSize(m_FeatureSampleProbabilities);
+    mem += core::CMemory::dynamicSize(m_MissingFeatureRowMasks);
+    mem += core::CMemory::dynamicSize(m_TrainingRowMasks);
+    mem += core::CMemory::dynamicSize(m_TestingRowMasks);
+    mem += core::CMemory::dynamicSize(m_BestForest);
+    mem += core::CMemory::dynamicSize(m_BayesianOptimization);
+    return mem;
 }
 
 const double CBoostedTreeImpl::MINIMUM_RELATIVE_GAIN_PER_SPLIT{1e-7};

--- a/lib/maths/CDataFrameRegressionModel.cc
+++ b/lib/maths/CDataFrameRegressionModel.cc
@@ -10,8 +10,10 @@ namespace ml {
 namespace maths {
 
 CDataFrameRegressionModel::CDataFrameRegressionModel(core::CDataFrame& frame,
-                                                     TProgressCallback recordProgress)
-    : m_Frame{frame}, m_RecordProgress{recordProgress} {
+                                                     TProgressCallback recordProgress,
+                                                     TMemoryUsageCallback recordMemoryUsage)
+    : m_Frame{frame}, m_RecordProgress{std::move(recordProgress)},
+      m_RecordMemoryUsage{std::move(recordMemoryUsage)} {
 }
 
 core::CDataFrame& CDataFrameRegressionModel::frame() const {
@@ -21,6 +23,11 @@ core::CDataFrame& CDataFrameRegressionModel::frame() const {
 const CDataFrameRegressionModel::TProgressCallback&
 CDataFrameRegressionModel::progressRecorder() const {
     return m_RecordProgress;
+}
+
+const CDataFrameRegressionModel::TMemoryUsageCallback&
+CDataFrameRegressionModel::memoryUsageRecorder() const {
+    return m_RecordMemoryUsage;
 }
 }
 }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -606,6 +606,70 @@ void CBoostedTreeTest::testCategoricalRegressors() {
     CPPUNIT_ASSERT(modelRSquared > 0.9);
 }
 
+void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
+
+    // Test estimation of the memory used training a model.
+
+    test::CRandomNumbers rng;
+
+    std::size_t rows{1000};
+    std::size_t cols{6};
+    std::size_t capacity{600};
+
+    TDoubleVecVec x(cols - 1);
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    auto target = [&](std::size_t i) {
+        double result{0.0};
+        for (std::size_t j = 0; j < cols - 1; ++j) {
+            result += x[j][i];
+        }
+        return result;
+    };
+
+    auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+    frame->categoricalColumns({true, false, false, false, false, false});
+    for (std::size_t i = 0; i < rows; ++i) {
+        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            *(column++) = std::floor(x[0][i]);
+            for (std::size_t j = 1; j < cols - 1; ++j, ++column) {
+                *column = x[j][i];
+            }
+            *column = target(i);
+        });
+    }
+    frame->finishWritingRows();
+
+    std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
+                                     1, std::make_unique<maths::boosted_tree::CMse>())
+                                     .estimateMemoryUsage(rows, cols));
+
+    std::int64_t memoryUsage{0};
+    std::int64_t maxMemoryUsage{0};
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .memoryUsageCallback([&](std::int64_t delta) {
+                              memoryUsage += delta;
+                              maxMemoryUsage = std::max(maxMemoryUsage, memoryUsage);
+                              LOG_TRACE(<< "current memory = " << memoryUsage
+                                        << ", high water mark = " << maxMemoryUsage);
+                          })
+                          .buildFor(*frame, cols - 1);
+
+    regression->train();
+
+    LOG_DEBUG(<< "estimated memory usage = " << estimatedMemory);
+    LOG_DEBUG(<< "high water mark = " << maxMemoryUsage);
+
+    // Currently, the estimated memory is a little over 2 times the high water
+    // mark for the test data.
+
+    CPPUNIT_ASSERT(maxMemoryUsage < estimatedMemory);
+    CPPUNIT_ASSERT(3 * maxMemoryUsage > estimatedMemory);
+}
+
 void CBoostedTreeTest::testProgressMonitoring() {
 
     // Test progress monitoring invariants.
@@ -851,6 +915,9 @@ CppUnit::Test* CBoostedTreeTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testCategoricalRegressors",
         &CBoostedTreeTest::testCategoricalRegressors));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testEstimateMemoryUsedByTrain",
+        &CBoostedTreeTest::testEstimateMemoryUsedByTrain));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testProgressMonitoring", &CBoostedTreeTest::testProgressMonitoring));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -682,6 +682,9 @@ void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
                 *column = x[j][i];
             }
             *column = target(i);
+        });
+    }
+    frame->finishWritingRows();
 
     std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
                                      1, std::make_unique<maths::boosted_tree::CMse>())

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -663,11 +663,11 @@ void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
     LOG_DEBUG(<< "estimated memory usage = " << estimatedMemory);
     LOG_DEBUG(<< "high water mark = " << maxMemoryUsage);
 
-    // Currently, the estimated memory is a little over 2 times the high water
+    // Currently, the estimated memory is a little over 3 times the high water
     // mark for the test data.
 
     CPPUNIT_ASSERT(maxMemoryUsage < estimatedMemory);
-    CPPUNIT_ASSERT(3 * maxMemoryUsage > estimatedMemory);
+    CPPUNIT_ASSERT(4 * maxMemoryUsage > estimatedMemory);
 }
 
 void CBoostedTreeTest::testProgressMonitoring() {

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -18,6 +18,7 @@ public:
     void testConstantFeatures();
     void testConstantTarget();
     void testCategoricalRegressors();
+    void testEstimateMemoryUsedByTrain();
     void testProgressMonitoring();
     void testMissingData();
     // TODO void testFeatureWeights();

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -574,7 +574,7 @@ void COutliersTest::testEstimateMemoryUsedByCompute() {
                                                             memoryUsage_) == false) {
                 }
                 LOG_TRACE(<< "current memory = " << memoryUsage_
-                          << ", high water mark " << maxMemoryUsage.load());
+                          << ", high water mark = " << maxMemoryUsage.load());
             });
 
         LOG_DEBUG(<< "estimated peak memory = " << estimatedMemoryUsage);


### PR DESCRIPTION
This instruments the regression code to extract peak memory usage and training run time. This enabled me to test memory usage estimation better and I've fixed a bug where we weren't properly accounting for the maximum tree and forest size.