### PR TITLE
[ML] Avoid temporaries in vector expressions

### DIFF
--- a/include/maths/CLbfgs.h
+++ b/include/maths/CLbfgs.h
@@ -141,8 +141,8 @@ public:
 
         // Functions to compute the augmented Lagrangian and its gradient w.r.t. x.
         auto al = [&](const VECTOR& x_) {
-            las::assignExpr(r1) = x_ - z1 + w1 - a;
-            las::assignExpr(r2) = x_ + z2 + w2 - b;
+            r1 = x_ - z1 + w1 - a;
+            r2 = x_ + z2 + w2 - b;
             double n1{las::norm(r1)};
             double n2{las::norm(r2)};
             // Explicitly construct the return type before returning from the lambda,
@@ -167,8 +167,8 @@ public:
             std::tie(x, std::ignore) = this->minimize(al, gal, x, eps, iterations);
 
             // z-minimization.
-            las::assignExpr(z1) = x - a + w1;
-            las::assignExpr(z2) = b - x - w2;
+            z1 = x - a + w1;
+            z2 = b - x - w2;
             las::max(zero, z1);
             las::max(zero, z2);
 
@@ -233,7 +233,7 @@ private:
                                 fs - m_Fx > this->minimumDecrease(s);
              ++i) {
             s *= m_StepScale;
-            las::assignExpr(xs) = m_X - s * m_P;
+            xs = m_X - s * m_P;
             fs = f(xs);
         }
 
