### PR TITLE
[ML] Assorted runtime optimisations for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ tree which is trained for both regression and classification. (See {ml-pull}811[
 * Emit `prediction_probability` field alongside prediction field in ml results.
 (See {ml-pull}818[#818].)
 * Reduce memory usage of {ml} native processes on Windows. (See {ml-pull}844[#844].)
+* Reduce runtime of classification and regression. (See {ml-pull}863[#863].)
 
 === Bug Fixes
 * Fixes potential memory corruption when determining seasonality. (See {ml-pull}852[#852].)

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -8,6 +8,7 @@
 #define INCLUDED_ml_core_CDataFrame_h
 
 #include <core/CFloatStorage.h>
+#include <core/CPackedBitVector.h>
 #include <core/CVectorRange.h>
 #include <core/Concurrency.h>
 #include <core/ImportExport.h>
@@ -26,7 +27,6 @@ namespace ml {
 namespace core {
 class CDataFrameRowSlice;
 class CDataFrameRowSliceHandle;
-class CPackedBitVector;
 class CTemporaryDirectory;
 
 namespace data_frame_detail {
@@ -35,7 +35,29 @@ using TFloatVec = std::vector<CFloatStorage>;
 using TFloatVecItr = TFloatVec::iterator;
 using TInt32Vec = std::vector<std::int32_t>;
 using TInt32VecCItr = TInt32Vec::const_iterator;
-using TPopMaskedRowFunc = std::function<std::size_t()>;
+
+//! \brief A callback used to iterate over only the masked rows.
+class CORE_EXPORT CPopMaskedRow {
+public:
+    CPopMaskedRow(std::size_t endSliceRows,
+                  CPackedBitVector::COneBitIndexConstIterator& maskedRow,
+                  const CPackedBitVector::COneBitIndexConstIterator& endMaskedRows)
+        : m_EndSliceRows{endSliceRows}, m_MaskedRow{&maskedRow}, m_EndMaskedRows{&endMaskedRows} {
+    }
+
+    std::size_t operator()() const {
+        return ++(*m_MaskedRow) == *m_EndMaskedRows
+                   ? m_EndSliceRows
+                   : std::min(**m_MaskedRow, m_EndSliceRows);
+    }
+
+private:
+    std::size_t m_EndSliceRows;
+    CPackedBitVector::COneBitIndexConstIterator* m_MaskedRow;
+    const CPackedBitVector::COneBitIndexConstIterator* m_EndMaskedRows;
+};
+
+using TOptionalPopMaskedRow = boost::optional<CPopMaskedRow>;
 
 //! \brief A lightweight wrapper around a single row of the data frame.
 //!
@@ -123,7 +145,7 @@ public:
                  std::size_t index,
                  TFloatVecItr rowItr,
                  TInt32VecCItr docHashItr,
-                 TPopMaskedRowFunc popMaskedRow = nullptr);
+                 const TOptionalPopMaskedRow& popMaskedRow);
 
     //! \name Forward Iterator Contract
     //@{
@@ -141,7 +163,7 @@ private:
     std::size_t m_Index = 0;
     TFloatVecItr m_RowItr;
     TInt32VecCItr m_DocHashItr;
-    TPopMaskedRowFunc m_PopMaskedRow;
+    TOptionalPopMaskedRow m_PopMaskedRow;
 };
 }
 
@@ -469,7 +491,7 @@ private:
     using TStrSizeUMapVec = std::vector<TStrSizeUMap>;
     using TSizeSizePr = std::pair<std::size_t, std::size_t>;
     using TSizeDataFrameRowSlicePtrVecPr = std::pair<std::size_t, TRowSlicePtrVec>;
-    using TPopMaskedRowFunc = data_frame_detail::TPopMaskedRowFunc;
+    using TOptionalPopMaskedRow = data_frame_detail::TOptionalPopMaskedRow;
 
     //! \brief Writes rows to the data frame.
     class CDataFrameRowSliceWriter final {
@@ -504,19 +526,19 @@ private:
     TRowFuncVecBoolPr parallelApplyToAllRows(std::size_t numberThreads,
                                              std::size_t beginRows,
                                              std::size_t endRows,
-                                             TRowFunc func,
+                                             TRowFunc& func,
                                              const CPackedBitVector* rowMask,
                                              bool commitResult) const;
     TRowFuncVecBoolPr sequentialApplyToAllRows(std::size_t beginRows,
                                                std::size_t endRows,
-                                               TRowFunc func,
+                                               TRowFunc& func,
                                                const CPackedBitVector* rowMask,
                                                bool commitResult) const;
 
     void applyToRowsOfOneSlice(TRowFunc& func,
                                std::size_t firstRowToRead,
                                std::size_t endRowsToRead,
-                               TPopMaskedRowFunc popMaskedRow,
+                               const TOptionalPopMaskedRow& popMaskedRow,
                                const CDataFrameRowSliceHandle& slice) const;
 
     TRowSlicePtrVecCItr beginSlices(std::size_t beginRows) const;

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -526,7 +526,7 @@ private:
     TRowFuncVecBoolPr parallelApplyToAllRows(std::size_t numberThreads,
                                              std::size_t beginRows,
                                              std::size_t endRows,
-                                             TRowFunc& func,
+                                             TRowFunc&& func,
                                              const CPackedBitVector* rowMask,
                                              bool commitResult) const;
     TRowFuncVecBoolPr sequentialApplyToAllRows(std::size_t beginRows,

--- a/include/core/CFloatStorage.h
+++ b/include/core/CFloatStorage.h
@@ -83,6 +83,46 @@ public:
     //! Implicit construction from a double.
     CFloatStorage(double value) : m_Value() { this->set(value); }
 
+    //! \name Operators
+    //@{
+    bool operator==(const CFloatStorage& rhs) const {
+        return m_Value == rhs.m_Value;
+    }
+    bool operator==(const double& rhs) const {
+        return static_cast<double>(m_Value) == rhs;
+    }
+    bool operator!=(const CFloatStorage& rhs) const {
+        return m_Value != rhs.m_Value;
+    }
+    bool operator!=(const double& rhs) const {
+        return static_cast<double>(m_Value) != rhs;
+    }
+    bool operator<(const CFloatStorage& rhs) const {
+        return m_Value < rhs.m_Value;
+    }
+    bool operator<(const double& rhs) const {
+        return static_cast<double>(m_Value) < rhs;
+    }
+    bool operator<=(const CFloatStorage& rhs) const {
+        return m_Value <= rhs.m_Value;
+    }
+    bool operator<=(const double& rhs) const {
+        return static_cast<double>(m_Value) <= rhs;
+    }
+    bool operator>(const CFloatStorage& rhs) const {
+        return m_Value > rhs.m_Value;
+    }
+    bool operator>(const double& rhs) const {
+        return static_cast<double>(m_Value) > rhs;
+    }
+    bool operator>=(const CFloatStorage& rhs) const {
+        return m_Value >= rhs.m_Value;
+    }
+    bool operator>=(const double& rhs) const {
+        return static_cast<double>(m_Value) >= rhs;
+    }
+    //@}
+
     //! Set from a string.
     bool fromString(const std::string& string) {
         double value;

--- a/include/core/CImmutableRadixSet.h
+++ b/include/core/CImmutableRadixSet.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_core_CImmutableRadixSet_h
+#define INCLUDED_ml_core_CImmutableRadixSet_h
+
+#include <core/CContainerPrinter.h>
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+namespace ml {
+namespace core {
+
+//! \brief An immutable sorted set which provides very fast lookup.
+//!
+//! DESCRIPTION:\n
+//! This supports lower bound and look up by index as well as a subset of the non
+//! modifying interface of std::set. Its main purpose is to provide much faster
+//! lookup. To this end it subdivides the range of sorted values into buckets.
+//! In the case that the values are uniformly distributed lowerBound will be O(1)
+//! with low constant. Otherwise, it is worst case O(log(n)).
+template<typename T>
+class CImmutableRadixSet {
+public:
+    using TVec = std::vector<T>;
+    using TCItr = typename std::vector<T>::const_iterator;
+
+public:
+    // We only need to support floating point types at present (although it
+    // could easily extended to support any numeric type).
+    static_assert(std::is_floating_point<T>::value, "Only supports floating point types");
+
+public:
+    CImmutableRadixSet() = default;
+    explicit CImmutableRadixSet(std::initializer_list<T> values)
+        : m_Values{std::move(values)} {
+        this->initialize();
+    }
+    explicit CImmutableRadixSet(TVec values) : m_Values{std::move(values)} {
+        this->initialize();
+    }
+
+    // This is movable only because we hold iterators to the underlying container.
+    CImmutableRadixSet(const CImmutableRadixSet&) = delete;
+    CImmutableRadixSet& operator=(const CImmutableRadixSet&) = delete;
+    CImmutableRadixSet(CImmutableRadixSet&&) = default;
+    CImmutableRadixSet& operator=(CImmutableRadixSet&&) = default;
+
+    //! \name Capacity
+    //@{
+    bool empty() const { return m_Values.size(); }
+    std::size_t size() const { return m_Values.size(); }
+    //@}
+
+    //! \name Iterators
+    //@{
+    TCItr begin() const { m_Values.begin(); }
+    TCItr end() const { m_Values.end(); }
+    //@}
+
+    //! \name Lookup
+    //@{
+    const T& operator[](std::size_t i) const { return m_Values[i]; }
+    std::ptrdiff_t upperBound(const T& value) const {
+        // This branch is predictable so essentially free.
+        if (m_Values.size() < 2) {
+            return std::distance(m_Values.begin(),
+                                 std::upper_bound(m_Values.begin(), m_Values.end(), value));
+        }
+
+        std::ptrdiff_t bucket{static_cast<std::ptrdiff_t>(m_Scale * (value - m_Min))};
+        if (bucket < 0) {
+            return 0;
+        }
+        if (bucket >= static_cast<std::ptrdiff_t>(m_Buckets.size())) {
+            return static_cast<std::ptrdiff_t>(m_Values.size());
+        }
+        TCItr beginBucket;
+        TCItr endBucket;
+        std::tie(beginBucket, endBucket) = m_Buckets[bucket];
+        return std::distance(m_Values.begin(),
+                             std::upper_bound(beginBucket, endBucket, value));
+    }
+    //@}
+
+    std::string print() const {
+        return core::CContainerPrinter::print(m_Values);
+    }
+
+private:
+    using TCItrCItrPr = std::pair<TCItr, TCItr>;
+    using TCItrCItrPrVec = std::vector<TCItrCItrPr>;
+    using TPtrdiffVec = std::vector<std::ptrdiff_t>;
+
+private:
+    void initialize() {
+        std::sort(m_Values.begin(), m_Values.end());
+        m_Values.erase(std::unique(m_Values.begin(), m_Values.end()), m_Values.end());
+        if (m_Values.size() > 1) {
+            std::size_t numberBuckets{m_Values.size()};
+            m_Min = m_Values[0];
+            m_Scale = static_cast<T>(numberBuckets) / (m_Values.back() - m_Min);
+            m_Buckets.reserve(numberBuckets);
+            T bucket{1};
+            T bucketClose{m_Min + bucket / m_Scale};
+            auto start = m_Values.begin();
+            for (auto i = m_Values.begin(); i != m_Values.end(); ++i) {
+                if (*i > bucketClose) {
+                    m_Buckets.emplace_back(start, i);
+                    bucket += T{1};
+                    bucketClose = m_Min + bucket / m_Scale;
+                    start = i;
+                    while (*i > bucketClose) {
+                        m_Buckets.emplace_back(start, i + 1);
+                        bucket += T{1};
+                        bucketClose = m_Min + bucket / m_Scale;
+                    }
+                }
+            }
+            if (m_Buckets.size() < numberBuckets) {
+                m_Buckets.emplace_back(start, m_Values.end());
+            }
+        }
+    }
+
+private:
+    T m_Min = T{0};
+    T m_Scale = T{0};
+    TCItrCItrPrVec m_Buckets;
+    TVec m_Values;
+};
+}
+}
+
+#endif // INCLUDED_ml_core_CImmutableRadixSet_h

--- a/include/maths/CBoostedTreeHyperparameters.h
+++ b/include/maths/CBoostedTreeHyperparameters.h
@@ -108,7 +108,7 @@ public:
                                      m_SoftTreeDepthLimit, inserter);
         core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
                                      m_SoftTreeDepthTolerance, inserter);
-    };
+    }
 
     //! Populate the object from serialized data.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
@@ -131,7 +131,7 @@ public:
                                                  m_SoftTreeDepthTolerance, traverser))
         } while (traverser.next());
         return true;
-    };
+    }
 
 public:
     static const std::string REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -9,6 +9,7 @@
 
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
+#include <core/CImmutableRadixSet.h>
 #include <core/CLogger.h>
 #include <core/CMemory.h>
 #include <core/CPackedBitVector.h>
@@ -36,6 +37,10 @@
 #include <vector>
 
 namespace ml {
+namespace core {
+template<typename>
+class CImmutableRadixSet;
+}
 namespace maths {
 class CBayesianOptimisation;
 
@@ -129,9 +134,8 @@ public:
 private:
     using TSizeDoublePr = std::pair<std::size_t, double>;
     using TDoubleDoublePr = std::pair<double, double>;
-    using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
     using TOptionalSize = boost::optional<std::size_t>;
-    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TImmutableRadixSetVec = std::vector<core::CImmutableRadixSet<double>>;
     using TSizeVec = std::vector<std::size_t>;
     using TVector = CDenseVector<double>;
     using TRowItr = core::CDataFrame::TRowItr;
@@ -154,7 +158,7 @@ private:
                             const core::CDataFrame& frame,
                             const CDataFrameCategoryEncoder& encoder,
                             const TRegularization& regularization,
-                            const TDoubleVecVec& candidateSplits,
+                            const TImmutableRadixSetVec& candidateSplits,
                             const TSizeVec& featureBag,
                             std::size_t depth,
                             const core::CPackedBitVector& rowMask);
@@ -165,7 +169,7 @@ private:
                             const core::CDataFrame& frame,
                             const CDataFrameCategoryEncoder& encoder,
                             const TRegularization& regularization,
-                            const TDoubleVecVec& candidateSplits,
+                            const TImmutableRadixSetVec& candidateSplits,
                             const TSizeVec& featureBag,
                             bool isLeftChild,
                             std::size_t depth,
@@ -196,7 +200,7 @@ private:
                    const core::CDataFrame& frame,
                    const CDataFrameCategoryEncoder& encoder,
                    const TRegularization& regularization,
-                   const TDoubleVecVec& candidateSplits,
+                   const TImmutableRadixSetVec& candidateSplits,
                    const TSizeVec& featureBag,
                    const CBoostedTreeNode& split,
                    bool leftChildHasFewerRows);
@@ -322,7 +326,7 @@ private:
 
         //! \brief A collection of aggregate derivatives for candidate feature splits.
         struct SSplitAggregateDerivatives {
-            SSplitAggregateDerivatives(const TDoubleVecVec& candidateSplits)
+            SSplitAggregateDerivatives(const TImmutableRadixSetVec& candidateSplits)
                 : s_Derivatives(candidateSplits.size()),
                   s_MissingDerivatives(candidateSplits.size()) {
                 for (std::size_t i = 0; i < candidateSplits.size(); ++i) {
@@ -367,7 +371,7 @@ private:
 
     private:
         std::size_t m_Id;
-        const TDoubleVecVec& m_CandidateSplits;
+        const TImmutableRadixSetVec& m_CandidateSplits;
         std::size_t m_Depth;
         core::CPackedBitVector m_RowMask;
         TAggregateDerivativesVecVec m_Derivatives;
@@ -413,13 +417,13 @@ private:
     core::CPackedBitVector downsample(const core::CPackedBitVector& trainingRowMask) const;
 
     //! Get the candidate splits values for each feature.
-    TDoubleVecVec candidateSplits(const core::CDataFrame& frame,
-                                  const core::CPackedBitVector& trainingRowMask) const;
+    TImmutableRadixSetVec candidateSplits(const core::CDataFrame& frame,
+                                          const core::CPackedBitVector& trainingRowMask) const;
 
     //! Train one tree on the rows of \p frame in the mask \p trainingRowMask.
     TNodeVec trainTree(core::CDataFrame& frame,
                        const core::CPackedBitVector& trainingRowMask,
-                       const TDoubleVecVec& candidateSplits,
+                       const TImmutableRadixSetVec& candidateSplits,
                        const std::size_t maximumTreeSize,
                        const TMemoryUsageCallback& recordMemoryUsage) const;
 

--- a/include/maths/CBoundingBox.h
+++ b/include/maths/CBoundingBox.h
@@ -31,6 +31,7 @@ public:
     static bool dynamicSizeAlwaysZero() {
         return core::memory_detail::SDynamicSizeAlwaysZero<POINT>::value();
     }
+    using TCoordinate = typename SCoordinate<POINT>::Type;
     using TPointPrecise = typename SFloatingPoint<POINT, double>::Type;
 
 public:
@@ -90,7 +91,7 @@ public:
         POINT xy = y - x;
         POINT f(m_B);
         for (std::size_t i = 0u; i < las::dimension(x); ++i) {
-            if (xy(i) < 0) {
+            if (xy(i) < TCoordinate{0}) {
                 f(i) = m_A(i);
             }
         }

--- a/include/maths/CKdTree.h
+++ b/include/maths/CKdTree.h
@@ -401,7 +401,7 @@ private:
         if (primary != nullptr && secondary != nullptr) {
             TCoordinate distanceToHyperplane{point(coordinate) - node.s_Point(coordinate)};
 
-            if (distanceToHyperplane > 0) {
+            if (distanceToHyperplane > TCoordinate{0}) {
                 std::swap(primary, secondary);
             } else {
                 distanceToHyperplane = std::fabs(distanceToHyperplane);
@@ -454,7 +454,7 @@ private:
         if (primary != nullptr && secondary != nullptr) {
             TCoordinate distanceToHyperplane{point(coordinate) - node.s_Point(coordinate)};
 
-            if (distanceToHyperplane > 0) {
+            if (distanceToHyperplane > TCoordinate{0}) {
                 std::swap(primary, secondary);
             } else {
                 distanceToHyperplane = std::fabs(distanceToHyperplane);

--- a/include/maths/CQuantileSketch.h
+++ b/include/maths/CQuantileSketch.h
@@ -94,7 +94,7 @@ public:
     double count() const;
 
     //! Get a checksum of this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
     void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
@@ -152,7 +152,7 @@ public:
     //! NB1: Needs to be redeclared to work with CChecksum.
     //! NB2: This method is not currently virtual - needs changing if any of the
     //! methods of this class ever do anything other than forward to the base class
-    uint64_t checksum(uint64_t seed = 0) const {
+    std::uint64_t checksum(std::uint64_t seed = 0) const {
         return this->CQuantileSketch::checksum(seed);
     }
 

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -188,7 +188,7 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::readRows(std::size_t numberThreads,
 
     return numberThreads > 1
                ? this->parallelApplyToAllRows(numberThreads, beginRows, endRows,
-                                              reader, rowMask, false)
+                                              std::move(reader), rowMask, false)
                : this->sequentialApplyToAllRows(beginRows, endRows, reader, rowMask, false);
 }
 
@@ -207,7 +207,7 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::writeColumns(std::size_t numberThreads
 
     return numberThreads > 1
                ? this->parallelApplyToAllRows(numberThreads, beginRows, endRows,
-                                              writer, rowMask, true)
+                                              std::move(writer), rowMask, true)
                : this->sequentialApplyToAllRows(beginRows, endRows, writer, rowMask, true);
 }
 
@@ -408,7 +408,7 @@ CDataFrame::TRowFuncVecBoolPr
 CDataFrame::parallelApplyToAllRows(std::size_t numberThreads,
                                    std::size_t beginRows,
                                    std::size_t endRows,
-                                   TRowFunc& func,
+                                   TRowFunc&& func,
                                    const CPackedBitVector* rowMask,
                                    bool commitResult) const {
 

--- a/lib/core/unittest/CImmutableRadixSetTest.cc
+++ b/lib/core/unittest/CImmutableRadixSetTest.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CContainerPrinter.h>
+#include <core/CImmutableRadixSet.h>
+#include <core/CLogger.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+using namespace ml;
+
+BOOST_AUTO_TEST_SUITE(CImmutableRadixSetTest)
+
+using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
+
+BOOST_AUTO_TEST_CASE(construction) {
+
+    core::CImmutableRadixSet<double> test1{1.0, 3.0, 1.0, 6.0};
+    BOOST_REQUIRE_EQUAL(3, test1.size());
+    BOOST_REQUIRE_EQUAL(1.0, test1[0]);
+    BOOST_REQUIRE_EQUAL(3.0, test1[1]);
+    BOOST_REQUIRE_EQUAL(6.0, test1[2]);
+
+    core::CImmutableRadixSet<double> test2{3.4, 1.0, 1.0, 0.1, 1.0};
+    BOOST_REQUIRE_EQUAL(3, test2.size());
+    BOOST_REQUIRE_EQUAL(0.1, test2[0]);
+    BOOST_REQUIRE_EQUAL(1.0, test2[1]);
+    BOOST_REQUIRE_EQUAL(3.4, test2[2]);
+}
+
+BOOST_AUTO_TEST_CASE(testUpperBound) {
+
+    test::CRandomNumbers rng;
+
+    LOG_DEBUG(<< "Empty");
+    {
+        core::CImmutableRadixSet<double> empty;
+        BOOST_REQUIRE_EQUAL(0, empty.upperBound(0.0));
+    }
+    {
+        core::CImmutableRadixSet<double> unary{1.0};
+        BOOST_REQUIRE_EQUAL(0, unary.upperBound(0.0));
+        BOOST_REQUIRE_EQUAL(1, unary.upperBound(1.0));
+    }
+
+    for (std::size_t test = 0; test < 1000; ++test) {
+        TDoubleVec values;
+        rng.generateUniformSamples(5.0, 95.0, 50, values);
+        for (auto& value : values) {
+            value = std::floor(value);
+        }
+        std::sort(values.begin(), values.end());
+        values.erase(std::unique(values.begin(), values.end()), values.end());
+
+        core::CImmutableRadixSet<double> set{values};
+
+        TSizeVec probes;
+        rng.generateUniformSamples(0, 100, 500, probes);
+
+        for (auto probe : probes) {
+            BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) - values.begin(),
+                                set.upperBound(probe));
+        }
+    }
+
+    for (std::size_t test = 0; test < 1000; ++test) {
+        TDoubleVec values;
+        rng.generateUniformSamples(0.0, 10.0, 40, values);
+        std::sort(values.begin(), values.end());
+        values.erase(std::unique(values.begin(), values.end()), values.end());
+
+        core::CImmutableRadixSet<double> set{values};
+
+        TDoubleVec probes;
+        rng.generateNormalSamples(0.0, 20.0, 500, probes);
+
+        for (auto probe : probes) {
+            BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) - values.begin(),
+                                set.upperBound(probe));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/unittest/CImmutableRadixSetTest.cc
+++ b/lib/core/unittest/CImmutableRadixSetTest.cc
@@ -66,7 +66,8 @@ BOOST_AUTO_TEST_CASE(testUpperBound) {
         rng.generateUniformSamples(0, 100, 500, probes);
 
         for (auto probe : probes) {
-            BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) - values.begin(),
+            BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) -
+                                    values.begin(),
                                 set.upperBound(probe));
         }
     }
@@ -83,7 +84,8 @@ BOOST_AUTO_TEST_CASE(testUpperBound) {
         rng.generateNormalSamples(0.0, 20.0, 500, probes);
 
         for (auto probe : probes) {
-            BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) - values.begin(),
+            BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) -
+                                    values.begin(),
                                 set.upperBound(probe));
         }
     }

--- a/lib/core/unittest/Makefile
+++ b/lib/core/unittest/Makefile
@@ -42,6 +42,7 @@ CFlatPrefixTreeTest.cc \
 CFunctionalTest.cc \
 CHashingTest.cc \
 CIEEE754Test.cc \
+CImmutableRadixSetTest.cc \
 CJsonLogLayoutTest.cc \
 CJsonOutputStreamWrapperTest.cc \
 CJsonStatePersistInserterTest.cc \

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -6,6 +6,7 @@
 
 #include <maths/CBoostedTreeImpl.h>
 
+#include <core/CImmutableRadixSet.h>
 #include <core/CLoopProgress.h>
 #include <core/CPersistUtils.h>
 #include <core/CProgramCounters.h>
@@ -95,7 +96,7 @@ CBoostedTreeImpl::CLeafNodeStatistics::CLeafNodeStatistics(
     const core::CDataFrame& frame,
     const CDataFrameCategoryEncoder& encoder,
     const TRegularization& regularization,
-    const TDoubleVecVec& candidateSplits,
+    const TImmutableRadixSetVec& candidateSplits,
     const TSizeVec& featureBag,
     std::size_t depth,
     const core::CPackedBitVector& rowMask)
@@ -112,7 +113,7 @@ CBoostedTreeImpl::CLeafNodeStatistics::CLeafNodeStatistics(
     const core::CDataFrame& frame,
     const CDataFrameCategoryEncoder& encoder,
     const TRegularization& regularization,
-    const TDoubleVecVec& candidateSplits,
+    const TImmutableRadixSetVec& candidateSplits,
     const TSizeVec& featureBag,
     bool isLeftChild,
     std::size_t depth,
@@ -188,7 +189,7 @@ auto CBoostedTreeImpl::CLeafNodeStatistics::split(std::size_t leftChildId,
                                                   const core::CDataFrame& frame,
                                                   const CDataFrameCategoryEncoder& encoder,
                                                   const TRegularization& regularization,
-                                                  const TDoubleVecVec& candidateSplits,
+                                                  const TImmutableRadixSetVec& candidateSplits,
                                                   const TSizeVec& featureBag,
                                                   const CBoostedTreeNode& split,
                                                   bool leftChildHasFewerRows) {
@@ -310,10 +311,7 @@ void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(
         if (CDataFrameUtils::isMissing(featureValue)) {
             splitAggregateDerivatives.s_MissingDerivatives[i].add(1, gradient, curvature);
         } else {
-            const auto& featureCandidateSplits = m_CandidateSplits[i];
-            auto j = std::upper_bound(featureCandidateSplits.begin(),
-                                      featureCandidateSplits.end(), featureValue) -
-                     featureCandidateSplits.begin();
+            std::ptrdiff_t j{m_CandidateSplits[i].upperBound(featureValue)};
             splitAggregateDerivatives.s_Derivatives[i][j].add(1, gradient, curvature);
         }
     }
@@ -675,7 +673,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
         forest.size() + static_cast<std::size_t>(std::max(0.5 / eta, 1.0))};
 
     auto downsampledRowMask = this->downsample(trainingRowMask);
-    TDoubleVecVec candidateSplits(this->candidateSplits(frame, downsampledRowMask));
+    auto candidateSplits = this->candidateSplits(frame, downsampledRowMask);
     scopeMemoryUsage.add(candidateSplits);
 
     std::size_t retries{0};
@@ -742,7 +740,7 @@ CBoostedTreeImpl::downsample(const core::CPackedBitVector& trainingRowMask) cons
     return result;
 }
 
-CBoostedTreeImpl::TDoubleVecVec
+CBoostedTreeImpl::TImmutableRadixSetVec
 CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
                                   const core::CPackedBitVector& trainingRowMask) const {
 
@@ -768,12 +766,11 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
             m_Encoder.get(), readLossCurvature)
             .first;
 
-    TDoubleVecVec candidateSplits(this->numberFeatures());
+    TImmutableRadixSetVec candidateSplits(this->numberFeatures());
 
     for (auto i : binaryFeatures) {
-        candidateSplits[i] = TDoubleVec{0.5};
-        LOG_TRACE(<< "feature '" << i << "' splits = "
-                  << core::CContainerPrinter::print(candidateSplits[i]));
+        candidateSplits[i] = core::CImmutableRadixSet<double>{0.5};
+        LOG_TRACE(<< "feature '" << i << "' splits = " << candidateSplits[i].print());
     }
     for (std::size_t i = 0; i < features.size(); ++i) {
 
@@ -810,13 +807,12 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
                                                       split > dataType.s_Max;
                                            }),
                             featureSplits.end());
-        candidateSplits[features[i]] = std::move(featureSplits);
+        candidateSplits[features[i]] =
+            core::CImmutableRadixSet<double>{std::move(featureSplits)};
 
-        LOG_TRACE(<< "feature '" << features[i] << "' splits = "
-                  << core::CContainerPrinter::print(candidateSplits[features[i]]));
+        LOG_TRACE(<< "feature '" << features[i]
+                  << "' splits = " << candidateSplits[features[i]].print());
     }
-
-    LOG_TRACE(<< "candidate splits = " << core::CContainerPrinter::print(candidateSplits));
 
     return candidateSplits;
 }
@@ -824,7 +820,7 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
 CBoostedTreeImpl::TNodeVec
 CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
-                            const TDoubleVecVec& candidateSplits,
+                            const TImmutableRadixSetVec& candidateSplits,
                             const std::size_t maximumTreeSize,
                             const TMemoryUsageCallback& recordMemoryUsage) const {
 

--- a/lib/maths/CSignal.cc
+++ b/lib/maths/CSignal.cc
@@ -183,7 +183,7 @@ void CSignal::autocorrelations(const TFloatMeanAccumulatorVec& values, TDoubleVe
     TComplexVec f(n, TComplex{0.0, 0.0});
     for (std::size_t i = 0; i < n; ++i) {
         std::size_t j = i;
-        while (j < n && CBasicStatistics::count(values[j]) == 0) {
+        while (j < n && CBasicStatistics::count(values[j]) == 0.0) {
             ++j;
         }
         if (i < j) {

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1728,7 +1728,7 @@ void CTimeSeriesDecompositionDetail::CComponents::adjustValuesForPiecewiseConsta
         std::size_t a{segmentation[i - 1]};
         std::size_t b{segmentation[i]};
         for (std::size_t k = a; k < b && j > 0; --j, ++k) {
-            if (CBasicStatistics::count(values[k]) > 0) {
+            if (CBasicStatistics::count(values[k]) > 0.0) {
                 scale.add(scales[i - 1]);
             }
         }


### PR DESCRIPTION
The principal change is to bucket the candidate split points so we only check a subset of the splits when searching for the derivatives to update when computing split statistics. There are also some smaller optimisations which profiling showed up as worthwhile. The impact is largest for the case we have many metric valued features. These are pure runtime optimisations, i.e. the results are unaffected.