### PR TITLE
[ML] Fix restore from checkpoint damaging seasonality modelling for anomaly detection

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -63,7 +63,7 @@ errors to be logged during boosted tree training. (See {ml-pull}732[#732].)
 
 === Bug Fixes
 
-* Restore from checkpoint could damage seasonality modelling. For example, it could
+* Restore from checkpoint could damage seasonality modeling. For example, it could
 cause seasonal components to be overwritten in error. (See {ml-pull}821[#821].)
 
 == {es} version 7.4.1

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -61,6 +61,11 @@ are unexpectedly missing. (See {ml-pull}721[#721].)
 * Trap numeric errors causing bad hyperparameter search initialisation and repeated
 errors to be logged during boosted tree training. (See {ml-pull}732[#732].)
 
+=== Bug Fixes
+
+* Restore from checkpoint could damage seasonality modelling. For example, it could
+cause seasonal components to be overwritten in error. (See {ml-pull}821[#821].)
+
 == {es} version 7.4.1
 
 === Enhancements

--- a/include/maths/CSeasonalTime.h
+++ b/include/maths/CSeasonalTime.h
@@ -41,7 +41,7 @@ public:
     virtual CSeasonalTime* clone() const = 0;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(const std::string& value) = 0;
+    virtual bool fromString(std::string value) = 0;
 
     //! Convert to a string.
     virtual std::string toString() const = 0;
@@ -121,7 +121,11 @@ public:
     virtual bool hasWeekend() const = 0;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const = 0;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const = 0;
+
+protected:
+    double precedence() const;
+    void precedence(double precedence);
 
 private:
     //! Get the start of the repeat interval beginning at
@@ -161,7 +165,7 @@ public:
     CDiurnalTime* clone() const;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(const std::string& value);
+    virtual bool fromString(std::string value);
 
     //! Convert to a string.
     virtual std::string toString() const;
@@ -182,7 +186,7 @@ public:
     virtual bool hasWeekend() const;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
 
 private:
     //! Get the scale to apply when computing the regression time.
@@ -208,7 +212,7 @@ public:
     CGeneralPeriodTime* clone() const;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(const std::string& value);
+    virtual bool fromString(std::string value);
 
     //! Convert to a string.
     virtual std::string toString() const;
@@ -229,7 +233,7 @@ public:
     virtual bool hasWeekend() const;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
 
 private:
     //! Get the scale to apply when computing the regression time.

--- a/lib/maths/CSeasonalTime.cc
+++ b/lib/maths/CSeasonalTime.cc
@@ -11,6 +11,7 @@
 #include <core/CPersistUtils.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
+#include <core/CStringUtils.h>
 #include <core/Constants.h>
 
 #include <maths/CChecksum.h>
@@ -143,7 +144,7 @@ CDiurnalTime* CDiurnalTime::clone() const {
 }
 
 bool CDiurnalTime::fromString(std::string value) {
-    std::size_t delimiter{value.find(DELIMITER)};
+    std::size_t delimiter{value.rfind(DELIMITER)};
     if (delimiter != std::string::npos) {
         double precedence{0.0};
         if (core::CStringUtils::stringToType(value.substr(delimiter + 1), precedence) == false) {
@@ -223,7 +224,7 @@ CGeneralPeriodTime* CGeneralPeriodTime::clone() const {
 }
 
 bool CGeneralPeriodTime::fromString(std::string value) {
-    std::size_t delimiter{value.find(DELIMITER)};
+    std::size_t delimiter{value.rfind(DELIMITER)};
     if (delimiter != std::string::npos) {
         double precedence{0.0};
         if (core::CStringUtils::stringToType(value.substr(delimiter + 1), precedence) == false) {

--- a/lib/maths/CSeasonalTime.cc
+++ b/lib/maths/CSeasonalTime.cc
@@ -6,6 +6,7 @@
 
 #include <maths/CSeasonalTime.h>
 
+#include <core/CIEEE754.h>
 #include <core/CLogger.h>
 #include <core/CPersistUtils.h>
 #include <core/CStatePersistInserter.h>
@@ -15,10 +16,9 @@
 #include <maths/CChecksum.h>
 #include <maths/CIntegerTools.h>
 
-#include <boost/array.hpp>
-#include <boost/numeric/conversion/bounds.hpp>
-
+#include <array>
 #include <cstddef>
+#include <memory>
 #include <string>
 
 namespace ml {
@@ -27,6 +27,7 @@ namespace {
 // DO NOT change the existing tags if new sub-classes are added.
 const core::TPersistenceTag DIURNAL_TIME_TAG{"a", "diurnal_time"};
 const core::TPersistenceTag ARBITRARY_PERIOD_TIME_TAG{"b", "arbitrary_period_time"};
+const std::string DELIMITER(",");
 }
 
 //////// CSeasonalTime ////////
@@ -109,6 +110,14 @@ bool CSeasonalTime::excludes(const CSeasonalTime& other) const {
            m_Precedence >= other.m_Precedence;
 }
 
+double CSeasonalTime::precedence() const {
+    return m_Precedence;
+}
+
+void CSeasonalTime::precedence(double precedence) {
+    m_Precedence = precedence;
+}
+
 core_t::TTime CSeasonalTime::startOfWindowRepeat(core_t::TTime offset,
                                                  core_t::TTime time) const {
     return offset + CIntegerTools::floor(time - offset, this->windowRepeat());
@@ -133,7 +142,17 @@ CDiurnalTime* CDiurnalTime::clone() const {
     return new CDiurnalTime(*this);
 }
 
-bool CDiurnalTime::fromString(const std::string& value) {
+bool CDiurnalTime::fromString(std::string value) {
+    std::size_t delimiter{value.find(DELIMITER)};
+    if (delimiter != std::string::npos) {
+        double precedence{0.0};
+        if (core::CStringUtils::stringToType(value.substr(delimiter + 1), precedence) == false) {
+            return false;
+        }
+        this->precedence(precedence);
+        value = value.substr(0, delimiter);
+    }
+
     std::array<core_t::TTime, 5> times;
     if (core::CPersistUtils::fromString(value, times)) {
         m_StartOfWeek = times[0];
@@ -143,6 +162,7 @@ bool CDiurnalTime::fromString(const std::string& value) {
         this->regressionOrigin(times[4]);
         return true;
     }
+
     return false;
 }
 
@@ -153,7 +173,9 @@ std::string CDiurnalTime::toString() const {
     times[2] = m_WindowEnd;
     times[3] = this->period();
     times[4] = this->regressionOrigin();
-    return core::CPersistUtils::toString(times);
+    return core::CPersistUtils::toString(times) + DELIMITER +
+           core::CStringUtils::typeToStringPrecise(
+               this->precedence(), core::CIEEE754::E_DoublePrecision);
 }
 
 core_t::TTime CDiurnalTime::windowRepeat() const {
@@ -177,11 +199,13 @@ bool CDiurnalTime::hasWeekend() const {
            this->windowLength() == core::constants::WEEKDAYS;
 }
 
-uint64_t CDiurnalTime::checksum(uint64_t seed) const {
+std::uint64_t CDiurnalTime::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_StartOfWeek);
     seed = CChecksum::calculate(seed, m_WindowStart);
     seed = CChecksum::calculate(seed, m_WindowEnd);
-    return CChecksum::calculate(seed, this->period());
+    seed = CChecksum::calculate(seed, this->period());
+    seed = CChecksum::calculate(seed, this->regressionOrigin());
+    return CChecksum::calculate(seed, this->precedence());
 }
 
 core_t::TTime CDiurnalTime::regressionTimeScale() const {
@@ -198,13 +222,24 @@ CGeneralPeriodTime* CGeneralPeriodTime::clone() const {
     return new CGeneralPeriodTime(*this);
 }
 
-bool CGeneralPeriodTime::fromString(const std::string& value) {
+bool CGeneralPeriodTime::fromString(std::string value) {
+    std::size_t delimiter{value.find(DELIMITER)};
+    if (delimiter != std::string::npos) {
+        double precedence{0.0};
+        if (core::CStringUtils::stringToType(value.substr(delimiter + 1), precedence) == false) {
+            return false;
+        }
+        this->precedence(precedence);
+        value = value.substr(0, delimiter);
+    }
+
     std::array<core_t::TTime, 2> times;
     if (core::CPersistUtils::fromString(value, times)) {
         this->period(times[0]);
         this->regressionOrigin(times[1]);
         return true;
     }
+
     return false;
 }
 
@@ -212,7 +247,9 @@ std::string CGeneralPeriodTime::toString() const {
     std::array<core_t::TTime, 2> times;
     times[0] = this->period();
     times[1] = this->regressionOrigin();
-    return core::CPersistUtils::toString(times);
+    return core::CPersistUtils::toString(times) + DELIMITER +
+           core::CStringUtils::typeToStringPrecise(
+               this->precedence(), core::CIEEE754::E_DoublePrecision);
 }
 
 core_t::TTime CGeneralPeriodTime::windowRepeat() const {
@@ -235,8 +272,10 @@ bool CGeneralPeriodTime::hasWeekend() const {
     return false;
 }
 
-uint64_t CGeneralPeriodTime::checksum(uint64_t seed) const {
-    return CChecksum::calculate(seed, this->period());
+std::uint64_t CGeneralPeriodTime::checksum(std::uint64_t seed) const {
+    seed = CChecksum::calculate(seed, this->period());
+    seed = CChecksum::calculate(seed, this->regressionOrigin());
+    return CChecksum::calculate(seed, this->precedence());
 }
 
 core_t::TTime CGeneralPeriodTime::regressionTimeScale() const {
@@ -247,7 +286,7 @@ core_t::TTime CGeneralPeriodTime::regressionTimeScale() const {
 
 bool CSeasonalTimeStateSerializer::acceptRestoreTraverser(TSeasonalTimePtr& result,
                                                           core::CStateRestoreTraverser& traverser) {
-    std::size_t numResults = 0;
+    std::size_t numResults{0};
 
     do {
         const std::string& name = traverser.name();

--- a/lib/maths/unittest/CSeasonalTimeTest.cc
+++ b/lib/maths/unittest/CSeasonalTimeTest.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CLogger.h>
+
+#include <maths/CSeasonalTime.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+using namespace ml;
+
+BOOST_AUTO_TEST_SUITE(CSeasonalTimeTest)
+
+BOOST_AUTO_TEST_CASE(testPersist) {
+
+    // Check that persistence preserves checksums.
+
+    maths::CDiurnalTime origDiurnal{3600, 0, 86400, 86400, 1.5};
+
+    LOG_DEBUG(<< "Test persist/restore");
+
+    std::string diurnalRepresentation{origDiurnal.toString()};
+    LOG_DEBUG(<< "diurnal time representation: " << diurnalRepresentation);
+    maths::CDiurnalTime restoredDiurnal;
+    BOOST_TEST_REQUIRE(restoredDiurnal.fromString(diurnalRepresentation));
+    BOOST_REQUIRE_EQUAL(origDiurnal.checksum(), restoredDiurnal.checksum());
+
+    maths::CGeneralPeriodTime origPeriodic{7200, 2.1};
+    std::string periodicRepresentation{origPeriodic.toString()};
+    LOG_DEBUG(<< "periodic time representation: " << periodicRepresentation);
+    maths::CGeneralPeriodTime restoredPeriodic;
+    BOOST_TEST_REQUIRE(restoredPeriodic.fromString(periodicRepresentation));
+    BOOST_REQUIRE_EQUAL(origPeriodic.checksum(), restoredPeriodic.checksum());
+
+    LOG_DEBUG(<< "Test upgrade");
+
+    restoredDiurnal = maths::CDiurnalTime{0, 3600, 43200, 43200, 1.5};
+    BOOST_TEST_REQUIRE(restoredDiurnal.fromString("3600:0:86400:86400:0"));
+    BOOST_REQUIRE_EQUAL(origDiurnal.checksum(), restoredDiurnal.checksum());
+
+    restoredPeriodic = maths::CGeneralPeriodTime{16800, 2.1};
+    BOOST_TEST_REQUIRE(restoredPeriodic.fromString("7200:0"));
+    BOOST_REQUIRE_EQUAL(origPeriodic.checksum(), restoredPeriodic.checksum());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -88,6 +88,7 @@ SRCS=\
 	CSamplingTest.cc \
 	CSeasonalComponentTest.cc \
 	CSeasonalComponentAdaptiveBucketingTest.cc \
+    CSeasonalTimeTest.cc \
 	CSetToolsTest.cc \
 	CSignalTest.cc \
 	CSolversTest.cc \

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -88,7 +88,7 @@ SRCS=\
 	CSamplingTest.cc \
 	CSeasonalComponentTest.cc \
 	CSeasonalComponentAdaptiveBucketingTest.cc \
-    CSeasonalTimeTest.cc \
+	CSeasonalTimeTest.cc \
 	CSetToolsTest.cc \
 	CSignalTest.cc \
 	CSolversTest.cc \


### PR DESCRIPTION
We weren't persisting and restoring all the state we should have been. This should only affect behaviour after a restore.

Fixes #820.