### PR TITLE
[ML] Multiclass maximise minimum recall

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -41,6 +41,8 @@
 
 * Reduce CPU scheduling priority of native analysis processes to favor the ES JVM
   when CPU is constrained. (See {ml-pull}1109[#1109].)
+* Support maximize minimum recall when assigning class labels for multiclass classification.
+  (See {ml-pull}1113[#1113].)
 
 == {es} version 7.7.0
 

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -112,7 +112,7 @@ public:
     //! Get the number of columns training the model will add to the data frame.
     static std::size_t numberExtraColumnsForTrain(std::size_t numberLossParameters) {
         // We store as follows:
-        //   1. The predicted values for the dependent variables
+        //   1. The predicted values for the dependent variable
         //   2. The gradient of the loss function
         //   3. The upper triangle of the hessian of the loss function
         //   4. The example's weight

--- a/include/maths/CDataFrameUtils.h
+++ b/include/maths/CDataFrameUtils.h
@@ -69,7 +69,8 @@ public:
     using TRowRef = core::CDataFrame::TRowRef;
     using TWeightFunc = std::function<double(const TRowRef&)>;
     using TDoubleVector = CDenseVector<double>;
-    using TReadPredictionFunc = std::function<TDoubleVector(const TRowRef)>;
+    using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage>;
+    using TReadPredictionFunc = std::function<TMemoryMappedFloatVector(const TRowRef&)>;
     using TQuantileSketchVec = std::vector<CQuantileSketch>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
@@ -408,6 +409,19 @@ private:
                                        const core::CPackedBitVector& rowMask,
                                        const TSizeVec& columnMask,
                                        std::size_t numberSamples);
+    static TDoubleVector
+    maximizeMinimumRecallForBinary(std::size_t numberThreads,
+                                   const core::CDataFrame& frame,
+                                   const core::CPackedBitVector& rowMask,
+                                   std::size_t targetColumn,
+                                   const TReadPredictionFunc& readPrediction);
+    static TDoubleVector
+    maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
+                                       const core::CDataFrame& frame,
+                                       const core::CPackedBitVector& rowMask,
+                                       std::size_t numberClasses,
+                                       std::size_t targetColumn,
+                                       const TReadPredictionFunc& readPrediction);
     static void removeMetricColumns(const core::CDataFrame& frame, TSizeVec& columnMask);
     static void removeCategoricalColumns(const core::CDataFrame& frame, TSizeVec& columnMask);
     static double unitWeight(const TRowRef&);

--- a/include/maths/CToolsDetail.h
+++ b/include/maths/CToolsDetail.h
@@ -11,6 +11,7 @@
 
 #include <maths/CCompositeFunctions.h>
 #include <maths/CIntegration.h>
+#include <maths/CLinearAlgebraEigen.h>
 #include <maths/CMixtureDistribution.h>
 #include <maths/COrderings.h>
 #include <maths/CTools.h>
@@ -307,6 +308,15 @@ void CTools::inplaceSoftmax(CDenseVector<T>& z) {
     z.array() -= zmax;
     z.array() = z.array().exp();
     z /= z.sum();
+}
+
+template<typename SCALAR>
+void CTools::inplaceLogSoftmax(CDenseVector<SCALAR>& z) {
+    // Handle under/overflow when taking exponentials by subtracting zmax.
+    double zmax{z.maxCoeff()};
+    z.array() -= zmax;
+    double Z{z.array().exp().sum()};
+    z.array() -= std::log(Z);
 }
 }
 }

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -8,6 +8,7 @@
 #define INCLUDED_ml_test_CDataFrameAnalyzerTrainingFactory_h
 
 #include <core/CDataFrame.h>
+#include <core/CSmallVector.h>
 
 #include <maths/CBoostedTreeFactory.h>
 #include <maths/CBoostedTreeLoss.h>
@@ -122,13 +123,11 @@ public:
                 auto prediction = tree->readAndAdjustPrediction(*row);
                 switch (type) {
                 case E_Regression:
-                    appendPrediction(*frame, weights.size(), prediction[0], expectedPredictions);
+                    appendPrediction(*frame, weights.size(), prediction, expectedPredictions);
                     break;
                 case E_BinaryClassification:
-                    appendPrediction(*frame, weights.size(), prediction[1], expectedPredictions);
-                    break;
                 case E_MulticlassClassification:
-                    // TODO.
+                    appendPrediction(*frame, weights.size(), prediction, expectedPredictions);
                     break;
                 }
             }
