### PR TITLE
[ML] Speed up the lat_long function

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,9 @@
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
   or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
 
+== {es} version 7.8.0
+* Speedup anomaly detection for the lat_long function. (See {ml-pull}1102[#1102].)
+
 == {es} version 7.7.0
 
 === New Features

--- a/lib/maths/CInformationCriteria.cc
+++ b/lib/maths/CInformationCriteria.cc
@@ -32,8 +32,8 @@ const double VARIANCE_CONFIDENCE = 0.99;
 }
 
 double confidence(double df) {
-    boost::math::chi_squared_distribution<> chi(df);
-    return boost::math::quantile(chi, VARIANCE_CONFIDENCE) / df;
+    boost::math::chi_squared chi2(df);
+    return boost::math::quantile(chi2, VARIANCE_CONFIDENCE) / df;
 }
 
 #define LOG_DETERMINANT(N)                                                         \


### PR DESCRIPTION
Clustering can be the bottleneck for the `lat_long` function.

This reworks the calculation of the distances to the selected points in k-means++ initialisation. Before we were creating a k-d tree for each point we added and looking up nearest neighbours. This is unnecessary since we can simply update the distances directly, i.e. `distance_i = min(distance_i, distance(selected, x_i))`. The other main speedup comes from the fact that in #1037 I reworked online k-means to remove the points buffer. This saves us memory and we can spend this memory by accumulating more points before we re-cluster.

I also made some tweaks to cutdown the number of allocations (principally by moving various variables into place). Finally, I corrected `CKMeansOnline::split` to copy all the parent clustering parameters into each split and made a couple of other small tidy ups.

In total, I get around a 60% improvement in runtime from these changes for `CXMeansOnline`.