### PR TITLE
[ML] Rename result shap prefix

### DIFF
--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -34,8 +34,6 @@ using TDoubleVec = std::vector<double>;
 using TStrVec = std::vector<std::string>;
 using TMeanVarAccumulator = ml::maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
-const std::string SHAP_PREFIX{"feature_importance."};
-
 void setupLinearRegressionData(const TStrVec& fieldNames,
                                TStrVec& fieldValues,
                                api::CDataFrameAnalyzer& analyzer,

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -7,6 +7,7 @@
 #include <core/CDataFrame.h>
 
 #include <maths/CBasicStatistics.h>
+#include <maths/CDataFrameRegressionModel.h>
 #include <maths/CTools.h>
 
 #include <api/CDataFrameAnalyzer.h>
@@ -32,6 +33,8 @@ using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
 using TDoubleVec = std::vector<double>;
 using TStrVec = std::vector<std::string>;
 using TMeanVarAccumulator = ml::maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+
+const std::string SHAP_PREFIX{"feature_importance."};
 
 void setupLinearRegressionData(const TStrVec& fieldNames,
                                TStrVec& fieldValues,
@@ -186,10 +189,14 @@ BOOST_FIXTURE_TEST_CASE(testRunBoostedTreeRegressionFeatureImportanceAllShap, SF
     double c1Sum{0.0}, c2Sum{0.0}, c3Sum{0.0}, c4Sum{0.0};
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
-            double c1{result["row_results"]["results"]["ml"]["shap.c1"].GetDouble()};
-            double c2{result["row_results"]["results"]["ml"]["shap.c2"].GetDouble()};
-            double c3{result["row_results"]["results"]["ml"]["shap.c3"].GetDouble()};
-            double c4{result["row_results"]["results"]["ml"]["shap.c4"].GetDouble()};
+            double c1{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c1"]
+                          .GetDouble()};
+            double c2{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c2"]
+                          .GetDouble()};
+            double c3{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c3"]
+                          .GetDouble()};
+            double c4{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c4"]
+                          .GetDouble()};
             double prediction{
                 result["row_results"]["results"]["ml"]["c5_prediction"].GetDouble()};
             // the difference between the prediction and the sum of all SHAP values constitutes bias
@@ -223,10 +230,14 @@ BOOST_FIXTURE_TEST_CASE(testRunBoostedTreeRegressionFeatureImportanceNoImportanc
 
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
-            double c1{result["row_results"]["results"]["ml"]["shap.c1"].GetDouble()};
-            double c2{result["row_results"]["results"]["ml"]["shap.c2"].GetDouble()};
-            double c3{result["row_results"]["results"]["ml"]["shap.c3"].GetDouble()};
-            double c4{result["row_results"]["results"]["ml"]["shap.c4"].GetDouble()};
+            double c1{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c1"]
+                          .GetDouble()};
+            double c2{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c2"]
+                          .GetDouble()};
+            double c3{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c3"]
+                          .GetDouble()};
+            double c4{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c4"]
+                          .GetDouble()};
             double prediction{
                 result["row_results"]["results"]["ml"]["c5_prediction"].GetDouble()};
             // c1 explain 97% of the prediction value, i.e. the difference from the prediction is less than 1%.
@@ -252,10 +263,14 @@ BOOST_FIXTURE_TEST_CASE(testRunBoostedTreeClassificationFeatureImportanceAllShap
     double c1Sum{0.0}, c2Sum{0.0}, c3Sum{0.0}, c4Sum{0.0};
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
-            double c1{result["row_results"]["results"]["ml"]["shap.c1"].GetDouble()};
-            double c2{result["row_results"]["results"]["ml"]["shap.c2"].GetDouble()};
-            double c3{result["row_results"]["results"]["ml"]["shap.c3"].GetDouble()};
-            double c4{result["row_results"]["results"]["ml"]["shap.c4"].GetDouble()};
+            double c1{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c1"]
+                          .GetDouble()};
+            double c2{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c2"]
+                          .GetDouble()};
+            double c3{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c3"]
+                          .GetDouble()};
+            double c4{result["row_results"]["results"]["ml"][maths::CDataFrameRegressionModel::SHAP_PREFIX + "c4"]
+                          .GetDouble()};
             double predictionProbability{
                 result["row_results"]["results"]["ml"]["prediction_probability"].GetDouble()};
             std::string c5Prediction{
@@ -297,14 +312,14 @@ BOOST_FIXTURE_TEST_CASE(testRunBoostedTreeRegressionFeatureImportanceNoShap, SFi
 
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember("shap.c1") == false);
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember("shap.c2") == false);
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember("shap.c3") == false);
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember("shap.c4") == false);
+            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
+                                   maths::CDataFrameRegressionModel::SHAP_PREFIX + "c1") == false);
+            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
+                                   maths::CDataFrameRegressionModel::SHAP_PREFIX + "c2") == false);
+            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
+                                   maths::CDataFrameRegressionModel::SHAP_PREFIX + "c3") == false);
+            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
+                                   maths::CDataFrameRegressionModel::SHAP_PREFIX + "c4") == false);
         }
     }
 }

--- a/lib/maths/CDataFrameRegressionModel.cc
+++ b/lib/maths/CDataFrameRegressionModel.cc
@@ -9,7 +9,7 @@
 namespace ml {
 namespace maths {
 
-const std::string CDataFrameRegressionModel::SHAP_PREFIX{"shap."};
+const std::string CDataFrameRegressionModel::SHAP_PREFIX{"feature_importance."};
 
 CDataFrameRegressionModel::CDataFrameRegressionModel(core::CDataFrame& frame,
                                                      TProgressCallback recordProgress,


### PR DESCRIPTION
This PR renames the prefix for the SHAP value fields form `ml.shap.<field_name>` to `ml.feature_importance.<field_name>`.