### PR TITLE
[ML] Improvements to upfront memory estimation for data frame analyses

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -48,6 +48,9 @@ progress, memory usage, etc. (See {ml-pull}906[#906].)
 and classification. (See {ml-pull}948[#948].)
 * Add new model_size_stats fields to instrument categorization.  (See {ml-pull}948[#948]
 and {pull}51879[#51879], issue: {issue}50794[#50749].)
+* Improve upfront memory estimation for all data frame analyses, which were higher than
+necessary. This will improve the allocation of data frame analyses to cluster nodes.
+(See {ml-pull}1003[#1003].)
 
 === Bug Fixes
 

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -74,7 +74,7 @@ protected:
 private:
     void writeProgress(std::uint32_t step);
     void writeMemory(std::uint32_t step);
-    void writeState(uint32_t step);
+    void writeState(std::uint32_t step);
 
 private:
     std::atomic_bool m_Finished;

--- a/include/maths/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/CDataFrameAnalysisInstrumentationInterface.h
@@ -20,6 +20,7 @@ class MATHS_EXPORT CDataFrameAnalysisInstrumentationInterface {
 public:
     using TProgressCallback = std::function<void(double)>;
     using TMemoryUsageCallback = std::function<void(std::int64_t)>;
+    using TStepCallback = std::function<void(std::uint32_t)>;
 
 public:
     virtual ~CDataFrameAnalysisInstrumentationInterface() = default;
@@ -46,6 +47,10 @@ public:
     //! Factory for the updateMemoryUsage() callback function object.
     TMemoryUsageCallback memoryUsageCallback() {
         return [this](std::int64_t delta) { this->updateMemoryUsage(delta); };
+    }
+    //! Factory for the nextStep() callback function object.
+    TStepCallback stepCallback() {
+        return [this](std::uint32_t step) { this->nextStep(step); };
     }
 };
 

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -48,7 +48,7 @@ TBoolVec CDataFrameAnalysisRunner::columnsForWhichEmptyIsMissing(const TStrVec& 
 
 void CDataFrameAnalysisRunner::estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const {
     std::size_t numberRows{m_Spec.numberRows()};
-    std::size_t numberColumns{m_Spec.numberColumns() + this->numberExtraColumns()};
+    std::size_t numberColumns{m_Spec.numberColumns()};
     std::size_t maxNumberPartitions{maximumNumberPartitions(m_Spec)};
     if (maxNumberPartitions == 0) {
         writer.write("0", "0");
@@ -68,7 +68,7 @@ void CDataFrameAnalysisRunner::estimateMemoryUsage(CMemoryUsageEstimationResultJ
 void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
 
     std::size_t numberRows{m_Spec.numberRows()};
-    std::size_t numberColumns{m_Spec.numberColumns() + this->numberExtraColumns()};
+    std::size_t numberColumns{m_Spec.numberColumns()};
     std::size_t memoryLimit{m_Spec.memoryLimit()};
 
     LOG_TRACE(<< "memory limit = " << memoryLimit);
@@ -163,8 +163,9 @@ const CDataFrameAnalysisSpecification& CDataFrameAnalysisRunner::spec() const {
 std::size_t CDataFrameAnalysisRunner::estimateMemoryUsage(std::size_t totalNumberRows,
                                                           std::size_t partitionNumberRows,
                                                           std::size_t numberColumns) const {
-    return core::CDataFrame::estimateMemoryUsage(this->storeDataFrameInMainMemory(),
-                                                 totalNumberRows, numberColumns) +
+    return core::CDataFrame::estimateMemoryUsage(
+               this->storeDataFrameInMainMemory(), totalNumberRows,
+               numberColumns + this->numberExtraColumns()) +
            this->estimateBookkeepingMemoryUsage(m_NumberPartitions, totalNumberRows,
                                                 partitionNumberRows, numberColumns);
 }

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -115,6 +115,7 @@ BOOST_AUTO_TEST_CASE(testComputeAndSaveExecutionStrategyDiskUsageFlag) {
     }
 }
 
+namespace {
 void testEstimateMemoryUsage(std::int64_t numberRows,
                              const std::string& expectedExpectedMemoryWithoutDisk,
                              const std::string& expectedExpectedMemoryWithDisk,
@@ -152,12 +153,13 @@ void testEstimateMemoryUsage(std::int64_t numberRows,
 
     BOOST_TEST_REQUIRE(result.HasMember("expected_memory_without_disk"));
     BOOST_REQUIRE_EQUAL(expectedExpectedMemoryWithoutDisk,
-                        std::string(result["expected_memory_without_disk"].GetString()));
+                        result["expected_memory_without_disk"].GetString());
     BOOST_TEST_REQUIRE(result.HasMember("expected_memory_with_disk"));
     BOOST_REQUIRE_EQUAL(expectedExpectedMemoryWithDisk,
-                        std::string(result["expected_memory_with_disk"].GetString()));
+                        result["expected_memory_with_disk"].GetString());
 
     BOOST_REQUIRE_EQUAL(expectedNumberErrors, static_cast<int>(errors.size()));
+}
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor0Rows) {
@@ -165,19 +167,19 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor0Rows) {
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor1Row) {
-    testEstimateMemoryUsage(1, "6kB", "6kB", 0);
+    testEstimateMemoryUsage(1, "4kB", "4kB", 0);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor10Rows) {
-    testEstimateMemoryUsage(10, "15kB", "13kB", 0);
+    testEstimateMemoryUsage(10, "12kB", "10kB", 0);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor100Rows) {
-    testEstimateMemoryUsage(100, "62kB", "35kB", 0);
+    testEstimateMemoryUsage(100, "57kB", "35kB", 0);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor1000Rows) {
-    testEstimateMemoryUsage(1000, "450kB", "143kB", 0);
+    testEstimateMemoryUsage(1000, "403kB", "142kB", 0);
 }
 
 void testColumnsForWhichEmptyIsMissing(const std::string& analysis,

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -163,6 +163,10 @@ struct SFixture {
         LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
                   << "ms");
 
+        BOOST_TEST_REQUIRE(
+            core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
+            core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
+
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(s_Output.str()));
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
@@ -198,6 +202,10 @@ struct SFixture {
         LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
                   << "ms");
 
+        BOOST_TEST_REQUIRE(
+            core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
+            core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
+
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(s_Output.str()));
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
@@ -228,6 +236,10 @@ struct SFixture {
                   << core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage));
         LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
                   << "ms");
+
+        BOOST_TEST_REQUIRE(
+            core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
+            core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
 
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(s_Output.str()));

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -156,6 +156,13 @@ struct SFixture {
 
         analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
+        LOG_DEBUG(<< "estimated memory usage = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
+        LOG_DEBUG(<< "peak memory = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage));
+        LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
+                  << "ms");
+
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(s_Output.str()));
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
@@ -184,6 +191,13 @@ struct SFixture {
 
         analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
+        LOG_DEBUG(<< "estimated memory usage = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
+        LOG_DEBUG(<< "peak memory = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage));
+        LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
+                  << "ms");
+
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(s_Output.str()));
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
@@ -207,6 +221,13 @@ struct SFixture {
         setupRegressionDataWithMissingFeatures(fieldNames, fieldValues, analyzer, s_Rows, 5);
 
         analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+        LOG_DEBUG(<< "estimated memory usage = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
+        LOG_DEBUG(<< "peak memory = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage));
+        LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
+                  << "ms");
 
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(s_Output.str()));

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -4,8 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include "CDataFrameMockAnalysisRunner.h"
-
 #include <core/CContainerPrinter.h>
 #include <core/CJsonOutputStreamWrapper.h>
 #include <core/CProgramCounters.h>
@@ -17,10 +15,9 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameAnalyzer.h>
 
+#include <test/BoostTestCloseAbsolute.h>
 #include <test/CDataFrameAnalysisSpecificationFactory.h>
 #include <test/CRandomNumbers.h>
-
-#include <test/BoostTestCloseAbsolute.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -87,9 +84,10 @@ void addOutlierTestData(TStrVec fieldNames,
     }
 
     frame->finishWritingRows();
-    CDataFrameMockAnalysisState state;
+    maths::CDataFrameAnalysisInstrumentationStub instrumentation;
     maths::COutliers::compute(
-        {1, 1, true, method, numberNeighbours, computeFeatureInfluence, 0.05}, *frame, state);
+        {1, 1, true, method, numberNeighbours, computeFeatureInfluence, 0.05},
+        *frame, instrumentation);
 
     expectedScores.resize(numberInliers + numberOutliers);
     expectedFeatureInfluences.resize(numberInliers + numberOutliers, TDoubleVec(5));
@@ -202,10 +200,16 @@ BOOST_AUTO_TEST_CASE(testRunOutlierDetection) {
 
     LOG_DEBUG(<< "number partitions = "
               << core::CProgramCounters::counter(counter_t::E_DFONumberPartitions));
+    LOG_DEBUG(<< "estimated memory usage = "
+              << core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage));
     LOG_DEBUG(<< "peak memory = "
               << core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage));
+
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) == 1);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 100000);
+    BOOST_TEST_REQUIRE(
+        core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) <
+        core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage));
 }
 
 BOOST_AUTO_TEST_CASE(testRunOutlierDetectionPartitioned) {
@@ -249,11 +253,16 @@ BOOST_AUTO_TEST_CASE(testRunOutlierDetectionPartitioned) {
 
     LOG_DEBUG(<< "number partitions = "
               << core::CProgramCounters::counter(counter_t::E_DFONumberPartitions));
+    LOG_DEBUG(<< "estimated memory usage = "
+              << core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage));
     LOG_DEBUG(<< "peak memory = "
               << core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage));
+
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) > 1);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) <
-                       300000); // + 16%
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 100000);
+    BOOST_TEST_REQUIRE(
+        core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) <
+        core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage));
 }
 
 BOOST_AUTO_TEST_CASE(testRunOutlierFeatureInfluences) {

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -207,10 +207,10 @@ BOOST_AUTO_TEST_CASE(testRunOutlierDetection) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) == 1);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 100000);
-    // Allow a 16% margin
+    // Allow a 20% margin
     BOOST_TEST_REQUIRE(
         core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) <
