### PR TITLE
[ML] Activate writing inference definition in analyzer

### DIFF
--- a/include/api/CBoostedTreeRegressionInferenceModelBuilder.h
+++ b/include/api/CBoostedTreeRegressionInferenceModelBuilder.h
@@ -23,16 +23,15 @@ class API_EXPORT CBoostedTreeRegressionInferenceModelBuilder
     : public maths::CBoostedTree::CVisitor {
 public:
     using TDoubleVec = std::vector<double>;
-    using TStringVec = std::vector<std::string>;
-    using TStringSizeUMap = std::unordered_map<std::string, std::size_t>;
-    using TStringSizeUMapVec = std::vector<TStringSizeUMap>;
+    using TStrVec = std::vector<std::string>;
+    using TStrVecVec = std::vector<TStrVec>;
     using TSizeStringUMap = std::unordered_map<std::size_t, std::string>;
     using TSizeStringUMapVec = std::vector<TSizeStringUMap>;
 
 public:
-    CBoostedTreeRegressionInferenceModelBuilder(TStringVec fieldNames,
+    CBoostedTreeRegressionInferenceModelBuilder(TStrVec fieldNames,
                                                 std::size_t dependentVariableColumnIndex,
-                                                const TStringSizeUMapVec& categoryNameMap);
+                                                const TStrVecVec& categoryNames);
     ~CBoostedTreeRegressionInferenceModelBuilder() override = default;
     void addTree() override;
     void addNode(std::size_t splitFeature,
@@ -58,14 +57,14 @@ private:
 private:
     TStringDoubleUMap encodingMap(std::size_t inputColumnIndex, const TDoubleVec& map_);
 
-    void categoryNameMap(const CInferenceModelDefinition::TStringSizeUMapVec& categoryNameMap);
+    void categoryNames(const TStrVecVec& categoryNames);
 
 private:
     CInferenceModelDefinition m_Definition;
-    TSizeStringUMapVec m_ReverseCategoryNameMap;
+    TStrVecVec m_CategoryNames;
     TOneHotEncodingUMap m_OneHotEncodingMaps;
-    TStringVec m_FieldNames;
-    TStringVec m_FeatureNames;
+    TStrVec m_FieldNames;
+    TStrVec m_FeatureNames;
 };
 }
 }

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -21,7 +21,6 @@
 #include <memory>
 #include <string>
 #include <thread>
-#include <unordered_map>
 #include <vector>
 
 namespace ml {
@@ -65,9 +64,7 @@ public:
     using TStrVec = std::vector<std::string>;
     using TRowRef = core::data_frame_detail::CRowRef;
     using TProgressRecorder = std::function<void(double)>;
-
-    using TStrSizeUMap = std::unordered_map<std::string, std::size_t>;
-    using TStrSizeUMapVec = std::vector<TStrSizeUMap>;
+    using TStrVecVec = std::vector<TStrVec>;
     using TInferenceModelDefinitionUPtr = std::unique_ptr<CInferenceModelDefinition>;
 
 public:
@@ -145,8 +142,7 @@ public:
     double progress() const;
 
     virtual TInferenceModelDefinitionUPtr
-    inferenceModelDefinition(const TStrVec& fieldNames,
-                             const TStrSizeUMapVec& categoryNameMap) const;
+    inferenceModelDefinition(const TStrVec& fieldNames, const TStrVecVec& categoryNames) const;
 
 protected:
     using TStatePersister =

--- a/include/api/CDataFrameBoostedTreeRunner.h
+++ b/include/api/CDataFrameBoostedTreeRunner.h
@@ -59,7 +59,7 @@ protected:
 
     TInferenceModelDefinitionUPtr
     inferenceModelDefinition(const TStrVec& fieldNames,
-                             const TStrSizeUMapVec& categoryNameMap) const override;
+                             const TStrVecVec& categoryNames) const override;
 
 private:
     using TBoostedTreeFactoryUPtr = std::unique_ptr<maths::CBoostedTreeFactory>;

