### PR TITLE
[ML] Reduce analysis process priority for CPU scheduling

### DIFF
--- a/bin/autoconfig/Main.cc
+++ b/bin/autoconfig/Main.cc
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -82,6 +82,10 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
     const TInputParserUPtr inputParser{[lengthEncodedInput, &ioMgr, delimiter]() -> TInputParserUPtr {

--- a/bin/autoconfig/Main.cc
+++ b/bin/autoconfig/Main.cc
@@ -74,6 +74,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
+    // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
@@ -84,7 +85,8 @@ int main(int argc, char** argv) {
     }
 
     // Reduce CPU priority after connecting named pipes so the JVM gets more
-    // time when CPU is constrained
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
     ml::core::CProcessPriority::reduceCpuPriority();
 
     using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -151,6 +151,10 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     if (jobId.empty()) {
         LOG_FATAL(<< "No job ID specified");

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -143,6 +143,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
+    // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
@@ -153,7 +154,8 @@ int main(int argc, char** argv) {
     }
 
     // Reduce CPU priority after connecting named pipes so the JVM gets more
-    // time when CPU is constrained
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
     ml::core::CProcessPriority::reduceCpuPriority();
 
     if (jobId.empty()) {

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -92,6 +92,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
+    // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
@@ -102,7 +103,8 @@ int main(int argc, char** argv) {
     }
 
     // Reduce CPU priority after connecting named pipes so the JVM gets more
-    // time when CPU is constrained
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
     ml::core::CProcessPriority::reduceCpuPriority();
 
     if (jobId.empty()) {

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -100,6 +100,10 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     if (jobId.empty()) {
         LOG_FATAL(<< "No job ID specified");

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -134,6 +134,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
+    // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
@@ -144,7 +145,8 @@ int main(int argc, char** argv) {
     }
 
     // Reduce CPU priority after connecting named pipes so the JVM gets more
-    // time when CPU is constrained
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
     ml::core::CProcessPriority::reduceCpuPriority();
 
     using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -132,12 +132,16 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     if (ioMgr.initIo() == false) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
 

--- a/bin/normalize/Main.cc
+++ b/bin/normalize/Main.cc
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -83,6 +83,10 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     ml::model::CAnomalyDetectorModelConfig modelConfig =
         ml::model::CAnomalyDetectorModelConfig::defaultConfig(bucketSpan);

--- a/bin/normalize/Main.cc
+++ b/bin/normalize/Main.cc
@@ -75,6 +75,7 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
+    // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
@@ -85,7 +86,8 @@ int main(int argc, char** argv) {
     }
 
     // Reduce CPU priority after connecting named pipes so the JVM gets more
-    // time when CPU is constrained
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
     ml::core::CProcessPriority::reduceCpuPriority();
 
     ml::model::CAnomalyDetectorModelConfig modelConfig =

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,13 @@
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
   or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
 
+== {es} version 7.8.0
+
+=== Enhancements
+
+* Reduce CPU scheduling priority of native analysis processes to favor the ES JVM
+  when CPU is constrained. (See {ml-pull}1109[#1109].)
+
 == {es} version 7.7.0
 
 === New Features

--- a/include/core/CProcessPriority.h
+++ b/include/core/CProcessPriority.h
@@ -26,6 +26,8 @@ namespace core {
 //! IMPLEMENTATION DECISIONS:\n
 //! This is a static class - it's not possible to construct an instance of it.
 //!
+//! On Linux and macOS we reduce the CPU scheduling priority using "nice".
+//!
 //! On Linux we also attempt to increase the OOM killer adjustment for the
 //! process such that it is more likely to be killed than other processes
 //! when the Linux kernel decides that there isn't enough free memory.

--- a/include/core/CProcessPriority.h
+++ b/include/core/CProcessPriority.h
@@ -27,6 +27,9 @@ namespace core {
 //! This is a static class - it's not possible to construct an instance of it.
 //!
 //! On Linux and macOS we reduce the CPU scheduling priority using "nice".
+//! This should be done after connecting named pipes to the JVM, because
+//! named pipe connection can be time-sensitive and failures are hard to
+//! diagnose.
 //!
 //! On Linux we also attempt to increase the OOM killer adjustment for the
 //! process such that it is more likely to be killed than other processes

--- a/include/core/CProcessPriority.h
+++ b/include/core/CProcessPriority.h
@@ -26,19 +26,19 @@ namespace core {
 //! IMPLEMENTATION DECISIONS:\n
 //! This is a static class - it's not possible to construct an instance of it.
 //!
-//! The basic implementation does nothing.  Platform-specific implementations
-//! exist for platforms where we have decided to do something.
-//!
-//! Currently the only platform-specific implementation is for Linux, and it
-//! attempts to increase the OOM killer adjustment for the process such that
-//! it is more likely to be killed than other processes when the Linux kernel
-//! decides that there isn't enough free memory.
+//! On Linux we also attempt to increase the OOM killer adjustment for the
+//! process such that it is more likely to be killed than other processes
+//! when the Linux kernel decides that there isn't enough free memory.
 //!
 class CORE_EXPORT CProcessPriority : private CNonInstantiatable {
 public:
-    //! Reduce whatever priority measures are deemed appropriate for the
+    //! Reduce priority for memory if deemed appropriate for the
     //! current OS.
-    static void reducePriority();
+    static void reduceMemoryPriority();
+
+    //! Reduce priority for CPU if deemed appropriate for the
+    //! current OS.
+    static void reduceCpuPriority();
 };
 }
 }

--- a/lib/core/CProcessPriority.cc
+++ b/lib/core/CProcessPriority.cc
@@ -8,8 +8,8 @@
 #include <core/CLogger.h>
 
 #include <errno.h>
-#include <unistd.h>
 #include <string.h>
+#include <unistd.h>
 
 namespace ml {
 namespace core {

--- a/lib/core/CProcessPriority_Linux.cc
+++ b/lib/core/CProcessPriority_Linux.cc
@@ -52,10 +52,17 @@ void increaseOomKillerAdj() {
 }
 }
 
-void CProcessPriority::reducePriority() {
-    // Currently the only action is to increase the OOM killer adjustment, but
-    // there could be others in the future.
+void CProcessPriority::reduceMemoryPriority() {
     increaseOomKillerAdj();
+}
+
+void CProcessPriority::reduceCpuPriority() {
+    errno = 0;
+    // Linux's scheduler reduces priority more gradually than other *nix, so 
+    // nice value is 15 rather than 5
+    if (::nice(15) == -1 && errno != 0) {
+        LOG_ERROR(<< "Failed to reduce process priority: " << ::strerror(errno));
+    }
 }
 }
 }

--- a/lib/core/CProcessPriority_Linux.cc
+++ b/lib/core/CProcessPriority_Linux.cc
@@ -58,7 +58,7 @@ void CProcessPriority::reduceMemoryPriority() {
 
 void CProcessPriority::reduceCpuPriority() {
     errno = 0;
-    // Linux's scheduler reduces priority more gradually than other *nix, so 
+    // Linux's scheduler reduces priority more gradually than other *nix, so
     // nice value is 15 rather than 5
     if (::nice(15) == -1 && errno != 0) {
         LOG_ERROR(<< "Failed to reduce process priority: " << ::strerror(errno));

--- a/lib/core/CProcessPriority_Windows.cc
+++ b/lib/core/CProcessPriority_Windows.cc
@@ -5,12 +5,6 @@
  */
 #include <core/CProcessPriority.h>
 
-#include <core/CLogger.h>
-
-#include <errno.h>
-#include <unistd.h>
-#include <string.h>
-
 namespace ml {
 namespace core {
 
@@ -20,10 +14,7 @@ void CProcessPriority::reduceMemoryPriority() {
 }
 
 void CProcessPriority::reduceCpuPriority() {
-    errno = 0;
-    if (::nice(5) == -1 && errno != 0) {
-        LOG_ERROR(<< "Failed to reduce process priority: " << ::strerror(errno));
-    }
+    // Nothing at present on Windows
 }
 }
 }

--- a/lib/core/unittest/CProcessPriorityTest.cc
+++ b/lib/core/unittest/CProcessPriorityTest.cc
@@ -10,8 +10,12 @@
 
 BOOST_AUTO_TEST_SUITE(CProcessPriorityTest)
 
-BOOST_AUTO_TEST_CASE(testReducePriority) {
-    BOOST_REQUIRE_NO_THROW(ml::core::CProcessPriority::reducePriority());
+BOOST_AUTO_TEST_CASE(testReduceMemoryPriority) {
+    BOOST_REQUIRE_NO_THROW(ml::core::CProcessPriority::reduceMemoryPriority());
+}
+
+BOOST_AUTO_TEST_CASE(testReduceCpuPriority) {
+    BOOST_REQUIRE_NO_THROW(ml::core::CProcessPriority::reduceCpuPriority());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When many ML jobs are running at the same time and there is
insufficient CPU it is more important to prioritise the JVM
performance so that search and indexing latency remains
acceptable.

This change is an attempt to do this by increasing the "nice"
setting of the analysis processes (not controller) to reduce
their CPU scheduling priority.

This change should have little or no effect on performance on
machines that are not CPU constrained.

The exact numbers may need to be tweaked in a followup PR.