@@ -291,7 +291,7 @@ private:
             }
 
             if (las::inner(m_Gx, m_P) <= 0.0) {
-                las::assignExpr(m_P) = (las::norm(m_P) / (las::norm(m_Gx) + eps)) * m_Gx;
+                m_P = (las::norm(m_P) / (las::norm(m_Gx) + eps)) * m_Gx;
             }
         } else {
             m_Initial = false;

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -199,6 +199,7 @@ public:
     CDenseMatrix(CDenseMatrix&& other) = default;
     CDenseMatrix& operator=(const CDenseMatrix& other) = default;
     CDenseMatrix& operator=(CDenseMatrix&& other) = default;
+    TBase& assignExpr() { return *this; }
     // @}
 
     //! Debug the memory usage of this object.
@@ -256,6 +257,7 @@ public:
     CDenseVector(CDenseVector&& other) = default;
     CDenseVector& operator=(const CDenseVector& other) = default;
     CDenseVector& operator=(CDenseVector&& other) = default;
+    TBase& assignExpr() { return *this; }
     // @}
 
     //! Debug the memory usage of this object.

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -199,7 +199,11 @@ public:
     CDenseMatrix(CDenseMatrix&& other) = default;
     CDenseMatrix& operator=(const CDenseMatrix& other) = default;
     CDenseMatrix& operator=(CDenseMatrix&& other) = default;
-    TBase& assignExpr() { return *this; }
+    template<typename EXPR>
+    CDenseMatrix& operator=(const EXPR& expr) {
+        static_cast<TBase&>(*this) = expr;
+        return *this;
+    }
     // @}
 
     //! Debug the memory usage of this object.
@@ -257,7 +261,11 @@ public:
     CDenseVector(CDenseVector&& other) = default;
     CDenseVector& operator=(const CDenseVector& other) = default;
     CDenseVector& operator=(CDenseVector&& other) = default;
-    TBase& assignExpr() { return *this; }
+    template<typename EXPR>
+    CDenseVector& operator=(const EXPR& expr) {
+        static_cast<TBase&>(*this) = expr;
+        return *this;
+    }
     // @}
 
     //! Debug the memory usage of this object.

--- a/include/maths/CLinearAlgebraShims.h
+++ b/include/maths/CLinearAlgebraShims.h
@@ -18,6 +18,24 @@ namespace ml {
 namespace maths {
 namespace las {
 
+//! Assign \p x from a linear algebra expression.
+template<typename VECTOR>
+VECTOR& assignExpr(const VECTOR& x) {
+    return x;
+}
+
+//! Assign \p x from a linear algebra expression.
+template<typename SCALAR>
+auto assignExpr(CDenseVector<SCALAR>& x) -> decltype(x.assignExpr()) {
+    return x.assignExpr();
+}
+
+//! Assign \p x from a linear algebra expression.
+template<typename SCALAR>
+auto assignExpr(CDenseMatrix<SCALAR>& x) -> decltype(x.assignExpr()) {
+    return x.assignExpr();
+}
+
 //! Get the dimension of one of our internal vectors.
 template<typename VECTOR>
 std::size_t dimension(const VECTOR& x) {

--- a/include/maths/CLinearAlgebraShims.h
+++ b/include/maths/CLinearAlgebraShims.h
@@ -18,24 +18,6 @@ namespace ml {
 namespace maths {
 namespace las {
 
-//! Assign \p x from a linear algebra expression.
-template<typename VECTOR>
-VECTOR& assignExpr(const VECTOR& x) {
-    return x;
-}
-
-//! Assign \p x from a linear algebra expression.
-template<typename SCALAR>
-auto assignExpr(CDenseVector<SCALAR>& x) -> decltype(x.assignExpr()) {
-    return x.assignExpr();
-}
-
-//! Assign \p x from a linear algebra expression.
-template<typename SCALAR>
-auto assignExpr(CDenseMatrix<SCALAR>& x) -> decltype(x.assignExpr()) {
-    return x.assignExpr();
-}
-
 //! Get the dimension of one of our internal vectors.
 template<typename VECTOR>
 std::size_t dimension(const VECTOR& x) {

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -691,7 +691,7 @@ public:
     //! \tparam COLLECTION Is assumed to be a collection type, i.e. it
     //! must support iterator based access.
     template<typename COLLECTION>
-    static COLLECTION softmax(COLLECTION z) {
+    static void inplaceSoftmax(COLLECTION& z) {
         double Z{0.0};
         double zmax{*std::max_element(z.begin(), z.end())};
         for (auto& zi : z) {
@@ -701,12 +701,11 @@ public:
         for (auto& zi : z) {
             zi /= Z;
         }
-        return std::move(z);
     }
 
     //! Specialize the softmax for our dense vector type.
     template<typename T>
-    static CDenseVector<T> softmax(CDenseVector<T> z);
+    static void inplaceSoftmax(CDenseVector<T>& z);
 
     //! Linearly interpolate a function on the interval [\p a, \p b].
     static double linearlyInterpolate(double a, double b, double fa, double fb, double x);

--- a/include/maths/CToolsDetail.h
+++ b/include/maths/CToolsDetail.h
@@ -302,12 +302,11 @@ void CTools::spread(double a, double b, double separation, T& points) {
 }
 
 template<typename T>
-CDenseVector<T> CTools::softmax(CDenseVector<T> z) {
+void CTools::inplaceSoftmax(CDenseVector<T>& z) {
     double zmax{z.maxCoeff()};
     z.array() -= zmax;
-    z = z.array().exp();
+    z.array() = z.array().exp();
     z /= z.sum();
-    return std::move(z);
 }
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -150,8 +150,9 @@ void setupMultiClassClassificationData(const TStrVec& fieldNames,
         for (int i = 0; i < numberFeatures; ++i) {
             x(i) = row[i];
         }
-        TVector logit{W * x};
-        return maths::CTools::softmax(std::move(logit));
+        TVector result{W * x};
+        maths::CTools::inplaceSoftmax(result);
+        return result;
     };
     auto target = [&](const TDoubleVec& row) {
         TDoubleVec probabilities{probability(row).to<TDoubleVec>()};
@@ -413,19 +414,6 @@ double readShapValue(const RESULTS& results, std::string shapField, std::string 
                 if (shapResult.HasMember(className)) {
                     return shapResult[className].GetDouble();
                 }
-            }
-        }
-    }
-    return 0.0;
-}
-
-template<typename RESULTS>
-double readClassProbability(const RESULTS& results, std::string className) {
-    if (results["row_results"]["results"]["ml"].HasMember("top_classes")) {
-        for (const auto& topClasses :
-             results["row_results"]["results"]["ml"]["top_classes"].GetArray()) {
-            if (topClasses["class_name"].GetString() == className) {
-                return topClasses["class_probability"].GetDouble();
             }
         }
     }

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -118,7 +118,7 @@ CBayesianOptimisation::maximumExpectedImprovement() {
         for (int i = 0, j = 0; j < interpolate.size(); ++i, ++j) {
             interpolate(j) = interpolates[i];
         }
-        xmax.assignExpr() = a + interpolate.cwiseProduct(b - a);
+        xmax = a + interpolate.cwiseProduct(b - a);
 
     } else {
 
@@ -128,7 +128,7 @@ CBayesianOptimisation::maximumExpectedImprovement() {
             for (int j = 0; j < interpolate.size(); ++i, ++j) {
                 interpolate(j) = interpolates[i];
             }
-            x.assignExpr() = a + interpolate.cwiseProduct(b - a);
+            x = a + interpolate.cwiseProduct(b - a);
             double fx{minusEI(x)};
             LOG_TRACE(<< "x = " << x.transpose() << " EI(x) = " << fx);
 
@@ -166,7 +166,7 @@ CBayesianOptimisation::maximumExpectedImprovement() {
     // random search.
     TOptionalDouble expectedImprovement;
     if (xmax.size() == 0) {
-        xmax.assignExpr() = a + interpolate.cwiseProduct(b - a);
+        xmax = a + interpolate.cwiseProduct(b - a);
         expectedImprovement = TOptionalDouble{};
     } else if (fmax < 0.0 || CMathsFuncs::isFinite(fmax) == false) {
         expectedImprovement = TOptionalDouble{};
@@ -358,7 +358,7 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
 
     // Ensure that kernel lengths are always positive. It shouldn't change the results
     // but improves traceability.
-    m_KernelParameters.assignExpr() = amax.cwiseAbs();
+    m_KernelParameters = amax.cwiseAbs();
     LOG_TRACE(<< "kernel parameters = " << m_KernelParameters.transpose());
 
     return m_KernelParameters;

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -40,9 +40,9 @@ double logLogistic(double logOdds) {
     return std::log(CTools::logisticFunction(logOdds));
 }
 
-//template<typename T>
-void inplaceLogSoftmax(Eigen::VectorXd& z) {
-    // Handle overflow and underflow when taking exponentials by subtracting zmax.
+template<typename SCALAR>
+void inplaceLogSoftmax(CDenseVector<SCALAR>& z) {
+    // Handle under/overflow when taking exponentials by subtracting zmax.
     double zmax{z.maxCoeff()};
     z.array() -= zmax;
     double Z{z.array().exp().sum()};

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -372,7 +372,7 @@ CArgMinMultinomialLogisticLossImpl::objective() const {
     double lambda{this->lambda()};
     if (m_Centres.size() == 1) {
         return [logProbabilities, lambda, this](const TDoubleVector& weight) mutable {
-            logProbabilities.assignExpr() = m_Centres[0] + weight;
+            logProbabilities = m_Centres[0] + weight;
             inplaceLogSoftmax(logProbabilities);
             return lambda * weight.squaredNorm() - m_ClassCounts.transpose() * logProbabilities;
         };
@@ -381,7 +381,7 @@ CArgMinMultinomialLogisticLossImpl::objective() const {
         double loss{0.0};
         for (std::size_t i = 0; i < m_CentresClassCounts.size(); ++i) {
             if (m_CentresClassCounts[i].sum() > 0.0) {
-                logProbabilities.assignExpr() = m_Centres[i] + weight;
+                logProbabilities = m_Centres[i] + weight;
                 inplaceLogSoftmax(logProbabilities);
                 loss -= m_CentresClassCounts[i].transpose() * logProbabilities;
             }
@@ -397,9 +397,9 @@ CArgMinMultinomialLogisticLossImpl::objectiveGradient() const {
     double lambda{this->lambda()};
     if (m_Centres.size() == 1) {
         return [probabilities, lossGradient, lambda, this](const TDoubleVector& weight) mutable {
-            probabilities.assignExpr() = m_Centres[0] + weight;
+            probabilities = m_Centres[0] + weight;
             CTools::inplaceSoftmax(probabilities);
-            lossGradient.assignExpr() = m_ClassCounts.array().sum() * probabilities - m_ClassCounts;
+            lossGradient = m_ClassCounts.array().sum() * probabilities - m_ClassCounts;
             return TDoubleVector{2.0 * lambda * weight + lossGradient};
         };
     }
@@ -408,7 +408,7 @@ CArgMinMultinomialLogisticLossImpl::objectiveGradient() const {
         for (std::size_t i = 0; i < m_CentresClassCounts.size(); ++i) {
             double n{m_CentresClassCounts[i].array().sum()};
             if (n > 0.0) {
-                probabilities.assignExpr() = m_Centres[i] + weight;
+                probabilities = m_Centres[i] + weight;
                 CTools::inplaceSoftmax(probabilities);
                 lossGradient -= m_CentresClassCounts[i] - n * probabilities;
             }

--- a/lib/maths/unittest/CBoostedTreeLossTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLossTest.cc
@@ -458,7 +458,8 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticMinimizerEdgeCases) {
         expectedProbabilities(0) = 2.0 / 6.0;
         expectedProbabilities(1) = 3.0 / 6.0;
         expectedProbabilities(2) = 1.0 / 6.0;
-        TDoubleVector actualProbabilities{maths::CTools::softmax(argmin.value())};
+        TDoubleVector actualProbabilities{argmin.value()};
+        maths::CTools::inplaceSoftmax(actualProbabilities);
 
         BOOST_REQUIRE_SMALL((actualProbabilities - expectedProbabilities).norm(), 1e-3);
     }
@@ -493,8 +494,8 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticMinimizerEdgeCases) {
         expectedProbabilities(0) = static_cast<double>(counts[0]) / 20.0;
         expectedProbabilities(1) = static_cast<double>(counts[1]) / 20.0;
         expectedProbabilities(2) = static_cast<double>(counts[2]) / 20.0;
-        TDoubleVector actualLogit{prediction + argmin.value()};
-        TDoubleVector actualProbabilities{maths::CTools::softmax(actualLogit)};
+        TDoubleVector actualProbabilities{prediction + argmin.value()};
+        maths::CTools::inplaceSoftmax(actualProbabilities);
 
         BOOST_REQUIRE_SMALL((actualProbabilities - expectedProbabilities).norm(), 0.001);
     }
@@ -597,7 +598,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticMinimizerRandom) {
             double loss{0.0};
             for (std::size_t j = 0; j < labels.size(); ++j) {
                 TDoubleVector probabilities{predictions[j] + weight};
-                probabilities = maths::CTools::softmax(std::move(probabilities));
+                maths::CTools::inplaceSoftmax(probabilities);
                 loss -= maths::CTools::fastLog(probabilities(static_cast<int>(labels[j])));
             }
             return loss + lambda * weight.squaredNorm();

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1110,7 +1110,8 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
                 n(i) = noise[numberFeatures * row.index() + i];
             }
             TVector logit{W * x + n};
-            return maths::CTools::softmax(std::move(logit));
+            maths::CTools::inplaceSoftmax(logit);
+            return logit;
         };
 
         auto target = [&](const TRowRef& row) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1109,9 +1109,9 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
                 x(i) = row[i];
                 n(i) = noise[numberFeatures * row.index() + i];
             }
-            TVector logit{W * x + n};
-            maths::CTools::inplaceSoftmax(logit);
-            return logit;
+            TVector result{W * x + n};
+            maths::CTools::inplaceSoftmax(result);
+            return result;
         };
 
         auto target = [&](const TRowRef& row) {

--- a/lib/maths/unittest/CToolsTest.cc
+++ b/lib/maths/unittest/CToolsTest.cc
@@ -1217,12 +1217,14 @@ BOOST_AUTO_TEST_CASE(testSoftMax) {
     for (std::size_t t = 0; t < 100; ++t) {
 
         rng.generateUniformSamples(-3.0, 3.0, 5, z);
-        TDoubleVec p{CTools::softmax(z)};
+        TDoubleVec p{z};
+        CTools::inplaceSoftmax(p);
 
         BOOST_REQUIRE_CLOSE(1.0, std::accumulate(p.begin(), p.end(), 0.0), 1e-6);
         BOOST_TEST_REQUIRE(*std::min_element(p.begin(), p.end()) >= 0.0);
 
-        TDoubleVector p_{CTools::softmax(TDoubleVector::fromStdVector(z))};
+        TDoubleVector p_{TDoubleVector::fromStdVector(z)};
+        CTools::inplaceSoftmax(p_);
         for (std::size_t i = 0; i < 5; ++i) {
             BOOST_REQUIRE_CLOSE(p[i], p_[i], 1e-6);
         }


### PR DESCRIPTION
Generally, Eigen elides all vector temporaries in vector expressions. The one exception is when we assign to a `CDenseVector`. We use placeholder vectors in various places to avoid additional allocations and we're not getting the full benefits from these as a result.

This gets about 30% improvement in multiclass classification runtime.