### PR TITLE
[ML] Adding memory usage methods for categorization classes

### DIFF
--- a/include/core/CCsvLineParser.h
+++ b/include/core/CCsvLineParser.h
@@ -8,6 +8,8 @@
 
 #include <core/ImportExport.h>
 
+#include <core/CMemoryUsage.h>
+
 #include <boost/scoped_array.hpp>
 
 #include <string>
@@ -59,6 +61,12 @@ public:
 
     //! Are we at the end of the current line?
     bool atEnd() const;
+
+    //! Debug the memory used by this parser.
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+
+    //! Get the memory used by this parser.
+    std::size_t memoryUsage() const;
 
 private:
     //! Attempt to parse the next token from the working record

--- a/include/core/CCsvLineParser.h
+++ b/include/core/CCsvLineParser.h
@@ -6,9 +6,8 @@
 #ifndef INCLUDED_ml_core_CCsvLineParser_h
 #define INCLUDED_ml_core_CCsvLineParser_h
 
-#include <core/ImportExport.h>
-
 #include <core/CMemoryUsage.h>
+#include <core/ImportExport.h>
 
 #include <boost/scoped_array.hpp>
 

--- a/include/core/CMemory.h
+++ b/include/core/CMemory.h
@@ -996,7 +996,7 @@ public:
         componentName += "_list";
 
         std::size_t listSize = (memory_detail::EXTRA_NODES + t.size()) *
-                               (sizeof(T) + 4 * sizeof(std::size_t));
+                               (sizeof(T) + 2 * sizeof(std::size_t));
 
         CMemoryUsage::SMemoryUsage usage(componentName, listSize);
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();

--- a/include/core/CStringSimilarityTester.h
+++ b/include/core/CStringSimilarityTester.h
@@ -7,6 +7,7 @@
 #define INCLUDED_ml_core_CStringSimilarityTester_h
 
 #include <core/CLogger.h>
+#include <core/CMemoryUsage.h>
 #include <core/CNonCopyable.h>
 #include <core/CompressUtils.h>
 #include <core/ImportExport.h>
@@ -285,6 +286,12 @@ public:
         // Result is the value in the bottom right hand corner of the matrix
         return currentCol[secondLen];
     }
+
+    //! Debug the memory used by this similarity tester.
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+
+    //! Get the memory used by this similarity tester.
+    std::size_t memoryUsage() const;
 
 private:
     //! Calculate the Levenshtein distance using the naive method of

--- a/include/core/CompressUtils.h
+++ b/include/core/CompressUtils.h
@@ -6,6 +6,7 @@
 #ifndef INCLUDED_ml_core_CCompressUtils_h
 #define INCLUDED_ml_core_CCompressUtils_h
 
+#include <core/CMemoryUsage.h>
 #include <core/CNonCopyable.h>
 #include <core/ImportExport.h>
 
@@ -97,6 +98,12 @@ public:
     //! round, but sometimes, for example when recovering from an
     //! error, it may be desirable to explicitly reset the state.
     void reset();
+
+    //! Debug the memory used by these compression utils.
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+
+    //! Get the memory used by these compression utils.
+    std::size_t memoryUsage() const;
 
 protected:
     //! Get the underlying stream.
@@ -191,26 +198,26 @@ private:
 class CORE_EXPORT CDeflator final : public CCompressUtil {
 public:
     CDeflator(bool lengthOnly, int level = Z_DEFAULT_COMPRESSION);
-    ~CDeflator();
+    ~CDeflator() override;
 
 private:
     //! Process a chunk of state (optionally flushing).
-    virtual int streamProcessChunk(int flush);
+    int streamProcessChunk(int flush) override;
     //! Reset the underlying stream.
-    virtual int resetStream();
+    int resetStream() override;
 };
 
 //! \brief Implementation of CompressUtil for inflating data.
 class CORE_EXPORT CInflator final : public CCompressUtil {
 public:
     CInflator(bool lengthOnly);
-    ~CInflator();
+    ~CInflator() override;
 
 private:
     //! Process a chunk of state (optionally flushing).
-    virtual int streamProcessChunk(int flush);
+    int streamProcessChunk(int flush) override;
     //! Reset the underlying stream.
-    virtual int resetStream();
+    int resetStream() override;
 };
 }
 }

