### PR TITLE
[7.5][ML] Remote obsolete reference to persisterSupplier in Analyzer (#683)

### DIFF
--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -179,7 +179,8 @@ int main(int argc, char** argv) {
     };
 
     auto analysisSpecification = std::make_unique<ml::api::CDataFrameAnalysisSpecification>(
-        analysisSpecificationJson, std::move(persisterSupplier));
+        analysisSpecificationJson, std::move(persisterSupplier),
+        std::move(restoreSearcherSupplier));
 
     if (memoryUsageEstimationOnly) {
         auto outStream = [&ioMgr]() {
@@ -195,8 +196,7 @@ int main(int argc, char** argv) {
     }
 
     ml::api::CDataFrameAnalyzer dataFrameAnalyzer{
-        std::move(analysisSpecification), std::move(resultsStreamSupplier),
-        std::move(restoreSearcherSupplier)};
+        std::move(analysisSpecification), std::move(resultsStreamSupplier)};
 
     CCleanUpOnExit::add(dataFrameAnalyzer.dataFrameDirectory());
 

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -51,8 +51,7 @@ public:
 
 public:
     CDataFrameAnalyzer(TDataFrameAnalysisSpecificationUPtr analysisSpecification,
-                       TJsonOutputStreamWrapperUPtrSupplier resultsStreamSupplier,
-                       TDataSearcherUPtrSupplier dataSearcher = nullptr);
+                       TJsonOutputStreamWrapperUPtrSupplier resultsStreamSupplier);
     ~CDataFrameAnalyzer();
 
     //! This is true if the analyzer is receiving control messages.
@@ -112,7 +111,6 @@ private:
     TStrVec m_FieldNames;
     TTemporaryDirectoryPtr m_DataFrameDirectory;
     TJsonOutputStreamWrapperUPtrSupplier m_ResultsStreamSupplier;
-    TDataSearcherUPtrSupplier m_DataSearcher;
 };
 }
 }

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -46,10 +46,9 @@ const std::string RESULTS{"results"};
 }
 
 CDataFrameAnalyzer::CDataFrameAnalyzer(TDataFrameAnalysisSpecificationUPtr analysisSpecification,
-                                       TJsonOutputStreamWrapperUPtrSupplier resultsStreamSupplier,
-                                       TDataSearcherUPtrSupplier dataSearcher)
+                                       TJsonOutputStreamWrapperUPtrSupplier resultsStreamSupplier)
     : m_AnalysisSpecification{std::move(analysisSpecification)},
-      m_ResultsStreamSupplier{std::move(resultsStreamSupplier)}, m_DataSearcher{std::move(dataSearcher)} {
+      m_ResultsStreamSupplier{std::move(resultsStreamSupplier)} {
 
     if (m_AnalysisSpecification != nullptr) {
         auto frameAndDirectory = m_AnalysisSpecification->makeDataFrame();


### PR DESCRIPTION
This PR fixes the way restoreSearcherSupplier is passed from main to the business logic.

Backport to #683 