### PR TITLE
[ML] Temporarily disable writing memory usage

### DIFF
--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -73,10 +73,10 @@ void CDataFrameAnalysisInstrumentation::nextStep(std::uint32_t step) {
     this->writeState(step);
 }
 
-void CDataFrameAnalysisInstrumentation::writeState(std::uint32_t step) {
+void CDataFrameAnalysisInstrumentation::writeState(std::uint32_t /*step*/) {
     //this->writeProgress(step);
-    std::int64_t timestamp{core::CTimeUtils::toEpochMs(core::CTimeUtils::now())};
-    this->writeMemory(timestamp);
+    //std::int64_t timestamp{core::CTimeUtils::toEpochMs(core::CTimeUtils::now())};
+    //this->writeMemory(timestamp);
 }
 
 std::int64_t CDataFrameAnalysisInstrumentation::memory() const {


### PR DESCRIPTION
This seems like the most likely candidate for sporadic integration test failures: they first happened after this was committed.