### PR TITLE
[ML] Add unit test checks for new hyperparameters in supervised learning

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -51,6 +51,13 @@ public:
     //! \return The number of columns this adds to the data frame.
     std::size_t numberExtraColumns() const override;
 
+    //! The boosted tree.
+    const maths::CBoostedTree& boostedTree() const;
+
+    //! The boosted tree factory.
+    const maths::CBoostedTreeFactory& boostedTreeFactory() const;
+
+
 protected:
     using TBoostedTreeUPtr = std::unique_ptr<maths::CBoostedTree>;
     using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
@@ -66,8 +73,6 @@ protected:
     const std::string& dependentVariableFieldName() const;
     //! Name of prediction field.
     const std::string& predictionFieldName() const;
-    //! The boosted tree.
-    const maths::CBoostedTree& boostedTree() const;
 
     //! The boosted tree factory.
     maths::CBoostedTreeFactory& boostedTreeFactory();

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -57,7 +57,6 @@ public:
     //! The boosted tree factory.
     const maths::CBoostedTreeFactory& boostedTreeFactory() const;
 
-
 protected:
     using TBoostedTreeUPtr = std::unique_ptr<maths::CBoostedTree>;
     using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -404,6 +404,7 @@ public:
     //! A list of the names of the best individual hyperparameters in the state document.
     static TStrVec bestHyperparameterNames();
 
+    //! \return Class containing best hyperparameters.
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
 
     //! Persist by passing information to \p inserter.

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -12,6 +12,7 @@
 #include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBasicStatistics.h>
+#include <maths/CBoostedTreeHyperparameters.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CDataFrameRegressionModel.h>
 #include <maths/CLinearAlgebra.h>
@@ -403,6 +404,7 @@ public:
     //! A list of the names of the best individual hyperparameters in the state document.
     static TStrVec bestHyperparameterNames();
 
+    const CBoostedTreeHyperparameters& bestHyperparameters() const;
 
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -403,6 +403,7 @@ public:
     //! A list of the names of the best individual hyperparameters in the state document.
     static TStrVec bestHyperparameterNames();
 
+
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 

--- a/include/maths/CBoostedTreeHyperparameters.h
+++ b/include/maths/CBoostedTreeHyperparameters.h
@@ -174,7 +174,7 @@ const std::string CBoostedTreeRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_
     "regularization_soft_tree_depth_tolerance"};
 
 //! \brief The algorithm parameters we'll directly optimise to improve test error.
