### PR TITLE
[ML] Rework computing SHAP to avoid using data frame storage

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -56,6 +56,7 @@ necessary. This will improve the allocation of data frame analyses to cluster no
 (See {ml-pull}1003[#1003].)
 * Upgrade the compiler used on Linux from gcc 7.3 to gcc 7.5, and the binutils used in
 the build from version 2.20 to 2.34.  (See {ml-pull}1013[#1013].)
+* Remove all memory overheads for computing tree SHAP values. (See {ml-pull}1023[#1023].)
 
 === Bug Fixes
 

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -13,6 +13,9 @@
 #include <rapidjson/fwd.h>
 
 namespace ml {
+namespace maths {
+class CTreeShapFeatureImportance;
+}
 namespace api {
 
 //! \brief Runs boosted tree classification on a core::CDataFrame.
@@ -52,7 +55,8 @@ public:
                      std::size_t columnHoldingPrediction,
                      double probabilityAtWhichToAssignClassOne,
                      const TRowRef& row,
-                     core::CRapidJsonConcurrentLineWriter& writer) const;
+                     core::CRapidJsonConcurrentLineWriter& writer,
+                     maths::CTreeShapFeatureImportance* featureImportance = nullptr) const;
 
     //! \return A serialisable definition of the trained classification model.
     TInferenceModelDefinitionUPtr

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -62,9 +62,6 @@ public:
     //! The boosted tree factory.
     const maths::CBoostedTreeFactory& boostedTreeFactory() const;
 
-    //! The number of (largest magnitude) SHAP values to return.
-    std::size_t topShapValues() const;
-
     //! \return Reference to the analysis state.
     const CDataFrameAnalysisInstrumentation& instrumentation() const override;
     //! \return Reference to the analysis state.

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -450,22 +450,16 @@ public:
     //! \warning This can only be called after train.
     void predict() const override;
 
-    //! Write SHAP values to the data frame supplied to the constructor.
+    //! Get the SHAP value calculator.
     //!
-    //! \warning This can only be called after train.
-    void computeShapValues() override;
+    //! \warning Will return a nullptr if a trained model isn't available.
+    CTreeShapFeatureImportance* shap() const override;
 
     //! Get the column containing the dependent variable.
     std::size_t columnHoldingDependentVariable() const override;
 
     //! Get the column containing the model's prediction for the dependent variable.
     std::size_t columnHoldingPrediction() const override;
-
-    //! Get the optional vector of column indices with SHAP values
-    TSizeRange columnsHoldingShapValues() const override;
-
-    //! Get the number of largest SHAP values that will be returned for every row.
-    std::size_t topShapValues() const override;
 
     //! Get the probability threshold at which to classify a row as class one.
     double probabilityAtWhichToAssignClassOne() const override;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -95,7 +95,7 @@ public:
     //! Set the number of training examples we need per feature we'll include.
     CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
     //! Set the number of training examples we need per feature we'll include.
-    CBoostedTreeFactory& topShapValues(std::size_t topShapValues);
+    CBoostedTreeFactory& numberTopShapValues(std::size_t numberTopShapValues);
 
     //! Set pointer to the analysis instrumentation.
     CBoostedTreeFactory&

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -184,6 +184,9 @@ private:
     //! Compute the probability threshold at which to classify a row as class one.
     void computeProbabilityAtWhichToAssignClassOne(const core::CDataFrame& frame);
 
+    //! Prepare to calculate SHAP feature importances.
+    void initializeTreeShap(const core::CDataFrame& frame);
+
     //! Train the forest and compute loss moments on each fold.
     TMeanVarAccumulatorSizePr crossValidateForest(core::CDataFrame& frame);
 

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -12,7 +12,6 @@
 #include <maths/ImportExport.h>
 
 #include <boost/optional.hpp>
-#include <boost/range/irange.hpp>
 
 #include <functional>
 #include <utility>
@@ -24,13 +23,13 @@ class CDataFrame;
 class CRapidJsonConcurrentLineWriter;
 }
 namespace maths {
+class CTreeShapFeatureImportance;
 
 //! \brief Defines the interface for fitting and inferring a predictive model
 //! with a data frame.
 class MATHS_EXPORT CDataFramePredictiveModel {
 public:
     using TDoubleVec = std::vector<double>;
-    using TSizeRange = boost::integer_range<std::size_t>;
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
     using TTrainingStateCallback = std::function<void(TPersistFunc)>;
 
@@ -39,9 +38,6 @@ public:
         E_Accuracy,     //!< Maximize prediction accuracy.
         E_MinimumRecall //!< Maximize the minimum per class recall.
     };
-
-public:
-    static const std::string SHAP_PREFIX;
 
 public:
     virtual ~CDataFramePredictiveModel() = default;
@@ -55,22 +51,16 @@ public:
     //! \warning This can only be called after train.
     virtual void predict() const = 0;
 
-    //! Write SHAP values to the data frame supplied to the contructor.
+    //! Get the SHAP value calculator.
     //!
-    //! \warning This can only be called after train.
-    virtual void computeShapValues() = 0;
+    //! \warning Will return a nullptr if a trained model isn't available.
+    virtual CTreeShapFeatureImportance* shap() const = 0;
 
     //! Get the column containing the dependent variable.
     virtual std::size_t columnHoldingDependentVariable() const = 0;
 
     //! Get the column containing the model's prediction for the dependent variable.
     virtual std::size_t columnHoldingPrediction() const = 0;
-
-    //! Get the number of largest SHAP values that will be returned for every row.
-    virtual std::size_t topShapValues() const = 0;
-
-    //! Get the optional vector of column indices with SHAP values
-    virtual TSizeRange columnsHoldingShapValues() const = 0;
 
     //! Get the probability threshold at which to classify a row as class one.
     virtual double probabilityAtWhichToAssignClassOne() const = 0;

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -16,6 +16,7 @@
 #include <maths/CDataFrameUtils.h>
 #include <maths/COrderings.h>
 #include <maths/CTools.h>
+#include <maths/CTreeShapFeatureImportance.h>
 
 #include <api/CBoostedTreeInferenceModelBuilder.h>
 #include <api/CDataFrameAnalysisConfigReader.h>
@@ -86,12 +87,11 @@ CDataFrameTrainBoostedTreeClassifierRunner::CDataFrameTrainBoostedTreeClassifier
     const TStrVec& categoricalFieldNames{spec.categoricalFieldNames()};
     if (std::find(categoricalFieldNames.begin(), categoricalFieldNames.end(),
                   this->dependentVariableFieldName()) == categoricalFieldNames.end()) {
-        HANDLE_FATAL(<< "Input error: trying to perform classification with numeric target.");
+        HANDLE_FATAL(<< "Input error: trying to perform classification with numeric target.")
     }
     if (PREDICTION_FIELD_NAME_BLACKLIST.count(this->predictionFieldName()) > 0) {
         HANDLE_FATAL(<< "Input error: " << PREDICTION_FIELD_NAME << " must not be equal to any of "
-                     << core::CContainerPrinter::print(PREDICTION_FIELD_NAME_BLACKLIST)
-                     << ".");
+                     << core::CContainerPrinter::print(PREDICTION_FIELD_NAME_BLACKLIST) << ".")
     }
 }
 
@@ -116,7 +116,8 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     const auto& tree = this->boostedTree();
     this->writeOneRow(frame, tree.columnHoldingDependentVariable(),
                       tree.columnHoldingPrediction(),
-                      tree.probabilityAtWhichToAssignClassOne(), row, writer);
+                      tree.probabilityAtWhichToAssignClassOne(), row, writer,
+                      tree.shap());
 }
 
 void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
@@ -125,7 +126,8 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     std::size_t columnHoldingPrediction,
     double probabilityAtWhichToAssignClassOne,
     const TRowRef& row,
-    core::CRapidJsonConcurrentLineWriter& writer) const {
+    core::CRapidJsonConcurrentLineWriter& writer,
+    maths::CTreeShapFeatureImportance* featureImportance) const {
 
     // TODO generalise when supporting multiple categories.
 
@@ -177,22 +179,19 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
         writer.EndArray();
     }
 
-    if (this->topShapValues() > 0) {
-        auto largestShapValues =
-            maths::CBasicStatistics::orderStatisticsAccumulator<std::size_t>(
-                this->topShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
-                    return std::fabs(row[lhs]) > std::fabs(row[rhs]);
-                });
-        for (auto col : this->boostedTree().columnsHoldingShapValues()) {
-            largestShapValues.add(col);
-        }
-        largestShapValues.sort();
-        for (auto i : largestShapValues) {
-            if (row[i] != 0.0) {
-                writer.Key(frame.columnNames()[i]);
-                writer.Double(row[i]);
-            }
-        }
+    if (featureImportance != nullptr) {
+        featureImportance->shap(
+            row, [&writer](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
+                           const TStrVec& names,
+                           const maths::CTreeShapFeatureImportance::TVectorVec& shap) {
+                for (auto i : indices) {
+                    if (shap[i].norm() != 0.0) {
+                        writer.Key(names[i]);
+                        // TODO fixme
+                        writer.Double(shap[i](0));
+                    }
+                }
+            });
     }
     writer.EndObject();
 }
