### PR TITLE
[ML] Fix potential problem for boosted tree training initialisation

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@ Bayesian optimisation based hyperparameter search. (See {ml-pull}698[#698].)
 * Improvements to count and sum anomaly detection for sparse data. This primarily
 aims to improve handling of data which are predictably present: detecting when they
 are unexpectedly missing. (See {ml-pull}721[#721].)
+* Trap numeric errors causing bad hyperparameter search initialisation and repeated
+errors to be logged during boosted tree training. (See {ml-pull}732[#732].)
 
 == {es} version 7.4.1
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -110,13 +110,18 @@ CBoostedTreeImpl::CLeafNodeStatistics::CLeafNodeStatistics(std::size_t id,
         m_Gradients[i].resize(numberSplits);
         m_Curvatures[i].resize(numberSplits);
         for (std::size_t j = 0; j < numberSplits; ++j) {
-            m_Gradients[i][j] = parent.m_Gradients[i][j] - sibling.m_Gradients[i][j];
             m_Curvatures[i][j] = parent.m_Curvatures[i][j] - sibling.m_Curvatures[i][j];
+            m_Gradients[i][j] = m_Curvatures[i][j] == 0.0
+                                    ? 0.0
+                                    : parent.m_Gradients[i][j] -
+                                          sibling.m_Gradients[i][j];
         }
-        m_MissingGradients[i] = parent.m_MissingGradients[i] -
-                                sibling.m_MissingGradients[i];
         m_MissingCurvatures[i] = parent.m_MissingCurvatures[i] -
                                  sibling.m_MissingCurvatures[i];
+        m_MissingGradients[i] = m_MissingCurvatures[i] == 0.0
+                                    ? 0.0
+                                    : parent.m_MissingGradients[i] -
+                                          sibling.m_MissingGradients[i];
     }
 
     LOG_TRACE(<< "gradients = " << core::CContainerPrinter::print(m_Gradients));


### PR DESCRIPTION
Numeric errors mean that it's possible the sum curvature for a candidate split is identically zero while the gradient is epsilon. This can cause the node gain to appear infinite (when there is no weight regularisation) which in turns causes problems initialising the region we search for optimal hyperparameter values.

Since none of our loss functions should have curvature identically equal to zero, we can safely force the gradient to be zero if detect that the curvature is zero.

\cc @przemekwitek.