### PR TITLE
[ML] Start writing memory usage again

### DIFF
--- a/include/api/CDataFrameAnalysisSpecification.h
+++ b/include/api/CDataFrameAnalysisSpecification.h
@@ -161,20 +161,8 @@ public:
     //! appropriate.
     TDataFrameUPtrTemporaryDirectoryPtrPr makeDataFrame();
 
-    //! Run the analysis in a background thread.
-    //!
-    //! This returns a handle to the object responsible for running the analysis.
-    //! Destroying this object waits for the analysis to complete and joins the
-    //! thread. It is expected that the caller will mainly sleep and wake up
-    //! periodically to report progess, errors and see if it has finished.
-    //!
-    //! \return A handle to the analysis runner.
-    //! \note The commit of the results of the analysis is atomic per partition.
-    //! \warning This assumes that there is no access to the data frame in the
-    //! calling thread until the runner has finished.
-    CDataFrameAnalysisRunner*
-    run(core::CDataFrame& frame,
-        core::CRapidJsonConcurrentLineWriter* outputWriter = nullptr) const;
+    //! \return A handle to the object responsible for running the analysis.
+    CDataFrameAnalysisRunner* runner();
 
     //! Estimates memory usage in two cases:
     //!   1. disk is not used (the whole data frame fits in main memory)
@@ -186,9 +174,6 @@ public:
 
     //! \return The stream from which to retore state if there is one.
     TDataSearcherUPtr restoreSearcher() const;
-
-    //! \return The analysis runner.
-    CDataFrameAnalysisRunner* runner();
 
 private:
     void initializeRunner(const rapidjson::Value& jsonAnalysis);

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -44,6 +44,9 @@ public:
                        TJsonOutputStreamWrapperUPtrSupplier resultsStreamSupplier);
     ~CDataFrameAnalyzer();
 
+    CDataFrameAnalyzer(const CDataFrameAnalyzer&) = delete;
+    CDataFrameAnalyzer& operator=(const CDataFrameAnalyzer&) = delete;
+
     //! This is true if the analyzer is receiving control messages.
     bool usingControlMessages() const;
 

