### PR TITLE
[ML] Fix invalid read in tests

### DIFF
--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -350,7 +350,7 @@ CBoostedTreeNode::TSizeSizePr CBoostedTreeNode::split(std::size_t splitFeature,
     m_Gain = gain;
     m_Curvature = curvature;
     TSizeSizePr result{m_LeftChild.get(), m_RightChild.get()};
-    // Don't access members after calling resize.
+    // Don't access members after calling resize because this object is likely an element of the vector being resized.
     tree.resize(tree.size() + 2);
     return result;
 }

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -349,8 +349,10 @@ CBoostedTreeNode::TSizeSizePr CBoostedTreeNode::split(std::size_t splitFeature,
     m_RightChild = static_cast<TNodeIndex>(tree.size() + 1);
     m_Gain = gain;
     m_Curvature = curvature;
+    TSizeSizePr result{m_LeftChild.get(), m_RightChild.get()};
+    // Don't access members after calling resize.
     tree.resize(tree.size() + 2);
-    return {m_LeftChild.get(), m_RightChild.get()};
+    return result;
 }
 
 void CBoostedTreeNode::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -71,7 +71,6 @@ struct SFixtureSingleTree {
         s_Frame->finishWritingRows();
 
         TTree tree(1);
-        tree.reserve(7);
         tree[0].split(0, 0.5, true, 0.0, 0.0, tree);
         tree[1].split(1, 0.5, true, 0.0, 0.0, tree);
         tree[2].split(1, 0.5, true, 0.0, 0.0, tree);
@@ -189,7 +188,6 @@ struct SFixtureMultipleTrees {
         s_Frame->finishWritingRows();
 
         TTree tree1(1);
-        tree1.reserve(7);
         tree1[0].split(0, 0.55, true, 0.0, 0.0, tree1);
         tree1[1].split(0, 0.41, true, 0.0, 0.0, tree1);
         tree1[2].split(1, 0.25, true, 0.0, 0.0, tree1);
@@ -199,7 +197,6 @@ struct SFixtureMultipleTrees {
         tree1[6].value(2.42384369);
 
         TTree tree2(1);
-        tree2.reserve(7);
         tree2[0].split(0, 0.45, true, 0.0, 0.0, tree2);
         tree2[1].split(0, 0.25, true, 0.0, 0.0, tree2);
         tree2[2].split(0, 0.59, true, 0.0, 0.0, tree2);

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -70,8 +70,8 @@ struct SFixtureSingleTree {
         }
         s_Frame->finishWritingRows();
 
-        TTree tree;
-        tree.emplace_back();
+        TTree tree(1);
+        tree.reserve(7);
         tree[0].split(0, 0.5, true, 0.0, 0.0, tree);
         tree[1].split(1, 0.5, true, 0.0, 0.0, tree);
         tree[2].split(1, 0.5, true, 0.0, 0.0, tree);
@@ -188,8 +188,8 @@ struct SFixtureMultipleTrees {
         }
         s_Frame->finishWritingRows();
 
-        TTree tree1;
-        tree1.emplace_back();
+        TTree tree1(1);
+        tree1.reserve(7);
         tree1[0].split(0, 0.55, true, 0.0, 0.0, tree1);
         tree1[1].split(0, 0.41, true, 0.0, 0.0, tree1);
         tree1[2].split(1, 0.25, true, 0.0, 0.0, tree1);
@@ -198,8 +198,8 @@ struct SFixtureMultipleTrees {
         tree1[5].value(3.25350885);
         tree1[6].value(2.42384369);
 
-        TTree tree2;
-        tree2.emplace_back();
+        TTree tree2(1);
+        tree2.reserve(7);
         tree2[0].split(0, 0.45, true, 0.0, 0.0, tree2);
         tree2[1].split(0, 0.25, true, 0.0, 0.0, tree2);
         tree2[2].split(0, 0.59, true, 0.0, 0.0, tree2);


### PR DESCRIPTION
Avoid the need to reserve the vector before calling the `CBoostedTreeNode::split` function. This rejigs this method to avoid reading member variables after calling `resize` on the supplied vector. Shown up by #922.