### PR TITLE
[7.x][ML] Rename to num_top_feature_importance_values (#932)

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -47,7 +47,7 @@ public:
     static const std::string STOP_CROSS_VALIDATION_EARLY;
     static const std::string NUMBER_ROUNDS_PER_HYPERPARAMETER;
     static const std::string BAYESIAN_OPTIMISATION_RESTARTS;
-    static const std::string TOP_FEATURE_IMPORTANCE_VALUES;
+    static const std::string NUM_TOP_FEATURE_IMPORTANCE_VALUES;
 
 public:
     ~CDataFrameTrainBoostedTreeRunner() override;

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -57,7 +57,7 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(BAYESIAN_OPTIMISATION_RESTARTS,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
-        theReader.addParameter(TOP_FEATURE_IMPORTANCE_VALUES,
+        theReader.addParameter(NUM_TOP_FEATURE_IMPORTANCE_VALUES,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
@@ -85,8 +85,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     std::size_t bayesianOptimisationRestarts{
         parameters[BAYESIAN_OPTIMISATION_RESTARTS].fallback(std::size_t{0})};
     bool stopCrossValidationEarly{parameters[STOP_CROSS_VALIDATION_EARLY].fallback(true)};
-    std::size_t topFeatureImportanceValues{
-        parameters[TOP_FEATURE_IMPORTANCE_VALUES].fallback(std::size_t{0})};
+    std::size_t numTopFeatureImportanceValues{
+        parameters[NUM_TOP_FEATURE_IMPORTANCE_VALUES].fallback(std::size_t{0})};
 
     double alpha{parameters[ALPHA].fallback(-1.0)};
     double lambda{parameters[LAMBDA].fallback(-1.0)};
@@ -165,8 +165,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     if (bayesianOptimisationRestarts > 0) {
         m_BoostedTreeFactory->bayesianOptimisationRestarts(bayesianOptimisationRestarts);
     }
-    if (topFeatureImportanceValues > 0) {
-        m_BoostedTreeFactory->topShapValues(topFeatureImportanceValues);
+    if (numTopFeatureImportanceValues > 0) {
+        m_BoostedTreeFactory->topShapValues(numTopFeatureImportanceValues);
     }
 }
 
@@ -316,7 +316,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::NUMBER_FOLDS{"number_folds"}
 const std::string CDataFrameTrainBoostedTreeRunner::STOP_CROSS_VALIDATION_EARLY{"stop_cross_validation_early"};
 const std::string CDataFrameTrainBoostedTreeRunner::NUMBER_ROUNDS_PER_HYPERPARAMETER{"number_rounds_per_hyperparameter"};
 const std::string CDataFrameTrainBoostedTreeRunner::BAYESIAN_OPTIMISATION_RESTARTS{"bayesian_optimisation_restarts"};
-const std::string CDataFrameTrainBoostedTreeRunner::TOP_FEATURE_IMPORTANCE_VALUES{"top_feature_importance_values"};
+const std::string CDataFrameTrainBoostedTreeRunner::NUM_TOP_FEATURE_IMPORTANCE_VALUES{"num_top_feature_importance_values"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -594,7 +594,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
                 params.s_Lambda, params.s_Gamma, params.s_SoftTreeDepthLimit,
                 params.s_SoftTreeDepthTolerance, params.s_Eta,
                 params.s_MaximumNumberTrees, params.s_FeatureBagFraction,
-                0 /*topFeatureImportanceValues*/, &persisterSupplier);
+                0 /*numTopFeatureImportanceValues*/, &persisterSupplier);
         };
 
         finalIteration = params.numberUnset() * numberRoundsPerHyperparameter;

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -80,7 +80,7 @@ CDataFrameAnalysisSpecificationFactory::predictionSpec(
     double eta,
     std::size_t maximumNumberTrees,
     double featureBagFraction,
-    size_t topFeatureImportanceValues,
+    size_t numTopFeatureImportanceValues,
     TPersisterSupplier* persisterSupplier,
     TRestoreSearcherSupplier* restoreSearcherSupplier) {
 
@@ -131,9 +131,9 @@ CDataFrameAnalysisSpecificationFactory::predictionSpec(
         writer.Key(api::CDataFrameTrainBoostedTreeRunner::BAYESIAN_OPTIMISATION_RESTARTS);
         writer.Uint64(bayesianOptimisationRestarts);
     }
-    if (topFeatureImportanceValues > 0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::TOP_FEATURE_IMPORTANCE_VALUES);
-        writer.Uint64(topFeatureImportanceValues);
+    if (numTopFeatureImportanceValues > 0) {
+        writer.Key(api::CDataFrameTrainBoostedTreeRunner::NUM_TOP_FEATURE_IMPORTANCE_VALUES);
+        writer.Uint64(numTopFeatureImportanceValues);
     }
     writer.EndObject();
 


### PR DESCRIPTION
Renames boosted tree param `top_feature_importance_values` to
`num_top_feature_importance_values`.

Backport of #932