### PR TITLE
[ML] Add getpriority/setpriority to Linux system call whitelist

### DIFF
--- a/lib/seccomp/CSystemCallFilter_Linux.cc
+++ b/lib/seccomp/CSystemCallFilter_Linux.cc
@@ -46,12 +46,14 @@ const struct sock_filter FILTER[] = {
     // Load the system call number into accumulator
     BPF_STMT(BPF_LD | BPF_W | BPF_ABS, SECCOMP_DATA_NR_OFFSET),
     // Only applies to X86_64 arch. Jump to disallow for calls using the x32 ABI
-    BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, UPPER_NR_LIMIT, 40, 0),
+    BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, UPPER_NR_LIMIT, 42, 0),
     // If any sys call filters are added or removed then the jump
     // destination for each statement including the one above must
     // be updated accordingly
 
     // Allowed sys calls, jump to return allow on match
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpriority, 42, 0), // for nice
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_setpriority, 41, 0), // for nice
     BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_read, 40, 0),
     BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 39, 0),
     BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_writev, 38, 0),


### PR DESCRIPTION
This is to support #1109.

The risk with setpriority is that it can possibly be used on a
different process.  However, it is extremely unlikely that the
user that Elasticsearch is running as in production will have
been granted permission to call it.  Running as root is banned
and it's an extra admin action to grant the privilege to any
other user and there is no good reason for it to have been
granted to the Elasticsearch user.