### PR TITLE
[ML] Modernize the categorization code

### DIFF
--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -67,13 +67,13 @@ public:
     //! Compute a category from a string.  The raw string length may be longer
     //! than the length of the passed string, because the passed string may
     //! have the date stripped out of it.
-    int computeCategory(bool isDryRun, const std::string& str, size_t rawStringLen);
+    int computeCategory(bool isDryRun, const std::string& str, std::size_t rawStringLen);
 
     //! As above, but also take into account field names/values.
     virtual int computeCategory(bool isDryRun,
                                 const TStrStrUMap& fields,
                                 const std::string& str,
-                                size_t rawStringLen) = 0;
+                                std::size_t rawStringLen) = 0;
 
     //! Create reverse search commands that will (more or less) just
     //! select the records that are classified as the given category when
@@ -83,7 +83,7 @@ public:
     virtual bool createReverseSearch(int categoryId,
                                      std::string& part1,
                                      std::string& part2,
-                                     size_t& maxMatchingLength,
+                                     std::size_t& maxMatchingLength,
                                      bool& wasCached) = 0;
 
     //! Has the data categorizer's state changed?

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -41,25 +41,21 @@ public:
     //! Used to associate tokens with weightings:
     //! first -> token ID
     //! second -> weighting
-    using TSizeSizePr = std::pair<size_t, size_t>;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
 
     //! Used for storing token ID sequences
     using TSizeSizePrVec = std::vector<TSizeSizePr>;
-    using TSizeSizePrVecItr = TSizeSizePrVec::iterator;
-    using TSizeSizePrVecCItr = TSizeSizePrVec::const_iterator;
 
     //! Used for storing distinct token IDs mapped to weightings
-    using TSizeSizeMap = std::map<size_t, size_t>;
-    using TSizeSizeMapItr = TSizeSizeMap::iterator;
-    using TSizeSizeMapCItr = TSizeSizeMap::const_iterator;
+    using TSizeSizeMap = std::map<std::size_t, std::size_t>;
 
 public:
     //! Create a new category
     CTokenListCategory(bool isDryRun,
                        const std::string& baseString,
-                       size_t rawStringLen,
+                       std::size_t rawStringLen,
                        const TSizeSizePrVec& baseTokenIds,
-                       size_t baseWeight,
+                       std::size_t baseWeight,
                        const TSizeSizeMap& uniqueTokenIds);
 
     //! Constructor used when restoring from XML
@@ -69,28 +65,27 @@ public:
     //! how well matched the string is
     bool addString(bool isDryRun,
                    const std::string& str,
-                   size_t rawStringLen,
+                   std::size_t rawStringLen,
                    const TSizeSizePrVec& tokenIds,
-                   const TSizeSizeMap& uniqueTokenIds,
-                   double similarity);
+                   const TSizeSizeMap& uniqueTokenIds);
 
     //! Accessors
     const std::string& baseString() const;
     const TSizeSizePrVec& baseTokenIds() const;
-    size_t baseWeight() const;
+    std::size_t baseWeight() const;
     const TSizeSizePrVec& commonUniqueTokenIds() const;
-    size_t commonUniqueTokenWeight() const;
-    size_t origUniqueTokenWeight() const;
-    size_t maxStringLen() const;
-    size_t outOfOrderCommonTokenIndex() const;
+    std::size_t commonUniqueTokenWeight() const;
+    std::size_t origUniqueTokenWeight() const;
+    std::size_t maxStringLen() const;
+    TSizeSizePr orderedCommonTokenBounds() const;
 
     //! What's the longest string we'll consider a match for this category?
     //! Currently simply 10% longer than the longest string we've seen.
-    size_t maxMatchingStringLen() const;
+    std::size_t maxMatchingStringLen() const;
 
     //! What is the weight of tokens in a given map that are missing from
     //! this category's common unique tokens?
-    size_t missingCommonTokenWeight(const TSizeSizeMap& uniqueTokenIds) const;
+    std::size_t missingCommonTokenWeight(const TSizeSizeMap& uniqueTokenIds) const;
 
     //! Is the weight of tokens in a given map that are missing from this
     //! category's common unique tokens equal to zero?  It is possible to test:
@@ -104,7 +99,7 @@ public:
     bool containsCommonTokensInOrder(const TSizeSizePrVec& tokenIds) const;
 
     //! How many matching strings are there?
-    size_t numMatches() const;
+    std::size_t numMatches() const;
 
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
@@ -130,34 +125,33 @@ private:
     TSizeSizePrVec m_BaseTokenIds;
 
     //! Cache the total weight of the base tokens
-    size_t m_BaseWeight;
+    std::size_t m_BaseWeight;
 
     //! The maximum original length of all the strings that have been
     //! classified as this category.  The original length may be longer than the
     //! length of the strings in passed to the addString() method, because
     //! it will include the date.
-    size_t m_MaxStringLen;
+    std::size_t m_MaxStringLen;
 
-    //! The index into the base token IDs that we should stop at when
-    //! generating an ordered regex, because subsequent common token IDs are
-    //! not in the same order for all strings of this category.
-    size_t m_OutOfOrderCommonTokenIndex;
+    //! One past the index into the base token IDs where the subsequence of
+    //! tokens that are in the same order for all strings of this category ends.
+    std::size_t m_OrderedCommonTokenEndIndex;
 
     //! The unique token IDs that all strings classified to be this category
     //! contain.  This vector must always be sorted into ascending order.
     TSizeSizePrVec m_CommonUniqueTokenIds;
 
     //! Cache the weight of the common unique tokens
-    size_t m_CommonUniqueTokenWeight;
+    std::size_t m_CommonUniqueTokenWeight;
 
     //! What was the weight of the original unique tokens (i.e. when the category
     //! only represented one string)?  Remembering this means we can ensure
     //! that the degree of commonality doesn't fall below a certain level as
     //! the number of strings classified as this category grows.
-    size_t m_OrigUniqueTokenWeight;
+    std::size_t m_OrigUniqueTokenWeight;
 
     //! Number of matched strings
-    size_t m_NumMatches;
+    std::size_t m_NumMatches;
 
     //! Cache reverse searches to save repeated recalculations
     std::string m_ReverseSearchPart1;

