### PR TITLE
[7.x][ML] Change core::CMemoryUsage::TMemoryUsagePtr to be a smart pointer

### DIFF
--- a/include/core/CConcurrentQueue.h
+++ b/include/core/CConcurrentQueue.h
@@ -116,7 +116,7 @@ public:
     }
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CConcurrentQueue");
         CMemoryDebug::dynamicSize("m_Queue", m_Queue, mem);
     }

--- a/include/core/CConcurrentWrapper.h
+++ b/include/core/CConcurrentWrapper.h
@@ -57,7 +57,7 @@ public:
     }
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CConcurrentWrapper");
         m_Queue.debugMemoryUsage(mem->addChild());
     }

--- a/include/core/CCsvLineParser.h
+++ b/include/core/CCsvLineParser.h
@@ -62,7 +62,7 @@ public:
     bool atEnd() const;
 
     //! Debug the memory used by this parser.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this parser.
     std::size_t memoryUsage() const;

--- a/include/core/CJsonOutputStreamWrapper.h
+++ b/include/core/CJsonOutputStreamWrapper.h
@@ -77,7 +77,7 @@ public:
     void syncFlush();
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;

--- a/include/core/CMemoryUsage.h
+++ b/include/core/CMemoryUsage.h
@@ -51,19 +51,13 @@ public:
         std::size_t s_Unused;
     };
 
-    using TMemoryUsagePtr = CMemoryUsage*;
+    using TMemoryUsagePtr = std::shared_ptr<CMemoryUsage>;
     using TMemoryUsagePtrList = std::list<TMemoryUsagePtr>;
-    using TMemoryUsagePtrListCItr = TMemoryUsagePtrList::const_iterator;
-    using TMemoryUsagePtrListItr = TMemoryUsagePtrList::iterator;
     using TMemoryUsageVec = std::vector<SMemoryUsage>;
-    using TMemoryUsageVecCitr = TMemoryUsageVec::const_iterator;
 
 public:
     //! Constructor
     CMemoryUsage();
-
-    //! Destructor
-    ~CMemoryUsage();
 
     //! Create a child node
     TMemoryUsagePtr addChild();

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -190,7 +190,7 @@ public:
     std::uint64_t checksum() const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/core/CRapidJsonConcurrentLineWriter.h
+++ b/include/core/CRapidJsonConcurrentLineWriter.h
@@ -43,7 +43,7 @@ public:
     bool EndObject(rapidjson::SizeType memberCount = 0);
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;

--- a/include/core/CStoredStringPtr.h
+++ b/include/core/CStoredStringPtr.h
@@ -72,7 +72,7 @@ public:
     //! Get the actual memory usage of the string.  For use by the string
     //! store.
     std::size_t actualMemoryUsage() const;
-    void debugActualMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugActualMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! These factory methods return a stored string pointer given a string.
     //! They must only be used within string store classes that contain code

--- a/include/core/CStringSimilarityTester.h
+++ b/include/core/CStringSimilarityTester.h
@@ -288,7 +288,7 @@ public:
     }
 
     //! Debug the memory used by this similarity tester.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this similarity tester.
     std::size_t memoryUsage() const;

--- a/include/core/CTriple.h
+++ b/include/core/CTriple.h
@@ -68,7 +68,7 @@ public:
         return seed;
     }
 
-    void debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CTriple");
         CMemoryDebug::dynamicSize("first", first, mem);
         CMemoryDebug::dynamicSize("second", second, mem);

--- a/include/core/CompressUtils.h
+++ b/include/core/CompressUtils.h
@@ -100,7 +100,7 @@ public:
     void reset();
 
     //! Debug the memory used by these compression utils.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by these compression utils.
     std::size_t memoryUsage() const;

--- a/include/maths/CAnnotatedVector.h
+++ b/include/maths/CAnnotatedVector.h
@@ -51,7 +51,7 @@ public:
     ANNOTATION& annotation() { return m_Annotation; }
 
     //! Debug the memory usage of this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CAnnotatedVector");
         mem->addItem("vector", core::CMemory::dynamicSize(static_cast<VECTOR>(*this)));
         mem->addItem("annotation", core::CMemory::dynamicSize(m_Annotation));

--- a/include/maths/CBjkstUniqueValues.h
+++ b/include/maths/CBjkstUniqueValues.h
@@ -108,7 +108,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this sketch.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this sketch.
     std::size_t memoryUsage() const;

--- a/include/maths/CCalendarComponent.h
+++ b/include/maths/CCalendarComponent.h
@@ -135,7 +135,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;

--- a/include/maths/CCalendarComponentAdaptiveBucketing.h
+++ b/include/maths/CCalendarComponentAdaptiveBucketing.h
@@ -91,7 +91,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     std::size_t memoryUsage() const;

--- a/include/maths/CCalendarCyclicTest.h
+++ b/include/maths/CCalendarCyclicTest.h
@@ -66,7 +66,7 @@ public:
     std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/maths/CClusterer.h
+++ b/include/maths/CClusterer.h
@@ -68,7 +68,7 @@ public:
         void recycle(std::size_t index);
 
         //! Get the memory used by this component
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this component
         std::size_t memoryUsage() const;
@@ -237,7 +237,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const = 0;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const = 0;

--- a/include/maths/CConstantPrior.h
+++ b/include/maths/CConstantPrior.h
@@ -146,7 +146,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CCooccurrences.h
+++ b/include/maths/CCooccurrences.h
@@ -71,7 +71,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/maths/CCountMinSketch.h
+++ b/include/maths/CCountMinSketch.h
@@ -108,7 +108,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this sketch.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this sketch.
     std::size_t memoryUsage() const;

--- a/include/maths/CDecayRateController.h
+++ b/include/maths/CDecayRateController.h
@@ -84,7 +84,7 @@ public:
     std::size_t dimension() const;
 
     //! Debug the memory used by this controller.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this controller.
     std::size_t memoryUsage() const;

--- a/include/maths/CDecompositionComponent.h
+++ b/include/maths/CDecompositionComponent.h
@@ -99,7 +99,7 @@ protected:
         uint64_t checksum(uint64_t seed) const;
 
         //! Debug the memory used by the splines.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by these splines.
         std::size_t memoryUsage() const;

--- a/include/maths/CExpandingWindow.h
+++ b/include/maths/CExpandingWindow.h
@@ -113,7 +113,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/maths/CGammaRateConjugate.h
+++ b/include/maths/CGammaRateConjugate.h
@@ -298,7 +298,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CKMeansOnline.h
+++ b/include/maths/CKMeansOnline.h
@@ -482,7 +482,7 @@ public:
     }
 
     //! Get the memory used by this component
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CKMeansOnline");
         core::CMemoryDebug::dynamicSize("m_Clusters", m_Clusters, mem);
         core::CMemoryDebug::dynamicSize("m_PointsBuffer", m_PointsBuffer, mem);

--- a/include/maths/CKMeansOnline1d.h
+++ b/include/maths/CKMeansOnline1d.h
@@ -117,7 +117,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CKMostCorrelated.h
+++ b/include/maths/CKMostCorrelated.h
@@ -108,7 +108,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -208,7 +208,7 @@ public:
     // @}
 
     //! Debug the memory usage of this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CDenseMatrix");
         mem->addItem("components", this->memoryUsage());
     }
@@ -259,7 +259,7 @@ public:
     // @}
 
     //! Debug the memory usage of this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CDenseVector");
         mem->addItem("components", this->memoryUsage());
     }

--- a/include/maths/CLogNormalMeanPrecConjugate.h
+++ b/include/maths/CLogNormalMeanPrecConjugate.h
@@ -309,7 +309,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -412,7 +412,7 @@ public:
     virtual std::uint64_t checksum(std::uint64_t seed = 0) const = 0;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this object.
     virtual std::size_t memoryUsage() const = 0;
@@ -547,7 +547,7 @@ public:
     std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const override;

--- a/include/maths/CMultimodalPrior.h
+++ b/include/maths/CMultimodalPrior.h
@@ -278,7 +278,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CMultimodalPriorMode.h
+++ b/include/maths/CMultimodalPriorMode.h
@@ -50,7 +50,7 @@ struct SMultimodalPriorMode {
     }
 
     //! Get the memory used by this component
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMultimodalPrior::SMode");
         core::CMemoryDebug::dynamicSize("s_Prior", s_Prior, mem);
     }

--- a/include/maths/CMultinomialConjugate.h
+++ b/include/maths/CMultinomialConjugate.h
@@ -257,7 +257,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CMultivariateConstantPrior.h
+++ b/include/maths/CMultivariateConstantPrior.h
@@ -121,7 +121,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CMultivariateMultimodalPrior.h
+++ b/include/maths/CMultivariateMultimodalPrior.h
@@ -794,7 +794,7 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMultivariateMultimodalPrior");
         core::CMemoryDebug::dynamicSize("m_Clusterer", m_Clusterer, mem);
         core::CMemoryDebug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);

--- a/include/maths/CMultivariateNormalConjugate.h
+++ b/include/maths/CMultivariateNormalConjugate.h
@@ -729,7 +729,7 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMultivariateNormalConjugate");
     }
 

--- a/include/maths/CMultivariateOneOfNPrior.h
+++ b/include/maths/CMultivariateOneOfNPrior.h
@@ -258,7 +258,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CMultivariatePrior.h
+++ b/include/maths/CMultivariatePrior.h
@@ -320,7 +320,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const = 0;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const = 0;

--- a/include/maths/CNaiveBayes.h
+++ b/include/maths/CNaiveBayes.h
@@ -67,7 +67,7 @@ public:
     virtual void propagateForwardsByTime(double time) = 0;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the static size of this object.
     virtual std::size_t staticSize() const = 0;
@@ -120,7 +120,7 @@ public:
     virtual void propagateForwardsByTime(double time);
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the static size of this object.
     virtual std::size_t staticSize() const;
@@ -221,7 +221,7 @@ public:
     TDoubleSizePrVec classProbabilities(const TDouble1VecVec& x) const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
@@ -261,7 +261,7 @@ private:
         TFeatureDensityPtrVec& conditionalDensities();
 
         //! Debug the memory used by this object.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
         //! Get the memory used by this object.
         std::size_t memoryUsage() const;
 

--- a/include/maths/CNaturalBreaksClassifier.h
+++ b/include/maths/CNaturalBreaksClassifier.h
@@ -232,7 +232,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     std::size_t memoryUsage() const;

--- a/include/maths/CNormalMeanPrecConjugate.h
+++ b/include/maths/CNormalMeanPrecConjugate.h
@@ -276,7 +276,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/COneOfNPrior.h
+++ b/include/maths/COneOfNPrior.h
@@ -295,7 +295,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CPoissonMeanConjugate.h
+++ b/include/maths/CPoissonMeanConjugate.h
@@ -244,7 +244,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CPrior.h
+++ b/include/maths/CPrior.h
@@ -382,7 +382,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const = 0;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this component
     virtual std::size_t memoryUsage() const = 0;