--- a/include/model/CBaseTokenListDataCategorizer.h
+++ b/include/model/CBaseTokenListDataCategorizer.h
@@ -102,16 +102,16 @@ public:
                                   const std::string& fieldName);
 
     //! Dump stats
-    virtual void dumpStats() const;
+    void dumpStats() const override;
 
     //! Compute a category from a string.  The raw string length may be longer
     //! than the length of the passed string, because the passed string may
     //! have the date stripped out of it.  Field names/values are available
     //! to the category computation.
-    virtual int computeCategory(bool dryRun,
-                                const TStrStrUMap& fields,
-                                const std::string& str,
-                                size_t rawStringLen);
+    int computeCategory(bool dryRun,
+                        const TStrStrUMap& fields,
+                        const std::string& str,
+                        size_t rawStringLen) override;
 
     // Bring the other overload of computeCategory() into scope
     using CDataCategorizer::computeCategory;
@@ -120,23 +120,29 @@ public:
     //! that are classified as the given category.  Note that the reverse search
     //! is only approximate - it may select more records than have actually
     //! been classified as the returned category.
-    virtual bool createReverseSearch(int categoryId,
-                                     std::string& part1,
-                                     std::string& part2,
-                                     size_t& maxMatchingLength,
-                                     bool& wasCached);
+    bool createReverseSearch(int categoryId,
+                             std::string& part1,
+                             std::string& part2,
+                             size_t& maxMatchingLength,
+                             bool& wasCached) override;
 
     //! Has the data categorizer's state changed?
-    virtual bool hasChanged() const;
+    bool hasChanged() const override;
 
     //! Populate the object from part of a state document
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Make a function that can be called later to persist state
-    virtual TPersistFunc makePersistFunc() const;
+    TPersistFunc makePersistFunc() const override;
+
+    //! Debug the memory used by this categorizer.
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+
+    //! Get the memory used by this categorizer.
+    std::size_t memoryUsage() const override;
 
 protected:
     //! Split the string into a list of tokens.  The result of the
@@ -204,6 +210,12 @@ private:
 
         //! Increment the category count
         void incCategoryCount();
+
+        //! Debug the memory used by this item.
+        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+
+        //! Get the memory used by this item.
+        std::size_t memoryUsage() const;
 
     private:
         //! String value of the token

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -6,6 +6,7 @@
 #ifndef INCLUDED_ml_model_CDataCategorizer_h
 #define INCLUDED_ml_model_CDataCategorizer_h
 
+#include <core/CMemoryUsage.h>
 #include <core/CoreTypes.h>
 
 #include <model/ImportExport.h>
@@ -99,6 +100,12 @@ public:
 
     //! Set last persistence time
     void lastPersistTime(core_t::TTime lastPersistTime);
+
+    //! Debug the memory used by this categorizer.
+    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+
+    //! Get the memory used by this categorizer.
+    virtual std::size_t memoryUsage() const;
 
 protected:
     //! Used if no fields are supplied to the computeCategory() method.

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -32,7 +32,6 @@ namespace model {
 
 class CAnomalyDetector;
 class CAnomalyDetectorModel;
-class CResourcePruner;
 
 //! \brief Assess memory used by models and decide on further memory allocations.
 //!

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -6,6 +6,8 @@
 #ifndef INCLUDED_ml_model_CTokenListCategory_h
 #define INCLUDED_ml_model_CTokenListCategory_h
 
+#include <core/CMemoryUsage.h>
+
 #include <model/ImportExport.h>
 
 #include <map>
@@ -112,6 +114,12 @@ public:
 
     //! Set the cached reverse search
     void cacheReverseSearch(const std::string& part1, const std::string& part2);
+
+    //! Debug the memory used by this category.
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+
+    //! Get the memory used by this category.
+    std::size_t memoryUsage() const;
 
 private:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);

--- a/include/model/CTokenListReverseSearchCreator.h
+++ b/include/model/CTokenListReverseSearchCreator.h
@@ -34,51 +34,57 @@ public:
     //! What's the maximum cost of tokens we can include in the reverse
     //! search?  This cost is loosely based on the maximum length of an
     //! Internet Explorer URL.
