### PR TITLE
[7.x][ML] Copy categorization data structures before background persist

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -64,6 +64,12 @@ stop early if the expected improvement is too small. (See {ml-pull}903[#903].)
 (See {ml-pull}861[#861].)
 
 
+== {es} version 7.5.2
+
+=== Bug Fixes
+* Fixes potential memory corruption or inconsistent state when background persisting
+categorizer state. (See {ml-pull}921[#921].)
+
 == {es} version 7.5.0
 
 === Enhancements

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -21,6 +21,7 @@
 namespace CPersistenceManagerTest {
 class CTestFixture;
 struct testCategorizationOnlyPersist;
+struct testBackgroundPersistCategorizationConsistency;
 }
 
 namespace ml {
@@ -218,6 +219,7 @@ private:
     // For testing
     friend class CPersistenceManagerTest::CTestFixture;
     friend struct CPersistenceManagerTest::testCategorizationOnlyPersist;
+    friend struct CPersistenceManagerTest::testBackgroundPersistCategorizationConsistency;
 };
 }
 }

--- a/include/model/CBaseTokenListDataCategorizer.h
+++ b/include/model/CBaseTokenListDataCategorizer.h
@@ -135,8 +135,16 @@ public:
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
-    //! Make a function that can be called later to persist state
-    TPersistFunc makePersistFunc() const override;
+    //! Make a function that can be called later to persist state in the
+    //! foreground, i.e. in the knowledge that no other thread will be
+    //! accessing the data structures this method accesses.
+    TPersistFunc makeForegroundPersistFunc() const override;
+
+    //! Make a function that can be called later to persist state in the
+    //! background, i.e. copying any required data such that other threads
+    //! may modify the original data structures while persistence is taking
+    //! place.
+    TPersistFunc makeBackgroundPersistFunc() const override;
 
     //! Debug the memory used by this categorizer.
     void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -89,8 +89,16 @@ public:
     //! Persist state by passing information to the supplied inserter
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const = 0;
 
-    //! Make a function that can be called later to persist state
-    virtual TPersistFunc makePersistFunc() const = 0;
+    //! Make a function that can be called later to persist state in the
+    //! foreground, i.e. in the knowledge that no other thread will be
+    //! accessing the data structures this method accesses.
+    virtual TPersistFunc makeForegroundPersistFunc() const = 0;
+
+    //! Make a function that can be called later to persist state in the
+    //! background, i.e. copying any required data such that other threads
+    //! may modify the original data structures while persistence is taking
+    //! place.
+    virtual TPersistFunc makeBackgroundPersistFunc() const = 0;
 
     //! Access to the field name
     const std::string& fieldName() const;

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -333,7 +333,7 @@ bool CFieldDataCategorizer::persistState(core::CDataAdder& persister,
 
     LOG_DEBUG(<< "Persist categorizer state");
 
-    return this->doPersistState(m_DataCategorizer->makePersistFunc(),
+    return this->doPersistState(m_DataCategorizer->makeForegroundPersistFunc(),
                                 m_ExamplesCollector, persister);
 }
 
@@ -425,8 +425,8 @@ bool CFieldDataCategorizer::periodicPersistStateInBackground() {
                       // Do NOT add std::ref wrappers
                       // around these arguments - they
                       // MUST be copied for thread safety
-                      m_DataCategorizer->makePersistFunc(), m_ExamplesCollector,
-                      std::placeholders::_1)) == false) {
+                      m_DataCategorizer->makeBackgroundPersistFunc(),
+                      m_ExamplesCollector, std::placeholders::_1)) == false) {
         LOG_ERROR(<< "Failed to add categorizer background persistence function");
         return false;
     }

--- a/lib/model/CBaseTokenListDataCategorizer.cc
+++ b/lib/model/CBaseTokenListDataCategorizer.cc
@@ -403,11 +403,20 @@ void CBaseTokenListDataCategorizer::acceptPersistInserter(const TTokenMIndex& to
     }
 }
 
-CDataCategorizer::TPersistFunc CBaseTokenListDataCategorizer::makePersistFunc() const {
+CDataCategorizer::TPersistFunc CBaseTokenListDataCategorizer::makeForegroundPersistFunc() const {
     return std::bind(
         static_cast<void (*)(const TTokenMIndex&, const TTokenListCategoryVec&, core::CStatePersistInserter&)>(
             &CBaseTokenListDataCategorizer::acceptPersistInserter),
         std::cref(m_TokenIdLookup), std::cref(m_Categories), std::placeholders::_1);
+}
+
+CDataCategorizer::TPersistFunc CBaseTokenListDataCategorizer::makeBackgroundPersistFunc() const {
+    return std::bind(
+        static_cast<void (*)(const TTokenMIndex&, const TTokenListCategoryVec&, core::CStatePersistInserter&)>(
+            &CBaseTokenListDataCategorizer::acceptPersistInserter),
+        // Do NOT add std::ref wrappers around these arguments - they MUST be
+        // copied for thread safety
+        m_TokenIdLookup, m_Categories, std::placeholders::_1);
 }
 
 void CBaseTokenListDataCategorizer::addCategoryMatch(bool isDryRun,


### PR DESCRIPTION
All data structures to be persisted need to be copied before a
background persist is started, otherwise inconsistent state could
be persisted as the foreground thread updates the data structures
(or worse, the program could crash).

Backport of #921