### PR TITLE
[ML] Persisting time series decomposition state with readable tags

### DIFF
--- a/devbin/model_extractor/Main.cc
+++ b/devbin/model_extractor/Main.cc
@@ -125,8 +125,7 @@ int main(int argc, char** argv) {
         ml::api::CSingleStreamDataAdder persister{persistStrm};
 
         // Attempt to persist state in a plain JSON formatted file or stream
-        if (restoredJob.persistResidualModelsState(persister, completeToTime,
-                                                   outputFormat) == false) {
+        if (restoredJob.persistModelsState(persister, completeToTime, outputFormat) == false) {
             LOG_FATAL(<< "Failed to persist state as JSON");
             exit(EXIT_FAILURE);
         }

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -177,9 +177,9 @@ public:
     bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
 
     //! Persist state of the residual models only
-    bool persistResidualModelsState(core::CDataAdder& persister,
-                                    core_t::TTime timestamp,
-                                    const std::string& outputFormat);
+    bool persistModelsState(core::CDataAdder& persister,
+                            core_t::TTime timestamp,
+                            const std::string& outputFormat);
 
     //! Initialise normalizer from quantiles state
     virtual bool initNormalizer(const std::string& quantilesStateFile);
@@ -274,10 +274,10 @@ private:
     bool periodicPersistStateInForeground() override;
 
     //! Persist state of the residual models only
-    bool persistResidualModelsState(const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
-                                    core::CDataAdder& persister,
-                                    core_t::TTime timestamp,
-                                    const std::string& outputFormat);
+    bool persistModelsState(const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
+                            core::CDataAdder& persister,
+                            core_t::TTime timestamp,
+                            const std::string& outputFormat);
 
     //! Acknowledge a flush request
     void acknowledgeFlush(const std::string& flushId);

--- a/include/maths/CLeastSquaresOnlineRegression.h
+++ b/include/maths/CLeastSquaresOnlineRegression.h
@@ -102,7 +102,7 @@ public:
     using TVectorMeanAccumulator = typename CBasicStatistics::SSampleMean<TVector>::TAccumulator;
 
 public:
-    static const std::string STATISTIC_TAG;
+    static const core::TPersistenceTag STATISTIC_TAG;
     static const T MAX_CONDITION;
 
 public:
@@ -423,7 +423,8 @@ private:
 };
 
 template<std::size_t N_, typename T>
-const std::string CLeastSquaresOnlineRegression<N_, T>::STATISTIC_TAG("a");
+const core::TPersistenceTag
+    CLeastSquaresOnlineRegression<N_, T>::STATISTIC_TAG("a", "statistic");
 template<std::size_t N_, typename T>
 const T CLeastSquaresOnlineRegression<N_, T>::MAX_CONDITION{
     least_squares_online_regression_detail::CMaxCondition<T>::VALUE};

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -315,7 +315,7 @@ public:
     static EUpdateResult combine(EUpdateResult lhs, EUpdateResult rhs);
 
 public:
-    CModel(const CModelParams& params);
+    explicit CModel(const CModelParams& params);
     virtual ~CModel() = default;
 
     //! These don't need to be and shouldn't be copied.
@@ -438,7 +438,7 @@ public:
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const = 0;
 
     //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& inserter) const = 0;
+    virtual void persistModelsState(core::CStatePersistInserter& inserter) const = 0;
 
     //! Get the type of data being modeled.
     virtual maths_t::EDataType dataType() const = 0;
@@ -490,102 +490,103 @@ public:
     CModelStub();
 
     //! Returns 0.
-    virtual std::size_t identifier() const;
+    std::size_t identifier() const override;
 
     //! Create a copy of this model passing ownership to the caller.
-    virtual CModelStub* clone(std::size_t id) const;
+    CModelStub* clone(std::size_t id) const override;
 
     //! Create a copy of the state we need to persist passing ownership to the caller.
-    virtual CModelStub* cloneForPersistence() const;
+    CModelStub* cloneForPersistence() const override;
 
     //! Create a copy of the state we need to run forecasting.
-    virtual CModelStub* cloneForForecast() const;
+    CModelStub* cloneForForecast() const override;
 
     //! Return false;
-    virtual bool isForecastPossible() const;
+    bool isForecastPossible() const override;
 
     //! No-op.
-    virtual void modelCorrelations(CTimeSeriesCorrelations& model);
+    void modelCorrelations(CTimeSeriesCorrelations& model) override;
 
     //! Returns empty.
-    virtual TSize2Vec1Vec correlates() const;
+    TSize2Vec1Vec correlates() const override;
 
     //! No-op.
-    virtual void addBucketValue(const TTimeDouble2VecSizeTrVec& value);
+    void addBucketValue(const TTimeDouble2VecSizeTrVec& value) override;
 
     //! No-op.
-    virtual EUpdateResult addSamples(const CModelAddSamplesParams& params,
-                                     TTimeDouble2VecSizeTrVec samples);
+    EUpdateResult addSamples(const CModelAddSamplesParams& params,
+                             TTimeDouble2VecSizeTrVec samples) override;
 
     //! No-op.
-    virtual void skipTime(core_t::TTime gap);
+    void skipTime(core_t::TTime gap) override;
 
     //! Returns empty.
-    virtual TDouble2Vec mode(core_t::TTime time, const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec mode(core_t::TTime time, const TDouble2VecWeightsAry& weights) const override;
 
     //! Returns empty.
-    virtual TDouble2Vec1Vec
-    correlateModes(core_t::TTime time, const TDouble2VecWeightsAry1Vec& weights) const;
+    TDouble2Vec1Vec correlateModes(core_t::TTime time,
+                                   const TDouble2VecWeightsAry1Vec& weights) const override;
 
     //! Returns empty.
-    virtual TDouble2Vec1Vec residualModes(const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec1Vec residualModes(const TDouble2VecWeightsAry& weights) const override;
 
     //! No-op.
-    virtual void detrend(const TTime2Vec1Vec& time,
-                         double confidenceInterval,
-                         TDouble2Vec1Vec& value) const;
+    void detrend(const TTime2Vec1Vec& time,
+                 double confidenceInterval,
+                 TDouble2Vec1Vec& value) const override;
 
     //! Returns empty.
-    virtual TDouble2Vec predict(core_t::TTime time,
-                                const TSizeDoublePr1Vec& correlated,
-                                TDouble2Vec hint = TDouble2Vec()) const;
+    TDouble2Vec predict(core_t::TTime time,
+                        const TSizeDoublePr1Vec& correlated,
+                        TDouble2Vec hint = TDouble2Vec()) const override;
 
     //! Returns empty.
-    virtual TDouble2Vec3Vec confidenceInterval(core_t::TTime time,
-                                               double confidenceInterval,
-                                               const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec3Vec confidenceInterval(core_t::TTime time,
+                                       double confidenceInterval,
+                                       const TDouble2VecWeightsAry& weights) const override;
 
     //! Returns empty.
-    virtual bool forecast(core_t::TTime firstDataTime,
-                          core_t::TTime lastDataTime,
-                          core_t::TTime startTime,
-                          core_t::TTime endTime,
-                          double confidenceInterval,
-                          const TDouble2Vec& minimum,
-                          const TDouble2Vec& maximum,
-                          const TForecastPushDatapointFunc& forecastPushDataPointFunc,
-                          std::string& messageOut);
+    bool forecast(core_t::TTime firstDataTime,
+                  core_t::TTime lastDataTime,
+                  core_t::TTime startTime,
+                  core_t::TTime endTime,
+                  double confidenceInterval,
+                  const TDouble2Vec& minimum,
+                  const TDouble2Vec& maximum,
+                  const TForecastPushDatapointFunc& forecastPushDataPointFunc,
+                  std::string& messageOut) override;
 
     //! Returns true.
-    virtual bool probability(const CModelProbabilityParams& params,
-                             const TTime2Vec1Vec& time,
-                             const TDouble2Vec1Vec& value,
-                             SModelProbabilityResult& result) const;
+    bool probability(const CModelProbabilityParams& params,
+                     const TTime2Vec1Vec& time,
+                     const TDouble2Vec1Vec& value,
+                     SModelProbabilityResult& result) const override;
 
     //! Returns empty.
-    virtual TDouble2Vec
-    winsorisationWeight(double derate, core_t::TTime time, const TDouble2Vec& value) const;
+    TDouble2Vec winsorisationWeight(double derate,
+                                    core_t::TTime time,
+                                    const TDouble2Vec& value) const override;
 
     //! Returns empty.
-    virtual TDouble2Vec seasonalWeight(double confidence, core_t::TTime time) const;
+    TDouble2Vec seasonalWeight(double confidence, core_t::TTime time) const override;
 
     //! Returns the seed.
-    virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! No-op.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& inserter) const;
+    void persistModelsState(core::CStatePersistInserter& inserter) const override;
 
     //! Returns mixed data type since we don't know.
-    virtual maths_t::EDataType dataType() const;
+    maths_t::EDataType dataType() const override;
 };
 }
 }

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -80,116 +80,117 @@ public:
                                bool modelAnomalies = true);
     CUnivariateTimeSeriesModel(const SModelRestoreParams& params,
                                core::CStateRestoreTraverser& traverser);
-    ~CUnivariateTimeSeriesModel();
+    ~CUnivariateTimeSeriesModel() override;
 
     const CUnivariateTimeSeriesModel& operator=(const CUnivariateTimeSeriesModel&) = delete;
 
     //! Get the model identifier.
-    virtual std::size_t identifier() const;
+    std::size_t identifier() const override;
 
     //! Create a copy of this model passing ownership to the caller.
-    virtual CUnivariateTimeSeriesModel* clone(std::size_t id) const;
+    CUnivariateTimeSeriesModel* clone(std::size_t id) const override;
 
     //! Create a copy of the state we need to persist passing ownership
     //! to the caller.
-    virtual CUnivariateTimeSeriesModel* cloneForPersistence() const;
+    CUnivariateTimeSeriesModel* cloneForPersistence() const override;
 
     //! Create a copy of the state we need to run forecasting.
-    virtual CUnivariateTimeSeriesModel* cloneForForecast() const;
+    CUnivariateTimeSeriesModel* cloneForForecast() const override;
 
     //! Return true if forecast is currently possible for this model.
-    virtual bool isForecastPossible() const;
+    bool isForecastPossible() const override;
 
     //! Tell this to model correlations.
-    virtual void modelCorrelations(CTimeSeriesCorrelations& model);
+    void modelCorrelations(CTimeSeriesCorrelations& model) override;
 
     //! Get the correlated time series identifier pairs if any.
-    virtual TSize2Vec1Vec correlates() const;
+    TSize2Vec1Vec correlates() const override;
 
     //! Update the model with the bucket \p value.
-    virtual void addBucketValue(const TTimeDouble2VecSizeTrVec& value);
+    void addBucketValue(const TTimeDouble2VecSizeTrVec& value) override;
 
     //! Update the model with new samples.
-    virtual EUpdateResult addSamples(const CModelAddSamplesParams& params,
-                                     TTimeDouble2VecSizeTrVec samples);
+    EUpdateResult addSamples(const CModelAddSamplesParams& params,
+                             TTimeDouble2VecSizeTrVec samples) override;
 
     //! Advance time by \p gap.
-    virtual void skipTime(core_t::TTime gap);
+    void skipTime(core_t::TTime gap) override;
 
     //! Get the most likely value for the time series at \p time.