-    virtual size_t availableCost() const;
+    size_t availableCost() const override;
 
     //! What would be the cost of adding the specified token occurring the
     //! specified number of times to the reverse search?
-    virtual size_t costOfToken(const std::string& token, size_t numOccurrences) const;
+    size_t costOfToken(const std::string& token, size_t numOccurrences) const override;
 
     //! Create a reverse search for a NULL field value.
-    virtual bool createNullSearch(std::string& part1, std::string& part2) const;
+    bool createNullSearch(std::string& part1, std::string& part2) const override;
 
     //! If possible, create a reverse search for the case where there are no
     //! unique tokens identifying the type.  (If this is not possible return
     //! false.)
-    virtual bool createNoUniqueTokenSearch(int type,
-                                           const std::string& example,
-                                           size_t maxMatchingStringLen,
-                                           std::string& part1,
-                                           std::string& part2) const;
+    bool createNoUniqueTokenSearch(int type,
+                                   const std::string& example,
+                                   size_t maxMatchingStringLen,
+                                   std::string& part1,
+                                   std::string& part2) const override;
 
     //! Initialise the two strings that form a reverse search.  For example,
     //! this could be as simple as clearing the strings or setting them to
     //! some sort of one-off preamble.
-    virtual void initStandardSearch(int type,
-                                    const std::string& example,
-                                    size_t maxMatchingStringLen,
-                                    std::string& part1,
-                                    std::string& part2) const;
+    void initStandardSearch(int type,
+                            const std::string& example,
+                            size_t maxMatchingStringLen,
+                            std::string& part1,
+                            std::string& part2) const override;
 
     //! Modify the two strings that form a reverse search to account for the
     //! specified token, which may occur anywhere within the original
     //! message, but has been determined to be a good thing to distinguish
     //! this type of messages from other types.
-    virtual void addCommonUniqueToken(const std::string& token,
-                                      std::string& part1,
-                                      std::string& part2) const;
+    void addCommonUniqueToken(const std::string& token,
+                              std::string& part1,
+                              std::string& part2) const override;
 
     //! Modify the two strings that form a reverse search to account for the
     //! specified token.
-    virtual void addInOrderCommonToken(const std::string& token,
-                                       bool first,
-                                       std::string& part1,
-                                       std::string& part2) const;
+    void addInOrderCommonToken(const std::string& token,
+                               bool first,
+                               std::string& part1,
+                               std::string& part2) const override;
 
     //! Close off the two strings that form a reverse search.  For example,
     //! this may be when closing brackets need to be appended.
-    virtual void closeStandardSearch(std::string& part1, std::string& part2) const;
+    void closeStandardSearch(std::string& part1, std::string& part2) const override;
+
+    //! Debug the memory used by this reverse search creator.
+    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+
+    //! Get the memory used by this reverse search creator.
+    std::size_t memoryUsage() const override;
 };
 }
 }

--- a/include/model/CTokenListReverseSearchCreatorIntf.h
+++ b/include/model/CTokenListReverseSearchCreatorIntf.h
@@ -6,6 +6,8 @@
 #ifndef INCLUDED_ml_model_CTokenListReverseSearchCreatorIntf_h
 #define INCLUDED_ml_model_CTokenListReverseSearchCreatorIntf_h
 
+#include <core/CMemoryUsage.h>
+
 #include <model/ImportExport.h>
 
 #include <string>
@@ -90,6 +92,12 @@ public:
 
     //! Access to the field name
     const std::string& fieldName() const;
+
+    //! Debug the memory used by this reverse search creator.
+    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+
+    //! Get the memory used by this reverse search creator.
+    virtual std::size_t memoryUsage() const;
 
 private:
     //! Which field name is being used for categorisation?

--- a/lib/core/CCsvLineParser.cc
+++ b/lib/core/CCsvLineParser.cc
@@ -6,6 +6,7 @@
 #include <core/CCsvLineParser.h>
 
 #include <core/CLogger.h>