-class CBoostedTreeHyperparameters {
+class MATHS_EXPORT CBoostedTreeHyperparameters {
 public:
     using TRegularization = CBoostedTreeRegularization<double>;
 

--- a/include/maths/CBoostedTreeHyperparameters.h
+++ b/include/maths/CBoostedTreeHyperparameters.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CBoostedTreeHyperparameters_h
+#define INCLUDED_ml_maths_CBoostedTreeHyperparameters_h
+
+#include <core/CStatePersistInserter.h>
+#include <core/CStateRestoreTraverser.h>
+
+#include <boost/optional.hpp>
+
+#include <cmath>
+
+namespace ml {
+namespace maths {
+
+//! \brief Holds the parameters associated with the different types of regularizer
+//! terms available.
+template<typename T>
+class CRegularization final {
+public:
+    //! Set the multiplier of the tree depth penalty.
+    CRegularization& depthPenaltyMultiplier(double depthPenaltyMultiplier) {
+        m_DepthPenaltyMultiplier = depthPenaltyMultiplier;
+        return *this;
+    }
+
+    //! Set the multiplier of the tree size penalty.
+    CRegularization& treeSizePenaltyMultiplier(double treeSizePenaltyMultiplier) {
+        m_TreeSizePenaltyMultiplier = treeSizePenaltyMultiplier;
+        return *this;
+    }
+
+    //! Set the multiplier of the square leaf weight penalty.
+    CRegularization& leafWeightPenaltyMultiplier(double leafWeightPenaltyMultiplier) {
+        m_LeafWeightPenaltyMultiplier = leafWeightPenaltyMultiplier;
+        return *this;
+    }
+
+    //! Set the soft depth tree depth limit.
+    CRegularization& softTreeDepthLimit(double softTreeDepthLimit) {
+        m_SoftTreeDepthLimit = softTreeDepthLimit;
+        return *this;
+    }
+
+    //! Set the tolerance in the depth tree depth limit.
+    CRegularization& softTreeDepthTolerance(double softTreeDepthTolerance) {
+        m_SoftTreeDepthTolerance = softTreeDepthTolerance;
+        return *this;
+    }
+
+    //! Count the number of parameters which have their default values.
+    std::size_t countNotSet() const {
+        return (m_DepthPenaltyMultiplier == T{} ? 1 : 0) +
+               (m_TreeSizePenaltyMultiplier == T{} ? 1 : 0) +
+               (m_LeafWeightPenaltyMultiplier == T{} ? 1 : 0) +
+               (m_SoftTreeDepthLimit == T{} ? 1 : 0) +
+               (m_SoftTreeDepthTolerance == T{} ? 1 : 0);
+    }
+
+    //! Multiplier of the tree depth penalty.
+    T depthPenaltyMultiplier() const { return m_DepthPenaltyMultiplier; }
+
+    //! Multiplier of the tree size penalty.
+    T treeSizePenaltyMultiplier() const {
+        return m_TreeSizePenaltyMultiplier;
+    }
+
+    //! Multiplier of the square leaf weight penalty.
+    T leafWeightPenaltyMultiplier() const {
+        return m_LeafWeightPenaltyMultiplier;
+    }
+
+    //! Soft depth tree depth limit.
+    T softTreeDepthLimit() const { return m_SoftTreeDepthLimit; }
+
+    //! Soft depth tree depth limit tolerance.
+    T softTreeDepthTolerance() const { return m_SoftTreeDepthTolerance; }
+
+    //! Get the penalty which applies to a leaf at depth \p depth.
+    T penaltyForDepth(std::size_t depth) const {
+        return std::exp((static_cast<double>(depth) / m_SoftTreeDepthLimit - 1.0) /
+                        m_SoftTreeDepthTolerance);
+    }
+
+    //! Get description of the regularization parameters.
+    std::string print() const {
+        return "(depth penalty multiplier = " + toString(m_DepthPenaltyMultiplier) +
+               ", soft depth limit = " + toString(m_SoftTreeDepthLimit) +
+               ", soft depth tolerance = " + toString(m_SoftTreeDepthTolerance) +
+               ", tree size penalty multiplier = " + toString(m_TreeSizePenaltyMultiplier) +
+               ", leaf weight penalty multiplier = " +
+               toString(m_LeafWeightPenaltyMultiplier) + ")";
+    }
+
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
+public:
+    static const std::string REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG;
+    static const std::string REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG;
+    static const std::string REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG;
+    static const std::string REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG;
+    static const std::string REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG;
+
+private:
+    using TOptionalDouble = boost::optional<double>;
+
+private:
+    static std::string toString(double x) { return std::to_string(x); }
+    static std::string toString(TOptionalDouble x) {
+        return x != boost::none ? toString(*x) : "null";
+    }
+
+private:
+    T m_DepthPenaltyMultiplier = T{};
+    T m_TreeSizePenaltyMultiplier = T{};
+    T m_LeafWeightPenaltyMultiplier = T{};
+    T m_SoftTreeDepthLimit = T{};
+    T m_SoftTreeDepthTolerance = T{};
+};
+
+template<typename T>
+const std::string CRegularization<T>::REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG{"regularization_depth_penalty_multiplier"};
+template<typename T>
+const std::string CRegularization<T>::REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG{
+        "regularization_tree_size_penalty_multiplier"};
+template<typename T>
+const std::string CRegularization<T>::REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG{
+        "regularization_leaf_weight_penalty_multiplier"};
+template<typename T>
+const std::string CRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG{"regularization_soft_tree_depth_limit"};
+template<typename T>
+const std::string CRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG{
+        "regularization_soft_tree_depth_tolerance"};
+
+//! \brief The algorithm parameters we'll directly optimise to improve test error.
+class CBoostedTreeHyperparameters {
+public:
+    using TRegularization = CRegularization<double>;
+
+public:
+    CBoostedTreeHyperparameters() = default;
+
+    CBoostedTreeHyperparameters(const TRegularization& regularization, double downsampleFactor, double eta,
+                                double etaGrowthRatePerTree, double featureBagFraction);
+
+    void regularization(const TRegularization &regularization);
+
+    void downsampleFactor(double downsampleFactor);
+
+    void eta(double eta);
+
+    void etaGrowthRatePerTree(double etaGrowthRatePerTree);
+
+    void featureBagFraction(double featureBagFraction);
+
+    const TRegularization &regularization() const;
+
+    double downsampleFactor() const;
+
+    double eta() const;
+
+    double etaGrowthRatePerTree() const;
+
+    double featureBagFraction() const;
+
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
+public:
+    static const std::string HYPERPARAM_DOWNSAMPLE_FACTOR_TAG;
+    static const std::string HYPERPARAM_ETA_TAG;
+    static const std::string HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG;
+    static const std::string HYPERPARAM_FEATURE_BAG_FRACTION_TAG;
+    static const std::string HYPERPARAM_REGULARIZATION_TAG;
+
+private:
+    //! The regularisation parameters.
+    TRegularization m_BestRegularization;
+
+    //! The downsample factor.
+    double m_BestDownsampleFactor;
+
+    //! Shrinkage.
+    double m_BestEta;
+
+    //! Rate of growth of shrinkage in the training loop.
+    double m_BestEtaGrowthRatePerTree;
+
+    //! The fraction of features we use per bag.
+    double m_BestFeatureBagFraction;
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CBoostedTreeHyperparameters_h

--- a/include/maths/CBoostedTreeHyperparameters.h
+++ b/include/maths/CBoostedTreeHyperparameters.h
@@ -7,8 +7,10 @@
 #ifndef INCLUDED_ml_maths_CBoostedTreeHyperparameters_h
 #define INCLUDED_ml_maths_CBoostedTreeHyperparameters_h
 
+#include <core/CPersistUtils.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
+#include <core/RestoreMacros.h>
 
 #include <boost/optional.hpp>
 
@@ -20,34 +22,34 @@ namespace maths {
 //! \brief Holds the parameters associated with the different types of regularizer
 //! terms available.
 template<typename T>
-class CRegularization final {
+class CBoostedTreeRegularization final {
 public:
     //! Set the multiplier of the tree depth penalty.
-    CRegularization& depthPenaltyMultiplier(double depthPenaltyMultiplier) {
+    CBoostedTreeRegularization& depthPenaltyMultiplier(double depthPenaltyMultiplier) {
         m_DepthPenaltyMultiplier = depthPenaltyMultiplier;
         return *this;
     }
 
     //! Set the multiplier of the tree size penalty.
-    CRegularization& treeSizePenaltyMultiplier(double treeSizePenaltyMultiplier) {
+    CBoostedTreeRegularization& treeSizePenaltyMultiplier(double treeSizePenaltyMultiplier) {
         m_TreeSizePenaltyMultiplier = treeSizePenaltyMultiplier;
         return *this;
     }
 
     //! Set the multiplier of the square leaf weight penalty.
-    CRegularization& leafWeightPenaltyMultiplier(double leafWeightPenaltyMultiplier) {
+    CBoostedTreeRegularization& leafWeightPenaltyMultiplier(double leafWeightPenaltyMultiplier) {
         m_LeafWeightPenaltyMultiplier = leafWeightPenaltyMultiplier;
         return *this;
     }
 
     //! Set the soft depth tree depth limit.
-    CRegularization& softTreeDepthLimit(double softTreeDepthLimit) {
+    CBoostedTreeRegularization& softTreeDepthLimit(double softTreeDepthLimit) {
         m_SoftTreeDepthLimit = softTreeDepthLimit;
         return *this;
     }
 
     //! Set the tolerance in the depth tree depth limit.
-    CRegularization& softTreeDepthTolerance(double softTreeDepthTolerance) {
+    CBoostedTreeRegularization& softTreeDepthTolerance(double softTreeDepthTolerance) {
         m_SoftTreeDepthTolerance = softTreeDepthTolerance;
         return *this;
     }
@@ -65,9 +67,7 @@ public:
     T depthPenaltyMultiplier() const { return m_DepthPenaltyMultiplier; }
 
     //! Multiplier of the tree size penalty.
-    T treeSizePenaltyMultiplier() const {
-        return m_TreeSizePenaltyMultiplier;
-    }
+    T treeSizePenaltyMultiplier() const { return m_TreeSizePenaltyMultiplier; }
 
     //! Multiplier of the square leaf weight penalty.
     T leafWeightPenaltyMultiplier() const {
@@ -97,10 +97,41 @@ public:
     }
 
     //! Persist by passing information to \p inserter.
-    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+        core::CPersistUtils::persist(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
+                                     m_DepthPenaltyMultiplier, inserter);
+        core::CPersistUtils::persist(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                                     m_TreeSizePenaltyMultiplier, inserter);
+        core::CPersistUtils::persist(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                                     m_LeafWeightPenaltyMultiplier, inserter);
+        core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
+                                     m_SoftTreeDepthLimit, inserter);
+        core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                                     m_SoftTreeDepthTolerance, inserter);
+    };
 
     //! Populate the object from serialized data.
-    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+        do {
+            const std::string& name = traverser.name();
+            RESTORE(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
+                    core::CPersistUtils::restore(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
+                                                 m_DepthPenaltyMultiplier, traverser))
+            RESTORE(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                    core::CPersistUtils::restore(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                                                 m_TreeSizePenaltyMultiplier, traverser))
+            RESTORE(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                    core::CPersistUtils::restore(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                                                 m_LeafWeightPenaltyMultiplier, traverser))
+            RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
+                    core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
+                                                 m_SoftTreeDepthLimit, traverser))
+            RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                    core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                                                 m_SoftTreeDepthTolerance, traverser))
+        } while (traverser.next());
+        return true;
+    };
 
 public:
     static const std::string REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG;
@@ -127,48 +158,53 @@ private:
 };
 
 template<typename T>
-const std::string CRegularization<T>::REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG{"regularization_depth_penalty_multiplier"};
+const std::string CBoostedTreeRegularization<T>::REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG{
+    "regularization_depth_penalty_multiplier"};
 template<typename T>
-const std::string CRegularization<T>::REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG{
-        "regularization_tree_size_penalty_multiplier"};
+const std::string CBoostedTreeRegularization<T>::REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG{
+    "regularization_tree_size_penalty_multiplier"};
 template<typename T>
-const std::string CRegularization<T>::REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG{
-        "regularization_leaf_weight_penalty_multiplier"};
+const std::string CBoostedTreeRegularization<T>::REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG{
+    "regularization_leaf_weight_penalty_multiplier"};
 template<typename T>
-const std::string CRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG{"regularization_soft_tree_depth_limit"};
+const std::string CBoostedTreeRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG{
+    "regularization_soft_tree_depth_limit"};
 template<typename T>
-const std::string CRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG{
-        "regularization_soft_tree_depth_tolerance"};
+const std::string CBoostedTreeRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG{
+    "regularization_soft_tree_depth_tolerance"};
 
 //! \brief The algorithm parameters we'll directly optimise to improve test error.
 class CBoostedTreeHyperparameters {
 public:
-    using TRegularization = CRegularization<double>;
+    using TRegularization = CBoostedTreeRegularization<double>;
 
 public:
     CBoostedTreeHyperparameters() = default;
 
-    CBoostedTreeHyperparameters(const TRegularization& regularization, double downsampleFactor, double eta,
-                                double etaGrowthRatePerTree, double featureBagFraction);
-
-    void regularization(const TRegularization &regularization);
-
+    CBoostedTreeHyperparameters(const TRegularization& regularization,
+                                double downsampleFactor,
+                                double eta,
+                                double etaGrowthRatePerTree,
+                                double featureBagFraction);
+    //! The regularisation parameters.
+    void regularization(const TRegularization& regularization);
+    //! The regularisation parameters.
+    const TRegularization& regularization() const;
+    //! The downsample factor.
     void downsampleFactor(double downsampleFactor);
-
-    void eta(double eta);
-
-    void etaGrowthRatePerTree(double etaGrowthRatePerTree);
-
-    void featureBagFraction(double featureBagFraction);
-
-    const TRegularization &regularization() const;
-
+    //! The downsample factor.
     double downsampleFactor() const;
-
+    //! Shrinkage.
+    void eta(double eta);
+    //! Shrinkage.
     double eta() const;
-
+    //! Rate of growth of shrinkage in the training loop.
+    void etaGrowthRatePerTree(double etaGrowthRatePerTree);
+    //! Rate of growth of shrinkage in the training loop.
     double etaGrowthRatePerTree() const;
-
+    //! The fraction of features we use per bag.
+    void featureBagFraction(double featureBagFraction);
+    //! The fraction of features we use per bag.
     double featureBagFraction() const;
 
     //! Persist by passing information to \p inserter.
@@ -186,19 +222,19 @@ public:
 
 private:
     //! The regularisation parameters.
-    TRegularization m_BestRegularization;
+    TRegularization m_Regularization;
 
     //! The downsample factor.
-    double m_BestDownsampleFactor;
+    double m_downsampleFactor;
 
     //! Shrinkage.
-    double m_BestEta;
+    double m_eta;
 
     //! Rate of growth of shrinkage in the training loop.
-    double m_BestEtaGrowthRatePerTree;
+    double m_etaGrowthRatePerTree;
 
     //! The fraction of features we use per bag.
-    double m_BestFeatureBagFraction;
+    double m_featureBagFraction;
 };
 }
 }

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -24,7 +24,6 @@
 #include <maths/CPRNG.h>
 #include <maths/CTools.h>
 #include <maths/ImportExport.h>
-#include <maths/CBoostedTreeHyperparameters.h>
 
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
@@ -54,7 +53,7 @@ public:
     using TMemoryUsageCallback = CBoostedTree::TMemoryUsageCallback;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
     using TOptionalDouble = boost::optional<double>;
-    using TRegularization = CRegularization<double>;
+    using TRegularization = CBoostedTreeRegularization<double>;
 
 public:
     static const double MINIMUM_RELATIVE_GAIN_PER_SPLIT;
@@ -126,7 +125,7 @@ public:
 
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
 
-    const TRegularization &regularization() const;
+    const TRegularization& regularization() const;
 
     double downsampleFactor() const;
 
@@ -140,7 +139,6 @@ public:
 
     double featureBagFraction() const;
 
-
 private:
     using TSizeDoublePr = std::pair<std::size_t, double>;
     using TDoubleDoublePr = std::pair<double, double>;
@@ -153,12 +151,7 @@ private:
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
-
-
-
-    using TRegularizationOverride = CRegularization<TOptionalDouble>;
-
-
+    using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
 
     //! \brief Maintains a collection of statistics about a leaf of the regression
     //! tree as it is built.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -123,21 +123,8 @@ public:
     //! Visit this tree trainer implementation.
     void accept(CBoostedTree::CVisitor& visitor);
 
+    //! \return Class containing best hyperparameters.
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
-
-    const TRegularization& regularization() const;
-
-    double downsampleFactor() const;
-
-    double eta() const;
-
-    double etaGrowthRatePerTree() const;
-
-    std::size_t numberFolds() const;
-
-    std::size_t maximumNumberTrees() const;
-
-    double featureBagFraction() const;
 
 private:
     using TSizeDoublePr = std::pair<std::size_t, double>;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -17,12 +17,14 @@
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
+#include <maths/CBoostedTreeHyperparameters.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CDataFrameUtils.h>
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CPRNG.h>
 #include <maths/CTools.h>
 #include <maths/ImportExport.h>
+#include <maths/CBoostedTreeHyperparameters.h>
 
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
@@ -51,6 +53,8 @@ public:
     using TProgressCallback = CBoostedTree::TProgressCallback;
     using TMemoryUsageCallback = CBoostedTree::TMemoryUsageCallback;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
+    using TOptionalDouble = boost::optional<double>;
+    using TRegularization = CRegularization<double>;
 
 public:
     static const double MINIMUM_RELATIVE_GAIN_PER_SPLIT;
@@ -120,11 +124,27 @@ public:
     //! Visit this tree trainer implementation.
     void accept(CBoostedTree::CVisitor& visitor);
 
+    const CBoostedTreeHyperparameters& bestHyperparameters() const;
+
+    const TRegularization &regularization() const;
+
+    double downsampleFactor() const;
+
+    double eta() const;
+
+    double etaGrowthRatePerTree() const;
+
+    std::size_t numberFolds() const;
+
+    std::size_t maximumNumberTrees() const;
+
+    double featureBagFraction() const;
+
+
 private:
     using TSizeDoublePr = std::pair<std::size_t, double>;
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
-    using TOptionalDouble = boost::optional<double>;
     using TOptionalSize = boost::optional<std::size_t>;
     using TDoubleVecVec = std::vector<TDoubleVec>;
     using TSizeVec = std::vector<std::size_t>;
@@ -134,131 +154,11 @@ private:
     using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
 
-    //! \brief Holds the parameters associated with the different types of regularizer
-    //! terms available.
-    template<typename T>
-    class CRegularization final {
-    public:
-        //! Set the multiplier of the tree depth penalty.
-        CRegularization& depthPenaltyMultiplier(double depthPenaltyMultiplier) {
-            m_DepthPenaltyMultiplier = depthPenaltyMultiplier;
-            return *this;
-        }
 
-        //! Set the multiplier of the tree size penalty.
-        CRegularization& treeSizePenaltyMultiplier(double treeSizePenaltyMultiplier) {
-            m_TreeSizePenaltyMultiplier = treeSizePenaltyMultiplier;
-            return *this;
-        }
 
-        //! Set the multiplier of the square leaf weight penalty.
-        CRegularization& leafWeightPenaltyMultiplier(double leafWeightPenaltyMultiplier) {
-            m_LeafWeightPenaltyMultiplier = leafWeightPenaltyMultiplier;
-            return *this;
-        }
-
-        //! Set the soft depth tree depth limit.
-        CRegularization& softTreeDepthLimit(double softTreeDepthLimit) {
-            m_SoftTreeDepthLimit = softTreeDepthLimit;
-            return *this;
-        }
-
-        //! Set the tolerance in the depth tree depth limit.
-        CRegularization& softTreeDepthTolerance(double softTreeDepthTolerance) {
-            m_SoftTreeDepthTolerance = softTreeDepthTolerance;
-            return *this;
-        }
-
-        //! Count the number of parameters which have their default values.
-        std::size_t countNotSet() const {
-            return (m_DepthPenaltyMultiplier == T{} ? 1 : 0) +
-                   (m_TreeSizePenaltyMultiplier == T{} ? 1 : 0) +
-                   (m_LeafWeightPenaltyMultiplier == T{} ? 1 : 0) +
-                   (m_SoftTreeDepthLimit == T{} ? 1 : 0) +
-                   (m_SoftTreeDepthTolerance == T{} ? 1 : 0);
-        }
-
-        //! Multiplier of the tree depth penalty.
-        T depthPenaltyMultiplier() const { return m_DepthPenaltyMultiplier; }
-
-        //! Multiplier of the tree size penalty.
-        T treeSizePenaltyMultiplier() const {
-            return m_TreeSizePenaltyMultiplier;
-        }
-
-        //! Multiplier of the square leaf weight penalty.
-        T leafWeightPenaltyMultiplier() const {
-            return m_LeafWeightPenaltyMultiplier;
-        }
-
-        //! Soft depth tree depth limit.
-        T softTreeDepthLimit() const { return m_SoftTreeDepthLimit; }
-
-        //! Soft depth tree depth limit tolerance.
-        T softTreeDepthTolerance() const { return m_SoftTreeDepthTolerance; }
-
-        //! Get the penalty which applies to a leaf at depth \p depth.
-        T penaltyForDepth(std::size_t depth) const {
-            return std::exp((static_cast<double>(depth) / m_SoftTreeDepthLimit - 1.0) /
-                            m_SoftTreeDepthTolerance);
-        }
-
-        //! Get description of the regularization parameters.
-        std::string print() const {
-            return "(depth penalty multiplier = " + toString(m_DepthPenaltyMultiplier) +
-                   ", soft depth limit = " + toString(m_SoftTreeDepthLimit) +
-                   ", soft depth tolerance = " + toString(m_SoftTreeDepthTolerance) +
-                   ", tree size penalty multiplier = " + toString(m_TreeSizePenaltyMultiplier) +
-                   ", leaf weight penalty multiplier = " +
-                   toString(m_LeafWeightPenaltyMultiplier) + ")";
-        }
-
-        //! Persist by passing information to \p inserter.
-        void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
-
-        //! Populate the object from serialized data.
-        bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
-
-    private:
-        static std::string toString(double x) { return std::to_string(x); }
-        static std::string toString(TOptionalDouble x) {
-            return x != boost::none ? toString(*x) : "null";
-        }
-
-    private:
-        T m_DepthPenaltyMultiplier = T{};
-        T m_TreeSizePenaltyMultiplier = T{};
-        T m_LeafWeightPenaltyMultiplier = T{};
-        T m_SoftTreeDepthLimit = T{};
-        T m_SoftTreeDepthTolerance = T{};
-    };
-
-    using TRegularization = CRegularization<double>;
     using TRegularizationOverride = CRegularization<TOptionalDouble>;
 
-    //! \brief The algorithm parameters we'll directly optimise to improve test error.
-    struct SHyperparameters {
-        //! The regularisation parameters.
-        TRegularization s_Regularization;
 
-        //! The downsample factor.
-        double s_DownsampleFactor;
-
-        //! Shrinkage.
-        double s_Eta;
-
-        //! Rate of growth of shrinkage in the training loop.
-        double s_EtaGrowthRatePerTree;
-
-        //! The fraction of features we use per bag.
-        double s_FeatureBagFraction;
-
-        //! Persist by passing information to \p inserter.
-        void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
-
-        //! Populate the object from serialized data.
-        bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
-    };
 
     //! \brief Maintains a collection of statistics about a leaf of the regression
     //! tree as it is built.
@@ -636,7 +536,7 @@ private:
     TPackedBitVectorVec m_TrainingRowMasks;
     TPackedBitVectorVec m_TestingRowMasks;
     double m_BestForestTestLoss = INF;
-    SHyperparameters m_BestHyperparameters;
+    CBoostedTreeHyperparameters m_BestHyperparameters;
     TNodeVecVec m_BestForest;
     TBayesinOptimizationUPtr m_BayesianOptimization;
     std::size_t m_NumberRounds = 1;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -123,7 +123,7 @@ public:
     //! Visit this tree trainer implementation.
     void accept(CBoostedTree::CVisitor& visitor);
 
-    //! \return Class containing best hyperparameters.
+    //! \return The best hyperparameters for validation error found so far.
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
 
 private:

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -191,6 +191,13 @@ maths::CBoostedTreeFactory& CDataFrameTrainBoostedTreeRunner::boostedTreeFactory
     return *m_BoostedTreeFactory;
 }
 
+const maths::CBoostedTreeFactory& CDataFrameTrainBoostedTreeRunner::boostedTreeFactory() const {
+    if (m_BoostedTreeFactory == nullptr) {
+        HANDLE_FATAL(<< "Internal error: boosted tree factory missing. Please report this problem.");
+    }
+    return *m_BoostedTreeFactory;
+}
+
 void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
     auto dependentVariablePos = std::find(frame.columnNames().begin(),
                                           frame.columnNames().end(),

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -321,7 +321,7 @@ void testOneRunOfBoostedTreeTrainingWithStateRecovery(F makeSpec, std::size_t it
     persistedStates = splitOnNull(std::stringstream{std::move(persistenceStream->str())});
     auto actualTree = restoreTree(std::move(persistedStates.back()), frame, dependentVariable);
 
-    // Compare bestHyperparameters.
+    // Compare hyperparameters.
 
     rapidjson::Document expectedResults{treeToJsonDocument(*expectedTree)};
     const auto& expectedHyperparameters =
@@ -441,7 +441,6 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithParams) {
 
     TStrVec fieldNames{"c1", "c2", "c3", "c4", "c5", ".", "."};
     TStrVec fieldValues{"", "", "", "", "", "0", ""};
-
     addPredictionTestData(E_Regression, fieldNames, fieldValues, analyzer,
                           expectedPredictions, 100, alpha, lambda, gamma,
                           softTreeDepthLimit, softTreeDepthTolerance, eta,

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -459,5 +459,9 @@ void CBoostedTree::acceptPersistInserter(core::CStatePersistInserter& inserter) 
 void CBoostedTree::accept(CBoostedTree::CVisitor& visitor) const {
     m_Impl->accept(visitor);
 }
+
+const CBoostedTreeHyperparameters& CBoostedTree::bestHyperparameters() const {
+    return m_Impl->bestHyperparameters();
+}
 }
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -344,7 +344,11 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) {
         .treeSizePenaltyMultiplier(
             m_TreeImpl->m_RegularizationOverride.treeSizePenaltyMultiplier().value_or(0.0))
         .leafWeightPenaltyMultiplier(
-            m_TreeImpl->m_RegularizationOverride.leafWeightPenaltyMultiplier().value_or(0.0));
+            m_TreeImpl->m_RegularizationOverride.leafWeightPenaltyMultiplier().value_or(0.0))
+        .softTreeDepthLimit(
+            m_TreeImpl->m_RegularizationOverride.softTreeDepthLimit().value_or(0.0))
+        .softTreeDepthTolerance(
+            m_TreeImpl->m_RegularizationOverride.softTreeDepthTolerance().value_or(0.0));
 
     if (m_TreeImpl->m_RegularizationOverride.countNotSet() > 0) {
         this->initializeUnsetRegularizationHyperparameters(frame);

--- a/lib/maths/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/CBoostedTreeHyperparameters.cc
@@ -12,128 +12,94 @@
 namespace ml {
 namespace maths {
 
+const std::string CBoostedTreeHyperparameters::HYPERPARAM_DOWNSAMPLE_FACTOR_TAG{
+    "hyperparam_downsample_factor"};
+const std::string CBoostedTreeHyperparameters::HYPERPARAM_ETA_TAG{"hyperparam_eta"};
+const std::string CBoostedTreeHyperparameters::HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG{
+    "hyperparam_eta_growth_rate_per_tree"};
+const std::string CBoostedTreeHyperparameters::HYPERPARAM_FEATURE_BAG_FRACTION_TAG{
+    "hyperparam_feature_bag_fraction"};
+const std::string CBoostedTreeHyperparameters::HYPERPARAM_REGULARIZATION_TAG{
+    "hyperparam_regularization"};
 
-
-
-const std::string  CBoostedTreeHyperparameters::HYPERPARAM_DOWNSAMPLE_FACTOR_TAG{"hyperparam_downsample_factor"};
-const std::string  CBoostedTreeHyperparameters::HYPERPARAM_ETA_TAG{"hyperparam_eta"};
-const std::string  CBoostedTreeHyperparameters::HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG{"hyperparam_eta_growth_rate_per_tree"};
-const std::string  CBoostedTreeHyperparameters::HYPERPARAM_FEATURE_BAG_FRACTION_TAG{"hyperparam_feature_bag_fraction"};
-const std::string  CBoostedTreeHyperparameters::HYPERPARAM_REGULARIZATION_TAG{"hyperparam_regularization"};
-
-void CBoostedTreeHyperparameters::acceptPersistInserter(core::CStatePersistInserter &inserter) const {
+void CBoostedTreeHyperparameters::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     core::CPersistUtils::persist(HYPERPARAM_DOWNSAMPLE_FACTOR_TAG,
-                                 m_BestDownsampleFactor, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_ETA_TAG, m_BestEta, inserter);
+                                 m_downsampleFactor, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_ETA_TAG, m_eta, inserter);
     core::CPersistUtils::persist(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
-                                 m_BestEtaGrowthRatePerTree, inserter);
+                                 m_etaGrowthRatePerTree, inserter);
     core::CPersistUtils::persist(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                                 m_BestFeatureBagFraction, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_REGULARIZATION_TAG, m_BestRegularization, inserter);
+                                 m_featureBagFraction, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_REGULARIZATION_TAG, m_Regularization, inserter);
 }
 
 bool CBoostedTreeHyperparameters::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     do {
         const std::string& name = traverser.name();
         RESTORE(HYPERPARAM_ETA_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, m_BestEta, traverser))
+                core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, m_eta, traverser))
         RESTORE(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
                 core::CPersistUtils::restore(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
-                                             m_BestEtaGrowthRatePerTree, traverser))
+                                             m_etaGrowthRatePerTree, traverser))
         RESTORE(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
                 core::CPersistUtils::restore(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                                             m_BestFeatureBagFraction, traverser))
