### PR TITLE
[ML] Rename maximum_number_trees to max_trees

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -68,6 +68,8 @@ model training. (See {ml-pull}1034[#1034].)
 (See {ml-pull}970[#970], issue: {ml-issue}949[#949].)
 * Account for the data frame's memory when estimating the peak memory used by classification
 and regression model training. (See {ml-pull}996[#996].)
+* Rename classification and regression parameter maximum_number_trees to max_trees.
+(See {ml-pull}1047[#1047].)
 
 == {es} version 7.6.2
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -42,6 +42,7 @@ public:
     static const std::string ETA;
     static const std::string SOFT_TREE_DEPTH_LIMIT;
     static const std::string SOFT_TREE_DEPTH_TOLERANCE;
+    static const std::string MAX_TREES;
     static const std::string MAXIMUM_NUMBER_TREES;
     static const std::string FEATURE_BAG_FRACTION;
     static const std::string NUMBER_FOLDS;

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -155,7 +155,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         m_BoostedTreeFactory->softTreeDepthTolerance(softTreeDepthTolerance);
     }
     // This is deprecated in favour of max_trees
-    // Will be removed after java side is changed to pass max_trees
+    // TODO Will be removed after java side is changed to pass max_trees
     if (maximumNumberTrees > 0) {
         m_BoostedTreeFactory->maximumNumberTrees(maximumNumberTrees);
     }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -47,6 +47,7 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(SOFT_TREE_DEPTH_TOLERANCE,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(MAX_TREES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(MAXIMUM_NUMBER_TREES,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(FEATURE_BAG_FRACTION,
@@ -81,6 +82,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
 
     std::size_t maximumNumberTrees{
         parameters[MAXIMUM_NUMBER_TREES].fallback(std::size_t{0})};
+    std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
     std::size_t numberFolds{parameters[NUMBER_FOLDS].fallback(std::size_t{0})};
     std::size_t numberRoundsPerHyperparameter{
         parameters[NUMBER_ROUNDS_PER_HYPERPARAMETER].fallback(std::size_t{0})};
@@ -152,8 +154,13 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     if (softTreeDepthTolerance > 0.0) {
         m_BoostedTreeFactory->softTreeDepthTolerance(softTreeDepthTolerance);
     }
+    // This is deprecated in favour of max_trees
+    // Will be removed after java side is changed to pass max_trees
     if (maximumNumberTrees > 0) {
         m_BoostedTreeFactory->maximumNumberTrees(maximumNumberTrees);
+    }
+    if (maxTrees > 0) {
+        m_BoostedTreeFactory->maximumNumberTrees(maxTrees);
     }
     if (featureBagFraction > 0.0 && featureBagFraction <= 1.0) {
         m_BoostedTreeFactory->featureBagFraction(featureBagFraction);
@@ -306,6 +313,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::GAMMA{"gamma"};
 const std::string CDataFrameTrainBoostedTreeRunner::ETA{"eta"};
 const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT{"soft_tree_depth_limit"};
 const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE{"soft_tree_depth_tolerance"};
+const std::string CDataFrameTrainBoostedTreeRunner::MAX_TREES{"max_trees"};
 const std::string CDataFrameTrainBoostedTreeRunner::MAXIMUM_NUMBER_TREES{"maximum_number_trees"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION{"feature_bag_fraction"};
 const std::string CDataFrameTrainBoostedTreeRunner::NUMBER_FOLDS{"number_folds"};

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -48,6 +48,7 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
         theReader.addParameter(SOFT_TREE_DEPTH_TOLERANCE,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(MAX_TREES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        // TODO remove MAXIMUM_NUMBER_TREES
         theReader.addParameter(MAXIMUM_NUMBER_TREES,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(FEATURE_BAG_FRACTION,


### PR DESCRIPTION
Adds a new param `max_trees` to replace the existing
`maximum_number_trees` for classification and regression
analyses.