### PR TITLE
[ML] Missing variable initialisation causing spurious model reinitialisation for lat/long function

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,8 @@ train time. (See {ml-pull}622[#622].)
 
 * Rename outlier detection method values knn and tnn to distance_kth_nn and distance_knn
 respectively to match the API. (See {ml-pull}598[#598].)
+* Fix occasional (non-deterministic) reinitialisation of modelling for the lat_long
+function. (See {ml-pull}641[#641].)
 
 == {es} version 7.3.1
 

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1607,8 +1607,6 @@ CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
         }
     }
 
-    EUpdateResult result = E_Success;
-
     // Time order is not reliable, for example if the data are polled
     // or for count feature, the times of all samples will be the same.
     TSizeVec timeorder(samples.size());
@@ -1623,6 +1621,7 @@ CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
     // Do the update.
 
     TFloatMeanAccumulatorVec window;
+    EUpdateResult result{E_Success};
     auto componentChangeCallback = [&window, &result](TFloatMeanAccumulatorVec window_) {
         window = std::move(window_);
         result = E_Reset;
@@ -2944,7 +2943,7 @@ CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& sample
 
     // Do the update.
 
-    EUpdateResult result;
+    EUpdateResult result{E_Success};
     auto componentChangeCallback = [&result](TFloatMeanAccumulatorVec) {
         result = E_Reset;
     };


### PR DESCRIPTION
We were missing the initialisation of the return type from updating the trend for multivariate models (this only, potentially, affects results for the lat/long function). This could in rare circumstances cause us to reinitialise the model.

This is a good candidate cause for some sporadic test failures we've seen.