### PR TITLE
[ML] Correct the top class probabilities

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -25,6 +25,12 @@ public:
         E_PredictionFieldTypeBool
     };
 
+public:
+    static const std::string NUM_TOP_CLASSES;
+    static const std::string PREDICTION_FIELD_TYPE;
+    static const std::string CLASS_ASSIGNMENT_OBJECTIVE;
+
+public:
     static const CDataFrameAnalysisConfigReader& parameterReader();
 
     //! This is not intended to be called directly: use CDataFrameTrainBoostedTreeClassifierRunnerFactory.

--- a/include/api/CDataFrameTrainBoostedTreeRegressionRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRegressionRunner.h
@@ -19,6 +19,9 @@ namespace api {
 class API_EXPORT CDataFrameTrainBoostedTreeRegressionRunner final
     : public CDataFrameTrainBoostedTreeRunner {
 public:
+    static const std::string STRATIFIED_CROSS_VALIDATION;
+
+public:
     static const CDataFrameAnalysisConfigReader& parameterReader();
 
     //! This is not intended to be called directly: use CDataFrameTrainBoostedTreeRegressionRunnerFactory.

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -32,6 +32,9 @@ public:
     using TSpecificationUPtr = std::unique_ptr<api::CDataFrameAnalysisSpecification>;
 
 public:
+    static const std::string& classification();
+    static const std::string& regression();
+
     static TSpecificationUPtr outlierSpec(std::size_t rows = 110,
                                           std::size_t cols = 5,
                                           std::size_t memoryLimit = 100000,

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -24,9 +24,6 @@
 namespace ml {
 namespace api {
 namespace {
-// Configuration
-const std::string STRATIFIED_CROSS_VALIDATION{"stratified_cross_validation"};
-
 // Output
 const std::string IS_TRAINING_FIELD_NAME{"is_training"};
 
@@ -119,6 +116,10 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelDefinition(
 
     return std::make_unique<CInferenceModelDefinition>(builder.build());
 }
+
+// clang-format off
+const std::string CDataFrameTrainBoostedTreeRegressionRunner::STRATIFIED_CROSS_VALIDATION{"stratified_cross_validation"};
+// clang-format on
 
 const std::string& CDataFrameTrainBoostedTreeRegressionRunnerFactory::name() const {
     return NAME;

--- a/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
+++ b/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
@@ -97,10 +97,11 @@ BOOST_AUTO_TEST_CASE(testIntegrationRegression) {
         values[2].push_back(values[0][i] * weights[0] + values[1][i] * weights[1]);
     }
 
-    api::CDataFrameAnalyzer analyzer{test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-                                         "regression", "target_col", numberExamples,
-                                         cols, 30000000, 0, 0, {"categorical_col"}),
-                                     outputWriterFactory};
+    api::CDataFrameAnalyzer analyzer{
+        test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
+            test::CDataFrameAnalysisSpecificationFactory::regression(), "target_col",
+            numberExamples, cols, 30000000, 0, 0, {"categorical_col"}),
+        outputWriterFactory};
 
     TDataFrameUPtr frame =
         core::makeMainStorageDataFrame(cols + 2, numberExamples).first;
@@ -187,8 +188,8 @@ BOOST_AUTO_TEST_CASE(testIntegrationClassification) {
 
     api::CDataFrameAnalyzer analyzer{
         test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-            "classification", "target_col", numberExamples, cols, 30000000, 0,
-            0, {"categorical_col", "target_col"}),
+            test::CDataFrameAnalysisSpecificationFactory::classification(), "target_col",
+            numberExamples, cols, 30000000, 0, 0, {"categorical_col", "target_col"}),
         outputWriterFactory};
 
     TDataFrameUPtr frame =
@@ -247,10 +248,11 @@ BOOST_AUTO_TEST_CASE(testJsonSchema) {
         values[2].push_back(values[0][i] * weights[0] + values[1][i] * weights[1]);
     }
 
-    api::CDataFrameAnalyzer analyzer{test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-                                         "regression", "target_col", numberExamples,
-                                         cols, 30000000, 0, 0, {"categorical_col"}),
-                                     outputWriterFactory};
+    api::CDataFrameAnalyzer analyzer{
+        test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
+            test::CDataFrameAnalysisSpecificationFactory::regression(), "target_col",
+            numberExamples, cols, 30000000, 0, 0, {"categorical_col"}),
+        outputWriterFactory};
 
     TDataFrameUPtr frame =
         core::makeMainStorageDataFrame(cols + 2, numberExamples).first;

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -105,9 +105,10 @@ struct SFixture {
         };
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-                "regression", "target", s_Rows, 5, 8000000, 0, 0, {"c1"}, s_Alpha,
-                s_Lambda, s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance,
-                s_Eta, s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
+                test::CDataFrameAnalysisSpecificationFactory::regression(),
+                "target", s_Rows, 5, 8000000, 0, 0, {"c1"}, s_Alpha, s_Lambda,
+                s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance, s_Eta,
+                s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};
         TStrVec fieldNames{"target", "c1", "c2", "c3", "c4", ".", "."};
         TStrVec fieldValues{"", "", "", "", "", "0", ""};
@@ -137,9 +138,10 @@ struct SFixture {
         };
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-                "classification", "target", s_Rows, 5, 8000000, 0, 0, {"target"},
-                s_Alpha, s_Lambda, s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance,
-                s_Eta, s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
+                test::CDataFrameAnalysisSpecificationFactory::classification(),
+                "target", s_Rows, 5, 8000000, 0, 0, {"target"}, s_Alpha, s_Lambda,
+                s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance, s_Eta,
+                s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};
         TStrVec fieldNames{"target", "c1", "c2", "c3", "c4", ".", "."};
         TStrVec fieldValues{"", "", "", "", "", "0", ""};

