### PR TITLE
[7.x][ML] Remove impossible move constructor/assignment

### DIFF
--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -181,11 +181,9 @@ private:
 
         CLeafNodeStatistics(const CLeafNodeStatistics&) = delete;
 
-        CLeafNodeStatistics(CLeafNodeStatistics&&) = default;
+        // Move construction/assignment not possible due to const reference member
 
         CLeafNodeStatistics& operator=(const CLeafNodeStatistics&) = delete;
-
-        CLeafNodeStatistics& operator=(CLeafNodeStatistics&&) = default;
 
         //! Apply the split defined by \p split.
         //!


### PR DESCRIPTION
CLeafNodeStatistics specified a default move constructor
and move assignment operator.  However, these cannot be
generated because the class has a const reference member.
They were not called anywhere, so this change removes the
= default directives to avoid compiler warnings.

Backport of #866