### PR TITLE
[ML] Improvements to boosted tree training hyperparameter optimisation loop

### DIFF
--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -82,6 +82,11 @@ public:
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
+    //! Estimate the maximum booking memory used by this class for optimising
+    //! \p numberParameters using \p numberRounds rounds.
+    static std::size_t estimateMemoryUsage(std::size_t numberParameters,
+                                           std::size_t numberRounds);
+
     //! \name Test Interface
     //@{
     //! Get minus the data likelihood and its gradient as a function of the kernel

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -448,12 +448,11 @@ private:
                 static_cast<std::size_t>(std::ceil(
                     featureBagFraction * static_cast<double>(numberCols - 1))) *
                 sizeof(std::size_t)};
-            // 256 is the number of rows encoded by a single byte in the packed bit
-            // vector assuming best compression. We will typically get this for most
-            // of the leaves when the set of splits becomes large, corresponding to
-            // the worst case for memory usage. This is because the masks will mainly
-            // contain 0 bits in this case.
-            std::size_t rowMaskSize{numberRows / 256};
+            // We will typically get the close to the best compression for most of the
+            // leaves when the set of splits becomes large, corresponding to the worst
+            // case for memory usage. This is because the rows will be spread over many
+            // rows so the masks will mainly contain 0 bits in this case.
+            std::size_t rowMaskSize{numberRows / PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
             std::size_t gradientsSize{(numberCols - 1) *
                                       numberSplitsPerFeature * sizeof(double)};
             std::size_t curvatureSize{gradientsSize};
@@ -644,6 +643,11 @@ private:
         TDoubleVec m_MissingCurvatures;
         mutable boost::optional<SSplitStatistics> m_BestSplit;
     };
+
+private:
+    // The maximum number of rows encoded by a single byte in the packed bit
+    // vector assuming best compression.
+    static const std::size_t PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE;
 
 private:
     CBoostedTreeImpl();

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -756,17 +756,48 @@ private:
     std::size_t m_NumberThreads;
     std::size_t m_DependentVariable = std::numeric_limits<std::size_t>::max();
     CBoostedTree::TLossFunctionUPtr m_Loss;
+
+    //! \name User Defined Overrides for the Hyperparameters
+    //!
+    //! If non-null, these fix the corresponding parameter value to a supplied
+    //! value in the hyperparameter optimisation loop.
+    //@{
     TOptionalDouble m_LambdaOverride;
     TOptionalDouble m_GammaOverride;
     TOptionalDouble m_EtaOverride;
     TOptionalSize m_MaximumNumberTreesOverride;
     TOptionalDouble m_FeatureBagFractionOverride;
+    //@}
+
+    //! The scale which is being applied to the amount of regularisation, i.e.
+    //! we use:
+    //!   m_Lambda = m_RegularizationScale * m_LambdaBase and
+    //!   m_Gamma = m_RegularizationScale * m_GammaBase
     double m_RegularizationScale = 1.0;
+
+    //! The proportion of gamma vs lambda regularisation, i.e. we use
+    //!   m_Lambda *= 1.0 - m_RegularizationGammaFraction and
+    //!   m_Gamma *= m_RegularizationGammaFraction
     double m_RegularizationGammaFraction = 0.5;
+
+    //! The initial choice for gamma based on the change in loss from fitting
+    //! a tree with zero regularisation.
     double m_BaseGamma = 0.0;
+
+    //! The initial choice for lambda based on the change in loss from fitting
+    //! a tree with zero regularisation.
     double m_BaseLambda = 0.0;
+
+    //! The actual choice for lambda for the current iteration of the hyperparameter
+    //! optimisation loop. This is the regularisation term proportional to the sum
+    //! squared leaf weights.
     double m_Lambda = 0.0;
+
+    //! The actual choice for gamma for the current iteration of the hyperparameter
+    //! optimisation loop. This is the regularisation term proportional to the size
+    //! of the tree.
     double m_Gamma = 0.0;
+
     double m_Eta = 0.1;
     double m_EtaGrowthRatePerTree = 1.05;
     std::size_t m_NumberFolds = 4;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -738,6 +738,10 @@ private:
     TOptionalDouble m_EtaOverride;
     TOptionalSize m_MaximumNumberTreesOverride;
     TOptionalDouble m_FeatureBagFractionOverride;
+    double m_RegularizationScale = 1.0;
+    double m_RegularizationGammaFraction = 0.5;
+    double m_BaseGamma = 0.0;
+    double m_BaseLambda = 0.0;
     double m_Lambda = 0.0;
     double m_Gamma = 0.0;
     double m_Eta = 0.1;
