### PR TITLE
[ML] Support for multi-parameter loss functions in derivative aggregation and finding best splits

### DIFF
--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -35,7 +35,8 @@ class CEncodedDataFrameRowRef;
 namespace boosted_tree_detail {
 class MATHS_EXPORT CArgMinLossImpl {
 public:
-    using TDouble1Vec = core::CSmallVector<double, 1>;
+    using TDoubleVector = CDenseVector<double>;
+    using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage>;
 
 public:
     CArgMinLossImpl(double lambda);
@@ -43,9 +44,11 @@ public:
 
     virtual std::unique_ptr<CArgMinLossImpl> clone() const = 0;
     virtual bool nextPass() = 0;
-    virtual void add(TDouble1Vec prediction, double actual, double weight = 1.0) = 0;
+    virtual void add(const TMemoryMappedFloatVector& prediction,
+                     double actual,
+                     double weight = 1.0) = 0;
     virtual void merge(const CArgMinLossImpl& other) = 0;
-    virtual TDouble1Vec value() const = 0;
+    virtual TDoubleVector value() const = 0;
 
 protected:
     double lambda() const;
@@ -61,9 +64,9 @@ public:
     CArgMinMseImpl(double lambda);
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
-    void add(TDouble1Vec prediction, double actual, double weight = 1.0) override;
+    void add(const TMemoryMappedFloatVector& prediction, double actual, double weight = 1.0) override;
     void merge(const CArgMinLossImpl& other) override;
-    TDouble1Vec value() const override;
+    TDoubleVector value() const override;
 
 private:
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
@@ -79,14 +82,14 @@ public:
     CArgMinLogisticImpl(double lambda);
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
-    void add(TDouble1Vec prediction, double actual, double weight = 1.0) override;
+    void add(const TMemoryMappedFloatVector& prediction, double actual, double weight = 1.0) override;
     void merge(const CArgMinLossImpl& other) override;
-    TDouble1Vec value() const override;
+    TDoubleVector value() const override;
 
 private:
     using TMinMaxAccumulator = CBasicStatistics::CMinMax<double>;
-    using TVector = CVectorNx1<double, 2>;
-    using TVectorVec = std::vector<TVector>;
+    using TDoubleVector2x1 = CVectorNx1<double, 2>;
+    using TDoubleVector2x1Vec = std::vector<TDoubleVector2x1>;
 
 private:
     std::size_t bucket(double prediction) const {
@@ -108,8 +111,8 @@ private:
 private:
     std::size_t m_CurrentPass = 0;
     TMinMaxAccumulator m_PredictionMinMax;
-    TVector m_CategoryCounts;
-    TVectorVec m_BucketCategoryCounts;
+    TDoubleVector2x1 m_CategoryCounts;
+    TDoubleVector2x1Vec m_BucketCategoryCounts;
 };
 }
 
@@ -118,7 +121,8 @@ namespace boosted_tree {
 //! \brief Computes the leaf value which minimizes the loss function.
 class MATHS_EXPORT CArgMinLoss {
 public:
-    using TDouble1Vec = core::CSmallVector<double, 1>;
+    using TDoubleVector = CDenseVector<double>;
+    using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage>;
 
 public:
     CArgMinLoss(const CArgMinLoss& other);
@@ -133,7 +137,7 @@ public:
     bool nextPass() const;
 
     //! Update with a point prediction and actual value.
-    void add(TDouble1Vec prediction, double actual, double weight = 1.0);
+    void add(const TMemoryMappedFloatVector& prediction, double actual, double weight = 1.0);
 
     //! Get the minimiser over the predictions and actual values added to both
     //! this and \p other.
@@ -144,7 +148,7 @@ public:
     //!
     //! Formally, returns \f$x^* = arg\min_x\{\sum_i{L(p_i + x, a_i)}\}\f$
     //! for predictions and actuals \f$p_i\f$ and \f$a_i\f$, respectively.
-    TDouble1Vec value() const;
+    TDoubleVector value() const;
 
 private:
     using TArgMinLossImplUPtr = std::unique_ptr<boosted_tree_detail::CArgMinLossImpl>;
@@ -161,7 +165,9 @@ private:
 //! \brief Defines the loss function for the regression problem.
 class MATHS_EXPORT CLoss {
 public:
-    using TDouble1Vec = core::CSmallVector<double, 1>;
+    using TDoubleVector = CDenseVector<double>;
+    using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage>;
+    using TWriter = std::function<void(std::size_t, double)>;
 
 public:
     virtual ~CLoss() = default;
@@ -170,17 +176,23 @@ public:
     //! The number of parameters to the loss function.
     virtual std::size_t numberParameters() const = 0;
     //! The value of the loss function.
-    virtual double value(TDouble1Vec prediction, double actual, double weight = 1.0) const = 0;
+    virtual double value(const TMemoryMappedFloatVector& prediction,
+                         double actual,
+                         double weight = 1.0) const = 0;
     //! The gradient of the loss function.
-    virtual TDouble1Vec
-    gradient(TDouble1Vec prediction, double actual, double weight = 1.0) const = 0;
+    virtual void gradient(const TMemoryMappedFloatVector& prediction,
+                          double actual,
+                          TWriter writer,
+                          double weight = 1.0) const = 0;
     //! The Hessian of the loss function (flattened).
-    virtual TDouble1Vec
-    curvature(TDouble1Vec prediction, double actual, double weight = 1.0) const = 0;
+    virtual void curvature(const TMemoryMappedFloatVector& prediction,
+                           double actual,
+                           TWriter writer,
+                           double weight = 1.0) const = 0;
     //! Returns true if the loss curvature is constant.
     virtual bool isCurvatureConstant() const = 0;
     //! Transforms a prediction from the forest to the target space.
-    virtual TDouble1Vec transform(TDouble1Vec prediction) const = 0;
+    virtual TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const = 0;
     //! Get an object which computes the leaf value that minimises loss.
     virtual CArgMinLoss minimizer(double lambda) const = 0;
     //! Get the name of the loss function
@@ -198,11 +210,19 @@ public:
 public:
     std::unique_ptr<CLoss> clone() const override;
     std::size_t numberParameters() const override;
-    double value(TDouble1Vec prediction, double actual, double weight = 1.0) const override;
-    TDouble1Vec gradient(TDouble1Vec prediction, double actual, double weight = 1.0) const override;
-    TDouble1Vec curvature(TDouble1Vec prediction, double actual, double weight = 1.0) const override;
+    double value(const TMemoryMappedFloatVector& prediction,
+                 double actual,
+                 double weight = 1.0) const override;
+    void gradient(const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  TWriter writer,
+                  double weight = 1.0) const override;
+    void curvature(const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   TWriter writer,
+                   double weight = 1.0) const override;
     bool isCurvatureConstant() const override;
-    TDouble1Vec transform(TDouble1Vec prediction) const override;
+    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
     CArgMinLoss minimizer(double lambda) const override;
     const std::string& name() const override;
 };
@@ -223,11 +243,19 @@ public:
 public:
     std::unique_ptr<CLoss> clone() const override;
     std::size_t numberParameters() const override;
-    double value(TDouble1Vec prediction, double actual, double weight = 1.0) const override;
-    TDouble1Vec gradient(TDouble1Vec prediction, double actual, double weight = 1.0) const override;
-    TDouble1Vec curvature(TDouble1Vec prediction, double actual, double weight = 1.0) const override;
+    double value(const TMemoryMappedFloatVector& prediction,
+                 double actual,
+                 double weight = 1.0) const override;
+    void gradient(const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  TWriter writer,
+                  double weight = 1.0) const override;
+    void curvature(const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   TWriter writer,
+                   double weight = 1.0) const override;
     bool isCurvatureConstant() const override;
-    TDouble1Vec transform(TDouble1Vec prediction) const override;
+    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
     CArgMinLoss minimizer(double lambda) const override;
     const std::string& name() const override;
 };

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -278,13 +278,12 @@ public:
         //! Estimate the split derivatives' memory usage for a data frame with
         //! \p numberCols columns using \p numberSplitsPerFeature for a loss
         //! function with \p numberLossParameters parameters.
-        static std::size_t estimateMemoryUsage(std::size_t numberCols,
+        static std::size_t estimateMemoryUsage(std::size_t numberFeatures,
                                                std::size_t numberSplitsPerFeature,
                                                std::size_t numberLossParameters) {
-            std::size_t derivativesSize{(numberCols - 1) * (numberSplitsPerFeature + 1) *
+            std::size_t derivativesSize{numberFeatures * (numberSplitsPerFeature + 1) *
                                         sizeof(CDerivatives)};
-            std::size_t storageSize{(numberCols - 1) * (numberSplitsPerFeature + 1) *
-                                    numberLossParameters *
+            std::size_t storageSize{numberFeatures * (numberSplitsPerFeature + 1) * numberLossParameters *
                                     (numberLossParameters + 1) * sizeof(double)};
             return sizeof(CPerSplitDerivatives) + derivativesSize + storageSize;
         }
@@ -467,6 +466,7 @@ private:
     };
 
 private:
+    void maybeRecoverMemory();
     void computeAggregateLossDerivatives(std::size_t numberThreads,
                                          const core::CDataFrame& frame,
                                          const CDataFrameCategoryEncoder& encoder);

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -223,7 +223,7 @@ public:
         }
 
         //! Add \p gradient and \p curvature to the accumulated derivatives for
-        //! the split \p split of feature \p feature.
+        //! the \p split of \p feature.
         void addDerivatives(std::size_t feature,
                             std::size_t split,
                             const TMemoryMappedFloatVector& gradient,

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -110,8 +110,9 @@ public:
                 m_Curvature -= rhs.m_Curvature;
                 // None of our loss functions have negative curvature therefore we
                 // shouldn't allow the cumulative curvature to be negative either.
-                // In this case we force it to be a v.small multiple of the magnitude
-                // of the gradient since this is the closest feasible estimate.
+                // In this case we force it to be a very small multiple of the
+                // magnitude of the gradient since this is the closest feasible
+                // estimate.
                 for (int i = 0; i < m_Gradient.size(); ++i) {
                     m_Curvature(i, i) = std::max(m_Curvature(i, i),
                                                  SMALLEST_RELATIVE_CURVATURE *

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -308,6 +308,15 @@ public:
         }
         template<typename SPLITS>
         void map(const SPLITS& splits) {
+            // This function maps the memory in a single presized buffer containing
+            // enough space to store all gradient vectors and curvatures. For each
+            // feature the layout in this buffer is as follows:
+            //
+            // "split grad" "split hessian"       "missing grad" "missing hessian"
+            //       |            |                     |              |
+            //       V            V                     V              V
+            // |     n     |      n^2      | ... |      n       |      n^2       |
+
             std::size_t totalNumberSplits{
                 std::accumulate(splits.begin(), splits.end(), std::size_t{0},
                                 [](std::size_t size, const auto& featureSplits) {

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -132,10 +132,10 @@ public:
 
         //! Remap the accumulated curvature to lower triangle row major format.
         void remapCurvature() {
-            // We accumulate curvatures in the first n (n + 1) / elements however
-            // users of TMemoryMappedDoubleMatrix expect them stored column major
-            // in the lower triangle of n x n matrix. This copies them backwards
-            // to their correct positions.
+            // For performance, we accumulate curvatures into the first n (n + 1) / 2
+            // elements of the array backing m_Curvature. However, the memory mapped
+            // matrix class expects them to be stored column major in the lower triangle
+            // of n x n matrix. This copies them backwards to their correct positions.
             for (std::ptrdiff_t j = m_Curvature.cols() - 1,
                                 k = m_Curvature.rows() * (m_Curvature.rows() + 1) / 2 - 1;
                  j >= 0; --j) {

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -370,6 +370,16 @@ public:
     }
     //@}
 
+    //! Get a checksum of this object.
+    std::uint64_t checksum(std::uint64_t seed = 0) const {
+        for (std::ptrdiff_t i = 0; i < this->rows(); ++i) {
+            for (std::ptrdiff_t j = 0; j < this->rows(); ++j) {
+                seed = CChecksum::calculate(seed, (*this)(i, j));
+            }
+        }
+        return seed;
+    }
+
 private:
     void reseat(const CMemoryMappedDenseMatrix& other) {
         TBase* base{static_cast<TBase*>(this)};
@@ -666,6 +676,18 @@ CVector<T>::CVector(const CDenseVectorInitializer<VECTOR>& v) {
     }
 }
 }
+}
+
+namespace Eigen {
+template<typename BIN_OP>
+struct ScalarBinaryOpTraits<ml::core::CFloatStorage, double, BIN_OP> {
+    using ReturnType = double;
+};
+
+template<typename BIN_OP>
+struct ScalarBinaryOpTraits<double, ml::core::CFloatStorage, BIN_OP> {
+    using ReturnType = double;
+};
 }
 
 #endif // INCLUDED_ml_maths_CLinearAlgebraEigen_h

--- a/include/maths/CLinearAlgebraShims.h
+++ b/include/maths/CLinearAlgebraShims.h
@@ -335,37 +335,63 @@ outer(const CAnnotatedVector<VECTOR, ANNOTATION>& x) {
 
 namespace las_detail {
 template<typename VECTOR>
-struct SEstimateMemoryUsage {
+struct SEstimateVectorMemoryUsage {
     static std::size_t value(std::size_t) { return 0; }
 };
 template<typename T>
-struct SEstimateMemoryUsage<CVector<T>> {
+struct SEstimateVectorMemoryUsage<CVector<T>> {
     static std::size_t value(std::size_t dimension) {
         return dimension * sizeof(T);
     }
 };
 template<typename SCALAR>
-struct SEstimateMemoryUsage<CDenseVector<SCALAR>> {
+struct SEstimateVectorMemoryUsage<CDenseVector<SCALAR>> {
     static std::size_t value(std::size_t dimension) {
         // Ignore pad for alignment.
         return dimension * sizeof(SCALAR);
     }
 };
 template<typename VECTOR, typename ANNOTATION>
-struct SEstimateMemoryUsage<CAnnotatedVector<VECTOR, ANNOTATION>> {
+struct SEstimateVectorMemoryUsage<CAnnotatedVector<VECTOR, ANNOTATION>> {
     static std::size_t value(std::size_t dimension) {
         // Ignore any dynamic memory used by the annotation: we don't know how to
         // compute this here. It will be up to the calling code to estimate this
         // correctly.
-        return SEstimateMemoryUsage<VECTOR>::value(dimension);
+        return SEstimateVectorMemoryUsage<VECTOR>::value(dimension);
+    }
+};
+
+template<typename MATRIX>
+struct SEstimateMatrixMemoryUsage {
+    static std::size_t value(std::size_t, std::size_t) { return 0; }
+};
+template<typename T>
+struct SEstimateMatrixMemoryUsage<CSymmetricMatrix<T>> {
+    static std::size_t value(std::size_t rows, std::size_t) {
+        return sizeof(T) * rows * (rows + 1) / 2;
+    }
+};
+template<typename SCALAR>
+struct SEstimateMatrixMemoryUsage<CDenseMatrix<SCALAR>> {
+    static std::size_t value(std::size_t rows, std::size_t columns) {
+        // Ignore pad for alignment.
+        return sizeof(SCALAR) * rows * columns;
     }
 };
 }
 
-//! Estimate the amount of memory a point of type VECTOR and \p dimension will use.
+//! Estimate the amount of memory a vector of type VECTOR and size \p dimension
+//! will use.
 template<typename VECTOR>
 std::size_t estimateMemoryUsage(std::size_t dimension) {
-    return las_detail::SEstimateMemoryUsage<VECTOR>::value(dimension);
+    return las_detail::SEstimateVectorMemoryUsage<VECTOR>::value(dimension);
+}
+
+//! Estimate the amount of memory a matrix of type MATRIX and size \p rows by
+//! \p columns will use.
+template<typename MATRIX>
+std::size_t estimateMemoryUsage(std::size_t rows, std::size_t columns) {
+    return las_detail::SEstimateMatrixMemoryUsage<MATRIX>::value(rows, columns);
 }
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -136,7 +136,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::regression(),
-                "target", s_Rows, 5, 24000000, 0, 0, {"c1"}, s_Alpha, s_Lambda,
+                "target", s_Rows, 5, 26000000, 0, 0, {"c1"}, s_Alpha, s_Lambda,
                 s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance, s_Eta,
                 s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};
@@ -169,7 +169,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::classification(),
-                "target", s_Rows, 5, 24000000, 0, 0, {"target"}, s_Alpha,
+                "target", s_Rows, 5, 26000000, 0, 0, {"target"}, s_Alpha,
                 s_Lambda, s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance,
                 s_Eta, s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};
@@ -197,7 +197,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::regression(),
-                "target", s_Rows, 5, 24000000, 0, 0, {}, s_Alpha, s_Lambda,
+                "target", s_Rows, 5, 26000000, 0, 0, {}, s_Alpha, s_Lambda,
                 s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance, s_Eta,
                 s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -136,7 +136,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::regression(),
-                "target", s_Rows, 5, 8000000, 0, 0, {"c1"}, s_Alpha, s_Lambda,
+                "target", s_Rows, 5, 24000000, 0, 0, {"c1"}, s_Alpha, s_Lambda,
                 s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance, s_Eta,
                 s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};
@@ -169,9 +169,9 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::classification(),
-                "target", s_Rows, 5, 8000000, 0, 0, {"target"}, s_Alpha, s_Lambda,
-                s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance, s_Eta,
-                s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
+                "target", s_Rows, 5, 24000000, 0, 0, {"target"}, s_Alpha,
+                s_Lambda, s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance,
+                s_Eta, s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};
         TStrVec fieldNames{"target", "c1", "c2", "c3", "c4", ".", "."};
         TStrVec fieldValues{"", "", "", "", "", "0", ""};
@@ -197,7 +197,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::regression(),
-                "target", s_Rows, 5, 8000000, 0, 0, {}, s_Alpha, s_Lambda,
+                "target", s_Rows, 5, 24000000, 0, 0, {}, s_Alpha, s_Lambda,
                 s_Gamma, s_SoftTreeDepthLimit, s_SoftTreeDepthTolerance, s_Eta,
                 s_MaximumNumberTrees, s_FeatureBagFraction, shapValues),
             outputWriterFactory};

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierImbalanced) {
     api::CDataFrameAnalyzer analyzer{
         test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
             test::CDataFrameAnalysisSpecificationFactory::classification(),
-            "target", numberExamples, 4, 14000000, 0, 0, {"target"}),
+            "target", numberExamples, 4, 16000000, 0, 0, {"target"}),
         outputWriterFactory};
 
     TStrVec actuals;
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFields) {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::regression(),
-                "x5", 1000, 5, 19000000, 0, 0, {"x1", "x2"}),
+                "x5", 1000, 5, 24000000, 0, 0, {"x1", "x2"}),
             outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
@@ -906,7 +906,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFieldsEmptyAsMissing) {
     api::CDataFrameAnalyzer analyzer{
         test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
             test::CDataFrameAnalysisSpecificationFactory::classification(),
-            "x5", 1000, 5, 19000000, 0, 0, {"x1", "x2", "x5"}),
+            "x5", 1000, 5, 24000000, 0, 0, {"x1", "x2", "x5"}),
         outputWriterFactory};
 
     TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierImbalanced) {
     api::CDataFrameAnalyzer analyzer{
         test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
             test::CDataFrameAnalysisSpecificationFactory::classification(),
-            "target", numberExamples, 4, 16000000, 0, 0, {"target"}),
+            "target", numberExamples, 4, 17000000, 0, 0, {"target"}),
         outputWriterFactory};
 
     TStrVec actuals;
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFields) {
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
                 test::CDataFrameAnalysisSpecificationFactory::regression(),
-                "x5", 1000, 5, 24000000, 0, 0, {"x1", "x2"}),
+                "x5", 1000, 5, 26000000, 0, 0, {"x1", "x2"}),
             outputWriterFactory};
 
         TStrVec x[]{{"x11", "x12", "x13", "x14", "x15"},
@@ -906,7 +906,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFieldsEmptyAsMissing) {
     api::CDataFrameAnalyzer analyzer{
         test::CDataFrameAnalysisSpecificationFactory::predictionSpec(
             test::CDataFrameAnalysisSpecificationFactory::classification(),
-            "x5", 1000, 5, 24000000, 0, 0, {"x1", "x2", "x5"}),
+            "x5", 1000, 5, 26000000, 0, 0, {"x1", "x2", "x5"}),
         outputWriterFactory};
 
     TStrVec fieldNames{"x1", "x2", "x3", "x4", "x5", ".", "."};

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 6000000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1400000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1500000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -724,7 +724,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
               << "ms");
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 6000000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1400000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1500000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -12,7 +12,6 @@
 #include <core/CLoopProgress.h>
 #include <core/CPersistUtils.h>
 #include <core/CProgramCounters.h>
