### PR TITLE
[ML] calculate feature importance for multi-class results

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -64,6 +64,7 @@ the build from version 2.20 to 2.34.  (See {ml-pull}1013[#1013].)
 model training. (See {ml-pull}1034[#1034].)
 * Add instrumentation information for supervised learning data frame analytics jobs.
 (See {ml-pull}1031[#1031].)
+* Write out feature importance for multi-class models. (See {ml-pull}1071[#1071])
 
 === Bug Fixes
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -50,6 +50,12 @@ public:
     static const std::string BAYESIAN_OPTIMISATION_RESTARTS;
     static const std::string NUM_TOP_FEATURE_IMPORTANCE_VALUES;
 
+    //Output
+    static const std::string IS_TRAINING_FIELD_NAME;
+    static const std::string FEATURE_NAME_FIELD_NAME;
+    static const std::string IMPORTANCE_FIELD_NAME;
+    static const std::string FEATURE_IMPORTANCE_FIELD_NAME;
+
 public:
     ~CDataFrameTrainBoostedTreeRunner() override;
 

--- a/include/maths/CTreeShapFeatureImportance.h
+++ b/include/maths/CTreeShapFeatureImportance.h
@@ -44,9 +44,6 @@ public:
         std::function<void(const TSizeVec&, const TStrVec&, const TVectorVec&)>;
 
 public:
-    static const std::string SHAP_PREFIX;
-
-public:
     CTreeShapFeatureImportance(const core::CDataFrame& frame,
                                const CDataFrameCategoryEncoder& encoder,
                                TTreeVec& trees,

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -118,7 +118,7 @@ private:
     TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
     // Classification
     std::size_t m_NumberClasses = 2;
-    std::size_t m_NumberTopClasses = 1;
+    std::size_t m_NumberTopClasses = 0;
     std::string m_PredictionFieldType;
 };
 }

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -75,6 +75,7 @@ public:
 
     // Classification
     CDataFrameAnalysisSpecificationFactory& numberClasses(std::size_t number);
+    CDataFrameAnalysisSpecificationFactory& numberTopClasses(std::size_t number);
     CDataFrameAnalysisSpecificationFactory& predictionFieldType(const std::string& type);
 
     std::string outlierParams() const;
@@ -117,6 +118,7 @@ private:
     TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
     // Classification
     std::size_t m_NumberClasses = 2;
+    std::size_t m_NumberTopClasses = 1;
     std::string m_PredictionFieldType;
 };
 }

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -44,9 +44,9 @@ const std::string CLASS_NAME_FIELD_NAME{"class_name"};
 const std::string CLASS_PROBABILITY_FIELD_NAME{"class_probability"};
 const std::string CLASS_SCORE_FIELD_NAME{"class_score"};
 
-const TStrSet PREDICTION_FIELD_NAME_BLACKLIST{
-    CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME,
-    PREDICTION_SCORE_FIELD_NAME, TOP_CLASSES_FIELD_NAME};
+const TStrSet PREDICTION_FIELD_NAME_BLACKLIST{"is_training", PREDICTION_PROBABILITY_FIELD_NAME,
+                                              PREDICTION_SCORE_FIELD_NAME,
+                                              TOP_CLASSES_FIELD_NAME};
 }
 
 const CDataFrameAnalysisConfigReader&

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -37,19 +37,15 @@ using TSizeVec = std::vector<std::size_t>;
 using TStrSet = std::set<std::string>;
 
 // Output
-const std::string IS_TRAINING_FIELD_NAME{"is_training"};
 const std::string PREDICTION_PROBABILITY_FIELD_NAME{"prediction_probability"};
 const std::string PREDICTION_SCORE_FIELD_NAME{"prediction_score"};
 const std::string TOP_CLASSES_FIELD_NAME{"top_classes"};
 const std::string CLASS_NAME_FIELD_NAME{"class_name"};
 const std::string CLASS_PROBABILITY_FIELD_NAME{"class_probability"};
 const std::string CLASS_SCORE_FIELD_NAME{"class_score"};
-const std::string FEATURE_NAME_FIELD_NAME{"feature_name"};
-const std::string IMPORTANCE_FIELD_NAME{"importance"};
-const std::string FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
 
 const TStrSet PREDICTION_FIELD_NAME_BLACKLIST{
-    IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME,
+    CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME,
     PREDICTION_SCORE_FIELD_NAME, TOP_CLASSES_FIELD_NAME};
 }
 
@@ -170,25 +166,23 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
                      const maths::CTreeShapFeatureImportance::TSizeVec& indices,
                      const TStrVec& names,
                      const maths::CTreeShapFeatureImportance::TVectorVec& shap) {
-                writer.Key(FEATURE_IMPORTANCE_FIELD_NAME);
+                writer.Key(CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME);
                 writer.StartArray();
                 for (auto i : indices) {
                     if (shap[i].norm() != 0.0) {
                         writer.StartObject();
-                        writer.Key(FEATURE_NAME_FIELD_NAME);
+                        writer.Key(CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME);
                         writer.String(names[i]);
                         if (shap[i].size() == 1) {
-                            writer.Key(IMPORTANCE_FIELD_NAME);
+                            writer.Key(CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME);
                             writer.Double(shap[i](0));
                         } else {
-                            double absSum{0.0};
                             for (int j = 0; j < shap[i].size(); ++j) {
-                                absSum += std::abs(shap[i](j));
                                 writer.Key(classValues[j]);
                                 writer.Double(shap[i](j));
                             }
-                            writer.Key(IMPORTANCE_FIELD_NAME);
-                            writer.Double(absSum);
+                            writer.Key(CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME);
+                            writer.Double(shap[i].lpNorm<1>());
                         }
                         writer.EndObject();
                     }

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -177,14 +177,19 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
                         writer.StartObject();
                         writer.Key(FEATURE_NAME_FIELD_NAME);
                         writer.String(names[i]);
-                        double absSum{0.0};
-                        for (int j = 0; j < shap[i].size(); ++j) {
-                            absSum += std::abs(shap[i](j));
-                            writer.Key(classValues[j]);
-                            writer.Double(shap[i](j));
+                        if (shap[i].size() == 1) {
+                            writer.Key(IMPORTANCE_FIELD_NAME);
+                            writer.Double(shap[i](0));
+                        } else {
+                            double absSum{0.0};
+                            for (int j = 0; j < shap[i].size(); ++j) {
+                                absSum += std::abs(shap[i](j));
+                                writer.Key(classValues[j]);
+                                writer.Double(shap[i](j));
+                            }
+                            writer.Key(IMPORTANCE_FIELD_NAME);
+                            writer.Double(absSum);
                         }
-                        writer.Key(IMPORTANCE_FIELD_NAME);
-                        writer.Double(absSum);
                         writer.EndObject();
                     }
                 }

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -37,6 +37,7 @@ using TSizeVec = std::vector<std::size_t>;
 using TStrSet = std::set<std::string>;
 
 // Output
+const std::string IS_TRAINING_FIELD_NAME{"is_training"};
 const std::string PREDICTION_PROBABILITY_FIELD_NAME{"prediction_probability"};
 const std::string PREDICTION_SCORE_FIELD_NAME{"prediction_score"};
 const std::string TOP_CLASSES_FIELD_NAME{"top_classes"};
@@ -44,9 +45,9 @@ const std::string CLASS_NAME_FIELD_NAME{"class_name"};
 const std::string CLASS_PROBABILITY_FIELD_NAME{"class_probability"};
 const std::string CLASS_SCORE_FIELD_NAME{"class_score"};
 
-const TStrSet PREDICTION_FIELD_NAME_BLACKLIST{"is_training", PREDICTION_PROBABILITY_FIELD_NAME,
-                                              PREDICTION_SCORE_FIELD_NAME,
-                                              TOP_CLASSES_FIELD_NAME};
+const TStrSet PREDICTION_FIELD_NAME_BLACKLIST{
+    IS_TRAINING_FIELD_NAME, PREDICTION_PROBABILITY_FIELD_NAME,
+    PREDICTION_SCORE_FIELD_NAME, TOP_CLASSES_FIELD_NAME};
 }
 
 const CDataFrameAnalysisConfigReader&

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -26,6 +26,7 @@
 namespace ml {
 namespace api {
 namespace {
+// Output
 const std::string IS_TRAINING_FIELD_NAME{"is_training"};
 
 const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{IS_TRAINING_FIELD_NAME};

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -26,7 +26,9 @@
 namespace ml {
 namespace api {
 namespace {
-const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{"is_training"};
+const std::string IS_TRAINING_FIELD_NAME{"is_training"};
+
+const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{IS_TRAINING_FIELD_NAME};
 }
 
 const CDataFrameAnalysisConfigReader&
@@ -71,7 +73,7 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
     writer.StartObject();
     writer.Key(this->predictionFieldName());
     writer.Double(tree.readPrediction(row)[0]);
-    writer.Key(CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME);
+    writer.Key(IS_TRAINING_FIELD_NAME);
     writer.Bool(maths::CDataFrameUtils::isMissing(row[columnHoldingDependentVariable]) == false);
     auto featureImportance = tree.shap();
     if (featureImportance != nullptr) {

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -26,8 +26,7 @@
 namespace ml {
 namespace api {
 namespace {
-const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{
-    CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME};
+const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{"is_training"};
 }
 
 const CDataFrameAnalysisConfigReader&

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -28,6 +28,9 @@ namespace api {
 namespace {
 // Output
 const std::string IS_TRAINING_FIELD_NAME{"is_training"};
+const std::string FEATURE_NAME_FIELD_NAME{"feature_name"};
+const std::string IMPORTANCE_FIELD_NAME{"importance"};
+const std::string FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
 
 const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{IS_TRAINING_FIELD_NAME};
 }
@@ -82,12 +85,19 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
             row, [&writer](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
                            const TStrVec& names,
                            const maths::CTreeShapFeatureImportance::TVectorVec& shap) {
+                writer.Key(FEATURE_IMPORTANCE_FIELD_NAME);
+                writer.StartArray();
                 for (auto i : indices) {
                     if (shap[i].norm() != 0.0) {
-                        writer.Key(names[i]);
+                        writer.StartObject();
+                        writer.Key(FEATURE_NAME_FIELD_NAME);
+                        writer.String(names[i]);
+                        writer.Key(IMPORTANCE_FIELD_NAME);
                         writer.Double(shap[i](0));
+                        writer.EndObject();
                     }
                 }
+                writer.EndArray();
             });
     }
     writer.EndObject();

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -26,13 +26,8 @@
 namespace ml {
 namespace api {
 namespace {
-// Output
-const std::string IS_TRAINING_FIELD_NAME{"is_training"};
-const std::string FEATURE_NAME_FIELD_NAME{"feature_name"};
-const std::string IMPORTANCE_FIELD_NAME{"importance"};
-const std::string FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
-
-const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{IS_TRAINING_FIELD_NAME};
+const std::set<std::string> PREDICTION_FIELD_NAME_BLACKLIST{
+    CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME};
 }
 
 const CDataFrameAnalysisConfigReader&
@@ -77,7 +72,7 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
     writer.StartObject();
     writer.Key(this->predictionFieldName());
     writer.Double(tree.readPrediction(row)[0]);
-    writer.Key(IS_TRAINING_FIELD_NAME);
+    writer.Key(CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME);
     writer.Bool(maths::CDataFrameUtils::isMissing(row[columnHoldingDependentVariable]) == false);
     auto featureImportance = tree.shap();
     if (featureImportance != nullptr) {
@@ -85,14 +80,14 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
             row, [&writer](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
                            const TStrVec& names,
                            const maths::CTreeShapFeatureImportance::TVectorVec& shap) {
-                writer.Key(FEATURE_IMPORTANCE_FIELD_NAME);
+                writer.Key(CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME);
                 writer.StartArray();
                 for (auto i : indices) {
                     if (shap[i].norm() != 0.0) {
                         writer.StartObject();
-                        writer.Key(FEATURE_NAME_FIELD_NAME);
+                        writer.Key(CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME);
                         writer.String(names[i]);
-                        writer.Key(IMPORTANCE_FIELD_NAME);
+                        writer.Key(CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME);
                         writer.Double(shap[i](0));
                         writer.EndObject();
                     }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -311,6 +311,10 @@ const std::string CDataFrameTrainBoostedTreeRunner::STOP_CROSS_VALIDATION_EARLY{
 const std::string CDataFrameTrainBoostedTreeRunner::NUMBER_ROUNDS_PER_HYPERPARAMETER{"number_rounds_per_hyperparameter"};
 const std::string CDataFrameTrainBoostedTreeRunner::BAYESIAN_OPTIMISATION_RESTARTS{"bayesian_optimisation_restarts"};
 const std::string CDataFrameTrainBoostedTreeRunner::NUM_TOP_FEATURE_IMPORTANCE_VALUES{"num_top_feature_importance_values"};
+const std::string CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME{"is_training"};
+const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME{"feature_name"};
+const std::string CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME{"importance"};
+const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -143,14 +143,14 @@ void setupMultiClassClassificationData(const TStrVec& fieldNames,
     TDoubleVec w{weights};
     int numberClasses{static_cast<int>(classes.size())};
     auto probability = [&](const TDoubleVec& row) {
-            TMemoryMappedMatrix W(&w[0], numberClasses, numberFeatures);
-            TVector x(numberFeatures);
-            for (int i = 0; i < numberFeatures; ++i) {
-                x(i) = row[i];
-            }
-            TVector logit{W * x};
-            return maths::CTools::softmax(std::move(logit));
-        };
+        TMemoryMappedMatrix W(&w[0], numberClasses, numberFeatures);
+        TVector x(numberFeatures);
+        for (int i = 0; i < numberFeatures; ++i) {
+            x(i) = row[i];
+        }
+        TVector logit{W * x};
+        return maths::CTools::softmax(std::move(logit));
+    };
     auto target = [&](const TDoubleVec& row) {
         TDoubleVec probabilities{probability(row).to<TDoubleVec>()};
         return classes[maths::CSampling::categoricalSample(rng, probabilities)];
@@ -564,22 +564,26 @@ BOOST_FIXTURE_TEST_CASE(testMultiClassClassificationFeatureImportanceAllShap, SF
             double c1f{readShapValue(result, "c1", "foo")};
             double c1bar{readShapValue(result, "c1", "bar")};
             double c1baz{readShapValue(result, "c1", "baz")};
-            BOOST_REQUIRE_CLOSE(c1Sum, std::abs(c1f) + std::abs(c1bar) + std::abs(c1baz), 1e-6);
+            BOOST_REQUIRE_CLOSE(
+                c1Sum, std::abs(c1f) + std::abs(c1bar) + std::abs(c1baz), 1e-6);
 
             double c2f{readShapValue(result, "c2", "foo")};
             double c2bar{readShapValue(result, "c2", "bar")};
             double c2baz{readShapValue(result, "c2", "baz")};
-            BOOST_REQUIRE_CLOSE(c2Sum, std::abs(c2f) + std::abs(c2bar) + std::abs(c2baz), 1e-6);
+            BOOST_REQUIRE_CLOSE(
+                c2Sum, std::abs(c2f) + std::abs(c2bar) + std::abs(c2baz), 1e-6);
 
             double c3f{readShapValue(result, "c3", "foo")};
             double c3bar{readShapValue(result, "c3", "bar")};
             double c3baz{readShapValue(result, "c3", "baz")};
-            BOOST_REQUIRE_CLOSE(c3Sum, std::abs(c3f) + std::abs(c3bar) + std::abs(c3baz), 1e-6);
+            BOOST_REQUIRE_CLOSE(
+                c3Sum, std::abs(c3f) + std::abs(c3bar) + std::abs(c3baz), 1e-6);
 
             double c4f{readShapValue(result, "c4", "foo")};
             double c4bar{readShapValue(result, "c4", "bar")};
             double c4baz{readShapValue(result, "c4", "baz")};
-            BOOST_REQUIRE_CLOSE(c4Sum, std::abs(c4f) + std::abs(c4bar) + std::abs(c4baz), 1e-6);
+            BOOST_REQUIRE_CLOSE(
+                c4Sum, std::abs(c4f) + std::abs(c4bar) + std::abs(c4baz), 1e-6);
         }
     }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -8,6 +8,7 @@
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CDataFramePredictiveModel.h>
+#include <maths/CSampling.h>
 #include <maths/CTools.h>
 #include <maths/CTreeShapFeatureImportance.h>
 
@@ -27,12 +28,14 @@ using namespace ml;
 
 namespace {
 using TDoubleVec = std::vector<double>;
+using TVector = maths::CDenseVector<double>;
 using TStrVec = std::vector<std::string>;
 using TRowItr = core::CDataFrame::TRowItr;
 using TRowRef = core::CDataFrame::TRowRef;
 using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
 using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+using TMemoryMappedMatrix = maths::CMemoryMappedDenseMatrix<double>;
 
 void setupLinearRegressionData(const TStrVec& fieldNames,
                                TStrVec& fieldValues,
@@ -110,6 +113,47 @@ void setupBinaryClassificationData(const TStrVec& fieldNames,
             logOddsBar += weights[i] * regressors[i];
         }
         return classes[u01(rng) < maths::CTools::logisticFunction(logOddsBar)];
+    };
+
+    for (std::size_t i = 0; i < values.size(); i += weights.size()) {
+        TDoubleVec row(weights.size());
+        for (std::size_t j = 0; j < weights.size(); ++j) {
+            row[j] = values[i + j];
+        }
+
+        fieldValues[0] = target(row);
+        for (std::size_t j = 0; j < row.size(); ++j) {
+            fieldValues[j + 1] = core::CStringUtils::typeToStringPrecise(
+                row[j], core::CIEEE754::E_DoublePrecision);
+        }
+
+        analyzer.handleRecord(fieldNames, fieldValues);
+    }
+}
+
+void setupMultiClassClassificationData(const TStrVec& fieldNames,
+                                       TStrVec& fieldValues,
+                                       api::CDataFrameAnalyzer& analyzer,
+                                       const TDoubleVec& weights,
+                                       const TDoubleVec& values) {
+    TStrVec classes{"foo", "bar", "baz"};
+    maths::CPRNG::CXorOShiro128Plus rng;
+    std::uniform_real_distribution<double> u01;
+    int numberFeatures{static_cast<int>(weights.size())};
+    TDoubleVec w{weights};
+    int numberClasses{static_cast<int>(classes.size())};
+    auto probability = [&](const TDoubleVec& row) {
+            TMemoryMappedMatrix W(&w[0], numberClasses, numberFeatures);
+            TVector x(numberFeatures);
+            for (int i = 0; i < numberFeatures; ++i) {
+                x(i) = row[i];
+            }
+            TVector logit{W * x};
+            return maths::CTools::softmax(std::move(logit));
+        };
+    auto target = [&](const TDoubleVec& row) {
+        TDoubleVec probabilities{probability(row).to<TDoubleVec>()};
+        return classes[maths::CSampling::categoricalSample(rng, probabilities)];
     };
 
     for (std::size_t i = 0; i < values.size(); i += weights.size()) {
@@ -231,6 +275,57 @@ struct SFixture {
         return results;
     }
 
+    rapidjson::Document runMultiClassClassification(std::size_t shapValues,
+                                                    TDoubleVec&& weights) {
+        auto outputWriterFactory = [&]() {
+            return std::make_unique<core::CJsonOutputStreamWrapper>(s_Output);
+        };
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        api::CDataFrameAnalyzer analyzer{
+            specFactory.rows(s_Rows)
+                .memoryLimit(26000000)
+                .predictionCategoricalFieldNames({"target"})
+                .predictionAlpha(s_Alpha)
+                .predictionLambda(s_Lambda)
+                .predictionGamma(s_Gamma)
+                .predictionSoftTreeDepthLimit(s_SoftTreeDepthLimit)
+                .predictionSoftTreeDepthTolerance(s_SoftTreeDepthTolerance)
+                .predictionEta(s_Eta)
+                .predictionMaximumNumberTrees(s_MaximumNumberTrees)
+                .predictionFeatureBagFraction(s_FeatureBagFraction)
+                .predictionNumberTopShapValues(shapValues)
+                .numberClasses(3)
+                .numberTopClasses(3)
+                .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(), "target"),
+            outputWriterFactory};
+        TStrVec fieldNames{"target", "c1", "c2", "c3", "c4", ".", "."};
+        TStrVec fieldValues{"", "", "", "", "", "0", ""};
+        test::CRandomNumbers rng;
+
+        TDoubleVec values;
+        rng.generateUniformSamples(-10.0, 10.0, weights.size() * s_Rows, values);
+
+        setupMultiClassClassificationData(fieldNames, fieldValues, analyzer, weights, values);
+
+        analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+        LOG_DEBUG(<< "estimated memory usage = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
+        LOG_DEBUG(<< "peak memory = "
+                  << core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage));
+        LOG_DEBUG(<< "time to train = " << core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain)
+                  << "ms");
+
+        BOOST_TEST_REQUIRE(
+            core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
+            core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
+
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(s_Output.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        return results;
+    }
+
     rapidjson::Document runRegressionWithMissingFeatures(std::size_t shapValues) {
         auto outputWriterFactory = [&]() {
             return std::make_unique<core::CJsonOutputStreamWrapper>(s_Output);
@@ -289,9 +384,41 @@ struct SFixture {
 
 template<typename RESULTS>
 double readShapValue(const RESULTS& results, std::string shapField) {
-    shapField = maths::CTreeShapFeatureImportance::SHAP_PREFIX + shapField;
-    if (results["row_results"]["results"]["ml"].HasMember(shapField)) {
-        return results["row_results"]["results"]["ml"][shapField].GetDouble();
+    if (results["row_results"]["results"]["ml"].HasMember("feature_importance")) {
+        for (const auto& shapResult :
+             results["row_results"]["results"]["ml"]["feature_importance"].GetArray()) {
+            if (shapResult["feature_name"].GetString() == shapField) {
+                return shapResult["importance"].GetDouble();
+            }
+        }
+    }
+    return 0.0;
+}
+
+template<typename RESULTS>
+double readShapValue(const RESULTS& results, std::string shapField, std::string className) {
+    if (results["row_results"]["results"]["ml"].HasMember("feature_importance")) {
+        for (const auto& shapResult :
+             results["row_results"]["results"]["ml"]["feature_importance"].GetArray()) {
+            if (shapResult["feature_name"].GetString() == shapField) {
+                if (shapResult.HasMember(className)) {
+                    return shapResult[className].GetDouble();
+                }
+            }
+        }
+    }
+    return 0.0;
+}
+
+template<typename RESULTS>
+double readClassProbability(const RESULTS& results, std::string className) {
+    if (results["row_results"]["results"]["ml"].HasMember("top_classes")) {
+        for (const auto& topClasses :
+             results["row_results"]["results"]["ml"]["top_classes"].GetArray()) {
+            if (topClasses["class_name"].GetString() == className) {
+                return topClasses["class_probability"].GetDouble();
+            }
+        }
     }
     return 0.0;
 }
@@ -324,9 +451,7 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceAllShap, SFixture) {
             c3Sum += std::fabs(c3);
             c4Sum += std::fabs(c4);
             // assert that no SHAP value for the dependent variable is returned
-            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
-                                   maths::CTreeShapFeatureImportance::SHAP_PREFIX +
-                                   "target") == false);
+            BOOST_REQUIRE_EQUAL(readShapValue(result, "target"), 0.0);
         }
     }
 
@@ -421,6 +546,44 @@ BOOST_FIXTURE_TEST_CASE(testClassificationFeatureImportanceAllShap, SFixture) {
     BOOST_REQUIRE_SMALL(maths::CBasicStatistics::variance(bias), 1e-6);
 }
 
+BOOST_FIXTURE_TEST_CASE(testMultiClassClassificationFeatureImportanceAllShap, SFixture) {
+
+    std::size_t topShapValues{4};
+    auto results{runMultiClassClassification(topShapValues, {0.5, -0.7, 0.2, -0.2})};
+
+    for (const auto& result : results.GetArray()) {
+        if (result.HasMember("row_results")) {
+            double c1Sum{readShapValue(result, "c1")};
+            double c2Sum{readShapValue(result, "c2")};
+            double c3Sum{readShapValue(result, "c3")};
+            double c4Sum{readShapValue(result, "c4")};
+            // We should have at least one feature that is important
+            BOOST_TEST_REQUIRE((c1Sum > 0.0 || c2Sum > 0.0 || c3Sum > 0.0 || c4Sum > 0.0));
+
+            // class shap values should sum(abs()) to the overall feature importance
+            double c1f{readShapValue(result, "c1", "foo")};
+            double c1bar{readShapValue(result, "c1", "bar")};
+            double c1baz{readShapValue(result, "c1", "baz")};
+            BOOST_REQUIRE_CLOSE(c1Sum, std::abs(c1f) + std::abs(c1bar) + std::abs(c1baz), 1e-6);
+
+            double c2f{readShapValue(result, "c2", "foo")};
+            double c2bar{readShapValue(result, "c2", "bar")};
+            double c2baz{readShapValue(result, "c2", "baz")};
+            BOOST_REQUIRE_CLOSE(c2Sum, std::abs(c2f) + std::abs(c2bar) + std::abs(c2baz), 1e-6);
+
+            double c3f{readShapValue(result, "c3", "foo")};
+            double c3bar{readShapValue(result, "c3", "bar")};
+            double c3baz{readShapValue(result, "c3", "baz")};
+            BOOST_REQUIRE_CLOSE(c3Sum, std::abs(c3f) + std::abs(c3bar) + std::abs(c3baz), 1e-6);
+
+            double c4f{readShapValue(result, "c4", "foo")};
+            double c4bar{readShapValue(result, "c4", "bar")};
+            double c4baz{readShapValue(result, "c4", "baz")};
+            BOOST_REQUIRE_CLOSE(c4Sum, std::abs(c4f) + std::abs(c4bar) + std::abs(c4baz), 1e-6);
+        }
+    }
+}
+
 BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoShap, SFixture) {
     // Test that if topShapValue is set to 0, no feature importance values are returned.
     std::size_t topShapValues{0};
@@ -428,18 +591,8 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoShap, SFixture) {
 
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember(
-                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c1") == false);
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember(
-                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c2") == false);
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember(
-                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c3") == false);
-            BOOST_TEST_REQUIRE(
-                result["row_results"]["results"]["ml"].HasMember(
-                    maths::CTreeShapFeatureImportance::SHAP_PREFIX + "c4") == false);
+            BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
+                                   "feature_importance") == false);
         }
     }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -10,9 +10,11 @@
 #include <maths/CDataFramePredictiveModel.h>
 #include <maths/CSampling.h>
 #include <maths/CTools.h>
+#include <maths/CToolsDetail.h>
 #include <maths/CTreeShapFeatureImportance.h>
 
 #include <api/CDataFrameAnalyzer.h>
+#include <api/CDataFrameTrainBoostedTreeRunner.h>
 
 #include <test/CDataFrameAnalysisSpecificationFactory.h>
 #include <test/CRandomNumbers.h>
@@ -384,11 +386,15 @@ struct SFixture {
 
 template<typename RESULTS>
 double readShapValue(const RESULTS& results, std::string shapField) {
-    if (results["row_results"]["results"]["ml"].HasMember("feature_importance")) {
+    if (results["row_results"]["results"]["ml"].HasMember(
+            api::CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME)) {
         for (const auto& shapResult :
-             results["row_results"]["results"]["ml"]["feature_importance"].GetArray()) {
-            if (shapResult["feature_name"].GetString() == shapField) {
-                return shapResult["importance"].GetDouble();
+             results["row_results"]["results"]["ml"][api::CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME]
+                 .GetArray()) {
+            if (shapResult[api::CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME]
+                    .GetString() == shapField) {
+                return shapResult[api::CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME]
+                    .GetDouble();
             }
         }
     }
@@ -397,10 +403,13 @@ double readShapValue(const RESULTS& results, std::string shapField) {
 
 template<typename RESULTS>
 double readShapValue(const RESULTS& results, std::string shapField, std::string className) {
-    if (results["row_results"]["results"]["ml"].HasMember("feature_importance")) {
+    if (results["row_results"]["results"]["ml"].HasMember(
+            api::CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME)) {
         for (const auto& shapResult :
-             results["row_results"]["results"]["ml"]["feature_importance"].GetArray()) {
-            if (shapResult["feature_name"].GetString() == shapField) {
+             results["row_results"]["results"]["ml"][api::CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME]
+                 .GetArray()) {
+            if (shapResult[api::CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME]
+                    .GetString() == shapField) {
                 if (shapResult.HasMember(className)) {
                     return shapResult[className].GetDouble();
                 }
@@ -596,7 +605,8 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoShap, SFixture) {
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
             BOOST_TEST_REQUIRE(result["row_results"]["results"]["ml"].HasMember(
-                                   "feature_importance") == false);
+                                   api::CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME) ==
+                               false);
         }
     }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -587,6 +587,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
     api::CDataFrameAnalyzer analyzer{
         specFactory.memoryLimit(6000000)
             .predictionCategoricalFieldNames({"target"})
+            .numberTopClasses(1)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(), "target"),
         outputWriterFactory};
     test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(

--- a/lib/maths/CTreeShapFeatureImportance.cc
+++ b/lib/maths/CTreeShapFeatureImportance.cc
@@ -28,7 +28,7 @@ CTreeShapFeatureImportance::CTreeShapFeatureImportance(const core::CDataFrame& f
 
     m_ColumnNames.reserve(frame.columnNames().size());
     for (const auto& name : frame.columnNames()) {
-        m_ColumnNames.push_back(SHAP_PREFIX + name);
+        m_ColumnNames.push_back(name);
     }
 
     // When traversing a tree, we successively copy the parent path and add one
@@ -311,7 +311,5 @@ void CTreeShapFeatureImportance::unwindPath(CSplitPath& path, int pathIndex, int
     }
     --nextIndex;
 }
-
-const std::string CTreeShapFeatureImportance::SHAP_PREFIX{"feature_importance."};
 }
 }

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -428,9 +428,6 @@ BOOST_FIXTURE_TEST_CASE(testSingleTreeExpectedNodeValues, SFixtureSingleTree) {
 BOOST_FIXTURE_TEST_CASE(testSingleTreeShap, SFixtureSingleTree) {
 
     TStrVec expectedNames{s_Frame->columnNames()};
-    for (auto& name : expectedNames) {
-        name = maths::CTreeShapFeatureImportance::SHAP_PREFIX + name;
-    }
 
     TDoubleVecVec expectedPhi{{-5., -2.5}, {-5., 2.5}, {5., -2.5}, {5., 2.5}};
 
@@ -460,9 +457,6 @@ BOOST_FIXTURE_TEST_CASE(testSingleTreeShap, SFixtureSingleTree) {
 BOOST_FIXTURE_TEST_CASE(testMultipleTreesShap, SFixtureMultipleTrees) {
 
     TStrVec expectedNames{s_Frame->columnNames()};
-    for (auto& name : expectedNames) {
-        name = maths::CTreeShapFeatureImportance::SHAP_PREFIX + name;
-    }
 
     TDoubleVecVec expectedPhi{
         {-1.65320002, -0.12444978}, {-1.65320002, -0.12444978},
@@ -511,9 +505,6 @@ BOOST_FIXTURE_TEST_CASE(testSingleTreeShapRandomDataFrame, SFixtureSingleTreeRan
     // 1 in paper by Lundberg et al.) on a random data set with a random tree.
 
     TStrVec expectedNames{s_Frame->columnNames()};
-    for (auto& name : expectedNames) {
-        name = maths::CTreeShapFeatureImportance::SHAP_PREFIX + name;
-    }
 
     CBruteForceTreeShap bfShap(s_Trees[0], s_NumberFeatures);
     auto expectedPhi = bfShap.shap(*s_Frame, *s_Encoder, 1);

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -182,6 +182,12 @@ CDataFrameAnalysisSpecificationFactory::numberClasses(std::size_t number) {
 }
 
 CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::numberTopClasses(std::size_t number) {
+    m_NumberTopClasses = number;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::predictionFieldType(const std::string& type) {
     m_PredictionFieldType = type;
     return *this;
@@ -299,7 +305,7 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
         writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES);
         writer.Uint64(m_NumberClasses);
         writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES);
-        writer.Uint64(1);
+        writer.Uint64(m_NumberTopClasses);
     }
     writer.EndObject();
 


### PR DESCRIPTION
Feature importance is already calculated for multi-class models. This commit adjusts the output sent to ES so that multi-class importance can be explored.

Feature importance objects are now mapped as follows
(logistic) Regression:
```
{
   "feature_name": "feature_0",
   "importance": -1.3
}
```
Multi-class [class names are `foo`, `bar`, `baz`]
```
{ 
   “feature_name”: “feature_0”, 
   “importance”: 2.0, // sum(abs()) of class importances
   “foo”: 1.0, 
   “bar”: 0.5, 
   “baz”: -0.5 
},
```
Java side change: https://github.com/elastic/elasticsearch/pull/53803