--- a/lib/api/CBoostedTreeRegressionInferenceModelBuilder.cc
+++ b/lib/api/CBoostedTreeRegressionInferenceModelBuilder.cc
@@ -36,7 +36,7 @@ void CBoostedTreeRegressionInferenceModelBuilder::addIdentityEncoding(std::size_
 void CBoostedTreeRegressionInferenceModelBuilder::addOneHotEncoding(std::size_t inputColumnIndex,
                                                                     std::size_t hotCategory) {
     std::string fieldName{m_Definition.input().fieldNames()[inputColumnIndex]};
-    std::string category = m_ReverseCategoryNameMap[inputColumnIndex][hotCategory];
+    std::string category = m_CategoryNames[inputColumnIndex][hotCategory];
     std::string featureName = fieldName + "_" + category;
     if (m_OneHotEncodingMaps.find(fieldName) == m_OneHotEncodingMaps.end()) {
         auto apiEncoding = std::make_unique<COneHotEncoding>(
@@ -105,9 +105,9 @@ void CBoostedTreeRegressionInferenceModelBuilder::addNode(
 }
 
 CBoostedTreeRegressionInferenceModelBuilder::CBoostedTreeRegressionInferenceModelBuilder(
-    TStringVec fieldNames,
+    TStrVec fieldNames,
     std::size_t dependentVariableColumnIndex,
-    const TStringSizeUMapVec& categoryNameMap) {
+    const TStrVecVec& categoryNames) {
     // filter filed names containing only "."
     fieldNames.erase(std::remove(fieldNames.begin(), fieldNames.end(), "."),
                      fieldNames.end());
@@ -117,7 +117,7 @@ CBoostedTreeRegressionInferenceModelBuilder::CBoostedTreeRegressionInferenceMode
                      static_cast<std::ptrdiff_t>(dependentVariableColumnIndex));
     m_FieldNames = fieldNames;
 
-    this->categoryNameMap(categoryNameMap);
+    this->categoryNames(categoryNames);
     m_Definition.fieldNames(fieldNames);
     m_Definition.trainedModel(std::make_unique<CEnsemble>());
     m_Definition.typeString(INFERENCE_MODEL);
@@ -128,26 +128,14 @@ CBoostedTreeRegressionInferenceModelBuilder::encodingMap(std::size_t inputColumn
                                                          const TDoubleVec& map_) {
     TStringDoubleUMap map;
     for (std::size_t categoryUInt = 0; categoryUInt < map_.size(); ++categoryUInt) {
-        std::string category{m_ReverseCategoryNameMap[inputColumnIndex][categoryUInt]};
+        std::string category{m_CategoryNames[inputColumnIndex][categoryUInt]};
         map.emplace(category, map_[categoryUInt]);
     }
     return map;
 }
 
-void CBoostedTreeRegressionInferenceModelBuilder::categoryNameMap(
-    const CInferenceModelDefinition::TStringSizeUMapVec& categoryNameMap) {
-    m_ReverseCategoryNameMap.reserve(categoryNameMap.size());
-    for (const auto& categoryNameMapping : categoryNameMap) {
-        if (categoryNameMapping.empty() == false) {
-            TSizeStringUMap map;
-            for (const auto& categoryMappingPair : categoryNameMapping) {
-                map.emplace(categoryMappingPair.second, categoryMappingPair.first);
-            }
-            m_ReverseCategoryNameMap.emplace_back(std::move(map));
-        } else {
-            m_ReverseCategoryNameMap.emplace_back();
-        }
-    }
+void CBoostedTreeRegressionInferenceModelBuilder::categoryNames(const TStrVecVec& categoryNames) {
+    m_CategoryNames = categoryNames;
 }
 }
 }

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -222,7 +222,7 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
 
 CDataFrameAnalysisRunner::TInferenceModelDefinitionUPtr
 CDataFrameAnalysisRunner::inferenceModelDefinition(const TStrVec& /*fieldNames*/,
-                                                   const TStrSizeUMapVec& /*categoryNameMap*/) const {
+                                                   const TStrVecVec& /*categoryNames*/) const {
     return TInferenceModelDefinitionUPtr();
 }
 

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -318,6 +318,18 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
         }
     });
 
