### PR TITLE
[ML] Better handling of unbalanced class representation in the training data

### DIFF
--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -85,7 +85,8 @@ int main(int argc, char** argv) {
         ml::counter_t::E_DFONumberPartitions,
         ml::counter_t::E_DFTPMEstimatedPeakMemoryUsage,
         ml::counter_t::E_DFTPMPeakMemoryUsage,
-        ml::counter_t::E_DFTPMTimeToTrain};
+        ml::counter_t::E_DFTPMTimeToTrain,
+        ml::counter_t::E_DFTPMTrainedForestNumberTrees};
     ml::core::CProgramCounters::registerProgramCounterTypes(counters);
 
     // Read command line options

--- a/include/api/CDataFrameBoostedTreeRunner.h
+++ b/include/api/CDataFrameBoostedTreeRunner.h
@@ -31,13 +31,6 @@ namespace api {
 //! \brief Runs boosted tree regression on a core::CDataFrame.
 class API_EXPORT CDataFrameBoostedTreeRunner : public CDataFrameAnalysisRunner {
 public:
-    //! This is not intended to be called directly: use CDataFrameBoostedTreeRunnerFactory.
-    CDataFrameBoostedTreeRunner(const CDataFrameAnalysisSpecification& spec,
-                                const CDataFrameAnalysisConfigReader::CParameters& parameters);
-
-    //! This is not intended to be called directly: use CDataFrameBoostedTreeRunnerFactory.
-    CDataFrameBoostedTreeRunner(const CDataFrameAnalysisSpecification& spec);
-
     ~CDataFrameBoostedTreeRunner() override;
 
     //! \return The number of columns this adds to the data frame.
@@ -48,14 +41,21 @@ protected:
     using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
 
 protected:
+    CDataFrameBoostedTreeRunner(const CDataFrameAnalysisSpecification& spec,
+                                const CDataFrameAnalysisConfigReader::CParameters& parameters);
+    CDataFrameBoostedTreeRunner(const CDataFrameAnalysisSpecification& spec);
+
     //! Parameter reader handling parameters that are shared by subclasses.
     static CDataFrameAnalysisConfigReader getParameterReader();
     //! Name of dependent variable field.
     const std::string& dependentVariableFieldName() const;
     //! Name of prediction field.
     const std::string& predictionFieldName() const;
-    //! Underlying boosted tree.
+    //! The boosted tree.
     const maths::CBoostedTree& boostedTree() const;
+
+    //! The boosted tree factory.
+    maths::CBoostedTreeFactory& boostedTreeFactory();
 
 private:
     using TBoostedTreeFactoryUPtr = std::unique_ptr<maths::CBoostedTreeFactory>;

--- a/include/core/CProgramCounters.h
+++ b/include/core/CProgramCounters.h
@@ -116,10 +116,13 @@ enum ECounterTypes {
     //! The time in ms to train the model
     E_DFTPMTimeToTrain = 26,
 
+    //! The trained forest total number of trees
+    E_DFTPMTrainedForestNumberTrees = 27,
+
     // Add any new values here
 
     //! This MUST be last, increment the value for every new enum added
-    E_LastEnumCounter = 27
+    E_LastEnumCounter = 28
 };
 
 static constexpr size_t NUM_COUNTERS = static_cast<size_t>(E_LastEnumCounter);
@@ -323,8 +326,9 @@ private:
           "The upfront estimate of the peak memory training the predictive model would use"},
          {counter_t::E_DFTPMPeakMemoryUsage, "E_DFTPMPeakMemoryUsage",
           "The peak memory training the predictive model used"},
-         {counter_t::E_DFTPMTimeToTrain, "E_DFTPMTimeToTrain",
-          "The time it took to train the predictive model"}}};
+         {counter_t::E_DFTPMTimeToTrain, "E_DFTPMTimeToTrain", "The time it took to train the predictive model"},
+         {counter_t::E_DFTPMTrainedForestNumberTrees, "E_DFTPMTrainedForestNumberTrees",
+          "The total number of trees in the trained forest"}}};
 
     //! Enabling printing out the current counters.
     friend CORE_EXPORT std::ostream& operator<<(std::ostream& o,

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -37,7 +37,7 @@ public:
 
     virtual std::unique_ptr<CArgMinLossImpl> clone() const = 0;
     virtual bool nextPass() = 0;
-    virtual void add(double prediction, double actual) = 0;
+    virtual void add(double prediction, double actual, double weight = 1.0) = 0;
     virtual void merge(const CArgMinLossImpl& other) = 0;
     virtual double value() const = 0;
 
@@ -55,7 +55,7 @@ public:
     CArgMinMseImpl(double lambda);
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
-    void add(double prediction, double actual) override;
+    void add(double prediction, double actual, double weight = 1.0) override;
     void merge(const CArgMinLossImpl& other) override;
     double value() const override;
 
@@ -73,14 +73,14 @@ public:
     CArgMinLogisticImpl(double lambda);
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
-    void add(double prediction, double actual) override;
+    void add(double prediction, double actual, double weight = 1.0) override;
     void merge(const CArgMinLossImpl& other) override;
     double value() const override;
 
 private:
     using TMinMaxAccumulator = CBasicStatistics::CMinMax<double>;
-    using TSizeVector = CVectorNx1<std::size_t, 2>;
-    using TSizeVectorVec = std::vector<TSizeVector>;
+    using TVector = CVectorNx1<double, 2>;
+    using TVectorVec = std::vector<TVector>;
 
 private:
     std::size_t bucket(double prediction) const {
@@ -102,8 +102,8 @@ private:
 private:
     std::size_t m_CurrentPass = 0;
     TMinMaxAccumulator m_PredictionMinMax;
-    TSizeVector m_CategoryCounts;
-    TSizeVectorVec m_BucketCategoryCounts;
+    TVector m_CategoryCounts;
+    TVectorVec m_BucketCategoryCounts;
 };
 }
 
@@ -124,7 +124,7 @@ public:
     bool nextPass() const;
 
     //! Update with a point prediction and actual value.
-    void add(double prediction, double actual);
+    void add(double prediction, double actual, double weight = 1.0);
 
     //! Get the minimiser over the predictions and actual values added to both
     //! this and \p other.
@@ -156,11 +156,11 @@ public:
     //! Clone the loss.
     virtual std::unique_ptr<CLoss> clone() const = 0;
     //! The value of the loss function.
-    virtual double value(double prediction, double actual) const = 0;
+    virtual double value(double prediction, double actual, double weight = 1.0) const = 0;
     //! The slope of the loss function.
