### PR TITLE
[7.x][ML] Add classification num_classes param (#1054)

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -29,6 +29,7 @@ public:
     };
 
 public:
+    static const std::string NUM_CLASSES;
     static const std::string NUM_TOP_CLASSES;
     static const std::string PREDICTION_FIELD_TYPE;
     static const std::string CLASS_ASSIGNMENT_OBJECTIVE;

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -53,6 +53,11 @@ const CDataFrameAnalysisConfigReader&
 CDataFrameTrainBoostedTreeClassifierRunner::parameterReader() {
     static const CDataFrameAnalysisConfigReader PARAMETER_READER{[] {
         auto theReader = CDataFrameTrainBoostedTreeRunner::parameterReader();
+
+        // This is added as optional at the moment and is not used to
+        // allow java to supply it without breaking.
+        theReader.addParameter(NUM_CLASSES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+
         theReader.addParameter(NUM_TOP_CLASSES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         const std::string typeString{"string"};
         const std::string typeInt{"int"};
@@ -234,6 +239,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelDefinition(
 }
 
 // clang-format off
+const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES{"num_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"num_top_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE{"prediction_field_type"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE{"class_assignment_objective"};


### PR DESCRIPTION
Adds `num_classes` as a parameter to classification.
The parameter is currently unused but this prepares us to
be able to merge in supplying the parameter from the java side
before it's required.

Backport of #1054