--- a/include/maths/CQuantileSketch.h
+++ b/include/maths/CQuantileSketch.h
@@ -99,7 +99,7 @@ public:
     virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     virtual std::size_t memoryUsage() const;
@@ -177,7 +177,7 @@ public:
     //! Debug the memory used by this object.
     //!
     //! \note Needs to be redeclared to work with CMemoryDebug.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         this->CQuantileSketch::debugMemoryUsage(mem);
     }
 
@@ -210,7 +210,7 @@ public:
     std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const override;

--- a/include/maths/CSeasonalComponent.h
+++ b/include/maths/CSeasonalComponent.h
@@ -185,7 +185,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;

--- a/include/maths/CSeasonalComponentAdaptiveBucketing.h
+++ b/include/maths/CSeasonalComponentAdaptiveBucketing.h
@@ -129,7 +129,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const;
 
     //! Get the memory used by this component
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component
     std::size_t memoryUsage() const;

--- a/include/maths/CSpline.h
+++ b/include/maths/CSpline.h
@@ -614,7 +614,7 @@ public:
     }
 
     //! Get the memory used by this component
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CSpline");
         core::CMemoryDebug::dynamicSize("m_Knots", m_Knots, mem);
         core::CMemoryDebug::dynamicSize("m_Values", m_Values, mem);

--- a/include/maths/CTimeSeriesChangeDetector.h
+++ b/include/maths/CTimeSeriesChangeDetector.h
@@ -121,7 +121,7 @@ public:
     bool stopTesting() const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
@@ -216,7 +216,7 @@ public:
                             TDoubleWeightsAry1Vec weights) = 0;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -183,7 +183,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -173,7 +173,7 @@ public:
         void registerHandler(CHandler& handler);
 
         //! Debug the memory used by this object.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this object.
         std::size_t memoryUsage() const;
@@ -234,7 +234,7 @@ public:
         uint64_t checksum(uint64_t seed = 0) const;
 
         //! Debug the memory used by this object.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this object.
         std::size_t memoryUsage() const;
@@ -320,7 +320,7 @@ public:
         uint64_t checksum(uint64_t seed = 0) const;
 
         //! Debug the memory used by this object.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this object.
         std::size_t memoryUsage() const;
@@ -441,7 +441,7 @@ public:
         uint64_t checksum(uint64_t seed = 0) const;
 
         //! Debug the memory used by this object.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this object.
         std::size_t memoryUsage() const;
@@ -650,7 +650,7 @@ public:
             uint64_t checksum(uint64_t seed = 0) const;
 
             //! Debug the memory used by this object.
-            void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+            void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
             //! Get the memory used by this object.
             std::size_t memoryUsage() const;
@@ -731,7 +731,7 @@ public:
             uint64_t checksum(uint64_t seed = 0) const;
 
             //! Debug the memory used by this object.
-            void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+            void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
             //! Get the memory used by this object.
             std::size_t memoryUsage() const;

--- a/include/maths/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/CTimeSeriesDecompositionInterface.h
@@ -174,7 +174,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const = 0;
 
     //! Get the memory used by this instance
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this instance
     virtual std::size_t memoryUsage() const = 0;

--- a/include/maths/CTimeSeriesDecompositionStub.h
+++ b/include/maths/CTimeSeriesDecompositionStub.h
@@ -93,7 +93,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     virtual std::size_t memoryUsage() const;

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -174,7 +174,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const override;
@@ -423,7 +423,7 @@ public:
     const TSizeSizePrMultivariatePriorPtrDoublePrUMap& correlationModels() const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
@@ -646,7 +646,7 @@ public:
     uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const override;

--- a/include/maths/CTimeSeriesMultibucketFeatures.h
+++ b/include/maths/CTimeSeriesMultibucketFeatures.h
@@ -72,7 +72,7 @@ public:
     virtual uint64_t checksum(uint64_t seed = 0) const = 0;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the static size of object.
     virtual std::size_t staticSize() const = 0;
@@ -208,7 +208,7 @@ public:
     }
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CTimeSeriesMultibucketMean");
         core::CMemoryDebug::dynamicSize("m_SlidingWindow", m_SlidingWindow, mem);
     }

--- a/include/maths/CXMeansOnline.h
+++ b/include/maths/CXMeansOnline.h
@@ -325,7 +325,7 @@ public:
         }
 
         //! Debug the memory used by this component.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
             mem->setName("CXMeansOnline");
             core::CMemoryDebug::dynamicSize("m_Structure", m_Structure, mem);
         }
@@ -928,7 +928,7 @@ public:
     }
 
     //! Debug the memory used by the object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CXMeansOnline");
         core::CMemoryDebug::dynamicSize("m_ClusterIndexGenerator",
                                         m_ClusterIndexGenerator, mem);

--- a/include/maths/CXMeansOnline1d.h
+++ b/include/maths/CXMeansOnline1d.h
@@ -202,7 +202,7 @@ public:
         uint64_t checksum(uint64_t seed) const;
 
         //! Debug the memory used by this object.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this cluster.
         std::size_t memoryUsage() const;
@@ -351,7 +351,7 @@ public:
     virtual double probability(std::size_t index) const;
 
     //! Debug the memory used by the object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     virtual std::size_t memoryUsage() const;

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -249,7 +249,7 @@ public:
     void showMemoryUsage(std::ostream& stream) const;
 
     //! Get the memory used by this detector
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Return the total memory usage
     std::size_t memoryUsage() const override;

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -440,7 +440,7 @@ public:
     virtual uint64_t checksum(bool includeCurrentBucketStats = true) const = 0;
 
     //! Get the memory used by this model
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this model
     virtual std::size_t memoryUsage() const = 0;
@@ -508,7 +508,7 @@ protected:
         void persistModelsState(core::CStatePersistInserter& inserter) const;
 
         //! Debug the memory used by this model.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
         //! Get the memory used by this model.
         std::size_t memoryUsage() const;
 
@@ -538,7 +538,7 @@ protected:
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
         //! Debug the memory used by this model.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
         //! Get the memory used by this model.
         std::size_t memoryUsage() const;
 

--- a/include/model/CBucketGatherer.h
+++ b/include/model/CBucketGatherer.h
@@ -316,7 +316,7 @@ public:
     virtual uint64_t checksum() const = 0;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this component.
     virtual std::size_t memoryUsage() const = 0;

--- a/include/model/CBucketQueue.h
+++ b/include/model/CBucketQueue.h
@@ -165,7 +165,7 @@ public:
     core_t::TTime latestBucketEnd() const { return m_LatestBucketEnd; }
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CBucketQueue");
         core::CMemoryDebug::dynamicSize("m_Queue", m_Queue, mem);
     }

--- a/include/model/CCategoryExamplesCollector.h
+++ b/include/model/CCategoryExamplesCollector.h
@@ -65,7 +65,7 @@ public:
     void clear();
 
     //! Debug the memory used by this examples collector.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this examples collector.
     std::size_t memoryUsage() const;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -205,7 +205,7 @@ public:
     uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Get the memory used by this model
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this model
     std::size_t memoryUsage() const override;

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -116,7 +116,7 @@ public:
     void lastPersistTime(core_t::TTime lastPersistTime);
 
     //! Debug the memory used by this categorizer.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this categorizer.
     std::size_t memoryUsage() const override;

--- a/include/model/CDataGatherer.h
+++ b/include/model/CDataGatherer.h
@@ -580,7 +580,7 @@ public:
     uint64_t checksum() const;
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;

--- a/include/model/CDynamicStringIdRegistry.h
+++ b/include/model/CDynamicStringIdRegistry.h
@@ -132,7 +132,7 @@ public:
     uint64_t checksum() const;
 
     //! Debug the memory used by this registry.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this registry.
     std::size_t memoryUsage() const;

--- a/include/model/CEventRateBucketGatherer.h
+++ b/include/model/CEventRateBucketGatherer.h
@@ -68,7 +68,7 @@ public:
     uint64_t checksum() const;
 
     //! Get the memory usage of this object in a tree structure.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory usage of this object.
     std::size_t memoryUsage() const;
@@ -242,7 +242,7 @@ public:
     virtual uint64_t checksum() const;
 
     //! Get the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     virtual std::size_t memoryUsage() const;

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -251,7 +251,7 @@ public:
     uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Debug the memory used by this model.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this model.
     std::size_t memoryUsage() const override;

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -290,7 +290,7 @@ public:
     uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Debug the memory used by this model.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this model.
     std::size_t memoryUsage() const override;

--- a/include/model/CFeatureData.h
+++ b/include/model/CFeatureData.h
@@ -57,7 +57,7 @@ struct MODEL_EXPORT SEventRateFeatureData {
     std::size_t memoryUsage() const;
 
     //! Get the memory usage of this component in a tree structure.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     uint64_t s_Count;
     TStrCRefDouble1VecDoublePrPrVecVec s_InfluenceValues;
@@ -92,7 +92,7 @@ struct MODEL_EXPORT SMetricFeatureData {
     std::size_t memoryUsage() const;
 
     //! Get the memory usage of this component in a tree structure.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! The bucket value.
     TOptionalSample s_BucketValue;

--- a/include/model/CGathererTools.h
+++ b/include/model/CGathererTools.h
@@ -295,7 +295,7 @@ public:
         uint64_t checksum() const;
 
         //! Debug the memory used by this gatherer.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this gatherer.
         std::size_t memoryUsage() const;

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -145,7 +145,7 @@ public:
     virtual uint64_t checksum(bool includeCurrentBucketStats = true) const = 0;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this model.
     virtual std::size_t memoryUsage() const = 0;

--- a/include/model/CInterimBucketCorrector.h
+++ b/include/model/CInterimBucketCorrector.h
@@ -77,7 +77,7 @@ public:
     TDouble10Vec corrections(const TDouble10Vec& modes, const TDouble10Vec& values) const;
 
     //! Get the memory used by the corrector
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by the corrector
     std::size_t memoryUsage() const;

--- a/include/model/CMemoryUsageEstimator.h
+++ b/include/model/CMemoryUsageEstimator.h
@@ -66,7 +66,7 @@ public:
     void addValue(const TSizeArray& predictors, std::size_t memory);
 
     //! Debug the memory used by this component.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this component.
     std::size_t memoryUsage() const;

--- a/include/model/CMetricBucketGatherer.h
+++ b/include/model/CMetricBucketGatherer.h
@@ -191,7 +191,7 @@ public:
     virtual uint64_t checksum() const;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     virtual std::size_t memoryUsage() const;

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -246,7 +246,7 @@ public:
     uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Debug the memory used by this model.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this model.
     std::size_t memoryUsage() const override;

--- a/include/model/CMetricMultivariateStatistic.h
+++ b/include/model/CMetricMultivariateStatistic.h
@@ -140,7 +140,7 @@ public:
     }
 
     //! Debug the memory used by the statistic.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMetricPartialStatistic", sizeof(*this));
         core::CMemoryDebug::dynamicSize("m_Value", m_Values, mem);
     }

