### PR TITLE
[ML] Account for data frame memory in the peak memory usage estimate for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -53,6 +53,8 @@ and {pull}51879[#51879], issue: {issue}50794[#50749].)
 
 * Use largest ordered subset of categorization tokens for category reverse search regex.
 (See {ml-pull}970[#970], issue: {ml-issue}949[#949].)
+* Account for the data frame's memory when estimating the peak memory used by classification
+and regression model training. (See {ml-pull}996[#996].)
 
 == {es} version 7.6.0
 

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -44,6 +44,8 @@ public:
     //! than 0.001. In fact, it is unlikely that such high resolution is needed
     //! and typically this would be called significantly less frequently.
     void updateProgress(double fractionalProgress) override;
+
+    //! Record that the analysis is complete.
     void setToFinished();
 
     //! \return True if the running analysis has finished.

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -98,7 +98,8 @@ public:
     CBoostedTreeFactory& topShapValues(std::size_t topShapValues);
 
     //! Set pointer to the analysis instrumentation.
-    CBoostedTreeFactory& analysisInstrumentation(CDataFrameAnalysisInstrumentationInterface& instrumentation);
+    CBoostedTreeFactory&
+    analysisInstrumentation(CDataFrameAnalysisInstrumentationInterface& instrumentation);
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
 

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -35,8 +35,6 @@ class MATHS_EXPORT CBoostedTreeFactory final {
 public:
     using TVector = CVectorNx1<double, 3>;
     using TBoostedTreeUPtr = std::unique_ptr<CBoostedTree>;
-    using TProgressCallback = CBoostedTree::TProgressCallback;
-    using TMemoryUsageCallback = CBoostedTree::TMemoryUsageCallback;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
     using TLossFunctionUPtr = CBoostedTree::TLossFunctionUPtr;
     using TAnalysisInstrumentationPtr = CDataFrameAnalysisInstrumentationInterface*;
@@ -100,11 +98,7 @@ public:
     CBoostedTreeFactory& topShapValues(std::size_t topShapValues);
 
     //! Set pointer to the analysis instrumentation.
-    CBoostedTreeFactory& analysisInstrumentation(TAnalysisInstrumentationPtr instrumentation);
-    //! Set the callback function for progress monitoring.
-    CBoostedTreeFactory& progressCallback(TProgressCallback callback);
-    //! Set the callback function for memory monitoring.
-    CBoostedTreeFactory& memoryUsageCallback(TMemoryUsageCallback callback);
+    CBoostedTreeFactory& analysisInstrumentation(CDataFrameAnalysisInstrumentationInterface& instrumentation);
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
 
@@ -204,8 +198,7 @@ private:
     //! The maximum number of trees to use in the hyperparameter optimisation loop.
     std::size_t mainLoopMaximumNumberTrees(double eta) const;
 
-    static void noopRecordProgress(double);
-    static void noopRecordMemoryUsage(std::int64_t);
+    //! Stubs out persistence.
     static void noopRecordTrainingState(CBoostedTree::TPersistFunc);
 
 private:
@@ -221,9 +214,6 @@ private:
     TVector m_LogLeafWeightPenaltyMultiplierSearchInterval;
     TVector m_SoftDepthLimitSearchInterval;
     TVector m_LogEtaSearchInterval;
-    TAnalysisInstrumentationPtr m_Instrumentation;
-    TProgressCallback m_RecordProgress = noopRecordProgress;
-    TMemoryUsageCallback m_RecordMemoryUsage = noopRecordMemoryUsage;
     TTrainingStateCallback m_RecordTrainingState = noopRecordTrainingState;
     std::size_t m_TopShapValues = 0;
 };

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -216,7 +216,6 @@ private:
     TVector m_SoftDepthLimitSearchInterval;
     TVector m_LogEtaSearchInterval;
     TTrainingStateCallback m_RecordTrainingState = noopRecordTrainingState;
-    std::size_t m_TopShapValues = 0;
 };
 }
 }

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -56,8 +56,6 @@ public:
     using TNodeVec = CBoostedTree::TNodeVec;
     using TNodeVecVec = CBoostedTree::TNodeVecVec;
     using TLossFunctionUPtr = CBoostedTree::TLossFunctionUPtr;
-    using TProgressCallback = CBoostedTree::TProgressCallback;
-    using TMemoryUsageCallback = CBoostedTree::TMemoryUsageCallback;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
     using TOptionalDouble = boost::optional<double>;
     using TRegularization = CBoostedTreeRegularization<double>;
@@ -191,8 +189,7 @@ private:
     void computeProbabilityAtWhichToAssignClassOne(const core::CDataFrame& frame);
 
     //! Train the forest and compute loss moments on each fold.
-    TMeanVarAccumulatorSizePr crossValidateForest(core::CDataFrame& frame,
-                                                  const TMemoryUsageCallback& recordMemoryUsage);
+    TMeanVarAccumulatorSizePr crossValidateForest(core::CDataFrame& frame);
 
     //! Initialize the predictions and loss function derivatives for the masked
     //! rows in \p frame.
@@ -204,8 +201,7 @@ private:
     TNodeVecVecDoublePr trainForest(core::CDataFrame& frame,
                                     const core::CPackedBitVector& trainingRowMask,
                                     const core::CPackedBitVector& testingRowMask,
-                                    core::CLoopProgress& trainingProgress,
-                                    const TMemoryUsageCallback& recordMemoryUsage) const;
+                                    core::CLoopProgress& trainingProgress) const;
 
     //! Randomly downsamples the training row mask by the downsample factor.
     core::CPackedBitVector downsample(const core::CPackedBitVector& trainingRowMask) const;
@@ -218,8 +214,7 @@ private:
     TNodeVec trainTree(core::CDataFrame& frame,
                        const core::CPackedBitVector& trainingRowMask,
                        const TImmutableRadixSetVec& candidateSplits,
-                       const std::size_t maximumTreeSize,
-                       const TMemoryUsageCallback& recordMemoryUsage) const;
+                       const std::size_t maximumTreeSize) const;
 
     //! Compute the minimum mean test loss per fold for any round.
     double minimumTestLoss() const;
