### PR TITLE
[ML] Split up CBoostedTreeImpl

### DIFF
--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -7,28 +7,24 @@
 #ifndef INCLUDED_ml_maths_CBoostedTreeImpl_h
 #define INCLUDED_ml_maths_CBoostedTreeImpl_h
 
-#include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 #include <core/CImmutableRadixSet.h>
-#include <core/CLogger.h>
 #include <core/CMemory.h>
 #include <core/CPackedBitVector.h>
-#include <core/CSmallVector.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeHyperparameters.h>
+#include <maths/CBoostedTreeUtils.h>
 #include <maths/CDataFrameAnalysisInstrumentationInterface.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CDataFrameUtils.h>
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CPRNG.h>
-#include <maths/CTools.h>
 #include <maths/ImportExport.h>
 
-#include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/range/irange.hpp>
 
@@ -161,265 +157,17 @@ public:
     //@}
 
 private:
-    using TSizeDoublePr = std::pair<std::size_t, double>;
     using TDoubleDoublePr = std::pair<double, double>;
     using TOptionalDoubleVec = std::vector<TOptionalDouble>;
     using TOptionalDoubleVecVec = std::vector<TOptionalDoubleVec>;
     using TOptionalSize = boost::optional<std::size_t>;
-    using TImmutableRadixSetVec = std::vector<core::CImmutableRadixSet<double>>;
     using TVector = CDenseVector<double>;
-    using TRowItr = core::CDataFrame::TRowItr;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+    using TImmutableRadixSetVec = std::vector<core::CImmutableRadixSet<double>>;
     using TNodeVecVecDoublePr = std::pair<TNodeVecVec, double>;
     using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
     using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
-
-    //! \brief Maintains a collection of statistics about a leaf of the regression
-    //! tree as it is built.
-    //!
-    //! DESCRIPTION:\N
-    //! The regression tree is grown top down by greedily selecting the split with
-    //! the maximum gain (in the loss). This finds and scores the maximum gain split
-    //! of a single leaf of the tree.
-    class CLeafNodeStatistics final {
-    public:
-        CLeafNodeStatistics(std::size_t id,
-                            std::size_t numberInputColumns,
-                            std::size_t numberLossParameters,
-                            std::size_t numberThreads,
-                            const core::CDataFrame& frame,
-                            const CDataFrameCategoryEncoder& encoder,
-                            const TRegularization& regularization,
-                            const TImmutableRadixSetVec& candidateSplits,
-                            const TSizeVec& featureBag,
-                            std::size_t depth,
-                            const core::CPackedBitVector& rowMask);
-
-        //! Only called by split but is public so it's accessible to std::make_shared.
-        CLeafNodeStatistics(std::size_t id,
-                            std::size_t numberInputColumns,
-                            std::size_t numberLossParameters,
-                            std::size_t numberThreads,
-                            const core::CDataFrame& frame,
-                            const CDataFrameCategoryEncoder& encoder,
-                            const TRegularization& regularization,
-                            const TImmutableRadixSetVec& candidateSplits,
-                            const TSizeVec& featureBag,
-                            bool isLeftChild,
-                            std::size_t depth,
-                            const CBoostedTreeNode& split,
-                            const core::CPackedBitVector& parentRowMask);
-        //! Only called by split but is public so it's accessible to std::make_shared.
-        CLeafNodeStatistics(std::size_t id,
-                            const CLeafNodeStatistics& parent,
-                            const CLeafNodeStatistics& sibling,
-                            const TRegularization& regularization,
-                            const TSizeVec& featureBag,
-                            core::CPackedBitVector rowMask);
-
-        CLeafNodeStatistics(const CLeafNodeStatistics&) = delete;
-        CLeafNodeStatistics& operator=(const CLeafNodeStatistics&) = delete;
-
-        // Move construction/assignment not possible due to const reference member.
-
-        //! Apply the split defined by \p split.
-        //!
-        //! \return Shared pointers to the left and right child node statistics.
-        auto split(std::size_t leftChildId,
-                   std::size_t rightChildId,
-                   std::size_t numberThreads,
-                   const core::CDataFrame& frame,
-                   const CDataFrameCategoryEncoder& encoder,
-                   const TRegularization& regularization,
-                   const TImmutableRadixSetVec& candidateSplits,
-                   const TSizeVec& featureBag,
-                   const CBoostedTreeNode& split,
-                   bool leftChildHasFewerRows);
-
-        //! Order two leaves by decreasing gain in splitting them.
-        bool operator<(const CLeafNodeStatistics& rhs) const {
-            return m_BestSplit < rhs.m_BestSplit;
-        }
-
-        //! Get the gain in loss of the best split of this leaf.
-        double gain() const { return m_BestSplit.s_Gain; }
-
-        //! Get the total curvature of node.
-        double curvature() const { return m_BestSplit.s_Curvature; }
-
-        //! Get the best (feature, feature value) split.
-        TSizeDoublePr bestSplit() const {
-            return {m_BestSplit.s_Feature, m_BestSplit.s_SplitAt};
-        }
-
-        //! Check if the left child has fewer rows than the right child.
-        bool leftChildHasFewerRows() const {
-            return m_BestSplit.s_LeftChildHasFewerRows;
-        }
-
-        //! Check if we should assign the missing feature rows to the left child
-        //! of the split.
-        bool assignMissingToLeft() const {
-            return m_BestSplit.s_AssignMissingToLeft;
-        }
-
-        //! Get the node's identifier.
-        std::size_t id() const { return m_Id; }
-
-        //! Get the row mask for this leaf node.
-        core::CPackedBitVector& rowMask() { return m_RowMask; }
-
-        //! Get the memory used by this object.
-        std::size_t memoryUsage() const {
-            std::size_t mem{core::CMemory::dynamicSize(m_RowMask)};
-            mem += core::CMemory::dynamicSize(m_Derivatives);
-            mem += core::CMemory::dynamicSize(m_MissingDerivatives);
-            return mem;
-        }
-
-        //! Estimate the maximum leaf statistics' memory usage training on a data frame
-        //! with \p numberRows rows and \p numberCols columns using \p featureBagFraction
-        //! and \p numberSplitsPerFeature.
-        static std::size_t estimateMemoryUsage(std::size_t numberRows,
-                                               std::size_t numberCols,
-                                               std::size_t numberSplitsPerFeature) {
-            // We will typically get the close to the best compression for most of the
-            // leaves when the set of splits becomes large, corresponding to the worst
-            // case for memory usage. This is because the rows will be spread over many
-            // rows so the masks will mainly contain 0 bits in this case.
-            std::size_t rowMaskSize{numberRows / PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
-            std::size_t derivativesSize{(numberCols - 1) * numberSplitsPerFeature *
-                                        sizeof(SAggregateDerivatives)};
-            std::size_t missingDerivativesSize{(numberCols - 1) * sizeof(SAggregateDerivatives)};
-            return sizeof(CLeafNodeStatistics) + rowMaskSize + derivativesSize + missingDerivativesSize;
-        }
-
-    private:
-        using TDouble1Vec = core::CSmallVector<double, 1>;
-
-        //! \brief Statistics relating to a split of the node.
-        struct SSplitStatistics : private boost::less_than_comparable<SSplitStatistics> {
-            SSplitStatistics() = default;
-            SSplitStatistics(double gain,
-                             double curvature,
-                             std::size_t feature,
-                             double splitAt,
-                             bool leftChildHasFewerRows,
-                             bool assignMissingToLeft)
-                : s_Gain{gain}, s_Curvature{curvature}, s_Feature{feature}, s_SplitAt{splitAt},
-                  s_LeftChildHasFewerRows{leftChildHasFewerRows}, s_AssignMissingToLeft{assignMissingToLeft} {
-            }
-
-            bool operator<(const SSplitStatistics& rhs) const {
-                return COrderings::lexicographical_compare(
-                    s_Gain, s_Curvature, s_Feature, rhs.s_Gain, rhs.s_Curvature, rhs.s_Feature);
-            }
-
-            std::string print() const {
-                std::ostringstream result;
-                result << "split feature '" << s_Feature << "' @ " << s_SplitAt
-                       << ", gain = " << s_Gain;
-                return result.str();
-            }
-
-            double s_Gain = -INF;
-            double s_Curvature = 0.0;
-            std::size_t s_Feature = -1;
-            double s_SplitAt = INF;
-            bool s_LeftChildHasFewerRows = true;
-            bool s_AssignMissingToLeft = true;
-        };
-
-        //! \brief Aggregate derivatives.
-        struct SAggregateDerivatives {
-            void add(std::size_t count, const TDouble1Vec& gradient, const TDouble1Vec& curvature) {
-                s_Count += count;
-                s_Gradient += gradient[0];
-                s_Curvature += curvature[0];
-            }
-
-            void merge(const SAggregateDerivatives& other) {
-                this->add(other.s_Count, {other.s_Gradient}, {other.s_Curvature});
-            }
-
-            std::string print() const {
-                std::ostringstream result;
-                result << "count = " << s_Count << ", gradient = " << s_Gradient
-                       << ", curvature = " << s_Curvature;
-                return result.str();
-            }
-
-            std::size_t s_Count = 0;
-            double s_Gradient = 0.0;
-            double s_Curvature = 0.0;
-        };
-
-        using TAggregateDerivativesVec = std::vector<SAggregateDerivatives>;
-        using TAggregateDerivativesVecVec = std::vector<TAggregateDerivativesVec>;
-
-        //! \brief A collection of aggregate derivatives for candidate feature splits.
-        struct SSplitAggregateDerivatives {
-            SSplitAggregateDerivatives(const TImmutableRadixSetVec& candidateSplits)
-                : s_Derivatives(candidateSplits.size()),
-                  s_MissingDerivatives(candidateSplits.size()) {
-                for (std::size_t i = 0; i < candidateSplits.size(); ++i) {
-                    s_Derivatives[i].resize(candidateSplits[i].size() + 1);
-                }
-            }
-
-            void merge(const SSplitAggregateDerivatives& other) {
-                for (std::size_t i = 0; i < s_Derivatives.size(); ++i) {
-                    for (std::size_t j = 0; j < s_Derivatives[i].size(); ++j) {
-                        s_Derivatives[i][j].merge(other.s_Derivatives[i][j]);
-                    }
-                    s_MissingDerivatives[i].merge(other.s_MissingDerivatives[i]);
-                }
-            }
-
-            auto move() {
-                return std::make_pair(std::move(s_Derivatives),
-                                      std::move(s_MissingDerivatives));
-            }
-
-            TAggregateDerivativesVecVec s_Derivatives;
-            TAggregateDerivativesVec s_MissingDerivatives;
-        };
-
-    private:
-        void computeAggregateLossDerivatives(std::size_t numberThreads,
-                                             const core::CDataFrame& frame,
-                                             const CDataFrameCategoryEncoder& encoder);
-        void computeRowMaskAndAggregateLossDerivatives(std::size_t numberThreads,
-                                                       const core::CDataFrame& frame,
-                                                       const CDataFrameCategoryEncoder& encoder,
-                                                       bool isLeftChild,
-                                                       const CBoostedTreeNode& split,
-                                                       const core::CPackedBitVector& parentRowMask);
-
-        void addRowDerivatives(const CEncodedDataFrameRowRef& row,
-                               SSplitAggregateDerivatives& splitAggregateDerivatives) const;
-
-        SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,
-                                                    const TSizeVec& featureBag) const;
-
-    private:
-        std::size_t m_Id;
-        std::size_t m_Depth;
-        std::size_t m_NumberInputColumns;
-        std::size_t m_NumberLossParameters;
-        const TImmutableRadixSetVec& m_CandidateSplits;
-        core::CPackedBitVector m_RowMask;
-        TAggregateDerivativesVecVec m_Derivatives;
-        TAggregateDerivativesVec m_MissingDerivatives;
-        SSplitStatistics m_BestSplit;
-    };
-
-private:
-    // The maximum number of rows encoded by a single byte in the packed bit
-    // vector assuming best compression.
-    static const std::size_t PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE;
-    static const double INF;
 
 private:
     CBoostedTreeImpl();