--- a/include/model/CMetricPartialStatistic.h
+++ b/include/model/CMetricPartialStatistic.h
@@ -123,7 +123,7 @@ public:
     }
 
     //! Debug the memory used by the statistic.
-    inline void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    inline void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMetricPartialStatistic", sizeof(*this));
         core::CMemoryDebug::dynamicSize("m_Value", m_Value, mem);
         core::CMemoryDebug::dynamicSize("m_Time", m_Time, mem);

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -273,7 +273,7 @@ public:
                                                    core_t::TTime time) const;
 
     //! Debug the memory used by this model.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this model.
     std::size_t memoryUsage() const override;

--- a/include/model/CModelTools.h
+++ b/include/model/CModelTools.h
@@ -184,7 +184,7 @@ public:
         bool lookup(std::size_t category, double& result) const;
 
         //! Get the memory usage of the component
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory usage of the component
         std::size_t memoryUsage() const;

--- a/include/model/CMonitoredResource.h
+++ b/include/model/CMonitoredResource.h
@@ -32,7 +32,7 @@ public:
     virtual ~CMonitoredResource() = default;
 
     //! Get the memory used by this detector.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Return the total memory usage.
     virtual std::size_t memoryUsage() const = 0;

--- a/include/model/CPopulationModel.h
+++ b/include/model/CPopulationModel.h
@@ -153,7 +153,7 @@ public:
     virtual uint64_t checksum(bool includeCurrentBucketStats = true) const = 0;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
 
     //! Get the memory used by this model.
     virtual std::size_t memoryUsage() const = 0;

--- a/include/model/CSample.h
+++ b/include/model/CSample.h
@@ -66,7 +66,7 @@ public:
     std::string print() const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/model/CSampleCounts.h
+++ b/include/model/CSampleCounts.h
@@ -91,7 +91,7 @@ public:
     uint64_t checksum(const CDataGatherer& gatherer) const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;

--- a/include/model/CSampleGatherer.h
+++ b/include/model/CSampleGatherer.h
@@ -307,7 +307,7 @@ public:
     }
 
     //! Debug the memory used by this gatherer.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CSampleGatherer", sizeof(*this));
         core::CMemoryDebug::dynamicSize("m_SampleStats", m_SampleStats, mem);
         core::CMemoryDebug::dynamicSize("m_BucketStats", m_BucketStats, mem);

--- a/include/model/CSampleQueue.h
+++ b/include/model/CSampleQueue.h
@@ -151,7 +151,7 @@ private:
         }
 
         //! Debug the memory used by the sub-sample.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
             mem->setName("SSubSample", sizeof(*this));
             core::CMemoryDebug::dynamicSize("s_Statistic", s_Statistic, mem);
         }
@@ -339,7 +339,7 @@ public:
     }
 
     //! Debug the memory used by the queue.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CSampleQueue", sizeof(*this));
         core::CMemoryDebug::dynamicSize("m_Queue", m_Queue, mem);
     }

--- a/include/model/CStringStore.h
+++ b/include/model/CStringStore.h
@@ -99,7 +99,7 @@ public:
     void pruneNotThreadSafe();
 
     //! Get the memory used by this string store
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this string store
     std::size_t memoryUsage() const;

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -116,7 +116,7 @@ public:
     void cacheReverseSearch(const std::string& part1, const std::string& part2);
 
     //! Debug the memory used by this category.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this category.
     std::size_t memoryUsage() const;

--- a/include/model/CTokenListDataCategorizer.h
+++ b/include/model/CTokenListDataCategorizer.h
@@ -64,7 +64,7 @@ public:
     CTokenListDataCategorizer& operator=(const CTokenListDataCategorizer&) = delete;
 
     //! Debug the memory used by this categorizer.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CTokenListDataCategorizer");
         this->CTokenListDataCategorizerBase::debugMemoryUsage(mem->addChild());
         core::CMemoryDebug::dynamicSize("m_SimilarityTester", m_SimilarityTester, mem);

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -152,7 +152,7 @@ public:
     TPersistFunc makeBackgroundPersistFunc() const override;
 
     //! Debug the memory used by this categorizer.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this categorizer.
     std::size_t memoryUsage() const override;
@@ -225,7 +225,7 @@ private:
         void incCategoryCount();
 
         //! Debug the memory used by this item.
-        void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+        void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
         //! Get the memory used by this item.
         std::size_t memoryUsage() const;

--- a/include/model/CTokenListReverseSearchCreator.h
+++ b/include/model/CTokenListReverseSearchCreator.h
@@ -88,7 +88,7 @@ public:
     const std::string& fieldName() const;
 
     //! Debug the memory used by this reverse search creator.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this reverse search creator.
     std::size_t memoryUsage() const;

--- a/lib/core/CCsvLineParser.cc
+++ b/lib/core/CCsvLineParser.cc
@@ -125,7 +125,7 @@ bool CCsvLineParser::parseNextToken(const char* end, const char*& current) {
     return true;
 }
 
-void CCsvLineParser::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCsvLineParser::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCsvLineParser");
     mem->addItem("m_WorkField", m_WorkFieldCapacity);
 }

--- a/lib/core/CJsonOutputStreamWrapper.cc
+++ b/lib/core/CJsonOutputStreamWrapper.cc
@@ -108,7 +108,7 @@ void CJsonOutputStreamWrapper::syncFlush() {
     c.wait(lock);
 }
 
