### PR TITLE
[7.x][ML] Replace std::auto_ptr with std::unique_ptr

### DIFF
--- a/include/core/CContainerPrinter.h
+++ b/include/core/CContainerPrinter.h
@@ -255,10 +255,10 @@ private:
         return result.str();
     }
 
-    //! Print a std::auto_ptr.
+    //! Print a std::unique_ptr.
     template<typename T>
-    static std::string printElement(const std::auto_ptr<T>& value) {
-        if (value.get() == nullptr) {
+    static std::string printElement(const std::unique_ptr<T>& value) {
+        if (value == nullptr) {
             return "\"null\"";
         }
         std::ostringstream result;

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -162,7 +162,7 @@ public:
     using TFeatureCorrelationsPtrPr = std::pair<model_t::EFeature, TCorrelationsPtr>;
     using TFeatureCorrelationsPtrPrVec = std::vector<TFeatureCorrelationsPtrPr>;
     using TDataGathererPtr = std::shared_ptr<CDataGatherer>;
-    using CModelDetailsViewPtr = std::auto_ptr<CModelDetailsView>;
+    using TModelDetailsViewUPtr = std::unique_ptr<CModelDetailsView>;
     using TModelPtr = std::unique_ptr<CAnomalyDetectorModel>;
 
 public:
@@ -471,7 +471,7 @@ public:
     core_t::TTime bucketLength() const;
 
     //! Get a view of the internals of the model for visualization.
-    virtual CModelDetailsViewPtr details() const = 0;
+    virtual TModelDetailsViewUPtr details() const = 0;
 
     //! Get the frequency of the person identified by \p pid.
     double personFrequency(std::size_t pid) const;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -212,7 +212,7 @@ public:
     std::size_t staticSize() const override;
 
     //! Returns null.
-    CModelDetailsViewPtr details() const override;
+    TModelDetailsViewUPtr details() const override;
 
     //! Get the descriptions of any occurring scheduled event descriptions for the bucket time
     const TStr1Vec& scheduledEventDescriptions(core_t::TTime time) const override;

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -263,7 +263,7 @@ public:
     std::size_t computeMemoryUsage() const override;
 
     //! Get a view of the internals of the model for visualization.
-    CModelDetailsViewPtr details() const override;
+    TModelDetailsViewUPtr details() const override;
 
     //! Get the value of the \p feature of the person identified
     //! by \p pid for the bucketing interval containing \p time.

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -302,7 +302,7 @@ public:
     std::size_t computeMemoryUsage() const override;
 
     //! Get a view of the internals of the model for visualization.
-    CModelDetailsViewPtr details() const override;
+    TModelDetailsViewUPtr details() const override;
 
     //! Get the feature data corresponding to \p feature at \p time.
     const TSizeSizePrFeatureDataPrVec& featureData(model_t::EFeature feature,

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -258,7 +258,7 @@ public:
     std::size_t computeMemoryUsage() const override;
 
     //! Get a view of the internals of the model for visualization.
-    CModelDetailsViewPtr details() const override;
+    TModelDetailsViewUPtr details() const override;
 
     //! Get the value of the \p feature of the person identified
     //! by \p pid for the bucketing interval containing \p time.

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -266,7 +266,7 @@ public:
     uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Get a view of the internals of the model for visualization.
-    CModelDetailsViewPtr details() const override;
+    TModelDetailsViewUPtr details() const override;
 
     //! Get the feature data corresponding to \p feature at \p time.
     const TSizeSizePrFeatureDataPrVec& featureData(model_t::EFeature feature,

--- a/lib/core/unittest/CContainerPrinterTest.cc
+++ b/lib/core/unittest/CContainerPrinterTest.cc
@@ -54,9 +54,9 @@ void CContainerPrinterTest::testAll() {
     CPPUNIT_ASSERT_EQUAL(std::string("[(1, \"null\"), (1.1, 3), (3.3, 5.1)]"),
                          CContainerPrinter::print(map));
 
-    std::auto_ptr<int> pints[] = {std::auto_ptr<int>(new int(2)),
-                                  std::auto_ptr<int>(new int(3)),
-                                  std::auto_ptr<int>(new int(2))};
+    std::unique_ptr<int> pints[] = {std::unique_ptr<int>(new int(2)),
+                                    std::unique_ptr<int>(new int(3)),
+                                    std::unique_ptr<int>(new int(2))};
     LOG_DEBUG(<< "pints = "
               << CContainerPrinter::print(std::begin(pints), std::end(pints)));
     CPPUNIT_ASSERT_EQUAL(std::string("[2, 3, 2]"),

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -36,7 +36,7 @@ namespace model {
 // We use short field names to reduce the state size
 namespace {
 
-using TModelDetailsViewPtr = CAnomalyDetectorModel::CModelDetailsViewPtr;
+using TModelDetailsViewUPtr = CAnomalyDetectorModel::TModelDetailsViewUPtr;
 
 // tag 'a' was previously used for persisting first time;
 // DO NOT USE; unless it is decided to break model state BWC
@@ -439,7 +439,7 @@ void CAnomalyDetector::generateModelPlot(core_t::TTime bucketStartTime,
     if (terms.empty() || m_DataGatherer->partitionFieldValue().empty() ||
         terms.find(m_DataGatherer->partitionFieldValue()) != terms.end()) {
         const CSearchKey& key = m_DataGatherer->searchKey();
-        TModelDetailsViewPtr view = m_Model.get()->details();
+        TModelDetailsViewUPtr view = m_Model.get()->details();
         if (view.get()) {
             core_t::TTime bucketLength = m_ModelConfig.bucketLength();
             for (core_t::TTime time = bucketStartTime; time < bucketEndTime;
@@ -458,7 +458,7 @@ CForecastDataSink::SForecastModelPrerequisites
 CAnomalyDetector::getForecastPrerequisites() const {
     CForecastDataSink::SForecastModelPrerequisites prerequisites{0, 0, 0, true, false};
 
-    TModelDetailsViewPtr view = m_Model->details();
+    TModelDetailsViewUPtr view = m_Model->details();
 
     // The view can be empty, e.g. for the counting model.
     if (view.get() == nullptr) {
@@ -508,7 +508,7 @@ CAnomalyDetector::getForecastModels(bool persistOnDisk,
         return series;
     }
 
-    TModelDetailsViewPtr view = m_Model.get()->details();
+    TModelDetailsViewUPtr view = m_Model.get()->details();
 
     // The view can be empty, e.g. for the counting model.
     if (view.get() == nullptr) {

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -329,8 +329,8 @@ std::size_t CCountingModel::staticSize() const {
     return sizeof(*this);
 }
 
-CCountingModel::CModelDetailsViewPtr CCountingModel::details() const {
-    return CModelDetailsViewPtr();
+CCountingModel::TModelDetailsViewUPtr CCountingModel::details() const {
+    return TModelDetailsViewUPtr();
 }
 
 core_t::TTime CCountingModel::currentBucketStartTime() const {

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -502,8 +502,8 @@ std::size_t CEventRateModel::computeMemoryUsage() const {
     return mem;
 }
 
-CEventRateModel::CModelDetailsViewPtr CEventRateModel::details() const {
-    return CModelDetailsViewPtr(new CEventRateModelDetailsView(*this));
+CEventRateModel::TModelDetailsViewUPtr CEventRateModel::details() const {
+    return TModelDetailsViewUPtr(new CEventRateModelDetailsView(*this));
 }
 
 const CEventRateModel::TFeatureData*

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -852,8 +852,8 @@ std::size_t CEventRatePopulationModel::staticSize() const {
     return sizeof(*this);
 }
 
-CEventRatePopulationModel::CModelDetailsViewPtr CEventRatePopulationModel::details() const {
-    return CModelDetailsViewPtr(new CEventRatePopulationModelDetailsView(*this));
+CEventRatePopulationModel::TModelDetailsViewUPtr CEventRatePopulationModel::details() const {
+    return TModelDetailsViewUPtr(new CEventRatePopulationModelDetailsView(*this));
 }
 
 const CEventRatePopulationModel::TSizeSizePrFeatureDataPrVec&

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -466,8 +466,8 @@ std::size_t CMetricModel::staticSize() const {
     return sizeof(*this);
 }
 
-CMetricModel::CModelDetailsViewPtr CMetricModel::details() const {
-    return CModelDetailsViewPtr(new CMetricModelDetailsView(*this));
+CMetricModel::TModelDetailsViewUPtr CMetricModel::details() const {
+    return TModelDetailsViewUPtr(new CMetricModelDetailsView(*this));
 }
 
 const CMetricModel::TFeatureData*

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -761,8 +761,8 @@ std::size_t CMetricPopulationModel::staticSize() const {
     return sizeof(*this);
 }
 
-CMetricPopulationModel::CModelDetailsViewPtr CMetricPopulationModel::details() const {
-    return CModelDetailsViewPtr(new CMetricPopulationModelDetailsView(*this));
+CMetricPopulationModel::TModelDetailsViewUPtr CMetricPopulationModel::details() const {
+    return TModelDetailsViewUPtr(new CMetricPopulationModelDetailsView(*this));
 }
 
 const TSizeSizePrFeatureDataPrVec&

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2895,9 +2895,9 @@ void CEventRateModelTest::testIgnoreSamplingGivenDetectionRules() {
     CPPUNIT_ASSERT(modelWithSkip->checksum() != modelNoSkip->checksum());
 
     // but the underlying models should be the same
-    CAnomalyDetectorModel::CModelDetailsViewPtr modelWithSkipView =
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
         modelWithSkip->details();
-    CAnomalyDetectorModel::CModelDetailsViewPtr modelNoSkipView = modelNoSkip->details();
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
 
     uint64_t withSkipChecksum =
         static_cast<const maths::CUnivariateTimeSeriesModel*>(

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2478,9 +2478,9 @@ void CMetricModelTest::testIgnoreSamplingGivenDetectionRules() {
     CPPUNIT_ASSERT(modelWithSkip->checksum() != modelNoSkip->checksum());
 
     // but the underlying models should be the same
-    CAnomalyDetectorModel::CModelDetailsViewPtr modelWithSkipView =
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
         modelWithSkip->details();
-    CAnomalyDetectorModel::CModelDetailsViewPtr modelNoSkipView = modelNoSkip->details();
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
 
     // TODO this test fails due a different checksums for the decay rate and prior
     // uint64_t withSkipChecksum = modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0)->checksum();

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -1499,9 +1499,9 @@ void CMetricPopulationModelTest::testIgnoreSamplingGivenDetectionRules() {
     // Checksums will be different because a 3rd model is created for attribute c3
     CPPUNIT_ASSERT(modelWithSkip->checksum() != modelNoSkip->checksum());
 
-    CAnomalyDetectorModel::CModelDetailsViewPtr modelWithSkipView =
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
         modelWithSkip->details();
-    CAnomalyDetectorModel::CModelDetailsViewPtr modelNoSkipView = modelNoSkip->details();
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
 
     // but the underlying models for people p1 and p2 are the same
     uint64_t withSkipChecksum = modelWithSkipView

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -132,8 +132,8 @@ std::size_t CMockModel::staticSize() const {
     return 0;
 }
 
-CMockModel::CModelDetailsViewPtr CMockModel::details() const {
-    CModelDetailsViewPtr result{new CMockModelDetailsView(*this)};
+CMockModel::TModelDetailsViewUPtr CMockModel::details() const {
+    TModelDetailsViewUPtr result{new CMockModelDetailsView(*this)};
     return result;
 }
 

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -94,7 +94,7 @@ public:
 
     std::size_t staticSize() const override;
 
-    CModelDetailsViewPtr details() const override;
+    TModelDetailsViewUPtr details() const override;
 
     double attributeFrequency(std::size_t cid) const override;
 


### PR DESCRIPTION
std::auto_ptr has been removed from C++17, so we need
to stop using it before we can upgrade to C++17.

Also corrected the type name of a typedef of a
std::auto_ptr.

Backport of #717