### PR TITLE
[ML] add geo point formatting string for actual|typical

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 * Reduce the peak memory used by boosted tree training and fix an overcounting bug
 estimating maximum memory usage. (See {ml-pull}781[#781].)
 * Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
+* Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809].)
 
 == {es} version 7.5.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,7 +37,7 @@
 * Reduce the peak memory used by boosted tree training and fix an overcounting bug
 estimating maximum memory usage. (See {ml-pull}781[#781].)
 * Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
-* Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809].)
+* Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809], {pull}47050[#47050].)
 
 == {es} version 7.5.0
 

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -13,9 +13,9 @@
 #include <model/CHierarchicalResultsNormalizer.h>
 #include <model/ModelTypes.h>
 
+#include <api/CFieldConfig.h>
 #include <api/CModelSizeStatsJsonWriter.h>
 #include <api/CModelSnapshotJsonWriter.h>
-#include <api/CFieldConfig.h>
 
 #include <algorithm>
 #include <ostream>
@@ -566,10 +566,12 @@ void CJsonOutputWriter::addMetricFields(const CHierarchicalResultsWriter::TResul
             return result.str();
         };
         if (results.s_BaselineMean.size() == 2) {
-            m_Writer.addStringFieldCopyToObj(TYPICAL_POINT, geoPointToString(results.s_BaselineMean), geoResults);
+            m_Writer.addStringFieldCopyToObj(
+                TYPICAL_POINT, geoPointToString(results.s_BaselineMean), geoResults);
         }
         if (results.s_CurrentMean.size() == 2) {
-            m_Writer.addStringFieldCopyToObj(ACTUAL_POINT, geoPointToString(results.s_CurrentMean), geoResults);
+            m_Writer.addStringFieldCopyToObj(
+                ACTUAL_POINT, geoPointToString(results.s_CurrentMean), geoResults);
         }
         m_Writer.addMember(GEO_RESULTS, geoResults, *docPtr);
     }
