### PR TITLE
[DO NOT MERGE] Find Windows empty base class inefficiency

### DIFF
--- a/mk/windows.mk
+++ b/mk/windows.mk
@@ -42,7 +42,7 @@ VCLDFLAGS=-LIBPATH:$(LOCAL_DRIVE):/$(VCBASE)/VC/Tools/MSVC/$(VCVER)/lib/x64
 WINSDKINCLUDES=-I$(LOCAL_DRIVE):/$(WINSDKBASE)/10/Include/$(UCRTVER)/ucrt -I$(LOCAL_DRIVE):/$(WINSDKBASE)/8.0/Include/shared -I$(LOCAL_DRIVE):/$(WINSDKBASE)/8.0/Include/um
 WINSDKLDFLAGS=-LIBPATH:$(LOCAL_DRIVE):/$(WINSDKBASE)/10/Lib/$(UCRTVER)/ucrt/x64 -LIBPATH:$(LOCAL_DRIVE):/$(WINSDKBASE)/8.0/Lib/win8/um/x64
 CFLAGS=-nologo $(OPTCFLAGS) -W4 $(CRT_OPT) -EHsc -Zi -Gw -FS -Zc:inline -diagnostics:caret -utf-8
-CXXFLAGS=-TP $(CFLAGS) -Zc:rvalueCast -Zc:strictStrings -wd4127 -we4150 -wd4201 -wd4231 -wd4251 -wd4355 -wd4512 -wd4702 -bigobj
+CXXFLAGS=-TP $(CFLAGS) -Zc:rvalueCast -Zc:strictStrings -wd4127 -we4150 -wd4201 -wd4231 -wd4251 -wd4355 -wd4512 -wd4702 -bigobj -d1reportClassLayoutChanges
 ANALYZEFLAGS=-nologo -analyze:only -analyze:stacksize100000 $(CRT_OPT)
 
 CPPFLAGS=-X -I$(CPP_SRC_HOME)/3rd_party/include -I$(LOCAL_DRIVE):/usr/local/include $(VCINCLUDES) $(WINSDKINCLUDES) -D$(OS) -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -DWIN32_LEAN_AND_MEAN -DNTDDI_VERSION=0x06010000 -D_WIN32_WINNT=0x0601 -DBUILDING_$(basename $(notdir $(TARGET))) $(OPTCPPFLAGS)


### PR DESCRIPTION
Visual Studio doesn't implement the empty base class
optimisation by default in cases of multiple inheritance.
To preserve ABI backwards compatibility it only does this
when explicitly told.

The secret `/d1reportClassLayoutChanges` option will reveal
where we might benefit from using `__declspec(empty_bases)`.

Relates #840