-    virtual TDouble2Vec mode(core_t::TTime time, const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec mode(core_t::TTime time, const TDouble2VecWeightsAry& weights) const override;
 
     //! Get the most likely value for each correlate time series
     //! at \p time, if there are any.
-    virtual TDouble2Vec1Vec
-    correlateModes(core_t::TTime time, const TDouble2VecWeightsAry1Vec& weights) const;
+    TDouble2Vec1Vec correlateModes(core_t::TTime time,
+                                   const TDouble2VecWeightsAry1Vec& weights) const override;
 
     //! Get the local maxima of the residual distribution.
-    virtual TDouble2Vec1Vec residualModes(const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec1Vec residualModes(const TDouble2VecWeightsAry& weights) const override;
 
     //! Remove any trend components from \p value.
-    virtual void detrend(const TTime2Vec1Vec& time,
-                         double confidenceInterval,
-                         TDouble2Vec1Vec& value) const;
+    void detrend(const TTime2Vec1Vec& time,
+                 double confidenceInterval,
+                 TDouble2Vec1Vec& value) const override;
 
     //! Get the best (least MSE) predicted value at \p time.
-    virtual TDouble2Vec predict(core_t::TTime time,
-                                const TSizeDoublePr1Vec& correlated = TSizeDoublePr1Vec(),
-                                TDouble2Vec hint = TDouble2Vec()) const;
+    TDouble2Vec predict(core_t::TTime time,
+                        const TSizeDoublePr1Vec& correlated = TSizeDoublePr1Vec(),
+                        TDouble2Vec hint = TDouble2Vec()) const override;
 
     //! Get the prediction and \p confidenceInterval percentage
     //! confidence interval for the time series at \p time.
-    virtual TDouble2Vec3Vec confidenceInterval(core_t::TTime time,
-                                               double confidenceInterval,
-                                               const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec3Vec confidenceInterval(core_t::TTime time,
+                                       double confidenceInterval,
+                                       const TDouble2VecWeightsAry& weights) const override;
 
     //! Forecast the time series and get its \p confidenceInterval
     //! percentage confidence interval between \p startTime and
     //! \p endTime.
-    virtual bool forecast(core_t::TTime firstDataTime,
-                          core_t::TTime lastDataTime,
-                          core_t::TTime startTime,
-                          core_t::TTime endTime,
-                          double confidenceInterval,
-                          const TDouble2Vec& minimum,
-                          const TDouble2Vec& maximum,
-                          const TForecastPushDatapointFunc& forecastPushDataPointFunc,
-                          std::string& messageOut);
+    bool forecast(core_t::TTime firstDataTime,
+                  core_t::TTime lastDataTime,
+                  core_t::TTime startTime,
+                  core_t::TTime endTime,
+                  double confidenceInterval,
+                  const TDouble2Vec& minimum,
+                  const TDouble2Vec& maximum,
+                  const TForecastPushDatapointFunc& forecastPushDataPointFunc,
+                  std::string& messageOut) override;
 
     //! Compute the probability of drawing \p value at \p time.
-    virtual bool probability(const CModelProbabilityParams& params,
-                             const TTime2Vec1Vec& time,
-                             const TDouble2Vec1Vec& value,
-                             SModelProbabilityResult& result) const;
+    bool probability(const CModelProbabilityParams& params,
+                     const TTime2Vec1Vec& time,
+                     const TDouble2Vec1Vec& value,
+                     SModelProbabilityResult& result) const override;
 
     //! Get the Winsorisation weight to apply to \p value.
-    virtual TDouble2Vec
-    winsorisationWeight(double derate, core_t::TTime time, const TDouble2Vec& value) const;
+    TDouble2Vec winsorisationWeight(double derate,
+                                    core_t::TTime time,
+                                    const TDouble2Vec& value) const override;
 
     //! Get the seasonal variance scale at \p time.
-    virtual TDouble2Vec seasonalWeight(double confidence, core_t::TTime time) const;
+    TDouble2Vec seasonalWeight(double confidence, core_t::TTime time) const override;
 
     //! Compute a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! Initialize reading state from \p traverser.
     bool acceptRestoreTraverser(const SModelRestoreParams& params,
                                 core::CStateRestoreTraverser& traverser);
 
     //! Persist by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& inserter) const;
+    void persistModelsState(core::CStatePersistInserter& inserter) const override;
 
     //! Get the type of data being modeled.
-    virtual maths_t::EDataType dataType() const;
+    maths_t::EDataType dataType() const override;
 
     //! Unpack the weights in \p weights.
     static TDoubleWeightsAry unpack(const TDouble2VecWeightsAry& weights);
@@ -554,113 +555,114 @@ public:
     CMultivariateTimeSeriesModel(const CMultivariateTimeSeriesModel& other);
     CMultivariateTimeSeriesModel(const SModelRestoreParams& params,
                                  core::CStateRestoreTraverser& traverser);
-    ~CMultivariateTimeSeriesModel();
+    ~CMultivariateTimeSeriesModel() override;
 
     const CMultivariateTimeSeriesModel& operator=(const CMultivariateTimeSeriesModel&) = delete;
 
     //! Returns 0 since these models don't need a unique identifier.
-    virtual std::size_t identifier() const;
+    std::size_t identifier() const override;
 
     //! Create a copy of this model passing ownership to the caller.
-    virtual CMultivariateTimeSeriesModel* clone(std::size_t id) const;
+    CMultivariateTimeSeriesModel* clone(std::size_t id) const override;
 
     //! Create a copy of the state we need to persist passing ownership
     //! to the caller.
-    virtual CMultivariateTimeSeriesModel* cloneForPersistence() const;
+    CMultivariateTimeSeriesModel* cloneForPersistence() const override;
 
     //! Create a copy of the state we need to run forecasting.
-    virtual CMultivariateTimeSeriesModel* cloneForForecast() const;
+    CMultivariateTimeSeriesModel* cloneForForecast() const override;
 
     //! Returns false (not currently supported for multivariate features).
-    virtual bool isForecastPossible() const;
+    bool isForecastPossible() const override;
 
     //! No-op.
-    virtual void modelCorrelations(CTimeSeriesCorrelations& model);
+    void modelCorrelations(CTimeSeriesCorrelations& model) override;
 
     //! Returns empty.
-    virtual TSize2Vec1Vec correlates() const;
+    TSize2Vec1Vec correlates() const override;
 
     //! Update the model with the bucket \p value.
-    virtual void addBucketValue(const TTimeDouble2VecSizeTrVec& value);
+    void addBucketValue(const TTimeDouble2VecSizeTrVec& value) override;
 
     //! Update the model with new samples.
-    virtual EUpdateResult addSamples(const CModelAddSamplesParams& params,
-                                     TTimeDouble2VecSizeTrVec samples);
+    EUpdateResult addSamples(const CModelAddSamplesParams& params,
+                             TTimeDouble2VecSizeTrVec samples) override;
 
     //! Advance time by \p gap.
-    virtual void skipTime(core_t::TTime gap);
+    void skipTime(core_t::TTime gap) override;
 
     //! Get the most likely value for the time series at \p time.
-    virtual TDouble2Vec mode(core_t::TTime time, const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec mode(core_t::TTime time, const TDouble2VecWeightsAry& weights) const override;
 
     //! Returns empty.
-    virtual TDouble2Vec1Vec
-    correlateModes(core_t::TTime time, const TDouble2VecWeightsAry1Vec& weights) const;
+    TDouble2Vec1Vec correlateModes(core_t::TTime time,
+                                   const TDouble2VecWeightsAry1Vec& weights) const override;
 
     //! Get the local maxima of the residual distribution.
-    virtual TDouble2Vec1Vec residualModes(const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec1Vec residualModes(const TDouble2VecWeightsAry& weights) const override;
 
     //! Remove any trend components from \p value.
-    virtual void detrend(const TTime2Vec1Vec& time,
-                         double confidenceInterval,
-                         TDouble2Vec1Vec& value) const;
+    void detrend(const TTime2Vec1Vec& time,
+                 double confidenceInterval,
+                 TDouble2Vec1Vec& value) const override;
 
     //! Get the best (least MSE) predicted value at \p time.
-    virtual TDouble2Vec predict(core_t::TTime time,
-                                const TSizeDoublePr1Vec& correlated = TSizeDoublePr1Vec(),
-                                TDouble2Vec hint = TDouble2Vec()) const;
+    TDouble2Vec predict(core_t::TTime time,
+                        const TSizeDoublePr1Vec& correlated = TSizeDoublePr1Vec(),
+                        TDouble2Vec hint = TDouble2Vec()) const override;
 
     //! Get the prediction and \p confidenceInterval percentage
     //! confidence interval for the time series at \p time.
-    virtual TDouble2Vec3Vec confidenceInterval(core_t::TTime time,
-                                               double confidenceInterval,
-                                               const TDouble2VecWeightsAry& weights) const;
+    TDouble2Vec3Vec confidenceInterval(core_t::TTime time,
+                                       double confidenceInterval,
+                                       const TDouble2VecWeightsAry& weights) const override;
 
     //! Not currently supported.
-    virtual bool forecast(core_t::TTime firstDataTime,
-                          core_t::TTime lastDataTime,
-                          core_t::TTime startTime,
-                          core_t::TTime endTime,
-                          double confidenceInterval,
-                          const TDouble2Vec& minimum,
-                          const TDouble2Vec& maximum,
-                          const TForecastPushDatapointFunc& forecastPushDataPointFunc,
-                          std::string& messageOut);
+    bool forecast(core_t::TTime firstDataTime,
+                  core_t::TTime lastDataTime,
+                  core_t::TTime startTime,
+                  core_t::TTime endTime,
+                  double confidenceInterval,
+                  const TDouble2Vec& minimum,
+                  const TDouble2Vec& maximum,
+                  const TForecastPushDatapointFunc& forecastPushDataPointFunc,
+                  std::string& messageOut) override;
 
     //! Compute the probability of drawing \p value at \p time.
-    virtual bool probability(const CModelProbabilityParams& params,
-                             const TTime2Vec1Vec& time,
-                             const TDouble2Vec1Vec& value,
-                             SModelProbabilityResult& result) const;
+    bool probability(const CModelProbabilityParams& params,
+                     const TTime2Vec1Vec& time,
+                     const TDouble2Vec1Vec& value,
+                     SModelProbabilityResult& result) const override;
 
     //! Get the Winsorisation weight to apply to \p value.
-    virtual TDouble2Vec
-    winsorisationWeight(double derate, core_t::TTime time, const TDouble2Vec& value) const;
+    TDouble2Vec winsorisationWeight(double derate,
+                                    core_t::TTime time,
+                                    const TDouble2Vec& value) const override;
 
     //! Get the seasonal variance scale at \p time.
-    virtual TDouble2Vec seasonalWeight(double confidence, core_t::TTime time) const;
+    TDouble2Vec seasonalWeight(double confidence, core_t::TTime time) const override;
 
     //! Compute a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! Initialize reading state from \p traverser.
     bool acceptRestoreTraverser(const SModelRestoreParams& params,
                                 core::CStateRestoreTraverser& traverser);
 
     //! Persist by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& inserter) const;
+    void persistModelsState(core::CStatePersistInserter& inserter) const override;
 
     //! Get the type of data being modeled.
-    virtual maths_t::EDataType dataType() const;
+    maths_t::EDataType dataType() const override;
 
     //! Unpack the weights in \p weights.
     static TDouble10VecWeightsAry unpack(const TDouble2VecWeightsAry& weights);

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -190,7 +190,7 @@ public:
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
     // Persist the state of the residual models only.
-    void persistResidualModelsState(core::CStatePersistInserter& inserter) const;
+    void persistModelsState(core::CStatePersistInserter& inserter) const;
 
     //! Get the cue for this detector.  This consists of the search key cue
     //! with the partition field value appended.

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -196,8 +196,8 @@ public:
 
     //! \name Persistence
     //@{
-    //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& inserter) const = 0;
+    //! Persist the state of the models.
+    virtual void persistModelsState(core::CStatePersistInserter& inserter) const = 0;
 
     //! Persist state by passing information to the supplied inserter.
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const = 0;
@@ -505,7 +505,7 @@ protected:
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
         //! Persist the state of the residual models only.
-        void persistResidualModelsState(core::CStatePersistInserter& inserter) const;
+        void persistModelsState(core::CStatePersistInserter& inserter) const;
 
         //! Debug the memory used by this model.
         void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -64,36 +64,36 @@ public:
     //@}
 
     //! Returns event rate online.
-    virtual model_t::EModelType category() const;
+    model_t::EModelType category() const override;
 
     //! Returns false.
-    virtual bool isPopulation() const;
+    bool isPopulation() const override;
 
     //! Returns false.
-    virtual bool isEventRate() const;
+    bool isEventRate() const override;
 
     //! Returns false.
-    virtual bool isMetric() const;
+    bool isMetric() const override;
 
     //! \name Persistence
     //@{
-    //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& /*inserter*/) const {
+    //! Persist the state of the models only.
+    void persistModelsState(core::CStatePersistInserter& /*inserter*/) const override {
         // NO-OP
     }
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Add to the contents of the object.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
     //! Create a clone of this model that will result in the same persisted
     //! state.  The clone may be incomplete in ways that do not affect the
     //! persisted representation, and must not be used for any other
     //! purpose.
     //! \warning The caller owns the object returned.
-    virtual CAnomalyDetectorModel* cloneForPersistence() const;
+    CAnomalyDetectorModel* cloneForPersistence() const override;
     //@}
 
     //! \name Bucket Statistics
@@ -105,13 +105,13 @@ public:
     //! \param[in] time The time of interest.
     //! \return The count in the bucketing interval at \p time for the
     //! person identified by \p pid if available and null otherwise.
-    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const;
+    TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
 
     //! Get the mean bucket count or the reference model mean bucket
     //! count if one is defined for the person identified by \p pid.
     //!
     //! \param[in] pid The identifier of the person of interest.
-    virtual TOptionalDouble baselineBucketCount(std::size_t pid) const;
+    TOptionalDouble baselineBucketCount(std::size_t pid) const override;
 
     //! Get the count of the bucketing interval containing \p time
     //! for the person identified by \p pid.
@@ -120,10 +120,10 @@ public:
     //! \param[in] pid The identifier of the person of interest.
     //! \param[in] cid Ignored.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec currentBucketValue(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           core_t::TTime time) const;
+    TDouble1Vec currentBucketValue(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   core_t::TTime time) const override;
 
     //! Get the mean bucket count or the reference model mean bucket
     //! count if one is defined for the person identified by \p pid.
@@ -134,12 +134,12 @@ public:
     //! \param[in] type Ignored.
     //! \param[in] correlated Ignored.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec baselineBucketMean(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           model_t::CResultType type,
-                                           const TSizeDoublePr1Vec& correlated,
-                                           core_t::TTime time) const;
+    TDouble1Vec baselineBucketMean(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   model_t::CResultType type,
+                                   const TSizeDoublePr1Vec& correlated,
+                                   core_t::TTime time) const override;
     //@}
 
     //! \name Person
@@ -150,7 +150,7 @@ public:
     //! \param[in] time The time of interest.
     //! \param[out] result Filled in with the person identifiers
     //! in the bucketing time interval of interest.
-    virtual void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const;
+    void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const override;
     //@}
 
     //! \name Update
@@ -161,9 +161,9 @@ public:
     //!
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
-    virtual void sampleBucketStatistics(core_t::TTime startTime,
-                                        core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor);
+    void sampleBucketStatistics(core_t::TTime startTime,
+                                core_t::TTime endTime,
+                                CResourceMonitor& resourceMonitor) override;
 
     //! This samples the bucket statistics, in the time interval
     //! [\p startTime, \p endTime].
@@ -171,27 +171,27 @@ public:
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
     //! \param[in] resourceMonitor The resourceMonitor.
-    virtual void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor);
+    void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor) override;
 
     //! No-op.
-    virtual void prune(std::size_t maximumAge);
+    void prune(std::size_t maximumAge) override;
     //@}
 
     //! \name Probability
     //@{
     //! Sets \p probability to 1.
-    virtual bool computeProbability(std::size_t pid,
-                                    core_t::TTime startTime,
-                                    core_t::TTime endTime,
-                                    CPartitioningFields& partitioningFields,
-                                    std::size_t numberAttributeProbabilities,
-                                    SAnnotatedProbability& result) const;
+    bool computeProbability(std::size_t pid,
+                            core_t::TTime startTime,
+                            core_t::TTime endTime,
+                            CPartitioningFields& partitioningFields,
+                            std::size_t numberAttributeProbabilities,
+                            SAnnotatedProbability& result) const override;
 
     //! Sets \p probability to 1.
-    virtual bool computeTotalProbability(const std::string& person,
-                                         std::size_t numberAttributeProbabilities,
-                                         TOptionalDouble& probability,
-                                         TAttributeProbability1Vec& attributeProbabilities) const;
+    bool computeTotalProbability(const std::string& person,
+                                 std::size_t numberAttributeProbabilities,
+                                 TOptionalDouble& probability,
+                                 TAttributeProbability1Vec& attributeProbabilities) const override;
     //@}
 
     //! Get the checksum of this model.
@@ -200,32 +200,32 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Get the memory used by this model
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this model
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    std::size_t staticSize() const override;
 
     //! Returns null.
-    virtual CModelDetailsViewPtr details() const;
+    CModelDetailsViewPtr details() const override;
 
     //! Get the descriptions of any occurring scheduled event descriptions for the bucket time
-    virtual const TStr1Vec& scheduledEventDescriptions(core_t::TTime time) const;
+    const TStr1Vec& scheduledEventDescriptions(core_t::TTime time) const override;
 
 protected:
     //! Get the start time of the current bucket.
-    virtual core_t::TTime currentBucketStartTime() const;
+    core_t::TTime currentBucketStartTime() const override;
 
     //! Set the start time of the current bucket.
-    virtual void currentBucketStartTime(core_t::TTime time);
+    void currentBucketStartTime(core_t::TTime time) override;
 
     //! Get the non-estimated value of the the memory used by this model.
-    virtual std::size_t computeMemoryUsage() const;
+    std::size_t computeMemoryUsage() const override;
 
 private:
     //! Get the scheduled events that match at sampleTime.
@@ -236,37 +236,37 @@ private:
     void setMatchedEventsDescriptions(core_t::TTime sampleTime, core_t::TTime bucketStartTime);
 
     //! Returns one.
-    virtual double attributeFrequency(std::size_t cid) const;
+    double attributeFrequency(std::size_t cid) const override;
 
     //! Monitor the resource usage while creating new models.
     void createUpdateNewModels(core_t::TTime, CResourceMonitor& resourceMonitor);
 
     //! Create the mean counts for "n" newly observed people.
-    virtual void createNewModels(std::size_t n, std::size_t m);
+    void createNewModels(std::size_t n, std::size_t m) override;
 
     //! Update start time and counts for the given bucket.
     void updateCurrentBucketsStats(core_t::TTime time);
 
     //! Reinitialize the time series models for recycled people.
-    virtual void updateRecycledModels();
+    void updateRecycledModels() override;
 
     //! Initialize the time series models for newly observed people.
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override;
 
     //! Get the object which calculates corrections for interim buckets.
-    virtual const CInterimBucketCorrector& interimValueCorrector() const;
+    const CInterimBucketCorrector& interimValueCorrector() const override;
 
     //! Check if bucket statistics are available for the specified time.
-    bool bucketStatsAvailable(core_t::TTime time) const;
+    bool bucketStatsAvailable(core_t::TTime time) const override;
 
     //! Print the current bucketing interval.
     std::string printCurrentBucket() const;
 
     //! Perform derived class specific operations to accomplish skipping sampling
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime);
+    void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
 
     //! Get the model memory usage estimator
-    virtual CMemoryUsageEstimator* memoryUsageEstimator() const;
+    CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
 private:
     using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -127,36 +127,36 @@ public:
 
     //! \name Persistence
     //@{
-    //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& inserter) const;
+    //! Persist the state of the models only.
+    void persistModelsState(core::CStatePersistInserter& inserter) const override;
 
     //! Persist state by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Restore reading state from \p traverser.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
     //! Create a clone of this model that will result in the same persisted
     //! state.  The clone may be incomplete in ways that do not affect the
     //! persisted representation, and must not be used for any other
     //! purpose.
     //! \warning The caller owns the object returned.
-    virtual CAnomalyDetectorModel* cloneForPersistence() const;
+    CAnomalyDetectorModel* cloneForPersistence() const override;
     //@}
 
     //! Get the model category.
-    virtual model_t::EModelType category() const;
+    model_t::EModelType category() const override;
 
     //! Returns true.
-    virtual bool isEventRate() const;
+    bool isEventRate() const override;
 
     //! Returns false.
-    virtual bool isMetric() const;
+    bool isMetric() const override;
 
     //! \name Bucket Statistics
     //@{
     //! Returns null.
-    virtual TOptionalDouble baselineBucketCount(std::size_t pid) const;
+    TOptionalDouble baselineBucketCount(std::size_t pid) const override;
 
     //! Get the value of \p feature for the person identified
     //! by \p pid in the bucketing interval containing \p time.
@@ -165,10 +165,10 @@ public:
     //! \param[in] pid The identifier of the person of interest.
     //! \param[in] cid Ignored.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec currentBucketValue(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           core_t::TTime time) const;
+    TDouble1Vec currentBucketValue(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   core_t::TTime time) const override;
 
     //! Get the baseline bucket value of \p feature for the person
     //! identified by \p pid as of the start of the current bucketing
@@ -182,12 +182,12 @@ public:
     //! \param[in] correlated The correlated series' identifiers and
     //! their values if any.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec baselineBucketMean(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           model_t::CResultType type,
-                                           const TSizeDoublePr1Vec& correlated,
-                                           core_t::TTime time) const;
+    TDouble1Vec baselineBucketMean(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   model_t::CResultType type,
+                                   const TSizeDoublePr1Vec& correlated,
+                                   core_t::TTime time) const override;
 
     //@}
 