@@ -577,7 +325,7 @@ private:
     TPackedBitVectorVec m_MissingFeatureRowMasks;
     TPackedBitVectorVec m_TrainingRowMasks;
     TPackedBitVectorVec m_TestingRowMasks;
-    double m_BestForestTestLoss = INF;
+    double m_BestForestTestLoss = boosted_tree_detail::INF;
     TOptionalDoubleVecVec m_FoldRoundTestLosses;
     CBoostedTreeHyperparameters m_BestHyperparameters;
     TNodeVecVec m_BestForest;
@@ -593,37 +341,6 @@ private:
 private:
     friend class CBoostedTreeFactory;
 };
-
-namespace boosted_tree_detail {
-inline std::size_t lossHessianStoredSize(std::size_t numberLossParameters) {
-    return numberLossParameters * (numberLossParameters + 1) / 2;
-}
-
-inline std::size_t numberLossParametersForHessianStoredSize(std::size_t lossHessianStoredSize) {
-    return static_cast<std::size_t>(
-        (std::sqrt(8.0 * static_cast<double>(lossHessianStoredSize) + 1.0) - 1.0) / 2.0 + 0.5);
-}
-
-inline std::size_t predictionColumn(std::size_t numberInputColumns) {
-    return numberInputColumns;
-}
-
-inline std::size_t lossGradientColumn(std::size_t numberInputColumns,
-                                      std::size_t numberLossParameters) {
-    return predictionColumn(numberInputColumns) + numberLossParameters;
-}
-
-inline std::size_t lossCurvatureColumn(std::size_t numberInputColumns,
-                                       std::size_t numberLossParameters) {
-    return lossGradientColumn(numberInputColumns, numberLossParameters) + numberLossParameters;
-}
-
-inline std::size_t exampleWeightColumn(std::size_t numberInputColumns,
-                                       std::size_t numberLossParameters) {
-    return lossCurvatureColumn(numberInputColumns, numberLossParameters) +
-           lossHessianStoredSize(numberLossParameters);
-}
-}
 }
 }
 

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -1,0 +1,258 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CBoostedTreeLeafNodeStatistics_h
+#define INCLUDED_ml_maths_CBoostedTreeLeafNodeStatistics_h
+
+#include <core/CImmutableRadixSet.h>
+#include <core/CPackedBitVector.h>
+#include <core/CSmallVector.h>
+
+#include <maths/CBoostedTreeHyperparameters.h>
+#include <maths/CBoostedTreeUtils.h>
+#include <maths/COrderings.h>
+
+#include <boost/operators.hpp>
+
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+namespace ml {
+namespace core {
+class CDataFrame;
+}
+namespace maths {
+class CBoostedTreeNode;
+class CDataFrameCategoryEncoder;
+class CEncodedDataFrameRowRef;
+
+//! \brief Maintains a collection of statistics about a leaf of the regression
+//! tree as it is built.
+//!
+//! DESCRIPTION:\N
+//! The regression tree is grown top down by greedily selecting the split with
+//! the maximum gain (in the loss). This finds and scores the maximum gain split
+//! of a single leaf of the tree.
+class CBoostedTreeLeafNodeStatistics final {
+public:
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeDoublePr = std::pair<std::size_t, double>;
+    using TRegularization = CBoostedTreeRegularization<double>;
+    using TImmutableRadixSetVec = std::vector<core::CImmutableRadixSet<double>>;
+    using TPtr = std::shared_ptr<CBoostedTreeLeafNodeStatistics>;
+    using TPtrPtrPr = std::pair<TPtr, TPtr>;
+
+public:
+    CBoostedTreeLeafNodeStatistics(std::size_t id,
+                                   std::size_t numberInputColumns,
+                                   std::size_t numberLossParameters,
+                                   std::size_t numberThreads,
+                                   const core::CDataFrame& frame,
+                                   const CDataFrameCategoryEncoder& encoder,
+                                   const TRegularization& regularization,
+                                   const TImmutableRadixSetVec& candidateSplits,
+                                   const TSizeVec& featureBag,
+                                   std::size_t depth,
+                                   const core::CPackedBitVector& rowMask);
+
+    //! Only called by split but is public so it's accessible to std::make_shared.
+    CBoostedTreeLeafNodeStatistics(std::size_t id,
+                                   std::size_t numberInputColumns,
+                                   std::size_t numberLossParameters,
+                                   std::size_t numberThreads,
+                                   const core::CDataFrame& frame,
+                                   const CDataFrameCategoryEncoder& encoder,
+                                   const TRegularization& regularization,
+                                   const TImmutableRadixSetVec& candidateSplits,
+                                   const TSizeVec& featureBag,
+                                   bool isLeftChild,
+                                   std::size_t depth,
+                                   const CBoostedTreeNode& split,
+                                   const core::CPackedBitVector& parentRowMask);
+
+    //! Only called by split but is public so it's accessible to std::make_shared.
+    CBoostedTreeLeafNodeStatistics(std::size_t id,
+                                   const CBoostedTreeLeafNodeStatistics& parent,
+                                   const CBoostedTreeLeafNodeStatistics& sibling,
+                                   const TRegularization& regularization,
+                                   const TSizeVec& featureBag,
+                                   core::CPackedBitVector rowMask);
+
+    CBoostedTreeLeafNodeStatistics(const CBoostedTreeLeafNodeStatistics&) = delete;
+    CBoostedTreeLeafNodeStatistics& operator=(const CBoostedTreeLeafNodeStatistics&) = delete;
+
+    // Move construction/assignment not possible due to const reference member.
+
+    //! Apply the split defined by \p split.
+    //!
+    //! \return Shared pointers to the left and right child node statistics.
+    TPtrPtrPr split(std::size_t leftChildId,
+                    std::size_t rightChildId,
+                    std::size_t numberThreads,
+                    const core::CDataFrame& frame,
+                    const CDataFrameCategoryEncoder& encoder,
+                    const TRegularization& regularization,
+                    const TImmutableRadixSetVec& candidateSplits,
+                    const TSizeVec& featureBag,
+                    const CBoostedTreeNode& split,
+                    bool leftChildHasFewerRows);
+
+    //! Order two leaves by decreasing gain in splitting them.
+    bool operator<(const CBoostedTreeLeafNodeStatistics& rhs) const;
+
+    //! Get the gain in loss of the best split of this leaf.
+    double gain() const;
+
+    //! Get the total curvature of node.
+    double curvature() const;
+
+    //! Get the best (feature, feature value) split.
+    TSizeDoublePr bestSplit() const;
+
+    //! Check if the left child has fewer rows than the right child.
+    bool leftChildHasFewerRows() const;
+
+    //! Check if we should assign the missing feature rows to the left child
+    //! of the split.
+    bool assignMissingToLeft() const;
+
+    //! Get the node's identifier.
+    std::size_t id() const;
+
+    //! Get the row mask for this leaf node.
+    core::CPackedBitVector& rowMask();
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const;
+
+    //! Estimate the maximum leaf statistics' memory usage training on a data frame
+    //! with \p numberRows rows and \p numberCols columns using \p featureBagFraction
+    //! and \p numberSplitsPerFeature.
+    static std::size_t estimateMemoryUsage(std::size_t numberRows,
+                                           std::size_t numberCols,
+                                           std::size_t numberSplitsPerFeature);
+
+private:
+    using TDouble1Vec = core::CSmallVector<double, 1>;
+
+    //! \brief Statistics relating to a split of the node.
+    struct SSplitStatistics : private boost::less_than_comparable<SSplitStatistics> {
+        SSplitStatistics() = default;
+        SSplitStatistics(double gain,
+                         double curvature,
+                         std::size_t feature,
+                         double splitAt,
+                         bool leftChildHasFewerRows,
+                         bool assignMissingToLeft)
+            : s_Gain{gain}, s_Curvature{curvature}, s_Feature{feature}, s_SplitAt{splitAt},
+              s_LeftChildHasFewerRows{leftChildHasFewerRows}, s_AssignMissingToLeft{assignMissingToLeft} {
+        }
+
+        bool operator<(const SSplitStatistics& rhs) const {
+            return COrderings::lexicographical_compare(
+                s_Gain, s_Curvature, s_Feature, rhs.s_Gain, rhs.s_Curvature, rhs.s_Feature);
+        }
+
+        std::string print() const {
+            std::ostringstream result;
+            result << "split feature '" << s_Feature << "' @ " << s_SplitAt
+                   << ", gain = " << s_Gain;
+            return result.str();
+        }
+
+        double s_Gain = -boosted_tree_detail::INF;
+        double s_Curvature = 0.0;
+        std::size_t s_Feature = -1;
+        double s_SplitAt = boosted_tree_detail::INF;
+        bool s_LeftChildHasFewerRows = true;
+        bool s_AssignMissingToLeft = true;
+    };
+
+    //! \brief Aggregate derivatives.
+    struct SAggregateDerivatives {
+        void add(std::size_t count, const TDouble1Vec& gradient, const TDouble1Vec& curvature) {
+            s_Count += count;
+            s_Gradient += gradient[0];
+            s_Curvature += curvature[0];
+        }
+
+        void merge(const SAggregateDerivatives& other) {
+            this->add(other.s_Count, {other.s_Gradient}, {other.s_Curvature});
+        }
+
+        std::string print() const {
+            std::ostringstream result;
+            result << "count = " << s_Count << ", gradient = " << s_Gradient
+                   << ", curvature = " << s_Curvature;
+            return result.str();
+        }
+
+        std::size_t s_Count = 0;
+        double s_Gradient = 0.0;
+        double s_Curvature = 0.0;
+    };
+
+    using TAggregateDerivativesVec = std::vector<SAggregateDerivatives>;
+    using TAggregateDerivativesVecVec = std::vector<TAggregateDerivativesVec>;
+
+    //! \brief A collection of aggregate derivatives for candidate feature splits.
+    struct SSplitAggregateDerivatives {
+        SSplitAggregateDerivatives(const TImmutableRadixSetVec& candidateSplits)
+            : s_Derivatives(candidateSplits.size()),
+              s_MissingDerivatives(candidateSplits.size()) {
+            for (std::size_t i = 0; i < candidateSplits.size(); ++i) {
+                s_Derivatives[i].resize(candidateSplits[i].size() + 1);
+            }
+        }
+
+        void merge(const SSplitAggregateDerivatives& other) {
+            for (std::size_t i = 0; i < s_Derivatives.size(); ++i) {
+                for (std::size_t j = 0; j < s_Derivatives[i].size(); ++j) {
+                    s_Derivatives[i][j].merge(other.s_Derivatives[i][j]);
+                }
+                s_MissingDerivatives[i].merge(other.s_MissingDerivatives[i]);
+            }
+        }
+
+        auto move() {
+            return std::make_pair(std::move(s_Derivatives), std::move(s_MissingDerivatives));
+        }
+
+        TAggregateDerivativesVecVec s_Derivatives;
+        TAggregateDerivativesVec s_MissingDerivatives;
+    };
+
+private:
+    void computeAggregateLossDerivatives(std::size_t numberThreads,
+                                         const core::CDataFrame& frame,
+                                         const CDataFrameCategoryEncoder& encoder);
+    void computeRowMaskAndAggregateLossDerivatives(std::size_t numberThreads,
+                                                   const core::CDataFrame& frame,
+                                                   const CDataFrameCategoryEncoder& encoder,
+                                                   bool isLeftChild,
+                                                   const CBoostedTreeNode& split,
+                                                   const core::CPackedBitVector& parentRowMask);
+    void addRowDerivatives(const CEncodedDataFrameRowRef& row,
+                           SSplitAggregateDerivatives& splitAggregateDerivatives) const;
+    SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,
+                                                const TSizeVec& featureBag) const;
+
+private:
+    std::size_t m_Id;
+    std::size_t m_Depth;
+    std::size_t m_NumberInputColumns;
+    std::size_t m_NumberLossParameters;
+    const TImmutableRadixSetVec& m_CandidateSplits;
+    core::CPackedBitVector m_RowMask;
+    TAggregateDerivativesVecVec m_Derivatives;
+    TAggregateDerivativesVec m_MissingDerivatives;
+    SSplitStatistics m_BestSplit;
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CBoostedTreeLeafNodeStatistics_h

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CBoostedTreeUtils_h
+#define INCLUDED_ml_maths_CBoostedTreeUtils_h
+
+#include <core/CDataFrame.h>
+#include <core/CSmallVector.h>
+
+#include <cmath>
+#include <cstddef>
+
+namespace ml {
+namespace maths {
+namespace boosted_tree_detail {
+using TDouble1Vec = core::CSmallVector<double, 1>;
+using TRowRef = core::CDataFrame::TRowRef;
+
+inline std::size_t lossHessianStoredSize(std::size_t numberLossParameters) {
+    return numberLossParameters * (numberLossParameters + 1) / 2;
+}
+
+inline std::size_t numberLossParametersForHessianStoredSize(std::size_t lossHessianStoredSize) {
+    return static_cast<std::size_t>(
+        (std::sqrt(8.0 * static_cast<double>(lossHessianStoredSize) + 1.0) - 1.0) / 2.0 + 0.5);
+}
+
+inline std::size_t predictionColumn(std::size_t numberInputColumns) {
+    return numberInputColumns;
+}
+
+inline std::size_t lossGradientColumn(std::size_t numberInputColumns,
+                                      std::size_t numberLossParameters) {
+    return predictionColumn(numberInputColumns) + numberLossParameters;
+}
+
+inline std::size_t lossCurvatureColumn(std::size_t numberInputColumns,
+                                       std::size_t numberLossParameters) {
+    return lossGradientColumn(numberInputColumns, numberLossParameters) + numberLossParameters;
+}
+
+inline std::size_t exampleWeightColumn(std::size_t numberInputColumns,
+                                       std::size_t numberLossParameters) {
+    return lossCurvatureColumn(numberInputColumns, numberLossParameters) +
+           lossHessianStoredSize(numberLossParameters);
+}
+
+MATHS_EXPORT
+TDouble1Vec readPrediction(const TRowRef& row,
+                           std::size_t numberInputColumns,
+                           std::size_t numberLossParamaters);
+
+MATHS_EXPORT
+void writePrediction(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& prediction);
+
+MATHS_EXPORT
+TDouble1Vec readLossGradient(const TRowRef& row,
+                             std::size_t numberInputColumns,
+                             std::size_t numberLossParameters);
+
+MATHS_EXPORT
+void writeLossGradient(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& gradient);
+
+MATHS_EXPORT
+TDouble1Vec readLossCurvature(const TRowRef& row,
+                              std::size_t numberInputColumns,
+                              std::size_t numberLossParameters);
+
+MATHS_EXPORT
+void writeLossCurvature(const TRowRef& row,
+                        std::size_t numberInputColumns,
+                        const TDouble1Vec& curvature);
+
+MATHS_EXPORT
+double readExampleWeight(const TRowRef& row,
+                         std::size_t numberInputColumns,
+                         std::size_t numberLossParameters);
+
+MATHS_EXPORT
+double readActual(const TRowRef& row, std::size_t dependentVariable);
+
+// The maximum number of rows encoded by a single byte in the packed bit vector
+// assuming best compression.
+constexpr std::size_t PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE{256};
+constexpr double INF{std::numeric_limits<double>::max()};
+}
+}
+}
+
+#endif // INCLUDED_ml_maths_CBoostedTreeUtils_h

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -6,33 +6,45 @@
 
 #include <maths/CBoostedTreeImpl.h>
 
+#include <core/CContainerPrinter.h>
 #include <core/CImmutableRadixSet.h>
+#include <core/CLogger.h>
 #include <core/CLoopProgress.h>
 #include <core/CPersistUtils.h>
 #include <core/CProgramCounters.h>
+#include <core/CSmallVector.h>
 #include <core/CStopWatch.h>
 
 #include <maths/CBasicStatisticsPersist.h>
 #include <maths/CBayesianOptimisation.h>
+#include <maths/CBoostedTreeLeafNodeStatistics.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CQuantileSketch.h>
 #include <maths/CSampling.h>
 #include <maths/CSetTools.h>
 #include <maths/CTreeShapFeatureImportance.h>
 
-#include <limits>
-
 namespace ml {
 namespace maths {
 using namespace boosted_tree;
 using namespace boosted_tree_detail;
-
-namespace {
 using TStrVec = CBoostedTreeImpl::TStrVec;
-using TRowRef = core::CDataFrame::TRowRef;
-using TDouble1Vec = core::CSmallVector<double, 1>;
+using TRowItr = core::CDataFrame::TRowItr;
 using TMeanVarAccumulator = CBoostedTreeImpl::TMeanVarAccumulator;
 
+namespace {
+// It isn't critical to recompute splits every tree we add because random
+// downsampling means they're only approximate estimates of the full data
+// quantiles anyway. So we amortise their compute cost w.r.t. training trees
+// by only refreshing once every MINIMUM_SPLIT_REFRESH_INTERVAL trees we add.
+const double MINIMUM_SPLIT_REFRESH_INTERVAL{3.0};
+
+double lossAtNSigma(double n, const TMeanVarAccumulator& lossMoments) {
+    return CBasicStatistics::mean(lossMoments) +
+           n * std::sqrt(CBasicStatistics::variance(lossMoments));
+}
+
+//! \brief Record the memory used by a supplied object using the RAII idiom.
 class CScopeRecordMemoryUsage {
 public:
     using TMemoryUsageCallback = CBoostedTreeImpl::TMemoryUsageCallback;
@@ -112,398 +124,6 @@ private:
     std::size_t m_MaximumNumberTreesWithoutImprovement;
     TDoubleSizePrMinAccumulator m_BestTestLoss;
 };
-
-TDouble1Vec readPrediction(const TRowRef& row,
-                           std::size_t numberInputColumns,
-                           std::size_t numberLossParamaters) {
-    const auto* start = row.data() + predictionColumn(numberInputColumns);
-    return TDouble1Vec(start, start + numberLossParamaters);
-}
-
-void writePrediction(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& prediction) {
-    std::size_t offset{predictionColumn(numberInputColumns)};
-    for (std::size_t i = 0; i < prediction.size(); ++i) {
-        row.writeColumn(offset + i, prediction[i]);
-    }
-}
-
-TDouble1Vec readLossGradient(const TRowRef& row,
-                             std::size_t numberInputColumns,
-                             std::size_t numberLossParameters) {
-    const auto* start = row.data() + lossGradientColumn(numberInputColumns, numberLossParameters);
-    return TDouble1Vec(start, start + numberLossParameters);
-}
-
-void writeLossGradient(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& gradient) {
-    std::size_t offset{lossGradientColumn(numberInputColumns, gradient.size())};
-    for (std::size_t i = 0; i < gradient.size(); ++i) {
-        row.writeColumn(offset + i, gradient[i]);
-    }
-}
-
-TDouble1Vec readLossCurvature(const TRowRef& row,
-                              std::size_t numberInputColumns,
-                              std::size_t numberLossParameters) {
-    const auto* start = row.data() + lossCurvatureColumn(numberInputColumns, numberLossParameters);
-    return TDouble1Vec(start, start + lossHessianStoredSize(numberLossParameters));
-}
-
-void writeLossCurvature(const TRowRef& row,
-                        std::size_t numberInputColumns,
-                        const TDouble1Vec& curvature) {
-    // This comes from solving x(x+1)/2 = n.
-    std::size_t numberLossParameters{
-        numberLossParametersForHessianStoredSize(curvature.size())};
-    std::size_t offset{lossCurvatureColumn(numberInputColumns, numberLossParameters)};
-    for (std::size_t i = 0; i < curvature.size(); ++i) {
-        row.writeColumn(offset + i, curvature[i]);
-    }
-}
-
-double readExampleWeight(const TRowRef& row,
-                         std::size_t numberInputColumns,
-                         std::size_t numberLossParameters) {
-    return row[exampleWeightColumn(numberInputColumns, numberLossParameters)];
-}
-
-double readActual(const TRowRef& row, std::size_t dependentVariable) {
-    return row[dependentVariable];
-}
-
-double lossAtNSigma(double n, const TMeanVarAccumulator& lossMoments) {
-    return CBasicStatistics::mean(lossMoments) +
-           n * std::sqrt(CBasicStatistics::variance(lossMoments));
-}
-
-const std::size_t ASSIGN_MISSING_TO_LEFT{0};
-const std::size_t ASSIGN_MISSING_TO_RIGHT{1};
-const double SMALLEST_RELATIVE_CURVATURE{1e-20};
-// It isn't critical to recompute splits every tree we add because random
-// downsampling means they're only approximate estimates of the full data
-// quantiles anyway. So we amortise their compute cost w.r.t. training trees
-// by only refreshing once every MINIMUM_SPLIT_REFRESH_INTERVAL trees we add.
-const double MINIMUM_SPLIT_REFRESH_INTERVAL{3.0};
-}
-
-CBoostedTreeImpl::CLeafNodeStatistics::CLeafNodeStatistics(
-    std::size_t id,
-    std::size_t numberInputColumns,
-    std::size_t numberLossParameters,
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder,
-    const TRegularization& regularization,
-    const TImmutableRadixSetVec& candidateSplits,
-    const TSizeVec& featureBag,
-    std::size_t depth,
-    const core::CPackedBitVector& rowMask)
-    : m_Id{id}, m_Depth{depth}, m_NumberInputColumns{numberInputColumns},
-      m_NumberLossParameters{numberLossParameters}, m_CandidateSplits{candidateSplits}, m_RowMask{rowMask} {
-
-    LOG_TRACE(<< "row mask = " << m_RowMask);
-    this->computeAggregateLossDerivatives(numberThreads, frame, encoder);
-    m_BestSplit = this->computeBestSplitStatistics(regularization, featureBag);
-}
-
-CBoostedTreeImpl::CLeafNodeStatistics::CLeafNodeStatistics(
-    std::size_t id,
-    std::size_t numberInputColumns,
-    std::size_t numberLossParameters,
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder,
-    const TRegularization& regularization,
-    const TImmutableRadixSetVec& candidateSplits,
-    const TSizeVec& featureBag,
-    bool isLeftChild,
-    std::size_t depth,
-    const CBoostedTreeNode& split,
-    const core::CPackedBitVector& parentRowMask)
-    : m_Id{id}, m_Depth{depth}, m_NumberInputColumns{numberInputColumns},
-      m_NumberLossParameters{numberLossParameters}, m_CandidateSplits{candidateSplits} {
-
-    this->computeRowMaskAndAggregateLossDerivatives(
-        numberThreads, frame, encoder, isLeftChild, split, parentRowMask);
-    m_BestSplit = this->computeBestSplitStatistics(regularization, featureBag);
-}
-
-CBoostedTreeImpl::CLeafNodeStatistics::CLeafNodeStatistics(std::size_t id,
-                                                           const CLeafNodeStatistics& parent,
-                                                           const CLeafNodeStatistics& sibling,
-                                                           const TRegularization& regularization,
-                                                           const TSizeVec& featureBag,
-                                                           core::CPackedBitVector rowMask)
-    : m_Id{id}, m_Depth{sibling.m_Depth}, m_NumberInputColumns{sibling.m_NumberInputColumns},
-      m_NumberLossParameters{sibling.m_NumberLossParameters},
-      m_CandidateSplits{sibling.m_CandidateSplits}, m_RowMask{std::move(rowMask)} {
-
-    LOG_TRACE(<< "row mask = " << m_RowMask);
-
-    m_Derivatives.resize(m_CandidateSplits.size());
-    m_MissingDerivatives.resize(m_CandidateSplits.size());
-
-    for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
-        std::size_t numberSplits{m_CandidateSplits[i].size() + 1};
-        m_Derivatives[i].resize(numberSplits);
-        for (std::size_t j = 0; j < numberSplits; ++j) {
-            // Numeric errors mean that it's possible the sum curvature for a candidate
-            // split is identically zero while the gradient is epsilon. This can cause
-            // the node gain to appear infinite (when there is no weight regularisation)
-            // which in turns causes problems initialising the region we search for optimal
-            // hyperparameter values. We can safely force the gradient and curvature to
-            // be zero if we detect that the count is zero. Also, none of our loss functions
-            // have negative curvature therefore we shouldn't allow the cumulative curvature
-            // to be negative either. In this case we force it to be a v.small multiple
-            // of the magnitude of the gradient since this is the closest feasible estimate.
-            std::size_t count{parent.m_Derivatives[i][j].s_Count -
-                              sibling.m_Derivatives[i][j].s_Count};
-            if (count > 0) {
-                double gradient{parent.m_Derivatives[i][j].s_Gradient -
-                                sibling.m_Derivatives[i][j].s_Gradient};
-                double curvature{parent.m_Derivatives[i][j].s_Curvature -
-                                 sibling.m_Derivatives[i][j].s_Curvature};
-                curvature = std::max(curvature, SMALLEST_RELATIVE_CURVATURE *
-                                                    std::fabs(gradient));
-                m_Derivatives[i][j] = SAggregateDerivatives{count, gradient, curvature};
-            }
-        }
-        std::size_t count{parent.m_MissingDerivatives[i].s_Count -
-                          sibling.m_MissingDerivatives[i].s_Count};
-        if (count > 0) {
-            double gradient{parent.m_MissingDerivatives[i].s_Gradient -
-                            sibling.m_MissingDerivatives[i].s_Gradient};
-            double curvature{parent.m_MissingDerivatives[i].s_Curvature -
-                             sibling.m_MissingDerivatives[i].s_Curvature};
-            curvature = std::max(curvature, SMALLEST_RELATIVE_CURVATURE * std::fabs(gradient));
-            m_MissingDerivatives[i] = SAggregateDerivatives{count, gradient, curvature};
-        }
-    }
-    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
-    LOG_TRACE(<< "missing derivatives = "
-              << core::CContainerPrinter::print(m_MissingDerivatives));
-
-    m_BestSplit = this->computeBestSplitStatistics(regularization, featureBag);
-}
-
-auto CBoostedTreeImpl::CLeafNodeStatistics::split(std::size_t leftChildId,
-                                                  std::size_t rightChildId,
-                                                  std::size_t numberThreads,
-                                                  const core::CDataFrame& frame,
-                                                  const CDataFrameCategoryEncoder& encoder,
-                                                  const TRegularization& regularization,
-                                                  const TImmutableRadixSetVec& candidateSplits,
-                                                  const TSizeVec& featureBag,
-                                                  const CBoostedTreeNode& split,
-                                                  bool leftChildHasFewerRows) {
-
-    if (leftChildHasFewerRows) {
-        auto leftChild = std::make_shared<CLeafNodeStatistics>(
-            leftChildId, m_NumberInputColumns, m_NumberLossParameters,
-            numberThreads, frame, encoder, regularization, candidateSplits,
-            featureBag, true /*is left child*/, m_Depth + 1, split, m_RowMask);
-        core::CPackedBitVector rightChildRowMask{m_RowMask};
-        rightChildRowMask ^= leftChild->rowMask();
-        auto rightChild = std::make_shared<CLeafNodeStatistics>(
-            rightChildId, *this, *leftChild, regularization, featureBag,
-            std::move(rightChildRowMask));
-
-        return std::make_pair(leftChild, rightChild);
-    }
-
-    auto rightChild = std::make_shared<CLeafNodeStatistics>(
-        rightChildId, m_NumberInputColumns, m_NumberLossParameters,
-        numberThreads, frame, encoder, regularization, candidateSplits,
-        featureBag, false /*is left child*/, m_Depth + 1, split, m_RowMask);
-    core::CPackedBitVector leftChildRowMask{m_RowMask};
-    leftChildRowMask ^= rightChild->rowMask();
-    auto leftChild = std::make_shared<CLeafNodeStatistics>(
-        leftChildId, *this, *rightChild, regularization, featureBag,
-        std::move(leftChildRowMask));
-
-    return std::make_pair(leftChild, rightChild);
-}
-
-void CBoostedTreeImpl::CLeafNodeStatistics::computeAggregateLossDerivatives(
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder) {
-
-    auto result = frame.readRows(
-        numberThreads, 0, frame.numberRows(),
-        core::bindRetrievableState(
-            [&](SSplitAggregateDerivatives& splitAggregateDerivatives,
-                TRowItr beginRows, TRowItr endRows) {
-                for (auto row = beginRows; row != endRows; ++row) {
-                    this->addRowDerivatives(encoder.encode(*row), splitAggregateDerivatives);
-                }
-            },
-            SSplitAggregateDerivatives{m_CandidateSplits}),
-        &m_RowMask);
-    auto& state = result.first;
-
-    SSplitAggregateDerivatives derivatives{std::move(state[0].s_FunctionState)};
-    for (std::size_t i = 1; i < state.size(); ++i) {
-        derivatives.merge(state[i].s_FunctionState);
-    }
-
-    std::tie(m_Derivatives, m_MissingDerivatives) = derivatives.move();
-
-    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
-    LOG_TRACE(<< "missing derivatives = "
-              << core::CContainerPrinter::print(m_MissingDerivatives));
-}
-
-void CBoostedTreeImpl::CLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder,
-    bool isLeftChild,
-    const CBoostedTreeNode& split,
-    const core::CPackedBitVector& parentRowMask) {
-
-    auto result = frame.readRows(
-        numberThreads, 0, frame.numberRows(),
-        core::bindRetrievableState(
-            [&](std::pair<core::CPackedBitVector, SSplitAggregateDerivatives>& state,
-                TRowItr beginRows, TRowItr endRows) {
-                auto& mask = state.first;
-                auto& splitAggregateDerivatives = state.second;
-                for (auto row = beginRows; row != endRows; ++row) {
-                    auto encodedRow = encoder.encode(*row);
-                    if (split.assignToLeft(encodedRow) == isLeftChild) {
-                        std::size_t index{row->index()};
-                        mask.extend(false, index - mask.size());
-                        mask.extend(true);
-                        this->addRowDerivatives(encodedRow, splitAggregateDerivatives);
-                    }
-                }
-            },
-            std::make_pair(core::CPackedBitVector{}, SSplitAggregateDerivatives{m_CandidateSplits})),
-        &parentRowMask);
-    auto& state = result.first;
-
-    for (auto& mask_ : state) {
-        auto& mask = mask_.s_FunctionState.first;
-        mask.extend(false, parentRowMask.size() - mask.size());
-    }
-
-    m_RowMask = std::move(state[0].s_FunctionState.first);
-    SSplitAggregateDerivatives derivatives{std::move(state[0].s_FunctionState.second)};
-    for (std::size_t i = 1; i < state.size(); ++i) {
-        m_RowMask |= state[i].s_FunctionState.first;
-        derivatives.merge(state[i].s_FunctionState.second);
-    }
-
-    std::tie(m_Derivatives, m_MissingDerivatives) = derivatives.move();
-
-    LOG_TRACE(<< "row mask = " << m_RowMask);
-    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
-    LOG_TRACE(<< "missing derivatives = "
-              << core::CContainerPrinter::print(m_MissingDerivatives));
-}
-
-void CBoostedTreeImpl::CLeafNodeStatistics::addRowDerivatives(
-    const CEncodedDataFrameRowRef& row,
-    SSplitAggregateDerivatives& splitAggregateDerivatives) const {
-
-    const TRowRef& unencodedRow{row.unencodedRow()};
-    auto gradient = readLossGradient(unencodedRow, m_NumberInputColumns, m_NumberLossParameters);
-    auto curvature = readLossCurvature(unencodedRow, m_NumberInputColumns, m_NumberLossParameters);
-
-    for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
-        double featureValue{row[i]};
-        if (CDataFrameUtils::isMissing(featureValue)) {
-            splitAggregateDerivatives.s_MissingDerivatives[i].add(1, gradient, curvature);
-        } else {
-            std::ptrdiff_t j{m_CandidateSplits[i].upperBound(featureValue)};
-            splitAggregateDerivatives.s_Derivatives[i][j].add(1, gradient, curvature);
-        }
-    }
-}
-
-CBoostedTreeImpl::CLeafNodeStatistics::SSplitStatistics
-CBoostedTreeImpl::CLeafNodeStatistics::computeBestSplitStatistics(const TRegularization& regularization,
-                                                                  const TSizeVec& featureBag) const {
-
-    // We have three possible regularization terms we'll use:
-    //   1. Tree size: gamma * "node count"
-    //   2. Sum square weights: lambda * sum{"leaf weight" ^ 2)}
-    //   3. Tree depth: alpha * sum{exp(("depth" / "target depth" - 1.0) / "tolerance")}
-
-    SSplitStatistics result;
-
-    for (auto i : featureBag) {
-        std::size_t c{m_MissingDerivatives[i].s_Count};
-        double g{m_MissingDerivatives[i].s_Gradient};
-        double h{m_MissingDerivatives[i].s_Curvature};
-        for (const auto& derivatives : m_Derivatives[i]) {
-            c += derivatives.s_Count;
-            g += derivatives.s_Gradient;
-            h += derivatives.s_Curvature;
-        }
-        std::size_t cl[]{m_MissingDerivatives[i].s_Count, 0};
-        double gl[]{m_MissingDerivatives[i].s_Gradient, 0.0};
-        double hl[]{m_MissingDerivatives[i].s_Curvature, 0.0};
-
-        double maximumGain{-INF};
-        double splitAt{-INF};
-        bool leftChildHasFewerRows{true};
-        bool assignMissingToLeft{true};
-
-        for (std::size_t j = 0; j + 1 < m_Derivatives[i].size(); ++j) {
-            cl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Count;
-            gl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Gradient;
-            hl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Curvature;
-            cl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Count;
-            gl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Gradient;
-            hl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Curvature;
-
-            double gain[]{CTools::pow2(gl[ASSIGN_MISSING_TO_LEFT]) /
-                                  (hl[ASSIGN_MISSING_TO_LEFT] +
-                                   regularization.leafWeightPenaltyMultiplier()) +
-                              CTools::pow2(g - gl[ASSIGN_MISSING_TO_LEFT]) /
-                                  (h - hl[ASSIGN_MISSING_TO_LEFT] +
-                                   regularization.leafWeightPenaltyMultiplier()),
-                          CTools::pow2(gl[ASSIGN_MISSING_TO_RIGHT]) /
-                                  (hl[ASSIGN_MISSING_TO_RIGHT] +
-                                   regularization.leafWeightPenaltyMultiplier()) +
-                              CTools::pow2(g - gl[ASSIGN_MISSING_TO_RIGHT]) /
-                                  (h - hl[ASSIGN_MISSING_TO_RIGHT] +
-                                   regularization.leafWeightPenaltyMultiplier())};
-
-            if (gain[ASSIGN_MISSING_TO_LEFT] > maximumGain) {
-                maximumGain = gain[ASSIGN_MISSING_TO_LEFT];
-                splitAt = m_CandidateSplits[i][j];
-                leftChildHasFewerRows = (2 * cl[ASSIGN_MISSING_TO_LEFT] < c);
-                assignMissingToLeft = true;
-            }
-            if (gain[ASSIGN_MISSING_TO_RIGHT] > maximumGain) {
-                maximumGain = gain[ASSIGN_MISSING_TO_RIGHT];
-                splitAt = m_CandidateSplits[i][j];
-                leftChildHasFewerRows = (2 * cl[ASSIGN_MISSING_TO_RIGHT] < c);
-                assignMissingToLeft = false;
-            }
-        }
-
-        double penaltyForDepth{regularization.penaltyForDepth(m_Depth)};
-        double penaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 1)};
-        double gain{0.5 * (maximumGain - CTools::pow2(g) / (h + regularization.leafWeightPenaltyMultiplier())) -
-                    regularization.treeSizePenaltyMultiplier() -
-                    regularization.depthPenaltyMultiplier() *
-                        (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
-
-        SSplitStatistics candidate{
-            gain, h, i, splitAt, leftChildHasFewerRows, assignMissingToLeft};
-        LOG_TRACE(<< "candidate split: " << candidate.print());
-
-        if (candidate > result) {
-            result = candidate;
-        }
-    }
-
-    LOG_TRACE(<< "best split: " << result.print());
-
-    return result;
 }
 
 CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads,
@@ -677,7 +297,7 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
                                         numberRows * sizeof(CFloatStorage)};
     std::size_t hyperparametersMemoryUsage{numberColumns * sizeof(double)};
     std::size_t leafNodeStatisticsMemoryUsage{
-        maximumNumberLeaves * CLeafNodeStatistics::estimateMemoryUsage(
+        maximumNumberLeaves * CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(
                                   numberRows, numberColumns, m_NumberSplitsPerFeature)};
     std::size_t dataTypeMemoryUsage{numberColumns * sizeof(CDataFrameUtils::SDataType)};
     std::size_t featureSampleProbabilities{numberColumns * sizeof(double)};
@@ -1040,7 +660,7 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
     LOG_TRACE(<< "Training one tree...");
 
-    using TLeafNodeStatisticsPtr = std::shared_ptr<CLeafNodeStatistics>;
+    using TLeafNodeStatisticsPtr = CBoostedTreeLeafNodeStatistics::TPtr;
     using TLeafNodeStatisticsPtrQueue =
         std::priority_queue<TLeafNodeStatisticsPtr, std::vector<TLeafNodeStatisticsPtr>, COrderings::SLess>;
 
@@ -1048,7 +668,7 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
     tree.reserve(2 * maximumTreeSize + 1);
 
     TLeafNodeStatisticsPtrQueue leaves;
-    leaves.push(std::make_shared<CLeafNodeStatistics>(
+    leaves.push(std::make_shared<CBoostedTreeLeafNodeStatistics>(
         0 /*root*/, m_NumberInputColumns, m_Loss->numberParameters(),
         m_NumberThreads, frame, *m_Encoder, m_Regularization, candidateSplits,
         this->featureBag(), 0 /*depth*/, trainingRowMask));
@@ -1860,8 +1480,6 @@ std::size_t CBoostedTreeImpl::numberInputColumns() const {
     return m_NumberInputColumns;
 }
 
-const std::size_t CBoostedTreeImpl::PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE{256};
 const double CBoostedTreeImpl::MINIMUM_RELATIVE_GAIN_PER_SPLIT{1e-7};
-const double CBoostedTreeImpl::INF{std::numeric_limits<double>::max()};
 }
 }

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -1,0 +1,402 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CBoostedTreeLeafNodeStatistics.h>
+
+#include <core/CDataFrame.h>
+#include <core/CImmutableRadixSet.h>
+#include <core/CLogger.h>
+#include <core/CMemory.h>
+
+#include <maths/CBoostedTree.h>
+#include <maths/CDataFrameCategoryEncoder.h>
+#include <maths/CTools.h>
+
+namespace ml {
+namespace maths {
+using namespace boosted_tree_detail;
+using TRowItr = core::CDataFrame::TRowItr;
+
+namespace {
+const std::size_t ASSIGN_MISSING_TO_LEFT{0};
+const std::size_t ASSIGN_MISSING_TO_RIGHT{1};
+const double SMALLEST_RELATIVE_CURVATURE{1e-20};
+}
+
+CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
+    std::size_t id,
+    std::size_t numberInputColumns,
+    std::size_t numberLossParameters,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TRegularization& regularization,
+    const TImmutableRadixSetVec& candidateSplits,
+    const TSizeVec& featureBag,
+    std::size_t depth,
+    const core::CPackedBitVector& rowMask)
+    : m_Id{id}, m_Depth{depth}, m_NumberInputColumns{numberInputColumns},
+      m_NumberLossParameters{numberLossParameters}, m_CandidateSplits{candidateSplits}, m_RowMask{rowMask} {
+
+    this->computeAggregateLossDerivatives(numberThreads, frame, encoder);
+    m_BestSplit = this->computeBestSplitStatistics(regularization, featureBag);
+}
+
+CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
+    std::size_t id,
+    std::size_t numberInputColumns,
+    std::size_t numberLossParameters,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TRegularization& regularization,
+    const TImmutableRadixSetVec& candidateSplits,
+    const TSizeVec& featureBag,
+    bool isLeftChild,
+    std::size_t depth,
+    const CBoostedTreeNode& split,
+    const core::CPackedBitVector& parentRowMask)
+    : m_Id{id}, m_Depth{depth}, m_NumberInputColumns{numberInputColumns},
+      m_NumberLossParameters{numberLossParameters}, m_CandidateSplits{candidateSplits} {
+
+    this->computeRowMaskAndAggregateLossDerivatives(
+        numberThreads, frame, encoder, isLeftChild, split, parentRowMask);
+    m_BestSplit = this->computeBestSplitStatistics(regularization, featureBag);
+}
+
+CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
+    std::size_t id,
+    const CBoostedTreeLeafNodeStatistics& parent,
+    const CBoostedTreeLeafNodeStatistics& sibling,
+    const TRegularization& regularization,
+    const TSizeVec& featureBag,
+    core::CPackedBitVector rowMask)
+    : m_Id{id}, m_Depth{sibling.m_Depth}, m_NumberInputColumns{sibling.m_NumberInputColumns},
+      m_NumberLossParameters{sibling.m_NumberLossParameters},
+      m_CandidateSplits{sibling.m_CandidateSplits}, m_RowMask{std::move(rowMask)} {
+
+    m_Derivatives.resize(m_CandidateSplits.size());
+    m_MissingDerivatives.resize(m_CandidateSplits.size());
+
+    for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
+        std::size_t numberSplits{m_CandidateSplits[i].size() + 1};
+        m_Derivatives[i].resize(numberSplits);
+        for (std::size_t j = 0; j < numberSplits; ++j) {
+            // Numeric errors mean that it's possible the sum curvature for a candidate
+            // split is identically zero while the gradient is epsilon. This can cause
+            // the node gain to appear infinite (when there is no weight regularisation)
+            // which in turns causes problems initialising the region we search for optimal
+            // hyperparameter values. We can safely force the gradient and curvature to
+            // be zero if we detect that the count is zero. Also, none of our loss functions
+            // have negative curvature therefore we shouldn't allow the cumulative curvature
+            // to be negative either. In this case we force it to be a v.small multiple
+            // of the magnitude of the gradient since this is the closest feasible estimate.
+            std::size_t count{parent.m_Derivatives[i][j].s_Count -
+                              sibling.m_Derivatives[i][j].s_Count};
+            if (count > 0) {
+                double gradient{parent.m_Derivatives[i][j].s_Gradient -
+                                sibling.m_Derivatives[i][j].s_Gradient};
+                double curvature{parent.m_Derivatives[i][j].s_Curvature -
+                                 sibling.m_Derivatives[i][j].s_Curvature};
+                curvature = std::max(curvature, SMALLEST_RELATIVE_CURVATURE *
+                                                    std::fabs(gradient));
+                m_Derivatives[i][j] = SAggregateDerivatives{count, gradient, curvature};
+            }
+        }
+        std::size_t count{parent.m_MissingDerivatives[i].s_Count -
+                          sibling.m_MissingDerivatives[i].s_Count};
+        if (count > 0) {
+            double gradient{parent.m_MissingDerivatives[i].s_Gradient -
+                            sibling.m_MissingDerivatives[i].s_Gradient};
+            double curvature{parent.m_MissingDerivatives[i].s_Curvature -
+                             sibling.m_MissingDerivatives[i].s_Curvature};
+            curvature = std::max(curvature, SMALLEST_RELATIVE_CURVATURE * std::fabs(gradient));
+            m_MissingDerivatives[i] = SAggregateDerivatives{count, gradient, curvature};
+        }
+    }
+    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
+    LOG_TRACE(<< "missing derivatives = "
+              << core::CContainerPrinter::print(m_MissingDerivatives));
+
+    m_BestSplit = this->computeBestSplitStatistics(regularization, featureBag);
+}
+
+CBoostedTreeLeafNodeStatistics::TPtrPtrPr
+CBoostedTreeLeafNodeStatistics::split(std::size_t leftChildId,
+                                      std::size_t rightChildId,
+                                      std::size_t numberThreads,
+                                      const core::CDataFrame& frame,
+                                      const CDataFrameCategoryEncoder& encoder,
+                                      const TRegularization& regularization,
+                                      const TImmutableRadixSetVec& candidateSplits,
+                                      const TSizeVec& featureBag,
+                                      const CBoostedTreeNode& split,
+                                      bool leftChildHasFewerRows) {
+    if (leftChildHasFewerRows) {
+        auto leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+            leftChildId, m_NumberInputColumns, m_NumberLossParameters,
+            numberThreads, frame, encoder, regularization, candidateSplits,
+            featureBag, true /*is left child*/, m_Depth + 1, split, m_RowMask);
+        core::CPackedBitVector rightChildRowMask{m_RowMask};
+        rightChildRowMask ^= leftChild->rowMask();
+        auto rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+            rightChildId, *this, *leftChild, regularization, featureBag,
+            std::move(rightChildRowMask));
+
+        return std::make_pair(leftChild, rightChild);
+    }
+
+    auto rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+        rightChildId, m_NumberInputColumns, m_NumberLossParameters,
+        numberThreads, frame, encoder, regularization, candidateSplits,
+        featureBag, false /*is left child*/, m_Depth + 1, split, m_RowMask);
+    core::CPackedBitVector leftChildRowMask{m_RowMask};
+    leftChildRowMask ^= rightChild->rowMask();
+    auto leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+        leftChildId, *this, *rightChild, regularization, featureBag,
+        std::move(leftChildRowMask));
+
+    return std::make_pair(leftChild, rightChild);
+}
+
+bool CBoostedTreeLeafNodeStatistics::operator<(const CBoostedTreeLeafNodeStatistics& rhs) const {
+    return m_BestSplit < rhs.m_BestSplit;
+}
+
+double CBoostedTreeLeafNodeStatistics::gain() const {
+    return m_BestSplit.s_Gain;
+}
+
+double CBoostedTreeLeafNodeStatistics::curvature() const {
+    return m_BestSplit.s_Curvature;
+}
+
+CBoostedTreeLeafNodeStatistics::TSizeDoublePr CBoostedTreeLeafNodeStatistics::bestSplit() const {
+    return {m_BestSplit.s_Feature, m_BestSplit.s_SplitAt};
+}
+
+bool CBoostedTreeLeafNodeStatistics::leftChildHasFewerRows() const {
+    return m_BestSplit.s_LeftChildHasFewerRows;
+}
+
+bool CBoostedTreeLeafNodeStatistics::assignMissingToLeft() const {
+    return m_BestSplit.s_AssignMissingToLeft;
+}
+
+std::size_t CBoostedTreeLeafNodeStatistics::id() const {
+    return m_Id;
+}
+
+core::CPackedBitVector& CBoostedTreeLeafNodeStatistics::rowMask() {
+    return m_RowMask;
+}
+
+std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
+    std::size_t mem{core::CMemory::dynamicSize(m_RowMask)};
+    mem += core::CMemory::dynamicSize(m_Derivatives);
+    mem += core::CMemory::dynamicSize(m_MissingDerivatives);
+    return mem;
+}
+
+std::size_t CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(std::size_t numberRows,
+                                                                std::size_t numberCols,
+                                                                std::size_t numberSplitsPerFeature) {
+    // We will typically get the close to the best compression for most of the
+    // leaves when the set of splits becomes large, corresponding to the worst
+    // case for memory usage. This is because the rows will be spread over many
+    // rows so the masks will mainly contain 0 bits in this case.
+    std::size_t rowMaskSize{numberRows / PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
+    std::size_t derivativesSize{(numberCols - 1) * numberSplitsPerFeature *
+                                sizeof(SAggregateDerivatives)};
+    std::size_t missingDerivativesSize{(numberCols - 1) * sizeof(SAggregateDerivatives)};
+    return sizeof(CBoostedTreeLeafNodeStatistics) + rowMaskSize +
+           derivativesSize + missingDerivativesSize;
+}
+
+void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivatives(
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder) {
+
+    auto result = frame.readRows(
+        numberThreads, 0, frame.numberRows(),
+        core::bindRetrievableState(
+            [&](SSplitAggregateDerivatives& splitAggregateDerivatives,
+                TRowItr beginRows, TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    this->addRowDerivatives(encoder.encode(*row), splitAggregateDerivatives);
+                }
+            },
+            SSplitAggregateDerivatives{m_CandidateSplits}),
+        &m_RowMask);
+    auto& state = result.first;
+
+    SSplitAggregateDerivatives derivatives{std::move(state[0].s_FunctionState)};
+    for (std::size_t i = 1; i < state.size(); ++i) {
+        derivatives.merge(state[i].s_FunctionState);
+    }
+
+    std::tie(m_Derivatives, m_MissingDerivatives) = derivatives.move();
+
+    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
+    LOG_TRACE(<< "missing derivatives = "
+              << core::CContainerPrinter::print(m_MissingDerivatives));
+}
+
+void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    bool isLeftChild,
+    const CBoostedTreeNode& split,
+    const core::CPackedBitVector& parentRowMask) {
+
+    auto result = frame.readRows(
+        numberThreads, 0, frame.numberRows(),
+        core::bindRetrievableState(
+            [&](std::pair<core::CPackedBitVector, SSplitAggregateDerivatives>& state,
+                TRowItr beginRows, TRowItr endRows) {
+                auto& mask = state.first;
+                auto& splitAggregateDerivatives = state.second;
+                for (auto row = beginRows; row != endRows; ++row) {
+                    auto encodedRow = encoder.encode(*row);
+                    if (split.assignToLeft(encodedRow) == isLeftChild) {
+                        std::size_t index{row->index()};
+                        mask.extend(false, index - mask.size());
+                        mask.extend(true);
+                        this->addRowDerivatives(encodedRow, splitAggregateDerivatives);
+                    }
+                }
+            },
+            std::make_pair(core::CPackedBitVector{}, SSplitAggregateDerivatives{m_CandidateSplits})),
+        &parentRowMask);
+    auto& state = result.first;
+
+    for (auto& mask_ : state) {
+        auto& mask = mask_.s_FunctionState.first;
+        mask.extend(false, parentRowMask.size() - mask.size());
+    }
+
+    m_RowMask = std::move(state[0].s_FunctionState.first);
+    SSplitAggregateDerivatives derivatives{std::move(state[0].s_FunctionState.second)};
+    for (std::size_t i = 1; i < state.size(); ++i) {
+        m_RowMask |= state[i].s_FunctionState.first;
+        derivatives.merge(state[i].s_FunctionState.second);
+    }
+
+    std::tie(m_Derivatives, m_MissingDerivatives) = derivatives.move();
+
+    LOG_TRACE(<< "row mask = " << m_RowMask);
+    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
+    LOG_TRACE(<< "missing derivatives = "
+              << core::CContainerPrinter::print(m_MissingDerivatives));
+}
+
+void CBoostedTreeLeafNodeStatistics::addRowDerivatives(
+    const CEncodedDataFrameRowRef& row,
+    SSplitAggregateDerivatives& splitAggregateDerivatives) const {
+
+    const TRowRef& unencodedRow{row.unencodedRow()};
+    auto gradient = readLossGradient(unencodedRow, m_NumberInputColumns, m_NumberLossParameters);
+    auto curvature = readLossCurvature(unencodedRow, m_NumberInputColumns, m_NumberLossParameters);
+
+    for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
+        double featureValue{row[i]};
+        if (CDataFrameUtils::isMissing(featureValue)) {
+            splitAggregateDerivatives.s_MissingDerivatives[i].add(1, gradient, curvature);
+        } else {
+            std::ptrdiff_t j{m_CandidateSplits[i].upperBound(featureValue)};
+            splitAggregateDerivatives.s_Derivatives[i][j].add(1, gradient, curvature);
+        }
+    }
+}
+
+CBoostedTreeLeafNodeStatistics::SSplitStatistics
+CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization& regularization,
+                                                           const TSizeVec& featureBag) const {
+
+    // We have three possible regularization terms we'll use:
+    //   1. Tree size: gamma * "node count"
+    //   2. Sum square weights: lambda * sum{"leaf weight" ^ 2)}
+    //   3. Tree depth: alpha * sum{exp(("depth" / "target depth" - 1.0) / "tolerance")}
+
+    SSplitStatistics result;
+
+    for (auto i : featureBag) {
+        std::size_t c{m_MissingDerivatives[i].s_Count};
+        double g{m_MissingDerivatives[i].s_Gradient};
+        double h{m_MissingDerivatives[i].s_Curvature};
+        for (const auto& derivatives : m_Derivatives[i]) {
+            c += derivatives.s_Count;
+            g += derivatives.s_Gradient;
+            h += derivatives.s_Curvature;
+        }
+        std::size_t cl[]{m_MissingDerivatives[i].s_Count, 0};
+        double gl[]{m_MissingDerivatives[i].s_Gradient, 0.0};
+        double hl[]{m_MissingDerivatives[i].s_Curvature, 0.0};
+
+        double maximumGain{-INF};
+        double splitAt{-INF};
+        bool leftChildHasFewerRows{true};
+        bool assignMissingToLeft{true};
+
+        for (std::size_t j = 0; j + 1 < m_Derivatives[i].size(); ++j) {
+            cl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Count;
+            gl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Gradient;
+            hl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Curvature;
+            cl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Count;
+            gl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Gradient;
+            hl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Curvature;
+
+            double gain[]{CTools::pow2(gl[ASSIGN_MISSING_TO_LEFT]) /
+                                  (hl[ASSIGN_MISSING_TO_LEFT] +
+                                   regularization.leafWeightPenaltyMultiplier()) +
+                              CTools::pow2(g - gl[ASSIGN_MISSING_TO_LEFT]) /
+                                  (h - hl[ASSIGN_MISSING_TO_LEFT] +
+                                   regularization.leafWeightPenaltyMultiplier()),
+                          CTools::pow2(gl[ASSIGN_MISSING_TO_RIGHT]) /
+                                  (hl[ASSIGN_MISSING_TO_RIGHT] +
+                                   regularization.leafWeightPenaltyMultiplier()) +
+                              CTools::pow2(g - gl[ASSIGN_MISSING_TO_RIGHT]) /
+                                  (h - hl[ASSIGN_MISSING_TO_RIGHT] +
+                                   regularization.leafWeightPenaltyMultiplier())};
+
+            if (gain[ASSIGN_MISSING_TO_LEFT] > maximumGain) {
+                maximumGain = gain[ASSIGN_MISSING_TO_LEFT];
+                splitAt = m_CandidateSplits[i][j];
+                leftChildHasFewerRows = (2 * cl[ASSIGN_MISSING_TO_LEFT] < c);
+                assignMissingToLeft = true;
+            }
+            if (gain[ASSIGN_MISSING_TO_RIGHT] > maximumGain) {
+                maximumGain = gain[ASSIGN_MISSING_TO_RIGHT];
+                splitAt = m_CandidateSplits[i][j];
+                leftChildHasFewerRows = (2 * cl[ASSIGN_MISSING_TO_RIGHT] < c);
+                assignMissingToLeft = false;
+            }
+        }
+
+        double penaltyForDepth{regularization.penaltyForDepth(m_Depth)};
+        double penaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 1)};
+        double gain{0.5 * (maximumGain - CTools::pow2(g) / (h + regularization.leafWeightPenaltyMultiplier())) -
+                    regularization.treeSizePenaltyMultiplier() -
+                    regularization.depthPenaltyMultiplier() *
+                        (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
+
+        SSplitStatistics candidate{
+            gain, h, i, splitAt, leftChildHasFewerRows, assignMissingToLeft};
+        LOG_TRACE(<< "candidate split: " << candidate.print());
+
+        if (candidate > result) {
+            result = candidate;
+        }
+    }
+
+    LOG_TRACE(<< "best split: " << result.print());
+
+    return result;
+}
+}
+}

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CBoostedTreeUtils.h>
+
+namespace ml {
+namespace maths {
+namespace boosted_tree_detail {
+
+TDouble1Vec readPrediction(const TRowRef& row,
+                           std::size_t numberInputColumns,
+                           std::size_t numberLossParamaters) {
+    const auto* start = row.data() + predictionColumn(numberInputColumns);
+    return TDouble1Vec(start, start + numberLossParamaters);
+}
+
+void writePrediction(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& prediction) {
+    std::size_t offset{predictionColumn(numberInputColumns)};
+    for (std::size_t i = 0; i < prediction.size(); ++i) {
+        row.writeColumn(offset + i, prediction[i]);
+    }
+}
+
+TDouble1Vec readLossGradient(const TRowRef& row,
+                             std::size_t numberInputColumns,
+                             std::size_t numberLossParameters) {
+    const auto* start = row.data() + lossGradientColumn(numberInputColumns, numberLossParameters);
+    return TDouble1Vec(start, start + numberLossParameters);
+}
+
+void writeLossGradient(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& gradient) {
+    std::size_t offset{lossGradientColumn(numberInputColumns, gradient.size())};
+    for (std::size_t i = 0; i < gradient.size(); ++i) {
+        row.writeColumn(offset + i, gradient[i]);
+    }
+}
+
+TDouble1Vec readLossCurvature(const TRowRef& row,
+                              std::size_t numberInputColumns,
+                              std::size_t numberLossParameters) {
+    const auto* start = row.data() + lossCurvatureColumn(numberInputColumns, numberLossParameters);
+    return TDouble1Vec(start, start + lossHessianStoredSize(numberLossParameters));
+}
+
+void writeLossCurvature(const TRowRef& row,
+                        std::size_t numberInputColumns,
+                        const TDouble1Vec& curvature) {
+    // This comes from solving x(x+1)/2 = n.
+    std::size_t numberLossParameters{
+        numberLossParametersForHessianStoredSize(curvature.size())};
+    std::size_t offset{lossCurvatureColumn(numberInputColumns, numberLossParameters)};
+    for (std::size_t i = 0; i < curvature.size(); ++i) {
+        row.writeColumn(offset + i, curvature[i]);
+    }
+}
+
+double readExampleWeight(const TRowRef& row,
+                         std::size_t numberInputColumns,
+                         std::size_t numberLossParameters) {
+    return row[exampleWeightColumn(numberInputColumns, numberLossParameters)];
+}
+
+double readActual(const TRowRef& row, std::size_t dependentVariable) {
+    return row[dependentVariable];
+}
+}
+}
+}

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -27,6 +27,8 @@ CBoostedTree.cc \
 CBoostedTreeFactory.cc \
 CBoostedTreeHyperparameters.cc \
 CBoostedTreeImpl.cc \
+CBoostedTreeLeafNodeStatistics.cc \
+CBoostedTreeUtils.cc \
 CCalendarCyclicTest.cc \
 CCalendarComponentAdaptiveBucketing.cc \
 CCalendarComponent.cc \


### PR DESCRIPTION
As a precursor to extending `CLeafNodeStatistics` to support multi-parameter loss functions this is a non-functional change to factor it's implementation out of `CBoostedTreeImpl`. This file and class was becoming unwieldy and I also plan to write some standalone unit tests for `CLeafNodeStatistics` as its implementation becomes somewhat more complex.