+                                             m_featureBagFraction, traverser))
         RESTORE(HYPERPARAM_REGULARIZATION_TAG,
                 core::CPersistUtils::restore(HYPERPARAM_REGULARIZATION_TAG,
-                                             m_BestRegularization, traverser))
+                                             m_Regularization, traverser))
     } while (traverser.next());
     return true;
 }
 
-const CBoostedTreeHyperparameters::TRegularization &CBoostedTreeHyperparameters::regularization() const {
-    return m_BestRegularization;
+const CBoostedTreeHyperparameters::TRegularization&
+CBoostedTreeHyperparameters::regularization() const {
+    return m_Regularization;
 }
 
 double CBoostedTreeHyperparameters::downsampleFactor() const {
-    return m_BestDownsampleFactor;
+    return m_downsampleFactor;
 }
 
 double CBoostedTreeHyperparameters::eta() const {
-    return m_BestEta;
+    return m_eta;
 }
 
 double CBoostedTreeHyperparameters::etaGrowthRatePerTree() const {
-    return m_BestEtaGrowthRatePerTree;
+    return m_etaGrowthRatePerTree;
 }
 
 double CBoostedTreeHyperparameters::featureBagFraction() const {
-    return m_BestFeatureBagFraction;
+    return m_featureBagFraction;
 }
 
-void
-CBoostedTreeHyperparameters::regularization(const TRegularization &regularization) {
-    m_BestRegularization = regularization;
+void CBoostedTreeHyperparameters::regularization(const TRegularization& regularization) {
+    m_Regularization = regularization;
 }
 
 void CBoostedTreeHyperparameters::downsampleFactor(double downsampleFactor) {
-    m_BestDownsampleFactor = downsampleFactor;
+    m_downsampleFactor = downsampleFactor;
 }
 
 void CBoostedTreeHyperparameters::eta(double eta) {
-    m_BestEta = eta;
+    m_eta = eta;
 }
 
 void CBoostedTreeHyperparameters::etaGrowthRatePerTree(double etaGrowthRatePerTree) {
-    m_BestEtaGrowthRatePerTree = etaGrowthRatePerTree;
+    m_etaGrowthRatePerTree = etaGrowthRatePerTree;
 }
 
 void CBoostedTreeHyperparameters::featureBagFraction(double featureBagFraction) {
-    m_BestFeatureBagFraction = featureBagFraction;
+    m_featureBagFraction = featureBagFraction;
 }
 
-CBoostedTreeHyperparameters::CBoostedTreeHyperparameters(const TRegularization &regularization,
-                                                     double downsampleFactor, double eta, double etaGrowthRatePerTree,
-                                                     double featureBagFraction): m_BestRegularization{regularization}, m_BestDownsampleFactor{downsampleFactor},
-                                                                                 m_BestEta{eta}, m_BestEtaGrowthRatePerTree{etaGrowthRatePerTree}{
-
+CBoostedTreeHyperparameters::CBoostedTreeHyperparameters(
+    const CBoostedTreeHyperparameters::TRegularization& regularization,
+    double downsampleFactor,
+    double eta,
+    double etaGrowthRatePerTree,
+    double featureBagFraction)
+    : m_Regularization{regularization}, m_downsampleFactor{downsampleFactor}, m_eta{eta},
+      m_etaGrowthRatePerTree{etaGrowthRatePerTree}, m_featureBagFraction{featureBagFraction} {
 }
-
-template<typename T>
-void CRegularization<T>::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    core::CPersistUtils::persist(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
-                                 m_DepthPenaltyMultiplier, inserter);
-    core::CPersistUtils::persist(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
-                                 m_TreeSizePenaltyMultiplier, inserter);
-    core::CPersistUtils::persist(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
-                                 m_LeafWeightPenaltyMultiplier, inserter);
-    core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
-                                 m_SoftTreeDepthLimit, inserter);
-    core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
-                                 m_SoftTreeDepthTolerance, inserter);
-}
-
-template<typename T>
-bool CRegularization<T>::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    do {
-        const std::string& name = traverser.name();
-        RESTORE(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
-                core::CPersistUtils::restore(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
-                                             m_DepthPenaltyMultiplier, traverser))
-        RESTORE(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
-                core::CPersistUtils::restore(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
-                                             m_TreeSizePenaltyMultiplier, traverser))
-        RESTORE(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
-                core::CPersistUtils::restore(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
-                                             m_LeafWeightPenaltyMultiplier, traverser))
-        RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
-                core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
-                                             m_SoftTreeDepthLimit, traverser))
-        RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
-                core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
-                                             m_SoftTreeDepthTolerance, traverser))
-    } while (traverser.next());
-    return true;
-}
-
 }
 }

