### PR TITLE
[7.x][ML] Adjust platform specific artifact creation and upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ task format(type: Exec) {
 }
 
 def zipSpec = copySpec {
-  from("${projectDir}/build/distribution") {
+  from("${buildDir}/distribution") {
     // Don't copy Windows import libraries
     exclude "**/*.lib"
     // Don't copy the test support library
@@ -117,7 +117,7 @@ task buildZip(type: Zip) {
 }
 
 def zipSpecSymbols = copySpec {
-  from("${projectDir}/build/distribution") {
+  from("${buildDir}/distribution") {
     // only take debug files
     include "**/*-debug"
     include "**/*.pdb"
@@ -140,7 +140,7 @@ def uberZipSpec = copySpec {
   // We know we'll have binaries from the current build
   from(zipTree(buildZip.outputs.files.singleFile))
   // We might also have binaries for other platforms (e.g. if they've been built in Docker)
-  def localZips = fileTree("${projectDir}/build/distributions").matching {
+  def localZips = fileTree("${buildDir}/distributions").matching {
       include "${artifactName}-${project.version}-darwin-*.zip"
       include "${artifactName}-${project.version}-linux-*.zip"
       include "${artifactName}-${project.version}-windows-*.zip"

--- a/upload.gradle
+++ b/upload.gradle
@@ -2,6 +2,8 @@ description = 'Uploads the Machine Learning native binaries to s3'
 
 import org.elastic.gradle.UploadS3Task
 
+import java.util.zip.ZipFile
+
 String versionQualifier = System.getProperty("build.version_qualifier", "")
 boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 
@@ -32,57 +34,97 @@ if (envMlAwsSecretKey != null) {
   project.ext.mlAwsSecretKey = ML_AWS_SECRET_KEY
 }
 
-allprojects {
-  repositories {
-    if (System.getProperty("repos.mavenlocal") != null) {
-      // with -Drepos.mavenlocal=true we can force checking the local .m2 repo which is useful for building against
-      // elasticsearch snapshots
-      mavenLocal()
-    }
-    maven {
-      url "s3://prelert-artifacts/maven"
-      credentials(AwsCredentials) {
-        accessKey "${mlAwsAccessKey}"
-        secretKey "${mlAwsSecretKey}"
-      }
+/**
+ * Gradle 6 gets confused if we try to use its standard dependency management to
+ * convert artifacts with a classifier to an artifact for the same project
+ * without a classifier.  Therefore this class uses low level functionality to
+ * get the platform-specific artifacts.
+ */
+class DownloadPlatformSpecific extends DefaultTask {
+
+  String version = project.version
+  String artifactGroupPath = project.group.replaceAll("\\.", "/")
+
+  /**
+   * Base name for the artifacts
+   */
+  String baseName
+
+  /**
+   * Directory to download platform specific zip files into
+   */
+  File downloadDirectory
+
+  /**
+   * Directory to extract downloaded zip files into
+   */
+  @OutputDirectory
+  File extractDirectory
+
+  List<String> platforms = [ 'darwin-x86_64', 'linux-x86_64', 'windows-x86_64' ]
+
+  DownloadPlatformSpecific() {
+    // Always run this task, in case the platform-specific zips have changed
+    outputs.upToDateWhen {
+      return false
     }
   }
-}
 
-configurations {
-  archives
-}
-
-dependencies {
-  archives group: "${project.group}", name: "${artifactName}", version:"${project.version}", classifier: 'darwin-x86_64', ext: 'zip'
-  archives group: "${project.group}", name: "${artifactName}", version:"${project.version}", classifier: 'linux-x86_64', ext: 'zip'
-  archives group: "${project.group}", name: "${artifactName}", version:"${project.version}", classifier: 'windows-x86_64', ext: 'zip'
+  @TaskAction
+  void combine() {
+    extractDirectory.deleteDir()
+    platforms.each {
+      File zipFile = new File(downloadDirectory, "${baseName}-${version}-${it}.zip")
+      zipFile.parentFile.mkdirs()
+      new URL("https://prelert-artifacts.s3.amazonaws.com/maven/${artifactGroupPath}/${baseName}/${version}/${zipFile.name}").withInputStream { i ->
+        zipFile.withOutputStream { o ->
+          o << i
+        }
+      }
+      ZipFile zip = new ZipFile(zipFile)
+      zip.entries().each {
+        File target = new File(extractDirectory, it.name)
+        // There can be overlaps between the platform-specific zips, so skip duplicates
+        if (target.exists() == false) {
+          if (it.isDirectory()) {
+            target.mkdirs()
+          } else {
+            target.parentFile.mkdirs()
+            target.withOutputStream { o ->
+              o << zip.getInputStream(it)
+            }
+            target.setLastModified(it.getTime())
+          }
+        }
+      }
+      zip.close()
+    }
+  }
 }
 
 task upload(type: UploadS3Task) {
   bucket 'prelert-artifacts'
   // Only upload the platform-specific artifacts in this task
-  def zipFileDir = fileTree(dir: "${projectDir}/build/distributions").matching { include "*-x86_64.zip" }
+  def zipFileDir = fileTree("${buildDir}/distributions").matching { include "*-x86_64.zip" }
   for (zipFile in zipFileDir) {
     upload zipFile, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${zipFile.name}"
   }
   description = 'Upload C++ zips to S3 Bucket'
 }
 
-task buildUberZip(type: Zip) {
-  dependsOn configurations.archives
-  baseName = "$artifactName"
-  // The 'from' section must be a closure, otherwise the dependencies will be downloaded during
-  // the configuration phase, which is not what we want when simply using the 'upload' task
-  from {
-    configurations.archives.collect {
-      from(zipTree(it))
-    }
-    duplicatesStrategy 'exclude'
-  }
-  destinationDir = file("${buildDir}/distributions")
+task downloadPlatformSpecific(type: DownloadPlatformSpecific) {
+  baseName = artifactName
+  downloadDirectory = file("${buildDir}/distributions")
+  extractDirectory = file("${buildDir}/temp")
+  description = 'Download and extract previously created platform-specific C++ zips'
+}
+
+task buildUberZip(type: Zip, dependsOn: downloadPlatformSpecific) {
+  baseName = artifactName
   version = project.version
-  description = 'Download previously created platform-specific C++ zips and combine them into an uber zip'
+  destinationDirectory = file("${buildDir}/distributions")
+  from(fileTree(downloadPlatformSpecific.outputs.files.singleFile))
+  description = 'Create an uber zip from combined platform-specific C++ distributions'
 }
 
 task uberUpload(type: UploadS3Task, dependsOn: buildUberZip) {


### PR DESCRIPTION
Gradle 6 gets confused if we try to use its standard dependency
management to convert artifacts with a classifier to an artifact
for the same project without a classifier.

To sidestep this problem this PR changes upload.gradle to use
low level functionality to get the platform-specific artifacts.

Backport of #910