### PR TITLE
[ML] Detect feature data types and refine candidate splits in boosted tree training based on type

### DIFF
--- a/include/maths/CBasicStatistics.h
+++ b/include/maths/CBasicStatistics.h
@@ -938,7 +938,7 @@ private:
         //! Initialize from a delimited string using \p fromString to initialize
         //! values of type T from a string.
         //!
-        //! \warning This functions must not use CBasicStatistics::INTERNAL_DELIMITER.
+        //! \warning This function must not use CBasicStatistics::EXTERNAL_DELIMITER.
         bool fromDelimited(const std::string& value, const TFromString& fromString);
 
         //! Convert to a delimited string.
@@ -947,7 +947,7 @@ private:
         //! Convert to a delimited string using \p toString to convert individual
         //! values of type T to a string.
         //!
-        //! \warning This functions must not use CBasicStatistics::INTERNAL_DELIMITER.
+        //! \warning This function must not use CBasicStatistics::EXTERNAL_DELIMITER.
         std::string toDelimited(const TToString& toString) const;
         //@}
 

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -99,6 +99,9 @@ private:
     //! as regressors.
     void selectFeaturesAndEncodeCategories(const core::CDataFrame& frame) const;
 
+    //! Determine the encoded feature types.
+    void determineFeatureDataTypes(const core::CDataFrame& frame) const;
+
     //! Initialize the regressors sample distribution.
     bool initializeFeatureSampleDistribution() const;
 

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -101,6 +101,7 @@ private:
     using TRowItr = core::CDataFrame::TRowItr;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
+    using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
 
     class CNode;
     using TNodeVec = std::vector<CNode>;
@@ -717,6 +718,7 @@ private:
     std::size_t m_RowsPerFeature = 50;
     double m_FeatureBagFraction = 0.5;
     double m_MaximumTreeSizeFraction = 1.0;
+    TDataTypeVec m_FeatureDataTypes;
     TDataFrameCategoryEncoderUPtr m_Encoder;
     TDoubleVec m_FeatureSampleProbabilities;
     TPackedBitVectorVec m_MissingFeatureRowMasks;

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -68,6 +68,21 @@ public:
     using TQuantileSketchVec = std::vector<CQuantileSketch>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