@@ -195,7 +195,7 @@ public:
     //@{
     //! Get the person unique identifiers which have a feature value
     //! in the bucketing time interval including \p time.
-    virtual void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const;
+    void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const override;
     //@}
 
     //! \name Update
@@ -206,9 +206,9 @@ public:
     //!
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
-    virtual void sampleBucketStatistics(core_t::TTime startTime,
-                                        core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor);
+    void sampleBucketStatistics(core_t::TTime startTime,
+                                core_t::TTime endTime,
+                                CResourceMonitor& resourceMonitor) override;
 
     //! Update the model with features samples from the time interval
     //! [\p startTime, \p endTime].
@@ -216,7 +216,7 @@ public:
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
     //! \param[in] resourceMonitor The resourceMonitor.
-    virtual void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor);
+    void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor) override;
     //@}
 
     //! \name Probability
@@ -234,12 +234,12 @@ public:
     //! \param[out] result A structure containing the probability,
     //! the smallest \p numberAttributeProbabilities attribute
     //! probabilities, the influences and any extra descriptive data
-    virtual bool computeProbability(std::size_t pid,
-                                    core_t::TTime startTime,
-                                    core_t::TTime endTime,
-                                    CPartitioningFields& partitioningFields,
-                                    std::size_t numberAttributeProbabilities,
-                                    SAnnotatedProbability& result) const;
+    bool computeProbability(std::size_t pid,
+                            core_t::TTime startTime,
+                            core_t::TTime endTime,
+                            CPartitioningFields& partitioningFields,
+                            std::size_t numberAttributeProbabilities,
+                            SAnnotatedProbability& result) const override;
     //@}
 
     //! Get the checksum of this model.
