### PR TITLE
[ML] Change the way hardening flags are set for libgcc_s.so.1

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -63,7 +63,7 @@ Unlike most automake-based tools, gcc must be built in a directory adjacent to t
 tar zxvf gcc-7.5.0.tar.gz
 cd gcc-7.5.0
 contrib/download_prerequisites
-sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
+sed -i -e 's/$(SHLIB_LDFLAGS)/-Wl,-z,relro -Wl,-z,now $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
 cd ..
 mkdir gcc-7.5.0-build
 cd gcc-7.5.0-build

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -17,7 +17,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=13
+VERSION=14
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:13
+FROM docker.elastic.co/ml-dev/ml-linux-build:14
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -26,7 +26,7 @@ RUN \
   wget --quiet -O - http://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz | tar zxf - && \
   cd gcc-7.5.0 && \
   contrib/download_prerequisites && \
-  sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc && \
+  sed -i -e 's/$(SHLIB_LDFLAGS)/-Wl,-z,relro -Wl,-z,now $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc && \
   cd .. && \
   mkdir gcc-7.5.0-build && \
   cd gcc-7.5.0-build && \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:13
+FROM docker.elastic.co/ml-dev/ml-linux-build:14
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/vagrant/linux/provision.sh
+++ b/dev-tools/vagrant/linux/provision.sh
@@ -49,7 +49,7 @@ if [ ! -f gcc.state ]; then
   tar xfz gcc-7.5.0.tar.gz -C gcc-source --strip-components=1
   cd gcc-source
   contrib/download_prerequisites
-  sed -i -e 's/$(SHLIB_LDFLAGS)/$(LDFLAGS) $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
+  sed -i -e 's/$(SHLIB_LDFLAGS)/-Wl,-z,relro -Wl,-z,now $(SHLIB_LDFLAGS)/' libgcc/config/t-slibgcc
   cd ..
   mkdir gcc-build
   cd gcc-build


### PR DESCRIPTION
The gcc build process makes it hard to set extra linker flags for
the libgcc_s.so.1 library.  We had a [hack](https://github.com/elastic/ml-cpp/blob/07bd27fa66ccacdf6bfe333e3e5dab3335344679/dev-tools/docker/linux_image/Dockerfile#L29) in our build steps that
worked for gcc 7.3, but stopped working in gcc 7.5 with the result
that Debian's lintian tool flags the library as being insecure - see
elastic/elasticsearch#52554.  This change alters the hack to simply
add the required flags directly to the linker command that is used
for libgcc_s.so.1.

Relates elastic/elasticsearch#52554