### PR TITLE
[ML] Upgrade gcc to version 7.5

### DIFF
--- a/3rd_party/3rd_party.sh
+++ b/3rd_party/3rd_party.sh
@@ -47,15 +47,15 @@ case `uname` in
 
     Linux)
         if [ -z "$CPP_CROSS_COMPILE" ] ; then
-            BOOST_LOCATION=/usr/local/gcc73/lib
+            BOOST_LOCATION=/usr/local/gcc75/lib
             BOOST_COMPILER=gcc
             BOOST_EXTENSION=mt-x64-1_71.so.1.71.0
             BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread'
-            XML_LOCATION=/usr/local/gcc73/lib
+            XML_LOCATION=/usr/local/gcc75/lib
             XML_EXTENSION=.so.2
-            GCC_RT_LOCATION=/usr/local/gcc73/lib64
+            GCC_RT_LOCATION=/usr/local/gcc75/lib64
             GCC_RT_EXTENSION=.so.1
-            STL_LOCATION=/usr/local/gcc73/lib64
+            STL_LOCATION=/usr/local/gcc75/lib64
             STL_PREFIX=libstdc++
             STL_EXTENSION=.so.6
             ZLIB_LOCATION=

--- a/3rd_party/licenses/gcc-runtime-INFO.csv
+++ b/3rd_party/licenses/gcc-runtime-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright
-GCC Runtime Library,6.2.0,6ac74a62ba7258299cf85fbef9bf45333ddf10c0,https://gcc.gnu.org,GPL-3.0 WITH GCC-exception-3.1,"Copyright (C) 2016 Free Software Foundation, Inc."
+GCC Runtime Library,7.5.0,b2d961e7342b5ba4e57adfa81cb189b738d10901,https://gcc.gnu.org,GPL-3.0 WITH GCC-exception-3.1,"Copyright (C) 2019 Free Software Foundation, Inc."

--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -7,16 +7,16 @@ You will need the following environment variables to be defined:
 
 - `JAVA_HOME` - Should point to the JDK you want to use to run Gradle.
 - `CPP_SRC_HOME` - Only required if building the C++ code directly using `make`, as Gradle sets it automatically.
-- `PATH` - Must have `/usr/local/gcc73/bin` before `/usr/bin` and `/bin`.
-- `LD_LIBRARY_PATH` - Must have `/usr/local/gcc73/lib64` and `/usr/local/gcc73/lib` before `/usr/lib` and `/lib`.
+- `PATH` - Must have `/usr/local/gcc75/bin` before `/usr/bin` and `/bin`.
+- `LD_LIBRARY_PATH` - Must have `/usr/local/gcc75/lib64` and `/usr/local/gcc75/lib` before `/usr/lib` and `/lib`.
 
 For example, you might create a `.bashrc` file in your home directory containing something like this:
 
 ```
 umask 0002
 export JAVA_HOME=/usr/local/jdk1.8.0_121
-export LD_LIBRARY_PATH=/usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
-export PATH=$JAVA_HOME/bin:/usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
+export LD_LIBRARY_PATH=/usr/local/gcc75/lib64:/usr/local/gcc75/lib:/usr/lib:/lib
+export PATH=$JAVA_HOME/bin:/usr/local/gcc75/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
 # Only required if building the C++ code directly using make - adjust depending on the location of your Git clone
 export CPP_SRC_HOME=$HOME/ml-cpp
 ```
@@ -28,6 +28,7 @@ You need the C++ compiler and the headers for the `zlib` library that comes with
 ```
 sudo yum install bzip2
 sudo yum install gcc-c++
+sudo yum install texinfo
 sudo yum install tzdata
 sudo yum install unzip
 sudo yum install zlib-devel
@@ -54,22 +55,22 @@ These environment variables only need to be set when building tools on Linux. Th
 
 We have to build on old Linux versions to enable our software to run on the older versions of Linux that users have.  However, this means the default compiler on our Linux build servers is also very old.  To enable use of more modern C++ features, we use the default compiler to build a newer version of gcc and then use that to build all our other dependencies.
 
-Download `gcc-7.3.0.tar.gz` from <http://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.gz>.
+Download `gcc-7.5.0.tar.gz` from <http://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz>.
 
 Unlike most automake-based tools, gcc must be built in a directory adjacent to the directory containing its source code, so build and install it like this:
 
 ```