-#include <core/CSmallVector.h>
 #include <core/CStopWatch.h>
 
 #include <maths/CBasicStatisticsPersist.h>
@@ -38,11 +37,6 @@ namespace {
 // quantiles anyway. So we amortise their compute cost w.r.t. training trees
 // by only refreshing once every MINIMUM_SPLIT_REFRESH_INTERVAL trees we add.
 const double MINIMUM_SPLIT_REFRESH_INTERVAL{3.0};
-
-double lossAtNSigma(double n, const TMeanVarAccumulator& lossMoments) {
-    return CBasicStatistics::mean(lossMoments) +
-           n * std::sqrt(CBasicStatistics::variance(lossMoments));
-}
 
 //! \brief Record the memory used by a supplied object using the RAII idiom.
 class CScopeRecordMemoryUsage {
@@ -124,6 +118,21 @@ private:
     std::size_t m_MaximumNumberTreesWithoutImprovement;
     TDoubleSizePrMinAccumulator m_BestTestLoss;
 };
+
+double lossAtNSigma(double n, const TMeanVarAccumulator& lossMoments) {
+    return CBasicStatistics::mean(lossMoments) +
+           n * std::sqrt(CBasicStatistics::variance(lossMoments));
+}
+
+double trace(std::size_t columns, const TMemoryMappedFloatVector& upperTriangle) {
+    // This assumes the upper triangle of the matrix is stored row major.
+    double result{0.0};
+    for (int i = 0, j = static_cast<int>(columns);
+         i < upperTriangle.size() && j > 0; i += j, --j) {
+        result += upperTriangle(i);
+    }
+    return result;
+}
 }
 
 CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads,
