### PR TITLE
[ML] Fix categorization encoding error

### DIFF
--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -219,7 +219,7 @@ public:
     //! List of the field names.
     const TStringVec& fieldNames() const;
     //! List of the field names.
-    void fieldNames(const TStringVec& columns);
+    void fieldNames(TStringVec&& fieldNames);
 
 private:
     //! List of the column names.
@@ -233,6 +233,7 @@ public:
     void addToDocument(rapidjson::Value& parentObject, TRapidJsonWriter& writer) const override;
     //! Input field name. Must be defined in the input section.
     void field(const std::string& field);
+    const std::string& field() const;
     //! Encoding type as string.
     virtual const std::string& typeString() const = 0;
 
@@ -324,9 +325,12 @@ public:
     std::unique_ptr<CTrainedModel>& trainedModel();
     void addToDocument(rapidjson::Value& parentObject, TRapidJsonWriter& writer) const override;
     std::string jsonString();
-    void fieldNames(const TStringVec& fieldNames);
+    void fieldNames(TStringVec&& fieldNames, std::size_t dependentVariableColumnIndex);
+    const TStringVec& fieldNames() const;
     const std::string& typeString() const;
     void typeString(const std::string& typeString);
+    size_t dependentVariableColumnIndex() const;
+    void dependentVariableColumnIndex(size_t dependentVariableColumnIndex);
 
 private:
     //! Information related to the input.
@@ -337,6 +341,7 @@ private:
     std::unique_ptr<CTrainedModel> m_TrainedModel;
     TStringVec m_FieldNames;
     std::string m_TypeString;
+    std::size_t m_DependentVariableColumnIndex;
 };
 }
 }

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -329,7 +329,7 @@ public:
     const TStringVec& fieldNames() const;
     const std::string& typeString() const;
     void typeString(const std::string& typeString);
-    size_t dependentVariableColumnIndex() const;
+    std::size_t dependentVariableColumnIndex() const;
     void dependentVariableColumnIndex(size_t dependentVariableColumnIndex);
 
 private:

