### PR TITLE
[ML] Logistic regression loss function for boosted tree training

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ boosted tree training. Hard depth based regularization is often the strategy of
 choice to prevent over fitting for XGBoost. By smoothing we can make better tradeoffs.
 Also, the parameters of the penalty function are mode suited to optimising with our
 Bayesian optimisation based hyperparameter search. (See {ml-pull}698[#698].)
+* Binomial logistic regression targeting cross entropy. (See {ml-pull}713[#713].) 
 
 == {es} version 7.4.1
 

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -18,6 +18,8 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace ml {
 namespace core {
@@ -328,6 +330,7 @@ private:
 //! proposed by Reshef for this purpose. See CDataFrameCategoryEncoder for more details.
 class MATHS_EXPORT CBoostedTree final : public CDataFrameRegressionModel {
 public:
+    using TStrVec = std::vector<std::string>;
     using TRowRef = core::CDataFrame::TRowRef;
     using TLossFunctionUPtr = std::unique_ptr<boosted_tree::CLoss>;
     using TDataFramePtr = core::CDataFrame*;
@@ -364,6 +367,16 @@ public:
 
     //! Get the model produced by training if it has been run.
     const TNodeVecVec& trainedModel() const;
+
+    //! The name of the object holding the best hyperaparameters in the state document.
+    static const std::string& bestHyperparametersName();
+
+    //! The name of the object holding the best regularisation hyperparameters in the
+    //! state document.
+    static const std::string& bestRegularizationHyperparametersName();
+
+    //! A list of the names of the best individual hyperparameters in the state document.
+    static TStrVec bestHyperparameterNames();
 
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -46,7 +46,8 @@ private:
     double m_Lambda;
 };
 
-//! \brief Finds the value to add to a set of predictions which minimises the MSE.
+//! \brief Finds the value to add to a set of predictions which minimises the
+//! regularized MSE w.r.t. the actual values.
 class MATHS_EXPORT CArgMinMseImpl final : public CArgMinLossImpl {
 public:
     CArgMinMseImpl(double lambda);
@@ -63,8 +64,8 @@ private:
     TMeanAccumulator m_MeanError;
 };
 
-//! \brief Finds the value to add to the argument of the logistic function which
-//! minimises the cross entropy loss.
+//! \brief Finds the value to add to a set of predicted log-odds which minimises
+//! regularised the cross entropy loss w.r.t. the actual categories.
 class MATHS_EXPORT CArgMinLogisticImpl final : public CArgMinLossImpl {
 public:
     CArgMinLogisticImpl(double lambda);
@@ -182,12 +183,10 @@ public:
     static const std::string NAME;
 };
 
-//! \brief Implements loss for logistic regression for binary classification.
+//! \brief Implements loss for binomial logistic regression.
 //!
 //! DESCRIPTION:\n
-//! This targets the cross entropy loss using the logistic function of the sum of
-//! the of the tree predictions to estimate the probability of one of the classes
-//! for a binary classification task
+//! This targets the cross entropy loss using the tree to predict class log-odds:
 //! <pre class="fragment">
 //!   \f$\displaystyle l_i(p) = -(1 - a_i) \log(1 - S(p)) - a_i \log(S(p))\f$
 //! </pre>

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -67,7 +67,7 @@ private:
 };
 
 //! \brief Finds the value to add to a set of predicted log-odds which minimises
-//! regularised the cross entropy loss w.r.t. the actual categories.
+//! regularised cross entropy loss w.r.t. the actual categories.
 class MATHS_EXPORT CArgMinLogisticImpl final : public CArgMinLossImpl {
 public:
     CArgMinLogisticImpl(double lambda);

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -118,7 +118,9 @@ public:
     CArgMinLoss& operator=(const CArgMinLoss& other);
     CArgMinLoss& operator=(CArgMinLoss&& other) = default;
 
-    //! The number of passes over the data this needs.
+    //! Start another pass over the predictions and actuals.
+    //!
+    //! \return True if we need to perform another pass to compute value().
     bool nextPass() const;
 
     //! Update with a point prediction and actual value.

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -84,24 +84,24 @@ private:
 
 private:
     std::size_t bucket(double prediction) const {
-        double bucket{(prediction - m_MinMaxPrediction.min()) / this->bucketWidth()};
+        double bucket{(prediction - m_PredictionMinMax.min()) / this->bucketWidth()};
         return std::min(static_cast<std::size_t>(bucket),
                         m_BucketCategoryCounts.size() - 1);
     }
 
     double bucketCentre(std::size_t bucket) const {
-        return m_MinMaxPrediction.min() +
+        return m_PredictionMinMax.min() +
                (static_cast<double>(bucket) + 0.5) * this->bucketWidth();
     }
 
     double bucketWidth() const {
-        return m_MinMaxPrediction.range() /
+        return m_PredictionMinMax.range() /
                static_cast<double>(m_BucketCategoryCounts.size());
     }
 
 private:
     std::size_t m_CurrentPass = 0;
-    TMinMaxAccumulator m_MinMaxPrediction;
+    TMinMaxAccumulator m_PredictionMinMax;
     TSizeVector m_CategoryCounts;
     TSizeVectorVec m_BucketCategoryCounts;
 };

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -177,6 +177,8 @@ private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
     TOptionalSize m_BayesianOptimisationRestarts;
     bool m_Restored = false;
+    std::size_t m_NumberThreads;
+    TLossFunctionUPtr m_Loss;
     TBoostedTreeImplUPtr m_TreeImpl;
     TVector m_LogDepthPenaltyMultiplierSearchInterval;
     TVector m_LogTreeSizePenaltyMultiplierSearchInterval;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -48,6 +48,7 @@ inline std::size_t predictionColumn(std::size_t numberColumns) {
 class MATHS_EXPORT CBoostedTreeImpl final {
 public:
     using TDoubleVec = std::vector<double>;
+    using TStrVec = std::vector<std::string>;
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TBayesinOptimizationUPtr = std::unique_ptr<maths::CBayesianOptimisation>;
@@ -100,6 +101,16 @@ public:
     //! Estimate the maximum booking memory that training the boosted tree on a data
     //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
+
+    //! The name of the object holding the best hyperaparameters in the state document.
+    static const std::string& bestHyperparametersName();
+
+    //! The name of the object holding the best regularisation hyperparameters in the
+    //! state document.
+    static const std::string& bestRegularizationHyperparametersName();
+
+    //! A list of the names of the best individual hyperparameters in the state document.
+    static TStrVec bestHyperparameterNames();
 
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -678,7 +678,8 @@ public:
     //! \param[in] width The step width.
     //! \param[in] x0 The centre of the step.
     //! \param[in] sign Determines whether it's a step up or down.
-    static double logisticFunction(double x, double width, double x0 = 0.0, double sign = 1.0) {
+    static double
+    logisticFunction(double x, double width = 1.0, double x0 = 0.0, double sign = 1.0) {
         return sigmoid(std::exp(std::copysign(1.0, sign) * (x - x0) / width));
     }
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -7,24 +7,9 @@
 #ifndef INCLUDED_CDataFrameAnalyzerTest_h
 #define INCLUDED_CDataFrameAnalyzerTest_h
 
-#include <core/CDataFrame.h>
-#include <core/CDataSearcher.h>
-
-#include <maths/CBoostedTreeFactory.h>
-#include <maths/CLinearAlgebraEigen.h>
-
-#include <api/CDataFrameAnalyzer.h>
-
 #include <cppunit/extensions/HelperMacros.h>
 
 class CDataFrameAnalyzerTest : public CppUnit::TestFixture {
-public:
-    using TDataAdderUPtr = std::unique_ptr<ml::core::CDataAdder>;
-    using TPersisterSupplier = std::function<TDataAdderUPtr()>;
-    using TDataSearcherUPtr = std::unique_ptr<ml::core::CDataSearcher>;
-    using TRestoreSearcherSupplier = std::function<TDataSearcherUPtr()>;
-    using TDataFrameUPtr = std::unique_ptr<ml::core::CDataFrame>;
-
 public:
     void testWithoutControlMessages();
     void testRunOutlierDetection();
@@ -41,25 +26,6 @@ public:
     void testCategoricalFields();
 
     static CppUnit::Test* suite();
-
-private:
-    using TDoubleVec = std::vector<double>;
-    using TStrVec = std::vector<std::string>;
-
-private:
-    void testRunBoostedTreeTrainingWithStateRecoverySubroutine(
-        double lambda,
-        double gamma,
-        double eta,
-        std::size_t maximumNumberTrees,
-        double featureBagFraction,
-        std::size_t numberRoundsPerHyperparameter,
-        std::size_t iterationToRestartFrom) const;
-
-    ml::maths::CBoostedTreeFactory::TBoostedTreeUPtr
-    getFinalTree(const TStrVec& persistedStates,
-                 TDataFrameUPtr& frame,
-                 std::size_t dependentVariable) const;
 };
 
 #endif // INCLUDED_CDataFrameAnalyzerTest_h

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -464,6 +464,22 @@ const CBoostedTree::TNodeVecVec& CBoostedTree::trainedModel() const {
     return m_Impl->trainedModel();
 }
 
+const std::string& CBoostedTree::bestHyperparametersName() {
+    return CBoostedTreeImpl::bestHyperparametersName();
+}
+
+const std::string& CBoostedTree::bestRegularizationHyperparametersName() {
+    return CBoostedTreeImpl::bestRegularizationHyperparametersName();
+}
+
+CBoostedTree::TStrVec CBoostedTree::bestHyperparameterNames() {
+    return CBoostedTreeImpl::bestHyperparameterNames();
+}
+
+bool CBoostedTree::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    return m_Impl->acceptRestoreTraverser(traverser);
+}
+
 void CBoostedTree::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     m_Impl->acceptPersistInserter(inserter);
 }

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -67,7 +67,7 @@ double CArgMinMseImpl::value() const {
     //
     //    x^* = argmin_x{ sum_i{(a_i - (p_i + x))^2} + lambda * x^2 }
     //
-    // This is convex so there is one minimum where derivative w.r.t. x is zero
+    // This is convex so there is one minimum where the derivative w.r.t. x is zero
     // and x^* = 1 / (n + lambda) sum_i{ a_i - p_i }. Denoting the mean prediction
     // error m = 1/n sum_i{ a_i - p_i } we have x^* = n / (n + lambda) m.
 

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -169,9 +169,12 @@ double CArgMinLogisticImpl::value() const {
         };
 
         // Choose a weight interval in which all probabilites vary from close to
-        // zero to close to one.
-        minWeight = -m_PredictionMinMax.max() - 2.0;
-        maxWeight = -m_PredictionMinMax.min() + 2.0;
+        // zero to close to one. In particular, the idea is to minimize the leaf
+        // weight on an interval [a, b] where if we add "a" the log-odds for all
+        // rows <= -5, i.e. max prediction + a = -5, and if we add "b" the log-odds
+        // for all rows >= 5, i.e. min prediction + a = 5.
+        minWeight = -m_PredictionMinMax.max() - 5.0;
+        maxWeight = -m_PredictionMinMax.min() + 5.0;
     }
 
     if (minWeight == maxWeight) {

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -85,7 +85,7 @@ bool CArgMinLogisticImpl::nextPass() {
 void CArgMinLogisticImpl::add(double prediction, double actual) {
     switch (m_CurrentPass) {
     case 0: {
-        m_MinMaxPrediction.add(prediction);
+        m_PredictionMinMax.add(prediction);
         ++m_CategoryCounts(static_cast<std::size_t>(actual));
         break;
     }
@@ -104,7 +104,7 @@ void CArgMinLogisticImpl::merge(const CArgMinLossImpl& other) {
     if (logistic != nullptr) {
         switch (m_CurrentPass) {
         case 0:
-            m_MinMaxPrediction += logistic->m_MinMaxPrediction;
+            m_PredictionMinMax += logistic->m_PredictionMinMax;
             m_CategoryCounts += logistic->m_CategoryCounts;
             break;
         case 1:
@@ -158,8 +158,8 @@ double CArgMinLogisticImpl::value() const {
 
         // Choose a weight interval in which all probabilites vary from close to
         // zero to close to one.
-        minWeight = -m_MinMaxPrediction.max() - 2.0;
-        maxWeight = -m_MinMaxPrediction.min() + 2.0;
+        minWeight = -m_PredictionMinMax.max() - 2.0;
+        maxWeight = -m_PredictionMinMax.min() + 2.0;
     }
 
     if (minWeight == maxWeight) {

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -10,6 +10,11 @@
 #include <core/CJsonStatePersistInserter.h>
 
 #include <maths/CBoostedTreeImpl.h>
+#include <maths/CLinearAlgebraPersist.h>
+#include <maths/CSolvers.h>
+#include <maths/CTools.h>
+
+#include <maths/CMathsFuncs.h>
 
 #include <sstream>
 #include <utility>
@@ -27,8 +32,22 @@ const std::string SPLIT_VALUE_TAG{"split_value"};
 
 namespace boosted_tree_detail {
 
+CArgMinLossImpl::CArgMinLossImpl(double lambda) : m_Lambda{lambda} {
+}
+
+double CArgMinLossImpl::lambda() const {
+    return m_Lambda;
+}
+
+CArgMinMseImpl::CArgMinMseImpl(double lambda) : CArgMinLossImpl{lambda} {
+}
+
 std::unique_ptr<CArgMinLossImpl> CArgMinMseImpl::clone() const {
     return std::make_unique<CArgMinMseImpl>(*this);
+}
+
+bool CArgMinMseImpl::nextPass() {
+    return false;
 }
 
 void CArgMinMseImpl::add(double prediction, double actual) {
@@ -43,7 +62,118 @@ void CArgMinMseImpl::merge(const CArgMinLossImpl& other) {
 }
 
 double CArgMinMseImpl::value() const {
-    return CBasicStatistics::mean(m_MeanError);
+    double count{CBasicStatistics::count(m_MeanError)};
+    return count == 0.0
+               ? 0.0
+               : count / (count + this->lambda()) * CBasicStatistics::mean(m_MeanError);
+}
+
+CArgMinLogisticImpl::CArgMinLogisticImpl(double lambda)
+    : CArgMinLossImpl{lambda}, m_CategoryCounts{0},
+      m_BucketCategoryCounts(128, TSizeVector{0}) {
+}
+
+std::unique_ptr<CArgMinLossImpl> CArgMinLogisticImpl::clone() const {
+    return std::make_unique<CArgMinLogisticImpl>(*this);
+}
+
+bool CArgMinLogisticImpl::nextPass() {
+    m_CurrentPass += this->bucketWidth() > 0.0 ? 1 : 2;
+    return m_CurrentPass < 2;
+}
+
+void CArgMinLogisticImpl::add(double prediction, double actual) {
+    switch (m_CurrentPass) {
+    case 0: {
+        m_MinMaxPrediction.add(prediction);
+        ++m_CategoryCounts(static_cast<std::size_t>(actual));
+        break;
+    }
+    case 1: {
+        auto& count = m_BucketCategoryCounts[this->bucket(prediction)];
+        ++count(static_cast<std::size_t>(actual));
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void CArgMinLogisticImpl::merge(const CArgMinLossImpl& other) {
+    const auto* logistic = dynamic_cast<const CArgMinLogisticImpl*>(&other);
+    if (logistic != nullptr) {
+        switch (m_CurrentPass) {
+        case 0:
+            m_MinMaxPrediction += logistic->m_MinMaxPrediction;
+            m_CategoryCounts += logistic->m_CategoryCounts;
+            break;
+        case 1:
+            for (std::size_t i = 0; i < m_BucketCategoryCounts.size(); ++i) {
+                m_BucketCategoryCounts[i] += logistic->m_BucketCategoryCounts[i];
+            }
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+double CArgMinLogisticImpl::value() const {
+
+    std::function<double(double)> objective;
+    double minWeight;
+    double maxWeight;
+
+    if (this->bucketWidth() == 0.0) {
+        objective = [this](double weight) {
+            double p{CTools::logisticFunction(weight)};
+            std::size_t c0{m_CategoryCounts(0)};
+            std::size_t c1{m_CategoryCounts(1)};
+            return this->lambda() * CTools::pow2(weight) -
+                   static_cast<double>(c0) * CTools::fastLog(1.0 - p) -
+                   static_cast<double>(c1) * CTools::fastLog(p);
+        };
+
+        // Weight shrinkage means the optimal weight will be somewhere
+        // between the logit of the empirical probability and zero.
+        std::size_t c0{m_CategoryCounts(0) + 1};
+        std::size_t c1{m_CategoryCounts(1) + 1};
+        double p{static_cast<double>(c1) / static_cast<double>(c0 + c1)};
+        minWeight = p < 0.5 ? std::log(p / (1.0 - p)) : 0.0;
+        maxWeight = p < 0.5 ? 0.0 : std::log(p / (1.0 - p));
+
+    } else {
+        objective = [this](double weight) {
+            double loss{0.0};
+            for (std::size_t i = 0; i < m_BucketCategoryCounts.size(); ++i) {
+                double bucketPrediction{this->bucketCentre(i)};
+                double p{CTools::logisticFunction(bucketPrediction + weight)};
+                std::size_t c0{m_BucketCategoryCounts[i](0)};
+                std::size_t c1{m_BucketCategoryCounts[i](1)};
+                loss -= static_cast<double>(c0) * CTools::fastLog(1.0 - p) +
+                        static_cast<double>(c1) * CTools::fastLog(p);
+            }
+            return loss + this->lambda() * CTools::pow2(weight);
+        };
+
+        // Choose a weight interval in which all probabilites vary from close to
+        // zero to close to one.
+        minWeight = -m_MinMaxPrediction.max() - 2.0;
+        maxWeight = -m_MinMaxPrediction.min() + 2.0;
+    }
+
+    if (minWeight == maxWeight) {
+        return minWeight;
+    }
+
+    double minimum;
+    double objectiveAtMinimum;
+    std::size_t maxIterations{10};
+    CSolvers::minimize(minWeight, maxWeight, objective(minWeight), objective(maxWeight),
+                       objective, 1e-3, maxIterations, minimum, objectiveAtMinimum);
+    LOG_TRACE(<< "minimum = " << minimum << " objective(minimum) = " << objectiveAtMinimum);
+
+    return minimum;
 }
 }
 
@@ -59,6 +189,10 @@ CArgMinLoss& CArgMinLoss::operator=(const CArgMinLoss& other) {
         m_Impl = other.m_Impl->clone();
     }
     return *this;
+}
+
+bool CArgMinLoss::nextPass() const {
+    return m_Impl->nextPass();
 }
 
 void CArgMinLoss::add(double prediction, double actual) {
@@ -80,6 +214,10 @@ CArgMinLoss CLoss::makeMinimizer(const boosted_tree_detail::CArgMinLossImpl& imp
     return {impl};
 }
 
+std::unique_ptr<CLoss> CMse::clone() const {
+    return std::make_unique<CMse>(*this);
+}
+
 double CMse::value(double prediction, double actual) const {
     return CTools::pow2(prediction - actual);
 }
@@ -96,8 +234,8 @@ bool CMse::isCurvatureConstant() const {
     return true;
 }
 
-CArgMinLoss CMse::minimizer() const {
-    return this->makeMinimizer(CArgMinMseImpl{});
+CArgMinLoss CMse::minimizer(double lambda) const {
+    return this->makeMinimizer(CArgMinMseImpl{lambda});
 }
 
 const std::string& CMse::name() const {
@@ -105,6 +243,41 @@ const std::string& CMse::name() const {
 }
 
 const std::string CMse::NAME{"mse"};
+
+std::unique_ptr<CLoss> CLogistic::clone() const {
+    return std::make_unique<CLogistic>(*this);
+}
+
+double CLogistic::value(double prediction, double actual) const {
+    // Cross entropy
+    prediction = CTools::logisticFunction(prediction);
+    return -((1.0 - actual) * CTools::fastLog(1.0 - prediction) +
+             actual * CTools::fastLog(prediction));
+}
+
+double CLogistic::gradient(double prediction, double actual) const {
+    prediction = CTools::logisticFunction(prediction);
+    return prediction - actual;
+}
+
+double CLogistic::curvature(double prediction, double /*actual*/) const {
+    prediction = CTools::logisticFunction(prediction);
+    return prediction * (1.0 - prediction);
+}
+
+bool CLogistic::isCurvatureConstant() const {
+    return false;
+}
+
+CArgMinLoss CLogistic::minimizer(double lambda) const {
+    return this->makeMinimizer(CArgMinLogisticImpl{lambda});
+}
+
+const std::string& CLogistic::name() const {
+    return NAME;
+}
+
+const std::string CLogistic::NAME{"logistic"};
 }
 
 std::size_t CBoostedTreeNode::leafIndex(const CEncodedDataFrameRowRef& row,

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -62,6 +62,15 @@ void CArgMinMseImpl::merge(const CArgMinLossImpl& other) {
 }
 
 double CArgMinMseImpl::value() const {
+
+    // We searching for the value x which minimises
+    //
+    //    x^* = argmin_x{ sum_i{(a_i - (p_i + x))^2} + lambda * x^2 }
+    //
+    // This is convex so there is one minimum where derivative w.r.t. x is zero
+    // and x^* = 1 / (n + lambda) sum_i{ a_i - p_i }. Denoting the mean prediction
+    // error m = 1/n sum_i{ a_i - p_i } we have x^* = n / (n + lambda) m.
+
     double count{CBasicStatistics::count(m_MeanError)};
     return count == 0.0
                ? 0.0

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -150,9 +150,12 @@ double CArgMinLogisticImpl::value() const {
         // between the logit of the empirical probability and zero.
         std::size_t c0{m_CategoryCounts(0) + 1};
         std::size_t c1{m_CategoryCounts(1) + 1};
-        double p{static_cast<double>(c1) / static_cast<double>(c0 + c1)};
-        minWeight = p < 0.5 ? std::log(p / (1.0 - p)) : 0.0;
-        maxWeight = p < 0.5 ? 0.0 : std::log(p / (1.0 - p));
+        double empiricalProbabilityC1{static_cast<double>(c1) /
+                                      static_cast<double>(c0 + c1)};
+        double empiricalLogOddsC1{
+            std::log(empiricalProbabilityC1 / (1.0 - empiricalProbabilityC1))};
+        minWeight = empiricalProbabilityC1 < 0.5 ? empiricalLogOddsC1 : 0.0;
+        maxWeight = empiricalProbabilityC1 < 0.5 ? 0.0 : empiricalLogOddsC1;
 
     } else {
         objective = [this](double weight) {

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -133,6 +133,9 @@ double CArgMinLogisticImpl::value() const {
     double minWeight;
     double maxWeight;
 
+    // This is true if and only if all the predictions were identical. In this
+    // case we only need one pass over the data and can compute the optimal
+    // value from the counts of the two categories.
     if (this->bucketWidth() == 0.0) {
         objective = [this](double weight) {
             double p{CTools::logisticFunction(weight)};

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -80,7 +80,8 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
         }
     }
 
-    auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads, m_Loss->clone());
+    auto treeImpl = std::make_unique<CBoostedTreeImpl>(
+        m_NumberThreads, m_Loss != nullptr ? m_Loss->clone() : nullptr);
     std::swap(m_TreeImpl, treeImpl);
     return TBoostedTreeUPtr{new CBoostedTree{frame, m_RecordProgress, m_RecordMemoryUsage,
                                              m_RecordTrainingState, std::move(treeImpl)}};
@@ -616,7 +617,9 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonS
 }
 
 CBoostedTreeFactory::CBoostedTreeFactory(bool restored, std::size_t numberThreads, TLossFunctionUPtr loss)
-    : m_Restored{restored}, m_NumberThreads{numberThreads}, m_Loss{loss->clone()},
+    : m_Restored{restored}, m_NumberThreads{numberThreads}, m_Loss{loss != nullptr
+                                                                       ? loss->clone()
+                                                                       : nullptr},
       m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))},
       m_LogDepthPenaltyMultiplierSearchInterval{0.0}, m_LogTreeSizePenaltyMultiplierSearchInterval{0.0},
       m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0} {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -80,9 +80,10 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
         }
     }
 
-    // TODO can only use factory to create one object since this is moved. This seems trappy.
+    auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads, m_Loss->clone());
+    std::swap(m_TreeImpl, treeImpl);
     return TBoostedTreeUPtr{new CBoostedTree{frame, m_RecordProgress, m_RecordMemoryUsage,
-                                             m_RecordTrainingState, std::move(m_TreeImpl)}};
+                                             m_RecordTrainingState, std::move(treeImpl)}};
 }
 
 std::size_t CBoostedTreeFactory::numberHyperparameterTuningRounds() const {
@@ -534,7 +535,6 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
         double testLoss{m_TreeImpl->meanLoss(frame, testRowMask, forest)};
         leastSquaresQuadraticTestLoss.add(static_cast<double>(i) * stepSize, testLoss);
         testLosses[i] = testLoss;
-        m_TreeImpl->m_TrainingProgress.increment();
     }
     LOG_TRACE(<< "test losses = " << core::CContainerPrinter::print(testLosses));
 
@@ -616,8 +616,8 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonS
 }
 
 CBoostedTreeFactory::CBoostedTreeFactory(bool restored, std::size_t numberThreads, TLossFunctionUPtr loss)
-    : m_Restored{restored}, m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads,
-                                                                          std::move(loss))},
+    : m_Restored{restored}, m_NumberThreads{numberThreads}, m_Loss{loss->clone()},
+      m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))},
       m_LogDepthPenaltyMultiplierSearchInterval{0.0}, m_LogTreeSizePenaltyMultiplierSearchInterval{0.0},
       m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0} {
 }
@@ -793,12 +793,16 @@ void CBoostedTreeFactory::initializeTrainingProgressMonitoring() {
     // This comprises:
     //  - The cost of category encoding and feature selection which we count as
     //    one unit,
+    //  - One unit for estimating the expected gain and sum curvature per node,
     //  - INITIAL_REGULARIZER_SEARCH_ITERATIONS units per regularization parameter
     //    which isn't user defined,
     //  - The main optimisation loop which costs number folds units per iteration,
     //  - The cost of the final train which we count as number folds units.
 
-    std::size_t totalNumberSteps{1};
+    std::size_t totalNumberSteps{2};
+    if (m_TreeImpl->m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
+        totalNumberSteps += INITIAL_REGULARIZER_SEARCH_ITERATIONS;
+    }
     if (m_TreeImpl->m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
         totalNumberSteps += INITIAL_REGULARIZER_SEARCH_ITERATIONS;
     }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1023,6 +1023,25 @@ const std::string HYPERPARAM_FEATURE_BAG_FRACTION_TAG{"hyperparam_feature_bag_fr
 const std::string HYPERPARAM_REGULARIZATION_TAG{"hyperparam_regularization"};
 }
 
+const std::string& CBoostedTreeImpl::bestHyperparametersName() {
+    return BEST_HYPERPARAMETERS_TAG;
+}
+
+const std::string& CBoostedTreeImpl::bestRegularizationHyperparametersName() {
+    return HYPERPARAM_REGULARIZATION_TAG;
+}
+
+CBoostedTreeImpl::TStrVec CBoostedTreeImpl::bestHyperparameterNames() {
+    return {HYPERPARAM_ETA_TAG,
+            HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+            HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+            REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
+            REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+            REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+            REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
+            REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG};
+}
+
 template<typename T>
 void CBoostedTreeImpl::CRegularization<T>::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     core::CPersistUtils::persist(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -433,7 +433,6 @@ CBoostedTreeImpl::crossValidateForest(core::CDataFrame& frame,
         lossMoments.add(loss);
         LOG_TRACE(<< "fold = " << i << " forest size = " << forest.size()
                   << " test set loss = " << loss);
-        m_TrainingProgress.increment();
     }
     LOG_TRACE(<< "test mean loss = " << CBasicStatistics::mean(lossMoments)
               << ", sigma = " << std::sqrt(CBasicStatistics::mean(lossMoments)));
@@ -520,6 +519,8 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
     } while (forest.size() < m_MaximumNumberTrees);
 
     LOG_TRACE(<< "Trained one forest");
+
+    m_TrainingProgress.increment();
 
     return forest;
 }
@@ -733,27 +734,39 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
 
     using TArgMinLossVec = std::vector<CArgMinLoss>;
 
-    auto result = frame.readRows(
-        m_NumberThreads, 0, frame.numberRows(),
-        core::bindRetrievableState(
-            [&](TArgMinLossVec& leafValues, TRowItr beginRows, TRowItr endRows) {
-                for (auto itr = beginRows; itr != endRows; ++itr) {
-                    const TRowRef& row{*itr};
-                    double prediction{readPrediction(row)};
-                    double actual{readActual(row, m_DependentVariable)};
-                    leafValues[root(tree).leafIndex(m_Encoder->encode(row), tree)]
-                        .add(prediction, actual);
-                }
-            },
-            TArgMinLossVec(tree.size(), m_Loss->minimizer())),
-        &trainingRowMask);
-
-    auto leafValues = std::move(result.first[0].s_FunctionState);
-    for (std::size_t i = 1; i < result.first.size(); ++i) {
-        for (std::size_t j = 0; j < leafValues.size(); ++j) {
-            leafValues[j].merge(result.first[i].s_FunctionState[j]);
+    TArgMinLossVec leafValues(
+        tree.size(), m_Loss->minimizer(m_Regularization.leafWeightPenaltyMultiplier()));
+    auto nextPass = [&] {
+        bool done{true};
+        for (const auto& value : leafValues) {
+            done &= (value.nextPass() == false);
         }
-    }
+        return done == false;
+    };
+
+    do {
+        auto result = frame.readRows(
+            m_NumberThreads, 0, frame.numberRows(),
+            core::bindRetrievableState(
+                [&](TArgMinLossVec& leafValues_, TRowItr beginRows, TRowItr endRows) {
+                    for (auto itr = beginRows; itr != endRows; ++itr) {
+                        const TRowRef& row{*itr};
+                        double prediction{readPrediction(row)};
+                        double actual{readActual(row, m_DependentVariable)};
+                        leafValues_[root(tree).leafIndex(m_Encoder->encode(row), tree)]
+                            .add(prediction, actual);
+                    }
+                },
+                std::move(leafValues)),
+            &trainingRowMask);
+
+        leafValues = std::move(result.first[0].s_FunctionState);
+        for (std::size_t i = 1; i < result.first.size(); ++i) {
+            for (std::size_t j = 0; j < leafValues.size(); ++j) {
+                leafValues[j].merge(result.first[i].s_FunctionState[j]);
+            }
+        }
+    } while (nextPass());
 
     for (std::size_t i = 0; i < tree.size(); ++i) {
         tree[i].value(eta * leafValues[i].value());

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -414,8 +414,9 @@ CBoostedTreeImpl::gainAndCurvatureAtPercentile(double percentile,
         return {0.0, 0.0};
     }
 
-    std::size_t index{static_cast<std::size_t>(
-        percentile * static_cast<double>(gains.size()) / 100.0 + 0.5)};
+    std::size_t index{std::min(
+        static_cast<std::size_t>(percentile * static_cast<double>(gains.size()) / 100.0 + 0.5),
+        gains.size() - 1)};
     std::nth_element(gains.begin(), gains.begin() + index, gains.end());
     std::nth_element(curvatures.begin(), curvatures.begin() + index, curvatures.end());
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -352,7 +352,7 @@ void CBoostedTreeTest::testNonLinear() {
             0.0, modelBias[i][0],
             4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.97);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.96);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
@@ -818,7 +818,7 @@ void CBoostedTreeTest::testDepthBasedRegularization() {
         TMeanAccumulator meanDepth;
         for (const auto& tree : regression->trainedModel()) {
             CPPUNIT_ASSERT(maxDepth(tree, tree[0], 0) <= static_cast<std::size_t>(targetDepth));
-            meanDepth.add(maxDepth(tree, tree[0], 0));
+            meanDepth.add(static_cast<double>(maxDepth(tree, tree[0], 0)));
         }
         LOG_DEBUG(<< "mean depth = " << maths::CBasicStatistics::mean(meanDepth));
         CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanDepth) > targetDepth - 1.0);
@@ -1025,8 +1025,8 @@ void CBoostedTreeTest::testLogisticRegression() {
         LOG_DEBUG(<< "actual cross entropy = " << actualCrossEntropy
                   << ", minimum cross entropy = " << minimumCrossEntropy);
 
-        // We should be with 35% of the minimum possible cross entropy.
-        CPPUNIT_ASSERT(actualCrossEntropy < 1.35 * minimumCrossEntropy);
+        // We should be with 40% of the minimum possible cross entropy.
+        CPPUNIT_ASSERT(actualCrossEntropy < 1.4 * minimumCrossEntropy);
         meanExcessCrossEntropy.add(actualCrossEntropy / minimumCrossEntropy);
     }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -961,8 +961,17 @@ void CBoostedTreeTest::testLogisticMinimizer() {
 
 void CBoostedTreeTest::testLogisticRegression() {
 
-    // Test we approximately minimise the cross entropy if the category labels
-    // are generated from log odds which are a linear function of the regressors.
+    // The idea of this test is to create a random linear relationship between
+    // the feature values and the log-odds of each class, i.e.
+    //
+    //   log-odds(class_1) = sum_i{ w * x_i }
+    //
+    // where, w is some fixed weight vector and x_i denoted the i'th feature vector.
+    // We are try to recover this relationship in logistic regression by observing
+    // the actual labels. We want to test that we've roughly correctly estimated the
+    // log-odds. However, we target the cross-entropy so the errors in our estimates
+    // p_i^ should be measured in terms of cross entropy: sum_i{ p_i^ log(p_i) }
+    // where p_i = logistic(sum_i{ w_i * x_i}).
 
     test::CRandomNumbers rng;
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -826,8 +826,8 @@ void CBoostedTreeTest::testDepthBasedRegularization() {
 
 void CBoostedTreeTest::testLogisticMinimizer() {
 
-    // Test that we a good approximation of the minimizing additive weight for
-    // the cross entropy objective of logistic regression.
+    // Test that we a good approximation of the additive term for the log-odds
+    // which minimises the cross entropy objective.
 
     using maths::boosted_tree_detail::CArgMinLogisticImpl;
 
@@ -836,7 +836,7 @@ void CBoostedTreeTest::testLogisticMinimizer() {
     TDoubleVec labels;
     TDoubleVec weights;
 
-    // All predictions equal
+    // All predictions equal and zero.
     {
         CArgMinLogisticImpl argmin{0.0};
         argmin.add(0.0, 0.0);
@@ -846,6 +846,7 @@ void CBoostedTreeTest::testLogisticMinimizer() {
         argmin.nextPass();
         CPPUNIT_ASSERT_EQUAL(0.0, argmin.value());
     }
+    // All predictions are equal.
     {
         rng.generateUniformSamples(0.0, 1.0, 1000, labels);
         for (auto& label : labels) {
@@ -876,6 +877,8 @@ void CBoostedTreeTest::testLogisticMinimizer() {
     for (auto lambda : {0.0, 10.0}) {
 
         LOG_DEBUG(<< "lambda = " << lambda);
+
+        // The true objective.
         auto objective = [&](double weight) {
             double loss{0.0};
             for (std::size_t i = 0; i < labels.size(); ++i) {
@@ -940,6 +943,8 @@ void CBoostedTreeTest::testLogisticMinimizer() {
             LOG_DEBUG(<< "actual = " << actual
                       << " objective at actual = " << objective(actual));
 
+            // We should be within 1% for the value and 0.001% for the objective
+            // at the value.
             CPPUNIT_ASSERT_EQUAL(actual, actualPartition);
             CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, actual, 0.01 * std::fabs(expected));
             CPPUNIT_ASSERT_DOUBLES_EQUAL(objectiveAtExpected, objective(actual),
@@ -1016,15 +1021,18 @@ void CBoostedTreeTest::testLogisticRegression() {
                 }
             }
         });
-
         LOG_DEBUG(<< "actual cross entropy = " << actualCrossEntropy
                   << ", minimum cross entropy = " << minimumCrossEntropy);
+
+        // We should be with 35% of the minimum possible cross entropy.
         CPPUNIT_ASSERT(actualCrossEntropy < 1.35 * minimumCrossEntropy);
         meanExcessCrossEntropy.add(actualCrossEntropy / minimumCrossEntropy);
     }
 
     LOG_DEBUG(<< "mean excess cross entropy = "
               << maths::CBasicStatistics::mean(meanExcessCrossEntropy));
+
+    // We should be within 25% of the minimum possible cross entropy on average.
     CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanExcessCrossEntropy) < 1.25);
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -290,7 +290,7 @@ void CBoostedTreeTest::testLinear() {
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.98);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
 }
 
 void CBoostedTreeTest::testNonLinear() {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -951,7 +951,7 @@ void CBoostedTreeTest::testLogisticMinimizer() {
 void CBoostedTreeTest::testLogisticRegression() {
 
     // Test we approximately minimise the cross entropy if the category labels
-    // are generated from log odds which are a linaer function of the regressors.
+    // are generated from log odds which are a linear function of the regressors.
 
     test::CRandomNumbers rng;
 
@@ -1018,12 +1018,12 @@ void CBoostedTreeTest::testLogisticRegression() {
         });
 
         LOG_DEBUG(<< "actual cross entropy = " << actualCrossEntropy
-                  << " minimum cross entropy = " << minimumCrossEntropy);
+                  << ", minimum cross entropy = " << minimumCrossEntropy);
         CPPUNIT_ASSERT(actualCrossEntropy < 1.35 * minimumCrossEntropy);
         meanExcessCrossEntropy.add(actualCrossEntropy / minimumCrossEntropy);
     }
 
-    LOG_DEBUG(<< "mean excess cross entropy "
+    LOG_DEBUG(<< "mean excess cross entropy = "
               << maths::CBasicStatistics::mean(meanExcessCrossEntropy));
     CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanExcessCrossEntropy) < 1.25);
 }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -227,12 +227,13 @@ void CBoostedTreeTest::testPiecewiseConstant() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.96);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
+
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
     CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
 }
@@ -282,14 +283,14 @@ void CBoostedTreeTest::testLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.98);
 }
 
 void CBoostedTreeTest::testNonLinear() {
@@ -349,14 +350,14 @@ void CBoostedTreeTest::testNonLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
 }
 
 void CBoostedTreeTest::testThreading() {
@@ -922,7 +923,7 @@ void CBoostedTreeTest::testLogisticMinimizer() {
                 bool done{argmin.nextPass() == false};
                 done &= (argminPartition[0].nextPass() == false);
                 done &= (argminPartition[1].nextPass() == false);
-                return done;
+                return done == false;
             };
 
             do {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -908,6 +908,11 @@ void CBoostedTreeTest::testLogisticMinimizer() {
                 max = std::max(max, weight[0]);
             }
 
+            // Choose a weight interval in which all probabilites vary from close to
+            // zero to close which we know will contain the true optimum. The idea is
+            // to minimize the leaf weight on an interval [a, b] where if we add "a"
+            // the log-odds for all rows <= 0, i.e. max prediction + a = 0, and if we
+            // add "b" the log-odds for all rows >= 0, i.e. min prediction + a = 0.
             double expected;
             double objectiveAtExpected;
             std::size_t maxIterations{20};

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -984,27 +984,24 @@ void CBoostedTreeTest::testLogisticRegression() {
 
     TMeanAccumulator meanExcessCrossEntropy;
     for (std::size_t test = 0; test < 3; ++test) {
-        auto probability = [&] {
-            TDoubleVec weights;
-            rng.generateUniformSamples(-2.0, 2.0, cols - 1, weights);
-            TDoubleVec noise;
-            rng.generateNormalSamples(0.0, 1.0, rows, noise);
-            return [=](const TRowRef& row) {
-                double x{0.0};
-                for (std::size_t i = 0; i < cols - 1; ++i) {
-                    x += weights[i] * row[i];
-                }
-                return maths::CTools::logisticFunction(x + noise[row.index()]);
-            };
-        }();
+        TDoubleVec weights;
+        rng.generateUniformSamples(-2.0, 2.0, cols - 1, weights);
+        TDoubleVec noise;
+        rng.generateNormalSamples(0.0, 1.0, rows, noise);
+        TDoubleVec uniform01;
+        rng.generateUniformSamples(0.0, 1.0, rows, uniform01);
 
-        auto target = [&] {
-            TDoubleVec uniform01;
-            rng.generateUniformSamples(0.0, 1.0, rows, uniform01);
-            return [=](const TRowRef& row) {
-                return uniform01[row.index()] < probability(row) ? 1.0 : 0.0;
-            };
-        }();
+        auto probability = [&](const TRowRef& row) {
+            double x{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                x += weights[i] * row[i];
+            }
+            return maths::CTools::logisticFunction(x + noise[row.index()]);
+        };
+
+        auto target = [&](const TRowRef& row) {
+            return uniform01[row.index()] < probability(row) ? 1.0 : 0.0;
+        };
 
         TDoubleVecVec x(cols - 1);
         for (std::size_t i = 0; i < cols - 1; ++i) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -890,6 +890,8 @@ void CBoostedTreeTest::testLogisticMinimizer() {
             return loss + lambda * maths::CTools::pow2(weight);
         };
 
+        // This loop is fuzzing the predicted log-odds and testing we get consistently
+        // good estimates of the true minimizer.
         for (std::size_t t = 0; t < 10; ++t) {
 
             double min{std::numeric_limits<double>::max()};

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -910,11 +910,6 @@ void CBoostedTreeTest::testLogisticMinimizer() {
                 max = std::max(max, weight[0]);
             }
 
-            // Choose a weight interval in which all probabilites vary from close to
-            // zero to close which we know will contain the true optimum. The idea is
-            // to minimize the leaf weight on an interval [a, b] where if we add "a"
-            // the log-odds for all rows <= 0, i.e. max prediction + a = 0, and if we
-            // add "b" the log-odds for all rows >= 0, i.e. min prediction + a = 0.
             double expected;
             double objectiveAtExpected;
             std::size_t maxIterations{20};

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -19,6 +19,7 @@ public:
     void testConstantTarget();
     void testCategoricalRegressors();
     void testIntegerRegressor();
+    void testSingleSplit();
     void testTranslationInvariance();
     void testDepthBasedRegularization();
     void testEstimateMemoryUsedByTrain();

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -22,6 +22,8 @@ public:
     void testSingleSplit();
     void testTranslationInvariance();
     void testDepthBasedRegularization();
+    void testLogisticMinimizer();
+    void testLogisticRegression();
     void testEstimateMemoryUsedByTrain();
     void testProgressMonitoring();
     void testMissingData();


### PR DESCRIPTION
This implements binomial logistic regression for the boosted tree. In particular, this targets cross entropy and builds a forest to predict the class log-odds.

We should also have been including sum square leaf weight penalty in the calculation of the optimum tree leaf values, since the splits are chosen targeting the regularised objective. (Note that the regularisation applies to the log-odds for logistic regression, i.e. we'll shrink the log-odds towards zero and so the predicted probabilities towards 0.5.)

I haven't wired this in yet, since that work depends on #701.