### PR TITLE
[ML] Instrumentation parameter names should match analysis config where applicable

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -40,6 +40,8 @@ public:
     static const std::string NUM_TOP_CLASSES;
     static const std::string PREDICTION_FIELD_TYPE;
     static const std::string CLASS_ASSIGNMENT_OBJECTIVE;
+    static const std::string MAXIMIZE_ACCURACY;
+    static const std::string MAXIMIZE_MINIMUM_RECALL;
 
 public:
     static const CDataFrameAnalysisConfigReader& parameterReader();

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -40,8 +40,7 @@ public:
     static const std::string NUM_TOP_CLASSES;
     static const std::string PREDICTION_FIELD_TYPE;
     static const std::string CLASS_ASSIGNMENT_OBJECTIVE;
-    static const std::string MAXIMIZE_ACCURACY;
-    static const std::string MAXIMIZE_MINIMUM_RECALL;
+    static const TStrVec CLASS_ASSIGNMENT_OBJECTIVE_VALUES;
 
 public:
     static const CDataFrameAnalysisConfigReader& parameterReader();

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -45,9 +45,9 @@ public:
     static const std::string SOFT_TREE_DEPTH_TOLERANCE;
     static const std::string MAX_TREES;
     static const std::string FEATURE_BAG_FRACTION;
-    static const std::string NUMBER_FOLDS;
+    static const std::string NUM_FOLDS;
     static const std::string STOP_CROSS_VALIDATION_EARLY;
-    static const std::string NUMBER_ROUNDS_PER_HYPERPARAMETER;
+    static const std::string MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER;
     static const std::string BAYESIAN_OPTIMISATION_RESTARTS;
     static const std::string NUM_TOP_FEATURE_IMPORTANCE_VALUES;
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -36,6 +36,7 @@ public:
     static const std::string DEPENDENT_VARIABLE_NAME;
     static const std::string PREDICTION_FIELD_NAME;
     static const std::string DOWNSAMPLE_ROWS_PER_FEATURE;
+    static const std::string DOWNSAMPLE_FACTOR;
     static const std::string ALPHA;
     static const std::string LAMBDA;
     static const std::string GAMMA;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -68,6 +68,8 @@ public:
     CBoostedTreeFactory& stopCrossValidationEarly(bool stopEarly);
     //! The number of rows per feature to sample in the initial downsample.
     CBoostedTreeFactory& initialDownsampleRowsPerFeature(double rowsPerFeature);
+    //! The amount by which to downsample the data for stochastic gradient estimates.
+    CBoostedTreeFactory& downsampleFactor(double factor);
     //! Set the sum of leaf depth penalties multiplier.
     CBoostedTreeFactory& depthPenaltyMultiplier(double depthPenaltyMultiplier);
     //! Set the tree size penalty multiplier.

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -337,7 +337,7 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
             rapidjson::Value(this->m_Hyperparameters.s_DownsampleFactor).Move(),
             parentObject);
         writer->addMember(
-            CDataFrameTrainBoostedTreeRunner::NUMBER_FOLDS,
+            CDataFrameTrainBoostedTreeRunner::NUM_FOLDS,
             rapidjson::Value(static_cast<std::uint64_t>(this->m_Hyperparameters.s_NumFolds))
                 .Move(),
             parentObject);
@@ -365,7 +365,7 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
                 .Move(),
             parentObject);
         writer->addMember(
-            CDataFrameTrainBoostedTreeRunner::NUMBER_ROUNDS_PER_HYPERPARAMETER,
+            CDataFrameTrainBoostedTreeRunner::MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER,
             rapidjson::Value(static_cast<std::uint64_t>(this->m_Hyperparameters.s_MaxOptimizationRoundsPerHyperparameter))
                 .Move(),
             parentObject);

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -49,12 +49,6 @@ const std::string VALIDATION_LOSS_TYPE_TAG{"loss_type"};
 const std::string VALIDATION_LOSS_VALUES_TAG{"values"};
 
 // Hyperparameters