@@ -248,22 +248,22 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies.
-    virtual std::size_t staticSize() const;
+    std::size_t staticSize() const override;
 
     //! Get the non-estimated value of the the memory used by this model.
-    virtual std::size_t computeMemoryUsage() const;
+    std::size_t computeMemoryUsage() const override;
 
     //! Get a view of the internals of the model for visualization.
-    virtual CModelDetailsViewPtr details() const;
+    CModelDetailsViewPtr details() const override;
 
     //! Get the value of the \p feature of the person identified
     //! by \p pid for the bucketing interval containing \p time.
@@ -272,25 +272,25 @@ public:
 
 private:
     //! Get the start time of the current bucket.
-    virtual core_t::TTime currentBucketStartTime() const;
+    core_t::TTime currentBucketStartTime() const override;
 
     //! Set the start time of the current bucket.
-    virtual void currentBucketStartTime(core_t::TTime time);
+    void currentBucketStartTime(core_t::TTime time) override;
 
     //! Get the person counts in the current bucket.
-    virtual const TSizeUInt64PrVec& currentBucketPersonCounts() const;
+    const TSizeUInt64PrVec& currentBucketPersonCounts() const override;
 
     //! Get writable person counts in the current bucket.
-    virtual TSizeUInt64PrVec& currentBucketPersonCounts();
+    TSizeUInt64PrVec& currentBucketPersonCounts() override;
 
     //! Get the interim corrections of the current bucket.
     TFeatureSizeSizeTripleDouble1VecUMap& currentBucketInterimCorrections() const;
 
     //! Clear out large state objects for people that are pruned.
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override;
 
     //! Get the object which calculates corrections for interim buckets.
-    virtual const CInterimBucketCorrector& interimValueCorrector() const;
+    const CInterimBucketCorrector& interimValueCorrector() const override;
 
     //! Check if there are correlates for \p feature and the person
     //! identified by \p pid.

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -158,33 +158,33 @@ public:
 
     //! \name Persistence
     //@{
-    //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& /*inserter*/) const {
+    //! Persist the state of the models only.
+    void persistModelsState(core::CStatePersistInserter& /*inserter*/) const override {
         // NO-OP
     }
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Add to the contents of the object.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
     //! Create a clone of this model that will result in the same persisted
     //! state.  The clone may be incomplete in ways that do not affect the
     //! persisted representation, and must not be used for any other
     //! purpose.
     //! \warning The caller owns the object returned.
-    virtual CAnomalyDetectorModel* cloneForPersistence() const;
+    CAnomalyDetectorModel* cloneForPersistence() const override;
     //@}
 
     //! Get the model category.
-    virtual model_t::EModelType category() const;
+    model_t::EModelType category() const override;
 
     //! Returns true.
-    virtual bool isEventRate() const;
+    bool isEventRate() const override;
 
     //! Returns false.
-    virtual bool isMetric() const;
+    bool isMetric() const override;
 
     //! \name Bucket Statistics
     //@{
@@ -196,10 +196,10 @@ public:
     //! \param[in] pid The identifier of the person of interest.
     //! \param[in] cid The identifier of the attribute of interest.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec currentBucketValue(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           core_t::TTime time) const;
+    TDouble1Vec currentBucketValue(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   core_t::TTime time) const override;
 
     //! Get the population baseline mean of \p feature for the
     //! attribute identified by \p cid as of the start of the
@@ -213,15 +213,15 @@ public:
     //! \param[in] correlated The correlated series' identifiers and
     //! their values if any.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec baselineBucketMean(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           model_t::CResultType type,
-                                           const TSizeDoublePr1Vec& correlated,
-                                           core_t::TTime time) const;
+    TDouble1Vec baselineBucketMean(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   model_t::CResultType type,
+                                   const TSizeDoublePr1Vec& correlated,
+                                   core_t::TTime time) const override;
 
     //! Check if bucket statistics are available for the specified time.
-    virtual bool bucketStatsAvailable(core_t::TTime time) const;
+    bool bucketStatsAvailable(core_t::TTime time) const override;
     //@}
 
     //! \name Update
@@ -233,9 +233,9 @@ public:
     //!
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
-    virtual void sampleBucketStatistics(core_t::TTime startTime,
-                                        core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor);
+    void sampleBucketStatistics(core_t::TTime startTime,
+                                core_t::TTime endTime,
+                                CResourceMonitor& resourceMonitor) override;
 
     //! Update the model with the samples of the various processes
     //! in the time interval [\p startTime, \p endTime].
@@ -243,13 +243,13 @@ public:
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
     //! \param[in] resourceMonitor The resourceMonitor.
-    virtual void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor);
+    void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor) override;
 
     //! Prune any data for people and attributes which haven't been
     //! seen for a sufficiently long period. This is based on the
     //! prior decay rates and the number of batches into which we
     //! are partitioning time.
-    virtual void prune(std::size_t maximumAge);
+    void prune(std::size_t maximumAge) override;
     //@}
 
     //! \name Probability
@@ -267,18 +267,18 @@ public:
     //! \param[out] result A structure containing the probability,
     //! the smallest \p numberAttributeProbabilities attribute
     //! probabilities, the influences and any extra descriptive data
-    virtual bool computeProbability(std::size_t pid,
-                                    core_t::TTime startTime,
-                                    core_t::TTime endTime,
-                                    CPartitioningFields& partitioningFields,
-                                    std::size_t numberAttributeProbabilities,
-                                    SAnnotatedProbability& result) const;
+    bool computeProbability(std::size_t pid,
+                            core_t::TTime startTime,
+                            core_t::TTime endTime,
+                            CPartitioningFields& partitioningFields,
+                            std::size_t numberAttributeProbabilities,
+                            SAnnotatedProbability& result) const override;
 
     //! Clears \p probability and \p attributeProbabilities.
-    virtual bool computeTotalProbability(const std::string& person,
-                                         std::size_t numberAttributeProbabilities,
-                                         TOptionalDouble& probability,
-                                         TAttributeProbability1Vec& attributeProbabilities) const;
+    bool computeTotalProbability(const std::string& person,
+                                 std::size_t numberAttributeProbabilities,
+                                 TOptionalDouble& probability,
+                                 TAttributeProbability1Vec& attributeProbabilities) const override;
     //@}
 
     //! Get the checksum of this model.
@@ -287,22 +287,22 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    std::size_t staticSize() const override;
 
     //! Get the non-estimated memory used by this model.
-    virtual std::size_t computeMemoryUsage() const;
+    std::size_t computeMemoryUsage() const override;
 
     //! Get a view of the internals of the model for visualization.
-    virtual CModelDetailsViewPtr details() const;
+    CModelDetailsViewPtr details() const override;
 
     //! Get the feature data corresponding to \p feature at \p time.
     const TSizeSizePrFeatureDataPrVec& featureData(model_t::EFeature feature,
@@ -315,36 +315,36 @@ private:
                     TFeatureCorrelationsPtrPrVec&& featureCorrelatesModels);
 
     //! Get the start time of the current bucket.
-    virtual core_t::TTime currentBucketStartTime() const;
+    core_t::TTime currentBucketStartTime() const override;
 
     //! Set the start time of the current bucket.
-    virtual void currentBucketStartTime(core_t::TTime time);
+    void currentBucketStartTime(core_t::TTime time) override;
 
     //! Get the current bucket person counts.
-    virtual const TSizeUInt64PrVec& personCounts() const;
+    const TSizeUInt64PrVec& personCounts() const override;
 
     //! Get the interim corrections of the current bucket.
     TCorrectionKeyDouble1VecUMap& currentBucketInterimCorrections() const;
 
     //! Initialize the time series models for "n" newly observed people
     //! and "m" attributes.
-    virtual void createNewModels(std::size_t n, std::size_t m);
+    void createNewModels(std::size_t n, std::size_t m) override;
 
     //! Initialize the time series models for recycled attributes and/or people.
-    virtual void updateRecycledModels();
+    void updateRecycledModels() override;
 
     //! Update the correlation models.
-    virtual void refreshCorrelationModels(std::size_t resourceLimit,
-                                          CResourceMonitor& resourceMonitor);
+    void refreshCorrelationModels(std::size_t resourceLimit,
+                                  CResourceMonitor& resourceMonitor) override;
 
     //! Clear out large state objects for people/attributes that are pruned
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override;
 
     //! Get the object which calculates corrections for interim buckets.
-    virtual const CInterimBucketCorrector& interimValueCorrector() const;
+    const CInterimBucketCorrector& interimValueCorrector() const override;
 
     //! Skip sampling the interval \p endTime - \p startTime.
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime);
+    void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
 
     //! Get a read only model for \p feature and the attribute identified
     //! by \p cid.
@@ -368,7 +368,7 @@ private:
               CProbabilityAndInfluenceCalculator::SParams& params) const;
 
     //! Get the model memory usage estimator
-    virtual CMemoryUsageEstimator* memoryUsageEstimator() const;
+    CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
 private:
     //! The statistics we maintain about the bucket.

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -171,8 +171,8 @@ protected:
         std::vector<TStrCRefDouble1VecDouble1VecPrPrVecVec>;
 
 protected:
-    //! Persist the state of the residual models only.
-    void doPersistResidualModelsState(core::CStatePersistInserter& inserter) const;
+    //! Persist the state of the models only.
+    void doPersistModelsState(core::CStatePersistInserter& inserter) const;
 
     //! Persist state by passing information to the supplied inserter.
     void doAcceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -120,38 +120,38 @@ public:
 
     //! \name Persistence
     //@{
-    //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& /* inserter*/) const {
+    //! Persist the state of the models only.
+    void persistModelsState(core::CStatePersistInserter& /* inserter*/) const override {
         // NO-OP
     }
 
     //! Persist state by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Restore reading state from \p traverser.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
     //! Create a clone of this model that will result in the same persisted
     //! state.  The clone may be incomplete in ways that do not affect the
     //! persisted representation, and must not be used for any other
     //! purpose.
     //! \warning The caller owns the object returned.
-    virtual CAnomalyDetectorModel* cloneForPersistence() const;
+    CAnomalyDetectorModel* cloneForPersistence() const override;
     //@}
 
     //! Get the model category.
-    virtual model_t::EModelType category() const;
+    model_t::EModelType category() const override;
 
     //! Returns false.
-    virtual bool isEventRate() const;
+    bool isEventRate() const override;
 
     //! Returns true.
-    virtual bool isMetric() const;
+    bool isMetric() const override;
 
     //! \name Bucket Statistics
     //@{
     //! Returns null.
-    virtual TOptionalDouble baselineBucketCount(std::size_t pid) const;
+    TOptionalDouble baselineBucketCount(std::size_t pid) const override;
 
     //! Get the value of \p feature for the person identified
     //! by \p pid in the bucketing interval containing \p time.
@@ -160,10 +160,10 @@ public:
     //! \param[in] pid The identifier of the person of interest.
     //! \param[in] cid Ignored.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec currentBucketValue(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           core_t::TTime time) const;
+    TDouble1Vec currentBucketValue(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   core_t::TTime time) const override;
 
     //! Get the baseline bucket value of \p feature for the person
     //! identified by \p pid as of the start of the current bucketing
@@ -177,12 +177,12 @@ public:
     //! \param[in] correlated The correlated series' identifiers and
     //! their values if any.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec baselineBucketMean(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           model_t::CResultType type,
-                                           const TSizeDoublePr1Vec& correlated,
-                                           core_t::TTime time) const;
+    TDouble1Vec baselineBucketMean(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   model_t::CResultType type,
+                                   const TSizeDoublePr1Vec& correlated,
+                                   core_t::TTime time) const override;
 
     //@}
 
