### PR TITLE
[ML] Switch the record memory callback usage to use a signed type for memory

### DIFF
--- a/include/maths/CDataFrameRegressionModel.h
+++ b/include/maths/CDataFrameRegressionModel.h
@@ -28,7 +28,7 @@ class MATHS_EXPORT CDataFrameRegressionModel {
 public:
     using TDoubleVec = std::vector<double>;
     using TProgressCallback = std::function<void(double)>;
-    using TMemoryUsageCallback = std::function<void(std::uint64_t)>;
+    using TMemoryUsageCallback = std::function<void(std::int64_t)>;
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
     using TTrainingStateCallback = std::function<void(TPersistFunc)>;
 

--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -41,7 +41,7 @@ using TDouble1VecVec = std::vector<TDouble1Vec>;
 using TDouble1VecVec2Vec = core::CSmallVector<TDouble1VecVec, 2>;
 using TDouble1Vec2Vec = core::CSmallVector<TDouble1Vec, 2>;
 using TProgressCallback = std::function<void(double)>;
-using TMemoryUsageCallback = std::function<void(std::uint64_t)>;
+using TMemoryUsageCallback = std::function<void(std::int64_t)>;
 using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 //! Get the distance in the complement space of the projection.

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -474,7 +474,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     m_TrainingProgress.progressCallback(recordProgress);
 
-    std::uint64_t lastMemoryUsage(this->memoryUsage());
+    std::int64_t lastMemoryUsage(this->memoryUsage());
     recordMemoryUsage(lastMemoryUsage);
 
     core::CPackedBitVector allTrainingRowsMask{this->allTrainingRowsMask()};


### PR DESCRIPTION
We end up needing to subtract memory usage when it's freed so the record memory usage callback needs to allow for the supplied memory being negative. Also, we should never overflow `int64_t` so can just go ahead and cast values where they're supplied to this function.

This PR fixes the function typedef used for outlier detection and regression and tidies up its usage. I'm marking as non-issue since it is non-functional, but this makes the intention much clearer.

Fixes #836.