--- a/lib/maths/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/CBoostedTreeHyperparameters.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CBoostedTreeHyperparameters.h>
+
+#include <core/CPersistUtils.h>
+#include <core/RestoreMacros.h>
+
+namespace ml {
+namespace maths {
+
+
+
+
+const std::string  CBoostedTreeHyperparameters::HYPERPARAM_DOWNSAMPLE_FACTOR_TAG{"hyperparam_downsample_factor"};
+const std::string  CBoostedTreeHyperparameters::HYPERPARAM_ETA_TAG{"hyperparam_eta"};
+const std::string  CBoostedTreeHyperparameters::HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG{"hyperparam_eta_growth_rate_per_tree"};
+const std::string  CBoostedTreeHyperparameters::HYPERPARAM_FEATURE_BAG_FRACTION_TAG{"hyperparam_feature_bag_fraction"};
+const std::string  CBoostedTreeHyperparameters::HYPERPARAM_REGULARIZATION_TAG{"hyperparam_regularization"};
+
+void CBoostedTreeHyperparameters::acceptPersistInserter(core::CStatePersistInserter &inserter) const {
+    core::CPersistUtils::persist(HYPERPARAM_DOWNSAMPLE_FACTOR_TAG,
+                                 m_BestDownsampleFactor, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_ETA_TAG, m_BestEta, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                                 m_BestEtaGrowthRatePerTree, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                                 m_BestFeatureBagFraction, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_REGULARIZATION_TAG, m_BestRegularization, inserter);
+}
+
+bool CBoostedTreeHyperparameters::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(HYPERPARAM_ETA_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, m_BestEta, traverser))
+        RESTORE(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+                                             m_BestEtaGrowthRatePerTree, traverser))
+        RESTORE(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+                                             m_BestFeatureBagFraction, traverser))
+        RESTORE(HYPERPARAM_REGULARIZATION_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_REGULARIZATION_TAG,
+                                             m_BestRegularization, traverser))
+    } while (traverser.next());
+    return true;
+}
+
+const CBoostedTreeHyperparameters::TRegularization &CBoostedTreeHyperparameters::regularization() const {
+    return m_BestRegularization;
+}
+
+double CBoostedTreeHyperparameters::downsampleFactor() const {
+    return m_BestDownsampleFactor;
+}
+
+double CBoostedTreeHyperparameters::eta() const {
+    return m_BestEta;
+}
+
+double CBoostedTreeHyperparameters::etaGrowthRatePerTree() const {
+    return m_BestEtaGrowthRatePerTree;
+}
+
+double CBoostedTreeHyperparameters::featureBagFraction() const {
+    return m_BestFeatureBagFraction;
+}
+
+void
+CBoostedTreeHyperparameters::regularization(const TRegularization &regularization) {
+    m_BestRegularization = regularization;
+}
+
+void CBoostedTreeHyperparameters::downsampleFactor(double downsampleFactor) {
+    m_BestDownsampleFactor = downsampleFactor;
+}
+
+void CBoostedTreeHyperparameters::eta(double eta) {
+    m_BestEta = eta;
+}
+
+void CBoostedTreeHyperparameters::etaGrowthRatePerTree(double etaGrowthRatePerTree) {
+    m_BestEtaGrowthRatePerTree = etaGrowthRatePerTree;
+}
+
+void CBoostedTreeHyperparameters::featureBagFraction(double featureBagFraction) {
+    m_BestFeatureBagFraction = featureBagFraction;
+}
+
+CBoostedTreeHyperparameters::CBoostedTreeHyperparameters(const TRegularization &regularization,
+                                                     double downsampleFactor, double eta, double etaGrowthRatePerTree,
+                                                     double featureBagFraction): m_BestRegularization{regularization}, m_BestDownsampleFactor{downsampleFactor},
+                                                                                 m_BestEta{eta}, m_BestEtaGrowthRatePerTree{etaGrowthRatePerTree}{
+
+}
+
+template<typename T>
+void CRegularization<T>::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
+                                 m_DepthPenaltyMultiplier, inserter);
+    core::CPersistUtils::persist(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                                 m_TreeSizePenaltyMultiplier, inserter);
+    core::CPersistUtils::persist(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                                 m_LeafWeightPenaltyMultiplier, inserter);
+    core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
+                                 m_SoftTreeDepthLimit, inserter);
+    core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                                 m_SoftTreeDepthTolerance, inserter);
+}
+
+template<typename T>
+bool CRegularization<T>::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
+                core::CPersistUtils::restore(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
+                                             m_DepthPenaltyMultiplier, traverser))
+        RESTORE(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                core::CPersistUtils::restore(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                                             m_TreeSizePenaltyMultiplier, traverser))
+        RESTORE(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                core::CPersistUtils::restore(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                                             m_LeafWeightPenaltyMultiplier, traverser))
+        RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
+                core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
+                                             m_SoftTreeDepthLimit, traverser))
+        RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                                             m_SoftTreeDepthTolerance, traverser))
+    } while (traverser.next());
+    return true;
+}
+
+}
+}

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -456,7 +456,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
             this->captureBestHyperparameters(lossMoments);
 
             // Trap the case that the dependent variable is (effectively) constant.
