### PR TITLE
[7.x][ML] Adjust test threshold for debug build

### DIFF
--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -757,7 +757,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierImbalanced) {
     for (const auto& label : {"foo", "bar"}) {
         double recall{static_cast<double>(correct[label]) /
                       static_cast<double>(counts[label])};
-        BOOST_TEST_REQUIRE(recall > 0.85);
+        BOOST_TEST_REQUIRE(recall > 0.84);
     }
 }
 


### PR DESCRIPTION
The threshold of 0.85 worked in optimised code but
failed (only by a margin of 0.05) when code was
built without optimisation.

Backport of #971