@@ -682,10 +684,12 @@ void CJsonOutputWriter::addPopulationCauseFields(const CHierarchicalResultsWrite
             return result.str();
         };
         if (results.s_BaselineMean.size() == 2) {
-            m_Writer.addStringFieldCopyToObj(TYPICAL_POINT, geoPointToString(results.s_PopulationAverage), geoResults);
+            m_Writer.addStringFieldCopyToObj(
+                TYPICAL_POINT, geoPointToString(results.s_PopulationAverage), geoResults);
         }
         if (results.s_FunctionValue.size() == 2) {
-            m_Writer.addStringFieldCopyToObj(ACTUAL_POINT, geoPointToString(results.s_FunctionValue), geoResults);
+            m_Writer.addStringFieldCopyToObj(
+                ACTUAL_POINT, geoPointToString(results.s_FunctionValue), geoResults);
         }
         m_Writer.addMember(GEO_RESULTS, geoResults, *docPtr);
     }

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -559,21 +559,17 @@ void CJsonOutputWriter::addMetricFields(const CHierarchicalResultsWriter::TResul
     m_Writer.addDoubleArrayFieldToObj(ACTUAL, results.s_CurrentMean, *docPtr);
     if (results.s_FunctionName == CFieldConfig::FUNCTION_LAT_LONG) {
         rapidjson::Value geoResults = m_Writer.makeObject();
-        if (results.s_BaselineMean.size() == 2) {
-            std::ostringstream ptStr;
+        auto geoPointToString = [](const auto& point) -> std::string {
+            std::ostringstream result;
             // We don't want scientific notation and geo points only have precision up to 12 digits
-            ptStr << std::fixed;
-            ptStr << std::setprecision(12);
-            ptStr << results.s_BaselineMean[0] << "," << results.s_BaselineMean[1];
-            m_Writer.addStringFieldCopyToObj(TYPICAL_POINT, ptStr.str(), geoResults);
+            result << std::fixed << std::setprecision(12) << point[0] << "," << point[1];
+            return result.str();
+        };
+        if (results.s_BaselineMean.size() == 2) {
+            m_Writer.addStringFieldCopyToObj(TYPICAL_POINT, geoPointToString(results.s_BaselineMean), geoResults);
         }
         if (results.s_CurrentMean.size() == 2) {
-            std::ostringstream ptStr;
-            // We don't want scientific notation and geo points only have precision up to 12 digits
-            ptStr << std::fixed;
-            ptStr << std::setprecision(12);
-            ptStr << results.s_CurrentMean[0] << "," << results.s_CurrentMean[1];
-            m_Writer.addStringFieldCopyToObj(ACTUAL_POINT, ptStr.str(), geoResults);
+            m_Writer.addStringFieldCopyToObj(ACTUAL_POINT, geoPointToString(results.s_CurrentMean), geoResults);
         }
         m_Writer.addMember(GEO_RESULTS, geoResults, *docPtr);
     }
@@ -679,21 +675,17 @@ void CJsonOutputWriter::addPopulationCauseFields(const CHierarchicalResultsWrite
     m_Writer.addDoubleArrayFieldToObj(ACTUAL, results.s_FunctionValue, *docPtr);
     if (results.s_FunctionName == CFieldConfig::FUNCTION_LAT_LONG) {
         rapidjson::Value geoResults = m_Writer.makeObject();
-        if (results.s_BaselineMean.size() == 2) {
-            std::ostringstream ptStr;
+        auto geoPointToString = [](const auto& point) -> std::string {
+            std::ostringstream result;
             // We don't want scientific notation and geo points only have precision up to 12 digits
-            ptStr << std::fixed;
-            ptStr << std::setprecision(12);
-            ptStr << results.s_PopulationAverage[0] << "," << results.s_PopulationAverage[1];
-            m_Writer.addStringFieldCopyToObj(TYPICAL_POINT, ptStr.str(), geoResults);
+            result << std::fixed << std::setprecision(12) << point[0] << "," << point[1];
+            return result.str();
+        };
+        if (results.s_BaselineMean.size() == 2) {
+            m_Writer.addStringFieldCopyToObj(TYPICAL_POINT, geoPointToString(results.s_PopulationAverage), geoResults);
         }
         if (results.s_FunctionValue.size() == 2) {
-            std::ostringstream ptStr;
-            // We don't want scientific notation and geo points only have precision up to 12 digits
-            ptStr << std::fixed;
-            ptStr << std::setprecision(12);
-            ptStr << results.s_FunctionValue[0] << "," << results.s_FunctionValue[1];
-            m_Writer.addStringFieldCopyToObj(ACTUAL_POINT, ptStr.str(), geoResults);
+            m_Writer.addStringFieldCopyToObj(ACTUAL_POINT, geoPointToString(results.s_FunctionValue), geoResults);
         }
         m_Writer.addMember(GEO_RESULTS, geoResults, *docPtr);
     }

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -1056,6 +1056,110 @@ BOOST_AUTO_TEST_CASE(testSimpleWrite) {
                         std::string(object2["field_name"].GetString()));
 }
 
+BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
+    ml::api::CJsonOutputWriter::TStrStrUMap emptyFields;
+
+    std::ostringstream sstream;
+    std::string partitionFieldName("tfn");
+    std::string partitionFieldValue("");
+    std::string overFieldName("pfn");
+    std::string overFieldValue("pfv");
+    std::string byFieldName("airline");
+    std::string byFieldValue("GAL");
+    std::string correlatedByFieldValue("BAW");
+    std::string fieldName("location");
+    std::string function("lat_long");
+    std::string functionDescription("lat_long(location)");
+    ml::api::CHierarchicalResultsWriter::TStoredStringPtrStoredStringPtrPrDoublePrVec influences;
+    std::string emptyString;
+    // The output writer won't close the JSON structures until is is destroyed
+    {
+        ml::core::CJsonOutputStreamWrapper outputStream(sstream);
+        ml::api::CJsonOutputWriter writer("job", outputStream);
+        TDouble1Vec actual(2, 0.0);
+        actual[0] = 40.0;
+        actual[1] = -40.0;
+        TDouble1Vec typical(2, 0.0);
+        typical[0] = 90.0;
+        typical[1] = -90.0;
+        ml::api::CHierarchicalResultsWriter::SResults result(
+                false, false, partitionFieldName, partitionFieldValue,
+                overFieldName, overFieldValue, byFieldName, byFieldValue,
+                correlatedByFieldValue, 1, function, functionDescription,
+                typical, actual, 2.24, 0.5, 10.0,
+                79, fieldName, influences, false, true, 1, 100);
+        writer.acceptResult(result);
+        BOOST_TEST_REQUIRE(writer.acceptResult(result));
+        BOOST_TEST_REQUIRE(writer.endOutputBatch(true, 1U));
+    }
+
+    {
+        ml::core::CJsonOutputStreamWrapper outputStream(sstream);
+        ml::api::CJsonOutputWriter writer("job", outputStream);
+        TDouble1Vec actual(1, 500);
+        TDouble1Vec typical(1, 64);
+        ml::api::CHierarchicalResultsWriter::SResults result(
+                false, false, partitionFieldName, partitionFieldValue,
+                overFieldName, overFieldValue, byFieldName, byFieldValue,
+                correlatedByFieldValue, 1, function, functionDescription,
+                typical, actual, 2.24, 0.5, 10.0,
+                79, fieldName, influences, false, true, 1, 100);
+        BOOST_TEST_REQUIRE(writer.acceptResult(result));
+        BOOST_TEST_REQUIRE(writer.endOutputBatch(true, 1U));
+    }
+
+    {
+        ml::core::CJsonOutputStreamWrapper outputStream(sstream);
+        ml::api::CJsonOutputWriter writer("job", outputStream);
+        TDouble1Vec actual(2, 0.0);
+        actual[0] = 40.0;
+        actual[1] = -40.0;
+        TDouble1Vec typical(2, 0.0);
+        typical[0] = 90.0;
+        typical[1] = -90.0;
+        ml::api::CHierarchicalResultsWriter::SResults result(
+                false, false, partitionFieldName, partitionFieldValue,
+                overFieldName, overFieldValue, byFieldName, byFieldValue,
+                correlatedByFieldValue, 1, "mean", functionDescription,
+                typical, actual, 2.24, 0.5, 10.0,
+                79, fieldName, influences, false, true, 1, 100);
+        BOOST_TEST_REQUIRE(writer.acceptResult(result));
+        BOOST_TEST_REQUIRE(writer.endOutputBatch(true, 1U));
+    }
+
+    LOG_WARN(<< sstream.str());
+    rapidjson::Document arrayDoc;
+    arrayDoc.Parse<rapidjson::kParseDefaultFlags>(sstream.str().c_str());
+
+    BOOST_TEST_REQUIRE(arrayDoc.IsArray());
+    BOOST_REQUIRE_EQUAL(rapidjson::SizeType(3), arrayDoc.Size());
+
+    const rapidjson::Value& object = arrayDoc[rapidjson::SizeType(0)];
+    BOOST_TEST_REQUIRE(object.IsObject());
+
+    BOOST_TEST_REQUIRE(object.HasMember("typical"));
+    //BOOST_REQUIRE_EQUAL(2, object["typical"].GetArray().Size());
+    //BOOST_REQUIRE_EQUAL(90.0, object["typical"].GetArray()[0].GetDouble());
+    //BOOST_REQUIRE_EQUAL(-90.0, object["typical"].GetArray()[1].GetDouble());
+    //BOOST_TEST_REQUIRE(object.HasMember("actual"));
+    //BOOST_REQUIRE_EQUAL(2, object["actual"].GetArray().Size());
+    //BOOST_REQUIRE_EQUAL(40.0, object["actual"].GetArray()[0].GetDouble());
+    //BOOST_REQUIRE_EQUAL(-40.0, object["actual"].GetArray()[1].GetDouble());
+
+    BOOST_TEST_REQUIRE(object.HasMember("geo_results"));
+    auto geoResultsObject = object["geo_results"].GetObject();
+    BOOST_TEST_REQUIRE(geoResultsObject.HasMember("actual_point"));
+    BOOST_REQUIRE_EQUAL(std::string("40.0,-40.0"), (geoResultsObject["actual_point"].GetString()));
+    BOOST_TEST_REQUIRE(geoResultsObject.HasMember("typical_point"));
+    BOOST_REQUIRE_EQUAL(std::string("90.0,-90.0"), (geoResultsObject["typical_point"].GetString()));
+
+    const rapidjson::Value& object2 = arrayDoc[rapidjson::SizeType(1)];
+    BOOST_REQUIRE_EQUAL(false, object2.HasMember("geo_results"));
+
+    const rapidjson::Value& object3 = arrayDoc[rapidjson::SizeType(2)];
+    BOOST_REQUIRE_EQUAL(false, object3.HasMember("geo_results"));
+}
+
 BOOST_AUTO_TEST_CASE(testWriteNonAnomalousBucket) {
     std::ostringstream sstream;
 

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -1084,11 +1084,11 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
             typical[0] = 90.0;
             typical[1] = -90.0;
             ml::api::CHierarchicalResultsWriter::SResults result(
-                ml::api::CHierarchicalResultsWriter::E_Result, 
-                partitionFieldName, partitionFieldValue,
-                byFieldName, byFieldValue, correlatedByFieldValue,
-                1, function, functionDescription, 2.24, 79, typical, actual, 
-                10.0, 10.0, 0.5, 0.0, fieldName, influences, false, true, 1, 1, EMPTY_STRING_LIST);
+                ml::api::CHierarchicalResultsWriter::E_Result,
+                partitionFieldName, partitionFieldValue, byFieldName,
+                byFieldValue, correlatedByFieldValue, 1, function,
+                functionDescription, 2.24, 79, typical, actual, 10.0, 10.0, 0.5,
+                0.0, fieldName, influences, false, true, 1, 1, EMPTY_STRING_LIST);
             BOOST_TEST_REQUIRE(writer.acceptResult(result));
             BOOST_TEST_REQUIRE(writer.endOutputBatch(false, 1U));
         }
@@ -1105,7 +1105,8 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
         BOOST_TEST_REQUIRE(arrayDoc.IsArray());
         BOOST_REQUIRE_EQUAL(rapidjson::SizeType(2), arrayDoc.Size());
         BOOST_TEST_REQUIRE(arrayDoc[rapidjson::SizeType(0)].HasMember("records"));
-        const rapidjson::Value& record = arrayDoc[rapidjson::SizeType(0)]["records"][rapidjson::SizeType(0)];
+        const rapidjson::Value& record =
+            arrayDoc[rapidjson::SizeType(0)]["records"][rapidjson::SizeType(0)];
 
         BOOST_TEST_REQUIRE(record.HasMember("typical"));
         BOOST_TEST_REQUIRE(record.HasMember("actual"));
@@ -1127,11 +1128,11 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
             TDouble1Vec actual(1, 500);
             TDouble1Vec typical(1, 64);
             ml::api::CHierarchicalResultsWriter::SResults result(
-                ml::api::CHierarchicalResultsWriter::E_Result, 
-                partitionFieldName, partitionFieldValue,
-                byFieldName, byFieldValue, correlatedByFieldValue,
-                1, function, functionDescription, 2.24, 79, typical, actual, 
-                10.0, 10.0, 0.5, 0.0, fieldName, influences, false, true, 1, 1, EMPTY_STRING_LIST);
+                ml::api::CHierarchicalResultsWriter::E_Result,
+                partitionFieldName, partitionFieldValue, byFieldName,
+                byFieldValue, correlatedByFieldValue, 1, function,
+                functionDescription, 2.24, 79, typical, actual, 10.0, 10.0, 0.5,
+                0.0, fieldName, influences, false, true, 1, 1, EMPTY_STRING_LIST);
             BOOST_TEST_REQUIRE(writer.acceptResult(result));
             BOOST_TEST_REQUIRE(writer.endOutputBatch(false, 1U));
         }