--- a/lib/api/CBoostedTreeInferenceModelBuilder.cc
+++ b/lib/api/CBoostedTreeInferenceModelBuilder.cc
@@ -53,7 +53,7 @@ void CBoostedTreeInferenceModelBuilder::addTargetMeanEncoding(std::size_t inputC
                                                               const TDoubleVec& map,
                                                               double fallback) {
     if (inputColumnIndex != m_Definition.dependentVariableColumnIndex()) {
-        std::string fieldName{m_Definition.fieldNames()[inputColumnIndex]};
+        const std::string& fieldName{m_Definition.fieldNames()[inputColumnIndex]};
         std::string featureName{fieldName + "_targetmean"};
         auto stringMap = this->encodingMap(inputColumnIndex, map);
         m_Definition.preprocessors().push_back(std::make_unique<CTargetMeanEncoding>(
@@ -65,7 +65,7 @@ void CBoostedTreeInferenceModelBuilder::addTargetMeanEncoding(std::size_t inputC
 void CBoostedTreeInferenceModelBuilder::addFrequencyEncoding(std::size_t inputColumnIndex,
                                                              const TDoubleVec& map) {
     if (inputColumnIndex != m_Definition.dependentVariableColumnIndex()) {
-        std::string fieldName{m_Definition.fieldNames()[inputColumnIndex]};
+        const std::string& fieldName{m_Definition.fieldNames()[inputColumnIndex]};
         std::string featureName{fieldName + "_frequency"};
         auto stringMap = this->encodingMap(inputColumnIndex, map);
         m_Definition.preprocessors().push_back(std::make_unique<CFrequencyEncoding>(

--- a/lib/api/CBoostedTreeInferenceModelBuilder.cc
+++ b/lib/api/CBoostedTreeInferenceModelBuilder.cc
@@ -27,7 +27,7 @@ void CBoostedTreeInferenceModelBuilder::addTree() {
 }
 
 void CBoostedTreeInferenceModelBuilder::addIdentityEncoding(std::size_t inputColumnIndex) {
-    if (inputColumnIndex < m_FieldNames.size()) {
+    if (inputColumnIndex != m_Definition.dependentVariableColumnIndex()) {
         // The target column is excluded from m_FieldNames.
         m_FeatureNames.push_back(m_FieldNames[inputColumnIndex]);
     }
@@ -35,8 +35,8 @@ void CBoostedTreeInferenceModelBuilder::addIdentityEncoding(std::size_t inputCol
 
 void CBoostedTreeInferenceModelBuilder::addOneHotEncoding(std::size_t inputColumnIndex,
                                                           std::size_t hotCategory) {
-    if (inputColumnIndex < m_Definition.input().fieldNames().size()) {
-        std::string fieldName{m_Definition.input().fieldNames()[inputColumnIndex]};
+    if (inputColumnIndex != m_Definition.dependentVariableColumnIndex()) {
+        std::string fieldName{m_Definition.fieldNames()[inputColumnIndex]};
         std::string category = m_CategoryNames[inputColumnIndex][hotCategory];
         std::string featureName = fieldName + "_" + category;
         if (m_OneHotEncodingMaps.find(fieldName) == m_OneHotEncodingMaps.end()) {
@@ -52,8 +52,8 @@ void CBoostedTreeInferenceModelBuilder::addOneHotEncoding(std::size_t inputColum
 void CBoostedTreeInferenceModelBuilder::addTargetMeanEncoding(std::size_t inputColumnIndex,
                                                               const TDoubleVec& map,
                                                               double fallback) {
-    if (inputColumnIndex < m_Definition.input().fieldNames().size()) {
-        std::string fieldName{m_Definition.input().fieldNames()[inputColumnIndex]};
+    if (inputColumnIndex != m_Definition.dependentVariableColumnIndex()) {
+        std::string fieldName{m_Definition.fieldNames()[inputColumnIndex]};
         std::string featureName{fieldName + "_targetmean"};
         auto stringMap = this->encodingMap(inputColumnIndex, map);
         m_Definition.preprocessors().push_back(std::make_unique<CTargetMeanEncoding>(
@@ -64,8 +64,8 @@ void CBoostedTreeInferenceModelBuilder::addTargetMeanEncoding(std::size_t inputC
 
 void CBoostedTreeInferenceModelBuilder::addFrequencyEncoding(std::size_t inputColumnIndex,
                                                              const TDoubleVec& map) {
-    if (inputColumnIndex < m_Definition.input().fieldNames().size()) {
-        std::string fieldName{m_Definition.input().fieldNames()[inputColumnIndex]};
+    if (inputColumnIndex != m_Definition.dependentVariableColumnIndex()) {
+        std::string fieldName{m_Definition.fieldNames()[inputColumnIndex]};
         std::string featureName{fieldName + "_frequency"};
         auto stringMap = this->encodingMap(inputColumnIndex, map);
         m_Definition.preprocessors().push_back(std::make_unique<CFrequencyEncoding>(
@@ -122,9 +122,8 @@ CBoostedTreeInferenceModelBuilder::CBoostedTreeInferenceModelBuilder(TStrVec fie
     m_FieldNames = fieldNames;
 
     this->categoryNames(categoryNames);
-    fieldNames.erase(fieldNames.begin() +
-                     static_cast<std::ptrdiff_t>(dependentVariableColumnIndex));
-    m_Definition.fieldNames(fieldNames);
+    m_Definition.dependentVariableColumnIndex(dependentVariableColumnIndex);
+    m_Definition.fieldNames(std::move(fieldNames), dependentVariableColumnIndex);
     m_Definition.trainedModel(std::make_unique<CEnsemble>());
     m_Definition.typeString(INFERENCE_MODEL);
 }

--- a/lib/api/CInferenceModelDefinition.cc
+++ b/lib/api/CInferenceModelDefinition.cc
@@ -336,9 +336,12 @@ void CTrainedModel::featureNames(CTrainedModel::TStringVec&& featureNames) {
     m_FeatureNames = featureNames;
 }
 
-void CInferenceModelDefinition::fieldNames(const TStringVec& fieldNames) {
+void CInferenceModelDefinition::fieldNames(TStringVec&& fieldNames,
+                                           std::size_t dependentVariableColumnIndex) {
     m_FieldNames = fieldNames;
-    m_Input.fieldNames(fieldNames);
+    fieldNames.erase(fieldNames.begin() +
+                     static_cast<std::ptrdiff_t>(dependentVariableColumnIndex));
+    m_Input.fieldNames(std::move(fieldNames));
 }
 
 void CInferenceModelDefinition::trainedModel(std::unique_ptr<CTrainedModel>&& trainedModel) {
@@ -365,12 +368,24 @@ void CInferenceModelDefinition::typeString(const std::string& typeString) {
     CInferenceModelDefinition::m_TypeString = typeString;
 }
 
+const CInferenceModelDefinition::TStringVec& CInferenceModelDefinition::fieldNames() const {
+    return m_FieldNames;
+}
+
+size_t CInferenceModelDefinition::dependentVariableColumnIndex() const {
+    return m_DependentVariableColumnIndex;
+}
+
+void CInferenceModelDefinition::dependentVariableColumnIndex(size_t dependentVariableColumnIndex) {
+    m_DependentVariableColumnIndex = dependentVariableColumnIndex;
+}
+
 const CInput::TStringVec& CInput::fieldNames() const {
     return m_FieldNames;
 }
 
-void CInput::fieldNames(const TStringVec& columns) {
-    m_FieldNames = columns;
+void CInput::fieldNames(TStringVec&& fieldNames) {
+    m_FieldNames = fieldNames;
 }
 
 void CInput::addToDocument(rapidjson::Value& parentObject, TRapidJsonWriter& writer) const {
@@ -431,6 +446,10 @@ void CEncoding::addToDocument(rapidjson::Value& parentObject, TRapidJsonWriter& 
 }
 
 CEncoding::CEncoding(std::string field) : m_Field(std::move(field)) {
+}
+
+const std::string& CEncoding::field() const {
+    return m_Field;
 }
 
 void CFrequencyEncoding::addToDocument(rapidjson::Value& parentObject,

--- a/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
+++ b/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
@@ -13,6 +13,7 @@
 
 #include <maths/CLinearAlgebraEigen.h>
 
+#include <api/CBoostedTreeInferenceModelBuilder.h>
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameAnalyzer.h>
@@ -321,6 +322,60 @@ void CBoostedTreeInferenceModelBuilderTest::testJsonSchema() {
     }
 }
 
+void CBoostedTreeInferenceModelBuilderTest::testEncoders() {
+    {
+        TStrVec fieldNames{"col1", "target", "col2", "col3"};
+        std::size_t dependentVariableColumnIndex{1};
+        TStrVecVec categoryNames{{},
+                                 {"targetcat1", "targetcat2"},
+                                 {"col2cat1", "col2cat2", "col2cat3"},
+                                 {"col3cat1", "col3cat2"}};
+        api::CClassificationInferenceModelBuilder builder(
+            fieldNames, dependentVariableColumnIndex, categoryNames);
+        builder.addIdentityEncoding(0);
+        builder.addOneHotEncoding(2, 0);
+        builder.addOneHotEncoding(2, 1);
+        builder.addFrequencyEncoding(2, {1.0, 1.0, 1.0});
+        builder.addOneHotEncoding(3, 0);
+        builder.addFrequencyEncoding(3, {1.0, 1.0});
+        auto definition{builder.build()};
+        const auto& preprocessors{definition.preprocessors()};
+        CPPUNIT_ASSERT_EQUAL(std::size_t(4), preprocessors.size());
+        for (const auto& encoding : preprocessors) {
+            if (encoding->typeString() == "frequency_encoding") {
+                const auto& frequencyEncoding{
+                    static_cast<api::CFrequencyEncoding*>(encoding.get())};
+                const auto& map{frequencyEncoding->frequencyMap()};
+                if (frequencyEncoding->featureName() == "col2_frequency") {
+                    CPPUNIT_ASSERT_EQUAL(std::size_t(3), map.size());
+                    CPPUNIT_ASSERT(map.find("col2cat1") != map.end());
+                    CPPUNIT_ASSERT(map.find("col2cat2") != map.end());
+                    CPPUNIT_ASSERT(map.find("col2cat3") != map.end());
+                } else if (frequencyEncoding->featureName() == "col3_frequency") {
+                    CPPUNIT_ASSERT_EQUAL(std::size_t(2), map.size());
+                    CPPUNIT_ASSERT(map.find("col3cat1") != map.end());
+                    CPPUNIT_ASSERT(map.find("col3cat2") != map.end());
+                }
+            } else if (encoding->typeString() == "one_hot_encoding") {
+                const auto& oneHotEncoding{
+                    static_cast<api::COneHotEncoding*>(encoding.get())};
+                const auto& map{oneHotEncoding->hotMap()};
+
+                if (oneHotEncoding->field() == "col2") {
+                    CPPUNIT_ASSERT_EQUAL(std::size_t(2), map.size());
+                    CPPUNIT_ASSERT(map.find("col2cat1") != map.end());
+                    CPPUNIT_ASSERT(map.find("col2cat2") != map.end());
+                } else if (oneHotEncoding->field() == "col3") {
+                    CPPUNIT_ASSERT_EQUAL(std::size_t(1), map.size());
+                    CPPUNIT_ASSERT(map.find("col3cat1") != map.end());
+                }
+            } else {
+                CPPUNIT_FAIL("Unexpected encoding type");
+            }
+        }
+    }
+}
+
 CppUnit::Test* CBoostedTreeInferenceModelBuilderTest::suite() {
     CppUnit::TestSuite* suiteOfTests =
         new CppUnit::TestSuite("CBoostedTreeInferenceModelBuilderTest");
@@ -334,6 +389,9 @@ CppUnit::Test* CBoostedTreeInferenceModelBuilderTest::suite() {
     suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeInferenceModelBuilderTest>(
         "CBoostedTreeInferenceModelBuilderTest::testJsonSchema",
         &CBoostedTreeInferenceModelBuilderTest::testJsonSchema));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CBoostedTreeInferenceModelBuilderTest>(
+        "CBoostedTreeInferenceModelBuilderTest::testEncoders",
+        &CBoostedTreeInferenceModelBuilderTest::testEncoders));
 
     return suiteOfTests;
 }

--- a/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.h
+++ b/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.h
@@ -14,6 +14,7 @@ public:
     void testIntegrationRegression();
     void testIntegrationClassification();
     void testJsonSchema();
+    void testEncoders();
 
     static CppUnit::Test* suite();
 };


### PR DESCRIPTION
This PR fixes an erroneous handling categorical fields that follow the target field. It also adds a unit test to catch similar cases in the future.

closes https://github.com/elastic/ml-cpp/issues/752