-        (116 * core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage)) / 100);
+        (120 * core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage)) / 100);
 }
 
 BOOST_AUTO_TEST_CASE(testRunOutlierDetectionPartitioned) {
@@ -260,11 +260,11 @@ BOOST_AUTO_TEST_CASE(testRunOutlierDetectionPartitioned) {
               << core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage));
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) > 1);
-    // Allow a 16% margin
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 116000);
+    // Allow a 20% margin
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 120000);
     BOOST_TEST_REQUIRE(
         core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) <
-        (116 * core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage)) / 100);
+        (120 * core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage)) / 100);
 }
 
 BOOST_AUTO_TEST_CASE(testRunOutlierFeatureInfluences) {

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -207,9 +207,10 @@ BOOST_AUTO_TEST_CASE(testRunOutlierDetection) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) == 1);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 100000);
+    // Allow a 16% margin
     BOOST_TEST_REQUIRE(
         core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) <
-        core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage));
+        (116 * core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage)) / 100);
 }
 
 BOOST_AUTO_TEST_CASE(testRunOutlierDetectionPartitioned) {
@@ -259,10 +260,11 @@ BOOST_AUTO_TEST_CASE(testRunOutlierDetectionPartitioned) {
               << core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage));
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFONumberPartitions) > 1);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 100000);
+    // Allow a 16% margin
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) < 116000);
     BOOST_TEST_REQUIRE(
         core::CProgramCounters::counter(counter_t::E_DFOPeakMemoryUsage) <
-        core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage));
+        (116 * core::CProgramCounters::counter(counter_t::E_DFOEstimatedPeakMemoryUsage)) / 100);
 }
 
 BOOST_AUTO_TEST_CASE(testRunOutlierFeatureInfluences) {

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -427,6 +427,9 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 6000000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1500000);
+    BOOST_TEST_REQUIRE(
+        core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
+        core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -722,9 +725,13 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
               << core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage));
     LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
               << "ms");