@@ -190,7 +190,7 @@ public:
     //@{
     //! Get the person unique identifiers which have a feature value
     //! in the bucketing time interval including \p time.
-    virtual void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const;
+    void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const override;
     //@}
 
     //! \name Update
@@ -201,9 +201,9 @@ public:
     //!
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
-    virtual void sampleBucketStatistics(core_t::TTime startTime,
-                                        core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor);
+    void sampleBucketStatistics(core_t::TTime startTime,
+                                core_t::TTime endTime,
+                                CResourceMonitor& resourceMonitor) override;
 
     //! Update the model with features samples from the time interval
     //! [\p startTime, \p endTime].
@@ -211,7 +211,7 @@ public:
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
     //! \param[in] resourceMonitor The resourceMonitor.
-    virtual void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor);
+    void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor) override;
     //@}
 
     //! \name Probability
@@ -229,12 +229,12 @@ public:
     //! \param[out] result A structure containing the probability,
     //! the smallest \p numberAttributeProbabilities attribute
     //! probabilities, the influences and any extra descriptive data
-    virtual bool computeProbability(std::size_t pid,
-                                    core_t::TTime startTime,
-                                    core_t::TTime endTime,
-                                    CPartitioningFields& partitioningFields,
-                                    std::size_t numberAttributeProbabilities,
-                                    SAnnotatedProbability& result) const;
+    bool computeProbability(std::size_t pid,
+                            core_t::TTime startTime,
+                            core_t::TTime endTime,
+                            CPartitioningFields& partitioningFields,
+                            std::size_t numberAttributeProbabilities,
+                            SAnnotatedProbability& result) const override;
     //@}
 
     //! Get the checksum of this model.
@@ -243,22 +243,22 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies.
-    virtual std::size_t staticSize() const;
+    std::size_t staticSize() const override;
 
     //! Get the non-estimated value of the the memory used by this model.
-    virtual std::size_t computeMemoryUsage() const;
+    std::size_t computeMemoryUsage() const override;
 
     //! Get a view of the internals of the model for visualization.
-    virtual CModelDetailsViewPtr details() const;
+    CModelDetailsViewPtr details() const override;
 
     //! Get the value of the \p feature of the person identified
     //! by \p pid for the bucketing interval containing \p time.
@@ -273,25 +273,25 @@ private:
 
 private:
     //! Get the start time of the current bucket.
-    virtual core_t::TTime currentBucketStartTime() const;
+    core_t::TTime currentBucketStartTime() const override;
 
     //! Set the start time of the current bucket.
-    virtual void currentBucketStartTime(core_t::TTime time);
+    void currentBucketStartTime(core_t::TTime time) override;
 
     //! Get the interim corrections of the current bucket.
     TFeatureSizeSizeTripleDouble1VecUMap& currentBucketInterimCorrections() const;
 
     //! Get the person counts in the current bucket.
-    virtual const TSizeUInt64PrVec& currentBucketPersonCounts() const;
+    const TSizeUInt64PrVec& currentBucketPersonCounts() const override;
 
     //! Get writable person counts in the current bucket.
-    virtual TSizeUInt64PrVec& currentBucketPersonCounts();
+    TSizeUInt64PrVec& currentBucketPersonCounts() override;
 
     //! Clear out large state objects for people that are pruned.
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override;
 
     //! Get the object which calculates corrections for interim buckets.
-    virtual const CInterimBucketCorrector& interimValueCorrector() const;
+    const CInterimBucketCorrector& interimValueCorrector() const override;
 
     //! Check if there are correlates for \p feature and the person
     //! identified by \p pid.

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -133,34 +133,34 @@ public:
     //@}
 
     //! Returns false.
-    virtual bool isEventRate() const;
+    bool isEventRate() const override;
 
     //! Returns true.
-    virtual bool isMetric() const;
+    bool isMetric() const override;
 
     //! \name Persistence
     //@{
-    //! Persist the state of the residual models only.
-    virtual void persistResidualModelsState(core::CStatePersistInserter& /* inserter*/) const {
+    //! Persist the state of the models only.
+    void persistModelsState(core::CStatePersistInserter& /* inserter*/) const override {
         // NO-OP
     }
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Add to the contents of the object.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
     //! Create a clone of this model that will result in the same persisted
     //! state.  The clone may be incomplete in ways that do not affect the
     //! persisted representation, and must not be used for any other
     //! purpose.
     //! \warning The caller owns the object returned.
-    virtual CAnomalyDetectorModel* cloneForPersistence() const;
+    CAnomalyDetectorModel* cloneForPersistence() const override;
     //@}
 
     //! Get the model category.
-    virtual model_t::EModelType category() const;
+    model_t::EModelType category() const override;
 
     //! \name Bucket Statistics
     //@{
@@ -172,10 +172,10 @@ public:
     //! \param[in] pid The identifier of the person of interest.
     //! \param[in] cid The identifier of the attribute of interest.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec currentBucketValue(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           core_t::TTime time) const;
+    TDouble1Vec currentBucketValue(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   core_t::TTime time) const override;
 
     //! Get the population baseline mean of \p feature for the
     //! attribute identified by \p cid as of the start of the
@@ -189,15 +189,15 @@ public:
     //! \param[in] correlated The correlated series' identifiers and
     //! their values if any.
     //! \param[in] time The time of interest.
-    virtual TDouble1Vec baselineBucketMean(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           model_t::CResultType type,
-                                           const TSizeDoublePr1Vec& correlated,
-                                           core_t::TTime time) const;
+    TDouble1Vec baselineBucketMean(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   model_t::CResultType type,
+                                   const TSizeDoublePr1Vec& correlated,
+                                   core_t::TTime time) const override;
 
     //! Check if bucket statistics are available for the specified time.
-    virtual bool bucketStatsAvailable(core_t::TTime time) const;
+    bool bucketStatsAvailable(core_t::TTime time) const override;
     //@}
 
     //! \name Update
@@ -209,9 +209,9 @@ public:
     //!
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
-    virtual void sampleBucketStatistics(core_t::TTime startTime,
-                                        core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor);
+    void sampleBucketStatistics(core_t::TTime startTime,
+                                core_t::TTime endTime,
+                                CResourceMonitor& resourceMonitor) override;
 
     //! Update the model with the samples of the various processes
     //! in the time interval [\p startTime, \p endTime].
@@ -219,13 +219,13 @@ public:
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
     //! \param[in] resourceMonitor The resourceMonitor.
-    virtual void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor);
+    void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor) override;
 
     //! Prune any data for people and attributes which haven't been
     //! seen for a sufficiently long period. This is based on the
     //! prior decay rates and the number of batches into which we
     //! are partitioning time.
-    virtual void prune(std::size_t maximumAge);
+    void prune(std::size_t maximumAge) override;
     //@}
 
     //! \name Probability
@@ -243,18 +243,18 @@ public:
     //! \param[out] result A structure containing the probability,
     //! the smallest \p numberAttributeProbabilities attribute
     //! probabilities, the influences and any extra descriptive data
-    virtual bool computeProbability(std::size_t pid,
-                                    core_t::TTime startTime,
-                                    core_t::TTime endTime,
-                                    CPartitioningFields& partitioningFields,
-                                    std::size_t numberAttributeProbabilities,
-                                    SAnnotatedProbability& result) const;
+    bool computeProbability(std::size_t pid,
+                            core_t::TTime startTime,
+                            core_t::TTime endTime,
+                            CPartitioningFields& partitioningFields,
+                            std::size_t numberAttributeProbabilities,
+                            SAnnotatedProbability& result) const override;
 
     //! Clears \p probability and \p attributeProbabilities.
-    virtual bool computeTotalProbability(const std::string& person,
-                                         std::size_t numberAttributeProbabilities,
-                                         TOptionalDouble& probability,
-                                         TAttributeProbability1Vec& attributeProbabilities) const;
+    bool computeTotalProbability(const std::string& person,
+                                 std::size_t numberAttributeProbabilities,
+                                 TOptionalDouble& probability,
+                                 TAttributeProbability1Vec& attributeProbabilities) const override;
     //@}
 
     //! Get the checksum of this model.
@@ -263,26 +263,26 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Get a view of the internals of the model for visualization.
-    virtual CModelDetailsViewPtr details() const;
+    CModelDetailsViewPtr details() const override;
 
     //! Get the feature data corresponding to \p feature at \p time.
     const TSizeSizePrFeatureDataPrVec& featureData(model_t::EFeature feature,
                                                    core_t::TTime time) const;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    std::size_t staticSize() const override;
 
     //! Get the non-estimated memory used by this model.
-    virtual std::size_t computeMemoryUsage() const;
+    std::size_t computeMemoryUsage() const override;
 
 private:
     //! Initialize the feature models.
@@ -291,36 +291,36 @@ private:
                     TFeatureCorrelationsPtrPrVec&& featureCorrelatesModels);
 
     //! Get the start time of the current bucket.
-    virtual core_t::TTime currentBucketStartTime() const;
+    core_t::TTime currentBucketStartTime() const override;
 
     //! Set the start time of the current bucket.
-    virtual void currentBucketStartTime(core_t::TTime time);
+    void currentBucketStartTime(core_t::TTime time) override;
 
     //! Get the current bucket person counts.
-    virtual const TSizeUInt64PrVec& personCounts() const;
+    const TSizeUInt64PrVec& personCounts() const override;
 
     //! Get the interim corrections of the current bucket.
     TCorrectionKeyDouble1VecUMap& currentBucketInterimCorrections() const;
 
     //! Initialize the time series models for "n" newly observed people
     //! and "m" attributes.
-    virtual void createNewModels(std::size_t n, std::size_t m);
+    void createNewModels(std::size_t n, std::size_t m) override;
 
     //! Initialize the time series models for recycled attributes and/or people
-    virtual void updateRecycledModels();
+    void updateRecycledModels() override;
 
     //! Update the correlation models.
-    virtual void refreshCorrelationModels(std::size_t resourceLimit,
-                                          CResourceMonitor& resourceMonitor);
+    void refreshCorrelationModels(std::size_t resourceLimit,
+                                  CResourceMonitor& resourceMonitor) override;
 
     //! Clear out large state objects for people/attributes that are pruned
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override;
 
     //! Get the object which calculates corrections for interim buckets.
-    virtual const CInterimBucketCorrector& interimValueCorrector() const;
+    const CInterimBucketCorrector& interimValueCorrector() const override;
 
     //! Skip sampling the interval \p endTime - \p startTime.
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime);
+    void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
 
     //! Get a read only model for \p feature and the attribute identified
     //! by \p cid.
@@ -344,7 +344,7 @@ private:
               CProbabilityAndInfluenceCalculator::SParams& params) const;
 
     //! Get the model memory usage estimator
-    virtual CMemoryUsageEstimator* memoryUsageEstimator() const;
+    CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
 private:
     //! The statistics we maintain about the bucket.

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -999,9 +999,9 @@ bool CAnomalyJob::restoreDetectorState(const model::CSearchKey& key,
     return true;
 }
 