+    //! \brief Defines the data type of a collection of numbers.
+    struct MATHS_EXPORT SDataType {
+        static const char EXTERNAL_DELIMITER;
+        static const char INTERNAL_DELIMITER;
+
+        std::string toDelimited() const;
+        bool fromDelimited(const std::string& delimited);
+
+        bool s_IsInteger;
+        double s_Min;
+        double s_Max;
+    };
+
+    using TDataTypeVec = std::vector<SDataType>;
+
     //! \brief Used to extract the value from a specific column of the data frame.
     class MATHS_EXPORT CColumnValue {
     public:
@@ -183,6 +198,20 @@ public:
     //! \param[in] numberThreads The number of threads available.
     //! \param[in,out] frame The data frame whose columns are to be standardized.
     static bool standardizeColumns(std::size_t numberThreads, core::CDataFrame& frame);
+
+    //! Extract column data types.
+    //!
+    //! \param[in] numberThreads The number of threads available.
+    //! \param[in] frame The data frame whose columns are to be standardized.
+    //! \param[in] rowMask A mask of the rows from which to compute data types.
+    //! \param[in] columnMask A mask of the columns for which to compute data types.
+    //! \param[in] encoder If non-null used to encode the rows for which to compute
+    //! data types.
+    static TDataTypeVec columnDataTypes(std::size_t numberThreads,
+                                        const core::CDataFrame& frame,
+                                        const core::CPackedBitVector& rowMask,
+                                        const TSizeVec& columnMask,
+                                        const CDataFrameCategoryEncoder* encoder = nullptr);
 
     //! Get a quantile sketch of each column's values.
     //!

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -376,6 +376,11 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
         const auto& dataType = m_FeatureDataTypes[features[i]];
 
         if (dataType.s_IsInteger) {
+            // The key point here is that we know that if two distinct splits fall
+            // between two consecutive integers we know that they must produce
+            // identical partitions of the data and so always have the same loss.
+            // We only need to retain one such split for training. We achieve this
+            // by snapping to the midpoint and subsquently deduplicating.
             std::for_each(featureSplits.begin(), featureSplits.end(),
                           [](double& split) { split = std::floor(split) + 0.5; });
         }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -92,7 +92,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
     // We account for cost of setup as one round. The main optimisation loop runs
     // for "m_NumberRounds + 1" rounds and training on the choosen hyperparameter
     // values is counted as one round. This gives a total of m_NumberRounds + 3.
-    core::CLoopProgress progress{m_NumberRounds + 3, recordProgress};
+    core::CLoopProgress progress{m_NumberRounds + 3 - m_CurrentRound, recordProgress};
     progress.increment();
 
     if (this->canTrain() == false) {
@@ -340,10 +340,10 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
     LOG_TRACE(<< "binary features = " << core::CContainerPrinter::print(binaryFeatures)
               << " other features = " << core::CContainerPrinter::print(features));
 
-    TQuantileSketchVec columnQuantiles;
+    TQuantileSketchVec featureQuantiles;
     CDataFrameUtils::columnQuantiles(m_NumberThreads, frame, trainingRowMask, features,
                                      CQuantileSketch{CQuantileSketch::E_Linear, 100},
-                                     columnQuantiles, m_Encoder.get(), readLossCurvature);
+                                     featureQuantiles, m_Encoder.get(), readLossCurvature);
 
     TDoubleVecVec candidateSplits(this->numberFeatures());
 
@@ -354,23 +354,35 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
     }
     for (std::size_t i = 0; i < features.size(); ++i) {
 
-        TDoubleVec columnSplits;
-        columnSplits.reserve(m_NumberSplitsPerFeature - 1);
+        TDoubleVec featureSplits;
+        featureSplits.reserve(m_NumberSplitsPerFeature - 1);
 
         for (std::size_t j = 1; j < m_NumberSplitsPerFeature; ++j) {
             double rank{100.0 * static_cast<double>(j) /
                         static_cast<double>(m_NumberSplitsPerFeature)};
             double q;
-            if (columnQuantiles[i].quantile(rank, q)) {
-                columnSplits.push_back(q);
+            if (featureQuantiles[i].quantile(rank, q)) {
+                featureSplits.push_back(q);
             } else {
                 LOG_WARN(<< "Failed to compute quantile " << rank << ": ignoring split");
             }
         }
 
-        columnSplits.erase(std::unique(columnSplits.begin(), columnSplits.end()),
-                           columnSplits.end());
-        candidateSplits[features[i]] = std::move(columnSplits);
+        const auto& dataType = m_FeatureDataTypes[features[i]];
+
+        if (dataType.s_IsInteger) {
+            std::for_each(featureSplits.begin(), featureSplits.end(),
+                          [](double& split) { split = std::floor(split) + 0.5; });
+        }
+        featureSplits.erase(std::unique(featureSplits.begin(), featureSplits.end()),
+                            featureSplits.end());
+        featureSplits.erase(std::remove_if(featureSplits.begin(), featureSplits.end(),
+                                           [&dataType](double split) {
+                                               return split < dataType.s_Min ||
+                                                      split > dataType.s_Max;
+                                           }),
+                            featureSplits.end());
+        candidateSplits[features[i]] = std::move(featureSplits);
 
         LOG_TRACE(<< "feature '" << features[i] << "' splits = "
                   << core::CContainerPrinter::print(candidateSplits[features[i]]));
@@ -685,12 +697,13 @@ const std::string BEST_FOREST_TEST_LOSS_TAG{"best_forest_test_loss"};
 const std::string BEST_HYPERPARAMETERS_TAG{"best_hyperparameters"};
 const std::string CURRENT_ROUND_TAG{"current_round"};
 const std::string DEPENDENT_VARIABLE_TAG{"dependent_variable"};
+const std::string ENCODER_TAG{"encoder_tag"};
 const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
 const std::string ETA_OVERRIDE_TAG{"eta_override"};
 const std::string ETA_TAG{"eta"};
 const std::string FEATURE_BAG_FRACTION_OVERRIDE_TAG{"feature_bag_fraction_override"};
 const std::string FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
-const std::string ENCODER_TAG{"encoder_tag"};
+const std::string FEATURE_DATA_TYPES_TAG{"feature_data_types"};
 const std::string FEATURE_SAMPLE_PROBABILITIES_TAG{"feature_sample_probabilities"};
 const std::string GAMMA_OVERRIDE_TAG{"gamma_override"};
 const std::string GAMMA_TAG{"gamma"};
@@ -732,11 +745,12 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persist(BEST_FOREST_TEST_LOSS_TAG, m_BestForestTestLoss, inserter);
     core::CPersistUtils::persist(CURRENT_ROUND_TAG, m_CurrentRound, inserter);
     core::CPersistUtils::persist(DEPENDENT_VARIABLE_TAG, m_DependentVariable, inserter);
+    core::CPersistUtils::persist(ENCODER_TAG, *m_Encoder, inserter);
     core::CPersistUtils::persist(ETA_GROWTH_RATE_PER_TREE_TAG,
                                  m_EtaGrowthRatePerTree, inserter);
     core::CPersistUtils::persist(ETA_TAG, m_Eta, inserter);
     core::CPersistUtils::persist(FEATURE_BAG_FRACTION_TAG, m_FeatureBagFraction, inserter);
-    core::CPersistUtils::persist(ENCODER_TAG, *m_Encoder, inserter);
+    core::CPersistUtils::persist(FEATURE_DATA_TYPES_TAG, m_FeatureDataTypes, inserter);
     core::CPersistUtils::persist(FEATURE_SAMPLE_PROBABILITIES_TAG,
                                  m_FeatureSampleProbabilities, inserter);
     core::CPersistUtils::persist(GAMMA_TAG, m_Gamma, inserter);
@@ -859,6 +873,8 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
         RESTORE(DEPENDENT_VARIABLE_TAG,
                 core::CPersistUtils::restore(DEPENDENT_VARIABLE_TAG,
                                              m_DependentVariable, traverser))
+        RESTORE_NO_ERROR(ENCODER_TAG,
+                         m_Encoder = std::make_unique<CDataFrameCategoryEncoder>(traverser))
         RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
                 core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
                                              m_EtaGrowthRatePerTree, traverser))