@@ -273,9 +282,10 @@ void CBoostedTreeImpl::predict(core::CDataFrame& frame) const {
     bool successful;
     std::tie(std::ignore, successful) = frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(), [&](TRowItr beginRows, TRowItr endRows) {
+            std::size_t numberLossParameters{m_Loss->numberParameters()};
             for (auto row = beginRows; row != endRows; ++row) {
-                writePrediction(*row, m_NumberInputColumns,
-                                {predictRow(m_Encoder->encode(*row), m_BestForest)});
+                auto prediction = readPrediction(*row, m_NumberInputColumns, numberLossParameters);
+                prediction(0) = predictRow(m_Encoder->encode(*row), m_BestForest);
             }
         });
     if (successful == false) {
@@ -298,7 +308,8 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
     std::size_t hyperparametersMemoryUsage{numberColumns * sizeof(double)};
     std::size_t leafNodeStatisticsMemoryUsage{
         maximumNumberLeaves * CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(
-                                  numberRows, numberColumns, m_NumberSplitsPerFeature)};
+                                  numberRows, numberColumns, m_NumberSplitsPerFeature,
+                                  m_Loss->numberParameters())};
     std::size_t dataTypeMemoryUsage{numberColumns * sizeof(CDataFrameUtils::SDataType)};
     std::size_t featureSampleProbabilities{numberColumns * sizeof(double)};
     std::size_t missingFeatureMaskMemoryUsage{
@@ -440,12 +451,10 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
         m_NumberThreads, 0, frame.numberRows(),
         [this](TRowItr beginRows, TRowItr endRows) {
             std::size_t numberLossParameters{m_Loss->numberParameters()};
-            TDouble1Vec zero(numberLossParameters, 0.0);
-            TDouble1Vec zeroHessian(lossHessianStoredSize(numberLossParameters), 0.0);
             for (auto row = beginRows; row != endRows; ++row) {
-                writePrediction(*row, m_NumberInputColumns, zero);
-                writeLossGradient(*row, m_NumberInputColumns, zero);
-                writeLossCurvature(*row, m_NumberInputColumns, zeroHessian);
+                zeroPrediction(*row, m_NumberInputColumns, numberLossParameters);
+                zeroLossGradient(*row, m_NumberInputColumns, numberLossParameters);
+                zeroLossCurvature(*row, m_NumberInputColumns, numberLossParameters);
             }
         },
         &updateRowMask);
@@ -595,8 +604,9 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
             m_Encoder.get(),
             [this](const TRowRef& row) {
                 // TODO Think about what scalar measure of the Hessian to use here?
-                return readLossCurvature(row, m_NumberInputColumns,
-                                         m_Loss->numberParameters())[0];
+                std::size_t numberLossParameters{m_Loss->numberParameters()};
+                return trace(numberLossParameters,
+                             readLossCurvature(row, m_NumberInputColumns, numberLossParameters));
             })
             .first;
 
@@ -949,14 +959,13 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
             std::size_t numberLossParameters{m_Loss->numberParameters()};
             for (auto row = beginRows; row != endRows; ++row) {
                 auto prediction = readPrediction(*row, m_NumberInputColumns, numberLossParameters);
-                prediction[0] += root(tree).value(m_Encoder->encode(*row), tree);
                 double actual{readActual(*row, m_DependentVariable)};
                 double weight{readExampleWeight(*row, m_NumberInputColumns, numberLossParameters)};
-                writePrediction(*row, m_NumberInputColumns, prediction);
-                writeLossGradient(*row, m_NumberInputColumns,
-                                  m_Loss->gradient(prediction, actual, weight));
-                writeLossCurvature(*row, m_NumberInputColumns,
-                                   m_Loss->curvature(prediction, actual, weight));
+                prediction(0) += root(tree).value(m_Encoder->encode(*row), tree);
+                writeLossGradient(*row, m_NumberInputColumns, *m_Loss,
+                                  prediction, actual, weight);
+                writeLossCurvature(*row, m_NumberInputColumns, *m_Loss,
+                                   prediction, actual, weight);
             }
         },
         &updateRowMask);

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -718,7 +718,6 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         double splitValue;
         std::tie(splitFeature, splitValue) = leaf->bestSplit();
 
-        bool leftChildHasFewerRows{leaf->leftChildHasFewerRows()};
         bool assignMissingToLeft{leaf->assignMissingToLeft()};
 
         std::size_t leftChildId, rightChildId;
@@ -728,10 +727,9 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
         TLeafNodeStatisticsPtr leftChild;
         TLeafNodeStatisticsPtr rightChild;
-        std::tie(leftChild, rightChild) =
-            leaf->split(leftChildId, rightChildId, m_NumberThreads, frame, *m_Encoder,
-                        m_Regularization, candidateSplits, this->featureBag(),
-                        tree[leaf->id()], leftChildHasFewerRows);
+        std::tie(leftChild, rightChild) = leaf->split(
+            leftChildId, rightChildId, m_NumberThreads, frame, *m_Encoder,
+            m_Regularization, candidateSplits, this->featureBag(), tree[leaf->id()]);
 
         scopeMemoryUsage.add(leftChild);
         scopeMemoryUsage.add(rightChild);

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -15,6 +15,8 @@
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CTools.h>
 
+#include <maths/CMathsFuncs.h>
+
 namespace ml {
 namespace maths {
 using namespace boosted_tree_detail;
@@ -79,11 +81,11 @@ CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
       m_CandidateSplits{sibling.m_CandidateSplits}, m_RowMask{std::move(rowMask)} {
 
     m_Derivatives.resize(m_CandidateSplits.size());
-    m_MissingDerivatives.resize(m_CandidateSplits.size());
+    m_MissingDerivatives.reserve(m_CandidateSplits.size());
 
     for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
         std::size_t numberSplits{m_CandidateSplits[i].size() + 1};
-        m_Derivatives[i].resize(numberSplits);
+        m_Derivatives[i].reserve(numberSplits);
         for (std::size_t j = 0; j < numberSplits; ++j) {
             // Numeric errors mean that it's possible the sum curvature for a candidate
             // split is identically zero while the gradient is epsilon. This can cause
@@ -97,29 +99,44 @@ CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
             std::size_t count{parent.m_Derivatives[i][j].s_Count -
                               sibling.m_Derivatives[i][j].s_Count};
             if (count > 0) {
-                double gradient{parent.m_Derivatives[i][j].s_Gradient -
-                                sibling.m_Derivatives[i][j].s_Gradient};
-                double curvature{parent.m_Derivatives[i][j].s_Curvature -
-                                 sibling.m_Derivatives[i][j].s_Curvature};
-                curvature = std::max(curvature, SMALLEST_RELATIVE_CURVATURE *
-                                                    std::fabs(gradient));
-                m_Derivatives[i][j] = SAggregateDerivatives{count, gradient, curvature};
+                TDoubleVector gradient{parent.m_Derivatives[i][j].s_Gradient -
+                                       sibling.m_Derivatives[i][j].s_Gradient};
+                TDoubleMatrix curvature{parent.m_Derivatives[i][j].s_Curvature -
+                                        sibling.m_Derivatives[i][j].s_Curvature};
+                for (int k = 0; k < gradient.size(); ++k) {
+                    curvature(k, k) =
+                        std::max(curvature(k, k), SMALLEST_RELATIVE_CURVATURE *
+                                                      std::fabs(gradient(k)));
+                }
+                m_Derivatives[i].emplace_back(count, std::move(gradient),
+                                              std::move(curvature));
+            } else {
+                m_Derivatives[i].emplace_back(
+                    0, TDoubleVector{TDoubleVector::Zero(m_NumberLossParameters)},
+                    TDoubleMatrix{TDoubleMatrix::Zero(m_NumberLossParameters,
+                                                      m_NumberLossParameters)});
             }
         }
         std::size_t count{parent.m_MissingDerivatives[i].s_Count -
                           sibling.m_MissingDerivatives[i].s_Count};
         if (count > 0) {
-            double gradient{parent.m_MissingDerivatives[i].s_Gradient -
-                            sibling.m_MissingDerivatives[i].s_Gradient};
-            double curvature{parent.m_MissingDerivatives[i].s_Curvature -
-                             sibling.m_MissingDerivatives[i].s_Curvature};
-            curvature = std::max(curvature, SMALLEST_RELATIVE_CURVATURE * std::fabs(gradient));
-            m_MissingDerivatives[i] = SAggregateDerivatives{count, gradient, curvature};
+            TDoubleVector gradient{parent.m_MissingDerivatives[i].s_Gradient -
+                                   sibling.m_MissingDerivatives[i].s_Gradient};
+            TDoubleVector curvature{parent.m_MissingDerivatives[i].s_Curvature -
+                                    sibling.m_MissingDerivatives[i].s_Curvature};
+            for (int k = 0; k < gradient.size(); ++k) {
+                curvature(k, k) =
+                    std::max(curvature(k, k),
+                             SMALLEST_RELATIVE_CURVATURE * std::fabs(gradient(k)));
+            }
+            m_MissingDerivatives.emplace_back(count, std::move(gradient),
+                                              std::move(curvature));
+        } else {
+            m_MissingDerivatives.emplace_back(
+                0, TDoubleVector{TDoubleVector::Zero(m_NumberLossParameters)},
+                TDoubleMatrix{TDoubleMatrix::Zero(m_NumberLossParameters, m_NumberLossParameters)});
         }
     }
-    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
-    LOG_TRACE(<< "missing derivatives = "
-              << core::CContainerPrinter::print(m_MissingDerivatives));
 
     m_BestSplit = this->computeBestSplitStatistics(regularization, featureBag);
 }
@@ -201,17 +218,20 @@ std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
     return mem;
 }
 