--- a/lib/api/unittest/CDataFrameTrainBoostedTreeClassifierRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameTrainBoostedTreeClassifierRunnerTest.cc
@@ -31,7 +31,8 @@ BOOST_AUTO_TEST_CASE(testPredictionFieldNameClash) {
     core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
 
     const auto spec{test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-        "classification", "dep_var", 5, 6, 13000000, 0, 0, {"dep_var"})};
+        test::CDataFrameAnalysisSpecificationFactory::classification(),
+        "dep_var", 5, 6, 13000000, 0, 0, {"dep_var"})};
     rapidjson::Document jsonParameters;
     jsonParameters.Parse("{"
                          "  \"dependent_variable\": \"dep_var\","
@@ -76,8 +77,8 @@ void testWriteOneRow(const std::string& dependentVariableField,
 
     // Create classification analysis runner object
     const auto spec{test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-        "classification", dependentVariableField, rows.size(),
-        columnNames.size(), 13000000, 0, 0, categoricalColumns)};
+        test::CDataFrameAnalysisSpecificationFactory::classification(), dependentVariableField,
+        rows.size(), columnNames.size(), 13000000, 0, 0, categoricalColumns)};
     rapidjson::Document jsonParameters;
     if (predictionFieldType.empty()) {
         jsonParameters.Parse("{\"dependent_variable\": \"" + dependentVariableField + "\"}");

--- a/lib/api/unittest/CDataFrameTrainBoostedTreeRegressionRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameTrainBoostedTreeRegressionRunnerTest.cc
@@ -29,7 +29,8 @@ BOOST_AUTO_TEST_CASE(testPredictionFieldNameClash) {
     core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
 
     const auto spec{test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
-        "regression", "dep_var", 5, 6, 13000000, 0, 0)};
+        test::CDataFrameAnalysisSpecificationFactory::regression(), "dep_var",
+        5, 6, 13000000, 0, 0)};
     rapidjson::Document jsonParameters;
     jsonParameters.Parse("{"
                          "  \"dependent_variable\": \"dep_var\","

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -11,6 +11,8 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameAnalysisSpecificationJsonWriter.h>
 #include <api/CDataFrameOutliersRunner.h>
+#include <api/CDataFrameTrainBoostedTreeClassifierRunner.h>
+#include <api/CDataFrameTrainBoostedTreeRegressionRunner.h>
 #include <api/CDataFrameTrainBoostedTreeRunner.h>
 
 #include <test/CTestTmpDir.h>
@@ -20,6 +22,14 @@
 namespace ml {
 namespace test {
 using TRapidJsonLineWriter = core::CRapidJsonLineWriter<rapidjson::StringBuffer>;
+
+const std::string& CDataFrameAnalysisSpecificationFactory::classification() {
+    return api::CDataFrameTrainBoostedTreeClassifierRunnerFactory::NAME;
+}
+
+const std::string& CDataFrameAnalysisSpecificationFactory::regression() {
+    return api::CDataFrameTrainBoostedTreeRegressionRunnerFactory::NAME;
+}
 
 CDataFrameAnalysisSpecificationFactory::TSpecificationUPtr
 CDataFrameAnalysisSpecificationFactory::outlierSpec(std::size_t rows,
@@ -134,6 +144,10 @@ CDataFrameAnalysisSpecificationFactory::predictionSpec(
     if (numTopFeatureImportanceValues > 0) {
         writer.Key(api::CDataFrameTrainBoostedTreeRunner::NUM_TOP_FEATURE_IMPORTANCE_VALUES);
         writer.Uint64(numTopFeatureImportanceValues);
+    }
+    if (analysis == classification()) {
+        writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES);
+        writer.Uint64(1);
     }
     writer.EndObject();
 


### PR DESCRIPTION
We weren't writing out the probabilities for the top classes correctly. This error was introduced by #926. I've marked as a non-issue since that code isn't yet released.