### PR TITLE
[ML] Rework caching and reading predictions and derivatives in boosted tree training to anticipate multiple values

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -37,9 +37,6 @@ public:
     CDataFrameTrainBoostedTreeClassifierRunner(const CDataFrameAnalysisSpecification& spec,
                                                const CDataFrameAnalysisParameters& parameters);
 
-    //! This is not intended to be called directly: use CDataFrameTrainBoostedTreeClassifierRunnerFactory.
-    CDataFrameTrainBoostedTreeClassifierRunner(const CDataFrameAnalysisSpecification& spec);
-
     //! \return Indicator of columns for which empty value should be treated as missing.
     TBoolVec columnsForWhichEmptyIsMissing(const TStrVec& fieldNames) const override;
 
@@ -63,8 +60,8 @@ public:
                              const TStrVecVec& categoryNames) const override;
 
 private:
-    TLossFunctionUPtr chooseLossFunction(const core::CDataFrame& frame,
-                                         std::size_t dependentVariableColumn) const override;
+    void validate(const core::CDataFrame& frame,
+                  std::size_t dependentVariableColumn) const override;
 
     void writePredictedCategoryValue(const std::string& categoryValue,
                                      core::CRapidJsonConcurrentLineWriter& writer) const;

--- a/include/api/CDataFrameTrainBoostedTreeRegressionRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRegressionRunner.h
@@ -28,9 +28,6 @@ public:
     CDataFrameTrainBoostedTreeRegressionRunner(const CDataFrameAnalysisSpecification& spec,
                                                const CDataFrameAnalysisParameters& parameters);
 
-    //! This is not intended to be called directly: use CDataFrameTrainBoostedTreeRegressionRunnerFactory.
-    CDataFrameTrainBoostedTreeRegressionRunner(const CDataFrameAnalysisSpecification& spec);
-
     //! Write the prediction for \p row to \p writer.
     void writeOneRow(const core::CDataFrame& frame,
                      const TRowRef& row,
@@ -42,8 +39,8 @@ public:
                              const TStrVecVec& categoryNameMap) const override;
 
 private:
-    TLossFunctionUPtr chooseLossFunction(const core::CDataFrame& frame,
-                                         std::size_t dependentVariableColumn) const override;
+    void validate(const core::CDataFrame& frame,
+                  std::size_t dependentVariableColumn) const override;
 };
 
 //! \brief Makes a core::CDataFrame boosted tree regression runner.

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -63,7 +63,7 @@ public:
     const maths::CBoostedTreeFactory& boostedTreeFactory() const;
 
     //! The number of (largest magnitude) SHAP values to return.
-    std::size_t numberTopShapValues() const;
+    std::size_t topShapValues() const;
 
     //! \return Reference to the analysis state.
     const CDataFrameAnalysisInstrumentation& instrumentation() const override;

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -62,7 +62,8 @@ public:
     //! The boosted tree factory.
     const maths::CBoostedTreeFactory& boostedTreeFactory() const;
 
-    std::size_t topShapValues() const;
+    //! The number of (largest magnitude) SHAP values to return.
+    std::size_t numberTopShapValues() const;
 
     //! \return Reference to the analysis state.
     const CDataFrameAnalysisInstrumentation& instrumentation() const override;
@@ -75,8 +76,8 @@ protected:
 
 protected:
     CDataFrameTrainBoostedTreeRunner(const CDataFrameAnalysisSpecification& spec,
-                                     const CDataFrameAnalysisParameters& parameters);
-    CDataFrameTrainBoostedTreeRunner(const CDataFrameAnalysisSpecification& spec);
+                                     const CDataFrameAnalysisParameters& parameters,
+                                     TLossFunctionUPtr loss);
 
     //! Parameter reader handling parameters that are shared by subclasses.
     static const CDataFrameAnalysisConfigReader& parameterReader();
@@ -102,8 +103,8 @@ private:
                                                std::size_t partitionNumberRows,
                                                std::size_t numberColumns) const override;
 
-    virtual TLossFunctionUPtr chooseLossFunction(const core::CDataFrame& frame,
-                                                 std::size_t dependentVariableColumn) const = 0;
+    virtual void validate(const core::CDataFrame& frame,
+                          std::size_t dependentVariableColumn) const = 0;
 
 private:
     // Note custom config is written directly to the factory object.

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -49,7 +49,7 @@ public:
     //! Construct a boosted tree object from its serialized version.
     //!
     //! \warning Throws runtime error on fail to restore.
