### PR TITLE
[ML] Adjust use of BOOST_REQUIRE and BOOST_TEST_REQUIRE

### DIFF
--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -1167,15 +1167,15 @@ BOOST_AUTO_TEST_CASE(testSmallVector) {
         if (size <= 2) {
             BOOST_TEST_REQUIRE(memory[0] == 0);
         }
-        BOOST_TEST_REQUIRE((memory[0] == 0 || memory[0] == vec1.capacity() * sizeof(double)));
+        BOOST_REQUIRE(memory[0] == 0 || memory[0] == vec1.capacity() * sizeof(double));
         if (size <= 6) {
             BOOST_TEST_REQUIRE(memory[1] == 0);
         }
-        BOOST_TEST_REQUIRE((memory[1] == 0 || memory[1] == vec2.capacity() * sizeof(double)));
+        BOOST_REQUIRE(memory[1] == 0 || memory[1] == vec2.capacity() * sizeof(double));
         if (size <= 8) {
             BOOST_TEST_REQUIRE(memory[2] == 0);
         }
-        BOOST_TEST_REQUIRE((memory[2] == 0 || memory[2] == vec3.capacity() * sizeof(double)));
+        BOOST_REQUIRE(memory[2] == 0 || memory[2] == vec3.capacity() * sizeof(double));
     }
 
     // Test growing and shrinking

--- a/lib/core/unittest/CRapidXmlParserTest.cc
+++ b/lib/core/unittest/CRapidXmlParserTest.cc
@@ -277,8 +277,8 @@ BOOST_AUTO_TEST_CASE(testConvert) {
     BOOST_TEST_REQUIRE(converted.find("</child>") != std::string::npos);
     BOOST_TEST_REQUIRE(converted.find("<child ") != std::string::npos);
     BOOST_TEST_REQUIRE(converted.find("&amp; ") != std::string::npos);
-    BOOST_TEST_REQUIRE((converted.find("<empty/>") != std::string::npos ||
-                        converted.find("<empty></empty>") != std::string::npos));
+    BOOST_REQUIRE(converted.find("<empty/>") != std::string::npos ||
+                  converted.find("<empty></empty>") != std::string::npos);
     BOOST_TEST_REQUIRE(converted.find("<dual ") != std::string::npos);
     BOOST_TEST_REQUIRE(converted.find("first") != std::string::npos);
     BOOST_TEST_REQUIRE(converted.find("second") != std::string::npos);

--- a/lib/maths/unittest/CCalendarFeatureTest.cc
+++ b/lib/maths/unittest/CCalendarFeatureTest.cc
@@ -97,10 +97,10 @@ BOOST_AUTO_TEST_CASE(testComparison) {
 
     for (std::size_t i = 0u; i < features.size(); ++i) {
         BOOST_TEST_REQUIRE(features[i] == features[i]);
-        BOOST_TEST_REQUIRE(!(features[i] < features[i] || features[i] > features[i]));
+        BOOST_REQUIRE(!(features[i] < features[i] || features[i] > features[i]));
         for (std::size_t j = i + 1; j < features.size(); ++j) {
             BOOST_TEST_REQUIRE(features[i] != features[j]);
-            BOOST_TEST_REQUIRE((features[i] < features[j] || features[i] > features[j]));
+            BOOST_REQUIRE(features[i] < features[j] || features[i] > features[j]);
         }
     }
 }

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(testStratifiedCrossValidationRowMasks) {
             }
             LOG_DEBUG(<< "variance in test set target percentile = "
                       << maths::CBasicStatistics::variance(testTargetDecileMoments));
-            BOOST_REQUIRE(maths::CBasicStatistics::variance(testTargetDecileMoments) < 0.02);
+            BOOST_TEST_REQUIRE(maths::CBasicStatistics::variance(testTargetDecileMoments) < 0.02);
         }
     }
 }

--- a/lib/maths/unittest/CXMeansTest.cc
+++ b/lib/maths/unittest/CXMeansTest.cc
@@ -668,8 +668,8 @@ BOOST_AUTO_TEST_CASE(testPoorlyConditioned) {
             TVector2Vec clusterPoints = xmeans.clusters()[i].points();
             std::sort(clusterPoints.begin(), clusterPoints.end());
             LOG_DEBUG(<< "points = " << core::CContainerPrinter::print(clusterPoints));
-            BOOST_TEST_REQUIRE((clusterPoints == cluster1 || clusterPoints == cluster2 ||
-                                clusterPoints == cluster3));
+            BOOST_REQUIRE(clusterPoints == cluster1 ||
+                          clusterPoints == cluster2 || clusterPoints == cluster3);
         }
     }
 }


### PR DESCRIPTION
BOOST_TEST_REQUIRE:

- Clever assertion that looks at LHS/RHS of expression
- Prints LHS/RHS values in any failure message
- Can't cope with logical operators
- Requires LHS/RHS of comparison be printable

BOOST_REQUIRE:

- Simple boolean assertion
- Simple pass/fail diagnostics
- Works with arbitrary expressions that evaluate to a boolean
- No printability constraints

This PR changes the usage of the two macros to reflect their
strengths and weaknesses.