-    virtual double gradient(double prediction, double actual) const = 0;
+    virtual double gradient(double prediction, double actual, double weight = 1.0) const = 0;
     //! The curvature of the loss function.
-    virtual double curvature(double prediction, double actual) const = 0;
+    virtual double curvature(double prediction, double actual, double weight = 1.0) const = 0;
     //! Returns true if the loss curvature is constant.
     virtual bool isCurvatureConstant() const = 0;
     //! Get an object which computes the leaf value that minimises loss.
@@ -176,9 +176,9 @@ protected:
 class MATHS_EXPORT CMse final : public CLoss {
 public:
     std::unique_ptr<CLoss> clone() const override;
-    double value(double prediction, double actual) const override;
-    double gradient(double prediction, double actual) const override;
-    double curvature(double prediction, double actual) const override;
+    double value(double prediction, double actual, double weight = 1.0) const override;
+    double gradient(double prediction, double actual, double weight = 1.0) const override;
+    double curvature(double prediction, double actual, double weight = 1.0) const override;
     bool isCurvatureConstant() const override;
     CArgMinLoss minimizer(double lambda) const override;
     const std::string& name() const override;
@@ -199,9 +199,9 @@ public:
 class MATHS_EXPORT CLogistic final : public CLoss {
 public:
     std::unique_ptr<CLoss> clone() const override;
-    double value(double prediction, double actual) const override;
-    double gradient(double prediction, double actual) const override;
-    double curvature(double prediction, double actual) const override;
+    double value(double prediction, double actual, double weight = 1.0) const override;
+    double gradient(double prediction, double actual, double weight = 1.0) const override;
+    double curvature(double prediction, double actual, double weight = 1.0) const override;
     bool isCurvatureConstant() const override;
     CArgMinLoss minimizer(double lambda) const override;
     const std::string& name() const override;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -86,7 +86,7 @@ public:
     //! Set whether to try and balance within class accuracy. For classification
     //! this reweights examples so approximately the same total loss is assigned
     //! to every class.
-    CBoostedTreeFactory& balanceWithinClassAccuracy(bool balance);
+    CBoostedTreeFactory& balanceClassTrainingLoss(bool balance);
     //! Set the callback function for progress monitoring.
     CBoostedTreeFactory& progressCallback(TProgressCallback callback);
     //! Set the callback function for memory monitoring.
@@ -184,7 +184,7 @@ private:
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
     TOptionalSize m_BayesianOptimisationRestarts;
-    bool m_BalanceWithinClassAccuracy = true;
+    bool m_BalanceClassTrainingLoss = true;
     std::size_t m_NumberThreads;
     TBoostedTreeImplUPtr m_TreeImpl;
     TVector m_LogDepthPenaltyMultiplierSearchInterval;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -83,6 +83,10 @@ public:
     CBoostedTreeFactory& bayesianOptimisationRestarts(std::size_t restarts);
     //! Set the number of training examples we need per feature we'll include.
     CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
+    //! Set whether to try and balance within class accuracy. For classification
+    //! this reweights examples so approximately the same total loss is assigned
+    //! to every class.
+    CBoostedTreeFactory& balanceWithinClassAccuracy(bool balance);
     //! Set the callback function for progress monitoring.
     CBoostedTreeFactory& progressCallback(TProgressCallback callback);
     //! Set the callback function for memory monitoring.
@@ -124,11 +128,8 @@ private:
     //! Compute the row masks for the missing values for each feature.
     void initializeMissingFeatureMasks(const core::CDataFrame& frame) const;
 
-    //! Compute the (train, test) row masks for performing cross validation.
-    void initializeCrossValidationRowMasks(const core::CDataFrame& frame) const;
-
-    //! Set the example weights.
-    void initializeExampleWeights(const TPackedBitVectorVec& trainRowMasks) const;
+    //! Set up cross validation.
+    void initializeCrossValidation(core::CDataFrame& frame) const;
 
     //! Encode categorical fields and at the same time select the features to use
     //! as regressors.
@@ -183,6 +184,7 @@ private:
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
     TOptionalSize m_BayesianOptimisationRestarts;
+    bool m_BalanceWithinClassAccuracy = true;
     std::size_t m_NumberThreads;
     TBoostedTreeImplUPtr m_TreeImpl;
     TVector m_LogDepthPenaltyMultiplierSearchInterval;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -90,8 +90,8 @@ public:
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
 
-    //! Estimate the maximum booking memory that training the boosted tree on a data
-    //! frame with \p numberRows row and \p numberColumns columns will use.
+    //! Estimate the maximum booking memory that training the boosted tree on a
+    //! data frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
     //! Get the number of columns training the model will add to the data frame.
     std::size_t numberExtraColumnsForTrain() const;
@@ -124,8 +124,11 @@ private:
     //! Compute the row masks for the missing values for each feature.
     void initializeMissingFeatureMasks(const core::CDataFrame& frame) const;
 
-    //! Get the (train, test) row masks for performing cross validation.
-    std::pair<TPackedBitVectorVec, TPackedBitVectorVec> crossValidationRowMasks() const;
+    //! Compute the (train, test) row masks for performing cross validation.
+    void initializeCrossValidationRowMasks(const core::CDataFrame& frame) const;
+
+    //! Set the example weights.
+    void initializeExampleWeights(const TPackedBitVectorVec& trainRowMasks) const;
 
     //! Encode categorical fields and at the same time select the features to use
     //! as regressors.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -38,12 +38,6 @@ namespace ml {
 namespace maths {
 class CBayesianOptimisation;
 
-namespace boosted_tree_detail {
-inline std::size_t predictionColumn(std::size_t numberColumns) {
-    return numberColumns - 3;
-}
-}
-
 //! \brief Implementation of CBoostedTree.
 class MATHS_EXPORT CBoostedTreeImpl final {
 public:
@@ -93,7 +87,15 @@ public:
     std::size_t columnHoldingDependentVariable() const;
 
     //! Get the number of columns training the model will add to the data frame.
-    static std::size_t numberExtraColumnsForTrain();
+    constexpr static std::size_t numberExtraColumnsForTrain() {
+        // We store as follows:
+        //   1. The predicted value for the dependent variable
+        //   2. The gradient of the loss function
+        //   3. The curvature of the loss function
+        //   4. The example's weight
+        // In the last four rows of the data frame.
+        return 4;
+    }
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
@@ -665,6 +667,24 @@ private:
 
     friend class CBoostedTreeFactory;
 };
+
+namespace boosted_tree_detail {
+constexpr inline std::size_t predictionColumn(std::size_t numberColumns) {
+    return numberColumns - CBoostedTreeImpl::numberExtraColumnsForTrain();
+}
+
+constexpr inline std::size_t lossGradientColumn(std::size_t numberColumns) {
+    return predictionColumn(numberColumns) + 1;
+}
+
+constexpr inline std::size_t lossCurvatureColumn(std::size_t numberColumns) {
+    return predictionColumn(numberColumns) + 2;
+}
+
+constexpr inline std::size_t exampleWeightColumn(std::size_t numberColumns) {
+    return predictionColumn(numberColumns) + 3;
+}
+}
 }
 }
 

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -317,6 +317,7 @@ private:
     using TSizeUSetVec = std::vector<TSizeUSet>;
 
 private:
+    TEncodingUPtrVec readEncodings() const;
     TSizeDoublePrVecVec mics(const CDataFrameUtils::CColumnValue& target,
                              const TSizeVec& metricColumnMask,
                              const TSizeVec& categoricalColumnMask) const;

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -11,11 +11,14 @@
 #include <core/CNonInstantiatable.h>
 
 #include <maths/CLinearAlgebraEigen.h>
+#include <maths/CPRNG.h>
 #include <maths/ImportExport.h>
 
 #include <boost/unordered_set.hpp>
 
 #include <functional>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 namespace ml {
@@ -233,6 +236,38 @@ public:
                                 TQuantileSketchVec& result,
                                 const CDataFrameCategoryEncoder* encoder = nullptr,
                                 TWeightFunction weight = unitWeight);