@@ -149,15 +148,19 @@ public:
                                                     TStrVec& targets);
 
 private:
+    using TDouble2Vec = core::CSmallVector<double, 2>;
     using TBoolVec = std::vector<bool>;
     using TRowItr = core::CDataFrame::TRowItr;
 
 private:
-    static void appendPrediction(core::CDataFrame&, std::size_t, double prediction, TDoubleVec& predictions);
+    static void appendPrediction(core::CDataFrame&,
+                                 std::size_t,
+                                 const TDouble2Vec& prediction,
+                                 TDoubleVec& predictions);
 
     static void appendPrediction(core::CDataFrame& frame,
                                  std::size_t target,
-                                 double class1Score,
+                                 const TDouble2Vec& class1Score,
                                  TStrVec& predictions);
 };
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -377,12 +377,16 @@ void CBoostedTreeImpl::initializePerFoldTestLosses() {
 }
 
 void CBoostedTreeImpl::computeClassificationWeights(const core::CDataFrame& frame) {
+
+    using TFloatStorageVec = std::vector<CFloatStorage>;
+
     if (m_Loss->type() == CLoss::E_BinaryClassification ||
         m_Loss->type() == CLoss::E_MulticlassClassification) {
 
         std::size_t numberClasses{m_Loss->type() == CLoss::E_BinaryClassification
                                       ? 2
                                       : m_Loss->numberParameters()};
+        TFloatStorageVec storage(2);
 
         switch (m_ClassAssignmentObjective) {
         case CBoostedTree::E_Accuracy:
@@ -391,9 +395,18 @@ void CBoostedTreeImpl::computeClassificationWeights(const core::CDataFrame& fram
         case CBoostedTree::E_MinimumRecall:
             m_ClassificationWeights = CDataFrameUtils::maximumMinimumRecallClassWeights(
                 m_NumberThreads, frame, this->allTrainingRowsMask(),
-                numberClasses, m_DependentVariable, [this](const TRowRef& row) {
-                    return m_Loss->transform(readPrediction(
-                        row, m_NumberInputColumns, m_Loss->numberParameters()));
+                numberClasses, m_DependentVariable,
+                [storage, numberClasses, this](const TRowRef& row) mutable {
+                    if (m_Loss->type() == CLoss::E_BinaryClassification) {
+                        TMemoryMappedFloatVector result{&storage[0], 2};
+                        result.array() = m_Loss
+                                             ->transform(readPrediction(
+                                                 row, m_NumberInputColumns, numberClasses))
+                                             .array()
+                                             .log();
+                        return result;
+                    }
+                    return readPrediction(row, m_NumberInputColumns, numberClasses);
                 });
             break;
         }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -398,6 +398,8 @@ void CBoostedTreeImpl::computeClassificationWeights(const core::CDataFrame& fram
                 numberClasses, m_DependentVariable,
                 [storage, numberClasses, this](const TRowRef& row) mutable {
                     if (m_Loss->type() == CLoss::E_BinaryClassification) {
+                        // We predict the log-odds but this is expected to return
+                        // the log of the predicted class probabilities.
                         TMemoryMappedFloatVector result{&storage[0], 2};
                         result.array() = m_Loss
                                              ->transform(readPrediction(

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -39,15 +39,6 @@ double logLogistic(double logOdds) {
     }
     return std::log(CTools::logisticFunction(logOdds));
 }
-
-template<typename SCALAR>
-void inplaceLogSoftmax(CDenseVector<SCALAR>& z) {
-    // Handle under/overflow when taking exponentials by subtracting zmax.
-    double zmax{z.maxCoeff()};
-    z.array() -= zmax;
-    double Z{z.array().exp().sum()};
-    z.array() -= std::log(Z);
-}
 }
 
 namespace boosted_tree_detail {
@@ -332,7 +323,7 @@ CArgMinMultinomialLogisticLossImpl::objective() const {
     if (m_Centres.size() == 1) {
         return [logProbabilities, lambda, this](const TDoubleVector& weight) mutable {
             logProbabilities = m_Centres[0] + weight;
-            inplaceLogSoftmax(logProbabilities);
+            CTools::inplaceLogSoftmax(logProbabilities);
             return lambda * weight.squaredNorm() - m_ClassCounts.transpose() * logProbabilities;
         };
     }
@@ -341,7 +332,7 @@ CArgMinMultinomialLogisticLossImpl::objective() const {
         for (std::size_t i = 0; i < m_CentresClassCounts.size(); ++i) {
             if (m_CentresClassCounts[i].sum() > 0.0) {
                 logProbabilities = m_Centres[i] + weight;
-                inplaceLogSoftmax(logProbabilities);
+                CTools::inplaceLogSoftmax(logProbabilities);
                 loss -= m_CentresClassCounts[i].transpose() * logProbabilities;
             }
         }

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -1208,7 +1208,8 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
                     }
                 }
             },
-            TDoubleVectorVec(numberClasses + 1, TDoubleVector::Zero(numberClasses)));
+            TDoubleVectorVec(numberClasses + 1,
+                             TDoubleVector{TDoubleVector::Zero(numberClasses)}));
         auto copyObjectiveAndGradient = [](TDoubleVectorVec state, TDoubleVectorVec& result) {
             result = std::move(state);
         };

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1038,17 +1038,17 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
         TDoubleVec falseNegatives(2, 0.0);
         frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                double prediction{
-                    classification->readAndAdjustPrediction(*row)[1] < 0.5 ? 0.0 : 1.0};
+                auto scores = classification->readAndAdjustPrediction(*row);
+                std::size_t prediction(scores[1] < scores[0] ? 0 : 1);
                 if (row->index() >= trainRows &&
                     row->index() < trainRows + classesRowCounts[2]) {
                     // Actual is zero.
-                    (prediction == 0.0 ? truePositives[0] : falseNegatives[0]) += 1.0;
-                    (prediction == 0.0 ? trueNegatives[1] : falsePositives[1]) += 1.0;
+                    (prediction == 0 ? truePositives[0] : falseNegatives[0]) += 1.0;
+                    (prediction == 0 ? trueNegatives[1] : falsePositives[1]) += 1.0;
                 } else if (row->index() >= trainRows + classesRowCounts[2]) {
                     // Actual is one.
-                    (prediction == 1.0 ? truePositives[1] : falseNegatives[1]) += 1.0;
-                    (prediction == 1.0 ? trueNegatives[0] : falsePositives[0]) += 1.0;
+                    (prediction == 1 ? truePositives[1] : falseNegatives[1]) += 1.0;
+                    (prediction == 1 ? trueNegatives[0] : falsePositives[0]) += 1.0;
                 }
             }
         });

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -1307,7 +1307,7 @@ BOOST_AUTO_TEST_CASE(testMaximumMinimumRecallClassWeights) {
             // We improved the minimum class recall by at least 10%.
             BOOST_TEST_REQUIRE(minRecalls[0][0] > 1.1 * minRecalls[0][1]);
 
-            // The minimum and maximum class recalls are close: we're at the global minimum.
+            // The minimum and maximum class recalls are close: we're at the global maximum.
             BOOST_TEST_REQUIRE(1.02 * minRecalls[0][0] > maxRecalls[0][0]);
             BOOST_TEST_REQUIRE(1.02 * minRecalls[1][0] > maxRecalls[1][0]);
         }

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -10,9 +10,12 @@
 #include <maths/CBasicStatistics.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CDataFrameUtils.h>
+#include <maths/CLinearAlgebraEigen.h>
 #include <maths/CMic.h>
 #include <maths/COrderings.h>
 #include <maths/CQuantileSketch.h>
+#include <maths/CTools.h>
+#include <maths/CToolsDetail.h>
 
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
@@ -1200,6 +1203,117 @@ BOOST_AUTO_TEST_CASE(testCategoryMicWithColumnWithMissing) {
         BOOST_REQUIRE_EQUAL(std::string{"[1, 3, 0, 4, 2]"},
                             core::CContainerPrinter::print(categoryOrder));
     }
+}
+
+BOOST_AUTO_TEST_CASE(testMaximumMinimumRecallClassWeights) {
+
+    // Test we reliably increase the minimum class recall for predictions with uneven accuracy.
+
+    using TDoubleVector = maths::CDenseVector<double>;
+    using TMemoryMappedFloatVector = maths::CMemoryMappedDenseVector<maths::CFloatStorage>;
+
+    std::size_t rows{5000};
+    std::size_t capacity{2000};
+
+    test::CRandomNumbers rng;
+
+    for (std::size_t numberClasses : {2, 3}) {
+
+        std::size_t cols{numberClasses + 1};
+
+        auto readPrediction = [&](const core::CDataFrame::TRowRef& row) {
+            return TMemoryMappedFloatVector{row.data(), static_cast<int>(numberClasses)};
+        };
+
+        TBoolVec categoricalColumns(cols, false);
+        categoricalColumns[numberClasses] = true;
+
+        for (std::size_t t = 0; t < 5; ++t) {
+            core::stopDefaultAsyncExecutor();
+
+            TDoubleVec predictions;
+            TSizeVec category;
+            auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+            frame->categoricalColumns(categoricalColumns);
+            for (std::size_t i = 0; i < rows; ++i) {
+                frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                    rng.generateUniformSamples(0, numberClasses, 1, category);
+                    rng.generateNormalSamples(0.0, 1.0, numberClasses, predictions);
+                    for (std::size_t j = 0; j < numberClasses; ++j) {
+                        column[j] += predictions[j];
+                    }
+                    column[category[0]] += static_cast<double>(category[0] + 1);
+                    column[numberClasses] = static_cast<double>(category[0]);
+                });
+            }
+            frame->finishWritingRows();
+
+            TDoubleVecVec minRecalls(2, TDoubleVec(2));
+            TDoubleVecVec maxRecalls(2, TDoubleVec(2));
+
+            std::size_t i{0};
+            for (auto numberThreads : {1, 4}) {
+
+                auto weights = maths::CDataFrameUtils::maximumMinimumRecallClassWeights(
+                    numberThreads, *frame, maskAll(rows), numberClasses,
+                    numberClasses, readPrediction);
+
+                TDoubleVector prediction;
+                TDoubleVector correct[2]{TDoubleVector::Zero(numberClasses),
+                                         TDoubleVector::Zero(numberClasses)};
+                TDoubleVector counts{TDoubleVector::Zero(numberClasses)};
+
+                frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
+                                       core::CDataFrame::TRowItr endRows) {
+                    for (auto row = beginRows; row != endRows; ++row) {
+                        prediction = readPrediction(*row);
+                        maths::CTools::inplaceSoftmax(prediction);
+                        std::size_t weightedPredictedClass;
+                        weights.cwiseProduct(prediction).maxCoeff(&weightedPredictedClass);
+                        std::size_t actualClass{
+                            static_cast<std::size_t>((*row)[numberClasses])};
+                        if (weightedPredictedClass == actualClass) {
+                            correct[0](actualClass) += 1.0;
+                        }
+                        std::size_t unweightedPredictedClass;
+                        prediction.maxCoeff(&unweightedPredictedClass);
+                        if (unweightedPredictedClass == actualClass) {
+                            correct[1](actualClass) += 1.0;
+                        }
+                        counts(actualClass) += 1.0;
+                    }
+                });
+
+                LOG_TRACE(<< "weighted class recalls = "
+                          << correct[0].cwiseQuotient(counts).transpose());
+                LOG_TRACE(<< "unweighted class recalls = "
+                          << correct[1].cwiseQuotient(counts).transpose());
+
+                minRecalls[i][0] = correct[0].cwiseQuotient(counts).minCoeff();
+                maxRecalls[i][0] = correct[0].cwiseQuotient(counts).maxCoeff();
+                minRecalls[i][1] = correct[1].cwiseQuotient(counts).minCoeff();
+                maxRecalls[i][1] = correct[1].cwiseQuotient(counts).maxCoeff();
+
+                ++i;
+                core::startDefaultAsyncExecutor();
+            }
+
+            LOG_DEBUG(<< "min recalls = " << core::CContainerPrinter::print(minRecalls));
+            LOG_DEBUG(<< "max recalls = " << core::CContainerPrinter::print(maxRecalls));
+
+            // Threaded and non-threaded results are close.
+            BOOST_REQUIRE_CLOSE(minRecalls[0][0], minRecalls[1][0], 1.0); // 1 %
+
+            // We improved the minimum class recall by at least 10%.
+            BOOST_TEST_REQUIRE(minRecalls[0][0] > 1.1 * minRecalls[0][1]);
+
+            // The minimum and maximum class recalls are close: we're at the global minimum.
+            BOOST_TEST_REQUIRE(1.02 * minRecalls[0][0] > maxRecalls[0][0]);
+            BOOST_TEST_REQUIRE(1.02 * minRecalls[1][0] > maxRecalls[1][0]);
+        }
+    }
+
+    core::stopDefaultAsyncExecutor();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CToolsTest.cc
+++ b/lib/maths/unittest/CToolsTest.cc
@@ -1206,7 +1206,7 @@ BOOST_AUTO_TEST_CASE(testLgamma) {
     BOOST_REQUIRE_EQUAL(result, std::numeric_limits<double>::infinity());
 }
 
