### PR TITLE
[ML] take training_percent into account when estimating memory

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,12 @@
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
   or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
 
+== {es} version 7.8.0
+
+=== Enhancements
+
+* Take `training_percent` into account when estimating memory usage. (See {ml-pull}1111[1111].)
+
 == {es} version 7.7.0
 
 === New Features

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,7 +39,8 @@
 
 === Enhancements
 
-* Take `training_percent` into account when estimating memory usage. (See {ml-pull}1111[1111].)
+* Take `training_percent` into account when estimating memory usage for classification and regression. 
+(See {ml-pull}1111[1111].)
 
 == {es} version 7.7.0
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -50,6 +50,7 @@ public:
     static const std::string MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER;
     static const std::string BAYESIAN_OPTIMISATION_RESTARTS;
     static const std::string NUM_TOP_FEATURE_IMPORTANCE_VALUES;
+    static const std::string TRAINING_PERCENT_FIELD_NAME;
 
     //Output
     static const std::string IS_TRAINING_FIELD_NAME;
@@ -115,6 +116,7 @@ private:
 
     std::string m_DependentVariableFieldName;
     std::string m_PredictionFieldName;
+    double m_trainingPercent;
     TBoostedTreeFactoryUPtr m_BoostedTreeFactory;
     TBoostedTreeUPtr m_BoostedTree;
     CDataFrameTrainBoostedTreeInstrumentation m_Instrumentation;

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -116,7 +116,7 @@ private:
 
     std::string m_DependentVariableFieldName;
     std::string m_PredictionFieldName;