+
+    //! \brief Compute disjoint random train/test row masks suitable for cross
+    //! validation ensuring nearly equal numbers of examples for each distinct
+    //! value of the target column.
+    //!
+    //! TODO stratify by target quantiles for regression.
+    //!
+    //! \param[in] numberThreads The number of threads available.
+    //! \param[in] frame The data frame for which to compute the row masks.
+    //! \param[in] targetColumn The index of the column to predict.
+    //! \param[in] rng The random number generator to use.
+    //! \param[in] numberFolds The number of folds to use.
+    //! \param[in] allTrainingRowsMask A mask of the candidate training rows.
+    //! \warning This fails if the target is not categorical.
+    static std::tuple<TPackedBitVectorVec, TPackedBitVectorVec, TDoubleVec>
+    stratifiedCrossValidationRowMasks(std::size_t numberThreads,
+                                      const core::CDataFrame& frame,
+                                      std::size_t targetColumn,
+                                      CPRNG::CXorOShiro128Plus rng,
+                                      std::size_t numberFolds,
+                                      core::CPackedBitVector allTrainingRowsMask);
+
+    //! \brief Compute disjoint random train/test row masks suitable for cross
+    //! validation.
+    //!
+    //! \param[in] rng The random number generator to use.
+    //! \param[in] numberFolds The number of folds to use.
+    //! \param[in] allTrainingRowsMask A mask of the candidate training rows.
+    static std::pair<TPackedBitVectorVec, TPackedBitVectorVec>
+    crossValidationRowMasks(CPRNG::CXorOShiro128Plus rng,
+                            std::size_t numberFolds,
+                            core::CPackedBitVector allTrainingRowsMask);
 
     //! Get the relative frequency of each category in \p frame.
     //!

--- a/include/maths/CSampling.h
+++ b/include/maths/CSampling.h
@@ -66,7 +66,7 @@ public:
     //! wanted it is easy to provide a callback to achieve this as follows:
     //! \code{.cpp}
     //! std::vector<double> sample;
-    //! CRandomStreamSampler sampler{[&sample](std::size_t i, const double& x) {
+    //! CRandomStreamSampler<double> sampler{[&sample](std::size_t i, const double& x) {
     //!     if (i >= sample.size()) {
     //!         sample.resize(i + 1);
     //!     }
@@ -92,6 +92,9 @@ public:
             : m_Rng{rng}, m_TargetSampleSize{std::max(targetSampleSize, MINIMUM_TARGET_SAMPLE_SIZE)},
               m_OnSample{onSample} {}
 
+        //! Reset in preparation for resampling.
+        void reset() { m_StreamSize = m_SampleSize = 0; }
+
         //! Get the sampler's random number generator.
         CPRNG::CXorOShiro128Plus& rng() { return m_Rng; }
 
