### PR TITLE
[7.x][ML] On disk data frame memory depends on directory name

### DIFF
--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -410,10 +410,10 @@ void CDataFrameTest::testMemoryUsage() {
     std::size_t capacity{5000};
     TFloatVec components{testData(rows, cols)};
 
+    const std::string& rootDirectory{test::CTestTmpDir::tmpDir()};
     TFactoryFunc makeOnDisk = [=] {
-        return core::makeDiskStorageDataFrame(
-                   test::CTestTmpDir::tmpDir(), cols, rows, capacity,
-                   core::CDataFrame::EReadWriteToStorage::E_Async)
+        return core::makeDiskStorageDataFrame(rootDirectory, cols, rows, capacity,
+                                              core::CDataFrame::EReadWriteToStorage::E_Async)
             .first;
     };
     TFactoryFunc makeMainMemory = [=] {
@@ -423,9 +423,10 @@ void CDataFrameTest::testMemoryUsage() {
     };
 
     // Memory usage should be less than:
-    //   1) 1100 bytes for on disk, and
+    //   1) 1075 + 4 times the root directory length bytes for on disk, and
     //   2) data size + doc ids size + 900 byte overhead in main memory.
-    std::size_t maximumMemory[]{1100, rows * (cols + 1) * 4 + 900};
+    std::size_t maximumMemory[]{1075 + 4 * rootDirectory.length(),
+                                rows * (cols + 1) * 4 + 900};
 
     std::string type[]{"on disk", "main memory"};
     std::size_t t{0};


### PR DESCRIPTION
The longer the name of the directory storing the data
frame, the greater the memory usage. This needs to be
taken into account in the expected results, otherwise
the test fails when run in certain CI systems but not
others.

Backport of #741