### PR TITLE
[7.x][ML] Add new categorization stats to model_size_stats

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,6 +39,8 @@ progress, memory usage, etc. (See {ml-pull}906[#906].)
 
 * Improve initialization of learn rate for better and more stable results in regression
 and classification. (See {ml-pull}948[#948].)
+* Add new model_size_stats fields to instrument categorization.  (See {ml-pull}948[#948]
+and {pull}51879[#51879], issue: {issue}50794[#50749].)
 
 === Bug Fixes
 

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -120,14 +120,14 @@ public:
 
     struct SBackgroundPersistArgs {
         SBackgroundPersistArgs(core_t::TTime time,
-                               const model::CResourceMonitor::SResults& modelSizeStats,
+                               const model::CResourceMonitor::SModelSizeStats& modelSizeStats,
                                const model::CInterimBucketCorrector& interimBucketCorrector,
                                const model::CHierarchicalResultsAggregator& aggregator,
                                core_t::TTime latestRecordTime,
                                core_t::TTime lastResultsTime);
 
         core_t::TTime s_Time;
-        model::CResourceMonitor::SResults s_ModelSizeStats;
+        model::CResourceMonitor::SModelSizeStats s_ModelSizeStats;
         model::CInterimBucketCorrector s_InterimBucketCorrector;
         model::CHierarchicalResultsAggregator s_Aggregator;
         std::string s_NormalizerState;
@@ -258,7 +258,7 @@ private:
     bool persistCopiedState(const std::string& descriptionPrefix,
                             core_t::TTime time,
                             const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
-                            const model::CResourceMonitor::SResults& modelSizeStats,
+                            const model::CResourceMonitor::SModelSizeStats& modelSizeStats,
                             const model::CInterimBucketCorrector& interimBucketCorrector,
                             const model::CHierarchicalResultsAggregator& aggregator,
                             const std::string& normalizerState,

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -232,7 +232,7 @@ public:
 
     //! Report the current levels of resource usage, as given to us
     //! from the CResourceMonitor via a callback
-    void reportMemoryUsage(const model::CResourceMonitor::SResults& results);
+    void reportMemoryUsage(const model::CResourceMonitor::SModelSizeStats& modelSizeStats);
 
     //! Acknowledge a flush request by echoing back the flush ID
     void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd);

--- a/include/api/CModelSizeStatsJsonWriter.h
+++ b/include/api/CModelSizeStatsJsonWriter.h
@@ -24,7 +24,7 @@ class API_EXPORT CModelSizeStatsJsonWriter : private core::CNonInstantiatable {
 public:
     //! Writes the model size stats in the \p results in JSON format.
     static void write(const std::string& jobId,
-                      const model::CResourceMonitor::SResults& results,
+                      const model::CResourceMonitor::SModelSizeStats& results,
                       core::CRapidJsonConcurrentLineWriter& writer);
 };
 }

--- a/include/api/CModelSnapshotJsonWriter.h
+++ b/include/api/CModelSnapshotJsonWriter.h
@@ -33,7 +33,7 @@ public:
         std::string s_Description;
         std::string s_SnapshotId;
         size_t s_NumDocs;
-        model::CResourceMonitor::SResults s_ModelSizeStats;
+        model::CResourceMonitor::SModelSizeStats s_ModelSizeStats;
         std::string s_NormalizerState;
         core_t::TTime s_LatestRecordTime;
         core_t::TTime s_LatestFinalResultTime;

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -270,9 +270,9 @@ public:
     //! Prune the model.
     void prune(std::size_t maximumAge) override;
 
-    //! Update the overall model memory stats results with stats from this
-    //! anomaly detector.
-    void updateMemoryResults(CResourceMonitor::SResults& results) const override;
+    //! Update the overall model size stats with information from this anomaly
+    //! detector.
+    void updateModelSizeStats(CResourceMonitor::SModelSizeStats& modelSizeStats) const override;
 
     //! Get end of the last complete bucket we've observed.
     const core_t::TTime& lastBucketEndTime() const;

--- a/include/model/CMonitoredResource.h
+++ b/include/model/CMonitoredResource.h
@@ -58,9 +58,10 @@ public:
     //! discarding the least recently seen entities it knows about.
     virtual void prune(std::size_t maximumAge);
 
-    //! Update the overall model memory stats results with stats from this
+    //! Update the overall model size stats results with stats from this
     //! monitored resource.
-    virtual void updateMemoryResults(CResourceMonitor::SResults& results) const = 0;
+    virtual void
+    updateModelSizeStats(CResourceMonitor::SModelSizeStats& modelSizeStats) const = 0;
 };
 }
 }

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -38,23 +38,30 @@ class CMonitoredResource;
 //! Assess memory used by models and decide on further memory allocations.
 class MODEL_EXPORT CResourceMonitor {
 public:
-    struct MODEL_EXPORT SResults {
-        std::size_t s_Usage;
-        std::size_t s_AdjustedUsage;
-        std::size_t s_ByFields;
-        std::size_t s_PartitionFields;
-        std::size_t s_OverFields;
-        std::size_t s_AllocationFailures;
-        model_t::EMemoryStatus s_MemoryStatus;
-        core_t::TTime s_BucketStartTime;
-        std::size_t s_BytesExceeded;
-        std::size_t s_BytesMemoryLimit;
+    struct MODEL_EXPORT SModelSizeStats {
+        std::size_t s_Usage = 0;
+        std::size_t s_AdjustedUsage = 0;
+        std::size_t s_ByFields = 0;
+        std::size_t s_PartitionFields = 0;
+        std::size_t s_OverFields = 0;
+        std::size_t s_AllocationFailures = 0;
+        model_t::EMemoryStatus s_MemoryStatus = model_t::E_MemoryStatusOk;
+        core_t::TTime s_BucketStartTime = 0;
+        std::size_t s_BytesExceeded = 0;
+        std::size_t s_BytesMemoryLimit = 0;
+        std::size_t s_CategorizedMessages = 0;
+        std::size_t s_TotalCategories = 0;
+        std::size_t s_FrequentCategories = 0;
+        std::size_t s_RareCategories = 0;
+        std::size_t s_DeadCategories = 0;
+        model_t::ECategorizationStatus s_CategorizationStatus = model_t::E_CategorizationStatusOk;
     };
 
 public:
     using TMonitoredResourcePtrSizeUMap =
         boost::unordered_map<CMonitoredResource*, std::size_t>;
-    using TMemoryUsageReporterFunc = std::function<void(const CResourceMonitor::SResults&)>;
+    using TMemoryUsageReporterFunc =
+        std::function<void(const CResourceMonitor::SModelSizeStats&)>;
     using TTimeSizeMap = std::map<core_t::TTime, std::size_t>;
 
     //! The minimum time between prunes
@@ -109,7 +116,7 @@ public:
     void sendMemoryUsageReport(core_t::TTime bucketStartTime);
 
     //! Create a memory usage report
-    SResults createMemoryUsageReport(core_t::TTime bucketStartTime);
+    SModelSizeStats createMemoryUsageReport(core_t::TTime bucketStartTime);
 
     //! We are being told that a class has failed to allocate memory
     //! based on the resource limits, and we will report this to the

--- a/include/model/CTokenListDataCategorizer.h
+++ b/include/model/CTokenListDataCategorizer.h
@@ -81,12 +81,6 @@ public:
     //! Get the static size of this object - used for virtual hierarchies
     std::size_t staticSize() const override { return sizeof(*this); }
 
-    //! Currently the overall model memory stats do not contain any categorizer
-    //! stats fields.
-    void updateMemoryResults(CResourceMonitor::SResults& /*results*/) const override {
-        // NO-OP
-    }
-
 protected:
     //! Split the string into a list of tokens.  The result of the
     //! tokenisation is returned in \p tokenIds, \p tokenUniqueIds and

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -802,6 +802,18 @@ enum EMemoryStatus {
 MODEL_EXPORT
 std::string print(EMemoryStatus memoryStatus);
 
+//! An enumeration of the TokenListDataCategorizer status -
+//! Start in the OK state. Moves into the "warn" state if too
+//! few categories are being seen frequently.
+enum ECategorizationStatus {
+    E_CategorizationStatusOk = 0,  //!< Categorization working as intended
+    E_CategorizationStatusWarn = 1 //!< Too many categories being created
+};
+
+//! Get a string description of \p categorizationStatus.
+MODEL_EXPORT
+std::string print(ECategorizationStatus categorizationStatus);
+
 //! Styles of probability aggregation available:
 //!   -# AggregatePeople: the style used to aggregate results for distinct
 //!      values of the over and partition field.

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1179,7 +1179,7 @@ bool CAnomalyJob::persistModelsState(const TKeyCRefAnomalyDetectorPtrPrVec& dete
 bool CAnomalyJob::persistCopiedState(const std::string& descriptionPrefix,
                                      core_t::TTime time,
                                      const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
-                                     const model::CResourceMonitor::SResults& modelSizeStats,
+                                     const model::CResourceMonitor::SModelSizeStats& modelSizeStats,
                                      const model::CInterimBucketCorrector& interimBucketCorrector,
                                      const model::CHierarchicalResultsAggregator& aggregator,
                                      const std::string& normalizerState,
@@ -1563,7 +1563,7 @@ void CAnomalyJob::addRecord(const TAnomalyDetectorPtr detector,
 
 CAnomalyJob::SBackgroundPersistArgs::SBackgroundPersistArgs(
     core_t::TTime time,
-    const model::CResourceMonitor::SResults& modelSizeStats,
+    const model::CResourceMonitor::SModelSizeStats& modelSizeStats,
     const model::CInterimBucketCorrector& interimBucketCorrector,
     const model::CHierarchicalResultsAggregator& aggregator,
     core_t::TTime latestRecordTime,

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -857,7 +857,7 @@ void CJsonOutputWriter::popAllocator() {
     m_Writer.popAllocator();
 }
 
-void CJsonOutputWriter::reportMemoryUsage(const model::CResourceMonitor::SResults& results) {
+void CJsonOutputWriter::reportMemoryUsage(const model::CResourceMonitor::SModelSizeStats& results) {
     m_Writer.StartObject();
     CModelSizeStatsJsonWriter::write(m_JobId, results, m_Writer);
     m_Writer.EndObject();

--- a/lib/api/CModelSizeStatsJsonWriter.cc
+++ b/lib/api/CModelSizeStatsJsonWriter.cc
@@ -13,22 +13,28 @@ namespace api {
 namespace {
 
 // JSON field names
-const std::string JOB_ID("job_id");
-const std::string MODEL_SIZE_STATS("model_size_stats");
-const std::string MODEL_BYTES("model_bytes");
-const std::string MODEL_BYTES_EXCEEDED("model_bytes_exceeded");
-const std::string MODEL_BYTES_MEMORY_LIMIT("model_bytes_memory_limit");
-const std::string TOTAL_BY_FIELD_COUNT("total_by_field_count");
-const std::string TOTAL_OVER_FIELD_COUNT("total_over_field_count");
-const std::string TOTAL_PARTITION_FIELD_COUNT("total_partition_field_count");
-const std::string BUCKET_ALLOCATION_FAILURES_COUNT("bucket_allocation_failures_count");
-const std::string MEMORY_STATUS("memory_status");
-const std::string TIMESTAMP("timestamp");
-const std::string LOG_TIME("log_time");
+const std::string JOB_ID{"job_id"};
+const std::string MODEL_SIZE_STATS{"model_size_stats"};
+const std::string MODEL_BYTES{"model_bytes"};
+const std::string MODEL_BYTES_EXCEEDED{"model_bytes_exceeded"};
+const std::string MODEL_BYTES_MEMORY_LIMIT{"model_bytes_memory_limit"};
+const std::string TOTAL_BY_FIELD_COUNT{"total_by_field_count"};
+const std::string TOTAL_OVER_FIELD_COUNT{"total_over_field_count"};
+const std::string TOTAL_PARTITION_FIELD_COUNT{"total_partition_field_count"};
+const std::string BUCKET_ALLOCATION_FAILURES_COUNT{"bucket_allocation_failures_count"};
+const std::string MEMORY_STATUS{"memory_status"};
+const std::string CATEGORIZED_DOC_COUNT{"categorized_doc_count"};
+const std::string TOTAL_CATEGORY_COUNT{"total_category_count"};
+const std::string FREQUENT_CATEGORY_COUNT{"frequent_category_count"};
+const std::string RARE_CATEGORY_COUNT{"rare_category_count"};
+const std::string DEAD_CATEGORY_COUNT{"dead_category_count"};
+const std::string CATEGORIZATION_STATUS{"categorization_status"};
+const std::string TIMESTAMP{"timestamp"};
+const std::string LOG_TIME{"log_time"};
 }
 
 void CModelSizeStatsJsonWriter::write(const std::string& jobId,
-                                      const model::CResourceMonitor::SResults& results,
+                                      const model::CResourceMonitor::SModelSizeStats& results,
                                       core::CRapidJsonConcurrentLineWriter& writer) {
     writer.String(MODEL_SIZE_STATS);
     writer.StartObject();
@@ -59,6 +65,24 @@ void CModelSizeStatsJsonWriter::write(const std::string& jobId,
 
     writer.String(MEMORY_STATUS);
     writer.String(print(results.s_MemoryStatus));
+
+    writer.String(CATEGORIZED_DOC_COUNT);
+    writer.Uint64(results.s_CategorizedMessages);
+
+    writer.String(TOTAL_CATEGORY_COUNT);
+    writer.Uint64(results.s_TotalCategories);
+
+    writer.String(FREQUENT_CATEGORY_COUNT);
+    writer.Uint64(results.s_FrequentCategories);
+
+    writer.String(RARE_CATEGORY_COUNT);
+    writer.Uint64(results.s_RareCategories);
+
+    writer.String(DEAD_CATEGORY_COUNT);
+    writer.Uint64(results.s_DeadCategories);
+
+    writer.String(CATEGORIZATION_STATUS);
+    writer.String(print(results.s_CategorizationStatus));
 
     writer.String(TIMESTAMP);
     writer.Time(results.s_BucketStartTime);

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -1746,7 +1746,7 @@ BOOST_AUTO_TEST_CASE(testReportMemoryUsage) {
         ml::core::CJsonOutputStreamWrapper outputStream(sstream);
         ml::api::CJsonOutputWriter writer("job", outputStream);
 
-        ml::model::CResourceMonitor::SResults resourceUsage;
+        ml::model::CResourceMonitor::SModelSizeStats resourceUsage;
         resourceUsage.s_Usage = 1;
         resourceUsage.s_AdjustedUsage = 2;
         resourceUsage.s_ByFields = 3;

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -627,11 +627,11 @@ void CAnomalyDetector::prune(std::size_t maximumAge) {
     m_Model->prune(maximumAge);
 }
 
-void CAnomalyDetector::updateMemoryResults(CResourceMonitor::SResults& results) const {
-    ++results.s_PartitionFields;
+void CAnomalyDetector::updateModelSizeStats(CResourceMonitor::SModelSizeStats& modelSizeStats) const {
+    ++modelSizeStats.s_PartitionFields;
     const auto& dataGatherer = m_Model->dataGatherer();
-    results.s_OverFields += dataGatherer.numberOverFieldValues();
-    results.s_ByFields += dataGatherer.numberByFieldValues();
+    modelSizeStats.s_OverFields += dataGatherer.numberOverFieldValues();
+    modelSizeStats.s_ByFields += dataGatherer.numberByFieldValues();
 }
 
 const core_t::TTime& CAnomalyDetector::lastBucketEndTime() const {

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -260,20 +260,17 @@ void CResourceMonitor::sendMemoryUsageReport(core_t::TTime bucketStartTime) {
     m_PreviousTotal = total;
 }
 
-CResourceMonitor::SResults CResourceMonitor::createMemoryUsageReport(core_t::TTime bucketStartTime) {
-    SResults res;
-    res.s_ByFields = 0;
-    res.s_OverFields = 0;
-    res.s_PartitionFields = 0;
+CResourceMonitor::SModelSizeStats
+CResourceMonitor::createMemoryUsageReport(core_t::TTime bucketStartTime) {
+    SModelSizeStats res;
     res.s_Usage = this->totalMemory();
     res.s_AdjustedUsage = this->adjustedUsage(res.s_Usage);
     res.s_BytesMemoryLimit = 2 * m_ByteLimitHigh;
     res.s_BytesExceeded = m_CurrentBytesExceeded;
-    res.s_AllocationFailures = 0;
     res.s_MemoryStatus = m_MemoryStatus;
     res.s_BucketStartTime = bucketStartTime;
     for (const auto& resource : m_Resources) {
-        resource.first->updateMemoryResults(res);
+        resource.first->updateModelSizeStats(res);
     }
     res.s_AllocationFailures += m_AllocationFailures.size();
     return res;

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -11,7 +11,6 @@
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
 
-#include <algorithm>
 #include <functional>
 
 namespace ml {
@@ -411,52 +410,27 @@ std::size_t CTokenListCategory::missingCommonTokenWeight(const TSizeSizeMap& uni
     return m_CommonUniqueTokenWeight - presentWeight;
 }
 
-bool CTokenListCategory::isMissingCommonTokenWeightZero(const TSizeSizeMap& uniqueTokenIds) const {
-    // This method could be implemented as:
-    // return this->missingCommonTokenWeight(uniqueTokenIds) == 0;
-    //
-    // However, it's much faster to return false as soon as a mismatch occurs
+bool CTokenListCategory::containsCommonInOrderTokensInOrder(const TSizeSizePrVec& tokenIds) const {
 
-    auto commonIter = m_CommonUniqueTokenIds.begin();
-    auto testIter = uniqueTokenIds.begin();
-    while (commonIter != m_CommonUniqueTokenIds.end() &&
-           testIter != uniqueTokenIds.end()) {
-        if (commonIter->first < testIter->first) {
-            return false;
-        }
-
-        if (commonIter->first == testIter->first) {
-            // The tokens must appear the same number of times in the two
-            // strings
-            if (commonIter->second != testIter->second) {
-                return false;
-            }
-            ++commonIter;
-        }
-
-        ++testIter;
-    }
-
-    return commonIter == m_CommonUniqueTokenIds.end();
-}
-
-bool CTokenListCategory::containsCommonTokensInOrder(const TSizeSizePrVec& tokenIds) const {
     auto testIter = tokenIds.begin();
-    for (auto baseTokenId : m_BaseTokenIds) {
+    for (std::size_t index = m_OrderedCommonTokenBeginIndex;
+         index < m_OrderedCommonTokenEndIndex; ++index) {
+        std::size_t baseTokenId{m_BaseTokenIds[index].first};
+
         // Ignore tokens that are not in the common unique tokens
-        if (this->isTokenCommon(baseTokenId.first) == false) {
+        if (this->isTokenCommon(baseTokenId) == false) {
             continue;
         }
 
         // Skip tokens in the test tokens until we find one that matches the
         // base token.  If we reach the end of the test tokens whilst doing
-        // this, it means the test tokens don't contain the base tokens in the
-        // correct order.
+        // this, it means the test tokens don't contain the common ordered base
+        // tokens in the correct order.
         do {
             if (testIter == tokenIds.end()) {
                 return false;
             }
-        } while ((testIter++)->first != baseTokenId.first);
+        } while ((testIter++)->first != baseTokenId);
     }
 
     return true;

--- a/lib/model/ModelTypes.cc
+++ b/lib/model/ModelTypes.cc
@@ -2045,5 +2045,15 @@ std::string print(EMemoryStatus memoryStatus) {
     }
     return "-";
 }
+
+std::string print(ECategorizationStatus categorizationStatus) {
+    switch (categorizationStatus) {
+    case E_CategorizationStatusOk:
+        return "ok";
+    case E_CategorizationStatusWarn:
+        return "warn";
+    }
+    return "-";
+}
 }
 }

--- a/lib/model/unittest/CTokenListDataCategorizerBaseTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerBaseTest.cc
@@ -60,4 +60,34 @@ BOOST_AUTO_TEST_CASE(testMaxMatchingWeights) {
                         ml::model::CTokenListDataCategorizerBase::maxMatchingWeight(10, 0.7));
 }
 
+BOOST_AUTO_TEST_CASE(testCalculateCategorizationStatus) {
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusOk,
+                        ml::model::CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                            99, 99, 0, 99, 0));
+
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        ml::model::CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                            1000, 1, 1, 0, 0));
+
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        ml::model::CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                            1000, 100, 3, 91, 1));
+
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        ml::model::CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                            1000, 501, 1, 99, 0));
+
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        ml::model::CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                            1000, 200, 0, 20, 0));
+
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        ml::model::CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                            1000, 300, 2, 50, 151));
+
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusOk,
+                        ml::model::CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                            1000, 120, 20, 40, 1));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change adds support for the following new model_size_stats
fields:

- categorized_doc_count
- total_category_count
- frequent_category_count
- rare_category_count
- dead_category_count
- categorization_status

Backport of #989