### PR TITLE
[ML] Add state format version for resilience

### DIFF
--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -974,13 +974,15 @@ std::size_t CBoostedTreeImpl::maximumTreeSize(std::size_t numberRows) const {
 const std::size_t CBoostedTreeImpl::PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE{256};
 
 namespace {
+const std::string VERSION_7_5_TAG{"7.5"};
+
 const std::string BAYESIAN_OPTIMIZATION_TAG{"bayesian_optimization"};
 const std::string BEST_FOREST_TAG{"best_forest"};
 const std::string BEST_FOREST_TEST_LOSS_TAG{"best_forest_test_loss"};
 const std::string BEST_HYPERPARAMETERS_TAG{"best_hyperparameters"};
 const std::string CURRENT_ROUND_TAG{"current_round"};
 const std::string DEPENDENT_VARIABLE_TAG{"dependent_variable"};
-const std::string ENCODER_TAG{"encoder_tag"};
+const std::string ENCODER_TAG{"encoder"};
 const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
 const std::string ETA_OVERRIDE_TAG{"eta_override"};
 const std::string ETA_TAG{"eta"};
@@ -1066,6 +1068,7 @@ void CBoostedTreeImpl::SHyperparameters::acceptPersistInserter(core::CStatePersi
 }
 
 void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(VERSION_7_5_TAG, "", inserter);
     core::CPersistUtils::persist(BAYESIAN_OPTIMIZATION_TAG, *m_BayesianOptimization, inserter);
     core::CPersistUtils::persist(BEST_FOREST_TEST_LOSS_TAG, m_BestForestTestLoss, inserter);
     core::CPersistUtils::persist(CURRENT_ROUND_TAG, m_CurrentRound, inserter);
@@ -1152,89 +1155,97 @@ bool CBoostedTreeImpl::SHyperparameters::acceptRestoreTraverser(core::CStateRest
 }
 
 bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    do {
-        const std::string& name = traverser.name();
-        RESTORE_NO_ERROR(BAYESIAN_OPTIMIZATION_TAG,
-                         m_BayesianOptimization =
-                             std::make_unique<CBayesianOptimisation>(traverser))
-        RESTORE(BEST_FOREST_TEST_LOSS_TAG,
-                core::CPersistUtils::restore(BEST_FOREST_TEST_LOSS_TAG,
-                                             m_BestForestTestLoss, traverser))
-        RESTORE(CURRENT_ROUND_TAG,
-                core::CPersistUtils::restore(CURRENT_ROUND_TAG, m_CurrentRound, traverser))
-        RESTORE(DEPENDENT_VARIABLE_TAG,
-                core::CPersistUtils::restore(DEPENDENT_VARIABLE_TAG,
-                                             m_DependentVariable, traverser))
-        RESTORE_NO_ERROR(ENCODER_TAG,
-                         m_Encoder = std::make_unique<CDataFrameCategoryEncoder>(traverser))
-        RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
-                core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
-                                             m_EtaGrowthRatePerTree, traverser))
-        RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
-        RESTORE(FEATURE_BAG_FRACTION_TAG,
-                core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
-                                             m_FeatureBagFraction, traverser))
-        RESTORE(FEATURE_DATA_TYPES_TAG,
-                core::CPersistUtils::restore(FEATURE_DATA_TYPES_TAG,
-                                             m_FeatureDataTypes, traverser));
-        RESTORE(FEATURE_SAMPLE_PROBABILITIES_TAG,
-                core::CPersistUtils::restore(FEATURE_SAMPLE_PROBABILITIES_TAG,
-                                             m_FeatureSampleProbabilities, traverser))
-        RESTORE(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
-                core::CPersistUtils::restore(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
-                                             m_MaximumAttemptsToAddTree, traverser))
-        RESTORE(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
-                core::CPersistUtils::restore(
-                    MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
-                    m_MaximumOptimisationRoundsPerHyperparameter, traverser))
-        RESTORE(MAXIMUM_TREE_SIZE_MULTIPLIER_TAG,
-                core::CPersistUtils::restore(MAXIMUM_TREE_SIZE_MULTIPLIER_TAG,
-                                             m_MaximumTreeSizeMultiplier, traverser))
-        RESTORE(MISSING_FEATURE_ROW_MASKS_TAG,
-                core::CPersistUtils::restore(MISSING_FEATURE_ROW_MASKS_TAG,
-                                             m_MissingFeatureRowMasks, traverser))
-        RESTORE(NUMBER_FOLDS_TAG,
-                core::CPersistUtils::restore(NUMBER_FOLDS_TAG, m_NumberFolds, traverser))
-        RESTORE(NUMBER_ROUNDS_TAG,
-                core::CPersistUtils::restore(NUMBER_ROUNDS_TAG, m_NumberRounds, traverser))
-        RESTORE(NUMBER_SPLITS_PER_FEATURE_TAG,
-                core::CPersistUtils::restore(NUMBER_SPLITS_PER_FEATURE_TAG,
-                                             m_NumberSplitsPerFeature, traverser))
-        RESTORE(NUMBER_THREADS_TAG,
-                core::CPersistUtils::restore(NUMBER_THREADS_TAG, m_NumberThreads, traverser))
-        RESTORE(RANDOM_NUMBER_GENERATOR_TAG, m_Rng.fromString(traverser.value()))
-        RESTORE(REGULARIZATION_TAG,
-                core::CPersistUtils::restore(REGULARIZATION_TAG, m_Regularization, traverser))
-        RESTORE(REGULARIZATION_OVERRIDE_TAG,
-                core::CPersistUtils::restore(REGULARIZATION_OVERRIDE_TAG,
-                                             m_RegularizationOverride, traverser))
-        RESTORE(ROWS_PER_FEATURE_TAG,
-                core::CPersistUtils::restore(ROWS_PER_FEATURE_TAG, m_RowsPerFeature, traverser))
-        RESTORE(TESTING_ROW_MASKS_TAG,
-                core::CPersistUtils::restore(TESTING_ROW_MASKS_TAG, m_TestingRowMasks, traverser))
-        RESTORE(MAXIMUM_NUMBER_TREES_TAG,
-                core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_TAG,
-                                             m_MaximumNumberTrees, traverser))
-        RESTORE(TRAINING_ROW_MASKS_TAG,
-                core::CPersistUtils::restore(TRAINING_ROW_MASKS_TAG, m_TrainingRowMasks, traverser))
-        RESTORE(TRAINING_PROGRESS_TAG,
-                core::CPersistUtils::restore(TRAINING_PROGRESS_TAG, m_TrainingProgress, traverser))
-        RESTORE(BEST_FOREST_TAG,
-                core::CPersistUtils::restore(BEST_FOREST_TAG, m_BestForest, traverser))
-        RESTORE(BEST_HYPERPARAMETERS_TAG,
-                core::CPersistUtils::restore(BEST_HYPERPARAMETERS_TAG,
-                                             m_BestHyperparameters, traverser))
-        RESTORE(ETA_OVERRIDE_TAG,
-                core::CPersistUtils::restore(ETA_OVERRIDE_TAG, m_EtaOverride, traverser))
-        RESTORE(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
-                core::CPersistUtils::restore(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
-                                             m_FeatureBagFractionOverride, traverser))
-        RESTORE(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
-                core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
-                                             m_MaximumNumberTreesOverride, traverser))
-        RESTORE(LOSS_TAG, restoreLoss(m_Loss, traverser))
-    } while (traverser.next());
-    return true;
+    if (traverser.name() == VERSION_7_5_TAG) {
+        do {
+            const std::string& name = traverser.name();
+            RESTORE_NO_ERROR(BAYESIAN_OPTIMIZATION_TAG,
+                             m_BayesianOptimization =
+                                 std::make_unique<CBayesianOptimisation>(traverser))
+            RESTORE(BEST_FOREST_TEST_LOSS_TAG,
+                    core::CPersistUtils::restore(BEST_FOREST_TEST_LOSS_TAG,
+                                                 m_BestForestTestLoss, traverser))
+            RESTORE(CURRENT_ROUND_TAG,
+                    core::CPersistUtils::restore(CURRENT_ROUND_TAG, m_CurrentRound, traverser))
+            RESTORE(DEPENDENT_VARIABLE_TAG,
+                    core::CPersistUtils::restore(DEPENDENT_VARIABLE_TAG,
+                                                 m_DependentVariable, traverser))
+            RESTORE_NO_ERROR(ENCODER_TAG,
+                             m_Encoder = std::make_unique<CDataFrameCategoryEncoder>(traverser))
+            RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
+                    core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
+                                                 m_EtaGrowthRatePerTree, traverser))
+            RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
+            RESTORE(FEATURE_BAG_FRACTION_TAG,
+                    core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
+                                                 m_FeatureBagFraction, traverser))
+            RESTORE(FEATURE_DATA_TYPES_TAG,
+                    core::CPersistUtils::restore(FEATURE_DATA_TYPES_TAG,
+                                                 m_FeatureDataTypes, traverser));
+            RESTORE(FEATURE_SAMPLE_PROBABILITIES_TAG,
+                    core::CPersistUtils::restore(FEATURE_SAMPLE_PROBABILITIES_TAG,
+                                                 m_FeatureSampleProbabilities, traverser))
+            RESTORE(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
+                                                 m_MaximumAttemptsToAddTree, traverser))
+            RESTORE(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                    core::CPersistUtils::restore(
+                        MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                        m_MaximumOptimisationRoundsPerHyperparameter, traverser))
+            RESTORE(MAXIMUM_TREE_SIZE_MULTIPLIER_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_TREE_SIZE_MULTIPLIER_TAG,
+                                                 m_MaximumTreeSizeMultiplier, traverser))
+            RESTORE(MISSING_FEATURE_ROW_MASKS_TAG,
+                    core::CPersistUtils::restore(MISSING_FEATURE_ROW_MASKS_TAG,
+                                                 m_MissingFeatureRowMasks, traverser))
+            RESTORE(NUMBER_FOLDS_TAG,
+                    core::CPersistUtils::restore(NUMBER_FOLDS_TAG, m_NumberFolds, traverser))
+            RESTORE(NUMBER_ROUNDS_TAG,
+                    core::CPersistUtils::restore(NUMBER_ROUNDS_TAG, m_NumberRounds, traverser))
+            RESTORE(NUMBER_SPLITS_PER_FEATURE_TAG,
+                    core::CPersistUtils::restore(NUMBER_SPLITS_PER_FEATURE_TAG,
+                                                 m_NumberSplitsPerFeature, traverser))
+            RESTORE(NUMBER_THREADS_TAG,
+                    core::CPersistUtils::restore(NUMBER_THREADS_TAG, m_NumberThreads, traverser))
+            RESTORE(RANDOM_NUMBER_GENERATOR_TAG, m_Rng.fromString(traverser.value()))
+            RESTORE(REGULARIZATION_TAG,
+                    core::CPersistUtils::restore(REGULARIZATION_TAG, m_Regularization, traverser))
+            RESTORE(REGULARIZATION_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(REGULARIZATION_OVERRIDE_TAG,
+                                                 m_RegularizationOverride, traverser))
+            RESTORE(ROWS_PER_FEATURE_TAG,
+                    core::CPersistUtils::restore(ROWS_PER_FEATURE_TAG, m_RowsPerFeature, traverser))
+            RESTORE(TESTING_ROW_MASKS_TAG,
+                    core::CPersistUtils::restore(TESTING_ROW_MASKS_TAG,
+                                                 m_TestingRowMasks, traverser))
+            RESTORE(MAXIMUM_NUMBER_TREES_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_TAG,
+                                                 m_MaximumNumberTrees, traverser))
+            RESTORE(TRAINING_ROW_MASKS_TAG,
+                    core::CPersistUtils::restore(TRAINING_ROW_MASKS_TAG,
+                                                 m_TrainingRowMasks, traverser))
+            RESTORE(TRAINING_PROGRESS_TAG,
+                    core::CPersistUtils::restore(TRAINING_PROGRESS_TAG,
+                                                 m_TrainingProgress, traverser))
+            RESTORE(BEST_FOREST_TAG,
+                    core::CPersistUtils::restore(BEST_FOREST_TAG, m_BestForest, traverser))
+            RESTORE(BEST_HYPERPARAMETERS_TAG,
+                    core::CPersistUtils::restore(BEST_HYPERPARAMETERS_TAG,
+                                                 m_BestHyperparameters, traverser))
+            RESTORE(ETA_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(ETA_OVERRIDE_TAG, m_EtaOverride, traverser))
+            RESTORE(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+                                                 m_FeatureBagFractionOverride, traverser))
+            RESTORE(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
+                    core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
+                                                 m_MaximumNumberTreesOverride, traverser))
+            RESTORE(LOSS_TAG, restoreLoss(m_Loss, traverser))
+        } while (traverser.next());
+        return true;
+    }
+    LOG_ERROR(<< "Input error: unsupported state serialization version. Currently supported version: "
+              << VERSION_7_5_TAG);
+    return false;
 }
 
 bool CBoostedTreeImpl::restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1341,6 +1341,7 @@ void CBoostedTreeTest::testRestoreErrorHandling() {
                        std::string::npos);
     }
     CPPUNIT_ASSERT(throwsExceptions);
