### PR TITLE
[7.x][ML] Reduce analysis process priority for CPU scheduling

### DIFF
--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -143,7 +143,8 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    // Reduce memory priority before installing system call filters.
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -151,6 +152,11 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     if (jobId.empty()) {
         LOG_FATAL(<< "No job ID specified");

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -92,7 +92,8 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    // Reduce memory priority before installing system call filters.
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -100,6 +101,11 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     if (jobId.empty()) {
         LOG_FATAL(<< "No job ID specified");

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -134,7 +134,8 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    // Reduce memory priority before installing system call filters.
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -142,6 +143,11 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
 

--- a/bin/normalize/Main.cc
+++ b/bin/normalize/Main.cc
@@ -75,7 +75,8 @@ int main(int argc, char** argv) {
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
 
-    ml::core::CProcessPriority::reducePriority();
+    // Reduce memory priority before installing system call filters.
+    ml::core::CProcessPriority::reduceMemoryPriority();
 
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
@@ -83,6 +84,11 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to initialise IO");
         return EXIT_FAILURE;
     }
+
+    // Reduce CPU priority after connecting named pipes so the JVM gets more
+    // time when CPU is constrained.  Named pipe connection is time-sensitive,
+    // hence is done before reducing CPU priority.
+    ml::core::CProcessPriority::reduceCpuPriority();
 
     ml::model::CAnomalyDetectorModelConfig modelConfig =
         ml::model::CAnomalyDetectorModelConfig::defaultConfig(bucketSpan);

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 7.8.0
+
+=== Enhancements
+
+* Reduce CPU scheduling priority of native analysis processes to favor the ES JVM
+  when CPU is constrained. (See {ml-pull}1109[#1109].)
+
 == {es} version 7.7.0
 
 === New Features

--- a/include/core/CProcessPriority.h
+++ b/include/core/CProcessPriority.h
@@ -26,19 +26,24 @@ namespace core {
 //! IMPLEMENTATION DECISIONS:\n
 //! This is a static class - it's not possible to construct an instance of it.
 //!
-//! The basic implementation does nothing.  Platform-specific implementations
-//! exist for platforms where we have decided to do something.
+//! On Linux and macOS we reduce the CPU scheduling priority using "nice".
+//! This should be done after connecting named pipes to the JVM, because
+//! named pipe connection can be time-sensitive and failures are hard to
+//! diagnose.
 //!
-//! Currently the only platform-specific implementation is for Linux, and it
-//! attempts to increase the OOM killer adjustment for the process such that
-//! it is more likely to be killed than other processes when the Linux kernel
-//! decides that there isn't enough free memory.
+//! On Linux we also attempt to increase the OOM killer adjustment for the
+//! process such that it is more likely to be killed than other processes
+//! when the Linux kernel decides that there isn't enough free memory.
 //!
 class CORE_EXPORT CProcessPriority : private CNonInstantiatable {
 public:
-    //! Reduce whatever priority measures are deemed appropriate for the
+    //! Reduce priority for memory if deemed appropriate for the
     //! current OS.
-    static void reducePriority();
+    static void reduceMemoryPriority();
+
+    //! Reduce priority for CPU if deemed appropriate for the
+    //! current OS.
+    static void reduceCpuPriority();
 };
 }
 }

--- a/lib/core/CProcessPriority_Linux.cc
+++ b/lib/core/CProcessPriority_Linux.cc
@@ -52,10 +52,17 @@ void increaseOomKillerAdj() {
 }
 }
 
-void CProcessPriority::reducePriority() {
-    // Currently the only action is to increase the OOM killer adjustment, but
-    // there could be others in the future.
+void CProcessPriority::reduceMemoryPriority() {
     increaseOomKillerAdj();
+}
+
+void CProcessPriority::reduceCpuPriority() {
+    errno = 0;
+    // Linux's scheduler reduces priority more gradually than other *nix, so
+    // nice value is 15 rather than 5
+    if (::nice(15) == -1 && errno != 0) {
+        LOG_ERROR(<< "Failed to reduce process priority: " << ::strerror(errno));
+    }
 }
 }
 }

--- a/lib/core/CProcessPriority_Windows.cc
+++ b/lib/core/CProcessPriority_Windows.cc
@@ -5,12 +5,6 @@
  */
 #include <core/CProcessPriority.h>
 
-#include <core/CLogger.h>
-
-#include <errno.h>
-#include <string.h>
-#include <unistd.h>
-
 namespace ml {
 namespace core {
 
@@ -20,10 +14,7 @@ void CProcessPriority::reduceMemoryPriority() {
 }
 
 void CProcessPriority::reduceCpuPriority() {
-    errno = 0;
-    if (::nice(5) == -1 && errno != 0) {
-        LOG_ERROR(<< "Failed to reduce process priority: " << ::strerror(errno));
-    }
+    // Nothing at present on Windows
 }
 }
 }

--- a/lib/core/unittest/CProcessPriorityTest.cc
+++ b/lib/core/unittest/CProcessPriorityTest.cc
@@ -10,8 +10,12 @@
 
 BOOST_AUTO_TEST_SUITE(CProcessPriorityTest)
 
-BOOST_AUTO_TEST_CASE(testReducePriority) {
-    BOOST_REQUIRE_NO_THROW(ml::core::CProcessPriority::reducePriority());
+BOOST_AUTO_TEST_CASE(testReduceMemoryPriority) {
+    BOOST_REQUIRE_NO_THROW(ml::core::CProcessPriority::reduceMemoryPriority());
+}
+
+BOOST_AUTO_TEST_CASE(testReduceCpuPriority) {
+    BOOST_REQUIRE_NO_THROW(ml::core::CProcessPriority::reduceCpuPriority());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When many ML jobs are running at the same time and there is
insufficient CPU it is more important to prioritise the JVM
performance so that search and indexing latency remains
acceptable.

This change is an attempt to do this by increasing the "nice"
setting of the analysis processes (not controller) to reduce
their CPU scheduling priority.

This change should have little or no effect on performance on
machines that are not CPU constrained.

The exact numbers may need to be tweaked in a followup PR.

Backport of #1109