-tar zxvf gcc-7.3.0.tar.gz
-cd gcc-7.3.0
+tar zxvf gcc-7.5.0.tar.gz
+cd gcc-7.5.0
 contrib/download_prerequisites
 sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
 cd ..
-mkdir gcc-7.3.0-build
-cd gcc-7.3.0-build
+mkdir gcc-7.5.0-build
+cd gcc-7.5.0-build
 unset CXX
 unset LD_LIBRARY_PATH
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
-../gcc-7.3.0/configure --prefix=/usr/local/gcc73 --enable-languages=c,c++ --enable-vtable-verify --with-system-zlib --disable-multilib
+../gcc-7.5.0/configure --prefix=/usr/local/gcc75 --enable-languages=c,c++ --enable-vtable-verify --with-system-zlib --disable-multilib
 make -j 6
 sudo make install
 ```
@@ -91,10 +92,31 @@ g++ --version
 It should print:
 
 ```
-g++ (GCC) 7.3.0
+g++ (GCC) 7.5.0
 ```
 
-in the first line of the output. If it doesn't then double check that `/usr/local/gcc73/bin` is near the beginning of your `PATH`.
+in the first line of the output. If it doesn't then double check that `/usr/local/gcc75/bin` is near the beginning of your `PATH`.
+
+### binutils
+
+Also due to building on old Linux versions yet wanting to use modern libraries we have to install an up-to-date version of binutils.
+
+Download `binutils-2.34.tar.bz2` from <http://ftpmirror.gnu.org/binutils/binutils-2.34.tar.bz2>.
+
+Uncompress and untar the resulting file. Then run:
+
+```
+./configure --prefix=/usr/local/gcc75 --enable-vtable-verify --with-system-zlib --disable-libstdcxx --with-gcc-major-version-only
+```
+
+This should build an appropriate Makefile. Assuming it does, type:
+
+```
+make
+sudo make install
+```
+
+to install.
 
 ### Git
 
@@ -139,7 +161,7 @@ Anonymous FTP to ftp.xmlsoft.org, change directory to libxml2, switch to binary 
 Uncompress and untar the resulting file. Then run:
 
 ```
-./configure --prefix=/usr/local/gcc73 --without-python --without-readline
+./configure --prefix=/usr/local/gcc75 --without-python --without-readline
 ```
 
 This should build an appropriate Makefile. Assuming it does, type:
@@ -197,7 +219,7 @@ Finally, run:
 
 ```
 ./b2 -j6 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now
-sudo env PATH="$PATH" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now
+sudo env PATH="$PATH" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" ./b2 install --prefix=/usr/local/gcc75 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now
 ```
 
 to install the Boost headers and libraries.  (Note the `env PATH="$PATH"` bit in the install command - this is because `sudo` usually resets `PATH` and that will cause Boost to rebuild everything again with the default compiler as part of the install!)
@@ -215,7 +237,7 @@ bzip2 -cd patchelf-0.9.tar.bz2 | tar xvf -
 In the resulting `patchelf-0.9` directory, run the:
 
 ```
