### PR TITLE
[ML] Some improvements and a correction to memory estimation for boosted tree training

### DIFF
--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -82,6 +82,11 @@ public:
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
+    //! Estimate the maximum booking memory used by this class for optimising
+    //! \p numberParameters using \p numberRounds rounds.
+    static std::size_t estimateMemoryUsage(std::size_t numberParameters,
+                                           std::size_t numberRounds);
+
     //! \name Test Interface
     //@{
     //! Get minus the data likelihood and its gradient as a function of the kernel

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -448,12 +448,11 @@ private:
                 static_cast<std::size_t>(std::ceil(
                     featureBagFraction * static_cast<double>(numberCols - 1))) *
                 sizeof(std::size_t)};
-            // 256 is the number of rows encoded by a single byte in the packed bit
-            // vector assuming best compression. We will typically get this for most
-            // of the leaves when the set of splits becomes large, corresponding to
-            // the worst case for memory usage. This is because the masks will mainly
-            // contain 0 bits in this case.
-            std::size_t rowMaskSize{numberRows / 256};
+            // We will typically get the close to the best compression for most of the
+            // leaves when the set of splits becomes large, corresponding to the worst
+            // case for memory usage. This is because the rows will be spread over many
+            // rows so the masks will mainly contain 0 bits in this case.
+            std::size_t rowMaskSize{numberRows / PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
             std::size_t gradientsSize{(numberCols - 1) *
                                       numberSplitsPerFeature * sizeof(double)};
             std::size_t curvatureSize{gradientsSize};
@@ -644,6 +643,11 @@ private:
         TDoubleVec m_MissingCurvatures;
         mutable boost::optional<SSplitStatistics> m_BestSplit;
     };
+
+private:
+    // The maximum number of rows encoded by a single byte in the packed bit
+    // vector assuming best compression.
+    static const std::size_t PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE;
 
 private:
     CBoostedTreeImpl();

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -159,7 +159,7 @@ void CDataFrameBoostedTreeRunner::runImpl(const TStrVec& featureNames,
     core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage) =
         this->estimateMemoryUsage(frame.numberRows(),
                                   frame.numberRows() / this->numberPartitions(),
-                                  frame.numberColumns());
+                                  frame.numberColumns() + this->numberExtraColumns());
 
     core::CStopWatch watch{true};
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -85,7 +85,7 @@ auto outlierSpec(std::size_t rows = 110,
 auto regressionSpec(std::string dependentVariable,
                     std::size_t rows = 100,
                     std::size_t cols = 5,
-                    std::size_t memoryLimit = 1500000,
+                    std::size_t memoryLimit = 3000000,
                     const TStrVec& categoricalFieldNames = TStrVec{},
                     double lambda = -1.0,
                     double gamma = -1.0,
@@ -563,8 +563,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTraining() {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 760000);
-    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 250000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2300000);
+    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1050000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -586,7 +586,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithParams() {
     };
 
     api::CDataFrameAnalyzer analyzer{
-        regressionSpec("c5", 100, 5, 1500000, {}, lambda, gamma, eta,
+        regressionSpec("c5", 100, 5, 3000000, {}, lambda, gamma, eta,
                        maximumNumberTrees, featureBagFraction),
         outputWriterFactory};
 
@@ -638,7 +638,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeTrainingWithRowsMissingTargetValu
 
     auto target = [](double feature) { return 10.0 * feature; };
 
-    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 1000000),
+    api::CDataFrameAnalyzer analyzer{regressionSpec("target", 50, 2, 2000000),
                                      outputWriterFactory};
 
     TDoubleVec feature;
@@ -856,7 +856,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
 
     {
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", 1000, 5, 4000000, {"x1", "x2"}), outputWriterFactory};
+            regressionSpec("x5", 1000, 5, 8000000, {"x1", "x2"}), outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
                     {"x21", "x22", "x23", "x24", "x25", "x26", "x27"}};
@@ -895,7 +895,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
         std::size_t rows{api::CDataFrameAnalyzer::MAX_CATEGORICAL_CARDINALITY + 3};
 
         api::CDataFrameAnalyzer analyzer{
-            regressionSpec("x5", rows, 5, 4000000000, {"x1"}), outputWriterFactory};
+            regressionSpec("x5", rows, 5, 8000000000, {"x1"}), outputWriterFactory};
 
         TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};
         TStrVec fieldValues{"", "", "", "", "", "", ""};

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -454,6 +454,18 @@ std::size_t CBayesianOptimisation::memoryUsage() const {
     return mem;
 }
 
