### PR TITLE
[ML] Wire in binomial logistic regression

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -60,6 +60,7 @@ class CMemoryUsageEstimationResultJsonWriter;
 class API_EXPORT CDataFrameAnalysisRunner {
 public:
     using TBoolVec = std::vector<bool>;
+    using TSizeVec = std::vector<std::size_t>;
     using TStrVec = std::vector<std::string>;
     using TStrVecVec = std::vector<TStrVec>;
     using TRowRef = core::data_frame_detail::CRowRef;
@@ -115,12 +116,11 @@ public:
     //! </pre>
     //! with one named member for each column added.
     //!
-    //! \param[in] featureNames The names of the analysis features.
+    //! \param[in] frame The data frane for which to write results.
     //! \param[in] row The row to write the columns added by this analysis.
     //! \param[in,out] writer The stream to which to write the extra columns.
-    virtual void writeOneRow(const TStrVec& featureNames,
-                             const TStrVecVec& categoricalFieldValues,
-                             TRowRef row,
+    virtual void writeOneRow(const core::CDataFrame& frame,
+                             const TRowRef& row,
                              core::CRapidJsonConcurrentLineWriter& writer) const = 0;
 
     //! Checks whether the analysis is already running and if not launches it
@@ -128,7 +128,7 @@ public:
     //!
     //! \note The thread calling this is expected to be nearly always idle, i.e.
     //! just progress monitoring, so this doesn't count towards the thread limit.
-    void run(const TStrVec& featureNames, core::CDataFrame& frame);
+    void run(core::CDataFrame& frame);
 
     //! This waits to until the analysis has finished and joins the thread.
     void waitToFinish();
@@ -155,7 +155,7 @@ protected:
     TStatePersister statePersister();
 
 private:
-    virtual void runImpl(const TStrVec& featureNames, core::CDataFrame& frame) = 0;
+    virtual void runImpl(core::CDataFrame& frame) = 0;
     virtual std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
                                                        std::size_t totalNumberRows,
                                                        std::size_t partitionNumberRows,

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -114,7 +114,7 @@ public:
     //! </pre>
     //! with one named member for each column added.
     //!
-    //! \param[in] frame The data frane for which to write results.
+    //! \param[in] frame The data frame for which to write results.
     //! \param[in] row The row to write the columns added by this analysis.
     //! \param[in,out] writer The stream to which to write the extra columns.
     virtual void writeOneRow(const core::CDataFrame& frame,

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -60,9 +60,7 @@ class CMemoryUsageEstimationResultJsonWriter;
 class API_EXPORT CDataFrameAnalysisRunner {
 public:
     using TBoolVec = std::vector<bool>;
-    using TSizeVec = std::vector<std::size_t>;
     using TStrVec = std::vector<std::string>;
-    using TStrVecVec = std::vector<TStrVec>;
     using TRowRef = core::data_frame_detail::CRowRef;
     using TProgressRecorder = std::function<void(double)>;
 

--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -44,6 +44,7 @@ namespace api {
 class API_EXPORT CDataFrameAnalysisSpecification {
 public:
     using TBoolVec = std::vector<bool>;
+    using TSizeVec = std::vector<std::size_t>;
     using TStrVec = std::vector<std::string>;
     using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
     using TTemporaryDirectoryPtr = std::shared_ptr<core::CTemporaryDirectory>;
@@ -163,11 +164,11 @@ public:
     //! thread. It is expected that the caller will mainly sleep and wake up
     //! periodically to report progess, errors and see if it has finished.
     //!
-    //! \return frame The data frame to analyse.
+    //! \return A handle to the analysis runner.
     //! \note The commit of the results of the analysis is atomic per partition.
     //! \warning This assumes that there is no access to the data frame in the
     //! calling thread until the runner has finished.
-    CDataFrameAnalysisRunner* run(const TStrVec& featureNames, core::CDataFrame& frame) const;
+    CDataFrameAnalysisRunner* run(core::CDataFrame& frame) const;
 
     //! Estimates memory usage in two cases:
     //!   1. disk is not used (the whole data frame fits in main memory)

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -90,6 +90,7 @@ private:
     std::ptrdiff_t m_BeginDataFieldValues = FIELD_UNSET;
     std::ptrdiff_t m_EndDataFieldValues = FIELD_UNSET;
     std::ptrdiff_t m_DocHashFieldIndex = FIELD_UNSET;
+    bool m_CapturedFieldNames = false;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
     TDataFrameUPtr m_DataFrame;
     TTemporaryDirectoryPtr m_DataFrameDirectory;

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -32,7 +32,6 @@ class CDataFrameAnalysisSpecification;
 //! \brief Handles input to the data_frame_analyzer command.
 class API_EXPORT CDataFrameAnalyzer {
 public:
-    using TBoolVec = std::vector<bool>;
     using TStrVec = std::vector<std::string>;
     using TJsonOutputStreamWrapperUPtr = std::unique_ptr<core::CJsonOutputStreamWrapper>;
     using TJsonOutputStreamWrapperUPtrSupplier =

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -30,8 +30,6 @@ class CDataFrameAnalysisRunner;
 class CDataFrameAnalysisSpecification;
 
 //! \brief Handles input to the data_frame_analyzer command.
-//! TODO implement functionality for restoring state from the index
-//!
 class API_EXPORT CDataFrameAnalyzer {
 public:
     using TBoolVec = std::vector<bool>;
@@ -41,11 +39,6 @@ public:
         std::function<TJsonOutputStreamWrapperUPtr()>;
     using TDataFrameAnalysisSpecificationUPtr = std::unique_ptr<CDataFrameAnalysisSpecification>;
     using TTemporaryDirectoryPtr = std::shared_ptr<core::CTemporaryDirectory>;
-
-public:
-    //! The maximum number of distinct categorical fields we can faithfully
-    //! represent.
-    static const std::size_t MAX_CATEGORICAL_CARDINALITY;
 
 public:
     CDataFrameAnalyzer(TDataFrameAnalysisSpecificationUPtr analysisSpecification,
@@ -72,8 +65,6 @@ public:
 
 private:
     using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
-    using TStrSizeUMap = boost::unordered_map<std::string, std::size_t>;
-    using TStrSizeUMapVec = std::vector<TStrSizeUMap>;
 
 private:
     static const std::ptrdiff_t FIELD_UNSET{-2};
@@ -99,15 +90,8 @@ private:
     std::ptrdiff_t m_BeginDataFieldValues = FIELD_UNSET;
     std::ptrdiff_t m_EndDataFieldValues = FIELD_UNSET;
     std::ptrdiff_t m_DocHashFieldIndex = FIELD_UNSET;
-    std::uint64_t m_MissingValueCount = 0;
-    std::uint64_t m_BadValueCount = 0;
-    std::uint64_t m_BadDocHashCount = 0;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
-    TStrVec m_CategoricalFieldNames;
-    TStrSizeUMapVec m_CategoricalFieldValues;
-    TBoolVec m_EmptyAsMissing;
     TDataFrameUPtr m_DataFrame;
-    TStrVec m_FieldNames;
     TTemporaryDirectoryPtr m_DataFrameDirectory;
     TJsonOutputStreamWrapperUPtrSupplier m_ResultsStreamSupplier;
 };

--- a/include/api/CDataFrameBoostedTreeRunner.h
+++ b/include/api/CDataFrameBoostedTreeRunner.h
@@ -20,6 +20,9 @@
 
 namespace ml {
 namespace maths {
+namespace boosted_tree {
+class CLoss;
+}
 class CBoostedTree;
 class CBoostedTreeFactory;
 }
@@ -42,6 +45,7 @@ public:
 
 protected:
     using TBoostedTreeUPtr = std::unique_ptr<maths::CBoostedTree>;
+    using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
 
 protected:
     //! Parameter reader handling parameters that are shared by subclasses.
@@ -59,16 +63,18 @@ private:
     using TMemoryEstimator = std::function<void(std::int64_t)>;
 
 private:
-    void runImpl(const TStrVec& featureNames, core::CDataFrame& frame) override;
+    void runImpl(core::CDataFrame& frame) override;
+    bool restoreBoostedTree(core::CDataFrame& frame,
+                            std::size_t dependentVariableColumn,
+                            TDataSearcherUPtr& restoreSearcher);
     std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
                                                std::size_t totalNumberRows,
                                                std::size_t partitionNumberRows,
                                                std::size_t numberColumns) const override;
     TMemoryEstimator memoryEstimator();
 
-    bool restoreBoostedTree(core::CDataFrame& frame,
-                            std::size_t dependentVariableColumn,
-                            TDataSearcherUPtr& restoreSearcher);
+    virtual TLossFunctionUPtr chooseLossFunction(const core::CDataFrame& frame,
+                                                 std::size_t dependentVariableColumn) const = 0;
 
 private:
     // Note custom config is written directly to the factory object.

--- a/include/api/CDataFrameClassificationRunner.h
+++ b/include/api/CDataFrameClassificationRunner.h
@@ -38,10 +38,13 @@ public:
     TBoolVec columnsForWhichEmptyIsMissing(const TStrVec& fieldNames) const override;
 
     //! Write the prediction for \p row to \p writer.
-    void writeOneRow(const TStrVec& featureNames,
-                     const TStrVecVec& categoricalFieldValues,
-                     TRowRef row,
+    void writeOneRow(const core::CDataFrame& frame,
+                     const TRowRef& row,
                      core::CRapidJsonConcurrentLineWriter& writer) const override;
+
+private:
+    TLossFunctionUPtr chooseLossFunction(const core::CDataFrame& frame,
+                                         std::size_t dependentVariableColumn) const override;
 
 private:
     std::size_t m_NumTopClasses;

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -31,13 +31,12 @@ public:
     std::size_t numberExtraColumns() const override;
 
     //! Write the extra columns of \p row added by outlier analysis to \p writer.
-    void writeOneRow(const TStrVec& featureNames,
-                     const TStrVecVec& categoricalFieldValues,
-                     TRowRef row,
+    void writeOneRow(const core::CDataFrame& frame,
+                     const TRowRef& row,
                      core::CRapidJsonConcurrentLineWriter& writer) const override;
 
 private:
-    void runImpl(const TStrVec& featureNames, core::CDataFrame& frame) override;
+    void runImpl(core::CDataFrame& frame) override;
     std::size_t estimateBookkeepingMemoryUsage(std::size_t numberPartitions,
                                                std::size_t totalNumberRows,
                                                std::size_t partitionNumberRows,

--- a/include/api/CDataFrameRegressionRunner.h
+++ b/include/api/CDataFrameRegressionRunner.h
@@ -34,10 +34,13 @@ public:
     CDataFrameRegressionRunner(const CDataFrameAnalysisSpecification& spec);
 
     //! Write the prediction for \p row to \p writer.
-    void writeOneRow(const TStrVec& featureNames,
-                     const TStrVecVec& categoricalFieldValues,
-                     TRowRef row,
+    void writeOneRow(const core::CDataFrame& frame,
+                     const TRowRef& row,
                      core::CRapidJsonConcurrentLineWriter& writer) const override;
+
+private:
+    TLossFunctionUPtr chooseLossFunction(const core::CDataFrame& frame,
+                                         std::size_t dependentVariableColumn) const override;
 };
 
 //! \brief Makes a core::CDataFrame boosted tree regression runner.

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -8,12 +8,15 @@
 #define INCLUDED_ml_core_CDataFrame_h
 
 #include <core/CFloatStorage.h>
+#include <core/CVectorRange.h>
 #include <core/Concurrency.h>
 #include <core/ImportExport.h>
 
 #include <boost/optional.hpp>
+#include <boost/unordered_map.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -187,6 +190,9 @@ private:
 class CORE_EXPORT CDataFrame final {
 public:
     using TBoolVec = std::vector<bool>;
+    using TStrVec = std::vector<std::string>;
+    using TStrVecVec = std::vector<TStrVec>;
+    using TStrCRng = CVectorRange<const TStrVec>;
     using TFloatVec = std::vector<CFloatStorage>;
     using TFloatVecItr = TFloatVec::iterator;
     using TInt32Vec = std::vector<std::int32_t>;
@@ -205,6 +211,10 @@ public:
 
     //! Controls whether to read and write to storage asynchronously.
     enum class EReadWriteToStorage { E_Async, E_Sync };
+
+public:
+    //! The maximum number of distinct categorical fields we can faithfully represent.
+    static const std::size_t MAX_CATEGORICAL_CARDINALITY;
 
 public:
     //! \param[in] inMainMemory True if the data frame is stored in main memory.
@@ -389,6 +399,9 @@ public:
         return this->writeColumns(numberThreads, 0, this->numberRows(), std::move(writer));
     }
 
+    //! Parses the strings in \p columnValues and writes one row via writeRow.
+    void parseAndWriteRow(const TStrCRng& columnValues, const std::string* hash = nullptr);
+
     //! This writes a single row of the data frame via a callback.
     //!
     //! If asynchronous read and write to store was selected in the constructor
@@ -405,6 +418,15 @@ public:
     //! writing rows.
     void writeRow(const TWriteFunc& writeRow);
 
+    //! Write the column names.
+    void columnNames(TStrVec columnNames);
+
+    //! Write for which columns an empty string implies the value is missing.
+    void emptyIsMissing(TBoolVec emptyIsMissing);
+
+    //! Write which columns contain categorical data.
+    void categoricalColumns(const TStrVec& categoricalColumnNames);
+
     //! Write which columns contain categorical data.
     void categoricalColumns(TBoolVec columnIsCategorical);
 
@@ -417,6 +439,12 @@ public:
     //! \warning This MUST be called after the last row is written to commit the
     //! work and to join the thread used to store the slices.
     void finishWritingRows();
+
+    //! \return The column names if any.
+    const TStrVec& columnNames() const;
+
+    //! \return The string values of the categories for each column.
+    const TStrVecVec& categoricalColumnValues() const;
 
     //! \return Indicator of columns containing categorical data.
     const TBoolVec& columnIsCategorical() const;
@@ -437,6 +465,8 @@ public:
     static double valueOfMissing();
 
 private:
+    using TStrSizeUMap = boost::unordered_map<std::string, std::size_t>;
+    using TStrSizeUMapVec = std::vector<TStrSizeUMap>;
     using TSizeSizePr = std::pair<std::size_t, std::size_t>;
     using TSizeDataFrameRowSlicePtrVecPr = std::pair<std::size_t, TRowSlicePtrVec>;
     using TPopMaskedRowFunc = data_frame_detail::TPopMaskedRowFunc;
@@ -516,8 +546,27 @@ private:
     //! The callback to write a slice to storage.
     TWriteSliceToStoreFunc m_WriteSliceToStore;
 
+    //! Optional column names.
+    TStrVec m_ColumnNames;
+
+    //! The string values of the categories.
+    TStrVecVec m_CategoricalColumnValues;
+
+    //! A lookup for the integer value of categories.
+    TStrSizeUMapVec m_CategoricalColumnValueLookup;
+
+    //! Indicator vector for treating empty strings as missing values.
+    TBoolVec m_EmptyIsMissing;
+
     //! Indicator vector of the columns which contain categorical values.
     TBoolVec m_ColumnIsCategorical;
+
+    //! \name Parse Counters
+    //@{
+    std::uint64_t m_MissingValueCount = 0;
+    std::uint64_t m_BadValueCount = 0;
+    std::uint64_t m_BadDocHashCount = 0;
+    //@}
 
     //! The stored slices.
     TRowSlicePtrVec m_Slices;

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -425,7 +425,7 @@ public:
     void emptyIsMissing(TBoolVec emptyIsMissing);
 
     //! Write which columns contain categorical data.
-    void categoricalColumns(const TStrVec& categoricalColumnNames);
+    void categoricalColumns(TStrVec categoricalColumnNames);
 
     //! Write which columns contain categorical data.
     void categoricalColumns(TBoolVec columnIsCategorical);

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -68,9 +68,9 @@ private:
 
 //! \brief Finds the value to add to a set of predicted log-odds which minimises
 //! regularised cross entropy loss w.r.t. the actual categories.
-class MATHS_EXPORT CArgMinBinomialLogisticImpl final : public CArgMinLossImpl {
+class MATHS_EXPORT CArgMinLogisticImpl final : public CArgMinLossImpl {
 public:
-    CArgMinBinomialLogisticImpl(double lambda);
+    CArgMinLogisticImpl(double lambda);
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(double prediction, double actual) override;
@@ -196,7 +196,7 @@ public:
 //! </pre>
 //! where \f$a_i\f$ denotes the actual class of the i'th example, \f$p\f$ is the
 //! prediction and \f$S(\cdot)\f$ denotes the logistic function.
-class MATHS_EXPORT CBinomialLogistic final : public CLoss {
+class MATHS_EXPORT CLogistic final : public CLoss {
     std::unique_ptr<CLoss> clone() const override;
     double value(double prediction, double actual) const override;
     double gradient(double prediction, double actual) const override;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -68,9 +68,9 @@ private:
 
 //! \brief Finds the value to add to a set of predicted log-odds which minimises
 //! regularised cross entropy loss w.r.t. the actual categories.
-class MATHS_EXPORT CArgMinLogisticImpl final : public CArgMinLossImpl {
+class MATHS_EXPORT CArgMinBinomialLogisticImpl final : public CArgMinLossImpl {
 public:
-    CArgMinLogisticImpl(double lambda);
+    CArgMinBinomialLogisticImpl(double lambda);
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(double prediction, double actual) override;
@@ -196,7 +196,7 @@ public:
 //! </pre>
 //! where \f$a_i\f$ denotes the actual class of the i'th example, \f$p\f$ is the
 //! prediction and \f$S(\cdot)\f$ denotes the logistic function.
-class MATHS_EXPORT CLogistic final : public CLoss {
+class MATHS_EXPORT CBinomialLogistic final : public CLoss {
     std::unique_ptr<CLoss> clone() const override;
     double value(double prediction, double actual) const override;
     double gradient(double prediction, double actual) const override;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -40,8 +40,7 @@ public:
 
 public:
     //! Construct a boosted tree object from parameters.
-    static CBoostedTreeFactory constructFromParameters(std::size_t numberThreads,
-                                                       TLossFunctionUPtr loss);
+    static CBoostedTreeFactory constructFromParameters(std::size_t numberThreads);
 
     //! Construct a boosted tree object from its serialized version.
     //!
@@ -97,7 +96,9 @@ public:
     //! Get the number of columns training the model will add to the data frame.
     std::size_t numberExtraColumnsForTrain() const;
     //! Build a boosted tree object for a given data frame.
-    TBoostedTreeUPtr buildFor(core::CDataFrame& frame, std::size_t dependentVariable);
+    TBoostedTreeUPtr buildFor(core::CDataFrame& frame,
+                              TLossFunctionUPtr loss,
+                              std::size_t dependentVariable);
 
 private:
     using TDoubleDoublePr = std::pair<double, double>;
@@ -115,7 +116,7 @@ private:
     static const std::size_t MAXIMUM_NUMBER_TREES;
 
 private:
-    CBoostedTreeFactory(bool restored, std::size_t numberThreads, TLossFunctionUPtr loss);
+    CBoostedTreeFactory(bool restored, std::size_t numberThreads);
 
     //! Compute the row masks for the missing values for each feature.
     void initializeMissingFeatureMasks(const core::CDataFrame& frame) const;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -181,7 +181,6 @@ private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
     TOptionalSize m_BayesianOptimisationRestarts;
     std::size_t m_NumberThreads;
-    TLossFunctionUPtr m_Loss;
     TBoostedTreeImplUPtr m_TreeImpl;
     TVector m_LogDepthPenaltyMultiplierSearchInterval;
     TVector m_LogTreeSizePenaltyMultiplierSearchInterval;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -99,6 +99,9 @@ public:
     TBoostedTreeUPtr buildFor(core::CDataFrame& frame,
                               TLossFunctionUPtr loss,
                               std::size_t dependentVariable);
+    //! Restore a boosted tree object for a given data frame.
+    //! \warning A tree object can only be restored once.
+    TBoostedTreeUPtr restoreFor(core::CDataFrame& frame, std::size_t dependentVariable);
 
 private:
     using TDoubleDoublePr = std::pair<double, double>;
@@ -116,7 +119,7 @@ private:
     static const std::size_t MAXIMUM_NUMBER_TREES;
 
 private:
-    CBoostedTreeFactory(bool restored, std::size_t numberThreads);
+    CBoostedTreeFactory(std::size_t numberThreads);
 
     //! Compute the row masks for the missing values for each feature.
     void initializeMissingFeatureMasks(const core::CDataFrame& frame) const;
@@ -177,7 +180,6 @@ private:
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
     TOptionalSize m_BayesianOptimisationRestarts;
-    bool m_Restored = false;
     std::size_t m_NumberThreads;
     TLossFunctionUPtr m_Loss;
     TBoostedTreeImplUPtr m_TreeImpl;

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -141,14 +141,14 @@ std::size_t CDataFrameAnalysisRunner::maximumNumberRowsPerPartition() const {
     return m_MaximumNumberRowsPerPartition;
 }
 
-void CDataFrameAnalysisRunner::run(const TStrVec& featureNames, core::CDataFrame& frame) {
+void CDataFrameAnalysisRunner::run(core::CDataFrame& frame) {
     if (m_Runner.joinable()) {
         LOG_INFO(<< "Already running analysis");
     } else {
         m_FractionalProgress.store(0.0);
         m_Finished.store(false);
-        m_Runner = std::thread([&featureNames, &frame, this]() {
-            this->runImpl(featureNames, frame);
+        m_Runner = std::thread([&frame, this]() {
+            this->runImpl(frame);
             this->setToFinished();
         });
     }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -192,10 +192,9 @@ CDataFrameAnalysisSpecification::makeDataFrame() {
     return result;
 }
 
-CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(const TStrVec& featureNames,
-                                                               core::CDataFrame& frame) const {
+CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(core::CDataFrame& frame) const {
     if (m_Runner != nullptr) {
-        m_Runner->run(featureNames, frame);
+        m_Runner->run(frame);
         return m_Runner.get();
     }
     return nullptr;
@@ -203,7 +202,8 @@ CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::run(const TStrVec& fe
 
 void CDataFrameAnalysisSpecification::estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const {
     if (m_Runner == nullptr) {
-        HANDLE_FATAL(<< "Internal error: no runner available so can't estimate memory. Please report this problem.");
+        HANDLE_FATAL(<< "Internal error: no runner available so can't estimate memory."
+                     << " Please report this problem.");
         return;
     }
     m_Runner->estimateMemoryUsage(writer);

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -245,13 +245,14 @@ void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
     if (m_DataFrame == nullptr) {
         return;
     }
-    if (m_DataFrame != nullptr && m_DataFrame->columnNames().empty()) {
+    if (m_DataFrame != nullptr && m_CapturedFieldNames == false) {
         TStrVec columnNames{fieldNames.begin() + m_BeginDataFieldValues,
                             fieldNames.begin() + m_EndDataFieldValues};
         m_DataFrame->columnNames(columnNames);
         m_DataFrame->emptyIsMissing(
             m_AnalysisSpecification->columnsForWhichEmptyIsMissing(columnNames));
         m_DataFrame->categoricalColumns(m_AnalysisSpecification->categoricalFieldNames());
+        m_CapturedFieldNames = true;
     }
 }
 

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -266,7 +266,7 @@ bool CDataFrameBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& frame,
                             .progressCallback(this->progressRecorder())
                             .trainingStateCallback(this->statePersister())
                             .memoryUsageCallback(this->memoryEstimator())
-                            .buildFor(frame, nullptr, dependentVariableColumn);
+                            .restoreFor(frame, dependentVariableColumn);
     } catch (std::exception& e) {
         LOG_ERROR(<< "Failed to restore state! " << e.what());
         return false;

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -119,8 +119,7 @@ CDataFrameBoostedTreeRunner::CDataFrameBoostedTreeRunner(
     }
 
     m_BoostedTreeFactory = std::make_unique<maths::CBoostedTreeFactory>(
-        maths::CBoostedTreeFactory::constructFromParameters(
-            this->spec().numberThreads(), std::make_unique<maths::boosted_tree::CMse>()));
+        maths::CBoostedTreeFactory::constructFromParameters(this->spec().numberThreads()));
 
     (*m_BoostedTreeFactory)
         .progressCallback(this->progressRecorder())
@@ -200,14 +199,14 @@ const maths::CBoostedTree& CDataFrameBoostedTreeRunner::boostedTree() const {
     return *m_BoostedTree;
 }
 
-void CDataFrameBoostedTreeRunner::runImpl(const TStrVec& featureNames,
-                                          core::CDataFrame& frame) {
-    auto dependentVariableColumn = std::find(
-        featureNames.begin(), featureNames.end(), m_DependentVariableFieldName);
-    if (dependentVariableColumn == featureNames.end()) {
+void CDataFrameBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
+    auto dependentVariablePos = std::find(frame.columnNames().begin(),
+                                          frame.columnNames().end(),
+                                          m_DependentVariableFieldName);
+    if (dependentVariablePos == frame.columnNames().end()) {
         HANDLE_FATAL(<< "Input error: supplied variable to predict '"
                      << m_DependentVariableFieldName << "' is missing from training"
-                     << " data " << core::CContainerPrinter::print(featureNames));
+                     << " data " << core::CContainerPrinter::print(frame.columnNames()));
         return;
     }
 
@@ -218,15 +217,18 @@ void CDataFrameBoostedTreeRunner::runImpl(const TStrVec& featureNames,
 
     core::CStopWatch watch{true};
 
+    std::size_t dependentVariableColumn(dependentVariablePos -
+                                        frame.columnNames().begin());
+
     auto restoreSearcher{this->spec().restoreSearcher()};
     bool treeRestored{false};
     if (restoreSearcher != nullptr) {
-        treeRestored = this->restoreBoostedTree(
-            frame, dependentVariableColumn - featureNames.begin(), restoreSearcher);
+        treeRestored = this->restoreBoostedTree(frame, dependentVariableColumn, restoreSearcher);
     }
     if (treeRestored == false) {
-        m_BoostedTree = m_BoostedTreeFactory->buildFor(
-            frame, dependentVariableColumn - featureNames.begin());
+        auto loss = this->chooseLossFunction(frame, dependentVariableColumn);
+        m_BoostedTree = m_BoostedTreeFactory->buildFor(frame, std::move(loss),
+                                                       dependentVariableColumn);
     }
 
     m_BoostedTree->train();
@@ -264,7 +266,7 @@ bool CDataFrameBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& frame,
                             .progressCallback(this->progressRecorder())
                             .trainingStateCallback(this->statePersister())
                             .memoryUsageCallback(this->memoryEstimator())
-                            .buildFor(frame, dependentVariableColumn);
+                            .buildFor(frame, nullptr, dependentVariableColumn);
     } catch (std::exception& e) {
         LOG_ERROR(<< "Failed to restore state! " << e.what());
         return false;

--- a/lib/api/CDataFrameClassificationRunner.cc
+++ b/lib/api/CDataFrameClassificationRunner.cc
@@ -127,7 +127,7 @@ CDataFrameClassificationRunner::chooseLossFunction(const core::CDataFrame& frame
     std::size_t categoryCount{
         frame.categoricalColumnValues()[dependentVariableColumn].size()};
     if (categoryCount == 2) {
-        return std::make_unique<maths::boosted_tree::CBinomialLogistic>();
+        return std::make_unique<maths::boosted_tree::CLogistic>();
     }
     HANDLE_FATAL(<< "Input error: only binary classification is supported. "
                  << "Trying to predict '" << categoryCount << "' categories.");

--- a/lib/api/CDataFrameClassificationRunner.cc
+++ b/lib/api/CDataFrameClassificationRunner.cc
@@ -92,8 +92,9 @@ void CDataFrameClassificationRunner::writeOneRow(const core::CDataFrame& frame,
     TDoubleVec probabilityOfCategory{1.0 - probabilityOfCategory1, probabilityOfCategory1};
 
     double actualCategoryId{row[columnHoldingDependentVariable]};
-    std::size_t predictedCategoryId{
-        probabilityOfCategory[0] > probabilityOfCategory[1] ? 0u : 1u};
+    std::size_t predictedCategoryId(std::max_element(probabilityOfCategory.begin(),
+                                                     probabilityOfCategory.end()) -
+                                    probabilityOfCategory.begin());
 
     writer.StartObject();
     writer.Key(this->predictionFieldName());

--- a/lib/api/CDataFrameClassificationRunner.cc
+++ b/lib/api/CDataFrameClassificationRunner.cc
@@ -32,6 +32,8 @@ namespace ml {
 namespace api {
 namespace {
 using TBoolVec = std::vector<bool>;
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 
 // Configuration
 const std::string NUM_TOP_CLASSES{"num_top_classes"};
@@ -61,9 +63,9 @@ CDataFrameClassificationRunner::CDataFrameClassificationRunner(const CDataFrameA
     : CDataFrameBoostedTreeRunner{spec} {
 }
 
-// The only field for which empty value should be treated as missing is dependent variable
-// which has empty value for non-training rows.
 TBoolVec CDataFrameClassificationRunner::columnsForWhichEmptyIsMissing(const TStrVec& fieldNames) const {
+    // The only field for which empty value should be treated as missing is dependent
+    // variable which has empty value for non-training rows.
     TBoolVec emptyAsMissing(fieldNames.size(), false);
     auto pos = std::find(fieldNames.begin(), fieldNames.end(),
                          this->dependentVariableFieldName());
@@ -83,9 +85,6 @@ void CDataFrameClassificationRunner::writeOneRow(const core::CDataFrame& frame,
     const TStrVec& categoryValues{frame.categoricalColumnValues()[columnHoldingDependentVariable]};
 
     // TODO generalise when supporting multiple categories.
-
-    using TDoubleVec = std::vector<double>;
-    using TSizeVec = std::vector<std::size_t>;
 
     double predictedLogOddsOfCategory1{row[columnHoldingPrediction]};
     double probabilityOfCategory1{maths::CTools::logisticFunction(predictedLogOddsOfCategory1)};

--- a/lib/api/CDataFrameClassificationRunner.cc
+++ b/lib/api/CDataFrameClassificationRunner.cc
@@ -16,6 +16,8 @@
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeFactory.h>
 #include <maths/CDataFrameUtils.h>
+#include <maths/COrderings.h>
+#include <maths/CTools.h>
 
 #include <api/CDataFrameAnalysisConfigReader.h>
 #include <api/CDataFrameAnalysisSpecification.h>
@@ -23,6 +25,8 @@
 #include <api/ElasticsearchStateIndex.h>
 
 #include <rapidjson/document.h>
+
+#include <numeric>
 
 namespace ml {
 namespace api {
@@ -69,46 +73,65 @@ TBoolVec CDataFrameClassificationRunner::columnsForWhichEmptyIsMissing(const TSt
     return emptyAsMissing;
 }
 
-void CDataFrameClassificationRunner::writeOneRow(const TStrVec&,
-                                                 const TStrVecVec& categoricalFieldValues,
-                                                 TRowRef row,
+void CDataFrameClassificationRunner::writeOneRow(const core::CDataFrame& frame,
+                                                 const TRowRef& row,
                                                  core::CRapidJsonConcurrentLineWriter& writer) const {
     const auto& tree = this->boostedTree();
     const std::size_t columnHoldingDependentVariable{tree.columnHoldingDependentVariable()};
     const std::size_t columnHoldingPrediction{
         tree.columnHoldingPrediction(row.numberColumns())};
-    const double dependentVariable{row[columnHoldingDependentVariable]};
-    const std::uint64_t prediction{
-        static_cast<std::uint64_t>(std::lround(row[columnHoldingPrediction]))};
-    if (prediction >= categoricalFieldValues[columnHoldingDependentVariable].size()) {
-        HANDLE_FATAL(<< "Index out of bounds: " << prediction);
-    }
-    const std::string& predictedClassName{
-        categoricalFieldValues[columnHoldingDependentVariable][prediction]};
+    const TStrVec& categoryValues{frame.categoricalColumnValues()[columnHoldingDependentVariable]};
+
+    // TODO generalise when supporting multiple categories.
+
+    using TDoubleVec = std::vector<double>;
+    using TSizeVec = std::vector<std::size_t>;
+
+    double predictedLogOddsOfCategory1{row[columnHoldingPrediction]};
+    double probabilityOfCategory1{maths::CTools::logisticFunction(predictedLogOddsOfCategory1)};
+    TDoubleVec probabilityOfCategory{1.0 - probabilityOfCategory1, probabilityOfCategory1};
+
+    double actualCategoryId{row[columnHoldingDependentVariable]};
+    std::size_t predictedCategoryId{
+        probabilityOfCategory[0] > probabilityOfCategory[1] ? 0u : 1u};
 
     writer.StartObject();
     writer.Key(this->predictionFieldName());
-    writer.String(predictedClassName);
+    writer.String(categoryValues[predictedCategoryId]);
     writer.Key(IS_TRAINING_FIELD_NAME);
-    writer.Bool(maths::CDataFrameUtils::isMissing(dependentVariable) == false);
-    // TODO: Uncomment and adapt the code below once top classes feature is implemented
-    //       See https://github.com/elastic/ml-cpp/issues/712
-    /*
+    writer.Bool(maths::CDataFrameUtils::isMissing(actualCategoryId) == false);
+
     if (m_NumTopClasses > 0) {
+        TSizeVec categoryIds(probabilityOfCategory.size());
+        std::iota(categoryIds.begin(), categoryIds.end(), 0);
+        maths::COrderings::simultaneousSort(probabilityOfCategory, categoryIds,
+                                            std::greater<double>());
         writer.Key(TOP_CLASSES_FIELD_NAME);
         writer.StartArray();
-        for (std::size_t i = 0; i < m_NumTopClasses; i++) {
+        for (std::size_t i = 0; i < std::min(categoryIds.size(), m_NumTopClasses); ++i) {
             writer.StartObject();
             writer.Key(CLASS_NAME_FIELD_NAME);
-            writer.String(???);
+            writer.String(categoryValues[categoryIds[i]]);
             writer.Key(CLASS_PROBABILITY_FIELD_NAME);
-            writer.Double(???);
+            writer.Double(probabilityOfCategory[i]);
             writer.EndObject();
         }
         writer.EndArray();
     }
-    */
     writer.EndObject();
+}
+
+CDataFrameClassificationRunner::TLossFunctionUPtr
+CDataFrameClassificationRunner::chooseLossFunction(const core::CDataFrame& frame,
+                                                   std::size_t dependentVariableColumn) const {
+    std::size_t categoryCount{
+        frame.categoricalColumnValues()[dependentVariableColumn].size()};
+    if (categoryCount == 2) {
+        return std::make_unique<maths::boosted_tree::CBinomialLogistic>();
+    }
+    HANDLE_FATAL(<< "Input error: only binary classification is supported. "
+                 << "Trying to predict '" << categoryCount << "' categories.");
+    return nullptr;
 }
 
 const std::string& CDataFrameClassificationRunnerFactory::name() const {

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -83,9 +83,8 @@ std::size_t CDataFrameOutliersRunner::numberExtraColumns() const {
     return m_ComputeFeatureInfluence ? this->spec().numberColumns() + 1 : 1;
 }
 
-void CDataFrameOutliersRunner::writeOneRow(const TStrVec& featureNames,
-                                           const TStrVecVec&,
-                                           TRowRef row,
+void CDataFrameOutliersRunner::writeOneRow(const core::CDataFrame& frame,
+                                           const TRowRef& row,
                                            core::CRapidJsonConcurrentLineWriter& writer) const {
     std::size_t scoreColumn{row.numberColumns() - this->numberExtraColumns()};
     std::size_t beginFeatureScoreColumns{scoreColumn + 1};
@@ -95,14 +94,14 @@ void CDataFrameOutliersRunner::writeOneRow(const TStrVec& featureNames,
     writer.Double(row[scoreColumn]);
     if (row[scoreColumn] > m_FeatureInfluenceThreshold) {
         for (std::size_t i = 0; i < numberFeatureScoreColumns; ++i) {
-            writer.Key(FEATURE_INFLUENCE_FIELD_NAME_PREFIX + featureNames[i]);
+            writer.Key(FEATURE_INFLUENCE_FIELD_NAME_PREFIX + frame.columnNames()[i]);
             writer.Double(row[beginFeatureScoreColumns + i]);
         }
     }
     writer.EndObject();
 }
 
-void CDataFrameOutliersRunner::runImpl(const TStrVec&, core::CDataFrame& frame) {
+void CDataFrameOutliersRunner::runImpl(core::CDataFrame& frame) {
 
     core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) =
         this->numberPartitions();

--- a/lib/api/CDataFrameRegressionRunner.cc
+++ b/lib/api/CDataFrameRegressionRunner.cc
@@ -45,9 +45,8 @@ CDataFrameRegressionRunner::CDataFrameRegressionRunner(const CDataFrameAnalysisS
     : CDataFrameBoostedTreeRunner{spec} {
 }
 
-void CDataFrameRegressionRunner::writeOneRow(const TStrVec&,
-                                             const TStrVecVec&,
-                                             TRowRef row,
+void CDataFrameRegressionRunner::writeOneRow(const core::CDataFrame&,
+                                             const TRowRef& row,
                                              core::CRapidJsonConcurrentLineWriter& writer) const {
     const auto& tree = this->boostedTree();
     const std::size_t columnHoldingDependentVariable = tree.columnHoldingDependentVariable();
@@ -60,6 +59,11 @@ void CDataFrameRegressionRunner::writeOneRow(const TStrVec&,
     writer.Key(IS_TRAINING_FIELD_NAME);
     writer.Bool(maths::CDataFrameUtils::isMissing(row[columnHoldingDependentVariable]) == false);
     writer.EndObject();
+}
+
+CDataFrameRegressionRunner::TLossFunctionUPtr
+CDataFrameRegressionRunner::chooseLossFunction(const core::CDataFrame&, std::size_t) const {
+    return std::make_unique<maths::boosted_tree::CMse>();
 }
 
 const std::string& CDataFrameRegressionRunnerFactory::name() const {

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -347,7 +347,7 @@ void CDataFrameAnalysisSpecificationTest::testRunAnalysis() {
         auto frameAndDirectory = core::makeMainStorageDataFrame(10);
         auto frame = std::move(frameAndDirectory.first);
 
-        api::CDataFrameAnalysisRunner* runner{spec.run({}, *frame)};
+        api::CDataFrameAnalysisRunner* runner{spec.run(*frame)};
         CPPUNIT_ASSERT(runner != nullptr);
 
         double lastProgress{runner->progress()};

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -675,7 +675,7 @@ void CDataFrameAnalyzerTest::testRunOutlierDetectionPartitioned() {
     LOG_DEBUG(<< "peak memory = "
               << core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage));
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) > 1);
-    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 115000); // + 15%
+    CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 116000); // + 16%
 }
 
 void CDataFrameAnalyzerTest::testRunOutlierFeatureInfluences() {

--- a/lib/api/unittest/CDataFrameAnalyzerTest.h
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.h
@@ -16,10 +16,11 @@ public:
     void testRunOutlierDetectionPartitioned();
     void testRunOutlierFeatureInfluences();
     void testRunOutlierDetectionWithParams();
-    void testRunBoostedTreeTraining();
-    void testRunBoostedTreeTrainingWithStateRecovery();
-    void testRunBoostedTreeTrainingWithParams();
-    void testRunBoostedTreeTrainingWithRowsMissingTargetValue();
+    void testRunBoostedTreeRegressionTraining();
+    void testRunBoostedTreeRegressionTrainingWithParams();
+    void testRunBoostedTreeRegressionTrainingWithRowsMissingTargetValue();
+    void testRunBoostedTreeRegressionTrainingWithStateRecovery();
+    void testRunBoostedTreeClassifierTraining();
     void testFlushMessage();
     void testErrors();
     void testRoundTripDocHashes();

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -17,13 +17,12 @@ std::size_t CDataFrameMockAnalysisRunner::numberExtraColumns() const {
     return 2;
 }
 
-void CDataFrameMockAnalysisRunner::writeOneRow(const TStrVec&,
-                                               const TStrVecVec&,
-                                               TRowRef,
+void CDataFrameMockAnalysisRunner::writeOneRow(const ml::core::CDataFrame&,
+                                               const TRowRef&,
                                                ml::core::CRapidJsonConcurrentLineWriter&) const {
 }
 
-void CDataFrameMockAnalysisRunner::runImpl(const TStrVec&, ml::core::CDataFrame&) {
+void CDataFrameMockAnalysisRunner::runImpl(ml::core::CDataFrame&) {
     ml::core::CLoopProgress progress{31, this->progressRecorder()};
     for (std::size_t i = 0; i < 31; ++i, progress.increment()) {
         std::vector<std::size_t> wait;

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -19,13 +19,12 @@ public:
     CDataFrameMockAnalysisRunner(const ml::api::CDataFrameAnalysisSpecification& spec);
 
     std::size_t numberExtraColumns() const override;
-    void writeOneRow(const TStrVec& featureNames,
-                     const TStrVecVec& categoricalFieldValues,
-                     TRowRef,
+    void writeOneRow(const ml::core::CDataFrame&,
+                     const TRowRef&,
                      ml::core::CRapidJsonConcurrentLineWriter&) const override;
 
 private:
-    void runImpl(const TStrVec&, ml::core::CDataFrame&) override;
+    void runImpl(ml::core::CDataFrame&) override;
     std::size_t estimateBookkeepingMemoryUsage(std::size_t,
                                                std::size_t,
                                                std::size_t,

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -349,8 +349,9 @@ void CDataFrame::finishWritingRows() {
             LOG_WARN(<< "Failed to represent all distinct values of " << m_ColumnNames[i]);
         }
         m_CategoricalColumnValues.shrink_to_fit();
-        m_CategoricalColumnValueLookup[i] = TStrSizeUMap{};
     }
+    m_CategoricalColumnValueLookup.clear();
+    m_CategoricalColumnValueLookup.shrink_to_fit();
 }
 
 const CDataFrame::TStrVec& CDataFrame::columnNames() const {

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -228,7 +228,7 @@ void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues, const std::strin
             // This encodes in a format suitable for efficient storage. The
             // actual encoding approach is chosen when the analysis runs.
             std::size_t id;
-            if (categoryLookup.size() == MAX_CATEGORICAL_CARDINALITY) {
+            if (categories.size() == MAX_CATEGORICAL_CARDINALITY) {
                 auto itr = categoryLookup.find(columnValue);
                 id = itr != categoryLookup.end()
                          ? itr->second
@@ -239,9 +239,9 @@ void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues, const std::strin
                 // up to around 17M distinct values. For higher cardinalities
                 // one would need to use some form of dimension reduction such
                 // as hashing anyway.
-                id = categoryLookup.emplace(columnValue, categories.size())
-                         .first->second;
-                if (id == categories.size()) {
+                std::size_t newId{categories.size()};
+                id = categoryLookup.emplace(columnValue, newId).first->second;
+                if (id == newId) {
                     categories.push_back(columnValue);
                 }
             }

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -309,11 +309,14 @@ void CDataFrame::emptyIsMissing(TBoolVec emptyIsMissing) {
     }
 }
 
-void CDataFrame::categoricalColumns(const TStrVec& categoricalColumnNames) {
+void CDataFrame::categoricalColumns(TStrVec categoricalColumnNames) {
+    std::sort(categoricalColumnNames.begin(), categoricalColumnNames.end());
     for (std::size_t i = 0; i < m_ColumnNames.size(); ++i) {
-        m_ColumnIsCategorical[i] =
-            std::find(categoricalColumnNames.begin(), categoricalColumnNames.end(),
-                      m_ColumnNames[i]) != categoricalColumnNames.end();
+        auto categorical = std::lower_bound(categoricalColumnNames.begin(),
+                                            categoricalColumnNames.end(),
+                                            m_ColumnNames[i]);
+        m_ColumnIsCategorical[i] = categorical != categoricalColumnNames.end() &&
+                                   *categorical == m_ColumnNames[i];
     }
 }
 

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -12,6 +12,7 @@
 #include <core/CLogger.h>
 #include <core/CMemory.h>
 #include <core/CPackedBitVector.h>
+#include <core/CStringUtils.h>
 #include <core/Concurrency.h>
 
 #include <algorithm>
@@ -21,6 +22,13 @@
 
 namespace ml {
 namespace core {
+namespace {
+core::CFloatStorage truncateToFloatRange(double value) {
+    double largest{static_cast<double>(std::numeric_limits<float>::max())};
+    return std::min(std::max(value, -largest), largest);
+}
+}
+
 namespace data_frame_detail {
 
 CRowRef::CRowRef(std::size_t index, TFloatVecItr beginColumns, TFloatVecItr endColumns, std::int32_t docHash)
@@ -117,6 +125,9 @@ CDataFrame::CDataFrame(bool inMainMemory,
     : m_InMainMemory{inMainMemory}, m_NumberColumns{numberColumns},
       m_RowCapacity{numberColumns}, m_SliceCapacityInRows{sliceCapacityInRows},
       m_ReadAndWriteToStoreSyncStrategy{readAndWriteToStoreSyncStrategy}, m_WriteSliceToStore{writeSliceToStore},
+      m_ColumnNames(numberColumns), m_CategoricalColumnValues(numberColumns),
+      m_CategoricalColumnValueLookup(numberColumns),
+      m_EmptyIsMissing(numberColumns, false),
       m_ColumnIsCategorical(numberColumns, false) {
 }
 
@@ -156,6 +167,10 @@ void CDataFrame::reserve(std::size_t numberThreads, std::size_t rowCapacity) {
 
 void CDataFrame::resizeColumns(std::size_t numberThreads, std::size_t numberColumns) {
     this->reserve(numberThreads, numberColumns);
+    m_ColumnNames.resize(numberColumns);
+    m_CategoricalColumnValues.resize(numberColumns);
+    m_CategoricalColumnValueLookup.resize(numberColumns);
+    m_EmptyIsMissing.resize(numberColumns, false);
     m_ColumnIsCategorical.resize(numberColumns, false);
     m_NumberColumns = numberColumns;
 }
@@ -200,6 +215,72 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::writeColumns(std::size_t numberThreads
                                                 std::move(writer), rowMask, true);
 }
 
+void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues, const std::string* hash) {
+
+    auto stringToValue = [this](bool isCategorical, TStrSizeUMap& categoryLookup,
+                                TStrVec& categories, bool emptyIsMissing,
+                                const std::string& columnValue) {
+        if (isCategorical) {
+            if (columnValue.empty() && emptyIsMissing) {
+                return core::CFloatStorage{valueOfMissing()};
+            }
+
+            // This encodes in a format suitable for efficient storage. The
+            // actual encoding approach is chosen when the analysis runs.
+            std::size_t id;
+            if (categoryLookup.size() == MAX_CATEGORICAL_CARDINALITY) {
+                auto itr = categoryLookup.find(columnValue);
+                id = itr != categoryLookup.end()
+                         ? itr->second
+                         : static_cast<std::int64_t>(MAX_CATEGORICAL_CARDINALITY);
+            } else {
+                // We can represent up to float mantissa bits - 1 distinct
+                // categories so can faithfully store categorical fields with
+                // up to around 17M distinct values. For higher cardinalities
+                // one would need to use some form of dimension reduction such
+                // as hashing anyway.
+                id = categoryLookup.emplace(columnValue, categories.size())
+                         .first->second;
+                if (id == categories.size()) {
+                    categories.push_back(columnValue);
+                }
+            }
+            return core::CFloatStorage{static_cast<double>(id)};
+        }
+
+        // Use NaN to indicate missing or bad values in the data frame. This
+        // needs handling with care from an analysis perspective. If analyses
+        // can deal with missing values they need to treat NaNs as missing
+        // otherwise we must impute or exit with failure.
+
+        double value;
+        if (columnValue.empty()) {
+            ++m_MissingValueCount;
+            return core::CFloatStorage{valueOfMissing()};
+        } else if (core::CStringUtils::stringToTypeSilent(columnValue, value) == false) {
+            ++m_BadValueCount;
+            return core::CFloatStorage{valueOfMissing()};
+        }
+
+        // Tuncation is very unlikely since the values will typically be
+        // standardised.
+        return truncateToFloatRange(value);
+    };
+
+    this->writeRow([&](TFloatVecItr columns, std::int32_t& docHash) {
+        for (std::size_t i = 0; i < columnValues.size(); ++i, ++columns) {
+            *columns = stringToValue(
+                m_ColumnIsCategorical[i], m_CategoricalColumnValueLookup[i],
+                m_CategoricalColumnValues[i], m_EmptyIsMissing[i], columnValues[i]);
+        }
+        docHash = 0;
+        if (hash != nullptr &&
+            core::CStringUtils::stringToTypeSilent(*hash, docHash) == false) {
+            ++m_BadDocHashCount;
+        }
+    });
+}
+
 void CDataFrame::writeRow(const TWriteFunc& writeRow) {
     if (m_Writer == nullptr) {
         m_Writer = std::make_unique<CDataFrameRowSliceWriter>(
@@ -207,6 +288,33 @@ void CDataFrame::writeRow(const TWriteFunc& writeRow) {
             m_ReadAndWriteToStoreSyncStrategy, m_WriteSliceToStore);
     }
     (*m_Writer)(writeRow);
+}
+
+void CDataFrame::columnNames(TStrVec columnNames) {
+    if (columnNames.size() != m_NumberColumns) {
+        HANDLE_FATAL(<< "Internal error: expected '" << m_NumberColumns << "' column names values but got "
+                     << CContainerPrinter::print(columnNames));
+    } else {
+        m_ColumnNames = std::move(columnNames);
+    }
+}
+
+void CDataFrame::emptyIsMissing(TBoolVec emptyIsMissing) {
+    if (emptyIsMissing.size() != m_NumberColumns) {
+        HANDLE_FATAL(<< "Internal error: expected '" << m_NumberColumns
+                     << "' 'empty is missing' column indicator values but got "
+                     << CContainerPrinter::print(emptyIsMissing));
+    } else {
+        m_EmptyIsMissing = std::move(emptyIsMissing);
+    }
+}
+
+void CDataFrame::categoricalColumns(const TStrVec& categoricalColumnNames) {
+    for (std::size_t i = 0; i < m_ColumnNames.size(); ++i) {
+        m_ColumnIsCategorical[i] =
+            std::find(categoricalColumnNames.begin(), categoricalColumnNames.end(),
+                      m_ColumnNames[i]) != categoricalColumnNames.end();
+    }
 }
 
 void CDataFrame::categoricalColumns(TBoolVec columnIsCategorical) {
@@ -233,6 +341,24 @@ void CDataFrame::finishWritingRows() {
         }
         LOG_TRACE(<< "# slices = " << m_Slices.size());
     }
+
+    // Recover memory from categorical field parsing.
+
+    for (std::size_t i = 0; i < m_CategoricalColumnValues.size(); ++i) {
+        if (m_CategoricalColumnValues[i].size() >= MAX_CATEGORICAL_CARDINALITY) {
+            LOG_WARN(<< "Failed to represent all distinct values of " << m_ColumnNames[i]);
+        }
+        m_CategoricalColumnValues.shrink_to_fit();
+        m_CategoricalColumnValueLookup[i] = TStrSizeUMap{};
+    }
+}
+
+const CDataFrame::TStrVec& CDataFrame::columnNames() const {
+    return m_ColumnNames;
+}
+
+const CDataFrame::TStrVecVec& CDataFrame::categoricalColumnValues() const {
+    return m_CategoricalColumnValues;
 }
 
 const CDataFrame::TBoolVec& CDataFrame::columnIsCategorical() const {
@@ -240,7 +366,14 @@ const CDataFrame::TBoolVec& CDataFrame::columnIsCategorical() const {
 }
 
 std::size_t CDataFrame::memoryUsage() const {
-    return CMemory::dynamicSize(m_Slices) + CMemory::dynamicSize(m_Writer);
+    std::size_t memory{CMemory::dynamicSize(m_ColumnNames)};
+    memory += CMemory::dynamicSize(m_CategoricalColumnValues);
+    memory += CMemory::dynamicSize(m_CategoricalColumnValueLookup);
+    memory += CMemory::dynamicSize(m_EmptyIsMissing);
+    memory += CMemory::dynamicSize(m_ColumnIsCategorical);
+    memory += CMemory::dynamicSize(m_Slices);
+    memory += CMemory::dynamicSize(m_Writer);
+    return memory;
 }
 
 std::uint64_t CDataFrame::checksum() const {
@@ -501,6 +634,9 @@ bool CDataFrame::maskedRowsInSlice(ITR& maskedRow,
     }
     return maskedRow != endMaskedRows && *maskedRow < endSliceRows;
 }
+
+const std::size_t CDataFrame::MAX_CATEGORICAL_CARDINALITY{
+    1 << (std::numeric_limits<float>::digits)};
 
 CDataFrame::CDataFrameRowSliceWriter::CDataFrameRowSliceWriter(
     std::size_t numberRows,

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -423,9 +423,9 @@ void CDataFrameTest::testMemoryUsage() {
     };
 
     // Memory usage should be less than:
-    //   1) 800 bytes for on disk, and
-    //   2) data size + doc ids size + 200 byte overhead in main memory.
-    std::size_t maximumMemory[]{850, rows * (cols + 1) * 4 + 350};
+    //   1) 1050 bytes for on disk, and
+    //   2) data size + doc ids size + 850 byte overhead in main memory.
+    std::size_t maximumMemory[]{1050, rows * (cols + 1) * 4 + 850};
 
     std::string type[]{"on disk", "main memory"};
     std::size_t t{0};

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -423,9 +423,9 @@ void CDataFrameTest::testMemoryUsage() {
     };
 
     // Memory usage should be less than:
-    //   1) 1050 bytes for on disk, and
-    //   2) data size + doc ids size + 850 byte overhead in main memory.
-    std::size_t maximumMemory[]{1050, rows * (cols + 1) * 4 + 850};
+    //   1) 1100 bytes for on disk, and
+    //   2) data size + doc ids size + 900 byte overhead in main memory.
+    std::size_t maximumMemory[]{1100, rows * (cols + 1) * 4 + 900};
 
     std::string type[]{"on disk", "main memory"};
     std::size_t t{0};

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -77,21 +77,21 @@ double CArgMinMseImpl::value() const {
                : count / (count + this->lambda()) * CBasicStatistics::mean(m_MeanError);
 }
 
-CArgMinBinomialLogisticImpl::CArgMinBinomialLogisticImpl(double lambda)
+CArgMinLogisticImpl::CArgMinLogisticImpl(double lambda)
     : CArgMinLossImpl{lambda}, m_CategoryCounts{0},
       m_BucketCategoryCounts(128, TSizeVector{0}) {
 }
 
-std::unique_ptr<CArgMinLossImpl> CArgMinBinomialLogisticImpl::clone() const {
-    return std::make_unique<CArgMinBinomialLogisticImpl>(*this);
+std::unique_ptr<CArgMinLossImpl> CArgMinLogisticImpl::clone() const {
+    return std::make_unique<CArgMinLogisticImpl>(*this);
 }
 
-bool CArgMinBinomialLogisticImpl::nextPass() {
+bool CArgMinLogisticImpl::nextPass() {
     m_CurrentPass += this->bucketWidth() > 0.0 ? 1 : 2;
     return m_CurrentPass < 2;
 }
 
-void CArgMinBinomialLogisticImpl::add(double prediction, double actual) {
+void CArgMinLogisticImpl::add(double prediction, double actual) {
     switch (m_CurrentPass) {
     case 0: {
         m_PredictionMinMax.add(prediction);
@@ -108,8 +108,8 @@ void CArgMinBinomialLogisticImpl::add(double prediction, double actual) {
     }
 }
 
-void CArgMinBinomialLogisticImpl::merge(const CArgMinLossImpl& other) {
-    const auto* logistic = dynamic_cast<const CArgMinBinomialLogisticImpl*>(&other);
+void CArgMinLogisticImpl::merge(const CArgMinLossImpl& other) {
+    const auto* logistic = dynamic_cast<const CArgMinLogisticImpl*>(&other);
     if (logistic != nullptr) {
         switch (m_CurrentPass) {
         case 0:
@@ -127,7 +127,7 @@ void CArgMinBinomialLogisticImpl::merge(const CArgMinLossImpl& other) {
     }
 }
 
-double CArgMinBinomialLogisticImpl::value() const {
+double CArgMinLogisticImpl::value() const {
 
     std::function<double(double)> objective;
     double minWeight;
@@ -262,40 +262,40 @@ const std::string& CMse::name() const {
 
 const std::string CMse::NAME{"mse"};
 
-std::unique_ptr<CLoss> CBinomialLogistic::clone() const {
-    return std::make_unique<CBinomialLogistic>(*this);
+std::unique_ptr<CLoss> CLogistic::clone() const {
+    return std::make_unique<CLogistic>(*this);
 }
 
-double CBinomialLogistic::value(double prediction, double actual) const {
+double CLogistic::value(double prediction, double actual) const {
     // Cross entropy
     prediction = CTools::logisticFunction(prediction);
     return -((1.0 - actual) * CTools::fastLog(1.0 - prediction) +
              actual * CTools::fastLog(prediction));
 }
 
-double CBinomialLogistic::gradient(double prediction, double actual) const {
+double CLogistic::gradient(double prediction, double actual) const {
     prediction = CTools::logisticFunction(prediction);
     return prediction - actual;
 }
 
-double CBinomialLogistic::curvature(double prediction, double /*actual*/) const {
+double CLogistic::curvature(double prediction, double /*actual*/) const {
     prediction = CTools::logisticFunction(prediction);
     return prediction * (1.0 - prediction);
 }
 
-bool CBinomialLogistic::isCurvatureConstant() const {
+bool CLogistic::isCurvatureConstant() const {
     return false;
 }
 
-CArgMinLoss CBinomialLogistic::minimizer(double lambda) const {
-    return this->makeMinimizer(CArgMinBinomialLogisticImpl{lambda});
+CArgMinLoss CLogistic::minimizer(double lambda) const {
+    return this->makeMinimizer(CArgMinLogisticImpl{lambda});
 }
 
-const std::string& CBinomialLogistic::name() const {
+const std::string& CLogistic::name() const {
     return NAME;
 }
 
-const std::string CBinomialLogistic::NAME{"binomial_logistic"};
+const std::string CLogistic::NAME{"binomial_logistic"};
 }
 
 std::size_t CBoostedTreeNode::leafIndex(const CEncodedDataFrameRowRef& row,

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -44,25 +44,30 @@ const double MAIN_TRAINING_LOOP_TREE_SIZE_MULTIPLIER{10.0};
 }
 
 CBoostedTreeFactory::TBoostedTreeUPtr
-CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVariable) {
+CBoostedTreeFactory::buildFor(core::CDataFrame& frame,
+                              TLossFunctionUPtr loss,
+                              std::size_t dependentVariable) {
 
     if (m_Restored) {
 
         if (dependentVariable != m_TreeImpl->m_DependentVariable) {
             HANDLE_FATAL(<< "Internal error: expected dependent variable "
                          << m_TreeImpl->m_DependentVariable << " got " << dependentVariable);
+            return nullptr;
         }
 
         this->resumeRestoredTrainingProgressMonitoring();
 
+        m_Loss = m_TreeImpl->m_Loss->clone();
         frame.resizeColumns(m_TreeImpl->m_NumberThreads,
                             frame.numberColumns() + this->numberExtraColumnsForTrain());
 
     } else {
 
-        m_TreeImpl->m_DependentVariable = dependentVariable;
-
         this->initializeTrainingProgressMonitoring();
+
+        m_TreeImpl->m_DependentVariable = dependentVariable;
+        m_Loss = std::move(loss);
 
         this->initializeMissingFeatureMasks(frame);
         std::tie(m_TreeImpl->m_TrainingRowMasks, m_TreeImpl->m_TestingRowMasks) =
@@ -80,8 +85,12 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
         }
     }
 
-    auto treeImpl = std::make_unique<CBoostedTreeImpl>(
-        m_NumberThreads, m_Loss != nullptr ? m_Loss->clone() : nullptr);
+    if (m_Loss == nullptr) {
+        HANDLE_FATAL(<< "Internal error: must supply a loss function");
+        return nullptr;
+    }
+
+    auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads, m_Loss->clone());
     std::swap(m_TreeImpl, treeImpl);
     return TBoostedTreeUPtr{new CBoostedTree{frame, m_RecordProgress, m_RecordMemoryUsage,
                                              m_RecordTrainingState, std::move(treeImpl)}};
@@ -597,13 +606,12 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
     return TOptionalVector{interval};
 }
 
-CBoostedTreeFactory CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads,
-                                                                 TLossFunctionUPtr loss) {
-    return {false, numberThreads, std::move(loss)};
+CBoostedTreeFactory CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads) {
+    return {false, numberThreads};
 }
 
 CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonStringStream) {
-    CBoostedTreeFactory result{true, 1, nullptr};
+    CBoostedTreeFactory result{true, 1};
     try {
         core::CJsonStateRestoreTraverser traverser(jsonStringStream);
         if (result.m_TreeImpl->acceptRestoreTraverser(traverser) == false ||
@@ -616,11 +624,9 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonS
     return result;
 }
 
-CBoostedTreeFactory::CBoostedTreeFactory(bool restored, std::size_t numberThreads, TLossFunctionUPtr loss)
-    : m_Restored{restored}, m_NumberThreads{numberThreads}, m_Loss{loss != nullptr
-                                                                       ? loss->clone()
-                                                                       : nullptr},
-      m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))},
+CBoostedTreeFactory::CBoostedTreeFactory(bool restored, std::size_t numberThreads)
+    : m_Restored{restored}, m_NumberThreads{numberThreads},
+      m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, nullptr)},
       m_LogDepthPenaltyMultiplierSearchInterval{0.0}, m_LogTreeSizePenaltyMultiplierSearchInterval{0.0},
       m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0} {
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -56,7 +56,7 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame,
     this->initializeTrainingProgressMonitoring();
 
     m_TreeImpl->m_DependentVariable = dependentVariable;
-    m_Loss = std::move(loss);
+    m_TreeImpl->m_Loss = std::move(loss);
 
     this->initializeMissingFeatureMasks(frame);
     std::tie(m_TreeImpl->m_TrainingRowMasks, m_TreeImpl->m_TestingRowMasks) =
@@ -73,7 +73,8 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame,
         this->initializeHyperparameterOptimisation();
     }
 
-    auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads, m_Loss->clone());
+    auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads,
+                                                       m_TreeImpl->m_Loss->clone());
     std::swap(m_TreeImpl, treeImpl);
     return TBoostedTreeUPtr{new CBoostedTree{frame, m_RecordProgress, m_RecordMemoryUsage,
                                              m_RecordTrainingState, std::move(treeImpl)}};

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -48,52 +48,53 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame,
                               TLossFunctionUPtr loss,
                               std::size_t dependentVariable) {
 
-    if (m_Restored) {
-
-        if (dependentVariable != m_TreeImpl->m_DependentVariable) {
-            HANDLE_FATAL(<< "Internal error: expected dependent variable "
-                         << m_TreeImpl->m_DependentVariable << " got " << dependentVariable);
-            return nullptr;
-        }
-
-        this->resumeRestoredTrainingProgressMonitoring();
-
-        m_Loss = m_TreeImpl->m_Loss->clone();
-        frame.resizeColumns(m_TreeImpl->m_NumberThreads,
-                            frame.numberColumns() + this->numberExtraColumnsForTrain());
-
-    } else {
-
-        this->initializeTrainingProgressMonitoring();
-
-        m_TreeImpl->m_DependentVariable = dependentVariable;
-        m_Loss = std::move(loss);
-
-        this->initializeMissingFeatureMasks(frame);
-        std::tie(m_TreeImpl->m_TrainingRowMasks, m_TreeImpl->m_TestingRowMasks) =
-            this->crossValidationRowMasks();
-
-        frame.resizeColumns(m_TreeImpl->m_NumberThreads,
-                            frame.numberColumns() + this->numberExtraColumnsForTrain());
-
-        this->selectFeaturesAndEncodeCategories(frame);
-        this->determineFeatureDataTypes(frame);
-
-        if (this->initializeFeatureSampleDistribution()) {
-            this->initializeHyperparameters(frame);
-            this->initializeHyperparameterOptimisation();
-        }
-    }
-
-    if (m_Loss == nullptr) {
+    if (loss == nullptr) {
         HANDLE_FATAL(<< "Internal error: must supply a loss function");
         return nullptr;
+    }
+
+    this->initializeTrainingProgressMonitoring();
+
+    m_TreeImpl->m_DependentVariable = dependentVariable;
+    m_Loss = std::move(loss);
+
+    this->initializeMissingFeatureMasks(frame);
+    std::tie(m_TreeImpl->m_TrainingRowMasks, m_TreeImpl->m_TestingRowMasks) =
+        this->crossValidationRowMasks();
+
+    frame.resizeColumns(m_TreeImpl->m_NumberThreads,
+                        frame.numberColumns() + this->numberExtraColumnsForTrain());
+
+    this->selectFeaturesAndEncodeCategories(frame);
+    this->determineFeatureDataTypes(frame);
+
+    if (this->initializeFeatureSampleDistribution()) {
+        this->initializeHyperparameters(frame);
+        this->initializeHyperparameterOptimisation();
     }
 
     auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads, m_Loss->clone());
     std::swap(m_TreeImpl, treeImpl);
     return TBoostedTreeUPtr{new CBoostedTree{frame, m_RecordProgress, m_RecordMemoryUsage,
                                              m_RecordTrainingState, std::move(treeImpl)}};
+}
+
+CBoostedTreeFactory::TBoostedTreeUPtr
+CBoostedTreeFactory::restoreFor(core::CDataFrame& frame, std::size_t dependentVariable) {
+
+    if (dependentVariable != m_TreeImpl->m_DependentVariable) {
+        HANDLE_FATAL(<< "Internal error: expected dependent variable "
+                     << m_TreeImpl->m_DependentVariable << " got " << dependentVariable);
+        return nullptr;
+    }
+
+    this->resumeRestoredTrainingProgressMonitoring();
+
+    frame.resizeColumns(m_TreeImpl->m_NumberThreads,
+                        frame.numberColumns() + this->numberExtraColumnsForTrain());
+
+    return TBoostedTreeUPtr{new CBoostedTree{frame, m_RecordProgress, m_RecordMemoryUsage,
+                                             m_RecordTrainingState, std::move(m_TreeImpl)}};
 }
 
 std::size_t CBoostedTreeFactory::numberHyperparameterTuningRounds() const {
@@ -607,11 +608,11 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
 }
 
 CBoostedTreeFactory CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads) {
-    return {false, numberThreads};
+    return {numberThreads};
 }
 
 CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonStringStream) {
-    CBoostedTreeFactory result{true, 1};
+    CBoostedTreeFactory result{1};
     try {
         core::CJsonStateRestoreTraverser traverser(jsonStringStream);
         if (result.m_TreeImpl->acceptRestoreTraverser(traverser) == false ||
@@ -624,8 +625,8 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonS
     return result;
 }
 
-CBoostedTreeFactory::CBoostedTreeFactory(bool restored, std::size_t numberThreads)
-    : m_Restored{restored}, m_NumberThreads{numberThreads},
+CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads)
+    : m_NumberThreads{numberThreads},
       m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, nullptr)},
       m_LogDepthPenaltyMultiplierSearchInterval{0.0}, m_LogTreeSizePenaltyMultiplierSearchInterval{0.0},
       m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0} {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -959,15 +959,15 @@ void CBoostedTreeTest::testLogisticMinimizer() {
 void CBoostedTreeTest::testLogisticRegression() {
 
     // The idea of this test is to create a random linear relationship between
-    // the feature values and the log-odds of each class, i.e.
+    // the feature values and the log-odds of class 1, i.e.
     //
     //   log-odds(class_1) = sum_i{ w * x_i }
     //
     // where, w is some fixed weight vector and x_i denoted the i'th feature vector.
     // We try to recover this relationship in logistic regression by observing
     // the actual labels. We want to test that we've roughly correctly estimated the
-    // log-odds. However, we target the cross-entropy so the errors in our estimates
-    // p_i^ should be measured in terms of cross entropy: sum_i{ p_i^ log(p_i) }
+    // log-odds function. However, we target the cross-entropy so the error in our
+    // estimates p_i^ should be measured in terms of cross entropy: sum_i{ p_i log(p_i^) }
     // where p_i = logistic(sum_i{ w_i * x_i}).
 
     test::CRandomNumbers rng;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1215,7 +1215,7 @@ void CBoostedTreeTest::testPersistRestore() {
     }
     // restore
     auto boostedTree = maths::CBoostedTreeFactory::constructFromString(persistOnceSStream)
-                           .buildFor(*frame, nullptr, cols - 1);
+                           .restoreFor(*frame, cols - 1);
     {
         core::CJsonStatePersistInserter inserter(persistTwiceSStream);
         boostedTree->acceptPersistInserter(inserter);
@@ -1273,7 +1273,7 @@ void CBoostedTreeTest::testRestoreErrorHandling() {
     bool throwsExceptions{false};
     try {
         auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBayesianOptimisationState)
-                               .buildFor(*frame, nullptr, 2);
+                               .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
         throwsExceptions = true;
@@ -1312,7 +1312,7 @@ void CBoostedTreeTest::testRestoreErrorHandling() {
     throwsExceptions = false;
     try {
         auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBoostedTreeImplState)
-                               .buildFor(*frame, nullptr, 2);
+                               .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
         throwsExceptions = true;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -153,9 +153,9 @@ auto predictAndComputeEvaluationMetrics(const F& generateFunction,
 
             fillDataFrame(trainRows, testRows, cols, x, noise, target, *frame);
 
-            auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                                  1, std::make_unique<maths::boosted_tree::CMse>())
-                                  .buildFor(*frame, cols - 1);
+            auto regression =
+                maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+                    *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
             regression->train();
             regression->predict();
@@ -412,9 +412,8 @@ void CBoostedTreeTest::testThreading() {
 
         fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
-        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                              2, std::make_unique<maths::boosted_tree::CMse>())
-                              .buildFor(*frame, cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(2).buildFor(
+            *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
         regression->train();
         regression->predict();
@@ -477,9 +476,8 @@ void CBoostedTreeTest::testConstantFeatures() {
 
     fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::boosted_tree::CMse>())
-                          .buildFor(*frame, cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+        *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
     regression->train();
 
@@ -508,9 +506,8 @@ void CBoostedTreeTest::testConstantTarget() {
     fillDataFrame(rows, 0, cols, x, TDoubleVec(rows, 0.0),
                   [](const TRowRef&) { return 1.0; }, *frame);
 
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::boosted_tree::CMse>())
-                          .buildFor(*frame, cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+        *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
     regression->train();
 
@@ -582,9 +579,8 @@ void CBoostedTreeTest::testCategoricalRegressors() {
         }
     });
 
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::boosted_tree::CMse>())
-                          .buildFor(*frame, cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+        *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
     regression->train();
     regression->predict();
@@ -625,9 +621,8 @@ void CBoostedTreeTest::testIntegerRegressor() {
     }
     frame->finishWritingRows();
 
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::boosted_tree::CMse>())
-                          .buildFor(*frame, 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+        *frame, std::make_unique<maths::boosted_tree::CMse>(), 1);
 
     regression->train();
     regression->predict();
@@ -672,9 +667,8 @@ void CBoostedTreeTest::testSingleSplit() {
     }
     frame->finishWritingRows();
 
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::boosted_tree::CMse>())
-                          .buildFor(*frame, cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+        *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
     regression->train();
 
@@ -731,9 +725,8 @@ void CBoostedTreeTest::testTranslationInvariance() {
         fillDataFrame(trainRows, rows - trainRows, cols, x,
                       TDoubleVec(rows, 0.0), target_, *frame);
 
-        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                              1, std::make_unique<maths::boosted_tree::CMse>())
-                              .buildFor(*frame, cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+            *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
         regression->train();
         regression->predict();
@@ -805,13 +798,13 @@ void CBoostedTreeTest::testDepthBasedRegularization() {
 
         fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
-        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                              1, std::make_unique<maths::boosted_tree::CMse>())
-                              .treeSizePenaltyMultiplier(0.0)
-                              .leafWeightPenaltyMultiplier(0.0)
-                              .softTreeDepthLimit(targetDepth)
-                              .softTreeDepthTolerance(0.05)
-                              .buildFor(*frame, cols - 1);
+        auto regression =
+            maths::CBoostedTreeFactory::constructFromParameters(1)
+                .treeSizePenaltyMultiplier(0.0)
+                .leafWeightPenaltyMultiplier(0.0)
+                .softTreeDepthLimit(targetDepth)
+                .softTreeDepthTolerance(0.05)
+                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
         regression->train();
 
@@ -1008,9 +1001,8 @@ void CBoostedTreeTest::testLogisticRegression() {
         fillDataFrame(trainRows, rows - trainRows, cols, {false, false, false, true},
                       x, TDoubleVec(rows, 0.0), target, *frame);
 
-        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                              1, std::make_unique<maths::boosted_tree::CLogistic>())
-                              .buildFor(*frame, cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
+            *frame, std::make_unique<maths::boosted_tree::CLogistic>(), cols - 1);
 
         regression->train();
         regression->predict();
@@ -1082,21 +1074,21 @@ void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
         }
         frame->finishWritingRows();
 
-        std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
-                                         1, std::make_unique<maths::boosted_tree::CMse>())
-                                         .estimateMemoryUsage(rows, cols));
+        std::int64_t estimatedMemory(
+            maths::CBoostedTreeFactory::constructFromParameters(1).estimateMemoryUsage(
+                rows, cols));
 
         std::int64_t memoryUsage{0};
         std::int64_t maxMemoryUsage{0};
-        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                              1, std::make_unique<maths::boosted_tree::CMse>())
-                              .memoryUsageCallback([&](std::int64_t delta) {
-                                  memoryUsage += delta;
-                                  maxMemoryUsage = std::max(maxMemoryUsage, memoryUsage);
-                                  LOG_TRACE(<< "current memory = " << memoryUsage
-                                            << ", high water mark = " << maxMemoryUsage);
-                              })
-                              .buildFor(*frame, cols - 1);
+        auto regression =
+            maths::CBoostedTreeFactory::constructFromParameters(1)
+                .memoryUsageCallback([&](std::int64_t delta) {
+                    memoryUsage += delta;
+                    maxMemoryUsage = std::max(maxMemoryUsage, memoryUsage);
+                    LOG_TRACE(<< "current memory = " << memoryUsage
+                              << ", high water mark = " << maxMemoryUsage);
+                })
+                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
 
         regression->train();
 
@@ -1146,10 +1138,11 @@ void CBoostedTreeTest::testProgressMonitoring() {
         std::atomic_bool finished{false};
 
         std::thread worker{[&]() {
-            auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                                  threads, std::make_unique<maths::boosted_tree::CMse>())
-                                  .progressCallback(reportProgress)
-                                  .buildFor(*frame, cols - 1);
+            auto regression =
+                maths::CBoostedTreeFactory::constructFromParameters(threads)
+                    .progressCallback(reportProgress)
+                    .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(),
+                              cols - 1);
 
             regression->train();
             finished.store(true);
@@ -1210,19 +1203,19 @@ void CBoostedTreeTest::testPersistRestore() {
 
     // persist
     {
-        auto boostedTree = maths::CBoostedTreeFactory::constructFromParameters(
-                               1, std::make_unique<maths::boosted_tree::CMse>())
-                               .numberFolds(2)
-                               .maximumNumberTrees(2)
-                               .maximumOptimisationRoundsPerHyperparameter(3)
-                               .buildFor(*frame, cols - 1);
+        auto boostedTree =
+            maths::CBoostedTreeFactory::constructFromParameters(1)
+                .numberFolds(2)
+                .maximumNumberTrees(2)
+                .maximumOptimisationRoundsPerHyperparameter(3)
+                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
         core::CJsonStatePersistInserter inserter(persistOnceSStream);
         boostedTree->acceptPersistInserter(inserter);
         persistOnceSStream.flush();
     }
     // restore
-    auto boostedTree =
-        maths::CBoostedTreeFactory::constructFromString(persistOnceSStream).buildFor(*frame, cols - 1);
+    auto boostedTree = maths::CBoostedTreeFactory::constructFromString(persistOnceSStream)
+                           .buildFor(*frame, nullptr, cols - 1);
     {
         core::CJsonStatePersistInserter inserter(persistTwiceSStream);
         boostedTree->acceptPersistInserter(inserter);
@@ -1280,7 +1273,7 @@ void CBoostedTreeTest::testRestoreErrorHandling() {
     bool throwsExceptions{false};
     try {
         auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBayesianOptimisationState)
-                               .buildFor(*frame, 2);
+                               .buildFor(*frame, nullptr, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
         throwsExceptions = true;
@@ -1319,7 +1312,7 @@ void CBoostedTreeTest::testRestoreErrorHandling() {
     throwsExceptions = false;
     try {
         auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBoostedTreeImplState)
-                               .buildFor(*frame, 2);
+                               .buildFor(*frame, nullptr, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
         throwsExceptions = true;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -609,7 +609,7 @@ void CBoostedTreeTest::testIntegerRegressor() {
 
     auto frame = core::makeMainStorageDataFrame(2).first;
 
-    frame->categoricalColumns({false, false});
+    frame->categoricalColumns(TBoolVec{false, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             TDoubleVec regressor;
@@ -658,7 +658,7 @@ void CBoostedTreeTest::testSingleSplit() {
     }
 
     auto frame = core::makeMainStorageDataFrame(cols).first;
-    frame->categoricalColumns({false, false});
+    frame->categoricalColumns(TBoolVec{false, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             *(column++) = x[i];
@@ -1062,7 +1062,7 @@ void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
         };
 
         auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
-        frame->categoricalColumns({true, false, false, false, false, false});
+        frame->categoricalColumns(TBoolVec{true, false, false, false, false, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 *(column++) = std::floor(x[0][i]);

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -561,7 +561,7 @@ void CBoostedTreeTest::testCategoricalRegressors() {
 
     auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
 
-    frame->categoricalColumns({true, true, false, false, false, false});
+    frame->categoricalColumns(TBoolVec{true, true, false, false, false, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             for (std::size_t j = 0; j < cols - 1; ++j, ++column) {

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -62,7 +62,7 @@ void CDataFrameCategoryEncoderTest::testOneHotEncoding() {
 
         auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
 
-        frame->categoricalColumns({true, false, false, false});
+        frame->categoricalColumns(TBoolVec{true, false, false, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 *(column++) = std::floor(features[0][i]);
@@ -128,7 +128,7 @@ void CDataFrameCategoryEncoderTest::testMeanValueEncoding() {
 
         TMeanAccumulatorVec expectedTargetMeanValues(static_cast<std::size_t>(numberCategories));
 
-        frame->categoricalColumns({true, false, false, false});
+        frame->categoricalColumns(TBoolVec{true, false, false, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 *(column++) = std::floor(features[0][i]);
@@ -206,7 +206,7 @@ void CDataFrameCategoryEncoderTest::testRareCategories() {
 
     TSizeVec categoryCounts(static_cast<std::size_t>(numberCategories), 0);
 
-    frame->categoricalColumns({false, false, true, false});
+    frame->categoricalColumns(TBoolVec{false, false, true, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             for (std::size_t j = 0; j + 2 < cols; ++j, ++column) {
@@ -263,7 +263,7 @@ void CDataFrameCategoryEncoderTest::testCorrelatedFeatures() {
 
         auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
 
-        frame->categoricalColumns({false, false, false, false, false, false, false});
+        frame->categoricalColumns(TBoolVec{false, false, false, false, false, false, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 for (std::size_t j = 0; j + 1 < cols; ++j, ++column) {
@@ -308,7 +308,7 @@ void CDataFrameCategoryEncoderTest::testCorrelatedFeatures() {
 
         auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
 
-        frame->categoricalColumns({true, true, true, true, false});
+        frame->categoricalColumns(TBoolVec{true, true, true, true, false});
         for (std::size_t i = 0; i < rows; ++i) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 for (std::size_t j = 0; j + 1 < cols; ++j, ++column) {
@@ -437,7 +437,7 @@ void CDataFrameCategoryEncoderTest::testEncodedDataFrameRowRef() {
         return TSizeVec{category};
     };
 
-    frame->categoricalColumns({true, false, false, true, false});
+    frame->categoricalColumns(TBoolVec{true, false, false, true, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             *(column++) = std::floor(features[0][i]);
@@ -547,7 +547,7 @@ void CDataFrameCategoryEncoderTest::testUnseenCategoryEncoding() {
     rng.generateUniformSamples(0.0, 3.0, rows, features[2]);
 
     auto frame = core::makeMainStorageDataFrame(cols).first;
-    frame->categoricalColumns({true, true, true, false});
+    frame->categoricalColumns(TBoolVec{true, true, true, false});
     for (std::size_t i = 0; i < rows; ++i) {
         auto writeOneRow = [&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             for (std::size_t j = 0; j + 1 < cols; ++j, ++column) {
@@ -601,7 +601,7 @@ void CDataFrameCategoryEncoderTest::testDiscardNuisanceFeatures() {
     rng.generateUniformSamples(0.0, 5.0, rows, features[5]);
 
     auto frame = core::makeMainStorageDataFrame(cols).first;
-    frame->categoricalColumns({false, false, false, false, false, false, false});
+    frame->categoricalColumns(TBoolVec{false, false, false, false, false, false, false});
     for (std::size_t i = 0; i < rows; ++i) {
         auto writeOneRow = [&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             double target{0.0};
@@ -656,7 +656,7 @@ void CDataFrameCategoryEncoderTest::testPersistRestore() {
 
     auto frame = core::makeMainStorageDataFrame(cols, 2 * rows).first;
 
-    frame->categoricalColumns({true, false, false, true, false});
+    frame->categoricalColumns(TBoolVec{true, false, false, true, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             *(column++) = std::floor(features[0][i]);

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.cc
@@ -23,6 +23,7 @@
 using namespace ml;
 
 namespace {
+using TBoolVec = std::vector<bool>;
 using TDoubleVec = std::vector<double>;
 using TDoubleVecVec = std::vector<TDoubleVec>;
 using TSizeVec = std::vector<std::size_t>;

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -26,6 +26,7 @@
 using namespace ml;
 
 namespace {
+using TBoolVec = std::vector<bool>;
 using TDoubleVec = std::vector<double>;
 using TDoubleVecVec = std::vector<TDoubleVec>;
 using TSizeVec = std::vector<std::size_t>;

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -381,7 +381,7 @@ void CDataFrameUtilsTest::testColumnQuantilesWithEncoding() {
 
     auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
 
-    frame->categoricalColumns({false, true, false, false, false, true});
+    frame->categoricalColumns(TBoolVec{false, true, false, false, false, true});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&features, target, i, rowFeatures = TDoubleVec{} ](
             core::CDataFrame::TFloatVecItr column, std::int32_t&) mutable {
@@ -575,7 +575,7 @@ void CDataFrameUtilsTest::testCategoryFrequencies() {
 
             auto frame = factory();
 
-            frame->categoricalColumns({true, false, true, false});
+            frame->categoricalColumns(TBoolVec{true, false, true, false});
             for (std::size_t i = 0; i < rows; ++i) {
                 frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column,
                                                    std::int32_t&) {
@@ -651,7 +651,7 @@ void CDataFrameUtilsTest::testMeanValueOfTargetForCategories() {
 
             auto frame = factory();
 
-            frame->categoricalColumns({true, false, true, false});
+            frame->categoricalColumns(TBoolVec{true, false, true, false});
             for (std::size_t i = 0; i < rows; ++i) {
                 frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column,
                                                    std::int32_t&) {
@@ -725,7 +725,7 @@ void CDataFrameUtilsTest::testMeanValueOfTargetForCategoriesWithMissing() {
 
     auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
 
-    frame->categoricalColumns({true, false, true, false});
+    frame->categoricalColumns(TBoolVec{true, false, true, false});
     for (std::size_t i = 0; i < rows; ++i) {
         frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             for (std::size_t j = 0; j < cols; ++j, ++column) {
@@ -783,7 +783,7 @@ void CDataFrameUtilsTest::testCategoryMicWithColumn() {
 
             auto frame = factory();
 
-            frame->categoricalColumns({true, false, true, false});
+            frame->categoricalColumns(TBoolVec{true, false, true, false});
             for (std::size_t i = 0; i < rows; ++i) {
                 frame->writeRow([&values, i, cols](core::CDataFrame::TFloatVecItr column,
                                                    std::int32_t&) {


### PR DESCRIPTION
Wires in binomial logistic regression to the data_frame_analyzer command.

This migrates all the state needed to run an analysis and write its results to `core::CDataFrame`. Storing category strings and related data on `api::CDataFrameAnalyzer` was proving a maintenance burden as we kept having to extend the runner interfaces. This has the added advantage of better memory usage estimates.

(Whilst making these changes I spotted a bug in our handling of recovery from failure to restore state. I'll unit test this in a follow on PR.)