@@ -1148,7 +1149,8 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
         BOOST_TEST_REQUIRE(arrayDoc.IsArray());
         BOOST_REQUIRE_EQUAL(rapidjson::SizeType(2), arrayDoc.Size());
         BOOST_TEST_REQUIRE(arrayDoc[rapidjson::SizeType(0)].HasMember("records"));
-        const rapidjson::Value& record = arrayDoc[rapidjson::SizeType(0)]["records"][rapidjson::SizeType(0)];
+        const rapidjson::Value& record =
+            arrayDoc[rapidjson::SizeType(0)]["records"][rapidjson::SizeType(0)];
 
         BOOST_TEST_REQUIRE(record.IsObject());
         BOOST_TEST_REQUIRE(record.HasMember("geo_results"));
@@ -1165,11 +1167,11 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
             TDouble1Vec actual(1, 500);
             TDouble1Vec typical(1, 64);
             ml::api::CHierarchicalResultsWriter::SResults result(
-                ml::api::CHierarchicalResultsWriter::E_Result, 
-                partitionFieldName, partitionFieldValue,
-                byFieldName, byFieldValue, correlatedByFieldValue,
-                1, "mean", functionDescription, 2.24, 79, typical, actual, 
-                10.0, 10.0, 0.5, 0.0, fieldName, influences, false, true, 1, 1, EMPTY_STRING_LIST);
+                ml::api::CHierarchicalResultsWriter::E_Result,
+                partitionFieldName, partitionFieldValue, byFieldName,
+                byFieldValue, correlatedByFieldValue, 1, "mean",
+                functionDescription, 2.24, 79, typical, actual, 10.0, 10.0, 0.5,
+                0.0, fieldName, influences, false, true, 1, 1, EMPTY_STRING_LIST);
             BOOST_TEST_REQUIRE(writer.acceptResult(result));
             BOOST_TEST_REQUIRE(writer.endOutputBatch(false, 1U));
         }
@@ -1186,7 +1188,8 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
         BOOST_TEST_REQUIRE(arrayDoc.IsArray());
         BOOST_REQUIRE_EQUAL(rapidjson::SizeType(2), arrayDoc.Size());
         BOOST_TEST_REQUIRE(arrayDoc[rapidjson::SizeType(0)].HasMember("records"));
-        const rapidjson::Value& record = arrayDoc[rapidjson::SizeType(0)]["records"][rapidjson::SizeType(0)];
+        const rapidjson::Value& record =
+            arrayDoc[rapidjson::SizeType(0)]["records"][rapidjson::SizeType(0)];
 
         BOOST_TEST_REQUIRE(record.IsObject());
         BOOST_REQUIRE_EQUAL(false, record.HasMember("geo_results"));


### PR DESCRIPTION
Adds new geo_point formatted fields for Java side consumption. These are only written if we have actual|typical values that have length of 2, and are using a `lat_long` function.

This is my first PR against this repo, let me know if I missed something. 

Blocked by https://github.com/elastic/elasticsearch/pull/47050