+#include <core/CMemory.h>
 #include <core/CoreTypes.h>
 
 namespace ml {
@@ -122,6 +123,17 @@ bool CCsvLineParser::parseNextToken(const char* end, const char*& current) {
     }
 
     return true;
+}
+
+void CCsvLineParser::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CStringSimilarityTester");
+    mem->addItem("m_WorkField", m_WorkFieldCapacity);
+}
+
+std::size_t CCsvLineParser::memoryUsage() const {
+    std::size_t mem = 0;
+    mem += m_WorkFieldCapacity;
+    return mem;
 }
 }
 }

--- a/lib/core/CCsvLineParser.cc
+++ b/lib/core/CCsvLineParser.cc
@@ -126,7 +126,7 @@ bool CCsvLineParser::parseNextToken(const char* end, const char*& current) {
 }
 
 void CCsvLineParser::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
-    mem->setName("CStringSimilarityTester");
+    mem->setName("CCsvLineParser");
     mem->addItem("m_WorkField", m_WorkFieldCapacity);
 }
 

--- a/lib/core/CStringSimilarityTester.cc
+++ b/lib/core/CStringSimilarityTester.cc
@@ -5,6 +5,8 @@
  */
 #include <core/CStringSimilarityTester.h>
 
+#include <core/CMemory.h>
+
 #include <limits>
 
 namespace ml {
@@ -130,6 +132,17 @@ int** CStringSimilarityTester::setupBerghelRoachMatrix(int maxDist,
     }
 
     return matrix;
+}
+
+void CStringSimilarityTester::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CStringSimilarityTester");
+    core::CMemoryDebug::dynamicSize("m_Compressor", m_Compressor, mem);
+}
+
+std::size_t CStringSimilarityTester::memoryUsage() const {
+    std::size_t mem = 0;
+    mem += core::CMemory::dynamicSize(m_Compressor);
+    return mem;
 }
 }
 }

--- a/lib/core/CompressUtils.cc
+++ b/lib/core/CompressUtils.cc
@@ -10,6 +10,24 @@
 
 #include <string.h>
 
+namespace {
+// The value of 5952 was found using this program compiled in the zlib 1.2.11
+// source directory:
+//
+// #include "deflate.h"
+// #include <iostream>
+// int main(int, char**) {
+//     std::cout << sizeof(internal_state) << '\n';
+//     return 0;
+// }
+//
+// There is no way to find this number dynamically in the ML code, as it is a
+// hidden implementation detail protected by an opaque pointer.  The size may
+// vary between zlib versions, but probably not by enough to be worth worrying
+// about.
+const std::size_t ZLIB_INTERNAL_STATE_SIZE{5952};
+}
+
 namespace ml {
 namespace core {
 
@@ -122,7 +140,7 @@ void CCompressUtil::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) co
     mem->setName("CCompressUtil");
     core::CMemoryDebug::dynamicSize("m_FullResult", m_FullResult, mem);
     if (m_ZlibStrm.state != nullptr) {
-        mem->addItem("m_ZlibStrm", 5952); // See below for where 5952 came from
+        mem->addItem("m_ZlibStrm", ZLIB_INTERNAL_STATE_SIZE);
     }
 }
 
@@ -130,21 +148,7 @@ std::size_t CCompressUtil::memoryUsage() const {
     std::size_t mem = 0;
     mem += core::CMemory::dynamicSize(m_FullResult);
     if (m_ZlibStrm.state != nullptr) {
-        // The value of 5952 was found using this program compiled in the zlib
-        // 1.2.11 source directory:
-        //
-        // #include "deflate.h"
-        // #include <iostream>
-        // int main(int, char**) {
-        //     std::cout << sizeof(internal_state) << '\n';
-        //     return 0;
-        // }
-        //
-        // There is no way to find this number dynamically in the ML code, as
-        // it is a hidden implementation detail protected by an opaque pointer.
-        // The size may vary between zlib versions, but probably not by enough
-        // to be worth worrying about.
-        mem += 5952;
+        mem += ZLIB_INTERNAL_STATE_SIZE;
     }
     return mem;
 }

--- a/lib/model/CBaseTokenListDataCategorizer.cc
+++ b/lib/model/CBaseTokenListDataCategorizer.cc
@@ -6,6 +6,7 @@
 #include <model/CBaseTokenListDataCategorizer.h>
 
 #include <core/CLogger.h>
+#include <core/CMemory.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
@@ -508,12 +509,49 @@ bool CBaseTokenListDataCategorizer::addPretokenisedTokens(const std::string& tok
     return true;
 }
 