-void CJsonOutputStreamWrapper::debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const {
+void CJsonOutputStreamWrapper::debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
     std::size_t bufferSize = 0;
     for (size_t i = 0; i < BUFFER_POOL_SIZE; ++i) {
         // GetSize() returns the length of the string, not the used memory, need to inspect internals

--- a/lib/core/CMemoryUsage.cc
+++ b/lib/core/CMemoryUsage.cc
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+#include <core/CMemoryUsage.h>
 
 #include <core/CLogger.h>
 #include <core/CMemory.h>
@@ -11,7 +12,6 @@
 #include <sstream>
 
 namespace ml {
-
 namespace core {
 
 namespace memory_detail {
@@ -23,7 +23,7 @@ public:
     explicit CMemoryUsageComparison(const std::string& baseline)
         : m_Baseline(baseline) {}
 
-    bool operator()(const CMemoryUsage* rhs) {
+    bool operator()(const CMemoryUsage::TMemoryUsagePtr& rhs) {
         return m_Baseline == rhs->m_Description.s_Name;
     }
 
@@ -35,11 +35,12 @@ private:
 //! their description, but ignoring the first in the collection
 class CMemoryUsageComparisonTwo {
 public:
-    explicit CMemoryUsageComparisonTwo(const std::string& baseline, const CMemoryUsage* firstItem)
-        : m_Baseline(baseline), m_FirstItem(firstItem) {}
+    explicit CMemoryUsageComparisonTwo(const std::string& baseline,
+                                       const CMemoryUsage::TMemoryUsagePtr& firstItem)
+        : m_Baseline(baseline), m_FirstItem(firstItem.get()) {}
 
-    bool operator()(const CMemoryUsage* rhs) {
-        return (rhs != m_FirstItem) && (m_Baseline == rhs->m_Description.s_Name);
+    bool operator()(const CMemoryUsage::TMemoryUsagePtr& rhs) {
+        return (rhs.get() != m_FirstItem) && (m_Baseline == rhs->m_Description.s_Name);
     }
 
 private:
@@ -51,20 +52,14 @@ private:
 CMemoryUsage::CMemoryUsage() : m_Description("", 0ull) {
 }
 
-CMemoryUsage::~CMemoryUsage() {
-    for (TMemoryUsagePtrListItr i = m_Children.begin(); i != m_Children.end(); ++i) {
-        delete *i;
-    }
-}
-
 CMemoryUsage::TMemoryUsagePtr CMemoryUsage::addChild() {
-    TMemoryUsagePtr child(new CMemoryUsage);
+    auto child = std::make_shared<CMemoryUsage>();
     m_Children.push_back(child);
     return child;
 }
 
 CMemoryUsage::TMemoryUsagePtr CMemoryUsage::addChild(std::size_t initialAmount) {
-    TMemoryUsagePtr child(new CMemoryUsage);
+    auto child = std::make_shared<CMemoryUsage>();
     child->m_Description.s_Memory = initialAmount;
     m_Children.push_back(child);
     return child;
@@ -97,24 +92,24 @@ void CMemoryUsage::setName(const std::string& name) {
 
 std::size_t CMemoryUsage::usage() const {
     std::size_t mem = m_Description.s_Memory;
-    for (TMemoryUsageVecCitr i = m_Items.begin(); i != m_Items.end(); ++i) {
-        mem += i->s_Memory;
+    for (const auto& item : m_Items) {
+        mem += item.s_Memory;
     }
 
-    for (TMemoryUsagePtrListCItr i = m_Children.begin(); i != m_Children.end(); ++i) {
-        mem += (*i)->usage();
+    for (const auto& child : m_Children) {
+        mem += child->usage();
     }
     return mem;
 }
 
 std::size_t CMemoryUsage::unusage() const {
     std::size_t mem = m_Description.s_Unused;
-    for (TMemoryUsageVecCitr i = m_Items.begin(); i != m_Items.end(); ++i) {
-        mem += i->s_Unused;
+    for (const auto& item : m_Items) {
+        mem += item.s_Unused;
     }
 
-    for (TMemoryUsagePtrListCItr i = m_Children.begin(); i != m_Children.end(); ++i) {
-        mem += (*i)->unusage();
+    for (const auto& child : m_Children) {
+        mem += child->unusage();
     }
     return mem;
 }
@@ -125,9 +120,9 @@ void CMemoryUsage::summary(CMemoryUsageJsonWriter& writer) const {
 
     if (m_Items.size() > 0) {
         writer.startArray("items");
-        for (TMemoryUsageVecCitr i = m_Items.begin(); i != m_Items.end(); ++i) {
+        for (const auto& item : m_Items) {
             writer.startObject();
-            writer.addItem(*i);
+            writer.addItem(item);
             writer.endObject();
         }
         writer.endArray();
@@ -135,8 +130,8 @@ void CMemoryUsage::summary(CMemoryUsageJsonWriter& writer) const {
 
     if (!m_Children.empty()) {
         writer.startArray("subItems");
-        for (TMemoryUsagePtrListCItr i = m_Children.begin(); i != m_Children.end(); ++i) {
-            (*i)->summary(writer);
+        for (const auto& child : m_Children) {
+            child->summary(writer);
         }
         writer.endArray();
     }
@@ -146,46 +141,45 @@ void CMemoryUsage::summary(CMemoryUsageJsonWriter& writer) const {
 
 void CMemoryUsage::compress() {
     using TStrSizeMap = std::map<std::string, std::size_t>;
-    using TStrSizeMapCItr = TStrSizeMap::const_iterator;
 
     if (!m_Children.empty()) {
         // Find out which of the children occur the most
         TStrSizeMap itemsByName;
-        for (TMemoryUsagePtrListCItr i = m_Children.begin(); i != m_Children.end(); ++i) {
-            itemsByName[(*i)->m_Description.s_Name]++;
-            LOG_TRACE(<< "Item " << (*i)->m_Description.s_Name << " : "
-                      << itemsByName[(*i)->m_Description.s_Name]);
+        for (const auto& child : m_Children) {
+            ++itemsByName[child->m_Description.s_Name];
+            LOG_TRACE(<< "Item " << child->m_Description.s_Name << " : "
+                      << itemsByName[child->m_Description.s_Name]);
         }
 
-        for (TStrSizeMapCItr i = itemsByName.begin(); i != itemsByName.end(); ++i) {
+        for (const auto& itemByName : itemsByName) {
             // For commonly-occuring children, add up their usage
             // then delete them
-            if (i->second > 1) {
-                std::size_t counter = 0;
-                memory_detail::CMemoryUsageComparison compareName(i->first);
+            if (itemByName.second > 1) {
+                std::size_t counter{0};
+                memory_detail::CMemoryUsageComparison compareName{itemByName.first};
 
-                TMemoryUsagePtrListItr firstChild =
-                    std::find_if(m_Children.begin(), m_Children.end(), compareName);
-                memory_detail::CMemoryUsageComparisonTwo comparison(i->first, *firstChild);
+                auto firstChildItr = std::find_if(m_Children.begin(),
+                                                  m_Children.end(), compareName);
+                memory_detail::CMemoryUsageComparisonTwo comparison(
+                    itemByName.first, *firstChildItr);
 
-                TMemoryUsagePtrListItr j = m_Children.begin();
-                while ((j = std::find_if(j, m_Children.end(), comparison)) !=
+                auto childItr = m_Children.begin();
+                while ((childItr = std::find_if(childItr, m_Children.end(), comparison)) !=
                        m_Children.end()) {
-                    LOG_TRACE(<< "Trying to remove " << *j);
-                    (*firstChild)->m_Description.s_Memory += (*j)->usage();
-                    (*firstChild)->m_Description.s_Unused += (*j)->unusage();
-                    delete *j;
-                    j = m_Children.erase(j);
-                    counter++;
+                    LOG_TRACE(<< "Trying to remove " << *childItr);
+                    (*firstChildItr)->m_Description.s_Memory += (*childItr)->usage();
+                    (*firstChildItr)->m_Description.s_Unused += (*childItr)->unusage();
+                    childItr = m_Children.erase(childItr);
+                    ++counter;
                 }
                 std::ostringstream ss;
-                ss << " [*" << counter + 1 << "]";
-                (*firstChild)->m_Description.s_Name += ss.str();
+                ss << " [*" << counter + 1 << ']';
+                (*firstChildItr)->m_Description.s_Name += ss.str();
             }
         }
     }
-    for (TMemoryUsagePtrListItr i = m_Children.begin(); i != m_Children.end(); ++i) {
-        (*i)->compress();
+    for (auto& child : m_Children) {
+        child->compress();
     }
 }
 
@@ -196,5 +190,4 @@ void CMemoryUsage::print(std::ostream& outStream) const {
 }
 
 } // core
-
 } // ml

--- a/lib/core/CPackedBitVector.cc
+++ b/lib/core/CPackedBitVector.cc
@@ -250,7 +250,7 @@ uint64_t CPackedBitVector::checksum() const {
         static_cast<int>(sizeof(std::uint8_t) * m_RunLengths.size()), seed);
 }
 
-void CPackedBitVector::debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const {
+void CPackedBitVector::debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPackedBitVector");
     CMemoryDebug::dynamicSize("m_RunLengths", m_RunLengths, mem);
 }

--- a/lib/core/CRapidJsonConcurrentLineWriter.cc
+++ b/lib/core/CRapidJsonConcurrentLineWriter.cc
@@ -34,7 +34,7 @@ bool CRapidJsonConcurrentLineWriter::EndObject(rapidjson::SizeType memberCount) 
     return baseReturnCode;
 }
 
-void CRapidJsonConcurrentLineWriter::debugMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const {
+void CRapidJsonConcurrentLineWriter::debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CRapidJsonConcurrentLineWriter", sizeof(*this));
     m_OutputStreamWrapper.debugMemoryUsage(mem->addChild());
 }

--- a/lib/core/CStoredStringPtr.cc
+++ b/lib/core/CStoredStringPtr.cc
@@ -75,7 +75,7 @@ std::size_t CStoredStringPtr::actualMemoryUsage() const {
     return CMemory::dynamicSize(m_String.get());
 }
 
-void CStoredStringPtr::debugActualMemoryUsage(CMemoryUsage::TMemoryUsagePtr mem) const {
+void CStoredStringPtr::debugActualMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
     // This is NOT the standard way to account for the memory of a
     // shared_ptr - do NOT copy this to other classes with shared_ptr members
     mem->addItem("m_String", this->actualMemoryUsage());

--- a/lib/core/CStringSimilarityTester.cc
+++ b/lib/core/CStringSimilarityTester.cc
@@ -134,7 +134,7 @@ int** CStringSimilarityTester::setupBerghelRoachMatrix(int maxDist,
     return matrix;
 }
 
-void CStringSimilarityTester::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CStringSimilarityTester::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CStringSimilarityTester");
     core::CMemoryDebug::dynamicSize("m_Compressor", m_Compressor, mem);
 }

--- a/lib/core/CompressUtils.cc
+++ b/lib/core/CompressUtils.cc
@@ -136,7 +136,7 @@ bool CCompressUtil::prepareToReturnData(bool finish) {
     return true;
 }
 
-void CCompressUtil::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCompressUtil::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCompressUtil");
     core::CMemoryDebug::dynamicSize("m_FullResult", m_FullResult, mem);
     if (m_ZlibStrm.state != nullptr) {

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -70,7 +70,7 @@ struct SFooWithMemoryUsage {
     }
     std::size_t memoryUsage() const { return 0; }
 
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("SFooWithMemoryUsage", 0);
     }
 
@@ -110,7 +110,7 @@ struct SBarDebug {
         return sizeof(SFoo) * s_State.capacity();
     }
 
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("SBarDebug", 0);
         core::CMemoryDebug::dynamicSize("s_State", s_State, mem);
     }
@@ -133,7 +133,7 @@ struct SBarVectorDebug {
         return core::CMemory::dynamicSize(s_State);
     }
 
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("SBarVectorDebug", 0);
         core::CMemoryDebug::dynamicSize("s_State", s_State, mem);
     }
@@ -160,7 +160,7 @@ public:
         return core::CMemory::dynamicSize(m_Vec);
     }
 
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CBase", 0);
         core::CMemoryDebug::dynamicSize("m_Vec", m_Vec, mem);
     }
@@ -185,7 +185,7 @@ public:
         return mem;
     }
 
-    virtual void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CDerived", 0);
         core::CMemoryDebug::dynamicSize("m_Strings", m_Strings, mem);
         this->CBase::debugMemoryUsage(mem->addChild());
@@ -549,30 +549,30 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         debugVisitor.registerCallback<TDoubleVec>();
         debugVisitor.registerCallback<TFooVec>();
 
-        core::CMemoryUsage mem;
-        core::CMemoryDebug::dynamicSize("", variables, &mem);
-        BOOST_REQUIRE_EQUAL(mem.usage(), core::CMemory::dynamicSize(variables));
+        auto mem = std::make_shared<core::CMemoryUsage>();
+        core::CMemoryDebug::dynamicSize("", variables, mem);
+        BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(variables));
         std::ostringstream ss;
-        mem.print(ss);
+        mem->print(ss);
         LOG_DEBUG(<< ss.str());
     }
     {
         CBase* base = new CBase(10);
         CBase* derived = new CDerived(10);
         {
-            core::CMemoryUsage mem;
-            core::CMemoryDebug::dynamicSize("", *base, &mem);
-            BOOST_REQUIRE_EQUAL(mem.usage(), core::CMemory::dynamicSize(*base));
+            auto mem = std::make_shared<core::CMemoryUsage>();
+            core::CMemoryDebug::dynamicSize("", *base, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(*base));
             std::ostringstream ss;
-            mem.print(ss);
+            mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
         {
-            core::CMemoryUsage mem;
-            core::CMemoryDebug::dynamicSize("", *derived, &mem);
-            BOOST_REQUIRE_EQUAL(mem.usage(), core::CMemory::dynamicSize(*derived));
+            auto mem = std::make_shared<core::CMemoryUsage>();
+            core::CMemoryDebug::dynamicSize("", *derived, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(*derived));
             std::ostringstream ss;
-            mem.print(ss);
+            mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
         BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(*base) <
@@ -581,30 +581,30 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         TBasePtr sharedBase(new CBase(10));
         TBasePtr sharedDerived(new CDerived(10));
         {
-            core::CMemoryUsage mem;
-            core::CMemoryDebug::dynamicSize("", sharedBase, &mem);
-            BOOST_REQUIRE_EQUAL(mem.usage(), core::CMemory::dynamicSize(sharedBase));
+            auto mem = std::make_shared<core::CMemoryUsage>();
+            core::CMemoryDebug::dynamicSize("", sharedBase, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(sharedBase));
             std::ostringstream ss;
-            mem.print(ss);
+            mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
         {
-            core::CMemoryUsage mem;
-            core::CMemoryDebug::dynamicSize("", sharedDerived, &mem);
-            BOOST_REQUIRE_EQUAL(mem.usage(), core::CMemory::dynamicSize(sharedDerived));
+            auto mem = std::make_shared<core::CMemoryUsage>();
+            core::CMemoryDebug::dynamicSize("", sharedDerived, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(sharedDerived));
             std::ostringstream ss;
-            mem.print(ss);
+            mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
         // boost:reference_wrapper should give zero
         std::reference_wrapper<CBase> baseRef(std::ref(*base));
         BOOST_REQUIRE_EQUAL(std::size_t(0), core::CMemory::dynamicSize(baseRef));
         {
-            core::CMemoryUsage mem;
-            core::CMemoryDebug::dynamicSize("", baseRef, &mem);
-            BOOST_REQUIRE_EQUAL(mem.usage(), core::CMemory::dynamicSize(baseRef));
+            auto mem = std::make_shared<core::CMemoryUsage>();
+            core::CMemoryDebug::dynamicSize("", baseRef, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(baseRef));
             std::ostringstream ss;
-            mem.print(ss);
+            mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
     }
@@ -691,22 +691,22 @@ BOOST_AUTO_TEST_CASE(testDebug) {
         BOOST_REQUIRE_EQUAL(sbar.memoryUsage(), sbarVectorDebug.memoryUsage());
 
         {
-            core::CMemoryUsage memoryUsage;
-            sbarDebug.debugMemoryUsage(&memoryUsage);
-            BOOST_REQUIRE_EQUAL(sbarDebug.memoryUsage(), memoryUsage.usage());
+            auto mem = std::make_shared<core::CMemoryUsage>();
+            sbarDebug.debugMemoryUsage(mem);
+            BOOST_REQUIRE_EQUAL(sbarDebug.memoryUsage(), mem->usage());
             std::ostringstream ss;
-            memoryUsage.print(ss);
+            mem->print(ss);
             LOG_TRACE(<< "SBarDebug: " + ss.str());
         }
         {
-            core::CMemoryUsage memoryUsage;
-            sbarVectorDebug.debugMemoryUsage(&memoryUsage);
+            auto mem = std::make_shared<core::CMemoryUsage>();
+            sbarVectorDebug.debugMemoryUsage(mem);
             std::ostringstream ss;
-            memoryUsage.print(ss);
+            mem->print(ss);
             LOG_TRACE(<< "SBarVectorDebug: " + ss.str());
             LOG_TRACE(<< "memoryUsage: " << sbarVectorDebug.memoryUsage()
-                      << ", debugUsage: " << memoryUsage.usage());
-            BOOST_REQUIRE_EQUAL(sbarVectorDebug.memoryUsage(), memoryUsage.usage());
+                      << ", debugUsage: " << mem->usage());
+            BOOST_REQUIRE_EQUAL(sbarVectorDebug.memoryUsage(), mem->usage());
         }
     }
     {
@@ -828,7 +828,7 @@ BOOST_AUTO_TEST_CASE(testCompress) {
         mem.setName("root", 1);
         mem.addChild()->setName("muffin", 4);
         mem.addChild()->setName("child", 3);
-        core::CMemoryUsage* child = mem.addChild();
+        auto child = mem.addChild();
         child->setName("child", 5);
         child->addChild()->setName("grandchild", 100);
         mem.addChild()->setName("child", 7);

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -416,7 +416,7 @@ uint64_t CBjkstUniqueValues::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, *values);
 }
 
-void CBjkstUniqueValues::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CBjkstUniqueValues::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CBjkstUniqueValues");
     const TUInt32Vec* values = boost::get<TUInt32Vec>(&m_Sketch);
     if (values) {

--- a/lib/maths/CCalendarComponent.cc
+++ b/lib/maths/CCalendarComponent.cc
@@ -172,7 +172,7 @@ uint64_t CCalendarComponent::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Bucketing);
 }
 
-void CCalendarComponent::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCalendarComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarComponent");
     core::CMemoryDebug::dynamicSize("m_Bucketing", m_Bucketing, mem);
     core::CMemoryDebug::dynamicSize("m_Splines", this->splines(), mem);

--- a/lib/maths/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/CCalendarComponentAdaptiveBucketing.cc
@@ -154,7 +154,8 @@ uint64_t CCalendarComponentAdaptiveBucketing::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Values);
 }
 
-void CCalendarComponentAdaptiveBucketing::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCalendarComponentAdaptiveBucketing::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarComponentAdaptiveBucketing");
     core::CMemoryDebug::dynamicSize("m_Endpoints", this->endpoints(), mem);
     core::CMemoryDebug::dynamicSize("m_Centres", this->centres(), mem);

--- a/lib/maths/CCalendarCyclicTest.cc
+++ b/lib/maths/CCalendarCyclicTest.cc
@@ -236,7 +236,7 @@ std::uint64_t CCalendarCyclicTest::checksum(std::uint64_t seed) const {
     return CChecksum::calculate(seed, errors);
 }
 
-void CCalendarCyclicTest::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCalendarCyclicTest::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarCyclicTest");
     core::CMemoryDebug::dynamicSize("m_ErrorQuantiles", m_ErrorQuantiles, mem);
     core::CMemoryDebug::dynamicSize("m_CompressedBucketErrorStats",

--- a/lib/maths/CClusterer.cc
+++ b/lib/maths/CClusterer.cc
@@ -54,7 +54,7 @@ void CClustererTypes::CIndexGenerator::recycle(std::size_t index) {
     std::push_heap(m_IndexHeap->begin(), m_IndexHeap->end(), std::greater<std::size_t>());
 }
 
-void CClustererTypes::CIndexGenerator::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CClustererTypes::CIndexGenerator::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CClusterer::CIndexGenerator");
     core::CMemoryDebug::dynamicSize("m_IndexHeap", m_IndexHeap, mem);
 }

--- a/lib/maths/CConstantPrior.cc
+++ b/lib/maths/CConstantPrior.cc
@@ -341,7 +341,7 @@ uint64_t CConstantPrior::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Constant);
 }
 
-void CConstantPrior::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CConstantPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CConstantPrior");
 }
 

--- a/lib/maths/CCooccurrences.cc
+++ b/lib/maths/CCooccurrences.cc
@@ -507,7 +507,7 @@ uint64_t CCooccurrences::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Indicators);
 }
 
-void CCooccurrences::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCooccurrences::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCooccurrences");
     core::CMemoryDebug::dynamicSize("m_CurrentIndicators", m_CurrentIndicators, mem);
     core::CMemoryDebug::dynamicSize("m_Indicators", m_Indicators, mem);

--- a/lib/maths/CCountMinSketch.cc
+++ b/lib/maths/CCountMinSketch.cc
@@ -308,7 +308,7 @@ uint64_t CCountMinSketch::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, *counts);
 }
 
-void CCountMinSketch::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCountMinSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCountMinSketch");
     const TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {

--- a/lib/maths/CDecayRateController.cc
+++ b/lib/maths/CDecayRateController.cc
@@ -256,7 +256,7 @@ std::size_t CDecayRateController::dimension() const {
     return m_PredictionMean.size();
 }
 
-void CDecayRateController::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CDecayRateController::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDecayRateController");
     core::CMemoryDebug::dynamicSize("m_PredictionMean", m_PredictionMean, mem);
     core::CMemoryDebug::dynamicSize("m_Bias", m_Bias, mem);

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -325,7 +325,8 @@ uint64_t CDecompositionComponent::CPackedSplines::checksum(uint64_t seed) const 
     return CChecksum::calculate(seed, m_Curvatures);
 }
 
-void CDecompositionComponent::CPackedSplines::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CDecompositionComponent::CPackedSplines::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPackedSplines");
     core::CMemoryDebug::dynamicSize("m_Knots", m_Knots, mem);
     core::CMemoryDebug::dynamicSize("m_Values[0]", m_Values[0], mem);

--- a/lib/maths/CExpandingWindow.cc
+++ b/lib/maths/CExpandingWindow.cc
@@ -194,7 +194,7 @@ uint64_t CExpandingWindow::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_MeanOffset);
 }
 
-void CExpandingWindow::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CExpandingWindow::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CExpandingWindow");
     core::CMemoryDebug::dynamicSize("m_BucketValues", m_BucketValues, mem);
     core::CMemoryDebug::dynamicSize("m_DeflatedBucketValues", m_DeflatedBucketValues, mem);

--- a/lib/maths/CGammaRateConjugate.cc
+++ b/lib/maths/CGammaRateConjugate.cc
@@ -1524,7 +1524,7 @@ uint64_t CGammaRateConjugate::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_PriorRate);
 }
 
-void CGammaRateConjugate::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CGammaRateConjugate::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CGammaRateConjugate");
 }
 

--- a/lib/maths/CKMeansOnline1d.cc
+++ b/lib/maths/CKMeansOnline1d.cc
@@ -253,7 +253,7 @@ double CKMeansOnline1d::probability(std::size_t index) const {
     return weightSum == 0.0 ? 0.0 : weight / weightSum;
 }
 
-void CKMeansOnline1d::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CKMeansOnline1d::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CKMeansOnline1d");
     core::CMemoryDebug::dynamicSize("m_Clusters", m_Clusters, mem);
 }

--- a/lib/maths/CKMostCorrelated.cc
+++ b/lib/maths/CKMostCorrelated.cc
@@ -361,7 +361,7 @@ uint64_t CKMostCorrelated::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_MostCorrelated);
 }
 