@@ -109,7 +112,6 @@ public:
             if (m_SampleSize < m_TargetSampleSize) {
                 m_OnSample(m_SampleSize, x);
                 ++m_SampleSize;
-
             } else {
                 double p{uniformSample(m_Rng, 0.0, 1.0)};
                 if (p * static_cast<double>(m_StreamSize) < static_cast<double>(m_SampleSize)) {

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -204,7 +204,7 @@ const maths::CBoostedTree& CDataFrameBoostedTreeRunner::boostedTree() const {
 
 maths::CBoostedTreeFactory& CDataFrameBoostedTreeRunner::boostedTreeFactory() {
     if (m_BoostedTreeFactory == nullptr) {
-        HANDLE_FATAL(<< "Internal error: boosted factory tree missing. Please report this error.");
+        HANDLE_FATAL(<< "Internal error: boosted tree factory missing. Please report this error.");
     }
     return *m_BoostedTreeFactory;
 }

--- a/lib/api/CDataFrameBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameBoostedTreeRunner.cc
@@ -194,9 +194,16 @@ const std::string& CDataFrameBoostedTreeRunner::predictionFieldName() const {
 
 const maths::CBoostedTree& CDataFrameBoostedTreeRunner::boostedTree() const {
     if (m_BoostedTree == nullptr) {
-        HANDLE_FATAL(<< "Internal error: boosted tree object missing. Please report this error.");
+        HANDLE_FATAL(<< "Internal error: boosted tree missing. Please report this error.");
     }
     return *m_BoostedTree;
+}
+
+maths::CBoostedTreeFactory& CDataFrameBoostedTreeRunner::boostedTreeFactory() {
+    if (m_BoostedTreeFactory == nullptr) {
+        HANDLE_FATAL(<< "Internal error: boosted factory tree missing. Please report this error.");
+    }
+    return *m_BoostedTreeFactory;
 }
 
 void CDataFrameBoostedTreeRunner::runImpl(core::CDataFrame& frame) {

--- a/lib/api/CDataFrameClassificationRunner.cc
+++ b/lib/api/CDataFrameClassificationRunner.cc
@@ -37,6 +37,7 @@ using TSizeVec = std::vector<std::size_t>;
 
 // Configuration
 const std::string NUM_TOP_CLASSES{"num_top_classes"};
+const std::string BALANCED_CLASS_LOSS{"balanced_class_loss"};
 
 // Output
 const std::string IS_TRAINING_FIELD_NAME{"is_training"};
@@ -48,6 +49,8 @@ const std::string CLASS_PROBABILITY_FIELD_NAME{"class_probability"};
 const CDataFrameAnalysisConfigReader CDataFrameClassificationRunner::getParameterReader() {
     CDataFrameAnalysisConfigReader theReader{CDataFrameBoostedTreeRunner::getParameterReader()};
     theReader.addParameter(NUM_TOP_CLASSES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+    theReader.addParameter(BALANCED_CLASS_LOSS,
+                           CDataFrameAnalysisConfigReader::E_OptionalParameter);
     return theReader;
 }
 
@@ -57,6 +60,8 @@ CDataFrameClassificationRunner::CDataFrameClassificationRunner(
     : CDataFrameBoostedTreeRunner{spec, parameters} {
 
     m_NumTopClasses = parameters[NUM_TOP_CLASSES].fallback(std::size_t{0});
+    this->boostedTreeFactory().balanceClassTrainingLoss(
+        parameters[BALANCED_CLASS_LOSS].fallback(true));
 }
 
 CDataFrameClassificationRunner::CDataFrameClassificationRunner(const CDataFrameAnalysisSpecification& spec)

--- a/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
+++ b/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
@@ -10,6 +10,7 @@
 #include <core/CDataFrame.h>
 #include <core/CDataSearcher.h>
 #include <core/CFloatStorage.h>
+#include <core/CProgramCounters.h>
 
 #include <maths/CLinearAlgebraEigen.h>
 
@@ -195,9 +196,12 @@ void CBoostedTreeInferenceModelBuilderTest::testIntegrationRegression() {
     CPPUNIT_ASSERT(oneHot && target && frequency);
 
     // assert trained model
-    auto trainedModel = dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
+    auto* trainedModel =
+        dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
     CPPUNIT_ASSERT_EQUAL(api::CTrainedModel::E_Regression, trainedModel->targetType());
-    CPPUNIT_ASSERT_EQUAL(std::size_t(22), trainedModel->size());
+    std::size_t expectedSize{core::CProgramCounters::counter(
+        ml::counter_t::E_DFTPMTrainedForestNumberTrees)};
+    CPPUNIT_ASSERT_EQUAL(expectedSize, trainedModel->size());
     CPPUNIT_ASSERT("weighted_sum" == trainedModel->aggregateOutput()->stringType());
 }
 
@@ -247,7 +251,9 @@ void CBoostedTreeInferenceModelBuilderTest::testIntegrationClassification() {
     // assert trained model
     auto trainedModel = dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
     CPPUNIT_ASSERT_EQUAL(api::CTrainedModel::E_Classification, trainedModel->targetType());
-    CPPUNIT_ASSERT_EQUAL(std::size_t(5), trainedModel->size());
+    std::size_t expectedSize{core::CProgramCounters::counter(
+        ml::counter_t::E_DFTPMTrainedForestNumberTrees)};
+    CPPUNIT_ASSERT_EQUAL(expectedSize, trainedModel->size());
     CPPUNIT_ASSERT("logistic_regression" == trainedModel->aggregateOutput()->stringType());
 }
 

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -823,7 +823,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeRegressionTraining() {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2600000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2800000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1050000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
@@ -1059,7 +1059,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeClassifierTraining() {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2600000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2800000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1050000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
@@ -1238,7 +1238,7 @@ void CDataFrameAnalyzerTest::testCategoricalFields() {
 
     {
         api::CDataFrameAnalyzer analyzer{
-            predictionSpec("regression", "x5", 1000, 5, 8000000, 0, 0, {"x1", "x2"}),
+            predictionSpec("regression", "x5", 1000, 5, 10000000, 0, 0, {"x1", "x2"}),
             outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
@@ -1341,7 +1341,7 @@ void CDataFrameAnalyzerTest::testCategoricalFieldsEmptyAsMissing() {
     };
 
     api::CDataFrameAnalyzer analyzer{predictionSpec("classification", "x5", 1000, 5,
-                                                    8000000, 0, 0, {"x1", "x2", "x5"}),
+                                                    10000000, 0, 0, {"x1", "x2", "x5"}),
                                      outputWriterFactory};
 
     TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};

--- a/lib/api/unittest/CDataFrameAnalyzerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTest.cc
@@ -824,7 +824,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeRegressionTraining() {
               << "ms");
 
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2800000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2900000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1050000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
@@ -1061,7 +1061,7 @@ void CDataFrameAnalyzerTest::testRunBoostedTreeClassifierTraining() {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     CPPUNIT_ASSERT(core::CProgramCounters::counter(
-                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2800000);
+                       counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 2900000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1050000);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     CPPUNIT_ASSERT(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -200,7 +200,7 @@ void CBoostedTreeFactory::initializeCrossValidation(core::CDataFrame& frame) con
         // Weight by inverse category frequency.
         writeRowWeight = [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                if (m_BalanceWithinClassAccuracy) {
+                if (m_BalanceClassTrainingLoss) {
                     std::size_t category{static_cast<std::size_t>(
                         (*row)[m_TreeImpl->m_DependentVariable])};
                     row->writeColumn(exampleWeightColumn(row->numberColumns()),
@@ -771,8 +771,8 @@ CBoostedTreeFactory& CBoostedTreeFactory::rowsPerFeature(std::size_t rowsPerFeat
     return *this;
 }
 
-CBoostedTreeFactory& CBoostedTreeFactory::balanceWithinClassAccuracy(bool balance) {
-    m_BalanceWithinClassAccuracy = balance;
+CBoostedTreeFactory& CBoostedTreeFactory::balanceClassTrainingLoss(bool balance) {
+    m_BalanceClassTrainingLoss = balance;
     return *this;
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -8,6 +8,7 @@
 
 #include <core/CLoopProgress.h>
 #include <core/CPersistUtils.h>
+#include <core/CProgramCounters.h>
 
 #include <maths/CBasicStatisticsPersist.h>
 #include <maths/CBayesianOptimisation.h>
@@ -321,6 +322,9 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
         m_BestForest = this->trainForest(frame, this->allTrainingRowsMask(), recordMemoryUsage);
         this->recordState(recordTrainStateCallback);
+
+        core::CProgramCounters::counter(counter_t::E_DFTPMTrainedForestNumberTrees) =
+            m_BestForest.size();
     }
 
     // Force to at least one here because we can have early exit from loop or take

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -831,6 +831,7 @@ CMakeDataFrameCategoryEncoder::selectFeatures(TSizeVec metricColumnMask,
     if (maximumNumberFeatures >= numberAvailableFeatures) {
 
         selectedFeatureMics = this->selectAllFeatures(mics);
+
     } else {
 
         CMinRedundancyMaxRelevancyGreedySearch search{m_RedundancyWeight, mics};

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -593,6 +593,12 @@ CMakeDataFrameCategoryEncoder::TEncodingUPtrVec CMakeDataFrameCategoryEncoder::m
     this->setupTargetMeanValueEncoding(categoricalColumnMask);
     this->finishEncoding(this->selectFeatures(metricColumnMask, categoricalColumnMask));
 
+    return this->readEncodings();
+}
+
+CMakeDataFrameCategoryEncoder::TEncodingUPtrVec
+CMakeDataFrameCategoryEncoder::readEncodings() const {
+
     // In the encoded row the layout of the encoding dimensions, for each categorical
     // feature, is as follows:
     //   (...| one-hot | mean target | frequency |...)
@@ -608,7 +614,7 @@ CMakeDataFrameCategoryEncoder::TEncodingUPtrVec CMakeDataFrameCategoryEncoder::m
     // relative to the start of the encoding dimensions for the feature, is equal
     // to the position of the one for the category.
 
-    TEncodingUPtrVec encoding;
+    TEncodingUPtrVec encodings;
 
     for (std::size_t encodedColumnIndex = 0;
          encodedColumnIndex < m_EncodedColumnInputColumnMap.size(); ++encodedColumnIndex) {
@@ -617,7 +623,7 @@ CMakeDataFrameCategoryEncoder::TEncodingUPtrVec CMakeDataFrameCategoryEncoder::m
         double mic{m_EncodedColumnMics[encodedColumnIndex]};
 
         if (m_Frame->columnIsCategorical()[inputColumnIndex] == false) {
-            encoding.push_back(std::make_unique<CIdentityEncoding>(inputColumnIndex, mic));
+            encodings.push_back(std::make_unique<CIdentityEncoding>(inputColumnIndex, mic));
             continue;
         }
 
@@ -627,23 +633,23 @@ CMakeDataFrameCategoryEncoder::TEncodingUPtrVec CMakeDataFrameCategoryEncoder::m
 
         if (categoryEncoding < numberOneHotCategories) {
             std::size_t hotCategory{m_OneHotEncodedCategories[inputColumnIndex][categoryEncoding]};
-            encoding.push_back(std::make_unique<COneHotEncoding>(inputColumnIndex,
-                                                                 mic, hotCategory));
+            encodings.push_back(std::make_unique<COneHotEncoding>(
+                inputColumnIndex, mic, hotCategory));
             continue;
         }
         if (categoryEncoding == numberOneHotCategories &&
             m_InputColumnUsesFrequencyEncoding[inputColumnIndex]) {
-            encoding.push_back(std::make_unique<CMappedEncoding>(
+            encodings.push_back(std::make_unique<CMappedEncoding>(
                 inputColumnIndex, mic, E_Frequency, m_CategoryFrequencies[inputColumnIndex],
                 m_MeanCategoryFrequencies[inputColumnIndex]));
             continue;
         }
-        encoding.push_back(std::make_unique<CMappedEncoding>(
+        encodings.push_back(std::make_unique<CMappedEncoding>(
             inputColumnIndex, mic, E_TargetMean, m_CategoryTargetMeanValues[inputColumnIndex],
             m_MeanCategoryTargetMeanValues[inputColumnIndex]));
     }
 
-    return encoding;
+    return encodings;
 }
 
 std::size_t CMakeDataFrameCategoryEncoder::encoding(std::size_t encodedColumnIndex) const {

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -27,6 +27,7 @@
 namespace ml {
 namespace maths {
 namespace {
+using TDoubleVec = std::vector<double>;
 using TFloatVec = std::vector<CFloatStorage>;
 using TFloatVecVec = std::vector<TFloatVec>;
 using TRowItr = core::CDataFrame::TRowItr;
@@ -34,6 +35,7 @@ using TRowRef = core::CDataFrame::TRowRef;
 using TRowSampler = CSampling::CRandomStreamSampler<TRowRef>;
 using TSizeEncoderPtrUMap =
     boost::unordered_map<std::size_t, std::unique_ptr<CDataFrameUtils::CColumnValue>>;
+using TPackedBitVectorVec = CDataFrameUtils::TPackedBitVectorVec;
 
 //! Reduce the results of a call to core::CDataFrame::readRows using \p reduceFirst
 //! for the first and \p reduce for the rest and writing the result \p reduction.
@@ -53,6 +55,16 @@ bool doReduce(std::pair<std::vector<READER>, bool> readResults,
         reduce(std::move(readResults.first[i].s_FunctionState), reduction);
     }
     return true;
+}
+
+//! Get the test row masks corresponding to \p foldRowMasks.
+TPackedBitVectorVec complementRowMasks(const TPackedBitVectorVec& foldRowMasks,
+                                       core::CPackedBitVector allRowsMask) {
+    TPackedBitVectorVec complementFoldRowMasks(foldRowMasks.size(), std::move(allRowsMask));
+    for (std::size_t fold = 0; fold < foldRowMasks.size(); ++fold) {
+        complementFoldRowMasks[fold] ^= foldRowMasks[fold];
+    }
+    return complementFoldRowMasks;
 }
 
 //! Get a row feature sampler.
@@ -308,6 +320,122 @@ bool CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
     return true;
 }
 
+std::tuple<TPackedBitVectorVec, TPackedBitVectorVec, TDoubleVec>
+CDataFrameUtils::stratifiedCrossValidationRowMasks(std::size_t numberThreads,
+                                                   const core::CDataFrame& frame,
+                                                   std::size_t targetColumn,
+                                                   CPRNG::CXorOShiro128Plus rng,
+                                                   std::size_t numberFolds,
+                                                   core::CPackedBitVector allTrainingRowsMask) {
+
+    if (frame.columnIsCategorical()[targetColumn] == false) {
+        HANDLE_FATAL(<< "Internal error: stratified cross validation is only supported"
+                     << " for classification");
+        return std::tuple<TPackedBitVectorVec, TPackedBitVectorVec, TDoubleVec>{};
+    }
+
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TRowSamplerVec = std::vector<TRowSampler>;
+
+    TDoubleVec frequencies{categoryFrequencies(
+        numberThreads, frame, allTrainingRowsMask, {targetColumn})[0]};
+
+    TSizeVec categoryCounts;
+    categoryCounts.reserve(frequencies.size());
+    double Z{allTrainingRowsMask.manhattan()};
+    for (auto& frequency : frequencies) {
+        std::size_t desiredCount{static_cast<std::size_t>(
+            Z * frequency / static_cast<double>(numberFolds) + 0.5)};
+        categoryCounts.push_back(std::max(desiredCount, std::size_t{1}));
+    }
+    LOG_TRACE(<< "desired category counts per test fold = "
+              << core::CContainerPrinter::print(categoryCounts));
+
+    TSizeVecVec sampledRowIndices(categoryCounts.size());
+    TRowSamplerVec samplers;
+    samplers.reserve(categoryCounts.size());
+
+    for (std::size_t i = 0; i < categoryCounts.size(); ++i) {
+        TSizeVec& categorySampledRowIndices{sampledRowIndices[i]};
+        categorySampledRowIndices.reserve(categoryCounts[i]);
+        auto sampler = [&](std::size_t slot, const TRowRef& row) {
+            if (slot >= categorySampledRowIndices.size()) {
+                categorySampledRowIndices.resize(slot + 1);
+            }
+            categorySampledRowIndices[slot] = row.index();
+        };
+        samplers.emplace_back(categoryCounts[i], sampler, rng);
+    }
+
+    TPackedBitVectorVec testingRowMasks(numberFolds);
+
+    TSizeVec rowIndices;
+    core::CPackedBitVector candidateTestingRowsMask{allTrainingRowsMask};
+    for (std::size_t fold = 0; fold < numberFolds - 1; ++fold) {
+        frame.readRows(1, 0, frame.numberRows(),
+                       [&](TRowItr beginRows, TRowItr endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               std::size_t category{
+                                   static_cast<std::size_t>((*row)[targetColumn])};
+                               samplers[category].sample(*row);
+                           }
+                       },
+                       &candidateTestingRowsMask);
+
+        rowIndices.clear();
+        for (std::size_t i = 0; i < sampledRowIndices.size(); ++i) {
+            std::size_t sampleSize{samplers[i].sampleSize()};
+            std::size_t desiredCount{std::min(categoryCounts[i], sampleSize)};
+            CSampling::random_shuffle(rng, sampledRowIndices[i].begin(),
+                                      sampledRowIndices[i].begin() + sampleSize);
+            rowIndices.insert(rowIndices.end(), sampledRowIndices[i].begin(),
+                              sampledRowIndices[i].begin() + desiredCount);
+            sampledRowIndices[i].clear();
+            samplers[i].reset();
+        }
+        std::sort(rowIndices.begin(), rowIndices.end());
+        LOG_TRACE(<< "# row indices = " << rowIndices.size());
+
+        for (auto row : rowIndices) {
+            testingRowMasks[fold].extend(false, row - testingRowMasks[fold].size());
+            testingRowMasks[fold].extend(true);
+        }
+        testingRowMasks[fold].extend(false, allTrainingRowsMask.size() -
+                                                testingRowMasks[fold].size());
+        candidateTestingRowsMask ^= testingRowMasks[fold];
+    }
+    testingRowMasks.back() = std::move(candidateTestingRowsMask);
+
+    TPackedBitVectorVec trainingRowMasks{complementRowMasks(testingRowMasks, allTrainingRowsMask)};
+
+    return {std::move(trainingRowMasks), std::move(testingRowMasks), std::move(frequencies)};
+}
+
+std::pair<TPackedBitVectorVec, TPackedBitVectorVec>
+CDataFrameUtils::crossValidationRowMasks(CPRNG::CXorOShiro128Plus rng,
+                                         std::size_t numberFolds,
+                                         core::CPackedBitVector allTrainingRowsMask) {
+
+    TPackedBitVectorVec trainingRowMasks(numberFolds);
+
+    for (auto row = allTrainingRowsMask.beginOneBits();
+         row != allTrainingRowsMask.endOneBits(); ++row) {
+        std::size_t fold{CSampling::uniformSample(rng, 0, numberFolds)};
+        trainingRowMasks[fold].extend(true, *row - trainingRowMasks[fold].size());
+        trainingRowMasks[fold].extend(false);
+    }
+
+    for (auto& fold : trainingRowMasks) {
+        fold.extend(true, allTrainingRowsMask.size() - fold.size());
+        fold &= allTrainingRowsMask;
+        LOG_TRACE(<< "# training = " << fold.manhattan());
+    }
+
+    TPackedBitVectorVec testingRowMasks{complementRowMasks(trainingRowMasks, allTrainingRowsMask)};
+
+    return {std::move(trainingRowMasks), std::move(testingRowMasks)};
+}
+
 CDataFrameUtils::TDoubleVecVec
 CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
                                      const core::CDataFrame& frame,
@@ -356,9 +484,11 @@ CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
         HANDLE_FATAL(<< "Internal error: '" << e.what() << "' exception calculating"
                      << " category frequencies. Please report this problem.");
     }
+
+    double Z{rowMask.manhattan()};
     for (std::size_t i = 0; i < result.size(); ++i) {
         for (std::size_t j = 0; j < result[i].size(); ++j) {
-            result[i][j] /= static_cast<double>(frame.numberRows());
+            result[i][j] /= Z;
         }
     }
 

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -338,7 +338,7 @@ CDataFrameUtils::stratifiedCrossValidationRowMasks(std::size_t numberThreads,
     using TRowSamplerVec = std::vector<TRowSampler>;
 
     TDoubleVec frequencies{categoryFrequencies(
-        numberThreads, frame, allTrainingRowsMask, {targetColumn})[0]};
+        numberThreads, frame, allTrainingRowsMask, {targetColumn})[targetColumn]};
 
     TSizeVec categoryCounts;
     categoryCounts.reserve(frequencies.size());
@@ -769,6 +769,7 @@ CDataFrameUtils::metricMicWithColumnDataFrameInMemory(const CColumnValue& target
 
     TFloatVecVec samples;
     samples.reserve(numberSamples);
+    double numberMaskedRows{rowMask.manhattan()};
 
     for (auto i : columnMask) {
 
@@ -792,7 +793,7 @@ CDataFrameUtils::metricMicWithColumnDataFrameInMemory(const CColumnValue& target
         LOG_TRACE(<< "# samples = " << samples.size());
 
         double fractionMissing{static_cast<double>(missingCount.first[0].s_FunctionState) /
-                               static_cast<double>(frame.numberRows())};
+                               numberMaskedRows};
         LOG_TRACE(<< "feature = " << i << " fraction missing = " << fractionMissing);
 
         // Compute MICe
@@ -821,6 +822,7 @@ CDataFrameUtils::metricMicWithColumnDataFrameOnDisk(const CColumnValue& target,
 
     TFloatVecVec samples;
     samples.reserve(numberSamples);
+    double numberMaskedRows{rowMask.manhattan()};
 
     // Do sampling
 
@@ -845,8 +847,8 @@ CDataFrameUtils::metricMicWithColumnDataFrameOnDisk(const CColumnValue& target,
     TDoubleVec fractionMissing(frame.numberColumns());
     for (std::size_t i = 0; i < fractionMissing.size(); ++i) {
         for (const auto& missingCount : missingCounts.first) {
-            fractionMissing[i] += static_cast<double>(missingCount.s_FunctionState[i]) /
-                                  static_cast<double>(frame.numberRows());
+            fractionMissing[i] +=
+                static_cast<double>(missingCount.s_FunctionState[i]) / numberMaskedRows;
         }
     }
     LOG_TRACE(<< "Fraction missing = " << core::CContainerPrinter::print(fractionMissing));

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -246,7 +246,7 @@ void CBoostedTreeTest::testPiecewiseConstant() {
             0.0, modelBias[i][0],
             4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.96);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
@@ -369,7 +369,7 @@ void CBoostedTreeTest::testNonLinear() {
             0.0, modelBias[i][0],
             4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.96);
+        CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
@@ -759,7 +759,7 @@ void CBoostedTreeTest::testTranslationInvariance() {
         rsquared.push_back(modelRSquared);
     }
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(rsquared[0], rsquared[1], 5e-3);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(rsquared[0], rsquared[1], 0.01);
 }
 
 std::size_t maxDepth(const std::vector<maths::CBoostedTreeNode>& tree,
@@ -1130,7 +1130,7 @@ void CBoostedTreeTest::testLogisticRegression() {
         LOG_DEBUG(<< "log relative error = "
                   << maths::CBasicStatistics::mean(logRelativeError));
 
-        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(logRelativeError) < 0.65);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(logRelativeError) < 0.7);
     }
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -367,7 +367,7 @@ void CBoostedTreeTest::testNonLinear() {
         // Unbiased...
         CPPUNIT_ASSERT_DOUBLES_EQUAL(
             0.0, modelBias[i][0],
-            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         CPPUNIT_ASSERT(modelRSquared[i][0] > 0.95);
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1106,7 +1106,7 @@ void CBoostedTreeTest::testLogisticRegression() {
 
         auto regression =
             maths::CBoostedTreeFactory::constructFromParameters(1)
-                .balanceWithinClassAccuracy(false)
+                .balanceClassTrainingLoss(false)
                 .buildFor(*frame, std::make_unique<maths::boosted_tree::CLogistic>(),
                           cols - 1);
 
@@ -1161,7 +1161,7 @@ void CBoostedTreeTest::testUnbalancedClasses() {
     TDoubleVecVec precisions;
     TDoubleVecVec recalls;
 
-    for (bool balanceWithinClassAccuracy : {false, true}) {
+    for (bool balanceClassTrainingLoss : {false, true}) {
         auto frame = core::makeMainStorageDataFrame(cols).first;
         frame->categoricalColumns(TBoolVec{false, false, true});
         for (std::size_t i = 0, index = 0; i < 4; ++i) {
@@ -1179,7 +1179,7 @@ void CBoostedTreeTest::testUnbalancedClasses() {
 
         auto regression =
             maths::CBoostedTreeFactory::constructFromParameters(1)
-                .balanceWithinClassAccuracy(balanceWithinClassAccuracy)
+                .balanceClassTrainingLoss(balanceClassTrainingLoss)
                 .buildFor(*frame, std::make_unique<maths::boosted_tree::CLogistic>(),
                           cols - 1);
 
@@ -1219,7 +1219,7 @@ void CBoostedTreeTest::testUnbalancedClasses() {
     LOG_DEBUG(<< "precisions = " << core::CContainerPrinter::print(precisions));
     LOG_DEBUG(<< "recalls    = " << core::CContainerPrinter::print(recalls));
 
-    // Because our test set is balanced we expect low
+    // We expect more similar precision and recall when balancing training loss.
     CPPUNIT_ASSERT(std::fabs(precisions[1][0] - precisions[1][1]) <
                    0.4 * std::fabs(precisions[0][0] - precisions[0][1]));
     CPPUNIT_ASSERT(std::fabs(recalls[1][0] - recalls[1][1]) <

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1074,7 +1074,6 @@ void CBoostedTreeTest::testLogisticRegression() {
     std::size_t cols{4};
     std::size_t capacity{600};
 
-    TMeanAccumulator meanExcessCrossEntropy;
     for (std::size_t test = 0; test < 3; ++test) {
         TDoubleVec weights;
         rng.generateUniformSamples(-2.0, 2.0, cols - 1, weights);
@@ -1105,40 +1104,126 @@ void CBoostedTreeTest::testLogisticRegression() {
         fillDataFrame(trainRows, rows - trainRows, cols, {false, false, false, true},
                       x, TDoubleVec(rows, 0.0), target, *frame);
 
-        auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
-            *frame, std::make_unique<maths::boosted_tree::CLogistic>(), cols - 1);
+        auto regression =
+            maths::CBoostedTreeFactory::constructFromParameters(1)
+                .balanceWithinClassAccuracy(false)
+                .buildFor(*frame, std::make_unique<maths::boosted_tree::CLogistic>(),
+                          cols - 1);
 
         regression->train();
         regression->predict();
 
-        double actualCrossEntropy{0.0};
-        double minimumCrossEntropy{0.0};
+        TMeanAccumulator logRelativeError;
         frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (row->index() >= trainRows) {
                     std::size_t index{
                         regression->columnHoldingPrediction(row->numberColumns())};
-                    actualCrossEntropy -=
-                        probability(*row) *
-                        std::log(maths::CTools::logisticFunction((*row)[index]));
-                    minimumCrossEntropy -= probability(*row) *
-                                           std::log(probability(*row));
+                    double expectedProbability{probability(*row)};
+                    double actualProbability{maths::CTools::logisticFunction((*row)[index])};
+                    logRelativeError.add(
+                        std::log(std::max(actualProbability, expectedProbability) /
+                                 std::min(actualProbability, expectedProbability)));
                 }
             }
         });
-        LOG_DEBUG(<< "actual cross entropy = " << actualCrossEntropy
-                  << ", minimum cross entropy = " << minimumCrossEntropy);
+        LOG_DEBUG(<< "log relative error = "
+                  << maths::CBasicStatistics::mean(logRelativeError));
 
-        // We should be with 40% of the minimum possible cross entropy.
-        CPPUNIT_ASSERT(actualCrossEntropy < 1.4 * minimumCrossEntropy);
-        meanExcessCrossEntropy.add(actualCrossEntropy / minimumCrossEntropy);
+        CPPUNIT_ASSERT(maths::CBasicStatistics::mean(logRelativeError) < 0.65);
+    }
+}
+
+void CBoostedTreeTest::testUnbalancedClasses() {
+
+    // Test we get similar per class precision and recall with unbalanced training
+    // data targeting balanced within class accuracy.
+
+    test::CRandomNumbers rng;
+
+    std::size_t trainRows{1000};
+    std::size_t classes[]{1, 0, 1, 0};
+    std::size_t classesRowCounts[]{800, 200, 100, 100};
+    std::size_t cols{3};
+
+    TDoubleVecVec x;
+    TDoubleVec means{0.0, 3.0};
+    TDoubleVec variances{6.0, 6.0};
+    for (std::size_t i = 0; i < 4; ++i) {
+        TDoubleVecVec xi;
+        double mean{means[classes[i]]};
+        double variance{variances[classes[i]]};
+        rng.generateMultivariateNormalSamples(
+            {mean, mean}, {{variance, 0.0}, {0.0, variance}}, classesRowCounts[i], xi);
+        x.insert(x.end(), xi.begin(), xi.end());
     }
 
-    LOG_DEBUG(<< "mean excess cross entropy = "
-              << maths::CBasicStatistics::mean(meanExcessCrossEntropy));
+    TDoubleVecVec precisions;
+    TDoubleVecVec recalls;
 
-    // We should be within 25% of the minimum possible cross entropy on average.
-    CPPUNIT_ASSERT(maths::CBasicStatistics::mean(meanExcessCrossEntropy) < 1.25);
+    for (bool balanceWithinClassAccuracy : {false, true}) {
+        auto frame = core::makeMainStorageDataFrame(cols).first;
+        frame->categoricalColumns(TBoolVec{false, false, true});
+        for (std::size_t i = 0, index = 0; i < 4; ++i) {
+            for (std::size_t j = 0; j < classesRowCounts[i]; ++j, ++index) {
+                frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                    for (std::size_t k = 0; k < cols - 1; ++k, ++column) {
+                        *column = x[index][k];
+                    }
+                    *column = index < trainRows ? static_cast<double>(i)
+                                                : core::CDataFrame::valueOfMissing();
+                });
+            }
+        }
+        frame->finishWritingRows();
+
+        auto regression =
+            maths::CBoostedTreeFactory::constructFromParameters(1)
+                .balanceWithinClassAccuracy(balanceWithinClassAccuracy)
+                .buildFor(*frame, std::make_unique<maths::boosted_tree::CLogistic>(),
+                          cols - 1);
+
+        regression->train();
+        regression->predict();
+
+        TDoubleVec truePositives(2, 0.0);
+        TDoubleVec trueNegatives(2, 0.0);
+        TDoubleVec falsePositives(2, 0.0);
+        TDoubleVec falseNegatives(2, 0.0);
+        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                double logOddsClassOne{
+                    (*row)[regression->columnHoldingPrediction(row->numberColumns())]};
+                double prediction{
+                    maths::CTools::logisticFunction(logOddsClassOne) < 0.5 ? 0.0 : 1.0};
+                if (row->index() >= trainRows &&
+                    row->index() < trainRows + classesRowCounts[2]) {
+                    // Actual is zero.
+                    (prediction == 0.0 ? truePositives[0] : falseNegatives[0]) += 1.0;
+                    (prediction == 0.0 ? trueNegatives[1] : falsePositives[1]) += 1.0;
+                } else if (row->index() >= trainRows + classesRowCounts[2]) {
+                    // Actual is one.
+                    (prediction == 1.0 ? truePositives[1] : falseNegatives[1]) += 1.0;
+                    (prediction == 1.0 ? trueNegatives[0] : falsePositives[0]) += 1.0;
+                }
+            }
+        });
+
+        precisions.push_back(
+            {truePositives[0] / (truePositives[0] + falsePositives[0]),
+             truePositives[1] / (truePositives[1] + falsePositives[1])});
+        recalls.push_back({truePositives[0] / (truePositives[0] + falseNegatives[0]),
+                           truePositives[1] / (truePositives[1] + falseNegatives[1])});
+    }
+
+    LOG_DEBUG(<< "precisions = " << core::CContainerPrinter::print(precisions));
+    LOG_DEBUG(<< "recalls    = " << core::CContainerPrinter::print(recalls));
+
+    // Because our test set is balanced we expect low
+    CPPUNIT_ASSERT(std::fabs(precisions[1][0] - precisions[1][1]) <
+                   0.4 * std::fabs(precisions[0][0] - precisions[0][1]));
+    CPPUNIT_ASSERT(std::fabs(recalls[1][0] - recalls[1][1]) <
+                   0.4 * std::fabs(recalls[0][0] - recalls[0][1]));
 }
 
 void CBoostedTreeTest::testEstimateMemoryUsedByTrain() {
@@ -1463,6 +1548,8 @@ CppUnit::Test* CBoostedTreeTest::suite() {
         &CBoostedTreeTest::testLogisticLossForUnderflow));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testLogisticRegression", &CBoostedTreeTest::testLogisticRegression));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
+        "CBoostedTreeTest::testUnbalancedClasses", &CBoostedTreeTest::testUnbalancedClasses));
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeTest>(
         "CBoostedTreeTest::testEstimateMemoryUsedByTrain",
         &CBoostedTreeTest::testEstimateMemoryUsedByTrain));

--- a/lib/maths/unittest/CBoostedTreeTest.h
+++ b/lib/maths/unittest/CBoostedTreeTest.h
@@ -26,6 +26,7 @@ public:
     void testLogisticMinimizerRandom();
     void testLogisticLossForUnderflow();
     void testLogisticRegression();
+    void testUnbalancedClasses();
     void testEstimateMemoryUsedByTrain();
     void testProgressMonitoring();
     void testMissingData();

--- a/lib/maths/unittest/CDataFrameUtilsTest.h
+++ b/lib/maths/unittest/CDataFrameUtilsTest.h
@@ -15,6 +15,8 @@ public:
     void testStandardizeColumns();
     void testColumnQuantiles();
     void testColumnQuantilesWithEncoding();
+    void testStratifiedCrossValidationRowMasks();
+    void testCrossValidationRowMasks();
     void testMicWithColumn();
     void testCategoryFrequencies();
     void testMeanValueOfTargetForCategories();


### PR DESCRIPTION
This adds two features:
1. Stratifying the sampling we do for each test/train fold for classification.
2. Implementing a reweighting scheme so that each class contributes approximately equal weight to the training loss.

We sample uniformly at random from the training rows for each class in proportion to their frequency in the full train set. We then optionally reweight the loss for each example by the inverse frequency of its category in the training set.