### PR TITLE
[6.8][ML] Fix restore from checkpoint damaging seasonality modelling for anomaly detection

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,9 @@
 
 Fix cause of "Sample out of bounds" error message (See {ml-pull}355[355].}
 
+Restore from checkpoint could damage seasonality modeling. For example, it could
+cause seasonal components to be overwritten in error. (See {ml-pull}821[#821].)
+
 === Regressions
 
  == {es} version 6.5.3

--- a/include/maths/CSeasonalTime.h
+++ b/include/maths/CSeasonalTime.h
@@ -41,7 +41,7 @@ public:
     virtual CSeasonalTime* clone() const = 0;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(const std::string& value) = 0;
+    virtual bool fromString(std::string value) = 0;
 
     //! Convert to a string.
     virtual std::string toString() const = 0;
@@ -123,6 +123,10 @@ public:
     //! Get a checksum for this object.
     virtual uint64_t checksum(uint64_t seed = 0) const = 0;
 
+protected:
+    double precedence() const;
+    void precedence(double precedence);
+
 private:
     //! Get the start of the repeat interval beginning at
     //! \p offset including \p time.
@@ -161,7 +165,7 @@ public:
     CDiurnalTime* clone() const;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(const std::string& value);
+    virtual bool fromString(std::string value);
 
     //! Convert to a string.
     virtual std::string toString() const;
@@ -208,7 +212,7 @@ public:
     CGeneralPeriodTime* clone() const;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(const std::string& value);
+    virtual bool fromString(std::string value);
 
     //! Convert to a string.
     virtual std::string toString() const;

--- a/include/maths/CSeasonalTime.h
+++ b/include/maths/CSeasonalTime.h
@@ -11,6 +11,7 @@
 
 #include <maths/ImportExport.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -121,7 +122,7 @@ public:
     virtual bool hasWeekend() const = 0;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const = 0;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const = 0;
 
 protected:
     double precedence() const;
@@ -186,7 +187,7 @@ public:
     virtual bool hasWeekend() const;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
 
 private:
     //! Get the scale to apply when computing the regression time.

--- a/lib/maths/unittest/CSeasonalTimeTest.cc
+++ b/lib/maths/unittest/CSeasonalTimeTest.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CSeasonalTimeTest.h"
+
+#include <core/CLogger.h>
+
+#include <maths/CSeasonalTime.h>
+
+using namespace ml;
+
+void CSeasonalTimeTest::testPersist() {
+    // Check that persistence preserves checksums.
+
+    maths::CDiurnalTime origDiurnal{3600, 0, 86400, 86400, 1.5};
+
+    LOG_DEBUG(<< "Test persist/restore");
+
+    std::string diurnalRepresentation{origDiurnal.toString()};
+    LOG_DEBUG(<< "diurnal time representation: " << diurnalRepresentation);
+    maths::CDiurnalTime restoredDiurnal;
+    CPPUNIT_ASSERT(restoredDiurnal.fromString(diurnalRepresentation));
+    CPPUNIT_ASSERT_EQUAL(origDiurnal.checksum(), restoredDiurnal.checksum());
+
+    maths::CGeneralPeriodTime origPeriodic{7200, 2.1};
+    std::string periodicRepresentation{origPeriodic.toString()};
+    LOG_DEBUG(<< "periodic time representation: " << periodicRepresentation);
+    maths::CGeneralPeriodTime restoredPeriodic;
+    CPPUNIT_ASSERT(restoredPeriodic.fromString(periodicRepresentation));
+    CPPUNIT_ASSERT_EQUAL(origPeriodic.checksum(), restoredPeriodic.checksum());
+
+    LOG_DEBUG(<< "Test upgrade");
+
+    restoredDiurnal = maths::CDiurnalTime{0, 3600, 43200, 43200, 1.5};
+    CPPUNIT_ASSERT(restoredDiurnal.fromString("3600:0:86400:86400:0"));
+    CPPUNIT_ASSERT_EQUAL(origDiurnal.checksum(), restoredDiurnal.checksum());
+
+    restoredPeriodic = maths::CGeneralPeriodTime{16800, 2.1};
+    CPPUNIT_ASSERT(restoredPeriodic.fromString("7200:0"));
+    CPPUNIT_ASSERT_EQUAL(origPeriodic.checksum(), restoredPeriodic.checksum());
+}
+
+CppUnit::Test* CSeasonalTimeTest::suite() {
+    CppUnit::TestSuite* suiteOfTests = new CppUnit::TestSuite("CSeasonalTimeTest");
+
+    suiteOfTests->addTest(new CppUnit::TestCaller<CSeasonalTimeTest>(
+        "CSeasonalTimeTest::testPersist", &CSeasonalTimeTest::testPersist));
+
+    return suiteOfTests;
+}

--- a/lib/maths/unittest/CSeasonalTimeTest.h
+++ b/lib/maths/unittest/CSeasonalTimeTest.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CSeasonalTimeTest_h
+#define INCLUDED_CSeasonalTimeTest_h
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class CSeasonalTimeTest : public CppUnit::TestFixture {
+public:
+    void testPersist();
+
+    static CppUnit::Test* suite();
+};
+
+#endif // INCLUDED_CSeasonalTimeTest_h

--- a/lib/maths/unittest/Main.cc
+++ b/lib/maths/unittest/Main.cc
@@ -69,6 +69,7 @@
 #include "CSamplingTest.h"
 #include "CSeasonalComponentAdaptiveBucketingTest.h"
 #include "CSeasonalComponentTest.h"
+#include "CSeasonalTimeTest.h"
 #include "CSetToolsTest.h"
 #include "CSignalTest.h"
 #include "CSolversTest.h"
@@ -151,6 +152,7 @@ int main(int argc, const char** argv) {
     runner.addTest(CSamplingTest::suite());
     runner.addTest(CSeasonalComponentTest::suite());
     runner.addTest(CSeasonalComponentAdaptiveBucketingTest::suite());
+    runner.addTest(CSeasonalTimeTest::suite());
     runner.addTest(CSetToolsTest::suite());
     runner.addTest(CSignalTest::suite());
     runner.addTest(CSolversTest::suite());

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -80,6 +80,7 @@ SRCS=\
 	CSamplingTest.cc \
 	CSeasonalComponentTest.cc \
 	CSeasonalComponentAdaptiveBucketingTest.cc \
+	CSeasonalTimeTest.cc \
 	CSetToolsTest.cc \
 	CSignalTest.cc \
 	CSolversTest.cc \


### PR DESCRIPTION
Backport #821. Note that this is not a trivial back port because of the test framework change so it is worthwhile reviewing.