-void CKMostCorrelated::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CKMostCorrelated::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CKMostCorrelated");
     core::CMemoryDebug::dynamicSize("m_Projections", m_Projections, mem);
     core::CMemoryDebug::dynamicSize("m_CurrentProjected", m_CurrentProjected, mem);

--- a/lib/maths/CLogNormalMeanPrecConjugate.cc
+++ b/lib/maths/CLogNormalMeanPrecConjugate.cc
@@ -1489,7 +1489,7 @@ uint64_t CLogNormalMeanPrecConjugate::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_GammaRate);
 }
 
-void CLogNormalMeanPrecConjugate::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CLogNormalMeanPrecConjugate::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CLogNormalMeanPrecConjugate");
 }
 

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -377,7 +377,7 @@ std::uint64_t CModelStub::checksum(std::uint64_t seed) const {
     return seed;
 }
 
-void CModelStub::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr /*mem*/) const {
+void CModelStub::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& /*mem*/) const {
 }
 
 std::size_t CModelStub::memoryUsage() const {

--- a/lib/maths/CMultimodalPrior.cc
+++ b/lib/maths/CMultimodalPrior.cc
@@ -529,7 +529,7 @@ uint64_t CMultimodalPrior::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Modes);
 }
 
-void CMultimodalPrior::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMultimodalPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultimodalPrior");
     core::CMemoryDebug::dynamicSize("m_Clusterer", m_Clusterer, mem);
     core::CMemoryDebug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);

--- a/lib/maths/CMultinomialConjugate.cc
+++ b/lib/maths/CMultinomialConjugate.cc
@@ -1238,7 +1238,7 @@ uint64_t CMultinomialConjugate::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_TotalConcentration);
 }
 
-void CMultinomialConjugate::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMultinomialConjugate::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultinomialConjugate");
     core::CMemoryDebug::dynamicSize("m_Categories", m_Categories, mem);
     core::CMemoryDebug::dynamicSize("m_Concentrations", m_Concentrations, mem);

--- a/lib/maths/CMultivariateConstantPrior.cc
+++ b/lib/maths/CMultivariateConstantPrior.cc
@@ -282,7 +282,7 @@ uint64_t CMultivariateConstantPrior::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Constant);
 }
 
-void CMultivariateConstantPrior::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMultivariateConstantPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultivariateConstantPrior");
     core::CMemoryDebug::dynamicSize("m_Constant", m_Constant, mem);
 }

--- a/lib/maths/CMultivariateOneOfNPrior.cc
+++ b/lib/maths/CMultivariateOneOfNPrior.cc
@@ -747,7 +747,7 @@ uint64_t CMultivariateOneOfNPrior::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Models);
 }
 
-void CMultivariateOneOfNPrior::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMultivariateOneOfNPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultivariateOneOfNPrior");
     core::CMemoryDebug::dynamicSize("m_Models", m_Models, mem);
 }