+
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 6000000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1500000);
+    BOOST_TEST_REQUIRE(
+        core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
+        core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -40,11 +40,11 @@ std::size_t CDataFrameMockAnalysisRunner::estimateBookkeepingMemoryUsage(std::si
 
 const ml::api::CDataFrameAnalysisInstrumentation&
 CDataFrameMockAnalysisRunner::instrumentation() const {
-    return m_State;
+    return m_Instrumentation;
 }
 
 ml::api::CDataFrameAnalysisInstrumentation& CDataFrameMockAnalysisRunner::instrumentation() {
-    return m_State;
+    return m_Instrumentation;
 }
 
 ml::test::CRandomNumbers CDataFrameMockAnalysisRunner::ms_Rng;

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -30,7 +30,6 @@ public:
                      ml::core::CRapidJsonConcurrentLineWriter&) const override;
 
     const ml::api::CDataFrameAnalysisInstrumentation& instrumentation() const override;
-
     ml::api::CDataFrameAnalysisInstrumentation& instrumentation() override;
 
 private:
@@ -42,7 +41,7 @@ private:
 
 private:
     static ml::test::CRandomNumbers ms_Rng;
-    CDataFrameMockAnalysisState m_State;
+    CDataFrameMockAnalysisState m_Instrumentation;
 };
 
 class CDataFrameMockAnalysisRunnerFactory final : public ml::api::CDataFrameAnalysisRunnerFactory {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -285,8 +285,6 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
     std::size_t forestMemoryUsage{
         m_MaximumNumberTrees *
         (sizeof(TNodeVec) + maximumNumberNodes * sizeof(CBoostedTreeNode))};
-    std::size_t extraColumnsMemoryUsage{numberExtraColumnsForTrain(m_Loss->numberParameters()) *
-                                        numberRows * sizeof(CFloatStorage)};
     std::size_t foldRoundLossMemoryUsage{m_NumberFolds * m_NumberRounds *
                                          sizeof(TOptionalDouble)};
     std::size_t hyperparametersMemoryUsage{numberColumns * sizeof(double)};
@@ -304,8 +302,8 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
         this->numberHyperparametersToTune(), m_NumberRounds)};
     std::size_t shapMemoryUsage{
         m_TopShapValues > 0 ? numberRows * numberColumns * sizeof(CFloatStorage) : 0};
-    return sizeof(*this) + forestMemoryUsage + extraColumnsMemoryUsage +
-           foldRoundLossMemoryUsage + hyperparametersMemoryUsage +
+    return sizeof(*this) + forestMemoryUsage + foldRoundLossMemoryUsage +
+           hyperparametersMemoryUsage +
            std::max(leafNodeStatisticsMemoryUsage, shapMemoryUsage) + // not concurrent
            dataTypeMemoryUsage + featureSampleProbabilities + missingFeatureMaskMemoryUsage +
            trainTestMaskMemoryUsage + bayesianOptimisationMemoryUsage;


### PR DESCRIPTION
This change fixes a double counting bug for the memory used by the extra columns for classification and regression model training. It also means they only count towards the data frame memory usage: previously they were wrongly being treated as features for memory estimation purposes. 

Incidentally, it also fixes the memory reported by the counter `E_DFOEstimatedPeakMemoryUsage`, which was missing the extra columns' memory usage.

Finally, it tidies up instrumentation of outlier detection, to more fully use the new instrumentation class, and corrects the memory estimates in `testRunOutlierDetectionPartitioned`.