### PR TITLE
[ML] Fix non-optimised Linux compilation

### DIFF
--- a/include/maths/CKMeansOnline.h
+++ b/include/maths/CKMeansOnline.h
@@ -119,8 +119,9 @@ public:
                   std::size_t bufferSize = BUFFER_SIZE,
                   std::size_t numberSeeds = NUMBER_SEEDS,
                   std::size_t maxIterations = MAX_ITERATIONS)
-        : m_K{std::max(k, MINIMUM_SPACE)}, m_BufferSize{bufferSize}, m_NumberSeeds{numberSeeds},
-          m_MaxIterations{maxIterations}, m_DecayRate{decayRate}, m_MinClusterSize{minClusterSize} {
+        : m_K{(k > MINIMUM_SPACE) ? k : MINIMUM_SPACE}, m_BufferSize{bufferSize},
+          m_NumberSeeds{numberSeeds}, m_MaxIterations{maxIterations},
+          m_DecayRate{decayRate}, m_MinClusterSize{minClusterSize} {
         m_Clusters.reserve(m_K + m_BufferSize + 1);
     }
 


### PR DESCRIPTION
std::max() takes its arguments by reference, and in older
C++ standards it was not permitted to take the address of
a constant declared and defined on the same line in a class
definition.  Linux still seems to be sticking to this
restriction, although I imagine the standard has changed
because the other two platforms coped with the code.  Also,
even Linux only fails to compile when all optimisation is
disabled presumably because the call to std::max() is
usually optimised away.

The pragmatic fix is to manually optimise away the std::max()
call.