@@ -866,8 +882,9 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
         RESTORE(FEATURE_BAG_FRACTION_TAG,
                 core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
                                              m_FeatureBagFraction, traverser))
-        RESTORE_NO_ERROR(ENCODER_TAG,
-                         m_Encoder = std::make_unique<CDataFrameCategoryEncoder>(traverser))
+        RESTORE(FEATURE_DATA_TYPES_TAG,
+                core::CPersistUtils::restore(FEATURE_DATA_TYPES_TAG,
+                                             m_FeatureDataTypes, traverser));
         RESTORE(FEATURE_SAMPLE_PROBABILITIES_TAG,
                 core::CPersistUtils::restore(FEATURE_SAMPLE_PROBABILITIES_TAG,
                                              m_FeatureSampleProbabilities, traverser))

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -377,10 +377,10 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
 
         if (dataType.s_IsInteger) {
             // The key point here is that we know that if two distinct splits fall
-            // between two consecutive integers we know that they must produce
-            // identical partitions of the data and so always have the same loss.
-            // We only need to retain one such split for training. We achieve this
-            // by snapping to the midpoint and subsquently deduplicating.
+            // between two consecutive integers they must produce identical partitions
+            // of the data and so always have the same loss. We only need to retain
+            // one such split for training. We achieve this by snapping to the midpoint
+            // and subsquently deduplicating.
             std::for_each(featureSplits.begin(), featureSplits.end(),
                           [](double& split) { split = std::floor(split) + 0.5; });
         }

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -100,6 +100,36 @@ auto computeEncodedCategory(CMic& mic,
 const std::size_t NUMBER_SAMPLES_TO_COMPUTE_MIC{10000};
 }
 