@@ -760,6 +764,7 @@ private:
     SHyperparameters m_BestHyperparameters;
     TNodeVecVec m_BestForest;
     TBayesinOptimizationUPtr m_BayesianOptimization;
+    TMeanAccumulator m_MeanLossVariance;
     std::size_t m_NumberRounds = 1;
     std::size_t m_CurrentRound = 0;
 

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -159,7 +159,7 @@ void CDataFrameBoostedTreeRunner::runImpl(const TStrVec& featureNames,
     core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage) =
         this->estimateMemoryUsage(frame.numberRows(),
                                   frame.numberRows() / this->numberPartitions(),
-                                  frame.numberColumns());
+                                  frame.numberColumns() + this->numberExtraColumns());
 
     core::CStopWatch watch{true};
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -563,8 +563,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTraining() {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 760000);
-    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 250000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 800000);
+    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 990000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -85,7 +85,7 @@ auto outlierSpec(std::size_t rows = 110,
 auto regressionSpec(std::string dependentVariable,
                     std::size_t rows = 100,
                     std::size_t cols = 5,
-                    std::size_t memoryLimit = 1500000,
+                    std::size_t memoryLimit = 3000000,
                     const TStrVec& categoricalFieldNames = TStrVec{},
                     double lambda = -1.0,
                     double gamma = -1.0,
@@ -563,8 +563,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTraining() {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 800000);
-    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 990000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2300000);
+    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1050000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -586,7 +586,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithParams() {
     };
 
     api::CDataFrameAnalyzer analyzer{
-        regressionSpec("c5", 100, 5, 1500000, {}, lambda, gamma, eta,
+        regressionSpec("c5", 100, 5, 3000000, {}, lambda, gamma, eta,
                        maximumNumberTrees, featureBagFraction),
         outputWriterFactory};
 
@@ -638,7 +638,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValu
 
     auto target = [](double feature) { return 10.0 * feature; };
 
-    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 1000000),
+    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 2000000),
                                      outputWriterFactory};
 
     TDoubleVec feature;
@@ -856,7 +856,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
 
     {
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", 1000, 5, 4000000, {"x1", "x2"}), outputWriterFactory};
+            regressionSpec("x5", 1000, 5, 8000000, {"x1", "x2"}), outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
                     {"x21", "x22", "x23", "x24", "x25", "x26", "x27"}};
@@ -895,7 +895,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
         std::size_t rows{api::CDataFrameAnalyzer::MAX_CATEGORICAL_CARDINALITY + 3};
 
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", rows, 5, 4000000000, {"x1"}), outputWriterFactory};
+            regressionSpec("x5", rows, 5, 8000000000, {"x1"}), outputWriterFactory};
 
         TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};
         TStrVec fieldValues{"", "", "", "", "", "", ""};

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -454,6 +454,18 @@ std::size_t CBayesianOptimisation::memoryUsage() const {
     return mem;
 }
 
+std::size_t CBayesianOptimisation::estimateMemoryUsage(std::size_t numberParameters,
+                                                       std::size_t numberRounds) {
+    std::size_t boundaryMemoryUsage{2 * numberParameters * sizeof(double)};
+    std::size_t functionMeanValuesMemoryUsage{numberRounds * sizeof(TVectorDoublePr)};
+    std::size_t errorVariancesMemoryUsage{numberRounds * sizeof(double)};
+    std::size_t kernelParametersMemoryUsage{(numberParameters + 1) * sizeof(double)};
+    std::size_t minimumKernelCoordinateDistanceScale{numberParameters * sizeof(double)};
+    return sizeof(CBayesianOptimisation) + boundaryMemoryUsage +
+           functionMeanValuesMemoryUsage + errorVariancesMemoryUsage +
+           kernelParametersMemoryUsage + minimumKernelCoordinateDistanceScale;
+}
+
 const double CBayesianOptimisation::MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE{1e-3};
 }
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -21,8 +21,8 @@ using TSizeVec = std::vector<std::size_t>;
 using TRowItr = core::CDataFrame::TRowItr;
 
 namespace {
-const double MIN_REGULARIZER_SCALE{0.01};
-const double MAX_REGULARIZER_SCALE{100.0};
+const double MIN_REGULARIZER_SCALE{0.05};
+const double MAX_REGULARIZER_SCALE{20.0};
 const double MIN_ETA_SCALE{0.3};
 const double MAX_ETA_SCALE{2.0};
 const double MIN_ETA_GROWTH_RATE_SCALE{0.5};

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -743,6 +743,10 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
               << ", feature bag fraction = " << m_FeatureBagFraction);
 
     double meanLoss{CBasicStatistics::mean(lossMoments)};
