### PR TITLE
[ML] Fix some bugs in multinomial logistic loss derivatives

### DIFF
--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1060,7 +1060,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     LOG_DEBUG(<< "recalls    = " << core::CContainerPrinter::print(recalls));
 
     BOOST_TEST_REQUIRE(std::fabs(precisions[0] - precisions[1]) < 0.1);
-    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.13);
+    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.14);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {


### PR DESCRIPTION
This also finishes up the loss function unit testing.

I've also migrated to using exact logs in the loss function. This enables me to test the gradient and curvature functions against numerical derivatives of the loss function, which otherwise suffer large errors. Since these quantities are cached they also aren't a runtime bottleneck.

I've marked this as a non-issue since the code isn't released yet.