+std::size_t CBayesianOptimisation::estimateMemoryUsage(std::size_t numberParameters,
+                                                       std::size_t numberRounds) {
+    std::size_t boundaryMemoryUsage{2 * numberParameters * sizeof(double)};
+    std::size_t functionMeanValuesMemoryUsage{numberRounds * sizeof(TVectorDoublePr)};
+    std::size_t errorVariancesMemoryUsage{numberRounds * sizeof(double)};
+    std::size_t kernelParametersMemoryUsage{(numberParameters + 1) * sizeof(double)};
+    std::size_t minimumKernelCoordinateDistanceScale{numberParameters * sizeof(double)};
+    return sizeof(CBayesianOptimisation) + boundaryMemoryUsage +
+           functionMeanValuesMemoryUsage + errorVariancesMemoryUsage +
+           kernelParametersMemoryUsage + minimumKernelCoordinateDistanceScale;
+}
+
 const double CBayesianOptimisation::MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE{1e-3};
 }
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -9,6 +9,7 @@
 #include <core/CLoopProgress.h>
 #include <core/CPersistUtils.h>
 
+#include <maths/CBasicStatisticsPersist.h>
 #include <maths/CBayesianOptimisation.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CQuantileSketch.h>
@@ -233,19 +234,30 @@ std::size_t CBoostedTreeImpl::numberExtraColumnsForTrain() {
 
 std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
                                                   std::size_t numberColumns) const {
-    std::size_t maximumNumberNodes{this->maximumTreeSize(numberRows)};
-    std::size_t forestMemoryUsage{m_MaximumNumberTrees * maximumNumberNodes * sizeof(CNode)};
+    // The maximum tree size is defined is the maximum number of leaves minus one.
+    // A binary tree with n + 1 leaves has 2n + 1 nodes in total.
+    std::size_t maximumNumberNodes{2 * this->maximumTreeSize(numberRows) + 1};
+    std::size_t forestMemoryUsage{
+        m_MaximumNumberTrees * (sizeof(TNodeVec) + maximumNumberNodes * sizeof(CNode))};
     std::size_t extraColumnsMemoryUsage{this->numberExtraColumnsForTrain() *
                                         numberRows * sizeof(CFloatStorage)};
-    std::size_t hyperparametersMemoryUsage{sizeof(SHyperparameters) +
-                                           numberColumns * sizeof(double)};
+    std::size_t hyperparametersMemoryUsage{numberColumns * sizeof(double)};
     std::size_t leafNodeStatisticsMemoryUsage{
         maximumNumberNodes * CLeafNodeStatistics::estimateMemoryUsage(
                                  numberRows, numberColumns, m_FeatureBagFraction,
                                  m_NumberSplitsPerFeature)};
-
-    return forestMemoryUsage + extraColumnsMemoryUsage +
-           hyperparametersMemoryUsage + leafNodeStatisticsMemoryUsage;
+    std::size_t dataTypeMemoryUsage{numberColumns * sizeof(CDataFrameUtils::SDataType)};
+    std::size_t featureSampleProbabilities{numberColumns * sizeof(double)};
+    std::size_t missingFeatureMaskMemoryUsage{
+        numberColumns * numberRows / PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
+    std::size_t trainTestMaskMemoryUsage{2 * m_NumberFolds * numberRows /
+                                         PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
+    std::size_t bayesianOptimisationMemoryUsage{CBayesianOptimisation::estimateMemoryUsage(
+        this->numberHyperparametersToTune(), m_NumberRounds)};
+    return sizeof(*this) + forestMemoryUsage + extraColumnsMemoryUsage +
+           hyperparametersMemoryUsage + leafNodeStatisticsMemoryUsage +
+           dataTypeMemoryUsage + featureSampleProbabilities + missingFeatureMaskMemoryUsage +
+           trainTestMaskMemoryUsage + bayesianOptimisationMemoryUsage;
 }
 
 bool CBoostedTreeImpl::canTrain() const {
@@ -352,6 +364,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
     double oneMinusBias{eta};
 
     TDoubleVecVec candidateSplits(this->candidateSplits(frame, trainingRowMask));
+    scopeMemoryUsage.add(candidateSplits);
 
     for (std::size_t retries = 0; forest.size() < m_MaximumNumberTrees; /**/) {
 
@@ -371,6 +384,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
             oneMinusBias += eta * (1.0 - oneMinusBias);
             retries = 0;
         } else if (oneMinusBias < 1.0) {
+            scopeMemoryUsage.add(tree);
             this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask, 1.0, tree);
             oneMinusBias = 1.0;
             forest.push_back(std::move(tree));
@@ -482,7 +496,7 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
     std::size_t maximumTreeSize{this->maximumTreeSize(frame)};
 
     TNodeVec tree(1);
-    tree.reserve(maximumTreeSize);
+    tree.reserve(2 * maximumTreeSize + 1);
 
     TLeafNodeStatisticsPtrQueue leaves;
     leaves.push(std::make_shared<CLeafNodeStatistics>(
@@ -497,64 +511,64 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         memory += delta;
         maxMemory = std::max(maxMemory, memory);
     }};
-    {
-        CScopeRecordMemoryUsage scopeMemoryUsage{leaves, localRecordMemoryUsage};
+    CScopeRecordMemoryUsage scopeMemoryUsage{leaves, localRecordMemoryUsage};
 
-        // For each iteration we:
-        //   1. Find the leaf with the greatest decrease in loss
-        //   2. If no split (significantly) reduced the loss we terminate
-        //   3. Otherwise we split that leaf
+    // For each iteration we:
+    //   1. Find the leaf with the greatest decrease in loss
+    //   2. If no split (significantly) reduced the loss we terminate
+    //   3. Otherwise we split that leaf
 
-        double totalGain{0.0};
+    double totalGain{0.0};
 
-        for (std::size_t i = 0; i < maximumTreeSize; ++i) {
+    for (std::size_t i = 0; i < maximumTreeSize; ++i) {
 
-            auto leaf = leaves.top();
-            leaves.pop();
+        auto leaf = leaves.top();
+        leaves.pop();
 
-            scopeMemoryUsage.remove(leaf);
+        scopeMemoryUsage.remove(leaf);
 
-            if (leaf->gain() < MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
-                break;
-            }
-
-            totalGain += leaf->gain();
-            LOG_TRACE(<< "splitting " << leaf->id() << " total gain = " << totalGain);
-
-            std::size_t splitFeature;
-            double splitValue;
-            std::tie(splitFeature, splitValue) = leaf->bestSplit();
-
-            bool assignMissingToLeft{leaf->assignMissingToLeft()};
-
-            std::size_t leftChildId, rightChildId;
-            std::tie(leftChildId, rightChildId) = tree[leaf->id()].split(
-                splitFeature, splitValue, assignMissingToLeft, tree);
-
-            TSizeVec featureBag{this->featureBag()};
-
-            core::CPackedBitVector leftChildRowMask;
-            core::CPackedBitVector rightChildRowMask;
-            bool leftChildHasFewerRows;
-            std::tie(leftChildRowMask, rightChildRowMask, leftChildHasFewerRows) =
-                tree[leaf->id()].rowMasks(m_NumberThreads, frame, *m_Encoder,
-                                          std::move(leaf->rowMask()));
-
-            TLeafNodeStatisticsPtr leftChild;
-            TLeafNodeStatisticsPtr rightChild;
-            std::tie(leftChild, rightChild) =
-                leaf->split(leftChildId, rightChildId, m_NumberThreads, frame,
-                            *m_Encoder, m_Lambda, m_Gamma, candidateSplits,
-                            std::move(featureBag), std::move(leftChildRowMask),
-                            std::move(rightChildRowMask), leftChildHasFewerRows);
-
-            scopeMemoryUsage.add(leftChild);
-            scopeMemoryUsage.add(rightChild);
-
-            leaves.push(std::move(leftChild));
-            leaves.push(std::move(rightChild));
+        if (leaf->gain() < MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
+            break;
         }
+
+        totalGain += leaf->gain();
+        LOG_TRACE(<< "splitting " << leaf->id() << " total gain = " << totalGain);
+
+        std::size_t splitFeature;
+        double splitValue;
+        std::tie(splitFeature, splitValue) = leaf->bestSplit();
+
+        bool assignMissingToLeft{leaf->assignMissingToLeft()};
+
+        std::size_t leftChildId, rightChildId;
+        std::tie(leftChildId, rightChildId) = tree[leaf->id()].split(
+            splitFeature, splitValue, assignMissingToLeft, tree);
+
+        TSizeVec featureBag{this->featureBag()};
+
+        core::CPackedBitVector leftChildRowMask;
+        core::CPackedBitVector rightChildRowMask;
+        bool leftChildHasFewerRows;
+        std::tie(leftChildRowMask, rightChildRowMask, leftChildHasFewerRows) =
+            tree[leaf->id()].rowMasks(m_NumberThreads, frame, *m_Encoder,
+                                      std::move(leaf->rowMask()));
+
+        TLeafNodeStatisticsPtr leftChild;
+        TLeafNodeStatisticsPtr rightChild;
+        std::tie(leftChild, rightChild) =
+            leaf->split(leftChildId, rightChildId, m_NumberThreads, frame,
+                        *m_Encoder, m_Lambda, m_Gamma, candidateSplits,
+                        std::move(featureBag), std::move(leftChildRowMask),
+                        std::move(rightChildRowMask), leftChildHasFewerRows);
+
+        scopeMemoryUsage.add(leftChild);
+        scopeMemoryUsage.add(rightChild);
+
+        leaves.push(std::move(leftChild));
+        leaves.push(std::move(rightChild));
     }
+
+    tree.shrink_to_fit();
 
     // Flush the maximum memory used by the leaf statistics to the callback.
     recordMemoryUsage(maxMemory);
@@ -795,13 +809,15 @@ std::size_t CBoostedTreeImpl::numberHyperparametersToTune() const {
 }
 
 std::size_t CBoostedTreeImpl::maximumTreeSize(const core::CDataFrame& frame) const {
-    return maximumTreeSize(frame.numberRows());
+    return this->maximumTreeSize(frame.numberRows());
 }
 
 std::size_t CBoostedTreeImpl::maximumTreeSize(std::size_t numberRows) const {
     return static_cast<std::size_t>(std::ceil(
         m_MaximumTreeSizeMultiplier * std::sqrt(static_cast<double>(numberRows))));
 }
+
+const std::size_t CBoostedTreeImpl::PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE{256};
 
 namespace {
 const std::string BAYESIAN_OPTIMIZATION_TAG{"bayesian_optimization"};

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -660,58 +660,56 @@ void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
     std::size_t cols{6};
     std::size_t capacity{600};
 
-    TDoubleVecVec x(cols - 1);
-    for (std::size_t i = 0; i < cols - 1; ++i) {
-        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
-    }
-
-    auto target = [&](std::size_t i) {
-        double result{0.0};
-        for (std::size_t j = 0; j < cols - 1; ++j) {
-            result += x[j][i];
+    for (std::size_t test = 0; test < 3; ++test) {
+        TDoubleVecVec x(cols - 1);
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
         }
-        return result;
-    };
 
-    auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
-    frame->categoricalColumns({true, false, false, false, false, false});
-    for (std::size_t i = 0; i < rows; ++i) {
-        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
-            *(column++) = std::floor(x[0][i]);
-            for (std::size_t j = 1; j < cols - 1; ++j, ++column) {
-                *column = x[j][i];
+        auto target = [&](std::size_t i) {
+            double result{0.0};
+            for (std::size_t j = 0; j < cols - 1; ++j) {
+                result += x[j][i];
             }
-            *column = target(i);
-        });
+            return result;
+        };
+
+        auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+        frame->categoricalColumns({true, false, false, false, false, false});
+        for (std::size_t i = 0; i < rows; ++i) {
+            frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                *(column++) = std::floor(x[0][i]);
+                for (std::size_t j = 1; j < cols - 1; ++j, ++column) {
+                    *column = x[j][i];
+                }
+                *column = target(i);
+            });
+        }
+        frame->finishWritingRows();
+
+        std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
+                                         1, std::make_unique<maths::boosted_tree::CMse>())
+                                         .estimateMemoryUsage(rows, cols));
+
+        std::int64_t memoryUsage{0};
+        std::int64_t maxMemoryUsage{0};
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .memoryUsageCallback([&](std::int64_t delta) {
+                                  memoryUsage += delta;
+                                  maxMemoryUsage = std::max(maxMemoryUsage, memoryUsage);
+                                  LOG_TRACE(<< "current memory = " << memoryUsage
+                                            << ", high water mark = " << maxMemoryUsage);
+                              })
+                              .buildFor(*frame, cols - 1);
+
+        regression->train();
+
+        LOG_DEBUG(<< "estimated memory usage = " << estimatedMemory);
+        LOG_DEBUG(<< "high water mark = " << maxMemoryUsage);
+
+        CPPUNIT_ASSERT(maxMemoryUsage < estimatedMemory);
     }
-    frame->finishWritingRows();
-
-    std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
-                                     1, std::make_unique<maths::boosted_tree::CMse>())
-                                     .estimateMemoryUsage(rows, cols));
-
-    std::int64_t memoryUsage{0};
-    std::int64_t maxMemoryUsage{0};
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::boosted_tree::CMse>())
-                          .memoryUsageCallback([&](std::int64_t delta) {
-                              memoryUsage += delta;
-                              maxMemoryUsage = std::max(maxMemoryUsage, memoryUsage);
-                              LOG_TRACE(<< "current memory = " << memoryUsage
-                                        << ", high water mark = " << maxMemoryUsage);
-                          })
-                          .buildFor(*frame, cols - 1);
-
-    regression->train();
-
-    LOG_DEBUG(<< "estimated memory usage = " << estimatedMemory);
-    LOG_DEBUG(<< "high water mark = " << maxMemoryUsage);
-
-    // Currently, the estimated memory is a little over 3 times the high water
-    // mark for the test data.
-
-    CPPUNIT_ASSERT(maxMemoryUsage < estimatedMemory);
-    CPPUNIT_ASSERT(4 * maxMemoryUsage > estimatedMemory);
 }
 
 void CBoostedTreeTest::testProgressMonitoring() {


### PR DESCRIPTION
The principal bug was that the tree size is defined by number of leaves, i.e. it is allowed to have `maximumTreeSize + 1` leaves. For a binary tree this translates to `2 * maximumTreeSize + 1` nodes in total. We also weren't accounting for the extra columns when reporting estimated memory usage to the logs. Finally, I've added some additional (albeit small) users of memory to the estimation calculation: the validate/train masks, the Bayesian optimisation state, etc. (This was factored out of #625.)