### PR TITLE
[7.x][ML] Factor out common test code

### DIFF
--- a/include/test/CThreadDataReader.h
+++ b/include/test/CThreadDataReader.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_test_CThreadDataReader_h
+#define INCLUDED_ml_test_CThreadDataReader_h
+
+#include <core/CMutex.h>
+#include <core/CThread.h>
+
+#include <test/ImportExport.h>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+
+namespace ml {
+namespace test {
+
+//! \brief
+//! Reads a file in a thread.
+//!
+//! DESCRIPTION:\n
+//! When the thread is started it makes several attempts to open
+//! the file, separated by the specified sleep.  This gives some
+//! other thread time to create the file.  The data is read into
+//! a string which can be accessed safely after the reader thread
+//! has completed (so this class should not be used to read
+//! collosal files that will exhaust memory).
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! Using core::CThread rather than std::thread to minimise risk
+//! as it was factored out of existing code using core::CThread.
+//!
+class TEST_EXPORT CThreadDataReader : public core::CThread {
+public:
+    CThreadDataReader(std::uint32_t sleepTimeMs, std::size_t maxAttempts, const std::string& fileName);
+
+    const std::string& data() const;
+    std::size_t attemptsTaken() const;
+    bool streamWentBad() const;
+
+protected:
+    void run() override;
+    void shutdown() override;
+
+private:
+    mutable core::CMutex m_Mutex;
+    std::atomic_bool m_Shutdown;
+    std::atomic_bool m_StreamWentBad;
+    const std::uint32_t m_SleepTimeMs;
+    const std::size_t m_MaxAttempts;
+    std::atomic_size_t m_Attempt;
+    const std::string m_FileName;
+    std::string m_Data;
+};
+}
+}
+
+#endif // INCLUDED_ml_test_CThreadDataReader_h

--- a/include/test/CThreadDataWriter.h
+++ b/include/test/CThreadDataWriter.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_test_CThreadDataWriter_h
+#define INCLUDED_ml_test_CThreadDataWriter_h
+
+#include <core/CThread.h>
+
+#include <test/ImportExport.h>
+
+#include <cstdint>
+#include <string>
+
+namespace ml {
+namespace test {
+
+//! \brief
+//! Writes to a file in a thread.
+//!
+//! DESCRIPTION:\n
+//! When the thread is started it waits a short time, then writes
+//! data of a specified size to a file.  The data consists of a
+//! single specified character repeated.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! Using core::CThread rather than std::thread to minimise risk
+//! as it was factored out of existing code using core::CThread.
+//!
+class TEST_EXPORT CThreadDataWriter : public core::CThread {
+public:
+    CThreadDataWriter(std::uint32_t sleepTimeMs,
+                      const std::string& fileName,
+                      char testChar,
+                      std::size_t size);
+
+protected:
+    void run() override;
+    void shutdown() override;
+
+private:
+    const std::uint32_t m_SleepTimeMs;
+    const std::string m_FileName;
+    const char m_TestChar;
+    const std::size_t m_Size;
+};
+}
+}
+
+#endif // INCLUDED_ml_test_CThreadDataWriter_h

--- a/lib/api/unittest/CIoManagerTest.cc
+++ b/lib/api/unittest/CIoManagerTest.cc
@@ -4,13 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <core/CMutex.h>
-#include <core/CNamedPipeFactory.h>
-#include <core/CScopedLock.h>
-#include <core/CSleep.h>
-#include <core/CThread.h>
-
 #include <api/CIoManager.h>
+
+#include <test/CThreadDataReader.h>
+#include <test/CThreadDataWriter.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -42,101 +39,13 @@ const char* const BAD_OUTPUT_FILE_NAME = "can't_create_a_file_here/bad_output_fi
 const char* const BAD_INPUT_PIPE_NAME = "can't_create_a_pipe_here/bad_input_pipe";
 const char* const BAD_OUTPUT_PIPE_NAME = "can't_create_a_pipe_here/bad_output_pipe";
 
