### PR TITLE
[6.8][ML] Pick up headers from the approved place on macOS Mojave

### DIFF
--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -61,12 +61,6 @@ xcode-select --install
 
 at the command prompt.
 
-If you are using Mojave you must take the further step of installing the developer header files into `/usr/include`. Previous versions did this automatically when the command line tools were installed. Create `/usr/include` by installing `/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg` this can be done with the command:
-
-```
-installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
-```
-
 ### log4cxx
 
 Download `apache-log4cxx-0.10.0.tar.gz` from one of the mirrors listed at <http://www.apache.org/dyn/closer.cgi/logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz>.

--- a/mk/macosx.mk
+++ b/mk/macosx.mk
@@ -22,6 +22,7 @@ COVERAGE=--coverage
 endif
 endif
 
+SDK_PATH:=$(shell xcrun --show-sdk-path)
 # Start by enabling all warnings and then disable the really pointless/annoying ones
 CFLAGS=-g $(OPTCFLAGS) -msse4.2 -fstack-protector -Weverything -Werror-switch -Wno-deprecated -Wno-disabled-macro-expansion -Wno-documentation-deprecated-sync -Wno-documentation-unknown-command -Wno-float-equal -Wno-gnu -Wno-missing-prototypes -Wno-padded -Wno-sign-conversion -Wno-unreachable-code -Wno-used-but-marked-unused $(COVERAGE)
 CXXFLAGS=$(CFLAGS) -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors -Wno-global-constructors -Wno-undefined-reinterpret-cast -Wno-unused-member-function -Wno-weak-vtables
@@ -48,7 +49,7 @@ BOOSTDATETIMELIBS=-lboost_date_time-clang-darwin$(BOOSTCLANGVER)-mt-$(BOOSTVER)
 RAPIDJSONINCLUDES=-isystem $(CPP_SRC_HOME)/3rd_party/rapidjson/include
 RAPIDJSONCPPFLAGS=-DRAPIDJSON_HAS_STDSTRING -DRAPIDJSON_SSE42
 EIGENCPPFLAGS=-DEIGEN_MPL2_ONLY
-XMLINCLUDES=-isystem /usr/include/libxml2
+XMLINCLUDES=-isystem $(SDK_PATH)/usr/include/libxml2
 XMLLIBLDFLAGS=-L/usr/lib
 XMLLIBS=-lxml2
 JAVANATIVEINCLUDES=-I`/usr/libexec/java_home`/include


### PR DESCRIPTION
Starting with macOS Mojave, Apple has deprecated picking
up system headers from /usr/include.  Instead they should
be picked up from the appropriate SDK directory in the
Xcode app.

Backport of #669