### PR TITLE
[ML] Remove unused references in CDataFrameAnalyzer

### DIFF
--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -9,7 +9,6 @@
 
 #include <api/ImportExport.h>
 
-#include <core/CDataSearcher.h>
 #include <core/CRapidJsonConcurrentLineWriter.h>
 
 #include <boost/unordered_map.hpp>
@@ -39,8 +38,6 @@ public:
     using TJsonOutputStreamWrapperUPtr = std::unique_ptr<core::CJsonOutputStreamWrapper>;
     using TJsonOutputStreamWrapperUPtrSupplier =
         std::function<TJsonOutputStreamWrapperUPtr()>;
-    using TDataSearcherUPtrSupplier =
-        std::function<std::unique_ptr<ml::core::CDataSearcher>()>;
     using TDataFrameAnalysisSpecificationUPtr = std::unique_ptr<CDataFrameAnalysisSpecification>;
     using TTemporaryDirectoryPtr = std::shared_ptr<core::CTemporaryDirectory>;
 


### PR DESCRIPTION
Refactors the code by removing an unused reference in `CDataFrameAnalyzer.h`.