@@ -231,7 +230,7 @@ void CDataFrameTrainBoostedTreeClassifierRunner::validate(const core::CDataFrame
         HANDLE_FATAL(<< "Input error: only binary classification is supported. "
                      << "Trying to predict '" << frame.columnNames()[dependentVariableColumn]
                      << "' which has '" << categoryCount << "' categories. "
-                     << "The number of rows read is '" << frame.numberRows() << "'.");
+                     << "The number of rows read is '" << frame.numberRows() << "'.")
     }
 }
 
@@ -249,7 +248,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelDefinition(
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"num_top_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE{"prediction_field_type"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE{"class_assignment_objective"};
-// clang-format off
+// clang-format on
 
 const std::string& CDataFrameTrainBoostedTreeClassifierRunnerFactory::name() const {
     return NAME;
@@ -257,7 +256,8 @@ const std::string& CDataFrameTrainBoostedTreeClassifierRunnerFactory::name() con
 
 CDataFrameTrainBoostedTreeClassifierRunnerFactory::TRunnerUPtr
 CDataFrameTrainBoostedTreeClassifierRunnerFactory::makeImpl(const CDataFrameAnalysisSpecification&) const {
-    HANDLE_FATAL(<< "Input error: classification has a non-optional parameter '" << CDataFrameTrainBoostedTreeRunner::DEPENDENT_VARIABLE_NAME << "'.")
+    HANDLE_FATAL(<< "Input error: classification has a non-optional parameter '"
+                 << CDataFrameTrainBoostedTreeRunner::DEPENDENT_VARIABLE_NAME << "'.")
     return nullptr;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -12,6 +12,7 @@
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeFactory.h>
 #include <maths/CDataFrameUtils.h>
+#include <maths/CTreeShapFeatureImportance.h>
 
 #include <api/CBoostedTreeInferenceModelBuilder.h>
 #include <api/CDataFrameAnalysisConfigReader.h>
@@ -53,17 +54,16 @@ CDataFrameTrainBoostedTreeRegressionRunner::CDataFrameTrainBoostedTreeRegression
     const TStrVec& categoricalFieldNames{spec.categoricalFieldNames()};
     if (std::find(categoricalFieldNames.begin(), categoricalFieldNames.end(),
                   this->dependentVariableFieldName()) != categoricalFieldNames.end()) {
-        HANDLE_FATAL(<< "Input error: trying to perform regression with categorical target.");
+        HANDLE_FATAL(<< "Input error: trying to perform regression with categorical target.")
     }
     if (PREDICTION_FIELD_NAME_BLACKLIST.count(this->predictionFieldName()) > 0) {
         HANDLE_FATAL(<< "Input error: " << PREDICTION_FIELD_NAME << " must not be equal to any of "
-                     << core::CContainerPrinter::print(PREDICTION_FIELD_NAME_BLACKLIST)
-                     << ".");
+                     << core::CContainerPrinter::print(PREDICTION_FIELD_NAME_BLACKLIST) << ".")
     }
 }
 
 void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
-    const core::CDataFrame& frame,
+    const core::CDataFrame&,
     const TRowRef& row,
     core::CRapidJsonConcurrentLineWriter& writer) const {
 
@@ -76,22 +76,20 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
     writer.Double(row[columnHoldingPrediction]);
     writer.Key(IS_TRAINING_FIELD_NAME);
     writer.Bool(maths::CDataFrameUtils::isMissing(row[columnHoldingDependentVariable]) == false);
-    if (this->topShapValues() > 0) {
-        auto largestShapValues =
-            maths::CBasicStatistics::orderStatisticsAccumulator<std::size_t>(
-                this->topShapValues(), [&row](std::size_t lhs, std::size_t rhs) {
-                    return std::fabs(row[lhs]) > std::fabs(row[rhs]);
-                });
-        for (auto col : this->boostedTree().columnsHoldingShapValues()) {
-            largestShapValues.add(col);
-        }
-        largestShapValues.sort();
-        for (auto i : largestShapValues) {
-            if (row[i] != 0.0) {
-                writer.Key(frame.columnNames()[i]);
-                writer.Double(row[i]);
-            }
-        }
+    auto featureImportance = tree.shap();
+    if (featureImportance != nullptr) {
+        featureImportance->shap(
+            row, [&writer](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
+                           const TStrVec& names,
+                           const maths::CTreeShapFeatureImportance::TVectorVec& shap) {
+                for (auto i : indices) {
+                    if (shap[i].norm() != 0.0) {
+                        writer.Key(names[i]);
+                        // TODO fixme
+                        writer.Double(shap[i](0));
+                    }
+                }
+            });
     }
     writer.EndObject();
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -167,7 +167,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         m_BoostedTreeFactory->bayesianOptimisationRestarts(bayesianOptimisationRestarts);
     }
     if (numTopFeatureImportanceValues > 0) {
-        m_BoostedTreeFactory->topShapValues(numTopFeatureImportanceValues);
+        m_BoostedTreeFactory->numberTopShapValues(numTopFeatureImportanceValues);
     }
 }
 
@@ -206,10 +206,6 @@ const maths::CBoostedTreeFactory& CDataFrameTrainBoostedTreeRunner::boostedTreeF
     return *m_BoostedTreeFactory;
 }
 
-std::size_t CDataFrameTrainBoostedTreeRunner::topShapValues() const {
-    return m_BoostedTree == nullptr ? 0 : m_BoostedTree->topShapValues();
-}
-
 void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
     auto dependentVariablePos = std::find(frame.columnNames().begin(),
                                           frame.columnNames().end(),
@@ -243,7 +239,6 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
     this->validate(frame, dependentVariableColumn);
     m_BoostedTree->train();
     m_BoostedTree->predict();
-    m_BoostedTree->computeShapValues();
 
     core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) = watch.stop();
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -9,6 +9,7 @@
 #include <maths/CBasicStatistics.h>
 #include <maths/CDataFramePredictiveModel.h>
 #include <maths/CTools.h>
+#include <maths/CTreeShapFeatureImportance.h>
 
 #include <api/CDataFrameAnalyzer.h>
 
@@ -262,7 +263,7 @@ struct SFixture {
 
 template<typename RESULTS>
 double readShapValue(const RESULTS& results, std::string shapField) {
-    shapField = maths::CDataFramePredictiveModel::SHAP_PREFIX + shapField;
+    shapField = maths::CTreeShapFeatureImportance::SHAP_PREFIX + shapField;
     if (results["row_results"]["results"]["ml"].HasMember(shapField)) {
         return results["row_results"]["results"]["ml"][shapField].GetDouble();
     }
@@ -298,7 +299,7 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceAllShap, SFixture) {
             c4Sum += std::fabs(c4);
             // assert that no SHAP value for the dependent variable is returned
             BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
-                                   maths::CDataFramePredictiveModel::SHAP_PREFIX +
+                                   maths::CTreeShapFeatureImportance::SHAP_PREFIX +
                                    "target") == false);
         }
     }
