### PR TITLE
[ML] Work around compile error in old Xcode

### DIFF
--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -22,7 +22,6 @@ const std::string LOOP_SIZE_TAG{"loop_size_tag"};
 const std::string PROGRESS_STEPS_TAG{"progress_steps_tag"};
 const std::string CURRENT_STEP_PROGRESS_TAG{"current_step_progress_tag"};
 const std::string LOOP_POS_TAG{"loop_pos_tag"};
-const std::hash<std::string> stringHasher;
 }
 
 CLoopProgress::CLoopProgress()
@@ -59,6 +58,7 @@ void CLoopProgress::resumeRestored() {
 std::uint64_t CLoopProgress::checksum() const {
     std::uint64_t seed{core::CHashing::hashCombine(
         static_cast<std::uint64_t>(m_Size), static_cast<std::uint64_t>(m_Steps))};
+    std::hash<std::string> stringHasher;
     seed = core::CHashing::hashCombine(
         seed, stringHasher(core::CStringUtils::typeToStringPrecise(
                   m_StepProgress, core::CIEEE754::E_DoublePrecision)));


### PR DESCRIPTION
The problem is described in
https://stackoverflow.com/questions/7411515/why-does-c-require-a-user-provided-default-constructor-to-default-construct-a

Moving construction of the hasher object into the checksum
method won't matter in practice as the constructor is a
no-op and the object has no data members, so it should get
completely optimised away.