### PR TITLE
[7.x][ML] Use largest ordered subset of categorization tokens for regex

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,6 +40,11 @@ progress, memory usage, etc. (See {ml-pull}906[#906].)
 * Improve initialization of learn rate for better and more stable results in regression
 and classification. (See {ml-pull}948[#948].)
 
+=== Bug Fixes
+
+* Use largest ordered subset of categorization tokens for category reverse search regex.
+(See {ml-pull}970[#970], issue: {ml-issue}949[#949].)
+
 == {es} version 7.6.0
 
 === New Features

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -77,6 +77,13 @@ public:
     std::size_t commonUniqueTokenWeight() const;
     std::size_t origUniqueTokenWeight() const;
     std::size_t maxStringLen() const;
+    //! \return A pair of indices indicating the beginning and end of the
+    //!         common ordered tokens within the base tokens.  Importantly,
+    //!         the tokens within the range may not all be common across the
+    //!         category.  The consumer of these bounds must check whether each
+    //!         base token in the range is common before using it for any
+    //!         purpose that relies on commonality (for example creating a
+    //!         reverse search).
     TSizeSizePr orderedCommonTokenBounds() const;
 
     //! What's the longest string we'll consider a match for this category?
@@ -97,6 +104,9 @@ public:
     //! Does the supplied token vector contain all our common tokens in the
     //! same order as our base token vector?
     bool containsCommonTokensInOrder(const TSizeSizePrVec& tokenIds) const;
+
+    //! \return Does the supplied token ID represent a common unique token?
+    bool isTokenCommon(std::size_t tokenId) const;
 
     //! How many matching strings are there?
     std::size_t numMatches() const;
@@ -119,6 +129,18 @@ public:
 private:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
+    //! Remove any token IDs from the common unique token map that aren't
+    //! present with the same weight in the new string, and adjust the common
+    //! weight accordingly.
+    //! \return Was a change made?
+    bool updateCommonUniqueTokenIds(const TSizeSizeMap& newUniqueTokenIds);
+
+    //! Adjust the common ordered token indices if there are tokens that
+    //! aren't in the same order in the new string, and adjust the common weight
+    //! accordingly.
+    //! \return Was a change made?
+    bool updateOrderedCommonTokenIds(const TSizeSizePrVec& newTokenIds);
+
 private:
     //! The string and tokens we base this category on
     std::string m_BaseString;
@@ -132,6 +154,10 @@ private:
     //! length of the strings in passed to the addString() method, because
     //! it will include the date.
     std::size_t m_MaxStringLen;
+
+    //! The index into the base token IDs where the subsequence of tokens that
+    //! are in the same order for all strings of this category begins.
+    std::size_t m_OrderedCommonTokenBeginIndex;
 
     //! One past the index into the base token IDs where the subsequence of
     //! tokens that are in the same order for all strings of this category ends.

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(testJobKilledReverseSearch) {
     // their respective classes, but this test helps to confirm that they work
     // together)
     BOOST_TEST_REQUIRE(output.find("\"terms\":\"Killing job\"") != std::string::npos);
-    BOOST_TEST_REQUIRE(output.find("\"regex\":\".*\"") != std::string::npos);
+    BOOST_TEST_REQUIRE(output.find("\"regex\":\".*?Killing.+?job.*\"") != std::string::npos);
     // The input data should NOT be in the output
     BOOST_TEST_REQUIRE(output.find("\"message\"") == std::string::npos);
 }

--- a/lib/api/unittest/CRestorePreviousStateTest.cc
+++ b/lib/api/unittest/CRestorePreviousStateTest.cc
@@ -49,8 +49,8 @@ struct SRestoreTestConfig {
 };
 
 const std::vector<SRestoreTestConfig> BWC_VERSIONS{
-    SRestoreTestConfig{"5.6.0", false, true}, SRestoreTestConfig{"6.0.0", false, true},
-    SRestoreTestConfig{"6.1.0", false, true}};
+    SRestoreTestConfig{"5.6.0", false, false}, SRestoreTestConfig{"6.0.0", false, false},
+    SRestoreTestConfig{"6.1.0", false, false}};
 
 std::string stripDocIds(const std::string& persistedState) {
     // State is persisted in the Elasticsearch bulk format.

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -23,15 +23,13 @@ namespace ml {
 namespace model {
 
 // Initialise statics
-const std::string CTokenListDataCategorizerBase::PRETOKENISED_TOKEN_FIELD("...");
+const std::string CTokenListDataCategorizerBase::PRETOKENISED_TOKEN_FIELD{"..."};
 
 // We use short field names to reduce the state size
 namespace {
 const std::string TOKEN_TAG{"a"};
 const std::string TOKEN_CATEGORY_COUNT_TAG{"b"};
 const std::string CATEGORY_TAG{"c"};
-
-const std::string EMPTY_STRING;
 }
 
 CTokenListDataCategorizerBase::CTokenListDataCategorizerBase(CLimits& limits,

--- a/lib/model/unittest/CTokenListCategoryTest.cc
+++ b/lib/model/unittest/CTokenListCategoryTest.cc
@@ -19,19 +19,20 @@ BOOST_AUTO_TEST_CASE(testCommonTokensSameOrder) {
 
     std::string baseString{"she sells seashells on the seashore"};
     ml::model::CTokenListCategory::TSizeSizePrVec baseTokenIds{
-        {0 /* she */, 1}, {1 /* sells */, 1}, {2 /* seashells */, 1},
-        {3 /* on */, 1},  {4 /* the */, 1},   {5 /* seashore */, 1}};
+        {0 /* she */, 2}, {1 /* sells */, 2}, {2 /* seashells */, 2},
+        {3 /* on */, 2},  {4 /* the */, 2},   {5 /* seashore */, 2}};
     ml::model::CTokenListCategory::TSizeSizeMap baseUniqueTokenIds(
         baseTokenIds.begin(), baseTokenIds.end());
 
-    ml::model::CTokenListCategory category(false, baseString, baseString.length(), baseTokenIds,
-                                           baseTokenIds.size(), baseUniqueTokenIds);
+    ml::model::CTokenListCategory category(false, baseString, baseString.length(),
+                                           baseTokenIds, baseTokenIds.size() * 2,
+                                           baseUniqueTokenIds);
 
     std::string newString{"she sells ice cream on the seashore"};
     ml::model::CTokenListCategory::TSizeSizePrVec newTokenIds{
-        {0 /* she */, 1},     {1 /* sells */, 1}, {6 /* ice */, 1},
-        {7 /* cream */, 1},   {3 /* on */, 1},    {4 /* the */, 1},
-        {5 /* seashore */, 1}};
+        {0 /* she */, 2},     {1 /* sells */, 2}, {6 /* ice */, 2},
+        {7 /* cream */, 2},   {3 /* on */, 2},    {4 /* the */, 2},
+        {5 /* seashore */, 2}};
     ml::model::CTokenListCategory::TSizeSizeMap newUniqueTokenIds(
         newTokenIds.begin(), newTokenIds.end());
 
@@ -41,15 +42,15 @@ BOOST_AUTO_TEST_CASE(testCommonTokensSameOrder) {
     BOOST_REQUIRE_EQUAL(baseString, category.baseString());
     BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseTokenIds),
                         ml::core::CContainerPrinter::print(category.baseTokenIds()));
-    BOOST_REQUIRE_EQUAL(baseTokenIds.size(), category.baseWeight());
+    BOOST_REQUIRE_EQUAL(baseTokenIds.size() * 2, category.baseWeight());
     ml::model::CTokenListCategory::TSizeSizeMap expectedCommonUniqueTokenIds{
-        {0 /* she */, 1}, {1 /* sells */, 1}, {3 /* on */, 1}, {4 /* the */, 1}, {5 /* seashore */, 1}};
+        {0 /* she */, 2}, {1 /* sells */, 2}, {3 /* on */, 2}, {4 /* the */, 2}, {5 /* seashore */, 2}};
     BOOST_REQUIRE_EQUAL(
         ml::core::CContainerPrinter::print(expectedCommonUniqueTokenIds),
         ml::core::CContainerPrinter::print(category.commonUniqueTokenIds()));
-    BOOST_REQUIRE_EQUAL(expectedCommonUniqueTokenIds.size(),
+    BOOST_REQUIRE_EQUAL(expectedCommonUniqueTokenIds.size() * 2,
                         category.commonUniqueTokenWeight());
-    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size(), category.origUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size() * 2, category.origUniqueTokenWeight());
     BOOST_REQUIRE_EQUAL(std::max(baseString.length(), newString.length()),
                         category.maxStringLen());
     ml::model::CTokenListCategory::TSizeSizePr expectedOrderedCommonTokenBounds{0, 6};
@@ -62,37 +63,102 @@ BOOST_AUTO_TEST_CASE(testCommonTokensDifferentOrder) {
 
     std::string baseString{"she sells seashells on the seashore"};
     ml::model::CTokenListCategory::TSizeSizePrVec baseTokenIds{
-        {0 /* she */, 1}, {1 /* sells */, 1}, {2 /* seashells */, 1},
-        {3 /* on */, 1},  {4 /* the */, 1},   {5 /* seashore */, 1}};
+        {0 /* she */, 2}, {1 /* sells */, 2}, {2 /* seashells */, 2},
+        {3 /* on */, 2},  {4 /* the */, 2},   {5 /* seashore */, 2}};
     ml::model::CTokenListCategory::TSizeSizeMap baseUniqueTokenIds(
         baseTokenIds.begin(), baseTokenIds.end());
 
-    ml::model::CTokenListCategory category(false, baseString, baseString.length(), baseTokenIds,
-                                           baseTokenIds.size(), baseUniqueTokenIds);
+    ml::model::CTokenListCategory category(false, baseString, baseString.length(),
+                                           baseTokenIds, baseTokenIds.size() * 2,
+                                           baseUniqueTokenIds);
 
-    std::string newString{"sells seashells on the seashore, she does"};
-    ml::model::CTokenListCategory::TSizeSizePrVec newTokenIds{
-        {1 /* sells */, 1}, {2 /* seashells */, 1}, {3 /* on */, 1},
-        {4 /* the */, 1},   {5 /* seashore */, 1},  {0 /* she */, 1},
-        {6 /* does */, 1}};
-    ml::model::CTokenListCategory::TSizeSizeMap newUniqueTokenIds(
-        newTokenIds.begin(), newTokenIds.end());
+    std::string newString1{"sells seashells on the seashore, she does"};
+    ml::model::CTokenListCategory::TSizeSizePrVec newTokenIds1{
+        {1 /* sells */, 2}, {2 /* seashells */, 2}, {3 /* on */, 2},
+        {4 /* the */, 2},   {5 /* seashore */, 2},  {0 /* she */, 2},
+        {6 /* does */, 2}};
+    ml::model::CTokenListCategory::TSizeSizeMap newUniqueTokenIds1(
+        newTokenIds1.begin(), newTokenIds1.end());
 
-    BOOST_TEST_REQUIRE(category.addString(false, newString, newString.length(),
-                                          newTokenIds, newUniqueTokenIds));
+    BOOST_TEST_REQUIRE(category.addString(false, newString1, newString1.length(),
+                                          newTokenIds1, newUniqueTokenIds1));
 
     BOOST_REQUIRE_EQUAL(baseString, category.baseString());
     BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseTokenIds),
                         ml::core::CContainerPrinter::print(category.baseTokenIds()));
-    BOOST_REQUIRE_EQUAL(baseTokenIds.size(), category.baseWeight());
+    BOOST_REQUIRE_EQUAL(baseTokenIds.size() * 2, category.baseWeight());
     BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseUniqueTokenIds),
                         ml::core::CContainerPrinter::print(category.commonUniqueTokenIds()));
-    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size(), category.commonUniqueTokenWeight());
-    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size(), category.origUniqueTokenWeight());
-    BOOST_REQUIRE_EQUAL(std::max(baseString.length(), newString.length()),
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size() * 2, category.commonUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size() * 2, category.origUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(std::max(baseString.length(), newString1.length()),
                         category.maxStringLen());
-    // FIXME: {0, 1} is clearly sub-optimal here; {1, 6} would be much better
-    ml::model::CTokenListCategory::TSizeSizePr expectedOrderedCommonTokenBounds{0, 1};
+    ml::model::CTokenListCategory::TSizeSizePr expectedOrderedCommonTokenBounds{1, 6};
+    BOOST_REQUIRE_EQUAL(
+        ml::core::CContainerPrinter::print(expectedOrderedCommonTokenBounds),
+        ml::core::CContainerPrinter::print(category.orderedCommonTokenBounds()));
+
+    std::string newString2{"nice seashells can be found near the seashore"};
+    ml::model::CTokenListCategory::TSizeSizePrVec newTokenIds2{
+        {7 /* nice */, 2}, {2 /* seashells */, 2}, {8 /* can */, 2},
+        {9 /* be */, 2},   {10 /* found */, 2},    {11 /* near */, 2},
+        {4 /* the */, 2},  {5 /* seashore */, 2}};
+    ml::model::CTokenListCategory::TSizeSizeMap newUniqueTokenIds2(
+        newTokenIds2.begin(), newTokenIds2.end());
+
+    BOOST_TEST_REQUIRE(category.addString(false, newString2, newString2.length(),
+                                          newTokenIds2, newUniqueTokenIds2));
+
+    BOOST_REQUIRE_EQUAL(baseString, category.baseString());
+    BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseTokenIds),
+                        ml::core::CContainerPrinter::print(category.baseTokenIds()));
+    BOOST_REQUIRE_EQUAL(baseTokenIds.size() * 2, category.baseWeight());
+    ml::model::CTokenListCategory::TSizeSizeMap expectedCommonUniqueTokenIds{
+        {2 /* seashells */, 2}, {4 /* the */, 2}, {5 /* seashore */, 2}};
+    BOOST_REQUIRE_EQUAL(
+        ml::core::CContainerPrinter::print(expectedCommonUniqueTokenIds),
+        ml::core::CContainerPrinter::print(category.commonUniqueTokenIds()));
+    BOOST_REQUIRE_EQUAL(expectedCommonUniqueTokenIds.size() * 2,
+                        category.commonUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size() * 2, category.origUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(std::max(newString1.length(), newString2.length()),
+                        category.maxStringLen());
+    // The bounds go from {1, 6} to {2, 6} even though there are now only 3
+    // common tokens, because the bounds reference the base token indices,
+    // and the range needs to be filtered to exclude tokens that are not common.
+    // (When the real reverse search is created tokens may also be filtered if
+    // their cost is too high for the available budget, so this doesn't create
+    // too much complexity outside of the unit test.)
+    expectedOrderedCommonTokenBounds = {2, 6};
+    BOOST_REQUIRE_EQUAL(
+        ml::core::CContainerPrinter::print(expectedOrderedCommonTokenBounds),
+        ml::core::CContainerPrinter::print(category.orderedCommonTokenBounds()));
+
+    std::string newString3{"the rock"};
+    ml::model::CTokenListCategory::TSizeSizePrVec newTokenIds3{{4 /* the */, 2},
+                                                               {12 /* rock */, 2}};
+    ml::model::CTokenListCategory::TSizeSizeMap newUniqueTokenIds3(
+        newTokenIds3.begin(), newTokenIds3.end());
+
+    BOOST_TEST_REQUIRE(category.addString(false, newString3, newString3.length(),
+                                          newTokenIds3, newUniqueTokenIds3));
+
+    BOOST_REQUIRE_EQUAL(baseString, category.baseString());
+    BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(baseTokenIds),
+                        ml::core::CContainerPrinter::print(category.baseTokenIds()));
+    BOOST_REQUIRE_EQUAL(baseTokenIds.size() * 2, category.baseWeight());
+    expectedCommonUniqueTokenIds = {{4 /* the */, 2}};
+    BOOST_REQUIRE_EQUAL(
+        ml::core::CContainerPrinter::print(expectedCommonUniqueTokenIds),
+        ml::core::CContainerPrinter::print(category.commonUniqueTokenIds()));
+    BOOST_REQUIRE_EQUAL(expectedCommonUniqueTokenIds.size() * 2,
+                        category.commonUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(baseUniqueTokenIds.size() * 2, category.origUniqueTokenWeight());
+    BOOST_REQUIRE_EQUAL(std::max(newString2.length(), newString3.length()),
+                        category.maxStringLen());
+    // The bounds go from {2, 6} to {4, 5} as there's now only one common token
+    // and it's in position 4.
+    expectedOrderedCommonTokenBounds = {4, 5};
     BOOST_REQUIRE_EQUAL(
         ml::core::CContainerPrinter::print(expectedOrderedCommonTokenBounds),
         ml::core::CContainerPrinter::print(category.orderedCommonTokenBounds()));


### PR DESCRIPTION
Previously, when reducing the subset of common tokens that
were in the same order for all messages in a category the
subset matching from the start of the original category
tokens would be used.  This was highly suboptimal in the
case of a message being added to the category that
contained the first token in the original category tokens,
but near the end of the new message rather than near the
beginning.

This PR changes categorization such that the largest
ordered subset is chosen, even if this involves excluding
tokens that occurred near the start of the original category
tokens.

In practice this means that if a category contains messages
of the form "a b c d e" and a message "b c d e a" is
considered close enough to match then the regex chosen that
matches all messages in the category will now be
".*?b.+?c.+?d.+?e.*" when previously it would have been
".*?a.*".

This change alters the categorization state format, by adding
the begin index for the ordered subset to complement the end
index.  Upgrade is seamless, because effectively the begin
index always used to be 0, so 0 can be assumed in the case
of an older version state being restored.  Downgrade (if the
job relocates to an older node in a mixed version cluster)
means that the begin index will get reset to 0.  This will
not cause a crash, but may mean that extra tokens are
erroneously reported in a regex generated after downgrade.
However, the problem will self-correct when a message that
doesn't match the erroneous regex is seen after the job
eventually relocates to a newer node again.

Backport of #970