### PR TITLE
[7.x][ML] Rename anonymous namespace apply function to avoid clash

### DIFF
--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -320,7 +320,7 @@ struct SMaybeConst<TCategoryAnyMap::const_iterator, T> {
 
 //! Apply a function \p f to all the data held in [\p begin, \p end).
 template<typename ITR, typename F>
-void apply(ITR begin, ITR end, const F& f) {
+void applyFunc(ITR begin, ITR end, const F& f) {
     for (ITR itr = begin; itr != end; ++itr) {
         model_t::EEventRateCategory category = itr->first;
         try {
@@ -351,8 +351,8 @@ void apply(ITR begin, ITR end, const F& f) {
 
 //! Apply a function \p f to all the data held in \p featureData.
 template<typename T, typename F>
-void apply(T& featureData, const F& f) {
-    apply(featureData.begin(), featureData.end(), f);
+void applyFunc(T& featureData, const F& f) {
+    applyFunc(featureData.begin(), featureData.end(), f);
 }
 
 //! \brief Removes people from the feature data.
@@ -960,15 +960,15 @@ void CEventRateBucketGatherer::recyclePeople(const TSizeVec& peopleToRemove) {
         return;
     }
 
-    apply(m_FeatureData, std::bind<void>(SRemovePeople(), std::placeholders::_1,
-                                         std::cref(peopleToRemove)));
+    applyFunc(m_FeatureData, std::bind<void>(SRemovePeople(), std::placeholders::_1,
+                                             std::cref(peopleToRemove)));
 
     this->CBucketGatherer::recyclePeople(peopleToRemove);
 }
 
 void CEventRateBucketGatherer::removePeople(std::size_t lowestPersonToRemove) {
-    apply(m_FeatureData, std::bind<void>(SRemovePeople(), std::placeholders::_1, lowestPersonToRemove,
-                                         m_DataGatherer.numberPeople()));
+    applyFunc(m_FeatureData, std::bind<void>(SRemovePeople(), std::placeholders::_1, lowestPersonToRemove,
+                                             m_DataGatherer.numberPeople()));
     this->CBucketGatherer::removePeople(lowestPersonToRemove);
 }
 
@@ -977,15 +977,15 @@ void CEventRateBucketGatherer::recycleAttributes(const TSizeVec& attributesToRem
         return;
     }
 
-    apply(m_FeatureData, std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
-                                         std::cref(attributesToRemove)));
+    applyFunc(m_FeatureData, std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
+                                             std::cref(attributesToRemove)));
 
     this->CBucketGatherer::recycleAttributes(attributesToRemove);
 }
 
 void CEventRateBucketGatherer::removeAttributes(std::size_t lowestAttributeToRemove) {
-    apply(m_FeatureData, std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
-                                         lowestAttributeToRemove));
+    applyFunc(m_FeatureData, std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
+                                             lowestAttributeToRemove));
     this->CBucketGatherer::removeAttributes(lowestAttributeToRemove);
 }
 
@@ -993,8 +993,8 @@ uint64_t CEventRateBucketGatherer::checksum() const {
     uint64_t seed = this->CBucketGatherer::checksum();
 
     TStrUInt64Map hashes;
-    apply(m_FeatureData, std::bind<void>(SChecksum(), std::placeholders::_1,
-                                         std::cref(m_DataGatherer), std::ref(hashes)));
+    applyFunc(m_FeatureData, std::bind<void>(SChecksum(), std::placeholders::_1,
+                                             std::cref(m_DataGatherer), std::ref(hashes)));
     LOG_TRACE(<< "seed = " << seed);
     LOG_TRACE(<< "hashes = " << core::CContainerPrinter::print(hashes));
     core::CHashing::CSafeMurmurHash2String64 hasher;
@@ -1510,7 +1510,7 @@ void CEventRateBucketGatherer::bucketMeanTimesPerPersonAttribute(model_t::EFeatu
 }
 
 void CEventRateBucketGatherer::resize(std::size_t pid, std::size_t cid) {
-    apply(m_FeatureData, std::bind<void>(SResize(), std::placeholders::_1, pid, cid));
+    applyFunc(m_FeatureData, std::bind<void>(SResize(), std::placeholders::_1, pid, cid));
 }
 
 void CEventRateBucketGatherer::addValue(std::size_t pid,
@@ -1522,13 +1522,14 @@ void CEventRateBucketGatherer::addValue(std::size_t pid,
                                         const TStoredStringPtrVec& influences) {
     // Check that we are correctly sized - a person/attribute might have been added
     this->resize(pid, cid);
-    apply(m_FeatureData, std::bind<void>(SAddValue(), std::placeholders::_1, pid,
-                                         cid, time, count, std::cref(values),
-                                         std::cref(stringValue), std::cref(influences)));
+    applyFunc(m_FeatureData,
+              std::bind<void>(SAddValue(), std::placeholders::_1, pid, cid,
+                              time, count, std::cref(values),
+                              std::cref(stringValue), std::cref(influences)));
 }
 
 void CEventRateBucketGatherer::startNewBucket(core_t::TTime time, bool /*skipUpdates*/) {
-    apply(m_FeatureData, std::bind<void>(SNewBucket(), std::placeholders::_1, time));
+    applyFunc(m_FeatureData, std::bind<void>(SNewBucket(), std::placeholders::_1, time));
 }
 
 void CEventRateBucketGatherer::initializeFieldNames(const std::string& personFieldName,

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -196,44 +196,44 @@ void registerMemoryCallbacks() {
 //! Apply a function \p f to a gatherer held as a value by map entry \p i
 //! of an explicit metric category
 template<model_t::EMetricCategory CATEGORY, typename ITR, typename F>
-void apply(ITR i, const F& f) {
+void applyFunc(ITR i, const F& f) {
     using TDataType = typename SDataType<CATEGORY>::Type;
     f(i->first, boost::any_cast<typename SMaybeConst<ITR, TDataType>::Type&>(i->second));
 }
 
 //! Apply a function \p f to all the gatherers held in [\p begin, \p end).
 template<typename ITR, typename F>
-bool apply(ITR begin, ITR end, const F& f) {
+bool applyFunc(ITR begin, ITR end, const F& f) {
     for (ITR i = begin; i != end; ++i) {
         model_t::EMetricCategory category = i->first.first;
         try {
             switch (category) {
             case model_t::E_Mean:
-                apply<model_t::E_Mean>(i, f);
+                applyFunc<model_t::E_Mean>(i, f);
                 break;
             case model_t::E_Median:
-                apply<model_t::E_Median>(i, f);
+                applyFunc<model_t::E_Median>(i, f);
                 break;
             case model_t::E_Min:
-                apply<model_t::E_Min>(i, f);
+                applyFunc<model_t::E_Min>(i, f);
                 break;
             case model_t::E_Max:
-                apply<model_t::E_Max>(i, f);
+                applyFunc<model_t::E_Max>(i, f);
                 break;
             case model_t::E_Variance:
-                apply<model_t::E_Variance>(i, f);
+                applyFunc<model_t::E_Variance>(i, f);
                 break;
             case model_t::E_Sum:
-                apply<model_t::E_Sum>(i, f);
+                applyFunc<model_t::E_Sum>(i, f);
                 break;
             case model_t::E_MultivariateMean:
-                apply<model_t::E_MultivariateMean>(i, f);
+                applyFunc<model_t::E_MultivariateMean>(i, f);
                 break;
             case model_t::E_MultivariateMin:
-                apply<model_t::E_MultivariateMin>(i, f);
+                applyFunc<model_t::E_MultivariateMin>(i, f);
                 break;
             case model_t::E_MultivariateMax:
-                apply<model_t::E_MultivariateMax>(i, f);
+                applyFunc<model_t::E_MultivariateMax>(i, f);
                 break;
             }
         } catch (const std::exception& e) {
@@ -247,8 +247,8 @@ bool apply(ITR begin, ITR end, const F& f) {
 
 //! Apply a function \p f to all the gatherers held in \p data.
 template<typename T, typename F>
-bool apply(T& data, const F& f) {
-    return apply(data.begin(), data.end(), f);
+bool applyFunc(T& data, const F& f) {
+    return applyFunc(data.begin(), data.end(), f);
 }
 
 //! Initialize feature data for a specific category
@@ -965,8 +965,9 @@ void CMetricBucketGatherer::acceptPersistInserter(core::CStatePersistInserter& i
     inserter.insertLevel(BASE_TAG, std::bind(&CBucketGatherer::baseAcceptPersistInserter,
                                              this, std::placeholders::_1));
     inserter.insertValue(VERSION_TAG, CURRENT_VERSION);
-    apply(m_FeatureData, std::bind<void>(CPersistFeatureData(), std::placeholders::_1,
-                                         std::placeholders::_2, std::ref(inserter)));
+    applyFunc(m_FeatureData,
+              std::bind<void>(CPersistFeatureData(), std::placeholders::_1,
+                              std::placeholders::_2, std::ref(inserter)));
 }
 
 bool CMetricBucketGatherer::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
@@ -1270,16 +1271,17 @@ void CMetricBucketGatherer::recyclePeople(const TSizeVec& peopleToRemove) {
         return;
     }
 
-    apply(m_FeatureData, std::bind<void>(SRemovePeople(), std::placeholders::_1,
-                                         std::placeholders::_2, std::cref(peopleToRemove)));
+    applyFunc(m_FeatureData,
+              std::bind<void>(SRemovePeople(), std::placeholders::_1,
+                              std::placeholders::_2, std::cref(peopleToRemove)));
 
     this->CBucketGatherer::recyclePeople(peopleToRemove);
 }
 
 void CMetricBucketGatherer::removePeople(std::size_t lowestPersonToRemove) {
-    apply(m_FeatureData, std::bind<void>(SRemovePeople(), std::placeholders::_1,
-                                         std::placeholders::_2, lowestPersonToRemove,
-                                         m_DataGatherer.numberPeople()));
+    applyFunc(m_FeatureData, std::bind<void>(SRemovePeople(), std::placeholders::_1,
+                                             std::placeholders::_2, lowestPersonToRemove,
+                                             m_DataGatherer.numberPeople()));
 
     this->CBucketGatherer::removePeople(lowestPersonToRemove);
 }
@@ -1290,9 +1292,9 @@ void CMetricBucketGatherer::recycleAttributes(const TSizeVec& attributesToRemove
     }
 
     if (m_DataGatherer.isPopulation()) {
-        apply(m_FeatureData,
-              std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
-                              std::placeholders::_2, std::cref(attributesToRemove)));
+        applyFunc(m_FeatureData,
+                  std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
+                                  std::placeholders::_2, std::cref(attributesToRemove)));
     }
 
     this->CBucketGatherer::recycleAttributes(attributesToRemove);
@@ -1300,9 +1302,10 @@ void CMetricBucketGatherer::recycleAttributes(const TSizeVec& attributesToRemove
 
 void CMetricBucketGatherer::removeAttributes(std::size_t lowestAttributeToRemove) {
     if (m_DataGatherer.isPopulation()) {
-        apply(m_FeatureData, std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
-                                             std::placeholders::_2, lowestAttributeToRemove,
-                                             m_DataGatherer.numberAttributes()));
+        applyFunc(m_FeatureData,
+                  std::bind<void>(SRemoveAttributes(), std::placeholders::_1,
+                                  std::placeholders::_2, lowestAttributeToRemove,
+                                  m_DataGatherer.numberAttributes()));
     }
 
     this->CBucketGatherer::removeAttributes(lowestAttributeToRemove);
@@ -1312,8 +1315,9 @@ uint64_t CMetricBucketGatherer::checksum() const {
     uint64_t seed = this->CBucketGatherer::checksum();
     seed = maths::CChecksum::calculate(seed, m_DataGatherer.params().s_DecayRate);
     TStrCRefStrCRefPrUInt64Map hashes;
-    apply(m_FeatureData, std::bind<void>(SHash(), std::placeholders::_1, std::placeholders::_2,
-                                         std::cref(*this), std::ref(hashes)));
+    applyFunc(m_FeatureData, std::bind<void>(SHash(), std::placeholders::_1,
+                                             std::placeholders::_2,
+                                             std::cref(*this), std::ref(hashes)));
     LOG_TRACE(<< "seed = " << seed);
     LOG_TRACE(<< "hashes = " << core::CContainerPrinter::print(hashes));
     return maths::CChecksum::calculate(seed, hashes);
@@ -1353,22 +1357,22 @@ bool CMetricBucketGatherer::resetBucket(core_t::TTime bucketStart) {
     if (this->CBucketGatherer::resetBucket(bucketStart) == false) {
         return false;
     }
-    apply(m_FeatureData, std::bind<void>(SResetBucket(), std::placeholders::_1,
-                                         std::placeholders::_2, bucketStart));
+    applyFunc(m_FeatureData, std::bind<void>(SResetBucket(), std::placeholders::_1,
+                                             std::placeholders::_2, bucketStart));
     return true;
 }
 
 void CMetricBucketGatherer::releaseMemory(core_t::TTime samplingCutoffTime) {
-    apply(m_FeatureData, std::bind<void>(SReleaseMemory(), std::placeholders::_1,
-                                         std::placeholders::_2, samplingCutoffTime));
+    applyFunc(m_FeatureData, std::bind<void>(SReleaseMemory(), std::placeholders::_1,
+                                             std::placeholders::_2, samplingCutoffTime));
 }
 
 void CMetricBucketGatherer::sample(core_t::TTime time) {
     if (m_DataGatherer.sampleCounts()) {
-        apply(m_FeatureData,
-              std::bind<void>(SDoSample(), std::placeholders::_1,
-                              std::placeholders::_2, time, std::cref(*this),
-                              std::ref(*m_DataGatherer.sampleCounts())));
+        applyFunc(m_FeatureData,
+                  std::bind<void>(SDoSample(), std::placeholders::_1,
+                                  std::placeholders::_2, time, std::cref(*this),
+                                  std::ref(*m_DataGatherer.sampleCounts())));
     }
 }
 
@@ -1392,10 +1396,10 @@ void CMetricBucketGatherer::featureData(core_t::TTime time,
             if (begin != m_FeatureData.end()) {
                 auto end = begin;
                 ++end;
-                apply(begin, end,
-                      std::bind<void>(SExtractFeatureData(), std::placeholders::_1,
-                                      std::placeholders::_2, std::cref(*this), feature,
-                                      time, bucketLength, std::ref(result)));
+                applyFunc(begin, end,
+                          std::bind<void>(SExtractFeatureData(), std::placeholders::_1,
+                                          std::placeholders::_2, std::cref(*this), feature,
+                                          time, bucketLength, std::ref(result)));
             } else {
                 LOG_ERROR(<< "No data for category " << model_t::print(category));
             }
@@ -1436,9 +1440,9 @@ void CMetricBucketGatherer::addValue(std::size_t pid,
     }
 
     stat.s_Influences = &influences;
-    apply(m_FeatureData, std::bind<void>(SAddValue(), std::placeholders::_1,
-                                         std::placeholders::_2, pid, cid,
-                                         std::cref(*this), std::ref(stat)));
+    applyFunc(m_FeatureData, std::bind<void>(SAddValue(), std::placeholders::_1,
+                                             std::placeholders::_2, pid, cid,
+                                             std::cref(*this), std::ref(stat)));
 }
 
 void CMetricBucketGatherer::startNewBucket(core_t::TTime time, bool skipUpdates) {
@@ -1480,8 +1484,8 @@ void CMetricBucketGatherer::startNewBucket(core_t::TTime time, bool skipUpdates)
             m_DataGatherer.sampleCounts()->refresh(m_DataGatherer);
         }
     }
-    apply(m_FeatureData, std::bind<void>(SStartNewBucket(), std::placeholders::_1,
-                                         std::placeholders::_2, time));
+    applyFunc(m_FeatureData, std::bind<void>(SStartNewBucket(), std::placeholders::_1,
+                                             std::placeholders::_2, time));
 }
 
 void CMetricBucketGatherer::initializeFieldNamesPart1(const std::string& personFieldName,


### PR DESCRIPTION
In C++17 there is a std::apply function that gets chosen in
preference to the apply function in the anonymous namespace
in the metric and event rate bucket gatherers.

This change renames our function so the compiler does not
have to resolve an ambiguity when it's called.

Backport of #871