### PR TITLE
[ML] Improve boosted tree training parameter initialisation 

### DIFF
--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -250,18 +250,24 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) con
     } else {
         core::CPackedBitVector trainingRowMask{m_TreeImpl->allTrainingRowsMask()};
 
-        auto vector = m_TreeImpl->initializePredictionsAndLossDerivatives(frame, trainingRowMask);
+        auto tree = m_TreeImpl->initializePredictionsAndLossDerivatives(frame, trainingRowMask);
 
         double L[2];
         double T[2];
         double W[2];
 
         std::tie(L[0], T[0], W[0]) =
-            m_TreeImpl->regularisedLoss(frame, trainingRowMask, {std::move(vector)});
+            m_TreeImpl->regularisedLoss(frame, trainingRowMask, {std::move(tree)});
         LOG_TRACE(<< "loss = " << L[0] << ", # leaves = " << T[0]
                   << ", sum square weights = " << W[0]);
 
+        double eta{1.0};
+        std::size_t maximumNumberOfTrees{1};
+        std::swap(eta, m_TreeImpl->m_Eta);
+        std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
         auto forest = m_TreeImpl->trainForest(frame, trainingRowMask, m_RecordMemoryUsage);
+        std::swap(eta, m_TreeImpl->m_Eta);
+        std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
 
         std::tie(L[1], T[1], W[1]) =
             m_TreeImpl->regularisedLoss(frame, trainingRowMask, forest);
@@ -274,8 +280,8 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) con
         // them.
         double scale{static_cast<double>(m_TreeImpl->m_NumberFolds - 1) /
                      static_cast<double>(m_TreeImpl->m_NumberFolds)};
-        double lambda{scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (W[1] - W[0])) / 5.0};
-        double gamma{scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (T[1] - T[0])) / 5.0};
+        double lambda{m_TreeImpl->m_Eta * scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (W[1] - W[0]))};
+        double gamma{m_TreeImpl->m_Eta * scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (T[1] - T[0]))};
 
         if (lambda == 0.0) {
             m_TreeImpl->m_LambdaOverride = lambda;

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -280,8 +280,10 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) con
         // them.
         double scale{static_cast<double>(m_TreeImpl->m_NumberFolds - 1) /
                      static_cast<double>(m_TreeImpl->m_NumberFolds)};
-        double lambda{m_TreeImpl->m_Eta * scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (W[1] - W[0]))};
-        double gamma{m_TreeImpl->m_Eta * scale * (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (T[1] - T[0]))};
+        double lambda{m_TreeImpl->m_Eta * scale *
+                      (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (W[1] - W[0]))};
+        double gamma{m_TreeImpl->m_Eta * scale *
+                     (L[0] <= L[1] ? 0.0 : (L[0] - L[1]) / (T[1] - T[0]))};
 
         if (lambda == 0.0) {
             m_TreeImpl->m_LambdaOverride = lambda;

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -143,12 +143,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
         // Fallback to using the constant predictor which minimises the loss.
 
         core::CPackedBitVector trainingRowMask{this->allTrainingRowsMask()};
-
-        double eta{1.0};
-        std::swap(eta, m_Eta);
         m_BestForest.assign(1, this->initializePredictionsAndLossDerivatives(frame, trainingRowMask));
-        std::swap(eta, m_Eta);
-
         m_BestForestTestLoss = this->meanLoss(frame, trainingRowMask, m_BestForest);
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
@@ -336,8 +331,9 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
                        },
                        &trainingRowMask);
 
+    // At the start we will centre the data w.r.t. the given loss function.
     TNodeVec tree(1);
-    this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask, m_Eta, tree);
+    this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask, 1.0, tree);
 
     return tree;
 }
@@ -366,8 +362,8 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
     TDoubleVecVec candidateSplits(this->candidateSplits(frame, trainingRowMask));
     scopeMemoryUsage.add(candidateSplits);
 