+void CBaseTokenListDataCategorizer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CBaseTokenListDataCategorizer");
+    this->CDataCategorizer::debugMemoryUsage(mem->addChild());
+    core::CMemoryDebug::dynamicSize("m_ReverseSearchCreator", m_ReverseSearchCreator, mem);
+    core::CMemoryDebug::dynamicSize("m_Categories", m_Categories, mem);
+    core::CMemoryDebug::dynamicSize("m_CategoriesByCount", m_CategoriesByCount, mem);
+    core::CMemoryDebug::dynamicSize("m_TokenIdLookup", m_TokenIdLookup, mem);
+    core::CMemoryDebug::dynamicSize("m_WorkTokenIds", m_WorkTokenIds, mem);
+    core::CMemoryDebug::dynamicSize("m_WorkTokenUniqueIds", m_WorkTokenUniqueIds, mem);
+    core::CMemoryDebug::dynamicSize("m_CsvLineParser", m_CsvLineParser, mem);
+}
+
+std::size_t CBaseTokenListDataCategorizer::memoryUsage() const {
+    std::size_t mem = 0;
+    mem += this->CDataCategorizer::memoryUsage();
+    mem += core::CMemory::dynamicSize(m_ReverseSearchCreator);
+    mem += core::CMemory::dynamicSize(m_Categories);
+    mem += core::CMemory::dynamicSize(m_CategoriesByCount);
+    mem += core::CMemory::dynamicSize(m_TokenIdLookup);
+    mem += core::CMemory::dynamicSize(m_WorkTokenIds);
+    mem += core::CMemory::dynamicSize(m_WorkTokenUniqueIds);
+    mem += core::CMemory::dynamicSize(m_CsvLineParser);
+    return mem;
+}
+
 CBaseTokenListDataCategorizer::CTokenInfoItem::CTokenInfoItem(const std::string& str, size_t index)
     : m_Str(str), m_Index(index), m_CategoryCount(0) {
 }
 
 const std::string& CBaseTokenListDataCategorizer::CTokenInfoItem::str() const {
     return m_Str;
+}
+
+void CBaseTokenListDataCategorizer::CTokenInfoItem::debugMemoryUsage(
+    core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CTokenInfoItem");
+    core::CMemoryDebug::dynamicSize("m_Str", m_Str, mem);
+}
+
+std::size_t CBaseTokenListDataCategorizer::CTokenInfoItem::memoryUsage() const {
+    std::size_t mem = 0;
+    mem += core::CMemory::dynamicSize(m_Str);
+    return mem;
 }
 
 size_t CBaseTokenListDataCategorizer::CTokenInfoItem::index() const {

--- a/lib/model/CDataCategorizer.cc
+++ b/lib/model/CDataCategorizer.cc
@@ -5,6 +5,8 @@
  */
 #include <model/CDataCategorizer.h>
 
+#include <core/CMemory.h>
+
 namespace ml {
 namespace model {
 
@@ -32,6 +34,17 @@ core_t::TTime CDataCategorizer::lastPersistTime() const {
 
 void CDataCategorizer::lastPersistTime(core_t::TTime lastPersistTime) {
     m_LastPersistTime = lastPersistTime;
+}
+
+void CDataCategorizer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CDataCategorizer");
+    core::CMemoryDebug::dynamicSize("m_FieldName", m_FieldName, mem);
+}
+
+std::size_t CDataCategorizer::memoryUsage() const {
+    std::size_t mem = 0;
+    mem += core::CMemory::dynamicSize(m_FieldName);
+    return mem;
 }
 }
 }

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -6,6 +6,7 @@
 #include <model/CTokenListCategory.h>
 
 #include <core/CLogger.h>
+#include <core/CMemory.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
@@ -397,6 +398,25 @@ void CTokenListCategory::cacheReverseSearch(const std::string& part1,
                                             const std::string& part2) {
     m_ReverseSearchPart1 = part1;
     m_ReverseSearchPart2 = part2;
+}
+
+void CTokenListCategory::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CTokenListCategory");
+    core::CMemoryDebug::dynamicSize("m_BaseString", m_BaseString, mem);
+    core::CMemoryDebug::dynamicSize("m_BaseTokenIds", m_BaseTokenIds, mem);
+    core::CMemoryDebug::dynamicSize("m_CommonUniqueTokenIds", m_CommonUniqueTokenIds, mem);
+    core::CMemoryDebug::dynamicSize("m_ReverseSearchPart1", m_ReverseSearchPart1, mem);
+    core::CMemoryDebug::dynamicSize("m_ReverseSearchPart2", m_ReverseSearchPart2, mem);
+}
+
+std::size_t CTokenListCategory::memoryUsage() const {
+    std::size_t mem = 0;
+    mem += core::CMemory::dynamicSize(m_BaseString);
+    mem += core::CMemory::dynamicSize(m_BaseTokenIds);
+    mem += core::CMemory::dynamicSize(m_CommonUniqueTokenIds);
+    mem += core::CMemory::dynamicSize(m_ReverseSearchPart1);
+    mem += core::CMemory::dynamicSize(m_ReverseSearchPart2);
+    return mem;
 }
 }
 }

