### PR TITLE
[ML] Use empty base optimization with multiple inheritance

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@
 estimating maximum memory usage. (See {ml-pull}781[#781].)
 * Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
 * Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809], {pull}47050[#47050].)
+* Reduce memory usage of {ml} native processes on Windows. (See {ml-pull}844[#844].)
 
 == {es} version 7.5.0
 

--- a/include/maths/CBasicStatistics.h
+++ b/include/maths/CBasicStatistics.h
@@ -1145,7 +1145,7 @@ public:
     //! \tparam LESS The comparison function object type used to test
     //! if one object of type T is less than another.
     template<typename T, std::size_t N, typename LESS = std::less<T>>
-    class COrderStatisticsStack
+    class EMPTY_BASE_OPT COrderStatisticsStack
         : public COrderStatisticsImpl<T, std::array<T, N>, LESS>,
           private boost::addable<COrderStatisticsStack<T, N, LESS>> {
 
@@ -1238,7 +1238,7 @@ public:
     //! \tparam LESS The comparison function object type used to test
     //! if one object of type T is less than another.
     template<typename T, typename LESS = std::less<T>>
-    class COrderStatisticsHeap
+    class EMPTY_BASE_OPT COrderStatisticsHeap
         : public COrderStatisticsImpl<T, std::vector<T>, LESS>,
           private boost::addable<COrderStatisticsHeap<T, LESS>> {
     private:

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -50,8 +50,9 @@ struct STimeSeriesDecompositionRestoreParams;
 //!
 //! By default this assumes the data has one day and one week
 //! periodicity, i.e. \f${ T_i } = { 86400, 604800 }\f$.
-class MATHS_EXPORT CTimeSeriesDecomposition : public CTimeSeriesDecompositionInterface,
-                                              private CTimeSeriesDecompositionDetail {
+class MATHS_EXPORT EMPTY_BASE_OPT CTimeSeriesDecomposition
+    : public CTimeSeriesDecompositionInterface,
+      private CTimeSeriesDecompositionDetail {
 public:
     //! \param[in] decayRate The rate at which information is lost.
     //! \param[in] bucketLength The data bucketing length.

--- a/include/maths/ImportExport.h
+++ b/include/maths/ImportExport.h
@@ -28,10 +28,14 @@
 #define MATHS_EXPORT __declspec(dllimport)
 #endif
 
+//! See https://devblogs.microsoft.com/cppblog/optimizing-the-layout-of-empty-base-classes-in-vs2015-update-2-3/
+#define EMPTY_BASE_OPT __declspec(empty_bases)
+
 #else
 
 // Empty string on Unix
 #define MATHS_EXPORT
+#define EMPTY_BASE_OPT
 
 #endif
 

--- a/include/maths/ProbabilityAggregators.h
+++ b/include/maths/ProbabilityAggregators.h
@@ -125,7 +125,7 @@ std::ostream& operator<<(std::ostream& o,
 //! joint probabilities, which should respect the error in the bounds.
 //! For example, two probabilities should be treated as equal if the
 //! intervals defined by their upper and lower bounds intersect.
-class MATHS_EXPORT CLogJointProbabilityOfLessLikelySamples
+class MATHS_EXPORT EMPTY_BASE_OPT CLogJointProbabilityOfLessLikelySamples
     : protected CJointProbabilityOfLessLikelySamples,
       private boost::addable<CLogJointProbabilityOfLessLikelySamples> {
 public:

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -50,10 +50,11 @@ using TUInt8UInt8Pr = std::pair<uint8_t, uint8_t>;
 //!   |(g(x) >> 8) % 256|    g(x) % 256   |    zeros(x)     |
 //! \endcode
 // clang-format off
-class CHashIterator : public std::iterator<std::random_access_iterator_tag, uint16_t>,
-                      private boost::less_than_comparable<CHashIterator,
-                              boost::addable<CHashIterator, ptrdiff_t,
-                              boost::subtractable<CHashIterator, ptrdiff_t>> > {
+class EMPTY_BASE_OPT CHashIterator
+    : public std::iterator<std::random_access_iterator_tag, uint16_t>,
+      private boost::less_than_comparable<CHashIterator,
+              boost::addable<CHashIterator, ptrdiff_t,
+              boost::subtractable<CHashIterator, ptrdiff_t>>> {
     // clang-format on
 public:
     //! The STL that comes with g++ requires a default constructor - this


### PR DESCRIPTION
The empty base optimization is not used by default with
multiple inheritance on Windows, but can be enabled using
__declspec(empty_bases).  The investigation in #842 shows
which of our classes would benefit, so this PR adds the
required option to the 5 affected classes.

Backport of #844