### PR TITLE
[7.5][ML] Fix blow up in minus log-likelihood for Bayesian optimisation

### DIFF
--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -144,13 +144,20 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
     TVector f{this->function()};
     double v{this->meanErrorVariance()};
 
-    auto likelihood = [f, v, this](const TVector& a) {
+    auto minusLogLikelihood = [f, v, this](const TVector& a) {
         Eigen::LDLT<Eigen::MatrixXd> Kldl{this->kernel(a, v)};
         TVector Kinvf{Kldl.solve(f)};
-        return 0.5 * (f.transpose() * Kinvf + Kldl.vectorD().array().log().sum());
+        // We can only determine values up to eps * "max diagonal". If the diagonal
+        // has a zero it blows up the determinant term. In practice, we know the
+        // kernel can't be singular by construction so we perturb the diagonal by
+        // the numerical error in such a way as to recover a non-singular matrix.
+        // (Note that the solve routine deals with the zero for us.)
+        double eps{std::numeric_limits<double>::epsilon() * Kldl.vectorD().maxCoeff()};
+        return 0.5 *
+               (f.transpose() * Kinvf + (Kldl.vectorD().array() + eps).log().sum());
     };
 
-    auto likelihoodGradient = [f, v, this](const TVector& a) {
+    auto minusLogLikelihoodGradient = [f, v, this](const TVector& a) {
         TMatrix K{this->kernel(a, v)};
         Eigen::LDLT<Eigen::MatrixXd> Kldl{K};
 
@@ -181,7 +188,7 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
         return gradient;
     };
 
-    return {std::move(likelihood), std::move(likelihoodGradient)};
+    return {std::move(minusLogLikelihood), std::move(minusLogLikelihoodGradient)};
 }
 
 std::pair<CBayesianOptimisation::TEIFunc, CBayesianOptimisation::TEIGradientFunc>
@@ -307,6 +314,7 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
     }
 
     m_KernelParameters = std::move(amax);
+    LOG_TRACE(<< "kernel parameters = " << m_KernelParameters.transpose());
 
     return m_KernelParameters;
 }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -204,7 +204,7 @@ void CBoostedTreeTest::testPiecewiseConstant() {
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.95);
 }
 
 void CBoostedTreeTest::testLinear() {


### PR DESCRIPTION
Backport #630.