### PR TITLE
[7.x][ML] Remove unary_function/binary_function and old-style binders

### DIFF
--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -15,7 +15,6 @@
 
 #include <boost/unordered_map.hpp>
 
-#include <functional>
 #include <string>
 #include <vector>
 
@@ -100,7 +99,7 @@ public:
 protected:
     //! Class to cache a hash value so that it doesn't have to be repeatedly
     //! recomputed
-    class API_EXPORT CPreComputedHash : public std::unary_function<std::string, size_t> {
+    class API_EXPORT CPreComputedHash {
     public:
         //! Store the given hash
         CPreComputedHash(size_t hash);

--- a/include/core/CCompressedDictionary.h
+++ b/include/core/CCompressedDictionary.h
@@ -125,7 +125,7 @@ public:
     };
 
     //! \brief A fast hash of a dictionary word.
-    class CHash : public std::unary_function<CWord, uint64_t> {
+    class CHash {
     public:
         inline std::size_t operator()(const CWord& word) const {
             return word.hash();

--- a/include/core/CHashing.h
+++ b/include/core/CHashing.h
@@ -362,7 +362,7 @@ public:
     //! \warning This is slower than boost::hash for the types I tested
     //! std::size_t, int, uint64_t, but does have better distributions.
     template<typename T>
-    class CMurmurHash2BT : public std::unary_function<T, std::size_t> {
+    class CMurmurHash2BT {
     public:
         //! See CMemory.
         static bool dynamicSizeAlwaysZero() { return true; }
@@ -380,8 +380,7 @@ public:
     //!
     //! \note This is significantly faster than boost::hash<std::string>
     //! and has better distributions.
-    class CORE_EXPORT CMurmurHash2String
-        : public std::unary_function<std::string, std::size_t> {
+    class CORE_EXPORT CMurmurHash2String {
     public:
         //! See CMemory.
         static bool dynamicSizeAlwaysZero() { return true; }
@@ -410,8 +409,7 @@ public:
     //! example would be where the hash value somehow affects data that is
     //! visible outside the program, such as state persisted to a data
     //! store.  This is also immune to endianness issues.
-    class CORE_EXPORT CSafeMurmurHash2String64
-        : public std::unary_function<std::string, uint64_t> {
+    class CORE_EXPORT CSafeMurmurHash2String64 {
     public:
         //! See CMemory.
         static bool dynamicSizeAlwaysZero() { return true; }

--- a/include/core/CStringCache.h
+++ b/include/core/CStringCache.h
@@ -77,7 +77,7 @@ private:
     //! Boost's hash function applied to an empty string returns a non-zero
     //! hash, which would be hard to reproduce for a range of characters,
     //! hence using a hand coded hash functor.
-    class CStrHash : public std::unary_function<std::string, size_t> {
+    class CStrHash {
     public:
         size_t operator()(const std::string& str) const;
     };
@@ -85,7 +85,7 @@ private:
     //! Class to hash a range of characters on construction to save
     //! calculating the length in operator().  Does NOT construct a
     //! temporary string object to create the hash.
-    class CCharPHash : public std::unary_function<const char*, size_t> {
+    class CCharPHash {
     public:
         //! Store the given hash
         CCharPHash(const char* str, const char* end);
@@ -100,7 +100,7 @@ private:
 
     //! Check for equality between a char pointer and a string without
     //! constructing a temporary string
-    class CCharPStrEqual : public std::binary_function<const char*, std::string, bool> {
+    class CCharPStrEqual {
     public:
         //! Cache the char pointer length to speed comparisons
         CCharPStrEqual(size_t length);

--- a/include/core/CWordDictionary.h
+++ b/include/core/CWordDictionary.h
@@ -12,7 +12,6 @@
 
 #include <boost/unordered_map.hpp>
 
-#include <functional>
 #include <string>
 
 namespace ml {
@@ -137,12 +136,12 @@ private:
     ~CWordDictionary();
 
 private:
-    class CStrHashIgnoreCase : std::unary_function<std::string, bool> {
+    class CStrHashIgnoreCase {
     public:
         size_t operator()(const std::string& str) const;
     };
 
-    class CStrEqualIgnoreCase : std::binary_function<std::string, std::string, bool> {
+    class CStrEqualIgnoreCase {
     public:
         bool operator()(const std::string& lhs, const std::string& rhs) const;
     };

--- a/include/maths/CBasicStatistics.h
+++ b/include/maths/CBasicStatistics.h
@@ -138,7 +138,7 @@ public:
     //! \tparam T The "floating point" type.
     //! \tparam ORDER The highest order moment to gather.
     template<typename T, unsigned int ORDER>
-    struct SSampleCentralMoments : public std::unary_function<T, void> {
+    struct SSampleCentralMoments {
         using TCoordinate = typename SCoordinate<T>::Type;
         using TValue = T;
 
@@ -718,7 +718,7 @@ public:
     //!
     //! \tparam POINT The "floating point" vector type.
     template<typename POINT>
-    struct SSampleCovariances : public std::unary_function<POINT, void> {
+    struct SSampleCovariances {
         //! See core::CMemory.
         static bool dynamicSizeAlwaysZero() {
             return core::memory_detail::SDynamicSizeAlwaysZero<POINT>::value();
@@ -916,7 +916,7 @@ private:
     //! function is supplied so that T can be any type which supports a
     //! partial ordering. (T must also have a default constructor.)
     template<typename T, typename CONTAINER, typename LESS>
-    class COrderStatisticsImpl : public std::unary_function<T, void> {
+    class COrderStatisticsImpl {
     public:
         using iterator = typename CONTAINER::iterator;
         using const_iterator = typename CONTAINER::const_iterator;

--- a/include/maths/CEqualWithTolerance.h
+++ b/include/maths/CEqualWithTolerance.h
@@ -11,8 +11,6 @@
 
 #include <maths/CLinearAlgebraFwd.h>
 
-#include <functional>
-
 namespace ml {
 namespace maths {
 
@@ -78,8 +76,7 @@ public:
 //! have has_multiplies and so, short of writing this functionality
 //! ourselves, we can't implement this.
 template<typename T>
-class CEqualWithTolerance : public std::binary_function<T, T, bool>,
-                            public CToleranceTypes {
+class CEqualWithTolerance : public CToleranceTypes {
 public:
     CEqualWithTolerance(unsigned int toleranceType, const T& eps)
         : m_ToleranceType(toleranceType), m_AbsoluteEps(abs(norm(eps))),

--- a/include/maths/CMathsFuncs.h
+++ b/include/maths/CMathsFuncs.h
@@ -13,7 +13,6 @@
 #include <maths/ImportExport.h>
 #include <maths/MathsTypes.h>
 
-#include <functional>
 #include <iterator>
 
 namespace ml {
@@ -87,7 +86,7 @@ public:
     static maths_t::EFloatingPointErrorStatus fpStatus(double val);
 
     //! Unary function object to check if a value is finite.
-    struct SIsFinite : std::unary_function<double, bool> {
+    struct SIsFinite {
         bool operator()(double val) const { return isFinite(val); }
     };
 

--- a/lib/core/CMemoryUsage.cc
+++ b/lib/core/CMemoryUsage.cc
@@ -18,7 +18,7 @@ namespace memory_detail {
 
 //! Comparison function class to compare CMemoryUsage objects by
 //! their description
-class CMemoryUsageComparison : public std::unary_function<std::string, bool> {
+class CMemoryUsageComparison {
 public:
     explicit CMemoryUsageComparison(const std::string& baseline)
         : m_Baseline(baseline) {}
@@ -33,8 +33,7 @@ private:
 
 //! Comparison function class to compare CMemoryUsage objects by
 //! their description, but ignoring the first in the collection
-class CMemoryUsageComparisonTwo
-    : public std::binary_function<std::string, CMemoryUsage*, bool> {
+class CMemoryUsageComparisonTwo {
 public:
     explicit CMemoryUsageComparisonTwo(const std::string& baseline, const CMemoryUsage* firstItem)
         : m_Baseline(baseline), m_FirstItem(firstItem) {}

--- a/lib/maths/CGammaRateConjugate.cc
+++ b/lib/maths/CGammaRateConjugate.cc
@@ -114,7 +114,7 @@ void truncateVariance(bool isInteger, TMeanAccumulator& logMean, TMeanVarAccumul
 
 //! Computes the derivative w.r.t. the shape of the marginal likelihood
 //! function for gamma distributed data with known prior for the rate.
-class CLikelihoodDerivativeFunction : public std::unary_function<double, double> {
+class CLikelihoodDerivativeFunction {
 public:
     CLikelihoodDerivativeFunction(double numberSamples, double target)
         : m_NumberSamples(numberSamples), m_Target(target) {}

--- a/lib/maths/CKMostCorrelated.cc
+++ b/lib/maths/CKMostCorrelated.cc
@@ -29,7 +29,6 @@
 
 #include <array>
 #include <cmath>
-#include <functional>
 
 namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;
@@ -48,7 +47,7 @@ using TPointSizePrVec = std::vector<TPointSizePr>;
 
 //! \brief Unary predicate to check variables, corresponding
 //! to labeled points, are not equal to a specified variable.
-class CNotEqual : public std::unary_function<TPointSizePr, bool> {
+class CNotEqual {
 public:
     CNotEqual(std::size_t X) : m_X(X) {}
 
@@ -64,7 +63,7 @@ private:
 //! \brief Unary predicate to check if one specified variable
 //! and others, corresponding to labeled points, are in a
 //! specified collection pairs of variables.
-class CPairNotIn : public std::unary_function<TPointSizePr, bool> {
+class CPairNotIn {
 public:
     CPairNotIn(const TSizeSizePrUSet& lookup, std::size_t X)
         : m_Lookup(&lookup), m_X(X) {}
@@ -82,7 +81,7 @@ private:
 //! \brief Unary predicate to check if a point is closer,
 //! in square Euclidean distance, to a specified point than
 //! a specified threshold.
-class CCloserThan : public std::unary_function<TPointSizePr, bool> {
+class CCloserThan {
 public:
     CCloserThan(double threshold, const TPoint& x)
         : m_Threshold(threshold), m_X(x) {}

--- a/lib/maths/CPrior.cc
+++ b/lib/maths/CPrior.cc
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <functional>
 #include <sstream>
 #include <stdexcept>
 #include <utility>
@@ -203,7 +202,9 @@ void CPrior::adjustOffsetResamples(double minimumSample,
     this->sampleMarginalLikelihood(ADJUST_OFFSET_SAMPLE_SIZE, resamples);
     std::size_t n = resamples.size();
     resamples.erase(std::remove_if(resamples.begin(), resamples.end(),
-                                   std::not1(CMathsFuncs::SIsFinite())),
+                                   [](double d) {
+                                       return CMathsFuncs::SIsFinite()(d) == false;
+                                   }),
                     resamples.end());
     if (resamples.size() != n) {
         LOG_ERROR(<< "Bad samples (" << this->debug() << ")");

--- a/lib/maths/unittest/CIntegrationTest.cc
+++ b/lib/maths/unittest/CIntegrationTest.cc
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
-#include <functional>
 #include <numeric>
 
 BOOST_AUTO_TEST_SUITE(CIntegrationTest)
@@ -32,7 +31,7 @@ using namespace maths;
 namespace {
 
 template<unsigned int ORDER>
-class CPolynomialFunction : public std::unary_function<double, double> {
+class CPolynomialFunction {
 public:
     CPolynomialFunction(const double (&coefficients)[ORDER + 1]) {
         std::copy(coefficients, coefficients + ORDER + 1, m_Coefficients);

--- a/lib/maths/unittest/TestUtils.cc
+++ b/lib/maths/unittest/TestUtils.cc
@@ -25,7 +25,7 @@ const core_t::TTime WEEK{core::constants::WEEK};
 
 //! \brief Computes the c.d.f. of the prior minus the target supplied
 //! to its constructor at specific locations.
-class CCdf : public std::unary_function<double, double> {
+class CCdf {
 public:
     enum EStyle { E_Lower, E_Upper, E_GeometricMean };
 

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -31,8 +31,7 @@ const std::string NUM_MATCHES("i");
 const std::string EMPTY_STRING;
 
 //! Functor for comparing just the first element of a pair of sizes
-class CSizePairFirstElementLess
-    : public std::binary_function<CTokenListCategory::TSizeSizePr, CTokenListCategory::TSizeSizePr, bool> {
+class CSizePairFirstElementLess {
 public:
     bool operator()(CTokenListCategory::TSizeSizePr lhs, CTokenListCategory::TSizeSizePr rhs) {
         return lhs.first < rhs.first;


### PR DESCRIPTION
C++11 deprecated the unary_function and binary_function base
classes, together with old-style binders like bind1st and not1.

These base classes and functions are completed removed in C++17,
so they need removing from the codebase before we can upgrade.
However, since they are unnecessary in C++11 and above it is
best to remove them in advance of any (master-only) C++17 work
so that the master and 7.x branches can stay more closely
aligned.

Backport of #840