-std::size_t CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(std::size_t numberRows,
-                                                                std::size_t numberCols,
-                                                                std::size_t numberSplitsPerFeature) {
+std::size_t
+CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(std::size_t numberRows,
+                                                    std::size_t numberCols,
+                                                    std::size_t numberSplitsPerFeature,
+                                                    std::size_t numberLossParameters) {
     // We will typically get the close to the best compression for most of the
     // leaves when the set of splits becomes large, corresponding to the worst
     // case for memory usage. This is because the rows will be spread over many
     // rows so the masks will mainly contain 0 bits in this case.
     std::size_t rowMaskSize{numberRows / PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
     std::size_t derivativesSize{(numberCols - 1) * numberSplitsPerFeature *
-                                sizeof(SAggregateDerivatives)};
-    std::size_t missingDerivativesSize{(numberCols - 1) * sizeof(SAggregateDerivatives)};
+                                SDerivatives::estimateMemoryUsage(numberLossParameters)};
+    std::size_t missingDerivativesSize{
+        (numberCols - 1) * SDerivatives::estimateMemoryUsage(numberLossParameters)};
     return sizeof(CBoostedTreeLeafNodeStatistics) + rowMaskSize +
            derivativesSize + missingDerivativesSize;
 }
@@ -224,26 +244,22 @@ void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivatives(
     auto result = frame.readRows(
         numberThreads, 0, frame.numberRows(),
         core::bindRetrievableState(
-            [&](SSplitAggregateDerivatives& splitAggregateDerivatives,
+            [&](CSplitDerivativesAccumulator& splitDerivativesAccumulator,
                 TRowItr beginRows, TRowItr endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
-                    this->addRowDerivatives(encoder.encode(*row), splitAggregateDerivatives);
+                    this->addRowDerivatives(encoder.encode(*row), splitDerivativesAccumulator);
                 }
             },
-            SSplitAggregateDerivatives{m_CandidateSplits}),
+            CSplitDerivativesAccumulator{m_CandidateSplits, m_NumberLossParameters}),
         &m_RowMask);
     auto& state = result.first;
 
-    SSplitAggregateDerivatives derivatives{std::move(state[0].s_FunctionState)};
+    CSplitDerivativesAccumulator accumulatedDerivatives{std::move(state[0].s_FunctionState)};
     for (std::size_t i = 1; i < state.size(); ++i) {
-        derivatives.merge(state[i].s_FunctionState);
+        accumulatedDerivatives.merge(state[i].s_FunctionState);
     }
 
-    std::tie(m_Derivatives, m_MissingDerivatives) = derivatives.move();
-
-    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
-    LOG_TRACE(<< "missing derivatives = "
-              << core::CContainerPrinter::print(m_MissingDerivatives));
+    std::tie(m_Derivatives, m_MissingDerivatives) = accumulatedDerivatives.read();
 }
 
 void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
@@ -257,21 +273,22 @@ void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
     auto result = frame.readRows(
         numberThreads, 0, frame.numberRows(),
         core::bindRetrievableState(
-            [&](std::pair<core::CPackedBitVector, SSplitAggregateDerivatives>& state,
+            [&](std::pair<core::CPackedBitVector, CSplitDerivativesAccumulator>& state,
                 TRowItr beginRows, TRowItr endRows) {
                 auto& mask = state.first;
-                auto& splitAggregateDerivatives = state.second;
+                auto& splitDerivativesAccumulator = state.second;
                 for (auto row = beginRows; row != endRows; ++row) {
                     auto encodedRow = encoder.encode(*row);
                     if (split.assignToLeft(encodedRow) == isLeftChild) {
                         std::size_t index{row->index()};
                         mask.extend(false, index - mask.size());
                         mask.extend(true);
-                        this->addRowDerivatives(encodedRow, splitAggregateDerivatives);
+                        this->addRowDerivatives(encodedRow, splitDerivativesAccumulator);
                     }
                 }
             },
-            std::make_pair(core::CPackedBitVector{}, SSplitAggregateDerivatives{m_CandidateSplits})),
+            std::make_pair(core::CPackedBitVector{},
+                           CSplitDerivativesAccumulator{m_CandidateSplits, m_NumberLossParameters})),
         &parentRowMask);
     auto& state = result.first;
 
@@ -281,23 +298,18 @@ void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
     }
 
     m_RowMask = std::move(state[0].s_FunctionState.first);
-    SSplitAggregateDerivatives derivatives{std::move(state[0].s_FunctionState.second)};
+    CSplitDerivativesAccumulator derivatives{std::move(state[0].s_FunctionState.second)};
     for (std::size_t i = 1; i < state.size(); ++i) {
         m_RowMask |= state[i].s_FunctionState.first;
         derivatives.merge(state[i].s_FunctionState.second);
     }
 
