### PR TITLE
[ML] Improvements to sparse count modelling

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,6 +43,9 @@ boosted tree training. Hard depth based regularization is often the strategy of
 choice to prevent over fitting for XGBoost. By smoothing we can make better tradeoffs.
 Also, the parameters of the penalty function are mode suited to optimising with our
 Bayesian optimisation based hyperparameter search. (See {ml-pull}698[#698].)
+* Improvements to count and sum anomaly detection for sparse data. This primarily
+aims to improve handling of data which are predictably present: detecting when they
+are unexpectedly missing. (See {ml-pull}721[#721].)
 
 == {es} version 7.4.1
 

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -74,12 +74,6 @@ public:
     //! Get the maximum time to test for a change point in the model.
     core_t::TTime maximumTimeToTestForChange() const;
 
-    //! Set the probability that the bucket will be empty for the model.
-    void probabilityBucketEmpty(double probability);
-
-    //! Get the probability that the bucket will be empty for the model.
-    double probabilityBucketEmpty() const;
-
 private:
     //! The data bucketing length.
     core_t::TTime m_BucketLength;
@@ -93,8 +87,6 @@ private:
     core_t::TTime m_MinimumTimeToDetectChange;
     //! The maximum time permitted to test for a change in the model.
     core_t::TTime m_MaximumTimeToTestForChange;
-    //! The probability that a bucket will be empty for the model.
-    double m_ProbabilityBucketEmpty;
 };
 
 //! \brief The extra parameters needed by CModel::addSamples.
@@ -169,13 +161,6 @@ public:
     //! Get the confidence interval to use when detrending.
     double seasonalConfidenceInterval() const;
 
-    //! Add whether a value's bucket is empty.
-    CModelProbabilityParams& addBucketEmpty(const TBool2Vec& empty);
-    //! Set whether or not the values' bucket is empty.
-    CModelProbabilityParams& bucketEmpty(const TBool2Vec1Vec& empty);
-    //! Get whether the values' bucket is empty.
-    const TBool2Vec1Vec& bucketEmpty() const;
-
     //! Add a value's weights.
     CModelProbabilityParams& addWeights(const TDouble2VecWeightsAry& weights);
     //! Set the values' weights.
@@ -215,8 +200,6 @@ private:
     TProbabilityCalculation2Vec m_Calculations;
     //! The confidence interval to use when detrending.
     double m_SeasonalConfidenceInterval;
-    //! True if the bucket is empty and false otherwise.
-    TBool2Vec1Vec m_BucketEmpty;
     //! The sample weights.
     TDouble2VecWeightsAry1Vec m_Weights;
     //! The coordinates for which to compute the probability.
@@ -468,16 +451,6 @@ protected:
     template<typename PRIOR, typename VECTOR>
     static boost::optional<VECTOR>
     predictionError(double propagationInterval, const PRIOR& prior, const VECTOR& sample);
-
-    //! Correct \p probability with \p probabilityEmptyBucket.
-    static double jointProbabilityGivenBucket(bool bucketEmpty,
-                                              double probabilityBucketEmpty,
-                                              double probability);
-
-    //! Correct \p probability with \p probabilityEmptyBucket.
-    static double jointProbabilityGivenBucket(const TBool2Vec& bucketEmpty,
-                                              const TDouble2Vec& probabilityEmptyBucket,
-                                              double probability);
 
 private:
     //! The model parameters.

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -144,10 +144,6 @@ public:
     //! category from the sketch to cluster.
     static const double DEFAULT_CATEGORY_DELETE_FRACTION;
 
-    //! The default minimum frequency of non-empty buckets at which we model
-    //! all buckets.
-    static const double DEFAULT_CUTOFF_TO_MODEL_EMPTY_BUCKETS;
-
     //! The default size of the seasonal components we will model.
     static const std::size_t DEFAULT_COMPONENT_SIZE;
 

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -236,10 +236,6 @@ protected:
     //! for features which count empty buckets.
     double emptyBucketWeight(model_t::EFeature feature, std::size_t pid, core_t::TTime time) const;
 
-    //! Get the "probability the bucket is empty" to use to correct probabilities
-    //! for features which count empty buckets.
-    double probabilityBucketEmpty(model_t::EFeature feature, std::size_t pid) const;
-
     //! Get a read only model corresponding to \p feature of the person \p pid.
     const maths::CModel* model(model_t::EFeature feature, std::size_t pid) const;
 

--- a/include/model/CModelParams.h
+++ b/include/model/CModelParams.h
@@ -83,9 +83,6 @@ struct MODEL_EXPORT SModelParams {
     //! The minimum permitted count of points in a distribution mode.
     double s_MinimumModeCount;
 
-    //! The minimum frequency of non-empty buckets at which we model all buckets.
-    double s_CutoffToModelEmptyBuckets;
-
     //! The number of points to use for approximating each seasonal component.
     std::size_t s_ComponentSize;
 

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -512,15 +512,9 @@ double inverseOffsetCountToZero(EFeature feature, double count);
 MODEL_EXPORT
 void inverseOffsetCountToZero(EFeature feature, TDouble1Vec& count);
 
-//! Check if the feature counts empty buckets.
+//! Check if the feature has a value for empty buckets.
 MODEL_EXPORT
-bool countsEmptyBuckets(EFeature feature);
-
-//! Get the weight to apply to an empty bucket sample based on the
-//! frequency \p feature at which empty buckets are seen for \p feature
-//! and the cutoff for empty buckets directly.
-MODEL_EXPORT
-double emptyBucketCountWeight(EFeature feature, double frequency, double cutoff);
+bool includeEmptyBuckets(EFeature feature);
 
 //! Get the rate at which \p feature learns.
 MODEL_EXPORT

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -44,8 +44,7 @@ CModelParams::CModelParams(core_t::TTime bucketLength,
     : m_BucketLength(bucketLength), m_LearnRate(learnRate), m_DecayRate(decayRate),
       m_MinimumSeasonalVarianceScale(minimumSeasonalVarianceScale),
       m_MinimumTimeToDetectChange(std::max(minimumTimeToDetectChange, 6 * bucketLength)),
-      m_MaximumTimeToTestForChange(std::max(maximumTimeToTestForChange, 12 * bucketLength)),
-      m_ProbabilityBucketEmpty(0.0) {
+      m_MaximumTimeToTestForChange(std::max(maximumTimeToTestForChange, 12 * bucketLength)) {
 }
 
 core_t::TTime CModelParams::bucketLength() const {
@@ -78,14 +77,6 @@ core_t::TTime CModelParams::minimumTimeToDetectChange() const {
 
 core_t::TTime CModelParams::maximumTimeToTestForChange() const {
     return m_MaximumTimeToTestForChange;
-}
-
-void CModelParams::probabilityBucketEmpty(double probability) {
-    m_ProbabilityBucketEmpty = probability;
-}
-
-double CModelParams::probabilityBucketEmpty() const {
-    return m_ProbabilityBucketEmpty;
 }
 
 //////// CModelAddSamplesParams ////////
@@ -166,20 +157,6 @@ CModelProbabilityParams& CModelProbabilityParams::seasonalConfidenceInterval(dou
 
 double CModelProbabilityParams::seasonalConfidenceInterval() const {
     return m_SeasonalConfidenceInterval;
-}
-
-CModelProbabilityParams& CModelProbabilityParams::addBucketEmpty(const TBool2Vec& empty) {
-    m_BucketEmpty.push_back(empty);
-    return *this;
-}
-
-CModelProbabilityParams& CModelProbabilityParams::bucketEmpty(const TBool2Vec1Vec& empty) {
-    m_BucketEmpty = empty;
-    return *this;
-}
-
-const CModelProbabilityParams::TBool2Vec1Vec& CModelProbabilityParams::bucketEmpty() const {
-    return m_BucketEmpty;
 }
 
 CModelProbabilityParams&
@@ -286,35 +263,6 @@ const CModelParams& CModel::params() const {
 
 CModelParams& CModel::params() {
     return m_Params;
-}
-
-double CModel::jointProbabilityGivenBucket(bool empty, double probabilityBucketEmpty, double probability) {
-    if (empty == false) {
-        return (1.0 - probabilityBucketEmpty) * probability;
-    }
-    return probabilityBucketEmpty + (1.0 - probabilityBucketEmpty) * probability;
-}
-
-double CModel::jointProbabilityGivenBucket(const TBool2Vec& empty,
-                                           const TDouble2Vec& probabilityEmptyBucket,
-                                           double probability) {
-
-    double p00{probabilityEmptyBucket[0]};
-    double p10{probabilityEmptyBucket[1]};
-
-    if (empty[0] == false && empty[1] == false) {
-        return (1.0 - p00) * (1.0 - p10) * probability;
-    }
-
-    if (empty[0] == false) {
-        return (1.0 - p00) * probability * (p10 + (1.0 - p10) * probability);
-    }
-
-    if (empty[1] == false) {
-        return (p00 + (1.0 - p00) * probability) * (1.0 - p10) * probability;
-    }
-
-    return (p00 + (1.0 - p00) * probability) * (p10 + (1.0 - p10) * probability);
 }
 
 //////// CModelStub ////////

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -344,7 +344,7 @@ void reweightOutliers(const std::vector<T>& trend,
         CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr, std::greater<TDoubleSizePr>>;
 
     std::size_t period{trend.size()};
-    std::size_t numberOutliers{static_cast<std::size_t>([&] {
+    std::size_t numberOutliers{static_cast<std::size_t>([&period, &values] {
         std::size_t count(std::count_if(
             values.begin(), values.end(), [](const TFloatMeanAccumulator& value) {
                 return CBasicStatistics::count(value) > 0.0;
@@ -1838,7 +1838,7 @@ bool CPeriodicityHypothesisTests::testPeriodWithScaling(const TTimeTimePr2Vec& w
     }
 
     // Compute the degrees of freedom given the alternative hypothesis.
-    double b{[&] {
+    double b{[&windows, &period_, &values, this] {
         TDoubleVec repeats(calculateRepeats(windows, period_, m_BucketLength, values));
         return static_cast<double>(
             std::count_if(repeats.begin(), repeats.end(),
@@ -2056,7 +2056,7 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
     //   3) The significance of the variance reduction, and
     //   4) The amount of variance reduction.
 
-    auto calculateMeanRepeats = [&](const TTimeTimePr2Vec& w, core_t::TTime p) {
+    auto calculateMeanRepeats = [&values, this](const TTimeTimePr2Vec& w, core_t::TTime p) {
         TMeanAccumulator result;
         result.add(calculateRepeats(w, p, m_BucketLength, values));
         return CBasicStatistics::mean(result);
@@ -2140,7 +2140,7 @@ bool CPeriodicityHypothesisTests::testVariance(const TTimeTimePr2Vec& window,
     LOG_TRACE(<< "  autocorrelation          = " << R);
     LOG_TRACE(<< "  autocorrelationThreshold = " << stats.s_AutocorrelationThreshold);
 
-    meanRepeats = [&] {
+    meanRepeats = [&window, &period_, &buckets, this] {
         TMeanAccumulator result;
         result.add(calculateRepeats(window, period_, m_BucketLength, buckets));
         return CBasicStatistics::mean(result);

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -303,18 +303,16 @@ void project(const TFloatMeanAccumulatorVec& values,
 
 //! Calculate the number of non-empty buckets at each bucket offset in
 //! the period for the \p values in \p windows.
-TSizeVec calculateRepeats(const TSizeSizePr2Vec& windows,
-                          std::size_t period,
-                          const TFloatMeanAccumulatorVec& values) {
-    TSizeVec result(std::min(period, length(windows[0])), 0);
+TDoubleVec calculateRepeats(const TSizeSizePr2Vec& windows,
+                            std::size_t period,
+                            const TFloatMeanAccumulatorVec& values) {
+    TDoubleVec result(std::min(period, length(windows[0])), 0);
     std::size_t n{values.size()};
     for (const auto& window : windows) {
         std::size_t a{window.first};
         std::size_t b{window.second};
         for (std::size_t i = a; i < b; ++i) {
-            if (CBasicStatistics::count(values[i % n]) > 0.0) {
-                ++result[(i - a) % period];
-            }
+            result[(i - a) % period] += CBasicStatistics::count(values[i % n]);
         }
     }
     return result;
@@ -322,10 +320,10 @@ TSizeVec calculateRepeats(const TSizeSizePr2Vec& windows,
 
 //! Calculate the number of non-empty buckets at each bucket offset in
 //! the period for the \p values in \p windows.
-TSizeVec calculateRepeats(const TTimeTimePr2Vec& windows_,
-                          core_t::TTime period,
-                          core_t::TTime bucketLength,
-                          const TFloatMeanAccumulatorVec& values) {
+TDoubleVec calculateRepeats(const TTimeTimePr2Vec& windows_,
+                            core_t::TTime period,
+                            core_t::TTime bucketLength,
+                            const TFloatMeanAccumulatorVec& values) {
     TSizeSizePr2Vec windows;
     calculateIndexWindows(windows_, bucketLength, windows);
     return calculateRepeats(windows, period / bucketLength, values);
@@ -344,53 +342,52 @@ void reweightOutliers(const std::vector<T>& trend,
     using TMaxAccumulator =
         CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr, std::greater<TDoubleSizePr>>;
 
-    if (values.size() > 0) {
+    std::size_t numberOutliers{static_cast<std::size_t>([&] {
+        double count{static_cast<double>(std::count_if(
+            values.begin(), values.end(), [](const TFloatMeanAccumulator& value) {
+                return CBasicStatistics::count(value) > 0.0;
+            }))};
+        return SEASONAL_OUTLIER_FRACTION * count;
+    }())};
+    LOG_TRACE(<< "Number outliers = " << numberOutliers);
+
+    if (numberOutliers > 0) {
         TSizeSizePr2Vec windows;
         calculateIndexWindows(windows_, bucketLength, windows);
         std::size_t period{trend.size()};
         std::size_t n{values.size()};
 
-        TSizeVec repeats{calculateRepeats(windows, period, values)};
-        double excess{std::accumulate(
-            repeats.begin(), repeats.end(), 0.0, [](double excess_, std::size_t repeat) {
-                return excess_ + static_cast<double>(repeat > 1 ? repeat - 1 : 0);
-            })};
-        std::size_t numberOutliers{static_cast<std::size_t>(SEASONAL_OUTLIER_FRACTION * excess)};
-        LOG_TRACE(<< "Number outliers = " << numberOutliers);
-
-        if (numberOutliers > 0) {
-            TMaxAccumulator outliers{numberOutliers};
-            TMeanAccumulator meanDifference;
-            for (const auto& window : windows) {
-                std::size_t a{window.first};
-                std::size_t b{window.second};
-                for (std::size_t j = a; j < b; ++j) {
-                    const TFloatMeanAccumulator& value{values[j % n]};
-                    if (CBasicStatistics::count(value) > 0.0) {
-                        std::size_t offset{(j - a) % period};
-                        double difference{std::fabs(CBasicStatistics::mean(value) -
-                                                    CBasicStatistics::mean(trend[offset]))};
-                        outliers.add({difference, j});
-                        meanDifference.add(difference);
-                    }
+        TMaxAccumulator outliers{numberOutliers};
+        TMeanAccumulator meanDifference;
+        for (const auto& window : windows) {
+            std::size_t a{window.first};
+            std::size_t b{window.second};
+            for (std::size_t j = a; j < b; ++j) {
+                const TFloatMeanAccumulator& value{values[j % n]};
+                if (CBasicStatistics::count(value) > 0.0) {
+                    std::size_t offset{(j - a) % period};
+                    double difference{std::fabs(CBasicStatistics::mean(value) -
+                                                CBasicStatistics::mean(trend[offset]))};
+                    outliers.add({difference, j});
+                    meanDifference.add(difference);
                 }
             }
-            TMeanAccumulator meanDifferenceOfOutliers;
-            for (const auto& outlier : outliers) {
-                meanDifferenceOfOutliers.add(outlier.first);
-            }
-            meanDifference -= meanDifferenceOfOutliers;
-            LOG_TRACE(<< "mean difference = " << CBasicStatistics::mean(meanDifference));
-            LOG_TRACE(<< "outliers = " << core::CContainerPrinter::print(outliers));
-
-            for (const auto& outlier : outliers) {
-                if (outlier.first > SEASONAL_OUTLIER_DIFFERENCE_THRESHOLD *
-                                        CBasicStatistics::mean(meanDifference)) {
-                    CBasicStatistics::count(values[outlier.second % n]) *= SEASONAL_OUTLIER_WEIGHT;
-                }
-            }
-            LOG_TRACE(<< "Values - outliers = " << core::CContainerPrinter::print(values));
         }
+        TMeanAccumulator meanDifferenceOfOutliers;
+        for (const auto& outlier : outliers) {
+            meanDifferenceOfOutliers.add(outlier.first);
+        }
+        meanDifference -= meanDifferenceOfOutliers;
+        LOG_TRACE(<< "mean difference = " << CBasicStatistics::mean(meanDifference));
+        LOG_TRACE(<< "outliers = " << core::CContainerPrinter::print(outliers));
+
+        for (const auto& outlier : outliers) {
+            if (outlier.first > SEASONAL_OUTLIER_DIFFERENCE_THRESHOLD *
+                                    CBasicStatistics::mean(meanDifference)) {
+                CBasicStatistics::count(values[outlier.second % n]) *= SEASONAL_OUTLIER_WEIGHT;
+            }
+        }
+        LOG_TRACE(<< "Values - outliers = " << core::CContainerPrinter::print(values));
     }
 }
 
@@ -1207,7 +1204,7 @@ CPeriodicityHypothesisTests::best(const TNestedHypothesesVec& hypotheses) const 
 
     for (const auto& hypothesis : hypotheses) {
         STestStats stats{meanMagnitude};
-        stats.s_TrendSegments = static_cast<double>(hypothesis.trendSegments());
+        stats.s_TrendSegments = std::max(static_cast<double>(hypothesis.trendSegments()), 1.0);
         CPeriodicityHypothesisTestsResult resultForHypothesis{hypothesis.test(stats)};
         if (stats.s_NonEmptyBuckets > stats.s_DF0) {
             if (resultForHypothesis.periodic() == false) {
@@ -1839,10 +1836,12 @@ bool CPeriodicityHypothesisTests::testPeriodWithScaling(const TTimeTimePr2Vec& w
     }
 
     // Compute the degrees of freedom given the alternative hypothesis.
-    TSizeVec repeats(calculateRepeats(windows, period_, m_BucketLength, values));
-    double b{static_cast<double>(
-        std::count_if(repeats.begin(), repeats.end(),
-                      [](std::size_t repeat) { return repeat > 0; }))};
+    double b{[&] {
+        TDoubleVec repeats(calculateRepeats(windows, period_, m_BucketLength, values));
+        return static_cast<double>(
+            std::count_if(repeats.begin(), repeats.end(),
+                          [](double repeat) { return repeat > 0.0; }));
+    }()};
     double df1{stats.s_NonEmptyBuckets - b - static_cast<double>(segmentation.size() - 2)};
     LOG_TRACE(<< "  populated = " << b);
 
@@ -2056,13 +2055,9 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
     //   4) The amount of variance reduction.
 
     auto calculateMeanRepeats = [&](const TTimeTimePr2Vec& w, core_t::TTime p) {
-        TSizeVec repeats{calculateRepeats(w, p, m_BucketLength, values)};
-        return CBasicStatistics::mean(
-            std::accumulate(repeats.begin(), repeats.end(), TMeanAccumulator{},
-                            [](TMeanAccumulator mean, std::size_t r) {
-                                mean.add(static_cast<double>(r));
-                                return mean;
-                            }));
+        TMeanAccumulator result;
+        result.add(calculateRepeats(w, p, m_BucketLength, values));
+        return CBasicStatistics::mean(result);
     };
 
     double p{0.0};
@@ -2143,13 +2138,11 @@ bool CPeriodicityHypothesisTests::testVariance(const TTimeTimePr2Vec& window,
     LOG_TRACE(<< "  autocorrelation          = " << R);
     LOG_TRACE(<< "  autocorrelationThreshold = " << stats.s_AutocorrelationThreshold);
 
-    TSizeVec repeats{calculateRepeats(window, period_, m_BucketLength, buckets)};
-    meanRepeats = CBasicStatistics::mean(
-        std::accumulate(repeats.begin(), repeats.end(), TMeanAccumulator{},
-                        [](TMeanAccumulator mean, std::size_t repeat) {
-                            mean.add(static_cast<double>(repeat));
-                            return mean;
-                        }));
+    meanRepeats = [&] {
+        TMeanAccumulator result;
+        result.add(calculateRepeats(window, period_, m_BucketLength, buckets));
+        return CBasicStatistics::mean(result);
+    }();
     LOG_TRACE(<< "  mean repeats = " << meanRepeats);
 
     // We're trading off:

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -253,7 +253,7 @@ void CForecastTest::testComplexVaryingLongTermTrend() {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    this->test(trend, bucketLength, 63, 4.0, 15.0, 0.04);
+    this->test(trend, bucketLength, 63, 4.0, 19.0, 0.04);
 }
 
 void CForecastTest::testNonNegative() {

--- a/lib/maths/unittest/CModelTest.cc
+++ b/lib/maths/unittest/CModelTest.cc
@@ -63,8 +63,6 @@ void CModelTest::testAll() {
         params.addCalculation(maths_t::E_OneSidedAbove)
             .addCalculation(maths_t::E_TwoSided)
             .seasonalConfidenceInterval(50.0)
-            .addBucketEmpty({true, true})
-            .addBucketEmpty({false, true})
             .addWeights(weight1)
             .addWeights(weight2)
             .mostAnomalousCorrelate(1)
@@ -74,8 +72,6 @@ void CModelTest::testAll() {
         CPPUNIT_ASSERT_EQUAL(maths_t::E_OneSidedAbove, params.calculation(0));
         CPPUNIT_ASSERT_EQUAL(maths_t::E_TwoSided, params.calculation(1));
         CPPUNIT_ASSERT_EQUAL(50.0, params.seasonalConfidenceInterval());
-        CPPUNIT_ASSERT_EQUAL(std::string("[[true, true], [false, true]]"),
-                             core::CContainerPrinter::print(params.bucketEmpty()));
         CPPUNIT_ASSERT_EQUAL(core::CContainerPrinter::print(weights),
                              core::CContainerPrinter::print(params.weights()));
         CPPUNIT_ASSERT_EQUAL(std::size_t(1), *params.mostAnomalousCorrelate());

--- a/lib/maths/unittest/CModelTest.cc
+++ b/lib/maths/unittest/CModelTest.cc
@@ -32,9 +32,6 @@ void CModelTest::testAll() {
         CPPUNIT_ASSERT_EQUAL(decayRate, params.decayRate());
         CPPUNIT_ASSERT_EQUAL(minimumSeasonalVarianceScale,
                              params.minimumSeasonalVarianceScale());
-        CPPUNIT_ASSERT_EQUAL(0.0, params.probabilityBucketEmpty());
-        params.probabilityBucketEmpty(0.2);
-        CPPUNIT_ASSERT_EQUAL(0.2, params.probabilityBucketEmpty());
         CPPUNIT_ASSERT_EQUAL(6 * core::constants::HOUR, params.minimumTimeToDetectChange());
         CPPUNIT_ASSERT_EQUAL(core::constants::DAY, params.maximumTimeToTestForChange());
     }

--- a/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
+++ b/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
@@ -660,9 +660,8 @@ void CPeriodicityHypothesisTestsTest::testWithOutliers() {
             maths::CPeriodicityHypothesisTestsResult result{
                 maths::testForPeriods(config, startTime, bucketLength, values)};
             LOG_DEBUG(<< "result = " << result.print());
-            CPPUNIT_ASSERT(
-                result.print() == std::string("{ 'weekend daily' 'weekday daily' }") ||
-                result.print() == std::string("{ 'weekend daily' 'weekday daily' 'weekend weekly' }"));
+            CPPUNIT_ASSERT(result.print() ==
+                           std::string("{ 'weekend daily' 'weekday daily' 'weekend weekly' }"));
         }
     }
 }

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -120,10 +120,7 @@ maths::CModelAddSamplesParams addSampleParams(const TDouble2VecWeightsAryVec& we
 
 maths::CModelProbabilityParams computeProbabilityParams(const TDouble2VecWeightsAry& weight) {
     maths::CModelProbabilityParams params;
-    params.addCalculation(maths_t::E_TwoSided)
-        .seasonalConfidenceInterval(50.0)
-        .addBucketEmpty({false})
-        .addWeights(weight);
+    params.addCalculation(maths_t::E_TwoSided).seasonalConfidenceInterval(50.0).addWeights(weight);
     return params;
 }
 
@@ -1211,7 +1208,6 @@ void CTimeSeriesModelTest::testProbability() {
         maths_t::EProbabilityCalculation calculations[]{maths_t::E_TwoSided,
                                                         maths_t::E_OneSidedAbove};
         double confidences[]{0.0, 20.0, 50.0};
-        bool empties[]{true, false};
         TDouble2VecWeightsAryVec weights(2, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
         maths_t::setCountVarianceScale(TDouble2Vec{0.9}, weights[0]);
         maths_t::setCountVarianceScale(TDouble2Vec{1.1}, weights[1]);
@@ -1221,47 +1217,41 @@ void CTimeSeriesModelTest::testProbability() {
             LOG_DEBUG(<< "calculation = " << calculation);
             for (auto confidence : confidences) {
                 LOG_DEBUG(<< " confidence = " << confidence);
-                for (auto empty : empties) {
-                    LOG_DEBUG(<< "  empty = " << empty);
-                    for (const auto& weight : weights) {
-                        LOG_DEBUG(<< "   weights = "
-                                  << core::CContainerPrinter::print(weight));
-                        double expectedProbability[2];
-                        maths_t::ETail expectedTail[2];
-                        {
-                            maths_t::TDoubleWeightsAry weight_(maths_t::CUnitWeights::UNIT);
-                            for (std::size_t i = 0u; i < weight.size(); ++i) {
-                                weight_[i] = weight[i][0];
-                            }
-                            double lb[2], ub[2];
-                            model0.residualModel().probabilityOfLessLikelySamples(
-                                calculation, sample, {weight_}, lb[0], ub[0],
-                                expectedTail[0]);
-                            model1.residualModel().probabilityOfLessLikelySamples(
-                                calculation,
-                                {model1.trendModel().detrend(time, sample[0], confidence)},
-                                {weight_}, lb[1], ub[1], expectedTail[1]);
-                            expectedProbability[0] = (lb[0] + ub[0]) / 2.0;
-                            expectedProbability[1] = (lb[1] + ub[1]) / 2.0;
+                for (const auto& weight : weights) {
+                    LOG_DEBUG(<< "   weights = " << core::CContainerPrinter::print(weight));
+                    double expectedProbability[2];
+                    maths_t::ETail expectedTail[2];
+                    {
+                        maths_t::TDoubleWeightsAry weight_(maths_t::CUnitWeights::UNIT);
+                        for (std::size_t i = 0u; i < weight.size(); ++i) {
+                            weight_[i] = weight[i][0];
                         }
-
-                        maths::SModelProbabilityResult results[2];
-                        {
-                            maths::CModelProbabilityParams params;
-                            params.addCalculation(calculation)
-                                .seasonalConfidenceInterval(confidence)
-                                .addBucketEmpty({empty})
-                                .addWeights(weight)
-                                .useMultibucketFeatures(false);
-                            model0.probability(params, time_, {sample}, results[0]);
-                            model1.probability(params, time_, {sample}, results[1]);
-                        }
-
-                        CPPUNIT_ASSERT_EQUAL(expectedProbability[0], results[0].s_Probability);
-                        CPPUNIT_ASSERT_EQUAL(expectedTail[0], results[0].s_Tail[0]);
-                        CPPUNIT_ASSERT_EQUAL(expectedProbability[1], results[1].s_Probability);
-                        CPPUNIT_ASSERT_EQUAL(expectedTail[1], results[1].s_Tail[0]);
+                        double lb[2], ub[2];
+                        model0.residualModel().probabilityOfLessLikelySamples(
+                            calculation, sample, {weight_}, lb[0], ub[0], expectedTail[0]);
+                        model1.residualModel().probabilityOfLessLikelySamples(
+                            calculation,
+                            {model1.trendModel().detrend(time, sample[0], confidence)},
+                            {weight_}, lb[1], ub[1], expectedTail[1]);
+                        expectedProbability[0] = (lb[0] + ub[0]) / 2.0;
+                        expectedProbability[1] = (lb[1] + ub[1]) / 2.0;
                     }
+
+                    maths::SModelProbabilityResult results[2];
+                    {
+                        maths::CModelProbabilityParams params;
+                        params.addCalculation(calculation)
+                            .seasonalConfidenceInterval(confidence)
+                            .addWeights(weight)
+                            .useMultibucketFeatures(false);
+                        model0.probability(params, time_, {sample}, results[0]);
+                        model1.probability(params, time_, {sample}, results[1]);
+                    }
+
+                    CPPUNIT_ASSERT_EQUAL(expectedProbability[0], results[0].s_Probability);
+                    CPPUNIT_ASSERT_EQUAL(expectedTail[0], results[0].s_Tail[0]);
+                    CPPUNIT_ASSERT_EQUAL(expectedProbability[1], results[1].s_Probability);
+                    CPPUNIT_ASSERT_EQUAL(expectedTail[1], results[1].s_Tail[0]);
                 }
             }
         }
@@ -1312,7 +1302,6 @@ void CTimeSeriesModelTest::testProbability() {
         maths_t::EProbabilityCalculation calculations[]{maths_t::E_TwoSided,
                                                         maths_t::E_OneSidedAbove};
         double confidences[]{0.0, 20.0, 50.0};
-        bool empties[]{true, false};
         TDouble2VecWeightsAryVec weights(2, maths_t::CUnitWeights::unit<TDouble2Vec>(3));
         maths_t::setCountVarianceScale(TDouble2Vec{0.9, 0.9, 0.8}, weights[0]);
         maths_t::setCountVarianceScale(TDouble2Vec{1.1, 1.0, 1.2}, weights[1]);
@@ -1322,53 +1311,48 @@ void CTimeSeriesModelTest::testProbability() {
             LOG_DEBUG(<< "calculation = " << calculation);
             for (auto confidence : confidences) {
                 LOG_DEBUG(<< " confidence = " << confidence);
-                for (auto empty : empties) {
-                    LOG_DEBUG(<< "  empty = " << empty);
-                    for (const auto& weight : weights) {
-                        LOG_DEBUG(<< "   weights = "
-                                  << core::CContainerPrinter::print(weight));
-                        double expectedProbability[2];
-                        TTail10Vec expectedTail[2];
-                        {
-                            maths_t::TDouble10VecWeightsAry weight_(
-                                maths_t::CUnitWeights::unit<TDouble10Vec>(3));
-                            for (std::size_t i = 0u; i < weight.size(); ++i) {
-                                weight_[i] = weight[i];
-                            }
-                            double lb[2], ub[2];
-                            model0.residualModel().probabilityOfLessLikelySamples(
-                                calculation, {TDouble10Vec(sample)}, {weight_},
-                                lb[0], ub[0], expectedTail[0]);
-                            TDouble10Vec detrended;
-                            for (std::size_t j = 0u; j < sample.size(); ++j) {
-                                detrended.push_back(model1.trendModel()[j]->detrend(
-                                    time, sample[j], confidence));
-                            }
-                            model1.residualModel().probabilityOfLessLikelySamples(
-                                calculation, {detrended}, {weight_}, lb[1],
-                                ub[1], expectedTail[1]);
-                            expectedProbability[0] = (lb[0] + ub[0]) / 2.0;
-                            expectedProbability[1] = (lb[1] + ub[1]) / 2.0;
+                for (const auto& weight : weights) {
+                    LOG_DEBUG(<< "   weights = " << core::CContainerPrinter::print(weight));
+                    double expectedProbability[2];
+                    TTail10Vec expectedTail[2];
+                    {
+                        maths_t::TDouble10VecWeightsAry weight_(
+                            maths_t::CUnitWeights::unit<TDouble10Vec>(3));
+                        for (std::size_t i = 0u; i < weight.size(); ++i) {
+                            weight_[i] = weight[i];
                         }
+                        double lb[2], ub[2];
+                        model0.residualModel().probabilityOfLessLikelySamples(
+                            calculation, {TDouble10Vec(sample)}, {weight_},
+                            lb[0], ub[0], expectedTail[0]);
+                        TDouble10Vec detrended;
+                        for (std::size_t j = 0u; j < sample.size(); ++j) {
+                            detrended.push_back(model1.trendModel()[j]->detrend(
+                                time, sample[j], confidence));
+                        }
+                        model1.residualModel().probabilityOfLessLikelySamples(
+                            calculation, {detrended}, {weight_}, lb[1], ub[1],
+                            expectedTail[1]);
+                        expectedProbability[0] = (lb[0] + ub[0]) / 2.0;
+                        expectedProbability[1] = (lb[1] + ub[1]) / 2.0;
+                    }
 
-                        maths::SModelProbabilityResult results[2];
-                        {
-                            maths::CModelProbabilityParams params;
-                            params.addCalculation(calculation)
-                                .seasonalConfidenceInterval(confidence)
-                                .addBucketEmpty({empty})
-                                .addWeights(weight)
-                                .useMultibucketFeatures(false);
-                            model0.probability(params, time_, {sample}, results[0]);
-                            model1.probability(params, time_, {sample}, results[1]);
-                        }
+                    maths::SModelProbabilityResult results[2];
+                    {
+                        maths::CModelProbabilityParams params;
+                        params.addCalculation(calculation)
+                            .seasonalConfidenceInterval(confidence)
+                            .addWeights(weight)
+                            .useMultibucketFeatures(false);
+                        model0.probability(params, time_, {sample}, results[0]);
+                        model1.probability(params, time_, {sample}, results[1]);
+                    }
 
-                        CPPUNIT_ASSERT_EQUAL(expectedProbability[0], results[0].s_Probability);
-                        CPPUNIT_ASSERT_EQUAL(expectedProbability[1], results[1].s_Probability);
-                        for (std::size_t j = 0u; j < 3; ++j) {
-                            CPPUNIT_ASSERT_EQUAL(expectedTail[0][j], results[0].s_Tail[j]);
-                            CPPUNIT_ASSERT_EQUAL(expectedTail[1][j], results[1].s_Tail[j]);
-                        }
+                    CPPUNIT_ASSERT_EQUAL(expectedProbability[0], results[0].s_Probability);
+                    CPPUNIT_ASSERT_EQUAL(expectedProbability[1], results[1].s_Probability);
+                    for (std::size_t j = 0u; j < 3; ++j) {
+                        CPPUNIT_ASSERT_EQUAL(expectedTail[0][j], results[0].s_Tail[j]);
+                        CPPUNIT_ASSERT_EQUAL(expectedTail[1][j], results[1].s_Tail[j]);
                     }
                 }
             }

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -67,7 +67,6 @@ const double CAnomalyDetectorModelConfig::DEFAULT_INDIVIDUAL_MINIMUM_MODE_FRACTI
 const double CAnomalyDetectorModelConfig::DEFAULT_POPULATION_MINIMUM_MODE_FRACTION(0.05);
 const double CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_CLUSTER_SPLIT_COUNT(12.0);
 const double CAnomalyDetectorModelConfig::DEFAULT_CATEGORY_DELETE_FRACTION(0.8);
-const double CAnomalyDetectorModelConfig::DEFAULT_CUTOFF_TO_MODEL_EMPTY_BUCKETS(0.2);
 const std::size_t CAnomalyDetectorModelConfig::DEFAULT_COMPONENT_SIZE(36u);
 const core_t::TTime
     CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_TIME_TO_DETECT_CHANGE(core::constants::DAY);

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -381,7 +381,7 @@ bool CEventRateModel::computeProbability(std::size_t pid,
 
         addPersonProbability = true;
 
-        LOG_TRACE(<< "Compute probability for " << data->print());
+        LOG_TRACE(<< "value(" << this->personName(pid) << ") = " << data->print());
 
         if (this->correlates(feature, pid, startTime)) {
             CProbabilityAndInfluenceCalculator::SCorrelateParams params(partitioningFields);

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -304,9 +304,6 @@ void CEventRateModel::sample(core_t::TTime startTime,
                           << ", empty bucket weight = " << emptyBucketWeight
                           << ", derate = " << derate << ", interval = " << interval);
 
-                model->params().probabilityBucketEmpty(
-                    this->probabilityBucketEmpty(feature, pid));
-
                 TDouble2Vec value{count};
                 values.assign(1, core::make_triple(sampleTime, value, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID));
                 weights.resize(1, maths_t::CUnitWeights::unit<TDouble2Vec>(dimension));
@@ -591,7 +588,6 @@ bool CEventRateModel::fill(model_t::EFeature feature,
     }
 
     core_t::TTime time{model_t::sampleTime(feature, bucketTime, this->bucketLength())};
-    TOptionalUInt64 count{this->currentBucketCount(pid, bucketTime)};
     double value{model_t::offsetCountToZero(feature, static_cast<double>(data->s_Count))};
     maths_t::TDouble2VecWeightsAry weight(maths_t::seasonalVarianceScaleWeight(
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time)));
@@ -612,8 +608,7 @@ bool CEventRateModel::fill(model_t::EFeature feature,
     }
     params.s_Count = 1.0;
     params.s_ComputeProbabilityParams
-        .addCalculation(model_t::probabilityCalculation(feature)) // new line
-        .addBucketEmpty({!count || *count == 0})
+        .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weight)
         .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 
@@ -674,12 +669,8 @@ void CEventRateModel::fill(model_t::EFeature feature,
             maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time)[0];
         scale[variables[1]] = models[1]->seasonalWeight(
             maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time)[0];
-        TOptionalUInt64 count[2];
-        count[0] = this->currentBucketCount(correlates[i][0], bucketTime);
-        count[1] = this->currentBucketCount(correlates[i][1], bucketTime);
-        params.s_ComputeProbabilityParams
-            .addBucketEmpty({!count[0] || *count[0] == 0, !count[1] || *count[1] == 0}) // new line
-            .addWeights(maths_t::seasonalVarianceScaleWeight(scale));
+        params.s_ComputeProbabilityParams.addWeights(
+            maths_t::seasonalVarianceScaleWeight(scale));
 
         const TFeatureData* data[2];
         data[0] = this->featureData(feature, correlates[i][0], bucketTime);

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -1040,7 +1040,6 @@ bool CEventRatePopulationModel::fill(model_t::EFeature feature,
     params.s_Count = 1.0;
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
-        .addBucketEmpty({false})
         .addWeights(weight)
         .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -277,9 +277,6 @@ void CMetricModel::sample(core_t::TTime startTime,
                           << ", count weight = " << count << ", dimension = " << dimension
                           << ", empty bucket weight = " << emptyBucketWeight);
 
-                model->params().probabilityBucketEmpty(
-                    this->probabilityBucketEmpty(feature, pid));
-
                 values.resize(n);
                 trendWeights.resize(n, maths_t::CUnitWeights::unit<TDouble2Vec>(dimension));
                 priorWeights.resize(n, maths_t::CUnitWeights::unit<TDouble2Vec>(dimension));
@@ -553,7 +550,6 @@ bool CMetricModel::fill(model_t::EFeature feature,
     maths_t::setSeasonalVarianceScale(
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time), weights);
     maths_t::setCountVarianceScale(TDouble2Vec(dimension, bucket->varianceScale()), weights);
-    TOptionalUInt64 count{this->currentBucketCount(pid, bucketTime)};
     bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
         feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
 
@@ -572,8 +568,7 @@ bool CMetricModel::fill(model_t::EFeature feature,
     }
     params.s_Count = bucket->count();
     params.s_ComputeProbabilityParams
-        .addCalculation(model_t::probabilityCalculation(feature)) // new line
-        .addBucketEmpty({!count || *count == 0})
+        .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weights)
         .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 
@@ -686,12 +681,7 @@ void CMetricModel::fill(model_t::EFeature feature,
                 }
             }
         }
-        TOptionalUInt64 count[2];
-        count[0] = this->currentBucketCount(correlates[i][0], bucketTime);
-        count[1] = this->currentBucketCount(correlates[i][1], bucketTime);
-        params.s_ComputeProbabilityParams
-            .addBucketEmpty({!count[0] || *count[0] == 0, !count[1] || *count[1] == 0}) // new line
-            .addWeights(weight);
+        params.s_ComputeProbabilityParams.addWeights(weight);
     }
     if (interim && model_t::requiresInterimResultAdjustment(feature)) {
         core_t::TTime time{bucketTime + bucketLength / 2};

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -959,7 +959,6 @@ bool CMetricPopulationModel::fill(model_t::EFeature feature,
     params.s_Count = bucket->count();
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
-        .addBucketEmpty({false})
         .addWeights(weights)
         .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
 

--- a/lib/model/CModelDetailsView.cc
+++ b/lib/model/CModelDetailsView.cc
@@ -132,7 +132,7 @@ void CModelDetailsView::addCurrentBucketValues(core_t::TTime time,
         }
     };
 
-    if (model_t::countsEmptyBuckets(feature)) {
+    if (model_t::includeEmptyBuckets(feature)) {
         for (std::size_t pid = 0u; pid < gatherer.numberPeople(); ++pid) {
             if (gatherer.isPersonActive(pid)) {
                 if (isPopulation) {

--- a/lib/model/CModelParams.cc
+++ b/lib/model/CModelParams.cc
@@ -30,7 +30,6 @@ SModelParams::SModelParams(core_t::TTime bucketLength)
       s_InitialDecayRateMultiplier(CAnomalyDetectorModelConfig::DEFAULT_INITIAL_DECAY_RATE_MULTIPLIER),
       s_ControlDecayRate(true), s_MinimumModeFraction(0.0),
       s_MinimumModeCount(CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_CLUSTER_SPLIT_COUNT),
-      s_CutoffToModelEmptyBuckets(CAnomalyDetectorModelConfig::DEFAULT_CUTOFF_TO_MODEL_EMPTY_BUCKETS),
       s_ComponentSize(CAnomalyDetectorModelConfig::DEFAULT_COMPONENT_SIZE),
       s_MinimumTimeToDetectChange(CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_TIME_TO_DETECT_CHANGE),
       s_MaximumTimeToTestForChange(CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE),
@@ -90,7 +89,6 @@ uint64_t SModelParams::checksum(uint64_t seed) const {
     seed = maths::CChecksum::calculate(seed, s_InitialDecayRateMultiplier);
     seed = maths::CChecksum::calculate(seed, s_MinimumModeFraction);
     seed = maths::CChecksum::calculate(seed, s_MinimumModeCount);
-    seed = maths::CChecksum::calculate(seed, s_CutoffToModelEmptyBuckets);
     seed = maths::CChecksum::calculate(seed, s_ComponentSize);
     seed = maths::CChecksum::calculate(seed, s_MinimumTimeToDetectChange);
     seed = maths::CChecksum::calculate(seed, s_MaximumTimeToTestForChange);

--- a/lib/model/CProbabilityAndInfluenceCalculator.cc
+++ b/lib/model/CProbabilityAndInfluenceCalculator.cc
@@ -146,6 +146,7 @@ double ratio(double numerator, double denominator, double zeroDividedByZero) {
 }
 
 // Functions to compute influence based on different criteria
+
 //! \brief Computes the value of summed statistics on the set difference.
 class CValueDifference {
 public:
@@ -154,16 +155,14 @@ public:
                     double n,
                     const TDouble1Vec& vi,
                     double ni,
-                    maths::CModelProbabilityParams& params,
+                    maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& difference) const {
         if (n < ni) {
             return false;
         }
-
         for (std::size_t i = 0u; i < v.size(); ++i) {
             difference[i] = v[i] - vi[i];
         }
-        params.bucketEmpty({{n == ni}});
         return true;
     }
 
@@ -172,17 +171,14 @@ public:
                     const TDouble2Vec& n,
                     const TDouble1Vec& vi,
                     const TDouble1Vec& ni,
-                    maths::CModelProbabilityParams& params,
+                    maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& difference) const {
         if (n < ni) {
             return false;
         }
-        TBool2Vec bucketEmpty(2);
         for (std::size_t d = 0u; d < 2; ++d) {
-            bucketEmpty[d] = (n[d] == ni[d]);
             difference[d] = v[d] - vi[d];
         }
-        params.bucketEmpty({bucketEmpty});
         return true;
     }
 };
@@ -195,12 +191,11 @@ public:
                     double /*n*/,
                     const TDouble1Vec& vi,
                     double ni,
-                    maths::CModelProbabilityParams& params,
+                    maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& intersection) const {
         for (std::size_t i = 0u; i < vi.size(); ++i) {
             intersection[i] = vi[i];
         }
-        params.bucketEmpty({{ni == 0}});
         return true;
     }
 
@@ -209,15 +204,11 @@ public:
                     const TDouble2Vec& /*n*/,
                     const TDouble1Vec& vi,
                     const TDouble1Vec& ni,
-                    maths::CModelProbabilityParams& params,
+                    maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& intersection) const {
-
-        TBool2Vec bucketEmpty(2);
         for (std::size_t d = 0u; d < 2; ++d) {
-            bucketEmpty[d] = (ni[d] == 0);
             intersection[d] = vi[d];
         }
-        params.bucketEmpty({bucketEmpty});
         return true;
     }
 };
@@ -251,7 +242,6 @@ public:
         }
         TDouble2Vec scale(dimension, n / (n - ni));
         maths_t::multiplyCountVarianceScale(scale, params.weights()[0]);
-        params.bucketEmpty({{n == ni}});
 
         return true;
     }
@@ -267,16 +257,13 @@ public:
             return false;
         }
 
-        TBool2Vec bucketEmpty(2);
         for (std::size_t d = 0u; d < 2; ++d) {
-            bucketEmpty[d] = (n[d] == ni[d]);
             difference[d] = maths::CBasicStatistics::mean(
                 maths::CBasicStatistics::momentsAccumulator(n[d], v[d]) -
                 maths::CBasicStatistics::momentsAccumulator(ni[d], vi[d]));
         }
         TDouble2Vec scale{n[0] / (n[0] - ni[0]), n[1] / (n[1] - ni[1])};
         maths_t::multiplyCountVarianceScale(scale, params.weights()[0]);
-        params.bucketEmpty({bucketEmpty});
 
         return true;
     }
@@ -311,7 +298,6 @@ public:
         }
         TDouble2Vec scale(dimension, n / (n - ni));
         maths_t::multiplyCountVarianceScale(scale, params.weights()[0]);
-        params.bucketEmpty({{n == ni}});
 
         return true;
     }
@@ -327,14 +313,11 @@ public:
             return false;
         }
 
-        TBool2Vec bucketEmpty(2);
         for (std::size_t d = 0u; d < 2; ++d) {
-            bucketEmpty[d] = (n[d] == ni[d]);
             difference[d] = maths::CBasicStatistics::maximumLikelihoodVariance(
                 maths::CBasicStatistics::momentsAccumulator(n[d], v[2 + d], v[d]) -
                 maths::CBasicStatistics::momentsAccumulator(ni[d], vi[2 + d], vi[d]));
         }
-        params.bucketEmpty({bucketEmpty});
         TDouble2Vec scale{n[0] / (n[0] - ni[0]), n[1] / (n[1] - ni[1])};
         maths_t::multiplyCountVarianceScale(scale, params.weights()[0]);
 
@@ -411,10 +394,7 @@ void doComputeInfluences(model_t::EFeature feature,
     };
 
     maths_t::TDouble2VecWeightsAry1Vec weights(computeProbabilityParams.weights());
-    computeProbabilityParams.weights(weights)
-        .useMultibucketFeatures(false)
-        .useAnomalyModel(false)
-        .bucketEmpty({{count == 0.0}});
+    computeProbabilityParams.weights(weights).useMultibucketFeatures(false).useAnomalyModel(false);
     maths::SModelProbabilityResult overallResult;
     model.probability(computeProbabilityParams, time,
                       model_t::stripExtraStatistics(feature, {value}), overallResult);
@@ -517,10 +497,7 @@ void doComputeCorrelateInfluences(model_t::EFeature feature,
     }
 
     maths_t::TDouble2VecWeightsAry1Vec weights(computeProbabilityParams.weights());
-    computeProbabilityParams.weights(weights)
-        .useMultibucketFeatures(false)
-        .useAnomalyModel(false)
-        .bucketEmpty({{count[0] == 0.0, count[1] == 0.0}});
+    computeProbabilityParams.weights(weights).useMultibucketFeatures(false).useAnomalyModel(false);
     maths::SModelProbabilityResult overallResult;
     model.probability(computeProbabilityParams, {time},
                       model_t::stripExtraStatistics(feature, {value}), overallResult);

--- a/lib/model/CProbabilityAndInfluenceCalculator.cc
+++ b/lib/model/CProbabilityAndInfluenceCalculator.cc
@@ -152,14 +152,11 @@ class CValueDifference {
 public:
     //! Features.
     bool operator()(const TDouble2Vec& v,
-                    double n,
+                    double /*n*/,
                     const TDouble1Vec& vi,
-                    double ni,
+                    double /*ni*/,
                     maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& difference) const {
-        if (n < ni) {
-            return false;
-        }
         for (std::size_t i = 0u; i < v.size(); ++i) {
             difference[i] = v[i] - vi[i];
         }
@@ -168,14 +165,11 @@ public:
 
     //! Correlates.
     bool operator()(const TDouble2Vec& v,
-                    const TDouble2Vec& n,
+                    const TDouble2Vec& /*n*/,
                     const TDouble1Vec& vi,
-                    const TDouble1Vec& ni,
+                    const TDouble1Vec& /*ni*/,
                     maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& difference) const {
-        if (n < ni) {
-            return false;
-        }
         for (std::size_t d = 0u; d < 2; ++d) {
             difference[d] = v[d] - vi[d];
         }
@@ -190,7 +184,7 @@ public:
     bool operator()(const TDouble2Vec& /*v*/,
                     double /*n*/,
                     const TDouble1Vec& vi,
-                    double ni,
+                    double /*ni*/,
                     maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& intersection) const {
         for (std::size_t i = 0u; i < vi.size(); ++i) {
@@ -203,7 +197,7 @@ public:
     bool operator()(const TDouble2Vec& /*v*/,
                     const TDouble2Vec& /*n*/,
                     const TDouble1Vec& vi,
-                    const TDouble1Vec& ni,
+                    const TDouble1Vec& /*ni*/,
                     maths::CModelProbabilityParams& /*params*/,
                     TDouble2Vec& intersection) const {
         for (std::size_t d = 0u; d < 2; ++d) {
@@ -286,7 +280,7 @@ public:
                     double ni,
                     maths::CModelProbabilityParams& params,
                     TDouble2Vec& difference) const {
-        if (n < ni) {
+        if (n <= ni) {
             return false;
         }
 
@@ -309,7 +303,7 @@ public:
                     const TDouble1Vec& ni,
                     maths::CModelProbabilityParams& params,
                     TDouble2Vec& difference) const {
-        if (n < ni) {
+        if (n <= ni) {
             return false;
         }
 

--- a/lib/model/ModelTypes.cc
+++ b/lib/model/ModelTypes.cc
@@ -693,7 +693,7 @@ void inverseOffsetCountToZero(EFeature feature, TDouble1Vec& count) {
     }
 }
 
-bool countsEmptyBuckets(EFeature feature) {
+bool includeEmptyBuckets(EFeature feature) {
     switch (feature) {
     case E_IndividualCountByBucketAndPerson:
     case E_IndividualLowCountsByBucketAndPerson:
@@ -749,22 +749,6 @@ bool countsEmptyBuckets(EFeature feature) {
         return false;
     }
     return false;
-}
-
-double emptyBucketCountWeight(EFeature feature, double frequency, double cutoff) {
-    if (countsEmptyBuckets(feature) && cutoff > 0.0) {
-        static const double M = 1.001;
-        static const double C = 0.025;
-        static const double K = std::log((M + 1.0) / (M - 1.0)) / C;
-        double df = frequency - std::min(cutoff + C, 1.0);
-        if (df < -C) {
-            return 0.0;
-        } else if (df < C) {
-            double fa = std::exp(K * df);
-            return 0.5 * (1.0 + M * (fa - 1.0) / (fa + 1.0));
-        }
-    }
-    return 1.0;
 }
 
 double learnRate(EFeature feature, const model::SModelParams& params) {

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -170,22 +170,20 @@ void importData(ml::core_t::TTime firstTime,
 }
 
 void CEventRateAnomalyDetectorTest::testAnomalies() {
-    // We have 11 instances of correlated 503s and rare SQL statements
-    // and one extended drop in status 200s, which are the principal
-    // anomalies to find in this data set.
-    static const double HIGH_ANOMALY_SCORE(0.0018);
-    static const size_t EXPECTED_ANOMALOUS_HOURS(13);
+    // We have 11 instances of correlated rare 503s and SQL statements.
+    static const double HIGH_ANOMALY_SCORE(0.0014);
+    static const size_t EXPECTED_ANOMALOUS_HOURS(11);
 
     static const ml::core_t::TTime FIRST_TIME(1346713620);
     static const ml::core_t::TTime LAST_TIME(1347317974);
-    static const ml::core_t::TTime BUCKET_SIZE(1800);
+    static const ml::core_t::TTime BUCKET_SIZE(600);
 
     ml::model::CAnomalyDetectorModelConfig modelConfig =
         ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
     ml::model::CLimits limits;
 
     ml::model::CSearchKey key(1, // identifier
-                              ml::model::function_t::E_IndividualRareCount, false,
+                              ml::model::function_t::E_IndividualRare, false,
                               ml::model_t::E_XF_None, EMPTY_STRING, "status");
     ml::model::CAnomalyDetector detector(1, // identifier
                                          limits, modelConfig, EMPTY_STRING,

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2130,7 +2130,8 @@ void CEventRateModelTest::testSkipSampling() {
 
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
-    model_t::TFeatureVec features{model_t::E_IndividualCountByBucketAndPerson};
+    model_t::EFeature feature{model_t::E_IndividualCountByBucketAndPerson};
+    model_t::TFeatureVec features{feature};
     CModelFactory::TDataGathererPtr gathererNoGap;
     CModelFactory::TModelPtr modelNoGap_;
     this->makeModel(params, features, startTime, 2, gathererNoGap, modelNoGap_);
@@ -2176,24 +2177,22 @@ void CEventRateModelTest::testSkipSampling() {
     modelWithGap->sample(1100, 1200, m_ResourceMonitor);
 
     // Check priors are the same
-    CPPUNIT_ASSERT_EQUAL(
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelWithGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 0))
-            ->residualModel()
-            .checksum(),
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelNoGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 0))
-            ->residualModel()
-            .checksum());
-    CPPUNIT_ASSERT_EQUAL(
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelWithGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 1))
-            ->residualModel()
-            .checksum(),
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelNoGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 1))
-            ->residualModel()
-            .checksum());
+    CPPUNIT_ASSERT_EQUAL(static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelWithGap->details()->model(feature, 0))
+                             ->residualModel()
+                             .checksum(),
+                         static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelNoGap->details()->model(feature, 0))
+                             ->residualModel()
+                             .checksum());
+    CPPUNIT_ASSERT_EQUAL(static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelWithGap->details()->model(feature, 1))
+                             ->residualModel()
+                             .checksum(),
+                         static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelNoGap->details()->model(feature, 1))
+                             ->residualModel()
+                             .checksum());
 
     // Confirm last seen times are only updated by gap duration by forcing p2 to be pruned
     modelWithGap->sample(1200, 1500, m_ResourceMonitor);
@@ -2213,7 +2212,8 @@ void CEventRateModelTest::testExplicitNulls() {
 
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
-    model_t::TFeatureVec features{model_t::E_IndividualCountByBucketAndPerson};
+    model_t::EFeature feature{model_t::E_IndividualNonZeroCountByBucketAndPerson};
+    model_t::TFeatureVec features{feature};
     CModelFactory::TDataGathererPtr gathererSkipGap;
     CModelFactory::TModelPtr modelSkipGap_;
     this->makeModel(params, features, startTime, 0, gathererSkipGap,
@@ -2286,24 +2286,22 @@ void CEventRateModelTest::testExplicitNulls() {
     modelExNullGap->sample(600, 700, m_ResourceMonitor);
 
     // Check priors are the same
-    CPPUNIT_ASSERT_EQUAL(
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelExNullGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 0))
-            ->residualModel()
-            .checksum(),
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelSkipGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 0))
-            ->residualModel()
-            .checksum());
-    CPPUNIT_ASSERT_EQUAL(
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelExNullGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 1))
-            ->residualModel()
-            .checksum(),
-        static_cast<const maths::CUnivariateTimeSeriesModel*>(
-            modelSkipGap->details()->model(model_t::E_IndividualCountByBucketAndPerson, 1))
-            ->residualModel()
-            .checksum());
+    CPPUNIT_ASSERT_EQUAL(static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelExNullGap->details()->model(feature, 0))
+                             ->residualModel()
+                             .checksum(),
+                         static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelSkipGap->details()->model(feature, 0))
+                             ->residualModel()
+                             .checksum());
+    CPPUNIT_ASSERT_EQUAL(static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelExNullGap->details()->model(feature, 1))
+                             ->residualModel()
+                             .checksum(),
+                         static_cast<const maths::CUnivariateTimeSeriesModel*>(
+                             modelSkipGap->details()->model(feature, 1))
+                             ->residualModel()
+                             .checksum());
 }
 
 void CEventRateModelTest::testInterimCorrections() {

--- a/lib/model/unittest/CModelToolsTest.cc
+++ b/lib/model/unittest/CModelToolsTest.cc
@@ -226,7 +226,6 @@ void CModelToolsTest::testProbabilityCache() {
             maths::CModelProbabilityParams params;
             params.addCalculation(maths_t::E_TwoSided)
                 .seasonalConfidenceInterval(0.0)
-                .addBucketEmpty({false})
                 .addWeights(weights[0]);
             maths::SModelProbabilityResult expectedResult;
             model.probability(params, time, sample, expectedResult);
@@ -263,7 +262,6 @@ void CModelToolsTest::testProbabilityCache() {
             maths::CModelProbabilityParams params;
             params.addCalculation(maths_t::E_TwoSided)
                 .seasonalConfidenceInterval(0.0)
-                .addBucketEmpty({false})
                 .addWeights(weights[0]);
             maths::SModelProbabilityResult expectedResult;
             model.probability(params, time, sample, expectedResult);

--- a/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
+++ b/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
@@ -128,7 +128,7 @@ void computeProbability(core_t::TTime time,
         maths_t::CUnitWeights::unit<TDouble2Vec>(sample.size()));
     maths_t::setSeasonalVarianceScale(model.seasonalWeight(0.0, time), weight);
     maths::CModelProbabilityParams params;
-    params.addCalculation(calculation).addBucketEmpty(TBool2Vec{false}).addWeights(weight);
+    params.addCalculation(calculation).addWeights(weight);
     maths::SModelProbabilityResult result;
     model.probability(params, {{time}}, {sample}, result);
     probability = result.s_Probability;
@@ -240,7 +240,6 @@ void testProbabilityAndGetInfluences(model_t::EFeature feature,
         maths::CModelProbabilityParams params_;
         params_.addCalculation(model_t::probabilityCalculation(feature))
             .seasonalConfidenceInterval(0.0)
-            .addBucketEmpty(TBool2Vec{false})
             .addWeights(weight);
 
         double p = 0.0;
@@ -1456,7 +1455,6 @@ void CProbabilityAndInfluenceCalculatorTest::testProbabilityAndInfluenceCalculat
                 maths::CModelProbabilityParams params_;
                 params_.addCalculation(maths_t::E_TwoSided)
                     .seasonalConfidenceInterval(0.0)
-                    .addBucketEmpty(TBool2Vec{false})
                     .addWeights(weights);
                 double p;
                 TTail2Vec tail;


### PR DESCRIPTION
This simplifies sparse count and sum modelling and migrates to always updating the time series model, but using a weight which decreases in proportion to the number of empty buckets. This means we simply smoothly transition to modelling non-empty buckets for sparse data.

I've also removed the correction to the probability which accounts for the fraction of non-empty buckets: we have the rare function anyway if this is the primary concern. Finally, I changed periodicity testing so that it approximates the old behaviour, i.e. it tends to ignoring empty buckets as their proportion increases.

Closes #696. 