### PR TITLE
[ML] Stop early (based on non-decreasing validation error) when adding trees to the forest

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -45,6 +45,8 @@ tree which is trained for both regression and classification. (See {ml-pull}811[
 (See {ml-pull}818[#818].)
 * Reduce memory usage of {ml} native processes on Windows. (See {ml-pull}844[#844].)
 * Reduce runtime of classification and regression. (See {ml-pull}863[#863].)
+* Stop early training a classification and regression forest when the validation error
+is no longer decreasing. (See {ml-pull}875[#875].)
 
 === Bug Fixes
 * Fixes potential memory corruption when determining seasonality. (See {ml-pull}852[#852].)

--- a/include/core/CImmutableRadixSet.h
+++ b/include/core/CImmutableRadixSet.h
@@ -20,10 +20,10 @@ namespace core {
 //! \brief An immutable sorted set which provides very fast lookup.
 //!
 //! DESCRIPTION:\n
-//! This supports lower bound and look up by index as well as a subset of the non
+//! This supports upper bound and look up by index as well as a subset of the non
 //! modifying interface of std::set. Its main purpose is to provide much faster
 //! lookup. To this end it subdivides the range of sorted values into buckets.
-//! In the case that the values are uniformly distributed lowerBound will be O(1)
+//! In the case that the values are uniformly distributed upperBound will be O(1)
 //! with low constant. Otherwise, it is worst case O(log(n)).
 template<typename T>
 class CImmutableRadixSet {

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -178,7 +178,9 @@ public:
     double euclidean() const { return std::sqrt(this->inner(*this)); }
 
     //! Manhattan norm.
-    double manhattan() const { return this->inner(*this); }
+    double manhattan() const {
+        return this->size() == 0 ? 0 : this->inner(*this);
+    }
     //@}
 
     //! Convert to a bit vector.

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -177,7 +177,7 @@ private:
     std::size_t numberHyperparameterTuningRounds() const;
 
     //! Setup monitoring for training progress.
-    void initializeTrainingProgressMonitoring();
+    void initializeTrainingProgressMonitoring(const core::CDataFrame& frame);
 
     //! Refresh progress monitoring after restoring from saved training state.
     void resumeRestoredTrainingProgressMonitoring();

--- a/include/maths/CBoostedTreeHyperparameters.h
+++ b/include/maths/CBoostedTreeHyperparameters.h
@@ -185,24 +185,30 @@ public:
                                 double downsampleFactor,
                                 double eta,
                                 double etaGrowthRatePerTree,
+                                std::size_t maximumNumberTrees,
                                 double featureBagFraction);
-    //! The regularisation parameters.
+
+    //! Set the regularisation parameters.
     void regularization(const TRegularization& regularization);
     //! The regularisation parameters.
     const TRegularization& regularization() const;
-    //! The downsample factor.
+    //! Set the maximum number of trees to use.
+    void maximumNumberTrees(std::size_t maximumNumberTrees);
+    //! The maximum number of trees to use.
+    std::size_t maximumNumberTrees() const;
+    //! Set the downsample factor.
     void downsampleFactor(double downsampleFactor);
     //! The downsample factor.
     double downsampleFactor() const;
-    //! Shrinkage.
+    //! Set the shrinkage.
     void eta(double eta);
     //! Shrinkage.
     double eta() const;
-    //! Rate of growth of shrinkage in the training loop.
+    //! Set the rate of growth of shrinkage in the training loop.
     void etaGrowthRatePerTree(double etaGrowthRatePerTree);
     //! Rate of growth of shrinkage in the training loop.
     double etaGrowthRatePerTree() const;
-    //! The fraction of features we use per bag.
+    //! Set the fraction of features we use per bag.
     void featureBagFraction(double featureBagFraction);
     //! The fraction of features we use per bag.
     double featureBagFraction() const;
@@ -218,6 +224,7 @@ public:
     static const std::string HYPERPARAM_ETA_TAG;
     static const std::string HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG;
     static const std::string HYPERPARAM_FEATURE_BAG_FRACTION_TAG;
+    static const std::string HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG;
     static const std::string HYPERPARAM_REGULARIZATION_TAG;
 
 private:
@@ -225,16 +232,19 @@ private:
     TRegularization m_Regularization;
 
     //! The downsample factor.
-    double m_downsampleFactor;
+    double m_DownsampleFactor;
 
     //! Shrinkage.
-    double m_eta;
+    double m_Eta;
 
     //! Rate of growth of shrinkage in the training loop.
-    double m_etaGrowthRatePerTree;
+    double m_EtaGrowthRatePerTree;
+
+    //! The maximum number of trees we'll use.
+    std::size_t m_MaximumNumberTrees;
 
     //! The fraction of features we use per bag.
-    double m_featureBagFraction;
+    double m_FeatureBagFraction;
 };
 }
 }

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -51,6 +51,7 @@ public:
     using TStrVec = std::vector<std::string>;
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using TMeanVarAccumulatorSizePr = std::pair<TMeanVarAccumulator, std::size_t>;
     using TBayesinOptimizationUPtr = std::unique_ptr<maths::CBayesianOptimisation>;
     using TNodeVec = CBoostedTree::TNodeVec;
     using TNodeVecVec = CBoostedTree::TNodeVecVec;
@@ -140,6 +141,7 @@ private:
     using TVector = CDenseVector<double>;
     using TRowItr = core::CDataFrame::TRowItr;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+    using TNodeVecVecDoublePr = std::pair<TNodeVecVec, double>;
     using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
     using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
@@ -400,18 +402,21 @@ private:
                                                  const TNodeVecVec& forest) const;
 
     //! Train the forest and compute loss moments on each fold.
-    TMeanVarAccumulator crossValidateForest(core::CDataFrame& frame,
-                                            const TMemoryUsageCallback& recordMemoryUsage) const;
+    TMeanVarAccumulatorSizePr crossValidateForest(core::CDataFrame& frame,
+                                                  const TMemoryUsageCallback& recordMemoryUsage);
 
     //! Initialize the predictions and loss function derivatives for the masked
     //! rows in \p frame.
     TNodeVec initializePredictionsAndLossDerivatives(core::CDataFrame& frame,
-                                                     const core::CPackedBitVector& trainingRowMask) const;
+                                                     const core::CPackedBitVector& trainingRowMask,
+                                                     const core::CPackedBitVector& testingRowMask) const;
 
     //! Train one forest on the rows of \p frame in the mask \p trainingRowMask.
-    TNodeVecVec trainForest(core::CDataFrame& frame,
-                            const core::CPackedBitVector& trainingRowMask,
-                            const TMemoryUsageCallback& recordMemoryUsage) const;
+    TNodeVecVecDoublePr trainForest(core::CDataFrame& frame,
+                                    const core::CPackedBitVector& trainingRowMask,
+                                    const core::CPackedBitVector& testingRowMask,
+                                    core::CLoopProgress& trainingProgress,
+                                    const TMemoryUsageCallback& recordMemoryUsage) const;
 
     //! Randomly downsamples the training row mask by the downsample factor.
     core::CPackedBitVector downsample(const core::CPackedBitVector& trainingRowMask) const;
@@ -440,13 +445,12 @@ private:
     //! rows in \p frame with predictions of \p tree.
     void refreshPredictionsAndLossDerivatives(core::CDataFrame& frame,
                                               const core::CPackedBitVector& trainingRowMask,
+                                              const core::CPackedBitVector& testingRowMask,
                                               double eta,
                                               TNodeVec& tree) const;
 
     //! Compute the mean of the loss function on the masked rows of \p frame.
-    double meanLoss(const core::CDataFrame& frame,
-                    const core::CPackedBitVector& rowMask,
-                    const TNodeVecVec& forest) const;
+    double meanLoss(const core::CDataFrame& frame, const core::CPackedBitVector& rowMask) const;
 
     //! Get a column mask of the suitable regressor features.
     TSizeVec candidateRegressorFeatures() const;
@@ -462,7 +466,8 @@ private:
                                    CBayesianOptimisation& bopt);
 
     //! Capture the current hyperparameter values.
-    void captureBestHyperparameters(const TMeanVarAccumulator& lossMoments);
+    void captureBestHyperparameters(const TMeanVarAccumulator& lossMoments,
+                                    std::size_t maximumNumberTrees);
 
     //! Set the hyperparamaters from the best recorded.
     void restoreBestHyperparameters();
@@ -525,7 +530,7 @@ private:
     TBayesinOptimizationUPtr m_BayesianOptimization;
     std::size_t m_NumberRounds = 1;
     std::size_t m_CurrentRound = 0;
-    mutable core::CLoopProgress m_TrainingProgress;
+    core::CLoopProgress m_TrainingProgress;
 
     friend class CBoostedTreeFactory;
 };

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -45,7 +45,7 @@ public:
                    const std::string& dependentVariable,
                    std::size_t rows = 100,
                    std::size_t cols = 5,
-                   std::size_t memoryLimit = 5000000,
+                   std::size_t memoryLimit = 7000000,
                    std::size_t numberRoundsPerHyperparameter = 0,
                    std::size_t bayesianOptimisationRestarts = 0,
                    const TStrVec& categoricalFieldNames = TStrVec{},

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -30,6 +30,7 @@ namespace {
 using TBoolVec = std::vector<bool>;
 using TDoubleVec = std::vector<double>;
 using TSizeVec = std::vector<std::size_t>;
+using TStrSet = std::set<std::string>;
 
 // Configuration
 const std::string NUM_TOP_CLASSES{"num_top_classes"};
@@ -43,7 +44,7 @@ const std::string TOP_CLASSES_FIELD_NAME{"top_classes"};
 const std::string CLASS_NAME_FIELD_NAME{"class_name"};
 const std::string CLASS_PROBABILITY_FIELD_NAME{"class_probability"};
 
-const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{
+const TStrSet PREDICTION_FIELD_NAME_BLACKLIST{
     IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME, TOP_CLASSES_FIELD_NAME};
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -22,6 +22,7 @@
 #include <api/ElasticsearchStateIndex.h>
 
 #include <numeric>
+#include <set>
 
 namespace ml {
 namespace api {
@@ -40,6 +41,9 @@ const std::string PREDICTION_PROBABILITY_FIELD_NAME{"prediction_probability"};
 const std::string TOP_CLASSES_FIELD_NAME{"top_classes"};
 const std::string CLASS_NAME_FIELD_NAME{"class_name"};
 const std::string CLASS_PROBABILITY_FIELD_NAME{"class_probability"};
+
+const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{
+    IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME, TOP_CLASSES_FIELD_NAME};
 }
 
 const CDataFrameAnalysisConfigReader&
@@ -68,11 +72,9 @@ CDataFrameTrainBoostedTreeClassifierRunner::CDataFrameTrainBoostedTreeClassifier
                   this->dependentVariableFieldName()) == categoricalFieldNames.end()) {
         HANDLE_FATAL(<< "Input error: trying to perform classification with numeric target.");
     }
-    const std::set<std::string> predictionFieldNameBlacklist{
-        IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME, TOP_CLASSES_FIELD_NAME};
-    if (predictionFieldNameBlacklist.count(this->predictionFieldName()) > 0) {
-        HANDLE_FATAL(<< "Input error: prediction_field_name must not be equal to any of "
-                     << core::CContainerPrinter::print(predictionFieldNameBlacklist)
+    if (PREDICTION_FIELD_NAME_BLACKLIST.count(this->predictionFieldName()) > 0) {
+        HANDLE_FATAL(<< "Input error: " << PREDICTION_FIELD_NAME << " must not be equal to any of "
+                     << core::CContainerPrinter::print(PREDICTION_FIELD_NAME_BLACKLIST)
                      << ".");
     }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -18,6 +18,8 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/ElasticsearchStateIndex.h>
 
+#include <set>
+
 namespace ml {
 namespace api {
 namespace {
@@ -26,6 +28,8 @@ const std::string STRATIFIED_CROSS_VALIDATION{"stratified_cross_validation"};
 
 // Output
 const std::string IS_TRAINING_FIELD_NAME{"is_training"};
+
+const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{IS_TRAINING_FIELD_NAME};
 }
 
 const CDataFrameAnalysisConfigReader&
@@ -52,10 +56,9 @@ CDataFrameTrainBoostedTreeRegressionRunner::CDataFrameTrainBoostedTreeRegression
                   this->dependentVariableFieldName()) != categoricalFieldNames.end()) {
         HANDLE_FATAL(<< "Input error: trying to perform regression with categorical target.");
     }
-    const std::set<std::string> predictionFieldNameBlacklist{IS_TRAINING_FIELD_NAME};
-    if (predictionFieldNameBlacklist.count(this->predictionFieldName()) > 0) {
-        HANDLE_FATAL(<< "Input error: prediction_field_name must not be equal to any of "
-                     << core::CContainerPrinter::print(predictionFieldNameBlacklist)
+    if (PREDICTION_FIELD_NAME_BLACKLIST.count(this->predictionFieldName()) > 0) {
+        HANDLE_FATAL(<< "Input error: " << PREDICTION_FIELD_NAME << " must not be equal to any of "
+                     << core::CContainerPrinter::print(PREDICTION_FIELD_NAME_BLACKLIST)
                      << ".");
     }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
               << "ms");
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
-                           counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
+                           counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 6000000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 300000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
@@ -663,7 +663,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
-                           counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
+                           counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 6000000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1200000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFields) {
     {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-                "regression", "x5", 1000, 5, 16000000, 0, 0, {"x1", "x2"}),
+                "regression", "x5", 1000, 5, 19000000, 0, 0, {"x1", "x2"}),
             outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
@@ -783,7 +783,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFieldsEmptyAsMissing) {
 
     api::CDataFrameAnalyzer analyzer{
         test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-            "classification", "x5", 1000, 5, 15000000, 0, 0, {"x1", "x2", "x5"}),
+            "classification", "x5", 1000, 5, 19000000, 0, 0, {"x1", "x2", "x5"}),
         outputWriterFactory};
 
     TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -63,7 +63,7 @@ double computeEta(std::size_t numberRegressors) {
 }
 
 std::size_t computeMaximumNumberTrees(double eta) {
-    return static_cast<std::size_t>(4.0 / eta / MIN_DOWNSAMPLE_FACTOR_SCALE + 0.5);
+    return static_cast<std::size_t>(3.0 / eta / MIN_DOWNSAMPLE_FACTOR_SCALE + 0.5);
 }
 
 std::size_t scaleMaximumNumberTrees(std::size_t maximumNumberTrees) {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -45,8 +45,25 @@ const double MIN_DOWNSAMPLE_FACTOR_SCALE{0.3};
 const double MAX_DOWNSAMPLE_FACTOR_SCALE{3.0};
 const std::size_t MAX_NUMBER_TREES{static_cast<std::size_t>(2.0 / MIN_ETA + 0.5)};
 
+double computeEta(std::size_t numberRegressors) {
+    // eta is the learning rate. There is a lot of empirical evidence that
+    // this should not be much larger than 0.1. Conceptually, we're making
+    // random choices regarding which features we'll use to split when
+    // fitting a single tree and we only observe a random sample from the
+    // function we're trying to learn. Using more trees with a smaller learning
+    // rate reduces the variance that the decisions or particular sample we
+    // train with introduces to predictions. The scope for variation increases
+    // with the number of features so we use a lower learning rate with more
+    // features. Furthermore, the leaf weights naturally decrease as we add
+    // more trees, since the prediction errors decrease, so we slowly increase
+    // the learning rate to maintain more equal tree weights. This tends to
+    // produce forests which generalise as well but are much smaller and so
+    // train faster.
+    return 1.0 / std::max(10.0, std::sqrt(static_cast<double>(numberRegressors)));
+}
+
 std::size_t computeMaximumNumberTrees(double eta) {
-    return static_cast<std::size_t>(2.0 / eta / MIN_DOWNSAMPLE_FACTOR_SCALE + 0.5);
+    return static_cast<std::size_t>(4.0 / eta / MIN_DOWNSAMPLE_FACTOR_SCALE + 0.5);
 }
 
 std::size_t scaleMaximumNumberTrees(std::size_t maximumNumberTrees) {
@@ -69,7 +86,7 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame,
         return nullptr;
     }
 
-    this->initializeTrainingProgressMonitoring();
+    this->initializeTrainingProgressMonitoring(frame);
 
     m_TreeImpl->m_DependentVariable = dependentVariable;
     m_TreeImpl->m_Loss = std::move(loss);
@@ -303,21 +320,8 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) {
     if (m_TreeImpl->m_EtaOverride != boost::none) {
         m_TreeImpl->m_Eta = *(m_TreeImpl->m_EtaOverride);
     } else {
-        // Eta is the learning rate. There is a lot of empirical evidence that
-        // this should not be much larger than 0.1. Conceptually, we're making
-        // random choices regarding which features we'll use to split when
-        // fitting a single tree and we only observe a random sample from the
-        // function we're trying to learn. Using more trees with a smaller learning
-        // rate reduces the variance that the decisions or particular sample we
-        // train with introduces to predictions. The scope for variation increases
-        // with the number of features so we use a lower learning rate with more
-        // features. Furthermore, the leaf weights naturally decrease as we add
-        // more trees, since the prediction errors decrease, so we slowly increase
-        // the learning rate to maintain more equal tree weights. This tends to
-        // produce forests which generalise as well but are much smaller and so
-        // train faster.
-        m_TreeImpl->m_Eta = 1.0 / std::max(10.0, std::sqrt(static_cast<double>(
-                                                     frame.numberColumns() - 4)));
+        m_TreeImpl->m_Eta =
+            computeEta(frame.numberColumns() - this->numberExtraColumnsForTrain());
         m_TreeImpl->m_EtaGrowthRatePerTree = 1.0 + m_TreeImpl->m_Eta / 2.0;
     }
 
@@ -648,8 +652,10 @@ CBoostedTreeFactory::estimateTreeGainAndCurvature(core::CDataFrame& frame,
 
     std::size_t maximumNumberOfTrees{1};
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
-    auto forest = m_TreeImpl->trainForest(frame, m_TreeImpl->m_TrainingRowMasks[0],
-                                          m_RecordMemoryUsage);
+    CBoostedTreeImpl::TNodeVecVec forest;
+    std::tie(forest, std::ignore) = m_TreeImpl->trainForest(
+        frame, m_TreeImpl->m_TrainingRowMasks[0], m_TreeImpl->m_TestingRowMasks[0],
+        m_TreeImpl->m_TrainingProgress, m_RecordMemoryUsage);
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
 
     TDoubleDoublePrVec result;
@@ -695,9 +701,11 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
                 (LINE_SEARCH_ITERATIONS - i - 1) * m_TreeImpl->m_MaximumNumberTrees);
             break;
         }
-        auto forest = m_TreeImpl->trainForest(
-            frame, m_TreeImpl->m_TrainingRowMasks[0], m_RecordMemoryUsage);
-        double testLoss{m_TreeImpl->meanLoss(frame, m_TreeImpl->m_TestingRowMasks[0], forest)};
+        CBoostedTreeImpl::TNodeVecVec forest;
+        double testLoss;
+        std::tie(forest, testLoss) = m_TreeImpl->trainForest(
+            frame, m_TreeImpl->m_TrainingRowMasks[0], m_TreeImpl->m_TestingRowMasks[0],
+            m_TreeImpl->m_TrainingProgress, m_RecordMemoryUsage);
         leastSquaresQuadraticTestLoss.add(static_cast<double>(i) * stepSize, testLoss);
         testLosses.push_back(testLoss);
     }
@@ -954,7 +962,7 @@ std::size_t CBoostedTreeFactory::numberExtraColumnsForTrain() const {
     return CBoostedTreeImpl::numberExtraColumnsForTrain();
 }
 
-void CBoostedTreeFactory::initializeTrainingProgressMonitoring() {
+void CBoostedTreeFactory::initializeTrainingProgressMonitoring(const core::CDataFrame& frame) {
 
     // The base unit is the cost of training on one tree.
     //
@@ -971,8 +979,10 @@ void CBoostedTreeFactory::initializeTrainingProgressMonitoring() {
     //  - The cost of the final train which we count as an extra loop.
 
     std::size_t totalNumberSteps{2};
-    std::size_t lineSearchMaximumNumberTrees{
-        computeMaximumNumberTrees(m_TreeImpl->m_Eta)};
+    double eta{m_TreeImpl->m_EtaOverride != boost::none
+                   ? *m_TreeImpl->m_EtaOverride
+                   : computeEta(frame.numberColumns())};
+    std::size_t lineSearchMaximumNumberTrees{computeMaximumNumberTrees(eta)};
     if (m_TreeImpl->m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
         totalNumberSteps += LINE_SEARCH_ITERATIONS * lineSearchMaximumNumberTrees;
     }

--- a/lib/maths/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/CBoostedTreeHyperparameters.cc
@@ -19,17 +19,21 @@ const std::string CBoostedTreeHyperparameters::HYPERPARAM_ETA_GROWTH_RATE_PER_TR
     "hyperparam_eta_growth_rate_per_tree"};
 const std::string CBoostedTreeHyperparameters::HYPERPARAM_FEATURE_BAG_FRACTION_TAG{
     "hyperparam_feature_bag_fraction"};
+const std::string CBoostedTreeHyperparameters::HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG{
+    "hyperparam_maximum_number_trees"};
 const std::string CBoostedTreeHyperparameters::HYPERPARAM_REGULARIZATION_TAG{
     "hyperparam_regularization"};
 
 void CBoostedTreeHyperparameters::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     core::CPersistUtils::persist(HYPERPARAM_DOWNSAMPLE_FACTOR_TAG,
-                                 m_downsampleFactor, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_ETA_TAG, m_eta, inserter);
+                                 m_DownsampleFactor, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_ETA_TAG, m_Eta, inserter);
     core::CPersistUtils::persist(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
-                                 m_etaGrowthRatePerTree, inserter);
+                                 m_EtaGrowthRatePerTree, inserter);
     core::CPersistUtils::persist(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                                 m_featureBagFraction, inserter);
+                                 m_FeatureBagFraction, inserter);
+    core::CPersistUtils::persist(HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG,
+                                 m_MaximumNumberTrees, inserter);
     core::CPersistUtils::persist(HYPERPARAM_REGULARIZATION_TAG, m_Regularization, inserter);
 }
 
@@ -37,13 +41,16 @@ bool CBoostedTreeHyperparameters::acceptRestoreTraverser(core::CStateRestoreTrav
     do {
         const std::string& name = traverser.name();
         RESTORE(HYPERPARAM_ETA_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, m_eta, traverser))
+                core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, m_Eta, traverser))
         RESTORE(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
                 core::CPersistUtils::restore(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
-                                             m_etaGrowthRatePerTree, traverser))
+                                             m_EtaGrowthRatePerTree, traverser))
         RESTORE(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
                 core::CPersistUtils::restore(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                                             m_featureBagFraction, traverser))
+                                             m_FeatureBagFraction, traverser))
+        RESTORE(HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG,
+                core::CPersistUtils::restore(HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG,
+                                             m_MaximumNumberTrees, traverser))
         RESTORE(HYPERPARAM_REGULARIZATION_TAG,
                 core::CPersistUtils::restore(HYPERPARAM_REGULARIZATION_TAG,
                                              m_Regularization, traverser))