--- a/lib/maths/CNaiveBayes.cc
+++ b/lib/maths/CNaiveBayes.cc
@@ -99,7 +99,8 @@ void CNaiveBayesFeatureDensityFromPrior::propagateForwardsByTime(double time) {
     m_Prior->propagateForwardsByTime(time);
 }
 
-void CNaiveBayesFeatureDensityFromPrior::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CNaiveBayesFeatureDensityFromPrior::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     return core::CMemoryDebug::dynamicSize("m_Prior", m_Prior, mem);
 }
 
@@ -338,7 +339,7 @@ CNaiveBayes::TDoubleSizePrVec CNaiveBayes::classProbabilities(const TDouble1VecV
     return p;
 }
 
-void CNaiveBayes::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CNaiveBayes::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     core::CMemoryDebug::dynamicSize("m_Exemplar", m_Exemplar, mem);
     core::CMemoryDebug::dynamicSize("m_ClassConditionalDensities",
                                     m_ClassConditionalDensities, mem);
@@ -441,7 +442,7 @@ CNaiveBayes::TFeatureDensityPtrVec& CNaiveBayes::CClass::conditionalDensities() 
     return m_ConditionalDensities;
 }
 
-void CNaiveBayes::CClass::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CNaiveBayes::CClass::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     core::CMemoryDebug::dynamicSize("s_ConditionalDensities", m_ConditionalDensities, mem);
 }
 

--- a/lib/maths/CNaturalBreaksClassifier.cc
+++ b/lib/maths/CNaturalBreaksClassifier.cc
@@ -491,7 +491,7 @@ uint64_t CNaturalBreaksClassifier::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_PointsBuffer);
 }
 
-void CNaturalBreaksClassifier::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CNaturalBreaksClassifier::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CNaturalBreaksClassifier");
     core::CMemoryDebug::dynamicSize("m_Categories", m_Categories, mem);
     core::CMemoryDebug::dynamicSize("m_PointsBuffer", m_PointsBuffer, mem);

--- a/lib/maths/CNormalMeanPrecConjugate.cc
+++ b/lib/maths/CNormalMeanPrecConjugate.cc
@@ -1239,7 +1239,7 @@ uint64_t CNormalMeanPrecConjugate::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_GammaRate);
 }
 
-void CNormalMeanPrecConjugate::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CNormalMeanPrecConjugate::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CNormalMeanPrecConjugate");
 }
 

--- a/lib/maths/COneOfNPrior.cc
+++ b/lib/maths/COneOfNPrior.cc
@@ -1000,7 +1000,7 @@ uint64_t COneOfNPrior::checksum(uint64_t seed) const {
     return seed;
 }
 
-void COneOfNPrior::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void COneOfNPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("COneOfNPrior");
     core::CMemoryDebug::dynamicSize("m_Models", m_Models, mem);
 }

--- a/lib/maths/CPoissonMeanConjugate.cc
+++ b/lib/maths/CPoissonMeanConjugate.cc
@@ -864,7 +864,7 @@ uint64_t CPoissonMeanConjugate::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Rate);
 }
 
-void CPoissonMeanConjugate::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CPoissonMeanConjugate::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPoissonMeanConjugate");
 }
 

--- a/lib/maths/CQuantileSketch.cc
+++ b/lib/maths/CQuantileSketch.cc
@@ -322,7 +322,7 @@ std::uint64_t CQuantileSketch::checksum(std::uint64_t seed) const {
     return CChecksum::calculate(seed, m_Count);
 }
 
-void CQuantileSketch::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CQuantileSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CQuantileSketch");
     core::CMemoryDebug::dynamicSize("m_Knots", m_Knots, mem);
 }
@@ -561,7 +561,7 @@ std::uint64_t CFastQuantileSketch::checksum(std::uint64_t seed) const {
     return CChecksum::calculate(seed, m_ReductionFraction);
 }
 
-void CFastQuantileSketch::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CFastQuantileSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CFastQuantileSketch");
     core::CMemoryDebug::dynamicSize("m_Knots", this->knots(), mem);
     core::CMemoryDebug::dynamicSize("m_MergeCosts", m_MergeCosts, mem);

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -282,7 +282,7 @@ uint64_t CSeasonalComponent::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Bucketing);
 }
 
-void CSeasonalComponent::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CSeasonalComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSeasonalComponent");
     core::CMemoryDebug::dynamicSize("m_Bucketing", m_Bucketing, mem);
     core::CMemoryDebug::dynamicSize("m_Splines", this->splines(), mem);

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -288,7 +288,8 @@ uint64_t CSeasonalComponentAdaptiveBucketing::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Buckets);
 }
 
-void CSeasonalComponentAdaptiveBucketing::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CSeasonalComponentAdaptiveBucketing::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSeasonalComponentAdaptiveBucketing");
     core::CMemoryDebug::dynamicSize("m_Endpoints", this->endpoints(), mem);
     core::CMemoryDebug::dynamicSize("m_Centres", this->centres(), mem);

--- a/lib/maths/CTimeSeriesChangeDetector.cc
+++ b/lib/maths/CTimeSeriesChangeDetector.cc
@@ -306,7 +306,8 @@ void CUnivariateTimeSeriesChangeDetector::addSamples(const TTimeDoublePr1Vec& sa
     }
 }
 
-void CUnivariateTimeSeriesChangeDetector::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CUnivariateTimeSeriesChangeDetector::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     core::CMemoryDebug::dynamicSize("m_ChangeModels", m_ChangeModels, mem);
 }
 
@@ -353,7 +354,7 @@ void CUnivariateChangeModel::acceptPersistInserter(core::CStatePersistInserter& 
     inserter.insertValue(SAMPLE_MOMENTS_TAG, m_SampleMoments.toDelimited());
 }
 
-void CUnivariateChangeModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CUnivariateChangeModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     // Note if the trend and residual models are shallow copied their
     // reference count will be updated so core::CMemory::dynamicSize
     // will give the correct contribution for these reference.

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -479,7 +479,7 @@ uint64_t CTimeSeriesDecomposition::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Components);
 }
 
-void CTimeSeriesDecomposition::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTimeSeriesDecomposition::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTimeSeriesDecomposition");
     core::CMemoryDebug::dynamicSize("m_Mediator", m_Mediator, mem);
     core::CMemoryDebug::dynamicSize("m_PeriodicityTest", m_PeriodicityTest, mem);

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -467,7 +467,8 @@ void CTimeSeriesDecompositionDetail::CMediator::registerHandler(CHandler& handle
     handler.mediator(this);
 }
 
-void CTimeSeriesDecompositionDetail::CMediator::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTimeSeriesDecompositionDetail::CMediator::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMediator");
     core::CMemoryDebug::dynamicSize("m_Handlers", m_Handlers, mem);
 }
@@ -671,7 +672,7 @@ uint64_t CTimeSeriesDecompositionDetail::CPeriodicityTest::checksum(uint64_t see
 }
 
 void CTimeSeriesDecompositionDetail::CPeriodicityTest::debugMemoryUsage(
-    core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPeriodicityTest");
     core::CMemoryDebug::dynamicSize("m_Windows", m_Windows, mem);
     core::CMemoryDebug::dynamicSize("m_LinearScales", m_LinearScales, mem);
@@ -989,7 +990,7 @@ uint64_t CTimeSeriesDecompositionDetail::CCalendarTest::checksum(uint64_t seed) 
 }
 
 void CTimeSeriesDecompositionDetail::CCalendarTest::debugMemoryUsage(
-    core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarTest");
     core::CMemoryDebug::dynamicSize("m_Test", m_Test, mem);
 }
@@ -1522,7 +1523,8 @@ uint64_t CTimeSeriesDecompositionDetail::CComponents::checksum(uint64_t seed) co
     return CChecksum::calculate(seed, m_UsingTrendForPrediction);
 }
 
-void CTimeSeriesDecompositionDetail::CComponents::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTimeSeriesDecompositionDetail::CComponents::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CComponents");
     core::CMemoryDebug::dynamicSize("m_Trend", m_Trend, mem);
     core::CMemoryDebug::dynamicSize("m_Seasonal", m_Seasonal, mem);
@@ -2412,7 +2414,7 @@ uint64_t CTimeSeriesDecompositionDetail::CComponents::CSeasonal::checksum(uint64
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::debugMemoryUsage(
-    core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSeasonal");
     core::CMemoryDebug::dynamicSize("m_Components", m_Components, mem);
     core::CMemoryDebug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);
@@ -2631,7 +2633,7 @@ uint64_t CTimeSeriesDecompositionDetail::CComponents::CCalendar::checksum(uint64
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::CCalendar::debugMemoryUsage(
-    core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendar");
     core::CMemoryDebug::dynamicSize("m_Components", m_Components, mem);
     core::CMemoryDebug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);

--- a/lib/maths/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/CTimeSeriesDecompositionStub.cc
@@ -104,7 +104,7 @@ uint64_t CTimeSeriesDecompositionStub::checksum(uint64_t seed) const {
     return seed;
 }
 
-void CTimeSeriesDecompositionStub::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTimeSeriesDecompositionStub::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTimeSeriesDecompositionStub");
 }
 

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -297,7 +297,7 @@ public:
     uint64_t checksum(uint64_t seed) const;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
@@ -563,7 +563,7 @@ uint64_t CTimeSeriesAnomalyModel::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_AnomalyFeatureModels[1]);
 }
 
-void CTimeSeriesAnomalyModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTimeSeriesAnomalyModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTimeSeriesAnomalyModel");
     core::CMemoryDebug::dynamicSize("m_Anomalies", m_Anomaly, mem);
     core::CMemoryDebug::dynamicSize("m_AnomalyFeatureModels", m_AnomalyFeatureModels, mem);
@@ -1257,7 +1257,7 @@ uint64_t CUnivariateTimeSeriesModel::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Correlations != nullptr);
 }
 
-void CUnivariateTimeSeriesModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CUnivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CUnivariateTimeSeriesModel");
     core::CMemoryDebug::dynamicSize("m_Controllers", m_Controllers, mem);
     core::CMemoryDebug::dynamicSize("m_TrendModel", m_TrendModel, mem);
@@ -1956,7 +1956,7 @@ CTimeSeriesCorrelations::correlationModels() const {
     return m_CorrelationDistributionModels;
 }
 
-void CTimeSeriesCorrelations::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTimeSeriesCorrelations::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTimeSeriesCorrelations");
     core::CMemoryDebug::dynamicSize("m_SampleData", m_SampleData, mem);
     core::CMemoryDebug::dynamicSize("m_Correlations", m_Correlations, mem);
@@ -2698,7 +2698,7 @@ uint64_t CMultivariateTimeSeriesModel::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_AnomalyModel);
 }
 
-void CMultivariateTimeSeriesModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMultivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CUnivariateTimeSeriesModel");
     core::CMemoryDebug::dynamicSize("m_Controllers", m_Controllers, mem);
     core::CMemoryDebug::dynamicSize("m_TrendModel", m_TrendModel, mem);

