### PR TITLE
[ML] Line search for best learn rate

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,13 @@
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
   or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
 
+== {es} version 7.7.0
+
+=== Enhancements
+
+* Improve initialization of learn rate for better and more stable results in regression
+and classification. (See {ml-pull}948[#948].)
+
 == {es} version 7.6.0
 
 === New Features

--- a/include/core/CLoopProgress.h
+++ b/include/core/CLoopProgress.h
@@ -70,6 +70,9 @@ public:
     //! Increment the progress by \p i.
     void increment(std::size_t i = 1);
 
+    //! Update the loop range by adding \p range.
+    void incrementRange(int range);
+
     //! Resume progress monitoring which was restored.
     void resumeRestored();
 
@@ -86,7 +89,7 @@ private:
     static void noop(double);
 
 private:
-    std::size_t m_Size;
+    std::size_t m_Range;
     std::size_t m_Steps;
     double m_StepProgress;
     std::size_t m_Pos = 0;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -159,6 +159,9 @@ private:
     //! Estimates a good central value for the downsample factor search interval.
     void initializeUnsetDownsampleFactor(core::CDataFrame& frame);
 
+    //! Estimate a good central value for learn rate.
+    void initializeUnsetEta(core::CDataFrame& frame);
+
     //! Estimate the reduction in gain from a split and the total curvature of
     //! the loss function at a split.
     TDoubleDoublePrVec estimateTreeGainAndCurvature(core::CDataFrame& frame,
@@ -189,6 +192,9 @@ private:
     //! Refresh progress monitoring after restoring from saved training state.
     void resumeRestoredTrainingProgressMonitoring();
 
+    //! The total number of progress steps used in the main loop.
+    std::size_t mainLoopNumberSteps(double eta) const;
+
     //! The maximum number of trees to use in the hyperparameter optimisation loop.
     std::size_t mainLoopMaximumNumberTrees(double eta) const;
 
@@ -208,6 +214,7 @@ private:
     TVector m_LogTreeSizePenaltyMultiplierSearchInterval;
     TVector m_LogLeafWeightPenaltyMultiplierSearchInterval;
     TVector m_SoftDepthLimitSearchInterval;
+    TVector m_LogEtaSearchInterval;
     TProgressCallback m_RecordProgress = noopRecordProgress;
     TMemoryUsageCallback m_RecordMemoryUsage = noopRecordMemoryUsage;
     TTrainingStateCallback m_RecordTrainingState = noopRecordTrainingState;

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -51,6 +51,17 @@ void CLoopProgress::increment(std::size_t i) {
 }
 
 void CLoopProgress::incrementRange(int i) {
+    // This function deals with the case that the number of iterations of the "loop"
+    // are changed after the CLoopProgress object is initialized. The main task we
+    // need to perform is to record progress and update last progress point. We treat
+    // progress as monotonic, so if the range is increased we'll simply stick at the
+    // current progress until some number of iterations have passed. However, if the
+    // range is reduced our fractional progress is now m_Pos / m_Range. If this is
+    // larger than the next step at which we need to output progress, i.e. larger than
+    // (m_LastProgress + 1) / m_Steps, then we output the new progress and update the
+    // last progress to the corresponding proportion of steps. We also always cap the
+    // number of progress steps by the loop range so must reduce this if necessary.
+
     std::size_t steps{m_Steps};
     m_Range += i;
     m_Steps = std::min(m_Range, m_Steps);

--- a/lib/core/unittest/CLoopProgressTest.cc
+++ b/lib/core/unittest/CLoopProgressTest.cc
@@ -145,6 +145,12 @@ BOOST_AUTO_TEST_CASE(testScaled) {
 
 BOOST_AUTO_TEST_CASE(testIncrementRange) {
 
+    // We're interested in four separate cases:
+    //   1) Number steps < range, decrement range followed by increment range.
+    //   2) Number steps > range, decrement range followed by increment range.
+    //   3) Number steps < range, increment range followed by decrement range.
+    //   4) Number steps > range, increment range followed by decrement range.
+
     for (std::size_t steps : {30, 100}) {
         double progress{0.0};
         auto recordProgress = [&progress](double p) { progress += p; };
@@ -154,9 +160,13 @@ BOOST_AUTO_TEST_CASE(testIncrementRange) {
             loopProgress.increment();
         }
 
+        // This should advance progress to iteration 20 out of (range) 30.
         loopProgress.incrementRange(-20);
         BOOST_REQUIRE_CLOSE(20.0 / 30.0, progress, 2.0);
 
+        // We've already incremented progress 20 times. We should be stuck at
+        // progress 2/3 until the iteration exceeds 2/3 x 60 = 40 and thereafter
+        // track (i + 20) / 60.
         loopProgress.incrementRange(30);
         for (std::size_t i = 0; i < 40; ++i) {
             loopProgress.increment();
@@ -174,9 +184,13 @@ BOOST_AUTO_TEST_CASE(testIncrementRange) {
             loopProgress.increment();
         }
 
+        // Progress should remain unchanged at 20 out of (original range) 50.
         loopProgress.incrementRange(30);
         BOOST_REQUIRE_CLOSE(20.0 / 50.0, progress, 2.0);
 
+        // We've already incremented progress 20 times. We should be stuck at
+        // progress 2/5 until the iteration exceeds 2/5 x 60 = 24 and thereafter
+        // track (i + 20) / 60.
         loopProgress.incrementRange(-20);
         for (std::size_t i = 0; i < 40; ++i) {
             loopProgress.increment();

--- a/lib/core/unittest/CLoopProgressTest.cc
+++ b/lib/core/unittest/CLoopProgressTest.cc
@@ -21,6 +21,7 @@ BOOST_AUTO_TEST_SUITE(CLoopProgressTest)
 
 using namespace ml;
 
+using TIntVec = std::vector<int>;
 using TSizeVec = std::vector<std::size_t>;
 
 BOOST_AUTO_TEST_CASE(testShort) {
@@ -139,6 +140,49 @@ BOOST_AUTO_TEST_CASE(testScaled) {
         }
 
         BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0 / static_cast<double>(step[0]), progress, 1e-15);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testIncrementRange) {
+
+    for (std::size_t steps : {30, 100}) {
+        double progress{0.0};
+        auto recordProgress = [&progress](double p) { progress += p; };
+        core::CLoopProgress loopProgress{50, recordProgress, 1.0, steps};
+
+        for (std::size_t i = 0; i < 20; ++i) {
+            loopProgress.increment();
+        }
+
+        loopProgress.incrementRange(-20);
+        BOOST_REQUIRE_CLOSE(20.0 / 30.0, progress, 2.0);
+
+        loopProgress.incrementRange(30);
+        for (std::size_t i = 0; i < 40; ++i) {
+            loopProgress.increment();
+            BOOST_REQUIRE_CLOSE(std::max(static_cast<double>(20 + i) / 60.0, 20.0 / 30.0),
+                                progress, 4.0);
+        }
+    }
+
+    for (std::size_t steps : {30, 100}) {
+        double progress{0.0};
+        auto recordProgress = [&progress](double p) { progress += p; };
+        core::CLoopProgress loopProgress{50, recordProgress, 1.0, steps};
+
+        for (std::size_t i = 0; i < 20; ++i) {
+            loopProgress.increment();
+        }
+
+        loopProgress.incrementRange(30);
+        BOOST_REQUIRE_CLOSE(20.0 / 50.0, progress, 2.0);
+
+        loopProgress.incrementRange(-20);
+        for (std::size_t i = 0; i < 40; ++i) {
+            loopProgress.increment();
+            BOOST_REQUIRE_CLOSE(std::max(static_cast<double>(20 + i) / 60.0, 20.0 / 50.0),
+                                progress, 4.0);
+        }
     }
 }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -746,9 +746,7 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
         m_LogEtaSearchInterval = min(m_LogEtaSearchInterval, TVector{0.0});
         LOG_TRACE(<< "log eta search interval = ["
                   << m_LogEtaSearchInterval.toDelimited() << "]");
-        m_TreeImpl->m_Eta = std::exp(m_LogEtaSearchInterval(BEST_REGULARIZER_INDEX));
-        m_TreeImpl->m_EtaGrowthRatePerTree = 1.0 + m_TreeImpl->m_Eta / 2.0;
-        m_TreeImpl->m_MaximumNumberTrees = computeMaximumNumberTrees(m_TreeImpl->m_Eta);
+        applyEta(*m_Tree, m_LogEtaSearchInterval(BEST_REGULARIZER_INDEX));
 
         if (intervalIsEmpty(m_LogEtaSearchInterval)) {
             m_TreeImpl->m_EtaOverride = m_TreeImpl->m_Eta;

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -746,7 +746,7 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
         m_LogEtaSearchInterval = min(m_LogEtaSearchInterval, TVector{0.0});
         LOG_TRACE(<< "log eta search interval = ["
                   << m_LogEtaSearchInterval.toDelimited() << "]");
-        applyEta(*m_Tree, m_LogEtaSearchInterval(BEST_REGULARIZER_INDEX));
+        applyEta(*m_TreeImpl, m_LogEtaSearchInterval(BEST_REGULARIZER_INDEX));
 
         if (intervalIsEmpty(m_LogEtaSearchInterval)) {
             m_TreeImpl->m_EtaOverride = m_TreeImpl->m_Eta;

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -36,8 +36,8 @@ const double MIN_SOFT_DEPTH_LIMIT{2.0};
 const double MIN_SOFT_DEPTH_LIMIT_TOLERANCE{0.05};
 const double MAX_SOFT_DEPTH_LIMIT_TOLERANCE{0.25};
 const double MIN_ETA{1e-3};
-const double MIN_ETA_SCALE{0.3};
-const double MAX_ETA_SCALE{3.0};
+const double MIN_ETA_SCALE{0.5};
+const double MAX_ETA_SCALE{2.0};
 const double MIN_ETA_GROWTH_RATE_SCALE{0.5};
 const double MAX_ETA_GROWTH_RATE_SCALE{1.5};
 const double MIN_FEATURE_BAG_FRACTION{0.2};
@@ -73,7 +73,7 @@ std::size_t computeMaximumNumberTrees(double eta) {
     return static_cast<std::size_t>(3.0 / eta / MIN_DOWNSAMPLE_FACTOR_SCALE + 0.5);
 }
 
-std::size_t scaleMaximumNumberTrees(std::size_t maximumNumberTrees) {
+std::size_t scaleMaximumNumberTreesForMainLoop(std::size_t maximumNumberTrees) {
     // We actively optimise for eta and allow it to be up to MIN_ETA_SCALE
     // smaller than the initial value. We need to allow the number of trees
     // to increase proportionally to avoid bias. In practice, we should use
@@ -191,8 +191,8 @@ void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {
     }
     if (m_TreeImpl->m_EtaOverride == boost::none) {
         double rate{m_TreeImpl->m_EtaGrowthRatePerTree - 1.0};
-        boundingBox.emplace_back(std::log(MIN_ETA_SCALE * m_TreeImpl->m_Eta),
-                                 std::log(MAX_ETA_SCALE * m_TreeImpl->m_Eta));
+        boundingBox.emplace_back(m_LogEtaSearchInterval(MIN_REGULARIZER_INDEX),
+                                 m_LogEtaSearchInterval(MAX_REGULARIZER_INDEX));
         boundingBox.emplace_back(1.0 + MIN_ETA_GROWTH_RATE_SCALE * rate,
                                  1.0 + MAX_ETA_GROWTH_RATE_SCALE * rate);
     }
@@ -405,10 +405,11 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) {
     }
 
     this->initializeUnsetDownsampleFactor(frame);
+    this->initializeUnsetEta(frame);
 
     if (m_TreeImpl->m_MaximumNumberTreesOverride == boost::none) {
         m_TreeImpl->m_MaximumNumberTrees =
-            scaleMaximumNumberTrees(m_TreeImpl->m_MaximumNumberTrees);
+            scaleMaximumNumberTreesForMainLoop(m_TreeImpl->m_MaximumNumberTrees);
     }
 }
 
@@ -705,6 +706,52 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
         if (intervalIsEmpty(m_LogDownsampleFactorSearchInterval)) {
             m_TreeImpl->m_DownsampleFactorOverride = m_TreeImpl->m_DownsampleFactor;
         }
+    }
+}
+
+void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
+
+    if (m_TreeImpl->m_EtaOverride == boost::none) {
+        double searchIntervalSize{5.0 * MAX_ETA_SCALE / MIN_ETA_SCALE};
+        double logMaxEta{std::log(std::sqrt(searchIntervalSize) * m_TreeImpl->m_Eta)};
+        double logMinEta{logMaxEta - std::log(searchIntervalSize)};
+        double meanLogEta{(logMaxEta + logMinEta) / 2.0};
+        double mainLoopSearchInterval{std::log(0.2 * searchIntervalSize)};
+        LOG_TRACE(<< "mean log eta = " << meanLogEta);
+
+        auto applyEta = [](CBoostedTreeImpl& tree, double eta) {
+            tree.m_Eta = std::exp(eta);
+            tree.m_EtaGrowthRatePerTree = 1.0 + tree.m_Eta / 2.0;
+            tree.m_MaximumNumberTrees = computeMaximumNumberTrees(tree.m_Eta);
+            return true;
+        };
+
+        double eta{m_TreeImpl->m_Eta};
+
+        TVector fallback;
+        fallback(MIN_REGULARIZER_INDEX) = logMinEta;
+        fallback(BEST_REGULARIZER_INDEX) = meanLogEta;
+        fallback(MAX_REGULARIZER_INDEX) = logMaxEta;
+
+        m_LogEtaSearchInterval =
+            this->testLossLineSearch(frame, applyEta, logMinEta, logMaxEta,
+                                     -mainLoopSearchInterval / 2.0,
+                                     mainLoopSearchInterval / 2.0)
+                .value_or(fallback);
+        m_LogEtaSearchInterval = min(m_LogEtaSearchInterval, TVector{0.0});
+        LOG_TRACE(<< "log eta search interval = ["
+                  << m_LogEtaSearchInterval.toDelimited() << "]");
+        m_TreeImpl->m_Eta = std::exp(m_LogEtaSearchInterval(BEST_REGULARIZER_INDEX));
+        m_TreeImpl->m_EtaGrowthRatePerTree = 1.0 + m_TreeImpl->m_Eta / 2.0;
+        m_TreeImpl->m_MaximumNumberTrees = computeMaximumNumberTrees(m_TreeImpl->m_Eta);
+
+        if (intervalIsEmpty(m_LogEtaSearchInterval)) {
+            m_TreeImpl->m_EtaOverride = m_TreeImpl->m_Eta;
+        }
+
+        m_TreeImpl->m_TrainingProgress.incrementRange(
+            static_cast<int>(this->mainLoopNumberSteps(m_TreeImpl->m_Eta)) -
+            static_cast<int>(this->mainLoopNumberSteps(eta)));
     }
 }
 
@@ -1138,14 +1185,17 @@ void CBoostedTreeFactory::initializeTrainingProgressMonitoring(const core::CData
     //    parameter which isn't user defined,
     //  - LINE_SEARCH_ITERATIONS * "maximum number trees" per forest for training
     //    the downsampling factor if it isn't user defined,
+    //  - LINE_SEARCH_ITERATIONS * "maximum number trees" per forest for the learn
+    //    learn rate if it isn't user defined,
     //  - The main optimisation loop which costs number folds * maximum number
     //    trees per forest units per iteration,
     //  - The cost of the final train which we count as an extra loop.
 
-    std::size_t totalNumberSteps{2};
     double eta{m_TreeImpl->m_EtaOverride != boost::none
                    ? *m_TreeImpl->m_EtaOverride
                    : computeEta(frame.numberColumns())};
+
+    std::size_t totalNumberSteps{2};
     std::size_t lineSearchMaximumNumberTrees{computeMaximumNumberTrees(eta)};
     if (m_TreeImpl->m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
         totalNumberSteps += MAX_LINE_SEARCH_ITERATIONS * lineSearchMaximumNumberTrees;
@@ -1162,8 +1212,12 @@ void CBoostedTreeFactory::initializeTrainingProgressMonitoring(const core::CData
     if (m_TreeImpl->m_DownsampleFactorOverride == boost::none) {
         totalNumberSteps += MAX_LINE_SEARCH_ITERATIONS * lineSearchMaximumNumberTrees;
     }
-    totalNumberSteps += (this->numberHyperparameterTuningRounds() + 1) *
-                        this->mainLoopMaximumNumberTrees(eta) * m_TreeImpl->m_NumberFolds;
+    if (m_TreeImpl->m_EtaOverride == boost::none) {
+        // The maximum number of trees varies in this loop so we use a margin.
+        totalNumberSteps += 2 * MAX_LINE_SEARCH_ITERATIONS * lineSearchMaximumNumberTrees;
+    }
+    // We don't know what we'll choose in the line search so we use a margin.
+    totalNumberSteps += 2 * this->mainLoopNumberSteps(eta);
     LOG_TRACE(<< "total number steps = " << totalNumberSteps);
     m_TreeImpl->m_TrainingProgress =
         core::CLoopProgress{totalNumberSteps, m_RecordProgress, 1.0, 1024};
@@ -1174,10 +1228,15 @@ void CBoostedTreeFactory::resumeRestoredTrainingProgressMonitoring() {
     m_TreeImpl->m_TrainingProgress.resumeRestored();
 }
 
+std::size_t CBoostedTreeFactory::mainLoopNumberSteps(double eta) const {
+    return (this->numberHyperparameterTuningRounds() + 1) *
+           this->mainLoopMaximumNumberTrees(eta) * m_TreeImpl->m_NumberFolds;
+}
+
 std::size_t CBoostedTreeFactory::mainLoopMaximumNumberTrees(double eta) const {
     if (m_TreeImpl->m_MaximumNumberTreesOverride == boost::none) {
         std::size_t maximumNumberTrees{computeMaximumNumberTrees(eta)};
-        maximumNumberTrees = scaleMaximumNumberTrees(maximumNumberTrees);
+        maximumNumberTrees = scaleMaximumNumberTreesForMainLoop(maximumNumberTrees);
         return maximumNumberTrees;
     }
     return *m_TreeImpl->m_MaximumNumberTreesOverride;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
             0.0, modelBias[i][0],
             9.1 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.95);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(testLinear) {
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testNonLinear) {
@@ -366,12 +366,12 @@ BOOST_AUTO_TEST_CASE(testNonLinear) {
             0.0, modelBias[i][0],
             5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.95);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testThreading) {
@@ -607,8 +607,8 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.12);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.97);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.05);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
@@ -1123,13 +1123,13 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.75);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.7);
         meanLogRelativeError.add(maths::CBasicStatistics::mean(logRelativeError));
     }
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.52);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {


### PR DESCRIPTION
This switches to performing an initial line search over the learn rate and reducing the range we search in the main optimisation loop. This does cost us some run time, but we generally get small wins in both the QoR and the stability of QoR as borne out by the sample results below.

Because we can't estimate the runtime upfront I've extended the progress monitor to allow us to reset the expected total number of steps. This will advance progress if it needs to; we have no mechanism for reducing progress if the expected number steps increase. In this case, we simply get stuck at the current progress. I use a margin in the initial estimates to reduce the chance of this so we get smoother progress monitoring.

Sample regression results:

| data set | master mean R^2 | master sd R^2 | patch mean R^2 | patch var R^2 |
| --- | --- | --- | --- | --- |
| boston | 0.85 | 0.011 | 0.92 | 0.006 |
| elevators | 0.88 | 0.028 | 0.89 | 0.002 |
| stock | 0.98 | 0.004 | 0.99 | 0.003 |
| houses | 0.68 | 0.026 | 0.66 | 0.016 |

Sample classification results:

| data set | master mean acc | master sd acc | patch mean acc | patch var acc |
| --- | --- | --- | --- | --- |
| bank | 0.87 | 0.003 | 0.88 | 0.006 |
| census | 0.84 | 0.004 | 0.84 | 0.003 |
| clicks | 0.66 | 0.016 | 0.67 | 0.009 |
| qsar | 0.84 | 0.007 | 0.85 | 0.008 |