-const TStrVec CLASS_ASSIGNMENT_OBJECTIVE{[] {
-    TStrVec result(2);
-    result[maths::CBoostedTree::E_Accuracy] = CDataFrameTrainBoostedTreeClassifierRunner::MAXIMIZE_ACCURACY;
-    result[maths::CBoostedTree::E_MinimumRecall] = CDataFrameTrainBoostedTreeClassifierRunner::MAXIMIZE_MINIMUM_RECALL;
-    return result;
-}()};
 // TODO we should expose these in the analysis config.
 const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
 const std::string MAX_ATTEMPTS_TO_ADD_TREE_TAG{"max_attempts_to_add_tree"};
@@ -307,9 +301,10 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
                           rapidjson::Value(this->m_Hyperparameters.s_Eta).Move(),
                           parentObject);
         if (m_Type == E_Classification) {
+            auto objective = this->m_Hyperparameters.s_ClassAssignmentObjective;
             writer->addMember(
                 CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE,
-                CLASS_ASSIGNMENT_OBJECTIVE[this->m_Hyperparameters.s_ClassAssignmentObjective],
+                CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE_VALUES[objective],
                 parentObject);
         }
         writer->addMember(

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -64,12 +64,10 @@ CDataFrameTrainBoostedTreeClassifierRunner::parameterReader() {
                                {{typeString, int{E_PredictionFieldTypeString}},
                                 {typeInt, int{E_PredictionFieldTypeInt}},
                                 {typeBool, int{E_PredictionFieldTypeBool}}});
-        const std::string accuracy{"maximize_accuracy"};
-        const std::string minRecall{"maximize_minimum_recall"};
         theReader.addParameter(
             CLASS_ASSIGNMENT_OBJECTIVE, CDataFrameAnalysisConfigReader::E_OptionalParameter,
-            {{accuracy, int{maths::CDataFramePredictiveModel::E_Accuracy}},
-             {minRecall, int{maths::CDataFramePredictiveModel::E_MinimumRecall}}});
+            {{MAXIMIZE_ACCURACY, int{maths::CDataFramePredictiveModel::E_Accuracy}},
+             {MAXIMIZE_MINIMUM_RECALL, int{maths::CDataFramePredictiveModel::E_MinimumRecall}}});
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -265,6 +263,8 @@ const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES{"num_c
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"num_top_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE{"prediction_field_type"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE{"class_assignment_objective"};
+const std::string CDataFrameTrainBoostedTreeClassifierRunner::MAXIMIZE_ACCURACY{"maximize_accuracy"};
+const std::string CDataFrameTrainBoostedTreeClassifierRunner::MAXIMIZE_MINIMUM_RECALL{"maximize_minimum_recall"};
 // clang-format on
 
 const std::string& CDataFrameTrainBoostedTreeClassifierRunnerFactory::name() const {

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -64,10 +64,12 @@ CDataFrameTrainBoostedTreeClassifierRunner::parameterReader() {
                                {{typeString, int{E_PredictionFieldTypeString}},
                                 {typeInt, int{E_PredictionFieldTypeInt}},
                                 {typeBool, int{E_PredictionFieldTypeBool}}});
+        int accuracy{maths::CDataFramePredictiveModel::E_Accuracy};
+        int recall{maths::CDataFramePredictiveModel::E_MinimumRecall};
         theReader.addParameter(
             CLASS_ASSIGNMENT_OBJECTIVE, CDataFrameAnalysisConfigReader::E_OptionalParameter,
-            {{MAXIMIZE_ACCURACY, int{maths::CDataFramePredictiveModel::E_Accuracy}},
-             {MAXIMIZE_MINIMUM_RECALL, int{maths::CDataFramePredictiveModel::E_MinimumRecall}}});
+            {{CLASS_ASSIGNMENT_OBJECTIVE_VALUES[accuracy], accuracy},
+             {CLASS_ASSIGNMENT_OBJECTIVE_VALUES[recall], int{recall}}});
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -263,8 +265,8 @@ const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES{"num_c
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"num_top_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE{"prediction_field_type"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE{"class_assignment_objective"};
-const std::string CDataFrameTrainBoostedTreeClassifierRunner::MAXIMIZE_ACCURACY{"maximize_accuracy"};
-const std::string CDataFrameTrainBoostedTreeClassifierRunner::MAXIMIZE_MINIMUM_RECALL{"maximize_minimum_recall"};
+const CDataFrameTrainBoostedTreeClassifierRunner::TStrVec
+CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE_VALUES{"maximize_accuracy", "maximize_minimum_recall"};
 // clang-format on
 
 const std::string& CDataFrameTrainBoostedTreeClassifierRunnerFactory::name() const {

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -39,6 +39,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(DOWNSAMPLE_ROWS_PER_FEATURE,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(DOWNSAMPLE_FACTOR,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(ALPHA, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(LAMBDA, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(GAMMA, CDataFrameAnalysisConfigReader::E_OptionalParameter);
@@ -77,6 +79,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
 
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
+    double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
 
     std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
     std::size_t numberFolds{parameters[NUMBER_FOLDS].fallback(std::size_t{0})};
@@ -96,27 +99,29 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double softTreeDepthTolerance{parameters[SOFT_TREE_DEPTH_TOLERANCE].fallback(-1.0)};
     double featureBagFraction{parameters[FEATURE_BAG_FRACTION].fallback(-1.0)};
     if (alpha != -1.0 && alpha < 0.0) {
-        HANDLE_FATAL(<< "Input error: bad alpha value. It should be non-negative.")
+        HANDLE_FATAL(<< "Input error: '" << ALPHA << "' should be non-negative.")
     }
     if (lambda != -1.0 && lambda < 0.0) {
-        HANDLE_FATAL(<< "Input error: bad lambda value. It should be non-negative.")
+        HANDLE_FATAL(<< "Input error: '" << LAMBDA << "' should be non-negative.")
     }
     if (gamma != -1.0 && gamma < 0.0) {
-        HANDLE_FATAL(<< "Input error: bad gamma value. It should be non-negative.")
+        HANDLE_FATAL(<< "Input error: '" << GAMMA << "' should be non-negative.")
     }
     if (eta != -1.0 && (eta <= 0.0 || eta > 1.0)) {
-        HANDLE_FATAL(<< "Input error: bad eta value. It should be in the range (0, 1].")
+        HANDLE_FATAL(<< "Input error: '" << ETA << "' should be in the range (0, 1].")
     }
     if (softTreeDepthLimit != -1.0 && softTreeDepthLimit < 0.0) {
-        HANDLE_FATAL(<< "Input error: bad tree depth limit value. It should be non-negative.")
+        HANDLE_FATAL(<< "Input error: '" << SOFT_TREE_DEPTH_LIMIT << "' should be non-negative.")
     }
     if (softTreeDepthTolerance != -1.0 && softTreeDepthTolerance <= 0.0) {
-        HANDLE_FATAL(<< "Input error: bad tree depth limit value. It should be positive.")
+        HANDLE_FATAL(<< "Input error: '" << SOFT_TREE_DEPTH_TOLERANCE << "' should be positive.")
+    }
+    if (downsampleFactor != -1.0 && (downsampleFactor <= 0.0 || downsampleFactor > 1.0)) {
+        HANDLE_FATAL(<< "Input error: '" << DOWNSAMPLE_FACTOR << "' should be in the range (0, 1]")
     }
     if (featureBagFraction != -1.0 &&
         (featureBagFraction <= 0.0 || featureBagFraction > 1.0)) {
-        HANDLE_FATAL(<< "Input error: bad feature bag fraction. "
-                     << "It should be in the range (0, 1]")
+        HANDLE_FATAL(<< "Input error: '" << FEATURE_BAG_FRACTION << "' should be in the range (0, 1]")
     }
 
     m_BoostedTreeFactory = std::make_unique<maths::CBoostedTreeFactory>(
@@ -131,6 +136,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     if (downsampleRowsPerFeature > 0) {
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(
             static_cast<double>(downsampleRowsPerFeature));
+    }
+    if (downsampleFactor > 0.0 && downsampleFactor <= 1.0) {
+        m_BoostedTreeFactory->downsampleFactor(downsampleFactor);
     }
     if (alpha >= 0.0) {
         m_BoostedTreeFactory->depthPenaltyMultiplier(alpha);
@@ -298,6 +306,7 @@ CDataFrameAnalysisInstrumentation& CDataFrameTrainBoostedTreeRunner::instrumenta
 const std::string CDataFrameTrainBoostedTreeRunner::DEPENDENT_VARIABLE_NAME{"dependent_variable"};
 const std::string CDataFrameTrainBoostedTreeRunner::PREDICTION_FIELD_NAME{"prediction_field_name"};
 const std::string CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_ROWS_PER_FEATURE{"downsample_rows_per_feature"};
+const std::string CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_FACTOR{"downsample_factor"};
 const std::string CDataFrameTrainBoostedTreeRunner::ALPHA{"alpha"};
 const std::string CDataFrameTrainBoostedTreeRunner::LAMBDA{"lambda"};
 const std::string CDataFrameTrainBoostedTreeRunner::GAMMA{"gamma"};

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -52,10 +52,10 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
         theReader.addParameter(MAX_TREES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(FEATURE_BAG_FRACTION,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
-        theReader.addParameter(NUMBER_FOLDS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(NUM_FOLDS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(STOP_CROSS_VALIDATION_EARLY,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
-        theReader.addParameter(NUMBER_ROUNDS_PER_HYPERPARAMETER,
+        theReader.addParameter(MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(BAYESIAN_OPTIMISATION_RESTARTS,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
@@ -82,9 +82,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
 
     std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
-    std::size_t numberFolds{parameters[NUMBER_FOLDS].fallback(std::size_t{0})};
+    std::size_t numberFolds{parameters[NUM_FOLDS].fallback(std::size_t{0})};
     std::size_t numberRoundsPerHyperparameter{
-        parameters[NUMBER_ROUNDS_PER_HYPERPARAMETER].fallback(std::size_t{0})};
+        parameters[MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER].fallback(std::size_t{0})};
     std::size_t bayesianOptimisationRestarts{
         parameters[BAYESIAN_OPTIMISATION_RESTARTS].fallback(std::size_t{0})};
     bool stopCrossValidationEarly{parameters[STOP_CROSS_VALIDATION_EARLY].fallback(true)};
@@ -315,9 +315,9 @@ const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT{"soft_
 const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE{"soft_tree_depth_tolerance"};
 const std::string CDataFrameTrainBoostedTreeRunner::MAX_TREES{"max_trees"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION{"feature_bag_fraction"};
-const std::string CDataFrameTrainBoostedTreeRunner::NUMBER_FOLDS{"number_folds"};
+const std::string CDataFrameTrainBoostedTreeRunner::NUM_FOLDS{"num_folds"};
 const std::string CDataFrameTrainBoostedTreeRunner::STOP_CROSS_VALIDATION_EARLY{"stop_cross_validation_early"};
-const std::string CDataFrameTrainBoostedTreeRunner::NUMBER_ROUNDS_PER_HYPERPARAMETER{"number_rounds_per_hyperparameter"};
+const std::string CDataFrameTrainBoostedTreeRunner::MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER{"max_optimization_rounds_per_hyperparameter"};
 const std::string CDataFrameTrainBoostedTreeRunner::BAYESIAN_OPTIMISATION_RESTARTS{"bayesian_optimisation_restarts"};
 const std::string CDataFrameTrainBoostedTreeRunner::NUM_TOP_FEATURE_IMPORTANCE_VALUES{"num_top_feature_importance_values"};
 const std::string CDataFrameTrainBoostedTreeRunner::IS_TRAINING_FIELD_NAME{"is_training"};

--- a/lib/api/unittest/testfiles/instrumentation/classification_stats.schema.json
+++ b/lib/api/unittest/testfiles/instrumentation/classification_stats.schema.json
@@ -25,23 +25,23 @@
         "class_assignment_objective": {
           "type": "string",
           "enum": [
-            "accuracy",
-            "minimum_recall"
+            "maximize_accuracy",
+            "maximize_minimum_recall"
           ]
         },
-        "regularization_depth_penalty_multiplier": {
+        "alpha": {
           "type": "number"
         },
-        "regularization_soft_tree_depth_limit": {
+        "soft_tree_depth_limit": {
           "type": "number"
         },
-        "regularization_soft_tree_depth_tolerance": {
+        "soft_tree_depth_tolerance": {
           "type": "number"
         },
-        "regularization_tree_size_penalty_multiplier": {
+        "gamma": {
           "type": "number"
         },
-        "regularization_leaf_weight_penalty_multiplier": {
+        "lambda": {
           "type": "number"
         },
         "downsample_factor": {
@@ -65,7 +65,7 @@
         "num_splits_per_feature": {
           "type": "integer"
         },
-        "max_optimization_rounds_per_hyperparameter": {
+        "number_rounds_per_hyperparameter": {
           "type": "integer"
         }
       }

--- a/lib/api/unittest/testfiles/instrumentation/classification_stats.schema.json
+++ b/lib/api/unittest/testfiles/instrumentation/classification_stats.schema.json
@@ -65,7 +65,7 @@
         "num_splits_per_feature": {
           "type": "integer"
         },
-        "number_rounds_per_hyperparameter": {
+        "max_optimization_rounds_per_hyperparameter": {
           "type": "integer"
         }
       }

--- a/lib/api/unittest/testfiles/instrumentation/regression_stats.schema.json
+++ b/lib/api/unittest/testfiles/instrumentation/regression_stats.schema.json
@@ -22,19 +22,19 @@
         "eta": {
           "type": "number"
         },
-        "regularization_depth_penalty_multiplier": {
+        "alpha": {
           "type": "number"
         },
-        "regularization_soft_tree_depth_limit": {
+        "soft_tree_depth_limit": {
           "type": "number"
         },
-        "regularization_soft_tree_depth_tolerance": {
+        "soft_tree_depth_tolerance": {
           "type": "number"
         },
-        "regularization_tree_size_penalty_multiplier": {
+        "gamma": {
           "type": "number"
         },
-        "regularization_leaf_weight_penalty_multiplier": {
+        "lambda": {
           "type": "number"
         },
         "downsample_factor": {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -45,6 +45,7 @@ const double MIN_FEATURE_BAG_FRACTION{0.2};
 const double MAX_FEATURE_BAG_FRACTION{0.8};
 const double MIN_DOWNSAMPLE_LINE_SEARCH_RANGE{2.0};
 const double MAX_DOWNSAMPLE_LINE_SEARCH_RANGE{144.0};
+const double MIN_DOWNSAMPLE_FACTOR{1e-3};
 const double MIN_DOWNSAMPLE_FACTOR_SCALE{0.3};
 const double MAX_DOWNSAMPLE_FACTOR_SCALE{3.0};
 // This isn't a hard limit but we increase the number of default training folds
@@ -1022,6 +1023,18 @@ CBoostedTreeFactory& CBoostedTreeFactory::stopCrossValidationEarly(bool stopEarl
 
 CBoostedTreeFactory& CBoostedTreeFactory::initialDownsampleRowsPerFeature(double rowsPerFeature) {
     m_InitialDownsampleRowsPerFeature = rowsPerFeature;
+    return *this;
+}
+
+CBoostedTreeFactory& CBoostedTreeFactory::downsampleFactor(double factor) {
+    if (factor <= MIN_DOWNSAMPLE_FACTOR) {
+        LOG_WARN(<< "Downsample factor must be non-negative");
+        factor = MIN_DOWNSAMPLE_FACTOR;
+    } else if (factor > 1.0) {
+        LOG_WARN(<< "Downsample factor must be no larger than one");
+        factor = 1.0;
+    }
+    m_TreeImpl->m_DownsampleFactorOverride = factor;
     return *this;
 }
 

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -282,7 +282,7 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
         writer.Double(m_FeatureBagFraction);
     }
     if (m_NumberRoundsPerHyperparameter > 0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::NUMBER_ROUNDS_PER_HYPERPARAMETER);
+        writer.Key(api::CDataFrameTrainBoostedTreeRunner::MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER);
         writer.Uint64(m_NumberRoundsPerHyperparameter);
     }
     if (m_BayesianOptimisationRestarts > 0) {


### PR DESCRIPTION
We should the same field names for instrumentation JSON that we do for the analysis configuration, so reported values can just be pasted (unmodified) into a new job config if desired. This cuts over to use the strings defined in the api runner objects and changes some of them in the process.

I think this should ideally released in 7.7 to save renaming after we've released this functionality so I've marked as non-issue.