+std::string CDataFrameUtils::SDataType::toDelimited() const {
+    // clang-format off
+    return core::CStringUtils::typeToString(static_cast<int>(s_IsInteger)) +
+           INTERNAL_DELIMITER +
+           core::CStringUtils::typeToStringPrecise(s_Min, core::CIEEE754::E_DoublePrecision) +
+           INTERNAL_DELIMITER +
+           core::CStringUtils::typeToStringPrecise(s_Max, core::CIEEE754::E_DoublePrecision) +
+           INTERNAL_DELIMITER;
+    // clang-format on
+}
+
+bool CDataFrameUtils::SDataType::fromDelimited(const std::string& delimited) {
+    TDoubleVec state(3);
+    int pos{0}, i{0};
+    for (auto delimiter = delimited.find(INTERNAL_DELIMITER); delimiter != std::string::npos;
+         delimiter = delimited.find(INTERNAL_DELIMITER, pos)) {
+        if (core::CStringUtils::stringToType(delimited.substr(pos, delimiter - pos),
+                                             state[i++]) == false) {
+            return false;
+        }
+        pos = static_cast<int>(delimiter + 1);
+    }
+    std::tie(s_IsInteger, s_Min, s_Max) =
+        std::make_tuple(state[0] == 1.0, state[1], state[2]);
+    return true;
+}
+
+const char CDataFrameUtils::SDataType::INTERNAL_DELIMITER{':'};
+const char CDataFrameUtils::SDataType::EXTERNAL_DELIMITER{';'};
+
 bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataFrame& frame) {
 
     using TMeanVarAccumulatorVec =
@@ -158,6 +188,74 @@ bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataF
     };
 
     return frame.writeColumns(numberThreads, standardiseColumns).second;
+}
+
+CDataFrameUtils::TDataTypeVec
+CDataFrameUtils::columnDataTypes(std::size_t numberThreads,
+                                 const core::CDataFrame& frame,
+                                 const core::CPackedBitVector& rowMask,
+                                 const TSizeVec& columnMask,
+                                 const CDataFrameCategoryEncoder* encoder) {
+
+    if (frame.numberRows() == 0) {
+        return {};
+    }
+
+    using TMinMax = CBasicStatistics::CMinMax<double>;
+    using TMinMaxBoolPrVec = std::vector<std::pair<TMinMax, bool>>;
+
+    auto readDataTypes = core::bindRetrievableState(
+        [&](TMinMaxBoolPrVec& types, TRowItr beginRows, TRowItr endRows) {
+            double integerPart;
+            if (encoder != nullptr) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    CEncodedDataFrameRowRef encodedRow{encoder->encode(*row)};
+                    for (auto i : columnMask) {
+                        double value{encodedRow[i]};
+                        if (isMissing(value) == false) {
+                            types[i].first.add(value);
+                            types[i].second = types[i].second &&
+                                              (std::modf(value, &integerPart) == 0.0);
+                        }
+                    }
+                }
+            } else {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    for (auto i : columnMask) {
+                        double value{(*row)[i]};
+                        if (isMissing(value) == false) {
+                            types[i].first.add(value);
+                            types[i].second = types[i].second &&
+                                              (std::modf(value, &integerPart) == 0.0);
+                        }
+                    }
+                }
+            }
+        },
+        TMinMaxBoolPrVec(encoder != nullptr ? encoder->numberFeatures() : frame.numberColumns(),
+                         {TMinMax{}, true}));
+
+    auto copyDataTypes = [](TMinMaxBoolPrVec types, TMinMaxBoolPrVec& result) {
+        result = std::move(types);
+    };
+    auto reduceDataTypes = [&](TMinMaxBoolPrVec types, TMinMaxBoolPrVec& result) {
+        for (auto i : columnMask) {
+            result[i].first += types[i].first;
+            result[i].second = result[i].second && types[i].second;
+        }
+    };
+
+    TMinMaxBoolPrVec types;
+    doReduce(frame.readRows(numberThreads, 0, frame.numberRows(), readDataTypes, &rowMask),
+             copyDataTypes, reduceDataTypes, types);
+
+    TDataTypeVec result(types.size());
+    for (auto i : columnMask) {
+        result[i] = SDataType{types[i].second, types[i].first.min(),
+                              types[i].first.max()};
+    }
+
+    return result;
 }
 
 bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -197,14 +197,14 @@ void CBoostedTreeTest::testPiecewiseConstant() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.9);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.92);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.93);
 }
 
 void CBoostedTreeTest::testLinear() {
@@ -252,7 +252,7 @@ void CBoostedTreeTest::testLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
 
@@ -319,7 +319,7 @@ void CBoostedTreeTest::testNonLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.92);
 