-    static CBoostedTreeFactory constructFromStream(std::istream& jsonStream);
+    static CBoostedTreeFactory constructFromString(std::istream& jsonStream);
 
     ~CBoostedTreeFactory();
     CBoostedTreeFactory(CBoostedTreeFactory&) = delete;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -43,12 +43,13 @@ public:
 
 public:
     //! Construct a boosted tree object from parameters.
-    static CBoostedTreeFactory constructFromParameters(std::size_t numberThreads);
+    static CBoostedTreeFactory constructFromParameters(std::size_t numberThreads,
+                                                       TLossFunctionUPtr loss);
 
     //! Construct a boosted tree object from its serialized version.
     //!
     //! \warning Throws runtime error on fail to restore.
-    static CBoostedTreeFactory constructFromString(std::istream& jsonStringStream);
+    static CBoostedTreeFactory constructFromStream(std::istream& jsonStream);
 
     ~CBoostedTreeFactory();
     CBoostedTreeFactory(CBoostedTreeFactory&) = delete;
@@ -113,9 +114,7 @@ public:
     //! Get the number of columns training the model will add to the data frame.
     std::size_t numberExtraColumnsForTrain() const;
     //! Build a boosted tree object for a given data frame.
-    TBoostedTreeUPtr buildFor(core::CDataFrame& frame,
-                              TLossFunctionUPtr loss,
-                              std::size_t dependentVariable);
+    TBoostedTreeUPtr buildFor(core::CDataFrame& frame, std::size_t dependentVariable);
     //! Restore a boosted tree object for a given data frame.
     //! \warning A tree object can only be restored once.
     TBoostedTreeUPtr restoreFor(core::CDataFrame& frame, std::size_t dependentVariable);
@@ -132,13 +131,16 @@ private:
     using TApplyRegularizer = std::function<bool(CBoostedTreeImpl&, double)>;
 
 private:
-    CBoostedTreeFactory(std::size_t numberThreads);
+    CBoostedTreeFactory(std::size_t numberThreads, TLossFunctionUPtr loss);
 
     //! Compute the row masks for the missing values for each feature.
     void initializeMissingFeatureMasks(const core::CDataFrame& frame) const;
 
     //! Set up the number of folds we'll use for cross-validation.
     void initializeNumberFolds(core::CDataFrame& frame) const;
