### PR TITLE
[ML] Snapshot boosted tree training state after final train

### DIFF
--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -995,7 +995,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeRegressionTrainingWithStateRecove
         };
 
         finalIteration = params.numberUnset() * numberRoundsPerHyperparameter;
-        finalIteration = std::max(finalIteration, std::size_t{1}) - 1;
+        finalIteration = std::max(params.numberUnset() * numberRoundsPerHyperparameter - 1, std::size_t{0});
         if (finalIteration > 1) {
             rng.generateUniformSamples(0, finalIteration - 1, 3, intermediateIterations);
         }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -972,14 +972,13 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeRegressionTrainingWithStateRecove
 
     std::size_t numberRoundsPerHyperparameter{3};
 
-    TSizeVec intermediateIterations;
+    TSizeVec intermediateIterations{0, 0, 0};
     std::size_t finalIteration{0};
 
     test::CRandomNumbers rng;
 
-    // TODO re-enable case that all parameters are set.
     for (const auto& params :
-         {/*SHyperparameters{},*/ SHyperparameters{-1.0},
+         {SHyperparameters{}, SHyperparameters{-1.0},
           SHyperparameters{-1.0, -1.0}, SHyperparameters{-1.0, -1.0, -1.0}}) {
 
         LOG_DEBUG(<< "Number parameters to search = " << params.numberUnset());
@@ -995,8 +994,11 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeRegressionTrainingWithStateRecove
                                   params.s_FeatureBagFraction, &persisterSupplier);
         };
 
-        finalIteration = params.numberUnset() * numberRoundsPerHyperparameter - 1;
-        rng.generateUniformSamples(0, finalIteration - 1, 3, intermediateIterations);
+        finalIteration = params.numberUnset() * numberRoundsPerHyperparameter;
+        finalIteration = std::max(finalIteration, std::size_t{1}) - 1;
+        if (finalIteration > 1) {
+            rng.generateUniformSamples(0, finalIteration - 1, 3, intermediateIterations);
+        }
 
         for (auto intermediateIteration : intermediateIterations) {
             LOG_DEBUG(<< "restart from " << intermediateIteration);

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -995,7 +995,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeRegressionTrainingWithStateRecove
         };
 
         finalIteration = params.numberUnset() * numberRoundsPerHyperparameter;
-        finalIteration = std::max(params.numberUnset() * numberRoundsPerHyperparameter - 1, std::size_t{0});
+        finalIteration = std::max(
+            params.numberUnset() * numberRoundsPerHyperparameter - 1, std::size_t{0});
         if (finalIteration > 1) {
             rng.generateUniformSamples(0, finalIteration - 1, 3, intermediateIterations);
         }

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -995,10 +995,8 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeRegressionTrainingWithStateRecove
         };
 
         finalIteration = params.numberUnset() * numberRoundsPerHyperparameter;
-        finalIteration = std::max(
-            params.numberUnset() * numberRoundsPerHyperparameter - 1, std::size_t{0});
-        if (finalIteration > 1) {
-            rng.generateUniformSamples(0, finalIteration - 1, 3, intermediateIterations);
+        if (finalIteration > 2) {
+            rng.generateUniformSamples(0, finalIteration - 2, 3, intermediateIterations);
         }
 
         for (auto intermediateIteration : intermediateIterations) {


### PR DESCRIPTION
We should be snapshotting the training state after the final train on the full data set. This incidentally means we can also re-enable the save/restore unit test case we'd disabled when all parameters are supplied by the user.