@@ -602,8 +602,50 @@ void CBoostedTreeTest::testCategoricalRegressors() {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.1);
-    CPPUNIT_ASSERT(modelRSquared > 0.9);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.05);
+    CPPUNIT_ASSERT(modelRSquared > 0.99);
+}
+
+void CBoostedTreeTest::testIntegerRegressor() {
+
+    // Test a simple integer regressor.
+
+    test::CRandomNumbers rng;
+
+    std::size_t trainRows{1000};
+    std::size_t testRows{200};
+    std::size_t rows{trainRows + testRows};
+
+    auto frame = core::makeMainStorageDataFrame(2).first;
+
+    frame->categoricalColumns({false, false});
+    for (std::size_t i = 0; i < rows; ++i) {
+        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            TDoubleVec regressor;
+            rng.generateUniformSamples(1.0, 4.0, 1, regressor);
+            *(column++) = std::floor(regressor[0]);
+            *column = i < trainRows ? 10.0 * std::floor(regressor[0])
+                                    : core::CDataFrame::valueOfMissing();
+        });
+    }
+    frame->finishWritingRows();
+
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .buildFor(*frame, 1);
+
+    regression->train();
+    regression->predict();
+
+    double modelBias;
+    double modelRSquared;
+    std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
+        *frame, trainRows, rows,
+        regression->columnHoldingPrediction(frame->numberColumns()),
+        [&](const TRowRef& x) { return 10.0 * x[0]; }, 0.0);
+
+    LOG_DEBUG(<< "bias = " << modelBias);
+    LOG_DEBUG(<< " R^2 = " << modelRSquared);
 }
 
 void CBoostedTreeTest::testProgressMonitoring() {
@@ -851,6 +893,8 @@ CppUnit::Test* CBoostedTreeTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testCategoricalRegressors",
         &CBoostedTreeTest::testCategoricalRegressors));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testIntegerRegressor", &CBoostedTreeTest::testIntegerRegressor));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testProgressMonitoring", &CBoostedTreeTest::testProgressMonitoring));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -197,7 +197,7 @@ void CBoostedTreeTest::testPiecewiseConstant() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.9);
 
@@ -252,7 +252,7 @@ void CBoostedTreeTest::testLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
 
@@ -602,8 +602,8 @@ void CBoostedTreeTest::testCategoricalRegressors() {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.05);
-    CPPUNIT_ASSERT(modelRSquared > 0.99);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.15);
+    CPPUNIT_ASSERT(modelRSquared > 0.9);
 }
 
 void CBoostedTreeTest::testIntegerRegressor() {
@@ -646,6 +646,8 @@ void CBoostedTreeTest::testIntegerRegressor() {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, modelBias, 0.05);
+    CPPUNIT_ASSERT(modelRSquared > 0.99);
 }
 
 void CBoostedTreeTest::testProgressMonitoring() {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -858,7 +858,7 @@ CppUnit::Test* CBoostedTreeTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testPersistRestore", &CBoostedTreeTest::testPersistRestore));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
-        "CBoostedTreeTest::testErrors", &CBoostedTreeTest::testRestoreErrorHandling));
+        "CBoostedTreeTest::testRestoreErrorHandling", &CBoostedTreeTest::testRestoreErrorHandling));
 
     return suiteOfTests;
 }

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -18,6 +18,7 @@ public:
     void testConstantFeatures();
     void testConstantTarget();
     void testCategoricalRegressors();