--- a/lib/model/CTokenListReverseSearchCreator.cc
+++ b/lib/model/CTokenListReverseSearchCreator.cc
@@ -79,5 +79,14 @@ void CTokenListReverseSearchCreator::closeStandardSearch(std::string& /*part1*/,
                                                          std::string& part2) const {
     part2 += ".*";
 }
+
+void CTokenListReverseSearchCreator::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CTokenListReverseSearchCreator");
+    this->CTokenListReverseSearchCreatorIntf::debugMemoryUsage(mem->addChild());
+}
+
+std::size_t CTokenListReverseSearchCreator::memoryUsage() const {
+    return this->CTokenListReverseSearchCreatorIntf::memoryUsage();
+}
 }
 }

--- a/lib/model/CTokenListReverseSearchCreatorIntf.cc
+++ b/lib/model/CTokenListReverseSearchCreatorIntf.cc
@@ -5,6 +5,8 @@
  */
 #include <model/CTokenListReverseSearchCreatorIntf.h>
 
+#include <core/CMemory.h>
+
 namespace ml {
 namespace model {
 
@@ -22,6 +24,17 @@ void CTokenListReverseSearchCreatorIntf::closeStandardSearch(std::string& /*part
 
 const std::string& CTokenListReverseSearchCreatorIntf::fieldName() const {
     return m_FieldName;
+}
+
+void CTokenListReverseSearchCreatorIntf::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    mem->setName("CTokenListReverseSearchCreatorIntf");
+    core::CMemoryDebug::dynamicSize("m_FieldName", m_FieldName, mem);
+}
+
+std::size_t CTokenListReverseSearchCreatorIntf::memoryUsage() const {
+    std::size_t mem = 0;
+    mem += core::CMemory::dynamicSize(m_FieldName);
+    return mem;
 }
 }
 }

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -41,15 +41,13 @@ void checkMemoryUsageInstrumentation(const TTokenListDataCategorizerKeepsFields&
     ml::core::CMemoryUsage::TMemoryUsagePtr mem{new ml::core::CMemoryUsage};
     categorizer.debugMemoryUsage(mem);
 
-    LOG_DEBUG(<< "Memory usage = " << memoryUsage);
-    BOOST_REQUIRE_EQUAL(memoryUsage, mem->usage());
-
     std::ostringstream strm;
     mem->compress();
     mem->print(strm);
     LOG_DEBUG(<< "Debug memory report = " << strm.str());
+    BOOST_REQUIRE_EQUAL(memoryUsage, mem->usage());
 
-    LOG_DEBUG(<< "Dynamic size = " << ml::core::CMemory::dynamicSize(categorizer));
+    LOG_TRACE(<< "Dynamic size = " << ml::core::CMemory::dynamicSize(&categorizer));
     BOOST_REQUIRE_EQUAL(memoryUsage + sizeof(TTokenListDataCategorizerKeepsFields),
                         ml::core::CMemory::dynamicSize(&categorizer));
 }


### PR DESCRIPTION
This is a step towards adding memory instrumentation to
categorization.  On its own this PR has no externally
visible effect, but by splitting out these boilerplate
changes the PR that eventually adds memory instrumentation
to categorization will be smaller.