### PR TITLE
[ML] Identity encode the target variable

### DIFF
--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -653,7 +653,8 @@ CMakeDataFrameCategoryEncoder::readEncodings() const {
         std::size_t inputColumnIndex{m_EncodedColumnInputColumnMap[encodedColumnIndex]};
         double mic{m_EncodedColumnMics[encodedColumnIndex]};
 
-        if (m_Frame->columnIsCategorical()[inputColumnIndex] == false) {
+        if (inputColumnIndex == m_TargetColumn ||
+            m_Frame->columnIsCategorical()[inputColumnIndex] == false) {
             encodings.push_back(std::make_unique<CIdentityEncoding>(inputColumnIndex, mic));
             continue;
         }

--- a/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
+++ b/lib/maths/unittest/CDataFrameCategoryEncoderTest.h
@@ -16,6 +16,7 @@ public:
     void testRareCategories();
     void testCorrelatedFeatures();
     void testWithRowMask();
+    void testEncodingOfCategoricalTarget();
     void testEncodedDataFrameRowRef();
     void testUnseenCategoryEncoding();
     void testDiscardNuisanceFeatures();


### PR DESCRIPTION
We should always just pass back the target variable unmodified in the encoded feature vector.