### PR TITLE
[ML] Adding num_matches and preferred_to_categories output to categories

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,12 +34,6 @@
 
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
   or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
-== {es} version 7.8.0
-
-=== Enhancements
-
-* Adds new `num_matches` and `preferred_to_categories` fields to category output.
-(See {ml-pull}1062[#1062])
 
 == {es} version 7.8.0
 
@@ -49,6 +43,8 @@
   when CPU is constrained. (See {ml-pull}1109[#1109].)
 * Take `training_percent` into account when estimating memory usage for classification and regression. 
   (See {ml-pull}1111[1111].)
+* Adds new `num_matches` and `preferred_to_categories` fields to category output.
+  (See {ml-pull}1062[#1062])
 
 == {es} version 7.7.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -62,7 +62,8 @@ the build from version 2.20 to 2.34.  (See {ml-pull}1013[#1013].)
 * Remove all memory overheads for computing tree SHAP values. (See {ml-pull}1023[#1023].)
 * Distinguish between empty and missing categorical fields in classification and regression
 model training. (See {ml-pull}1034[#1034].)
-
+* Adds new `num_matches` and `preferred_to_categories` fields to category output.
+(See {ml-pull}1062[#1062])
 === Bug Fixes
 
 * Use largest ordered subset of categorization tokens for category reverse search regex.

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -147,7 +147,7 @@ private:
     void acknowledgeFlush(const std::string& flushId, bool lastHandler);
 
     //! Writes out to the JSON output writer any category that has changed
-    //! since the last time this method was called. 
+    //! since the last time this method was called.
     void writeOutChangedCategories();
 
 private:

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -141,10 +141,14 @@ private:
     //!        buffers
     //! 'f' => Echo a flush ID so that the attached process knows that data
     //!        sent previously has all been processed
-    bool handleControlMessage(const std::string& controlMessage);
+    bool handleControlMessage(const std::string& controlMessage, bool lastHandler);
 
     //! Acknowledge a flush request
-    void acknowledgeFlush(const std::string& flushId);
+    void acknowledgeFlush(const std::string& flushId, bool lastHandler);
+
+    //! Writes out to the JSON output writer any category that has changed
+    //! since the last time this method was called. 
+    void writeOutChangedCategories();
 
 private:
     //! The job ID

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -111,6 +111,8 @@ public:
     using TStrVec = std::vector<std::string>;
     using TStr1Vec = core::CSmallVector<std::string, 1>;
     using TTimeVec = std::vector<core_t::TTime>;
+    using TIntVec = std::vector<int>;
+    using TIntVecCIter = std::vector<int>::const_iterator;
     using TDoubleVec = std::vector<double>;
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
@@ -242,7 +244,9 @@ public:
                                  const std::string& terms,
                                  const std::string& regex,
                                  std::size_t maxMatchingFieldLength,
-                                 const TStrFSet& examples);
+                                 const TStrFSet& examples,
+                                 std::size_t numMatches,
+                                 const TIntVec& usurpedCategories);
 
     //! Persist a normalizer by writing its state to the output
     void persistNormalizer(const model::CHierarchicalResultsNormalizer& normalizer,

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -136,6 +136,13 @@ public:
 
     virtual TIntVec usurpedCategories(int categoryId) = 0;
 
+    virtual std::size_t numCategories() const = 0;
+
+    //! Has the passed category changed since this method was called last?
+    //! Once called, the category is marked as unchanged, until the category
+    //! changes again.
+    virtual bool categoryChangedAndReset(int categoryId) = 0;
+
 protected:
     //! Used if no fields are supplied to the computeCategory() method.
     static const TStrStrUMap EMPTY_FIELDS;

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -51,6 +51,7 @@ public:
 
     //! Shared pointer to an instance of this class
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
+    using TIntVec = std::vector<int>;
 
 public:
     CDataCategorizer(CLimits& limits, const std::string& fieldName);
@@ -130,6 +131,10 @@ public:
 
     //! Restore the examples collector
     bool restoreExamplesCollector(core::CStateRestoreTraverser& traverser);
+
+    virtual std::size_t numMatches(int categoryId) = 0;
+
+    virtual TIntVec usurpedCategories(int categoryId) = 0;
 
 protected:
     //! Used if no fields are supplied to the computeCategory() method.

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -149,6 +149,10 @@ public:
     //! Get the memory used by this category.
     std::size_t memoryUsage() const;
 
+    //! Returns true if the category has changed recently and resets
+    //! the changed flag to false.
+    bool isChangedAndReset();
+
 private:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
@@ -205,6 +209,9 @@ private:
     //! Cache reverse searches to save repeated recalculations
     std::string m_ReverseSearchPart1;
     std::string m_ReverseSearchPart2;
+
+    //! Has the category changed recently
+    bool m_Changed;
 };
 }
 }

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -176,6 +176,10 @@ public:
                                   std::size_t rareCategories,
                                   std::size_t deadCategories);
 
+    std::size_t numMatches(int categoryId) override;
+
+    CDataCategorizer::TIntVec usurpedCategories(int categoryId) override;
+
 protected:
     //! Split the string into a list of tokens.  The result of the
     //! tokenisation is returned in \p tokenIds, \p tokenUniqueIds and

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -180,6 +180,10 @@ public:
 
     CDataCategorizer::TIntVec usurpedCategories(int categoryId) override;
 
+    std::size_t numCategories() const override;
+
+    bool categoryChangedAndReset(int categoryId) override;
+
 protected:
     //! Split the string into a list of tokens.  The result of the
     //! tokenisation is returned in \p tokenIds, \p tokenUniqueIds and

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -168,7 +168,9 @@ int CFieldDataCategorizer::computeCategory(const TStrStrUMap& dataRowFields) {
     if (exampleAdded || searchTermsChanged) {
         m_JsonOutputWriter.writeCategoryDefinition(
             categoryId, m_SearchTerms, m_SearchTermsRegex, m_MaxMatchingLength,
-            m_DataCategorizer->examplesCollector().examples(categoryId));
+            m_DataCategorizer->examplesCollector().examples(categoryId), 
+            m_DataCategorizer->numMatches(categoryId),
+            m_DataCategorizer->usurpedCategories(categoryId));
         if (categoryId % 10 == 0) {
             // Even if memory limiting is disabled, force a refresh occasionally
             // so the user has some idea what's going on with memory.

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -504,9 +504,11 @@ bool CFieldDataCategorizer::handleControlMessage(const std::string& controlMessa
         this->acknowledgeFlush(controlMessage.substr(1), lastHandler);
         break;
     default:
-        LOG_WARN(<< "Ignoring unknown control message of length "
-                 << controlMessage.length() << " beginning with '"
-                 << controlMessage[0] << '\'');
+        if (lastHandler) {
+            LOG_WARN(<< "Ignoring unknown control message of length "
+                     << controlMessage.length() << " beginning with '"
+                     << controlMessage[0] << '\'');
+        }
         // Don't return false here (for the time being at least), as it
         // seems excessive to cause the entire job to fail
         break;
@@ -535,12 +537,9 @@ void CFieldDataCategorizer::writeOutChangedCategories() {
     std::string searchTerms;
     std::string searchTermsRegex;
     std::size_t maxLength;
-    bool wasCached(false);
+    bool wasCached{false};
     for (int categoryId = 1; categoryId <= numCategories; categoryId++) {
         if (m_DataCategorizer->categoryChangedAndReset(categoryId)) {
-            searchTerms.clear();
-            searchTermsRegex.clear();
-            maxLength = 0;
             if (m_DataCategorizer->createReverseSearch(categoryId, searchTerms, searchTermsRegex,
                                                        maxLength, wasCached) == false) {
                 LOG_WARN(<< "Unable to create or retrieve reverse search for storing for category: "

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -91,7 +91,8 @@ bool CFieldDataCategorizer::handleRecord(const TStrStrUMap& dataRowFields) {
     if (iter != dataRowFields.end() && !iter->second.empty()) {
         // Always handle control messages, but signal completion of handling ONLY if we are the last handler
         // e.g. flush requests are acknowledged here if this is the last handler
-        bool msgHandled = this->handleControlMessage(iter->second, !m_OutputHandler.consumesControlMessages());
+        bool msgHandled = this->handleControlMessage(
+            iter->second, !m_OutputHandler.consumesControlMessages());
         if (m_OutputHandler.consumesControlMessages()) {
             return m_OutputHandler.writeRow(dataRowFields, m_Overrides);
         }
@@ -173,7 +174,7 @@ int CFieldDataCategorizer::computeCategory(const TStrStrUMap& dataRowFields) {
         m_DataCategorizer->categoryChangedAndReset(categoryId);
         m_JsonOutputWriter.writeCategoryDefinition(
             categoryId, m_SearchTerms, m_SearchTermsRegex, m_MaxMatchingLength,
-            m_DataCategorizer->examplesCollector().examples(categoryId), 
+            m_DataCategorizer->examplesCollector().examples(categoryId),
             m_DataCategorizer->numMatches(categoryId),
             m_DataCategorizer->usurpedCategories(categoryId));
         if (categoryId % 10 == 0) {
@@ -479,7 +480,8 @@ void CFieldDataCategorizer::resetAfterCorruptRestore() {
     this->createCategorizer(m_CategorizationFieldName);
 }
 
-bool CFieldDataCategorizer::handleControlMessage(const std::string& controlMessage, bool lastHandler) {
+bool CFieldDataCategorizer::handleControlMessage(const std::string& controlMessage,
+                                                 bool lastHandler) {
     if (controlMessage.empty()) {
         LOG_ERROR(<< "Programmatic error - handleControlMessage should only be "
                      "called with non-empty control messages");
@@ -532,23 +534,23 @@ void CFieldDataCategorizer::writeOutChangedCategories() {
     }
     std::string searchTerms;
     std::string searchTermsRegex;
-    std::size_t maxLength; 
+    std::size_t maxLength;
     bool wasCached(false);
-    for(int categoryId = 1; categoryId <= numCategories; categoryId++) {
+    for (int categoryId = 1; categoryId <= numCategories; categoryId++) {
         if (m_DataCategorizer->categoryChangedAndReset(categoryId)) {
             searchTerms.clear();
             searchTermsRegex.clear();
             maxLength = 0;
-            if (m_DataCategorizer->createReverseSearch(categoryId, searchTerms,
-                                                       searchTermsRegex, maxLength, wasCached) == false) {
-                LOG_WARN(<< "Unable to create or retrieve reverse search for storing for category: " << 
-                categoryId);
+            if (m_DataCategorizer->createReverseSearch(categoryId, searchTerms, searchTermsRegex,
+                                                       maxLength, wasCached) == false) {
+                LOG_WARN(<< "Unable to create or retrieve reverse search for storing for category: "
+                         << categoryId);
                 continue;
             }
             LOG_TRACE(<< "Writing out changed category: " << categoryId);
             m_JsonOutputWriter.writeCategoryDefinition(
                 categoryId, searchTerms, searchTermsRegex, maxLength,
-                m_DataCategorizer->examplesCollector().examples(categoryId), 
+                m_DataCategorizer->examplesCollector().examples(categoryId),
                 m_DataCategorizer->numMatches(categoryId),
                 m_DataCategorizer->usurpedCategories(categoryId));
         }

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -69,6 +69,8 @@ const std::string TERMS("terms");
 const std::string REGEX("regex");
 const std::string MAX_MATCHING_LENGTH("max_matching_length");
 const std::string EXAMPLES("examples");
+const std::string NUM_MATCHES("num_matches");
+const std::string PREFERRED_TO_CATEGORIES("preferred_to_categories");
 const std::string BUCKET_SPAN("bucket_span");
 const std::string PROCESSING_TIME("processing_time_ms");
 const std::string TIME_INFLUENCER("bucket_time");
@@ -888,7 +890,9 @@ void CJsonOutputWriter::writeCategoryDefinition(int categoryId,
                                                 const std::string& terms,
                                                 const std::string& regex,
                                                 std::size_t maxMatchingFieldLength,
-                                                const TStrFSet& examples) {
+                                                const TStrFSet& examples,
+                                                std::size_t numMatches,
+                                                const TIntVec& usurpedCategories) {
     m_Writer.StartObject();
     m_Writer.String(CATEGORY_DEFINITION);
     m_Writer.StartObject();
@@ -907,6 +911,15 @@ void CJsonOutputWriter::writeCategoryDefinition(int categoryId,
     for (TStrFSetCItr itr = examples.begin(); itr != examples.end(); ++itr) {
         const std::string& example = *itr;
         m_Writer.String(example);
+    }
+    m_Writer.EndArray();
+    m_Writer.String(NUM_MATCHES);
+    m_Writer.Uint64(numMatches);
+    m_Writer.String(PREFERRED_TO_CATEGORIES);
+    m_Writer.StartArray();
+    for (TIntVecCIter iter = usurpedCategories.begin(); iter != usurpedCategories.end(); ++iter) {
+        int id = *iter;
+        m_Writer.Int(id);
     }
     m_Writer.EndArray();
     m_Writer.EndObject();

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -917,8 +917,7 @@ void CJsonOutputWriter::writeCategoryDefinition(int categoryId,
     m_Writer.Uint64(numMatches);
     m_Writer.String(PREFERRED_TO_CATEGORIES);
     m_Writer.StartArray();
-    for (TIntVecCIter iter = usurpedCategories.begin(); iter != usurpedCategories.end(); ++iter) {
-        int id = *iter;
+    for (int id : usurpedCategories) {
         m_Writer.Int(id);
     }
     m_Writer.EndArray();

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -386,14 +386,14 @@ BOOST_AUTO_TEST_CASE(flushWritesOnlyChangedCategories) {
         std::string::size_type start = 0;
         while ((start = str.find(substr, start)) != std::string::npos) {
             ++occurrences;
-            start += substr.length(); 
+            start += substr.length();
         }
         return occurrences;
     };
     //! Output should have category_id 1 3 times. 2 for the first two calls, and one for the flush
     BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":1"), 3);
 
-    //! Output should only have the initial persistence as it did not change after the flush 
+    //! Output should only have the initial persistence as it did not change after the flush
     BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":2"), 1);
 }
 
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(finalizeWritesOnlyChangedCategories) {
         std::string::size_type start = 0;
         while ((start = str.find(substr, start)) != std::string::npos) {
             ++occurrences;
-            start += substr.length(); 
+            start += substr.length();
         }
         return occurrences;
     };
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(finalizeWritesOnlyChangedCategories) {
     //! Output should have category_id 1 3 times. 2 for the first two calls, and one for the finalize
     BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":1"), 3);
 
-    //! Output should only have the initial persistence as it did not change after the finalize  
+    //! Output should only have the initial persistence as it did not change after the finalize
     BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":2"), 1);
 }
 

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -1298,7 +1298,8 @@ BOOST_AUTO_TEST_CASE(testWriteCategoryDefinition) {
         ml::core::CJsonOutputStreamWrapper outputStream(sstream);
         ml::api::CJsonOutputWriter writer("job", outputStream);
 
-        writer.writeCategoryDefinition(categoryId, terms, regex, maxMatchingLength, examples, 0, {});
+        writer.writeCategoryDefinition(categoryId, terms, regex,
+                                       maxMatchingLength, examples, 0, {});
     }
 
     rapidjson::Document arrayDoc;

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -1298,7 +1298,7 @@ BOOST_AUTO_TEST_CASE(testWriteCategoryDefinition) {
         ml::core::CJsonOutputStreamWrapper outputStream(sstream);
         ml::api::CJsonOutputWriter writer("job", outputStream);
 
-        writer.writeCategoryDefinition(categoryId, terms, regex, maxMatchingLength, examples, std::size_t(0), vector<int>);
+        writer.writeCategoryDefinition(categoryId, terms, regex, maxMatchingLength, examples, 0, {});
     }
 
     rapidjson::Document arrayDoc;

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -1298,7 +1298,7 @@ BOOST_AUTO_TEST_CASE(testWriteCategoryDefinition) {
         ml::core::CJsonOutputStreamWrapper outputStream(sstream);
         ml::api::CJsonOutputWriter writer("job", outputStream);
 
-        writer.writeCategoryDefinition(categoryId, terms, regex, maxMatchingLength, examples);
+        writer.writeCategoryDefinition(categoryId, terms, regex, maxMatchingLength, examples, std::size_t(0), vector<int>);
     }
 
     rapidjson::Document arrayDoc;

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -60,9 +60,8 @@ CTokenListCategory::CTokenListCategory(bool isDryRun,
       m_OrderedCommonTokenEndIndex{baseTokenIds.size()},
       // Note: m_CommonUniqueTokenIds is required to be in sorted order, and
       // this relies on uniqueTokenIds being in sorted order
-      m_CommonUniqueTokenIds{uniqueTokenIds.begin(), uniqueTokenIds.end()},
-      m_CommonUniqueTokenWeight{0}, m_OrigUniqueTokenWeight{0}, m_NumMatches{isDryRun ? 0u : 1u},
-      m_Changed{!isDryRun} {
+      m_CommonUniqueTokenIds{uniqueTokenIds.begin(), uniqueTokenIds.end()}, m_CommonUniqueTokenWeight{0},
+      m_OrigUniqueTokenWeight{0}, m_NumMatches{isDryRun ? 0u : 1u}, m_Changed{!isDryRun} {
     for (auto uniqueTokenId : uniqueTokenIds) {
         m_CommonUniqueTokenWeight += uniqueTokenId.second;
     }

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -61,7 +61,8 @@ CTokenListCategory::CTokenListCategory(bool isDryRun,
       // Note: m_CommonUniqueTokenIds is required to be in sorted order, and
       // this relies on uniqueTokenIds being in sorted order
       m_CommonUniqueTokenIds{uniqueTokenIds.begin(), uniqueTokenIds.end()},
-      m_CommonUniqueTokenWeight{0}, m_OrigUniqueTokenWeight{0}, m_NumMatches{isDryRun ? 0u : 1u} {
+      m_CommonUniqueTokenWeight{0}, m_OrigUniqueTokenWeight{0}, m_NumMatches{isDryRun ? 0u : 1u},
+      m_Changed{!isDryRun} {
     for (auto uniqueTokenId : uniqueTokenIds) {
         m_CommonUniqueTokenWeight += uniqueTokenId.second;
     }
@@ -205,6 +206,9 @@ bool CTokenListCategory::addString(bool isDryRun,
     if (!isDryRun) {
         ++m_NumMatches;
         changed = true;
+    }
+    if (changed) {
+        m_Changed = true;
     }
 
     return changed;
@@ -505,6 +509,14 @@ std::size_t CTokenListCategory::memoryUsage() const {
     mem += core::CMemory::dynamicSize(m_ReverseSearchPart1);
     mem += core::CMemory::dynamicSize(m_ReverseSearchPart2);
     return mem;
+}
+
+bool CTokenListCategory::isChangedAndReset() {
+    if (m_Changed) {
+        m_Changed = false;
+        return true;
+    }
+    return false;
 }
 }
 }

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -637,10 +637,10 @@ CDataCategorizer::TIntVec CTokenListDataCategorizerBase::usurpedCategories(int c
                                  return pr.second == static_cast<std::size_t>(categoryId);
                                  });
     if (iter == m_CategoriesByCount.end()) {
-        LOG_WARN(<< "Could not find category count for category: " << categoryId);
+        LOG_WARN(<< "Could not find category definition for category: " << categoryId);
         return usurped;
     }
-    iter++;
+    ++iter;
     const CTokenListCategory& category{m_Categories[categoryId - 1]};
     for (; iter != m_CategoriesByCount.end(); ++iter) {
         const CTokenListCategory& lessFrequentCategory{m_Categories[static_cast<int>(iter->second) - 1]};
@@ -655,6 +655,18 @@ CDataCategorizer::TIntVec CTokenListDataCategorizerBase::usurpedCategories(int c
         }
     }
     return usurped;
+}
+
+std::size_t CTokenListDataCategorizerBase::numCategories() const {
+    return m_Categories.size();
+}
+
+bool CTokenListDataCategorizerBase::categoryChangedAndReset(int categoryId) {
+    if (categoryId < 1 || static_cast<std::size_t>(categoryId) > m_Categories.size()) {
+        LOG_ERROR(<< "Programmatic error - invalid ML category: " << categoryId);
+        return false;
+    }
+    return m_Categories[categoryId - 1].isChangedAndReset();
 }
 
 CTokenListDataCategorizerBase::CTokenInfoItem::CTokenInfoItem(const std::string& str,

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -632,10 +632,10 @@ CDataCategorizer::TIntVec CTokenListDataCategorizerBase::usurpedCategories(int c
         LOG_ERROR(<< "Programmatic error - invalid ML category: " << categoryId);
         return usurped;
     }
-    auto iter = std::find_if(m_CategoriesByCount.begin(), m_CategoriesByCount.end(), 
-                             [categoryId](const TSizeSizePr& pr){
+    auto iter = std::find_if(m_CategoriesByCount.begin(), m_CategoriesByCount.end(),
+                             [categoryId](const TSizeSizePr& pr) {
                                  return pr.second == static_cast<std::size_t>(categoryId);
-                                 });
+                             });
     if (iter == m_CategoriesByCount.end()) {
         LOG_WARN(<< "Could not find category definition for category: " << categoryId);
         return usurped;
@@ -643,7 +643,8 @@ CDataCategorizer::TIntVec CTokenListDataCategorizerBase::usurpedCategories(int c
     ++iter;
     const CTokenListCategory& category{m_Categories[categoryId - 1]};
     for (; iter != m_CategoriesByCount.end(); ++iter) {
-        const CTokenListCategory& lessFrequentCategory{m_Categories[static_cast<int>(iter->second) - 1]};
+        const CTokenListCategory& lessFrequentCategory{
+            m_Categories[static_cast<int>(iter->second) - 1]};
         bool matchesSearch{category.maxMatchingStringLen() >=
                                lessFrequentCategory.maxMatchingStringLen() &&
                            category.isMissingCommonTokenWeightZero(

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -618,6 +618,45 @@ CTokenListDataCategorizerBase::calculateCategorizationStatus(std::size_t categor
     return model_t::E_CategorizationStatusOk;
 }
 
+std::size_t CTokenListDataCategorizerBase::numMatches(int categoryId) {
+    if (categoryId < 1 || static_cast<std::size_t>(categoryId) > m_Categories.size()) {
+        LOG_ERROR(<< "Programmatic error - invalid ML category: " << categoryId);
+        return 0;
+    }
+    return m_Categories[categoryId - 1].numMatches();
+}
+
+CDataCategorizer::TIntVec CTokenListDataCategorizerBase::usurpedCategories(int categoryId) {
+    CDataCategorizer::TIntVec usurped;
+    if (categoryId < 1 || static_cast<std::size_t>(categoryId) > m_Categories.size()) {
+        LOG_ERROR(<< "Programmatic error - invalid ML category: " << categoryId);
+        return usurped;
+    }
+    auto iter = std::find_if(m_CategoriesByCount.begin(), m_CategoriesByCount.end(), 
+                             [categoryId](const TSizeSizePr& pr){
+                                 return pr.second == static_cast<std::size_t>(categoryId);
+                                 });
+    if (iter == m_CategoriesByCount.end()) {
+        LOG_WARN(<< "Could not find category count for category: " << categoryId);
+        return usurped;
+    }
+    iter++;
+    const CTokenListCategory& category{m_Categories[categoryId - 1]};
+    for (; iter != m_CategoriesByCount.end(); ++iter) {
+        const CTokenListCategory& lessFrequentCategory{m_Categories[static_cast<int>(iter->second) - 1]};
+        bool matchesSearch{category.maxMatchingStringLen() >=
+                               lessFrequentCategory.maxMatchingStringLen() &&
+                           category.isMissingCommonTokenWeightZero(
+                               lessFrequentCategory.commonUniqueTokenIds()) &&
+                           category.containsCommonInOrderTokensInOrder(
+                               lessFrequentCategory.baseTokenIds())};
+        if (matchesSearch) {
+            usurped.emplace_back(static_cast<int>(iter->second));
+        }
+    }
+    return usurped;
+}
+
 CTokenListDataCategorizerBase::CTokenInfoItem::CTokenInfoItem(const std::string& str,
                                                               std::size_t index)
     : m_Str{str}, m_Index{index}, m_CategoryCount{0} {

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -524,45 +524,29 @@ BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(
-                               false,
-                               "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r",
-                               500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(
-                               false,
-                               "2015-10-18 18:01:52,728 INFO [main] org.mortbay.log: Started HttpServer2$SelectChannelConnectorWithSafeStartup@0.0.0.0:62267\r",
-                               500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(
-                               false,
-                              "2015-10-18 18:01:53,400 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Registered webapp guice modules\r",
-                               500));
-    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(
-                               false,
-                               "2015-10-18 18:01:53,447 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerRequestor: nodeBlacklistingEnabled:true\r",
-                               500));
-    BOOST_REQUIRE_EQUAL(5, categorizer.computeCategory(
-                               false,
-                               "2015-10-18 18:01:52,728 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Web app /mapreduce started at 62267\r",
-                               500));
-    BOOST_REQUIRE_EQUAL(6, categorizer.computeCategory(
-                               false,
-                               "2015-10-18 18:01:53,557 INFO [main] org.apache.hadoop.yarn.client.RMProxy: Connecting to ResourceManager at msra-sa-41/10.190.173.170:8030\r",
-                               500));
-    BOOST_REQUIRE_EQUAL(7, categorizer.computeCategory(
-                               false,
-                               "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator: maxContainerCapability: <memory:8192, vCores:32>\r",
-                               500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(
-                               false,
-                               "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.yarn.client.api.impl.ContainerManagementProtocolProxy: yarn.client.max-cached-nodemanagers-proxies : 0\r",
-                               500));
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r",
+                                                       500));
+    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "2015-10-18 18:01:52,728 INFO [main] org.mortbay.log: Started HttpServer2$SelectChannelConnectorWithSafeStartup@0.0.0.0:62267\r",
+                                                       500));
+    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "2015-10-18 18:01:53,400 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Registered webapp guice modules\r",
+                                                       500));
+    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(false, "2015-10-18 18:01:53,447 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerRequestor: nodeBlacklistingEnabled:true\r",
+                                                       500));
+    BOOST_REQUIRE_EQUAL(5, categorizer.computeCategory(false, "2015-10-18 18:01:52,728 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Web app /mapreduce started at 62267\r",
+                                                       500));
+    BOOST_REQUIRE_EQUAL(6, categorizer.computeCategory(false, "2015-10-18 18:01:53,557 INFO [main] org.apache.hadoop.yarn.client.RMProxy: Connecting to ResourceManager at msra-sa-41/10.190.173.170:8030\r",
+                                                       500));
+    BOOST_REQUIRE_EQUAL(7, categorizer.computeCategory(false, "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator: maxContainerCapability: <memory:8192, vCores:32>\r",
+                                                       500));
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.yarn.client.api.impl.ContainerManagementProtocolProxy: yarn.client.max-cached-nodemanagers-proxies : 0\r",
+                                                       500));
 
     BOOST_REQUIRE_EQUAL(2, categorizer.numMatches(1));
-    std::vector<int> expected {2,3,4,5,6};
+    std::vector<int> expected{2, 3, 4, 5, 6};
     std::vector<int> actual = categorizer.usurpedCategories(1);
 
     BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
-    for(std::size_t i = 0; i < actual.size(); i++) {
+    for (std::size_t i = 0; i < actual.size(); i++) {
         BOOST_REQUIRE_EQUAL(expected[i], actual[i]);
     }
     checkMemoryUsageInstrumentation(categorizer);

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -520,4 +520,52 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {
+    TTokenListDataCategorizerKeepsFields categorizer(
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(
+                               false,
+                               "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r",
+                               500));
+    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(
+                               false,
+                               "2015-10-18 18:01:52,728 INFO [main] org.mortbay.log: Started HttpServer2$SelectChannelConnectorWithSafeStartup@0.0.0.0:62267\r",
+                               500));
+    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(
+                               false,
+                              "2015-10-18 18:01:53,400 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Registered webapp guice modules\r",
+                               500));
+    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(
+                               false,
+                               "2015-10-18 18:01:53,447 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerRequestor: nodeBlacklistingEnabled:true\r",
+                               500));
+    BOOST_REQUIRE_EQUAL(5, categorizer.computeCategory(
+                               false,
+                               "2015-10-18 18:01:52,728 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Web app /mapreduce started at 62267\r",
+                               500));
+    BOOST_REQUIRE_EQUAL(6, categorizer.computeCategory(
+                               false,
+                               "2015-10-18 18:01:53,557 INFO [main] org.apache.hadoop.yarn.client.RMProxy: Connecting to ResourceManager at msra-sa-41/10.190.173.170:8030\r",
+                               500));
+    BOOST_REQUIRE_EQUAL(7, categorizer.computeCategory(
+                               false,
+                               "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator: maxContainerCapability: <memory:8192, vCores:32>\r",
+                               500));
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(
+                               false,
+                               "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.yarn.client.api.impl.ContainerManagementProtocolProxy: yarn.client.max-cached-nodemanagers-proxies : 0\r",
+                               500));
+
+    BOOST_REQUIRE_EQUAL(2, categorizer.numMatches(1));
+    std::vector<int> expected {2,3,4,5,6};
+    std::vector<int> actual = categorizer.usurpedCategories(1);
+
+    BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
+    for(std::size_t i = 0; i < actual.size(); i++) {
+        BOOST_REQUIRE_EQUAL(expected[i], actual[i]);
+    }
+    checkMemoryUsageInstrumentation(categorizer);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Two new fields added to our category output when they are written back to Java.

* `num_matches` indicates the total number of matches this category has seen
* `preferred_to_categories` indicates that this particular category is matched now instead of the listed categories. 

Java side https://github.com/elastic/elasticsearch/pull/54214