@@ -57,19 +64,23 @@ CBoostedTreeHyperparameters::regularization() const {
 }
 
 double CBoostedTreeHyperparameters::downsampleFactor() const {
-    return m_downsampleFactor;
+    return m_DownsampleFactor;
 }
 
 double CBoostedTreeHyperparameters::eta() const {
-    return m_eta;
+    return m_Eta;
 }
 
 double CBoostedTreeHyperparameters::etaGrowthRatePerTree() const {
-    return m_etaGrowthRatePerTree;
+    return m_EtaGrowthRatePerTree;
+}
+
+std::size_t CBoostedTreeHyperparameters::maximumNumberTrees() const {
+    return m_MaximumNumberTrees;
 }
 
 double CBoostedTreeHyperparameters::featureBagFraction() const {
-    return m_featureBagFraction;
+    return m_FeatureBagFraction;
 }
 
 void CBoostedTreeHyperparameters::regularization(const TRegularization& regularization) {
@@ -77,19 +88,23 @@ void CBoostedTreeHyperparameters::regularization(const TRegularization& regulari
 }
 
 void CBoostedTreeHyperparameters::downsampleFactor(double downsampleFactor) {
-    m_downsampleFactor = downsampleFactor;
+    m_DownsampleFactor = downsampleFactor;
 }
 
 void CBoostedTreeHyperparameters::eta(double eta) {
-    m_eta = eta;
+    m_Eta = eta;
 }
 
 void CBoostedTreeHyperparameters::etaGrowthRatePerTree(double etaGrowthRatePerTree) {
-    m_etaGrowthRatePerTree = etaGrowthRatePerTree;
+    m_EtaGrowthRatePerTree = etaGrowthRatePerTree;
+}
+
+void CBoostedTreeHyperparameters::maximumNumberTrees(std::size_t maximumNumberTrees) {
+    m_MaximumNumberTrees = maximumNumberTrees;
 }
 
 void CBoostedTreeHyperparameters::featureBagFraction(double featureBagFraction) {
-    m_featureBagFraction = featureBagFraction;
+    m_FeatureBagFraction = featureBagFraction;
 }
 
 CBoostedTreeHyperparameters::CBoostedTreeHyperparameters(
@@ -97,9 +112,11 @@ CBoostedTreeHyperparameters::CBoostedTreeHyperparameters(
     double downsampleFactor,
     double eta,
     double etaGrowthRatePerTree,
+    std::size_t maximumNumberTrees,
     double featureBagFraction)
-    : m_Regularization{regularization}, m_downsampleFactor{downsampleFactor}, m_eta{eta},
-      m_etaGrowthRatePerTree{etaGrowthRatePerTree}, m_featureBagFraction{featureBagFraction} {
+    : m_Regularization{regularization}, m_DownsampleFactor{downsampleFactor}, m_Eta{eta},
+      m_EtaGrowthRatePerTree{etaGrowthRatePerTree},
+      m_MaximumNumberTrees{maximumNumberTrees}, m_FeatureBagFraction{featureBagFraction} {
 }
 }
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -86,7 +86,7 @@ public:
     CTrainForestStoppingCondition(std::size_t maximumNumberTrees)
         : m_MaximumNumberTrees{maximumNumberTrees},
           m_MaximumNumberTreesWithoutImprovement{std::max(
-              static_cast<std::size_t>(0.05 * static_cast<double>(maximumNumberTrees) + 0.5),
+              static_cast<std::size_t>(0.075 * static_cast<double>(maximumNumberTrees) + 0.5),
               std::size_t{1})} {}
 
     std::size_t bestSize() const { return m_BestTestLoss[0].second; }
@@ -514,13 +514,6 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
             this->captureBestHyperparameters(lossMoments, maximumNumberTrees);
 
-            // Trap the case that the dependent variable is (effectively) constant.
-            // There is no point adjusting hyperparameters in this case - and we run
-            // into numerical issues trying - since any forest will do.
-            if (std::sqrt(CBasicStatistics::variance(lossMoments)) <
-                1e-10 * std::fabs(CBasicStatistics::mean(lossMoments))) {
-                break;
-            }
             if (this->selectNextHyperparameters(lossMoments, *m_BayesianOptimization) == false) {
                 LOG_WARN(<< "Hyperparameter selection failed: exiting loop early");
                 break;

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -497,7 +497,6 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
     } else if (m_CurrentRound < m_NumberRounds || m_BestForest.empty()) {
-        using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
         TMeanVarAccumulator timeAccumulator;
         core::CStopWatch stopWatch;
         stopWatch.start();
@@ -537,7 +536,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
             this->recordState(recordTrainStateCallback);
             LOG_TRACE(<< "Round " << m_CurrentRound << " state recording finished");
 
-            timeAccumulator.add(static_cast<float>(stopWatch.lap()));
+            timeAccumulator.add(static_cast<double>(stopWatch.lap()));
         }
 
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
@@ -549,7 +548,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
         this->recordState(recordTrainStateCallback);
 
-        timeAccumulator.add(static_cast<float>(stopWatch.stop()));
+        timeAccumulator.add(static_cast<double>(stopWatch.stop()));
 
         LOG_INFO(<< "Training finished after " << m_CurrentRound << " iterations. Time per iteration in ms mean: "
                  << CBasicStatistics::mean(timeAccumulator) << " std. dev:  "

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -78,11 +78,6 @@ private:
 //! discard the extra trees at the end of training.
 class CTrainForestStoppingCondition {
 public:
-    //! This is the number of trees between sampling the test error. It is used
-    //! to amortise the cost of computing test error which is non-negligible.
-    static const std::size_t TEST_ERROR_SAMPLE_INTERVAL{2};
-
-public:
     CTrainForestStoppingCondition(std::size_t maximumNumberTrees)
         : m_MaximumNumberTrees{maximumNumberTrees},
           m_MaximumNumberTreesWithoutImprovement{std::max(
@@ -95,13 +90,11 @@ public:
 
     template<typename FUNC>
     bool shouldStop(std::size_t numberTrees, FUNC computeLoss) {
-        if (m_BestTestLoss.count() == 0 || (numberTrees % TEST_ERROR_SAMPLE_INTERVAL) == 0) {
-            double loss{computeLoss()};
-            m_BestTestLoss.add({loss, numberTrees});
-            LOG_TRACE(<< "test loss = " << loss);
-            if (numberTrees - m_BestTestLoss[0].second > m_MaximumNumberTreesWithoutImprovement) {
-                return true;
-            }
+        double loss{computeLoss()};
+        m_BestTestLoss.add({loss, numberTrees});
+        LOG_TRACE(<< "test loss = " << loss);
+        if (numberTrees - m_BestTestLoss[0].second > m_MaximumNumberTreesWithoutImprovement) {
+            return true;
         }
         return numberTrees > m_MaximumNumberTrees;
     }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -66,6 +66,56 @@ private:
     std::int64_t m_MemoryUsage;
 };
 
+//! \brief Manages exiting from the loop adding trees to the forest.
+//!
+//! DESCRIPTION:\n
+//! Typically, the test error will decrease exponentially to some minimum then
+//! slightly increase thereafter as more trees are added. The logic for exiting
+//! training a forest is simple: continue to add trees for some fraction of the
+//! maximum forest size after we see the smallest test loss. This amounts to a
+//! fixed relative runtime penalty for ensuring we don't stop too early since
+//! we record the forest size corresponding to the minimum test loss and simply
+//! discard the extra trees at the end of training.
+class CTrainForestStoppingCondition {
+public:
+    //! This is the number of trees between sampling the test error. It is used
+    //! to amortise the cost of computing test error which is non-negligible.
+    static const std::size_t TEST_ERROR_SAMPLE_INTERVAL{2};
+
+public:
+    CTrainForestStoppingCondition(std::size_t maximumNumberTrees)
+        : m_MaximumNumberTrees{maximumNumberTrees},
+          m_MaximumNumberTreesWithoutImprovement{std::max(
+              static_cast<std::size_t>(0.05 * static_cast<double>(maximumNumberTrees) + 0.5),
+              std::size_t{1})} {}
+
+    std::size_t bestSize() const { return m_BestTestLoss[0].second; }
+
+    double bestLoss() const { return m_BestTestLoss[0].first; }
+
+    template<typename FUNC>
+    bool shouldStop(std::size_t numberTrees, FUNC computeLoss) {
+        if (m_BestTestLoss.count() == 0 || (numberTrees % TEST_ERROR_SAMPLE_INTERVAL) == 0) {
+            double loss{computeLoss()};
+            m_BestTestLoss.add({loss, numberTrees});
+            LOG_TRACE(<< "test loss = " << loss);
+            if (numberTrees - m_BestTestLoss[0].second > m_MaximumNumberTreesWithoutImprovement) {
+                return true;
+            }
+        }
+        return numberTrees > m_MaximumNumberTrees;
+    }
+
+private:
+    using TDoubleSizePrMinAccumulator =
+        CBasicStatistics::SMin<std::pair<double, std::size_t>>::TAccumulator;
+
+private:
+    std::size_t m_MaximumNumberTrees;
+    std::size_t m_MaximumNumberTreesWithoutImprovement;
+    TDoubleSizePrMinAccumulator m_BestTestLoss;
+};
+
 double readPrediction(const TRowRef& row) {
     return row[predictionColumn(row.numberColumns())];
 }
@@ -405,8 +455,9 @@ CBoostedTreeImpl::CLeafNodeStatistics::computeBestSplitStatistics(const TRegular
 
 CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads, CBoostedTree::TLossFunctionUPtr loss)
     : m_NumberThreads{numberThreads}, m_Loss{std::move(loss)},
-      m_BestHyperparameters{m_Regularization, m_DownsampleFactor, m_Eta,
-                            m_EtaGrowthRatePerTree, m_FeatureBagFraction} {
+      m_BestHyperparameters{
+          m_Regularization,       m_DownsampleFactor,   m_Eta,
+          m_EtaGrowthRatePerTree, m_MaximumNumberTrees, m_FeatureBagFraction} {
 }
 
 CBoostedTreeImpl::CBoostedTreeImpl() = default;
@@ -433,13 +484,16 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
     std::uint64_t lastMemoryUsage(this->memoryUsage());
     recordMemoryUsage(lastMemoryUsage);
 
+    core::CPackedBitVector allTrainingRowsMask{this->allTrainingRowsMask()};
+    core::CPackedBitVector noRowsMask{allTrainingRowsMask.size(), false};
+
     if (this->canTrain() == false) {
 
         // Fallback to using the constant predictor which minimises the loss.
 
-        core::CPackedBitVector trainingRowMask{this->allTrainingRowsMask()};
-        m_BestForest.assign(1, this->initializePredictionsAndLossDerivatives(frame, trainingRowMask));
-        m_BestForestTestLoss = this->meanLoss(frame, trainingRowMask, m_BestForest);
+        m_BestForest.assign(1, this->initializePredictionsAndLossDerivatives(
+                                   frame, allTrainingRowsMask, noRowsMask));
+        m_BestForestTestLoss = this->meanLoss(frame, allTrainingRowsMask);
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
     } else if (m_CurrentRound < m_NumberRounds || m_BestForest.empty()) {
@@ -454,9 +508,12 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
             LOG_TRACE(<< "Optimisation round = " << m_CurrentRound + 1);
 
-            TMeanVarAccumulator lossMoments{this->crossValidateForest(frame, recordMemoryUsage)};
+            TMeanVarAccumulator lossMoments;
+            std::size_t maximumNumberTrees;
+            std::tie(lossMoments, maximumNumberTrees) =
+                this->crossValidateForest(frame, recordMemoryUsage);
 
-            this->captureBestHyperparameters(lossMoments);
+            this->captureBestHyperparameters(lossMoments, maximumNumberTrees);
 
             // Trap the case that the dependent variable is (effectively) constant.
             // There is no point adjusting hyperparameters in this case - and we run
@@ -486,8 +543,10 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
         this->restoreBestHyperparameters();
+        std::tie(m_BestForest, std::ignore) =
+            this->trainForest(frame, allTrainingRowsMask, allTrainingRowsMask,
+                              m_TrainingProgress, recordMemoryUsage);
 
-        m_BestForest = this->trainForest(frame, this->allTrainingRowsMask(), recordMemoryUsage);
         this->recordState(recordTrainStateCallback);
 
         timeAccumulator.add(static_cast<float>(stopWatch.stop()));
@@ -614,26 +673,34 @@ CBoostedTreeImpl::gainAndCurvatureAtPercentile(double percentile,
     return {gains[index], curvatures[index]};
 }
 
-CBoostedTreeImpl::TMeanVarAccumulator
+CBoostedTreeImpl::TMeanVarAccumulatorSizePr
 CBoostedTreeImpl::crossValidateForest(core::CDataFrame& frame,
-                                      const TMemoryUsageCallback& recordMemoryUsage) const {
+                                      const TMemoryUsageCallback& recordMemoryUsage) {
     TMeanVarAccumulator lossMoments;
+    TDoubleVec numberTrees(m_NumberFolds);
     for (std::size_t i = 0; i < m_NumberFolds; ++i) {
-        TNodeVecVec forest(this->trainForest(frame, m_TrainingRowMasks[i], recordMemoryUsage));
-        double loss{this->meanLoss(frame, m_TestingRowMasks[i], forest)};
-        lossMoments.add(loss);
+        TNodeVecVec forest;
+        double loss;
+        std::tie(forest, loss) =
+            this->trainForest(frame, m_TrainingRowMasks[i], m_TestingRowMasks[i],
+                              m_TrainingProgress, recordMemoryUsage);
         LOG_TRACE(<< "fold = " << i << " forest size = " << forest.size()
                   << " test set loss = " << loss);
+        lossMoments.add(loss);
+        numberTrees[i] = static_cast<double>(forest.size());
     }
+    std::sort(numberTrees.begin(), numberTrees.end());
     LOG_TRACE(<< "test mean loss = " << CBasicStatistics::mean(lossMoments)
               << ", sigma = " << std::sqrt(CBasicStatistics::mean(lossMoments)));
-    return lossMoments;
+    return {lossMoments, static_cast<std::size_t>(CBasicStatistics::median(numberTrees))};
 }
 
 CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivatives(
     core::CDataFrame& frame,
-    const core::CPackedBitVector& trainingRowMask) const {
+    const core::CPackedBitVector& trainingRowMask,
+    const core::CPackedBitVector& testingRowMask) const {
 
+    core::CPackedBitVector updateRowMask{trainingRowMask | testingRowMask};
     frame.writeColumns(m_NumberThreads, 0, frame.numberRows(),
                        [](TRowItr beginRows, TRowItr endRows) {
                            for (auto row = beginRows; row != endRows; ++row) {
@@ -643,25 +710,29 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
                                row->writeColumn(lossCurvatureColumn(numberColumns), 0.0);
                            }
                        },
-                       &trainingRowMask);
+                       &updateRowMask);
 
     // At the start we will centre the data w.r.t. the given loss function.
     TNodeVec tree(1);
-    this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask, 1.0, tree);
+    this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask,
+                                               testingRowMask, 1.0, tree);
 
     return tree;
 }
 
-CBoostedTreeImpl::TNodeVecVec
+CBoostedTreeImpl::TNodeVecVecDoublePr
 CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
                               const core::CPackedBitVector& trainingRowMask,
+                              const core::CPackedBitVector& testingRowMask,
+                              core::CLoopProgress& trainingProgress,
                               const TMemoryUsageCallback& recordMemoryUsage) const {
 
     LOG_TRACE(<< "Training one forest...");
 
     std::size_t maximumTreeSize{this->maximumTreeSize(trainingRowMask)};
 
-    TNodeVecVec forest{this->initializePredictionsAndLossDerivatives(frame, trainingRowMask)};
+    TNodeVecVec forest{this->initializePredictionsAndLossDerivatives(
+        frame, trainingRowMask, testingRowMask)};
     forest.reserve(m_MaximumNumberTrees);
 
     CScopeRecordMemoryUsage scopeMemoryUsage{forest, recordMemoryUsage};
@@ -690,6 +761,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
     scopeMemoryUsage.add(candidateSplits);
 
     std::size_t retries{0};
+    CTrainForestStoppingCondition stoppingCondition{m_MaximumNumberTrees};
     do {
         auto tree = this->trainTree(frame, downsampledRowMask, candidateSplits,
                                     maximumTreeSize, recordMemoryUsage);
@@ -702,11 +774,12 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
 
         if (tree.size() > 1) {
             scopeMemoryUsage.add(tree);
-            this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask, eta, tree);
+            this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask,
+                                                       testingRowMask, eta, tree);
             forest.push_back(std::move(tree));
             eta = std::min(1.0, m_EtaGrowthRatePerTree * eta);
             retries = 0;
-            m_TrainingProgress.increment();
+            trainingProgress.increment();
         } else {
             // Refresh splits in case it allows us to find tree which can reduce loss.
             candidateSplits = this->candidateSplits(frame, downsampledRowMask);
@@ -721,15 +794,21 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
             nextTreeCountToRefreshSplits +=
                 static_cast<std::size_t>(std::max(0.5 / eta, 2.0));
         }
-    } while (forest.size() < m_MaximumNumberTrees);
+    } while (stoppingCondition.shouldStop(forest.size(), [&]() {
+        return this->meanLoss(frame, testingRowMask);
+    }) == false);
+
+    LOG_TRACE(<< "Stopped at " << forest.size() - 1 << "/" << m_MaximumNumberTrees);
+
+    trainingProgress.increment(std::max(m_MaximumNumberTrees, forest.size()) -
+                               forest.size());
+
+    forest.resize(stoppingCondition.bestSize());
 
     LOG_TRACE(<< "Trained one forest");
     LOG_TRACE(<< "number trees = " << forest.size());
 
-    m_TrainingProgress.increment(std::max(m_MaximumNumberTrees, forest.size()) -
-                                 forest.size());
-
-    return forest;
+    return {forest, stoppingCondition.bestLoss()};
 }
 
 core::CPackedBitVector
@@ -946,6 +1025,7 @@ CBoostedTreeImpl::TSizeVec CBoostedTreeImpl::featureBag() const {
 
 void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& frame,
                                                             const core::CPackedBitVector& trainingRowMask,
+                                                            const core::CPackedBitVector& testingRowMask,
                                                             double eta,
                                                             TNodeVec& tree) const {
 
@@ -991,46 +1071,36 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
 
     LOG_TRACE(<< "tree =\n" << root(tree).print(tree));
 
+    core::CPackedBitVector updateRowMask{trainingRowMask | testingRowMask};
     auto results = frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(),
-        core::bindRetrievableState(
-            [&](double& loss, TRowItr beginRows, TRowItr endRows) {
-                for (auto row = beginRows; row != endRows; ++row) {
-                    std::size_t numberColumns{row->numberColumns()};
-                    double prediction{readPrediction(*row) +
-                                      root(tree).value(m_Encoder->encode(*row), tree)};
-                    double actual{readActual(*row, m_DependentVariable)};
-                    double weight{readExampleWeight(*row)};
+        [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                std::size_t numberColumns{row->numberColumns()};
+                double prediction{readPrediction(*row) +
+                                  root(tree).value(m_Encoder->encode(*row), tree)};
+                double actual{readActual(*row, m_DependentVariable)};
+                double weight{readExampleWeight(*row)};
 
-                    row->writeColumn(predictionColumn(numberColumns), prediction);
-                    row->writeColumn(lossGradientColumn(numberColumns),
-                                     m_Loss->gradient(prediction, actual, weight));
-                    row->writeColumn(lossCurvatureColumn(numberColumns),
-                                     m_Loss->curvature(prediction, actual, weight));
-
-                    loss += m_Loss->value(prediction, actual, weight);
-                }
-            },
-            0.0 /*total loss*/),
-        &trainingRowMask);
-
-    double totalLoss{0.0};
-    for (const auto& loss : results.first) {
-        totalLoss += loss.s_FunctionState;
-    }
-    LOG_TRACE(<< "training set loss = " << totalLoss);
+                row->writeColumn(predictionColumn(numberColumns), prediction);
+                row->writeColumn(lossGradientColumn(numberColumns),
+                                 m_Loss->gradient(prediction, actual, weight));
+                row->writeColumn(lossCurvatureColumn(numberColumns),
+                                 m_Loss->curvature(prediction, actual, weight));
+            }
+        },
+        &updateRowMask);
 }
 
 double CBoostedTreeImpl::meanLoss(const core::CDataFrame& frame,
-                                  const core::CPackedBitVector& rowMask,
-                                  const TNodeVecVec& forest) const {
+                                  const core::CPackedBitVector& rowMask) const {
 
     auto results = frame.readRows(
         m_NumberThreads, 0, frame.numberRows(),
         core::bindRetrievableState(
             [&](TMeanAccumulator& loss, TRowItr beginRows, TRowItr endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
-                    double prediction{predictRow(m_Encoder->encode(*row), forest)};
+                    double prediction{readPrediction(*row)};
                     double actual{readActual(*row, m_DependentVariable)};
                     loss.add(m_Loss->value(prediction, actual));
                 }
@@ -1168,7 +1238,8 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     return true;
 }
 
-void CBoostedTreeImpl::captureBestHyperparameters(const TMeanVarAccumulator& lossMoments) {
+void CBoostedTreeImpl::captureBestHyperparameters(const TMeanVarAccumulator& lossMoments,
+                                                  std::size_t maximumNumberTrees) {
     // We capture the parameters with the lowest error at one standard
     // deviation above the mean. If the mean error improvement is marginal
     // we prefer the solution with the least variation across the folds.
@@ -1177,8 +1248,8 @@ void CBoostedTreeImpl::captureBestHyperparameters(const TMeanVarAccumulator& los
     if (loss < m_BestForestTestLoss) {
         m_BestForestTestLoss = loss;
         m_BestHyperparameters = CBoostedTreeHyperparameters{
-            m_Regularization, m_DownsampleFactor, m_Eta, m_EtaGrowthRatePerTree,
-            m_FeatureBagFraction};
+            m_Regularization,       m_DownsampleFactor, m_Eta,
+            m_EtaGrowthRatePerTree, maximumNumberTrees, m_FeatureBagFraction};
     }
 }
 
@@ -1187,10 +1258,12 @@ void CBoostedTreeImpl::restoreBestHyperparameters() {
     m_DownsampleFactor = m_BestHyperparameters.downsampleFactor();
     m_Eta = m_BestHyperparameters.eta();
     m_EtaGrowthRatePerTree = m_BestHyperparameters.etaGrowthRatePerTree();
+    m_MaximumNumberTrees = m_BestHyperparameters.maximumNumberTrees();
     m_FeatureBagFraction = m_BestHyperparameters.featureBagFraction();
-    LOG_INFO(<< "Best hyperparameters: regularization* = " << m_Regularization.print()
+    LOG_INFO(<< "regularization* = " << m_Regularization.print()
              << ", downsample factor* = " << m_DownsampleFactor << ", eta* = " << m_Eta
              << ", eta growth rate per tree* = " << m_EtaGrowthRatePerTree
+             << ", maximum number trees* = " << m_MaximumNumberTrees
              << ", feature bag fraction* = " << m_FeatureBagFraction);
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(testNonLinear) {
         // Unbiased...
         BOOST_REQUIRE_CLOSE_ABSOLUTE(
             0.0, modelBias[i][0],
-            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.955);
 
@@ -651,7 +651,7 @@ BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.06);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.08);
     BOOST_TEST_REQUIRE(modelRSquared > 0.98);
 }
 
@@ -1130,13 +1130,13 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.8);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.7);
         meanLogRelativeError.add(maths::CBasicStatistics::mean(logRelativeError));
     }
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.6);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(testUnbalancedClasses) {
@@ -1146,9 +1146,9 @@ BOOST_AUTO_TEST_CASE(testUnbalancedClasses) {
 
     test::CRandomNumbers rng;
 
-    std::size_t trainRows{1000};
+    std::size_t trainRows{2000};
     std::size_t classes[]{1, 0, 1, 0};
-    std::size_t classesRowCounts[]{800, 200, 100, 100};
+    std::size_t classesRowCounts[]{1600, 400, 100, 100};
     std::size_t cols{3};
 
     TDoubleVecVec x;
@@ -1226,9 +1226,9 @@ BOOST_AUTO_TEST_CASE(testUnbalancedClasses) {
 
     // We expect more similar precision and recall when balancing training loss.
     BOOST_TEST_REQUIRE(std::fabs(precisions[1][0] - precisions[1][1]) <
-                       0.4 * std::fabs(precisions[0][0] - precisions[0][1]));
+                       0.25 * std::fabs(precisions[0][0] - precisions[0][1]));
     BOOST_TEST_REQUIRE(std::fabs(recalls[1][0] - recalls[1][1]) <
-                       0.4 * std::fabs(recalls[0][0] - recalls[0][1]));
+                       0.25 * std::fabs(recalls[0][0] - recalls[0][1]));
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1136,7 +1136,7 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.51);
 }
 
 BOOST_AUTO_TEST_CASE(testUnbalancedClasses) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.075);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.09);
     BOOST_TEST_REQUIRE(modelRSquared > 0.97);
 }
 