--- a/include/model/CTokenListDataCategorizer.h
+++ b/include/model/CTokenListDataCategorizer.h
@@ -45,7 +45,7 @@ template<bool DO_WARPING = true,
          bool IGNORE_HEX = true,
          bool IGNORE_DATE_WORDS = true,
          bool IGNORE_FIELD_NAMES = true,
-         size_t MIN_DICTIONARY_LENGTH = 2,
+         std::size_t MIN_DICTIONARY_LENGTH = 2,
          typename DICTIONARY_WEIGHT_FUNC = core::CWordDictionary::TWeightAll2>
 class CTokenListDataCategorizer : public CTokenListDataCategorizerBase {
 public:
@@ -95,7 +95,7 @@ protected:
                         const std::string& str,
                         TSizeSizePrVec& tokenIds,
                         TSizeSizeMap& tokenUniqueIds,
-                        size_t& totalWeight) override {
+                        std::size_t& totalWeight) override {
         tokenIds.clear();
         tokenUniqueIds.clear();
         totalWeight = 0;
@@ -146,7 +146,7 @@ protected:
     void tokenToIdAndWeight(const std::string& token,
                             TSizeSizePrVec& tokenIds,
                             TSizeSizeMap& tokenUniqueIds,
-                            size_t& totalWeight) override {
+                            std::size_t& totalWeight) override {
         TSizeSizePr idWithWeight(this->idForToken(token), 1);
 
         if (token.length() >= MIN_DICTIONARY_LENGTH) {
@@ -160,15 +160,15 @@ protected:
 
     //! Compute similarity between two vectors
     double similarity(const TSizeSizePrVec& left,
-                      size_t leftWeight,
+                      std::size_t leftWeight,
                       const TSizeSizePrVec& right,
-                      size_t rightWeight) const override {
+                      std::size_t rightWeight) const override {
         double similarity(1.0);
 
-        size_t maxWeight(std::max(leftWeight, rightWeight));
+        std::size_t maxWeight(std::max(leftWeight, rightWeight));
         if (maxWeight > 0) {
-            size_t diff(DO_WARPING ? m_SimilarityTester.weightedEditDistance(left, right)
-                                   : this->compareNoWarp(left, right));
+            std::size_t diff(DO_WARPING ? m_SimilarityTester.weightedEditDistance(left, right)
+                                        : this->compareNoWarp(left, right));
 
             similarity = 1.0 - double(diff) / double(maxWeight);
         }
@@ -180,13 +180,13 @@ private:
     //! Compare two vectors of tokens without doing any warping (this is an
     //! alternative to using the Levenshtein distance, which is a form of
     //! warping)
-    size_t compareNoWarp(const TSizeSizePrVec& left, const TSizeSizePrVec& right) const {
-        size_t minSize(std::min(left.size(), right.size()));
-        size_t maxSize(std::max(left.size(), right.size()));
+    std::size_t compareNoWarp(const TSizeSizePrVec& left, const TSizeSizePrVec& right) const {
+        std::size_t minSize(std::min(left.size(), right.size()));
+        std::size_t maxSize(std::max(left.size(), right.size()));
 
-        size_t diff(0);
+        std::size_t diff(0);
 
-        for (size_t index = 0; index < minSize; ++index) {
+        for (std::size_t index = 0; index < minSize; ++index) {
             if (left[index].first != right[index].first) {
                 diff += std::max(left[index].second, right[index].second);
             }
@@ -194,11 +194,11 @@ private:
 
         // Account for different length vector instances
         if (left.size() < right.size()) {
-            for (size_t index = minSize; index < maxSize; ++index) {
+            for (std::size_t index = minSize; index < maxSize; ++index) {
                 diff += right[index].second;
             }
         } else if (left.size() > right.size()) {
-            for (size_t index = minSize; index < maxSize; ++index) {
+            for (std::size_t index = minSize; index < maxSize; ++index) {
                 diff += left[index].second;
             }
         }
@@ -214,7 +214,7 @@ private:
                        std::string& token,
                        TSizeSizePrVec& tokenIds,
                        TSizeSizeMap& tokenUniqueIds,
-                       size_t& totalWeight) {
+                       std::size_t& totalWeight) {
         if (IGNORE_LEADING_DIGIT && std::isdigit(static_cast<unsigned char>(token[0]))) {
             return;
         }

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -73,13 +73,13 @@ public:
     //! Used to associate tokens with weightings:
     //! first -> token ID
     //! second -> weighting
-    using TSizeSizePr = std::pair<size_t, size_t>;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
 
     //! Used for storing token ID sequences
     using TSizeSizePrVec = std::vector<TSizeSizePr>;
 
     //! Used for storing distinct token IDs
-    using TSizeSizeMap = std::map<size_t, size_t>;
+    using TSizeSizeMap = std::map<std::size_t, std::size_t>;
 
     //! Used for stream output of token IDs translated back to the original
     //! tokens
@@ -116,7 +116,7 @@ public:
     int computeCategory(bool dryRun,
                         const TStrStrUMap& fields,
                         const std::string& str,
-                        size_t rawStringLen) override;
+                        std::size_t rawStringLen) override;
 
     // Bring the other overload of computeCategory() into scope
     using CDataCategorizer::computeCategory;
@@ -128,7 +128,7 @@ public:
     bool createReverseSearch(int categoryId,
                              std::string& part1,
                              std::string& part2,
-                             size_t& maxMatchingLength,
+                             std::size_t& maxMatchingLength,
                              bool& wasCached) override;
 
     //! Has the data categorizer's state changed?
@@ -165,20 +165,20 @@ protected:
                                 const std::string& str,
                                 TSizeSizePrVec& tokenIds,
                                 TSizeSizeMap& tokenUniqueIds,
-                                size_t& totalWeight) = 0;
+                                std::size_t& totalWeight) = 0;
 
     //! Take a string token, convert it to a numeric ID and a weighting and
     //! add these to the provided data structures.
     virtual void tokenToIdAndWeight(const std::string& token,
                                     TSizeSizePrVec& tokenIds,
                                     TSizeSizeMap& tokenUniqueIds,
-                                    size_t& totalWeight) = 0;
+                                    std::size_t& totalWeight) = 0;
 
     //! Compute similarity between two vectors
     virtual double similarity(const TSizeSizePrVec& left,
-                              size_t leftWeight,
+                              std::size_t leftWeight,
                               const TSizeSizePrVec& right,
-                              size_t rightWeight) const = 0;
+                              std::size_t rightWeight) const = 0;
 
     //! Used to hold statistics about the categories we compute:
     //! first -> count of matches
@@ -189,37 +189,36 @@ protected:
     //! Add a match to an existing category
     void addCategoryMatch(bool isDryRun,
                           const std::string& str,
-                          size_t rawStringLen,
+                          std::size_t rawStringLen,
                           const TSizeSizePrVec& tokenIds,
                           const TSizeSizeMap& tokenUniqueIds,
-                          double similarity,
                           TSizeSizePrListItr& iter);
 
     //! Given the total token weight in a vector and a threshold, what is
     //! the minimum possible token weight in a different vector that could
     //! possibly be considered to match?
-    static size_t minMatchingWeight(size_t weight, double threshold);
+    static std::size_t minMatchingWeight(std::size_t weight, double threshold);
 
     //! Given the total token weight in a vector and a threshold, what is
     //! maximum possible token weight in a different vector that could
     //! possibly be considered to match?
-    static size_t maxMatchingWeight(size_t weight, double threshold);
+    static std::size_t maxMatchingWeight(std::size_t weight, double threshold);
 
     //! Get the unique token ID for a given token (assigning one if it's
     //! being seen for the first time)
-    size_t idForToken(const std::string& token);
+    std::size_t idForToken(const std::string& token);
 
 private:
     //! Value category for the TTokenMIndex below
     class CTokenInfoItem {
     public:
-        CTokenInfoItem(const std::string& str, size_t index);
+        CTokenInfoItem(const std::string& str, std::size_t index);
 
         //! Accessors
         const std::string& str() const;
-        size_t index() const;
-        size_t categoryCount() const;
-        void categoryCount(size_t categoryCount);
+        std::size_t index() const;
+        std::size_t categoryCount() const;
+        void categoryCount(std::size_t categoryCount);
 
         //! Increment the category count
         void incCategoryCount();
@@ -235,26 +234,26 @@ private:
         std::string m_Str;
 
         //! Index of the token
-        size_t m_Index;
+        std::size_t m_Index;
 
         //! How many categories use this token?
-        size_t m_CategoryCount;
+        std::size_t m_CategoryCount;
     };
 
     //! Compute equality based on the first element of a pair only
     class CSizePairFirstElementEquals {
     public:
-        CSizePairFirstElementEquals(size_t value);
+        CSizePairFirstElementEquals(std::size_t value);
 
         //! PAIRTYPE can be any struct with a data member named "first"
-        //! that can be checked for equality to a size_t
+        //! that can be checked for equality to a std::size_t
         template<typename PAIRTYPE>
         bool operator()(const PAIRTYPE& lhs) const {
             return lhs.first == m_Value;
         }
 
     private:
-        size_t m_Value;
+        std::size_t m_Value;
     };
 
     //! Used to hold the distinct categories we compute (vector reallocations are
@@ -283,7 +282,7 @@ private:
     bool addPretokenisedTokens(const std::string& tokensCsv,
                                TSizeSizePrVec& tokenIds,
                                TSizeSizeMap& tokenUniqueIds,
-                               size_t& totalWeight);
+                               std::size_t& totalWeight);
 
 private:
     //! Reference to the object we'll use to create reverse searches

--- a/include/model/CTokenListReverseSearchCreator.h
+++ b/include/model/CTokenListReverseSearchCreator.h
@@ -38,21 +38,18 @@ public:
     //! What's the maximum cost of tokens we can include in the reverse
     //! search?  This cost is loosely based on the maximum length of an
     //! Internet Explorer URL.
-    size_t availableCost() const;
+    std::size_t availableCost() const;
 
     //! What would be the cost of adding the specified token occurring the
     //! specified number of times to the reverse search?
-    size_t costOfToken(const std::string& token, size_t numOccurrences) const;
-
-    //! Create a reverse search for a NULL field value.
-    bool createNullSearch(std::string& terms, std::string& regex) const;
+    std::size_t costOfToken(const std::string& token, std::size_t numOccurrences) const;
 
     //! If possible, create a reverse search for the case where there are no
     //! unique tokens identifying the category.  (If this is not possible return
     //! false.)
     bool createNoUniqueTokenSearch(int categoryId,
                                    const std::string& example,
-                                   size_t maxMatchingStringLen,
+                                   std::size_t maxMatchingStringLen,
                                    std::string& terms,
                                    std::string& regex) const;
 
@@ -61,16 +58,13 @@ public:
     //! some sort of one-off preamble.
     void initStandardSearch(int categoryId,
                             const std::string& example,
-                            size_t maxMatchingStringLen,
+                            std::size_t maxMatchingStringLen,
                             std::string& terms,
                             std::string& regex) const;
 
     //! Modify the two strings that form a reverse search to account for the
     //! specified token.
-    void addInOrderCommonToken(const std::string& token,
-                               bool first,
-                               std::string& terms,
-                               std::string& regex) const;
+    void addInOrderCommonToken(const std::string& token, std::string& terms, std::string& regex) const;
 
     //! Modify the two strings that form a reverse search to account for the
     //! specified token, which may occur anywhere within the original

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -124,7 +124,7 @@ void CFieldDataCategorizer::finalise() {
     }
 }
 
-uint64_t CFieldDataCategorizer::numRecordsHandled() const {
+std::uint64_t CFieldDataCategorizer::numRecordsHandled() const {
     return m_NumRecordsHandled;
 }
 
@@ -133,8 +133,8 @@ COutputHandler& CFieldDataCategorizer::outputHandler() {
 }
 
 int CFieldDataCategorizer::computeCategory(const TStrStrUMap& dataRowFields) {
-    const std::string& categorizationFieldName = m_DataCategorizer->fieldName();
-    TStrStrUMapCItr fieldIter = dataRowFields.find(categorizationFieldName);
+    const std::string& categorizationFieldName{m_DataCategorizer->fieldName()};
+    auto fieldIter = dataRowFields.find(categorizationFieldName);
     if (fieldIter == dataRowFields.end()) {
         LOG_WARN(<< "Assigning ML category -1 to record with no "
                  << categorizationFieldName << " field:" << core_t::LINE_ENDING
@@ -142,7 +142,7 @@ int CFieldDataCategorizer::computeCategory(const TStrStrUMap& dataRowFields) {
         return -1;
     }
 
-    const std::string& fieldValue = fieldIter->second;
+    const std::string& fieldValue{fieldIter->second};
     if (fieldValue.empty()) {
         LOG_WARN(<< "Assigning ML category -1 to record with blank "
                  << categorizationFieldName << " field:" << core_t::LINE_ENDING
@@ -150,7 +150,7 @@ int CFieldDataCategorizer::computeCategory(const TStrStrUMap& dataRowFields) {
         return -1;
     }
 
-    int categoryId = -1;
+    int categoryId{-1};
     if (m_CategorizationFilter.empty()) {
         categoryId = m_DataCategorizer->computeCategory(
             false, dataRowFields, fieldValue, fieldValue.length());
@@ -360,10 +360,10 @@ bool CFieldDataCategorizer::doPersistState(const model::CDataCategorizer::TPersi
                                            const model::CCategoryExamplesCollector& examplesCollector,
                                            core::CDataAdder& persister) {
     try {
-        core::CStateCompressor compressor(persister);
+        core::CStateCompressor compressor{persister};
 
-        core::CDataAdder::TOStreamP strm =
-            compressor.addStreamed(ML_STATE_INDEX, m_JobId + '_' + STATE_TYPE);
+        core::CDataAdder::TOStreamP strm{
+            compressor.addStreamed(ML_STATE_INDEX, m_JobId + '_' + STATE_TYPE)};
 
         if (strm == nullptr) {
             LOG_ERROR(<< "Failed to create persistence stream");
@@ -379,7 +379,7 @@ bool CFieldDataCategorizer::doPersistState(const model::CDataCategorizer::TPersi
         {
             // Keep the JSON inserter scoped as it only finishes the stream
             // when it is destructed
-            core::CJsonStatePersistInserter inserter(*strm);
+            core::CJsonStatePersistInserter inserter{*strm};
             this->acceptPersistInserter(dataCategorizerPersistFunc,
                                         examplesCollector, inserter);
         }

--- a/lib/api/unittest/CRestorePreviousStateTest.cc
+++ b/lib/api/unittest/CRestorePreviousStateTest.cc
@@ -104,7 +104,7 @@ void categorizerRestoreHelper(const std::string& stateFile, bool isSymmetric) {
 
     if (isSymmetric) {
         // Test the persisted state of the restored detector is the
-        // same as the riginial
+        // same as the original
         std::string newPersistedState;
         {
             std::ostringstream* strm(nullptr);

--- a/lib/model/CDataCategorizer.cc
+++ b/lib/model/CDataCategorizer.cc
@@ -26,7 +26,7 @@ CDataCategorizer::~CDataCategorizer() {
     m_Limits.resourceMonitor().unRegisterComponent(*this);
 }
 
-int CDataCategorizer::computeCategory(bool isDryRun, const std::string& str, size_t rawStringLen) {
+int CDataCategorizer::computeCategory(bool isDryRun, const std::string& str, std::size_t rawStringLen) {
     return this->computeCategory(isDryRun, EMPTY_FIELDS, str, rawStringLen);
 }
 

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -19,15 +19,15 @@ namespace model {
 
 // We use short field names to reduce the state size
 namespace {
-const std::string BASE_STRING("a");
-const std::string BASE_TOKEN_ID("b");
-const std::string BASE_TOKEN_WEIGHT("c");
-const std::string MAX_STRING_LEN("d");
-const std::string OUT_OF_ORDER_COMMON_TOKEN_INDEX("e");
-const std::string COMMON_UNIQUE_TOKEN_ID("f");
-const std::string COMMON_UNIQUE_TOKEN_WEIGHT("g");
-const std::string ORIG_UNIQUE_TOKEN_WEIGHT("h");
-const std::string NUM_MATCHES("i");
+const std::string BASE_STRING{"a"};
+const std::string BASE_TOKEN_ID{"b"};
+const std::string BASE_TOKEN_WEIGHT{"c"};
+const std::string MAX_STRING_LEN{"d"};
+const std::string ORDERED_COMMON_TOKEN_END_INDEX{"e"};
+const std::string COMMON_UNIQUE_TOKEN_ID{"f"};
+const std::string COMMON_UNIQUE_TOKEN_WEIGHT{"g"};
+const std::string ORIG_UNIQUE_TOKEN_WEIGHT{"h"};
+const std::string NUM_MATCHES{"i"};
 
 const std::string EMPTY_STRING;
 
@@ -42,41 +42,40 @@ public:
 
 CTokenListCategory::CTokenListCategory(bool isDryRun,
                                        const std::string& baseString,
-                                       size_t rawStringLen,
+                                       std::size_t rawStringLen,
                                        const TSizeSizePrVec& baseTokenIds,
-                                       size_t baseWeight,
+                                       std::size_t baseWeight,
                                        const TSizeSizeMap& uniqueTokenIds)
     : m_BaseString(baseString), m_BaseTokenIds(baseTokenIds),
       m_BaseWeight(baseWeight), m_MaxStringLen(rawStringLen),
-      m_OutOfOrderCommonTokenIndex(baseTokenIds.size()),
+      m_OrderedCommonTokenEndIndex(baseTokenIds.size()),
       // Note: m_CommonUniqueTokenIds is required to be in sorted order, and
       // this relies on uniqueTokenIds being in sorted order
       m_CommonUniqueTokenIds(uniqueTokenIds.begin(), uniqueTokenIds.end()),
       m_CommonUniqueTokenWeight(0), m_OrigUniqueTokenWeight(0),
       m_NumMatches(isDryRun ? 0 : 1) {
-    for (TSizeSizeMapCItr iter = uniqueTokenIds.begin();
-         iter != uniqueTokenIds.end(); ++iter) {
-        m_CommonUniqueTokenWeight += iter->second;
+    for (auto uniqueTokenId : uniqueTokenIds) {
+        m_CommonUniqueTokenWeight += uniqueTokenId.second;
     }
     m_OrigUniqueTokenWeight = m_CommonUniqueTokenWeight;
 }
 
 CTokenListCategory::CTokenListCategory(core::CStateRestoreTraverser& traverser)
-    : m_BaseWeight(0), m_MaxStringLen(0), m_OutOfOrderCommonTokenIndex(0),
+    : m_BaseWeight(0), m_MaxStringLen(0), m_OrderedCommonTokenEndIndex(0),
       m_CommonUniqueTokenWeight(0), m_OrigUniqueTokenWeight(0), m_NumMatches(0) {
     traverser.traverseSubLevel(std::bind(&CTokenListCategory::acceptRestoreTraverser,
                                          this, std::placeholders::_1));
 }
 
 bool CTokenListCategory::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
-    bool expectWeight(false);
+    bool expectWeight{false};
 
     do {
-        const std::string& name = traverser.name();
+        const std::string& name{traverser.name()};
         if (name == BASE_STRING) {
             m_BaseString = traverser.value();
         } else if (name == BASE_TOKEN_ID) {
-            TSizeSizePr tokenAndWeight(0, 0);
+            TSizeSizePr tokenAndWeight{0, 0};
             if (core::CStringUtils::stringToType(traverser.value(),
                                                  tokenAndWeight.first) == false) {
                 LOG_ERROR(<< "Invalid base token ID in " << traverser.value());
@@ -104,14 +103,15 @@ bool CTokenListCategory::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
                 LOG_ERROR(<< "Invalid maximum string length in " << traverser.value());
                 return false;
             }
-        } else if (name == OUT_OF_ORDER_COMMON_TOKEN_INDEX) {
+        } else if (name == ORDERED_COMMON_TOKEN_END_INDEX) {
             if (core::CStringUtils::stringToType(
-                    traverser.value(), m_OutOfOrderCommonTokenIndex) == false) {
-                LOG_ERROR(<< "Invalid maximum string length in " << traverser.value());
+                    traverser.value(), m_OrderedCommonTokenEndIndex) == false) {
+                LOG_ERROR(<< "Invalid ordered common token end index in "
+                          << traverser.value());
                 return false;
             }
         } else if (name == COMMON_UNIQUE_TOKEN_ID) {
-            TSizeSizePr tokenAndWeight(0, 0);
+            TSizeSizePr tokenAndWeight{0, 0};
             if (core::CStringUtils::stringToType(traverser.value(),
                                                  tokenAndWeight.first) == false) {
                 LOG_ERROR(<< "Invalid common unique token ID in " << traverser.value());
@@ -156,17 +156,16 @@ bool CTokenListCategory::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
 
 bool CTokenListCategory::addString(bool isDryRun,
                                    const std::string& /* str */,
-                                   size_t rawStringLen,
+                                   std::size_t rawStringLen,
                                    const TSizeSizePrVec& tokenIds,
-                                   const TSizeSizeMap& uniqueTokenIds,
-                                   double /* similarity */) {
-    bool changed(false);
+                                   const TSizeSizeMap& uniqueTokenIds) {
+    bool changed{false};
 
     // Remove any token IDs from the common unique token map that aren't present
     // with the same weight in the new string, and adjust the common weight
     // accordingly
-    TSizeSizePrVecItr commonIter = m_CommonUniqueTokenIds.begin();
-    TSizeSizeMapCItr newIter = uniqueTokenIds.begin();
+    auto commonIter = m_CommonUniqueTokenIds.begin();
+    auto newIter = uniqueTokenIds.begin();
     while (commonIter != m_CommonUniqueTokenIds.end()) {
         if (newIter == uniqueTokenIds.end() || commonIter->first < newIter->first) {
             m_CommonUniqueTokenWeight -= commonIter->second;
@@ -189,8 +188,8 @@ bool CTokenListCategory::addString(bool isDryRun,
     // Reduce the out-of-order common token index if there are tokens that
     // aren't in the same order in the new string, and adjust the common weight
     // accordingly
-    TSizeSizePrVecCItr testIter = tokenIds.begin();
-    for (size_t index = 0; index < m_OutOfOrderCommonTokenIndex; ++index) {
+    auto testIter = tokenIds.begin();
+    for (std::size_t index = 0; index < m_OrderedCommonTokenEndIndex; ++index) {
         // Ignore tokens that are not in the common unique tokens
         if (std::binary_search(m_CommonUniqueTokenIds.begin(),
                                m_CommonUniqueTokenIds.end(), m_BaseTokenIds[index],
@@ -205,7 +204,7 @@ bool CTokenListCategory::addString(bool isDryRun,
         // to be reset.
         do {
             if (testIter == tokenIds.end()) {
-                m_OutOfOrderCommonTokenIndex = index;
+                m_OrderedCommonTokenEndIndex = index;
                 changed = true;
                 break;
             }
@@ -240,7 +239,7 @@ const CTokenListCategory::TSizeSizePrVec& CTokenListCategory::baseTokenIds() con
     return m_BaseTokenIds;
 }
 
-size_t CTokenListCategory::baseWeight() const {
+std::size_t CTokenListCategory::baseWeight() const {
     return m_BaseWeight;
 }
 
@@ -248,32 +247,32 @@ const CTokenListCategory::TSizeSizePrVec& CTokenListCategory::commonUniqueTokenI
     return m_CommonUniqueTokenIds;
 }
 
-size_t CTokenListCategory::commonUniqueTokenWeight() const {
+std::size_t CTokenListCategory::commonUniqueTokenWeight() const {
     return m_CommonUniqueTokenWeight;
 }
 
-size_t CTokenListCategory::origUniqueTokenWeight() const {
+std::size_t CTokenListCategory::origUniqueTokenWeight() const {
     return m_OrigUniqueTokenWeight;
 }
 
-size_t CTokenListCategory::maxStringLen() const {
+std::size_t CTokenListCategory::maxStringLen() const {
     return m_MaxStringLen;
 }
 
-size_t CTokenListCategory::outOfOrderCommonTokenIndex() const {
-    return m_OutOfOrderCommonTokenIndex;
+CTokenListCategory::TSizeSizePr CTokenListCategory::orderedCommonTokenBounds() const {
+    return {std::size_t{0}, m_OrderedCommonTokenEndIndex};
 }
 
-size_t CTokenListCategory::maxMatchingStringLen() const {
+std::size_t CTokenListCategory::maxMatchingStringLen() const {
     // Add a 10% margin of error
     return (m_MaxStringLen * 11) / 10;
 }
 
-size_t CTokenListCategory::missingCommonTokenWeight(const TSizeSizeMap& uniqueTokenIds) const {
-    size_t presentWeight(0);
+std::size_t CTokenListCategory::missingCommonTokenWeight(const TSizeSizeMap& uniqueTokenIds) const {
+    std::size_t presentWeight{0};
 
-    TSizeSizePrVecCItr commonIter = m_CommonUniqueTokenIds.begin();
-    TSizeSizeMapCItr testIter = uniqueTokenIds.begin();
+    auto commonIter = m_CommonUniqueTokenIds.begin();
+    auto testIter = uniqueTokenIds.begin();
     while (commonIter != m_CommonUniqueTokenIds.end() &&
            testIter != uniqueTokenIds.end()) {
         if (commonIter->first == testIter->first) {
@@ -304,8 +303,8 @@ bool CTokenListCategory::isMissingCommonTokenWeightZero(const TSizeSizeMap& uniq
     //
     // However, it's much faster to return false as soon as a mismatch occurs
 
-    TSizeSizePrVecCItr commonIter = m_CommonUniqueTokenIds.begin();
-    TSizeSizeMapCItr testIter = uniqueTokenIds.begin();
+    auto commonIter = m_CommonUniqueTokenIds.begin();
+    auto testIter = uniqueTokenIds.begin();
     while (commonIter != m_CommonUniqueTokenIds.end() &&
            testIter != uniqueTokenIds.end()) {
         if (commonIter->first < testIter->first) {
@@ -328,12 +327,11 @@ bool CTokenListCategory::isMissingCommonTokenWeightZero(const TSizeSizeMap& uniq
 }
 
 bool CTokenListCategory::containsCommonTokensInOrder(const TSizeSizePrVec& tokenIds) const {
-    TSizeSizePrVecCItr testIter = tokenIds.begin();
-    for (TSizeSizePrVecCItr baseIter = m_BaseTokenIds.begin();
-         baseIter != m_BaseTokenIds.end(); ++baseIter) {
+    auto testIter = tokenIds.begin();
+    for (auto baseTokenId : m_BaseTokenIds) {
         // Ignore tokens that are not in the common unique tokens
         if (std::binary_search(m_CommonUniqueTokenIds.begin(),
-                               m_CommonUniqueTokenIds.end(), *baseIter,
+                               m_CommonUniqueTokenIds.end(), baseTokenId,
                                CSizePairFirstElementLess()) == false) {
             continue;
         }
@@ -346,32 +344,30 @@ bool CTokenListCategory::containsCommonTokensInOrder(const TSizeSizePrVec& token
             if (testIter == tokenIds.end()) {
                 return false;
             }
-        } while ((testIter++)->first != baseIter->first);
+        } while ((testIter++)->first != baseTokenId.first);
     }
 
     return true;
 }
 
-size_t CTokenListCategory::numMatches() const {
+std::size_t CTokenListCategory::numMatches() const {
     return m_NumMatches;
 }
 
 void CTokenListCategory::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     inserter.insertValue(BASE_STRING, m_BaseString);
 
-    for (TSizeSizePrVecCItr iter = m_BaseTokenIds.begin();
-         iter != m_BaseTokenIds.end(); ++iter) {
-        inserter.insertValue(BASE_TOKEN_ID, iter->first);
-        inserter.insertValue(BASE_TOKEN_WEIGHT, iter->second);
+    for (auto baseTokenId : m_BaseTokenIds) {
+        inserter.insertValue(BASE_TOKEN_ID, baseTokenId.first);
+        inserter.insertValue(BASE_TOKEN_WEIGHT, baseTokenId.second);
     }
 
     inserter.insertValue(MAX_STRING_LEN, m_MaxStringLen);
-    inserter.insertValue(OUT_OF_ORDER_COMMON_TOKEN_INDEX, m_OutOfOrderCommonTokenIndex);
+    inserter.insertValue(ORDERED_COMMON_TOKEN_END_INDEX, m_OrderedCommonTokenEndIndex);
 
-    for (TSizeSizePrVecCItr iter = m_CommonUniqueTokenIds.begin();
-         iter != m_CommonUniqueTokenIds.end(); ++iter) {
-        inserter.insertValue(COMMON_UNIQUE_TOKEN_ID, iter->first);
-        inserter.insertValue(COMMON_UNIQUE_TOKEN_WEIGHT, iter->second);
+    for (auto commonUniqueTokenId : m_CommonUniqueTokenIds) {
+        inserter.insertValue(COMMON_UNIQUE_TOKEN_ID, commonUniqueTokenId.first);
+        inserter.insertValue(COMMON_UNIQUE_TOKEN_WEIGHT, commonUniqueTokenId.second);
     }
 
     inserter.insertValue(ORIG_UNIQUE_TOKEN_WEIGHT, m_OrigUniqueTokenWeight);

--- a/lib/model/CTokenListReverseSearchCreator.cc
+++ b/lib/model/CTokenListReverseSearchCreator.cc
@@ -15,42 +15,35 @@ CTokenListReverseSearchCreator::CTokenListReverseSearchCreator(const std::string
     : m_FieldName(fieldName) {
 }
 
-size_t CTokenListReverseSearchCreator::availableCost() const {
+std::size_t CTokenListReverseSearchCreator::availableCost() const {
     // This is pretty arbitrary, but MUST be less than the maximum length of a
     // field in ES (currently 32766 bytes), and ideally should be quite a lot
     // less as a huge reverse search is pretty unwieldy
     return 10000;
 }
 
-size_t CTokenListReverseSearchCreator::costOfToken(const std::string& token,
-                                                   size_t numOccurrences) const {
-    size_t tokenLength = token.length();
+std::size_t CTokenListReverseSearchCreator::costOfToken(const std::string& token,
+                                                        std::size_t numOccurrences) const {
+    std::size_t tokenLength{token.length()};
     return (1 + tokenLength + // length of what we add to the terms
             3 + tokenLength   // length of what we add to the regex
             ) *
            numOccurrences;
 }
 
-bool CTokenListReverseSearchCreator::createNullSearch(std::string& terms,
-                                                      std::string& regex) const {
-    terms.clear();
-    regex.clear();
-    return true;
-}
-
 bool CTokenListReverseSearchCreator::createNoUniqueTokenSearch(int /*categoryId*/,
                                                                const std::string& /*example*/,
-                                                               size_t /*maxMatchingStringLen*/,
+                                                               std::size_t /*maxMatchingStringLen*/,
                                                                std::string& terms,
                                                                std::string& regex) const {
     terms.clear();
-    regex.clear();
+    regex = ".*";
     return true;
 }
 
 void CTokenListReverseSearchCreator::initStandardSearch(int /*categoryId*/,
                                                         const std::string& /*example*/,
-                                                        size_t /*maxMatchingStringLen*/,
+                                                        std::size_t /*maxMatchingStringLen*/,
                                                         std::string& terms,
                                                         std::string& regex) const {
     terms.clear();
@@ -58,14 +51,15 @@ void CTokenListReverseSearchCreator::initStandardSearch(int /*categoryId*/,
 }
 
 void CTokenListReverseSearchCreator::addInOrderCommonToken(const std::string& token,
-                                                           bool first,
                                                            std::string& terms,
                                                            std::string& regex) const {
-    if (first) {
+    if (regex.empty()) {
         regex += ".*?";
     } else {
-        terms += ' ';
         regex += ".+?";
+    }
+    if (terms.empty() == false) {
+        terms += ' ';
     }
     terms += token;
     regex += core::CRegex::escapeRegexSpecial(token);

--- a/lib/model/unittest/CTokenListCategoryTest.cc
+++ b/lib/model/unittest/CTokenListCategoryTest.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CContainerPrinter.h>
+
+#include <model/CTokenListCategory.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <string>
+
+BOOST_AUTO_TEST_SUITE(CTokenListCategoryTest)
+
+BOOST_AUTO_TEST_CASE(testCommonTokensSameOrder) {
+
+    std::string baseString{"she sells seashells on the seashore"};
+    ml::model::CTokenListCategory::TSizeSizePrVec baseTokenIds{
+        {0 /* she */, 1}, {1 /* sells */, 1}, {2 /* seashells */, 1},
+        {3 /* on */, 1},  {4 /* the */, 1},   {5 /* seashore */, 1}};
+    ml::model::CTokenListCategory::TSizeSizeMap baseUniqueTokenIds(
+        baseTokenIds.begin(), baseTokenIds.end());
+
+    ml::model::CTokenListCategory category(false, baseString, baseString.length(), baseTokenIds,
+                                           baseTokenIds.size(), baseUniqueTokenIds);
+
+    std::string newString{"she sells ice cream on the seashore"};
+    ml::model::CTokenListCategory::TSizeSizePrVec newTokenIds{
+        {0 /* she */, 1},     {1 /* sells */, 1}, {6 /* ice */, 1},
+        {7 /* cream */, 1},   {3 /* on */, 1},    {4 /* the */, 1},
+        {5 /* seashore */, 1}};
+    ml::model::CTokenListCategory::TSizeSizeMap newUniqueTokenIds(
+        newTokenIds.begin(), newTokenIds.end());
+
+    BOOST_TEST_REQUIRE(category.addString(false, newString, newString.length(),
+                                          newTokenIds, newUniqueTokenIds));
+
+    BOOST_REQUIRE_EQUAL(baseString, category.baseString());
+    BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseTokenIds),
+                        ml::core::CContainerPrinter::print(category.baseTokenIds()));
+    BOOST_REQUIRE_EQUAL(baseTokenIds.size(), category.baseWeight());
+    ml::model::CTokenListCategory::TSizeSizeMap expectedCommonUniqueTokenIds{
+        {0 /* she */, 1}, {1 /* sells */, 1}, {3 /* on */, 1}, {4 /* the */, 1}, {5 /* seashore */, 1}};
+    BOOST_REQUIRE_EQUAL(
+        ml::core::CContainerPrinter::print(expectedCommonUniqueTokenIds),
+        ml::core::CContainerPrinter::print(category.commonUniqueTokenIds()));
+    BOOST_REQUIRE_EQUAL(expectedCommonUniqueTokenIds.size(),
+                        category.commonUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size(), category.origUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(std::max(baseString.length(), newString.length()),
+                        category.maxStringLen());
+    ml::model::CTokenListCategory::TSizeSizePr expectedOrderedCommonTokenBounds{0, 6};
+    BOOST_REQUIRE_EQUAL(
+        ml::core::CContainerPrinter::print(expectedOrderedCommonTokenBounds),
+        ml::core::CContainerPrinter::print(category.orderedCommonTokenBounds()));
+}
+
+BOOST_AUTO_TEST_CASE(testCommonTokensDifferentOrder) {
+
+    std::string baseString{"she sells seashells on the seashore"};
+    ml::model::CTokenListCategory::TSizeSizePrVec baseTokenIds{
+        {0 /* she */, 1}, {1 /* sells */, 1}, {2 /* seashells */, 1},
+        {3 /* on */, 1},  {4 /* the */, 1},   {5 /* seashore */, 1}};
+    ml::model::CTokenListCategory::TSizeSizeMap baseUniqueTokenIds(
+        baseTokenIds.begin(), baseTokenIds.end());
+
+    ml::model::CTokenListCategory category(false, baseString, baseString.length(), baseTokenIds,
+                                           baseTokenIds.size(), baseUniqueTokenIds);
+
+    std::string newString{"sells seashells on the seashore, she does"};
+    ml::model::CTokenListCategory::TSizeSizePrVec newTokenIds{
+        {1 /* sells */, 1}, {2 /* seashells */, 1}, {3 /* on */, 1},
+        {4 /* the */, 1},   {5 /* seashore */, 1},  {0 /* she */, 1},
+        {6 /* does */, 1}};
+    ml::model::CTokenListCategory::TSizeSizeMap newUniqueTokenIds(
+        newTokenIds.begin(), newTokenIds.end());
+
+    BOOST_TEST_REQUIRE(category.addString(false, newString, newString.length(),
+                                          newTokenIds, newUniqueTokenIds));
+
+    BOOST_REQUIRE_EQUAL(baseString, category.baseString());
+    BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseTokenIds),
+                        ml::core::CContainerPrinter::print(category.baseTokenIds()));
+    BOOST_REQUIRE_EQUAL(baseTokenIds.size(), category.baseWeight());
+    BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseUniqueTokenIds),
+                        ml::core::CContainerPrinter::print(category.commonUniqueTokenIds()));
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size(), category.commonUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size(), category.origUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(std::max(baseString.length(), newString.length()),
+                        category.maxStringLen());
+    // FIXME: {0, 1} is clearly sub-optimal here; {1, 6} would be much better
+    ml::model::CTokenListCategory::TSizeSizePr expectedOrderedCommonTokenBounds{0, 1};
+    BOOST_REQUIRE_EQUAL(
+        ml::core::CContainerPrinter::print(expectedOrderedCommonTokenBounds),
+        ml::core::CContainerPrinter::print(category.orderedCommonTokenBounds()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/model/unittest/CTokenListDataCategorizerBaseTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerBaseTest.cc
@@ -11,53 +11,53 @@
 BOOST_AUTO_TEST_SUITE(CTokenListDataCategorizerBaseTest)
 
 BOOST_AUTO_TEST_CASE(testMinMatchingWeights) {
-    BOOST_REQUIRE_EQUAL(
-        size_t(0), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(0, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(1), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(1, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(2), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(2, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(3), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(3, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(3), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(4, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(4), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(5, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(5), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(6, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(5), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(7, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(6), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(8, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(7), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(9, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(8), ml::model::CTokenListDataCategorizerBase::minMatchingWeight(10, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(0),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(0, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(1),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(1, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(2),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(2, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(3),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(3, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(3),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(4, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(4),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(5, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(5),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(6, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(5),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(7, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(6),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(8, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(7),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(9, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(8),
+                        ml::model::CTokenListDataCategorizerBase::minMatchingWeight(10, 0.7));
 }
 
 BOOST_AUTO_TEST_CASE(testMaxMatchingWeights) {
-    BOOST_REQUIRE_EQUAL(
-        size_t(0), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(0, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(1), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(1, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(2), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(2, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(4), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(3, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(5), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(4, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(7), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(5, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(8), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(6, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(9), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(7, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(11), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(8, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(12), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(9, 0.7));
-    BOOST_REQUIRE_EQUAL(
-        size_t(14), ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(10, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(0),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(0, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(1),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(1, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(2),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(2, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(4),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(3, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(5),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(4, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(7),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(5, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(8),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(6, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(9),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(7, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(11),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(8, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(12),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(9, 0.7));
+    BOOST_REQUIRE_EQUAL(std::size_t(14),
+                        ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(10, 0.7));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/model/unittest/CTokenListReverseSearchCreatorTest.cc
+++ b/lib/model/unittest/CTokenListReverseSearchCreatorTest.cc
@@ -18,18 +18,6 @@ BOOST_AUTO_TEST_CASE(testCostOfToken) {
     BOOST_REQUIRE_EQUAL(std::size_t(110), reverseSearchCreator.costOfToken("someToken", 5));
 }
 
-BOOST_AUTO_TEST_CASE(testCreateNullSearch) {
-    CTokenListReverseSearchCreator reverseSearchCreator("foo");
-
-    std::string terms;
-    std::string regex;
-
-    BOOST_TEST_REQUIRE(reverseSearchCreator.createNullSearch(terms, regex));
-
-    BOOST_REQUIRE_EQUAL(std::string(), terms);
-    BOOST_REQUIRE_EQUAL(std::string(), regex);
-}
-
 BOOST_AUTO_TEST_CASE(testCreateNoUniqueTokenSearch) {
     CTokenListReverseSearchCreator reverseSearchCreator("status");
 
@@ -40,7 +28,7 @@ BOOST_AUTO_TEST_CASE(testCreateNoUniqueTokenSearch) {
         reverseSearchCreator.createNoUniqueTokenSearch(1, "404", 4, terms, regex));
 
     BOOST_REQUIRE_EQUAL(std::string(), terms);
-    BOOST_REQUIRE_EQUAL(std::string(), regex);
+    BOOST_REQUIRE_EQUAL(std::string(".*"), regex);
 }
 
 BOOST_AUTO_TEST_CASE(testInitStandardSearch) {
@@ -62,10 +50,10 @@ BOOST_AUTO_TEST_CASE(testAddInOrderCommonToken) {
     std::string terms;
     std::string regex;
 
-    reverseSearchCreator.addInOrderCommonToken("user", true, terms, regex);
-    reverseSearchCreator.addInOrderCommonToken("logged", false, terms, regex);
-    reverseSearchCreator.addInOrderCommonToken("b=0.15+a", false, terms, regex);
-    reverseSearchCreator.addInOrderCommonToken("logged", false, terms, regex);
+    reverseSearchCreator.addInOrderCommonToken("user", terms, regex);
+    reverseSearchCreator.addInOrderCommonToken("logged", terms, regex);
+    reverseSearchCreator.addInOrderCommonToken("b=0.15+a", terms, regex);
+    reverseSearchCreator.addInOrderCommonToken("logged", terms, regex);
 
     BOOST_REQUIRE_EQUAL(std::string("user logged b=0.15+a logged"), terms);
     BOOST_REQUIRE_EQUAL(std::string(".*?user.+?logged.+?b=0\\.15\\+a.+?logged"), regex);

--- a/lib/model/unittest/Makefile
+++ b/lib/model/unittest/Makefile
@@ -57,6 +57,7 @@ SRCS=\
 	CSampleQueueTest.cc \
 	CSearchKeyTest.cc \
 	CStringStoreTest.cc \
+	CTokenListCategoryTest.cc \
 	CTokenListDataCategorizerBaseTest.cc \
 	CTokenListDataCategorizerTest.cc \
 	CTokenListReverseSearchCreatorTest.cc \


### PR DESCRIPTION
While working on part 2 of the fix for #949 I noticed that
the categorization code could do with a little modernization,
such as using range based for loops in preference to
iterators where possible.

Additionally there is some dead code left over from the
days of multiple products that used categorization, for
example in our Elasticsearch integration there is never a
need to create a reverse search for a NULL field, so the
method to do that can be removed.

This PR does that modernization and dead code removal
without changing any externally visible functionality.
Then the eventual fix for part 2 of #949 will not be
polluted with lots of irrelevant refactoring.

This PR also adds a couple of low level tests for the
CTokenListCategory class.  One of these highlights the
outstanding problem reported in #949.  That test will
be adjusted when part 2 of #949 is fixed.