### PR TITLE
[ML] Fix return of SHAP values for dependent variable issue

### DIFF
--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -168,8 +168,10 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
         }
         largestShapValues.sort();
         for (auto i : largestShapValues) {
-            writer.Key(frame.columnNames()[i]);
-            writer.Double(row[i]);
+            if (row[i] != 0.0) {
+                writer.Key(frame.columnNames()[i]);
+                writer.Double(row[i]);
+            }
         }
     }
     writer.EndObject();

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -94,8 +94,10 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
         }
         largestShapValues.sort();
         for (auto i : largestShapValues) {
-            writer.Key(frame.columnNames()[i]);
-            writer.Double(row[i]);
+            if (row[i] != 0.0) {
+                writer.Key(frame.columnNames()[i]);
+                writer.Double(row[i]);
+            }
         }
     }
     writer.EndObject();

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -57,8 +57,8 @@ void setupLinearRegressionData(const TStrVec& fieldNames,
         }
 
         fieldValues[0] = target(row);
-        for (std::size_t j = 1; j < row.size() + 1; ++j) {
-            fieldValues[j] = core::CStringUtils::typeToStringPrecise(
+        for (std::size_t j = 0; j < row.size(); ++j) {
+            fieldValues[j + 1] = core::CStringUtils::typeToStringPrecise(
                 row[j], core::CIEEE754::E_DoublePrecision);
         }
 
@@ -89,8 +89,8 @@ void setupBinaryClassificationData(const TStrVec& fieldNames,
         }
 
         fieldValues[0] = target(row);
-        for (std::size_t j = 1; j < row.size() + 1; ++j) {
-            fieldValues[j] = core::CStringUtils::typeToStringPrecise(
+        for (std::size_t j = 0; j < row.size(); ++j) {
+            fieldValues[j + 1] = core::CStringUtils::typeToStringPrecise(
                 row[j], core::CIEEE754::E_DoublePrecision);
         }
 
@@ -179,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE(testRunBoostedTreeRegressionFeatureImportanceAllShap, SF
     // the significance is proportional to the multiplier. Also make sure that the SHAP values
     // are indeed a local approximation of the prediction up to the constant bias term.
 
-    std::size_t topShapValues{5};
+    std::size_t topShapValues{5}; //Note, number of requested shap values is larger than the number of regressors
     TDoubleVec weights{50, 150, 50, -50};
     auto results{runRegression(topShapValues, weights)};
 
@@ -213,6 +213,10 @@ BOOST_FIXTURE_TEST_CASE(testRunBoostedTreeRegressionFeatureImportanceAllShap, SF
             c2Sum += std::fabs(c2);
             c3Sum += std::fabs(c3);
             c4Sum += std::fabs(c4);
+            // assert that no SHAP value for the dependent variable is returned
+            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
+                                   maths::CDataFrameRegressionModel::SHAP_PREFIX +
+                                   "target") == false);
         }
     }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1545,7 +1545,7 @@ void CBoostedTreeImpl::computeShapValues(core::CDataFrame& frame, const TProgres
         }
         auto treeFeatureImportance = std::make_unique<CTreeShapFeatureImportance>(
             m_BestForest, m_NumberThreads);
-        std::size_t numberInputFields = m_NumberInputColumns - 1;
+        std::size_t numberInputFields = m_NumberInputColumns;
         // resize data frame to write SHAP values
         std::size_t offset{frame.numberColumns()};
         frame.resizeColumns(m_NumberThreads, frame.numberColumns() + numberInputFields);


### PR DESCRIPTION
This PR prevents the return of SHAP values for features if the SHAP value is 0. If the number of non-zero SHAP values was less than `top_shap_values` parameter, this could cause the return of the dependent variable with SHAP 0.0. 

I didn't catch the bug previously, because unit tests were assuming that the dependent variable is the last input field. I adjusted the unit test moving the dependent variable forward and adding assertions.

Fixes #918 