--- a/lib/maths/CXMeansOnline1d.cc
+++ b/lib/maths/CXMeansOnline1d.cc
@@ -1003,7 +1003,7 @@ double CXMeansOnline1d::probability(std::size_t index) const {
     return Z == 0.0 ? 0.0 : weight / Z;
 }
 
-void CXMeansOnline1d::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CXMeansOnline1d::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CXMeansOnline1d");
     core::CMemoryDebug::dynamicSize("m_ClusterIndexGenerator", m_ClusterIndexGenerator, mem);
     core::CMemoryDebug::dynamicSize("m_Clusters", m_Clusters, mem);
@@ -1516,7 +1516,7 @@ uint64_t CXMeansOnline1d::CCluster::checksum(uint64_t seed) const {
     return CChecksum::calculate(seed, m_Structure);
 }
 
-void CXMeansOnline1d::CCluster::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CXMeansOnline1d::CCluster::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CXMeansOnline1d::CCluster");
     core::CMemoryDebug::dynamicSize("m_Prior", m_Prior, mem);
     core::CMemoryDebug::dynamicSize("m_Structure", m_Structure, mem);

--- a/lib/maths/unittest/CMathsMemoryTest.cc
+++ b/lib/maths/unittest/CMathsMemoryTest.cc
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <maths/CBasicStatistics.h>
 #include <maths/CBjkstUniqueValues.h>
 #include <maths/CConstantPrior.h>
 #include <maths/CGammaRateConjugate.h>
@@ -121,10 +120,10 @@ BOOST_AUTO_TEST_CASE(testBjkstVec) {
     {
         // Test empty
         TBjkstValuesVec values;
-        core::CMemoryUsage mem;
-        mem.setName("root", 0);
-        core::CMemoryDebug::dynamicSize("values", values, &mem);
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem.usage());
+        auto mem = std::make_shared<core::CMemoryUsage>();
+        mem->setName("root", 0);
+        core::CMemoryDebug::dynamicSize("values", values, mem);
+        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem->usage());
     }
     {
         // Test adding values to the vector part
@@ -136,10 +135,10 @@ BOOST_AUTO_TEST_CASE(testBjkstVec) {
                 values[i].add(j);
             }
         }
-        core::CMemoryUsage mem;
-        mem.setName("root", 0);
-        core::CMemoryDebug::dynamicSize("values", values, &mem);
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem.usage());
+        auto mem = std::make_shared<core::CMemoryUsage>();
+        mem->setName("root", 0);
+        core::CMemoryDebug::dynamicSize("values", values, mem);
+        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem->usage());
     }
     {
         // Test adding values to the sketch part
@@ -151,10 +150,10 @@ BOOST_AUTO_TEST_CASE(testBjkstVec) {
                 values[i].add(j);
             }
         }
-        core::CMemoryUsage mem;
-        mem.setName("root", 0);
-        core::CMemoryDebug::dynamicSize("values", values, &mem);
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem.usage());
+        auto mem = std::make_shared<core::CMemoryUsage>();
+        mem->setName("root", 0);
+        core::CMemoryDebug::dynamicSize("values", values, mem);
+        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem->usage());
     }
 }
 

--- a/lib/maths/unittest/CNaiveBayesTest.cc
+++ b/lib/maths/unittest/CNaiveBayesTest.cc
@@ -262,7 +262,6 @@ BOOST_AUTO_TEST_CASE(testPropagationByTime) {
 BOOST_AUTO_TEST_CASE(testMemoryUsage) {
     // Check invariants.
 
-    using TMemoryUsageUPtr = std::unique_ptr<core::CMemoryUsage>;
     using TNaiveBayesUPtr = std::unique_ptr<maths::CNaiveBayes>;
 
     test::CRandomNumbers rng;
@@ -288,8 +287,8 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
     }
 
     std::size_t memoryUsage{nb->memoryUsage()};
-    TMemoryUsageUPtr mem{std::make_unique<core::CMemoryUsage>()};
-    nb->debugMemoryUsage(mem.get());
+    auto mem{std::make_shared<core::CMemoryUsage>()};
+    nb->debugMemoryUsage(mem);
 
     LOG_DEBUG(<< "Memory = " << memoryUsage);
     BOOST_REQUIRE_EQUAL(memoryUsage, mem->usage());

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -593,7 +593,7 @@ void CAnomalyDetector::showMemoryUsage(std::ostream& stream) const {
     }
 }
 
-void CAnomalyDetector::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CAnomalyDetector::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("Anomaly Detector Memory Usage");
     core::CMemoryDebug::dynamicSize("m_DataGatherer", m_DataGatherer, mem);
     core::CMemoryDebug::dynamicSize("m_Model", m_Model, mem);

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -299,7 +299,7 @@ uint64_t CAnomalyDetectorModel::checksum(bool /*includeCurrentBucketStats*/) con
     return maths::CChecksum::calculate(seed, hashes);
 }
 
-void CAnomalyDetectorModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CAnomalyDetectorModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CAnomalyDetectorModel");
     core::CMemoryDebug::dynamicSize("m_DataGatherer", m_DataGatherer, mem);
     core::CMemoryDebug::dynamicSize("m_Params", m_Params, mem);
@@ -513,7 +513,8 @@ void CAnomalyDetectorModel::SFeatureModels::acceptPersistInserter(core::CStatePe
     }
 }
 
-void CAnomalyDetectorModel::SFeatureModels::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CAnomalyDetectorModel::SFeatureModels::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SFeatureModels");
     core::CMemoryDebug::dynamicSize("s_NewModel", s_NewModel, mem);
     core::CMemoryDebug::dynamicSize("s_Models", s_Models, mem);
@@ -556,7 +557,7 @@ void CAnomalyDetectorModel::SFeatureCorrelateModels::acceptPersistInserter(
 }
 
 void CAnomalyDetectorModel::SFeatureCorrelateModels::debugMemoryUsage(
-    core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SFeatureCorrelateModels");
     core::CMemoryDebug::dynamicSize("s_ModelPrior", s_ModelPrior, mem);
     core::CMemoryDebug::dynamicSize("s_Models", s_Models, mem);

--- a/lib/model/CBucketGatherer.cc
+++ b/lib/model/CBucketGatherer.cc
@@ -551,7 +551,7 @@ uint64_t CBucketGatherer::checksum() const {
     return result;
 }
 
-void CBucketGatherer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CBucketGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CBucketGatherer");
     core::CMemoryDebug::dynamicSize("m_PersonAttributeCounts", m_PersonAttributeCounts, mem);
     core::CMemoryDebug::dynamicSize("m_PersonAttributeExplicitNulls",

--- a/lib/model/CCategoryExamplesCollector.cc
+++ b/lib/model/CCategoryExamplesCollector.cc
@@ -144,7 +144,7 @@ void CCategoryExamplesCollector::clear() {
     m_ExamplesByCategory.clear();
 }
 
-void CCategoryExamplesCollector::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCategoryExamplesCollector::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCategoryExamplesCollector");
     core::CMemoryDebug::dynamicSize("m_ExamplesByCategory", m_ExamplesByCategory, mem);
 }

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -304,7 +304,7 @@ uint64_t CCountingModel::checksum(bool includeCurrentBucketStats) const {
     return result;
 }
 
-void CCountingModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CCountingModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCountingModel");
     this->CAnomalyDetectorModel::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_Counts", m_Counts, mem);

--- a/lib/model/CDataCategorizer.cc
+++ b/lib/model/CDataCategorizer.cc
@@ -42,7 +42,7 @@ void CDataCategorizer::lastPersistTime(core_t::TTime lastPersistTime) {
     m_LastPersistTime = lastPersistTime;
 }
 
-void CDataCategorizer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CDataCategorizer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDataCategorizer");
     core::CMemoryDebug::dynamicSize("m_FieldName", m_FieldName, mem);
     core::CMemoryDebug::dynamicSize("m_ExamplesCollector", m_ExamplesCollector, mem);

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -592,7 +592,7 @@ uint64_t CDataGatherer::checksum() const {
     return result;
 }
 
-void CDataGatherer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CDataGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDataGatherer");
     core::CMemoryDebug::dynamicSize("m_Features", m_Features, mem);
     core::CMemoryDebug::dynamicSize("m_PeopleRegistry", m_PeopleRegistry, mem);

--- a/lib/model/CDynamicStringIdRegistry.cc
+++ b/lib/model/CDynamicStringIdRegistry.cc
@@ -217,7 +217,7 @@ uint64_t CDynamicStringIdRegistry::checksum() const {
     return maths::CChecksum::calculate(0, people);
 }
 
-void CDynamicStringIdRegistry::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CDynamicStringIdRegistry::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDynamicStringIdRegistry");
     core::CMemoryDebug::dynamicSize("m_NameType", m_NameType, mem);
     core::CMemoryDebug::dynamicSize("m_PersonUids", m_Uids, mem);

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -1001,7 +1001,7 @@ uint64_t CEventRateBucketGatherer::checksum() const {
     return core::CHashing::hashCombine(seed, hasher(core::CContainerPrinter::print(hashes)));
 }
 
-void CEventRateBucketGatherer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CEventRateBucketGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     registerMemoryCallbacks();
     mem->setName("CPopulationEventRateDataGatherer");
     CBucketGatherer::debugMemoryUsage(mem->addChild());
@@ -1847,7 +1847,7 @@ uint64_t CUniqueStringFeatureData::checksum() const {
     return maths::CChecksum::calculate(seed, m_InfluencerUniqueStrings);
 }
 
-void CUniqueStringFeatureData::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CUniqueStringFeatureData::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CUniqueStringFeatureData", sizeof(*this));
     core::CMemoryDebug::dynamicSize("s_NoInfluenceUniqueStrings", m_UniqueStrings, mem);
     core::CMemoryDebug::dynamicSize("s_InfluenceUniqueStrings",

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -461,7 +461,7 @@ uint64_t CEventRateModel::checksum(bool includeCurrentBucketStats) const {
     return maths::CChecksum::calculate(seed, hashes);
 }
 
-void CEventRateModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CEventRateModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CEventRateModel");
     this->CIndividualModel::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -798,7 +798,7 @@ uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) con
     return maths::CChecksum::calculate(seed, hashes);
 }
 
-void CEventRatePopulationModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CEventRatePopulationModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CEventRatePopulationModel");
     this->CPopulationModel::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",

--- a/lib/model/CFeatureData.cc
+++ b/lib/model/CFeatureData.cc
@@ -86,7 +86,7 @@ std::size_t SEventRateFeatureData::memoryUsage() const {
     return mem;
 }
 
-void SEventRateFeatureData::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void SEventRateFeatureData::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SMetricFeatureData", sizeof(*this));
     core::CMemoryDebug::dynamicSize("s_InfluenceValues", s_InfluenceValues, mem);
 }
@@ -125,7 +125,7 @@ std::size_t SMetricFeatureData::memoryUsage() const {
     return mem;
 }
 
