### PR TITLE
[7.6][ML] Include out-of-order as well as in-order terms in reverse search

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -69,7 +69,8 @@ issue: {ml-issue}724[#724].)
 * Fixes potential memory corruption when determining seasonality. (See {ml-pull}852[#852].)
 * Prevent prediction_field_name clashing with other fields in ml results.
 (See {ml-pull}861[#861].)
-
+* Include out-of-order as well as in-order terms in categorization reverse searches.
+(See {ml-pull}950[#950], issue: {ml-issue}949[#949].)
 
 == {es} version 7.5.2
 

--- a/include/model/CTokenListReverseSearchCreator.h
+++ b/include/model/CTokenListReverseSearchCreator.h
@@ -72,7 +72,9 @@ public:
     //! specified token, which may occur anywhere within the original
     //! message, but has been determined to be a good thing to distinguish
     //! this category of messages from other categories.
-    void addOutOfOrderCommonToken(const std::string&, std::string&, std::string&) const override;
+    void addOutOfOrderCommonToken(const std::string& token,
+                                  std::string& part1,
+                                  std::string& part2) const override;
 
     //! Close off the two strings that form a reverse search.  For example,
     //! this may be when closing brackets need to be appended.

--- a/include/model/CTokenListReverseSearchCreator.h
+++ b/include/model/CTokenListReverseSearchCreator.h
@@ -44,9 +44,9 @@ public:
     bool createNullSearch(std::string& part1, std::string& part2) const override;
 
     //! If possible, create a reverse search for the case where there are no
-    //! unique tokens identifying the type.  (If this is not possible return
+    //! unique tokens identifying the category.  (If this is not possible return
     //! false.)
-    bool createNoUniqueTokenSearch(int type,
+    bool createNoUniqueTokenSearch(int categoryId,
                                    const std::string& example,
                                    size_t maxMatchingStringLen,
                                    std::string& part1,
@@ -55,19 +55,11 @@ public:
     //! Initialise the two strings that form a reverse search.  For example,
     //! this could be as simple as clearing the strings or setting them to
     //! some sort of one-off preamble.
-    void initStandardSearch(int type,
+    void initStandardSearch(int categoryId,
                             const std::string& example,
                             size_t maxMatchingStringLen,
                             std::string& part1,
                             std::string& part2) const override;
-
-    //! Modify the two strings that form a reverse search to account for the
-    //! specified token, which may occur anywhere within the original
-    //! message, but has been determined to be a good thing to distinguish
-    //! this type of messages from other types.
-    void addCommonUniqueToken(const std::string& token,
-                              std::string& part1,
-                              std::string& part2) const override;
 
     //! Modify the two strings that form a reverse search to account for the
     //! specified token.
@@ -75,6 +67,12 @@ public:
                                bool first,
                                std::string& part1,
                                std::string& part2) const override;
+
+    //! Modify the two strings that form a reverse search to account for the
+    //! specified token, which may occur anywhere within the original
+    //! message, but has been determined to be a good thing to distinguish
+    //! this category of messages from other categories.
+    void addOutOfOrderCommonToken(const std::string&, std::string&, std::string&) const override;
 
     //! Close off the two strings that form a reverse search.  For example,
     //! this may be when closing brackets need to be appended.

--- a/include/model/CTokenListReverseSearchCreatorIntf.h
+++ b/include/model/CTokenListReverseSearchCreatorIntf.h
@@ -72,19 +72,19 @@ public:
                                     std::string& part2) const = 0;
 
     //! Modify the two strings that form a reverse search to account for the
-    //! specified token, which may occur anywhere within the original
-    //! message, but has been determined to be a good thing to distinguish
-    //! this category of messages from other categories.
-    virtual void addCommonUniqueToken(const std::string& token,
-                                      std::string& part1,
-                                      std::string& part2) const = 0;
-
-    //! Modify the two strings that form a reverse search to account for the
     //! specified token.
     virtual void addInOrderCommonToken(const std::string& token,
                                        bool first,
                                        std::string& part1,
                                        std::string& part2) const = 0;
+
+    //! Modify the two strings that form a reverse search to account for the
+    //! specified token, which may occur anywhere within the original
+    //! message, but has been determined to be a good thing to distinguish
+    //! this category of messages from other categories.
+    virtual void addOutOfOrderCommonToken(const std::string& token,
+                                          std::string& part1,
+                                          std::string& part2) const = 0;
 
     //! Close off the two strings that form a reverse search.  For example,
     //! this may be when closing brackets need to be appended.

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -297,20 +297,20 @@ bool CTokenListDataCategorizerBase::createReverseSearch(int categoryId,
                                                category.maxMatchingStringLen(),
                                                part1, part2);
 
-    for (auto costedCommonUniqueTokenId : costedCommonUniqueTokenIds) {
-        m_ReverseSearchCreator->addCommonUniqueToken(
-            m_TokenIdLookup[costedCommonUniqueTokenId].str(), part1, part2);
-    }
-
-    bool first(true);
-    size_t end(category.outOfOrderCommonTokenIndex());
-    for (size_t index = 0; index < end; ++index) {
-        size_t tokenId(baseTokenIds[index].first);
+    bool firstInOrderToken{true};
+    std::size_t endOfOrdered{category.outOfOrderCommonTokenIndex()};
+    for (std::size_t index = 0; index < baseTokenIds.size(); ++index) {
+        std::size_t tokenId(baseTokenIds[index].first);
         if (costedCommonUniqueTokenIds.find(tokenId) !=
             costedCommonUniqueTokenIds.end()) {
-            m_ReverseSearchCreator->addInOrderCommonToken(
-                m_TokenIdLookup[tokenId].str(), first, part1, part2);
-            first = false;
+            if (index < endOfOrdered) {
+                m_ReverseSearchCreator->addInOrderCommonToken(
+                    m_TokenIdLookup[tokenId].str(), firstInOrderToken, part1, part2);
+                firstInOrderToken = false;
+            } else {
+                m_ReverseSearchCreator->addOutOfOrderCommonToken(
+                    m_TokenIdLookup[tokenId].str(), part1, part2);
+            }
         }
     }
 

--- a/lib/model/CTokenListReverseSearchCreator.cc
+++ b/lib/model/CTokenListReverseSearchCreator.cc
@@ -56,11 +56,6 @@ void CTokenListReverseSearchCreator::initStandardSearch(int /*categoryId*/,
     part2.clear();
 }
 
-void CTokenListReverseSearchCreator::addCommonUniqueToken(const std::string& /*token*/,
-                                                          std::string& /*part1*/,
-                                                          std::string& /*part2*/) const {
-}
-
 void CTokenListReverseSearchCreator::addInOrderCommonToken(const std::string& token,
                                                            bool first,
                                                            std::string& part1,
@@ -73,6 +68,15 @@ void CTokenListReverseSearchCreator::addInOrderCommonToken(const std::string& to
     }
     part1 += token;
     part2 += core::CRegex::escapeRegexSpecial(token);
+}
+
+void CTokenListReverseSearchCreator::addOutOfOrderCommonToken(const std::string& token,
+                                                              std::string& part1,
+                                                              std::string& /*part2*/) const {
+    if (part1.empty() == false) {
+        part1 += ' ';
+    }
+    part1 += token;
 }
 
 void CTokenListReverseSearchCreator::closeStandardSearch(std::string& /*part1*/,

--- a/lib/model/unittest/CTokenListReverseSearchCreatorTest.cc
+++ b/lib/model/unittest/CTokenListReverseSearchCreatorTest.cc
@@ -57,19 +57,6 @@ BOOST_AUTO_TEST_CASE(testInitStandardSearch) {
     BOOST_REQUIRE_EQUAL(std::string(""), reverseSearchPart2);
 }
 
-BOOST_AUTO_TEST_CASE(testAddCommonUniqueToken) {
-    CTokenListReverseSearchCreator reverseSearchCreator("foo");
-
-    std::string reverseSearchPart1;
-    std::string reverseSearchPart2;
-
-    reverseSearchCreator.addCommonUniqueToken("user", reverseSearchPart1, reverseSearchPart2);
-    reverseSearchCreator.addCommonUniqueToken("logged", reverseSearchPart1, reverseSearchPart2);
-
-    BOOST_REQUIRE_EQUAL(std::string(""), reverseSearchPart1);
-    BOOST_REQUIRE_EQUAL(std::string(""), reverseSearchPart2);
-}
-
 BOOST_AUTO_TEST_CASE(testAddInOrderCommonToken) {
     CTokenListReverseSearchCreator reverseSearchCreator("foo");
 
@@ -88,6 +75,20 @@ BOOST_AUTO_TEST_CASE(testAddInOrderCommonToken) {
     BOOST_REQUIRE_EQUAL(std::string("user logged b=0.15+a logged"), reverseSearchPart1);
     BOOST_REQUIRE_EQUAL(std::string(".*?user.+?logged.+?b=0\\.15\\+a.+?logged"),
                         reverseSearchPart2);
+}
+
+BOOST_AUTO_TEST_CASE(testAddOutOfOrderCommonToken) {
+    CTokenListReverseSearchCreator reverseSearchCreator("foo");
+
+    std::string reverseSearchPart1;
+    std::string reverseSearchPart2;
+
+    reverseSearchCreator.addOutOfOrderCommonToken("user", reverseSearchPart1, reverseSearchPart2);
+    reverseSearchCreator.addOutOfOrderCommonToken("logged", reverseSearchPart1,
+                                                  reverseSearchPart2);
+
+    BOOST_REQUIRE_EQUAL(std::string("user logged"), reverseSearchPart1);
+    BOOST_REQUIRE_EQUAL(std::string(""), reverseSearchPart2);
 }
 
 BOOST_AUTO_TEST_CASE(testCloseStandardSearch) {


### PR DESCRIPTION
When categories include messages with different token orders,
we were not including the tokens whose order varied between
the messages in the terms of the reverse search.  This change
adds these out-of-order tokens that are part of the category
definition back into the reverse search terms.

Backport of #950