-            // There is no point adjusting bestHyperparameters in this case - and we run
+            // There is no point adjusting hyperparameters in this case - and we run
             // into numerical issues trying - since any forest will do.
             if (std::sqrt(CBasicStatistics::variance(lossMoments)) <
                 1e-10 * std::fabs(CBasicStatistics::mean(lossMoments))) {
@@ -1442,36 +1442,8 @@ void CBoostedTreeImpl::accept(CBoostedTree::CVisitor& visitor) {
 const double CBoostedTreeImpl::MINIMUM_RELATIVE_GAIN_PER_SPLIT{1e-7};
 const double CBoostedTreeImpl::INF{std::numeric_limits<double>::max()};
 
-double CBoostedTreeImpl::downsampleFactor() const {
-    return m_DownsampleFactor;
-}
-
-double CBoostedTreeImpl::eta() const {
-    return m_Eta;
-}
-
-double CBoostedTreeImpl::etaGrowthRatePerTree() const {
-    return m_EtaGrowthRatePerTree;
-}
-
-std::size_t CBoostedTreeImpl::numberFolds() const {
-    return m_NumberFolds;
-}
-
-std::size_t CBoostedTreeImpl::maximumNumberTrees() const {
-    return m_MaximumNumberTrees;
-}
-
-double CBoostedTreeImpl::featureBagFraction() const {
-    return m_FeatureBagFraction;
-}
-
 const CBoostedTreeHyperparameters& CBoostedTreeImpl::bestHyperparameters() const {
     return m_BestHyperparameters;
-}
-
-const CBoostedTreeImpl::TRegularization& CBoostedTreeImpl::regularization() const {
-    return m_Regularization;
 }
 }
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1167,9 +1167,9 @@ void CBoostedTreeImpl::captureBestHyperparameters(const TMeanVarAccumulator& los
                 std::sqrt(CBasicStatistics::variance(lossMoments))};
     if (loss < m_BestForestTestLoss) {
         m_BestForestTestLoss = loss;
-        m_BestHyperparameters = CBoostedTreeHyperparameters{m_Regularization, m_DownsampleFactor,
-                                                            m_Eta, m_EtaGrowthRatePerTree,
-                                                            m_FeatureBagFraction};
+        m_BestHyperparameters = CBoostedTreeHyperparameters{
+            m_Regularization, m_DownsampleFactor, m_Eta, m_EtaGrowthRatePerTree,
+            m_FeatureBagFraction};
     }
 }
 
