### PR TITLE
[ML] Fix off-by-one error in usurped categories

### DIFF
--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -324,7 +324,8 @@ private:
     TTokenListCategoryVec m_Categories;
 
     //! List of match count/index into category vector in descending order of
-    //! match count
+    //! match count.  Note that the second element is an index into m_Categories,
+    //! not a category ID.
     TSizeSizePrVec m_CategoriesByCount;
 
     //! Used for looking up tokens to a unique ID

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -179,6 +179,9 @@ bool CTokenListDataCategorizerBase::createReverseSearch(int categoryId,
                                                         std::string& part2,
                                                         std::size_t& maxMatchingLength,
                                                         bool& wasCached) {
+    wasCached = false;
+    maxMatchingLength = 0;
+
     if (m_ReverseSearchCreator == nullptr) {
         LOG_ERROR(<< "Cannot create reverse search - no reverse search creator");
 
@@ -200,9 +203,6 @@ bool CTokenListDataCategorizerBase::createReverseSearch(int categoryId,
             return false;
         }
 
-        // Ensure all reference arguments are set before returning true
-        wasCached = false;
-        maxMatchingLength = 0;
         return true;
     }
 

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
 #include <core/CRapidXmlParser.h>
 #include <core/CRapidXmlStatePersistInserter.h>
@@ -542,13 +543,13 @@ BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {
                                                        500));
 
     BOOST_REQUIRE_EQUAL(2, categorizer.numMatches(1));
-    std::vector<int> expected{2, 3, 4, 5, 6};
-    std::vector<int> actual = categorizer.usurpedCategories(1);
 
-    BOOST_REQUIRE_EQUAL(expected.size(), actual.size());
-    for (std::size_t i = 0; i < actual.size(); i++) {
-        BOOST_REQUIRE_EQUAL(expected[i], actual[i]);
-    }
+    using TIntVec = std::vector<int>;
+    TIntVec expected{2, 3, 4, 5, 6, 7};
+    TIntVec actual{categorizer.usurpedCategories(1)};
+
+    BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(expected),
+                        ml::core::CContainerPrinter::print(actual));
     checkMemoryUsageInstrumentation(categorizer);
 }
 


### PR DESCRIPTION
The mistake was that m_CategoriesByCount has indices into
m_Categories, not category IDs (which are one more than
the indices so that they start at 1 rather than 0).

Also fixed a couple of edge cases where reference arguments
were not being set despite a function returning success.

Fixes #1121