### PR TITLE
[ML][7.6]  Tidied up output writer classes (#847)

### DIFF
--- a/include/api/CCsvOutputWriter.h
+++ b/include/api/CCsvOutputWriter.h
@@ -75,7 +75,7 @@ public:
 
     //! Set field names, adding extra field names if they're not already
     //! present - this is only allowed once
-    virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames);
+    bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
     // Bring the other overload of writeRow() into scope
     using COutputHandler::writeRow;
@@ -84,8 +84,8 @@ public:
     //! original field values.  Where the same field is present in both
     //! overrideDataRowFields and dataRowFields, the value in
     //! overrideDataRowFields will be written.
-    virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields);
+    bool writeRow(const TStrStrUMap& dataRowFields,
+                  const TStrStrUMap& overrideDataRowFields) override;
 
     //! Get the contents of the internal string stream - for use with the
     //! zero argument constructor

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -184,11 +184,11 @@ public:
 
     //! Set field names.  In this class this function has no effect and it
     //! always returns true
-    virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames);
+    bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
     //! Write the data row fields as a JSON object
-    virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields);
+    bool writeRow(const TStrStrUMap& dataRowFields,
+                  const TStrStrUMap& overrideDataRowFields) override;
 
     //! Limit the output to the top count anomalous records and influencers.
     //! Each detector will write no more than count records and influencers
@@ -204,10 +204,7 @@ public:
     //! Close the JSON structures and flush output.
     //! This method should only be called once and will have no affect
     //! on subsequent invocations
-    virtual void finalise();
-
-    //! Receive a count of possible results
-    void possibleResultCount(core_t::TTime time, size_t count);
+    void finalise() override;
 
     //! Accept a result from the anomaly detector
     //! Virtual for testing mocks


### PR DESCRIPTION
Tidied up output writer classes as per clang-tidy suggestions

Backports #847