-bool CAnomalyJob::persistResidualModelsState(core::CDataAdder& persister,
-                                             core_t::TTime timestamp,
-                                             const std::string& outputFormat) {
+bool CAnomalyJob::persistModelsState(core::CDataAdder& persister,
+                                     core_t::TTime timestamp,
+                                     const std::string& outputFormat) {
     TKeyCRefAnomalyDetectorPtrPrVec detectors;
     this->sortedDetectors(detectors);
 
@@ -1010,7 +1010,7 @@ bool CAnomalyJob::persistResidualModelsState(core::CDataAdder& persister,
     // also must ensure that foreground persistence has access to an up-to-date cache of counters as well.
     core::CProgramCounters::cacheCounters();
 
-    return this->persistResidualModelsState(detectors, persister, timestamp, outputFormat);
+    return this->persistModelsState(detectors, persister, timestamp, outputFormat);
 }
 
 bool CAnomalyJob::persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) {
@@ -1130,10 +1130,10 @@ bool CAnomalyJob::runBackgroundPersist(TBackgroundPersistArgsPtr args,
         args->s_LastResultsTime, persister);
 }
 
-bool CAnomalyJob::persistResidualModelsState(const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
-                                             core::CDataAdder& persister,
-                                             core_t::TTime timestamp,
-                                             const std::string& outputFormat) {
+bool CAnomalyJob::persistModelsState(const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
+                                     core::CDataAdder& persister,
+                                     core_t::TTime timestamp,
+                                     const std::string& outputFormat) {
     try {
         const std::string snapShotId{core::CStringUtils::typeToString(timestamp)};
         core::CDataAdder::TOStreamP strm = persister.addStreamed(
@@ -1157,7 +1157,7 @@ bool CAnomalyJob::persistResidualModelsState(const TKeyCRefAnomalyDetectorPtrPrV
                         continue;
                     }
 
-                    detector->persistResidualModelsState(*inserter);
+                    detector->persistModelsState(*inserter);
 
                     LOG_DEBUG(<< "Persisted state for '" << detector->description() << "'");
                 }

--- a/lib/core/CStateMachine.cc
+++ b/lib/core/CStateMachine.cc
@@ -27,7 +27,7 @@ namespace {
 
 // CStateMachine
 //const std::string MACHINE_TAG("a"); No longer used
-const std::string STATE_TAG("b");
+const core::TPersistenceTag STATE_TAG("b", "state");
 
 // CStateMachine::SMachine
 const std::string ALPHABET_TAG("a");

--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -65,17 +65,17 @@ void clearAndShrink(std::vector<T>& vector) {
     empty.swap(vector);
 }
 
-const std::string DECAY_RATE_TAG{"a"};
-const std::string ENDPOINT_TAG{"b"};
-const std::string CENTRES_TAG{"c"};
-const std::string MEAN_DESIRED_DISPLACEMENT_TAG{"d"};
-const std::string MEAN_ABS_DESIRED_DISPLACEMENT_TAG{"e"};
-const std::string LARGE_ERROR_COUNTS_TAG{"f"};
-const std::string TARGET_SIZE_TAG{"g"};
-const std::string LAST_LARGE_ERROR_BUCKET_TAG{"h"};
-const std::string LAST_LARGE_ERROR_PERIOD_TAG{"i"};
-const std::string LARGE_ERROR_COUNT_SIGNIFICANCES_TAG{"j"};
-const std::string MEAN_WEIGHT_TAG{"k"};
+const core::TPersistenceTag DECAY_RATE_TAG{"a", "decay_rate"};
+const core::TPersistenceTag ENDPOINT_TAG{"b", "endpoint"};
+const core::TPersistenceTag CENTRES_TAG{"c", "centres"};
+const core::TPersistenceTag MEAN_DESIRED_DISPLACEMENT_TAG{"d", "mean_desired_displacement"};
+const core::TPersistenceTag MEAN_ABS_DESIRED_DISPLACEMENT_TAG{"e", "mean_abs_desired_displacement"};
+const core::TPersistenceTag LARGE_ERROR_COUNTS_TAG{"f", "large_error_counts"};
+const core::TPersistenceTag TARGET_SIZE_TAG{"g", "target size"};
+const core::TPersistenceTag LAST_LARGE_ERROR_BUCKET_TAG{"h", "last_large_error_bucket"};
+const core::TPersistenceTag LAST_LARGE_ERROR_PERIOD_TAG{"i", "last_large_error_period"};
+const core::TPersistenceTag LARGE_ERROR_COUNT_SIGNIFICANCES_TAG{"j", "large_error_counts_significance"};
+const core::TPersistenceTag MEAN_WEIGHT_TAG{"k", "mean weight"};
 const std::string EMPTY_STRING;
 
 const double SMOOTHING_FUNCTION[]{0.25, 0.5, 0.25};

--- a/lib/maths/CCalendarComponent.cc
+++ b/lib/maths/CCalendarComponent.cc
@@ -28,8 +28,8 @@ namespace ml {
 namespace maths {
 namespace {
 using TDoubleDoublePr = maths_t::TDoubleDoublePr;
-const std::string DECOMPOSITION_COMPONENT_TAG{"a"};
-const std::string BUCKETING_TAG{"b"};
+const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
+const core::TPersistenceTag BUCKETING_TAG{"b", "bucketing"};
 const std::string EMPTY_STRING;
 }
 

--- a/lib/maths/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/CCalendarComponentAdaptiveBucketing.cc
@@ -36,9 +36,9 @@ void clearAndShrink(std::vector<T>& vector) {
     empty.swap(vector);
 }
 
-const std::string ADAPTIVE_BUCKETING_TAG{"a"};
-const std::string FEATURE_TAG{"b"};
-const std::string VALUES_TAG{"c"};
+const core::TPersistenceTag ADAPTIVE_BUCKETING_TAG{"a", "adaptive_bucketing"};
+const core::TPersistenceTag FEATURE_TAG{"b", "feature"};
+const core::TPersistenceTag VALUES_TAG{"c", "values"};
 const std::string EMPTY_STRING;
 }
 

--- a/lib/maths/CCalendarCyclicTest.cc
+++ b/lib/maths/CCalendarCyclicTest.cc
@@ -51,11 +51,11 @@ struct SHashFeature {
 
 const std::string VERSION_6_4_TAG("6.4");
 // Version 6.4
-const std::string ERROR_QUANTILES_6_4_TAG("a");
-const std::string CURRENT_BUCKET_TIME_6_4_TAG("b");
-const std::string CURRENT_BUCKET_INDEX_6_4_TAG("c");
-const std::string CURRENT_BUCKET_ERROR_STATS_6_4_TAG("d");
-const std::string ERRORS_6_4_TAG("e");
+const core::TPersistenceTag ERROR_QUANTILES_6_4_TAG("a", "error_quantiles");
+const core::TPersistenceTag CURRENT_BUCKET_TIME_6_4_TAG("b", "current_bucket_time");
+const core::TPersistenceTag CURRENT_BUCKET_INDEX_6_4_TAG("c", "current_bucket_index");
+const core::TPersistenceTag CURRENT_BUCKET_ERROR_STATS_6_4_TAG("d", "current_bucket_error_stats");
+const core::TPersistenceTag ERRORS_6_4_TAG("e", "errors");
 // Version < 6.4
 const std::string ERROR_QUANTILES_OLD_TAG("a");
 // Everything else gets default initialised.

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -30,17 +30,17 @@ namespace {
 
 using TDoubleDoublePr = maths_t::TDoubleDoublePr;
 
-const std::string MAX_SIZE_TAG{"a"};
-const std::string RNG_TAG{"b"};
-const std::string BOUNDARY_CONDITION_TAG{"c"};
-const std::string BUCKETING_TAG{"d"};
-const std::string SPLINES_TAG{"e"};
+const core::TPersistenceTag MAX_SIZE_TAG{"a", "max_size"};
+const core::TPersistenceTag RNG_TAG{"b", "rng"};
+const core::TPersistenceTag BOUNDARY_CONDITION_TAG{"c", "boundary_condition"};
+const core::TPersistenceTag BUCKETING_TAG{"d", "bucketing"};
+const core::TPersistenceTag SPLINES_TAG{"e", "splines"};
 
 // Nested tags
-const std::string ESTIMATED_TAG{"a"};
-const std::string KNOTS_TAG{"b"};
-const std::string VALUES_TAG{"c"};
-const std::string VARIANCES_TAG{"d"};
+const core::TPersistenceTag ESTIMATED_TAG{"a", "estimated"};
+const core::TPersistenceTag KNOTS_TAG{"b", "knots"};
+const core::TPersistenceTag VALUES_TAG{"c", "values"};
+const core::TPersistenceTag VARIANCES_TAG{"d", "variances"};
 
 const std::string EMPTY_STRING;
 }

--- a/lib/maths/CExpandingWindow.cc
+++ b/lib/maths/CExpandingWindow.cc
@@ -23,10 +23,10 @@
 namespace ml {
 namespace maths {
 namespace {
-const std::string BUCKET_LENGTH_INDEX_TAG{"a"};
-const std::string BUCKET_VALUES_TAG{"b"};
-const std::string START_TIME_TAG{"c"};
-const std::string MEAN_OFFSET_TAG{"d"};
+const core::TPersistenceTag BUCKET_LENGTH_INDEX_TAG{"a", "bucket_length_index"};
+const core::TPersistenceTag BUCKET_VALUES_TAG{"b", "bucket_values"};
+const core::TPersistenceTag START_TIME_TAG{"c", "start_time"};
+const core::TPersistenceTag MEAN_OFFSET_TAG{"d", "mean_offset"};
 const std::size_t MAX_BUFFER_SIZE{5};
 }
 

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -439,7 +439,7 @@ std::size_t CModelStub::memoryUsage() const {
 void CModelStub::acceptPersistInserter(core::CStatePersistInserter& /*inserter*/) const {
 }
 
-void CModelStub::persistResidualModelsState(core::CStatePersistInserter& /*inserter*/) const {
+void CModelStub::persistModelsState(core::CStatePersistInserter& /*inserter*/) const {
 }
 
 maths_t::EDataType CModelStub::dataType() const {

--- a/lib/maths/CNaiveBayes.cc
+++ b/lib/maths/CNaiveBayes.cc
@@ -27,12 +27,13 @@
 namespace ml {
 namespace maths {
 namespace {
-const std::string PRIOR_TAG{"a"};
-const std::string CLASS_LABEL_TAG{"b"};
-const std::string CLASS_MODEL_TAG{"c"};
-const std::string MIN_MAX_LOG_LIKELIHOOD_TO_USE_FEATURE_TAG{"d"};
-const std::string COUNT_TAG{"e"};
-const std::string CONDITIONAL_DENSITY_FROM_PRIOR_TAG{"f"};
+const core::TPersistenceTag PRIOR_TAG{"a", "prior"};
+const core::TPersistenceTag CLASS_LABEL_TAG{"b", "class_label"};
+const core::TPersistenceTag CLASS_MODEL_TAG{"c", "class_model"};
+const core::TPersistenceTag MIN_MAX_LOG_LIKELIHOOD_TO_USE_FEATURE_TAG{
+    "d", "min_max_likelihood_to_use_feature"};
+const core::TPersistenceTag COUNT_TAG{"e", "count"};
+const core::TPersistenceTag CONDITIONAL_DENSITY_FROM_PRIOR_TAG{"f", "conditional_density_from_prior"};
 }
 
 CNaiveBayesFeatureDensityFromPrior::CNaiveBayesFeatureDensityFromPrior(const CPrior& prior)

--- a/lib/maths/CQuantileSketch.cc
+++ b/lib/maths/CQuantileSketch.cc
@@ -103,9 +103,9 @@ private:
 
 const double EPS = static_cast<double>(std::numeric_limits<float>::epsilon());
 const std::size_t MINIMUM_MAX_SIZE = 3u;
-const std::string UNSORTED_TAG("a");
-const std::string KNOTS_TAG("b");
-const std::string COUNT_TAG("c");
+const core::TPersistenceTag UNSORTED_TAG("a", "unsorted");
+const core::TPersistenceTag KNOTS_TAG("b", "knots");
+const core::TPersistenceTag COUNT_TAG("c", "count");
 }
 
 CQuantileSketch::CQuantileSketch(EInterpolation interpolation, std::size_t size)

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -31,9 +31,9 @@ namespace {
 
 using TDoubleDoublePr = maths_t::TDoubleDoublePr;
 
-const std::string DECOMPOSITION_COMPONENT_TAG{"a"};
-const std::string RNG_TAG{"b"};
-const std::string BUCKETING_TAG{"c"};
+const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
+const core::TPersistenceTag RNG_TAG{"b", "rng"};
+const core::TPersistenceTag BUCKETING_TAG{"c", "bucketing"};
 const std::string EMPTY_STRING;
 }
 

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -62,13 +62,13 @@ typename SPromoted<T>::Type promote(const T& vectorStat) {
 
 // Version 6.3
 const std::string VERSION_6_3_TAG("6.3");
-const std::string ADAPTIVE_BUCKETING_6_3_TAG{"a"};
-const std::string TIME_6_3_TAG{"b"};
-const std::string BUCKETS_6_3_TAG{"e"};
-const std::string REGRESSION_6_3_TAG{"e"};
-const std::string VARIANCE_6_3_TAG{"f"};
-const std::string FIRST_UPDATE_6_3_TAG{"g"};
-const std::string LAST_UPDATE_6_3_TAG{"h"};
+const core::TPersistenceTag ADAPTIVE_BUCKETING_6_3_TAG{"a", "adaptive_bucketing"};
+const core::TPersistenceTag TIME_6_3_TAG{"b", "time"};
+const core::TPersistenceTag BUCKETS_6_3_TAG{"e", "buckets"};
+const core::TPersistenceTag REGRESSION_6_3_TAG{"e", "regression"};
+const core::TPersistenceTag VARIANCE_6_3_TAG{"f", "variance"};
+const core::TPersistenceTag FIRST_UPDATE_6_3_TAG{"g", "first_update"};
+const core::TPersistenceTag LAST_UPDATE_6_3_TAG{"h", "last_update"};
 // Version < 6.3
 const std::string ADAPTIVE_BUCKETING_OLD_TAG{"a"};
 const std::string TIME_OLD_TAG{"b"};

--- a/lib/maths/CSeasonalTime.cc
+++ b/lib/maths/CSeasonalTime.cc
@@ -25,8 +25,8 @@ namespace ml {
 namespace maths {
 namespace {
 // DO NOT change the existing tags if new sub-classes are added.
-const std::string DIURNAL_TIME_TAG("a");
-const std::string ARBITRARY_PERIOD_TIME_TAG("b");
+const core::TPersistenceTag DIURNAL_TIME_TAG{"a", "diurnal-time"};
+const core::TPersistenceTag ARBITRARY_PERIOD_TIME_TAG{"b", "arbitrary_period_time"};
 }
 
 //////// CSeasonalTime ////////

--- a/lib/maths/CSeasonalTime.cc
+++ b/lib/maths/CSeasonalTime.cc
@@ -25,7 +25,7 @@ namespace ml {
 namespace maths {
 namespace {
 // DO NOT change the existing tags if new sub-classes are added.
-const core::TPersistenceTag DIURNAL_TIME_TAG{"a", "diurnal-time"};
+const core::TPersistenceTag DIURNAL_TIME_TAG{"a", "diurnal_time"};
 const core::TPersistenceTag ARBITRARY_PERIOD_TIME_TAG{"b", "arbitrary_period_time"};
 }
 

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -68,12 +68,12 @@ TDoubleDoublePr confidenceInterval(double confidence, double variance) {
 
 // Version 6.3
 const std::string VERSION_6_3_TAG("6.3");
-const std::string LAST_VALUE_TIME_6_3_TAG{"a"};
-const std::string LAST_PROPAGATION_TIME_6_3_TAG{"b"};
-const std::string PERIODICITY_TEST_6_3_TAG{"c"};
-const std::string CALENDAR_CYCLIC_TEST_6_3_TAG{"d"};
-const std::string COMPONENTS_6_3_TAG{"e"};
-const std::string TIME_SHIFT_6_3_TAG{"f"};
+const core::TPersistenceTag LAST_VALUE_TIME_6_3_TAG{"a", "last_value_time"};
+const core::TPersistenceTag LAST_PROPAGATION_TIME_6_3_TAG{"b", "last_propagation_time"};
+const core::TPersistenceTag PERIODICITY_TEST_6_3_TAG{"c", "periodicity_test"};
+const core::TPersistenceTag CALENDAR_CYCLIC_TEST_6_3_TAG{"d", "calendar_cyclic_test"};
+const core::TPersistenceTag COMPONENTS_6_3_TAG{"e", "components"};
+const core::TPersistenceTag TIME_SHIFT_6_3_TAG{"f", "time_shift"};
 // Version < 6.3
 const std::string DECAY_RATE_OLD_TAG{"a"};
 const std::string LAST_VALUE_TIME_OLD_TAG{"b"};

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -275,41 +275,41 @@ const std::string VERSION_6_3_TAG("6.3");
 const std::string VERSION_6_4_TAG("6.4");
 
 // Periodicity Test Tags
-const std::string LINEAR_SCALES_7_2_TAG{"d"};
+const core::TPersistenceTag LINEAR_SCALES_7_2_TAG{"d", "linear_scales"};
 // Version 6.3
-const std::string PERIODICITY_TEST_MACHINE_6_3_TAG{"a"};
-const std::string SHORT_WINDOW_6_3_TAG{"b"};
-const std::string LONG_WINDOW_6_3_TAG{"c"};
+const core::TPersistenceTag PERIODICITY_TEST_MACHINE_6_3_TAG{"a", "periodicity_test_machine"};
+const core::TPersistenceTag SHORT_WINDOW_6_3_TAG{"b", "short_window"};
+const core::TPersistenceTag LONG_WINDOW_6_3_TAG{"c", "long_window"};
 // Old versions can't be restored.
 
 // Calendar Cyclic Test Tags
 // Version 6.3
-const std::string CALENDAR_TEST_MACHINE_6_3_TAG{"a"};
-const std::string LAST_MONTH_6_3_TAG{"b"};
-const std::string CALENDAR_TEST_6_3_TAG{"c"};
+const core::TPersistenceTag CALENDAR_TEST_MACHINE_6_3_TAG{"a", "calendar_test_machine"};
+const core::TPersistenceTag LAST_MONTH_6_3_TAG{"b", "last_month"};
+const core::TPersistenceTag CALENDAR_TEST_6_3_TAG{"c", "calendar_test"};
 // These work for all versions.
 
 // Components Tags
 // Version 6.5
-const std::string TESTING_FOR_CHANGE_6_5_TAG{"m"};
+const core::TPersistenceTag TESTING_FOR_CHANGE_6_5_TAG{"m", "testing_for_change"};
 // Version 6.4
-const std::string COMPONENT_6_4_TAG{"f"};
-const std::string ERRORS_6_4_TAG{"g"};
-const std::string REGRESSION_ORIGIN_6_4_TAG{"a"};
-const std::string MEAN_SUM_AMPLITUDES_6_4_TAG{"b"};
-const std::string MEAN_SUM_AMPLITUDES_TREND_6_4_TAG{"c"};
+const core::TPersistenceTag COMPONENT_6_4_TAG{"f", "component"};
+const core::TPersistenceTag ERRORS_6_4_TAG{"g", "errors"};
+const core::TPersistenceTag REGRESSION_ORIGIN_6_4_TAG{"a", "regression_origin"};
+const core::TPersistenceTag MEAN_SUM_AMPLITUDES_6_4_TAG{"b", "mean_sum_amplitudes"};
+const core::TPersistenceTag MEAN_SUM_AMPLITUDES_TREND_6_4_TAG{"c", "mean_sum_amplitudes_trend"};
 // Version 6.3
-const std::string COMPONENTS_MACHINE_6_3_TAG{"a"};
-const std::string DECAY_RATE_6_3_TAG{"b"};
-const std::string TREND_6_3_TAG{"c"};
-const std::string SEASONAL_6_3_TAG{"d"};
-const std::string CALENDAR_6_3_TAG{"e"};
-const std::string COMPONENT_6_3_TAG{"f"};
-const std::string MEAN_VARIANCE_SCALE_6_3_TAG{"h"};
-const std::string MOMENTS_6_3_TAG{"i"};
-const std::string MOMENTS_MINUS_TREND_6_3_TAG{"j"};
-const std::string USING_TREND_FOR_PREDICTION_6_3_TAG{"k"};
-const std::string GAIN_CONTROLLER_6_3_TAG{"l"};
+const core::TPersistenceTag COMPONENTS_MACHINE_6_3_TAG{"a", "components_machine"};
+const core::TPersistenceTag DECAY_RATE_6_3_TAG{"b", "decay_rate"};
+const core::TPersistenceTag TREND_6_3_TAG{"c", "trend"};
+const core::TPersistenceTag SEASONAL_6_3_TAG{"d", "seasonal"};
+const core::TPersistenceTag CALENDAR_6_3_TAG{"e", "calendar"};
+const core::TPersistenceTag COMPONENT_6_3_TAG{"f", "component"};
+const core::TPersistenceTag MEAN_VARIANCE_SCALE_6_3_TAG{"h", "mean_variance_scale"};
+const core::TPersistenceTag MOMENTS_6_3_TAG{"i", "moments"};
+const core::TPersistenceTag MOMENTS_MINUS_TREND_6_3_TAG{"j", "moments_minus_trend"};
+const core::TPersistenceTag USING_TREND_FOR_PREDICTION_6_3_TAG{"k", "using_trend_for_prediction"};
+const core::TPersistenceTag GAIN_CONTROLLER_6_3_TAG{"l", "gain_controller"};
 // Version < 6.3
 const std::string COMPONENTS_MACHINE_OLD_TAG{"a"};
 const std::string TREND_OLD_TAG{"b"};
@@ -901,7 +901,7 @@ void CTimeSeriesDecompositionDetail::CCalendarTest::acceptPersistInserter(
                          std::bind(&core::CStateMachine::acceptPersistInserter,
                                    &m_Machine, std::placeholders::_1));
     inserter.insertValue(LAST_MONTH_6_3_TAG, m_LastMonth);
-    if (m_Test) {
+    if (m_Test != nullptr) {
         inserter.insertLevel(CALENDAR_TEST_6_3_TAG,
                              std::bind(&CCalendarCyclicTest::acceptPersistInserter,
                                        m_Test.get(), std::placeholders::_1));

--- a/lib/maths/CTimeSeriesDecompositionStateSerialiser.cc
+++ b/lib/maths/CTimeSeriesDecompositionStateSerialiser.cc
@@ -27,8 +27,8 @@ namespace {
 // There needs to be one constant here per sub-class
 // of CTimeSeriesDecompositionInterface.
 // DO NOT change the existing tags if new sub-classes are added.
-const std::string TIME_SERIES_DECOMPOSITION_TAG("a");
-const std::string TIME_SERIES_DECOMPOSITION_STUB_TAG("b");
+const core::TPersistenceTag TIME_SERIES_DECOMPOSITION_TAG("a", "time_series_decomposition");
+const core::TPersistenceTag TIME_SERIES_DECOMPOSITION_STUB_TAG("b", "time_series_decomposition_stub");
 const std::string EMPTY_STRING;
 
 //! Implements restore for std::shared_ptr.

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -92,20 +92,21 @@ CNormalMeanPrecConjugate initialMagnitudeOfChangeModel(double decayRate) {
 
 const std::string VERSION_7_1_TAG("7.1");
 
-const std::string TARGET_DECAY_RATE_TAG{"a"};
-const std::string FIRST_UPDATE_TAG{"b"};
-const std::string LAST_UPDATE_TAG{"c"};
-const std::string REGRESSION_ORIGIN_TAG{"d"};
-const std::string MODEL_TAG{"e"};
-const std::string PREDICTION_ERROR_VARIANCE_TAG{"f"};
-const std::string VALUE_MOMENTS_TAG{"g"};
-const std::string TIME_OF_LAST_LEVEL_CHANGE_TAG{"h"};
-const std::string PROBABILITY_OF_LEVEL_CHANGE_MODEL_TAG{"i"};
-const std::string MAGNITUDE_OF_LEVEL_CHANGE_MODEL_TAG{"j"};
+const core::TPersistenceTag TARGET_DECAY_RATE_TAG{"a", "target_decay_rate"};
+const core::TPersistenceTag FIRST_UPDATE_TAG{"b", "first_update"};
+const core::TPersistenceTag LAST_UPDATE_TAG{"c", "last_update"};
+const core::TPersistenceTag REGRESSION_ORIGIN_TAG{"d", "regression_origin"};
+const core::TPersistenceTag MODEL_TAG{"e", "model"};
+const core::TPersistenceTag PREDICTION_ERROR_VARIANCE_TAG{"f", "prediction_error_variance"};
+const core::TPersistenceTag VALUE_MOMENTS_TAG{"g", "value_moments"};
+const core::TPersistenceTag TIME_OF_LAST_LEVEL_CHANGE_TAG{"h", "time_of_last_level_change"};
+const core::TPersistenceTag PROBABILITY_OF_LEVEL_CHANGE_MODEL_TAG{
+    "i", "probability_of_level_change_model"};
+const core::TPersistenceTag MAGNITUDE_OF_LEVEL_CHANGE_MODEL_TAG{"j", "magnitude_of_level_change_model"};
 // Version 7.1
-const std::string WEIGHT_7_1_TAG{"a"};
-const std::string REGRESSION_7_1_TAG{"b"};
-const std::string MSE_7_1_TAG{"c"};
+const core::TPersistenceTag WEIGHT_7_1_TAG{"a", "weight"};
+const core::TPersistenceTag REGRESSION_7_1_TAG{"b", "regression"};
+const core::TPersistenceTag MSE_7_1_TAG{"c", "mse"};
 // Version < 7.1
 const std::string WEIGHT_OLD_TAG{"a"};
 const std::string REGRESSION_OLD_TAG{"b"};

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -341,8 +341,8 @@ void CAnomalyDetector::legacyModelEnsembleAcceptPersistInserter(core::CStatePers
                                                this, std::placeholders::_1));
 }
 
-void CAnomalyDetector::persistResidualModelsState(core::CStatePersistInserter& inserter) const {
-    m_Model->persistResidualModelsState(inserter);
+void CAnomalyDetector::persistModelsState(core::CStatePersistInserter& inserter) const {
+    m_Model->persistModelsState(inserter);
 }
 
 void CAnomalyDetector::legacyModelsAcceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -499,10 +499,9 @@ bool CAnomalyDetectorModel::SFeatureModels::acceptRestoreTraverser(const SModelP
     return true;
 }
 
-void CAnomalyDetectorModel::SFeatureModels::persistResidualModelsState(
-    core::CStatePersistInserter& inserter) const {
+void CAnomalyDetectorModel::SFeatureModels::persistModelsState(core::CStatePersistInserter& inserter) const {
     for (const auto& model : s_Models) {
-        model->persistResidualModelsState(inserter);
+        model->persistModelsState(inserter);
     }
 }
 

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -623,7 +623,7 @@ CAnomalyDetectorModelConfig::factory(int identifier,
     }
     result->scheduledEvents(m_ScheduledEvents);
 
-    return std::move(result);
+    return result;
 }
 
 void CAnomalyDetectorModelConfig::decayRate(double value) {

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -623,7 +623,7 @@ CAnomalyDetectorModelConfig::factory(int identifier,
     }
     result->scheduledEvents(m_ScheduledEvents);
 
-    return result;
+    return std::move(result);
 }
 
 void CAnomalyDetectorModelConfig::decayRate(double value) {

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -103,8 +103,8 @@ CEventRateModel::CEventRateModel(bool isForPersistence, const CEventRateModel& o
     }
 }
 
-void CEventRateModel::persistResidualModelsState(core::CStatePersistInserter& inserter) const {
-    this->doPersistResidualModelsState(inserter);
+void CEventRateModel::persistModelsState(core::CStatePersistInserter& inserter) const {
+    this->doPersistModelsState(inserter);
 }
 
 void CEventRateModel::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -326,9 +326,9 @@ const CIndividualModel::TTimeVec& CIndividualModel::lastBucketTimes() const {
     return m_LastBucketTimes;
 }
 
-void CIndividualModel::doPersistResidualModelsState(core::CStatePersistInserter& inserter) const {
+void CIndividualModel::doPersistModelsState(core::CStatePersistInserter& inserter) const {
     for (const auto& feature : m_FeatureModels) {
-        feature.persistResidualModelsState(inserter);
+        feature.persistModelsState(inserter);
     }
 }
 

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -18,7 +18,7 @@ CMockModel::CMockModel(const SModelParams& params,
       m_IsPopulation(false), m_InterimBucketCorrector(params.s_BucketLength) {
 }
 
-void CMockModel::persistResidualModelsState(core::CStatePersistInserter& /*inserter*/) const {
+void CMockModel::persistModelsState(core::CStatePersistInserter& /*inserter*/) const {
 }
 
 void CMockModel::acceptPersistInserter(core::CStatePersistInserter& /*inserter*/) const {

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -28,75 +28,75 @@ public:
                const TDataGathererPtr& dataGatherer,
                const TFeatureInfluenceCalculatorCPtrPrVecVec& influenceCalculators);
 
-    virtual void persistResidualModelsState(core::CStatePersistInserter& inserter) const;
+    void persistModelsState(core::CStatePersistInserter& inserter) const override;
 
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
-    virtual CAnomalyDetectorModel* cloneForPersistence() const;
+    CAnomalyDetectorModel* cloneForPersistence() const override;
 
-    virtual model_t::EModelType category() const;
+    model_t::EModelType category() const override;
 
-    virtual bool isPopulation() const;
+    bool isPopulation() const override;
 
-    virtual bool isEventRate() const;
+    bool isEventRate() const override;
 
-    virtual bool isMetric() const;
+    bool isMetric() const override;
 
-    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const;
+    TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
 
-    virtual TOptionalDouble baselineBucketCount(std::size_t pid) const;
+    TOptionalDouble baselineBucketCount(std::size_t pid) const override;
 
-    virtual TDouble1Vec currentBucketValue(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           core_t::TTime time) const;
+    TDouble1Vec currentBucketValue(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   core_t::TTime time) const override;
 
-    virtual TDouble1Vec baselineBucketMean(model_t::EFeature feature,
-                                           std::size_t pid,
-                                           std::size_t cid,
-                                           model_t::CResultType type,
-                                           const TSizeDoublePr1Vec& correlated,
-                                           core_t::TTime time) const;
+    TDouble1Vec baselineBucketMean(model_t::EFeature feature,
+                                   std::size_t pid,
+                                   std::size_t cid,
+                                   model_t::CResultType type,
+                                   const TSizeDoublePr1Vec& correlated,
+                                   core_t::TTime time) const override;
 
-    virtual bool bucketStatsAvailable(core_t::TTime time) const;
+    bool bucketStatsAvailable(core_t::TTime time) const override;
 
-    virtual void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const;
+    void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const override;
 
-    virtual void sampleBucketStatistics(core_t::TTime startTime,
-                                        core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor);
+    void sampleBucketStatistics(core_t::TTime startTime,
+                                core_t::TTime endTime,
+                                CResourceMonitor& resourceMonitor) override;
 
-    virtual void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor);
+    void sample(core_t::TTime startTime, core_t::TTime endTime, CResourceMonitor& resourceMonitor) override;
 
-    virtual void prune(std::size_t maximumAge);
+    void prune(std::size_t maximumAge) override;
 
-    virtual bool computeProbability(std::size_t pid,
-                                    core_t::TTime startTime,
-                                    core_t::TTime endTime,
-                                    CPartitioningFields& partitioningFields,
-                                    std::size_t numberAttributeProbabilities,
-                                    SAnnotatedProbability& result) const;
+    bool computeProbability(std::size_t pid,
+                            core_t::TTime startTime,
+                            core_t::TTime endTime,
+                            CPartitioningFields& partitioningFields,
+                            std::size_t numberAttributeProbabilities,
+                            SAnnotatedProbability& result) const override;
 
-    virtual bool computeTotalProbability(const std::string& person,
-                                         std::size_t numberAttributeProbabilities,
-                                         TOptionalDouble& probability,
-                                         TAttributeProbability1Vec& attributeProbabilities) const;
+    bool computeTotalProbability(const std::string& person,
+                                 std::size_t numberAttributeProbabilities,
+                                 TOptionalDouble& probability,
+                                 TAttributeProbability1Vec& attributeProbabilities) const override;
 
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
 
-    virtual std::size_t memoryUsage() const;
+    std::size_t memoryUsage() const override;
 
-    virtual std::size_t computeMemoryUsage() const;
+    std::size_t computeMemoryUsage() const override;
 
-    virtual std::size_t staticSize() const;
+    std::size_t staticSize() const override;
 
-    virtual CModelDetailsViewPtr details() const;
+    CModelDetailsViewPtr details() const override;
 
-    virtual double attributeFrequency(std::size_t cid) const;
+    double attributeFrequency(std::size_t cid) const override;
 
     const maths::CModel* model(std::size_t id) const;
 
@@ -126,14 +126,14 @@ private:
         boost::unordered_map<TFeatureSizeSizeTimeTriplePr, TDouble1Vec>;
 
 private:
-    virtual core_t::TTime currentBucketStartTime() const;
-    virtual void currentBucketStartTime(core_t::TTime time);
-    virtual void createNewModels(std::size_t n, std::size_t m);
-    virtual void updateRecycledModels();
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes);
-    virtual const model::CInterimBucketCorrector& interimValueCorrector() const;
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime);
-    virtual CMemoryUsageEstimator* memoryUsageEstimator() const;
+    core_t::TTime currentBucketStartTime() const override;
+    void currentBucketStartTime(core_t::TTime time) override;
+    void createNewModels(std::size_t n, std::size_t m) override;
+    void updateRecycledModels() override;
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override;
+    const model::CInterimBucketCorrector& interimValueCorrector() const override;
+    void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
+    CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
 private:
     bool m_IsPopulation;
@@ -146,15 +146,15 @@ private:
 //! \brief A details view for a mock model.
 class CMockModelDetailsView : public CModelDetailsView {
 public:
-    CMockModelDetailsView(const CMockModel& model);
+    explicit CMockModelDetailsView(const CMockModel& model);
 
 private:
-    virtual const maths::CModel* model(model_t::EFeature feature, std::size_t byFieldId) const;
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const;
-    virtual const CAnomalyDetectorModel& base() const;
-    virtual double countVarianceScale(model_t::EFeature feature,
-                                      std::size_t byFieldId,
-                                      core_t::TTime time) const;
+    const maths::CModel* model(model_t::EFeature feature, std::size_t byFieldId) const override;
+    TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
+    const CAnomalyDetectorModel& base() const override;
+    double countVarianceScale(model_t::EFeature feature,
+                              std::size_t byFieldId,
+                              core_t::TTime time) const override;
 
 private:
     //! The model.


### PR DESCRIPTION
As the first stage in extracting time series decomposition state for analysis as part of the `model_extractor` project, meaningful 'readable' tags have been added throughout the relevant persistence routines.

Also took the opportunity to attend to several code style warnings flagged up by `clang-tidy`