### PR TITLE
[ML] Refactor CLogger to use custom stream

### DIFF
--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -93,7 +93,7 @@ public:
     bool reconfigure(const std::string& pipeName, const std::string& propertiesFile);
 
     //! Reconfigure to use provided stream.
-    bool reconfigure(boost::shared_ptr<std::ostream>& streamPtr);
+    bool reconfigure(boost::shared_ptr<std::ostream> streamPtr);
 
     //! Tell the logger to log to a named pipe rather than a file.
     bool reconfigureLogToNamedPipe(const std::string& pipeName);

--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -92,6 +92,9 @@ public:
     //! If both are supplied the named pipe takes precedence.
     bool reconfigure(const std::string& pipeName, const std::string& propertiesFile);
 
+    //! Reconfigure to use provided stream.
+    bool reconfigure(boost::shared_ptr<std::ostream>& streamPtr);
+
     //! Tell the logger to log to a named pipe rather than a file.
     bool reconfigureLogToNamedPipe(const std::string& pipeName);
 

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -276,7 +276,7 @@ bool CLogger::reconfigure(const std::string& pipeName, const std::string& proper
     return this->reconfigureLogToNamedPipe(pipeName);
 }
 
-bool CLogger::reconfigure(boost::shared_ptr<std::ostream>& streamPtr) {
+bool CLogger::reconfigure(boost::shared_ptr<std::ostream> streamPtr) {
     if (streamPtr->good()) {
         auto newSink{boost::make_shared<TTextOStreamSynchronousSink>()};
         newSink->locked_backend()->add_stream(streamPtr);

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -56,8 +56,7 @@ const ml::core::CLogger& DO_NOT_USE_THIS_VARIABLE = ml::core::CLogger::instance(
 using TOStreamPtr = boost::shared_ptr<std::ostream>;
 using TTextOStream = boost::log::sinks::text_ostream_backend;
 using TTextOStreamSynchronousSink = boost::log::sinks::synchronous_sink<TTextOStream>;
-using TTextOStreamSynchronousSinkPtr =
-    boost::shared_ptr<boost::log::sinks::synchronous_sink<TTextOStream>>;
+using TTextOStreamSynchronousSinkPtr = boost::shared_ptr<TTextOStreamSynchronousSink>;
 
 class CTimeStampFormatterFactory
     : public boost::log::basic_formatter_factory<char, boost::posix_time::ptime> {
@@ -275,6 +274,16 @@ bool CLogger::reconfigure(const std::string& pipeName, const std::string& proper
         return this->reconfigureFromFile(propertiesFile);
     }
     return this->reconfigureLogToNamedPipe(pipeName);
+}
+
+bool CLogger::reconfigure(boost::shared_ptr<std::ostream>& streamPtr) {
+    if (streamPtr->good()) {
+        auto newSink{boost::make_shared<TTextOStreamSynchronousSink>()};
+        newSink->locked_backend()->add_stream(streamPtr);
+        resetSink(newSink);
+        return true;
+    }
+    return false;
 }
 
 bool CLogger::reconfigureLogToNamedPipe(const std::string& pipeName) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1424,11 +1424,8 @@ void CBoostedTreeTest::testRestoreErrorHandling() {
 
     auto stream = boost::make_shared<std::ostringstream>();
 
-    boost::shared_ptr<std::ostream> castedStream(
-        boost::static_pointer_cast<std::ostream>(stream));
-
     // log at level ERROR only
-    CPPUNIT_ASSERT(core::CLogger::instance().reconfigure(castedStream));
+    CPPUNIT_ASSERT(core::CLogger::instance().reconfigure(stream));
 
     std::size_t cols{3};
     std::size_t capacity{50};


### PR DESCRIPTION
Following the [discussion](https://github.com/elastic/ml-cpp/pull/726#discussion_r333475371) this PR adds a way to use custom stream in `CLogger`.