### PR TITLE
[7.5][ML] Encapsulate encoding logic (#689)

### DIFF
--- a/include/core/RestoreMacros.h
+++ b/include/core/RestoreMacros.h
@@ -23,6 +23,18 @@ namespace core {
         continue;                                                                      \
     }
 
+#define RESTORE_NO_LOOP(tag, restore)                                                  \
+    if (name == tag) {                                                                 \
+        if ((restore) == false) {                                                      \
+            if (traverser.value().empty()) {                                           \
+                LOG_ERROR(<< "Failed to restore " #tag);                               \
+            } else {                                                                   \
+                LOG_ERROR(<< "Failed to restore " #tag ", got " << traverser.value()); \
+            }                                                                          \
+            return false;                                                              \
+        }                                                                              \
+    }
+
 #define RESTORE_BUILT_IN(tag, target)                                                  \
     if (name == tag) {                                                                 \
         if (core::CStringUtils::stringToType(traverser.value(), target) == false) {    \

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -184,6 +184,8 @@ public:
     //! Populate the object from serialized data.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
+    CBoostedTree& operator=(const CBoostedTree&) = delete;
+
 private:
     using TImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
 

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -18,6 +18,7 @@
 #include <boost/unordered_set.hpp>
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -44,7 +45,7 @@ public:
     CEncodedDataFrameRowRef(TRowRef row, const CDataFrameCategoryEncoder& encoder);
 
     //! Get column \p i value.
-    CFloatStorage operator[](std::size_t i) const;
+    CFloatStorage operator[](std::size_t encodedColumnIndex) const;
 
     //! Get the row's index.
     std::size_t index() const;
@@ -72,6 +73,14 @@ private:
 
 class CMakeDataFrameCategoryEncoder;
 
+//! Encoding styles considered.
+enum EEncoding {
+    E_OneHot = 0,
+    E_Frequency,
+    E_TargetMean,
+    E_IdentityEncoding // This must stay at the end
+};
+
 //! \brief Performs encoding of the categorical columns in a data frame.
 //!
 //! DESCRIPTION:\n
@@ -85,60 +94,125 @@ class CMakeDataFrameCategoryEncoder;
 //! the number of features we use in total based on the quantity of training data.
 class MATHS_EXPORT CDataFrameCategoryEncoder final {
 public:
-    using TBoolVec = std::vector<bool>;
     using TDoubleVec = std::vector<double>;
-    using TDoubleVecVec = std::vector<TDoubleVec>;
     using TSizeVec = std::vector<std::size_t>;
-    using TSizeVecVec = std::vector<TSizeVec>;
     using TRowRef = core::CDataFrame::TRowRef;
 
+    //! \brief Base type of category encodings.
+    class MATHS_EXPORT CEncoding {
+    public:
+        CEncoding(std::size_t inputColumnIndex, double mic);
+        virtual ~CEncoding() = default;
+        virtual EEncoding type() const = 0;
+        virtual double encode(double value) const = 0;
+        virtual std::uint64_t checksum() const = 0;
+        virtual bool isBinary() const = 0;
+        //! return encoding type as string
+        virtual std::string typeString() const = 0;
+
+        std::size_t inputColumnIndex() const;
+        double encode(const TRowRef& row) const;
+        double mic() const;
+        //! Persist by passing information to \p inserter.
+        void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+        //! Populate the object from serialized data.
+        bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
+    protected:
+        std::size_t m_InputColumnIndex;
+        double m_Mic;
+
+    private:
+        virtual void
+        acceptPersistInserterForDerivedTypeState(core::CStatePersistInserter& inserter) const = 0;
+        virtual bool
+        acceptRestoreTraverserForDerivedTypeState(core::CStateRestoreTraverser& traverser) = 0;
+    };
+
+    using TEncodingUPtr = std::unique_ptr<CEncoding>;
+    using TEncodingUPtrVec = std::vector<TEncodingUPtr>;
+
+    //! \brief Returns the supplied value.
+    class MATHS_EXPORT CIdentityEncoding : public CEncoding {
+    public:
+        CIdentityEncoding(std::size_t inputColumnIndex, double mic);
+        EEncoding type() const override;
+        double encode(double value) const override;
+        bool isBinary() const override;
+        std::uint64_t checksum() const override;
+        std::string typeString() const override;
+
+    private:
+        void acceptPersistInserterForDerivedTypeState(core::CStatePersistInserter& inserter) const override;
+        bool acceptRestoreTraverserForDerivedTypeState(core::CStateRestoreTraverser& traverser) override;
+    };
+
+    //! \brief One-hot encoding.
+    class MATHS_EXPORT COneHotEncoding : public CEncoding {
+    public:
+        COneHotEncoding(std::size_t inputColumnIndex, double mic, std::size_t hotCategory);
+        EEncoding type() const override;
+        double encode(double value) const override;
+        bool isBinary() const override;
+        std::uint64_t checksum() const override;
+        std::string typeString() const override;
+
+    private:
+        void acceptPersistInserterForDerivedTypeState(core::CStatePersistInserter& inserter) const override;
+        bool acceptRestoreTraverserForDerivedTypeState(core::CStateRestoreTraverser& traverser) override;
+
+    private:
+        std::size_t m_HotCategory;
+    };
+
+    //! \brief Looks up the encoding in a map.
+    class MATHS_EXPORT CMappedEncoding : public CEncoding {
+    public:
+        CMappedEncoding(std::size_t inputColumnIndex,
+                        double mic,
+                        EEncoding encoding,
+                        const TDoubleVec& map,
+                        double fallback);
+        EEncoding type() const override;
+        double encode(double value) const override;
+        bool isBinary() const override;
+        std::uint64_t checksum() const override;
+        std::string typeString() const override;
+
+    private:
+        void acceptPersistInserterForDerivedTypeState(core::CStatePersistInserter& inserter) const override;
+        bool acceptRestoreTraverserForDerivedTypeState(core::CStateRestoreTraverser& traverser) override;
+
+    private:
+        EEncoding m_Encoding;
+        TDoubleVec m_Map;
+        double m_Fallback;
+        bool m_Binary;
+    };
+
 public:
-    CDataFrameCategoryEncoder(const CMakeDataFrameCategoryEncoder& parameters);
+    CDataFrameCategoryEncoder(CMakeDataFrameCategoryEncoder parameters);
 
     //! Initialize from serialized data.
     CDataFrameCategoryEncoder(core::CStateRestoreTraverser& traverser);
 
+    CDataFrameCategoryEncoder(const CDataFrameCategoryEncoder&) = delete;
+    CDataFrameCategoryEncoder& operator=(const CDataFrameCategoryEncoder&) = delete;
+
     //! Get a row reference which encodes the categories in \p row.
     CEncodedDataFrameRowRef encode(TRowRef row) const;
 
-    //! Check if \p feature is categorical.
-    bool columnIsCategorical(std::size_t feature) const;
-
     //! Get the MICs of the selected features.
-    const TDoubleVec& featureMics() const;
+    TDoubleVec encodedColumnMics() const;
 
     //! Get the total number of dimensions in the feature vector.
-    std::size_t numberFeatures() const;
+    std::size_t numberEncodedColumns() const;
 
-    //! Get the encoding offset in feature vector of \p index.
-    std::size_t encoding(std::size_t index) const;
+    //! Get the encoded feature at position \p encodedColumnIndex.
+    const CEncoding& encoding(std::size_t encodedColumnIndex) const;
 
-    //! Get the data frame column of \p index into the feature vector.
-    std::size_t column(std::size_t index) const;
-
-    //! Check if \p index is a binary encoded feature.
-    bool isBinary(std::size_t index) const;
-
-    //! Get the number of one-hot encoded categories for \p feature.
-    std::size_t numberOneHotEncodedCategories(std::size_t feature) const;
-
-    //! Check if \p category of \p feature uses one-hot encoding.
-    bool usesOneHotEncoding(std::size_t feature, std::size_t category) const;
-
-    //! Check if feature with encoding \p encoding is one for \p category of \p feature.
-    bool isHot(std::size_t encoding, std::size_t feature, std::size_t category) const;
-
-    //! Check if \p feature uses frequency encoding.
-    bool usesFrequencyEncoding(std::size_t feature) const;
-
-    //! Check if \p category of \p feature is a rare category.
-    bool isRareCategory(std::size_t feature, std::size_t category) const;
-
-    //! Get the frequency of \p category of \p feature.
-    double frequency(std::size_t feature, std::size_t category) const;
-
-    //! Get the mean value of the target variable for \p category of \p feature.
-    double targetMeanValue(std::size_t feature, std::size_t category) const;
+    //! Check if \p encodedColumnIndex is a binary encoded feature.
+    bool isBinary(std::size_t encodedColumnIndex) const;
 
     //! Get a checksum of the state of this object seeded with \p seed.
     std::uint64_t checksum(std::uint64_t seed = 0) const;
@@ -150,64 +224,21 @@ public:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
 private:
-    using TSizeDoublePr = std::pair<std::size_t, double>;
-    using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
-    using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
-    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-    using TSizeSizePrDoubleMap = std::map<TSizeSizePr, double>;
-    using TSizeUSet = boost::unordered_set<std::size_t>;
-    using TSizeUSetVec = std::vector<TSizeUSet>;
+    bool restoreEncodings(core::CStateRestoreTraverser& traverser);
+    template<typename T, typename... Args>
+    bool forwardRestoreEncodings(core::CStateRestoreTraverser& traverser, Args&&... args);
 
 private:
-    TSizeDoublePrVecVec mics(std::size_t numberThreads,
-                             const core::CDataFrame& frame,
-                             const CDataFrameUtils::CColumnValue& target,
-                             const core::CPackedBitVector& rowMask,
-                             const TSizeVec& metricColumnMask,
-                             const TSizeVec& categoricalColumnMask) const;
-    void setupFrequencyEncoding(std::size_t numberThreads,
-                                const core::CDataFrame& frame,
-                                const core::CPackedBitVector& rowMask,
-                                const TSizeVec& categoricalColumnMask);
-    void setupTargetMeanValueEncoding(std::size_t numberThreads,
-                                      const core::CDataFrame& frame,
-                                      const core::CPackedBitVector& rowMask,
-                                      const TSizeVec& categoricalColumnMask,
-                                      std::size_t targetColumn);
-    TSizeSizePrDoubleMap selectFeatures(std::size_t numberThreads,
-                                        const core::CDataFrame& frame,
-                                        const core::CPackedBitVector& rowMask,
-                                        TSizeVec metricColumnMask,
-                                        TSizeVec categoricalColumnMask,
-                                        std::size_t targetColumn);
-    TSizeSizePrDoubleMap selectAllFeatures(const TSizeDoublePrVecVec& mics);
-    void finishEncoding(std::size_t targetColumn, TSizeSizePrDoubleMap selectedFeatureMics);
-    void discardNuisanceFeatures(TSizeDoublePrVecVec& mics) const;
-    std::size_t numberAvailableFeatures(const TSizeDoublePrVecVec& mics) const;
-
-private:
-    std::size_t m_MinimumRowsPerFeature;
-    double m_MinimumFrequencyToOneHotEncode;
-    double m_MinimumRelativeMicToSelectFeature;
-    double m_RedundancyWeight;
-    TBoolVec m_ColumnIsCategorical;
-    TBoolVec m_ColumnUsesFrequencyEncoding;
-    TSizeVecVec m_OneHotEncodedCategories;
-    TSizeUSetVec m_RareCategories;
-    TDoubleVecVec m_CategoryFrequencies;
-    TDoubleVec m_MeanCategoryFrequencies;
-    TDoubleVecVec m_CategoryTargetMeanValues;
-    TDoubleVec m_MeanCategoryTargetMeanValues;
-    TDoubleVec m_FeatureVectorMics;
-    TSizeVec m_FeatureVectorColumnMap;
-    TSizeVec m_FeatureVectorEncodingMap;
+    TEncodingUPtrVec m_Encodings;
 };
 
 //! \brief Implements the named parameter idiom for CDataFrameCategoryEncoder.
 class MATHS_EXPORT CMakeDataFrameCategoryEncoder {
 public:
+    using TDoubleVec = std::vector<double>;
     using TSizeVec = std::vector<std::size_t>;
     using TOptionalDouble = boost::optional<double>;
+    using TEncodingUPtrVec = CDataFrameCategoryEncoder::TEncodingUPtrVec;
 
 public:
     //! The minimum number of training rows needed per feature used.
@@ -233,9 +264,6 @@ public:
                                   const core::CDataFrame& frame,
                                   std::size_t targetColumn);
 
-    CMakeDataFrameCategoryEncoder(const CMakeDataFrameCategoryEncoder&) = delete;
-    CMakeDataFrameCategoryEncoder& operator=(const CMakeDataFrameCategoryEncoder&) = delete;
-
     //! Set the minimum number of training rows needed per feature used.
     CMakeDataFrameCategoryEncoder& minimumRowsPerFeature(std::size_t minimumRowsPerFeature);
 
@@ -260,18 +288,69 @@ public:
     //! Set a mask of the columns to include.
     CMakeDataFrameCategoryEncoder& columnMask(TSizeVec columnMask);
 
+    //! Make the encoding.
+    TEncodingUPtrVec makeEncodings();
+
+    //! \name Test Methods
+    //@{
+    //! Get the encoding offset in feature vector of \p index.
+    std::size_t encoding(std::size_t index) const;
+
+    //! Check if \p category of \p inputColumnIndex uses one-hot encoding.
+    bool usesOneHotEncoding(std::size_t inputColumnIndex, std::size_t category) const;
+
+    //! Check if \p category of \p inputColumnIndex is a rare category.
+    bool isRareCategory(std::size_t inputColumnIndex, std::size_t category) const;
+    //@}
+
 private:
+    using TBoolVec = std::vector<bool>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TSizeDoublePr = std::pair<std::size_t, double>;
+    using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
+    using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+    using TSizeSizePrDoubleMap = std::map<TSizeSizePr, double>;
+    using TSizeUSet = boost::unordered_set<std::size_t>;
+    using TSizeUSetVec = std::vector<TSizeUSet>;
+
+private:
+    TSizeDoublePrVecVec mics(const CDataFrameUtils::CColumnValue& target,
+                             const TSizeVec& metricColumnMask,
+                             const TSizeVec& categoricalColumnMask) const;
+    void setupFrequencyEncoding(const TSizeVec& categoricalColumnMask);
+    void setupTargetMeanValueEncoding(const TSizeVec& categoricalColumnMask);
+    TSizeSizePrDoubleMap selectFeatures(TSizeVec metricColumnMask,
+                                        const TSizeVec& categoricalColumnMask);
+    TSizeSizePrDoubleMap selectAllFeatures(const TSizeDoublePrVecVec& mics);
+    void finishEncoding(TSizeSizePrDoubleMap selectedFeatureMics);
+    void discardNuisanceFeatures(TSizeDoublePrVecVec& mics) const;
+    std::size_t numberAvailableFeatures(const TSizeDoublePrVecVec& mics) const;
+
+private:
+    // Begin parameters
     std::size_t m_MinimumRowsPerFeature = MINIMUM_ROWS_PER_FEATURE;
     double m_MinimumFrequencyToOneHotEncode = MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE;
     double m_MinimumRelativeMicToSelectFeature = MINIMUM_RELATIVE_MIC_TO_SELECT_FEATURE;
     double m_RedundancyWeight = REDUNDANCY_WEIGHT;
     std::size_t m_NumberThreads;
-    const core::CDataFrame& m_Frame;
+    const core::CDataFrame* m_Frame;
     core::CPackedBitVector m_RowMask;
     TSizeVec m_ColumnMask;
     std::size_t m_TargetColumn;
+    // End parameters
 
-    friend CDataFrameCategoryEncoder;
+    TBoolVec m_InputColumnUsesFrequencyEncoding;
+    TSizeVecVec m_OneHotEncodedCategories;
+    TSizeUSetVec m_RareCategories;
+    TDoubleVecVec m_CategoryFrequencies;
+    TDoubleVec m_MeanCategoryFrequencies;
+    TDoubleVecVec m_CategoryTargetMeanValues;
+    TDoubleVec m_MeanCategoryTargetMeanValues;
+    TDoubleVec m_EncodedColumnMics;
+    TSizeVec m_EncodedColumnInputColumnMap;
+    TSizeVec m_EncodedColumnEncodingMap;
 };
 }
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -203,7 +203,7 @@ void CBoostedTreeFactory::selectFeaturesAndEncodeCategories(const core::CDataFra
 
 void CBoostedTreeFactory::determineFeatureDataTypes(const core::CDataFrame& frame) const {
 
-    TSizeVec columnMask(m_TreeImpl->m_Encoder->numberFeatures());
+    TSizeVec columnMask(m_TreeImpl->m_Encoder->numberEncodedColumns());
     std::iota(columnMask.begin(), columnMask.end(), 0);
     columnMask.erase(std::remove_if(columnMask.begin(), columnMask.end(),
                                     [this](std::size_t index) {
@@ -220,7 +220,7 @@ bool CBoostedTreeFactory::initializeFeatureSampleDistribution() const {
 
     // Compute feature sample probabilities.
 
-    TDoubleVec mics(m_TreeImpl->m_Encoder->featureMics());
+    TDoubleVec mics(m_TreeImpl->m_Encoder->encodedColumnMics());
     LOG_TRACE(<< "candidate regressors MICe = " << core::CContainerPrinter::print(mics));
 
     if (mics.size() > 0) {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -651,7 +651,7 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 }
 
 std::size_t CBoostedTreeImpl::numberFeatures() const {
-    return m_Encoder->numberFeatures();
+    return m_Encoder->numberEncodedColumns();
 }
 
 std::size_t CBoostedTreeImpl::featureBagSize() const {

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -9,6 +9,7 @@
 #include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
 #include <core/CPackedBitVector.h>
+#include <core/CPersistUtils.h>
 #include <core/CTriple.h>
 
 #include <maths/CBasicStatistics.h>
@@ -27,31 +28,46 @@ using TSizeDoublePr = std::pair<std::size_t, double>;
 using TSizeDoublePrVec = std::vector<TSizeDoublePr>;
 using TSizeDoublePrVecVec = std::vector<TSizeDoublePrVec>;
 using TSizeUSet = boost::unordered_set<std::size_t>;
-
-enum EEncoding {
-    E_OneHot = 0,
-    E_Frequency,
-    E_TargetMean,
-    E_CandidateEncodings
-};
+using TDoubleUSet = boost::unordered_set<double>;
+using CIdentityEncoding = CDataFrameCategoryEncoder::CIdentityEncoding;
+using COneHotEncoding = CDataFrameCategoryEncoder::COneHotEncoding;
+using CMappedEncoding = CDataFrameCategoryEncoder::CMappedEncoding;
 
 const std::size_t CATEGORY_FOR_METRICS{std::numeric_limits<std::size_t>::max()};
-const std::size_t CATEGORY_FOR_FREQUANCY_ENCODING{CATEGORY_FOR_METRICS - 1};
-const std::size_t CATEGORY_FOR_TARGET_MEAN_ENCODING{CATEGORY_FOR_FREQUANCY_ENCODING - 1};
+const std::size_t CATEGORY_FOR_FREQUENCY_ENCODING{CATEGORY_FOR_METRICS - 1};
+const std::size_t CATEGORY_FOR_TARGET_MEAN_ENCODING{CATEGORY_FOR_FREQUENCY_ENCODING - 1};
 const std::size_t CATEGORY_FOR_DEPENDENT_VARIABLE{CATEGORY_FOR_TARGET_MEAN_ENCODING - 1};
 
+const std::string ENCODING_VECTOR_TAG{"encoding_vector"};
+const std::string ENCODING_INPUT_COLUMN_INDEX_TAG{"encoding_input_column_index"};
+const std::string ENCODING_MIC_TAG{"encoding_mic"};
+const std::string ONE_HOT_ENCODING_CATEGORY_TAG{"one_hot_encoding_category"};
+const std::string MAPPED_ENCODING_TYPE_TAG{"mapped_encoding_type"};
+const std::string MAPPED_ENCODING_MAP_TAG{"mapped_encoding_map"};
+const std::string MAPPED_ENCODING_FALLBACK_TAG{"mapped_encoding_fallback"};
+const std::string MAPPED_ENCODING_BINARY_TAG{"mapped_encoding_binary"};
+const std::string IDENTITY_ENCODING_TAG{"identity_encoding"};
+const std::string ONE_HOT_ENCODING_TAG{"one_hot_encoding"};
+const std::string FREQUENCY_ENCODING_TAG{"frequency_encoding"};
+const std::string TARGET_MEAN_ENCODING_TAG{"target_mean_encoding"};
+
+// TODO can these constants be replaced with EEncodings?
 bool isMetric(std::size_t category) {
     return category == CATEGORY_FOR_METRICS;
 }
+
 bool isFrequency(std::size_t category) {
-    return category == CATEGORY_FOR_FREQUANCY_ENCODING;
+    return category == CATEGORY_FOR_FREQUENCY_ENCODING;
 }
+
 bool isTargetMean(std::size_t category) {
     return category == CATEGORY_FOR_TARGET_MEAN_ENCODING;
 }
+
 bool isCategory(std::size_t category) {
     return (isMetric(category) || isFrequency(category) || isTargetMean(category)) == false;
 }
+
 std::string print(std::size_t category) {
     if (isMetric(category)) {
         return "metric";
@@ -77,10 +93,15 @@ public:
                                                         micWithDependentVariable} {}
 
     bool isMetric() const { return maths::isMetric(m_Category); }
+
     bool isFrequency() const { return maths::isFrequency(m_Category); }
+
     bool isTargetMean() const { return maths::isTargetMean(m_Category); }
+
     bool isCategory() const { return maths::isCategory(m_Category); }
+
     std::size_t feature() const { return m_Feature; }
+
     std::size_t category() const { return m_Category; }
 
     double micWithDependentVariable() const {
@@ -190,55 +211,14 @@ private:
     double m_RedundancyWeight;
     TFeatureRelevanceMinusRedundancyList m_Features;
 };
-
-const std::string MINIMUM_ROWS_PER_FEATURE_TAG{"minimum_rows_per_feature"};
-const std::string MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE_TAG{"minimum_frequency_to_one_hot_encode"};
-const std::string REDUNDANCY_WEIGHT_TAG{"redundancy_weight"};
-const std::string MINIMUM_RELATIVE_MIC_TO_SELECT_FEATURE_TAG{
-    "minimum_relative_mic_to_select_feature_tag"};
-const std::string COLUMN_IS_CATEGORICAL_TAG{"is_categorical"};
-const std::string COLUMN_USES_FREQUENCY_ENCODING_TAG{"uses_frequency_encoding"};
-const std::string ONE_HOT_ENCODED_CATEGORIES_TAG{"one_hot_encoded_categories"};
-const std::string RARE_CATEGORIES_TAG{"rare_categories"};
-const std::string CATEGORY_FREQUENCIES_TAG{"category_frequencies"};
-const std::string MEAN_CATEGORY_FREQUENCIES_TAG{"mean_category_frequencies"};
-const std::string CATEGORY_TARGET_MEAN_VALUES_TAG{"category_target_mean_values"};
-const std::string MEAN_CATEGORY_TARGET_MEAN_VALUES_TAG{"mean_category_target_mean_values"};
-const std::string FEATURE_VECTOR_MICS_TAG{"feature_vector_mics"};
-const std::string FEATURE_VECTOR_COLUMN_MAP_TAG{"feature_vector_column_map"};
-const std::string FEATURE_VECTOR_ENCODING_MAP_TAG{"feature_vector_encoding_map"};
 }
 
 CEncodedDataFrameRowRef::CEncodedDataFrameRowRef(TRowRef row, const CDataFrameCategoryEncoder& encoder)
     : m_Row{std::move(row)}, m_Encoder{&encoder} {
 }
 
-CFloatStorage CEncodedDataFrameRowRef::operator[](std::size_t i) const {
-
-    std::size_t feature{m_Encoder->column(i)};
-
-    CFloatStorage value{m_Row[feature]};
-
-    if (m_Encoder->columnIsCategorical(feature) == false) {
-        return value;
-    }
-
-    std::size_t encoding{m_Encoder->encoding(i)};
-    std::size_t category{static_cast<std::size_t>(value)};
-
-    std::size_t numberOneHotEncodedCategories{
-        m_Encoder->numberOneHotEncodedCategories(feature)};
-
-    if (encoding < numberOneHotEncodedCategories) {
-        return m_Encoder->isHot(encoding, feature, category) ? 1.0 : 0.0;
-    }
-
-    if (encoding == numberOneHotEncodedCategories &&
-        m_Encoder->usesFrequencyEncoding(feature)) {
-        return m_Encoder->frequency(feature, category);
-    }
-
-    return m_Encoder->targetMeanValue(feature, category);
+CFloatStorage CEncodedDataFrameRowRef::operator[](std::size_t encodedColumnIndex) const {
+    return m_Encoder->encoding(encodedColumnIndex).encode(m_Row);
 }
 
 std::size_t CEncodedDataFrameRowRef::index() const {
@@ -246,57 +226,11 @@ std::size_t CEncodedDataFrameRowRef::index() const {
 }
 
 std::size_t CEncodedDataFrameRowRef::numberColumns() const {
-    return m_Encoder->numberFeatures();
+    return m_Encoder->numberEncodedColumns();
 }
 
-CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(const CMakeDataFrameCategoryEncoder& parameters)
-    : m_MinimumRowsPerFeature{parameters.m_MinimumRowsPerFeature},
-      m_MinimumFrequencyToOneHotEncode{parameters.m_MinimumFrequencyToOneHotEncode},
-      m_MinimumRelativeMicToSelectFeature{parameters.m_MinimumRelativeMicToSelectFeature},
-      m_RedundancyWeight{parameters.m_RedundancyWeight},
-      m_ColumnIsCategorical(parameters.m_Frame.columnIsCategorical()) {
-
-    TSizeVec metricColumnMask(parameters.m_ColumnMask);
-    metricColumnMask.erase(std::remove_if(metricColumnMask.begin(),
-                                          metricColumnMask.end(),
-                                          [&parameters, this](std::size_t i) {
-                                              return i == parameters.m_TargetColumn ||
-                                                     m_ColumnIsCategorical[i];
-                                          }),
-                           metricColumnMask.end());
-    LOG_TRACE(<< "metric column mask = " << core::CContainerPrinter::print(metricColumnMask));
-
-    TSizeVec categoricalColumnMask(parameters.m_ColumnMask);
-    categoricalColumnMask.erase(
-        std::remove_if(categoricalColumnMask.begin(), categoricalColumnMask.end(),
-                       [&parameters, this](std::size_t i) {
-                           return i == parameters.m_TargetColumn ||
-                                  m_ColumnIsCategorical[i] == false;
-                       }),
-        categoricalColumnMask.end());
-    LOG_TRACE(<< "categorical column mask = "
-              << core::CContainerPrinter::print(categoricalColumnMask));
-
-    // The top-level strategy is as follows:
-    //
-    // We one-hot encode the frequent categories with the highest non-zero MICe up
-    // to the permitted overall feature count.
-    // We mean value encode the remaining features where we have a representative
-    // sample size.
-    // We frequency encode all rare categories of a categorical feature.
-
-    this->setupFrequencyEncoding(parameters.m_NumberThreads, parameters.m_Frame,
-                                 parameters.m_RowMask, categoricalColumnMask);
-
-    this->setupTargetMeanValueEncoding(parameters.m_NumberThreads, parameters.m_Frame,
-                                       parameters.m_RowMask, categoricalColumnMask,
-                                       parameters.m_TargetColumn);
-
-    this->finishEncoding(
-        parameters.m_TargetColumn,
-        this->selectFeatures(parameters.m_NumberThreads, parameters.m_Frame,
-                             parameters.m_RowMask, metricColumnMask,
-                             categoricalColumnMask, parameters.m_TargetColumn));
+CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(CMakeDataFrameCategoryEncoder builder) {
+    m_Encodings = builder.makeEncodings();
 }
 
 CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(core::CStateRestoreTraverser& traverser) {
@@ -310,517 +244,278 @@ CEncodedDataFrameRowRef CDataFrameCategoryEncoder::encode(TRowRef row) const {
     return {std::move(row), *this};
 }
 
-bool CDataFrameCategoryEncoder::columnIsCategorical(std::size_t feature) const {
-    return m_ColumnIsCategorical[feature];
+CDataFrameCategoryEncoder::TDoubleVec CDataFrameCategoryEncoder::encodedColumnMics() const {
+    TDoubleVec mics;
+    mics.reserve(m_Encodings.size());
+    for (const auto& encoding : m_Encodings) {
+        mics.push_back(encoding->mic());
+    }
+    return mics;
 }
 
-const CDataFrameCategoryEncoder::TDoubleVec& CDataFrameCategoryEncoder::featureMics() const {
-    return m_FeatureVectorMics;
+std::size_t CDataFrameCategoryEncoder::numberEncodedColumns() const {
+    return m_Encodings.size();
 }
 
-std::size_t CDataFrameCategoryEncoder::numberFeatures() const {
-    return m_FeatureVectorMics.size();
+const CDataFrameCategoryEncoder::CEncoding&
+CDataFrameCategoryEncoder::encoding(std::size_t encodedColumnIndex) const {
+    return *m_Encodings[encodedColumnIndex];
 }
 
-std::size_t CDataFrameCategoryEncoder::encoding(std::size_t index) const {
-    return m_FeatureVectorEncodingMap[index];
-}
-
-std::size_t CDataFrameCategoryEncoder::column(std::size_t index) const {
-    return m_FeatureVectorColumnMap[index];
-}
-
-bool CDataFrameCategoryEncoder::isBinary(std::size_t index) const {
-    std::size_t encoding{this->encoding(index)};
-    std::size_t feature{this->column(index)};
-    return encoding < m_OneHotEncodedCategories[feature].size();
-}
-
-std::size_t CDataFrameCategoryEncoder::numberOneHotEncodedCategories(std::size_t feature) const {
-    return m_OneHotEncodedCategories[feature].size();
-}
-
-bool CDataFrameCategoryEncoder::usesOneHotEncoding(std::size_t feature,
-                                                   std::size_t category) const {
-    return std::binary_search(m_OneHotEncodedCategories[feature].begin(),
-                              m_OneHotEncodedCategories[feature].end(), category);
-}
-
-bool CDataFrameCategoryEncoder::isHot(std::size_t encoding,
-                                      std::size_t feature,
-                                      std::size_t category) const {
-
-    // The most important categories are one-hot encode. In the encoded row the
-    // layout of the encoding dimensions, for each categorical feature, is as
-    // follows:
-    //   (...| one-hot | mean target | frequency |...)
-    //
-    // The ones are in the order the categories appear in m_OneHotEncodedCategories.
-    // For example, if m_OneHotEncodedCategories[feature] = (2, 5, 7) for any other
-    // category the encoded row will contain (...| 0 0 0 | ...). For 2, 5 and 7 it
-    // will contain (...| 1 0 0 |...), (...| 0 1 0 |...) and (...| 0 0 1 |...),
-    // respectively.
-    //
-    // In the following we therefore 1) check to see if the category is being
-    // one-hot encoded, 2) check if the encoding of the dimension, i.e. its offset
-    // relative to the start of the encoding dimensions for the feature, is equal
-    // to the position of the one for the category.
-
-    auto one = std::lower_bound(m_OneHotEncodedCategories[feature].begin(),
-                                m_OneHotEncodedCategories[feature].end(), category);
-    return one != m_OneHotEncodedCategories[feature].end() && category == *one &&
-           static_cast<std::ptrdiff_t>(encoding) ==
-               one - m_OneHotEncodedCategories[feature].begin();
-}
-
-bool CDataFrameCategoryEncoder::usesFrequencyEncoding(std::size_t feature) const {
-    return m_ColumnUsesFrequencyEncoding[feature];
-}
-
-double CDataFrameCategoryEncoder::frequency(std::size_t feature, std::size_t category) const {
-    const auto& frequencies = m_CategoryFrequencies[feature];
-    return category < frequencies.size() ? frequencies[category]
-                                         : m_MeanCategoryFrequencies[feature];
-}
-
-bool CDataFrameCategoryEncoder::isRareCategory(std::size_t feature, std::size_t category) const {
-    return m_RareCategories[feature].find(category) != m_RareCategories[feature].end();
-}
-
-double CDataFrameCategoryEncoder::targetMeanValue(std::size_t feature,
-                                                  std::size_t category) const {
-    const auto& targetMeanValues = m_CategoryTargetMeanValues[feature];
-    return category < targetMeanValues.size() ? targetMeanValues[category]
-                                              : m_MeanCategoryTargetMeanValues[feature];
+bool CDataFrameCategoryEncoder::isBinary(std::size_t encodedColumnIndex) const {
+    return m_Encodings[encodedColumnIndex]->isBinary();
 }
 
 std::uint64_t CDataFrameCategoryEncoder::checksum(std::uint64_t seed) const {
-    seed = CChecksum::calculate(seed, m_MinimumRowsPerFeature);
-    seed = CChecksum::calculate(seed, m_MinimumFrequencyToOneHotEncode);
-    seed = CChecksum::calculate(seed, m_RedundancyWeight);
-    seed = CChecksum::calculate(seed, m_MinimumRelativeMicToSelectFeature);
-    seed = CChecksum::calculate(seed, m_ColumnIsCategorical);
-    seed = CChecksum::calculate(seed, m_ColumnUsesFrequencyEncoding);
-    seed = CChecksum::calculate(seed, m_OneHotEncodedCategories);
-    seed = CChecksum::calculate(seed, m_RareCategories);
-    seed = CChecksum::calculate(seed, m_CategoryFrequencies);
-    seed = CChecksum::calculate(seed, m_MeanCategoryFrequencies);
-    seed = CChecksum::calculate(seed, m_CategoryTargetMeanValues);
-    seed = CChecksum::calculate(seed, m_MeanCategoryTargetMeanValues);
-    seed = CChecksum::calculate(seed, m_FeatureVectorMics);
-    seed = CChecksum::calculate(seed, m_FeatureVectorColumnMap);
-    return CChecksum::calculate(seed, m_FeatureVectorEncodingMap);
+    return CChecksum::calculate(seed, m_Encodings);
 }
 
 void CDataFrameCategoryEncoder::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    inserter.insertValue(MINIMUM_ROWS_PER_FEATURE_TAG, m_MinimumRowsPerFeature);
-    inserter.insertValue(MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE_TAG, m_MinimumFrequencyToOneHotEncode,
-                         core::CIEEE754::E_DoublePrecision);
-    inserter.insertValue(REDUNDANCY_WEIGHT_TAG, m_RedundancyWeight,
-                         core::CIEEE754::E_DoublePrecision);
-    inserter.insertValue(MINIMUM_RELATIVE_MIC_TO_SELECT_FEATURE_TAG,
-                         m_MinimumRelativeMicToSelectFeature,
-                         core::CIEEE754::E_DoublePrecision);
-    core::CPersistUtils::persist(COLUMN_IS_CATEGORICAL_TAG, m_ColumnIsCategorical, inserter);
-    core::CPersistUtils::persist(COLUMN_USES_FREQUENCY_ENCODING_TAG,
-                                 m_ColumnUsesFrequencyEncoding, inserter);
-    core::CPersistUtils::persist(ONE_HOT_ENCODED_CATEGORIES_TAG,
-                                 m_OneHotEncodedCategories, inserter);
-    core::CPersistUtils::persist(RARE_CATEGORIES_TAG, m_RareCategories, inserter);
-    core::CPersistUtils::persist(CATEGORY_FREQUENCIES_TAG, m_CategoryFrequencies, inserter);
-    core::CPersistUtils::persist(MEAN_CATEGORY_FREQUENCIES_TAG,
-                                 m_MeanCategoryFrequencies, inserter);
-    core::CPersistUtils::persist(CATEGORY_TARGET_MEAN_VALUES_TAG,
-                                 m_CategoryTargetMeanValues, inserter);
-    core::CPersistUtils::persist(MEAN_CATEGORY_TARGET_MEAN_VALUES_TAG,
-                                 m_MeanCategoryTargetMeanValues, inserter);
-    core::CPersistUtils::persist(FEATURE_VECTOR_MICS_TAG, m_FeatureVectorMics, inserter);
-    core::CPersistUtils::persist(FEATURE_VECTOR_COLUMN_MAP_TAG,
-                                 m_FeatureVectorColumnMap, inserter);
-    core::CPersistUtils::persist(FEATURE_VECTOR_ENCODING_MAP_TAG,
-                                 m_FeatureVectorEncodingMap, inserter);
+    auto persistEncodingVector = [this](core::CStatePersistInserter& inserter) {
+        for (const auto& encoding : m_Encodings) {
+            auto acceptPersistInserter = [&encoding](core::CStatePersistInserter& inserter) {
+                encoding->acceptPersistInserter(inserter);
+            };
+            inserter.insertLevel(encoding->typeString(), acceptPersistInserter);
+        }
+    };
+    inserter.insertLevel(ENCODING_VECTOR_TAG, persistEncodingVector);
 }
 
 bool CDataFrameCategoryEncoder::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     do {
         const std::string& name{traverser.name()};
-        RESTORE_BUILT_IN(MINIMUM_ROWS_PER_FEATURE_TAG, m_MinimumRowsPerFeature)
-        RESTORE_BUILT_IN(MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE_TAG, m_MinimumFrequencyToOneHotEncode)
-        RESTORE_BUILT_IN(REDUNDANCY_WEIGHT_TAG, m_RedundancyWeight)
-        RESTORE_BUILT_IN(MINIMUM_RELATIVE_MIC_TO_SELECT_FEATURE_TAG, m_MinimumRelativeMicToSelectFeature)
-        RESTORE(COLUMN_IS_CATEGORICAL_TAG,
-                core::CPersistUtils::restore(COLUMN_IS_CATEGORICAL_TAG,
-                                             m_ColumnIsCategorical, traverser))
-        RESTORE(COLUMN_USES_FREQUENCY_ENCODING_TAG,
-                core::CPersistUtils::restore(COLUMN_USES_FREQUENCY_ENCODING_TAG,
-                                             m_ColumnUsesFrequencyEncoding, traverser))
-        RESTORE(ONE_HOT_ENCODED_CATEGORIES_TAG,
-                core::CPersistUtils::restore(ONE_HOT_ENCODED_CATEGORIES_TAG,
-                                             m_OneHotEncodedCategories, traverser))
-        RESTORE(RARE_CATEGORIES_TAG,
-                core::CPersistUtils::restore(RARE_CATEGORIES_TAG, m_RareCategories, traverser))
-        RESTORE(CATEGORY_FREQUENCIES_TAG,
-                core::CPersistUtils::restore(CATEGORY_FREQUENCIES_TAG,
-                                             m_CategoryFrequencies, traverser))
-        RESTORE(MEAN_CATEGORY_FREQUENCIES_TAG,
-                core::CPersistUtils::restore(MEAN_CATEGORY_FREQUENCIES_TAG,
-                                             m_MeanCategoryFrequencies, traverser))
-        RESTORE(CATEGORY_TARGET_MEAN_VALUES_TAG,
-                core::CPersistUtils::restore(CATEGORY_TARGET_MEAN_VALUES_TAG,
-                                             m_CategoryTargetMeanValues, traverser))
-        RESTORE(MEAN_CATEGORY_TARGET_MEAN_VALUES_TAG,
-                core::CPersistUtils::restore(MEAN_CATEGORY_TARGET_MEAN_VALUES_TAG,
-                                             m_MeanCategoryTargetMeanValues, traverser))
-        RESTORE(FEATURE_VECTOR_MICS_TAG,
-                core::CPersistUtils::restore(FEATURE_VECTOR_MICS_TAG,
-                                             m_FeatureVectorMics, traverser))
-        RESTORE(FEATURE_VECTOR_COLUMN_MAP_TAG,
-                core::CPersistUtils::restore(FEATURE_VECTOR_COLUMN_MAP_TAG,
-                                             m_FeatureVectorColumnMap, traverser))
-        RESTORE(FEATURE_VECTOR_ENCODING_MAP_TAG,
-                core::CPersistUtils::restore(FEATURE_VECTOR_ENCODING_MAP_TAG,
-                                             m_FeatureVectorEncodingMap, traverser))
+        RESTORE(ENCODING_VECTOR_TAG,
+                traverser.traverseSubLevel(std::bind(&CDataFrameCategoryEncoder::restoreEncodings,
+                                                     this, std::placeholders::_1)))
     } while (traverser.next());
     return true;
 }
 
-CDataFrameCategoryEncoder::TSizeDoublePrVecVec
-CDataFrameCategoryEncoder::mics(std::size_t numberThreads,
-                                const core::CDataFrame& frame,
-                                const CDataFrameUtils::CColumnValue& target,
-                                const core::CPackedBitVector& rowMask,
-                                const TSizeVec& metricColumnMask,
-                                const TSizeVec& categoricalColumnMask) const {
-
-    CDataFrameUtils::TEncoderFactoryVec encoderFactories(E_CandidateEncodings);
-    encoderFactories[E_OneHot] = std::make_pair(
-        [](std::size_t, std::size_t sampleColumn, std::size_t category) {
-            return std::make_unique<CDataFrameUtils::COneHotCategoricalColumnValue>(
-                sampleColumn, category);
-        },
-        m_MinimumFrequencyToOneHotEncode);
-    encoderFactories[E_TargetMean] = std::make_pair(
-        [this](std::size_t column, std::size_t sampleColumn, std::size_t) {
-            return std::make_unique<CDataFrameUtils::CTargetMeanCategoricalColumnValue>(
-                sampleColumn, m_RareCategories[column], m_CategoryTargetMeanValues[column]);
-        },
-        0.0);
-    encoderFactories[E_Frequency] = std::make_pair(
-        [this](std::size_t column, std::size_t sampleColumn, std::size_t) {
-            return std::make_unique<CDataFrameUtils::CFrequencyCategoricalColumnValue>(
-                sampleColumn, m_CategoryFrequencies[column]);
-        },
-        0.0);
-
-    auto metricMics = CDataFrameUtils::metricMicWithColumn(target, frame, rowMask,
-                                                           metricColumnMask);
-    auto categoricalMics = CDataFrameUtils::categoricalMicWithColumn(
-        target, numberThreads, frame, rowMask, categoricalColumnMask, encoderFactories);
-
-    TSizeDoublePrVecVec mics(std::move(categoricalMics[E_OneHot]));
-    for (std::size_t i = 0; i < categoricalMics[E_TargetMean].size(); ++i) {
-        if (categoricalMics[E_TargetMean][i].size() > 0) {
-            mics[i].emplace_back(CATEGORY_FOR_TARGET_MEAN_ENCODING,
-                                 categoricalMics[E_TargetMean][i][0].second);
-        }
-    }
-    for (std::size_t i = 0; i < categoricalMics[E_Frequency].size(); ++i) {
-        if (categoricalMics[E_Frequency][i].size() > 0) {
-            mics[i].emplace_back(CATEGORY_FOR_FREQUANCY_ENCODING,
-                                 categoricalMics[E_Frequency][i][0].second);
-        }
-    }
-    for (std::size_t i = 0; i < metricMics.size(); ++i) {
-        if (metricMics[i] > 0.0) {
-            mics[i].emplace_back(CATEGORY_FOR_METRICS, metricMics[i]);
-        }
-    }
-    LOG_TRACE(<< "MICe = " << core::CContainerPrinter::print(mics));
-
-    return mics;
-}
-
-void CDataFrameCategoryEncoder::setupFrequencyEncoding(std::size_t numberThreads,
-                                                       const core::CDataFrame& frame,
-                                                       const core::CPackedBitVector& rowMask,
-                                                       const TSizeVec& categoricalColumnMask) {
-
-    m_CategoryFrequencies = CDataFrameUtils::categoryFrequencies(
-        numberThreads, frame, rowMask, categoricalColumnMask);
-    LOG_TRACE(<< "category frequencies = "
-              << core::CContainerPrinter::print(m_CategoryFrequencies));
-
-    m_MeanCategoryFrequencies.resize(m_CategoryFrequencies.size());
-    m_RareCategories.resize(m_CategoryFrequencies.size());
-    for (std::size_t i = 0; i < m_CategoryFrequencies.size(); ++i) {
-        m_MeanCategoryFrequencies[i] =
-            m_CategoryFrequencies[i].empty()
-                ? 1.0
-                : 1.0 / static_cast<double>(m_CategoryFrequencies[i].size());
-        for (std::size_t j = 0; j < m_CategoryFrequencies[i].size(); ++j) {
-            std::size_t count{static_cast<std::size_t>(
-                m_CategoryFrequencies[i][j] * static_cast<double>(frame.numberRows()) + 0.5)};
-            if (count < m_MinimumRowsPerFeature) {
-                m_RareCategories[i].insert(j);
+bool CDataFrameCategoryEncoder::restoreEncodings(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& name = traverser.name();
+        if (name == IDENTITY_ENCODING_TAG) {
+            if (this->forwardRestoreEncodings<CIdentityEncoding>(traverser, 0, 0.0) == false) {
+                return false;
             }
+            continue;
         }
-    }
-    LOG_TRACE(<< "mean category frequencies = "
-              << core::CContainerPrinter::print(m_MeanCategoryFrequencies));
-    LOG_TRACE(<< "rare categories = " << core::CContainerPrinter::print(m_RareCategories));
-}
-
-void CDataFrameCategoryEncoder::setupTargetMeanValueEncoding(std::size_t numberThreads,
-                                                             const core::CDataFrame& frame,
-                                                             const core::CPackedBitVector& rowMask,
-                                                             const TSizeVec& categoricalColumnMask,
-                                                             std::size_t targetColumn) {
-
-    m_CategoryTargetMeanValues = CDataFrameUtils::meanValueOfTargetForCategories(
-        CDataFrameUtils::CMetricColumnValue{targetColumn}, numberThreads, frame,
-        rowMask, categoricalColumnMask);
-    LOG_TRACE(<< "category target mean values = "
-              << core::CContainerPrinter::print(m_CategoryTargetMeanValues));
-
-    m_MeanCategoryTargetMeanValues.resize(m_CategoryTargetMeanValues.size());
-    for (std::size_t i = 0; i < m_CategoryTargetMeanValues.size(); ++i) {
-        m_MeanCategoryTargetMeanValues[i] =
-            m_CategoryTargetMeanValues[i].empty()
-                ? 0.0
-                : CBasicStatistics::mean(m_CategoryTargetMeanValues[i]);
-    }
-    LOG_TRACE(<< "mean category target mean values = "
-              << core::CContainerPrinter::print(m_MeanCategoryTargetMeanValues));
-}
-
-CDataFrameCategoryEncoder::TSizeSizePrDoubleMap
-CDataFrameCategoryEncoder::selectAllFeatures(const TSizeDoublePrVecVec& mics) {
-
-    TSizeSizePrDoubleMap selectedFeatureMics;
-
-    for (std::size_t feature = 0; feature < mics.size(); ++feature) {
-        for (std::size_t i = 0; i < mics[feature].size(); ++i) {
-            std::size_t category;
-            double mic;
-            std::tie(category, mic) = mics[feature][i];
-            if (mic == 0.0) {
-                continue;
+        if (name == ONE_HOT_ENCODING_TAG) {
+            if (this->forwardRestoreEncodings<COneHotEncoding>(traverser, 0, 0.0, 0) == false) {
+                return false;
             }
-            LOG_TRACE(<< "Selected feature = " << feature << ", category = "
-                      << print(category) << ", mic with target = " << mic);
-
-            selectedFeatureMics[{feature, category}] = mic;
-
-            if (isCategory(category)) {
-                m_OneHotEncodedCategories[feature].push_back(category);
-            } else if (isFrequency(category)) {
-                m_ColumnUsesFrequencyEncoding[feature] = true;
-            } // else if (isTargetMean(category)) { nothing to do }
+            continue;
         }
-    }
+        if (name == FREQUENCY_ENCODING_TAG) {
+            if (this->forwardRestoreEncodings<CMappedEncoding>(
+                    traverser, 0, 0.0, E_Frequency, TDoubleVec(), 0.0) == false) {
+                return false;
+            }
+            continue;
+        }
+        if (name == TARGET_MEAN_ENCODING_TAG) {
+            if (this->forwardRestoreEncodings<CMappedEncoding>(
+                    traverser, 0, 0.0, E_TargetMean, TDoubleVec(), 0.0) == false) {
+                return false;
+            }
+            continue;
+        }
 
-    LOG_TRACE(<< "one-hot encoded = "
-              << core::CContainerPrinter::print(m_OneHotEncodedCategories));
-
-    return selectedFeatureMics;
+    } while (traverser.next());
+    return true;
 }
 
-CDataFrameCategoryEncoder::TSizeSizePrDoubleMap
-CDataFrameCategoryEncoder::selectFeatures(std::size_t numberThreads,
-                                          const core::CDataFrame& frame,
-                                          const core::CPackedBitVector& rowMask,
-                                          TSizeVec metricColumnMask,
-                                          TSizeVec categoricalColumnMask,
-                                          std::size_t targetColumn) {
-
-    // We want to choose features which provide independent information about the
-    // target variable. Ideally, we'd recompute MICe w.r.t. target - f(x) with x
-    // the features selected so far. This would be very computationally expensive
-    // since it requires training a model f(.) on a subset of the features after
-    // each decision. Instead, we use the average MICe between the unselected and
-    // selected features as a useful proxy. This is essentially the mRMR approach
-    // of Peng et al. albeit with MICe rather than mutual information. Except, it
-    // also supports a redundancy weight, which should be non-negative and is used
-    // to control the relative weight of MICe with the target vs the selected
-    // variables. A value of zero means exclusively maximise MICe with the target
-    // and as redundancy weight -> infinity means exclusively minimise MICe with
-    // the selected variables.
-
-    TSizeDoublePrVecVec mics(this->mics(
-        numberThreads, frame, CDataFrameUtils::CMetricColumnValue{targetColumn},
-        rowMask, metricColumnMask, categoricalColumnMask));
-    this->discardNuisanceFeatures(mics);
-    LOG_TRACE(<< "features MICe = " << core::CContainerPrinter::print(mics));
-
-    std::size_t numberAvailableFeatures{this->numberAvailableFeatures(mics)};
-    std::size_t maximumNumberFeatures{
-        (static_cast<std::size_t>(rowMask.manhattan()) + m_MinimumRowsPerFeature / 2) /
-        m_MinimumRowsPerFeature};
-    LOG_TRACE(<< "number possible features = " << numberAvailableFeatures
-              << " maximum permitted features = " << maximumNumberFeatures);
-
-    m_ColumnUsesFrequencyEncoding.resize(frame.numberColumns(), false);
-    m_OneHotEncodedCategories.resize(frame.numberColumns());
-
-    TSizeSizePrDoubleMap selectedFeatureMics;
-
-    if (maximumNumberFeatures >= numberAvailableFeatures) {
-
-        selectedFeatureMics = this->selectAllFeatures(mics);
-    } else {
-
-        CMinRedundancyMaxRelevancyGreedySearch search{m_RedundancyWeight, mics};
-
-        for (std::size_t i = 0; i < maximumNumberFeatures; ++i) {
-
-            CFeatureRelevanceMinusRedundancy selected{search.selectNext()};
-
-            double mic{selected.micWithDependentVariable()};
-            std::size_t feature{selected.feature()};
-            std::size_t category{selected.category()};
-            LOG_TRACE(<< "Selected feature = " << feature << ", category = "
-                      << print(category) << ", mic with target = " << mic);
-
-            selectedFeatureMics[{feature, category}] = mic;
-
-            if (selected.isCategory()) {
-                m_OneHotEncodedCategories[feature].push_back(category);
-            } else if (selected.isFrequency()) {
-                m_ColumnUsesFrequencyEncoding[feature] = true;
-            } else if (selected.isMetric()) {
-                metricColumnMask.erase(std::find(metricColumnMask.begin(),
-                                                 metricColumnMask.end(), feature));
-            } // else if (selected.isTargetMean()) { nothing to do }
-
-            auto columnValue = selected.columnValue(
-                m_RareCategories[feature], m_CategoryFrequencies[feature],
-                m_CategoryTargetMeanValues[feature]);
-            mics = this->mics(numberThreads, frame, *columnValue, rowMask,
-                              metricColumnMask, categoricalColumnMask);
-            search.update(mics);
-        }
+template<typename T, typename... Args>
+bool CDataFrameCategoryEncoder::forwardRestoreEncodings(core::CStateRestoreTraverser& traverser,
+                                                        Args&&... args) {
+    m_Encodings.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
+    if (traverser.traverseSubLevel(std::bind(&CIdentityEncoding::acceptRestoreTraverser,
+                                             static_cast<T*>(m_Encodings.back().get()),
+                                             std::placeholders::_1)) == false) {
+        LOG_ERROR(<< "Error restoring encoding " << traverser.name());
+        return false;
     }
-
-    for (auto& categories : m_OneHotEncodedCategories) {
-        categories.shrink_to_fit();
-        std::sort(categories.begin(), categories.end());
-    }
-
-    LOG_TRACE(<< "one-hot encoded = "
-              << core::CContainerPrinter::print(m_OneHotEncodedCategories));
-    LOG_TRACE(<< "selected features MICe = "
-              << core::CContainerPrinter::print(selectedFeatureMics));
-
-    return selectedFeatureMics;
+    return true;
 }
 
-void CDataFrameCategoryEncoder::finishEncoding(std::size_t targetColumn,
-                                               TSizeSizePrDoubleMap selectedFeatureMics) {
-
-    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
-
-    // Update the frequency and target mean encoding for one-hot and rare categories.
-
-    for (std::size_t i = 0; i < m_OneHotEncodedCategories.size(); ++i) {
-        TMeanAccumulator meanCategoryFrequency;
-        TMeanAccumulator meanCategoryTargetMeanValue;
-        for (auto category : m_OneHotEncodedCategories[i]) {
-            double frequency{m_CategoryFrequencies[i][category]};
-            double mean{m_CategoryTargetMeanValues[i][category]};
-            meanCategoryFrequency.add(frequency, frequency);
-            meanCategoryTargetMeanValue.add(mean, frequency);
-        }
-        for (auto category : m_OneHotEncodedCategories[i]) {
-            m_CategoryFrequencies[i][category] = CBasicStatistics::mean(meanCategoryFrequency);
-            m_CategoryTargetMeanValues[i][category] =
-                CBasicStatistics::mean(meanCategoryTargetMeanValue);
-        }
-    }
-    for (std::size_t i = 0; i < m_RareCategories.size(); ++i) {
-        TMeanAccumulator meanCategoryTargetMeanValue;
-        for (auto category : m_RareCategories[i]) {
-            double frequency{m_CategoryFrequencies[i][category]};
-            double mean{m_CategoryTargetMeanValues[i][category]};
-            meanCategoryTargetMeanValue.add(mean, frequency);
-        }
-        for (auto category : m_RareCategories[i]) {
-            m_CategoryTargetMeanValues[i][category] =
-                CBasicStatistics::mean(meanCategoryTargetMeanValue);
-        }
-    }
-
-    // Fill in a mapping from encoded column indices to raw column indices.
-
-    selectedFeatureMics[{targetColumn, CATEGORY_FOR_DEPENDENT_VARIABLE}] = 0.0;
-
-    m_FeatureVectorMics.reserve(selectedFeatureMics.size());
-    m_FeatureVectorColumnMap.reserve(selectedFeatureMics.size());
-    m_FeatureVectorEncodingMap.reserve(selectedFeatureMics.size());
-
-    auto i = selectedFeatureMics.begin();
-    auto end = selectedFeatureMics.end();
-    std::size_t encoding{0};
-    for (;;) {
-        std::size_t feature{i->first.first};
-        double mic{i->second};
-        m_FeatureVectorMics.push_back(mic);
-        m_FeatureVectorColumnMap.push_back(feature);
-        m_FeatureVectorEncodingMap.push_back(encoding);
-        if (++i == end) {
-            break;
-        }
-        encoding = i->first.first == feature ? encoding + 1 : 0;
-    }
-
-    LOG_TRACE(<< "feature vector MICe = "
-              << core::CContainerPrinter::print(m_FeatureVectorMics));
-    LOG_TRACE(<< "feature vector index to column map = "
-              << core::CContainerPrinter::print(m_FeatureVectorColumnMap));
-    LOG_TRACE(<< "feature vector index to encoding map = "
-              << core::CContainerPrinter::print(m_FeatureVectorEncodingMap));
+CDataFrameCategoryEncoder::CEncoding::CEncoding(std::size_t inputColumnIndex, double mic)
+    : m_InputColumnIndex{inputColumnIndex}, m_Mic{mic} {
 }
 
-void CDataFrameCategoryEncoder::discardNuisanceFeatures(TSizeDoublePrVecVec& mics) const {
-
-    // Discard features carrying very little relative information about the target.
-    // These will have a low chance of being selected and including them represents
-    // a poor runtime QoR tradeoff. We achieve this by zeroing their MICe.
-
-    using TSizeDoublePrVecItrVec = std::vector<TSizeDoublePrVec::iterator>;
-
-    TSizeDoublePrVecItrVec flatMics;
-    for (auto& featureMics : mics) {
-        for (auto i = featureMics.begin(); i != featureMics.end(); ++i) {
-            flatMics.push_back(i);
-        }
-    }
-    std::stable_sort(flatMics.begin(), flatMics.end(),
-                     [](auto lhs, auto rhs) { return lhs->second > rhs->second; });
-
-    double totalMic{0.0};
-    auto firstFeatureToDiscard =
-        std::find_if(flatMics.begin(), flatMics.end(), [&](auto mic) {
-            totalMic += mic->second;
-            return mic->second < m_MinimumRelativeMicToSelectFeature * totalMic;
-        });
-    for (auto i = firstFeatureToDiscard; i != flatMics.end(); ++i) {
-        (*i)->second = 0.0;
-    }
+std::size_t CDataFrameCategoryEncoder::CEncoding::inputColumnIndex() const {
+    return m_InputColumnIndex;
 }
 
-std::size_t CDataFrameCategoryEncoder::numberAvailableFeatures(const TSizeDoublePrVecVec& mics) const {
-    std::size_t count{0};
-    for (const auto& featureMics : mics) {
-        count += std::count_if(featureMics.begin(), featureMics.end(),
-                               [](const auto& mic) { return mic.second > 0.0; });
-    }
-    return count;
+double CDataFrameCategoryEncoder::CEncoding::encode(const TRowRef& row) const {
+    return this->encode(row[m_InputColumnIndex]);
+}
+
+double CDataFrameCategoryEncoder::CEncoding::mic() const {
+    return m_Mic;
+}
+
+void CDataFrameCategoryEncoder::CEncoding::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(ENCODING_INPUT_COLUMN_INDEX_TAG, m_InputColumnIndex, inserter);
+    core::CPersistUtils::persist(ENCODING_MIC_TAG, m_Mic, inserter);
+    this->acceptPersistInserterForDerivedTypeState(inserter);
+}
+
+bool CDataFrameCategoryEncoder::CEncoding::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(ENCODING_INPUT_COLUMN_INDEX_TAG,
+                core::CPersistUtils::restore(ENCODING_INPUT_COLUMN_INDEX_TAG,
+                                             m_InputColumnIndex, traverser))
+        RESTORE(ENCODING_MIC_TAG,
+                core::CPersistUtils::restore(ENCODING_MIC_TAG, m_Mic, traverser))
+        if (this->acceptRestoreTraverserForDerivedTypeState(traverser) == false) {
+            return false;
+        }
+
+    } while (traverser.next());
+    return true;
+}
+
+CDataFrameCategoryEncoder::CIdentityEncoding::CIdentityEncoding(std::size_t inputColumnIndex,
+                                                                double mic)
+    : CEncoding{inputColumnIndex, mic} {
+}
+
+EEncoding CDataFrameCategoryEncoder::CIdentityEncoding::type() const {
+    return E_IdentityEncoding;
+}
+
+double CDataFrameCategoryEncoder::CIdentityEncoding::encode(double value) const {
+    return value;
+}
+
+bool CDataFrameCategoryEncoder::CIdentityEncoding::isBinary() const {
+    return false;
+}
+
+std::uint64_t CDataFrameCategoryEncoder::CIdentityEncoding::checksum() const {
+    return CChecksum::calculate(this->inputColumnIndex(), this->mic());
+}
+
+std::string CDataFrameCategoryEncoder::CIdentityEncoding::typeString() const {
+    return IDENTITY_ENCODING_TAG;
+}
+
+void CDataFrameCategoryEncoder::CIdentityEncoding::acceptPersistInserterForDerivedTypeState(
+    core::CStatePersistInserter& /*inserter*/) const {
+    // do nothing
+}
+
+bool CDataFrameCategoryEncoder::CIdentityEncoding::acceptRestoreTraverserForDerivedTypeState(
+    core::CStateRestoreTraverser& /*traverser*/) {
+    return true;
+}
+
+CDataFrameCategoryEncoder::COneHotEncoding::COneHotEncoding(std::size_t inputColumnIndex,
+                                                            double mic,
+                                                            std::size_t hotCategory)
+    : CEncoding{inputColumnIndex, mic}, m_HotCategory{hotCategory} {
+}
+
+EEncoding CDataFrameCategoryEncoder::COneHotEncoding::type() const {
+    return E_OneHot;
+}
+
+double CDataFrameCategoryEncoder::COneHotEncoding::encode(double value) const {
+    return static_cast<std::size_t>(value) == m_HotCategory;
+}
+
+bool CDataFrameCategoryEncoder::COneHotEncoding::isBinary() const {
+    return true;
+}
+
+std::uint64_t CDataFrameCategoryEncoder::COneHotEncoding::checksum() const {
+    std::size_t seed{CChecksum::calculate(this->inputColumnIndex(), this->mic())};
+    return CChecksum::calculate(seed, m_HotCategory);
+}
+
+void CDataFrameCategoryEncoder::COneHotEncoding::acceptPersistInserterForDerivedTypeState(
+    core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(ONE_HOT_ENCODING_CATEGORY_TAG, m_HotCategory, inserter);
+}
+
+bool CDataFrameCategoryEncoder::COneHotEncoding::acceptRestoreTraverserForDerivedTypeState(
+    core::CStateRestoreTraverser& traverser) {
+
+    const std::string& name = traverser.name();
+    RESTORE_NO_LOOP(ONE_HOT_ENCODING_CATEGORY_TAG,
+                    core::CPersistUtils::restore(ONE_HOT_ENCODING_CATEGORY_TAG,
+                                                 m_HotCategory, traverser))
+    return true;
+}
+
+std::string CDataFrameCategoryEncoder::COneHotEncoding::typeString() const {
+    return ONE_HOT_ENCODING_TAG;
+}
+
+CDataFrameCategoryEncoder::CMappedEncoding::CMappedEncoding(std::size_t inputColumnIndex,
+                                                            double mic,
+                                                            EEncoding encoding,
+                                                            const TDoubleVec& map,
+                                                            double fallback)
+    : CEncoding{inputColumnIndex, mic}, m_Encoding{encoding}, m_Map{map}, m_Fallback{fallback} {
+    TDoubleUSet uniques{map.begin(), map.end()};
+    uniques.insert(m_Fallback);
+    m_Binary = uniques.size() == 2;
+}
+
+EEncoding CDataFrameCategoryEncoder::CMappedEncoding::type() const {
+    return m_Encoding;
+}
+
+double CDataFrameCategoryEncoder::CMappedEncoding::encode(double value) const {
+    std::size_t category{static_cast<std::size_t>(value)};
+    return category < m_Map.size() ? m_Map[category] : m_Fallback;
+}
+
+bool CDataFrameCategoryEncoder::CMappedEncoding::isBinary() const {
+    return m_Binary;
+}
+
+std::uint64_t CDataFrameCategoryEncoder::CMappedEncoding::checksum() const {
+    std::size_t seed{CChecksum::calculate(this->inputColumnIndex(), this->mic())};
+    seed = CChecksum::calculate(seed, m_Map);
+    seed = CChecksum::calculate(seed, m_Fallback);
+    return CChecksum::calculate(seed, m_Binary);
+}
+
+void CDataFrameCategoryEncoder::CMappedEncoding::acceptPersistInserterForDerivedTypeState(
+    core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(MAPPED_ENCODING_TYPE_TAG, m_Encoding, inserter);
+    core::CPersistUtils::persist(MAPPED_ENCODING_MAP_TAG, m_Map, inserter);
+    core::CPersistUtils::persist(MAPPED_ENCODING_FALLBACK_TAG, m_Fallback, inserter);
+    core::CPersistUtils::persist(MAPPED_ENCODING_BINARY_TAG, m_Binary, inserter);
+}
+
+bool CDataFrameCategoryEncoder::CMappedEncoding::acceptRestoreTraverserForDerivedTypeState(
+    core::CStateRestoreTraverser& traverser) {
+    const std::string& name = traverser.name();
+    RESTORE_NO_LOOP(MAPPED_ENCODING_MAP_TAG,
+                    core::CPersistUtils::restore(MAPPED_ENCODING_MAP_TAG, m_Map, traverser))
+    RESTORE_NO_LOOP(MAPPED_ENCODING_FALLBACK_TAG,
+                    core::CPersistUtils::restore(MAPPED_ENCODING_FALLBACK_TAG,
+                                                 m_Fallback, traverser))
+    RESTORE_NO_LOOP(MAPPED_ENCODING_BINARY_TAG,
+                    core::CPersistUtils::restore(MAPPED_ENCODING_BINARY_TAG, m_Binary, traverser))
+
+    return true;
+}
+
+std::string CDataFrameCategoryEncoder::CMappedEncoding::typeString() const {
+    return (m_Encoding == EEncoding::E_Frequency) ? FREQUENCY_ENCODING_TAG
+                                                  : TARGET_MEAN_ENCODING_TAG;
 }
 
 CMakeDataFrameCategoryEncoder::CMakeDataFrameCategoryEncoder(std::size_t numberThreads,
                                                              const core::CDataFrame& frame,
                                                              std::size_t targetColumn)
-    : m_NumberThreads{numberThreads}, m_Frame{frame}, m_RowMask{frame.numberRows(), true},
+    : m_NumberThreads{numberThreads}, m_Frame{&frame}, m_RowMask{frame.numberRows(), true},
       m_TargetColumn{targetColumn} {
 
     m_ColumnMask.resize(frame.numberColumns());
@@ -867,6 +562,428 @@ CMakeDataFrameCategoryEncoder::rowMask(core::CPackedBitVector rowMask) {
 CMakeDataFrameCategoryEncoder& CMakeDataFrameCategoryEncoder::columnMask(TSizeVec columnMask) {
     m_ColumnMask = std::move(columnMask);
     return *this;
+}
+
+CMakeDataFrameCategoryEncoder::TEncodingUPtrVec CMakeDataFrameCategoryEncoder::makeEncodings() {
+
+    TSizeVec metricColumnMask(m_ColumnMask);
+    metricColumnMask.erase(
+        std::remove_if(metricColumnMask.begin(), metricColumnMask.end(),
+                       [this](std::size_t i) {
+                           return i == m_TargetColumn ||
+                                  m_Frame->columnIsCategorical()[i];
+                       }),
+        metricColumnMask.end());
+    LOG_TRACE(<< "metric column mask = " << core::CContainerPrinter::print(metricColumnMask));
+
+    TSizeVec categoricalColumnMask(m_ColumnMask);
+    categoricalColumnMask.erase(
+        std::remove_if(categoricalColumnMask.begin(), categoricalColumnMask.end(),
+                       [this](std::size_t i) {
+                           return i == m_TargetColumn ||
+                                  m_Frame->columnIsCategorical()[i] == false;
+                       }),
+        categoricalColumnMask.end());
+    LOG_TRACE(<< "categorical column mask = "
+              << core::CContainerPrinter::print(categoricalColumnMask));
+
+    // The top-level strategy is as follows:
+    //
+    // We one-hot encode the frequent categories with the highest non-zero MICe up
+    // to the permitted overall feature count.
+    // We mean value encode the remaining features where we have a representative
+    // sample size.
+    // We frequency encode all rare categories of a categorical feature.
+
+    this->setupFrequencyEncoding(categoricalColumnMask);
+    this->setupTargetMeanValueEncoding(categoricalColumnMask);
+    this->finishEncoding(this->selectFeatures(metricColumnMask, categoricalColumnMask));
+
+    // In the encoded row the layout of the encoding dimensions, for each categorical
+    // feature, is as follows:
+    //   (...| one-hot | mean target | frequency |...)
+    //
+    // The ones are in the order the categories appear in m_OneHotEncodedCategories.
+    // For example, if m_OneHotEncodedCategories[feature] = (2, 5, 7) for any other
+    // category the encoded row will contain (...| 0 0 0 | ...). For 2, 5 and 7 it
+    // will contain (...| 1 0 0 |...), (...| 0 1 0 |...) and (...| 0 0 1 |...),
+    // respectively.
+    //
+    // In the following we therefore 1) check to see if the category is being
+    // one-hot encoded, 2) check if the encoding of the dimension, i.e. its offset
+    // relative to the start of the encoding dimensions for the feature, is equal
+    // to the position of the one for the category.
+
+    TEncodingUPtrVec encoding;
+
+    for (std::size_t encodedColumnIndex = 0;
+         encodedColumnIndex < m_EncodedColumnInputColumnMap.size(); ++encodedColumnIndex) {
+
+        std::size_t inputColumnIndex{m_EncodedColumnInputColumnMap[encodedColumnIndex]};
+        double mic{m_EncodedColumnMics[encodedColumnIndex]};
+
+        if (m_Frame->columnIsCategorical()[inputColumnIndex] == false) {
+            encoding.push_back(std::make_unique<CIdentityEncoding>(inputColumnIndex, mic));
+            continue;
+        }
+
+        std::size_t categoryEncoding{m_EncodedColumnEncodingMap[encodedColumnIndex]};
+        std::size_t numberOneHotCategories{
+            m_OneHotEncodedCategories[inputColumnIndex].size()};
+
+        if (categoryEncoding < numberOneHotCategories) {
+            std::size_t hotCategory{m_OneHotEncodedCategories[inputColumnIndex][categoryEncoding]};
+            encoding.push_back(std::make_unique<COneHotEncoding>(inputColumnIndex,
+                                                                 mic, hotCategory));
+            continue;
+        }
+        if (categoryEncoding == numberOneHotCategories &&
+            m_InputColumnUsesFrequencyEncoding[inputColumnIndex]) {
+            encoding.push_back(std::make_unique<CMappedEncoding>(
+                inputColumnIndex, mic, E_Frequency, m_CategoryFrequencies[inputColumnIndex],
+                m_MeanCategoryFrequencies[inputColumnIndex]));
+            continue;
+        }
+        encoding.push_back(std::make_unique<CMappedEncoding>(
+            inputColumnIndex, mic, E_TargetMean, m_CategoryTargetMeanValues[inputColumnIndex],
+            m_MeanCategoryTargetMeanValues[inputColumnIndex]));
+    }
+
+    return encoding;
+}
+
+std::size_t CMakeDataFrameCategoryEncoder::encoding(std::size_t encodedColumnIndex) const {
+    return m_EncodedColumnEncodingMap[encodedColumnIndex];
+}
+
+bool CMakeDataFrameCategoryEncoder::usesOneHotEncoding(std::size_t inputColumnIndex,
+                                                       std::size_t category) const {
+    return std::binary_search(m_OneHotEncodedCategories[inputColumnIndex].begin(),
+                              m_OneHotEncodedCategories[inputColumnIndex].end(), category);
+}
+
+bool CMakeDataFrameCategoryEncoder::isRareCategory(std::size_t inputColumnIndex,
+                                                   std::size_t category) const {
+    return m_RareCategories[inputColumnIndex].find(category) !=
+           m_RareCategories[inputColumnIndex].end();
+}
+
+CMakeDataFrameCategoryEncoder::TSizeDoublePrVecVec
+CMakeDataFrameCategoryEncoder::mics(const CDataFrameUtils::CColumnValue& target,
+                                    const TSizeVec& metricColumnMask,
+                                    const TSizeVec& categoricalColumnMask) const {
+
+    CDataFrameUtils::TEncoderFactoryVec encoderFactories(
+        static_cast<std::size_t>(E_IdentityEncoding));
+    encoderFactories[E_OneHot] = std::make_pair(
+        [](std::size_t, std::size_t sampleColumn, std::size_t category) {
+            return std::make_unique<CDataFrameUtils::COneHotCategoricalColumnValue>(
+                sampleColumn, category);
+        },
+        m_MinimumFrequencyToOneHotEncode);
+    encoderFactories[E_TargetMean] = std::make_pair(
+        [this](std::size_t column, std::size_t sampleColumn, std::size_t) {
+            return std::make_unique<CDataFrameUtils::CTargetMeanCategoricalColumnValue>(
+                sampleColumn, m_RareCategories[column], m_CategoryTargetMeanValues[column]);
+        },
+        0.0);
+    encoderFactories[E_Frequency] = std::make_pair(
+        [this](std::size_t column, std::size_t sampleColumn, std::size_t) {
+            return std::make_unique<CDataFrameUtils::CFrequencyCategoricalColumnValue>(
+                sampleColumn, m_CategoryFrequencies[column]);
+        },
+        0.0);
+
+    auto metricMics = CDataFrameUtils::metricMicWithColumn(target, *m_Frame, m_RowMask,
+                                                           metricColumnMask);
+    auto categoricalMics = CDataFrameUtils::categoricalMicWithColumn(
+        target, m_NumberThreads, *m_Frame, m_RowMask, categoricalColumnMask, encoderFactories);
+
+    TSizeDoublePrVecVec mics(std::move(categoricalMics[E_OneHot]));
+    for (std::size_t i = 0; i < categoricalMics[E_TargetMean].size(); ++i) {
+        if (categoricalMics[E_TargetMean][i].empty() == false) {
+            mics[i].emplace_back(CATEGORY_FOR_TARGET_MEAN_ENCODING,
+                                 categoricalMics[E_TargetMean][i][0].second);
+        }
+    }
+    for (std::size_t i = 0; i < categoricalMics[E_Frequency].size(); ++i) {
+        if (categoricalMics[E_Frequency][i].empty() == false) {
+            mics[i].emplace_back(CATEGORY_FOR_FREQUENCY_ENCODING,
+                                 categoricalMics[E_Frequency][i][0].second);
+        }
+    }
+    for (std::size_t i = 0; i < metricMics.size(); ++i) {
+        if (metricMics[i] > 0.0) {
+            mics[i].emplace_back(CATEGORY_FOR_METRICS, metricMics[i]);
+        }
+    }
+    LOG_TRACE(<< "MICe = " << core::CContainerPrinter::print(mics));
+
+    return mics;
+}
+
+void CMakeDataFrameCategoryEncoder::setupFrequencyEncoding(const TSizeVec& categoricalColumnMask) {
+
+    m_CategoryFrequencies = CDataFrameUtils::categoryFrequencies(
+        m_NumberThreads, *m_Frame, m_RowMask, categoricalColumnMask);
+    LOG_TRACE(<< "category frequencies = "
+              << core::CContainerPrinter::print(m_CategoryFrequencies));
+
+    m_MeanCategoryFrequencies.resize(m_CategoryFrequencies.size());
+    m_RareCategories.resize(m_CategoryFrequencies.size());
+    for (std::size_t i = 0; i < m_CategoryFrequencies.size(); ++i) {
+        m_MeanCategoryFrequencies[i] =
+            m_CategoryFrequencies[i].empty()
+                ? 1.0
+                : 1.0 / static_cast<double>(m_CategoryFrequencies[i].size());
+        for (std::size_t j = 0; j < m_CategoryFrequencies[i].size(); ++j) {
+            std::size_t count{static_cast<std::size_t>(
+                m_CategoryFrequencies[i][j] * static_cast<double>(m_Frame->numberRows()) + 0.5)};
+            if (count < m_MinimumRowsPerFeature) {
+                m_RareCategories[i].insert(j);
+            }
+        }
+    }
+    LOG_TRACE(<< "mean category frequencies = "
+              << core::CContainerPrinter::print(m_MeanCategoryFrequencies));
+    LOG_TRACE(<< "rare categories = " << core::CContainerPrinter::print(m_RareCategories));
+}
+
+void CMakeDataFrameCategoryEncoder::setupTargetMeanValueEncoding(const TSizeVec& categoricalColumnMask) {
+
+    m_CategoryTargetMeanValues = CDataFrameUtils::meanValueOfTargetForCategories(
+        CDataFrameUtils::CMetricColumnValue{m_TargetColumn}, m_NumberThreads,
+        *m_Frame, m_RowMask, categoricalColumnMask);
+    LOG_TRACE(<< "category target mean values = "
+              << core::CContainerPrinter::print(m_CategoryTargetMeanValues));
+
+    m_MeanCategoryTargetMeanValues.resize(m_CategoryTargetMeanValues.size());
+    for (std::size_t i = 0; i < m_CategoryTargetMeanValues.size(); ++i) {
+        m_MeanCategoryTargetMeanValues[i] =
+            m_CategoryTargetMeanValues[i].empty()
+                ? 0.0
+                : CBasicStatistics::mean(m_CategoryTargetMeanValues[i]);
+    }
+    LOG_TRACE(<< "mean category target mean values = "
+              << core::CContainerPrinter::print(m_MeanCategoryTargetMeanValues));
+}
+
+CMakeDataFrameCategoryEncoder::TSizeSizePrDoubleMap
+CMakeDataFrameCategoryEncoder::selectAllFeatures(const TSizeDoublePrVecVec& mics) {
+
+    TSizeSizePrDoubleMap selectedFeatureMics;
+
+    for (std::size_t feature = 0; feature < mics.size(); ++feature) {
+        for (std::size_t i = 0; i < mics[feature].size(); ++i) {
+            std::size_t category;
+            double mic;
+            std::tie(category, mic) = mics[feature][i];
+            if (mic == 0.0) {
+                continue;
+            }
+            LOG_TRACE(<< "Selected feature = " << feature << ", category = "
+                      << print(category) << ", mic with target = " << mic);
+
+            selectedFeatureMics[{feature, category}] = mic;
+
+            if (isCategory(category)) {
+                m_OneHotEncodedCategories[feature].push_back(category);
+            } else if (isFrequency(category)) {
+                m_InputColumnUsesFrequencyEncoding[feature] = true;
+            } // else if (isTargetMean(category)) { nothing to do }
+        }
+    }
+
+    LOG_TRACE(<< "one-hot encoded = "
+              << core::CContainerPrinter::print(m_OneHotEncodedCategories));
+
+    return selectedFeatureMics;
+}
+
+CMakeDataFrameCategoryEncoder::TSizeSizePrDoubleMap
+CMakeDataFrameCategoryEncoder::selectFeatures(TSizeVec metricColumnMask,
+                                              const TSizeVec& categoricalColumnMask) {
+
+    // We want to choose features which provide independent information about the
+    // target variable. Ideally, we'd recompute MICe w.r.t. target - f(x) with x
+    // the features selected so far. This would be very computationally expensive
+    // since it requires training a model f(.) on a subset of the features after
+    // each decision. Instead, we use the average MICe between the unselected and
+    // selected features as a useful proxy. This is essentially the mRMR approach
+    // of Peng et al. albeit with MICe rather than mutual information. Except, it
+    // also supports a redundancy weight, which should be non-negative and is used
+    // to control the relative weight of MICe with the target vs the selected
+    // variables. A value of zero means exclusively maximise MICe with the target
+    // and as redundancy weight -> infinity means exclusively minimise MICe with
+    // the selected variables.
+
+    TSizeDoublePrVecVec mics(this->mics(CDataFrameUtils::CMetricColumnValue{m_TargetColumn},
+                                        metricColumnMask, categoricalColumnMask));
+    this->discardNuisanceFeatures(mics);
+    LOG_TRACE(<< "features MICe = " << core::CContainerPrinter::print(mics));
+
+    std::size_t numberAvailableFeatures{this->numberAvailableFeatures(mics)};
+    std::size_t maximumNumberFeatures{
+        (static_cast<std::size_t>(m_RowMask.manhattan()) + m_MinimumRowsPerFeature / 2) /
+        m_MinimumRowsPerFeature};
+    LOG_TRACE(<< "number possible features = " << numberAvailableFeatures
+              << " maximum permitted features = " << maximumNumberFeatures);
+
+    m_InputColumnUsesFrequencyEncoding.resize(m_Frame->numberColumns(), false);
+    m_OneHotEncodedCategories.resize(m_Frame->numberColumns());
+
+    TSizeSizePrDoubleMap selectedFeatureMics;
+
+    if (maximumNumberFeatures >= numberAvailableFeatures) {
+
+        selectedFeatureMics = this->selectAllFeatures(mics);
+    } else {
+
+        CMinRedundancyMaxRelevancyGreedySearch search{m_RedundancyWeight, mics};
+
+        for (std::size_t i = 0; i < maximumNumberFeatures; ++i) {
+
+            CFeatureRelevanceMinusRedundancy selected{search.selectNext()};
+
+            double mic{selected.micWithDependentVariable()};
+            std::size_t feature{selected.feature()};
+            std::size_t category{selected.category()};
+            LOG_TRACE(<< "Selected feature = " << feature << ", category = "
+                      << print(category) << ", mic with target = " << mic);
+
+            selectedFeatureMics[{feature, category}] = mic;
+
+            if (selected.isCategory()) {
+                m_OneHotEncodedCategories[feature].push_back(category);
+            } else if (selected.isFrequency()) {
+                m_InputColumnUsesFrequencyEncoding[feature] = true;
+            } else if (selected.isMetric()) {
+                metricColumnMask.erase(std::find(metricColumnMask.begin(),
+                                                 metricColumnMask.end(), feature));
+            } // else if (selected.isTargetMean()) { nothing to do }
+
+            auto columnValue = selected.columnValue(
+                m_RareCategories[feature], m_CategoryFrequencies[feature],
+                m_CategoryTargetMeanValues[feature]);
+            mics = this->mics(*columnValue, metricColumnMask, categoricalColumnMask);
+            search.update(mics);
+        }
+    }
+
+    for (auto& categories : m_OneHotEncodedCategories) {
+        categories.shrink_to_fit();
+        std::sort(categories.begin(), categories.end());
+    }
+
+    LOG_TRACE(<< "one-hot encoded = "
+              << core::CContainerPrinter::print(m_OneHotEncodedCategories));
+    LOG_TRACE(<< "selected features MICe = "
+              << core::CContainerPrinter::print(selectedFeatureMics));
+
+    return selectedFeatureMics;
+}
+
+void CMakeDataFrameCategoryEncoder::finishEncoding(TSizeSizePrDoubleMap selectedFeatureMics) {
+
+    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+    // Update the frequency and target mean encoding for one-hot and rare categories.
+
+    for (std::size_t i = 0; i < m_OneHotEncodedCategories.size(); ++i) {
+        TMeanAccumulator meanCategoryFrequency;
+        TMeanAccumulator meanCategoryTargetMeanValue;
+        for (auto category : m_OneHotEncodedCategories[i]) {
+            double frequency{m_CategoryFrequencies[i][category]};
+            double mean{m_CategoryTargetMeanValues[i][category]};
+            meanCategoryFrequency.add(frequency, frequency);
+            meanCategoryTargetMeanValue.add(mean, frequency);
+        }
+        for (auto category : m_OneHotEncodedCategories[i]) {
+            m_CategoryFrequencies[i][category] = CBasicStatistics::mean(meanCategoryFrequency);
+            m_CategoryTargetMeanValues[i][category] =
+                CBasicStatistics::mean(meanCategoryTargetMeanValue);
+        }
+    }
+    for (std::size_t i = 0; i < m_RareCategories.size(); ++i) {
+        TMeanAccumulator meanCategoryTargetMeanValue;
+        for (auto category : m_RareCategories[i]) {
+            double frequency{m_CategoryFrequencies[i][category]};
+            double mean{m_CategoryTargetMeanValues[i][category]};
+            meanCategoryTargetMeanValue.add(mean, frequency);
+        }
+        for (auto category : m_RareCategories[i]) {
+            m_CategoryTargetMeanValues[i][category] =
+                CBasicStatistics::mean(meanCategoryTargetMeanValue);
+        }
+    }
+
+    // Fill in a mapping from encoded column indices to raw column indices.
+
+    selectedFeatureMics[{m_TargetColumn, CATEGORY_FOR_DEPENDENT_VARIABLE}] = 0.0;
+
+    m_EncodedColumnMics.reserve(selectedFeatureMics.size());
+    m_EncodedColumnInputColumnMap.reserve(selectedFeatureMics.size());
+    m_EncodedColumnEncodingMap.reserve(selectedFeatureMics.size());
+
+    auto i = selectedFeatureMics.begin();
+    auto end = selectedFeatureMics.end();
+    std::size_t encoding{0};
+    for (;;) {
+        std::size_t feature{i->first.first};
+        double mic{i->second};
+        m_EncodedColumnMics.push_back(mic);
+        m_EncodedColumnInputColumnMap.push_back(feature);
+        m_EncodedColumnEncodingMap.push_back(encoding);
+        if (++i == end) {
+            break;
+        }
+        encoding = i->first.first == feature ? encoding + 1 : 0;
+    }
+
+    LOG_TRACE(<< "feature vector MICe = "
+              << core::CContainerPrinter::print(m_EncodedColumnMics));
+    LOG_TRACE(<< "feature vector index to column map = "
+              << core::CContainerPrinter::print(m_EncodedColumnInputColumnMap));
+    LOG_TRACE(<< "feature vector index to encoding map = "
+              << core::CContainerPrinter::print(m_EncodedColumnEncodingMap));
+}
+
+void CMakeDataFrameCategoryEncoder::discardNuisanceFeatures(TSizeDoublePrVecVec& mics) const {
+
+    // Discard features carrying very little relative information about the target.
+    // These will have a low chance of being selected and including them represents
+    // a poor runtime QoR tradeoff. We achieve this by zeroing their MICe.
+
+    using TSizeDoublePrVecItrVec = std::vector<TSizeDoublePrVec::iterator>;
+
+    TSizeDoublePrVecItrVec flatMics;
+    for (auto& featureMics : mics) {
+        for (auto i = featureMics.begin(); i != featureMics.end(); ++i) {
+            flatMics.push_back(i);
+        }
+    }
+    std::stable_sort(flatMics.begin(), flatMics.end(),
+                     [](auto lhs, auto rhs) { return lhs->second > rhs->second; });
+
+    double totalMic{0.0};
+    auto firstFeatureToDiscard =
+        std::find_if(flatMics.begin(), flatMics.end(), [&](auto mic) {
+            totalMic += mic->second;
+            return mic->second < m_MinimumRelativeMicToSelectFeature * totalMic;
+        });
+    for (auto i = firstFeatureToDiscard; i != flatMics.end(); ++i) {
+        (*i)->second = 0.0;
+    }
+}
+
+std::size_t
+CMakeDataFrameCategoryEncoder::numberAvailableFeatures(const TSizeDoublePrVecVec& mics) const {
+    std::size_t count{0};
+    for (const auto& featureMics : mics) {
+        count += std::count_if(featureMics.begin(), featureMics.end(),
+                               [](const auto& mic) { return mic.second > 0.0; });
+    }
+    return count;
 }
 }
 }

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -232,7 +232,8 @@ CDataFrameUtils::columnDataTypes(std::size_t numberThreads,
                 }
             }
         },
-        TMinMaxBoolPrVec(encoder != nullptr ? encoder->numberFeatures() : frame.numberColumns(),
+        TMinMaxBoolPrVec(encoder != nullptr ? encoder->numberEncodedColumns()
+                                            : frame.numberColumns(),
                          {TMinMax{}, true}));
 
     auto copyDataTypes = [](TMinMaxBoolPrVec types, TMinMaxBoolPrVec& result) {

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -399,7 +399,7 @@ void CDataFrameUtilsTest::testColumnQuantilesWithEncoding() {
 
     maths::CDataFrameCategoryEncoder encoder{{1, *frame, 0}};
 
-    TSizeVec columnMask(encoder.numberFeatures());
+    TSizeVec columnMask(encoder.numberEncodedColumns());
     std::iota(columnMask.begin(), columnMask.end(), 0);
 
     TQuantileSketchVec expectedQuantiles{columnMask.size(),


### PR DESCRIPTION
This PR moves the logic of categorical encoding into a map and replaces online computations in operator[] by a look-up.

Backport to #689 