### PR TITLE
[7.x][ML] Tweak CBoostedTreeTest.testLogisticRegression test threshold further

### DIFF
--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1136,7 +1136,7 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.51);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.52);
 }
 
 BOOST_AUTO_TEST_CASE(testUnbalancedClasses) {


### PR DESCRIPTION
The older version of clang used on the 7.x El Capitan reference
build server creates an actual value of 0.51796218392671234, so
increase the threshold to 0.52

Backport of #887