### PR TITLE
[ML] Better handling of near singular loss Hessian

### DIFF
--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -17,6 +17,7 @@
 #include <maths/CChecksum.h>
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CLinearAlgebraShims.h>
+#include <maths/CMathsFuncs.h>
 #include <maths/COrderings.h>
 #include <maths/ImportExport.h>
 #include <maths/MathsTypes.h>
@@ -451,7 +452,8 @@ private:
                          double splitAt,
                          bool leftChildHasFewerRows,
                          bool assignMissingToLeft)
-            : s_Gain{gain}, s_Curvature{curvature}, s_Feature{feature}, s_SplitAt{splitAt},
+            : s_Gain{CMathsFuncs::isNan(gain) ? -boosted_tree_detail::INF : gain},
+              s_Curvature{curvature}, s_Feature{feature}, s_SplitAt{splitAt},
               s_LeftChildHasFewerRows{leftChildHasFewerRows}, s_AssignMissingToLeft{assignMissingToLeft} {
         }
 

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -9,6 +9,7 @@
 
 #include <core/CMemory.h>
 #include <core/CPersistUtils.h>
+#include <core/CSmallVector.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/RestoreMacros.h>
@@ -306,6 +307,16 @@ public:
 
     //! Convert from a std::vector.
     static CDenseVector<SCALAR> fromStdVector(const std::vector<SCALAR>& vector) {
+        CDenseVector<SCALAR> result(vector.size());
+        for (std::size_t i = 0; i < vector.size(); ++i) {
+            result(i) = vector[i];
+        }
+        return result;
+    }
+
+    //! Convert from a core::CSmallVector.
+    template<std::size_t N>
+    static CDenseVector<SCALAR> fromSmallVector(const core::CSmallVector<SCALAR, N>& vector) {
         CDenseVector<SCALAR> result(vector.size());
         for (std::size_t i = 0; i < vector.size(); ++i) {
             result(i) = vector[i];

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -321,14 +321,14 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
             for (std::size_t i = 0; i < 2; ++i) {
                 Eigen::LLT<Eigen::Ref<Eigen::MatrixXd>> llt{hessian};
                 hessianInvg = llt.solve(g);
-                if ((hessian_ * hessianInvg - g).norm() > 1e-2 * g.norm()) {
+                if ((hessian_ * hessianInvg - g).norm() < 1e-2 * g.norm()) {
+                    return g.transpose() * hessianInvg;
+                } else {
                     hessian_.diagonal().array() += eps;
                     hessian = hessian_;
-                } else {
-                    return g.transpose() * hessianInvg;
                 }
             }
-            return -INF; // We couldn't invert the Hessian: discard this split.
+            return -INF / 2.0; // We couldn't invert the Hessian: discard this split.
         };
     }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -13,7 +13,10 @@
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeFactory.h>
 #include <maths/CBoostedTreeLoss.h>
+#include <maths/CPRNG.h>
+#include <maths/CSampling.h>
 #include <maths/CTools.h>
+#include <maths/CToolsDetail.h>
 
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
@@ -895,7 +898,7 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(testLogisticRegression) {
+BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     // The idea of this test is to create a random linear relationship between
     // the feature values and the log-odds of class 1, i.e.
@@ -903,11 +906,13 @@ BOOST_AUTO_TEST_CASE(testLogisticRegression) {
     //   log-odds(class_1) = sum_i{ w * x_i }
     //
     // where, w is some fixed weight vector and x_i denoted the i'th feature vector.
+    //
     // We try to recover this relationship in logistic regression by observing
-    // the actual labels. We want to test that we've roughly correctly estimated the
-    // log-odds function. However, we target the cross-entropy so the error in our
-    // estimates p_i^ should be measured in terms of cross entropy: sum_i{ p_i log(p_i^) }
-    // where p_i = logistic(sum_i{ w_i * x_i}).
+    // the actual labels. We want to test that we've roughly correctly estimated
+    // the linear function. However, we target the cross-entropy which means we
+    // target effectively target relative error in the estimated probabilities.
+    // We therefore check the log of the ratio between the actual and predicted
+    // class probabilities.
 
     test::CRandomNumbers rng;
 
@@ -1061,6 +1066,108 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
 
     BOOST_TEST_REQUIRE(std::fabs(precisions[0] - precisions[1]) < 0.1);
     BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.14);
+}
+
+BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
+
+    // The idea of this test is to create a random linear relationship between
+    // the feature values and the logit, i.e. logit_i = W * x_i for matrix W is
+    // some fixed weight matrix and x_i denoted the i'th feature vector.
+    //
+    // We try to recover this relationship in logistic regression by observing
+    // the actual labels. We want to test that we've roughly correctly estimated
+    // the linear function. However, we target the cross-entropy which means we
+    // target effectively target relative error in the estimated probabilities.
+    // We therefore check the log of the ratio between the actual and predicted
+    // class probabilities.
+
+    using TVector = maths::CDenseVector<double>;
+    using TMemoryMappedMatrix = maths::CMemoryMappedDenseMatrix<double>;
+
+    maths::CPRNG::CXorOShiro128Plus rng;
+    test::CRandomNumbers testRng;
+
+    std::size_t trainRows{1000};
+    std::size_t rows{1200};
+    std::size_t cols{4};
+    std::size_t capacity{600};
+    int numberClasses{3};
+    int numberFeatures{static_cast<int>(cols - 1)};
+
+    TMeanAccumulator meanLogRelativeError;
+
+    TDoubleVec weights;
+    TDoubleVec noise;
+    TDoubleVec uniform01;
+
+    for (std::size_t test = 0; test < 1 /*TODO 3*/; ++test) {
+        testRng.generateUniformSamples(-2.0, 2.0, numberClasses * numberFeatures, weights);
+        testRng.generateNormalSamples(0.0, 1.0, numberFeatures * rows, noise);
+        testRng.generateUniformSamples(0.0, 1.0, rows, uniform01);
+
+        auto probability = [&](const TRowRef& row) {
+            TMemoryMappedMatrix W(&weights[0], numberClasses, numberFeatures);
+            TVector x(numberFeatures);
+            TVector n{numberFeatures};
+            for (int i = 0; i < numberFeatures; ++i) {
+                x(i) = row[i];
+                n(i) = noise[numberFeatures * row.index() + i];
+            }
+            TVector logit{W * x + n};
+            return maths::CTools::softmax(std::move(logit));
+        };
+
+        auto target = [&](const TRowRef& row) {
+            TDoubleVec probabilities{probability(row).to<TDoubleVec>()};
+            return static_cast<double>(maths::CSampling::categoricalSample(rng, probabilities));
+        };
+
+        TDoubleVecVec x(cols - 1);
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            testRng.generateUniformSamples(0.0, 4.0, rows, x[i]);
+        }
+
+        auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+
+        fillDataFrame(trainRows, rows - trainRows, cols, {false, false, false, true},
+                      x, TDoubleVec(rows, 0.0), target, *frame);
+
+        auto classifier =
+            maths::CBoostedTreeFactory::constructFromParameters(
+                1, std::make_unique<maths::boosted_tree::CMultinomialLogisticLoss>(numberClasses))
+                .buildFor(*frame, cols - 1);
+
+        classifier->train();
+        classifier->predict();
+
+        TMeanAccumulator logRelativeError;
+        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                if (row->index() >= trainRows) {
+                    TVector expectedProbability{probability(*row)};
+                    TVector actualProbability{
+                        TVector::fromSmallVector(classifier->readPrediction(*row))};
+                    logRelativeError.add(
+                        (expectedProbability.cwiseMax(actualProbability).array() /
+                         expectedProbability.cwiseMin(actualProbability).array())
+                            .log()
+                            .sum() /
+                        3.0);
+                }
+            }
+        });
+        LOG_DEBUG(<< "log relative error = "
+                  << maths::CBasicStatistics::mean(logRelativeError));
+
+        // TODO investigate results
+        //BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 1.2);
+        meanLogRelativeError.add(maths::CBasicStatistics::mean(logRelativeError));
+    }
+
+    LOG_DEBUG(<< "mean log relative error = "
+              << maths::CBasicStatistics::mean(meanLogRelativeError));
+    // TODO investigate results
+    //BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {


### PR DESCRIPTION
This change corrects the logic for dealing with singular (to working precision) Hessians. Before fixing these issues, I noticed that if a split gain is NaN it could be selected. Instead this forces the gain to be negative. Note that I've left TODOs to enable the unit test assertions as I'm still investigating accuracy.

Since this is unreleased code I've marked as a non-issue.