+    void testIntegerRegressor();
     void testProgressMonitoring();
     void testMissingData();
     // TODO void testFeatureWeights();

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -57,6 +57,107 @@ auto generateCategoricalData(test::CRandomNumbers& rng,
 
     return std::make_pair(frequencies, values);
 }
+
+core::CPackedBitVector maskAll(std::size_t rows) {
+    return {rows, true};
+}
+}
+
+void CDataFrameUtilsTest::testColumnDataTypes() {
+
+    test::CRandomNumbers rng;
+
+    std::size_t rows{2000};
+    std::size_t cols{4};
+
+    TFactoryFunc makeOnDisk{[=] {
+        return core::makeDiskStorageDataFrame(test::CTestTmpDir::tmpDir(), cols, rows)
+            .first;
+    }};
+    TFactoryFunc makeMainMemory{
+        [=] { return core::makeMainStorageDataFrame(cols).first; }};
+
+    TSizeVec columnMask(cols);
+    std::iota(columnMask.begin(), columnMask.end(), 0);
+
+    core::stopDefaultAsyncExecutor();
+
+    for (auto threads : {1, 2}) {
+        for (const auto& factory : {makeOnDisk, makeMainMemory}) {
+
+            auto frame = factory();
+
+            double min{0.0};
+            double max{10.0};
+            maths::CDataFrameUtils::TDataTypeVec expectedTypes{
+                {true, max, min}, {false, max, min}, {false, max, min}, {false, max, min}};
+
+            for (std::size_t i = 0; i < rows; ++i) {
+                frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                    TDoubleVec values;
+                    rng.generateUniformSamples(min, max, cols, values);
+                    *(column++) = std::floor(values[0]);
+                    expectedTypes[0].s_Min =
+                        std::min(expectedTypes[0].s_Min, std::floor(values[0]));
+                    expectedTypes[0].s_Max =
+                        std::max(expectedTypes[0].s_Max, std::floor(values[0]));
+                    for (std::size_t j = 1; j < cols; ++j, ++column) {
+                        *column = values[j];
+                        expectedTypes[j].s_Min =
+                            std::min(maths::CFloatStorage{expectedTypes[j].s_Min},
+                                     maths::CFloatStorage{values[j]});
+                        expectedTypes[j].s_Max =
+                            std::max(maths::CFloatStorage{expectedTypes[j].s_Max},
+                                     maths::CFloatStorage{values[j]});
+                    }
+                });
+            }
+            frame->finishWritingRows();
+
+            maths::CDataFrameUtils::TDataTypeVec actualTypes(maths::CDataFrameUtils::columnDataTypes(
+                threads, *frame, maskAll(rows), columnMask));
+
+            // Round trip the expected types to a string to check persistence.
+
+            maths::CDataFrameUtils::TDataTypeVec restoredTypes;
+            std::string delimitedCollection{core::CPersistUtils::toString(
+                expectedTypes,
+                [](const auto& type) { return type.toDelimited(); },
+                maths::CDataFrameUtils::SDataType::EXTERNAL_DELIMITER)};
+            LOG_DEBUG(<< "delimited = " << delimitedCollection);
+            CPPUNIT_ASSERT(core::CPersistUtils::fromString(
+                delimitedCollection,
+                [](const std::string& delimited, auto& type) {
+                    return type.fromDelimited(delimited);
+                },
+                restoredTypes, maths::CDataFrameUtils::SDataType::EXTERNAL_DELIMITER));
+
+            CPPUNIT_ASSERT_EQUAL(expectedTypes.size(), actualTypes.size());
+            for (std::size_t i = 0; i < expectedTypes.size(); ++i) {
+                double eps{100.0 * std::numeric_limits<double>::epsilon()};
+                CPPUNIT_ASSERT_EQUAL(expectedTypes[i].s_IsInteger,
+                                     actualTypes[i].s_IsInteger);
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedTypes[i].s_Min,
+                                             actualTypes[i].s_Min,
+                                             eps * expectedTypes[i].s_Min);
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedTypes[i].s_Max,
+                                             actualTypes[i].s_Max,
+                                             eps * expectedTypes[i].s_Max);
+                CPPUNIT_ASSERT_EQUAL(expectedTypes[i].s_IsInteger,
+                                     restoredTypes[i].s_IsInteger);
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedTypes[i].s_Min,
+                                             restoredTypes[i].s_Min,
+                                             eps * expectedTypes[i].s_Min);
+                CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedTypes[i].s_Max,
+                                             restoredTypes[i].s_Max,
+                                             eps * expectedTypes[i].s_Max);
+            }
+        }
+
+        core::startDefaultAsyncExecutor();
+    }
+
+    core::stopDefaultAsyncExecutor();
 }
 
 void CDataFrameUtilsTest::testStandardizeColumns() {
@@ -190,7 +291,6 @@ void CDataFrameUtilsTest::testColumnQuantiles() {
     TFactoryFunc makeMainMemory{
         [=] { return core::makeMainStorageDataFrame(cols, capacity).first; }};
 
-    core::CPackedBitVector rowMask{rows, true};
     TSizeVec columnMask(cols);
     std::iota(columnMask.begin(), columnMask.end(), 0);
 
@@ -215,7 +315,7 @@ void CDataFrameUtilsTest::testColumnQuantiles() {
             maths::CQuantileSketch sketch{maths::CQuantileSketch::E_Linear, 100};
             TQuantileSketchVec actualQuantiles;
             CPPUNIT_ASSERT(maths::CDataFrameUtils::columnQuantiles(
-                threads, *frame, rowMask, columnMask, sketch, actualQuantiles));
+                threads, *frame, maskAll(rows), columnMask, sketch, actualQuantiles));
 
             // Check the quantile sketches match.
 
@@ -298,9 +398,8 @@ void CDataFrameUtilsTest::testColumnQuantilesWithEncoding() {
     frame->finishWritingRows();
 
     maths::CDataFrameCategoryEncoder encoder{
-        1, *frame, core::CPackedBitVector{rows, true}, {1, 2, 3, 4, 5}, 0, 50};
+        1, *frame, maskAll(rows), {1, 2, 3, 4, 5}, 0, 50};
 
-    core::CPackedBitVector rowMask{rows, true};
     TSizeVec columnMask(encoder.numberFeatures());
     std::iota(columnMask.begin(), columnMask.end(), 0);
 
@@ -318,7 +417,7 @@ void CDataFrameUtilsTest::testColumnQuantilesWithEncoding() {
     TQuantileSketchVec actualQuantiles;
     maths::CQuantileSketch sketch{maths::CQuantileSketch::E_Linear, 100};
     CPPUNIT_ASSERT(maths::CDataFrameUtils::columnQuantiles(
-        1, *frame, rowMask, columnMask, sketch, actualQuantiles, &encoder));
+        1, *frame, maskAll(rows), columnMask, sketch, actualQuantiles, &encoder));
 
     for (std::size_t i = 5; i < 100; i += 5) {
         for (std::size_t feature = 0; feature < columnMask.size(); ++feature) {
@@ -338,8 +437,6 @@ void CDataFrameUtilsTest::testMicWithColumn() {
     std::size_t capacity{500};
     std::size_t numberRows{2000};
     std::size_t numberCols{4};
-
-    core::CPackedBitVector rowMask{numberRows, true};
 
     TFactoryFunc makeOnDisk{[=] {
         return core::makeDiskStorageDataFrame(test::CTestTmpDir::tmpDir(),
@@ -385,7 +482,8 @@ void CDataFrameUtilsTest::testMicWithColumn() {
         }
 
         TDoubleVec actual(maths::CDataFrameUtils::metricMicWithColumn(
-            maths::CDataFrameUtils::CMetricColumnValue{3}, *frame, rowMask, {0, 1, 2}));
+            maths::CDataFrameUtils::CMetricColumnValue{3}, *frame,
+            maskAll(numberRows), {0, 1, 2}));
 
         LOG_DEBUG(<< "expected = " << core::CContainerPrinter::print(expected));
         LOG_DEBUG(<< "actual   = " << core::CContainerPrinter::print(actual));
@@ -440,7 +538,8 @@ void CDataFrameUtilsTest::testMicWithColumn() {
         }
 
         TDoubleVec actual(maths::CDataFrameUtils::metricMicWithColumn(
-            maths::CDataFrameUtils::CMetricColumnValue{3}, *frame, rowMask, {0, 1, 2}));
+            maths::CDataFrameUtils::CMetricColumnValue{3}, *frame,
+            maskAll(numberRows), {0, 1, 2}));
 
         LOG_DEBUG(<< "expected = " << core::CContainerPrinter::print(expected));
         LOG_DEBUG(<< "actual   = " << core::CContainerPrinter::print(actual));
@@ -489,7 +588,7 @@ void CDataFrameUtilsTest::testCategoryFrequencies() {
             frame->finishWritingRows();
 
             TDoubleVecVec actualFrequencies{maths::CDataFrameUtils::categoryFrequencies(
-                threads, *frame, core::CPackedBitVector{rows, true}, {0, 1, 2, 3})};
+                threads, *frame, maskAll(rows), {0, 1, 2, 3})};
 
             CPPUNIT_ASSERT_EQUAL(std::size_t{4}, actualFrequencies.size());
             for (std::size_t i : {0, 2}) {
@@ -566,7 +665,7 @@ void CDataFrameUtilsTest::testMeanValueOfTargetForCategories() {
 
             TDoubleVecVec actualMeans(maths::CDataFrameUtils::meanValueOfTargetForCategories(
                 maths::CDataFrameUtils::CMetricColumnValue{3}, threads, *frame,
-                core::CPackedBitVector{rows, true}, {0, 1, 2}));
+                maskAll(rows), {0, 1, 2}));
 
             CPPUNIT_ASSERT_EQUAL(std::size_t{4}, actualMeans.size());
             for (std::size_t i : {0, 2}) {
@@ -635,7 +734,7 @@ void CDataFrameUtilsTest::testCategoryMicWithColumn() {
 
             auto mics = maths::CDataFrameUtils::categoricalMicWithColumn(
                 maths::CDataFrameUtils::CMetricColumnValue{3}, threads, *frame,
-                core::CPackedBitVector{rows, true}, {0, 1, 2},
+                maskAll(rows), {0, 1, 2},
                 {{[](std::size_t, std::size_t sampleColumn, std::size_t category) {
                       return std::make_unique<maths::CDataFrameUtils::COneHotCategoricalColumnValue>(
                           sampleColumn, category);
@@ -680,6 +779,8 @@ void CDataFrameUtilsTest::testCategoryMicWithColumn() {
 CppUnit::Test* CDataFrameUtilsTest::suite() {
     CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CDataFrameUtilsTest");
 
+    suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameUtilsTest>(
+        "CDataFrameUtilsTest::testColumnDataTypes", &CDataFrameUtilsTest::testColumnDataTypes));
     suiteOfTests->addTest(new CppUnit::TestCaller<CDataFrameUtilsTest>(
         "CDataFrameUtilsTest::testStandardizeColumns",
         &CDataFrameUtilsTest::testStandardizeColumns));

--- a/lib/maths/unittest/CDataFrameUtilsTest.h
+++ b/lib/maths/unittest/CDataFrameUtilsTest.h
@@ -11,6 +11,7 @@
 
 class CDataFrameUtilsTest : public CppUnit::TestFixture {
 public:
+    void testColumnDataTypes();
     void testStandardizeColumns();
     void testColumnQuantiles();
     void testColumnQuantilesWithEncoding();


### PR DESCRIPTION
This change detects if a feature comprises exclusively integers and also computes the feature range on the training set. For integer valued data we should be splitting at `n + 0.5` for `n` integer valued. Also we should never include splits which are less (greater) than the smallest (largest) feature value. This allows us to significantly prune candidate splits in cases where a feature only takes a small number of distinct integer values.

I also improved the exit condition from the loop which adds trees: it was exiting with significant bias on the training set in some cases.