### PR TITLE
[7.x][ML] Fix some Windows-specific cases of no assertions in tests

### DIFF
--- a/lib/core/unittest/CNamedPipeFactoryTest.cc
+++ b/lib/core/unittest/CNamedPipeFactoryTest.cc
@@ -258,6 +258,8 @@ BOOST_AUTO_TEST_CASE(testErrorIfSymlink) {
     // live under \\.\pipe\ and it's not possible to symlink to this part of
     // the file system
     LOG_DEBUG(<< "symlink test not relevant to Windows");
+    // Suppress the error about no assertions in this case
+    BOOST_REQUIRE(BOOST_IS_DEFINED(Windows));
 #else
     static const char* const TEST_SYMLINK_NAME = "test_symlink";
 

--- a/lib/core/unittest/COsFileFuncsTest.cc
+++ b/lib/core/unittest/COsFileFuncsTest.cc
@@ -77,6 +77,8 @@ BOOST_AUTO_TEST_CASE(testLStat) {
     // create symlinks on Windows, and we don't want to force the unit tests to
     // run as administrator
     LOG_WARN(<< "Skipping lstat() test as it would need to run as administrator");
+    // NTDDI_VERSION should only be defined on Windows
+    BOOST_REQUIRE(BOOST_IS_DEFINED(Windows));
 #else
 #ifdef Windows
     BOOST_TEST_REQUIRE(CreateSymbolicLink(symLink.c_str(), file.c_str(),


### PR DESCRIPTION
Backport of #791