@@ -319,8 +314,8 @@ private:
     std::size_t m_MaximumOptimisationRoundsPerHyperparameter = 2;
     std::size_t m_RowsPerFeature = 50;
     double m_FeatureBagFraction = 0.5;
-    TDataTypeVec m_FeatureDataTypes;
     TDataFrameCategoryEncoderUPtr m_Encoder;
+    TDataTypeVec m_FeatureDataTypes;
     TDoubleVec m_FeatureSampleProbabilities;
     TPackedBitVectorVec m_MissingFeatureRowMasks;
     TPackedBitVectorVec m_TrainingRowMasks;

--- a/include/maths/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/CDataFrameAnalysisInstrumentationInterface.h
@@ -50,7 +50,8 @@ public:
 };
 
 //! \brief Dummies out all instrumentation.
-class MATHS_EXPORT CDataFrameAnalysisInstrumentationStub final : public CDataFrameAnalysisInstrumentationInterface {
+class MATHS_EXPORT CDataFrameAnalysisInstrumentationStub final
+    : public CDataFrameAnalysisInstrumentationInterface {
     void updateMemoryUsage(std::int64_t) override {}
     void updateProgress(double) override {}
     void nextStep(std::uint32_t) override {}

--- a/include/maths/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/CDataFrameAnalysisInstrumentationInterface.h
@@ -48,6 +48,13 @@ public:
         return [this](std::int64_t delta) { this->updateMemoryUsage(delta); };
     }
 };
+
+//! \brief Dummies out all instrumentation.
+class MATHS_EXPORT CDataFrameAnalysisInstrumentationStub final : public CDataFrameAnalysisInstrumentationInterface {
+    void updateMemoryUsage(std::int64_t) override {}
+    void updateProgress(double) override {}
+    void nextStep(std::uint32_t) override {}
+};
 }
 }
 

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -31,8 +31,6 @@ class MATHS_EXPORT CDataFramePredictiveModel {
 public:
     using TDoubleVec = std::vector<double>;
     using TSizeRange = boost::integer_range<std::size_t>;
-    using TProgressCallback = std::function<void(double)>;
-    using TMemoryUsageCallback = std::function<void(std::int64_t)>;
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
     using TTrainingStateCallback = std::function<void(TPersistFunc)>;
 

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -126,7 +126,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
 
     (*m_BoostedTreeFactory)
         .stopCrossValidationEarly(stopCrossValidationEarly)
-        .analysisInstrumentation(&m_Instrumentation)
+        .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister());
 
     if (downsampleRowsPerFeature > 0) {
@@ -273,7 +273,7 @@ bool CDataFrameTrainBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& fram
             return false;
         }
         m_BoostedTree = maths::CBoostedTreeFactory::constructFromString(*inputStream)