+
+    //! Resize the data frame with the extra columns used by train.
+    void resizeDataFrame(core::CDataFrame& frame) const;
 
     //! Set up cross validation.
     void initializeCrossValidation(core::CDataFrame& frame) const;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -595,13 +595,13 @@ private:
 };
 
 namespace boosted_tree_detail {
-inline std::size_t lossHessianStoredSize(std::size_t numberInputColumns) {
+inline std::size_t lossHessianStoredSize(std::size_t numberLossParameters) {
     return numberLossParameters * (numberLossParameters + 1) / 2;
 }
 
 inline std::size_t numberLossParametersForHessianStoredSize(std::size_t lossHessianStoredSize) {
     return static_cast<std::size_t>(
-        (std::sqrt(8.0 * static_cast<double>(lossHessianStoredSize) + 1.0) - 1.0) / 2.0 + 0.5)
+        (std::sqrt(8.0 * static_cast<double>(lossHessianStoredSize) + 1.0) - 1.0) / 2.0 + 0.5);
 }
 
 inline std::size_t predictionColumn(std::size_t numberInputColumns) {

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -177,10 +177,10 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
         writer.EndArray();
     }
 
-    if (this->numberTopShapValues() > 0) {
+    if (this->topShapValues() > 0) {
         auto largestShapValues =
             maths::CBasicStatistics::orderStatisticsAccumulator<std::size_t>(
-                this->numberTopShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
+                this->topShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
                     return std::fabs(row[lhs]) > std::fabs(row[rhs]);
                 });
         for (auto col : this->boostedTree().columnsHoldingShapValues()) {

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -79,7 +79,7 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
     if (this->topShapValues() > 0) {
         auto largestShapValues =
             maths::CBasicStatistics::orderStatisticsAccumulator<std::size_t>(
-                this->t opShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
+                this->topShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
                     return std::fabs(row[lhs]) > std::fabs(row[rhs]);
                 });
         for (auto col : this->boostedTree().columnsHoldingShapValues()) {

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -76,10 +76,10 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
     writer.Double(row[columnHoldingPrediction]);
     writer.Key(IS_TRAINING_FIELD_NAME);
     writer.Bool(maths::CDataFrameUtils::isMissing(row[columnHoldingDependentVariable]) == false);
-    if (this->numberTopShapValues() > 0) {
+    if (this->topShapValues() > 0) {
         auto largestShapValues =
             maths::CBasicStatistics::orderStatisticsAccumulator<std::size_t>(
-                this->numberTopShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
+                this->t opShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
                     return std::fabs(row[lhs]) > std::fabs(row[rhs]);
                 });
         for (auto col : this->boostedTree().columnsHoldingShapValues()) {

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -66,8 +66,9 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
 
 CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     const CDataFrameAnalysisSpecification& spec,
-    const CDataFrameAnalysisParameters& parameters)
-    : CDataFrameTrainBoostedTreeRunner{spec} {
+    const CDataFrameAnalysisParameters& parameters,
+    TLossFunctionUPtr loss)
+    : CDataFrameAnalysisRunner{spec} {
 
     m_DependentVariableFieldName = parameters[DEPENDENT_VARIABLE_NAME].as<std::string>();
 
@@ -120,7 +121,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     }
 
     m_BoostedTreeFactory = std::make_unique<maths::CBoostedTreeFactory>(
-        maths::CBoostedTreeFactory::constructFromParameters(this->spec().numberThreads()));
+        maths::CBoostedTreeFactory::constructFromParameters(
+            this->spec().numberThreads(), std::move(loss)));
 
     (*m_BoostedTreeFactory)
         .stopCrossValidationEarly(stopCrossValidationEarly)
@@ -169,10 +171,6 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     }
 }
 
-CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(const CDataFrameAnalysisSpecification& spec)
-    : CDataFrameAnalysisRunner{spec} {
-}
-
 CDataFrameTrainBoostedTreeRunner::~CDataFrameTrainBoostedTreeRunner() = default;
 
 std::size_t CDataFrameTrainBoostedTreeRunner::numberExtraColumns() const {
@@ -208,6 +206,10 @@ const maths::CBoostedTreeFactory& CDataFrameTrainBoostedTreeRunner::boostedTreeF
     return *m_BoostedTreeFactory;
 }
 
+std::size_t CDataFrameTrainBoostedTreeRunner::numberTopShapValues() const {
+    return m_BoostedTree == nullptr ? 0 : m_BoostedTree->topShapValues();
+}
+
 void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
     auto dependentVariablePos = std::find(frame.columnNames().begin(),
                                           frame.columnNames().end(),
@@ -235,11 +237,10 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
         treeRestored = this->restoreBoostedTree(frame, dependentVariableColumn, restoreSearcher);
     }
     if (treeRestored == false) {
-        auto loss = this->chooseLossFunction(frame, dependentVariableColumn);
-        m_BoostedTree = m_BoostedTreeFactory->buildFor(frame, std::move(loss),
-                                                       dependentVariableColumn);
+        m_BoostedTree = m_BoostedTreeFactory->buildFor(frame, dependentVariableColumn);
     }
 
+    this->validate(frame, dependentVariableColumn);
     m_BoostedTree->train();
     m_BoostedTree->predict();
     m_BoostedTree->computeShapValues();
@@ -250,7 +251,7 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
 bool CDataFrameTrainBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& frame,
                                                           std::size_t dependentVariableColumn,
                                                           TDataSearcherUPtr& restoreSearcher) {
-    // Restore from Elasticsearch compressed data
+    // Restore from compressed JSON.
     try {
         core::CStateDecompressor decompressor(*restoreSearcher);
         decompressor.setStateRestoreSearch(
@@ -271,7 +272,7 @@ bool CDataFrameTrainBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& fram
             LOG_ERROR(<< "State restoration search returned failed stream");
             return false;
         }
-        m_BoostedTree = maths::CBoostedTreeFactory::constructFromString(*inputStream)
+        m_BoostedTree = maths::CBoostedTreeFactory::constructFromStream(*inputStream)
                             .analysisInstrumentation(&m_Instrumentation)
                             .trainingStateCallback(this->statePersister())
                             .restoreFor(frame, dependentVariableColumn);
@@ -288,13 +289,6 @@ std::size_t CDataFrameTrainBoostedTreeRunner::estimateBookkeepingMemoryUsage(
     std::size_t /*partitionNumberRows*/,
     std::size_t numberColumns) const {
     return m_BoostedTreeFactory->estimateMemoryUsage(totalNumberRows, numberColumns);
-}
-
-std::size_t CDataFrameTrainBoostedTreeRunner::topShapValues() const {
-    if (m_BoostedTree) {
-        return m_BoostedTree->topShapValues();
-    }
-    return 0;
 }
 
 const CDataFrameAnalysisInstrumentation&

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -206,7 +206,7 @@ const maths::CBoostedTreeFactory& CDataFrameTrainBoostedTreeRunner::boostedTreeF
     return *m_BoostedTreeFactory;
 }
 
-std::size_t CDataFrameTrainBoostedTreeRunner::numberTopShapValues() const {
+std::size_t CDataFrameTrainBoostedTreeRunner::topShapValues() const {
     return m_BoostedTree == nullptr ? 0 : m_BoostedTree->topShapValues();
 }
 
@@ -272,7 +272,7 @@ bool CDataFrameTrainBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& fram
             LOG_ERROR(<< "State restoration search returned failed stream");
             return false;
         }
-        m_BoostedTree = maths::CBoostedTreeFactory::constructFromStream(*inputStream)
+        m_BoostedTree = maths::CBoostedTreeFactory::constructFromString(*inputStream)
                             .analysisInstrumentation(&m_Instrumentation)
                             .trainingStateCallback(this->statePersister())
                             .restoreFor(frame, dependentVariableColumn);

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -441,7 +441,7 @@ std::size_t CBoostedTree::columnHoldingDependentVariable() const {
 }
 
 std::size_t CBoostedTree::columnHoldingPrediction() const {
-    return m_Impl->numberInputColumns();
+    return predictionColumn(m_Impl->numberInputColumns());
 }
 
 double CBoostedTree::probabilityAtWhichToAssignClassOne() const {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -955,7 +955,7 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromParameters(std::size_t num
     return {numberThreads, std::move(loss)};
 }
 
-CBoostedTreeFactory CBoostedTreeFactory::constructFromStream(std::istream& jsonStream) {
+CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonStream) {
     CBoostedTreeFactory result{1, nullptr};
     try {
         core::CJsonStateRestoreTraverser traverser(jsonStream);

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -84,25 +84,15 @@ bool intervalIsEmpty(const CBoostedTreeFactory::TVector& interval) {
 }
 
 CBoostedTreeFactory::TBoostedTreeUPtr
-CBoostedTreeFactory::buildFor(core::CDataFrame& frame,
-                              TLossFunctionUPtr loss,
-                              std::size_t dependentVariable) {
-
-    if (loss == nullptr) {
-        HANDLE_FATAL(<< "Internal error: must supply a loss function");
-        return nullptr;
-    }
+CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVariable) {
 
     m_TreeImpl->m_DependentVariable = dependentVariable;
-    m_TreeImpl->m_Loss = std::move(loss);
 
     this->initializeNumberFolds(frame);
     this->initializeTrainingProgressMonitoring(frame);
     this->initializeMissingFeatureMasks(frame);
 
-    m_TreeImpl->m_NumberInputColumns = frame.numberColumns();
-    frame.resizeColumns(m_TreeImpl->m_NumberThreads,
-                        frame.numberColumns() + this->numberExtraColumnsForTrain());
+    this->resizeDataFrame(frame);
 
     this->initializeCrossValidation(frame);
     this->selectFeaturesAndEncodeCategories(frame);
@@ -130,11 +120,9 @@ CBoostedTreeFactory::restoreFor(core::CDataFrame& frame, std::size_t dependentVa
     }
 
     this->resumeRestoredTrainingProgressMonitoring();
-
-    m_TreeImpl->m_NumberInputColumns = frame.numberColumns();
     m_TreeImpl->m_Instrumentation = m_Instrumentation;
-    frame.resizeColumns(m_TreeImpl->m_NumberThreads,
-                        frame.numberColumns() + this->numberExtraColumnsForTrain());
+
+    this->resizeDataFrame(frame);
 
     return TBoostedTreeUPtr{
         new CBoostedTree{frame, m_RecordTrainingState, std::move(m_TreeImpl)}};
@@ -281,6 +269,12 @@ void CBoostedTreeFactory::initializeNumberFolds(core::CDataFrame& frame) const {
     }
 }
 
+void CBoostedTreeFactory::resizeDataFrame(core::CDataFrame& frame) const {
+    m_TreeImpl->m_NumberInputColumns = frame.numberColumns();
+    frame.resizeColumns(m_TreeImpl->m_NumberThreads,
+                        frame.numberColumns() + this->numberExtraColumnsForTrain());
+}
+
 void CBoostedTreeFactory::initializeCrossValidation(core::CDataFrame& frame) const {
 
     core::CPackedBitVector allTrainingRowsMask{m_TreeImpl->allTrainingRowsMask()};
@@ -292,14 +286,16 @@ void CBoostedTreeFactory::initializeCrossValidation(core::CDataFrame& frame) con
             m_TreeImpl->m_NumberThreads, frame, dependentVariable, m_TreeImpl->m_Rng,
             m_TreeImpl->m_NumberFolds, numberBuckets, allTrainingRowsMask);
 
-    frame.writeColumns(
-        m_NumberThreads, 0, frame.numberRows(),
-        [&](TRowItr beginRows, TRowItr endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                row->writeColumn(exampleWeightColumn(row->numberColumns()), 1.0);
-            }
-        },
-        &allTrainingRowsMask);
+    frame.writeColumns(m_NumberThreads, 0, frame.numberRows(),
+                       [&](TRowItr beginRows, TRowItr endRows) {
+                           std::size_t column{exampleWeightColumn(
+                               m_TreeImpl->m_NumberInputColumns,
+                               m_TreeImpl->m_Loss->numberParameters())};
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               row->writeColumn(column, 1.0);
+                           }
+                       },
+                       &allTrainingRowsMask);
 }
 
 void CBoostedTreeFactory::selectFeaturesAndEncodeCategories(const core::CDataFrame& frame) const {
@@ -954,14 +950,15 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
     return TOptionalVector{interval};
 }
 
-CBoostedTreeFactory CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads) {
-    return {numberThreads};
+CBoostedTreeFactory CBoostedTreeFactory::constructFromParameters(std::size_t numberThreads,
+                                                                 TLossFunctionUPtr loss) {
+    return {numberThreads, std::move(loss)};
 }
 
-CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonStringStream) {
-    CBoostedTreeFactory result{1};
+CBoostedTreeFactory CBoostedTreeFactory::constructFromStream(std::istream& jsonStream) {
+    CBoostedTreeFactory result{1, nullptr};
     try {
-        core::CJsonStateRestoreTraverser traverser(jsonStringStream);
+        core::CJsonStateRestoreTraverser traverser(jsonStream);
         if (result.m_TreeImpl->acceptRestoreTraverser(traverser) == false ||
             traverser.haveBadState()) {
             throw std::runtime_error{"failed to restore boosted tree"};
@@ -972,9 +969,9 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonS
     return result;
 }
 
-CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads)
+CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads, TLossFunctionUPtr loss)
     : m_NumberThreads{numberThreads},
-      m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, nullptr)},
+      m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))},
       m_LogDepthPenaltyMultiplierSearchInterval{0.0}, m_LogTreeSizePenaltyMultiplierSearchInterval{0.0},
       m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0}, m_TopShapValues{0} {
 }