@@ -1240,9 +1240,6 @@ const std::string ROWS_PER_FEATURE_TAG{"rows_per_feature"};
 const std::string TESTING_ROW_MASKS_TAG{"testing_row_masks"};
 const std::string TRAINING_ROW_MASKS_TAG{"training_row_masks"};
 const std::string TRAINING_PROGRESS_TAG{"training_progress"};
-
-
-
 }
 
 const std::string& CBoostedTreeImpl::bestHyperparametersName() {
@@ -1264,10 +1261,6 @@ CBoostedTreeImpl::TStrVec CBoostedTreeImpl::bestHyperparameterNames() {
             TRegularization::REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
             TRegularization::REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG};
 }
-
-
-
-
 
 void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     core::CPersistUtils::persist(VERSION_7_6_TAG, "", inserter);
@@ -1313,10 +1306,6 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
                                  m_MaximumNumberTreesOverride, inserter);
     inserter.insertValue(LOSS_TAG, m_Loss->name());
 }
-
-
-
-
 
 bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     if (traverser.name() == VERSION_7_5_TAG) {
@@ -1453,8 +1442,6 @@ void CBoostedTreeImpl::accept(CBoostedTree::CVisitor& visitor) {
 const double CBoostedTreeImpl::MINIMUM_RELATIVE_GAIN_PER_SPLIT{1e-7};
 const double CBoostedTreeImpl::INF{std::numeric_limits<double>::max()};
 
-
-
 double CBoostedTreeImpl::downsampleFactor() const {
     return m_DownsampleFactor;
 }
@@ -1479,11 +1466,11 @@ double CBoostedTreeImpl::featureBagFraction() const {
     return m_FeatureBagFraction;
 }
 
-const CBoostedTreeHyperparameters &CBoostedTreeImpl::bestHyperparameters() const {
+const CBoostedTreeHyperparameters& CBoostedTreeImpl::bestHyperparameters() const {
     return m_BestHyperparameters;
 }
 
-const CBoostedTreeImpl::TRegularization &CBoostedTreeImpl::regularization() const {
+const CBoostedTreeImpl::TRegularization& CBoostedTreeImpl::regularization() const {
     return m_Regularization;
 }
 }

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -25,6 +25,7 @@ CBayesianOptimisation.cc \
 CBjkstUniqueValues.cc \
 CBoostedTree.cc \
 CBoostedTreeFactory.cc \
+CBoostedTreeHyperparameters.cc \
 CBoostedTreeImpl.cc \
 CCalendarCyclicTest.cc \
 CCalendarComponentAdaptiveBucketing.cc \


### PR DESCRIPTION
This PR adds check that user-specified hyperparameters are used as final hyperparameters by the boosted trees. Implementation of the unit test required factoring out classes `CBoostedTreeHyperparameters` and `CBoostedTreeRegularization` from `CBoostedTreeImpl`.

Also I added the setting of some user-specified hyperparameters in `CBoostedTreeFactory.cc` that were missing before.

Fixes #851 
Fixes #849 