-                            .analysisInstrumentation(&m_Instrumentation)
+                            .analysisInstrumentation(m_Instrumentation)
                             .trainingStateCallback(this->statePersister())
                             .restoreFor(frame, dependentVariableColumn);
     } catch (std::exception& e) {

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -266,7 +266,7 @@ void addPredictionTestData(EPredictionType type,
     }
 
     ml::api::CDataFrameTrainBoostedTreeInstrumentation instrumentation;
-    treeFactory.analysisInstrumentation(&instrumentation);
+    treeFactory.analysisInstrumentation(instrumentation);
 
     auto tree = treeFactory.buildFor(*frame, weights.size());
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -974,7 +974,7 @@ CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads, TLossFunctio
     : m_NumberThreads{numberThreads},
       m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))},
       m_LogDepthPenaltyMultiplierSearchInterval{0.0}, m_LogTreeSizePenaltyMultiplierSearchInterval{0.0},
-      m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0}, m_TopShapValues{0} {
+      m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0} {
 }
 
 CBoostedTreeFactory::CBoostedTreeFactory(CBoostedTreeFactory&&) = default;
@@ -1126,7 +1126,6 @@ CBoostedTreeFactory& CBoostedTreeFactory::rowsPerFeature(std::size_t rowsPerFeat
 }
 
 CBoostedTreeFactory& CBoostedTreeFactory::topShapValues(std::size_t topShapValues) {
-    m_TopShapValues = topShapValues;
     m_TreeImpl->m_TopShapValues = topShapValues;
     return *this;
 }
