### PR TITLE
[ML] Wire in multiclass classification to the data frame analyzer command

### DIFF
--- a/include/api/CBoostedTreeInferenceModelBuilder.h
+++ b/include/api/CBoostedTreeInferenceModelBuilder.h
@@ -76,7 +76,7 @@ public:
     CRegressionInferenceModelBuilder(const TStrVec& fieldNames,
                                      std::size_t dependentVariableColumnIndex,
                                      const TStrVecVec& categoryNames);
-    void addProbabilityAtWhichToAssignClassOne(double probability) override;
+    void addClassificationWeights(TDoubleVec weights) override;
 
 private:
     void setTargetType() override;
@@ -90,7 +90,7 @@ public:
                                          std::size_t dependentVariableColumnIndex,
                                          const TStrVecVec& categoryNames);
     ~CClassificationInferenceModelBuilder() override = default;
-    void addProbabilityAtWhichToAssignClassOne(double probability) override;
+    void addClassificationWeights(TDoubleVec weights) override;
 
 private:
     void setTargetType() override;

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -7,12 +7,12 @@
 #ifndef INCLUDED_ml_api_CDataFrameTrainBoostedTreeClassifierRunner_h
 #define INCLUDED_ml_api_CDataFrameTrainBoostedTreeClassifierRunner_h
 
+#include <core/CSmallVector.h>
+
 #include <api/CDataFrameTrainBoostedTreeRunner.h>
 #include <api/ImportExport.h>
 
 #include <rapidjson/fwd.h>
