### PR TITLE
[7.7][ML] Enable system call filter for data_frame_analyzer

### DIFF
--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -34,6 +34,8 @@
 #include <api/CSingleStreamSearcher.h>
 #include <api/CStateRestoreStreamFilter.h>
 
+#include <seccomp/CSystemCallFilter.h>
+
 #include "CCmdLineParser.h"
 
 #include <cstdlib>
@@ -133,6 +135,8 @@ int main(int argc, char** argv) {
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
     ml::core::CProcessPriority::reducePriority();
+
+    ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
     if (ioMgr.initIo() == false) {
         LOG_FATAL(<< "Failed to initialise IO");

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -59,6 +59,8 @@ model training. (See {ml-pull}1034[#1034].)
 (See {ml-pull}1031[#1031].)
 * Add instrumentation information for outlier detection data frame analytics jobs.
 * Write out feature importance for multi-class models. (See {ml-pull}1071[#1071])
+* Enable system call filtering to the native process used with data frame analytics.
+(See {ml-pull}1098[#1098])
 
 === Bug Fixes
 


### PR DESCRIPTION
This will sandbox the process to a degree in the event
of a security flaw being exploited.

Backport of #1098