### PR TITLE
[ML] Refactoring of the persistence for regression

### DIFF
--- a/bin/data_frame_analyzer/CCmdLineParser.cc
+++ b/bin/data_frame_analyzer/CCmdLineParser.cc
@@ -20,7 +20,6 @@ const std::string CCmdLineParser::DESCRIPTION = "Usage: data_frame_analyzer [opt
 bool CCmdLineParser::parse(int argc,
                            const char* const* argv,
                            std::string& configFile,
-                           std::string& jobId,
                            bool& memoryUsageEstimationOnly,
                            std::string& logProperties,
                            std::string& logPipe,
@@ -41,8 +40,6 @@ bool CCmdLineParser::parse(int argc,
             ("version", "Display version information and exit")
             ("config", boost::program_options::value<std::string>(),
                     "The configuration file")
-            ("jobId", boost::program_options::value<std::string>(),
-                 "ID of the job this process is associated with")
             ("memoryUsageEstimationOnly", "Whether to perform memory usage estimation only")
             ("logProperties", boost::program_options::value<std::string>(),
                     "Optional logger properties file")
@@ -80,9 +77,6 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("config") > 0) {
             configFile = vm["config"].as<std::string>();
-        }
-        if (vm.count("jobid") > 0) {
-            jobId = vm["jobid"].as<std::string>();
         }
         if (vm.count("memoryUsageEstimationOnly") > 0) {
             memoryUsageEstimationOnly = true;

--- a/bin/data_frame_analyzer/CCmdLineParser.h
+++ b/bin/data_frame_analyzer/CCmdLineParser.h
@@ -27,7 +27,6 @@ public:
     static bool parse(int argc,
                       const char* const* argv,
                       std::string& configFile,
-                      std::string& jobId,
                       bool& memoryUsageEstimationOnly,
                       std::string& logProperties,
                       std::string& logPipe,

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -158,8 +158,7 @@ int main(int argc, char** argv) {
     const std::string REGRESSION_TRAIN_STATE_TYPE("predictive_model_train_state");
 
     using TDataAdderUPtr = std::unique_ptr<ml::core::CDataAdder>;
-    auto persisterSupplier =
-        [&ioMgr]() -> TDataAdderUPtr {
+    auto persisterSupplier = [&ioMgr]() -> TDataAdderUPtr {
         if (ioMgr.persistStream() != nullptr) {
 
             return std::make_unique<ml::api::CSingleStreamDataAdder>(ioMgr.persistStream());

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -90,7 +90,6 @@ int main(int argc, char** argv) {
 
     // Read command line options
     std::string configFile;
-    std::string jobId;
     bool memoryUsageEstimationOnly(false);
     std::string logProperties;
     std::string logPipe;
@@ -104,10 +103,10 @@ int main(int argc, char** argv) {
     std::string persistFileName;
     bool isPersistFileNamedPipe(false);
     if (ml::data_frame_analyzer::CCmdLineParser::parse(
-            argc, argv, configFile, jobId, memoryUsageEstimationOnly, logProperties,
-            logPipe, lengthEncodedInput, inputFileName, isInputFileNamedPipe,
-            outputFileName, isOutputFileNamedPipe, restoreFileName,
-            isRestoreFileNamedPipe, persistFileName, isPersistFileNamedPipe) == false) {
+            argc, argv, configFile, memoryUsageEstimationOnly, logProperties, logPipe,
+            lengthEncodedInput, inputFileName, isInputFileNamedPipe, outputFileName,
+            isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe,
+            persistFileName, isPersistFileNamedPipe) == false) {
         return EXIT_FAILURE;
     }
 
@@ -152,10 +151,6 @@ int main(int argc, char** argv) {
     auto resultsStreamSupplier = [&ioMgr]() {
         return std::make_unique<ml::core::CJsonOutputStreamWrapper>(ioMgr.outputStream());
     };
-
-    // TODO Factor out these constants to an extra header file, e.g api/ElasticsearchStateIndex.h
-    const std::string ML_STATE_INDEX(".ml-state");
-    const std::string REGRESSION_TRAIN_STATE_TYPE("predictive_model_train_state");
 
     using TDataAdderUPtr = std::unique_ptr<ml::core::CDataAdder>;
     auto persisterSupplier = [&ioMgr]() -> TDataAdderUPtr {

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -9,6 +9,7 @@
 
 #include <core/CFastMutex.h>
 #include <core/CJsonOutputStreamWrapper.h>
+#include <core/CDataAdder.h>
 
 #include <api/CDataFrameAnalysisRunner.h>
 #include <api/ImportExport.h>
@@ -21,6 +22,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+
 
 namespace ml {
 namespace core {
@@ -44,8 +46,8 @@ public:
     using TStrVec = std::vector<std::string>;
     using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
     using TTemporaryDirectoryPtr = std::shared_ptr<core::CTemporaryDirectory>;
-    using TOStreamSPtr = std::shared_ptr<std::ostream>;
-    using TPersistStreamSupplier = std::function<TOStreamSPtr()>;
+    using TDataAdderUPtr = std::unique_ptr<ml::core::CDataAdder>;
+    using TPersisterSupplier = std::function<TDataAdderUPtr()>;
     using TDataFrameUPtrTemporaryDirectoryPtrPr =
         std::pair<TDataFrameUPtr, TTemporaryDirectoryPtr>;
     using TRunnerUPtr = std::unique_ptr<CDataFrameAnalysisRunner>;
@@ -53,6 +55,7 @@ public:
     using TRunnerFactoryUPtrVec = std::vector<TRunnerFactoryUPtr>;
 
 public:
+    static const std::string JOB_ID;
     static const std::string ROWS;
     static const std::string COLS;
     static const std::string MEMORY_LIMIT;
@@ -71,6 +74,7 @@ public:
     //! The specification has the following expected form:
     //! <CODE>
     //! {
+    //!   "job_id": <string>,
     //!   "rows": <integer>,
     //!   "cols": <integer>,
     //!   "memory_limit": <integer>,
@@ -94,9 +98,9 @@ public:
     //! \note temp_dir Is a directory which can be used to store the data frame
     //! out-of-core if we can't meet the memory constraint for the analysis without
     //! partitioning.
-    //! \param persistStreamSupplier Shared pointer to the string with  persist stream name.
+    //! \param persisterSupplier Shared pointer to the CDataAdder instance.
     CDataFrameAnalysisSpecification(const std::string& jsonSpecification,
-                                    TPersistStreamSupplier persistStreamSupplier = noopPersistStreamSupplier());
+                                    TPersisterSupplier persisterSupplier = noopPersisterSupplier());
 
     //! This construtor provides support for custom analysis types and is mainly
     //! intended for testing.
@@ -104,7 +108,7 @@ public:
     //! \param[in] runnerFactories Plugins for the supported analyses.
     CDataFrameAnalysisSpecification(TRunnerFactoryUPtrVec runnerFactories,
                                     const std::string& jsonSpecification,
-                                    TPersistStreamSupplier persistStreamSupplier = noopPersistStreamSupplier());
+                                    TPersisterSupplier persisterSupplier = noopPersisterSupplier());
 
     CDataFrameAnalysisSpecification(const CDataFrameAnalysisSpecification&) = delete;
     CDataFrameAnalysisSpecification& operator=(const CDataFrameAnalysisSpecification&) = delete;
@@ -129,6 +133,9 @@ public:
 
     //! \return The name of the results field.
     const std::string& resultsField() const;
+
+    //! \return The jobId.
+    const std::string& jobId() const;
 
     //! \return The names of the categorical fields.
     const TStrVec& categoricalFieldNames() const;
@@ -163,12 +170,12 @@ public:
     void estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const;
 
     //! \return shared pointer to the persistence stream.
-    TOStreamSPtr persistStream() const;
+    TDataAdderUPtr persister() const;
 
 private:
     void initializeRunner(const rapidjson::Value& jsonAnalysis);
 
-    static TPersistStreamSupplier noopPersistStreamSupplier();
+    static TPersisterSupplier noopPersisterSupplier();
 
 private:
     std::size_t m_NumberRows = 0;
@@ -177,13 +184,14 @@ private:
     std::size_t m_NumberThreads = 0;
     std::string m_TemporaryDirectory;
     std::string m_ResultsField;
+    std::string m_JobId;
     TStrVec m_CategoricalFieldNames;
     bool m_DiskUsageAllowed;
     // TODO Sparse table support
     // double m_TableLoadFactor = 0.0;
     TRunnerFactoryUPtrVec m_RunnerFactories;
     TRunnerUPtr m_Runner;
-    TPersistStreamSupplier m_PersistStreamSupplier;
+    TPersisterSupplier m_PersisterSupplier;
 };
 }
 }

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -7,9 +7,9 @@
 #ifndef INCLUDED_ml_api_CDataFrameAnalysisSpecification_h
 #define INCLUDED_ml_api_CDataFrameAnalysisSpecification_h
 
+#include <core/CDataAdder.h>
 #include <core/CFastMutex.h>
 #include <core/CJsonOutputStreamWrapper.h>
-#include <core/CDataAdder.h>
 
 #include <api/CDataFrameAnalysisRunner.h>
 #include <api/ImportExport.h>
@@ -22,7 +22,6 @@
 #include <string>
 #include <thread>
 #include <vector>
-
 
 namespace ml {
 namespace core {

--- a/include/api/ElasticsearchStateIndex.h
+++ b/include/api/ElasticsearchStateIndex.h
@@ -14,6 +14,10 @@ namespace api {
 static const std::string ML_STATE_INDEX(".ml-state");
 static const std::string MODEL_STATE_TYPE("model_state");
 static const std::string REGRESSION_TRAIN_STATE_TYPE("predictive_model_train_state");
+
+std::string getRegressionStateId(const std::string& jobId) {
+    return jobId + '_' + REGRESSION_TRAIN_STATE_TYPE;
+}
 }
 }
 

--- a/include/api/ElasticsearchStateIndex.h
+++ b/include/api/ElasticsearchStateIndex.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_ElasticsearchStateIndex_h
+#define INCLUDED_ml_api_ElasticsearchStateIndex_h
+
+#include <string>
+
+namespace ml {
+namespace api {
+//! Elasticsearch index for state
+static const std::string ML_STATE_INDEX(".ml-state");
+static const std::string MODEL_STATE_TYPE("model_state");
+static const std::string REGRESSION_TRAIN_STATE_TYPE("predictive_model_train_state");
+}
+}
+
+#endif // INCLUDED_ml_api_ElasticsearchStateIndex_h

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -202,7 +202,7 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
         auto persister = m_Spec.persister();
         if (persister != nullptr) {
             auto persistStream = persister->addStreamed(
-                ML_STATE_INDEX, m_Spec.jobId() + '_' + REGRESSION_TRAIN_STATE_TYPE);
+                ML_STATE_INDEX, getRegressionStateId(m_Spec.jobId()));
             {
                 core::CJsonStatePersistInserter inserter{*persistStream};
                 persistFunction(inserter);

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -12,13 +12,13 @@
 
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CMemoryUsageEstimationResultJsonWriter.h>
+#include <api/CSingleStreamDataAdder.h>
+#include <api/ElasticsearchStateIndex.h>
 
 #include <boost/iterator/counting_iterator.hpp>
 
 #include <algorithm>
 #include <cstddef>
-#include <api/CSingleStreamDataAdder.h>
-#include <api/ElasticsearchStateIndex.h>
 
 namespace ml {
 namespace api {
@@ -201,13 +201,15 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
     return [this](std::function<void(core::CStatePersistInserter&)> persistFunction) -> void {
         auto persister = m_Spec.persister();
         if (persister != nullptr) {
-            auto persistStream = persister->addStreamed(api::ML_STATE_INDEX, m_Spec.jobId() + '_' + REGRESSION_TRAIN_STATE_TYPE);
+            auto persistStream = persister->addStreamed(
+                api::ML_STATE_INDEX, m_Spec.jobId() + '_' + REGRESSION_TRAIN_STATE_TYPE);
             {
                 core::CJsonStatePersistInserter inserter{*persistStream};
                 persistFunction(inserter);
             }
-            if(persister->streamComplete(persistStream, true) == false || persistStream->bad()) {
-                LOG_ERROR(<<"Failed to complete last persistence stream");
+            if (persister->streamComplete(persistStream, true) == false ||
+                persistStream->bad()) {
+                LOG_ERROR(<< "Failed to complete last persistence stream");
             }
         }
     };

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -202,7 +202,7 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
         auto persister = m_Spec.persister();
         if (persister != nullptr) {
             auto persistStream = persister->addStreamed(
-                api::ML_STATE_INDEX, m_Spec.jobId() + '_' + REGRESSION_TRAIN_STATE_TYPE);
+                ML_STATE_INDEX, m_Spec.jobId() + '_' + REGRESSION_TRAIN_STATE_TYPE);
             {
                 core::CJsonStatePersistInserter inserter{*persistStream};
                 persistFunction(inserter);

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -202,8 +202,10 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
         auto persister = m_Spec.persister();
         if (persister != nullptr) {
             auto persistStream = persister->addStreamed(api::ML_STATE_INDEX, m_Spec.jobId() + '_' + REGRESSION_TRAIN_STATE_TYPE);
-            core::CJsonStatePersistInserter inserter{*persistStream};
-            persistFunction(inserter);
+            {
+                core::CJsonStatePersistInserter inserter{*persistStream};
+                persistFunction(inserter);
+            }
             if(persister->streamComplete(persistStream, true) == false || persistStream->bad()) {
                 LOG_ERROR(<<"Failed to complete last persistence stream");
             }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -93,12 +93,10 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(const std::stri
                                       std::move(persisterSupplier)} {
 }
 
-CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(
-        TRunnerFactoryUPtrVec runnerFactories,
-        const std::string& jsonSpecification,
-        TPersisterSupplier persisterSupplier)
-    : m_RunnerFactories{std::move(runnerFactories)}, m_PersisterSupplier{std::move(
-        persisterSupplier)} {
+CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(TRunnerFactoryUPtrVec runnerFactories,
+                                                                 const std::string& jsonSpecification,
+                                                                 TPersisterSupplier persisterSupplier)
+    : m_RunnerFactories{std::move(runnerFactories)}, m_PersisterSupplier{std::move(persisterSupplier)} {
 
     rapidjson::Document specification;
     if (specification.Parse(jsonSpecification.c_str()) == false) {
@@ -231,7 +229,7 @@ CDataFrameAnalysisSpecification::noopPersisterSupplier() {
     return nullptr;
 }
 
-const std::string &CDataFrameAnalysisSpecification::jobId() const {
+const std::string& CDataFrameAnalysisSpecification::jobId() const {
     return m_JobId;
 }
 }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -27,6 +27,7 @@ namespace ml {
 namespace api {
 
 // These must be consistent with Java names.
+const std::string CDataFrameAnalysisSpecification::JOB_ID("job_id");
 const std::string CDataFrameAnalysisSpecification::ROWS("rows");
 const std::string CDataFrameAnalysisSpecification::COLS("cols");
 const std::string CDataFrameAnalysisSpecification::MEMORY_LIMIT("memory_limit");
@@ -87,17 +88,17 @@ const CDataFrameAnalysisConfigReader ANALYSIS_READER{[] {
 }
 
 CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(const std::string& jsonSpecification,
-                                                                 TPersistStreamSupplier persistStreamSupplier)
+                                                                 TPersisterSupplier persisterSupplier)
     : CDataFrameAnalysisSpecification{analysisFactories(), jsonSpecification,
-                                      std::move(persistStreamSupplier)} {
+                                      std::move(persisterSupplier)} {
 }
 
 CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(
-    TRunnerFactoryUPtrVec runnerFactories,
-    const std::string& jsonSpecification,
-    TPersistStreamSupplier persistStreamSupplier)
-    : m_RunnerFactories{std::move(runnerFactories)}, m_PersistStreamSupplier{std::move(
-                                                         persistStreamSupplier)} {
+        TRunnerFactoryUPtrVec runnerFactories,
+        const std::string& jsonSpecification,
+        TPersisterSupplier persisterSupplier)
+    : m_RunnerFactories{std::move(runnerFactories)}, m_PersisterSupplier{std::move(
+        persisterSupplier)} {
 
     rapidjson::Document specification;
     if (specification.Parse(jsonSpecification.c_str()) == false) {
@@ -117,6 +118,7 @@ CDataFrameAnalysisSpecification::CDataFrameAnalysisSpecification(
         m_MemoryLimit = parameters[MEMORY_LIMIT].as<std::size_t>();
         m_NumberThreads = parameters[THREADS].as<std::size_t>();
         m_TemporaryDirectory = parameters[TEMPORARY_DIRECTORY].fallback(std::string{});
+        m_JobId = parameters[JOB_ID].fallback(std::string{});
         m_ResultsField = parameters[RESULTS_FIELD].fallback(DEFAULT_RESULT_FIELD);
         m_CategoricalFieldNames = parameters[CATEGORICAL_FIELD_NAMES].fallback(TStrVec{});
         m_DiskUsageAllowed = parameters[DISK_USAGE_ALLOWED].fallback(DEFAULT_DISK_USAGE_ALLOWED);
@@ -219,14 +221,18 @@ void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& j
                  << "'. Please report this problem.");
 }
 
-CDataFrameAnalysisSpecification::TOStreamSPtr
-CDataFrameAnalysisSpecification::persistStream() const {
-    return m_PersistStreamSupplier();
+CDataFrameAnalysisSpecification::TDataAdderUPtr
+CDataFrameAnalysisSpecification::persister() const {
+    return m_PersisterSupplier();
 }
 
-CDataFrameAnalysisSpecification::TPersistStreamSupplier
-CDataFrameAnalysisSpecification::noopPersistStreamSupplier() {
+CDataFrameAnalysisSpecification::TPersisterSupplier
+CDataFrameAnalysisSpecification::noopPersisterSupplier() {
     return nullptr;
+}
+
+const std::string &CDataFrameAnalysisSpecification::jobId() const {
+    return m_JobId;
 }
 }
 }


### PR DESCRIPTION
This PR introduces following changes:
- Persister is writing `{"index"...}` and `\0` for every persistence state to comply with requirements for bulk operations
- `JobId` is passed over JSON Specification instead of the command line
- Constants for `ML_STATE` and `REGRESSION_TRAIN_STATE_TYPE` are moved to a dedicated header file