+    ml::core::CLogger::instance().reset();
 }
 
 CppUnit::Test* CBoostedTreeTest::suite() {

--- a/lib/maths/unittest/testfiles/error_bayesian_optimisation_state.json
+++ b/lib/maths/unittest/testfiles/error_bayesian_optimisation_state.json
@@ -1,0 +1,116 @@
+{
+  "7.5": "",
+  "bayesian_optimization": {
+    "7.5": "",
+    "rng": "16294208416658607535:7960286522194355700",
+    "min_boundary": {
+      "dense_vector": "-6.18966:-2.047204:-4.574167:2:5e-2:-3.506558:1.025:2e-1"
+    },
+    "max_boundary": {
+      "dense_vector": "-1.584489:2.557966:-1.589118e-2:7.321928:2.5e-1:a:1.075:8e-1"
+    },
+    "error_variances": "",
+    "kernel_parameters": {
+      "dense_vector": "1:1:1:1:1:1:1:1:1"
+    },
+    "min_kernel_coordinate_distance_scales": {
+      "dense_vector": "1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3"
+    },
+    "function_mean_values": {
+      "d": "0"
+    },
+    "range_scale": "1",
+    "range_shift": "0",
+    "restarts": "10"
+  },
+  "best_forest_test_loss": "1.797693e308",
+  "current_round": "0",
+  "dependent_variable": "2",
+  "encoder_tag": {
+    "7.5": "",
+    "encoding_vector": {
+      "identity_encoding": {
+        "encoding_input_column_index": "0",
+        "encoding_mic": "3.556275e-1"
+      },
+      "identity_encoding": {
+        "encoding_input_column_index": "2",
+        "encoding_mic": "0"
+      }
+    }
+  },
+  "eta_growth_rate_per_tree": "1.05",
+  "eta": "1e-1",
+  "feature_bag_fraction": "5e-1",
+  "feature_data_types": {
+    "d": "2",
+    "a": "0:2.10813656449318e-1:9.96675395965576:",
+    "a": "0:2.90942788124084e-1:9.86151218414307:"
+  },
+  "feature_sample_probabilities": "1:0",
+  "maximum_attempts_to_add_tree": "3",
+  "maximum_optimisation_rounds_per_hyperparameter": "3",
+  "maximum_tree_size_multiplier": "10",
+  "missing_feature_row_masks": {
+    "d": "3",
+    "a": "50:0:1:50",
+    "a": "50:0:1:50",
+    "a": "50:0:1:50"
+  },
+  "number_folds": "2",
+  "number_rounds": "24",
+  "number_splits_per_feature": "75",
+  "number_threads": "1",
+  "random_number_generator": "6348936557884334503:6746432788814635579",
+  "regularization_override": {
+    "regularization_depth_penalty_multiplier": "false;0",
+    "regularization_tree_size_penalty_multiplier": "false;0",
+    "regularization_leaf_weight_penalty_multiplier": "false;0",
+    "regularization_soft_tree_depth_limit": "false;0",
+    "regularization_soft_tree_depth_tolerance": "false;0"
+  },
+  "regularization": {
+    "regularization_depth_penalty_multiplier": "2.050525e-2",
+    "regularization_tree_size_penalty_multiplier": "1.031488e-1",
+    "regularization_leaf_weight_penalty_multiplier": "1.290953",
+    "regularization_soft_tree_depth_limit": "3",
+    "regularization_soft_tree_depth_tolerance": "1.5e-1"
+  },
+  "rows_per_feature": "50",
+  "testing_row_masks": {
+    "d": "2",
+    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
+    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+  },
+  "maximum_number_trees": "2",
+  "training_row_masks": {
+    "d": "2",
+    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
+    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+  },
+  "training_progress": {
+    "loop_size_tag": "76",
+    "progress_steps_tag": "32",
+    "current_step_progress_tag": "3.125e-2",
+    "loop_pos_tag": "26"
+  },
+  "best_forest": {
+    "d": "0"
+  },
+  "best_hyperparameters": {
+    "hyperparam_eta": "1e-1",
+    "hyperparam_eta_growth_rate_per_tree": "1.05",
+    "hyperparam_feature_bag_fraction": "5e-1",
+    "hyperparam_regularization": {
+      "regularization_depth_penalty_multiplier": "0",
+      "regularization_tree_size_penalty_multiplier": "0",
+      "regularization_leaf_weight_penalty_multiplier": "0",
+      "regularization_soft_tree_depth_limit": "0",
+      "regularization_soft_tree_depth_tolerance": "0"
+    }
+  },
+  "eta_override": "false;0",
+  "feature_bag_fraction_override": "false;0",
+  "maximum_number_trees_override": "true;2",
+  "loss": "mse"
+}

--- a/lib/maths/unittest/testfiles/error_boosted_tree_impl_state.json
+++ b/lib/maths/unittest/testfiles/error_boosted_tree_impl_state.json
@@ -1,0 +1,116 @@
+{
+  "7.5": "",
+  "bayesian_optimization": {
+    "7.5": "",
+    "rng": "16294208416658607535:7960286522194355700",
+    "min_boundary": {
+      "dense_vector": "-6.18966:-2.047204:-4.574167:2:5e-2:-3.506558:1.025:2e-1"
+    },
+    "max_boundary": {
+      "dense_vector": "-1.584489:2.557966:-1.589118e-2:7.321928:2.5e-1:-1.203973:1.075:8e-1"
+    },
+    "error_variances": "",
+    "kernel_parameters": {
+      "dense_vector": "1:1:1:1:1:1:1:1:1"
+    },
+    "min_kernel_coordinate_distance_scales": {
+      "dense_vector": "1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3"
+    },
+    "function_mean_values": {
+      "d": "0"
+    },
+    "range_scale": "1",
+    "range_shift": "0",
+    "restarts": "10"
+  },
+  "best_forest_test_loss": "1.797693e308",
+  "current_round": "0",
+  "dependent_variable": "2",
+  "encoder_tag": {
+    "7.5": "",
+    "encoding_vector": {
+      "identity_encoding": {
+        "encoding_input_column_index": "0",
+        "encoding_mic": "3.556275e-1"
+      },
+      "identity_encoding": {
+        "encoding_input_column_index": "2",
+        "encoding_mic": "0"
+      }
+    }
+  },
+  "eta_growth_rate_per_tree": "1.05",
+  "eta": "1e-1",
+  "feature_bag_fraction": "5e-1",
+  "feature_data_types": {
+    "d": "2",
+    "a": "0:2.10813656449318e-1:9.96675395965576:",
+    "a": "0:2.90942788124084e-1:9.86151218414307:"
+  },
+  "feature_sample_probabilities": "1:0",
+  "maximum_attempts_to_add_tree": "3",
+  "maximum_optimisation_rounds_per_hyperparameter": "3",
+  "maximum_tree_size_multiplier": "10",
+  "missing_feature_row_masks": {
+    "d": "3",
+    "a": "50:0:1:50",
+    "a": "50:0:1:50",
+    "a": "50:0:1:50"
+  },
+  "number_folds": "",
+  "number_rounds": "24",
+  "number_splits_per_feature": "75",
+  "number_threads": "1",
+  "random_number_generator": "6348936557884334503:6746432788814635579",
+  "regularization_override": {
+    "regularization_depth_penalty_multiplier": "false;0",
+    "regularization_tree_size_penalty_multiplier": "false;0",
+    "regularization_leaf_weight_penalty_multiplier": "false;0",
+    "regularization_soft_tree_depth_limit": "false;0",
+    "regularization_soft_tree_depth_tolerance": "false;0"
+  },
+  "regularization": {
+    "regularization_depth_penalty_multiplier": "2.050525e-2",
+    "regularization_tree_size_penalty_multiplier": "1.031488e-1",
+    "regularization_leaf_weight_penalty_multiplier": "1.290953",
+    "regularization_soft_tree_depth_limit": "3",
+    "regularization_soft_tree_depth_tolerance": "1.5e-1"
+  },
+  "rows_per_feature": "50",
+  "testing_row_masks": {
+    "d": "2",
+    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
+    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+  },
+  "maximum_number_trees": "2",
+  "training_row_masks": {
+    "d": "2",
+    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
+    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+  },
+  "training_progress": {
+    "loop_size_tag": "76",
+    "progress_steps_tag": "32",
+    "current_step_progress_tag": "3.125e-2",
+    "loop_pos_tag": "26"
+  },
+  "best_forest": {
+    "d": "0"
+  },
+  "best_hyperparameters": {
+    "hyperparam_eta": "1e-1",
+    "hyperparam_eta_growth_rate_per_tree": "1.05",
+    "hyperparam_feature_bag_fraction": "5e-1",
+    "hyperparam_regularization": {
+      "regularization_depth_penalty_multiplier": "0",
+      "regularization_tree_size_penalty_multiplier": "0",
+      "regularization_leaf_weight_penalty_multiplier": "0",
+      "regularization_soft_tree_depth_limit": "0",
+      "regularization_soft_tree_depth_tolerance": "0"
+    }
+  },
+  "eta_override": "false;0",
+  "feature_bag_fraction_override": "false;0",
+  "maximum_number_trees_override": "true;2",
+  "loss": "mse"
+}

--- a/lib/maths/unittest/testfiles/error_no_version_state.json
+++ b/lib/maths/unittest/testfiles/error_no_version_state.json
@@ -1,0 +1,115 @@
+{
+  "bayesian_optimization": {
+    "7.5": "",
+    "rng": "16294208416658607535:7960286522194355700",
+    "min_boundary": {
+      "dense_vector": "-6.18966:-2.047204:-4.574167:2:5e-2:-3.506558:1.025:2e-1"
+    },
+    "max_boundary": {
+      "dense_vector": "-1.584489:2.557966:-1.589118e-2:7.321928:2.5e-1:-1.203973:1.075:8e-1"
+    },
+    "error_variances": "",
+    "kernel_parameters": {
+      "dense_vector": "1:1:1:1:1:1:1:1:1"
+    },
+    "min_kernel_coordinate_distance_scales": {
+      "dense_vector": "1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3"
+    },
+    "function_mean_values": {
+      "d": "0"
+    },
+    "range_scale": "1",
+    "range_shift": "0",
+    "restarts": "10"
+  },
+  "best_forest_test_loss": "1.797693e308",
+  "current_round": "0",
+  "dependent_variable": "2",
+  "encoder_tag": {
+    "7.5": "",
+    "encoding_vector": {
+      "identity_encoding": {
+        "encoding_input_column_index": "0",
+        "encoding_mic": "3.556275e-1"
+      },
+      "identity_encoding": {
+        "encoding_input_column_index": "2",
+        "encoding_mic": "0"
+      }
+    }
+  },
+  "eta_growth_rate_per_tree": "1.05",
+  "eta": "1e-1",
+  "feature_bag_fraction": "5e-1",
+  "feature_data_types": {
+    "d": "2",
+    "a": "0:2.10813656449318e-1:9.96675395965576:",
+    "a": "0:2.90942788124084e-1:9.86151218414307:"
+  },
+  "feature_sample_probabilities": "1:0",
+  "maximum_attempts_to_add_tree": "3",
+  "maximum_optimisation_rounds_per_hyperparameter": "3",
+  "maximum_tree_size_multiplier": "10",
+  "missing_feature_row_masks": {
+    "d": "3",
+    "a": "50:0:1:50",
+    "a": "50:0:1:50",
+    "a": "50:0:1:50"
+  },
+  "number_folds": "2",
+  "number_rounds": "24",
+  "number_splits_per_feature": "75",
+  "number_threads": "1",
+  "random_number_generator": "6348936557884334503:6746432788814635579",
+  "regularization_override": {
+    "regularization_depth_penalty_multiplier": "false;0",
+    "regularization_tree_size_penalty_multiplier": "false;0",
+    "regularization_leaf_weight_penalty_multiplier": "false;0",
+    "regularization_soft_tree_depth_limit": "false;0",
+    "regularization_soft_tree_depth_tolerance": "false;0"
+  },
+  "regularization": {
+    "regularization_depth_penalty_multiplier": "2.050525e-2",
+    "regularization_tree_size_penalty_multiplier": "1.031488e-1",
+    "regularization_leaf_weight_penalty_multiplier": "1.290953",
+    "regularization_soft_tree_depth_limit": "3",
+    "regularization_soft_tree_depth_tolerance": "1.5e-1"
+  },
+  "rows_per_feature": "50",
+  "testing_row_masks": {
+    "d": "2",
+    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
+    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+  },
+  "maximum_number_trees": "2",
+  "training_row_masks": {
+    "d": "2",
+    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
+    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+  },
+  "training_progress": {
+    "loop_size_tag": "76",
+    "progress_steps_tag": "32",
+    "current_step_progress_tag": "3.125e-2",
+    "loop_pos_tag": "26"
+  },
+  "best_forest": {
+    "d": "0"
+  },
+  "best_hyperparameters": {
+    "hyperparam_eta": "1e-1",
+    "hyperparam_eta_growth_rate_per_tree": "1.05",
+    "hyperparam_feature_bag_fraction": "5e-1",
+    "hyperparam_regularization": {
+      "regularization_depth_penalty_multiplier": "0",
+      "regularization_tree_size_penalty_multiplier": "0",
+      "regularization_leaf_weight_penalty_multiplier": "0",
+      "regularization_soft_tree_depth_limit": "0",
+      "regularization_soft_tree_depth_tolerance": "0"
+    }
+  },
+  "eta_override": "false;0",
+  "feature_bag_fraction_override": "false;0",
+  "maximum_number_trees_override": "true;2",
+  "loss": "mse"
+}


### PR DESCRIPTION
This PR adds the version number of the current release (7.5) to the format of the training state using for resilience. In the case of the version mismatch, the deserialization of the training state will fail and training will start from scratch.

I also took an opportunity to refactor the test for persistence state error handling to have a more granular control of the reasons for failure.