### PR TITLE
[7.x][ML] Use analysis name as suffix for the state doc id (#896)

### DIFF
--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -143,6 +143,9 @@ public:
     //! \return The jobId.
     const std::string& jobId() const;
 
+    //! \return The analysis name.
+    const std::string& analysisName() const;
+
     //! \return The names of the categorical fields.
     const TStrVec& categoricalFieldNames() const;
 
@@ -199,6 +202,7 @@ private:
     std::string m_TemporaryDirectory;
     std::string m_ResultsField;
     std::string m_JobId;
+    std::string m_AnalysisName;
     TStrVec m_CategoricalFieldNames;
     bool m_DiskUsageAllowed;
     // TODO Sparse table support

--- a/include/api/ElasticsearchStateIndex.h
+++ b/include/api/ElasticsearchStateIndex.h
@@ -15,9 +15,9 @@ namespace api {
 //! Elasticsearch index for state
 extern API_EXPORT const std::string ML_STATE_INDEX;
 extern API_EXPORT const std::string MODEL_STATE_TYPE;
-extern API_EXPORT const std::string REGRESSION_TRAIN_STATE_TYPE;
+extern API_EXPORT const std::string STATE_ID_SUFFIX;
 
-API_EXPORT std::string getRegressionStateId(const std::string& jobId);
+API_EXPORT std::string getStateId(const std::string& jobId, const std::string& analysisName);
 }
 }
 

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -221,7 +221,7 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
         if (persister != nullptr) {
             core::CStateCompressor compressor(*persister);
             auto persistStream = compressor.addStreamed(
-                ML_STATE_INDEX, getRegressionStateId(m_Spec.jobId()));
+                ML_STATE_INDEX, getStateId(m_Spec.jobId(), m_Spec.analysisName()));
             {
                 core::CJsonStatePersistInserter inserter{*persistStream};
                 persistFunction(inserter);

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -225,10 +225,11 @@ void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& j
 
     auto analysis = ANALYSIS_READER.read(jsonAnalysis);
 
-    std::string name{analysis[NAME].as<std::string>()};
+    m_AnalysisName = analysis[NAME].as<std::string>();
+    LOG_INFO(<< "Parsed analysis with name '" << m_AnalysisName << "'");
 
     for (const auto& factory : m_RunnerFactories) {
-        if (name == factory->name()) {
+        if (m_AnalysisName == factory->name()) {
             auto parameters = analysis[PARAMETERS].jsonObject();
             m_Runner = parameters != nullptr ? factory->make(*this, *parameters)
                                              : factory->make(*this);
@@ -236,7 +237,7 @@ void CDataFrameAnalysisSpecification::initializeRunner(const rapidjson::Value& j
         }
     }
 
-    HANDLE_FATAL(<< "Input error: unexpected analysis name '" << name
+    HANDLE_FATAL(<< "Input error: unexpected analysis name '" << m_AnalysisName
                  << "'. Please report this problem.");
 }
 
@@ -262,6 +263,10 @@ CDataFrameAnalysisSpecification::noopRestoreSearcherSupplier() {
 
 const std::string& CDataFrameAnalysisSpecification::jobId() const {
     return m_JobId;
+}
+
+const std::string& CDataFrameAnalysisSpecification::analysisName() const {
+    return m_AnalysisName;
 }
 
 const CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::runner() {

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -249,7 +249,7 @@ bool CDataFrameTrainBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& fram
     try {
         core::CStateDecompressor decompressor(*restoreSearcher);
         decompressor.setStateRestoreSearch(
-            ML_STATE_INDEX, getRegressionStateId(this->spec().jobId()));
+            ML_STATE_INDEX, getStateId(this->spec().jobId(), this->spec().analysisName()));
         core::CDataSearcher::TIStreamP inputStream{decompressor.search(1, 1)}; // search arguments are ignored
         if (inputStream == nullptr) {
             LOG_ERROR(<< "Unable to connect to data store");

--- a/lib/api/ElasticsearchStateIndex.cc
+++ b/lib/api/ElasticsearchStateIndex.cc
@@ -11,10 +11,10 @@ namespace api {
 
 const std::string ML_STATE_INDEX{".ml-state"};
 const std::string MODEL_STATE_TYPE{"model_state"};
-const std::string REGRESSION_TRAIN_STATE_TYPE{"regression_state"};
+const std::string STATE_ID_SUFFIX{"_state"};
 
-std::string getRegressionStateId(const std::string& jobId) {
-    return jobId + '_' + REGRESSION_TRAIN_STATE_TYPE;
+std::string getStateId(const std::string& jobId, const std::string& analysisName) {
+    return jobId + '_' + analysisName + STATE_ID_SUFFIX;
 }
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -94,7 +94,7 @@ auto restoreTree(std::string persistedState, TDataFrameUPtr& frame, std::size_t 
     CTestDataSearcher dataSearcher(persistedState);
     auto decompressor = std::make_unique<core::CStateDecompressor>(dataSearcher);
     decompressor->setStateRestoreSearch(api::ML_STATE_INDEX,
-                                        api::getRegressionStateId("testJob"));
+                                        api::getStateId("testJob", "regression"));
     auto stream = decompressor->search(1, 1);
     return maths::CBoostedTreeFactory::constructFromString(*stream).restoreFor(
         *frame, dependentVariable);


### PR DESCRIPTION
Currently the state document id for regression and classification
analysis both use the suffix `_regression_state`. However, it would
make things clearer to include the analysis name in the doc id as
it gives us the ability to check we are restoring the right state.

This commit makes this change.

Backport of #896