### PR TITLE
[ML] Boosted tree training performance improvements

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,14 @@
 
 //=== Regressions
 
+== {es} version 7.5.0
+
+=== Enhancements
+
+* Improve performance and concurrency training boosted tree regression model.
+For large data sets this was observed to give a 10% to 20% decrease in train
+time. (See {ml-pull}622[#622].)
+
 == {es} version 7.4.0
 
 === Bug Fixes

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -32,9 +32,9 @@
 
 === Enhancements
 
-* Improve performance and concurrency training boosted tree regression model.
-For large data sets this was observed to give a 10% to 20% decrease in train
-time. (See {ml-pull}622[#622].)
+* Improve performance and concurrency training boosted tree regression models.
+For large data sets this change was observed to give a 10% to 20% decrease in
+train time. (See {ml-pull}622[#622].)
 
 == {es} version 7.4.0
 

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -17,7 +17,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <thread>
 
 namespace ml {
 namespace maths {
@@ -28,7 +27,7 @@ public:
     virtual ~CArgMinLoss() = default;
 
     //! Update with a point prediction and actual value.
-    void add(double prediction, double actual);
+    virtual void add(double prediction, double actual) = 0;
 
     //! Returns the value at the node which minimises the loss for the
     //! at the predictions added.
@@ -36,12 +35,6 @@ public:
     //! Formally, returns \f$x^* = arg\min_x\{\sum_i{L(p_i + x, a_i)}\}\f$
     //! for predictions and actuals \f$p_i\f$ and \f$a_i\f$, respectively.
     virtual double value() const = 0;
-
-private:
-    virtual void addImpl(double prediction, double actual) = 0;
-
-private:
-    std::mutex m_Mutex;
 };
 
 //! \brief Defines the loss function for the regression problem.
@@ -68,13 +61,11 @@ public:
 //! \brief Finds the leaf node value which minimises the MSE.
 class MATHS_EXPORT CArgMinMse final : public CArgMinLoss {
 public:
+    void add(double prediction, double actual) override;
     double value() const override;
 
 private:
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
-
-private:
-    void addImpl(double prediction, double actual) override;
 
 private:
     TMeanAccumulator m_MeanError;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -207,7 +207,10 @@ private:
             auto result = frame.readRows(
                 numberThreads, 0, frame.numberRows(),
                 core::bindRetrievableState(
-                    [&](core::CPackedBitVector& leftRowMask, TRowItr beginRows, TRowItr endRows) {
+                    [&](auto& state, TRowItr beginRows, TRowItr endRows) {
+                        core::CPackedBitVector& leftRowMask{std::get<0>(state)};
+                        std::size_t& leftCount{std::get<1>(state)};
+                        std::size_t& rightCount{std::get<2>(state)};
                         for (auto row = beginRows; row != endRows; ++row) {
                             std::size_t index{row->index()};
                             double value{encoder.encode(*row)[m_SplitFeature]};
@@ -216,20 +219,29 @@ private:
                                 (missing == false && value < m_SplitValue)) {
                                 leftRowMask.extend(false, index - leftRowMask.size());
                                 leftRowMask.extend(true);
+                                ++leftCount;
+                            } else {
+                                ++rightCount;
                             }
                         }
                     },
-                    core::CPackedBitVector{}),
+                    std::make_tuple(core::CPackedBitVector{}, std::size_t{0}, std::size_t{0})),
                 &rowMask);
+            auto& masks = result.first;
 
-            for (auto& mask : result.first) {
-                mask.s_FunctionState.extend(
-                    false, rowMask.size() - mask.s_FunctionState.size());
+            for (auto& mask_ : masks) {
+                auto& mask = std::get<0>(mask_.s_FunctionState);
+                mask.extend(false, rowMask.size() - mask.size());
             }
 
-            core::CPackedBitVector leftRowMask{std::move(result.first[0].s_FunctionState)};
-            for (std::size_t i = 1; i < result.first.size(); ++i) {
-                leftRowMask |= result.first[i].s_FunctionState;
+            core::CPackedBitVector leftRowMask;
+            std::size_t leftCount;
+            std::size_t rightCount;
+            std::tie(leftRowMask, leftCount, rightCount) = std::move(masks[0].s_FunctionState);
+            for (std::size_t i = 1; i < masks.size(); ++i) {
+                leftRowMask |= std::get<0>(masks[i].s_FunctionState);
+                leftCount += std::get<1>(masks[i].s_FunctionState);
+                rightCount += std::get<2>(masks[i].s_FunctionState);
             }
             LOG_TRACE(<< "# rows in left node = " << leftRowMask.manhattan());
             LOG_TRACE(<< "left row mask = " << leftRowMask);
@@ -239,7 +251,8 @@ private:
             LOG_TRACE(<< "# rows in right node = " << rightRowMask.manhattan());
             LOG_TRACE(<< "left row mask = " << rightRowMask);
 
-            return std::make_pair(std::move(leftRowMask), std::move(rightRowMask));
+            return std::make_tuple(std::move(leftRowMask), std::move(rightRowMask),
+                                   leftCount < rightCount);
         }
 
         //! Get a human readable description of this tree.
@@ -365,12 +378,13 @@ private:
                    const TDoubleVecVec& candidateSplits,
                    TSizeVec featureBag,
                    core::CPackedBitVector leftChildRowMask,
-                   core::CPackedBitVector rightChildRowMask) {
+                   core::CPackedBitVector rightChildRowMask,
+                   bool leftChildHasFewerRows) {
 
-            if (leftChildRowMask.manhattan() < rightChildRowMask.manhattan()) {
+            if (leftChildHasFewerRows) {
                 auto leftChild = std::make_shared<CLeafNodeStatistics>(
-                    leftChildId, numberThreads, frame, encoder, lambda, gamma,
-                    candidateSplits, featureBag, std::move(leftChildRowMask));
+                    leftChildId, numberThreads, frame, encoder, lambda, gamma, candidateSplits,
+                    std::move(featureBag), std::move(leftChildRowMask));
                 auto rightChild = std::make_shared<CLeafNodeStatistics>(
                     rightChildId, *this, *leftChild, std::move(rightChildRowMask));
 
@@ -379,7 +393,7 @@ private:
 
             auto rightChild = std::make_shared<CLeafNodeStatistics>(
                 rightChildId, numberThreads, frame, encoder, lambda, gamma,
-                candidateSplits, featureBag, std::move(rightChildRowMask));
+                candidateSplits, std::move(featureBag), std::move(rightChildRowMask));
             auto leftChild = std::make_shared<CLeafNodeStatistics>(
                 leftChildId, *this, *rightChild, std::move(leftChildRowMask));
 
@@ -489,6 +503,23 @@ private:
                 }
             }
 
+            void merge(const SDerivatives& other) {
+                for (std::size_t i = 0; i < s_Gradients.size(); ++i) {
+                    for (std::size_t j = 0; j < s_Gradients[i].size(); ++j) {
+                        s_Gradients[i][j] += other.s_Gradients[i][j];
+                        s_Curvatures[i][j] += other.s_Curvatures[i][j];
+                    }
+                    s_MissingGradients[i] += other.s_MissingGradients[i];
+                    s_MissingCurvatures[i] += other.s_MissingCurvatures[i];
+                }
+            }
+
+            auto move() {
+                return std::make_tuple(std::move(s_Gradients), std::move(s_Curvatures),
+                                       std::move(s_MissingGradients),
+                                       std::move(s_MissingCurvatures));
+            }
+
             TDoubleVecVec s_Gradients;
             TDoubleVecVec s_Curvatures;
             TDoubleVec s_MissingGradients;
@@ -503,33 +534,21 @@ private:
             auto result = frame.readRows(
                 numberThreads, 0, frame.numberRows(),
                 core::bindRetrievableState(
-                    [&](SDerivatives& state, TRowItr beginRows, TRowItr endRows) {
+                    [&](SDerivatives& derivatives, TRowItr beginRows, TRowItr endRows) {
                         for (auto row = beginRows; row != endRows; ++row) {
-                            this->addRowDerivatives(encoder.encode(*row), state);
+                            this->addRowDerivatives(encoder.encode(*row), derivatives);
                         }
                     },
                     SDerivatives{m_CandidateSplits}),
                 &m_RowMask);
 
-            auto& results = result.first;
-
-            m_Gradients = std::move(results[0].s_FunctionState.s_Gradients);
-            m_Curvatures = std::move(results[0].s_FunctionState.s_Curvatures);
-            m_MissingGradients = std::move(results[0].s_FunctionState.s_MissingGradients);
-            m_MissingCurvatures = std::move(results[0].s_FunctionState.s_MissingCurvatures);
-
-            for (std::size_t k = 1; k < results.size(); ++k) {
-                const auto& derivatives = results[k].s_FunctionState;
-                for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
-                    std::size_t numberSplits{m_CandidateSplits[i].size() + 1};
-                    for (std::size_t j = 0; j < numberSplits; ++j) {
-                        m_Gradients[i][j] += derivatives.s_Gradients[i][j];
-                        m_Curvatures[i][j] += derivatives.s_Curvatures[i][j];
-                    }
-                    m_MissingGradients[i] += derivatives.s_MissingGradients[i];
-                    m_MissingCurvatures[i] += derivatives.s_MissingCurvatures[i];
-                }
+            SDerivatives derivatives{std::move(result.first[0].s_FunctionState)};
+            for (std::size_t i = 1; i < result.first.size(); ++i) {
+                derivatives.merge(result.first[i].s_FunctionState);
             }
+
+            std::tie(m_Gradients, m_Curvatures, m_MissingGradients,
+                     m_MissingCurvatures) = derivatives.move();
 
             LOG_TRACE(<< "gradients = " << core::CContainerPrinter::print(m_Gradients));
             LOG_TRACE(<< "curvatures = " << core::CContainerPrinter::print(m_Curvatures));

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -61,7 +61,7 @@ public:
     }
 
     //! Get the underlying row reference.
-    const TRowRef& unencodedRow() const;
+    const TRowRef& unencodedRow() const { return m_Row; }
 
 private:
     TRowRef m_Row;

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -21,11 +21,6 @@ using namespace boosted_tree_detail;
 
 namespace boosted_tree {
 
-void CArgMinLoss::add(double prediction, double actual) {
-    std::unique_lock<std::mutex> lock{m_Mutex};
-    this->addImpl(prediction, actual);
-}
-
 double CMse::value(double prediction, double actual) const {
     return CTools::pow2(prediction - actual);
 }
@@ -48,7 +43,7 @@ const std::string& CMse::name() const {
     return NAME;
 }
 
-void CArgMinMse::addImpl(double prediction, double actual) {
+void CArgMinMse::add(double prediction, double actual) {
     m_MeanError.add(actual - prediction);
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -87,18 +87,21 @@ void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(const CEncodedData
                                                               SDerivatives& derivatives) const {
 
     const TRowRef& unencodedRow{row.unencodedRow()};
+    double gradient{readLossGradient(unencodedRow)};
+    double curvature{readLossCurvature(unencodedRow)};
 
     for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
         double featureValue{row[i]};
         if (CDataFrameUtils::isMissing(featureValue)) {
-            derivatives.s_MissingGradients[i] += readLossGradient(unencodedRow);
-            derivatives.s_MissingCurvatures[i] += readLossCurvature(unencodedRow);
+            derivatives.s_MissingGradients[i] += gradient;
+            derivatives.s_MissingCurvatures[i] += curvature;
         } else {
-            auto j = std::upper_bound(m_CandidateSplits[i].begin(),
-                                      m_CandidateSplits[i].end(), featureValue) -
-                     m_CandidateSplits[i].begin();
-            derivatives.s_Gradients[i][j] += readLossGradient(unencodedRow);
-            derivatives.s_Curvatures[i][j] += readLossCurvature(unencodedRow);
+            const auto& featureCandidateSplits = m_CandidateSplits[i];
+            auto j = std::upper_bound(featureCandidateSplits.begin(),
+                                      featureCandidateSplits.end(), featureValue) -
+                     featureCandidateSplits.begin();
+            derivatives.s_Gradients[i][j] += gradient;
+            derivatives.s_Curvatures[i][j] += curvature;
         }
     }
 }
@@ -532,15 +535,18 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
             core::CPackedBitVector leftChildRowMask;
             core::CPackedBitVector rightChildRowMask;
-            std::tie(leftChildRowMask, rightChildRowMask) = tree[leaf->id()].rowMasks(
-                m_NumberThreads, frame, *m_Encoder, std::move(leaf->rowMask()));
+            bool leftChildHasFewerRows;
+            std::tie(leftChildRowMask, rightChildRowMask, leftChildHasFewerRows) =
+                tree[leaf->id()].rowMasks(m_NumberThreads, frame, *m_Encoder,
+                                          std::move(leaf->rowMask()));
 
             TLeafNodeStatisticsPtr leftChild;
             TLeafNodeStatisticsPtr rightChild;
-            std::tie(leftChild, rightChild) = leaf->split(
-                leftChildId, rightChildId, m_NumberThreads, frame, *m_Encoder,
-                m_Lambda, m_Gamma, candidateSplits, std::move(featureBag),
-                std::move(leftChildRowMask), std::move(rightChildRowMask));
+            std::tie(leftChild, rightChild) =
+                leaf->split(leftChildId, rightChildId, m_NumberThreads, frame,
+                            *m_Encoder, m_Lambda, m_Gamma, candidateSplits,
+                            std::move(featureBag), std::move(leftChildRowMask),
+                            std::move(rightChildRowMask), leftChildHasFewerRows);
 
             scopeMemoryUsage.add(leftChild);
             scopeMemoryUsage.add(rightChild);
@@ -600,10 +606,11 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
     frame.readRows(
         1, 0, frame.numberRows(),
         [&](TRowItr beginRows, TRowItr endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                double prediction{readPrediction(*row)};
-                double actual{readActual(*row, m_DependentVariable)};
-                leafValues[root(tree).leafIndex(m_Encoder->encode(*row), tree)]->add(
+            for (auto itr = beginRows; itr != endRows; ++itr) {
+                const TRowRef& row{*itr};
+                double prediction{readPrediction(row)};
+                double actual{readActual(row, m_DependentVariable)};
+                leafValues[root(tree).leafIndex(m_Encoder->encode(row), tree)]->add(
                     prediction, actual);
             }
         },

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -246,10 +246,6 @@ std::size_t CEncodedDataFrameRowRef::numberColumns() const {
     return m_Encoder->numberFeatures();
 }
 
-const CEncodedDataFrameRowRef::TRowRef& CEncodedDataFrameRowRef::unencodedRow() const {
-    return m_Row;
-}
-
 CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(std::size_t numberThreads,
                                                      const core::CDataFrame& frame,
                                                      const core::CPackedBitVector& rowMask,


### PR DESCRIPTION
Profiling showed up a couple of performance improvements:
1. We can calculate the node with the fewest rows more efficiently when refreshing derivative statistics
2. We benefit from inlining and a couple of small tweaks in one of the bottleneck functions `addRowDerivatives`

It also showed it is worthwhile threading the calculation of the leaf values which minimise the prediction errors. This required a refactor of `CArgMinLoss` so that we can get a copyable polymorphic type. I've wrapped up its implementation to achieve this.