### PR TITLE
[ML] Remove impossible move constructor/assignment

### DIFF
--- a/include/maths/CBoostedTreeHyperparameters.h
+++ b/include/maths/CBoostedTreeHyperparameters.h
@@ -108,7 +108,7 @@ public:
                                      m_SoftTreeDepthLimit, inserter);
         core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
                                      m_SoftTreeDepthTolerance, inserter);
-    };
+    }
 
     //! Populate the object from serialized data.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
@@ -131,7 +131,7 @@ public:
                                                  m_SoftTreeDepthTolerance, traverser))
         } while (traverser.next());
         return true;
-    };
+    }
 
 public:
     static const std::string REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -181,11 +181,9 @@ private:
 
         CLeafNodeStatistics(const CLeafNodeStatistics&) = delete;
 
-        CLeafNodeStatistics(CLeafNodeStatistics&&) = default;
+        // Move construction/assignment not possible due to const reference member
 
         CLeafNodeStatistics& operator=(const CLeafNodeStatistics&) = delete;
-
-        CLeafNodeStatistics& operator=(CLeafNodeStatistics&&) = default;
 
         //! Apply the split defined by \p split.
         //!


### PR DESCRIPTION
CLeafNodeStatistics specified a default move constructor
and move assignment operator.  However, these cannot be
generated because the class has a const reference member.
They were not called anywhere, so this change removes the
= default directives to avoid compiler warnings.