### PR TITLE
[7.x][ML] Fix memory leak in tokenization tests

### DIFF
--- a/lib/maths/unittest/CNaiveBayesTest.cc
+++ b/lib/maths/unittest/CNaiveBayesTest.cc
@@ -262,8 +262,8 @@ BOOST_AUTO_TEST_CASE(testPropagationByTime) {
 BOOST_AUTO_TEST_CASE(testMemoryUsage) {
     // Check invariants.
 
-    using TMemoryUsagePtr = std::unique_ptr<core::CMemoryUsage>;
-    using TNaiveBayesPtr = std::unique_ptr<maths::CNaiveBayes>;
+    using TMemoryUsageUPtr = std::unique_ptr<core::CMemoryUsage>;
+    using TNaiveBayesUPtr = std::unique_ptr<maths::CNaiveBayes>;
 
     test::CRandomNumbers rng;
 
@@ -277,8 +277,8 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
 
     maths::CNormalMeanPrecConjugate normal{maths::CNormalMeanPrecConjugate::nonInformativePrior(
         maths_t::E_ContinuousData, 0.1)};
-    TNaiveBayesPtr nb{new maths::CNaiveBayes{
-        maths::CNaiveBayesFeatureDensityFromPrior(normal), 0.1}};
+    TNaiveBayesUPtr nb{std::make_unique<maths::CNaiveBayes>(
+        maths::CNaiveBayesFeatureDensityFromPrior(normal), 0.1)};
 
     for (std::size_t i = 0u; i < 100; ++i) {
         nb->addTrainingDataPoint(1, {{trainingData[0][i]}, {trainingData[1][i]}});
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
     }
 
     std::size_t memoryUsage{nb->memoryUsage()};
-    TMemoryUsagePtr mem{new core::CMemoryUsage};
+    TMemoryUsageUPtr mem{std::make_unique<core::CMemoryUsage>()};
     nb->debugMemoryUsage(mem.get());
 
     LOG_DEBUG(<< "Memory = " << memoryUsage);

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -17,6 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <memory>
 #include <sstream>
 
 BOOST_AUTO_TEST_SUITE(CTokenListDataCategorizerTest)
@@ -38,9 +39,12 @@ using TTokenListDataCategorizerKeepsFields =
 const TTokenListDataCategorizerKeepsFields::TTokenListReverseSearchCreatorIntfCPtr NO_REVERSE_SEARCH_CREATOR;
 
 void checkMemoryUsageInstrumentation(const TTokenListDataCategorizerKeepsFields& categorizer) {
+
+    using TMemoryUsageUPtr = std::unique_ptr<ml::core::CMemoryUsage>;
+
     std::size_t memoryUsage{categorizer.memoryUsage()};
-    ml::core::CMemoryUsage::TMemoryUsagePtr mem{new ml::core::CMemoryUsage};
-    categorizer.debugMemoryUsage(mem);
+    TMemoryUsageUPtr mem{std::make_unique<ml::core::CMemoryUsage>()};
+    categorizer.debugMemoryUsage(mem.get());
 
     std::ostringstream strm;
     mem->compress();


### PR DESCRIPTION
This was introduced by #859.  A raw pointer with a confusing
typedef name was assumed to be a smart pointer when it wasn't.

Also checked for the same problem in other places, and didn't
find any, but corrected a couple of local typedef names.  (The
wider problem that CMemoryUsage::TMemoryUsagePtr aliases a
raw pointer will have to wait for a bigger PR.)

Backport of #940