### PR TITLE
[ML] Stop cross-validation early if the test loss isn't promising

### DIFF
--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -57,8 +57,10 @@ public:
     CBoostedTreeFactory& minimumFrequencyToOneHotEncode(double frequency);
     //! Set the number of folds to use for estimating the generalisation error.
     CBoostedTreeFactory& numberFolds(std::size_t numberFolds);
-    //! Stratify the cross validation we do for regression.
+    //! Stratify the cross-validation we do for regression.
     CBoostedTreeFactory& stratifyRegressionCrossValidation(bool stratify);
+    //! Stop cross-validation early if the test loss is not promising.
+    CBoostedTreeFactory& stopCrossValidationEarly(bool stopEarly);
     //! Set the sum of leaf depth penalties multiplier.
     CBoostedTreeFactory& depthPenaltyMultiplier(double depthPenaltyMultiplier);
     //! Set the tree size penalty multiplier.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -624,6 +624,7 @@ private:
     TOptionalSize m_MaximumNumberTreesOverride;
     TOptionalDouble m_FeatureBagFractionOverride;
     TRegularization m_Regularization;
+    bool m_StopCrossValidationEarly = true;
     double m_Eta = 0.1;
     double m_EtaGrowthRatePerTree = 1.05;
     std::size_t m_NumberFolds = 4;

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -41,6 +41,7 @@ const std::string SOFT_TREE_DEPTH_TOLERANCE{"soft_tree_depth_tolerance"};
 const std::string MAXIMUM_NUMBER_TREES{"maximum_number_trees"};
 const std::string FEATURE_BAG_FRACTION{"feature_bag_fraction"};
 const std::string NUMBER_FOLDS{"number_folds"};
+const std::string STOP_CROSS_VALIDATION_EARLY{"stop_cross_validation_early"};
 const std::string NUMBER_ROUNDS_PER_HYPERPARAMETER{"number_rounds_per_hyperparameter"};
 const std::string BAYESIAN_OPTIMISATION_RESTARTS{"bayesian_optimisation_restarts"};
 }
@@ -65,6 +66,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::getParam
         theReader.addParameter(FEATURE_BAG_FRACTION,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(NUMBER_FOLDS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(STOP_CROSS_VALIDATION_EARLY,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(NUMBER_ROUNDS_PER_HYPERPARAMETER,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(BAYESIAN_OPTIMISATION_RESTARTS,
@@ -92,6 +95,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         parameters[NUMBER_ROUNDS_PER_HYPERPARAMETER].fallback(std::size_t{0})};
     std::size_t bayesianOptimisationRestarts{
         parameters[BAYESIAN_OPTIMISATION_RESTARTS].fallback(std::size_t{0})};
+    bool stopCrossValidationEarly{parameters[STOP_CROSS_VALIDATION_EARLY].fallback(true)};
 
     double alpha{parameters[ALPHA].fallback(-1.0)};
     double lambda{parameters[LAMBDA].fallback(-1.0)};
@@ -128,6 +132,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         maths::CBoostedTreeFactory::constructFromParameters(this->spec().numberThreads()));
 
     (*m_BoostedTreeFactory)
+        .stopCrossValidationEarly(stopCrossValidationEarly)
         .progressCallback(this->progressRecorder())
         .trainingStateCallback(this->statePersister())
         .memoryUsageCallback(this->memoryMonitor(counter_t::E_DFTPMPeakMemoryUsage));

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -671,6 +671,11 @@ CBoostedTreeFactory& CBoostedTreeFactory::stratifyRegressionCrossValidation(bool
     return *this;
 }
 
+CBoostedTreeFactory& CBoostedTreeFactory::stopCrossValidationEarly(bool stopEarly) {
+    m_TreeImpl->m_StopCrossValidationEarly = stopEarly;
+    return *this;
+}
+
 CBoostedTreeFactory& CBoostedTreeFactory::depthPenaltyMultiplier(double depthPenaltyMultiplier) {
     if (depthPenaltyMultiplier < 0.0) {
         LOG_WARN(<< "Depth penalty multiplier must be non-negative");

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -931,12 +931,12 @@ CBoostedTreeImpl::estimateMissingTestLosses(const TSizeVec& missing) const {
     // estimate the test loss we'll see for the remaining folds to decide if it
     // is worthwhile to continue training with these parameters and to correct
     // the loss value supplied to Bayesian Optimisation to account for the folds
-    // we haven't trained on. We achieve this by for each missing fold m fitting
+    // we haven't trained on. We achieve this by for each missing fold fitting an
     // OLS to the data (x_i, loss(m_i)) where i ranges over the previous rounds
     // and x_i is the i'th vector whose components comprise the losses for which
-    // we have values in this round and indicators for whether they were present
-    // in the i'th round. We only include a round if it at least one of the folds
-    // matches a fold for which we have a test loss in the current round.
+    // we have values in the current round and indicators for whether they were
+    // present in the i'th round. We only include a round if we've trained for at
+    // least one of same folds in the current round.
 
     TSizeVec present(m_NumberFolds);
     std::iota(present.begin(), present.end(), 0);
@@ -954,7 +954,7 @@ CBoostedTreeImpl::estimateMissingTestLosses(const TSizeVec& missing) const {
     predictedTestLosses.reserve(missing.size());
 
     for (std::size_t target : missing) {
-        // Extract training mask.
+        // Extract the training mask.
         TSizeVec mask;
         mask.reserve(m_CurrentRound);
         for (std::size_t round = 0; round < m_CurrentRound; ++round) {
@@ -966,7 +966,7 @@ CBoostedTreeImpl::estimateMissingTestLosses(const TSizeVec& missing) const {
             }
         }
 
-        // Fit the OLS model.
+        // Fit the OLS regression.
         CDenseMatrix<double> A(mask.size(), 2 * present.size());
         CDenseVector<double> b(mask.size());
         for (std::size_t row = 0; row < mask.size(); ++row) {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -628,7 +628,8 @@ CBoostedTreeImpl::crossValidateForest(core::CDataFrame& frame,
     auto stopCrossValidationEarly = [&](TMeanVarAccumulator lossMoments) {
         // Always train on every folds for the first number folds rounds and at
         // least two folds per round.
-        if (m_CurrentRound > m_NumberFolds && folds.size() <= m_NumberFolds - 2) {
+        if (m_StopCrossValidationEarly && m_CurrentRound > m_NumberFolds &&
+            folds.size() <= m_NumberFolds - 2) {
             for (const auto& loss : this->estimateMissingTestLosses(folds)) {
                 lossMoments.add(
                     CBasicStatistics::mean(loss) -


### PR DESCRIPTION
This targets runtime by stopping cross-validation early if the test loss from the folds for which we've already trained suggest it is unlikely that the parameter values under test will be good. We account for the variation in test loss across the folds by fitting an OLS to the test losses from previous rounds of training to predict the missing folds' test errors. This gives us both a predicted loss and its variance for each missing fold. We use these to decide if there is any point proceeding with training and to correct the test loss we supply to Bayesian Optimisation.

This is somewhat experimental. On the data sets I've tested on we are able to stop training early on many rounds for little or no degradation in QoR. However, it'll need more thorough evaluation than I've performed so far. It is useful to get it in so it goes through the QA suite and also so it's available for others to test internally.