+    // Write the resulting model for inference
+    const auto& modelDefinition = m_AnalysisSpecification->runner()->inferenceModelDefinition(
+        m_DataFrame->columnNames(), m_DataFrame->categoricalColumnValues());
+    if (modelDefinition) {
+        rapidjson::Value inferenceModelObject{writer.makeObject()};
+        modelDefinition->addToDocument(inferenceModelObject, writer);
+        writer.StartObject();
+        writer.Key(modelDefinition->typeString());
+        writer.write(inferenceModelObject);
+        writer.EndObject();
+    }
+
     writer.flush();
 }
 

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -287,9 +287,9 @@ std::size_t CDataFrameBoostedTreeRunner::estimateBookkeepingMemoryUsage(
 
 CDataFrameAnalysisRunner::TInferenceModelDefinitionUPtr
 CDataFrameBoostedTreeRunner::inferenceModelDefinition(const TStrVec& fieldNames,
-                                                      const TStrSizeUMapVec& categoryNameMap) const {
+                                                      const TStrVecVec& categoryNames) const {
     CBoostedTreeRegressionInferenceModelBuilder builder(
-        fieldNames, m_BoostedTree->columnHoldingDependentVariable(), categoryNameMap);
+        fieldNames, m_BoostedTree->columnHoldingDependentVariable(), categoryNames);
     m_BoostedTree->accept(builder);
 
     return std::make_unique<CInferenceModelDefinition>(builder.build());

--- a/lib/api/unittest/CBoostedTreeRegressionInferenceModelBuilderTest.cc
+++ b/lib/api/unittest/CBoostedTreeRegressionInferenceModelBuilderTest.cc
@@ -42,8 +42,7 @@ using TDoubleVecVec = std::vector<TDoubleVec>;
 using TPoint = maths::CDenseVector<maths::CFloatStorage>;
 using TPointVec = std::vector<TPoint>;
 using TRowItr = core::CDataFrame::TRowItr;
-using TStrSizeUMap = std::unordered_map<std::string, std::size_t>;
-using TStrSizeUMapVec = std::vector<TStrSizeUMap>;
+using TStrVecVec = std::vector<TStrVec>;
 
 // TODO factor out this method to avoid code duplication
 auto regressionSpec(std::string dependentVariable,
@@ -169,7 +168,7 @@ void CBoostedTreeRegressionInferenceModelBuilderTest::testIntegration() {
     }
     analyzer.handleRecord(fieldNames, {"", "", "", "", "$"});
     auto analysisRunner = analyzer.runner();
-    TStrSizeUMapVec categoryMappingVector{{}, {{"cat1", 0}, {"cat2", 1}, {"cat3", 2}}, {}};
+    TStrVecVec categoryMappingVector{{}, {"cat1", "cat2", "cat3"}, {}};
     auto definition = analysisRunner->inferenceModelDefinition(fieldNames, categoryMappingVector);
 
     LOG_DEBUG(<< "Inference model definition: " << definition->jsonString());
@@ -254,7 +253,7 @@ void CBoostedTreeRegressionInferenceModelBuilderTest::testJsonSchema() {
     }
     analyzer.handleRecord(fieldNames, {"", "", "", "", "$"});
     auto analysisRunner = analyzer.runner();
-    TStrSizeUMapVec categoryMappingVector{{}, {{"cat1", 0}, {"cat2", 1}, {"cat3", 2}}, {}};
+    TStrVecVec categoryMappingVector{{}, {"cat1", "cat2", "cat3"}, {}};
     auto definition = analysisRunner->inferenceModelDefinition(fieldNames, categoryMappingVector);
 
     std::ifstream schemaFileStream("testfiles/inference_json_schema/definition.schema.combined.json");


### PR DESCRIPTION
This PR activates writing inference definition as a result type into a pipe. It also has necessary changes to accommodate for field names and categorical value names removed from `CDataFrameAnalyzer`.