@@ -1144,14 +1143,11 @@ CBoostedTreeFactory& CBoostedTreeFactory::trainingStateCallback(TTrainingStateCa
 
 std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
                                                      std::size_t numberColumns) const {
-    std::size_t shapValuesExtraColumns =
-        (m_TopShapValues > 0) ? numberRows * numberColumns * sizeof(CFloatStorage) : 0;
     std::size_t maximumNumberTrees{this->mainLoopMaximumNumberTrees(
         m_TreeImpl->m_EtaOverride != boost::none ? *m_TreeImpl->m_EtaOverride
                                                  : computeEta(numberColumns))};
     std::swap(maximumNumberTrees, m_TreeImpl->m_MaximumNumberTrees);
-    std::size_t result{m_TreeImpl->estimateMemoryUsage(numberRows, numberColumns) +
-                       shapValuesExtraColumns};
+    std::size_t result{m_TreeImpl->estimateMemoryUsage(numberRows, numberColumns)};
     std::swap(maximumNumberTrees, m_TreeImpl->m_MaximumNumberTrees);
     return result;
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -753,8 +753,8 @@ CBoostedTreeFactory::estimateTreeGainAndCurvature(core::CDataFrame& frame,
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
     CBoostedTreeImpl::TNodeVecVec forest;
     std::tie(forest, std::ignore) = m_TreeImpl->trainForest(
-        frame, m_TreeImpl->m_TrainingRowMasks[0], m_TreeImpl->m_TestingRowMasks[0],
-        m_TreeImpl->m_TrainingProgress);
+        frame, m_TreeImpl->m_TrainingRowMasks[0],
+        m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
 
     TDoubleDoublePrVec result;
@@ -821,8 +821,8 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
         CBoostedTreeImpl::TNodeVecVec forest;
         double testLoss;
         std::tie(forest, testLoss) = m_TreeImpl->trainForest(
-            frame, m_TreeImpl->m_TrainingRowMasks[0], m_TreeImpl->m_TestingRowMasks[0],
-            m_TreeImpl->m_TrainingProgress);
+            frame, m_TreeImpl->m_TrainingRowMasks[0],
+            m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
         bopt.add(boptVector(regularizer), testLoss, 0.0);
         minTestLoss.add(testLoss);
         testLosses.emplace_back(regularizer, testLoss);
@@ -842,8 +842,8 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
         CBoostedTreeImpl::TNodeVecVec forest;
         double testLoss;
         std::tie(forest, testLoss) = m_TreeImpl->trainForest(
-            frame, m_TreeImpl->m_TrainingRowMasks[0], m_TreeImpl->m_TestingRowMasks[0],
-            m_TreeImpl->m_TrainingProgress);
+            frame, m_TreeImpl->m_TrainingRowMasks[0],
+            m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
         bopt.add(regularizer, testLoss, 0.0);
         minTestLoss.add(testLoss);
         testLosses.emplace_back(regularizer(0), testLoss);
@@ -1131,8 +1131,8 @@ CBoostedTreeFactory& CBoostedTreeFactory::topShapValues(std::size_t topShapValue
     return *this;
 }
 
-CBoostedTreeFactory&
-CBoostedTreeFactory::analysisInstrumentation(CDataFrameAnalysisInstrumentationInterface& instrumentation) {
+CBoostedTreeFactory& CBoostedTreeFactory::analysisInstrumentation(
+    CDataFrameAnalysisInstrumentationInterface& instrumentation) {
     m_TreeImpl->m_Instrumentation = &instrumentation;
     return *this;
 }
@@ -1205,12 +1205,13 @@ void CBoostedTreeFactory::initializeTrainingProgressMonitoring(const core::CData
     }
     totalNumberSteps += this->mainLoopNumberSteps(LINE_SEARCH_ETA_MARGIN * eta);
     LOG_TRACE(<< "total number steps = " << totalNumberSteps);
-    m_TreeImpl->m_TrainingProgress =
-        core::CLoopProgress{totalNumberSteps, m_TreeImpl->m_Instrumentation->progressCallback(), 1.0, 1024};
+    m_TreeImpl->m_TrainingProgress = core::CLoopProgress{
+        totalNumberSteps, m_TreeImpl->m_Instrumentation->progressCallback(), 1.0, 1024};
 }
 
 void CBoostedTreeFactory::resumeRestoredTrainingProgressMonitoring() {
-    m_TreeImpl->m_TrainingProgress.progressCallback(m_TreeImpl->m_Instrumentation->progressCallback());
+    m_TreeImpl->m_TrainingProgress.progressCallback(
+        m_TreeImpl->m_Instrumentation->progressCallback());
     m_TreeImpl->m_TrainingProgress.resumeRestored();
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -31,6 +31,7 @@ using namespace boosted_tree_detail;
 using TStrVec = CBoostedTreeImpl::TStrVec;
 using TRowItr = core::CDataFrame::TRowItr;
 using TMeanVarAccumulator = CBoostedTreeImpl::TMeanVarAccumulator;
+using TMemoryUsageCallback = CDataFrameAnalysisInstrumentationInterface::TMemoryUsageCallback;
 
 namespace {
 // It isn't critical to recompute splits every tree we add because random
@@ -47,12 +48,9 @@ double lossAtNSigma(double n, const TMeanVarAccumulator& lossMoments) {
 //! \brief Record the memory used by a supplied object using the RAII idiom.
 class CScopeRecordMemoryUsage {
 public:
-    using TMemoryUsageCallback = CBoostedTreeImpl::TMemoryUsageCallback;
-
-public:
     template<typename T>
-    CScopeRecordMemoryUsage(const T& object, const TMemoryUsageCallback& recordMemoryUsage)
-        : m_RecordMemoryUsage{recordMemoryUsage},
+    CScopeRecordMemoryUsage(const T& object, TMemoryUsageCallback&& recordMemoryUsage)
+        : m_RecordMemoryUsage{std::move(recordMemoryUsage)},
           m_MemoryUsage(core::CMemory::dynamicSize(object)) {
         m_RecordMemoryUsage(m_MemoryUsage);
     }
@@ -60,7 +58,6 @@ public:
     ~CScopeRecordMemoryUsage() { m_RecordMemoryUsage(-m_MemoryUsage); }
 
     CScopeRecordMemoryUsage(const CScopeRecordMemoryUsage&) = delete;
-
     CScopeRecordMemoryUsage& operator=(const CScopeRecordMemoryUsage&) = delete;
 
     template<typename T>
@@ -78,7 +75,7 @@ public:
     }
 
 private:
-    const TMemoryUsageCallback& m_RecordMemoryUsage;
+    TMemoryUsageCallback m_RecordMemoryUsage;
     std::int64_t m_MemoryUsage;
 };
 
@@ -124,6 +121,8 @@ private:
     std::size_t m_MaximumNumberTreesWithoutImprovement;
     TDoubleSizePrMinAccumulator m_BestTestLoss;
 };
+
+CDataFrameAnalysisInstrumentationStub INSTRUMENTATION_STUB;
 }
 
 CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads,
@@ -133,7 +132,7 @@ CBoostedTreeImpl::CBoostedTreeImpl(std::size_t numberThreads,
       m_BestHyperparameters{
           m_Regularization,       m_DownsampleFactor,   m_Eta,
           m_EtaGrowthRatePerTree, m_MaximumNumberTrees, m_FeatureBagFraction},
-      m_Instrumentation{instrumentation} {
+      m_Instrumentation{instrumentation != nullptr ? instrumentation : &INSTRUMENTATION_STUB} {
 }
 
 CBoostedTreeImpl::CBoostedTreeImpl() = default;
@@ -144,15 +143,6 @@ CBoostedTreeImpl& CBoostedTreeImpl::operator=(CBoostedTreeImpl&&) = default;
 
 void CBoostedTreeImpl::train(core::CDataFrame& frame,
                              const TTrainingStateCallback& recordTrainStateCallback) {
-    CDataFrameAnalysisInstrumentationInterface::TProgressCallback recordProgress;
-    CDataFrameAnalysisInstrumentationInterface::TMemoryUsageCallback recordMemoryUsage;
-    if (m_Instrumentation != nullptr) {
-        recordProgress = this->m_Instrumentation->progressCallback();
-        recordMemoryUsage = this->m_Instrumentation->memoryUsageCallback();
-    } else {
-        recordProgress = [](double) {};
-        recordMemoryUsage = [](std::int64_t) {};
-    }
 
     if (m_DependentVariable >= frame.numberColumns()) {
         HANDLE_FATAL(<< "Internal error: dependent variable '" << m_DependentVariable
@@ -165,10 +155,9 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     LOG_TRACE(<< "Main training loop...");
 
-    m_TrainingProgress.progressCallback(recordProgress);
+    m_TrainingProgress.progressCallback(m_Instrumentation->progressCallback());
 
     std::int64_t lastMemoryUsage(this->memoryUsage());
-    recordMemoryUsage(lastMemoryUsage);
 
     core::CPackedBitVector allTrainingRowsMask{this->allTrainingRowsMask()};
     core::CPackedBitVector noRowsMask{allTrainingRowsMask.size(), false};
@@ -198,8 +187,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
             TMeanVarAccumulator lossMoments;
             std::size_t maximumNumberTrees;
-            std::tie(lossMoments, maximumNumberTrees) =
-                this->crossValidateForest(frame, recordMemoryUsage);
+            std::tie(lossMoments, maximumNumberTrees) = this->crossValidateForest(frame);
 
             this->captureBestHyperparameters(lossMoments, maximumNumberTrees);
 
@@ -209,7 +197,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
             }
 
             std::int64_t memoryUsage(this->memoryUsage());
-            recordMemoryUsage(memoryUsage - lastMemoryUsage);
+            m_Instrumentation->updateMemoryUsage(memoryUsage - lastMemoryUsage);
             lastMemoryUsage = memoryUsage;
 
             // Store the training state after each hyperparameter search step.
@@ -221,20 +209,15 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
             std::uint64_t currentLap{stopWatch.lap()};
             timeAccumulator.add(static_cast<double>(currentLap - lastLap));
             lastLap = currentLap;
-            if (m_Instrumentation != nullptr) {
-                m_Instrumentation->nextStep(static_cast<std::uint32_t>(m_CurrentRound));
-            }
+            m_Instrumentation->nextStep(static_cast<std::uint32_t>(m_CurrentRound));
         }
 
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
         this->restoreBestHyperparameters();
         std::tie(m_BestForest, std::ignore) =
-            this->trainForest(frame, allTrainingRowsMask, allTrainingRowsMask,
-                              m_TrainingProgress, recordMemoryUsage);
-        if (m_Instrumentation != nullptr) {
-            this->m_Instrumentation->nextStep(static_cast<std::uint32_t>(m_CurrentRound));
-        }
+            this->trainForest(frame, allTrainingRowsMask, allTrainingRowsMask, m_TrainingProgress);
+        m_Instrumentation->nextStep(static_cast<std::uint32_t>(m_CurrentRound));
         this->recordState(recordTrainStateCallback);
 
         timeAccumulator.add(static_cast<double>(stopWatch.stop()));
@@ -250,12 +233,9 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     this->computeProbabilityAtWhichToAssignClassOne(frame);
 
-    // Force to at least one here because we can have early exit from loop or take
-    // a different path.
-    recordProgress(1.0);
-
-    std::int64_t memoryUsage(this->memoryUsage());
-    recordMemoryUsage(memoryUsage - lastMemoryUsage);
+    // Force progress to one because we can have early exit from loop skip altogether.
+    m_Instrumentation->updateProgress(1.0);
+    m_Instrumentation->updateMemoryUsage(static_cast<std::int64_t>(this->memoryUsage()) - lastMemoryUsage);
 }
 
 void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainState) const {
@@ -373,8 +353,7 @@ void CBoostedTreeImpl::computeProbabilityAtWhichToAssignClassOne(const core::CDa
 }
 
 CBoostedTreeImpl::TMeanVarAccumulatorSizePr
-CBoostedTreeImpl::crossValidateForest(core::CDataFrame& frame,
-                                      const TMemoryUsageCallback& recordMemoryUsage) {
+CBoostedTreeImpl::crossValidateForest(core::CDataFrame& frame) {
 
     // We want to ensure we evaluate on equal proportions for each fold.
     TSizeVec folds(m_NumberFolds);
@@ -409,8 +388,7 @@ CBoostedTreeImpl::crossValidateForest(core::CDataFrame& frame,
         TNodeVecVec forest;
         double loss;
         std::tie(forest, loss) = this->trainForest(
-            frame, m_TrainingRowMasks[fold], m_TestingRowMasks[fold],
-            m_TrainingProgress, recordMemoryUsage);
+            frame, m_TrainingRowMasks[fold], m_TestingRowMasks[fold], m_TrainingProgress);
         LOG_TRACE(<< "fold = " << fold << " forest size = " << forest.size()
                   << " test set loss = " << loss);
         lossMoments.add(loss);
@@ -462,8 +440,7 @@ CBoostedTreeImpl::TNodeVecVecDoublePr
 CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
                               const core::CPackedBitVector& trainingRowMask,
                               const core::CPackedBitVector& testingRowMask,
-                              core::CLoopProgress& trainingProgress,
-                              const TMemoryUsageCallback& recordMemoryUsage) const {
+                              core::CLoopProgress& trainingProgress) const {
 
     LOG_TRACE(<< "Training one forest...");
 
@@ -473,7 +450,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
         frame, trainingRowMask, testingRowMask)};
     forest.reserve(m_MaximumNumberTrees);
 
-    CScopeRecordMemoryUsage scopeMemoryUsage{forest, recordMemoryUsage};
+    CScopeRecordMemoryUsage scopeMemoryUsage{forest, m_Instrumentation->memoryUsageCallback()};
 
     // For each iteration:
     //  1. Compute weighted quantiles for features F
@@ -495,14 +472,14 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
         forest.size() + static_cast<std::size_t>(std::max(0.5 / eta, 1.0))};
 
     auto downsampledRowMask = this->downsample(trainingRowMask);
+    scopeMemoryUsage.add(downsampledRowMask);
     auto candidateSplits = this->candidateSplits(frame, downsampledRowMask);
     scopeMemoryUsage.add(candidateSplits);
 
     std::size_t retries{0};
     CTrainForestStoppingCondition stoppingCondition{m_MaximumNumberTrees};
     do {
-        auto tree = this->trainTree(frame, downsampledRowMask, candidateSplits,
-                                    maximumTreeSize, recordMemoryUsage);
+        auto tree = this->trainTree(frame, downsampledRowMask, candidateSplits, maximumTreeSize);
 
         retries = tree.size() == 1 ? retries + 1 : 0;
 
@@ -655,8 +632,7 @@ CBoostedTreeImpl::TNodeVec
 CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
                             const TImmutableRadixSetVec& candidateSplits,
-                            const std::size_t maximumTreeSize,
-                            const TMemoryUsageCallback& recordMemoryUsage) const {
+                            const std::size_t maximumTreeSize) const {
 
     LOG_TRACE(<< "Training one tree...");
 
@@ -675,13 +651,15 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
     // We update local variables because the callback can be expensive if it
     // requires accessing atomics.
-    std::int64_t memory{0};
-    std::int64_t maxMemory{0};
+    struct SMemoryStats {
+        std::int64_t s_Current = 0;
+        std::int64_t s_Max = 0;
+    } memory;
     TMemoryUsageCallback localRecordMemoryUsage{[&](std::int64_t delta) {
-        memory += delta;
-        maxMemory = std::max(maxMemory, memory);
+        memory.s_Current += delta;
+        memory.s_Max = std::max(memory.s_Max, memory.s_Current);
     }};
-    CScopeRecordMemoryUsage scopeMemoryUsage{leaves, localRecordMemoryUsage};
+    CScopeRecordMemoryUsage scopeMemoryUsage{leaves, std::move(localRecordMemoryUsage)};
 
     // For each iteration we:
     //   1. Find the leaf with the greatest decrease in loss
@@ -733,8 +711,8 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
     tree.shrink_to_fit();
 
     // Flush the maximum memory used by the leaf statistics to the callback.
-    recordMemoryUsage(maxMemory);
-    recordMemoryUsage(-maxMemory);
+    m_Instrumentation->updateMemoryUsage(memory.s_Max);
+    m_Instrumentation->updateMemoryUsage(-memory.s_Max);
 
     LOG_TRACE(<< "Trained one tree. # nodes = " << tree.size());
 
@@ -1403,6 +1381,7 @@ bool CBoostedTreeImpl::restoreLoss(CBoostedTree::TLossFunctionUPtr& loss,
 std::size_t CBoostedTreeImpl::memoryUsage() const {
     std::size_t mem{core::CMemory::dynamicSize(m_Loss)};
     mem += core::CMemory::dynamicSize(m_Encoder);
+    mem += core::CMemory::dynamicSize(m_FeatureDataTypes);
     mem += core::CMemory::dynamicSize(m_FeatureSampleProbabilities);
     mem += core::CMemory::dynamicSize(m_MissingFeatureRowMasks);
     mem += core::CMemory::dynamicSize(m_TrainingRowMasks);
@@ -1410,6 +1389,7 @@ std::size_t CBoostedTreeImpl::memoryUsage() const {
     mem += core::CMemory::dynamicSize(m_FoldRoundTestLosses);
     mem += core::CMemory::dynamicSize(m_BestForest);
     mem += core::CMemory::dynamicSize(m_BayesianOptimization);
+    mem += core::CMemory::dynamicSize(m_Instrumentation);
     return mem;
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -215,8 +215,8 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
         this->restoreBestHyperparameters();
-        std::tie(m_BestForest, std::ignore) =
-            this->trainForest(frame, allTrainingRowsMask, allTrainingRowsMask, m_TrainingProgress);
+        std::tie(m_BestForest, std::ignore) = this->trainForest(
+            frame, allTrainingRowsMask, allTrainingRowsMask, m_TrainingProgress);
         m_Instrumentation->nextStep(static_cast<std::uint32_t>(m_CurrentRound));
         this->recordState(recordTrainStateCallback);
 
@@ -235,7 +235,8 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     // Force progress to one because we can have early exit from loop skip altogether.
     m_Instrumentation->updateProgress(1.0);
-    m_Instrumentation->updateMemoryUsage(static_cast<std::int64_t>(this->memoryUsage()) - lastMemoryUsage);
+    m_Instrumentation->updateMemoryUsage(
+        static_cast<std::int64_t>(this->memoryUsage()) - lastMemoryUsage);
 }
 
 void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainState) const {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1109,7 +1109,6 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
         fillDataFrame(trainRows, rows - trainRows, cols, {false, false, false, true},
                       x, TDoubleVec(rows, 0.0), target, *frame);
 
-
         auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                               1, std::make_unique<maths::boosted_tree::CBinomialLogistic>())
                               .buildFor(*frame, cols - 1);


### PR DESCRIPTION
We weren't accounting for the data frame's memory usage when reporting peak memory usage for training. Also, we were missing some state when estimating peak memory usage during the line searches to initialise hyperparameters.

I've also taken the opportunity to more fully migrate instrumentation of training to use the new instrumentation object and provide better automatic stubbing.