### PR TITLE
[ML] Speedup calculating leaf values for multiclass classification

### DIFF
--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -173,8 +173,7 @@ private:
     using TSampler = CSampling::CVectorDissimilaritySampler<TDoubleVector>;
 
 private:
-    static constexpr std::size_t NUMBER_CENTRES = 64;
-    static constexpr std::size_t NUMBER_RESTARTS = 3;
+    static constexpr std::size_t NUMBER_CENTRES = 96;
 
 private:
     std::size_t m_NumberClasses = 0;

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -304,7 +304,7 @@ CArgMinMultinomialLogisticLossImpl::value() const {
     // The optimisation objective is convex. To see this note that we can write
     // it as sum_i{ f_ij(w) } + ||w||^2 with f_ij(w) = -[log(softmax_j(z_i + w))].
     // Since the sum of convex functions is convex and ||.|| is clearly convex we
-    // just require the f_ij are convex. This is a standard result and follows from
+    // just require the f_ij to be convex. This is a standard result and follows from
     // the fact that their Hessian is of the form H = diag(p) - p p^t where 1-norm
     // of p is one. Convexity follows if this is positive definite. To verify note
     // that x^t H x = ||p^(1/2) x||^2 ||p^(1/2)||^2 - (p^t x)^2, which is greater

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -327,7 +327,7 @@ CArgMinMultinomialLogisticLossImpl::value() const {
     LOG_TRACE(<< "bounding box trc = " << weightBoundingBox[1].transpose());
 
     // The optimisation objective is convex. To see this note that we can write
-    // it as the sum_i{ f_ij(w) } + ||w||^2 with f_ij(w) = -[log(softmax_j(z_i + w))].
+    // it as sum_i{ f_ij(w) } + ||w||^2 with f_ij(w) = -[log(softmax_j(z_i + w))].
     // Since the sum of convex functions is convex and ||.|| is clearly convex we
     // just require the f_ij are convex. This is a standard result and follows from
     // the fact that their Hessian is of the form H = diag(p) - p p^t where 1-norm

--- a/lib/maths/unittest/CBoostedTreeLossTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLossTest.cc
@@ -537,7 +537,6 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticMinimizerEdgeCases) {
                 }
                 losses.push_back(lossAtEps);
             }
-            LOG_DEBUG(<< core::CContainerPrinter::print(losses));
             BOOST_TEST_REQUIRE(losses[0] >= losses[1]);
             BOOST_TEST_REQUIRE(losses[2] >= losses[1]);
         }

--- a/lib/maths/unittest/CBoostedTreeLossTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLossTest.cc
@@ -321,7 +321,6 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticLossForUnderflow) {
         TMemoryMappedFloatVector predictions[]{{&storage[0], 1}, {&storage[1], 1}};
         TDoubleVec previousLoss{loss.value(predictions[0], 0.0),
                                 loss.value(predictions[1], 1.0)};
-        LOG_DEBUG(<< core::CContainerPrinter::print(previousLoss));
         for (double scale : {0.75, 0.5, 0.25, 0.0, -0.25, -0.5, -0.75, -1.0}) {
             storage[0] = scale - std::log(eps);
             storage[1] = scale + std::log(eps);


### PR DESCRIPTION
The optimisation objective is convex so there is no need for restarts. Also, since we're getting unique vectors there is no need to stable sort them. Finally, I increased the size of the approximating partition somewhat because the optimisation is significantly cheaper.

This also truncates lambda to be (small and) positive. This has a couple of benefits: 1) it means we always have a unique minimum (otherwise the normalisation constraint means any {w_j' = k  + w_j} for {w_j} a minimum is also a minimum), 2) it naturally limits weights when all labels are equal so we no longer need to truncate them.