### PR TITLE
[ML] Add CHANGELOG entry for SHAP feature

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,11 @@
 
 == {es} version 7.6.0
 
+=== New Features
+
+* Add computation of tree SHAP feature importance values (SHapley Additive
+exPlanation) for classification and regression. (See {ml-pull}857[#857].)
+
 === Enhancements
 
 * Improve performance of boosted tree training for both classification and regression.

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,8 +39,8 @@
 
 === New Features
 
-* Add computation of tree SHAP feature importance values (SHapley Additive
-exPlanation) for classification and regression. (See {ml-pull}857[#857].)
+* Add feature importance values to classification and regression results (using tree 
+SHapley Additive exPlanation, or SHAP). (See {ml-pull}857[#857].)
 
 === Enhancements
 


### PR DESCRIPTION
I add missing doc entry about the new SHAP computation feature.