@@ -401,14 +402,18 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoShap, SFixture) {
 
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
-            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
-                                   maths::CDataFramePredictiveModel::SHAP_PREFIX + "c1") == false);
-            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
-                                   maths::CDataFramePredictiveModel::SHAP_PREFIX + "c2") == false);
-            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
-                                   maths::CDataFramePredictiveModel::SHAP_PREFIX + "c3") == false);
-            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
-                                   maths::CDataFramePredictiveModel::SHAP_PREFIX + "c4") == false);
+            BOOST_TEST_REQUIRE(
+                result["row_results"]["results"]["ml"].HasMember(
+                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c1") == false);
+            BOOST_TEST_REQUIRE(
+                result["row_results"]["results"]["ml"].HasMember(
+                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c2") == false);
+            BOOST_TEST_REQUIRE(
+                result["row_results"]["results"]["ml"].HasMember(
+                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c3") == false);
+            BOOST_TEST_REQUIRE(
+                result["row_results"]["results"]["ml"].HasMember(
+                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c4") == false);
         }
     }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -20,10 +20,9 @@
 #include <api/CSingleStreamDataAdder.h>
 #include <api/ElasticsearchStateIndex.h>
 
+#include <test/BoostTestCloseAbsolute.h>
 #include <test/CDataFrameAnalysisSpecificationFactory.h>
 #include <test/CRandomNumbers.h>
-
-#include <test/BoostTestCloseAbsolute.h>
 
 #include <boost/test/unit_test.hpp>
 #include <boost/unordered_map.hpp>

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -481,8 +481,8 @@ void CBoostedTree::predict() const {
     m_Impl->predict(this->frame());
 }
 
-void CBoostedTree::computeShapValues() {
-    m_Impl->computeShapValues(this->frame());
+CTreeShapFeatureImportance* CBoostedTree::shap() const {
+    return m_Impl->shap();
 }
 
 std::size_t CBoostedTree::columnHoldingDependentVariable() const {
@@ -531,17 +531,6 @@ void CBoostedTree::accept(CBoostedTree::CVisitor& visitor) const {
 
 const CBoostedTreeHyperparameters& CBoostedTree::bestHyperparameters() const {
     return m_Impl->bestHyperparameters();
-}
-
-CBoostedTree::TSizeRange CBoostedTree::columnsHoldingShapValues() const {
-    return m_Impl->columnsHoldingShapValues();
-}
-
-std::size_t CBoostedTree::topShapValues() const {
-    if (m_Impl) {
-        return m_Impl->topShapValues();
-    }
-    return 0;
 }
 }
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1125,8 +1125,8 @@ CBoostedTreeFactory& CBoostedTreeFactory::rowsPerFeature(std::size_t rowsPerFeat
     return *this;
 }
 
-CBoostedTreeFactory& CBoostedTreeFactory::topShapValues(std::size_t topShapValues) {
-    m_TreeImpl->m_TopShapValues = topShapValues;
+CBoostedTreeFactory& CBoostedTreeFactory::numberTopShapValues(std::size_t numberTopShapValues) {
+    m_TreeImpl->m_NumberTopShapValues = numberTopShapValues;
     return *this;
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -242,19 +242,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
     }
 
     this->computeProbabilityAtWhichToAssignClassOne(frame);
-
-    // Populate number samples reaching each node.
-    CTreeShapFeatureImportance::computeNumberSamples(m_NumberThreads, frame,
-                                                     *m_Encoder, m_BestForest);
-
-    if (m_NumberTopShapValues > 0) {
-        // Create the SHAP calculator.
-        m_TreeShap = std::make_unique<CTreeShapFeatureImportance>(
-            frame, *m_Encoder, m_BestForest, m_NumberTopShapValues);
-    } else {
-        // Make sure the internal node values are set anyway.
-        CTreeShapFeatureImportance::computeInternalNodeValues(m_BestForest);
-    }
+    this->initializeTreeShap(frame);
 
     // Force progress to one because we can have early exit from loop skip altogether.
     m_Instrumentation->updateProgress(1.0);
@@ -377,6 +365,21 @@ void CBoostedTreeImpl::computeProbabilityAtWhichToAssignClassOne(const core::CDa
                 m_DependentVariable, predictionColumn(m_NumberInputColumns));
             break;
         }
+    }
+}
+
+void CBoostedTreeImpl::initializeTreeShap(const core::CDataFrame& frame) {
+    // Populate number samples reaching each node.
+    CTreeShapFeatureImportance::computeNumberSamples(m_NumberThreads, frame,
+                                                     *m_Encoder, m_BestForest);
+
+    if (m_NumberTopShapValues > 0) {
+        // Create the SHAP calculator.
+        m_TreeShap = std::make_unique<CTreeShapFeatureImportance>(
+            frame, *m_Encoder, m_BestForest, m_NumberTopShapValues);
+    } else {
+        // Set internal node values anyway.
+        CTreeShapFeatureImportance::computeInternalNodeValues(m_BestForest);
     }
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -243,54 +243,23 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     this->computeProbabilityAtWhichToAssignClassOne(frame);
 
-    // populate numberSamples field in the final forest
-    this->computeNumberSamples(frame);
+    // Populate number samples reaching each node.
+    CTreeShapFeatureImportance::computeNumberSamples(m_NumberThreads, frame,
+                                                     *m_Encoder, m_BestForest);
+
+    if (m_NumberTopShapValues > 0) {
+        // Create the SHAP calculator.
+        m_TreeShap = std::make_unique<CTreeShapFeatureImportance>(
+            frame, *m_Encoder, m_BestForest, m_NumberTopShapValues);
+    } else {
+        // Make sure the internal node values are set anyway.
+        CTreeShapFeatureImportance::computeInternalNodeValues(m_BestForest);
+    }
 
     // Force progress to one because we can have early exit from loop skip altogether.
     m_Instrumentation->updateProgress(1.0);
     m_Instrumentation->updateMemoryUsage(
         static_cast<std::int64_t>(this->memoryUsage()) - lastMemoryUsage);
-}
-
-void CBoostedTreeImpl::computeNumberSamples(const core::CDataFrame& frame) {
-    for (auto& tree : m_BestForest) {
-        if (tree.size() == 1) {
-            root(tree).numberSamples(frame.numberRows());
-        } else {
-            auto result = frame.readRows(
-                m_NumberThreads,
-                core::bindRetrievableState(
-                    [&](TSizeVec& samplesPerNode, const TRowItr& beginRows, const TRowItr& endRows) {
-                        for (auto row = beginRows; row != endRows; ++row) {
-                            auto encodedRow{m_Encoder->encode(*row)};
-                            const CBoostedTreeNode* node{&root(tree)};
-                            samplesPerNode[0] += 1;
-                            std::size_t nextIndex;
-                            while (node->isLeaf() == false) {
-                                if (node->assignToLeft(encodedRow)) {
-                                    nextIndex = node->leftChildIndex();
-                                } else {
-                                    nextIndex = node->rightChildIndex();
-                                }
-                                samplesPerNode[nextIndex] += 1;
-                                node = &(tree[nextIndex]);
-                            }
-                        }
-                    },
-                    TSizeVec(tree.size())));
-            auto& state = result.first;
-            TSizeVec totalSamplesPerNode{std::move(state[0].s_FunctionState)};
-            for (std::size_t i = 1; i < state.size(); ++i) {
-                for (std::size_t nodeIndex = 0;
-                     nodeIndex < totalSamplesPerNode.size(); ++nodeIndex) {
-                    totalSamplesPerNode[nodeIndex] += state[i].s_FunctionState[nodeIndex];
-                }
-            }
-            for (std::size_t i = 0; i < tree.size(); ++i) {
-                tree[i].numberSamples(totalSamplesPerNode[i]);
-            }
-        }
-    }
 }
 
 void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainState) const {
@@ -346,11 +315,8 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
                                          PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
     std::size_t bayesianOptimisationMemoryUsage{CBayesianOptimisation::estimateMemoryUsage(
         this->numberHyperparametersToTune(), m_NumberRounds)};
-    std::size_t shapMemoryUsage{
-        m_TopShapValues > 0 ? numberRows * numberColumns * sizeof(CFloatStorage) : 0};
     return sizeof(*this) + forestMemoryUsage + foldRoundLossMemoryUsage +
-           hyperparametersMemoryUsage +
-           std::max(leafNodeStatisticsMemoryUsage, shapMemoryUsage) + // not concurrent
+           hyperparametersMemoryUsage + leafNodeStatisticsMemoryUsage +
            dataTypeMemoryUsage + featureSampleProbabilities + missingFeatureMaskMemoryUsage +
            trainTestMaskMemoryUsage + bayesianOptimisationMemoryUsage;
 }
@@ -1235,9 +1201,7 @@ const std::string STOP_CROSS_VALIDATION_EARLY_TAG{"stop_cross_validation_eraly"}
 const std::string TESTING_ROW_MASKS_TAG{"testing_row_masks"};
 const std::string TRAINING_ROW_MASKS_TAG{"training_row_masks"};
 const std::string TRAINING_PROGRESS_TAG{"training_progress"};
-const std::string TOP_SHAP_VALUES_TAG{"top_shap_values"};
-const std::string FIRST_SHAP_COLUMN_INDEX{"first_shap_column_index"};
-const std::string LAST_SHAP_COLUMN_INDEX{"last_shap_column_index"};
+const std::string NUMBER_TOP_SHAP_VALUES_TAG{"top_shap_values"};
 }
 
 const std::string& CBoostedTreeImpl::bestHyperparametersName() {
@@ -1307,9 +1271,7 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persist(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
                                  m_MaximumNumberTreesOverride, inserter);
     inserter.insertValue(LOSS_TAG, m_Loss->name());
-    core::CPersistUtils::persist(TOP_SHAP_VALUES_TAG, m_TopShapValues, inserter);
-    core::CPersistUtils::persist(FIRST_SHAP_COLUMN_INDEX, m_FirstShapColumnIndex, inserter);
-    core::CPersistUtils::persist(LAST_SHAP_COLUMN_INDEX, m_LastShapColumnIndex, inserter);
+    core::CPersistUtils::persist(NUMBER_TOP_SHAP_VALUES_TAG, m_NumberTopShapValues, inserter);
 }
 
 bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
@@ -1406,14 +1368,9 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
                 core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_OVERRIDE_TAG,
                                              m_MaximumNumberTreesOverride, traverser))
         RESTORE(LOSS_TAG, restoreLoss(m_Loss, traverser))
-        RESTORE(TOP_SHAP_VALUES_TAG,
-                core::CPersistUtils::restore(TOP_SHAP_VALUES_TAG, m_TopShapValues, traverser))
-        RESTORE(FIRST_SHAP_COLUMN_INDEX,
-                core::CPersistUtils::restore(FIRST_SHAP_COLUMN_INDEX,
-                                             m_FirstShapColumnIndex, traverser))
-        RESTORE(LAST_SHAP_COLUMN_INDEX,
-                core::CPersistUtils::restore(LAST_SHAP_COLUMN_INDEX,
-                                             m_LastShapColumnIndex, traverser))
+        RESTORE(NUMBER_TOP_SHAP_VALUES_TAG,
+                core::CPersistUtils::restore(NUMBER_TOP_SHAP_VALUES_TAG,
+                                             m_NumberTopShapValues, traverser))
     } while (traverser.next());
 
     return true;
@@ -1461,32 +1418,8 @@ const CBoostedTreeHyperparameters& CBoostedTreeImpl::bestHyperparameters() const
     return m_BestHyperparameters;
 }
 