--- a/include/core/CRapidJsonConcurrentLineWriter.h
+++ b/include/core/CRapidJsonConcurrentLineWriter.h
@@ -14,13 +14,27 @@ namespace ml {
 namespace core {
 
 //! \brief
-//! A Json line writer for concurrently writing to a shared output stream
+//! A Json line writer for concurrently writing to a shared output stream.
 //!
 //! DESCRIPTION:\n
 //! Takes a wrapped output stream, hides all buffering/pooling/concurrency.
+//! CRapidJsonConcurrentLineWriter objects must not be shared between threads.
+//! The intended usage is as follows:
+//! \code{.cpp}
+//! std::ostringstream stream;
+//! core::CJsonOutputStreamWrapper streamWrapper{stream};
+//! std::thread thread{[&streamWrapper]() {
+//!     core::CRapidJsonConcurrentLineWriter writer{streamWrapper};
+//!     writer.StartObject();
+//!     writer.Key("foo");
+//!     writer.Int(1)
+//!     writer.EndObject();
+//! }};
+//! ...
+//! \endcode
 //!
 //! IMPLEMENTATION DECISIONS:\n
-//! hard code encoding and stream type
+//! Hardcode encoding and stream type.
 //!
 class CORE_EXPORT CRapidJsonConcurrentLineWriter
     : public CRapidJsonLineWriter<rapidjson::StringBuffer> {

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -65,18 +65,14 @@ void CDataFrameAnalysisInstrumentation::resetProgress() {
     m_Finished.store(false);
 }
 
-void CDataFrameAnalysisInstrumentation::writer(core::CRapidJsonConcurrentLineWriter* writer) {
-    m_Writer = writer;
-}
-
 void CDataFrameAnalysisInstrumentation::nextStep(std::uint32_t step) {
     this->writeState(step);
 }
 
 void CDataFrameAnalysisInstrumentation::writeState(std::uint32_t /*step*/) {
     //this->writeProgress(step);
-    //std::int64_t timestamp{core::CTimeUtils::toEpochMs(core::CTimeUtils::now())};
-    //this->writeMemory(timestamp);
+    std::int64_t timestamp{core::CTimeUtils::toEpochMs(core::CTimeUtils::now())};
+    this->writeMemory(timestamp);
 }
 
 std::int64_t CDataFrameAnalysisInstrumentation::memory() const {
@@ -116,6 +112,18 @@ counter_t::ECounterTypes CDataFrameOutliersInstrumentation::memoryCounterType() 
 
 counter_t::ECounterTypes CDataFrameTrainBoostedTreeInstrumentation::memoryCounterType() {
     return counter_t::E_DFTPMPeakMemoryUsage;
+}
+
+CDataFrameAnalysisInstrumentation::CScopeSetOutputStream::CScopeSetOutputStream(
+    CDataFrameAnalysisInstrumentation& instrumentation,
+    core::CJsonOutputStreamWrapper& outStream)
+    : m_Instrumentation{instrumentation} {
+    instrumentation.m_Writer =
+        std::make_unique<core::CRapidJsonConcurrentLineWriter>(outStream);
+}
+
+CDataFrameAnalysisInstrumentation::CScopeSetOutputStream::~CScopeSetOutputStream() {
+    m_Instrumentation.m_Writer = nullptr;
 }
 }
 }

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -207,15 +207,8 @@ CDataFrameAnalysisSpecification::makeDataFrame() {
     return result;
 }
 
-CDataFrameAnalysisRunner*
-CDataFrameAnalysisSpecification::run(core::CDataFrame& frame,
-                                     core::CRapidJsonConcurrentLineWriter* writer) const {
-    if (m_Runner != nullptr) {
-        m_Runner->instrumentation().writer(writer);
-        m_Runner->run(frame);
-        return m_Runner.get();
-    }
-    return nullptr;
+CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::runner() {
+    return m_Runner.get();
 }
 
 void CDataFrameAnalysisSpecification::estimateMemoryUsage(CMemoryUsageEstimationResultJsonWriter& writer) const {
@@ -275,10 +268,6 @@ const std::string& CDataFrameAnalysisSpecification::jobId() const {
 
 const std::string& CDataFrameAnalysisSpecification::analysisName() const {
     return m_AnalysisName;
-}
-
-CDataFrameAnalysisRunner* CDataFrameAnalysisSpecification::runner() {
-    return m_Runner.get();
 }
 }
 }

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -131,11 +131,11 @@ void CDataFrameAnalyzer::run() {
     // get called and the wrapped stream does its job to close the array.
 
     auto analysisRunner = m_AnalysisSpecification->runner();
-    if (m_DataFrame != nullptr && analysisRunner != nullptr) {
+    if (analysisRunner != nullptr) {
         // We currently use a stream factory because the results are wrapped in
         // an array. This is managed by the CJsonOutputStreamWrapper constructor
-        // and destructor. We should probably migrate result to NDJSON format at
-        // which point this would no longer be necessary.
+        // and destructor. We should probably migrate to NDJSON format at which
+        // point this would no longer be necessary.
         auto outStream = m_ResultsStreamSupplier();
 
         CDataFrameAnalysisInstrumentation::CScopeSetOutputStream setStream{

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -11,6 +11,7 @@
 #include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
 
+#include <api/CDataFrameAnalysisInstrumentation.h>
 #include <api/CDataFrameAnalysisSpecification.h>
 
 #include <chrono>
@@ -129,12 +130,20 @@ void CDataFrameAnalyzer::run() {
     // We create the writer in run so that when it is finished destructors
     // get called and the wrapped stream does its job to close the array.
 
-    auto outStream = m_ResultsStreamSupplier();
-    core::CRapidJsonConcurrentLineWriter outputWriter{*outStream};
+    auto analysisRunner = m_AnalysisSpecification->runner();
+    if (m_DataFrame != nullptr && analysisRunner != nullptr) {
+        // We currently use a stream factory because the results are wrapped in
+        // an array. This is managed by the CJsonOutputStreamWrapper constructor
+        // and destructor. We should probably migrate result to NDJSON format at
+        // which point this would no longer be necessary.
+        auto outStream = m_ResultsStreamSupplier();
 
-    auto analysisRunner = m_AnalysisSpecification->run(*m_DataFrame, &outputWriter);
+        CDataFrameAnalysisInstrumentation::CScopeSetOutputStream setStream{
+            analysisRunner->instrumentation(), *outStream};
 
-    if (analysisRunner != nullptr) {
+        analysisRunner->run(*m_DataFrame);
+
+        core::CRapidJsonConcurrentLineWriter outputWriter{*outStream};
         this->monitorProgress(*analysisRunner, outputWriter);
         analysisRunner->waitToFinish();
         this->writeResultsOf(*analysisRunner, outputWriter);

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -393,8 +393,10 @@ BOOST_AUTO_TEST_CASE(testRunAnalysis) {
         auto frameAndDirectory = core::makeMainStorageDataFrame(10);
         auto frame = std::move(frameAndDirectory.first);
 
-        api::CDataFrameAnalysisRunner* runner{spec.run(*frame)};
+        api::CDataFrameAnalysisRunner* runner{spec.runner()};
         BOOST_TEST_REQUIRE(runner != nullptr);
+
+        runner->run(*frame);
 
         double lastProgress{runner->instrumentation().progress()};
         while (runner->instrumentation().finished() == false) {


### PR DESCRIPTION
This fixes the writing of memory usage and reinstates it.

We were previously sharing a `core::CRapidJsonConcurrentLineWriter` between the main thread and the thread running an analysis. This is not the intended usage: we should have one object per thread managing writing to a shared stream.

I've also taken the opportunity to make sure that the stream is unattached from the runner as soon as it is destroyed. It wasn't being used after this point previously, but this change makes it impossible to use it accidentally.

Finally, I noticed that we weren't actually asserting we were writing memory usage in the unit tests. I've added this check.

I've marked as a non-issue since this code is not released.