### PR TITLE
[7.4][ML] Don't add a margin when checking the memory limit for data frame analyses

### DIFF
--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -23,10 +23,6 @@
 namespace ml {
 namespace api {
 namespace {
-std::size_t memoryLimitWithSafetyMargin(const CDataFrameAnalysisSpecification& spec) {
-    return static_cast<std::size_t>(0.9 * static_cast<double>(spec.memoryLimit()) + 0.5);
-}
-
 std::size_t maximumNumberPartitions(const CDataFrameAnalysisSpecification& spec) {
     // We limit the maximum number of partitions to rows^(1/2) because very
     // large numbers of partitions are going to be slow and it is better to tell
@@ -69,7 +65,7 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
 
     std::size_t numberRows{m_Spec.numberRows()};
     std::size_t numberColumns{m_Spec.numberColumns() + this->numberExtraColumns()};
-    std::size_t memoryLimit{memoryLimitWithSafetyMargin(m_Spec)};
+    std::size_t memoryLimit{m_Spec.memoryLimit()};
 
     LOG_TRACE(<< "memory limit = " << memoryLimit);
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -479,7 +479,7 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
     LOG_DEBUG(<< "peak memory = "
               << core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage));
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) > 1);
-    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 110000); // + 10%
+    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 115000); // + 15%
 }
 
 void CDataFrameAnalyzerTest::testRunOutlierFeatureInfluences() {


### PR DESCRIPTION
Backport #666.