### PR TITLE
[7.5][ML] Fix dangling reference in CForecastModelPersist (#688)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,13 @@ For large data sets this change was observed to give a 10% to 20% decrease in
 train time. (See {ml-pull}622[#622].)
 * Upgrade Boost libraries to version 1.71. (See {ml-pull}638[#638].)
 
+== {es} version 7.4.1
+
+=== Bug Fixes
+
+* A reference to a temporary variable was causing forecast model restoration to fail.
+The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {ml-pull}688[#688].)
+
 == {es} version 7.4.0
 
 === Bug Fixes
@@ -107,6 +114,13 @@ to the model. (See {ml-pull}214[#214].)
 * Ensure statics are persisted in a consistent manner {ml-pull}360[#360]
 
 == {es} version 7.0.0-alpha1
+
+== {es} version 6.8.4
+
+=== Bug Fixes
+
+* A reference to a temporary variable was causing forecast model restoration to fail.
+The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {ml-pull}688[#688].)
 
 == {es} version 6.8.2
 

--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -116,12 +116,16 @@ bool CForecastModelPersist::CRestore::nextModel(TMathsModelPtr& model,
                     return false;
                 }
 
+                auto modelParams =
+                    maths::CModelParams{m_ModelParams.s_BucketLength,
+                                        m_ModelParams.s_LearnRate,
+                                        m_ModelParams.s_DecayRate,
+                                        m_MinimumSeasonalVarianceScale,
+                                        m_ModelParams.s_MinimumTimeToDetectChange,
+                                        m_ModelParams.s_MaximumTimeToTestForChange};
+
                 maths::SModelRestoreParams params{
-                    maths::CModelParams{
-                        m_ModelParams.s_BucketLength, m_ModelParams.s_LearnRate,
-                        m_ModelParams.s_DecayRate, m_MinimumSeasonalVarianceScale,
-                        m_ModelParams.s_MinimumTimeToDetectChange,
-                        m_ModelParams.s_MaximumTimeToTestForChange},
+                    modelParams,
                     maths::STimeSeriesDecompositionRestoreParams{
                         m_ModelParams.s_DecayRate, m_ModelParams.s_BucketLength,
                         m_ModelParams.s_ComponentSize,


### PR DESCRIPTION
A reference to a temporary variable was causing forecast model restoration to fail.
Oddly this was only occurring on Mac builds and even then only with versions of clangd > 10.0.0


Backports #688