### PR TITLE
[7.x][ML] Adjust Eigen linear algebra wrapper constructors

### DIFF
--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -240,7 +240,12 @@ public:
         const POINT* nearest{nullptr};
         if (m_Nodes.size() > 0) {
             auto inf = std::numeric_limits<TCoordinatePrecise>::max();
-            POINT distancesToHyperplanes{las::zero(point)};
+            // Sometimes the return type of las::zero() is not POINT. In this case
+            // we must convert it to POINT, but also must be careful that the POINT
+            // doesn't then end up referencing data owned by a temporary that has
+            // been destroyed.  (Some classes used for POINT do shallow copies.)
+            auto temp = las::zero(point);
+            POINT distancesToHyperplanes{std::move(temp)};
             return this->nearestNeighbour(point, m_Nodes[0], distancesToHyperplanes,
                                           0 /*split coordinate*/, nearest, inf);
         }
@@ -260,7 +265,12 @@ public:
             // with infinite distances so we get the correct value for the furthest
             // nearest neighbour at the start of the branch and bound search.
             COrderings::SLess less;
-            POINT distancesToHyperplanes{las::zero(point)};
+            // Sometimes the return type of las::zero() is not POINT. In this case
+            // we must convert it to POINT, but also must be careful that the POINT
+            // doesn't then end up referencing data owned by a temporary that has
+            // been destroyed.  (Some classes used for POINT do shallow copies.)
+            auto temp = las::zero(point);
+            POINT distancesToHyperplanes{std::move(temp)};
             TCoordinatePrecisePointCRefPrVec neighbours(
                 n, {inf, std::cref(m_Nodes[0].s_Point)});
             this->nearestNeighbours(point, less, m_Nodes[0], distancesToHyperplanes,

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -13,6 +13,7 @@
 #include <core/CStateRestoreTraverser.h>
 #include <core/RestoreMacros.h>
 
+#include <maths/CAnnotatedVector.h>
 #include <maths/CChecksum.h>
 #include <maths/CLinearAlgebra.h>
 #include <maths/CLinearAlgebraFwd.h>
@@ -200,10 +201,7 @@ public:
 
     //! \name Copy and Move Semantics
     //@{
-    CDenseMatrix(CDenseMatrix& other)
-        : CDenseMatrix{static_cast<const CDenseMatrix&>(other)} {}
-    CDenseMatrix(const CDenseMatrix& other)
-        : TBase{static_cast<const TBase&>(other)} {}
+    CDenseMatrix(const CDenseMatrix& other) = default;
     CDenseMatrix(CDenseMatrix&& other) = default;
     CDenseMatrix& operator=(const CDenseMatrix& other) = default;
     CDenseMatrix& operator=(CDenseMatrix&& other) = default;
@@ -254,10 +252,7 @@ public:
 
     //! \name Copy and Move Semantics
     //@{
-    CDenseVector(CDenseVector& other)
-        : CDenseVector{static_cast<const CDenseVector&>(other)} {}
-    CDenseVector(const CDenseVector& other)
-        : TBase{static_cast<const TBase&>(other)} {}
+    CDenseVector(const CDenseVector& other) = default;
     CDenseVector(CDenseVector&& other) = default;
     CDenseVector& operator=(const CDenseVector& other) = default;
     CDenseVector& operator=(CDenseVector&& other) = default;
@@ -353,8 +348,6 @@ public:
 
     //! \name Copy and Move Semantics
     //@{
-    CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix& other)
-        : CMemoryMappedDenseMatrix{static_cast<const CMemoryMappedDenseMatrix&>(other)} {}
     CMemoryMappedDenseMatrix(const CMemoryMappedDenseMatrix& other)
         : TBase{nullptr, 1, 1} {
         this->reseat(other);
@@ -433,7 +426,8 @@ template<typename SCALAR>
 class CMemoryMappedDenseVector
     : public Eigen::Map<typename CDenseVector<SCALAR>::TBase> {
 public:
-    using TBase = Eigen::Map<typename CDenseVector<SCALAR>::TBase>;
+    using TDenseVector = CDenseVector<SCALAR>;
+    using TBase = Eigen::Map<typename TDenseVector::TBase>;
 
     //! See core::CMemory.
     static bool dynamicSizeAlwaysZero() { return true; }
@@ -444,10 +438,14 @@ public:
     CMemoryMappedDenseVector(ARGS&&... args)
         : TBase{std::forward<ARGS>(args)...} {}
 
+    //! Added because the forwarding constructor above doesn't work with
+    //! annotated vector arguments with Visual Studio 2019 in C++17 mode.
+    template<typename ANNOTATION>
+    CMemoryMappedDenseVector(CAnnotatedVector<TDenseVector, ANNOTATION>&& annotatedDense)
+        : TBase{annotatedDense.data(), annotatedDense.size()} {}
+
     //! \name Copy and Move Semantics
     //@{
-    CMemoryMappedDenseVector(CMemoryMappedDenseVector& other)
-        : CMemoryMappedDenseVector{static_cast<const CMemoryMappedDenseVector&>(other)} {}
     CMemoryMappedDenseVector(const CMemoryMappedDenseVector& other)
         : TBase{nullptr, 1} {
         this->reseat(other);


### PR DESCRIPTION
This change was driven by problems compiling the previous
code in Visual Studio 2019 in C++17 mode.  However, the
changes should work with other compilers, so it is best
to separate them out of the Visual Studio 2019 upgrade
PR.

There are basically two changes in this PR, but both
relate to the same area of the code:

1. Remove redundant copy constructor definitions from the
   Eigen linear algebra wrappers.  Most classes had two
   copy constructors, one taking a const argument and the
   other non-const.  But since the non-const copy
   constructor just forwarded to the const one there was
   no need to have two.  This then allows the single const
   copy constructor to be specified using = default.
   (Visual Studio 2019 warns if both const and non-const
   copy constructors are defined, so this silences those
   warnings, and also = default reduces boilerplate code.)
2. A workaround for a compilation problem when CKdTree is
   instantiated using a POINT type that is a
   CAnnotatedVector\<CMemoryMappedDenseVector\>\>.  The
   problem is that las::zero() returns a CDenseVector when
   passed a CMemoryMappedDenseVector.  This then cannot be
   converted back to CMemoryMappedDenseVector by Visual Studio
   2019 in C++17 mode unless there is a specific constructor to
   do it.  (It's unclear whether the difference is C++17 or
   some bug in Visual Studio 2019.)  This must have been
   working previously via some intermediate temporary object,
   and this highlighted another problem: the
   CMemoryMappedDenseVector is basically just a reference
   to memory owned by some other object, so if that other
   object is a temporary that's gone out of scope then
   there's a risk of invalid memory reads.  So this change
   makes sure the intermediate temporary object remains
   in scope until the POINT that it's transferred to is
   finished with.

Backport of #843