### PR TITLE
[7.5][ML] Copy categorization data structures before background persist

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 7.5.2
+
+=== Bug Fixes
+* Fixes potential memory corruption or inconsistent state when background persisting
+categorizer state. (See {ml-pull}921[#921].)
+
 == {es} version 7.5.0
 
 === Enhancements

--- a/include/api/CBaseTokenListDataTyper.h
+++ b/include/api/CBaseTokenListDataTyper.h
@@ -130,8 +130,16 @@ public:
     //! Persist state by passing information to the supplied inserter
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
-    //! Make a function that can be called later to persist state
-    virtual TPersistFunc makePersistFunc() const;
+    //! Make a function that can be called later to persist state in the
+    //! foreground, i.e. in the knowledge that no other thread will be
+    //! accessing the data structures this method accesses.
+    virtual TPersistFunc makeForegroundPersistFunc() const;
+
+    //! Make a function that can be called later to persist state in the
+    //! background, i.e. copying any required data such that other threads
+    //! may modify the original data structures while persistence is taking
+    //! place.
+    virtual TPersistFunc makeBackgroundPersistFunc() const;
 
 protected:
     //! Split the string into a list of tokens.  The result of the

--- a/include/api/CDataTyper.h
+++ b/include/api/CDataTyper.h
@@ -88,8 +88,16 @@ public:
     //! Persist state by passing information to the supplied inserter
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const = 0;
 
-    //! Make a function that can be called later to persist state
-    virtual TPersistFunc makePersistFunc() const = 0;
+    //! Make a function that can be called later to persist state in the
+    //! foreground, i.e. in the knowledge that no other thread will be
+    //! accessing the data structures this method accesses.
+    virtual TPersistFunc makeForegroundPersistFunc() const = 0;
+
+    //! Make a function that can be called later to persist state in the
+    //! background, i.e. copying any required data such that other threads
+    //! may modify the original data structures while persistence is taking
+    //! place.
+    virtual TPersistFunc makeBackgroundPersistFunc() const = 0;
 
     //! Access to the field name
     const std::string& fieldName() const;

--- a/lib/api/CBaseTokenListDataTyper.cc
+++ b/lib/api/CBaseTokenListDataTyper.cc
@@ -398,11 +398,20 @@ void CBaseTokenListDataTyper::acceptPersistInserter(const TTokenMIndex& tokenIdL
     }
 }
 
-CDataTyper::TPersistFunc CBaseTokenListDataTyper::makePersistFunc() const {
+CDataTyper::TPersistFunc CBaseTokenListDataTyper::makeForegroundPersistFunc() const {
     return std::bind(
         static_cast<void (*)(const TTokenMIndex&, const TTokenListTypeVec&, core::CStatePersistInserter&)>(
             &CBaseTokenListDataTyper::acceptPersistInserter),
         std::cref(m_TokenIdLookup), std::cref(m_Types), std::placeholders::_1);
+}
+
+CDataTyper::TPersistFunc CBaseTokenListDataTyper::makeBackgroundPersistFunc() const {
+    return std::bind(
+        static_cast<void (*)(const TTokenMIndex&, const TTokenListTypeVec&, core::CStatePersistInserter&)>(
+            &CBaseTokenListDataTyper::acceptPersistInserter),
+        // Do NOT add std::ref wrappers around these arguments - they MUST be
+        // copied for thread safety
+        m_TokenIdLookup, m_Types, std::placeholders::_1);
 }
 
 void CBaseTokenListDataTyper::addTypeMatch(bool isDryRun,

--- a/lib/api/CFieldDataTyper.cc
+++ b/lib/api/CFieldDataTyper.cc
@@ -331,7 +331,8 @@ bool CFieldDataTyper::persistState(core::CDataAdder& persister,
 
     LOG_DEBUG(<< "Persist typer state");
 
-    return this->doPersistState(m_DataTyper->makePersistFunc(), m_ExamplesCollector, persister);
+    return this->doPersistState(m_DataTyper->makeForegroundPersistFunc(),
+                                m_ExamplesCollector, persister);
 }
 
 bool CFieldDataTyper::isPersistenceNeeded(const std::string& description) const {
@@ -420,8 +421,8 @@ bool CFieldDataTyper::periodicPersistStateInBackground() {
                       // Do NOT add std::ref wrappers
                       // around these arguments - they
                       // MUST be copied for thread safety
-                      m_DataTyper->makePersistFunc(), m_ExamplesCollector,
-                      std::placeholders::_1)) == false) {
+                      m_DataTyper->makeBackgroundPersistFunc(),
+                      m_ExamplesCollector, std::placeholders::_1)) == false) {
         LOG_ERROR(<< "Failed to add categorizer background persistence function");
         return false;
     }

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -54,6 +54,9 @@ CppUnit::Test* CPersistenceManagerTest::suite() {
         "CPersistenceManagerTest::testDetectorPersistPartition",
         &CPersistenceManagerTest::testDetectorPersistPartition));
     suiteOfTests->addTest(new CppUnit::TestCaller<CPersistenceManagerTest>(
+        "CPersistenceManagerTest::testBackgroundPersistCategorizationConsistency",
+        &CPersistenceManagerTest::testBackgroundPersistCategorizationConsistency));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CPersistenceManagerTest>(
         "CPersistenceManagerTest::testCategorizationOnlyPersist",
         &CPersistenceManagerTest::testCategorizationOnlyPersist));
     suiteOfTests->addTest(new CppUnit::TestCaller<CPersistenceManagerTest>(
@@ -78,6 +81,80 @@ void CPersistenceManagerTest::testDetectorPersistPartition() {
 
 void CPersistenceManagerTest::testDetectorBackgroundPersistStaticsConsistency() {
     this->foregroundBackgroundCompAnomalyDetectionAfterStaticsUpdate("testfiles/new_mlfields_over.conf");
+}
+
+void CPersistenceManagerTest::testBackgroundPersistCategorizationConsistency() {
+
+    static const std::string JOB_ID{"job"};
+    static const std::string FIRST_INPUT{
+        "{ \"message\": \"the quick brown fox jumped over the lazy dog\" }\n"};
+    static const std::string SECOND_INPUT{"{ \"message\": \"she sells sea shells on the seashore\" }\n"};
+
+    std::ofstream outputStrm{ml::core::COsFileFuncs::NULL_FILENAME};
+    CPPUNIT_ASSERT(outputStrm.is_open());
+
+    ml::model::CLimits limits;
+    ml::api::CFieldConfig fieldConfig{"message"};
+
+    std::ostringstream* backgroundStream{nullptr};
+    ml::api::CSingleStreamDataAdder::TOStreamP backgroundStreamPtr(
+        backgroundStream = new std::ostringstream());
+    ml::api::CSingleStreamDataAdder backgroundDataAdder(backgroundStreamPtr);
+
+    // The 30000 second persist interval is set large enough that the timer
+    // will not trigger during the test - we bypass the timer in this test
+    // and kick off the background persistence chain explicitly
+    ml::api::CPersistenceManager persistenceManager{30000, false, backgroundDataAdder};
+
+    std::string backgroundState1;
+    std::string backgroundState2;
+
+    {
+        ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
+        ml::api::CJsonOutputWriter outputWriter(JOB_ID, wrappedOutputStream);
+
+        ml::api::CFieldDataTyper categorizer(JOB_ID, fieldConfig, limits, outputWriter,
+                                             outputWriter, &persistenceManager);
+
+        std::istringstream inputStrm1{FIRST_INPUT};
+        ml::api::CNdJsonInputParser parser1{inputStrm1};
+
+        CPPUNIT_ASSERT(parser1.readStreamIntoMaps(std::bind(
+            &ml::api::CDataProcessor::handleRecord, &categorizer, std::placeholders::_1)));
+
+        // Now persist the categorizer's state in the background
+        CPPUNIT_ASSERT(categorizer.periodicPersistStateInBackground());
+        CPPUNIT_ASSERT(persistenceManager.startPersistInBackground());
+        CPPUNIT_ASSERT(persistenceManager.waitForIdle());
+
+        backgroundState1 = backgroundStream->str();
+
+        std::istringstream inputStrm2{SECOND_INPUT};
+        ml::api::CNdJsonInputParser parser2{inputStrm2};
+
+        CPPUNIT_ASSERT(categorizer.periodicPersistStateInBackground());
+        CPPUNIT_ASSERT(persistenceManager.startPersistInBackground());
+
+        // This time handle another record during background persistence.
+        // Due to thread scheduling, sometimes this will happen before the
+        // persistence is complete.  This shouldn't be a problem if the
+        // background persistence copied the state, but if it didn't then
+        // it should fail the test.
+        CPPUNIT_ASSERT(parser2.readStreamIntoMaps(std::bind(
+            &ml::api::CDataProcessor::handleRecord, &categorizer, std::placeholders::_1)));
+
+        CPPUNIT_ASSERT(persistenceManager.waitForIdle());
+
+        backgroundState2 = backgroundStream->str();
+        backgroundState2.erase(0, backgroundState1.length());
+    }
+
+    // Replace the zero byte separators to avoid '\0's in the output if the
+    // test fails
+    std::replace(backgroundState1.begin(), backgroundState1.end(), '\0', ',');
+    std::replace(backgroundState2.begin(), backgroundState2.end(), '\0', ',');
+
+    CPPUNIT_ASSERT_EQUAL(backgroundState1, backgroundState2);
 }
 
 void CPersistenceManagerTest::testCategorizationOnlyPersist() {

--- a/lib/api/unittest/CPersistenceManagerTest.h
+++ b/lib/api/unittest/CPersistenceManagerTest.h
@@ -15,6 +15,7 @@ public:
     void testDetectorPersistBy();
     void testDetectorPersistOver();
     void testDetectorPersistPartition();
+    void testBackgroundPersistCategorizationConsistency();
     void testCategorizationOnlyPersist();
     void testDetectorBackgroundPersistStaticsConsistency();
 


### PR DESCRIPTION
All data structures to be persisted need to be copied before a
background persist is started, otherwise inconsistent state could
be persisted as the foreground thread updates the data structures
(or worse, the program could crash).

Backport of #921