@@ -829,7 +829,7 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
             meanDepth.add(static_cast<double>(maxDepth(tree, tree[0], 0)));
         }
         LOG_DEBUG(<< "mean depth = " << maths::CBasicStatistics::mean(meanDepth));
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanDepth) > targetDepth - 1.0);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanDepth) > targetDepth - 1.1);
     }
 }
 


### PR DESCRIPTION
We can relatively cheaply (around a 2% overhead) compute predictions for the test rows at the same time as we compute them for the training rows. This means we can cheaply track the validation error as we add additional trees to the forest during training.

The validation error curve is fairly predictable: it decreases quickly (typically exponentially) at the start, hits a minimum and then often increases slightly as the model starts to overfit the training data. This change introduces a very simple exit condition designed to ensure we pay a fixed relative runtime cost for ensuring we don't exit too soon. Specifically, add at least f * "maximum number of trees" trees to the lowest validation error forest and resize the forest to minimise validation error at the end of training. We set f to be 0.05, i.e. 5% of the total cost of training the forest.

I don't think this is the final version of early stopping. When we have a compute budget, or some way for the user to fix a scale between the run time and accuracy they'd be happy with, we can be more clever in how we stop. However, I've tested this on 15 benchmark data sets and it often slightly improves QoR and I've seen large (6x) drops in runtime for some data sets. I think this therefore represents a clear improvement over our current strategy.