-void CBoostedTreeImpl::computeShapValues(core::CDataFrame& frame) {
-    if (m_TopShapValues > 0) {
-        if (m_BestForestTestLoss == INF) {
-            HANDLE_FATAL(<< "Internal error: no model available for prediction. "
-                         << "Please report this problem.");
-            return;
-        }
-        auto treeFeatureImportance = std::make_unique<CTreeShapFeatureImportance>(
-            m_BestForest, m_NumberThreads);
-        std::size_t offset{frame.numberColumns()};
-
-        // Resize data frame to write SHAP values.
-        std::size_t lastMemoryUsage{core::CMemory::dynamicSize(frame)};
-        frame.resizeColumns(m_NumberThreads, frame.numberColumns() + m_NumberInputColumns);
-        m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(frame) - lastMemoryUsage);
-
-        m_FirstShapColumnIndex = offset;
-        m_LastShapColumnIndex = frame.numberColumns() - 1;
-        TStrVec columnNames(frame.columnNames());
-        for (std::size_t i = 0; i < m_NumberInputColumns; ++i) {
-            columnNames[offset + i] = CDataFramePredictiveModel::SHAP_PREFIX +
-                                      frame.columnNames()[i];
-        }
-        frame.columnNames(columnNames);
-        treeFeatureImportance->shap(frame, *m_Encoder, offset);
-    }
+CTreeShapFeatureImportance* CBoostedTreeImpl::shap() {
+    return m_TreeShap.get();
 }
 
 const CBoostedTreeImpl::TDoubleVec& CBoostedTreeImpl::featureSampleProbabilities() const {
@@ -1503,14 +1436,6 @@ std::size_t CBoostedTreeImpl::columnHoldingDependentVariable() const {
 
 double CBoostedTreeImpl::probabilityAtWhichToAssignClassOne() const {
     return m_ProbabilityAtWhichToAssignClassOne;
-}
-
-CBoostedTreeImpl::TSizeRange CBoostedTreeImpl::columnsHoldingShapValues() const {
-    return TSizeRange{m_FirstShapColumnIndex, m_LastShapColumnIndex + 1};
-}
-
-std::size_t CBoostedTreeImpl::topShapValues() const {
-    return m_TopShapValues;
 }
 
 std::size_t CBoostedTreeImpl::numberInputColumns() const {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -378,8 +378,11 @@ void CBoostedTreeImpl::initializeTreeShap(const core::CDataFrame& frame) {
         m_TreeShap = std::make_unique<CTreeShapFeatureImportance>(
             frame, *m_Encoder, m_BestForest, m_NumberTopShapValues);
     } else {
+        // TODO these are not currently written into the inference model
+        // but they would be nice to expose since they provide good insight
+        // into how the splits affect the target variable.
         // Set internal node values anyway.
-        CTreeShapFeatureImportance::computeInternalNodeValues(m_BestForest);
+        //CTreeShapFeatureImportance::computeInternalNodeValues(m_BestForest);
     }
 }
 

--- a/lib/maths/CDataFramePredictiveModel.cc
+++ b/lib/maths/CDataFramePredictiveModel.cc
@@ -9,8 +9,6 @@
 namespace ml {
 namespace maths {
 
-const std::string CDataFramePredictiveModel::SHAP_PREFIX{"feature_importance."};
-
 CDataFramePredictiveModel::CDataFramePredictiveModel(core::CDataFrame& frame,
                                                      TTrainingStateCallback recordTrainingState)
     : m_Frame{frame}, m_RecordTrainingState(std::move(recordTrainingState)) {

--- a/lib/maths/CTreeShapFeatureImportance.cc
+++ b/lib/maths/CTreeShapFeatureImportance.cc
@@ -4,9 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include "core/Concurrency.h"
 #include <maths/CTreeShapFeatureImportance.h>
 
+#include <core/CContainerPrinter.h>
+#include <core/CDataFrame.h>
+
 #include <maths/CLinearAlgebraShims.h>
+#include <maths/COrderings.h>
 
 #include <algorithm>
 #include <limits>
@@ -15,70 +20,140 @@
 namespace ml {
 namespace maths {
 
-using TRowItr = core::CDataFrame::TRowItr;
+CTreeShapFeatureImportance::CTreeShapFeatureImportance(const core::CDataFrame& frame,
+                                                       const CDataFrameCategoryEncoder& encoder,
+                                                       TTreeVec& forest,
+                                                       std::size_t numberTopShapValues)
+    : m_NumberTopShapValues{numberTopShapValues}, m_Encoder{&encoder}, m_Forest{&forest} {
 
-void CTreeShapFeatureImportance::shap(core::CDataFrame& frame,
-                                      const CDataFrameCategoryEncoder& encoder,
-                                      std::size_t offset) {
-    std::size_t maxDepth{0};
-    for (auto& tree : m_Trees) {
-        maxDepth = std::max(maxDepth, updateNodeValues(tree, 0, 0));
+    m_ColumnNames.reserve(frame.columnNames().size());
+    for (const auto& name : frame.columnNames()) {
+        m_ColumnNames.push_back(SHAP_PREFIX + name);
     }
 
-    frame.writeColumns(m_NumberThreads, [&](TRowItr beginRows, TRowItr endRows) {
-        // When traversing a tree, we successively copy the parent path and add one
-        // new element to it. This means that if a tree has maxDepth depth, we store
-        // 1, 2, ... (maxDepth + 1) elements. The "+1" here comes from the fact that
-        // the initial element in the path has split feature -1. Altogether it results
-        // in ((maxDepth + 1) * (maxDepth + 2)) / 2 elements to be stored.
-        TElementVec pathVector(((maxDepth + 1) * (maxDepth + 2)) / 2);
-        TDoubleVec scaleVector(((maxDepth + 1) * (maxDepth + 2)) / 2);
-        TVectorVec shap;
-        for (auto row = beginRows; row != endRows; ++row) {
-            auto encodedRow{encoder.encode(*row)};
-            shap.assign(encoder.numberInputColumns(), las::zero(m_Trees[0][0].value()));
-            for (const auto& tree : m_Trees) {
-                this->shapRecursive(tree, encoder, encodedRow, 0, 1.0, 1.0, -1,
-                                    CSplitPath{pathVector.begin(), scaleVector.begin()},
-                                    0, shap);
+    // When traversing a tree, we successively copy the parent path and add one
+    // new element to it. This means that if a tree has maxDepth depth, we store
+    // 1, 2, ... (maxDepth + 1) elements. The "+1" here comes from the fact that
+    // the initial element in the path has split feature -1. Altogether it results
+    // in ((maxDepth + 1) * (maxDepth + 2)) / 2 elements to be stored.
+    std::size_t maxDepth{depth(forest)};
+    m_PathStorage.resize((maxDepth + 1) * (maxDepth + 2) / 2);
+    m_ScaleStorage.resize((maxDepth + 1) * (maxDepth + 2) / 2);
+
+    computeInternalNodeValues(forest);
+}
+
+void CTreeShapFeatureImportance::shap(const TRowRef& row, TShapWriter writer) {
+
+    if (m_NumberTopShapValues == 0) {
+        return;
+    }
+
+    auto encodedRow{m_Encoder->encode(row)};
+    m_ShapValues.assign(m_Encoder->numberInputColumns(),
+                        las::zero((*m_Forest)[0][0].value()));
+    for (const auto& tree : *m_Forest) {
+        this->shapRecursive(tree, encodedRow, 0, 1.0, 1.0, -1,
+                            CSplitPath{m_PathStorage.begin(), m_ScaleStorage.begin()},
+                            0, m_ShapValues);
+    }
+
+    m_TopShapValues.resize(m_ShapValues.size());
+    std::iota(m_TopShapValues.begin(), m_TopShapValues.end(), 0);
+    if (m_NumberTopShapValues < m_TopShapValues.size()) {
+        std::nth_element(
+            m_TopShapValues.begin(), m_TopShapValues.begin() + m_NumberTopShapValues,
+            m_TopShapValues.end(), [this](std::size_t lhs, std::size_t rhs) {
+                return COrderings::lexicographical_compare(
+                    -las::L1(m_ShapValues[lhs]), lhs, -las::L1(m_ShapValues[rhs]), rhs);
+            });
+        m_TopShapValues.resize(m_NumberTopShapValues);
+        std::sort(m_TopShapValues.begin(), m_TopShapValues.end());
+    }
+
+    writer(m_TopShapValues, m_ColumnNames, m_ShapValues);
+}
+
+void CTreeShapFeatureImportance::computeNumberSamples(std::size_t numberThreads,
+                                                      const core::CDataFrame& frame,
+                                                      const CDataFrameCategoryEncoder& encoder,
+                                                      TTreeVec& forest) {
+    using TRowItr = core::CDataFrame::TRowItr;
+    for (auto& tree : forest) {
+        if (tree.size() == 1) {
+            tree[0].numberSamples(frame.numberRows());
+        } else {
+            auto result = frame.readRows(
+                numberThreads,
+                core::bindRetrievableState(
+                    [&](TSizeVec& samplesPerNode, TRowItr beginRows, TRowItr endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            auto encodedRow{encoder.encode(*row)};
+                            const CBoostedTreeNode* node{&tree[0]};
+                            samplesPerNode[0] += 1;
+                            std::size_t nextIndex;
+                            while (node->isLeaf() == false) {
+                                nextIndex = node->assignToLeft(encodedRow)
+                                                ? node->leftChildIndex()
+                                                : node->rightChildIndex();
+                                samplesPerNode[nextIndex] += 1;
+                                node = &(tree[nextIndex]);
+                            }
+                        }
+                    },
+                    TSizeVec(tree.size())));
+            auto& state = result.first;
+            TSizeVec totalSamplesPerNode{std::move(state[0].s_FunctionState)};
+            for (std::size_t i = 1; i < state.size(); ++i) {
+                for (std::size_t nodeIndex = 0;
+                     nodeIndex < totalSamplesPerNode.size(); ++nodeIndex) {
+                    totalSamplesPerNode[nodeIndex] += state[i].s_FunctionState[nodeIndex];
+                }
             }
-            for (std::size_t i = 0; i < shap.size(); ++i) {
-                // TODO fixme
-                row->writeColumn(offset + i, shap[i](0));
+            for (std::size_t i = 0; i < tree.size(); ++i) {
+                tree[i].numberSamples(totalSamplesPerNode[i]);
             }
         }
-    });
-}
-
-CTreeShapFeatureImportance::CTreeShapFeatureImportance(TTreeVec trees, std::size_t threads)
-    : m_Trees{std::move(trees)}, m_NumberThreads{threads} {
-}
-
-std::size_t CTreeShapFeatureImportance::updateNodeValues(TTree& tree,
-                                                         std::size_t nodeIndex,
-                                                         std::size_t depth) {
-    auto& node = tree[nodeIndex];
-    if (node.isLeaf()) {
-        return 0;
     }
+}
 
-    std::size_t depthLeft{CTreeShapFeatureImportance::updateNodeValues(
-        tree, node.leftChildIndex(), depth + 1)};
-    std::size_t depthRight{CTreeShapFeatureImportance::updateNodeValues(
-        tree, node.rightChildIndex(), depth + 1)};
+void CTreeShapFeatureImportance::computeInternalNodeValues(TTreeVec& forest) {
+    for (auto& tree : forest) {
+        computeInternalNodeValues(tree, 0);
+    }
+}
 
-    auto& leftChild = tree[node.leftChildIndex()];
-    auto& rightChild = tree[node.rightChildIndex()];
-    double leftWeight{static_cast<double>(leftChild.numberSamples())};
-    double rightWeight{static_cast<double>(rightChild.numberSamples())};
-    node.value((leftWeight * leftChild.value() + rightWeight * rightChild.value()) /
-               (leftWeight + rightWeight));
+void CTreeShapFeatureImportance::computeInternalNodeValues(TTree& tree, std::size_t nodeIndex) {
+    auto& node = tree[nodeIndex];
+    if (node.isLeaf() == false) {
+        computeInternalNodeValues(tree, node.leftChildIndex());
+        computeInternalNodeValues(tree, node.rightChildIndex());
+        auto& leftChild = tree[node.leftChildIndex()];
+        auto& rightChild = tree[node.rightChildIndex()];
+        double leftWeight{static_cast<double>(leftChild.numberSamples())};
+        double rightWeight{static_cast<double>(rightChild.numberSamples())};
+        node.value((leftWeight * leftChild.value() + rightWeight * rightChild.value()) /
+                   (leftWeight + rightWeight));
+    }
+}
 
-    return std::max(depthLeft, depthRight) + 1;
+std::size_t CTreeShapFeatureImportance::depth(const TTreeVec& forest) {
+    std::size_t maxDepth{0};
+    for (const auto& tree : forest) {
+        maxDepth = std::max(maxDepth, depth(tree, 0));
+    }
+    return maxDepth;
+}
+
+std::size_t CTreeShapFeatureImportance::depth(const TTree& tree, std::size_t nodeIndex) {
+    auto& node = tree[nodeIndex];
+    return node.isLeaf() ? 0
+                         : std::max(depth(tree, node.leftChildIndex()),
+                                    depth(tree, node.rightChildIndex())) +
+                               1;
 }
 
 void CTreeShapFeatureImportance::shapRecursive(const TTree& tree,
-                                               const CDataFrameCategoryEncoder& encoder,
                                                const CEncodedDataFrameRowRef& encodedRow,
                                                std::size_t nodeIndex,
                                                double parentFractionZero,
@@ -96,7 +171,7 @@ void CTreeShapFeatureImportance::shapRecursive(const TTree& tree,
         for (int i = 1; i < nextIndex; ++i) {
             double scale{CTreeShapFeatureImportance::sumUnwoundPath(splitPath, i, nextIndex)};
             std::size_t inputColumnIndex{
-                encoder.encoding(splitPath.featureIndex(i)).inputColumnIndex()};
+                m_Encoder->encoding(splitPath.featureIndex(i)).inputColumnIndex()};
             // inputColumnIndex is read by seeing what the feature at position i is on the path to this leaf.
             // fractionOnes(i) is an indicator variable which tells us if we condition on this variable
             // do we visit this path from that node or not, fractionZeros(i) tells us what proportion of
@@ -125,21 +200,20 @@ void CTreeShapFeatureImportance::shapRecursive(const TTree& tree,
 
         int pathIndex{splitPath.find(splitFeature, nextIndex)};
         if (pathIndex >= 0) {
-            // Since we pass splitPath by reference, we need to backup the object before unwinding it.
             incomingFractionZero = splitPath.fractionZeros(pathIndex);
             incomingFractionOne = splitPath.fractionOnes(pathIndex);
             CTreeShapFeatureImportance::unwindPath(splitPath, pathIndex, nextIndex);
         }
 
-        double hotFractionZero{static_cast<double>(tree[hotIndex].numberSamples()) /
-                               tree[nodeIndex].numberSamples()};
-        double coldFractionZero{static_cast<double>(tree[coldIndex].numberSamples()) /
-                                tree[nodeIndex].numberSamples()};
-        this->shapRecursive(tree, encoder, encodedRow, hotIndex,
-                            incomingFractionZero * hotFractionZero, incomingFractionOne,
+        double hotFractionZero{incomingFractionZero *
+                               static_cast<double>(tree[hotIndex].numberSamples()) /
+                               static_cast<double>(tree[nodeIndex].numberSamples())};
+        double coldFractionZero{incomingFractionZero *
+                                static_cast<double>(tree[coldIndex].numberSamples()) /
+                                static_cast<double>(tree[nodeIndex].numberSamples())};
+        this->shapRecursive(tree, encodedRow, hotIndex, hotFractionZero, incomingFractionOne,
                             splitFeature, splitPath, nextIndex, shap);
-        this->shapRecursive(tree, encoder, encodedRow, coldIndex,
-                            incomingFractionZero * coldFractionZero, 0.0,
+        this->shapRecursive(tree, encodedRow, coldIndex, coldFractionZero, 0.0,
                             splitFeature, splitPath, nextIndex, shap);
     }
 }
@@ -237,5 +311,7 @@ void CTreeShapFeatureImportance::unwindPath(CSplitPath& path, int pathIndex, int
     }
     --nextIndex;
 }
+
+const std::string CTreeShapFeatureImportance::SHAP_PREFIX{"feature_importance."};
 }
 }

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -4,8 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 
+#include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
 #include <maths/CTreeShapFeatureImportance.h>
 
@@ -17,28 +19,42 @@
 
 #include <numeric>
 #include <set>
+#include <string>
 
 BOOST_AUTO_TEST_SUITE(CTreeShapFeatureImportanceTest)
 
 using namespace ml;
 namespace tt = boost::test_tools;
 
+using TDoubleSizePr = std::pair<double, std::size_t>;
 using TDoubleVec = std::vector<double>;
 using TDoubleVecVec = std::vector<TDoubleVec>;
 using TTree = std::vector<maths::CBoostedTreeNode>;
+using TTreeVec = std::vector<TTree>;
 using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
 using TTreeShapFeatureImportanceUPtr = std::unique_ptr<maths::CTreeShapFeatureImportance>;
 using TEncoderUPtr = std::unique_ptr<maths::CDataFrameCategoryEncoder>;
 using TRowItr = core::CDataFrame::TRowItr;
 using TSizeSet = std::set<std::size_t>;
 using TSizePowerset = std::set<TSizeSet>;
+using TStrVec = std::vector<std::string>;
 using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
 using TVector = maths::CDenseVector<double>;
+using TVectorVec = std::vector<TVector>;
 
 namespace {
 TVector toVector(double value) {
     TVector result{1};
     result(0) = value;
+    return result;
+}
+
+TStrVec columnNames(std::size_t numberFeatures) {
+    TStrVec result;
+    for (std::size_t i = 0; i < numberFeatures; ++i) {
+        result.push_back("f" + std::to_string(i + 1));
+    }
     return result;
 }
 
@@ -65,10 +81,12 @@ private:
 };
 
 struct SFixtureSingleTree {
-    SFixtureSingleTree() : s_Frame{}, s_TreeFeatureImportance{}, s_Encoder{} {
+    SFixtureSingleTree() : s_Trees(1) {
+
         TDoubleVecVec data{{0.25, 0.25}, {0.25, 0.75}, {0.75, 0.25}, {0.75, 0.75}};
 
         s_Frame = core::makeMainStorageDataFrame(s_NumberFeatures, s_NumberRows).first;
+        s_Frame->columnNames(columnNames(s_NumberFeatures));
         for (std::size_t i = 0; i < s_NumberRows; ++i) {
             s_Frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 for (std::size_t j = 0; j < s_NumberFeatures; ++j, ++column) {
@@ -78,7 +96,11 @@ struct SFixtureSingleTree {
         }
         s_Frame->finishWritingRows();
 
-        TTree tree(1);
+        CStubMakeDataFrameCategoryEncoder stubParameters{1, *s_Frame, 0};
+        s_Encoder = std::make_unique<maths::CDataFrameCategoryEncoder>(stubParameters);
+
+        auto& tree = s_Trees[0];
+        tree.resize(1);
         tree[0].split(0, 0.5, true, 0.0, 0.0, tree);
         tree[1].split(1, 0.5, true, 0.0, 0.0, tree);
         tree[2].split(1, 0.5, true, 0.0, 0.0, tree);
@@ -95,33 +117,32 @@ struct SFixtureSingleTree {
         tree[5].numberSamples(1);
         tree[6].numberSamples(1);
 
-        s_TreeFeatureImportance =
-            std::make_unique<maths::CTreeShapFeatureImportance, std::initializer_list<TTree>>(
-                {tree});
-        CStubMakeDataFrameCategoryEncoder stubParameters{1, *s_Frame, 0};
-        s_Encoder = std::make_unique<maths::CDataFrameCategoryEncoder>(stubParameters);
+        s_TreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
+        s_TopTreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            *s_Frame, *s_Encoder, s_Trees, 1);
     }
 
     TDataFrameUPtr s_Frame;
     std::size_t s_NumberFeatures{2};
     std::size_t s_NumberRows{4};
     TTreeShapFeatureImportanceUPtr s_TreeFeatureImportance;
+    TTreeShapFeatureImportanceUPtr s_TopTreeFeatureImportance;
     TEncoderUPtr s_Encoder;
+    mutable TTreeVec s_Trees;
 };
 
 struct SFixtureSingleTreeRandom {
-    SFixtureSingleTreeRandom() : s_TreeFeatureImportance{}, s_Encoder{} {
+    SFixtureSingleTreeRandom() {
         test::CRandomNumbers rng;
         this->initFrame(rng);
-
         CStubMakeDataFrameCategoryEncoder stubParameters{1, *s_Frame, 0, s_NumberFeatures};
         s_Encoder = std::make_unique<maths::CDataFrameCategoryEncoder>(stubParameters);
-
         this->initTree(rng);
-
-        s_TreeFeatureImportance =
-            std::make_unique<maths::CTreeShapFeatureImportance, std::initializer_list<TTree>>(
-                {s_Tree});
+        s_TreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
+        s_TopTwoTreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            *s_Frame, *s_Encoder, s_Trees, 2);
     }
 
     void initFrame(test::CRandomNumbers& rng) {
@@ -129,6 +150,7 @@ struct SFixtureSingleTreeRandom {
         rng.generateUniformSamples(-10.0, 10.0, s_NumberRows * s_NumberFeatures, values);
 
         s_Frame = core::makeMainStorageDataFrame(s_NumberFeatures, s_NumberRows).first;
+        s_Frame->columnNames(columnNames(s_NumberFeatures));
         for (std::size_t i = 0; i < s_NumberRows; ++i) {
             s_Frame->writeRow([&](core::CDataFrame::TFloatVecItr column, int32_t&) {
                 for (std::size_t j = 0; j < s_NumberFeatures; ++j, ++column) {
@@ -140,7 +162,10 @@ struct SFixtureSingleTreeRandom {
     }
 
     void initTree(test::CRandomNumbers& rng) {
-        s_Tree.reserve(s_NumberInnerNodes * 2 + 1);
+        s_Trees.resize(1);
+        auto& tree = s_Trees[0];
+
+        tree.reserve(s_NumberInnerNodes * 2 + 1);
         TDoubleVecVec bottom;
         bottom.reserve(s_NumberInnerNodes);
         TDoubleVecVec top;
@@ -148,15 +173,14 @@ struct SFixtureSingleTreeRandom {
         TSizeVec splitFeature(1);
         TDoubleVec splitThreshold(1);
 
-        s_Tree.emplace_back();
+        tree.emplace_back();
         bottom.emplace_back(s_NumberFeatures, -10);
         top.emplace_back(s_NumberFeatures, 10);
         for (std::size_t nodeIndex = 0; nodeIndex < s_NumberInnerNodes; ++nodeIndex) {
             rng.generateUniformSamples(0, s_NumberFeatures, 1, splitFeature);
             rng.generateUniformSamples(bottom[nodeIndex][splitFeature[0]],
                                        top[nodeIndex][splitFeature[0]], 1, splitThreshold);
-            s_Tree[nodeIndex].split(splitFeature[0], splitThreshold[0], true,
-                                    0.0, 0.0, s_Tree);
+            tree[nodeIndex].split(splitFeature[0], splitThreshold[0], true, 0.0, 0.0, tree);
             // keep the management of the boundaries, to make sure the generated thresholds are realistic
             TDoubleVec leftChildBottom{bottom[nodeIndex]};
             TDoubleVec rightChildBottom{bottom[nodeIndex]};
@@ -174,7 +198,7 @@ struct SFixtureSingleTreeRandom {
         TDoubleVec leafValues(numberLeafs);
         rng.generateUniformSamples(-5, 5, numberLeafs, leafValues);
         for (std::size_t i = 0; i < numberLeafs; ++i) {
-            s_Tree[s_NumberInnerNodes + i].value(toVector(leafValues[i]));
+            tree[s_NumberInnerNodes + i].value(toVector(leafValues[i]));
         }
 
         // set correct number samples
@@ -182,7 +206,7 @@ struct SFixtureSingleTreeRandom {
             1, core::bindRetrievableState(
                    [&](TSizeVec& numberSamples, const TRowItr& beginRows, const TRowItr& endRows) {
                        for (auto row = beginRows; row != endRows; ++row) {
-                           auto node{&(s_Tree[0])};
+                           auto node{&(tree[0])};
                            auto encodedRow{s_Encoder->encode(*row)};
                            numberSamples[0] += 1;
                            std::size_t nextIndex;
@@ -193,14 +217,14 @@ struct SFixtureSingleTreeRandom {
                                    nextIndex = node->rightChildIndex();
                                }
                                numberSamples[nextIndex] += 1;
-                               node = &(s_Tree[nextIndex]);
+                               node = &(tree[nextIndex]);
                            }
                        }
                    },
-                   TSizeVec(s_Tree.size())));
+                   TSizeVec(tree.size())));
         TSizeVec numberSamples{std::move(result.first[0].s_FunctionState)};
         for (std::size_t i = 0; i < numberSamples.size(); ++i) {
-            s_Tree[i].numberSamples(numberSamples[i]);
+            tree[i].numberSamples(numberSamples[i]);
         }
     }
 
@@ -209,19 +233,21 @@ struct SFixtureSingleTreeRandom {
     std::size_t s_NumberRows{1000};
     std::size_t s_NumberInnerNodes{15};
     TTreeShapFeatureImportanceUPtr s_TreeFeatureImportance;
+    TTreeShapFeatureImportanceUPtr s_TopTwoTreeFeatureImportance;
     TEncoderUPtr s_Encoder;
-    TTree s_Tree;
+    TTreeVec s_Trees;
 };
 
 struct SFixtureMultipleTrees {
-    SFixtureMultipleTrees()
-        : s_Frame{}, s_TreeFeatureImportance{}, s_Encoder{} {
+    SFixtureMultipleTrees() : s_Trees(2) {
+
         TDoubleVecVec data{
             {0.0, 0.9}, {0.1, 0.8}, {0.2, 0.7}, {0.3, 0.6}, {0.4, 0.5},
             {0.5, 0.4}, {0.6, 0.3}, {0.7, 0.2}, {0.8, 0.1}, {0.9, 0.0},
         };
 
         s_Frame = core::makeMainStorageDataFrame(s_NumberFeatures, s_NumberRows).first;
+        s_Frame->columnNames(columnNames(s_NumberFeatures));
         for (std::size_t i = 0; i < s_NumberRows; ++i) {
             s_Frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 for (std::size_t j = 0; j < s_NumberFeatures; ++j, ++column) {
@@ -231,7 +257,11 @@ struct SFixtureMultipleTrees {
         }
         s_Frame->finishWritingRows();
 
-        TTree tree1(1);
+        CStubMakeDataFrameCategoryEncoder stubParameters{1, *s_Frame, 0};
+        s_Encoder = std::make_unique<maths::CDataFrameCategoryEncoder>(stubParameters);
+
+        auto& tree1 = s_Trees[0];
+        tree1.resize(1);
         tree1[0].split(0, 0.55, true, 0.0, 0.0, tree1);
         tree1[0].numberSamples(10);
         tree1[1].split(0, 0.41, true, 0.0, 0.0, tree1);
@@ -247,7 +277,8 @@ struct SFixtureMultipleTrees {
         tree1[6].value(toVector(2.42384369));
         tree1[6].numberSamples(1);
 
-        TTree tree2(1);
+        auto& tree2 = s_Trees[1];
+        tree2.resize(1);
         tree2[0].split(0, 0.45, true, 0.0, 0.0, tree2);
         tree2[0].numberSamples(10);
         tree2[1].split(0, 0.25, true, 0.0, 0.0, tree2);
@@ -263,24 +294,25 @@ struct SFixtureMultipleTrees {
         tree2[6].value(toVector(2.950216));
         tree2[6].numberSamples(4);
 
-        s_TreeFeatureImportance =
-            std::make_unique<maths::CTreeShapFeatureImportance, std::initializer_list<TTree>>(
-                {tree1, tree2});
-        CStubMakeDataFrameCategoryEncoder stubParameters{1, *s_Frame, 0};
-        s_Encoder = std::make_unique<maths::CDataFrameCategoryEncoder>(stubParameters);
+        s_TreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
+        s_TopTreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            *s_Frame, *s_Encoder, s_Trees, 1);
     }
 
     TDataFrameUPtr s_Frame;
     std::size_t s_NumberFeatures{2};
     std::size_t s_NumberRows{10};
     TTreeShapFeatureImportanceUPtr s_TreeFeatureImportance;
+    TTreeShapFeatureImportanceUPtr s_TopTreeFeatureImportance;
     TEncoderUPtr s_Encoder;
+    TTreeVec s_Trees;
 };
 
 class CBruteForceTreeShap {
 public:
     CBruteForceTreeShap(const TTree& tree, std::size_t numberFeatures)
-        : m_Tree{tree}, m_Powerset{}, m_NumberFeatures{numberFeatures} {
+        : m_Tree{tree}, m_NumberFeatures{numberFeatures} {
         this->initPowerset({}, numberFeatures);
     }
 
@@ -383,55 +415,87 @@ private:
 }
 
 BOOST_FIXTURE_TEST_CASE(testSingleTreeExpectedNodeValues, SFixtureSingleTree) {
-
-    std::size_t depth = maths::CTreeShapFeatureImportance::updateNodeValues(
-        s_TreeFeatureImportance->trees()[0], 0, 0);
+    std::size_t depth{maths::CTreeShapFeatureImportance::depth(s_Trees)};
     BOOST_TEST_REQUIRE(depth == 2);
+    maths::CTreeShapFeatureImportance::computeInternalNodeValues(s_Trees);
     TDoubleVec expectedValues{10.5, 5.5, 15.5, 3.0, 8.0, 13.0, 18.0};
-    auto& tree{s_TreeFeatureImportance->trees()[0]};
+    const auto& tree = s_Trees[0];
     for (std::size_t i = 0; i < tree.size(); ++i) {
-        // TODO fixme
         BOOST_TEST_REQUIRE(tree[i].value()(0) == expectedValues[i]);
     }
 }
 
 BOOST_FIXTURE_TEST_CASE(testSingleTreeShap, SFixtureSingleTree) {
-    std::size_t offset{s_Frame->numberColumns()};
-    s_Frame->resizeColumns(1, offset * 2);
-    s_TreeFeatureImportance->shap(*s_Frame, *s_Encoder, offset);
+
+    TStrVec expectedNames{s_Frame->columnNames()};
+    for (auto& name : expectedNames) {
+        name = maths::CTreeShapFeatureImportance::SHAP_PREFIX + name;
+    }
+
     TDoubleVecVec expectedPhi{{-5., -2.5}, {-5., 2.5}, {5., -2.5}, {5., 2.5}};
+
+    TSizeVec expectedIndices{0, 0, 0, 0};
+
     s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            for (std::size_t col = 0; col < 2; ++col) {
-                BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedPhi[row->index()][col],
-                                             static_cast<double>((*row)[offset + col]), 1e-7);
-            }
+            s_TreeFeatureImportance->shap(*row, [&](const TSizeVec& indices, const TStrVec& names,
+                                                    const TVectorVec& shap) {
+                BOOST_REQUIRE_EQUAL(indices.size(), row->numberColumns());
+                BOOST_TEST_REQUIRE(std::is_sorted(indices.begin(), indices.end()));
+                for (auto i : indices) {
+                    BOOST_REQUIRE_EQUAL(expectedNames[i], names[i]);
+                    BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedPhi[row->index()][i],
+                                                 shap[i](0), 1e-7);
+                }
+            });
+            s_TopTreeFeatureImportance->shap(
+                *row, [&](const TSizeVec& indices, const TStrVec&, const TVectorVec&) {
+                    BOOST_REQUIRE_EQUAL(indices.size(), 1);
+                    BOOST_REQUIRE_EQUAL(expectedIndices[row->index()], indices[0]);
+                });
         }
     });
 }
 
 BOOST_FIXTURE_TEST_CASE(testMultipleTreesShap, SFixtureMultipleTrees) {
+
+    TStrVec expectedNames{s_Frame->columnNames()};
+    for (auto& name : expectedNames) {
+        name = maths::CTreeShapFeatureImportance::SHAP_PREFIX + name;
+    }
+
     TDoubleVecVec expectedPhi{
         {-1.65320002, -0.12444978}, {-1.65320002, -0.12444978},
         {-1.65320002, -0.12444978}, {-1.16997162, -0.12444978},
         {-1.16997162, -0.12444978}, {0.0798679, -0.12444978},
         {1.80491886, -0.4355742},   {2.0538184, 0.1451914},
         {2.0538184, 0.1451914},     {2.0538184, 0.1451914}};
-    std::size_t offset{s_Frame->numberColumns()};
-    s_Frame->resizeColumns(1, offset * 2);
-    s_TreeFeatureImportance->shap(*s_Frame, *s_Encoder, offset);
+
+    TSizeVec expectedIndices{0, 0, 0, 0, 0, 1, 0, 0, 0, 0};
+
     s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            for (std::size_t col = 0; col < 2; ++col) {
-                BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedPhi[row->index()][col],
-                                             static_cast<double>((*row)[offset + col]), 1e-7);
-            }
+            s_TreeFeatureImportance->shap(*row, [&](const TSizeVec& indices, const TStrVec& names,
+                                                    const TVectorVec& shap) {
+                BOOST_REQUIRE_EQUAL(indices.size(), row->numberColumns());
+                BOOST_TEST_REQUIRE(std::is_sorted(indices.begin(), indices.end()));
+                for (auto i : indices) {
+                    BOOST_REQUIRE_EQUAL(expectedNames[i], names[i]);
+                    BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedPhi[row->index()][i],
+                                                 shap[i](0), 1e-7);
+                }
+            });
+            s_TopTreeFeatureImportance->shap(
+                *row, [&](const TSizeVec& indices, const TStrVec&, const TVectorVec&) {
+                    BOOST_REQUIRE_EQUAL(indices.size(), 1);
+                    BOOST_REQUIRE_EQUAL(expectedIndices[row->index()], indices[0]);
+                });
         }
     });
 }
 
 BOOST_FIXTURE_TEST_CASE(testSingleTreeBruteForceShap, SFixtureSingleTree) {
-    CBruteForceTreeShap bfShap(s_TreeFeatureImportance->trees()[0], s_NumberFeatures);
+    CBruteForceTreeShap bfShap(s_Trees[0], s_NumberFeatures);
     auto actualPhi = bfShap.shap(*s_Frame, *s_Encoder, 1);
     TDoubleVecVec expectedPhi{{-5., -2.5}, {-5., 2.5}, {5., -2.5}, {5., 2.5}};
     for (std::size_t i = 0; i < s_NumberRows; ++i) {
@@ -442,19 +506,50 @@ BOOST_FIXTURE_TEST_CASE(testSingleTreeBruteForceShap, SFixtureSingleTree) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testSingleTreeShapRandomDataFrame, SFixtureSingleTreeRandom) {
+
     // Compare tree shap algorithm with the brute force approach (Algorithm
     // 1 in paper by Lundberg et al.) on a random data set with a random tree.
-    CBruteForceTreeShap bfShap(this->s_Tree, s_NumberFeatures);
+
+    TStrVec expectedNames{s_Frame->columnNames()};
+    for (auto& name : expectedNames) {
+        name = maths::CTreeShapFeatureImportance::SHAP_PREFIX + name;
+    }
+
+    CBruteForceTreeShap bfShap(s_Trees[0], s_NumberFeatures);
     auto expectedPhi = bfShap.shap(*s_Frame, *s_Encoder, 1);
-    std::size_t offset{s_Frame->numberColumns()};
-    s_Frame->resizeColumns(1, offset * 2);
-    s_TreeFeatureImportance->shap(*s_Frame, *s_Encoder, offset);
+
+    TSizeVecVec expectedIndices(expectedPhi.size());
+    for (std::size_t i = 0; i < expectedPhi.size(); ++i) {
+        auto largest = maths::CBasicStatistics::orderStatisticsAccumulator<TDoubleSizePr, 2>(
+            std::greater<TDoubleSizePr>());
+        for (std::size_t j = 0; j < expectedPhi[i].size(); ++j) {
+            largest.add({std::fabs(expectedPhi[i][j]), j});
+        }
+        for (auto& shap : largest) {
+            expectedIndices[i].push_back(shap.second);
+        }
+        std::sort(expectedIndices[i].begin(), expectedIndices[i].end());
+    }
+
     s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            for (std::size_t col = 0; col < s_NumberFeatures; ++col) {
-                BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedPhi[row->index()][col],
-                                             static_cast<double>((*row)[offset + col]), 1e-5);
-            }
+            s_TreeFeatureImportance->shap(*row, [&](const TSizeVec& indices, const TStrVec& names,
+                                                    const TVectorVec& shap) {
+                BOOST_REQUIRE_EQUAL(indices.size(), row->numberColumns());
+                BOOST_TEST_REQUIRE(std::is_sorted(indices.begin(), indices.end()));
+                for (auto i : indices) {
+                    BOOST_REQUIRE_EQUAL(expectedNames[i], names[i]);
+                    BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedPhi[row->index()][i],
+                                                 shap[i](0), 1e-5);
+                }
+            });
+            s_TopTwoTreeFeatureImportance->shap(
+                *row, [&](const TSizeVec& indices, const TStrVec&, const TVectorVec&) {
+                    BOOST_REQUIRE_EQUAL(indices.size(), 2);
+                    for (std::size_t i = 0; i < 2; ++i) {
+                        BOOST_REQUIRE_EQUAL(expectedIndices[row->index()][i], indices[i]);
+                    }
+                });
         }
     });
 }


### PR DESCRIPTION
This also finishes up multi-parameter loss function support.

Note I don't save and restore `CTreeShapFeatureImportance` because train is always run and so this will always be reinitialised before any SHAP values are computed. For failover we should almost certainly keep track of SHAP values already computed and written, but it might make more sense for the Java to pass this information. I'm therefore deferring this detail to a later PR.

Finally, I've removed multithreading of the SHAP code, because it only gets passed one row at a time now. We should be able to parallelise over trees, but this will require a small tweak to parallel_for_each. Since we don't currently pass number threads from Java, I'll make this change in a follow on PR.