### PR TITLE
[ML] Rework the approximate loss function for choosing leaf values for multiclass classification

### DIFF
--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -8,10 +8,10 @@
 #define INCLUDED_ml_maths_CBoostedTreeLoss_h
 
 #include <maths/CBasicStatistics.h>
-#include <maths/CKMeansOnline.h>
 #include <maths/CLinearAlgebra.h>
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CPRNG.h>
+#include <maths/CSampling.h>
 #include <maths/ImportExport.h>
 #include <maths/MathsTypes.h>
 
@@ -169,10 +169,10 @@ public:
 
 private:
     using TDoubleVectorVec = std::vector<TDoubleVector>;
-    using TKMeans = CKMeansOnline<TDoubleVector, TDoubleVector>;
+    using TSampler = CSampling::CVectorDissimilaritySampler<TDoubleVector>;
 
 private:
-    static constexpr std::size_t NUMBER_CENTRES = 128;
+    static constexpr std::size_t NUMBER_CENTRES = 64;
     static constexpr std::size_t NUMBER_RESTARTS = 3;
 
 private:
@@ -181,7 +181,7 @@ private:
     mutable CPRNG::CXorOShiro128Plus m_Rng;
     TDoubleVector m_ClassCounts;
     TDoubleVector m_DoublePrediction;
-    TKMeans m_PredictionSketch;
+    TSampler m_Sampler;
     TDoubleVectorVec m_Centres;
     TDoubleVectorVec m_CentresClassCounts;
 };

--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -147,7 +147,8 @@ private:
 //! Here, \f$P\f$ ranges over the subsets of the partition, \f$\bar{p}_P\f$ denotes
 //! the mean of the predictions in the P'th subset and \f$c_{a_i, P}\f$ denote the
 //! counts of each classes \f$\{a_i\}\f$ in the subset \f$P\f$. We compute this
-//! partition by k-means.
+//! partition via a weighted random sample where the weights are proportional to
+//! the mean distance between each point and the rest of the sample set.
 class MATHS_EXPORT CArgMinMultinomialLogisticLossImpl final : public CArgMinLossImpl {
 public:
     using TObjective = std::function<double(const TDoubleVector&)>;

--- a/include/maths/CSampling.h
+++ b/include/maths/CSampling.h
@@ -219,9 +219,6 @@ public:
         }
 
     private:
