### PR TITLE
[7.x][ML] Extend .gitignore to work with VSCode 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,10 @@ build-eclipse/
 nb-configuration.xml
 nbactions.xml
 
+#vscode files
+.vscode
+.clangd
+
 # gradle stuff
 .gradle/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ build-eclipse/
 nb-configuration.xml
 nbactions.xml
 
+#vscode files
+.vscode
+.clangd
+
 # gradle stuff
 .gradle/
 build/


### PR DESCRIPTION
This mini PR adds hidden directories of Visual Studio Code and clangd into the .gitignore and .dockerignore files. No functionality is changed.

Backport of #1089.