### PR TITLE
[ML] Fix blow up in minus log-likelihood for Bayesian optimisation

### DIFF
--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -188,7 +188,7 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
         return gradient;
     };
 
-    return {std::move(likelihood), std::move(likelihoodGradient)};
+    return {std::move(minusLogLikelihood), std::move(minusLogLikelihoodGradient)};
 }
 
 std::pair<CBayesianOptimisation::TEIFunc, CBayesianOptimisation::TEIGradientFunc>

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -204,7 +204,7 @@ void CBoostedTreeTest::testPiecewiseConstant() {
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.95);
 }
 
 void CBoostedTreeTest::testLinear() {


### PR DESCRIPTION
We could run into the case that kernel was singular to working precision. This was underflowing the log likelihood calculation, causing us to select a junk kernel.