### PR TITLE
[ML][7.6] Fix memory errors picked up by Valgrind (#852)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -7,7 +7,7 @@
 
 = Elasticsearch Release Notes
 
-////
+//
 // To add a release, copy and paste the following text,  uncomment the relevant
 // sections, and add a link to the new section in the list of releases at the
 // top of the page. Note that release subheads must be floated and sections
@@ -39,6 +39,10 @@ estimating maximum memory usage. (See {ml-pull}781[#781].)
 * Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
 * Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809], {pull}47050[#47050].)
 * Reduce memory usage of {ml} native processes on Windows. (See {ml-pull}844[#844].)
+
+=== Bug Fixes
+* Fixes potential memory corruption when determining seasonality. (See {ml-pull}852[#852].)
+
 
 == {es} version 7.5.0
 

--- a/include/api/CCsvOutputWriter.h
+++ b/include/api/CCsvOutputWriter.h
@@ -68,7 +68,7 @@ public:
                      char separator = COMMA);
 
     //! Destructor flushes the stream
-    virtual ~CCsvOutputWriter();
+    ~CCsvOutputWriter() override;
 
     // Bring the other overload of fieldNames() into scope
     using COutputHandler::fieldNames;

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -177,7 +177,7 @@ public:
     CJsonOutputWriter(const std::string& jobId, core::CJsonOutputStreamWrapper& strmOut);
 
     //! Destructor flushes the stream
-    virtual ~CJsonOutputWriter();
+    ~CJsonOutputWriter() override;
 
     // Bring the other overload of fieldNames() into scope
     using COutputHandler::fieldNames;


### PR DESCRIPTION
 * Fixes Valgrind errors in `CSignal`
 * Also fixes a couple more warnings picked up by clang_tidy

Backports #852 