-./configure --prefix=/usr/local/gcc73
+./configure --prefix=/usr/local/gcc75
 ```
 
 script. This should build an appropriate Makefile. Assuming it does, run:

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -17,7 +17,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=12
+VERSION=13
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:12
+FROM docker.elastic.co/ml-dev/ml-linux-build:13
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Make sure OS packages are up to date and required packages are installed
 RUN \
   rm /var/lib/rpm/__db.* && \
-  yum install -y gcc gcc-c++ git unzip wget zip zlib-devel
+  yum install -y gcc gcc-c++ git texinfo unzip wget zip zlib-devel
 
 # For compiling with hardening and optimisation
 ENV CFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
@@ -21,31 +21,41 @@ ENV CXXFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2"
 ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now"
 ENV LDFLAGS_FOR_TARGET "-Wl,-z,relro -Wl,-z,now"
 
-# Build gcc 7.3
+# Build gcc 7.5
 RUN \
-  wget --quiet -O - http://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.gz | tar zxf - && \
-  cd gcc-7.3.0 && \
+  wget --quiet -O - http://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz | tar zxf - && \
+  cd gcc-7.5.0 && \
   contrib/download_prerequisites && \
   sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc && \
   cd .. && \
-  mkdir gcc-7.3.0-build && \
-  cd gcc-7.3.0-build && \
-  ../gcc-7.3.0/configure --prefix=/usr/local/gcc73 --enable-languages=c,c++ --enable-vtable-verify --with-system-zlib --disable-multilib && \
+  mkdir gcc-7.5.0-build && \
+  cd gcc-7.5.0-build && \
+  ../gcc-7.5.0/configure --prefix=/usr/local/gcc75 --enable-languages=c,c++ --enable-vtable-verify --with-system-zlib --disable-multilib && \
   make -j`grep -c '^processor' /proc/cpuinfo` && \
   make install && \
   cd .. && \
-  rm -rf gcc-7.3.0 gcc-7.3.0-build
+  rm -rf gcc-7.5.0 gcc-7.5.0-build
 
 # Update paths to use the newly built compiler in C++14 mode
-ENV LD_LIBRARY_PATH /usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
-ENV PATH /usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin
+ENV LD_LIBRARY_PATH /usr/local/gcc75/lib64:/usr/local/gcc75/lib:/usr/lib:/lib
+ENV PATH /usr/local/gcc75/bin:/usr/bin:/bin:/usr/sbin:/sbin
 ENV CXX "g++ -std=gnu++14"
+
+# Build binutils
+RUN \
+  wget --quiet -O - http://ftpmirror.gnu.org/binutils/binutils-2.34.tar.bz2 | tar jxf - && \
+  cd binutils-2.34 && \
+  ./configure --prefix=/usr/local/gcc75 --enable-vtable-verify --with-system-zlib --disable-libstdcxx --with-gcc-major-version-only && \
+  make -j`grep -c '^processor' /proc/cpuinfo` && \
+  make install && \
+  cd .. && \
+  rm -rf binutils-2.34
 
 # Build libxml2
 RUN \
   wget --quiet -O - ftp://anonymous@ftp.xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz | tar zxf - && \
   cd libxml2-2.9.4 && \
-  ./configure --prefix=/usr/local/gcc73 --without-python --without-readline && \
+  ./configure --prefix=/usr/local/gcc75 --without-python --without-readline && \
   make -j`grep -c '^processor' /proc/cpuinfo` && \
   make install && \
   cd .. && \
@@ -59,7 +69,7 @@ RUN \
   sed -i -e 's/(17ul)(29ul)(37ul)(53ul)(67ul)(79ul) \\/(3ul)(17ul)(29ul)(37ul)(53ul)(67ul)(79ul) \\/' boost/unordered/detail/implementation.hpp && \
   sed -i -e 's%#if ((defined(__linux__) \&\& !defined(__UCLIBC__) \&\& !defined(BOOST_MATH_HAVE_FIXED_GLIBC)) || defined(__QNX__) || defined(__IBMCPP__)) \&\& !defined(BOOST_NO_FENV_H)%#if ((!defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS) \&\& defined(__linux__) \&\& !defined(__UCLIBC__) \&\& !defined(BOOST_MATH_HAVE_FIXED_GLIBC)) || defined(__QNX__) || defined(__IBMCPP__)) \&\& !defined(BOOST_NO_FENV_H)%g' boost/math/tools/config.hpp && \
   ./b2 -j`grep -c '^processor' /proc/cpuinfo` --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now && \
-  ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now && \
+  ./b2 install --prefix=/usr/local/gcc75 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now && \
   cd .. && \
   rm -rf boost_1_71_0
 
@@ -67,7 +77,7 @@ RUN \
 RUN \
   wget --quiet -O - http://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.gz | tar zxf - && \
   cd patchelf-0.9 && \
-  ./configure --prefix=/usr/local/gcc73 && \
+  ./configure --prefix=/usr/local/gcc75 && \
   make -j`grep -c '^processor' /proc/cpuinfo` && \
   make install && \
   cd .. && \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:12
+FROM docker.elastic.co/ml-dev/ml-linux-build:13
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/vagrant/linux/provision.sh
+++ b/dev-tools/vagrant/linux/provision.sh
@@ -18,7 +18,7 @@ if [ ! -f package.state ]; then
   echo "Installing misc packages..."
   add-apt-repository -y ppa:webupd8team/java
   apt-get update
-  apt-get -qq -y install git wget build-essential maven unzip perl libbz2-1.0 libbz2-dev bzip2 python-setuptools zlib1g-dev
+  apt-get -qq -y install git wget build-essential maven unzip perl libbz2-1.0 libbz2-dev bzip2 python-setuptools texinfo zlib1g-dev
   touch package.state
 fi
 
@@ -39,14 +39,14 @@ export LDFLAGS='-Wl,-z,relro -Wl,-z,now'
 export LDFLAGS_FOR_TARGET='-Wl,-z,relro -Wl,-z,now'
 unset LIBRARY_PATH
 
-# ----------------- Compile gcc 7.3 -------------------------
+# ----------------- Compile gcc 7.5 -------------------------
 if [ ! -f gcc.state ]; then
-  echo "Compiling GCC 7.3..."
+  echo "Compiling GCC 7.5..."
   echo "  Downloading..."
-  wget --quiet http://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.gz
+  wget --quiet http://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz
   # gcc needs different source and build directories
   mkdir gcc-source
-  tar xfz gcc-7.3.0.tar.gz -C gcc-source --strip-components=1
+  tar xfz gcc-7.5.0.tar.gz -C gcc-source --strip-components=1
   cd gcc-source
   contrib/download_prerequisites
   sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
@@ -54,19 +54,37 @@ if [ ! -f gcc.state ]; then
   mkdir gcc-build
   cd gcc-build
   echo "  Configuring..."
-  ../gcc-source/configure --prefix=/usr/local/gcc73 --enable-languages=c,c++ --enable-vtable-verify --with-system-zlib --disable-multilib > configure.log 2>&1
+  ../gcc-source/configure --prefix=/usr/local/gcc75 --enable-languages=c,c++ --enable-vtable-verify --with-system-zlib --disable-multilib > configure.log 2>&1
   echo "  Making..."
   make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
   make install > make_install.log 2>&1
   cd ..
-  rm gcc-7.3.0.tar.gz
+  rm gcc-7.5.0.tar.gz
   touch gcc.state
 fi
 
 # Update paths to use the newly built compiler in C++14 mode
-export LD_LIBRARY_PATH=/usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
-export PATH=/usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
+export LD_LIBRARY_PATH=/usr/local/gcc75/lib64:/usr/local/gcc75/lib:/usr/lib:/lib
+export PATH=/usr/local/gcc75/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
 export CXX='g++ -std=gnu++14'
+
+# ----------------- Compile binutils -------------------------
+if [ ! -f binutils.state ]; then
+  echo "Compiling binutils..."
+  echo "  Downloading..."
+  wget --quiet -O binutils-2.34.tar.gz http://ftpmirror.gnu.org/binutils/binutils-2.34.tar.gz
+  mkdir binutils
+  tar xfz binutils-2.34.tar.gz -C binutils --strip-components=1
+  cd binutils
+  echo "  Configuring..."
+  ./configure --prefix=/usr/local/gcc75 --enable-vtable-verify --with-system-zlib --disable-libstdcxx --with-gcc-major-version-only > configure.log 2>&1
+  echo "  Making..."
+  make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
+  make install > make_install.log 2>&1
+  cd ..
+  rm binutils-2.34.tar.gz
+  touch binutils.state
+fi
 
 # ----------------- Compile libxml2 -------------------------
 if [ ! -f libxml2.state ]; then
@@ -77,7 +95,7 @@ if [ ! -f libxml2.state ]; then
   tar xfz LATEST_LIBXML2.tar.gz -C libxml --strip-components=1
   cd libxml
   echo "  Configuring..."
-  ./configure --prefix=/usr/local/gcc73 --without-python --without-readline > configure.log 2>&1
+  ./configure --prefix=/usr/local/gcc75 --without-python --without-readline > configure.log 2>&1
   echo "  Making..."
   make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
   make install > make_install.log 2>&1
@@ -105,7 +123,7 @@ if [ ! -f boost.state ]; then
 
   echo "  Building..."
   ./b2 -j$NUMCPUS --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now > b2_make.log 2>&1
-  ./b2 install --prefix=/usr/local/gcc73 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now > b2_make_install.log 2>&1
+  ./b2 install --prefix=/usr/local/gcc75 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags=-std=gnu++14 cxxflags=-fstack-protector linkflags=-Wl,-z,relro linkflags=-Wl,-z,now > b2_make_install.log 2>&1
 
   cd ..
   rm boost_1_71_0.tar.gz
@@ -121,7 +139,7 @@ if [ ! -f patchelf.state ]; then
   tar xfz patchelf-0.9.tar.gz -C patchelf --strip-components=1
   cd patchelf
   echo "  Configuring..."
-  ./configure --prefix=/usr/local/gcc73 > configure.log 2>&1
+  ./configure --prefix=/usr/local/gcc75 > configure.log 2>&1
   echo "  Making..."
   make -j$NUMCPUS --load-average=$NUMCPUS > make.log 2>&1
   make install > make_install.log 2>&1
@@ -150,8 +168,8 @@ umask 0002
 export ML_SRC_HOME=/home/vagrant/ml/src
 export JAVA_HOME=/usr/lib/jvm/java-8-oracle
 unset JAVA_ROOT
-export LD_LIBRARY_PATH=/usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
-export PATH=$JAVA_HOME/bin:/bin:/usr/local/gcc73/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
+export LD_LIBRARY_PATH=/usr/local/gcc75/lib64:/usr/local/gcc75/lib:/usr/lib:/lib
+export PATH=$JAVA_HOME/bin:/bin:/usr/local/gcc75/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/vagrant/bin
 
 ulimit -c unlimited
 cd /home/vagrant/ml/src

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -53,6 +53,8 @@ and {pull}51879[#51879], issue: {issue}50794[#50749].)
 * Improve upfront memory estimation for all data frame analyses, which were higher than
 necessary. This will improve the allocation of data frame analyses to cluster nodes.
 (See {ml-pull}1003[#1003].)
+* Upgrade the compiler used on Linux from gcc 7.3 to gcc 7.5, and the binutils used in
+the build from version 2.20 to 2.34.  (See {ml-pull}1013[#1013].)
 
 === Bug Fixes
 

--- a/mk/linux.mk
+++ b/mk/linux.mk
@@ -27,7 +27,7 @@ PLATPICFLAGS=-fPIC
 PLATPIEFLAGS=-fPIE
 CFLAGS=-g $(OPTCFLAGS) -msse4.2 -mfpmath=sse -fstack-protector -fno-math-errno -fno-permissive -Wall -Wcast-align -Wconversion -Wextra -Winit-self -Wparentheses -Wpointer-arith -Wswitch-enum $(COVERAGE)
 CXXFLAGS=$(CFLAGS) -Wno-ctor-dtor-privacy -Wno-deprecated-declarations -Wold-style-cast -fvisibility-inlines-hidden
-CPPFLAGS=-isystem $(CPP_SRC_HOME)/3rd_party/include -isystem /usr/local/gcc73/include -D$(OS) -D_REENTRANT $(OPTCPPFLAGS)
+CPPFLAGS=-isystem $(CPP_SRC_HOME)/3rd_party/include -isystem /usr/local/gcc75/include -D$(OS) -D_REENTRANT $(OPTCPPFLAGS)
 CDEPFLAGS=-MM
 COMP_OUT_FLAG=-o
 LINK_OUT_FLAG=-o
@@ -45,7 +45,7 @@ NETLIBS=-lnsl
 BOOSTVER=1_71
 BOOSTGCCVER:=$(shell $(CXX) -dumpversion | awk -F. '{ print $$1; }')
 # Use -isystem instead of -I for Boost headers to suppress warnings from Boost
-BOOSTINCLUDES=-isystem /usr/local/gcc73/include/boost-$(BOOSTVER)
+BOOSTINCLUDES=-isystem /usr/local/gcc75/include/boost-$(BOOSTVER)
 BOOSTCPPFLAGS=-DBOOST_ALL_DYN_LINK -DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
 BOOSTLOGLIBS=-lboost_log-gcc$(BOOSTGCCVER)-mt-x64-$(BOOSTVER)
 BOOSTLOGSETUPLIBS=-lboost_log_setup-gcc$(BOOSTGCCVER)-mt-x64-$(BOOSTVER)
@@ -60,8 +60,8 @@ RAPIDJSONINCLUDES=-isystem $(CPP_SRC_HOME)/3rd_party/rapidjson/include
 RAPIDJSONCPPFLAGS=-DRAPIDJSON_HAS_STDSTRING -DRAPIDJSON_SSE42
 EIGENINCLUDES=-isystem $(CPP_SRC_HOME)/3rd_party/eigen
 EIGENCPPFLAGS=-DEIGEN_MPL2_ONLY
-XMLINCLUDES=`/usr/local/gcc73/bin/xml2-config --cflags`
-XMLLIBS=`/usr/local/gcc73/bin/xml2-config --libs`
+XMLINCLUDES=`/usr/local/gcc75/bin/xml2-config --cflags`
+XMLLIBS=`/usr/local/gcc75/bin/xml2-config --libs`
 DYNAMICLIBLDFLAGS=$(PLATPICFLAGS) -shared -Wl,--as-needed -L$(CPP_PLATFORM_HOME)/$(DYNAMIC_LIB_DIR) $(COVERAGE) -Wl,-z,relro -Wl,-z,now -Wl,-rpath,'$$ORIGIN/.'
 JAVANATIVEINCLUDES=-I$(JAVA_HOME)/include
 JAVANATIVELDFLAGS=-L$(JAVA_HOME)/jre/lib/server
@@ -80,7 +80,7 @@ LIB_ML_SECCOMP=-lMlSeccomp
 ML_SECCOMP_LDFLAGS=-L$(CPP_SRC_HOME)/lib/seccomp/.objs
 LIB_ML_TEST=-lMlTest
 
-LIB_PATH+=-L/usr/local/gcc73/lib
+LIB_PATH+=-L/usr/local/gcc75/lib
 
 # Using cp instead of install here, to avoid every file being given execute
 # permissions

--- a/set_env.sh
+++ b/set_env.sh
@@ -89,7 +89,7 @@ fi
 case $SIMPLE_PLATFORM in
 
     linux)
-        PATH=/usr/local/gcc73/bin:/usr/bin:/bin:/usr/local/gcc73/sbin:/usr/sbin:/sbin
+        PATH=/usr/local/gcc75/bin:/usr/bin:/bin:/usr/local/gcc75/sbin:/usr/sbin:/sbin
         ;;
 
     linux-musl)
@@ -118,7 +118,7 @@ fi
 case $SIMPLE_PLATFORM in
 
     linux)
-        export LD_LIBRARY_PATH=/usr/local/gcc73/lib64:/usr/local/gcc73/lib:/usr/lib:/lib
+        export LD_LIBRARY_PATH=/usr/local/gcc75/lib64:/usr/local/gcc75/lib:/usr/lib:/lib
         ;;
 
     linux-musl)


### PR DESCRIPTION
This change is primarily to upgrade the gcc we use from version 7.3
to version 7.5.

A secondary change is to build a recent version of the binutils
package from source for use in our builds instead of relying on
whatever happened to come with the build machine.

Both changes are driven by the desire to build Tensorflow in the
future.  gcc 7.3 suffers from an internal compiler error when
trying to compile Tensorflow.  The bug is fixed in gcc 7.5.  Also,
the assembler that comes with binutils 2.20 is too old to assemble
the compiler output when building Tensorflow, and version 2.20 is
what CentOS 6 ships with.  Since our build platform for released
product is CentOS 6 we also need to install a newer version of
binutils.