-        using TDoubleVec = std::vector<double>;
-
-    private:
         double seedWeights() override {
             double result{0.0};
             for (std::size_t i = 0; i < m_Samples.size(); ++i) {

--- a/include/maths/CSampling.h
+++ b/include/maths/CSampling.h
@@ -66,7 +66,7 @@ public:
             m_StreamWeight = m_SampleWeight = 0.0;
         }
 
-        //! Sample the value \p x uniformly at random.
+        //! Sample sample the value \p x.
         void sample(const T& x) {
             if (m_SampleSize < m_TargetSampleSize) {
                 this->doSample(m_SampleSize++, x, 1.0);
@@ -177,6 +177,16 @@ public:
     //! \brief Perform a weighted sample of stream of vectors of specified cardinality
     //! where the probability of sampling each vector is proportional to its average
     //! distance from the other sampled vectors.
+    //!
+    //! DESCRIPTION:\n
+    //! Each vector is sampled with probability
+    //! <pre class="fragment">
+    //!   \f$\displaystyle P(x) \propto \mathbb{E}\left[ \|x - Y\|_2 \right]\f$
+    //! </pre>
+    //! Here, \f$Y\f$ is distributed according to the empirical distribution of the
+    //! selected samples. This means samples already selected repel nearby ones from
+    //! subsequently being selected which has the effect tending to spread them more
+    //! regularly.
     template<typename T>
     class CVectorDissimilaritySampler final : public CStreamSampler<T> {
     public:

--- a/include/maths/CSampling.h
+++ b/include/maths/CSampling.h
@@ -13,6 +13,7 @@
 #include <core/CScopedFastLock.h>
 
 #include <maths/CLinearAlgebraFwd.h>
+#include <maths/CLinearAlgebraShims.h>
 #include <maths/CPRNG.h>
 #include <maths/ImportExport.h>
 
@@ -42,6 +43,69 @@ public:
     using TSizeVec = std::vector<std::size_t>;
     using TPtrdiffVec = std::vector<std::ptrdiff_t>;
 
+    //! \brief A basic stream sampler.
+    template<typename T>
+    class CStreamSampler {
+    public:
+        virtual ~CStreamSampler() = default;
+
+        //! Get the sampler's random number generator.
+        CPRNG::CXorOShiro128Plus& rng() { return m_Rng; }
+
+        //! Get the sample size.
+        std::size_t sampleSize() const { return m_SampleSize; }
+
+        //! Get the size of the sample we're targeting.
+        std::size_t targetSampleSize() const { return m_TargetSampleSize; }
+
+        //! Reset in preparation for resampling.
+        virtual void reset() {
+            m_SampleSize = 0;
+            m_StreamWeight = m_SampleWeight = 0.0;
+        }
+
+        //! Sample the value \p x uniformly at random.
+        void sample(const T& x) {
+            if (m_SampleSize < m_TargetSampleSize) {
+                this->doSample(m_SampleSize++, x, 1.0);
+                if (m_SampleSize == m_TargetSampleSize) {
+                    m_StreamWeight = m_SampleWeight = this->seedWeights();
+                }
+                return;
+            }
+
+            double weight{this->weight(x)};
+            double p{uniformSample(m_Rng, 0.0, 1.0)};
+            if (p * (m_StreamWeight + weight) < m_SampleWeight + weight) {
+                std::size_t slot{this->sampleToReplace(weight)};
+                if (slot < m_TargetSampleSize) {
+                    m_SampleWeight += weight - this->doSample(slot, x, weight);
+                }
+            }
+            m_StreamWeight += weight;
+        }
+
+    protected:
+        explicit CStreamSampler(std::size_t targetSampleSize,
+                                const CPRNG::CXorOShiro128Plus& rng = CPRNG::CXorOShiro128Plus{})
+            : m_Rng{rng}, m_TargetSampleSize{targetSampleSize} {}
+
+        double sampleWeight() const { return m_SampleWeight; }
+
+    private:
+        virtual double seedWeights() = 0;
+        virtual double weight(const T& x) = 0;
+        virtual std::size_t sampleToReplace(double weight) = 0;
+        virtual double doSample(std::size_t slot, const T& x, double weight) = 0;
+
+    private:
+        CPRNG::CXorOShiro128Plus m_Rng;
+        std::size_t m_TargetSampleSize;
+        std::size_t m_SampleSize = 0;
+        double m_StreamWeight = 0.0;
+        double m_SampleWeight = 0.0;
+    };
+
     //! \brief This produces (very nearly) a uniform random sample of a stream of values
     //! of a specified cardinality where the stream cardinality is not known in advance.
     //!
@@ -62,75 +126,148 @@ public:
     //! IMPLEMENTATION:\n
     //! To allow greater flexibility, this doesn't maintain the sample set, but instead a
     //! function is provided which is called when a value is sampled. This is passed the
-    //! index of the the item overwritten and the overwriting value. If the sample set is
+    //! index of the item overwritten and the overwriting value. If the sample set is
     //! wanted it is easy to provide a callback to achieve this as follows:
     //! \code{.cpp}
     //! std::vector<double> sample;
-    //! CRandomStreamSampler<double> sampler{[&sample](std::size_t i, const double& x) {
+    //! CReservoirSample<double> sampler{10, [&sample](std::size_t i, const double& x) {
     //!     if (i >= sample.size()) {
     //!         sample.resize(i + 1);
     //!     }
     //!     sample[i] = x;
     //! }};
-    //!
-    //! for (auto x : stream) {
-    //!     sampler.sample(x);
-    //! }
     //! \endcode
     template<typename T>
-    class CRandomStreamSampler {
+    class CReservoirSampler final : public CStreamSampler<T> {
     public:
         using TOnSampleCallback = std::function<void(std::size_t, const T&)>;
 
     public:
-        static const std::size_t MINIMUM_TARGET_SAMPLE_SIZE;
+        static constexpr std::size_t MINIMUM_TARGET_SAMPLE_SIZE{100};
 
     public:
-        CRandomStreamSampler(std::size_t targetSampleSize,
-                             const TOnSampleCallback& onSample,
-                             const CPRNG::CXorOShiro128Plus& rng = CPRNG::CXorOShiro128Plus{})
-            : m_Rng{rng}, m_TargetSampleSize{std::max(targetSampleSize, MINIMUM_TARGET_SAMPLE_SIZE)},
-              m_OnSample{onSample} {}
+        CReservoirSampler(std::size_t targetSampleSize,
+                          TOnSampleCallback onSample,
+                          const CPRNG::CXorOShiro128Plus& rng = CPRNG::CXorOShiro128Plus{})
+            : CStreamSampler<T>(std::max(targetSampleSize, MINIMUM_TARGET_SAMPLE_SIZE), rng),
+              m_OnSample{std::move(onSample)} {}
 
-        //! Reset in preparation for resampling.
-        void reset() { m_StreamSize = m_SampleSize = 0; }
-
-        //! Get the sampler's random number generator.
-        CPRNG::CXorOShiro128Plus& rng() { return m_Rng; }
-
-        //! Get the size of the sample we're targeting.
-        std::size_t targetSampleSize() const { return m_TargetSampleSize; }
-
-        //! Get the sample size.
-        std::size_t sampleSize() const { return m_SampleSize; }
-
-        //! Get the size of the stream processed.
-        std::size_t streamSize() const { return m_StreamSize; }
-
-        //! Sample the value \p x uniformly at random.
-        void sample(const T& x) {
-            if (m_SampleSize < m_TargetSampleSize) {
-                m_OnSample(m_SampleSize, x);
-                ++m_SampleSize;
-            } else {
-                double p{uniformSample(m_Rng, 0.0, 1.0)};
-                if (p * static_cast<double>(m_StreamSize) < static_cast<double>(m_SampleSize)) {
-                    std::size_t slot{uniformSample(m_Rng, 0, m_SampleSize + 1)};
-                    if (slot < m_SampleSize) {
-                        m_OnSample(slot, x);
-                    }
-                }
-            }
-
-            ++m_StreamSize;
+    private:
+        double seedWeights() override {
+            return static_cast<double>(this->targetSampleSize());
+        }
+        double weight(const T&) override { return 1.0; }
+        std::size_t sampleToReplace(double) override {
+            return uniformSample(this->rng(), 0, this->targetSampleSize() + 1);
+        }
+        double doSample(std::size_t slot, const T& x, double weight) override {
+            m_OnSample(slot, x);
+            return weight;
         }
 
     private:
-        CPRNG::CXorOShiro128Plus m_Rng;
-        std::size_t m_TargetSampleSize;
-        std::size_t m_StreamSize = 0;
-        std::size_t m_SampleSize = 0;
         TOnSampleCallback m_OnSample;
+    };
+
+    //! \brief Perform a weighted sample of stream of vectors of specified cardinality
+    //! where the probability of sampling each vector is proportional to its average
+    //! distance from the other sampled vectors.
+    template<typename T>
+    class CVectorDissimilaritySampler final : public CStreamSampler<T> {
+    public:
+        using TVec = std::vector<T>;
+
+    public:
+        CVectorDissimilaritySampler(std::size_t targetSampleSize,
+                                    const CPRNG::CXorOShiro128Plus& rng = CPRNG::CXorOShiro128Plus{})
+            : CStreamSampler<T>(targetSampleSize, rng),
+              m_SampleWeights(targetSampleSize, 0.0) {
+            m_Samples.reserve(targetSampleSize);
+            m_Probabilities.reserve(targetSampleSize + 1);
+        }
+
+        const TVec& samples() const { return m_Samples; }
+        TVec& samples() { return m_Samples; }
+        const TDoubleVec& sampleWeights() const { return m_SampleWeights; }
+
+        void reset() override {
+            this->CStreamSampler<T>::reset();
+            m_SampleWeights.assign(this->targetSampleSize(), 0.0);
+            m_Samples.clear();
+        }
+
+        void merge(const CVectorDissimilaritySampler& other) {
+            m_Samples.insert(m_Samples.end(), other.m_Samples.begin(),
+                             other.m_Samples.end());
+            m_SampleWeights.resize(m_Samples.size());
+            for (std::size_t i = 0; i < m_Samples.size(); ++i) {
+                m_SampleWeights[i] = this->weight(m_Samples[i]);
+            }
+            if (m_SampleWeights.size() > this->targetSampleSize()) {
+                TSizeVec selected;
+                TDoubleVec probabilities{m_SampleWeights};
+                categoricalSampleWithoutReplacement(this->rng(), probabilities,
+                                                    this->targetSampleSize(), selected);
+                std::sort(selected.begin(), selected.end());
+                for (std::size_t i = 0; i < selected.size(); ++i) {
+                    m_Samples[i] = m_Samples[selected[i]];
+                    m_SampleWeights[i] = m_SampleWeights[selected[i]];
+                }
+                m_Samples.resize(selected.size());
+                m_SampleWeights.resize(selected.size());
+            }
+        }
+
+    private:
+        using TDoubleVec = std::vector<double>;
+
+    private:
+        double seedWeights() override {
+            double result{0.0};
+            for (std::size_t i = 0; i < m_Samples.size(); ++i) {
+                result += m_SampleWeights[i] = this->weight(m_Samples[i]);
+            }
+            return result;
+        }
+
+        double weight(const T& x) override {
+            double result{0.0};
+            for (std::size_t i = 0; i < 10; ++i) {
+                result += las::distance(
+                    x, m_Samples[uniformSample(this->rng(), 0, m_Samples.size())]);
+            }
+            return result / 10.0;
+        }
+
+        std::size_t sampleToReplace(double weight) override {
+            if (this->sampleWeight() == 0.0) {
+                return uniformSample(this->rng(), 0, this->targetSampleSize() + 1);
+            }
+            // We're choosing the sample to _evict_. Therefore, we choose the samples with
+            // probability proportional to their inverse weight.
+            std::size_t n{m_SampleWeights.size()};
+            m_Probabilities.resize(n + 1);
+            double wmin{1e-6 * this->sampleWeight() / static_cast<double>(n + 1)};
+            for (std::size_t i = 0; i < n; ++i) {
+                m_Probabilities[i] = 1.0 / std::max(m_SampleWeights[i], wmin);
+            }
+            m_Probabilities[n] = 1.0 / std::max(weight, wmin);
+            return categoricalSample(this->rng(), m_Probabilities);
+        }
+
+        double doSample(std::size_t slot, const T& x, double weight) override {
+            if (m_Samples.size() <= slot) {
+                m_Samples.resize(slot + 1);
+            }
+            m_Samples[slot] = x;
+            std::swap(m_SampleWeights[slot], weight);
+            return weight;
+        }
+
+    private:
+        TVec m_Samples;
+        TDoubleVec m_SampleWeights;
+        TDoubleVec m_Probabilities;
     };
 
     //! \brief A mockable random number generator which uses boost::random::mt11213b.
@@ -521,9 +658,6 @@ private:
     //! The uniform random number generator.
     static CRandomNumberGenerator ms_Rng;
 };
-
-template<typename T>
-const std::size_t CSampling::CRandomStreamSampler<T>::MINIMUM_TARGET_SAMPLE_SIZE{100};
 }
 }
 

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -228,13 +228,7 @@ CArgMinMultinomialLogisticLossImpl::CArgMinMultinomialLogisticLossImpl(std::size
                                                                        double lambda,
                                                                        const CPRNG::CXorOShiro128Plus& rng)
     : CArgMinLossImpl{lambda}, m_NumberClasses{numberClasses}, m_Rng{rng},
-      m_ClassCounts{TDoubleVector::Zero(numberClasses)},
-      m_PredictionSketch{NUMBER_CENTRES / 4, // The size of the partition
-                         0.0, // The rate at which information is aged out (irrelevant)
-                         0.0, // The minimum permitted cluster size (irrelevant)
-                         3 * NUMBER_CENTRES / 4, // The buffer size
-                         1,   // The number of seeds for k-means to try
-                         2} { // The number of iterations to use in k-means
+      m_ClassCounts{TDoubleVector::Zero(numberClasses)}, m_Sampler{NUMBER_CENTRES} {
 }
 
 std::unique_ptr<CArgMinLossImpl> CArgMinMultinomialLogisticLossImpl::clone() const {
@@ -243,36 +237,14 @@ std::unique_ptr<CArgMinLossImpl> CArgMinMultinomialLogisticLossImpl::clone() con
 
 bool CArgMinMultinomialLogisticLossImpl::nextPass() {
 
-    using TMeanAccumulator = CBasicStatistics::SSampleMean<TDoubleVector>::TAccumulator;
-
     if (m_CurrentPass++ == 0) {
-        TKMeans::TSphericalClusterVecVec clusters;
-        if (m_PredictionSketch.kmeans(NUMBER_CENTRES / 4, clusters) == false) {
-            m_Centres.push_back(TDoubleVector::Zero(m_NumberClasses));
-            ++m_CurrentPass;
-        } else {
-            // Extract the k-centres.
-            m_Centres.reserve(clusters.size());
-            TMeanAccumulator empty{TDoubleVector::Zero(m_NumberClasses)};
-            TMeanAccumulator centroid;
-            for (const auto& cluster : clusters) {
-                centroid = empty;
-                for (const auto& point : cluster) {
-                    centroid.add(point);
-                }
-                m_Centres.push_back(CBasicStatistics::mean(centroid));
-            }
-            std::stable_sort(m_Centres.begin(), m_Centres.end());
-            m_Centres.erase(std::unique(m_Centres.begin(), m_Centres.end()),
-                            m_Centres.end());
-            LOG_TRACE(<< "# centres = " << m_Centres.size());
-            m_CurrentPass += m_Centres.size() == 1 ? 1 : 0;
-            m_CentresClassCounts.resize(m_Centres.size(),
-                                        TDoubleVector::Zero(m_NumberClasses));
-        }
-
-        // Reclaim the memory used by k-means.
-        m_PredictionSketch = TKMeans{0};
+        m_Centres = std::move(m_Sampler.samples());
+        std::stable_sort(m_Centres.begin(), m_Centres.end());
+        m_Centres.erase(std::unique(m_Centres.begin(), m_Centres.end()),
+                        m_Centres.end());
+        LOG_TRACE(<< "# centres = " << m_Centres.size());
+        m_CurrentPass += m_Centres.size() == 1 ? 1 : 0;
+        m_CentresClassCounts.resize(m_Centres.size(), TDoubleVector::Zero(m_NumberClasses));
     }
 
     LOG_TRACE(<< "current pass = " << m_CurrentPass);
@@ -290,7 +262,7 @@ void CArgMinMultinomialLogisticLossImpl::add(const TMemoryMappedFloatVector& pre
     case 0: {
         // We have a member variable to avoid allocating a tempory each time.
         m_DoublePrediction = prediction;
-        m_PredictionSketch.add(m_DoublePrediction, weight);
+        m_Sampler.sample(m_DoublePrediction);
         m_ClassCounts(static_cast<std::size_t>(actual)) += weight;
         break;
     }
@@ -313,7 +285,7 @@ void CArgMinMultinomialLogisticLossImpl::merge(const CArgMinLossImpl& other) {
     if (logistic != nullptr) {
         switch (m_CurrentPass) {
         case 0:
-            m_PredictionSketch.merge(logistic->m_PredictionSketch);
+            m_Sampler.merge(logistic->m_Sampler);
             m_ClassCounts += logistic->m_ClassCounts;
             break;
         case 1:
@@ -361,25 +333,34 @@ CArgMinMultinomialLogisticLossImpl::value() const {
 
     TMinAccumulator minLoss;
     TDoubleVector result;
+    TDoubleVector bounds[]{weightBoundingBox[0].array() - 5.0,
+                           weightBoundingBox[1].array() + 5.0};
 
-    TDoubleVector x0(m_NumberClasses);
+    TDoubleVector w0(m_NumberClasses);
     TObjective objective{this->objective()};
     TObjectiveGradient objectiveGradient{this->objectiveGradient()};
     for (std::size_t i = 0; i < NUMBER_RESTARTS; ++i) {
-        for (int j = 0; j < x0.size(); ++j) {
+        for (int j = 0; j < w0.size(); ++j) {
             double alpha{CSampling::uniformSample(m_Rng, 0.0, 1.0)};
-            x0(j) = weightBoundingBox[0](j) +
+            w0(j) = weightBoundingBox[0](j) +
                     alpha * (weightBoundingBox[1](j) - weightBoundingBox[0](j));
         }
-        LOG_TRACE(<< "x0 = " << x0.transpose());
+        LOG_TRACE(<< "x0 = " << w0.transpose());
 
         double loss;
         CLbfgs<TDoubleVector> lgbfs{5};
-        std::tie(x0, loss) = lgbfs.minimize(objective, objectiveGradient, std::move(x0));
+        std::tie(w0, loss) = lgbfs.minimize(objective, objectiveGradient, std::move(w0));
+
+        // Truncate the weight so the probabilities don't get too small if all the
+        // labels in a node are identical. Generally, shrinkage stops this happening
+        // but we can train with lambda zero.
+        w0 = w0.cwiseMax(bounds[0]).cwiseMin(bounds[1]);
+        loss = objective(w0);
+
         if (minLoss.add(loss)) {
-            result = x0;
+            result = w0;
         }
-        LOG_TRACE(<< "loss = " << loss << " weight for loss = " << x0.transpose());
+        LOG_TRACE(<< "loss = " << loss << " weight for loss = " << w0.transpose());
     }
     LOG_TRACE(<< "minimum loss = " << minLoss << " weight* = " << result.transpose());
 

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -345,7 +345,7 @@ CArgMinMultinomialLogisticLossImpl::value() const {
             w0(j) = weightBoundingBox[0](j) +
                     alpha * (weightBoundingBox[1](j) - weightBoundingBox[0](j));
         }
-        LOG_TRACE(<< "x0 = " << w0.transpose());
+        LOG_TRACE(<< "w0 = " << w0.transpose());
 
         double loss;
         CLbfgs<TDoubleVector> lgbfs{5};

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -37,7 +37,7 @@ using TFloatVec = std::vector<CFloatStorage>;
 using TFloatVecVec = std::vector<TFloatVec>;
 using TRowItr = core::CDataFrame::TRowItr;
 using TRowRef = core::CDataFrame::TRowRef;
-using TRowSampler = CSampling::CRandomStreamSampler<TRowRef>;
+using TRowSampler = CSampling::CReservoirSampler<TRowRef>;
 using TRowSamplerVec = std::vector<TRowSampler>;
 using TSizeEncoderPtrUMap =
     boost::unordered_map<std::size_t, std::unique_ptr<CDataFrameUtils::CColumnValue>>;

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -97,7 +97,7 @@ public:
         CModel make(const TMethodFactoryVec& methodFactories);
 
     private:
-        using TSampler = CSampling::CRandomStreamSampler<TRowRef>;
+        using TSampler = CSampling::CReservoirSampler<TRowRef>;
 
     private:
         TSampler makeSampler(CPRNG::CXorOShiro128Plus& rng, std::size_t sampleSize);

--- a/lib/maths/CSampling.cc
+++ b/lib/maths/CSampling.cc
@@ -124,18 +124,15 @@ std::size_t doCategoricalSample(RNG& rng, TDoubleVec& probabilities) {
     std::size_t p = probabilities.size();
 
     // Construct the transform function.
-    for (std::size_t i = 1u; i < p; ++i) {
+    for (std::size_t i = 1; i < p; ++i) {
         probabilities[i] += probabilities[i - 1];
     }
 
-    double uniform0X;
     if (probabilities[p - 1] == 0.0) {
         return doUniformSample(rng, std::size_t(0), p);
-    } else {
-        boost::random::uniform_real_distribution<> uniform(0.0, probabilities[p - 1]);
-        uniform0X = uniform(rng);
     }
 
+    double uniform0X{doUniformSample(rng, 0.0, probabilities[p - 1])};
     return std::min(static_cast<std::size_t>(std::lower_bound(probabilities.begin(),
                                                               probabilities.end(), uniform0X) -
                                              probabilities.begin()),

--- a/lib/maths/unittest/CSamplingTest.cc
+++ b/lib/maths/unittest/CSamplingTest.cc
@@ -8,7 +8,12 @@
 #include <core/CLogger.h>
 
 #include <maths/CBasicStatistics.h>
+#include <maths/CLinearAlgebraEigen.h>
+#include <maths/CPRNG.h>
 #include <maths/CSampling.h>
+#include <maths/CStatisticalTests.h>
+
+#include <test/CRandomNumbers.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -212,6 +217,106 @@ BOOST_AUTO_TEST_CASE(testMultivariateNormalSample) {
                                0.1 * test_detail::frobenius(C_));
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(testReservoirSampling) {
+
+    // Check we uniformly sample from a stream.
+
+    using TSampler = maths::CSampling::CReservoirSampler<double>;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+    TDoubleVec samples(200);
+    TSampler sampler{200, [&](std::size_t slot, const double& value) {
+                         samples[slot] = value;
+                     }};
+
+    TMeanAccumulator pValue;
+    for (std::size_t t = 0; t < 100; ++t) {
+        samples.assign(200, 0.0);
+        sampler.reset();
+        for (double x = 0.0; x < 1000.0; x += 1.0) {
+            sampler.sample(x);
+        }
+
+        maths::CStatisticalTests::CCramerVonMises cvm{20};
+        for (const auto& sample : samples) {
+            cvm.addF(sample / 1000.0);
+        }
+
+        // The p-value is small if the samples *aren't* distributed as expected.
+        BOOST_TEST_REQUIRE(cvm.pValue() > 0.05);
+        pValue.add(cvm.pValue());
+    }
+
+    LOG_DEBUG(<< "mean p-value = " << maths::CBasicStatistics::mean(pValue));
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(pValue) > 0.3);
+}
+
+BOOST_AUTO_TEST_CASE(testVectorDissimilaritySampler) {
+
+    // Test the average distance between points is significantly larger than
+    // for uniform random sampling.
+
+    using TVector = maths::CDenseVector<double>;
+    using TVectorVec = std::vector<TVector>;
+    using TReservoirSampler = maths::CSampling::CReservoirSampler<TVector>;
+    using TDissimilaritySampler = maths::CSampling::CVectorDissimilaritySampler<TVector>;
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+    std::size_t numberSamples{100};
+
+    TVectorVec samples(numberSamples);
+    TReservoirSampler randomSampler{
+        numberSamples,
+        [&](std::size_t slot, const TVector& value) { samples[slot] = value; }};
+    TDissimilaritySampler dissimilaritySampler{numberSamples};
+
+    test::CRandomNumbers rng;
+
+    TMeanAccumulator percentageSeparationIncrease;
+
+    TVector x{4};
+    TDoubleVec p;
+    TDoubleVec components;
+    TDoubleVec shift{-1.0, 0.0, 10.0, -20.0};
+    for (std::size_t t = 0; t < 50; ++t) {
+        samples.assign(numberSamples, TVector::Zero(3));
+        randomSampler.reset();
+        dissimilaritySampler.reset();
+        for (std::size_t i = 0; i < 1000; ++i) {
+            rng.generateLogNormalSamples(1.0, 2.0, 4, components);
+            for (std::size_t j = 0; j < components.size(); ++j) {
+                x(j) = components[j];
+            }
+            randomSampler.sample(x);
+            dissimilaritySampler.sample(x);
+        }
+
+        TMeanAccumulator randomSeparation;
+        TMeanAccumulator dissimilaritySeparation;
+        for (std::size_t i = 0; i < samples.size(); ++i) {
+            for (std::size_t j = 0; j < samples.size(); ++j) {
+                double distance{(samples[i] - samples[j]).norm()};
+                randomSeparation.add(distance);
+                distance = (dissimilaritySampler.samples()[i] -
+                            dissimilaritySampler.samples()[j])
+                               .norm();
+                dissimilaritySeparation.add(distance);
+            }
+        }
+        LOG_TRACE(<< "random mean separation = " << maths::CBasicStatistics::mean(randomSeparation)
+                  << ", dissimilar mean separation = "
+                  << maths::CBasicStatistics::mean(dissimilaritySeparation));
+        percentageSeparationIncrease.add(
+            100.0 *
+            (maths::CBasicStatistics::mean(dissimilaritySeparation) -
+             maths::CBasicStatistics::mean(randomSeparation)) /
+            maths::CBasicStatistics::mean(randomSeparation));
+    }
+    LOG_DEBUG(<< "% separation increase = "
+              << maths::CBasicStatistics::mean(percentageSeparationIncrease));
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentageSeparationIncrease) > 50.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CSamplingTest.cc
+++ b/lib/maths/unittest/CSamplingTest.cc
@@ -278,7 +278,6 @@ BOOST_AUTO_TEST_CASE(testVectorDissimilaritySampler) {
 
     TVector x{4};
     TDoubleVec components;
-    TDoubleVec shift{-1.0, 0.0, 10.0, -20.0};
     for (std::size_t t = 0; t < 50; ++t) {
         samples.assign(numberSamples, TVector::Zero(3));
         randomSampler.reset();

--- a/lib/maths/unittest/CSamplingTest.cc
+++ b/lib/maths/unittest/CSamplingTest.cc
@@ -277,7 +277,6 @@ BOOST_AUTO_TEST_CASE(testVectorDissimilaritySampler) {
     TMeanAccumulator percentageSeparationIncrease;
 
     TVector x{4};
-    TDoubleVec p;
     TDoubleVec components;
     TDoubleVec shift{-1.0, 0.0, 10.0, -20.0};
     for (std::size_t t = 0; t < 50; ++t) {


### PR DESCRIPTION
This change switches to using a weighted random sample of the leaf's training examples to determine the partition with which to approximate the log-loss objective for computing optimal leaf values. (Unfortunately, I couldn't get k-means fast enough for this purpose.)

The sample weights are chosen based on the mean distance between each prediction and the others in the random sample, i.e. they repel one another. This generates a more uniform sampling of the points, which results in lower average radius for the partition subsets. The result is a better approximation to the true loss function than using a uniform random sample. 