-    double m_trainingPercent;
+    double m_TrainingPercent;
     TBoostedTreeFactoryUPtr m_BoostedTreeFactory;
     TBoostedTreeUPtr m_BoostedTree;
     CDataFrameTrainBoostedTreeInstrumentation m_Instrumentation;

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -61,6 +61,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(NUM_TOP_FEATURE_IMPORTANCE_VALUES,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(TRAINING_PERCENT_FIELD_NAME,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -77,6 +79,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     m_PredictionFieldName = parameters[PREDICTION_FIELD_NAME].fallback(
         m_DependentVariableFieldName + "_prediction");
 
+    m_trainingPercent = parameters[TRAINING_PERCENT_FIELD_NAME].fallback(100.0) / 100.0;
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
     double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
@@ -290,7 +293,9 @@ std::size_t CDataFrameTrainBoostedTreeRunner::estimateBookkeepingMemoryUsage(
     std::size_t totalNumberRows,
     std::size_t /*partitionNumberRows*/,
     std::size_t numberColumns) const {
-    return m_BoostedTreeFactory->estimateMemoryUsage(totalNumberRows, numberColumns);
+    return m_BoostedTreeFactory->estimateMemoryUsage(
+        static_cast<std::size_t>(static_cast<double>(totalNumberRows) * m_trainingPercent + 0.5),
+        numberColumns);
 }
 
 const CDataFrameAnalysisInstrumentation&
@@ -305,6 +310,7 @@ CDataFrameAnalysisInstrumentation& CDataFrameTrainBoostedTreeRunner::instrumenta
 // clang-format off
 const std::string CDataFrameTrainBoostedTreeRunner::DEPENDENT_VARIABLE_NAME{"dependent_variable"};
 const std::string CDataFrameTrainBoostedTreeRunner::PREDICTION_FIELD_NAME{"prediction_field_name"};
+const std::string CDataFrameTrainBoostedTreeRunner::TRAINING_PERCENT_FIELD_NAME{"training_percent"};
 const std::string CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_ROWS_PER_FEATURE{"downsample_rows_per_feature"};
 const std::string CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_FACTOR{"downsample_factor"};
 const std::string CDataFrameTrainBoostedTreeRunner::ALPHA{"alpha"};

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -79,7 +79,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     m_PredictionFieldName = parameters[PREDICTION_FIELD_NAME].fallback(
         m_DependentVariableFieldName + "_prediction");
 
-    m_trainingPercent = parameters[TRAINING_PERCENT_FIELD_NAME].fallback(100.0) / 100.0;
+    m_TrainingPercent = parameters[TRAINING_PERCENT_FIELD_NAME].fallback(100.0) / 100.0;
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
     double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
@@ -294,7 +294,7 @@ std::size_t CDataFrameTrainBoostedTreeRunner::estimateBookkeepingMemoryUsage(
     std::size_t /*partitionNumberRows*/,
     std::size_t numberColumns) const {
     return m_BoostedTreeFactory->estimateMemoryUsage(
-        static_cast<std::size_t>(static_cast<double>(totalNumberRows) * m_trainingPercent + 0.5),
+        static_cast<std::size_t>(static_cast<double>(totalNumberRows) * m_TrainingPercent + 0.5),
         numberColumns);
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1221,6 +1221,73 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrainWithTestRows) {
+
+    // Test estimation of the memory used training a model.
+
+    test::CRandomNumbers rng;
+
+    std::size_t rows{1000};
+    std::size_t cols{6};
+    std::size_t capacity{600};
+
+    for (std::size_t test = 0; test < 3; ++test) {
+        TDoubleVecVec x(cols - 1);
+        std::size_t num_test_rows{((test + 1) * 100)};
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+        }
+
+        auto target = [&](std::size_t i) {
+            double result{0.0};
+            for (std::size_t j = 0; j < cols - 1; ++j) {
+                result += x[j][i];
+            }
+            return result;
+        };
+
+        auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+        frame->categoricalColumns(TBoolVec{true, false, false, false, false, false});
+        for (std::size_t i = 0; i < rows; ++i) {
+            frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                *(column++) = std::floor(x[0][i]);
+                for (std::size_t j = 1; j < cols - 1; ++j, ++column) {
+                    *column = x[j][i];
+                }
+                if (i < num_test_rows) {
+                    *column = core::CDataFrame::valueOfMissing();
+                } else {
+                    *column = target(i);
+                }
+            });
+        }
+        frame->finishWritingRows();
+
+        double percentTrainingRows = 1.0 - static_cast<double>(num_test_rows) /
+                                               static_cast<double>(rows);
+
+        std::int64_t estimatedMemory(
+            maths::CBoostedTreeFactory::constructFromParameters(
+                1, std::make_unique<maths::boosted_tree::CMse>())
+                .estimateMemoryUsage(static_cast<std::size_t>(static_cast<double>(rows) * percentTrainingRows),
+                                     cols));
+
+        CTestInstrumentation instrumentation;
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(instrumentation)
+                              .buildFor(*frame, cols - 1);
+
+        regression->train();
+
+        LOG_DEBUG(<< "percent training rows = " << percentTrainingRows);
+        LOG_DEBUG(<< "estimated memory usage = " << estimatedMemory);
+        LOG_DEBUG(<< "high water mark = " << instrumentation.maxMemoryUsage());
+
+        BOOST_TEST_REQUIRE(instrumentation.maxMemoryUsage() < estimatedMemory);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
 
     // Test progress monitoring invariants.

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <fstream>
 #include <functional>
-#include <limits.h>
+#include <limits>
 #include <memory>
 #include <streambuf>
 #include <utility>
@@ -1231,7 +1231,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrainWithTestRows) {
     std::size_t rows{1000};
     std::size_t cols{6};
     std::size_t capacity{600};
-    std::int64_t previousEstimatedMemory{LLONG_MAX};
+    std::int64_t previousEstimatedMemory{std::numeric_limits<std::int64_t>::max()};
 
     for (std::size_t test = 0; test < 3; ++test) {
         TDoubleVecVec x(cols - 1);


### PR DESCRIPTION
This change adjust the memory estimation by taking the parameter `training_percent` into account. 

It is an optional parameter that defaults to `100.0`. The Java side will write out the parameter as it is input by the user.