### PR TITLE
[ML] Bug in bounds calculation for the main optimisation hyperparameter search

### DIFF
--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -918,7 +918,7 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
     TVector interval{{returnedIntervalLeftEndOffset, 0.0, returnedIntervalRightEndOffset}};
     if (minGoodRegularizer > intervalLeftEnd) {
         interval(MIN_REGULARIZER_INDEX) = std::max(
-            maxGoodRegularizer - bestRegularizer, interval(MIN_REGULARIZER_INDEX));
+            minGoodRegularizer - bestRegularizer, interval(MIN_REGULARIZER_INDEX));
     }
     if (maxGoodRegularizer < intervalRightEnd) {
         interval(MAX_REGULARIZER_INDEX) = std::min(

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -243,13 +243,13 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
             0.0, modelBias[i][0],
             9.1 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
 
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testLinear) {
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.05);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.08);
     BOOST_TEST_REQUIRE(modelRSquared > 0.98);
 }
 


### PR DESCRIPTION
We were sometimes using a wrong lower bound for this interval. This regression was introduced in #903 which hasn't been released, so marking as a non-issue.