### PR TITLE
[6.8][ML] Include out-of-order as well as in-order terms in reverse search

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 6.8.7
+
+=== Bug Fixes
+
+* Include out-of-order as well as in-order terms in categorization reverse searches.
+(See {ml-pull}950[#950], issue: {ml-issue}949[#949].)
+
 == {es} version 6.8.5
 
 === Enhancements

--- a/include/api/CTokenListReverseSearchCreator.h
+++ b/include/api/CTokenListReverseSearchCreator.h
@@ -60,19 +60,19 @@ public:
                                     std::string& part2) const;
 
     //! Modify the two strings that form a reverse search to account for the
-    //! specified token, which may occur anywhere within the original
-    //! message, but has been determined to be a good thing to distinguish
-    //! this type of messages from other types.
-    virtual void addCommonUniqueToken(const std::string& token,
-                                      std::string& part1,
-                                      std::string& part2) const;
-
-    //! Modify the two strings that form a reverse search to account for the
     //! specified token.
     virtual void addInOrderCommonToken(const std::string& token,
                                        bool first,
                                        std::string& part1,
                                        std::string& part2) const;
+
+    //! Modify the two strings that form a reverse search to account for the
+    //! specified token, which may occur anywhere within the original
+    //! message, but has been determined to be a good thing to distinguish
+    //! this type of messages from other types.
+    virtual void addOutOfOrderCommonToken(const std::string& token,
+                                          std::string& part1,
+                                          std::string& part2) const;
 
     //! Close off the two strings that form a reverse search.  For example,
     //! this may be when closing brackets need to be appended.

--- a/include/api/CTokenListReverseSearchCreatorIntf.h
+++ b/include/api/CTokenListReverseSearchCreatorIntf.h
@@ -70,19 +70,19 @@ public:
                                     std::string& part2) const = 0;
 
     //! Modify the two strings that form a reverse search to account for the
-    //! specified token, which may occur anywhere within the original
-    //! message, but has been determined to be a good thing to distinguish
-    //! this type of messages from other types.
-    virtual void addCommonUniqueToken(const std::string& token,
-                                      std::string& part1,
-                                      std::string& part2) const = 0;
-
-    //! Modify the two strings that form a reverse search to account for the
     //! specified token.
     virtual void addInOrderCommonToken(const std::string& token,
                                        bool first,
                                        std::string& part1,
                                        std::string& part2) const = 0;
+
+    //! Modify the two strings that form a reverse search to account for the
+    //! specified token, which may occur anywhere within the original
+    //! message, but has been determined to be a good thing to distinguish
+    //! this type of messages from other types.
+    virtual void addOutOfOrderCommonToken(const std::string& token,
+                                          std::string& part1,
+                                          std::string& part2) const = 0;
 
     //! Close off the two strings that form a reverse search.  For example,
     //! this may be when closing brackets need to be appended.