@@ -1163,7 +1160,7 @@ std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
 }
 
 std::size_t CBoostedTreeFactory::numberExtraColumnsForTrain() const {
-    return CBoostedTreeImpl::numberExtraColumnsForTrain();
+    return CBoostedTreeImpl::numberExtraColumnsForTrain(m_TreeImpl->m_Loss->numberParameters());
 }
 
 void CBoostedTreeFactory::initializeTrainingProgressMonitoring(const core::CDataFrame& frame) {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1296,8 +1296,8 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
                 [&](TArgMinLossVec& leafValues_, TRowItr beginRows, TRowItr endRows) {
                     std::size_t numberLossParameters{m_Loss->numberParameters()};
                     for (auto row = beginRows; row != endRows; ++row) {
-                        TDouble1Vec prediction{readPrediction(
-                            *row, m_NumberInputColumns, numberLossParameters)};
+                        auto prediction = readPrediction(*row, m_NumberInputColumns,
+                                                         numberLossParameters);
                         double actual{readActual(*row, m_DependentVariable)};
                         double weight{readExampleWeight(*row, m_NumberInputColumns,
                                                         numberLossParameters)};
@@ -1328,8 +1328,7 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
         [&](TRowItr beginRows, TRowItr endRows) {
             std::size_t numberLossParameters{m_Loss->numberParameters()};
             for (auto row = beginRows; row != endRows; ++row) {
-                TDouble1Vec prediction{readPrediction(*row, m_NumberInputColumns,
-                                                      numberLossParameters)};
+                auto prediction = readPrediction(*row, m_NumberInputColumns, numberLossParameters);
                 prediction[0] += root(tree).value(m_Encoder->encode(*row), tree);
                 double actual{readActual(*row, m_DependentVariable)};
                 double weight{readExampleWeight(*row, m_NumberInputColumns, numberLossParameters)};
@@ -1352,8 +1351,8 @@ double CBoostedTreeImpl::meanLoss(const core::CDataFrame& frame,
             [&](TMeanAccumulator& loss, TRowItr beginRows, TRowItr endRows) {
                 std::size_t numberLossParameters{m_Loss->numberParameters()};
                 for (auto row = beginRows; row != endRows; ++row) {
-                    TDouble1Vec prediction{readPrediction(*row, m_NumberInputColumns,
-                                                          numberLossParameters)};
+                    auto prediction = readPrediction(*row, m_NumberInputColumns,
+                                                     numberLossParameters);
                     double actual{readActual(*row, m_DependentVariable)};
                     loss.add(m_Loss->value(prediction, actual));
                 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -145,7 +145,7 @@ TDouble1Vec readLossCurvature(const TRowRef& row,
                               std::size_t numberInputColumns,
                               std::size_t numberLossParameters) {
     const auto* start = row.data() + lossCurvatureColumn(numberInputColumns, numberLossParameters);
-    return TDouble1Vec(start, start + lossHessianStoredSize(numberLossParameters);
+    return TDouble1Vec(start, start + lossHessianStoredSize(numberLossParameters));
 }
 
 void writeLossCurvature(const TRowRef& row,

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1334,9 +1334,9 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
                 double weight{readExampleWeight(*row, m_NumberInputColumns, numberLossParameters)};
                 writePrediction(*row, m_NumberInputColumns, prediction);
                 writeLossGradient(*row, m_NumberInputColumns,
-                                  m_Loss->gradient({prediction}, actual, weight));
+                                  m_Loss->gradient(prediction, actual, weight));
                 writeLossCurvature(*row, m_NumberInputColumns,
-                                   m_Loss->curvature({prediction}, actual, weight));
+                                   m_Loss->curvature(prediction, actual, weight));
             }
         },
         &updateRowMask);

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -407,10 +407,8 @@ void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(
     SSplitAggregateDerivatives& splitAggregateDerivatives) const {
 
     const TRowRef& unencodedRow{row.unencodedRow()};
-    TDouble1Vec gradient{readLossGradient(unencodedRow, m_NumberInputColumns,
-                                          m_NumberLossParameters)};
-    TDouble1Vec curvature{readLossCurvature(unencodedRow, m_NumberInputColumns,
-                                            m_NumberLossParameters)};
+    auto gradient = readLossGradient(unencodedRow, m_NumberInputColumns, m_NumberLossParameters);
+    auto curvature = readLossCurvature(unencodedRow, m_NumberInputColumns, m_NumberLossParameters);
 
     for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
         double featureValue{row[i]};

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -170,11 +170,10 @@ auto predictAndComputeEvaluationMetrics(const F& generateFunction,
 
             CStubInstrumentation instr;
 
-            auto regression =
-                maths::CBoostedTreeFactory::constructFromParameters(1)
-                    .analysisInstrumentation(&instr)
-                    .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(),
-                              cols - 1);
+            auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                                  1, std::make_unique<maths::boosted_tree::CMse>())
+                                  .analysisInstrumentation(&instr)
+                                  .buildFor(*frame, cols - 1);
 
             regression->train();
             regression->predict();
@@ -441,10 +440,10 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
         fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
-        auto regression =
-            maths::CBoostedTreeFactory::constructFromParameters(2)
-                .analysisInstrumentation(&instr)
-                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              2, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(&instr)
+                              .buildFor(*frame, cols - 1);
 
         regression->train();
         regression->predict();
@@ -509,10 +508,10 @@ BOOST_AUTO_TEST_CASE(testConstantFeatures) {
 
     CStubInstrumentation instr;
 
-    auto regression =
-        maths::CBoostedTreeFactory::constructFromParameters(1)
-            .analysisInstrumentation(&instr)
-            .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .analysisInstrumentation(&instr)
+                          .buildFor(*frame, cols - 1);
 
     regression->train();
 
@@ -544,10 +543,10 @@ BOOST_AUTO_TEST_CASE(testConstantTarget) {
 
     CStubInstrumentation instr;
 
-    auto regression =
-        maths::CBoostedTreeFactory::constructFromParameters(1)
-            .analysisInstrumentation(&instr)
-            .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .analysisInstrumentation(&instr)
+                          .buildFor(*frame, cols - 1);
 
     regression->train();
 
@@ -621,10 +620,10 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
 
     CStubInstrumentation instr;
 
-    auto regression =
-        maths::CBoostedTreeFactory::constructFromParameters(1)
-            .analysisInstrumentation(&instr)
-            .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .analysisInstrumentation(&instr)
+                          .buildFor(*frame, cols - 1);
 
     regression->train();
     regression->predict();
@@ -666,10 +665,10 @@ BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
 
     CStubInstrumentation instr;
 
-    auto regression =
-        maths::CBoostedTreeFactory::constructFromParameters(1)
-            .analysisInstrumentation(&instr)
-            .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .analysisInstrumentation(&instr)
+                          .buildFor(*frame, 1);
 
     regression->train();
     regression->predict();
@@ -715,10 +714,10 @@ BOOST_AUTO_TEST_CASE(testSingleSplit) {
 
     CStubInstrumentation instr;
 
-    auto regression =
-        maths::CBoostedTreeFactory::constructFromParameters(1)
-            .analysisInstrumentation(&instr)
-            .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .analysisInstrumentation(&instr)
+                          .buildFor(*frame, cols - 1);
 
     regression->train();
 
@@ -778,10 +777,10 @@ BOOST_AUTO_TEST_CASE(testTranslationInvariance) {
         fillDataFrame(trainRows, rows - trainRows, cols, x,
                       TDoubleVec(rows, 0.0), target_, *frame);
 
-        auto regression =
-            maths::CBoostedTreeFactory::constructFromParameters(1)
-                .analysisInstrumentation(&instr)
-                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(&instr)
+                              .buildFor(*frame, cols - 1);
 
         regression->train();
         regression->predict();
@@ -851,14 +850,14 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
 
         fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
-        auto regression =
-            maths::CBoostedTreeFactory::constructFromParameters(1)
-                .analysisInstrumentation(&instr)
-                .treeSizePenaltyMultiplier(0.0)
-                .leafWeightPenaltyMultiplier(0.0)
-                .softTreeDepthLimit(targetDepth)
-                .softTreeDepthTolerance(0.01)
-                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(&instr)
+                              .treeSizePenaltyMultiplier(0.0)
+                              .leafWeightPenaltyMultiplier(0.0)
+                              .softTreeDepthLimit(targetDepth)
+                              .softTreeDepthTolerance(0.01)
+                              .buildFor(*frame, cols - 1);
 
         regression->train();
 
@@ -1147,11 +1146,10 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
 
         CStubInstrumentation instr;
 
-        auto regression =
-            maths::CBoostedTreeFactory::constructFromParameters(1)
-                .analysisInstrumentation(&instr)
-                .buildFor(*frame, std::make_unique<maths::boosted_tree::CBinomialLogistic>(),
-                          cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CBinomialLogistic>())
+                              .analysisInstrumentation(&instr)
+                              .buildFor(*frame, cols - 1);
 
         regression->train();
         regression->predict();
@@ -1222,11 +1220,10 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
 
     CStubInstrumentation instr;
 
-    auto regression =
-        maths::CBoostedTreeFactory::constructFromParameters(1)
-            .analysisInstrumentation(&instr)
-            .buildFor(*frame, std::make_unique<maths::boosted_tree::CBinomialLogistic>(),
-                      cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CBinomialLogistic>())
+                          .analysisInstrumentation(&instr)
+                          .buildFor(*frame, cols - 1);
 
     regression->train();
     regression->predict();
@@ -1311,22 +1308,23 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {
 
         CStubInstrumentation instr;
 
-        std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(1)
+        std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
+                                         1, std::make_unique<maths::boosted_tree::CMse>())
                                          .analysisInstrumentation(&instr)
                                          .estimateMemoryUsage(rows, cols));
 
         std::int64_t memoryUsage{0};
         std::int64_t maxMemoryUsage{0};
-        auto regression =
-            maths::CBoostedTreeFactory::constructFromParameters(1)
-                .analysisInstrumentation(&instr)
-                .memoryUsageCallback([&](std::int64_t delta) {
-                    memoryUsage += delta;
-                    maxMemoryUsage = std::max(maxMemoryUsage, memoryUsage);
-                    LOG_TRACE(<< "current memory = " << memoryUsage
-                              << ", high water mark = " << maxMemoryUsage);
-                })
-                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(&instr)
+                              .memoryUsageCallback([&](std::int64_t delta) {
+                                  memoryUsage += delta;
+                                  maxMemoryUsage = std::max(maxMemoryUsage, memoryUsage);
+                                  LOG_TRACE(<< "current memory = " << memoryUsage
+                                            << ", high water mark = " << maxMemoryUsage);
+                              })
+                              .buildFor(*frame, cols - 1);
 
         regression->train();
 
@@ -1378,12 +1376,11 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
         CStubInstrumentation instr;
 
         std::thread worker{[&]() {
-            auto regression =
-                maths::CBoostedTreeFactory::constructFromParameters(threads)
-                    .analysisInstrumentation(&instr)
-                    .progressCallback(reportProgress)
-                    .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(),
-                              cols - 1);
+            auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                                  threads, std::make_unique<maths::boosted_tree::CMse>())
+                                  .analysisInstrumentation(&instr)
+                                  .progressCallback(reportProgress)
+                                  .buildFor(*frame, cols - 1);
 
             regression->train();
             finished.store(true);
@@ -1462,8 +1459,9 @@ BOOST_AUTO_TEST_CASE(testMissingFeatures) {
     });
     frame->finishWritingRows();
 
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(1).buildFor(
-        *frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .buildFor(*frame, cols - 1);
 
     regression->train();
     regression->predict();
@@ -1519,19 +1517,19 @@ BOOST_AUTO_TEST_CASE(testPersistRestore) {
 
     // persist
     {
-        auto boostedTree =
-            maths::CBoostedTreeFactory::constructFromParameters(1)
-                .analysisInstrumentation(&instr)
-                .numberFolds(2)
-                .maximumNumberTrees(2)
-                .maximumOptimisationRoundsPerHyperparameter(3)
-                .buildFor(*frame, std::make_unique<maths::boosted_tree::CMse>(), cols - 1);
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromParameters(
+                               1, std::make_unique<maths::boosted_tree::CMse>())
+                               .analysisInstrumentation(&instr)
+                               .numberFolds(2)
+                               .maximumNumberTrees(2)
+                               .maximumOptimisationRoundsPerHyperparameter(3)
+                               .buildFor(*frame, cols - 1);
         core::CJsonStatePersistInserter inserter(persistOnceSStream);
         boostedTree->acceptPersistInserter(inserter);
         persistOnceSStream.flush();
     }
     // restore
-    auto boostedTree = maths::CBoostedTreeFactory::constructFromString(persistOnceSStream)
+    auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(persistOnceSStream)
                            .analysisInstrumentation(&instr)
                            .restoreFor(*frame, cols - 1);
     {
@@ -1574,10 +1572,7 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
 
     bool throwsExceptions{false};
     try {
-        CStubInstrumentation instr;
-
-        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBayesianOptimisationState)
-                               .analysisInstrumentation(&instr)
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(errorInBayesianOptimisationState)
                                .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
@@ -1597,10 +1592,7 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
     throwsExceptions = false;
     stream->clear();
     try {
-        CStubInstrumentation instr;
-
-        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBoostedTreeImplState)
-                               .analysisInstrumentation(&instr)
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(errorInBoostedTreeImplState)
                                .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
@@ -1620,10 +1612,7 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
     throwsExceptions = false;
     stream->clear();
     try {
-        CStubInstrumentation instr;
-
-        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBoostedTreeImplState)
-                               .analysisInstrumentation(&instr)
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(errorInBoostedTreeImplState)
                                .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1529,7 +1529,7 @@ BOOST_AUTO_TEST_CASE(testPersistRestore) {
         persistOnceSStream.flush();
     }
     // restore
-    auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(persistOnceSStream)
+    auto boostedTree = maths::CBoostedTreeFactory::constructFromString(persistOnceSStream)
                            .analysisInstrumentation(&instr)
                            .restoreFor(*frame, cols - 1);
     {
@@ -1572,7 +1572,7 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
 
     bool throwsExceptions{false};
     try {
-        auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(errorInBayesianOptimisationState)
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBayesianOptimisationState)
                                .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
@@ -1592,7 +1592,7 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
     throwsExceptions = false;
     stream->clear();
     try {
-        auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(errorInBoostedTreeImplState)
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBoostedTreeImplState)
                                .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());
@@ -1612,7 +1612,7 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
     throwsExceptions = false;
     stream->clear();
     try {
-        auto boostedTree = maths::CBoostedTreeFactory::constructFromStream(errorInBoostedTreeImplState)
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromString(errorInBoostedTreeImplState)
                                .restoreFor(*frame, 2);
     } catch (const std::exception& e) {
         LOG_DEBUG(<< "got = " << e.what());


### PR DESCRIPTION
This is a refractor in anticipation loss functions with multiple parameters. It is non-functional, but I noticed running the unit tests creating the temporaries (even though they're not allocating any memory) actually costs some run time. It will likely make sense to revisit the type choice when I work on updates to the aggregation code. A step towards #982.