### PR TITLE
[ML] Logging additional information for results

### DIFF
--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -306,7 +306,7 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
     // Java in the order they were written to the data_frame_analyzer so it
     // can join the extra columns with the original data frame.
     std::size_t numberThreads{1};
-    
+
     // TODO consider having a separate analysis phase to monitor result output instead
     LOG_INFO(<< "Start computing results. "
              << "For regression and classification with feature importance this may take a while.");

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -10,6 +10,9 @@
 #include <core/CFloatStorage.h>
 #include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
+#include <core/CStopWatch.h>
+
+#include <maths/CBasicStatistics.h>
 
 #include <api/CDataFrameAnalysisInstrumentation.h>
 #include <api/CDataFrameAnalysisSpecification.h>
@@ -23,6 +26,7 @@ namespace ml {
 namespace api {
 namespace {
 using TStrVec = std::vector<std::string>;
+using TMeanVarAccumulator = maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
 const std::string SPECIAL_COLUMN_FIELD_NAME{"."};
 
@@ -303,8 +307,17 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
     // can join the extra columns with the original data frame.
     std::size_t numberThreads{1};
 
+    LOG_INFO(<< "Start computing results. "
+             << "For regression and classification with feature importance this may take a while.");
+
     using TRowItr = core::CDataFrame::TRowItr;
     m_DataFrame->readRows(numberThreads, [&](TRowItr beginRows, TRowItr endRows) {
+        TMeanVarAccumulator timeAccumulator;
+        core::CStopWatch stopWatch;
+        stopWatch.start();
+        std::uint64_t lastLap{stopWatch.lap()};
+        std::size_t counter = 0;
+
         for (auto row = beginRows; row != endRows; ++row) {
             writer.StartObject();
             writer.Key(ROW_RESULTS);
@@ -320,8 +333,23 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
 
             writer.EndObject();
             writer.EndObject();
+
+            std::uint64_t currentLap{stopWatch.lap()};
+            std::uint64_t delta = currentLap - lastLap;
+
+            timeAccumulator.add(static_cast<double>(delta));
+            lastLap = currentLap;
+            // Log timing every 20000 rows to avoid output polution.
+            if (++counter % 20000 == 0) {
+                LOG_DEBUG(<< "Results computation in progress: " << counter << "/"
+                          << m_DataFrame->numberRows() << ". Average time per row in ms: "
+                          << maths::CBasicStatistics::mean(timeAccumulator) << " std. dev:  "
+                          << std::sqrt(maths::CBasicStatistics::variance(timeAccumulator)));
+            }
         }
     });
+
+    LOG_INFO(<< "Finished computing results.");
 
     // Write the resulting model for inference
     const auto& modelDefinition = m_AnalysisSpecification->runner()->inferenceModelDefinition(

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -306,7 +306,8 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
     // Java in the order they were written to the data_frame_analyzer so it
     // can join the extra columns with the original data frame.
     std::size_t numberThreads{1};
-
+    
+    // TODO consider having a separate analysis phase to monitor result output instead
     LOG_INFO(<< "Start computing results. "
              << "For regression and classification with feature importance this may take a while.");
 


### PR DESCRIPTION
This PR adds logging for computing results and writing the output. It aims to tell what's going on, if the job is stuck in the final phase in it takes a while (feature importance computation). I give a log info message at the beginning and at the end of computing results. Also every 20000 rows I produce an intermediate log debug message with timing and progress.

The output will be something like this:
```
2020-03-24 14:41:38,943646 UTC [14831] INFO  CDataFrameAnalyzer.cc@311 Start computing results. For regression and classification with feature importance this may take a while.
2020-03-24 14:41:38,943752 UTC [14831] DEBUG CDataFrameAnalyzer.cc@346 Results computation in progress: 20000/100000. Average time per row in ms: 10 std. dev:  0
2020-03-24 14:41:38,943823 UTC [14831] DEBUG CDataFrameAnalyzer.cc@346 Results computation in progress: 40000/100000. Average time per row in ms: 10 std. dev:  0
2020-03-24 14:41:38,943883 UTC [14831] DEBUG CDataFrameAnalyzer.cc@346 Results computation in progress: 60000/100000. Average time per row in ms: 10 std. dev:  0
2020-03-24 14:41:38,943947 UTC [14831] DEBUG CDataFrameAnalyzer.cc@346 Results computation in progress: 80000/100000. Average time per row in ms: 10 std. dev:  0
2020-03-24 14:41:38,944011 UTC [14831] DEBUG CDataFrameAnalyzer.cc@346 Results computation in progress: 100000/100000. Average time per row in ms: 10 std. dev:  0
2020-03-24 14:41:38,944342 UTC [14831] INFO  CDataFrameAnalyzer.cc@351 Finished computing results.
```