-
-#include <vector>
 
 namespace ml {
 namespace maths {
@@ -24,9 +24,9 @@ namespace api {
 class API_EXPORT CDataFrameTrainBoostedTreeClassifierRunner final
     : public CDataFrameTrainBoostedTreeRunner {
 public:
-    using TDoubleVec = std::vector<double>;
-    using TReadPredictionFunc = std::function<TDoubleVec(const TRowRef&)>;
-    using TReadClassScoresFunc = std::function<TDoubleVec(const TRowRef&)>;
+    using TDouble2Vec = core::CSmallVector<double, 2>;
+    using TReadPredictionFunc = std::function<TDouble2Vec(const TRowRef&)>;
+    using TReadClassScoresFunc = std::function<TDouble2Vec(const TRowRef&)>;
 
     enum EPredictionFieldType {
         E_PredictionFieldTypeString,
@@ -52,17 +52,6 @@ public:
     void writeOneRow(const core::CDataFrame& frame,
                      const TRowRef& row,
                      core::CRapidJsonConcurrentLineWriter& writer) const override;
-
-    //! Write the prediction for \p row to \p writer.
-    //!
-    //! \note This is only intended to be called directly from unit tests.
-    void writeOneRow(const core::CDataFrame& frame,
-                     std::size_t columnHoldingDependentVariable,
-                     const TReadPredictionFunc& readPrediction,
-                     const TReadClassScoresFunc& readClassScores,
-                     const TRowRef& row,
-                     core::CRapidJsonConcurrentLineWriter& writer,
-                     maths::CTreeShapFeatureImportance* featureImportance = nullptr) const;
 
     //! \return A serialisable definition of the trained classification model.
     TInferenceModelDefinitionUPtr

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -53,6 +53,17 @@ public:
                      const TRowRef& row,
                      core::CRapidJsonConcurrentLineWriter& writer) const override;
 
+    //! Write the prediction for \p row to \p writer.
+    //!
+    //! \note This is only intended to be called directly from unit tests.
+    void writeOneRow(const core::CDataFrame& frame,
+                     std::size_t columnHoldingDependentVariable,
+                     const TReadPredictionFunc& readClassProbabilities,
+                     const TReadClassScoresFunc& readClassScores,
+                     const TRowRef& row,
+                     core::CRapidJsonConcurrentLineWriter& writer,
+                     maths::CTreeShapFeatureImportance* featureImportance = nullptr) const;
+
     //! \return A serialisable definition of the trained classification model.
     TInferenceModelDefinitionUPtr
     inferenceModelDefinition(const TStrVec& fieldNames,

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -12,6 +12,8 @@
 
 #include <rapidjson/fwd.h>
 
+#include <vector>
+
 namespace ml {
 namespace maths {
 class CTreeShapFeatureImportance;
@@ -22,6 +24,10 @@ namespace api {
 class API_EXPORT CDataFrameTrainBoostedTreeClassifierRunner final
     : public CDataFrameTrainBoostedTreeRunner {
 public:
+    using TDoubleVec = std::vector<double>;
+    using TReadPredictionFunc = std::function<TDoubleVec(const TRowRef&)>;
+    using TReadClassScoresFunc = std::function<TDoubleVec(const TRowRef&)>;
+
     enum EPredictionFieldType {
         E_PredictionFieldTypeString,
         E_PredictionFieldTypeInt,
@@ -29,6 +35,7 @@ public:
     };
 
 public:
+    static const std::size_t MAX_NUMBER_CLASSES;
     static const std::string NUM_CLASSES;
     static const std::string NUM_TOP_CLASSES;
     static const std::string PREDICTION_FIELD_TYPE;
@@ -47,11 +54,12 @@ public:
                      core::CRapidJsonConcurrentLineWriter& writer) const override;
 
     //! Write the prediction for \p row to \p writer.
-    //! This is not intended to be called in production. Should only be used in tests.
+    //!
+    //! \note This is only intended to be called directly from unit tests.
     void writeOneRow(const core::CDataFrame& frame,
                      std::size_t columnHoldingDependentVariable,
-                     std::size_t columnHoldingPrediction,
-                     double probabilityAtWhichToAssignClassOne,
+                     const TReadPredictionFunc& readPrediction,
+                     const TReadClassScoresFunc& readClassScores,
                      const TRowRef& row,
                      core::CRapidJsonConcurrentLineWriter& writer,
                      maths::CTreeShapFeatureImportance* featureImportance = nullptr) const;
@@ -62,6 +70,8 @@ public:
                              const TStrVecVec& categoryNames) const override;
 
 private:
+    static TLossFunctionUPtr loss(std::size_t numberClasses);
+
     void validate(const core::CDataFrame& frame,
                   std::size_t dependentVariableColumn) const override;
 

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -133,7 +133,7 @@ public:
     //! Get the labels to use for each class.
     virtual const TOptionalStringVec& classificationLabels() const;
     //! Set weights by which to multiply classes when doing label assignment.
-    virtual void classificationWeights(const TDoubleVec& classificationWeights);
+    virtual void classificationWeights(TDoubleVec classificationWeights);
     //! Get weights by which to multiply classes when doing label assignment.
     virtual const TOptionalDoubleVec& classificationWeights() const;
 
@@ -218,7 +218,7 @@ public:
     //! Set the labels to use for each class.
     void classificationLabels(const TStringVec& classificationLabels) override;
     //! Set weights by which to multiply classes when doing label assignment.
-    void classificationWeights(const TDoubleVec& classificationWeights) override;
+    void classificationWeights(TDoubleVec classificationWeights) override;
     using CTrainedModel::classificationLabels;
     using CTrainedModel::classificationWeights;
     using CTrainedModel::targetType;

--- a/include/maths/CBasicStatistics.h
+++ b/include/maths/CBasicStatistics.h
@@ -12,6 +12,7 @@
 #include <core/CMemory.h>
 #include <core/CSmallVector.h>
 
+#include <maths/CLinearAlgebraShims.h>
 #include <maths/CTypeTraits.h>
 #include <maths/ImportExport.h>
 
@@ -246,14 +247,15 @@ public:
                 T r{x - s_Moments[0]};
                 T r2{r * r};
                 T dMean{mean - s_Moments[0]};
-                T dMean2{dMean * dMean};
+                T dMean2{las::componentwise(dMean) * las::componentwise(dMean)};
                 T variance{s_Moments[1]};
 
                 s_Moments[1] = beta * (variance + dMean2) + alpha * r2;
 
                 if (ORDER > 2) {
                     T skew{s_Moments[2]};
-                    T dSkew{(TCoordinate(3) * variance + dMean2) * dMean};
+                    T dSkew{TCoordinate(3) * variance + dMean2};
+                    dSkew = las::componentwise(dSkew) * las::componentwise(dMean);
 
                     s_Moments[2] = beta * (skew + dSkew) + alpha * r2 * r;
                 }
@@ -283,10 +285,10 @@ public:
 
             if (ORDER > 1) {
                 T dMeanLhs{meanLhs - s_Moments[0]};
-                T dMean2Lhs{dMeanLhs * dMeanLhs};
+                T dMean2Lhs{las::componentwise(dMeanLhs) * las::componentwise(dMeanLhs)};
                 T varianceLhs{s_Moments[1]};
                 T dMeanRhs{meanRhs - s_Moments[0]};
-                T dMean2Rhs{dMeanRhs * dMeanRhs};
+                T dMean2Rhs{las::componentwise(dMeanRhs) * las::componentwise(dMeanRhs)};
                 T varianceRhs{rhs.s_Moments[1]};
 
                 s_Moments[1] = beta * (varianceLhs + dMean2Lhs) +
@@ -294,10 +296,12 @@ public:
 
                 if (ORDER > 2) {
                     T skewLhs{s_Moments[2]};
-                    T dSkewLhs{(TCoordinate{3} * varianceLhs + dMean2Lhs) * dMeanLhs};
+                    T dSkewLhs{TCoordinate{3} * varianceLhs + dMean2Lhs};
+                    dSkewLhs = las::componentwise(dSkewLhs) * las::componentwise(dMeanLhs);
 
                     T skewRhs{rhs.s_Moments[2]};
-                    T dSkewRhs{(TCoordinate{3} * varianceRhs + dMean2Rhs) * dMeanRhs};
+                    T dSkewRhs{TCoordinate{3} * varianceRhs + dMean2Rhs};
+                    dSkewRhs = las::componentwise(dSkewRhs) * las::componentwise(dMeanRhs);
 
                     s_Moments[2] = beta * (skewLhs + dSkewLhs) + alpha * (skewRhs + dSkewRhs);
                 }
@@ -348,9 +352,9 @@ public:
 
             if (ORDER > 1) {
                 T dMeanLhs{s_Moments[0] - meanLhs};
-                T dMean2Lhs{dMeanLhs * dMeanLhs};
+                T dMean2Lhs{las::componentwise(dMeanLhs) * las::componentwise(dMeanLhs)};
                 T dMeanRhs{meanRhs - meanLhs};
-                T dMean2Rhs{dMeanRhs * dMeanRhs};
+                T dMean2Rhs{las::componentwise(dMeanRhs) * las::componentwise(dMeanRhs)};
                 T varianceRhs{rhs.s_Moments[1]};
 
                 s_Moments[1] = max(beta * (s_Moments[1] - dMean2Lhs) -
@@ -359,9 +363,11 @@ public:
 
                 if (ORDER > 2) {
                     T skewLhs{s_Moments[2]};
-                    T dSkewLhs{(TCoordinate{3} * s_Moments[1] + dMean2Lhs) * dMeanLhs};
+                    T dSkewLhs{TCoordinate{3} * s_Moments[1] + dMean2Lhs};
+                    dSkewLhs = las::componentwise(dSkewLhs) * las::componentwise(dMeanLhs);
                     T skewRhs{rhs.s_Moments[2]};
-                    T dSkewRhs{(TCoordinate{3} * varianceRhs + dMean2Rhs) * dMeanRhs};
+                    T dSkewRhs{TCoordinate{3} * varianceRhs + dMean2Rhs};
+                    dSkewRhs = las::componentwise(dSkewRhs) * las::componentwise(dMeanRhs);
 
                     s_Moments[2] = beta * (skewLhs - dSkewLhs) -
                                    alpha * (skewRhs + dSkewRhs - dSkewLhs);

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -196,7 +196,6 @@ private:
 class MATHS_EXPORT CBoostedTree final : public CDataFramePredictiveModel {
 public:
     using TStrVec = std::vector<std::string>;
-    using TRowRef = core::CDataFrame::TRowRef;
     using TLossFunctionUPtr = std::unique_ptr<boosted_tree::CLoss>;
     using TDataFramePtr = core::CDataFrame*;
     using TNodeVec = std::vector<CBoostedTreeNode>;
@@ -207,7 +206,7 @@ public:
     public:
         virtual ~CVisitor() = default;
         virtual void addTree() = 0;
-        virtual void addProbabilityAtWhichToAssignClassOne(double probability) = 0;
+        virtual void addClassificationWeights(TDoubleVec weights) = 0;
     };
 
 public:
@@ -232,11 +231,15 @@ public:
     //! Get the column containing the dependent variable.
     std::size_t columnHoldingDependentVariable() const override;
 
-    //! Get the column containing the model's prediction for the dependent variable.
-    std::size_t columnHoldingPrediction() const override;
+    //! Read the model prediction from \p row.
+    TDoubleVec readPrediction(const TRowRef& row) const override;
 
-    //! Get the probability threshold at which to classify a row as class one.
-    double probabilityAtWhichToAssignClassOne() const override;
+    //! Read the raw model prediction from \p row and make posthoc adjustments.
+    //!
+    //! For example, classification multiplicative weights are used for each
+    //! class to target different objectives (accuracy or minimum recall) when
+    //! assigning classes.
+    TDoubleVec readAndAdjustPrediction(const TRowRef& row) const override;
 
     //! Get the model produced by training if it has been run.
     const TNodeVecVec& trainedModel() const;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -232,14 +232,14 @@ public:
     std::size_t columnHoldingDependentVariable() const override;
 
     //! Read the model prediction from \p row.
-    TDoubleVec readPrediction(const TRowRef& row) const override;
+    TDouble2Vec readPrediction(const TRowRef& row) const override;
 
     //! Read the raw model prediction from \p row and make posthoc adjustments.
     //!
     //! For example, classification multiplicative weights are used for each
     //! class to target different objectives (accuracy or minimum recall) when
     //! assigning classes.
-    TDoubleVec readAndAdjustPrediction(const TRowRef& row) const override;
+    TDouble2Vec readAndAdjustPrediction(const TRowRef& row) const override;
 
     //! Get the model produced by training if it has been run.
     const TNodeVecVec& trainedModel() const;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -17,6 +17,7 @@
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeHyperparameters.h>
+#include <maths/CBoostedTreeLoss.h>
 #include <maths/CBoostedTreeUtils.h>
 #include <maths/CDataFrameAnalysisInstrumentationInterface.h>
 #include <maths/CDataFrameCategoryEncoder.h>
@@ -49,6 +50,7 @@ class MATHS_EXPORT CBoostedTreeImpl final {
 public:
     using TDoubleVec = std::vector<double>;
     using TStrVec = std::vector<std::string>;
+    using TVector = CDenseVector<double>;
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TMeanVarAccumulatorSizePr = std::pair<TMeanVarAccumulator, std::size_t>;
@@ -56,6 +58,7 @@ public:
     using TBayesinOptimizationUPtr = std::unique_ptr<maths::CBayesianOptimisation>;
     using TNodeVec = CBoostedTree::TNodeVec;
     using TNodeVecVec = CBoostedTree::TNodeVecVec;
+    using TLossFunction = boosted_tree::CLoss;
     using TLossFunctionUPtr = CBoostedTree::TLossFunctionUPtr;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
     using TOptionalDouble = boost::optional<double>;
@@ -93,8 +96,18 @@ public:
     //! Get the model produced by training if it has been run.
     const TNodeVecVec& trainedModel() const;
 
+    //! Get the training loss function.
+    TLossFunction& loss() const;
+
     //! Get the column containing the dependent variable.
     std::size_t columnHoldingDependentVariable() const;
+
+    //! Get the number of columns in the original data frame.
+    std::size_t numberInputColumns() const;
+
+    //! Get the weights to apply to each class's predicted probability when
+    //! assigning classes.
+    TVector classificationWeights() const;
 
     //! Get the number of columns training the model will add to the data frame.
     static std::size_t numberExtraColumnsForTrain(std::size_t numberLossParameters) {
@@ -125,12 +138,6 @@ public:
     //! \return The best hyperparameters for validation error found so far.
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
 
-    //! Get the probability threshold at which to classify a row as class one.
-    double probabilityAtWhichToAssignClassOne() const;
-
-    //! Get the number of columns in the original data frame.
-    std::size_t numberInputColumns() const;
-
     //!\ name Test Only
     //@{
     //! The name of the object holding the best hyperaparameters in the state document.
@@ -154,7 +161,6 @@ private:
     using TOptionalDoubleVec = std::vector<TOptionalDouble>;
     using TOptionalDoubleVecVec = std::vector<TOptionalDoubleVec>;
     using TOptionalSize = boost::optional<std::size_t>;
-    using TVector = CDenseVector<double>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TImmutableRadixSetVec = std::vector<core::CImmutableRadixSet<double>>;
     using TNodeVecVecDoublePr = std::pair<TNodeVecVec, double>;
@@ -182,7 +188,7 @@ private:
     void initializePerFoldTestLosses();
 
     //! Compute the probability threshold at which to classify a row as class one.
-    void computeProbabilityAtWhichToAssignClassOne(const core::CDataFrame& frame);
+    void computeClassificationWeights(const core::CDataFrame& frame);
 
     //! Prepare to calculate SHAP feature importances.
     void initializeTreeShap(const core::CDataFrame& frame);
@@ -305,7 +311,7 @@ private:
     TOptionalSize m_MaximumNumberTreesOverride;
     TOptionalDouble m_FeatureBagFractionOverride;
     TRegularization m_Regularization;
-    double m_ProbabilityAtWhichToAssignClassOne = 0.5;
+    TVector m_ClassificationWeights;
     double m_DownsampleFactor = 0.5;
     double m_Eta = 0.1;
     double m_EtaGrowthRatePerTree = 1.05;

--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -240,10 +240,18 @@ public:
     using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage>;
     using TWriter = std::function<void(std::size_t, double)>;
 
+    enum EType {
+        E_BinaryClassification,
+        E_MulticlassClassification,
+        E_Regression
+    };
+
 public:
     virtual ~CLoss() = default;
     //! Clone the loss.
     virtual std::unique_ptr<CLoss> clone() const = 0;
+    //! Get the type of prediction problem to which this loss applies.
+    virtual EType type() const = 0;
     //! The number of parameters to the loss function.
     virtual std::size_t numberParameters() const = 0;
     //! The value of the loss function.
@@ -281,6 +289,7 @@ public:
 
 public:
     std::unique_ptr<CLoss> clone() const override;
+    EType type() const override;
     std::size_t numberParameters() const override;
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
@@ -314,6 +323,7 @@ public:
 
 public:
     std::unique_ptr<CLoss> clone() const override;
+    EType type() const override;
     std::size_t numberParameters() const override;
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
@@ -349,6 +359,7 @@ public:
 
 public:
     CMultinomialLogisticLoss(std::size_t numberClasses);
+    EType type() const override;
     std::unique_ptr<CLoss> clone() const override;
     std::size_t numberParameters() const override;
     double value(const TMemoryMappedFloatVector& prediction,

--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -75,9 +75,9 @@ private:
 //!   \f$\displaystyle arg\min_w{ \lambda w^2 -\sum_i{ a_i \log(S(p_i + w)) + (1 - a_i) \log(1 - S(p_i + w)) } }\f$
 //! </pre>
 //!
-//! Rather than working with this function directly we bucket the predictions `p_i`
-//! in a first pass over the data and compute weight which minimizes the approximate
-//! function
+//! Rather than working with this function directly we we approximate it by computing
+//! the predictions `p_i` and actual class counts in a uniform bucketing of the data,
+//! i.e. we compute the weight which satisfies
 //! <pre class="fragment">
 //! \f$\displaystyle arg\min_w{ \lambda w^2 -\sum_{B}{ c_{1,B} \log(S(\bar{p}_B + w)) + c_{0,B} \log(1 - S(\bar{p}_B + w)) } }\f$
 //! </pre>
@@ -137,9 +137,9 @@ private:
 //! </pre>
 //!
 //! Here, \f$a_i\f$ is the index of the i'th example's true class. Rather than
-//! working with this function directly we approximate it by the means and count
-//! of predictions in a partition of the original data, i.e. we compute the weight
-//! weight which satisfies
+//! working with this function directly we approximate it by the means of the
+//! predictions and counts of actual classes in a partition of the data, i.e.
+//! we compute the weight which satisfies
 //! <pre class="fragment">
 //! \f$\displaystyle arg\min_w{ \lambda \|w\|^2 -\sum_P{ c_{a_i, P} \log([softmax(\bar{p}_P + w)]) } }\f$
 //! </pre>

--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -303,6 +303,7 @@ public:
                    TWriter writer,
                    double weight = 1.0) const override;
     bool isCurvatureConstant() const override;
+    //! \return \p prediction.
     TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
     CArgMinLoss minimizer(double lambda, const CPRNG::CXorOShiro128Plus& rng) const override;
     const std::string& name() const override;
@@ -337,6 +338,7 @@ public:
                    TWriter writer,
                    double weight = 1.0) const override;
     bool isCurvatureConstant() const override;
+    //! \return (P(class 0), P(class 1)).
     TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
     CArgMinLoss minimizer(double lambda, const CPRNG::CXorOShiro128Plus& rng) const override;
     const std::string& name() const override;
@@ -374,6 +376,7 @@ public:
                    TWriter writer,
                    double weight = 1.0) const override;
     bool isCurvatureConstant() const override;
+    //! \return (P(class 0), P(class 1), ..., P(class n)).
     TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
     CArgMinLoss minimizer(double lambda, const CPRNG::CXorOShiro128Plus& rng) const override;
     const std::string& name() const override;

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -8,6 +8,7 @@
 #define INCLUDED_ml_maths_CDataFramePredictiveModel_h
 
 #include <core/CDataFrame.h>
+#include <core/CSmallVector.h>
 #include <core/CStatePersistInserter.h>
 
 #include <maths/ImportExport.h>
@@ -31,6 +32,7 @@ class CTreeShapFeatureImportance;
 class MATHS_EXPORT CDataFramePredictiveModel {
 public:
     using TDoubleVec = std::vector<double>;
+    using TDouble2Vec = core::CSmallVector<double, 2>;
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
     using TTrainingStateCallback = std::function<void(TPersistFunc)>;
     using TRowRef = core::CDataFrame::TRowRef;
@@ -62,10 +64,10 @@ public:
     virtual std::size_t columnHoldingDependentVariable() const = 0;
 
     //! Read the prediction out of \p row.
-    virtual TDoubleVec readPrediction(const TRowRef& row) const = 0;
+    virtual TDouble2Vec readPrediction(const TRowRef& row) const = 0;
 
     //! Read the raw model prediction from \p row and make posthoc adjustments.
-    virtual TDoubleVec readAndAdjustPrediction(const TRowRef& row) const = 0;
+    virtual TDouble2Vec readAndAdjustPrediction(const TRowRef& row) const = 0;
 
     //! \name Test Only
     //@{

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -7,6 +7,7 @@
 #ifndef INCLUDED_ml_maths_CDataFramePredictiveModel_h
 #define INCLUDED_ml_maths_CDataFramePredictiveModel_h
 
+#include <core/CDataFrame.h>
 #include <core/CStatePersistInserter.h>
 
 #include <maths/ImportExport.h>
@@ -32,6 +33,7 @@ public:
     using TDoubleVec = std::vector<double>;
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
     using TTrainingStateCallback = std::function<void(TPersistFunc)>;
+    using TRowRef = core::CDataFrame::TRowRef;
 
     //! The objective for the classification decision (given predicted class probabilities).
     enum EClassAssignmentObjective {
@@ -59,11 +61,11 @@ public:
     //! Get the column containing the dependent variable.
     virtual std::size_t columnHoldingDependentVariable() const = 0;
 
-    //! Get the column containing the model's prediction for the dependent variable.
-    virtual std::size_t columnHoldingPrediction() const = 0;
+    //! Read the prediction out of \p row.
+    virtual TDoubleVec readPrediction(const TRowRef& row) const = 0;
 
-    //! Get the probability threshold at which to classify a row as class one.
-    virtual double probabilityAtWhichToAssignClassOne() const = 0;
+    //! Read the raw model prediction from \p row and make posthoc adjustments.
+    virtual TDoubleVec readAndAdjustPrediction(const TRowRef& row) const = 0;
 
     //! \name Test Only
     //@{

--- a/include/maths/CInformationCriteria.h
+++ b/include/maths/CInformationCriteria.h
@@ -102,14 +102,11 @@ public:
         typename CBasicStatistics::SSampleMeanVar<TBarePointPrecise>::TAccumulator;
 
 public:
-    CSphericalGaussianInfoCriterion()
-        : m_D(0.0), m_K(0.0), m_N(0.0), m_Likelihood(0.0) {}
-    explicit CSphericalGaussianInfoCriterion(const TPointVecVec& x)
-        : m_D(0.0), m_K(0.0), m_N(0.0), m_Likelihood(0.0) {
+    CSphericalGaussianInfoCriterion() = default;
+    explicit CSphericalGaussianInfoCriterion(const TPointVecVec& x) {
         this->add(x);
     }
-    explicit CSphericalGaussianInfoCriterion(const TPointVec& x)
-        : m_D(0.0), m_K(0.0), m_N(0.0), m_Likelihood(0.0) {
+    explicit CSphericalGaussianInfoCriterion(const TPointVec& x) {
         this->add(x);
     }
 
@@ -132,10 +129,10 @@ public:
     //! Update the sufficient statistics for computing info content.
     void add(const TMeanVarAccumulator& moments) {
         double ni = CBasicStatistics::count(moments);
-        const TBarePointPrecise& m = CBasicStatistics::mean(moments);
-        const TBarePointPrecise& c = CBasicStatistics::maximumLikelihoodVariance(moments);
-        std::size_t d = las::dimension(c);
-        double vi = 0.0;
+        const TBarePointPrecise& m{CBasicStatistics::mean(moments)};
+        const TBarePointPrecise& c{CBasicStatistics::maximumLikelihoodVariance(moments)};
+        std::size_t d{las::dimension(c)};
+        double vi{0.0};
         for (std::size_t i = 0u; i < d; ++i) {
             vi += c(i);
         }
@@ -160,8 +157,8 @@ public:
     //! Calculate the information content of the clusters added so far.
     double calculate() const {
         if (m_N != 0.0) {
-            double logN = std::log(m_N);
-            double p = (m_D * m_K + 2.0 * m_K - 1.0);
+            double logN{std::log(m_N)};
+            double p{m_D * m_K + 2.0 * m_K - 1.0};
             switch (TYPE) {
             case E_BIC:
                 return -2.0 * (m_Likelihood - m_N * logN) + p * logN;
@@ -175,13 +172,13 @@ public:
 
 private:
     //! The point dimension.
-    double m_D;
+    double m_D = 0.0;
     //! The number of clusters.
-    double m_K;
+    double m_K = 0.0;
     //! The number of points.
-    double m_N;
+    double m_N = 0.0;
     //! The data likelihood for the k spherically symmetric Gaussians.
-    double m_Likelihood;
+    double m_Likelihood = 0.0;
 };
 
 //! \brief Computes the information content of a collection of point
@@ -203,14 +200,11 @@ public:
     using TCovariances = CBasicStatistics::SSampleCovariances<TBarePointPrecise>;
 
 public:
-    CGaussianInfoCriterion()
-        : m_D(0.0), m_K(0.0), m_N(0.0), m_Likelihood(0.0) {}
-    explicit CGaussianInfoCriterion(const TPointVecVec& x)
-        : m_D(0.0), m_K(0.0), m_N(0.0), m_Likelihood(0.0) {
+    CGaussianInfoCriterion() = default;
+    explicit CGaussianInfoCriterion(const TPointVecVec& x) {
         this->add(x);
     }
-    explicit CGaussianInfoCriterion(const TPointVec& x)
-        : m_D(0.0), m_K(0.0), m_N(0.0), m_Likelihood(0.0) {
+    explicit CGaussianInfoCriterion(const TPointVec& x) {
         this->add(x);
     }
 
@@ -232,7 +226,7 @@ public:
 
     //! Update the sufficient statistics for computing info content.
     void add(const TCovariances& covariance) {
-        double ni = CBasicStatistics::count(covariance);
+        double ni{CBasicStatistics::count(covariance)};
         m_D = static_cast<double>(las::dimension(CBasicStatistics::mean(covariance)));
         m_K += 1.0;
         m_N += ni;
@@ -246,8 +240,8 @@ public:
     //! Calculate the information content of the clusters added so far.
     double calculate() const {
         if (m_N != 0.0) {
-            double logN = std::log(m_N);
-            double p = (m_D * (1.0 + 0.5 * (m_D + 1.0)) * m_K + m_K - 1.0);
+            double logN{std::log(m_N)};
+            double p{m_D * (1.0 + 0.5 * (m_D + 1.0)) * m_K + m_K - 1.0};
             switch (TYPE) {
             case E_BIC:
                 return -2.0 * (m_Likelihood - m_N * logN) + p * logN;
@@ -262,21 +256,21 @@ public:
 private:
     //! Compute the log of the determinant of \p covariance.
     double logDeterminant(const TCovariances& covariance) const {
-        double n = CBasicStatistics::count(covariance);
+        double n{CBasicStatistics::count(covariance)};
         const auto& c = CBasicStatistics::maximumLikelihoodCovariances(covariance);
-        double upper = information_criteria_detail::confidence(n - m_D - 1.0);
+        double upper{information_criteria_detail::confidence(n - m_D - 1.0)};
         return information_criteria_detail::logDeterminant(c, upper);
     }
 
 private:
     //! The point dimension.
-    double m_D;
+    double m_D = 0.0;
     //! The number of clusters.
-    double m_K;
+    double m_K = 0.0;
     //! The number of points.
-    double m_N;
+    double m_N = 0.0;
     //! The data likelihood for the k Gaussians.
-    double m_Likelihood;
+    double m_Likelihood = 0.0;
 };
 }
 }

--- a/include/maths/CInformationCriteria.h
+++ b/include/maths/CInformationCriteria.h
@@ -201,12 +201,8 @@ public:
 
 public:
     CGaussianInfoCriterion() = default;
-    explicit CGaussianInfoCriterion(const TPointVecVec& x) {
-        this->add(x);
-    }
-    explicit CGaussianInfoCriterion(const TPointVec& x) {
-        this->add(x);
-    }
+    explicit CGaussianInfoCriterion(const TPointVecVec& x) { this->add(x); }
+    explicit CGaussianInfoCriterion(const TPointVec& x) { this->add(x); }
 
     //! Update the sufficient statistics for computing info content.
     void add(const TPointVecVec& x) {

--- a/include/maths/CKMeans.h
+++ b/include/maths/CKMeans.h
@@ -20,6 +20,7 @@
 
 #include <boost/iterator/counting_iterator.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <sstream>
@@ -495,7 +496,8 @@ private:
             newCentre = CBasicStatistics::mean(newCentres[i]);
             if (las::distance(m_Centres[i], newCentre) >
                 precision * las::norm(m_Centres[i])) {
-                las::swap(m_Centres[i], newCentre);
+                using std::swap;
+                swap(m_Centres[i], newCentre);
                 changed = true;
             }
         }

--- a/include/maths/CLinearAlgebra.h
+++ b/include/maths/CLinearAlgebra.h
@@ -18,7 +18,6 @@
 
 #include <boost/array.hpp>
 #include <boost/geometry.hpp>
-//#include <boost/geometry/geometries/adapted/boost_array.hpp>
 #include <boost/geometry/geometries/adapted/std_array.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
 #include <boost/operators.hpp>

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -269,8 +269,8 @@ public:
 
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-        inserter.insertValue(DENSE_VECTOR_TAG,
-                             core::CPersistUtils::toString(this->toStdVector()));
+        inserter.insertValue(DENSE_VECTOR_TAG, core::CPersistUtils::toString(
+                                                   this->to<std::vector<SCALAR>>()));
     }
 
     //! Populate the object from serialized data.
@@ -286,8 +286,11 @@ public:
     }
 
     //! Convert to a std::vector.
-    std::vector<SCALAR> toStdVector() const {
-        std::vector<SCALAR> result;
+    //!
+    //! It is assumed that COLLECTION supports reserve and push_back.
+    template<typename COLLECTION>
+    COLLECTION to() const {
+        COLLECTION result;
         result.reserve(this->size());
         for (int i = 0; i < this->size(); ++i) {
             result.push_back(this->coeff(i));

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -217,6 +217,12 @@ public:
     }
 };
 
+//! Free efficient efficient swap for ADLU.
+template<typename SCALAR>
+void swap(CDenseMatrix<SCALAR>& lhs, CDenseMatrix<SCALAR>& rhs) {
+    lhs.swap(rhs);
+}
+
 //! \brief Gets a constant dense square matrix with specified dimension or with
 //! specified numbers of rows and columns.
 template<typename SCALAR>
@@ -311,6 +317,12 @@ public:
 template<typename SCALAR>
 const std::string CDenseVector<SCALAR>::DENSE_VECTOR_TAG{"dense_vector"};
 
+//! Free efficient efficient swap for ADLU.
+template<typename SCALAR>
+void swap(CDenseVector<SCALAR>& lhs, CDenseVector<SCALAR>& rhs) {
+    lhs.swap(rhs);
+}
+
 //! \brief Gets a constant dense vector with specified dimension.
 template<typename SCALAR>
 struct SConstant<CDenseVector<SCALAR>> {
@@ -391,6 +403,12 @@ private:
         new (base) TBase{const_cast<SCALAR*>(other.data()), other.rows(), other.cols()};
     }
 };
+
+//! Free efficient efficient swap for ADLU.
+template<typename SCALAR>
+void swap(CMemoryMappedDenseMatrix<SCALAR>& lhs, CMemoryMappedDenseMatrix<SCALAR>& rhs) {
+    lhs.swap(rhs);
+}
 
 //! \brief Gets a constant square dense matrix with specified dimension or with
 //! specified numbers of rows and columns.
@@ -504,6 +522,12 @@ private:
         new (base) TBase{const_cast<SCALAR*>(other.data()), other.size()};
     }
 };
+
+//! Free efficient efficient swap for ADLU.
+template<typename SCALAR>
+void swap(CMemoryMappedDenseVector<SCALAR>& lhs, CMemoryMappedDenseVector<SCALAR>& rhs) {
+    lhs.swap(rhs);
+}
 
 //! \brief Gets a constant dense vector with specified dimension.
 template<typename SCALAR>

--- a/include/maths/CLinearAlgebraShims.h
+++ b/include/maths/CLinearAlgebraShims.h
@@ -7,8 +7,6 @@
 #ifndef INCLUDED_ml_maths_CLinearAlgebraShims_h
 #define INCLUDED_ml_maths_CLinearAlgebraShims_h
 
-#include <maths/CLinearAlgebra.h>
-#include <maths/CLinearAlgebraEigen.h>
 #include <maths/CLinearAlgebraFwd.h>
 #include <maths/CTypeTraits.h>
 
@@ -19,32 +17,6 @@
 namespace ml {
 namespace maths {
 namespace las {
-
-//! Swap two vectors or matrices efficiently.
-template<typename T>
-void swap(T& lhs, T& rhs) {
-    lhs.swap(rhs);
-}
-
-//! Swap two stack vectors.
-template<typename T, std::size_t N>
-void swap(CVectorNx1<T, N>& lhs, CVectorNx1<T, N>& rhs) {
-    std::swap(lhs, rhs);
-}
-
-//! Swap two annotated vectors and their annotations.
-template<typename VECTOR, typename ANNOTATION>
-void swap(CAnnotatedVector<VECTOR, ANNOTATION>& lhs,
-          CAnnotatedVector<VECTOR, ANNOTATION>& rhs) {
-    swap(static_cast<VECTOR&>(lhs), static_cast<VECTOR&>(rhs));
-    std::swap(lhs.annotation(), rhs.annotation());
-}
-
-//! Swap two stack matrices.
-template<typename T, std::size_t N>
-void swap(CSymmetricMatrixNxN<T, N>& lhs, CSymmetricMatrixNxN<T, N>& rhs) {
-    std::swap(lhs, rhs);
-}
 
 //! Get the dimension of one of our internal vectors.
 template<typename VECTOR>

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -56,6 +56,7 @@ public:
     predicitionNumberRoundsPerHyperparameter(std::size_t rounds);
     CDataFrameAnalysisSpecificationFactory&
     predictionBayesianOptimisationRestarts(std::size_t restarts);
+    CDataFrameAnalysisSpecificationFactory& predictionFieldName(const std::string& name);
     CDataFrameAnalysisSpecificationFactory&
     predictionCategoricalFieldNames(const TStrVec& categorical);
     CDataFrameAnalysisSpecificationFactory& predictionAlpha(double alpha);
@@ -72,7 +73,15 @@ public:
     CDataFrameAnalysisSpecificationFactory&
     predictionRestoreSearcherSupplier(TRestoreSearcherSupplier* restoreSearcherSupplier);
 
+    // Classification
+    CDataFrameAnalysisSpecificationFactory& numberClasses(std::size_t number);
+    CDataFrameAnalysisSpecificationFactory& predictionFieldType(const std::string& type);
+
+    std::string outlierParams() const;
     TSpecificationUPtr outlierSpec() const;
+
+    std::string predictionParams(const std::string& analysis,
+                                 const std::string& dependentVariable) const;
     TSpecificationUPtr predictionSpec(const std::string& analysis,
                                       const std::string& dependentVariable) const;
 
@@ -94,6 +103,7 @@ private:
     std::size_t m_NumberRoundsPerHyperparameter = 0;
     std::size_t m_BayesianOptimisationRestarts = 0;
     TStrVec m_CategoricalFieldNames;
+    std::string m_PredictionFieldName;
     double m_Alpha = -1.0;
     double m_Lambda = -1.0;
     double m_Gamma = -1.0;
@@ -105,6 +115,9 @@ private:
     std::size_t m_NumberTopShapValues = 0;
     TPersisterSupplier* m_PersisterSupplier = nullptr;
     TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
+    // Classification
+    std::size_t m_NumberClasses = 2;
+    std::string m_PredictionFieldType;
 };
 }
 }

--- a/lib/api/CBoostedTreeInferenceModelBuilder.cc
+++ b/lib/api/CBoostedTreeInferenceModelBuilder.cc
@@ -142,7 +142,7 @@ CRegressionInferenceModelBuilder::CRegressionInferenceModelBuilder(const TStrVec
     : CBoostedTreeInferenceModelBuilder{fieldNames, dependentVariableColumnIndex, categoryNames} {
 }
 
-void CRegressionInferenceModelBuilder::addProbabilityAtWhichToAssignClassOne(double) {
+void CRegressionInferenceModelBuilder::addClassificationWeights(TDoubleVec /*weights*/) {
 }
 
 void CRegressionInferenceModelBuilder::setTargetType() {
@@ -162,9 +162,8 @@ CClassificationInferenceModelBuilder::CClassificationInferenceModelBuilder(
         categoryNames[dependentVariableColumnIndex]);
 }
 
-void CClassificationInferenceModelBuilder::addProbabilityAtWhichToAssignClassOne(double probability) {
-    this->definition().trainedModel()->classificationWeights(
-        {0.5 / (1.0 - probability), 0.5 / probability});
+void CClassificationInferenceModelBuilder::addClassificationWeights(TDoubleVec weights) {
+    this->definition().trainedModel()->classificationWeights(std::move(weights));
 }
 
 void CClassificationInferenceModelBuilder::setTargetType() {

--- a/lib/api/CBoostedTreeInferenceModelBuilder.cc
+++ b/lib/api/CBoostedTreeInferenceModelBuilder.cc
@@ -99,7 +99,7 @@ void CBoostedTreeInferenceModelBuilder::addNode(std::size_t splitFeature,
         HANDLE_FATAL(<< "Internal error. Tree points to a nullptr.")
     }
     tree->treeStructure().emplace_back(tree->size(), splitValue, assignMissingToLeft,
-                                       nodeValue.toStdVector(), splitFeature,
+                                       nodeValue.to<TDoubleVec>(), splitFeature,
                                        numberSamples, leftChild, rightChild, gain);
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -123,8 +123,8 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     core::CRapidJsonConcurrentLineWriter& writer,
     maths::CTreeShapFeatureImportance* featureImportance) const {
 
-    TDoubleVec probabilities{readClassProbabilities(row)};
-    TDoubleVec scores{readClassScores(row)};
+    auto probabilities = readClassProbabilities(row);
+    auto scores = readClassScores(row);
 
     double actualClassId{row[columnHoldingDependentVariable]};
     std::size_t predictedClassId(std::max_element(scores.begin(), scores.end()) -

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -104,27 +104,11 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     core::CRapidJsonConcurrentLineWriter& writer) const {
 
     const auto& tree = this->boostedTree();
-    auto readClassProbabilities = [&](const TRowRef& row_) {
-        return tree.readPrediction(row_);
-    };
-    auto readClassScores = [&](const TRowRef& row_) {
-        return tree.readAndAdjustPrediction(row_);
-    };
-    this->writeOneRow(frame, tree.columnHoldingDependentVariable(), readClassProbabilities,
-                      readClassScores, row, writer, tree.shap());
-}
+    std::size_t columnHoldingDependentVariable{tree.columnHoldingDependentVariable()};
+    maths::CTreeShapFeatureImportance* featureImportance{tree.shap()};
 
-void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
-    const core::CDataFrame& frame,
-    std::size_t columnHoldingDependentVariable,
-    const TReadPredictionFunc& readClassProbabilities,
-    const TReadClassScoresFunc& readClassScores,
-    const TRowRef& row,
-    core::CRapidJsonConcurrentLineWriter& writer,
-    maths::CTreeShapFeatureImportance* featureImportance) const {
-
-    auto probabilities = readClassProbabilities(row);
-    auto scores = readClassScores(row);
+    auto probabilities = tree.readPrediction(row);
+    auto scores = tree.readAndAdjustPrediction(row);
 
     double actualClassId{row[columnHoldingDependentVariable]};
     std::size_t predictedClassId(std::max_element(scores.begin(), scores.end()) -

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -242,6 +242,8 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelDefinition(
 }
 
 // clang-format off
+// The MAX_NUMBER_CLASSES must match the value used in the Java code. See the
+// MAX_DEPENDENT_VARIABLE_CARDINALITY in the x-pack classification code.
 const std::size_t CDataFrameTrainBoostedTreeClassifierRunner::MAX_NUMBER_CLASSES{30};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES{"num_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"num_top_classes"};

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -24,6 +24,7 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/ElasticsearchStateIndex.h>
 
+#include <memory>
 #include <numeric>
 #include <set>
 
@@ -53,11 +54,7 @@ const CDataFrameAnalysisConfigReader&
 CDataFrameTrainBoostedTreeClassifierRunner::parameterReader() {
     static const CDataFrameAnalysisConfigReader PARAMETER_READER{[] {
         auto theReader = CDataFrameTrainBoostedTreeRunner::parameterReader();
-
-        // This is added as optional at the moment and is not used to
-        // allow java to supply it without breaking.
-        theReader.addParameter(NUM_CLASSES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
-
+        theReader.addParameter(NUM_CLASSES, CDataFrameAnalysisConfigReader::E_RequiredParameter);
         theReader.addParameter(NUM_TOP_CLASSES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         const std::string typeString{"string"};
         const std::string typeInt{"int"};
@@ -82,8 +79,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::CDataFrameTrainBoostedTreeClassifier
     const CDataFrameAnalysisSpecification& spec,
     const CDataFrameAnalysisParameters& parameters)
     : CDataFrameTrainBoostedTreeRunner{
-          spec, parameters,
-          std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>()} {
+          spec, parameters, loss(parameters[NUM_CLASSES].as<std::size_t>())} {
 
     m_NumTopClasses = parameters[NUM_TOP_CLASSES].fallback(std::size_t{0});
     m_PredictionFieldType =
@@ -108,32 +104,27 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     core::CRapidJsonConcurrentLineWriter& writer) const {
 
     const auto& tree = this->boostedTree();
-    this->writeOneRow(frame, tree.columnHoldingDependentVariable(),
-                      tree.columnHoldingPrediction(),
-                      tree.probabilityAtWhichToAssignClassOne(), row, writer,
-                      tree.shap());
+    auto readClassProbabilities = [&](const TRowRef& row_) {
+        return tree.readPrediction(row_);
+    };
+    auto readClassScores = [&](const TRowRef& row_) {
+        return tree.readAndAdjustPrediction(row_);
+    };
+    this->writeOneRow(frame, tree.columnHoldingDependentVariable(), readClassProbabilities,
+                      readClassScores, row, writer, tree.shap());
 }
 
 void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     const core::CDataFrame& frame,
     std::size_t columnHoldingDependentVariable,
-    std::size_t columnHoldingPrediction,
-    double probabilityAtWhichToAssignClassOne,
+    const TReadPredictionFunc& readClassProbabilities,
+    const TReadClassScoresFunc& readClassScores,
     const TRowRef& row,
     core::CRapidJsonConcurrentLineWriter& writer,
     maths::CTreeShapFeatureImportance* featureImportance) const {
 
-    // TODO generalise when supporting multiple categories.
-
-    // Fetch log odds of class encoded as "1" (the classes are encoded as "0" and "1").
-    double predictedLogOddsOfClass1{row[columnHoldingPrediction]};
-    double probabilityOfClass1{maths::CTools::logisticFunction(predictedLogOddsOfClass1)};
-
-    // We adjust the probabilities to account for the threshold for choosing class 1.
-
-    TDoubleVec probabilities{1.0 - probabilityOfClass1, probabilityOfClass1};
-    TDoubleVec scores{0.5 / (1.0 - probabilityAtWhichToAssignClassOne) * probabilities[0],
-                      0.5 / probabilityAtWhichToAssignClassOne * probabilities[1]};
+    TDoubleVec probabilities{readClassProbabilities(row)};
+    TDoubleVec scores{readClassScores(row)};
 
     double actualClassId{row[columnHoldingDependentVariable]};
     std::size_t predictedClassId(std::max_element(scores.begin(), scores.end()) -
@@ -216,14 +207,29 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writePredictedCategoryValue(
     }
 }
 
+CDataFrameTrainBoostedTreeClassifierRunner::TLossFunctionUPtr
+CDataFrameTrainBoostedTreeClassifierRunner::loss(std::size_t numberClasses) {
+    using namespace maths::boosted_tree;
+    return numberClasses == 2
+               ? TLossFunctionUPtr{std::make_unique<CBinomialLogisticLoss>()}
+               : TLossFunctionUPtr{std::make_unique<CMultinomialLogisticLoss>(numberClasses)};
+}
+
 void CDataFrameTrainBoostedTreeClassifierRunner::validate(const core::CDataFrame& frame,
                                                           std::size_t dependentVariableColumn) const {
     std::size_t categoryCount{
         frame.categoricalColumnValues()[dependentVariableColumn].size()};
-    if (categoryCount != 2) {
-        HANDLE_FATAL(<< "Input error: only binary classification is supported. "
-                     << "Trying to predict '" << frame.columnNames()[dependentVariableColumn]
-                     << "' which has '" << categoryCount << "' categories. "
+    if (categoryCount < 2) {
+        HANDLE_FATAL(<< "Input error: can't run classification unless there are at least "
+                     << "two classes. Trying to predict '"
+                     << frame.columnNames()[dependentVariableColumn] << "' which has '"
+                     << categoryCount << "' categories in the training data. "
+                     << "The number of rows read is '" << frame.numberRows() << "'.")
+    } else if (categoryCount > MAX_NUMBER_CLASSES) {
+        HANDLE_FATAL(<< "Input error: the maximum number of classes supported is "
+                     << MAX_NUMBER_CLASSES << ". Trying to predict '"
+                     << frame.columnNames()[dependentVariableColumn] << "' which has '"
+                     << categoryCount << "' categories in the training data. "
                      << "The number of rows read is '" << frame.numberRows() << "'.")
     }
 }
@@ -239,6 +245,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelDefinition(
 }
 
 // clang-format off
+const std::size_t CDataFrameTrainBoostedTreeClassifierRunner::MAX_NUMBER_CLASSES{30};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES{"num_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"num_top_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE{"prediction_field_type"};

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -70,11 +70,10 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
 
     const auto& tree = this->boostedTree();
     const std::size_t columnHoldingDependentVariable{tree.columnHoldingDependentVariable()};
-    const std::size_t columnHoldingPrediction{tree.columnHoldingPrediction()};
 
     writer.StartObject();
     writer.Key(this->predictionFieldName());
-    writer.Double(row[columnHoldingPrediction]);
+    writer.Double(tree.readPrediction(row)[0]);
     writer.Key(IS_TRAINING_FIELD_NAME);
     writer.Bool(maths::CDataFrameUtils::isMissing(row[columnHoldingDependentVariable]) == false);
     auto featureImportance = tree.shap();
@@ -86,7 +85,6 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
                 for (auto i : indices) {
                     if (shap[i].norm() != 0.0) {
                         writer.Key(names[i]);
-                        // TODO fixme
                         writer.Double(shap[i](0));
                     }
                 }

--- a/lib/api/CInferenceModelDefinition.cc
+++ b/lib/api/CInferenceModelDefinition.cc
@@ -220,11 +220,11 @@ void CEnsemble::classificationLabels(const TStringVec& classificationLabels) {
     }
 }
 
-void CEnsemble::classificationWeights(const TDoubleVec& classificationWeights) {
-    this->CTrainedModel::classificationWeights(classificationWeights);
+void CEnsemble::classificationWeights(TDoubleVec classificationWeights) {
     for (auto& trainedModel : m_TrainedModels) {
         trainedModel->classificationWeights(classificationWeights);
     }
+    this->CTrainedModel::classificationWeights(std::move(classificationWeights));
 }
 
 void CTree::addToDocument(rapidjson::Value& parentObject, TRapidJsonWriter& writer) const {
@@ -368,8 +368,8 @@ const CTrainedModel::TOptionalDoubleVec& CTrainedModel::classificationWeights() 
     return m_ClassificationWeights;
 }
 
-void CTrainedModel::classificationWeights(const TDoubleVec& classificationWeights) {
-    m_ClassificationWeights = classificationWeights;
+void CTrainedModel::classificationWeights(TDoubleVec classificationWeights) {
+    m_ClassificationWeights = std::move(classificationWeights);
 }
 
 void CInferenceModelDefinition::fieldNames(TStringVec&& fieldNames) {

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -169,9 +169,10 @@ std::size_t CBoostedTree::columnHoldingDependentVariable() const {
 
 CBoostedTree::TDoubleVec CBoostedTree::readPrediction(const TRowRef& row) const {
     const auto& loss = m_Impl->loss();
-    auto result = loss.transform(boosted_tree_detail::readPrediction(
-        row, m_Impl->numberInputColumns(), loss.numberParameters()));
-    return result.toStdVector();
+    return loss
+        .transform(boosted_tree_detail::readPrediction(
+            row, m_Impl->numberInputColumns(), loss.numberParameters()))
+        .toStdVector();
 }
 
 CBoostedTree::TDoubleVec CBoostedTree::readAndAdjustPrediction(const TRowRef& row) const {

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -167,15 +167,15 @@ std::size_t CBoostedTree::columnHoldingDependentVariable() const {
     return m_Impl->columnHoldingDependentVariable();
 }
 
-CBoostedTree::TDoubleVec CBoostedTree::readPrediction(const TRowRef& row) const {
+CBoostedTree::TDouble2Vec CBoostedTree::readPrediction(const TRowRef& row) const {
     const auto& loss = m_Impl->loss();
     return loss
         .transform(boosted_tree_detail::readPrediction(
             row, m_Impl->numberInputColumns(), loss.numberParameters()))
-        .toStdVector();
+        .to<TDouble2Vec>();
 }
 
-CBoostedTree::TDoubleVec CBoostedTree::readAndAdjustPrediction(const TRowRef& row) const {
+CBoostedTree::TDouble2Vec CBoostedTree::readAndAdjustPrediction(const TRowRef& row) const {
 
     const auto& loss = m_Impl->loss();
 
@@ -191,7 +191,7 @@ CBoostedTree::TDoubleVec CBoostedTree::readAndAdjustPrediction(const TRowRef& ro
         break;
     }
 
-    return prediction.toStdVector();
+    return prediction.to<TDouble2Vec>();
 }
 
 const CBoostedTree::TNodeVecVec& CBoostedTree::trainedModel() const {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1430,7 +1430,7 @@ void CBoostedTreeImpl::accept(CBoostedTree::CVisitor& visitor) {
             node.accept(visitor);
         }
     }
-    visitor.addClassificationWeights(m_ClassificationWeights.toStdVector());
+    visitor.addClassificationWeights(m_ClassificationWeights.to<TDoubleVec>());
 }
 
 const CBoostedTreeHyperparameters& CBoostedTreeImpl::bestHyperparameters() const {

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -567,8 +567,10 @@ bool CBinomialLogisticLoss::isCurvatureConstant() const {
 
 CBinomialLogisticLoss::TDoubleVector
 CBinomialLogisticLoss::transform(const TMemoryMappedFloatVector& prediction) const {
-    TDoubleVector result{prediction};
-    result(0) = CTools::logisticFunction(result(0));
+    double p1{CTools::logisticFunction(prediction(0))};
+    TDoubleVector result{2};
+    result(0) = 1.0 - p1;
+    result(1) = p1;
     return result;
 }
 

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -475,6 +475,10 @@ std::unique_ptr<CLoss> CMse::clone() const {
     return std::make_unique<CMse>(*this);
 }
 
+CMse::EType CMse::type() const {
+    return E_Regression;
+}
+
 std::size_t CMse::numberParameters() const {
     return 1;
 }
@@ -517,6 +521,10 @@ const std::string CMse::NAME{"mse"};
 
 std::unique_ptr<CLoss> CBinomialLogisticLoss::clone() const {
     return std::make_unique<CBinomialLogisticLoss>(*this);
+}
+
+CBinomialLogisticLoss::EType CBinomialLogisticLoss::type() const {
+    return E_BinaryClassification;
 }
 
 std::size_t CBinomialLogisticLoss::numberParameters() const {
@@ -581,6 +589,10 @@ CMultinomialLogisticLoss::CMultinomialLogisticLoss(std::size_t numberClasses)
 
 std::unique_ptr<CLoss> CMultinomialLogisticLoss::clone() const {
     return std::make_unique<CMultinomialLogisticLoss>(m_NumberClasses);
+}
+
+CMultinomialLogisticLoss::EType CMultinomialLogisticLoss::type() const {
+    return E_MulticlassClassification;
 }
 
 std::size_t CMultinomialLogisticLoss::numberParameters() const {

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -747,7 +747,7 @@ CDataFrameUtils::maximumMinimumRecallClassWeights(std::size_t numberThreads,
                 for (auto row = beginRows; row != endRows; ++row) {
                     if (isMissing((*row)[targetColumn]) == false) {
                         quantiles[static_cast<std::size_t>((*row)[targetColumn])]
-                            .add(readPrediction(*row)(0));
+                            .add(readPrediction(*row)(1));
                     }
                 }
             },

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -93,12 +93,12 @@ private:
     std::atomic<std::int64_t> m_MaxMemoryUsage;
 };
 
-template<typename F>
+template<typename F, typename G>
 auto computeEvaluationMetrics(const core::CDataFrame& frame,
                               std::size_t beginTestRows,
                               std::size_t endTestRows,
-                              std::size_t columnHoldingPrediction,
-                              const F& target,
+                              const F& actual,
+                              const G& target,
                               double noiseVariance) {
 
     TMeanVarAccumulator functionMoments;
@@ -107,7 +107,7 @@ auto computeEvaluationMetrics(const core::CDataFrame& frame,
     frame.readRows(1, beginTestRows, endTestRows, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             functionMoments.add(target(*row));
-            modelPredictionErrorMoments.add(target(*row) - (*row)[columnHoldingPrediction]);
+            modelPredictionErrorMoments.add(target(*row) - actual(*row));
         }
     });
 
@@ -217,7 +217,10 @@ auto predictAndComputeEvaluationMetrics(const F& generateFunction,
             double bias;
             double rSquared;
             std::tie(bias, rSquared) = computeEvaluationMetrics(
-                *frame, trainRows, rows, regression->columnHoldingPrediction(),
+                *frame, trainRows, rows,
+                [&](const TRowRef& row) {
+                    return regression->readPrediction(row)[0];
+                },
                 target, noiseVariance / static_cast<double>(rows));
             modelBias[test].push_back(bias);
             modelRSquared[test].push_back(rSquared);
@@ -485,8 +488,8 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
         frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                std::size_t index{regression->columnHoldingPrediction()};
-                modelPredictionErrorMoments.add(target(*row) - (*row)[index]);
+                modelPredictionErrorMoments.add(
+                    target(*row) - regression->readPrediction(*row)[0]);
             }
         });
 
@@ -581,8 +584,7 @@ BOOST_AUTO_TEST_CASE(testConstantTarget) {
 
     frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            std::size_t index{regression->columnHoldingPrediction()};
-            modelPredictionError.add(1.0 - (*row)[index]);
+            modelPredictionError.add(1.0 - regression->readPrediction(*row)[0]);
         }
     });
 
@@ -655,7 +657,9 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     double modelBias;
     double modelRSquared;
     std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
-        *frame, trainRows, rows, regression->columnHoldingPrediction(), target, 0.0);
+        *frame, trainRows, rows,
+        [&](const TRowRef& row) { return regression->readPrediction(row)[0]; },
+        target, 0.0);
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
@@ -697,7 +701,8 @@ BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
     double modelBias;
     double modelRSquared;
     std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
-        *frame, trainRows, rows, regression->columnHoldingPrediction(),
+        *frame, trainRows, rows,
+        [&](const TRowRef& row) { return regression->readPrediction(row)[0]; },
         [&](const TRowRef& x) { return 10.0 * x[0]; }, 0.0);
 
     LOG_DEBUG(<< "bias = " << modelBias);
@@ -742,7 +747,8 @@ BOOST_AUTO_TEST_CASE(testSingleSplit) {
     double modelBias;
     double modelRSquared;
     std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
-        *frame, 0, rows, regression->columnHoldingPrediction(),
+        *frame, 0, rows,
+        [&](const TRowRef& row) { return regression->readPrediction(row)[0]; },
         [](const TRowRef& row) { return 10.0 * row[0]; }, 0.0);
 
     LOG_DEBUG(<< "bias = " << modelBias);
@@ -802,8 +808,12 @@ BOOST_AUTO_TEST_CASE(testTranslationInvariance) {
 
         double modelBias;
         double modelRSquared;
-        std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
-            *frame, trainRows, rows, regression->columnHoldingPrediction(), target_, 0.0);
+        std::tie(modelBias, modelRSquared) =
+            computeEvaluationMetrics(*frame, trainRows, rows,
+                                     [&](const TRowRef& row) {
+                                         return regression->readPrediction(row)[0];
+                                     },
+                                     target_, 0.0);
 
         LOG_DEBUG(<< "bias = " << modelBias);
         LOG_DEBUG(<< " R^2 = " << modelRSquared);
@@ -938,21 +948,20 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
         fillDataFrame(trainRows, rows - trainRows, cols, {false, false, false, true},
                       x, TDoubleVec(rows, 0.0), target, *frame);
 
-        auto regression =
+        auto classifier =
             maths::CBoostedTreeFactory::constructFromParameters(
                 1, std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>())
                 .buildFor(*frame, cols - 1);
 
-        regression->train();
-        regression->predict();
+        classifier->train();
+        classifier->predict();
 
         TMeanAccumulator logRelativeError;
         frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (row->index() >= trainRows) {
-                    std::size_t index{regression->columnHoldingPrediction()};
                     double expectedProbability{probability(*row)};
-                    double actualProbability{maths::CTools::logisticFunction((*row)[index])};
+                    double actualProbability{classifier->readPrediction(*row)[1]};
                     logRelativeError.add(
                         std::log(std::max(actualProbability, expectedProbability) /
                                  std::min(actualProbability, expectedProbability)));
@@ -1010,14 +1019,13 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     }
     frame->finishWritingRows();
 
-    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>())
-                          .buildFor(*frame, cols - 1);
+    auto classification =
+        maths::CBoostedTreeFactory::constructFromParameters(
+            1, std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>())
+            .buildFor(*frame, cols - 1);
 
-    regression->train();
-    regression->predict();
-    LOG_DEBUG(<< "P(class 1) threshold = "
-              << regression->probabilityAtWhichToAssignClassOne());
+    classification->train();
+    classification->predict();
 
     TDoubleVec precisions;
     TDoubleVec recalls;
@@ -1028,11 +1036,8 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
         TDoubleVec falseNegatives(2, 0.0);
         frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                double logOddsClassOne{(*row)[regression->columnHoldingPrediction()]};
-                double prediction{maths::CTools::logisticFunction(logOddsClassOne) <
-                                          regression->probabilityAtWhichToAssignClassOne()
-                                      ? 0.0
-                                      : 1.0};
+                double prediction{
+                    classification->readAndAdjustPrediction(*row)[1] < 0.5 ? 0.0 : 1.0};
                 if (row->index() >= trainRows &&
                     row->index() < trainRows + classesRowCounts[2]) {
                     // Actual is zero.
@@ -1249,7 +1254,7 @@ BOOST_AUTO_TEST_CASE(testMissingFeatures) {
     frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             if (maths::CDataFrameUtils::isMissing((*row)[cols - 1])) {
-                actualPredictions.push_back((*row)[regression->columnHoldingPrediction()]);
+                actualPredictions.push_back(regression->readPrediction(*row)[0]);
             }
         }
     });


### PR DESCRIPTION
This wires up multiclass classification so it can be run by the data frame analyzer and also . Marking as a non-issue since the feature was documented in #1037.

I need some more unit testing, so keeping as WIP at the moment, but the code changes are complete. I've also left some TODOs for supporting maximize minimum class recall, which I'll revisit in a later PR.