-void SMetricFeatureData::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void SMetricFeatureData::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SMetricFeatureData");
     core::CMemoryDebug::dynamicSize("s_BucketValue", s_BucketValue, mem);
     core::CMemoryDebug::dynamicSize("s_InfluenceValues", s_InfluenceValues, mem);

--- a/lib/model/CGathererTools.cc
+++ b/lib/model/CGathererTools.cc
@@ -293,7 +293,7 @@ uint64_t CGathererTools::CSumGatherer::checksum() const {
     return maths::CChecksum::calculate(seed, m_InfluencerBucketSums);
 }
 
-void CGathererTools::CSumGatherer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CGathererTools::CSumGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSumGatherer");
     core::CMemoryDebug::dynamicSize("m_BucketSums", m_BucketSums, mem);
     core::CMemoryDebug::dynamicSize("m_InfluencerBucketSums", m_InfluencerBucketSums, mem);

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -283,7 +283,7 @@ uint64_t CIndividualModel::checksum(bool includeCurrentBucketStats) const {
     return maths::CChecksum::calculate(seed, hashes2);
 }
 
-void CIndividualModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CIndividualModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CIndividualModel");
     this->CAnomalyDetectorModel::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_FirstBucketTimes", m_FirstBucketTimes, mem);

--- a/lib/model/CInterimBucketCorrector.cc
+++ b/lib/model/CInterimBucketCorrector.cc
@@ -77,7 +77,7 @@ CInterimBucketCorrector::corrections(const TDouble10Vec& modes,
     return corrections;
 }
 
-void CInterimBucketCorrector::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CInterimBucketCorrector::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CInterimBucketCorrector");
     core::CMemoryDebug::dynamicSize("m_CountTrend", m_FinalCountTrend, mem);
 }

--- a/lib/model/CMemoryUsageEstimator.cc
+++ b/lib/model/CMemoryUsageEstimator.cc
@@ -120,7 +120,7 @@ void CMemoryUsageEstimator::addValue(const TSizeArray& predictors, std::size_t m
     ++core::CProgramCounters::counter(counter_t::E_TSADNumberMemoryUsageChecks);
 }
 
-void CMemoryUsageEstimator::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMemoryUsageEstimator::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMemoryUsageEstimator");
     core::CMemoryDebug::dynamicSize("m_Values", m_Values, mem);
 }

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -1323,7 +1323,7 @@ uint64_t CMetricBucketGatherer::checksum() const {
     return maths::CChecksum::calculate(seed, hashes);
 }
 
-void CMetricBucketGatherer::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMetricBucketGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     registerMemoryCallbacks();
     mem->setName("CMetricBucketGatherer");
     this->CBucketGatherer::debugMemoryUsage(mem->addChild());

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -429,7 +429,7 @@ uint64_t CMetricModel::checksum(bool includeCurrentBucketStats) const {
     return maths::CChecksum::calculate(seed, hashes);
 }
 
-void CMetricModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMetricModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMetricModel");
     this->CIndividualModel::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -716,7 +716,7 @@ uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const 
     return maths::CChecksum::calculate(seed, hashes);
 }
 
-void CMetricPopulationModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CMetricPopulationModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMetricPopulationModel");
     this->CPopulationModel::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",

--- a/lib/model/CModelTools.cc
+++ b/lib/model/CModelTools.cc
@@ -296,7 +296,8 @@ bool CModelTools::CCategoryProbabilityCache::lookup(std::size_t attribute, doubl
     return true;
 }
 
-void CModelTools::CCategoryProbabilityCache::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CModelTools::CCategoryProbabilityCache::debugMemoryUsage(
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTools::CLessLikelyProbability");
     core::CMemoryDebug::dynamicSize("m_Cache", m_Cache, mem->addChild());
     if (m_Prior) {

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -201,7 +201,7 @@ uint64_t CPopulationModel::checksum(bool includeCurrentBucketStats) const {
     return maths::CChecksum::calculate(seed, hashes);
 }
 
-void CPopulationModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CPopulationModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPopulationModel");
     this->CAnomalyDetectorModel::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_PersonLastBucketTimes", m_PersonLastBucketTimes, mem);

--- a/lib/model/CSample.cc
+++ b/lib/model/CSample.cc
@@ -94,7 +94,7 @@ std::string CSample::print() const {
     return result.str();
 }
 
-void CSample::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CSample::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSample");
     core::CMemoryDebug::dynamicSize("m_Value", m_Value, mem);
 }

--- a/lib/model/CSampleCounts.cc
+++ b/lib/model/CSampleCounts.cc
@@ -226,7 +226,7 @@ uint64_t CSampleCounts::checksum(const CDataGatherer& gatherer) const {
     return maths::CChecksum::calculate(0, hashes);
 }
 
-void CSampleCounts::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CSampleCounts::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSampleCounts");
     core::CMemoryDebug::dynamicSize("m_SampleCounts", m_SampleCounts, mem);
     core::CMemoryDebug::dynamicSize("m_MeanNonZeroBucketCounts",

--- a/lib/model/CStringStore.cc
+++ b/lib/model/CStringStore.cc
@@ -147,7 +147,7 @@ void CStringStore::pruneNotThreadSafe() {
     }
 }
 
-void CStringStore::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CStringStore::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName(this == &CStringStore::names()
                      ? "names StringStore"
                      : (this == &CStringStore::influencers() ? "influencers StringStore"

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -400,7 +400,7 @@ void CTokenListCategory::cacheReverseSearch(const std::string& part1,
     m_ReverseSearchPart2 = part2;
 }
 
-void CTokenListCategory::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTokenListCategory::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenListCategory");
     core::CMemoryDebug::dynamicSize("m_BaseString", m_BaseString, mem);
     core::CMemoryDebug::dynamicSize("m_BaseTokenIds", m_BaseTokenIds, mem);

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -515,7 +515,7 @@ bool CTokenListDataCategorizerBase::addPretokenisedTokens(const std::string& tok
     return true;
 }
 
-void CTokenListDataCategorizerBase::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTokenListDataCategorizerBase::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenListDataCategorizerBase");
     this->CDataCategorizer::debugMemoryUsage(mem->addChild());
     core::CMemoryDebug::dynamicSize("m_ReverseSearchCreator", m_ReverseSearchCreator, mem);
@@ -549,7 +549,7 @@ const std::string& CTokenListDataCategorizerBase::CTokenInfoItem::str() const {
 }
 
 void CTokenListDataCategorizerBase::CTokenInfoItem::debugMemoryUsage(
-    core::CMemoryUsage::TMemoryUsagePtr mem) const {
+    const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenInfoItem");
     core::CMemoryDebug::dynamicSize("m_Str", m_Str, mem);
 }

--- a/lib/model/CTokenListReverseSearchCreator.cc
+++ b/lib/model/CTokenListReverseSearchCreator.cc
@@ -89,7 +89,7 @@ const std::string& CTokenListReverseSearchCreator::fieldName() const {
     return m_FieldName;
 }
 
-void CTokenListReverseSearchCreator::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const {
+void CTokenListReverseSearchCreator::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenListReverseSearchCreator");
     core::CMemoryDebug::dynamicSize("m_FieldName", m_FieldName, mem);
 }

--- a/lib/model/unittest/CModelMemoryTest.cc
+++ b/lib/model/unittest/CModelMemoryTest.cc
@@ -105,10 +105,10 @@ BOOST_AUTO_TEST_CASE(testOnlineEventRateModel) {
     LOG_INFO(<< "Sizeof model now: " << model.memoryUsage());
     BOOST_TEST_REQUIRE(model.memoryUsage() > startMemoryUsage);
 
-    core::CMemoryUsage memoryUsage;
-    model.debugMemoryUsage(&memoryUsage);
-    LOG_DEBUG(<< "Debug sizeof model: " << memoryUsage.usage());
-    BOOST_REQUIRE_EQUAL(model.computeMemoryUsage(), memoryUsage.usage());
+    auto memoryUsage = std::make_shared<core::CMemoryUsage>();
+    model.debugMemoryUsage(memoryUsage);
+    LOG_DEBUG(<< "Debug sizeof model: " << memoryUsage->usage());
+    BOOST_REQUIRE_EQUAL(model.computeMemoryUsage(), memoryUsage->usage());
 }
 
 BOOST_AUTO_TEST_CASE(testOnlineMetricModel) {
@@ -165,10 +165,10 @@ BOOST_AUTO_TEST_CASE(testOnlineMetricModel) {
     LOG_INFO(<< "Sizeof model now: " << model.memoryUsage());
     BOOST_TEST_REQUIRE(model.memoryUsage() > startMemoryUsage);
 
-    core::CMemoryUsage memoryUsage;
-    model.debugMemoryUsage(&memoryUsage);
-    LOG_DEBUG(<< "Debug sizeof model: " << memoryUsage.usage());
-    BOOST_REQUIRE_EQUAL(model.computeMemoryUsage(), memoryUsage.usage());
+    auto memoryUsage = std::make_shared<core::CMemoryUsage>();
+    model.debugMemoryUsage(memoryUsage);
+    LOG_DEBUG(<< "Debug sizeof model: " << memoryUsage->usage());
+    BOOST_REQUIRE_EQUAL(model.computeMemoryUsage(), memoryUsage->usage());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -40,11 +40,9 @@ const TTokenListDataCategorizerKeepsFields::TTokenListReverseSearchCreatorCPtr N
 
 void checkMemoryUsageInstrumentation(const TTokenListDataCategorizerKeepsFields& categorizer) {
 
-    using TMemoryUsageUPtr = std::unique_ptr<ml::core::CMemoryUsage>;
-
     std::size_t memoryUsage{categorizer.memoryUsage()};
-    TMemoryUsageUPtr mem{std::make_unique<ml::core::CMemoryUsage>()};
-    categorizer.debugMemoryUsage(mem.get());
+    auto mem{std::make_shared<ml::core::CMemoryUsage>()};
+    categorizer.debugMemoryUsage(mem);
 
     std::ostringstream strm;
     mem->compress();

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -117,7 +117,7 @@ uint64_t CMockModel::checksum(bool /*includeCurrentBucketStats*/) const {
     return 0;
 }
 
-void CMockModel::debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr /*mem*/) const {
+void CMockModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& /*mem*/) const {
 }
 
 std::size_t CMockModel::memoryUsage() const {

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -86,7 +86,7 @@ public:
 
     uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
-    void debugMemoryUsage(core::CMemoryUsage::TMemoryUsagePtr mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     std::size_t memoryUsage() const override;
 


### PR DESCRIPTION
This refactoring reduces the risk of memory leaks by making the
confusingly named type core::CMemoryUsage::TMemoryUsagePtr the
shared pointer the name suggests it should be.  (Prior to this PR
it was a raw pointer.)

The debugMemoryUsage() methods take const references to these
shared pointers to avoid the large numbers of atomic increments
and decrements of the reference count through deep call stacks
that would occur if the shared pointers were passed by value.

Backport of #959