-    for (std::size_t retries = 0; forest.size() < m_MaximumNumberTrees; /**/) {
-
+    std::size_t retries = 0;
+    do {
         auto tree = this->trainTree(frame, trainingRowMask, candidateSplits, recordMemoryUsage);
 
         retries = tree.size() == 1 ? retries + 1 : 0;
@@ -394,7 +390,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
         if (m_Loss->isCurvatureConstant() == false) {
             candidateSplits = this->candidateSplits(frame, trainingRowMask);
         }
-    }
+    } while (forest.size() < m_MaximumNumberTrees);
 
     LOG_TRACE(<< "Trained one forest");
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -650,6 +650,83 @@ void CBoostedTreeTest::testIntegerRegressor() {
     CPPUNIT_ASSERT(modelRSquared > 0.99);
 }
 
+void CBoostedTreeTest::testTranslationInvariance() {
+
+    // We should get similar performance independent of fixed shifts for the target.
+
+    using TTargetFunc = std::function<double(const TRowRef& row)>;
+
+    test::CRandomNumbers rng;
+
+    std::size_t trainRows{1000};
+    std::size_t rows{1200};
+    std::size_t cols{4};
+    std::size_t capacity{1200};
+
+    TDoubleVecVec x(cols - 1);
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    TTargetFunc target{[&](const TRowRef& row) {
+        double result{0.0};
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            result += row[i];
+        }
+        return result;
+    }};
+    TTargetFunc shiftedTarget{[&](const TRowRef& row) {
+        double result{10000.0};
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            result += row[i];
+        }
+        return result;
+    }};
+
+    TDoubleVec rsquared;
+
+    for (const auto& target_ : {target, shiftedTarget}) {
+
+        auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+        frame->categoricalColumns({false, false, false, false});
+        for (std::size_t i = 0; i < rows; ++i) {
+            frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                for (std::size_t j = 0; j < cols - 1; ++j, ++column) {
+                    *column = x[j][i];
+                }
+            });
+        }
+        frame->finishWritingRows();
+        frame->writeColumns(1, [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                double targetValue{row->index() < trainRows
+                                       ? target_(*row)
+                                       : core::CDataFrame::valueOfMissing()};
+                row->writeColumn(cols - 1, targetValue);
+            }
+        });
+
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .buildFor(*frame, cols - 1);
+
+        regression->train();
+        regression->predict();
+
+        double modelBias;
+        double modelRSquared;
+        std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
+            *frame, trainRows, rows,
+            regression->columnHoldingPrediction(frame->numberColumns()), target_, 0.0);
+
+        LOG_DEBUG(<< "bias = " << modelBias);
+        LOG_DEBUG(<< " R^2 = " << modelRSquared);
+        rsquared.push_back(modelRSquared);
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(rsquared[0], rsquared[1], 5e-3);
+}
+
 void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
 
     // Test estimation of the memory used training a model.
@@ -959,6 +1036,9 @@ CppUnit::Test* CBoostedTreeTest::suite() {
         &CBoostedTreeTest::testCategoricalRegressors));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testIntegerRegressor", &CBoostedTreeTest::testIntegerRegressor));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testTranslationInvariance",
+        &CBoostedTreeTest::testTranslationInvariance));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testEstimateMemoryUsedByTrain",
         &CBoostedTreeTest::testEstimateMemoryUsedByTrain));

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -19,6 +19,7 @@ public:
     void testConstantTarget();
     void testCategoricalRegressors();
     void testIntegerRegressor();
+    void testTranslationInvariance();
     void testEstimateMemoryUsedByTrain();
     void testProgressMonitoring();
     void testMissingData();


### PR DESCRIPTION
We weren't properly centring the data when measuring the change in loss. For data where the variance across the training set is small compared to the mean this meant we could significantly over estimate the initial values for `lambda` and `gamma`.

I've also switched to using a single tree to estimate the magnitude of the change in the loss term of the objective. Using a full forest tests underestimates the change per split by roughly a factor of the shrinkage. Finally, rather than using a fixed scaling of `lambda` and `gamma` I scale them by the shrinkage on initialisation to account for the regularisation effect of smaller shrinkage.

This change also closes #631 since it was useful to be able to train a forest of size one for this change.