--- a/lib/api/CBaseTokenListDataTyper.cc
+++ b/lib/api/CBaseTokenListDataTyper.cc
@@ -297,20 +297,20 @@ bool CBaseTokenListDataTyper::createReverseSearch(int type,
     m_ReverseSearchCreator->initStandardSearch(
         type, typeObj.baseString(), typeObj.maxMatchingStringLen(), part1, part2);
 
-    for (auto costedCommonUniqueTokenId : costedCommonUniqueTokenIds) {
-        m_ReverseSearchCreator->addCommonUniqueToken(
-            m_TokenIdLookup[costedCommonUniqueTokenId].str(), part1, part2);
-    }
-
-    bool first(true);
-    size_t end(typeObj.outOfOrderCommonTokenIndex());
-    for (size_t index = 0; index < end; ++index) {
-        size_t tokenId(baseTokenIds[index].first);
+    bool firstInOrderToken{true};
+    std::size_t endOfOrdered{typeObj.outOfOrderCommonTokenIndex()};
+    for (std::size_t index = 0; index < baseTokenIds.size(); ++index) {
+        std::size_t tokenId(baseTokenIds[index].first);
         if (costedCommonUniqueTokenIds.find(tokenId) !=
             costedCommonUniqueTokenIds.end()) {
-            m_ReverseSearchCreator->addInOrderCommonToken(
-                m_TokenIdLookup[tokenId].str(), first, part1, part2);
-            first = false;
+            if (index < endOfOrdered) {
+                m_ReverseSearchCreator->addInOrderCommonToken(
+                    m_TokenIdLookup[tokenId].str(), firstInOrderToken, part1, part2);
+                firstInOrderToken = false;
+            } else {
+                m_ReverseSearchCreator->addOutOfOrderCommonToken(
+                    m_TokenIdLookup[tokenId].str(), part1, part2);
+            }
         }
     }
 

--- a/lib/api/CTokenListReverseSearchCreator.cc
+++ b/lib/api/CTokenListReverseSearchCreator.cc
@@ -56,11 +56,6 @@ void CTokenListReverseSearchCreator::initStandardSearch(int /*type*/,
     part2.clear();
 }
 
-void CTokenListReverseSearchCreator::addCommonUniqueToken(const std::string& /*token*/,
-                                                          std::string& /*part1*/,
-                                                          std::string& /*part2*/) const {
-}
-
 void CTokenListReverseSearchCreator::addInOrderCommonToken(const std::string& token,
                                                            bool first,
                                                            std::string& part1,
@@ -73,6 +68,15 @@ void CTokenListReverseSearchCreator::addInOrderCommonToken(const std::string& to
     }
     part1 += token;
     part2 += core::CRegex::escapeRegexSpecial(token);
+}
+
+void CTokenListReverseSearchCreator::addOutOfOrderCommonToken(const std::string& token,
+                                                              std::string& part1,
+                                                              std::string& /*part2*/) const {
+    if (part1.empty() == false) {
+        part1 += ' ';
+    }
+    part1 += token;
 }
 
 void CTokenListReverseSearchCreator::closeStandardSearch(std::string& /*part1*/,

--- a/lib/api/unittest/CFieldDataTyperTest.h
+++ b/lib/api/unittest/CFieldDataTyperTest.h
@@ -14,6 +14,7 @@ class CFieldDataTyperTest : public CppUnit::TestFixture {
 public:
     void testAll();
     void testNodeReverseSearch();
+    void testJobKilledReverseSearch();
     void testPassOnControlMessages();
     void testHandleControlMessages();
     void testRestoreStateFailsWithEmptyState();

--- a/lib/api/unittest/CTokenListReverseSearchCreatorTest.cc
+++ b/lib/api/unittest/CTokenListReverseSearchCreatorTest.cc
@@ -27,11 +27,11 @@ CppUnit::Test* CTokenListReverseSearchCreatorTest::suite() {
         "CTokenListReverseSearchCreatorTest::testInitStandardSearch",
         &CTokenListReverseSearchCreatorTest::testInitStandardSearch));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTokenListReverseSearchCreatorTest>(
-        "CTokenListReverseSearchCreatorTest::testAddCommonUniqueToken",
-        &CTokenListReverseSearchCreatorTest::testAddCommonUniqueToken));
-    suiteOfTests->addTest(new CppUnit::TestCaller<CTokenListReverseSearchCreatorTest>(
         "CTokenListReverseSearchCreatorTest::testAddInOrderCommonToken",
         &CTokenListReverseSearchCreatorTest::testAddInOrderCommonToken));
+    suiteOfTests->addTest(new CppUnit::TestCaller<CTokenListReverseSearchCreatorTest>(
+        "CTokenListReverseSearchCreatorTest::testAddOutOfOrderCommonToken",
+        &CTokenListReverseSearchCreatorTest::testAddOutOfOrderCommonToken));
     suiteOfTests->addTest(new CppUnit::TestCaller<CTokenListReverseSearchCreatorTest>(
         "CTokenListReverseSearchCreatorTest::testCloseStandardSearch",
         &CTokenListReverseSearchCreatorTest::testCloseStandardSearch));
@@ -83,19 +83,6 @@ void CTokenListReverseSearchCreatorTest::testInitStandardSearch() {
     CPPUNIT_ASSERT_EQUAL(std::string(""), reverseSearchPart2);
 }
 
-void CTokenListReverseSearchCreatorTest::testAddCommonUniqueToken() {
-    CTokenListReverseSearchCreator reverseSearchCreator("foo");
-
-    std::string reverseSearchPart1;
-    std::string reverseSearchPart2;
-
-    reverseSearchCreator.addCommonUniqueToken("user", reverseSearchPart1, reverseSearchPart2);
-    reverseSearchCreator.addCommonUniqueToken("logged", reverseSearchPart1, reverseSearchPart2);
-
-    CPPUNIT_ASSERT_EQUAL(std::string(""), reverseSearchPart1);
-    CPPUNIT_ASSERT_EQUAL(std::string(""), reverseSearchPart2);
-}
-
 void CTokenListReverseSearchCreatorTest::testAddInOrderCommonToken() {
     CTokenListReverseSearchCreator reverseSearchCreator("foo");
 
@@ -114,6 +101,20 @@ void CTokenListReverseSearchCreatorTest::testAddInOrderCommonToken() {
     CPPUNIT_ASSERT_EQUAL(std::string("user logged b=0.15+a logged"), reverseSearchPart1);
     CPPUNIT_ASSERT_EQUAL(std::string(".*?user.+?logged.+?b=0\\.15\\+a.+?logged"),
                          reverseSearchPart2);
+}
+
+void CTokenListReverseSearchCreatorTest::testAddOutOfOrderCommonToken() {
+    CTokenListReverseSearchCreator reverseSearchCreator("foo");
+
+    std::string reverseSearchPart1;
+    std::string reverseSearchPart2;
+
+    reverseSearchCreator.addOutOfOrderCommonToken("user", reverseSearchPart1, reverseSearchPart2);
+    reverseSearchCreator.addOutOfOrderCommonToken("logged", reverseSearchPart1,
+                                                  reverseSearchPart2);
+
+    CPPUNIT_ASSERT_EQUAL(std::string("user logged"), reverseSearchPart1);
+    CPPUNIT_ASSERT_EQUAL(std::string(""), reverseSearchPart2);
 }
 
 void CTokenListReverseSearchCreatorTest::testCloseStandardSearch() {

--- a/lib/api/unittest/CTokenListReverseSearchCreatorTest.h
+++ b/lib/api/unittest/CTokenListReverseSearchCreatorTest.h
@@ -14,8 +14,8 @@ public:
     void testCreateNullSearch();
     void testCreateNoUniqueTokenSearch();
     void testInitStandardSearch();
-    void testAddCommonUniqueToken();
     void testAddInOrderCommonToken();
+    void testAddOutOfOrderCommonToken();
     void testCloseStandardSearch();
 
     static CppUnit::Test* suite();


### PR DESCRIPTION
When categories include messages with different token orders,
we were not including the tokens whose order varied between
the messages in the terms of the reverse search.  This change
adds these out-of-order tokens that are part of the category
definition back into the reverse search terms.

Backport of #950