-class CThreadDataWriter : public ml::core::CThread {
-public:
-    CThreadDataWriter(const std::string& fileName, size_t size)
-        : m_FileName(fileName), m_Size(size) {}
-
-protected:
-    virtual void run() {
-        // Wait for the file to exist
-        ml::core::CSleep::sleep(SLEEP_TIME_MS);
-
-        std::ofstream strm(m_FileName.c_str());
-        for (size_t i = 0; i < m_Size && strm.good(); ++i) {
-            strm << TEST_CHAR;
-        }
-    }
-
-    virtual void shutdown() {}
-
-private:
-    std::string m_FileName;
-    size_t m_Size;
-};
-
-class CThreadDataReader : public ml::core::CThread {
-public:
-    CThreadDataReader(const std::string& fileName)
-        : m_FileName(fileName), m_Shutdown(false) {}
-
-    const std::string& data() const {
-        // The memory barriers associated with the mutex lock should ensure
-        // the thread calling this method has as up-to-date view of m_Data's
-        // member variables as the thread that updated it
-        ml::core::CScopedLock lock(m_Mutex);
-        return m_Data;
-    }
-
-protected:
-    virtual void run() {
-        m_Data.clear();
-
-        std::ifstream strm;
-
-        // Try to open the file repeatedly to allow time for the other
-        // thread to create it
-        size_t attempt(1);
-        do {
-            if (m_Shutdown) {
-                return;
-            }
-            BOOST_TEST_REQUIRE(attempt++ <= MAX_ATTEMPTS);
-            ml::core::CSleep::sleep(PAUSE_TIME_MS);
-            strm.open(m_FileName.c_str());
-        } while (!strm.is_open());
-
-        static const std::streamsize BUF_SIZE = 512;
-        char buffer[BUF_SIZE];
-        while (strm.good()) {
-            if (m_Shutdown) {
-                return;
-            }
-            strm.read(buffer, BUF_SIZE);
-            BOOST_TEST_REQUIRE(!strm.bad());
-            if (strm.gcount() > 0) {
-                ml::core::CScopedLock lock(m_Mutex);
-                // This code deals with the test character we write to
-                // detect the short-lived connection problem on Windows
-                const char* copyFrom = buffer;
-                size_t copyLen = static_cast<size_t>(strm.gcount());
-                if (m_Data.empty() && *buffer == ml::core::CNamedPipeFactory::TEST_CHAR) {
-                    ++copyFrom;
-                    --copyLen;
-                }
-                if (copyLen > 0) {
-                    m_Data.append(copyFrom, copyLen);
-                }
-            }
-        }
-    }
-
-    virtual void shutdown() { m_Shutdown = true; }
-
-private:
-    mutable ml::core::CMutex m_Mutex;
-    std::string m_FileName;
-    std::string m_Data;
-    volatile bool m_Shutdown;
-};
-
 void testCommon(const std::string& inputFileName,
                 bool isInputFileNamedPipe,
                 const std::string& outputFileName,
                 bool isOutputFileNamedPipe,
                 bool isGood) {
     // Test reader reads from the IO manager's output stream.
-    CThreadDataReader threadReader(outputFileName);
+    ml::test::CThreadDataReader threadReader(PAUSE_TIME_MS, MAX_ATTEMPTS, outputFileName);
     BOOST_TEST_REQUIRE(threadReader.start());
 
     std::string processedData;
@@ -165,6 +74,8 @@ void testCommon(const std::string& inputFileName,
 
     if (isGood) {
         BOOST_TEST_REQUIRE(threadReader.waitForFinish());
+        BOOST_TEST_REQUIRE(threadReader.attemptsTaken() <= MAX_ATTEMPTS);
+        BOOST_TEST_REQUIRE(threadReader.streamWentBad() == false);
         BOOST_REQUIRE_EQUAL(TEST_SIZE, processedData.length());
         BOOST_REQUIRE_EQUAL(std::string(TEST_SIZE, TEST_CHAR), processedData);
         BOOST_REQUIRE_EQUAL(processedData.length(), threadReader.data().length());
@@ -214,12 +125,13 @@ BOOST_AUTO_TEST_CASE(testFileIoBad) {
 BOOST_AUTO_TEST_CASE(testNamedPipeIoGood) {
     // For the named pipe test, data needs to be written to the IO manager's
     // input pipe after the IO manager has started
-    CThreadDataWriter threadWriter(GOOD_INPUT_PIPE_NAME, TEST_SIZE);
+    ml::test::CThreadDataWriter threadWriter(SLEEP_TIME_MS, GOOD_INPUT_PIPE_NAME,
+                                             TEST_CHAR, TEST_SIZE);
     BOOST_TEST_REQUIRE(threadWriter.start());
 
     testCommon(GOOD_INPUT_PIPE_NAME, true, GOOD_OUTPUT_PIPE_NAME, true, true);
 
-    BOOST_TEST_REQUIRE(threadWriter.stop());
+    BOOST_TEST_REQUIRE(threadWriter.waitForFinish());
 }
 
 BOOST_AUTO_TEST_CASE(testNamedPipeIoBad) {

--- a/lib/test/CThreadDataReader.cc
+++ b/lib/test/CThreadDataReader.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include <test/CThreadDataReader.h>
+
+#include <core/CNamedPipeFactory.h>
+#include <core/CScopedLock.h>
+#include <core/CSleep.h>
+
+#include <fstream>
+
+namespace ml {
+namespace test {
+
+CThreadDataReader::CThreadDataReader(std::uint32_t sleepTimeMs,
+                                     std::size_t maxAttempts,
+                                     const std::string& fileName)
+    : m_Shutdown(false), m_StreamWentBad(false), m_SleepTimeMs(sleepTimeMs),
+      m_MaxAttempts(maxAttempts), m_Attempt(0), m_FileName(fileName) {
+}
+
+const std::string& CThreadDataReader::data() const {
+    // The memory barriers associated with the mutex lock should ensure
+    // the thread calling this method has as up-to-date view of m_Data's
+    // member variables as the thread that updated it
+    core::CScopedLock lock{m_Mutex};
+    return m_Data;
+}
+
+std::size_t CThreadDataReader::attemptsTaken() const {
+    return m_Attempt;
+}
+
+bool CThreadDataReader::streamWentBad() const {
+    return m_StreamWentBad;
+}
+
+void CThreadDataReader::run() {
+    m_StreamWentBad = false;
+    m_Attempt = 0;
+    m_Data.clear();
+
+    std::ifstream strm;
+
+    // Try to open the file repeatedly to allow time for the other
+    // thread to create it
+    do {
+        if (m_Shutdown) {
+            return;
+        }
+        if (++m_Attempt > m_MaxAttempts) {
+            return;
+        }
+        core::CSleep::sleep(m_SleepTimeMs);
+        strm.open(m_FileName);
+    } while (strm.is_open() == false);
+
+    static const std::streamsize BUF_SIZE{512};
+    char buffer[BUF_SIZE];
+    while (strm.good()) {
+        if (m_Shutdown) {
+            return;
+        }
+        strm.read(buffer, BUF_SIZE);
+        if (strm.bad()) {
+            m_StreamWentBad = true;
+            return;
+        }
+        if (strm.gcount() > 0) {
+            core::CScopedLock lock(m_Mutex);
+            // This code deals with the test character we write to
+            // detect the short-lived connection problem on Windows
+            const char* copyFrom{buffer};
+            std::size_t copyLen{static_cast<std::size_t>(strm.gcount())};
+            if (m_Data.empty() && *buffer == core::CNamedPipeFactory::TEST_CHAR) {
+                ++copyFrom;
+                --copyLen;
+            }
+            if (copyLen > 0) {
+                m_Data.append(copyFrom, copyLen);
+            }
+        }
+    }
+}
+
+void CThreadDataReader::shutdown() {
+    m_Shutdown = true;
+}
+}
+}

--- a/lib/test/CThreadDataWriter.cc
+++ b/lib/test/CThreadDataWriter.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include <test/CThreadDataWriter.h>
+
+#include <core/CSleep.h>
+
+#include <fstream>
+
+namespace ml {
+namespace test {
+
+CThreadDataWriter::CThreadDataWriter(std::uint32_t sleepTimeMs,
+                                     const std::string& fileName,
+                                     char testChar,
+                                     std::size_t size)
+    : m_SleepTimeMs(sleepTimeMs), m_FileName(fileName), m_TestChar(testChar),
+      m_Size(size) {
+}
+
+void CThreadDataWriter::run() {
+    core::CSleep::sleep(m_SleepTimeMs);
+
+    std::ofstream strm{m_FileName};
+    for (std::size_t i = 0; i < m_Size && strm.good(); ++i) {
+        strm << m_TestChar;
+    }
+}
+
+void CThreadDataWriter::shutdown() {
+}
+}
+}

--- a/lib/test/Makefile
+++ b/lib/test/Makefile
@@ -25,6 +25,8 @@ SRCS= \
     CMultiFileSearcher.cc \
     CRandomNumbers.cc \
     CTestObserver.cc \
+    CThreadDataReader.cc \
+    CThreadDataWriter.cc \
     CTimeSeriesTestData.cc \
 
 TARGET=$(OBJS_DIR)/libMlTest$(DYNAMIC_LIB_EXT)


### PR DESCRIPTION
Three test suites were all using extremely similar
local classes for reading/writing named pipes in
separate threads.  This change factors out the
common code into classes in the test library.

Backport of #796