### PR TITLE
[7.x][ML] Ensure DF analytics reports progress after finishing (#626)

### DIFF
--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -359,6 +359,7 @@ void CDataFrameAnalyzer::monitorProgress(const CDataFrameAnalysisRunner& analysi
             this->writeProgress(progress, writer);
         }
     }
+    this->writeProgress(100, writer);
 }
 
 void CDataFrameAnalyzer::writeProgress(int progress,


### PR DESCRIPTION
CI failures revealed that `analyzing` progress may get stuck at `0`
even though the analysis completed correctly. After investigating
the code, there is a race condition where if the analysis completed
before we started the progress monitoring loop, we might never report
progress. While I could not reproduce to get this confirmed, this seems
the prime suspect at the moment.

This commit addressed this by always reporting progress was completed
after the analysis finishes.

Closes elastic/elasticsearch#46038

Backport of #626