### PR TITLE
[7.x] Emit prediction_probability field alongside prediction field in ml results. (#818)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,8 +38,7 @@
 estimating maximum memory usage. (See {ml-pull}781[#781].)
 * Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
 * Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809], {pull}47050[#47050].)
-* Emit `prediction_probability` field alongside prediction field in ml results.
-(See {ml-pull}818[#818].)
+* Emit `prediction_probability` field alongside prediction field in ml results. (See {ml-pull}818[#818].)
 
 == {es} version 7.5.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,6 +38,8 @@
 estimating maximum memory usage. (See {ml-pull}781[#781].)
 * Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
 * Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809], {pull}47050[#47050].)
+* Emit `prediction_probability` field alongside prediction field in ml results.
+(See {ml-pull}818[#818].)
 
 == {es} version 7.5.0
 

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -36,6 +36,14 @@ public:
                      const TRowRef& row,
                      core::CRapidJsonConcurrentLineWriter& writer) const override;
 
+    //! Write the prediction for \p row to \p writer.
+    //! This is not intended to be called in production. Should only be used in tests.
+    void writeOneRow(const core::CDataFrame& frame,
+                     const std::size_t columnHoldingDependentVariable,
+                     const std::size_t columnHoldingPrediction,
+                     const TRowRef& row,
+                     core::CRapidJsonConcurrentLineWriter& writer) const;
+
     //! \return A serialisable definition of the trained classification model.
     TInferenceModelDefinitionUPtr
     inferenceModelDefinition(const TStrVec& fieldNames,

--- a/lib/api/unittest/CDataFrameTrainBoostedTreeClassifierRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameTrainBoostedTreeClassifierRunnerTest.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CDataFrame.h>
+
+#include <api/CDataFrameAnalysisConfigReader.h>
+#include <api/CDataFrameTrainBoostedTreeClassifierRunner.h>
+
+#include <test/CDataFrameAnalysisSpecificationFactory.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(CDataFrameTrainBoostedTreeClassifierRunnerTest)
+
+using namespace ml;
+namespace {
+using TRowItr = core::CDataFrame::TRowItr;
+using TStrVec = std::vector<std::string>;
+using TStrVecVec = std::vector<TStrVec>;
+}
+
+BOOST_AUTO_TEST_CASE(testWriteOneRow) {
+    // Prepare input data frame
+    const TStrVec columnNames{"x1", "x2", "x3", "x4", "x5", "x5_prediction"};
+    const TStrVec categoricalColumns{"x1", "x2", "x5"};
+    const TStrVecVec rows{{"a", "b", "1.0", "1.0", "cat", "-1.0"},
+                          {"a", "b", "2.0", "2.0", "cat", "-0.5"},
+                          {"a", "b", "5.0", "5.0", "dog", "-0.1"},
+                          {"c", "d", "5.0", "5.0", "dog", "1.0"},
+                          {"e", "f", "5.0", "5.0", "dog", "1.5"}};
+    std::unique_ptr<core::CDataFrame> frame =
+        core::makeMainStorageDataFrame(columnNames.size()).first;
+    frame->columnNames(columnNames);
+    frame->categoricalColumns(categoricalColumns);
+    for (std::size_t i = 0; i < rows.size(); ++i) {
+        frame->parseAndWriteRow(
+            core::CVectorRange<const TStrVec>(rows[i], 0, rows[i].size()));
+    }
+    frame->finishWritingRows();
+    BOOST_TEST_REQUIRE(frame->numberRows() == rows.size());
+
+    // Create classification analysis runner object
+    const auto spec{test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
+        "classification", "x5", rows.size(), columnNames.size(), 13000000, 0, 0,
+        categoricalColumns)};
+    rapidjson::Document jsonParameters;
+    jsonParameters.Parse("{\"dependent_variable\": \"x5\"}");
+    const auto parameters{
+        api::CDataFrameTrainBoostedTreeClassifierRunner::parameterReader().read(jsonParameters)};
+    api::CDataFrameTrainBoostedTreeClassifierRunner runner(*spec, parameters);
+
+    // Write results to the output stream
+    std::stringstream output;
+    {
+        core::CJsonOutputStreamWrapper outputStreamWrapper(output);
+        core::CRapidJsonConcurrentLineWriter writer(outputStreamWrapper);
+
+        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+            const auto columnHoldingDependentVariable{
+                std::find(columnNames.begin(), columnNames.end(), "x5") -
+                columnNames.begin()};
+            const auto columnHoldingPrediction{
+                std::find(columnNames.begin(), columnNames.end(), "x5_prediction") -
+                columnNames.begin()};
+            for (auto row = beginRows; row != endRows; ++row) {
+                runner.writeOneRow(*frame, columnHoldingDependentVariable,
+                                   columnHoldingPrediction, *row, writer);
+            }
+        });
+    }
+    // Verify results
+    const TStrVec expectedPredictions{"cat", "cat", "cat", "dog", "dog"};
+    rapidjson::Document arrayDoc;
+    arrayDoc.Parse<rapidjson::kParseDefaultFlags>(output.str().c_str());
+    BOOST_TEST_REQUIRE(arrayDoc.IsArray());
+    BOOST_TEST_REQUIRE(arrayDoc.Size() == rows.size());
+    for (std::size_t i = 0; i < arrayDoc.Size(); ++i) {
+        BOOST_TEST_CONTEXT("Result for row " << i) {
+            const rapidjson::Value& object = arrayDoc[rapidjson::SizeType(i)];
+            BOOST_TEST_REQUIRE(object.IsObject());
+            BOOST_TEST_REQUIRE(object.HasMember("x5_prediction"));
+            BOOST_TEST_REQUIRE(object["x5_prediction"].GetString() ==
+                               expectedPredictions[i]);
+            BOOST_TEST_REQUIRE(object.HasMember("prediction_probability"));
+            BOOST_TEST_REQUIRE(object["prediction_probability"].GetDouble() > 0.5);
+            BOOST_TEST_REQUIRE(object.HasMember("is_training"));
+            BOOST_TEST_REQUIRE(object["is_training"].GetBool());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -30,6 +30,7 @@ SRCS=\
 	CDataFrameAnalysisSpecificationTest.cc \
 	CDataFrameAnalyzerOutlierTest.cc \
 	CDataFrameAnalyzerTrainingTest.cc \
+	CDataFrameTrainBoostedTreeClassifierRunnerTest.cc \
 	CDataFrameMockAnalysisRunner.cc \
 	CDetectionRulesJsonParserTest.cc \
 	CFieldConfigTest.cc \


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Emit prediction_probability field alongside prediction field in ml results.  (#818)