### PR TITLE
[ML] Add some missing boosted tree state initialisation

### DIFF
--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -254,15 +254,23 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) con
         LOG_TRACE(<< "loss = " << L[1] << ", # leaves = " << T[1]
                   << ", sum square weights = " << W[1]);
 
+        // If we can't improve the loss with no regularisation on the train set
+        // we're not going to be able to make much headway! In this case we just
+        // force the regularisation parameters to zero and don't try to optimise
+        // them.
         double scale{static_cast<double>(m_TreeImpl->m_NumberFolds - 1) /
                      static_cast<double>(m_TreeImpl->m_NumberFolds)};
-        double lambda{scale * std::max((L[0] - L[1]) / (W[1] - W[0]), 0.0) / 5.0};
-        double gamma{scale * std::max((L[0] - L[1]) / (T[1] - T[0]), 0.0) / 5.0};
+        double lambda{scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (W[1] - W[0])) / 5.0};
+        double gamma{scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (T[1] - T[0])) / 5.0};
 
-        if (m_TreeImpl->m_LambdaOverride == boost::none) {
+        if (lambda == 0.0) {
+            m_TreeImpl->m_LambdaOverride = lambda;
+        } else if (m_TreeImpl->m_LambdaOverride == boost::none) {
             m_TreeImpl->m_Lambda = m_TreeImpl->m_GammaOverride ? lambda : 0.5 * lambda;
         }
-        if (m_TreeImpl->m_GammaOverride == boost::none) {
+        if (gamma == 0.0) {
+            m_TreeImpl->m_GammaOverride = gamma;
+        } else if (m_TreeImpl->m_GammaOverride == boost::none) {
             m_TreeImpl->m_Gamma = m_TreeImpl->m_LambdaOverride ? gamma : 0.5 * gamma;
         }
         LOG_TRACE(<< "lambda(initial) = " << m_TreeImpl->m_Lambda

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -69,7 +69,8 @@ void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(const CEncodedData
 }
 
 CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads, CBoostedTree::TLossFunctionUPtr loss)
-    : m_NumberThreads{numberThreads}, m_Loss{std::move(loss)} {
+    : m_NumberThreads{numberThreads}, m_Loss{std::move(loss)},
+      m_BestHyperparameters{m_Lambda, m_Gamma, m_Eta, m_EtaGrowthRatePerTree, m_FeatureBagFraction, m_FeatureSampleProbabilities} {
 }
 
 CBoostedTreeImpl::CBoostedTreeImpl() = default;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -739,7 +739,7 @@ void CBoostedTreeTest::testPersistRestore() {
     std::stringstream persistOnceSStream;
     std::stringstream persistTwiceSStream;
 
-    // generate completely random data
+    // Generate completely random data.
     TDoubleVecVec x(cols);
     for (std::size_t i = 0; i < cols; ++i) {
         rng.generateUniformSamples(0.0, 10.0, rows, x[i]);


### PR DESCRIPTION
This also handles the case that we can't improve the loss on the train set with no regularisation. This ought not to be possible, at least for MSE, except for a constant zero target or regressors which we handle as a special case. However, to be safe we force the regularisation parameters to zero in this case, which should be harmless.

Closes #611.