### PR TITLE
[7.4][ML] Ignore rows which are missing the target value when mean target encoding

### DIFF
--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -288,9 +288,11 @@ CDataFrameUtils::meanValueOfTargetForCategories(const CColumnValue& target,
         [&](TMeanAccumulatorVecVec& means_, TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t i : columnMask) {
-                    std::size_t category{static_cast<std::size_t>((*row)[i])};
-                    means_[i].resize(std::max(means_[i].size(), category + 1));
-                    means_[i][category].add(target(*row));
+                    if (isMissing(target(*row)) == false) {
+                        std::size_t category{static_cast<std::size_t>((*row)[i])};
+                        means_[i].resize(std::max(means_[i].size(), category + 1));
+                        means_[i][category].add(target(*row));
+                    }
                 }
             }
         },

--- a/lib/maths/unittest/CDataFrameUtilsTest.h
+++ b/lib/maths/unittest/CDataFrameUtilsTest.h
@@ -17,6 +17,7 @@ public:
     void testMicWithColumn();
     void testCategoryFrequencies();
     void testMeanValueOfTargetForCategories();
+    void testMeanValueOfTargetForCategoriesWithMissing();
     void testCategoryMicWithColumn();
 
     static CppUnit::Test* suite();


### PR DESCRIPTION
Backport #600.