+    // We have a sample moments estimates for the validation error. We use the
+    // mean estimate of the validation error for the n-folds and we expect the
+    // sample variance of this statistic to be 1/n * sample variance for the
+    // validation error for the individual folds.
     double meanLossVariance{CBasicStatistics::variance(lossMoments) /
                             CBasicStatistics::count(lossMoments)};
     m_MeanLossVariance.add(meanLossVariance);

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -807,7 +807,7 @@ void CBoostedTreeImpl::restoreBestHyperparameters() {
     m_EtaGrowthRatePerTree = m_BestHyperparameters.s_EtaGrowthRatePerTree;
     m_FeatureBagFraction = m_BestHyperparameters.s_FeatureBagFraction;
     m_FeatureSampleProbabilities = m_BestHyperparameters.s_FeatureSampleProbabilities;
-    LOG_DEBUG(<< "loss = " << m_BestForestTestLoss << ": lambda* = " << m_Lambda
+    LOG_TRACE(<< "loss = " << m_BestForestTestLoss << ": lambda* = " << m_Lambda
               << ", gamma* = " << m_Gamma << ", eta* = " << m_Eta
               << ", eta growth rate per tree* = " << m_EtaGrowthRatePerTree
               << ", feature bag fraction* = " << m_FeatureBagFraction);

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -708,6 +708,10 @@ void CBoostedTreeTest::testMissingData() {
     regression->train();
     regression->predict();
 
+    // For each missing value given we censor for regression variables greater
+    // than 9.0, target = sum_i{R_i} for regressors R_i and R_i ~ U([0,10]) so
+    // we expect a n * E[U([0, 10]) | U([0, 10]) > 9.0] = 9.5 * n contribution
+    // to the target for n equal to the number of missing variables.
     TDoubleVec expectedPredictions{17.5, 17.5, 17.5, 22.0};
     TDoubleVec actualPredictions;
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -324,7 +324,7 @@ void CBoostedTreeTest::testNonLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.93);
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -202,7 +202,7 @@ void CBoostedTreeTest::testPiecewiseConstant() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.94);
 
@@ -721,7 +721,7 @@ void CBoostedTreeTest::testMissingData() {
 
     CPPUNIT_ASSERT_EQUAL(expectedPredictions.size(), actualPredictions.size());
     for (std::size_t i = 0; i < expectedPredictions.size(); ++i) {
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPredictions[i], actualPredictions[i], 0.75);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPredictions[i], actualPredictions[i], 0.8);
     }
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -19,11 +19,11 @@ public:
     void testConstantTarget();
     void testCategoricalRegressors();
     void testIntegerRegressor();
+    void testMissingData();
+    //void testFeatureWeights();
+    //void testNuisanceFeatures();
     void testEstimateMemoryUsedByTrain();
     void testProgressMonitoring();
-    void testMissingData();
-    // TODO void testFeatureWeights();
-    // TODO void testNuisanceFeatures();
     void testPersistRestore();
     void testRestoreErrorHandling();
 


### PR DESCRIPTION
This makes some improvements to the hyperparameter optimisation loop based on further experimentation. These are as follows:
1. Rather than parameterising regularisation in terms of lambda and gamma I've introduced an amount of regularisation parameter and then a gamma vs lambda weighting. This has two advantages: i) it extends the bounding box to allow for either lambda or gamma to be zero, ii) a-priori we assign equal chance to each degree of regularisation (previously we were assigning more weight to regularisation equal to the initial choice for lambda and gamma),
2. We consider error uncertainty in the value of the GP (as we do when we pick the best parameters overall),
3. The variance in the mean estimate of the validation error is the quantity we care about which should be scaled by `1/"number of folds"`,
4. We were almost never choosing `eta` > 0.2 across a range of data sets, so I've reduce the upper bound,
5. By using the local estimate of variance we could get stuck exploring regions where the error is relatively low and the variance across the folds is relatively high since the mass GP has significant spread here and so there is a chance assigned for large improvements. This is undesirable because we typically want to avoid regions where we can't estimate the validation error well. Item 2 mitigates this somewhat, but I have also switched to just using the mean error variance overall.

This also adds a unit test for missing value handling, which was missing.