-BOOST_AUTO_TEST_CASE(testSoftMax) {
+BOOST_AUTO_TEST_CASE(testSoftmax) {
     // Test some invariants and that std::vector and maths::CDenseVector versions agree.
 
     using TDoubleVector = maths::CDenseVector<double>;
@@ -1227,6 +1227,35 @@ BOOST_AUTO_TEST_CASE(testSoftMax) {
         CTools::inplaceSoftmax(p_);
         for (std::size_t i = 0; i < 5; ++i) {
             BOOST_REQUIRE_CLOSE(p[i], p_[i], 1e-6);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testLogSoftmax) {
+    // Test some invariants and that std::vector and maths::CDenseVector versions agree.
+
+    using TDoubleVector = maths::CDenseVector<double>;
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec z;
+    for (std::size_t t = 0; t < 100; ++t) {
+
+        rng.generateUniformSamples(-3.0, 3.0, 5, z);
+        TDoubleVec p{z};
+        CTools::inplaceSoftmax(p);
+        TDoubleVec logP{z};
+        CTools::inplaceLogSoftmax(logP);
+
+        BOOST_TEST_REQUIRE(*std::max_element(logP.begin(), logP.end()) <= 0.0);
+        for (std::size_t i = 0; i < 5; ++i) {
+            BOOST_REQUIRE_CLOSE(std::log(p[i]), logP[i], 1e-6);
+        }
+
+        TDoubleVector logP_{TDoubleVector::fromStdVector(z)};
+        CTools::inplaceLogSoftmax(logP_);
+        for (std::size_t i = 0; i < 5; ++i) {
+            BOOST_REQUIRE_CLOSE(logP[i], logP_[i], 1e-6);
         }
     }
 }

--- a/lib/test/CDataFrameAnalyzerTrainingFactory.cc
+++ b/lib/test/CDataFrameAnalyzerTrainingFactory.cc
@@ -11,18 +11,17 @@ namespace test {
 
 void CDataFrameAnalyzerTrainingFactory::appendPrediction(core::CDataFrame&,
                                                          std::size_t,
-                                                         double prediction,
+                                                         const TDouble2Vec& prediction,
                                                          TDoubleVec& predictions) {
-    predictions.push_back(prediction);
+    predictions.push_back(prediction[0]);
 }
 
 void CDataFrameAnalyzerTrainingFactory::appendPrediction(core::CDataFrame& frame,
                                                          std::size_t target,
-                                                         double class1Score,
+                                                         const TDouble2Vec& scores,
                                                          TStrVec& predictions) {
-    predictions.push_back(class1Score < 0.5
-                              ? frame.categoricalColumnValues()[target][0]
-                              : frame.categoricalColumnValues()[target][1]);
+    std::size_t i(std::max_element(scores.begin(), scores.end()) - scores.begin());
+    predictions.push_back(frame.categoricalColumnValues()[target][i]);
 }
 
 CDataFrameAnalyzerTrainingFactory::TDataFrameUPtr


### PR DESCRIPTION
This implements maximise minimum class recall for multiclass classification when assigning class labels, which is often a better objective when classes are imbalanced in the training data.