### PR TITLE
[7.x] Blacklist a number of prediction field names. (#861)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -46,6 +46,8 @@ tree which is trained for both regression and classification. (See {ml-pull}811[
 
 === Bug Fixes
 * Fixes potential memory corruption when determining seasonality. (See {ml-pull}852[#852].)
+* Prevent prediction_field_name clashing with other fields in ml results.
+(See {ml-pull}861[#861].)
 
 
 == {es} version 7.5.0

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -68,6 +68,13 @@ CDataFrameTrainBoostedTreeClassifierRunner::CDataFrameTrainBoostedTreeClassifier
                   this->dependentVariableFieldName()) == categoricalFieldNames.end()) {
         HANDLE_FATAL(<< "Input error: trying to perform classification with numeric target.");
     }
+    const std::set<std::string> predictionFieldNameBlacklist{
+        IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME, TOP_CLASSES_FIELD_NAME};
+    if (predictionFieldNameBlacklist.count(this->predictionFieldName()) > 0) {
+        HANDLE_FATAL(<< "Input error: prediction_field_name must not be equal to any of "
+                     << core::CContainerPrinter::print(predictionFieldNameBlacklist)
+                     << ".");
+    }
 }
 
 CDataFrameTrainBoostedTreeClassifierRunner::CDataFrameTrainBoostedTreeClassifierRunner(

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -52,6 +52,12 @@ CDataFrameTrainBoostedTreeRegressionRunner::CDataFrameTrainBoostedTreeRegression
                   this->dependentVariableFieldName()) != categoricalFieldNames.end()) {
         HANDLE_FATAL(<< "Input error: trying to perform regression with categorical target.");
     }
+    const std::set<std::string> predictionFieldNameBlacklist{IS_TRAINING_FIELD_NAME};
+    if (predictionFieldNameBlacklist.count(this->predictionFieldName()) > 0) {
+        HANDLE_FATAL(<< "Input error: prediction_field_name must not be equal to any of "
+                     << core::CContainerPrinter::print(predictionFieldNameBlacklist)
+                     << ".");
+    }
 }
 
 CDataFrameTrainBoostedTreeRegressionRunner::CDataFrameTrainBoostedTreeRegressionRunner(

--- a/lib/api/unittest/CDataFrameTrainBoostedTreeRegressionRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameTrainBoostedTreeRegressionRunnerTest.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CDataFrame.h>
+
+#include <api/CDataFrameAnalysisConfigReader.h>
+#include <api/CDataFrameTrainBoostedTreeRegressionRunner.h>
+
+#include <test/CDataFrameAnalysisSpecificationFactory.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(CDataFrameTrainBoostedTreeRegressionRunnerTest)
+
+using namespace ml;
+namespace {
+using TStrVec = std::vector<std::string>;
+}
+
+BOOST_AUTO_TEST_CASE(testPredictionFieldNameClash) {
+    TStrVec errors;
+    auto errorHandler = [&errors](std::string error) { errors.push_back(error); };
+    core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
+
+    const auto spec{test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
+        "regression", "dep_var", 5, 6, 13000000, 0, 0)};
+    rapidjson::Document jsonParameters;
+    jsonParameters.Parse("{"
+                         "  \"dependent_variable\": \"dep_var\","
+                         "  \"prediction_field_name\": \"is_training\""
+                         "}");
+    const auto parameters{
+        api::CDataFrameTrainBoostedTreeRegressionRunner::parameterReader().read(jsonParameters)};
+    api::CDataFrameTrainBoostedTreeRegressionRunner runner(*spec, parameters);
+
+    BOOST_TEST_REQUIRE(errors.size() == 1);
+    BOOST_TEST_REQUIRE(errors[0] == "Input error: prediction_field_name must not be equal to any of [is_training].");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -31,6 +31,7 @@ SRCS=\
 	CDataFrameAnalyzerOutlierTest.cc \
 	CDataFrameAnalyzerTrainingTest.cc \
 	CDataFrameTrainBoostedTreeClassifierRunnerTest.cc \
+	CDataFrameTrainBoostedTreeRegressionRunnerTest.cc \
 	CDataFrameMockAnalysisRunner.cc \
 	CDetectionRulesJsonParserTest.cc \
 	CFieldConfigTest.cc \


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Blacklist a number of prediction field names.  (#861)