-    std::tie(m_Derivatives, m_MissingDerivatives) = derivatives.move();
-
-    LOG_TRACE(<< "row mask = " << m_RowMask);
-    LOG_TRACE(<< "derivatives = " << core::CContainerPrinter::print(m_Derivatives));
-    LOG_TRACE(<< "missing derivatives = "
-              << core::CContainerPrinter::print(m_MissingDerivatives));
+    std::tie(m_Derivatives, m_MissingDerivatives) = derivatives.read();
 }
 
 void CBoostedTreeLeafNodeStatistics::addRowDerivatives(
     const CEncodedDataFrameRowRef& row,
-    SSplitAggregateDerivatives& splitAggregateDerivatives) const {
+    CSplitDerivativesAccumulator& splitAggregateDerivatives) const {
 
     const TRowRef& unencodedRow{row.unencodedRow()};
     auto gradient = readLossGradient(unencodedRow, m_NumberInputColumns, m_NumberLossParameters);
@@ -306,10 +318,10 @@ void CBoostedTreeLeafNodeStatistics::addRowDerivatives(
     for (std::size_t i = 0; i < m_CandidateSplits.size(); ++i) {
         double featureValue{row[i]};
         if (CDataFrameUtils::isMissing(featureValue)) {
-            splitAggregateDerivatives.s_MissingDerivatives[i].add(1, gradient, curvature);
+            splitAggregateDerivatives.addMissingDerivatives(i, gradient, curvature);
         } else {
             std::ptrdiff_t j{m_CandidateSplits[i].upperBound(featureValue)};
-            splitAggregateDerivatives.s_Derivatives[i][j].add(1, gradient, curvature);
+            splitAggregateDerivatives.addDerivatives(i, j, gradient, curvature);
         }
     }
 }
@@ -325,18 +337,58 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
 
     SSplitStatistics result;
 
+    // We seek to find the value at the minimum of the quadratic expansion of the
+    // regularized loss function. For a given leaf this expansion is
+    //
+    //   L(w) = 1/2 w^t H(\lambda) w + g^t w
+    //
+    // where H(\lambda) = \sum_i H_i + \lambda I, g = \sum_i g_i and w is the leaf's
+    // weight. Here, g_i and H_i denote an example's loss gradient and Hessian and i
+    // ranges over the examples in the leaf. Completing the square and noting that
+    // the minimum is given when the quadratic form is zero we have
+    //
+    //   L(w^*) = -1/2 g^t H(\lambda) g
+    //
+    // where w^* = arg\min_w{ L(w) }.
+
+    using TMinimumLoss =
+        std::function<double(const TDoubleVector& g, const TDoubleMatrix& h)>;
+
+    TMinimumLoss minimumLoss;
+    
+    double lambda{regularization.leafWeightPenaltyMultiplier()};
+    if (m_NumberLossParameters == 1) {
+        minimumLoss = [lambda](const TDoubleVector& g, const TDoubleMatrix& h) -> double {
+            return CTools::pow2(g(0)) / (h(0, 0) + lambda);
+        };
+    } else {
+        // TODO this turns out to be extremely expensive even when m_NumberLossParameters
+        // is one. I'm not sure why yet. Maybe solving in-place would help.
+        minimumLoss = [lambda](const TDoubleVector& g, const TDoubleMatrix& h) -> double {
+            return g.transpose() *
+                   (h + lambda * TDoubleMatrix::Identity(h.rows(), h.cols()))
+                       .selfadjointView<Eigen::Upper>()
+                       .ldlt()
+                       .solve(g);
+        };
+    }
+
     for (auto i : featureBag) {
         std::size_t c{m_MissingDerivatives[i].s_Count};
-        double g{m_MissingDerivatives[i].s_Gradient};
-        double h{m_MissingDerivatives[i].s_Curvature};
+        TDoubleVector g{m_MissingDerivatives[i].s_Gradient};
+        TDoubleMatrix h{m_MissingDerivatives[i].s_Curvature};
         for (const auto& derivatives : m_Derivatives[i]) {
             c += derivatives.s_Count;
             g += derivatives.s_Gradient;
             h += derivatives.s_Curvature;
         }
         std::size_t cl[]{m_MissingDerivatives[i].s_Count, 0};
-        double gl[]{m_MissingDerivatives[i].s_Gradient, 0.0};
-        double hl[]{m_MissingDerivatives[i].s_Curvature, 0.0};
+        TDoubleVector gl[]{m_MissingDerivatives[i].s_Gradient,
+                           TDoubleVector::Zero(g.rows())};
+        TDoubleMatrix hl[]{m_MissingDerivatives[i].s_Curvature,
+                           TDoubleMatrix::Zero(h.rows(), h.cols())};
+        TDoubleVector gr[]{g - m_MissingDerivatives[i].s_Gradient, g};
+        TDoubleMatrix hr[]{h - m_MissingDerivatives[i].s_Curvature, h};
 
         double maximumGain{-INF};
         double splitAt{-INF};
@@ -344,25 +396,26 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
         bool assignMissingToLeft{true};
 
         for (std::size_t j = 0; j + 1 < m_Derivatives[i].size(); ++j) {
+
             cl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Count;
             gl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Gradient;
+            gr[ASSIGN_MISSING_TO_LEFT] -= m_Derivatives[i][j].s_Gradient;
             hl[ASSIGN_MISSING_TO_LEFT] += m_Derivatives[i][j].s_Curvature;
+            hr[ASSIGN_MISSING_TO_LEFT] -= m_Derivatives[i][j].s_Curvature;
+
             cl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Count;
             gl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Gradient;
+            gr[ASSIGN_MISSING_TO_RIGHT] -= m_Derivatives[i][j].s_Gradient;
             hl[ASSIGN_MISSING_TO_RIGHT] += m_Derivatives[i][j].s_Curvature;
+            hr[ASSIGN_MISSING_TO_RIGHT] -= m_Derivatives[i][j].s_Curvature;
 
-            double gain[]{CTools::pow2(gl[ASSIGN_MISSING_TO_LEFT]) /
-                                  (hl[ASSIGN_MISSING_TO_LEFT] +
-                                   regularization.leafWeightPenaltyMultiplier()) +
-                              CTools::pow2(g - gl[ASSIGN_MISSING_TO_LEFT]) /
-                                  (h - hl[ASSIGN_MISSING_TO_LEFT] +
-                                   regularization.leafWeightPenaltyMultiplier()),
-                          CTools::pow2(gl[ASSIGN_MISSING_TO_RIGHT]) /
-                                  (hl[ASSIGN_MISSING_TO_RIGHT] +
-                                   regularization.leafWeightPenaltyMultiplier()) +
-                              CTools::pow2(g - gl[ASSIGN_MISSING_TO_RIGHT]) /
-                                  (h - hl[ASSIGN_MISSING_TO_RIGHT] +
-                                   regularization.leafWeightPenaltyMultiplier())};
+            double gain[2];
+            gain[ASSIGN_MISSING_TO_LEFT] =
+                minimumLoss(gl[ASSIGN_MISSING_TO_LEFT], hl[ASSIGN_MISSING_TO_LEFT]) +
+                minimumLoss(gr[ASSIGN_MISSING_TO_LEFT], hr[ASSIGN_MISSING_TO_LEFT]);
+            gain[ASSIGN_MISSING_TO_RIGHT] =
+                minimumLoss(gl[ASSIGN_MISSING_TO_RIGHT], hl[ASSIGN_MISSING_TO_RIGHT]) +
+                minimumLoss(gr[ASSIGN_MISSING_TO_RIGHT], hr[ASSIGN_MISSING_TO_RIGHT]);
 
             if (gain[ASSIGN_MISSING_TO_LEFT] > maximumGain) {
                 maximumGain = gain[ASSIGN_MISSING_TO_LEFT];
@@ -380,13 +433,17 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
 
         double penaltyForDepth{regularization.penaltyForDepth(m_Depth)};
         double penaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 1)};
-        double gain{0.5 * (maximumGain - CTools::pow2(g) / (h + regularization.leafWeightPenaltyMultiplier())) -
+        double gain{0.5 * (maximumGain - minimumLoss(g, h)) -
                     regularization.treeSizePenaltyMultiplier() -
                     regularization.depthPenaltyMultiplier() *
                         (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
 
-        SSplitStatistics candidate{
-            gain, h, i, splitAt, leftChildHasFewerRows, assignMissingToLeft};
+        SSplitStatistics candidate{gain,
+                                   h.trace() / static_cast<double>(m_NumberLossParameters),
+                                   i,
+                                   splitAt,
+                                   leftChildHasFewerRows,
+                                   assignMissingToLeft};
         LOG_TRACE(<< "candidate split: " << candidate.print());
 
         if (candidate > result) {

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -282,12 +282,12 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
     //
     // where H(\lambda) = \sum_i H_i + \lambda I, g = \sum_i g_i and w is the leaf's
     // weight. Here, g_i and H_i denote an example's loss gradient and Hessian and i
-    // ranges over the examples in the leaf. Completing the square and noting that
-    // the minimum is given when the quadratic form is zero we have
+    // ranges over the examples in the leaf. Writing this as the sum of a quadratic
+    // form and constant, i.e. x(w)^t H(\lambda) x(w) + constant, and noting that H
+    // is positive definite, we see that we'll minimise loss by choosing w such that
+    // x is zero, i.e. w^* = arg\min_w(L(w)) satisfies x(w) = 0. This gives
     //
-    //   L(w^*) = -1/2 g^t H(\lambda) g
-    //
-    // where w^* = arg\min_w{ L(w) }.
+    //   L(w^*) = -1/2 g^t H(\lambda)^{-1} g
 
     using TDoubleVector = CDenseVector<double>;
     using TDoubleMatrix = CDenseMatrix<double>;
@@ -392,6 +392,9 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
 
         double penaltyForDepth{regularization.penaltyForDepth(m_Depth)};
         double penaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 1)};
+
+        // The gain is the difference between the quadratic minimum for loss with
+        // no split and the loss with the minimum loss split we found.
         double gain{0.5 * (maximumGain - minimumLoss(g, h)) -
                     regularization.treeSizePenaltyMultiplier() -
                     regularization.depthPenaltyMultiplier() *

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -6,55 +6,86 @@
 
 #include <maths/CBoostedTreeUtils.h>
 
+#include <maths/CBoostedTree.h>
+
 namespace ml {
 namespace maths {
 namespace boosted_tree_detail {
+using namespace boosted_tree;
 
-TDouble1Vec readPrediction(const TRowRef& row,
-                           std::size_t numberInputColumns,
-                           std::size_t numberLossParamaters) {
-    const auto* start = row.data() + predictionColumn(numberInputColumns);
-    return TDouble1Vec(start, start + numberLossParamaters);
+TMemoryMappedFloatVector readPrediction(const TRowRef& row,
+                                        std::size_t numberInputColumns,
+                                        std::size_t numberLossParamaters) {
+    return {row.data() + predictionColumn(numberInputColumns),
+            static_cast<int>(numberLossParamaters)};
 }
 
-void writePrediction(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& prediction) {
+void zeroPrediction(const TRowRef& row, std::size_t numberInputColumns, std::size_t numberLossParamaters) {
     std::size_t offset{predictionColumn(numberInputColumns)};
-    for (std::size_t i = 0; i < prediction.size(); ++i) {
-        row.writeColumn(offset + i, prediction[i]);
+    for (std::size_t i = 0; i < numberLossParamaters; ++i) {
+        row.writeColumn(offset + i, 0.0);
     }
 }
 
-TDouble1Vec readLossGradient(const TRowRef& row,
-                             std::size_t numberInputColumns,
-                             std::size_t numberLossParameters) {
-    const auto* start = row.data() + lossGradientColumn(numberInputColumns, numberLossParameters);
-    return TDouble1Vec(start, start + numberLossParameters);
+TMemoryMappedFloatVector readLossGradient(const TRowRef& row,
+                                          std::size_t numberInputColumns,
+                                          std::size_t numberLossParameters) {
+    return {row.data() + lossGradientColumn(numberInputColumns, numberLossParameters),
+            static_cast<int>(numberLossParameters)};
 }
 
-void writeLossGradient(const TRowRef& row, std::size_t numberInputColumns, const TDouble1Vec& gradient) {
-    std::size_t offset{lossGradientColumn(numberInputColumns, gradient.size())};
-    for (std::size_t i = 0; i < gradient.size(); ++i) {
-        row.writeColumn(offset + i, gradient[i]);
+void zeroLossGradient(const TRowRef& row, std::size_t numberInputColumns, std::size_t numberLossParameters) {
+    std::size_t offset{lossGradientColumn(numberInputColumns, numberLossParameters)};
+    for (std::size_t i = 0; i < numberLossParameters; ++i) {
+        row.writeColumn(offset + i, 0.0);
     }
 }
 
-TDouble1Vec readLossCurvature(const TRowRef& row,
-                              std::size_t numberInputColumns,
-                              std::size_t numberLossParameters) {
-    const auto* start = row.data() + lossCurvatureColumn(numberInputColumns, numberLossParameters);
-    return TDouble1Vec(start, start + lossHessianStoredSize(numberLossParameters));
+void writeLossGradient(const TRowRef& row,
+                       std::size_t numberInputColumns,
+                       const CLoss& loss,
+                       const TMemoryMappedFloatVector& prediction,
+                       double actual,
+                       double weight) {
+    std::size_t offset{lossGradientColumn(numberInputColumns, prediction.size())};
+    auto writer = [&row, offset](std::size_t i, double value) {
+        row.writeColumn(offset + i, value);
+    };
+    // We wrap the writer in another lambda which we know takes advantage
+    // of std::function small size optimization to avoid heap allocations.
+    loss.gradient(prediction, actual,
+                  [&writer](std::size_t i, double value) { writer(i, value); }, weight);
+}
+
+TMemoryMappedFloatVector readLossCurvature(const TRowRef& row,
+                                           std::size_t numberInputColumns,
+                                           std::size_t numberLossParameters) {
+    return {row.data() + lossCurvatureColumn(numberInputColumns, numberLossParameters),
+            static_cast<int>(lossHessianStoredSize(numberLossParameters))};
+}
+
+void zeroLossCurvature(const TRowRef& row, std::size_t numberInputColumns, std::size_t numberLossParameters) {
+    std::size_t offset{lossCurvatureColumn(numberInputColumns, numberLossParameters)};
+    for (std::size_t i = 0, size = lossHessianStoredSize(numberLossParameters);
+         i < size; ++i) {
+        row.writeColumn(offset + i, 0.0);
+    }
 }
 
 void writeLossCurvature(const TRowRef& row,
                         std::size_t numberInputColumns,
-                        const TDouble1Vec& curvature) {
-    // This comes from solving x(x+1)/2 = n.
-    std::size_t numberLossParameters{
-        numberLossParametersForHessianStoredSize(curvature.size())};
-    std::size_t offset{lossCurvatureColumn(numberInputColumns, numberLossParameters)};
-    for (std::size_t i = 0; i < curvature.size(); ++i) {
-        row.writeColumn(offset + i, curvature[i]);
-    }
+                        const CLoss& loss,
+                        const TMemoryMappedFloatVector& prediction,
+                        double actual,
+                        double weight) {
+    std::size_t offset{lossCurvatureColumn(numberInputColumns, prediction.size())};
+    auto writer = [&row, offset](std::size_t i, double value) {
+        row.writeColumn(offset + i, value);
+    };
+    // We wrap the writer in another lambda which we know takes advantage
+    // of std::function small size optimization to avoid heap allocations.
+    loss.curvature(prediction, actual,
+                   [&writer](std::size_t i, double value) { writer(i, value); }, weight);
 }
 
 double readExampleWeight(const TRowRef& row,

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -127,7 +127,7 @@ void testDerivativesFor(std::size_t numberParameters) {
     }
     derivatives2.remapCurvature();
 
-    derivatives1.merge(derivatives2);
+    derivatives1.add(derivatives2);
 
     BOOST_REQUIRE_EQUAL(20, derivatives1.count());
     for (std::size_t i = 0; i < numberGradients; ++i) {
@@ -144,22 +144,19 @@ void testDerivativesFor(std::size_t numberParameters) {
 
     LOG_DEBUG(<< "Difference");
 
-    TDoubleVec storage3(numberGradients * (numberGradients + 1), 0.0);
-    TDerivatives derivatives3{numberParameters, &storage2[0]};
+    derivatives1.subtract(derivatives2);
 
-    derivatives3.assignDifference(derivatives1, derivatives2);
-
-    BOOST_REQUIRE_EQUAL(10, derivatives3.count());
+    BOOST_REQUIRE_EQUAL(10, derivatives1.count());
     for (std::size_t i = 0; i < numberGradients; ++i) {
         BOOST_REQUIRE_CLOSE(
             std::accumulate(gradients[i].begin(), gradients[i].begin() + 10, 0.0),
-            derivatives3.gradient()(i), 1e-4);
+            derivatives1.gradient()(i), 1e-4);
     }
     for (std::size_t j = 0, k = 0; j < numberGradients; ++j) {
         for (std::size_t i = j; i < numberGradients; ++i, ++k) {
             BOOST_REQUIRE_CLOSE(std::accumulate(curvatures[k].begin(),
                                                 curvatures[k].begin() + 10, 0.0),
-                                derivatives3.curvature()(i, j), 1e-4);
+                                derivatives1.curvature()(i, j), 1e-4);
         }
     }
 }
@@ -273,7 +270,7 @@ void testPerSplitDerivativesFor(std::size_t numberParameters) {
         TPerSplitDerivatives derivatives2{featureSplits, numberParameters};
 
         addDerivatives(derivatives2);
-        derivatives1.merge(derivatives2);
+        derivatives1.add(derivatives2);
         validate(derivatives1);
 
         LOG_TRACE(<< "Test copy");

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -1,0 +1,297 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/CBoostedTreeLeafNodeStatistics.h>
+
+#include <core/CLogger.h>
+
+#include <maths/CBoostedTreeUtils.h>
+#include <maths/CLinearAlgebraEigen.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(CBoostedTreeLeafNodeStatisticsTest)
+
+using namespace ml;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TFloatVec = std::vector<maths::CFloatStorage>;
+using TVector = maths::CDenseVector<double>;
+using TVectorVec = std::vector<TVector>;
+using TVectorVecVec = std::vector<TVectorVec>;
+using TMatrix = maths::CDenseMatrix<double>;
+using TMatrixVec = std::vector<TMatrix>;
+using TMatrixVecVec = std::vector<TMatrixVec>;
+using TImmutableRadixSet = maths::CBoostedTreeLeafNodeStatistics::TImmutableRadixSet;
+using TImmutableRadixSetVec = maths::CBoostedTreeLeafNodeStatistics::TImmutableRadixSetVec;
+using TDerivativesVec = maths::CBoostedTreeLeafNodeStatistics::TDerivativesVec;
+using TDerivativesVecVec = maths::CBoostedTreeLeafNodeStatistics::TDerivativesVecVec;
+using TDerivativesAccumulator = maths::CBoostedTreeLeafNodeStatistics::CDerivativesAccumulator;
+using TSplitDerivativesAccumulator = maths::CBoostedTreeLeafNodeStatistics::CSplitDerivativesAccumulator;
+
+namespace {
+
+template<typename T>
+maths::CMemoryMappedDenseVector<T> makeGradient(T* storage, std::size_t n) {
+    return maths::CMemoryMappedDenseVector<T>{storage, static_cast<int>(n)};
+}
+
+template<typename T>
+maths::CMemoryMappedDenseVector<T> makeCurvature(T* storage, std::size_t n) {
+    return maths::CMemoryMappedDenseVector<T>(storage, static_cast<int>(n));
+}
+
+template<typename T>
+TMatrix rowMajorHessian(std::size_t n, const maths::CMemoryMappedDenseVector<T>& curvatures) {
+    TMatrix result{n, n};
+    for (std::size_t i = 0, k = 0; i < n; ++i) {
+        for (std::size_t j = i; j < n; ++j, ++k) {
+            result(i, j) = result(j, i) = curvatures(k);
+        }
+    }
+    return result;
+}
+
+void testDerivativesAccumulatorFor(std::size_t numberParameters) {
+
+    LOG_DEBUG(<< "Testing " << numberParameters << " parameters");
+
+    test::CRandomNumbers rng;
+
+    std::size_t numberGradients{numberParameters};
+    std::size_t numberCurvatures{
+        maths::boosted_tree_detail::lossHessianStoredSize(numberParameters)};
+
+    TDoubleVecVec gradients(numberGradients);
+    TDoubleVecVec curvatures(numberCurvatures);
+    for (std::size_t i = 0; i < numberGradients; ++i) {
+        rng.generateUniformSamples(-1.0, 1.5, 20, gradients[i]);
+    }
+    for (std::size_t i = 0; i < numberCurvatures; ++i) {
+        rng.generateUniformSamples(0.1, 0.5, 20, curvatures[i]);
+    }
+
+    TDoubleVec storage1(numberGradients + numberCurvatures, 0.0);
+    auto totalGradient1 = makeGradient(&storage1[0], numberGradients);
+    auto totalCurvature1 = makeCurvature(&storage1[numberGradients], numberCurvatures);
+    TDerivativesAccumulator accumulator1{totalGradient1, totalCurvature1};
+
+    for (std::size_t j = 0; j < 10; ++j) {
+        TFloatVec storage;
+        for (std::size_t i = 0; i < numberGradients; ++i) {
+            storage.push_back(gradients[i][j]);
+        }
+        for (std::size_t i = 0; i < numberCurvatures; ++i) {
+            storage.push_back(curvatures[i][j]);
+        }
+        auto gradient = makeGradient(&storage[0], numberGradients);
+        auto curvature = makeCurvature(&storage[numberGradients], numberCurvatures);
+        accumulator1.add(1, gradient, curvature);
+    }
+
+    BOOST_REQUIRE_EQUAL(10, accumulator1.count());
+    for (std::size_t i = 0; i < numberGradients; ++i) {
+        BOOST_REQUIRE_CLOSE(
+            std::accumulate(gradients[i].begin(), gradients[i].begin() + 10, 0.0),
+            accumulator1.gradient()(i), 1e-4);
+    }
+    for (std::size_t i = 0; i < numberCurvatures; ++i) {
+        BOOST_REQUIRE_CLOSE(std::accumulate(curvatures[i].begin(),
+                                            curvatures[i].begin() + 10, 0.0),
+                            accumulator1.curvature()(i), 1e-4);
+    }
+
+    TDoubleVec storage2(numberGradients + numberCurvatures, 0.0);
+    auto totalGradient2 = makeGradient(&storage2[0], numberGradients);
+    auto totalCurvature2 = makeCurvature(&storage2[numberGradients], numberCurvatures);
+    TDerivativesAccumulator accumulator2{totalGradient2, totalCurvature2};
+
+    for (std::size_t j = 10; j < 20; ++j) {
+        TFloatVec storage;
+        for (std::size_t i = 0; i < numberGradients; ++i) {
+            storage.push_back(gradients[i][j]);
+        }
+        for (std::size_t i = 0; i < numberCurvatures; ++i) {
+            storage.push_back(curvatures[i][j]);
+        }
+        auto gradient = makeGradient(&storage[0], numberGradients);
+        auto curvature = makeCurvature(&storage[numberGradients], numberCurvatures);
+        accumulator2.add(1, gradient, curvature);
+    }
+
+    BOOST_REQUIRE_EQUAL(10, accumulator2.count());
+    for (std::size_t i = 0; i < numberGradients; ++i) {
+        BOOST_REQUIRE_CLOSE(
+            std::accumulate(gradients[i].begin() + 10, gradients[i].end(), 0.0),
+            accumulator2.gradient()(i), 1e-4);
+    }
+    for (std::size_t i = 0; i < numberCurvatures; ++i) {
+        BOOST_REQUIRE_CLOSE(
+            std::accumulate(curvatures[i].begin() + 10, curvatures[i].end(), 0.0),
+            accumulator2.curvature()(i), 1e-4);
+    }
+
+    accumulator1.merge(accumulator2);
+    BOOST_REQUIRE_EQUAL(20, accumulator1.count());
+    for (std::size_t i = 0; i < numberGradients; ++i) {
+        BOOST_REQUIRE_CLOSE(std::accumulate(gradients[i].begin(), gradients[i].end(), 0.0),
+                            accumulator1.gradient()(i), 1e-4);
+    }
+    for (std::size_t i = 0; i < numberCurvatures; ++i) {
+        BOOST_REQUIRE_CLOSE(std::accumulate(curvatures[i].begin(), curvatures[i].end(), 0.0),
+                            accumulator1.curvature()(i), 1e-4);
+    }
+}
+
+void testSplitDerivativesAccumulatorFor(std::size_t numberParameters) {
+
+    LOG_DEBUG(<< "Testing " << numberParameters << " parameters");
+
+    TImmutableRadixSetVec featureSplits;
+    featureSplits.push_back(TImmutableRadixSet{1.0, 2.0, 3.0});
+    featureSplits.push_back(TImmutableRadixSet{0.1, 0.7, 1.1, 1.4});
+
+    test::CRandomNumbers rng;
+
+    std::size_t numberSamples{20};
+    std::size_t numberGradients{numberParameters};
+    std::size_t numberCurvatures{
+        maths::boosted_tree_detail::lossHessianStoredSize(numberParameters)};
+
+    for (std::size_t t = 0; t < 100; ++t) {
+        TSizeVec features;
+        TSizeVec splits[2];
+        TDoubleVec uniform01;
+        TDoubleVec gradients;
+        TDoubleVec curvatures;
+        rng.generateUniformSamples(0, 2, numberSamples, features);
+        rng.generateUniformSamples(0, featureSplits[0].size() + 1,
+                                   numberSamples, splits[0]);
+        rng.generateUniformSamples(0, featureSplits[1].size() + 1,
+                                   numberSamples, splits[1]);
+        rng.generateUniformSamples(0.0, 1.0, numberSamples, uniform01);
+        rng.generateUniformSamples(-1.5, 1.0, numberSamples * numberGradients, gradients);
+        rng.generateUniformSamples(0.1, 0.5, numberSamples * numberCurvatures, curvatures);
+
+        TSizeVecVec expectedCounts(2);
+        TVectorVecVec expectedGradients(2);
+        TMatrixVecVec expectedCurvatures(2);
+        TSizeVec expectedMissingCounts(2, 0);
+        TVectorVec expectedMissingGradients(2, TVector::Zero(numberParameters));
+        TMatrixVec expectedMissingCurvatures(2, TMatrix::Zero(numberParameters, numberParameters));
+        for (std::size_t i = 0; i < 2; ++i) {
+            expectedCounts[i].resize(featureSplits[i].size() + 1, 0);
+            expectedGradients[i].resize(featureSplits[i].size() + 1,
+                                         TVector::Zero(numberParameters));
+            expectedCurvatures[i].resize(featureSplits[i].size() + 1,
+                                          TMatrix::Zero(numberParameters, numberParameters));
+        }
+
+        auto addDerivatives = [&](TSplitDerivativesAccumulator& accumulator) {
+            for (std::size_t i = 0, j = 0, k = 0; i < numberSamples;
+                ++i, j += numberGradients, k += numberCurvatures) {
+
+                TFloatVec storage;
+                storage.insert(storage.end(), &gradients[j], &gradients[j + numberGradients]);
+                storage.insert(storage.end(), &curvatures[j], &curvatures[k + numberCurvatures]);
+                auto gradient = makeGradient(&storage[0], numberGradients);
+                auto curvature = makeCurvature(&storage[numberGradients], numberCurvatures);
+
+                if (uniform01[i] < 0.1) {
+                    accumulator.addMissingDerivatives(features[i], gradient, curvature);
+                    ++expectedMissingCounts[features[i]];
+                    expectedMissingGradients[features[i]] += gradient;
+                    expectedMissingCurvatures[features[i]] += rowMajorHessian(numberParameters, curvature);
+                } else {
+                    accumulator.addDerivatives(features[i], splits[features[i]][i],
+                                               gradient, curvature);
+                    ++expectedCounts[features[i]][splits[features[i]][i]];
+                    expectedGradients[features[i]][splits[features[i]][i]] += gradient;
+                    expectedCurvatures[features[i]][splits[features[i]][i]] +=
+                        rowMajorHessian(numberParameters, curvature);
+                }
+            }
+        };
+
+        auto validate = [&](const TDerivativesVecVec& derivatives, 
+                            const TDerivativesVec& missingDerivatives) {
+            BOOST_REQUIRE_EQUAL(expectedCounts.size(), derivatives.size());
+            for (std::size_t i = 0; i < expectedCounts.size(); ++i) {
+                BOOST_REQUIRE_EQUAL(expectedCounts[i].size(), derivatives[i].size());
+                for (std::size_t j = 0; j < expectedGradients[i].size(); ++j) {
+                    TMatrix curvature{
+                        derivatives[i][j].s_Curvature.selfadjointView<Eigen::Upper>()};
+                    BOOST_REQUIRE_EQUAL(expectedCounts[i][j], derivatives[i][j].s_Count);
+                    BOOST_REQUIRE_EQUAL(expectedGradients[i][j], derivatives[i][j].s_Gradient);
+                    BOOST_REQUIRE_EQUAL(expectedCurvatures[i][j], curvature);
+                }
+            }
+            BOOST_REQUIRE_EQUAL(expectedMissingCounts.size(), missingDerivatives.size());
+            for (std::size_t i = 0; i < expectedMissingCounts.size(); ++i) {
+                TMatrix curvature{
+                    missingDerivatives[i].s_Curvature.selfadjointView<Eigen::Upper>()};
+                BOOST_REQUIRE_EQUAL(expectedMissingCounts[i], missingDerivatives[i].s_Count);
+                BOOST_REQUIRE_EQUAL(expectedMissingGradients[i], missingDerivatives[i].s_Gradient);
+                BOOST_REQUIRE_EQUAL(expectedMissingCurvatures[i], curvature);
+            }
+        };
+
+        LOG_TRACE(<< "Test accumulation");
+
+        TSplitDerivativesAccumulator accumulator1{featureSplits, numberParameters};
+        addDerivatives(accumulator1);
+
+        TDerivativesVecVec derivatives;
+        TDerivativesVec missingDerivatives;
+        std::tie(derivatives, missingDerivatives) = accumulator1.read();
+
+        validate(derivatives, missingDerivatives);
+
+        LOG_TRACE(<< "Test merge");
+
+        rng.generateUniformSamples(0.0, 1.0, numberSamples, uniform01);
+        rng.generateUniformSamples(-1.5, 1.0, numberSamples * numberGradients, gradients);
+        rng.generateUniformSamples(0.1, 0.5, numberSamples * numberCurvatures, curvatures);
+
+        TSplitDerivativesAccumulator accumulator2{featureSplits, numberParameters};
+        addDerivatives(accumulator2);
+        accumulator1.merge(accumulator2);
+
+        std::tie(derivatives, missingDerivatives) = accumulator1.read();
+
+        validate(derivatives, missingDerivatives);
+
+        LOG_TRACE(<< "Test copy");
+
+        TSplitDerivativesAccumulator accumulator3{accumulator1};
+        BOOST_REQUIRE_EQUAL(accumulator1.checksum(), accumulator3.checksum());
+    }
+}
+}
+
+BOOST_AUTO_TEST_CASE(testDerivativesAccumulator) {
+
+    // Test individual derivatives accumulation for single and multi parameter
+    // loss functions.
+
+    testDerivativesAccumulatorFor(1 /*loss function parameter*/);
+    testDerivativesAccumulatorFor(3 /*loss function parameters*/);
+}
+
+BOOST_AUTO_TEST_CASE(testSplitDerivativesAccumulator) {
+
+    // Test per split derivatives accumulation for single and multi parameter
+    // loss functions.
+
+    testSplitDerivativesAccumulatorFor(1 /*loss function parameter*/);
+    testSplitDerivativesAccumulatorFor(3 /*loss function parameters*/);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -1,63 +1,111 @@
 #
-#Copyright Elasticsearch B.V.and / or licensed to Elasticsearch B.V.under one
-# or more contributor license agreements.Licensed under the Elastic License;
-#you may not use this file except in compliance with the Elastic License.
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
 #
-include $(CPP_SRC_HOME) / mk /
-    defines.mk
+include $(CPP_SRC_HOME)/mk/defines.mk
 
-    TARGET = ml_test$(EXE_EXT)
+TARGET=ml_test$(EXE_EXT)
 
-    USE_BOOST = 1 USE_BOOST_FILESYSTEM_LIBS = 1 USE_BOOST_TEST_LIBS = 1 USE_RAPIDJSON = 1 USE_EIGEN = 1
+USE_BOOST=1
+USE_BOOST_FILESYSTEM_LIBS=1
+USE_BOOST_TEST_LIBS=1
+USE_RAPIDJSON=1
+USE_EIGEN=1
 
-    LIBS : = $(LIB_ML_MATHS)
+LIBS:=$(LIB_ML_MATHS)
 
-               all
-    : build
+all: build
 
-      SRCS =
-          Main.cc CAgglomerativeClustererTest.cc
-          CAssignmentTest.cc CBasicStatisticsTest.cc CBayesianOptimisationTest
-              .cc CBjkstUniqueValuesTest.cc CBoostedTreeLeafNodeStatisticsTest
-              .cc CBoostedTreeTest.cc CBootstrapClustererTest
-              .cc CBoundingBoxTest.cc CCalendarComponentAdaptiveBucketingTest
-              .cc CCalendarCyclicTestTest.cc CCalendarFeatureTest
-              .cc CCategoricalToolsTest.cc CChecksumTest.cc
-          CClustererTest.cc CCountMinSketchTest.cc CDataFrameCategoryEncoderTest
-              .cc CDataFrameUtilsTest.cc CDecayRateControllerTest
-              .cc CEntropySketchTest.cc
-          CEqualWithToleranceTest.cc CExpandingWindowTest.cc
-          CForecastTest.cc CGammaRateConjugateTest.cc CInformationCriteriaTest
-              .cc CIntegerToolsTest.cc CIntegrationTest.cc CKdTreeTest
-              .cc CKMeansTest.cc CKMeansOnlineTest.cc
-          CKMostCorrelatedTest.cc CLassoLogisticRegressionTest.cc
-          CLbfgsTest.cc CLeastSquaresOnlineRegressionTest.cc CLinearAlgebraTest
-              .cc CLogNormalMeanPrecConjugateTest.cc CLogTDistributionTest
-              .cc CMathsFuncsTest.cc CMathsMemoryTest.cc CMicTest
-              .cc CMixtureDistributionTest.cc CModelTest.cc CMultimodalPriorTest
-              .cc CMultinomialConjugateTest.cc
-          CMultivariateConstantPriorTest.cc
-          CMultivariateMultimodalPriorTest.cc CMultivariateNormalConjugateTest
-              .cc CMultivariateOneOfNPriorTest.cc CNaiveBayesTest
-              .cc CNaturalBreaksClassifierTest.cc
-          CNormalMeanPrecConjugateTest.cc COneOfNPriorTest.cc
-          COrderingsTest.cc COrdinalTest.cc COrthogonaliserTest.cc COutliersTest
-              .cc CPeriodicityHypothesisTestsTest.cc CPoissonMeanConjugateTest
-              .cc CPriorTest.cc CPRNGTest.cc CProbabilityAggregatorsTest
-              .cc CProbabilityCalibratorTest.cc
-          CQDigestTest.cc CQuantileSketchTest.cc
-          CRadialBasisFunctionTest.cc CRandomizedPeriodicityTestTest
-              .cc CRandomProjectionClustererTest.cc
-          CSamplingTest.cc CSeasonalComponentTest
-              .cc CSeasonalComponentAdaptiveBucketingTest.cc CSeasonalTimeTest
-              .cc CSetToolsTest.cc CSignalTest.cc CSolversTest.cc
-          CSplineTest.cc CStatisticalTestsTest.cc CTimeSeriesChangeDetectorTest
-              .cc CTimeSeriesDecompositionTest.cc
-          CTimeSeriesModelTest.cc CTimeSeriesMultibucketFeaturesTest
-              .cc CTimeSeriesSegmentationTest.cc
-          CToolsTest.cc CTreeShapFeatureImportanceTest.cc
-          CTrendComponentTest.cc CXMeansOnlineTest.cc
-          CXMeansOnline1dTest.cc CXMeansTest.cc TestUtils.cc
+SRCS=\
+	Main.cc \
+	CAgglomerativeClustererTest.cc \
+	CAssignmentTest.cc \
+	CBasicStatisticsTest.cc \
+	CBayesianOptimisationTest.cc \
+	CBjkstUniqueValuesTest.cc \
+	CBoostedTreeLeafNodeStatisticsTest.cc \
+	CBoostedTreeTest.cc \
+	CBootstrapClustererTest.cc \
+	CBoundingBoxTest.cc \
+	CCalendarComponentAdaptiveBucketingTest.cc \
+	CCalendarCyclicTestTest.cc \
+	CCalendarFeatureTest.cc \
+	CCategoricalToolsTest.cc \
+	CChecksumTest.cc \
+	CClustererTest.cc \
+	CCountMinSketchTest.cc \
+	CDataFrameCategoryEncoderTest.cc \
+	CDataFrameUtilsTest.cc \
+	CDecayRateControllerTest.cc \
+	CEntropySketchTest.cc \
+	CEqualWithToleranceTest.cc \
+	CExpandingWindowTest.cc \
+	CForecastTest.cc \
+	CGammaRateConjugateTest.cc \
+	CInformationCriteriaTest.cc \
+	CIntegerToolsTest.cc \
+	CIntegrationTest.cc \
+	CKdTreeTest.cc \
+	CKMeansTest.cc \
+	CKMeansOnlineTest.cc \
+	CKMostCorrelatedTest.cc \
+	CLassoLogisticRegressionTest.cc \
+	CLbfgsTest.cc \
+	CLeastSquaresOnlineRegressionTest.cc \
+	CLinearAlgebraTest.cc \
+	CLogNormalMeanPrecConjugateTest.cc \
+	CLogTDistributionTest.cc \
+	CMathsFuncsTest.cc \
+	CMathsMemoryTest.cc \
+	CMicTest.cc \
+	CMixtureDistributionTest.cc \
+	CModelTest.cc \
+	CMultimodalPriorTest.cc \
+	CMultinomialConjugateTest.cc \
+	CMultivariateConstantPriorTest.cc \
+	CMultivariateMultimodalPriorTest.cc \
+	CMultivariateNormalConjugateTest.cc \
+	CMultivariateOneOfNPriorTest.cc \
+	CNaiveBayesTest.cc \
+	CNaturalBreaksClassifierTest.cc \
+	CNormalMeanPrecConjugateTest.cc \
+	COneOfNPriorTest.cc \
+	COrderingsTest.cc \
+	COrdinalTest.cc \
+	COrthogonaliserTest.cc \
+	COutliersTest.cc \
+	CPeriodicityHypothesisTestsTest.cc \
+	CPoissonMeanConjugateTest.cc \
+	CPriorTest.cc \
+	CPRNGTest.cc \
+	CProbabilityAggregatorsTest.cc \
+	CProbabilityCalibratorTest.cc \
+	CQDigestTest.cc \
+	CQuantileSketchTest.cc \
+	CRadialBasisFunctionTest.cc \
+	CRandomizedPeriodicityTestTest.cc \
+	CRandomProjectionClustererTest.cc \
+	CSamplingTest.cc \
+	CSeasonalComponentTest.cc \
+	CSeasonalComponentAdaptiveBucketingTest.cc \
+	CSeasonalTimeTest.cc \
+	CSetToolsTest.cc \
+	CSignalTest.cc \
+	CSolversTest.cc \
+	CSplineTest.cc \
+	CStatisticalTestsTest.cc \
+	CTimeSeriesChangeDetectorTest.cc \
+	CTimeSeriesDecompositionTest.cc \
+	CTimeSeriesModelTest.cc \
+	CTimeSeriesMultibucketFeaturesTest.cc \
+	CTimeSeriesSegmentationTest.cc \
+	CToolsTest.cc \
+	CTreeShapFeatureImportanceTest.cc \
+	CTrendComponentTest.cc \
+	CXMeansOnlineTest.cc \
+	CXMeansOnline1dTest.cc \
+	CXMeansTest.cc \
+	TestUtils.cc \
 
-          include $(CPP_SRC_HOME) /
-          mk / stdboosttest.mk
+include $(CPP_SRC_HOME)/mk/stdboosttest.mk

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -1,110 +1,63 @@
 #
-# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-# or more contributor license agreements. Licensed under the Elastic License;
-# you may not use this file except in compliance with the Elastic License.
+#Copyright Elasticsearch B.V.and / or licensed to Elasticsearch B.V.under one
+# or more contributor license agreements.Licensed under the Elastic License;
+#you may not use this file except in compliance with the Elastic License.
 #
-include $(CPP_SRC_HOME)/mk/defines.mk
+include $(CPP_SRC_HOME) / mk /
+    defines.mk
 
-TARGET=ml_test$(EXE_EXT)
+    TARGET = ml_test$(EXE_EXT)
 
-USE_BOOST=1
-USE_BOOST_FILESYSTEM_LIBS=1
-USE_BOOST_TEST_LIBS=1
-USE_RAPIDJSON=1
-USE_EIGEN=1
+    USE_BOOST = 1 USE_BOOST_FILESYSTEM_LIBS = 1 USE_BOOST_TEST_LIBS = 1 USE_RAPIDJSON = 1 USE_EIGEN = 1
 
-LIBS:=$(LIB_ML_MATHS)
+    LIBS : = $(LIB_ML_MATHS)
 
-all: build
+               all
+    : build
 
-SRCS=\
-	Main.cc \
-	CAgglomerativeClustererTest.cc \
-	CAssignmentTest.cc \
-	CBasicStatisticsTest.cc \
-	CBayesianOptimisationTest.cc \
-	CBjkstUniqueValuesTest.cc \
-	CBoostedTreeTest.cc \
-	CBootstrapClustererTest.cc \
-	CBoundingBoxTest.cc \
-	CCalendarComponentAdaptiveBucketingTest.cc \
-	CCalendarCyclicTestTest.cc \
-	CCalendarFeatureTest.cc \
-	CCategoricalToolsTest.cc \
-	CChecksumTest.cc \
-	CClustererTest.cc \
-	CCountMinSketchTest.cc \
-	CDataFrameCategoryEncoderTest.cc \
-	CDataFrameUtilsTest.cc \
-	CDecayRateControllerTest.cc \
-	CEntropySketchTest.cc \
-	CEqualWithToleranceTest.cc \
-	CExpandingWindowTest.cc \
-	CForecastTest.cc \
-	CGammaRateConjugateTest.cc \
-	CInformationCriteriaTest.cc \
-	CIntegerToolsTest.cc \
-	CIntegrationTest.cc \
-	CKdTreeTest.cc \
-	CKMeansTest.cc \
-	CKMeansOnlineTest.cc \
-	CKMostCorrelatedTest.cc \
-	CLassoLogisticRegressionTest.cc \
-	CLbfgsTest.cc \
-	CLeastSquaresOnlineRegressionTest.cc \
-	CLinearAlgebraTest.cc \
-	CLogNormalMeanPrecConjugateTest.cc \
-	CLogTDistributionTest.cc \
-	CMathsFuncsTest.cc \
-	CMathsMemoryTest.cc \
-	CMicTest.cc \
-	CMixtureDistributionTest.cc \
-	CModelTest.cc \
-	CMultimodalPriorTest.cc \
-	CMultinomialConjugateTest.cc \
-	CMultivariateConstantPriorTest.cc \
-	CMultivariateMultimodalPriorTest.cc \
-	CMultivariateNormalConjugateTest.cc \
-	CMultivariateOneOfNPriorTest.cc \
-	CNaiveBayesTest.cc \
-	CNaturalBreaksClassifierTest.cc \
-	CNormalMeanPrecConjugateTest.cc \
-	COneOfNPriorTest.cc \
-	COrderingsTest.cc \
-	COrdinalTest.cc \
-	COrthogonaliserTest.cc \
-	COutliersTest.cc \
-	CPeriodicityHypothesisTestsTest.cc \
-	CPoissonMeanConjugateTest.cc \
-	CPriorTest.cc \
-	CPRNGTest.cc \
-	CProbabilityAggregatorsTest.cc \
-	CProbabilityCalibratorTest.cc \
-	CQDigestTest.cc \
-	CQuantileSketchTest.cc \
-	CRadialBasisFunctionTest.cc \
-	CRandomizedPeriodicityTestTest.cc \
-	CRandomProjectionClustererTest.cc \
-	CSamplingTest.cc \
-	CSeasonalComponentTest.cc \
-	CSeasonalComponentAdaptiveBucketingTest.cc \
-	CSeasonalTimeTest.cc \
-	CSetToolsTest.cc \
-	CSignalTest.cc \
-	CSolversTest.cc \
-	CSplineTest.cc \
-	CStatisticalTestsTest.cc \
-	CTimeSeriesChangeDetectorTest.cc \
-	CTimeSeriesDecompositionTest.cc \
-	CTimeSeriesModelTest.cc \
-	CTimeSeriesMultibucketFeaturesTest.cc \
-	CTimeSeriesSegmentationTest.cc \
-	CToolsTest.cc \
-	CTreeShapFeatureImportanceTest.cc \
-	CTrendComponentTest.cc \
-	CXMeansOnlineTest.cc \
-	CXMeansOnline1dTest.cc \
-	CXMeansTest.cc \
-	TestUtils.cc \
+      SRCS =
+          Main.cc CAgglomerativeClustererTest.cc
+          CAssignmentTest.cc CBasicStatisticsTest.cc CBayesianOptimisationTest
+              .cc CBjkstUniqueValuesTest.cc CBoostedTreeLeafNodeStatisticsTest
+              .cc CBoostedTreeTest.cc CBootstrapClustererTest
+              .cc CBoundingBoxTest.cc CCalendarComponentAdaptiveBucketingTest
+              .cc CCalendarCyclicTestTest.cc CCalendarFeatureTest
+              .cc CCategoricalToolsTest.cc CChecksumTest.cc
+          CClustererTest.cc CCountMinSketchTest.cc CDataFrameCategoryEncoderTest
+              .cc CDataFrameUtilsTest.cc CDecayRateControllerTest
+              .cc CEntropySketchTest.cc
+          CEqualWithToleranceTest.cc CExpandingWindowTest.cc
+          CForecastTest.cc CGammaRateConjugateTest.cc CInformationCriteriaTest
+              .cc CIntegerToolsTest.cc CIntegrationTest.cc CKdTreeTest
+              .cc CKMeansTest.cc CKMeansOnlineTest.cc
+          CKMostCorrelatedTest.cc CLassoLogisticRegressionTest.cc
+          CLbfgsTest.cc CLeastSquaresOnlineRegressionTest.cc CLinearAlgebraTest
+              .cc CLogNormalMeanPrecConjugateTest.cc CLogTDistributionTest
+              .cc CMathsFuncsTest.cc CMathsMemoryTest.cc CMicTest
+              .cc CMixtureDistributionTest.cc CModelTest.cc CMultimodalPriorTest
+              .cc CMultinomialConjugateTest.cc
+          CMultivariateConstantPriorTest.cc
+          CMultivariateMultimodalPriorTest.cc CMultivariateNormalConjugateTest
+              .cc CMultivariateOneOfNPriorTest.cc CNaiveBayesTest
+              .cc CNaturalBreaksClassifierTest.cc
+          CNormalMeanPrecConjugateTest.cc COneOfNPriorTest.cc
+          COrderingsTest.cc COrdinalTest.cc COrthogonaliserTest.cc COutliersTest
+              .cc CPeriodicityHypothesisTestsTest.cc CPoissonMeanConjugateTest
+              .cc CPriorTest.cc CPRNGTest.cc CProbabilityAggregatorsTest
+              .cc CProbabilityCalibratorTest.cc
+          CQDigestTest.cc CQuantileSketchTest.cc
+          CRadialBasisFunctionTest.cc CRandomizedPeriodicityTestTest
+              .cc CRandomProjectionClustererTest.cc
+          CSamplingTest.cc CSeasonalComponentTest
+              .cc CSeasonalComponentAdaptiveBucketingTest.cc CSeasonalTimeTest
+              .cc CSetToolsTest.cc CSignalTest.cc CSolversTest.cc
+          CSplineTest.cc CStatisticalTestsTest.cc CTimeSeriesChangeDetectorTest
+              .cc CTimeSeriesDecompositionTest.cc
+          CTimeSeriesModelTest.cc CTimeSeriesMultibucketFeaturesTest
+              .cc CTimeSeriesSegmentationTest.cc
+          CToolsTest.cc CTreeShapFeatureImportanceTest.cc
+          CTrendComponentTest.cc CXMeansOnlineTest.cc
+          CXMeansOnline1dTest.cc CXMeansTest.cc TestUtils.cc
 
-include $(CPP_SRC_HOME)/mk/stdboosttest.mk
+          include $(CPP_SRC_HOME) /
+          mk / stdboosttest.mk


### PR DESCRIPTION
This extends computing aggregate derivatives and solving for the highest quadratic gain split to support multi-parameter loss functions.

I experimented with various implementations. This version, which minimises the number of allocations by using memory mapped classes, proved to be much the most efficient.

This is the next step towards #982.