### PR TITLE
[ML] Reduce differences in regression and classification results between target platforms

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,173 +33,125 @@
 === Enhancements
 
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
-  or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {
-    ml - pull}867[#867].)
+  or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
 
 == {es} version 7.8.0
 
 === Enhancements
 
-* Speedup anomaly detection for the lat_long function. (See {
-    ml - pull}1102[#1102].)
+* Speedup anomaly detection for the lat_long function. (See {ml-pull}1102[#1102].)
 * Reduce CPU scheduling priority of native analysis processes to favor the ES JVM
-  when CPU is constrained. (See {
-    ml - pull}1109[#1109].)
+  when CPU is constrained. (See {ml-pull}1109[#1109].)
 * Take `training_percent` into account when estimating memory usage for classification and regression. 
-  (See {
-    ml - pull}1111[1111].)
-* Improve robustness of anomaly detection to bad input data. (See {
-    ml - pull}1114[#1114].)
+  (See {ml-pull}1111[1111].)
+* Support maximize minimum recall when assigning class labels for multiclass classification.
+  (See {ml-pull}1113[#1113].)
+* Improve robustness of anomaly detection to bad input data. (See {ml-pull}1114[#1114].)
 * Adds new `num_matches` and `preferred_to_categories` fields to category output.
-  (See {
-    ml - pull}1062[#1062])
+  (See {ml-pull}1062[#1062].)
 * Ensure classification and regression results agree for all our target operating systems.
-  (See {
-    ml - pull}1127[#1127].)
+  (See {ml-pull}1127[#1127].)
+
 
 == {es} version 7.7.0
 
 === New Features
 
 * Add instrumentation to report statistics related to data frame analytics jobs, i.e.
-progress, memory usage, etc. (See {
-    ml - pull}906[#906].)
-* Multiclass classification. (See {
-    ml - pull}1037[#1037].)
+progress, memory usage, etc. (See {ml-pull}906[#906].)
+* Multiclass classification. (See {ml-pull}1037[#1037].)
 
 === Enhancements
 
-* Improve computational performance of the feature importance computation. (See {
-    ml - pull}1005[1005].)
+* Improve computational performance of the feature importance computation. (See {ml-pull}1005[1005].)
 * Improve initialization of learn rate for better and more stable results in regression
-and classification. (See {
-    ml - pull}948[#948].)
+and classification. (See {ml-pull}948[#948].)
 * Add number of processed training samples to the definition of decision tree nodes.
-(See {
-    ml - pull}991[#991].)
-* Add new model_size_stats fields to instrument categorization.  (See {
-    ml - pull}948[#948]
-and {
-    pull}51879[#51879], issue: {
-    issue}50794[#50749].)
+(See {ml-pull}991[#991].)
+* Add new model_size_stats fields to instrument categorization.  (See {ml-pull}948[#948]
+and {pull}51879[#51879], issue: {issue}50794[#50749].)
 * Improve upfront memory estimation for all data frame analyses, which were higher than
 necessary. This will improve the allocation of data frame analyses to cluster nodes.
-(See {
-    ml - pull}1003[#1003].)
+(See {ml-pull}1003[#1003].)
 * Upgrade the compiler used on Linux from gcc 7.3 to gcc 7.5, and the binutils used in
-the build from version 2.20 to 2.34.  (See {
-    ml - pull}1013[#1013].)
+the build from version 2.20 to 2.34.  (See {ml-pull}1013[#1013].)
 * Add instrumentation of the peak memory consumption for data frame analytics jobs.
-(See {
-    ml - pull}1022[#1022].)
-* Remove all memory overheads for computing tree SHAP values. (See {
-    ml - pull}1023[#1023].)
+(See {ml-pull}1022[#1022].)
+* Remove all memory overheads for computing tree SHAP values. (See {ml-pull}1023[#1023].)
 * Distinguish between empty and missing categorical fields in classification and regression
-model training. (See {
-    ml - pull}1034[#1034].)
+model training. (See {ml-pull}1034[#1034].)
 * Add instrumentation information for supervised learning data frame analytics jobs.
-(See {
-    ml - pull}1031[#1031].)
+(See {ml-pull}1031[#1031].)
 * Add instrumentation information for outlier detection data frame analytics jobs.
-* Write out feature importance for multi-class models. (See {
-    ml - pull}1071[#1071])
+* Write out feature importance for multi-class models. (See {ml-pull}1071[#1071])
 * Enable system call filtering to the native process used with data frame analytics.
-(See {
-    ml - pull}1098[#1098])
+(See {ml-pull}1098[#1098])
 
 === Bug Fixes
 
 * Use largest ordered subset of categorization tokens for category reverse search regex.
-(See {
-    ml - pull}970[#970], issue: {
-    ml - issue}949[#949].)
+(See {ml-pull}970[#970], issue: {ml-issue}949[#949].)
 * Account for the data frame's memory when estimating the peak memory used by classification
-and regression model training. (See {
-    ml - pull}996[#996].)
+and regression model training. (See {ml-pull}996[#996].)
 * Rename classification and regression parameter maximum_number_trees to max_trees.
-(See {
-    ml - pull}1047[#1047].)
+(See {ml-pull}1047[#1047].)
 
 == {es} version 7.6.2
 
 === Bug Fixes
 
 * Fix a bug in the calculation of the minimum loss leaf values for classification.
-(See {
-    ml - pull}1032[#1032].)
+(See {ml-pull}1032[#1032].)
 
 == {es} version 7.6.0
 
 === New Features
 
 * Add feature importance values to classification and regression results (using tree
-SHapley Additive exPlanation, or SHAP). (See {
-    ml - pull}857[#857].)
+SHapley Additive exPlanation, or SHAP). (See {ml-pull}857[#857].)
 
 === Enhancements
 
 * Improve performance of boosted tree training for both classification and regression.
-(See {
-    ml - pull}775[#775].)
+(See {ml-pull}775[#775].)
 * Reduce the peak memory used by boosted tree training and fix an overcounting bug
-estimating maximum memory usage. (See {
-    ml - pull}781[#781].)
-* Stratified fractional cross validation for regression. (See {
-    ml - pull}784[#784].)
-* Added `geo_point` supported output for `lat_long` function records. (See {
-    ml - pull}809[#809]
-and {
-    pull}47050[#47050].)
+estimating maximum memory usage. (See {ml-pull}781[#781].)
+* Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
+* Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809]
+and {pull}47050[#47050].)
 * Use a random bag of the data to compute the loss function derivatives for each new
-tree which is trained for both regression and classification. (See {
-    ml - pull}811[#811].)
+tree which is trained for both regression and classification. (See {ml-pull}811[#811].)
 * Emit `prediction_probability` field alongside prediction field in ml results.
-(See {
-    ml - pull}818[#818].)
-* Reduce memory usage of {ml} native processes on Windows. (See {
-    ml - pull}844[#844].)
-* Reduce runtime of classification and regression. (See {
-    ml - pull}863[#863].)
+(See {ml-pull}818[#818].)
+* Reduce memory usage of {ml} native processes on Windows. (See {ml-pull}844[#844].)
+* Reduce runtime of classification and regression. (See {ml-pull}863[#863].)
 * Stop early training a classification and regression forest when the validation error
-is no longer decreasing. (See {
-    ml - pull}875[#875].)
+is no longer decreasing. (See {ml-pull}875[#875].)
 * Emit `prediction_field_name` in ml results using the type provided as
-`prediction_field_type` parameter. (See {
-    ml - pull}877[#877].)
-* Improve performance updating quantile estimates. (See {
-    ml - pull}881[#881].)
+`prediction_field_type` parameter. (See {ml-pull}877[#877].)
+* Improve performance updating quantile estimates. (See {ml-pull}881[#881].)
 * Migrate to use Bayesian Optimisation for initial hyperparameter value line searches and
-stop early if the expected improvement is too small. (See {
-    ml - pull}903[#903].)
+stop early if the expected improvement is too small. (See {ml-pull}903[#903].)
 * Stop cross-validation early if the predicted test loss has a small chance of being
-smaller than for the best parameter values found so far. (See {
-    ml - pull}915[#915].)
+smaller than for the best parameter values found so far. (See {ml-pull}915[#915].)
 * Optimize decision threshold for classification to maximize minimum class recall.
-(See {
-    ml - pull}926[#926].)
+(See {ml-pull}926[#926].)
 * Include categorization memory usage in the `model_bytes` field in `model_size_stats`,
-so that it is taken into account in node assignment decisions. (See {
-    ml - pull}927[#927],
-issue: {
-    ml - issue}724[#724].)
+so that it is taken into account in node assignment decisions. (See {ml-pull}927[#927],
+issue: {ml-issue}724[#724].)
 
 === Bug Fixes
-* Fixes potential memory corruption when determining seasonality. (See {
-    ml - pull}852[#852].)
+* Fixes potential memory corruption when determining seasonality. (See {ml-pull}852[#852].)
 * Prevent prediction_field_name clashing with other fields in ml results.
-(See {
-    ml - pull}861[#861].)
+(See {ml-pull}861[#861].)
 * Include out-of-order as well as in-order terms in categorization reverse searches.
-(See {
-    ml - pull}950[#950], issue: {
-    ml - issue}949[#949].)
+(See {ml-pull}950[#950], issue: {ml-issue}949[#949].)
 
 == {es} version 7.5.2
 
 === Bug Fixes
 * Fixes potential memory corruption or inconsistent state when background persisting
-categorizer state. (See {
-    ml - pull}921[#921].)
+categorizer state. (See {ml-pull}921[#921].)
 
 == {es} version 7.5.0
 
@@ -207,59 +159,47 @@ categorizer state. (See {
 
 * Improve performance and concurrency training boosted tree regression models.
 For large data sets this change was observed to give a 10% to 20% decrease in
-train time. (See {
-    ml - pull}622[#622].)
-* Upgrade Boost libraries to version 1.71. (See {
-    ml - pull}638[#638].)
+train time. (See {ml-pull}622[#622].)
+* Upgrade Boost libraries to version 1.71. (See {ml-pull}638[#638].)
 * Improve initialisation of boosted tree training. This generally enables us to
-find lower loss models faster. (See {
-    ml - pull}686[#686].)
+find lower loss models faster. (See {ml-pull}686[#686].)
 * Include a smooth tree depth based penalty to regularized objective function for
 boosted tree training. Hard depth based regularization is often the strategy of
 choice to prevent over fitting for XGBoost. By smoothing we can make better tradeoffs.
 Also, the parameters of the penalty function are mode suited to optimising with our
-Bayesian optimisation based hyperparameter search. (See {
-    ml - pull}698[#698].)
-* Binomial logistic regression targeting cross entropy. (See {
-    ml - pull}713[#713].) 
+Bayesian optimisation based hyperparameter search. (See {ml-pull}698[#698].)
+* Binomial logistic regression targeting cross entropy. (See {ml-pull}713[#713].) 
 * Improvements to count and sum anomaly detection for sparse data. This primarily
 aims to improve handling of data which are predictably present: detecting when they
-are unexpectedly missing. (See {
-    ml - pull}721[#721].)
+are unexpectedly missing. (See {ml-pull}721[#721].)
 * Trap numeric errors causing bad hyperparameter search initialisation and repeated
-errors to be logged during boosted tree training. (See {
-    ml - pull}732[#732].)
+errors to be logged during boosted tree training. (See {ml-pull}732[#732].)
 
 === Bug Fixes
 
 * Restore from checkpoint could damage seasonality modeling. For example, it could
-cause seasonal components to be overwritten in error. (See {
-    ml - pull}821[#821].)
+cause seasonal components to be overwritten in error. (See {ml-pull}821[#821].)
 
 == {es} version 7.4.1
 
 === Enhancements
 
 * The {ml} native processes are now arranged in a .app directory structure on
-  macOS, to allow for notarization on macOS Catalina. (See {
-    ml - pull}593[#593].)
+  macOS, to allow for notarization on macOS Catalina. (See {ml-pull}593[#593].)
 
 === Bug Fixes
 
 * A reference to a temporary variable was causing forecast model restoration to fail.
-The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {
-    ml - pull}688[#688].)
+The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {ml-pull}688[#688].)
 
 == {es} version 7.4.0
 
 === Bug Fixes
 
 * Rename outlier detection method values knn and tnn to distance_kth_nn and distance_knn
-respectively to match the API. (See {
-    ml - pull}598[#598].)
+respectively to match the API. (See {ml-pull}598[#598].)
 * Fix occasional (non-deterministic) reinitialisation of modelling for the lat_long
-function. (See {
-    ml - pull}641[#641].)
+function. (See {ml-pull}641[#641].)
 
 == {es} version 7.3.1
 
@@ -269,125 +209,93 @@ function. (See {
 Previously, if rows were excluded from the data frame after supplying the row count
 in the configuration then we detected the inconsistency and failed outlier detection.
 However, this legitimately happens in case where the field values are non-numeric or
-array valued. (See {
-    ml - pull}569[#569].)
+array valued. (See {ml-pull}569[#569].)
 
 == {es} version 7.3.0
 
 === Enhancements
 
-* Upgrade to a newer version of the Apache Portable Runtime library. (See {
-    ml - pull}495[#495].)
-* Improve stability of modelling around change points. (See {
-    ml - pull}496[#496].)
+* Upgrade to a newer version of the Apache Portable Runtime library. (See {ml-pull}495[#495].)
+* Improve stability of modelling around change points. (See {ml-pull}496[#496].)
 
 === Bug Fixes
 
-* Reduce false positives associated with the multi-bucket feature. (See {
-    ml - pull}491[#491].)
-* Reduce false positives for sum and count functions on sparse data. (See {
-    ml - pull}492[#492].)
+* Reduce false positives associated with the multi-bucket feature. (See {ml-pull}491[#491].)
+* Reduce false positives for sum and count functions on sparse data. (See {ml-pull}492[#492].)
 
 == {es} version 7.2.1
 
 === Bug Fixes
 
 * Fix an edge case causing spurious anomalies (false positives) if the variance in the count of events
-changed significantly throughout the period of a seasonal quantity. (See {
-    ml - pull}489[#489].)
+changed significantly throughout the period of a seasonal quantity. (See {ml-pull}489[#489].)
 
 == {es} version 7.2.0
 
 === Enhancements
 
 * Remove hard limit for maximum forecast interval and limit based on the time interval of data added
-to the model. (See {
-    ml - pull}214[#214].)
+to the model. (See {ml-pull}214[#214].)
 
-* Use hardened compiler options to build 3rd party libraries. (See {
-    ml - pull}453[#453].)
+* Use hardened compiler options to build 3rd party libraries. (See {ml-pull}453[#453].)
 
 * Only select more complex trend models for forecasting if there is evidence that they are needed.
-(See {
-    ml - pull}463[#463].)
+(See {ml-pull}463[#463].)
 
-* Improve residual model selection. (See {
-    ml - pull}468[#468].)
+* Improve residual model selection. (See {ml-pull}468[#468].)
 
-* Stop linking to libcrypt on Linux. (See {
-    ml - pull}480[#480].)
+* Stop linking to libcrypt on Linux. (See {ml-pull}480[#480].)
 
-* Improvements to hard_limit audit message. (See {
-    ml - pull}486[#486].)
+* Improvements to hard_limit audit message. (See {ml-pull}486[#486].)
 
 === Bug Fixes
 
-* Handle NaNs when detrending seasonal components. {
-    ml - pull
-}
-408 [#408]
+* Handle NaNs when detrending seasonal components. {ml-pull}408[#408]
 
-    == {es} version 7.0.0 - alpha2
+== {es} version 7.0.0-alpha2
 
-    ==
-    = Bug Fixes
+=== Bug Fixes
 
-      * Fixes CPoissonMeanConjugate sampling error.{
-    ml - pull
-}
-335 [#335]
-    //NOTE: Remove from final 7.0.0 release notes if already in 6.x
+* Fixes CPoissonMeanConjugate sampling error. {ml-pull}335[#335]
+//NOTE: Remove from final 7.0.0 release notes if already in 6.x
 
-    * Ensure statics are persisted in a consistent manner {
-    ml - pull
-}
-360 [#360]
+* Ensure statics are persisted in a consistent manner {ml-pull}360[#360]
 
-    == {es} version 7.0.0 - alpha1
+== {es} version 7.0.0-alpha1
 
-    == {es} version 6.8.4
+== {es} version 6.8.4
 
-    == = Bug Fixes
+=== Bug Fixes
 
-                 * A reference to a temporary variable was causing forecast model restoration
-                       to fail.The bug exhibited itself on MacOS builds with versions of clangd >
-             10.0.0.(See { ml - pull } 688 [#688].)
+* A reference to a temporary variable was causing forecast model restoration to fail.
+The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {ml-pull}688[#688].)
 
-         == {es} version 6.8.2
+== {es} version 6.8.2
 
-         == = Bug Fixes
+=== Bug Fixes
 
-                  * Don't write model size stats when job is closed without any input {ml-pull}512[#512] (issue: {ml-issue}394[#394]) * Don't persist model state at the end of lookback if the lookback did not generate any input {ml-pull}521[#521] (issue: {ml-issue}519[#519])
+* Don't write model size stats when job is closed without any input {ml-pull}512[#512] (issue: {ml-issue}394[#394])
+* Don't persist model state at the end of lookback if the lookback did not generate any input {ml-pull}521[#521] (issue: {ml-issue}519[#519])
 
-              == {es} version 6.7.2
+== {es} version 6.7.2
 
-              == = Enhancements
+=== Enhancements
 
-                   * Adjust seccomp filter to allow the "time" system call {
-    ml - pull
-}459[#459]
+* Adjust seccomp filter to allow the "time" system call {ml-pull}459[#459]
 
 == {es} version 6.7.0
 
 === Bug Fixes
 
-* Improve autodetect logic for persistence. {
-    ml - pull
-}437[#437]
+* Improve autodetect logic for persistence. {ml-pull}437[#437]
 
 == {es} version 6.6.2
 
 === Enhancements
 
-* Adjust seccomp filter for Fedora 29. {
-    ml - pull
-}
-354 [#354]
+* Adjust seccomp filter for Fedora 29. {ml-pull}354[#354]
 
-    == = Bug Fixes
+=== Bug Fixes
 
-         * Fixes an issue where interim results would be calculated after
-               advancing time into an empty bucket.{
-    ml - pull
-}
-416 [#416]
+* Fixes an issue where interim results would be calculated after advancing time into an empty bucket. {ml-pull}416[#416]
+

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,122 +33,173 @@
 === Enhancements
 
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
-  or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
+  or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {
+    ml - pull}867[#867].)
 
 == {es} version 7.8.0
 
 === Enhancements
 
-* Speedup anomaly detection for the lat_long function. (See {ml-pull}1102[#1102].)
+* Speedup anomaly detection for the lat_long function. (See {
+    ml - pull}1102[#1102].)
 * Reduce CPU scheduling priority of native analysis processes to favor the ES JVM
-  when CPU is constrained. (See {ml-pull}1109[#1109].)
+  when CPU is constrained. (See {
+    ml - pull}1109[#1109].)
 * Take `training_percent` into account when estimating memory usage for classification and regression. 
-  (See {ml-pull}1111[1111].)
-* Improve robustness of anomaly detection to bad input data. (See {ml-pull}1114[#1114].)
+  (See {
+    ml - pull}1111[1111].)
+* Improve robustness of anomaly detection to bad input data. (See {
+    ml - pull}1114[#1114].)
 * Adds new `num_matches` and `preferred_to_categories` fields to category output.
-  (See {ml-pull}1062[#1062])
+  (See {
+    ml - pull}1062[#1062])
 * Ensure classification and regression results agree for all our target operating systems.
-  (See {ml-pull}1127[1127].)
+  (See {
+    ml - pull}1127[#1127].)
 
 == {es} version 7.7.0
 
 === New Features
 
 * Add instrumentation to report statistics related to data frame analytics jobs, i.e.
-progress, memory usage, etc. (See {ml-pull}906[#906].)
-* Multiclass classification. (See {ml-pull}1037[#1037].)
+progress, memory usage, etc. (See {
+    ml - pull}906[#906].)
+* Multiclass classification. (See {
+    ml - pull}1037[#1037].)
 
 === Enhancements
 
-* Improve computational performance of the feature importance computation. (See {ml-pull}1005[1005].)
+* Improve computational performance of the feature importance computation. (See {
+    ml - pull}1005[1005].)
 * Improve initialization of learn rate for better and more stable results in regression
-and classification. (See {ml-pull}948[#948].)
+and classification. (See {
+    ml - pull}948[#948].)
 * Add number of processed training samples to the definition of decision tree nodes.
-(See {ml-pull}991[#991].)
-* Add new model_size_stats fields to instrument categorization.  (See {ml-pull}948[#948]
-and {pull}51879[#51879], issue: {issue}50794[#50749].)
+(See {
+    ml - pull}991[#991].)
+* Add new model_size_stats fields to instrument categorization.  (See {
+    ml - pull}948[#948]
+and {
+    pull}51879[#51879], issue: {
+    issue}50794[#50749].)
 * Improve upfront memory estimation for all data frame analyses, which were higher than
 necessary. This will improve the allocation of data frame analyses to cluster nodes.
-(See {ml-pull}1003[#1003].)
+(See {
+    ml - pull}1003[#1003].)
 * Upgrade the compiler used on Linux from gcc 7.3 to gcc 7.5, and the binutils used in
-the build from version 2.20 to 2.34.  (See {ml-pull}1013[#1013].)
+the build from version 2.20 to 2.34.  (See {
+    ml - pull}1013[#1013].)
 * Add instrumentation of the peak memory consumption for data frame analytics jobs.
-(See {ml-pull}1022[#1022].)
-* Remove all memory overheads for computing tree SHAP values. (See {ml-pull}1023[#1023].)
+(See {
+    ml - pull}1022[#1022].)
+* Remove all memory overheads for computing tree SHAP values. (See {
+    ml - pull}1023[#1023].)
 * Distinguish between empty and missing categorical fields in classification and regression
-model training. (See {ml-pull}1034[#1034].)
+model training. (See {
+    ml - pull}1034[#1034].)
 * Add instrumentation information for supervised learning data frame analytics jobs.
-(See {ml-pull}1031[#1031].)
+(See {
+    ml - pull}1031[#1031].)
 * Add instrumentation information for outlier detection data frame analytics jobs.
-* Write out feature importance for multi-class models. (See {ml-pull}1071[#1071])
+* Write out feature importance for multi-class models. (See {
+    ml - pull}1071[#1071])
 * Enable system call filtering to the native process used with data frame analytics.
-(See {ml-pull}1098[#1098])
+(See {
+    ml - pull}1098[#1098])
 
 === Bug Fixes
 
 * Use largest ordered subset of categorization tokens for category reverse search regex.
-(See {ml-pull}970[#970], issue: {ml-issue}949[#949].)
+(See {
+    ml - pull}970[#970], issue: {
+    ml - issue}949[#949].)
 * Account for the data frame's memory when estimating the peak memory used by classification
-and regression model training. (See {ml-pull}996[#996].)
+and regression model training. (See {
+    ml - pull}996[#996].)
 * Rename classification and regression parameter maximum_number_trees to max_trees.
-(See {ml-pull}1047[#1047].)
+(See {
+    ml - pull}1047[#1047].)
 
 == {es} version 7.6.2
 
 === Bug Fixes
 
 * Fix a bug in the calculation of the minimum loss leaf values for classification.
-(See {ml-pull}1032[#1032].)
+(See {
+    ml - pull}1032[#1032].)
 
 == {es} version 7.6.0
 
 === New Features
 
 * Add feature importance values to classification and regression results (using tree
-SHapley Additive exPlanation, or SHAP). (See {ml-pull}857[#857].)
+SHapley Additive exPlanation, or SHAP). (See {
+    ml - pull}857[#857].)
 
 === Enhancements
 
 * Improve performance of boosted tree training for both classification and regression.
-(See {ml-pull}775[#775].)
+(See {
+    ml - pull}775[#775].)
 * Reduce the peak memory used by boosted tree training and fix an overcounting bug
-estimating maximum memory usage. (See {ml-pull}781[#781].)
-* Stratified fractional cross validation for regression. (See {ml-pull}784[#784].)
-* Added `geo_point` supported output for `lat_long` function records. (See {ml-pull}809[#809]
-and {pull}47050[#47050].)
+estimating maximum memory usage. (See {
+    ml - pull}781[#781].)
+* Stratified fractional cross validation for regression. (See {
+    ml - pull}784[#784].)
+* Added `geo_point` supported output for `lat_long` function records. (See {
+    ml - pull}809[#809]
+and {
+    pull}47050[#47050].)
 * Use a random bag of the data to compute the loss function derivatives for each new
-tree which is trained for both regression and classification. (See {ml-pull}811[#811].)
+tree which is trained for both regression and classification. (See {
+    ml - pull}811[#811].)
 * Emit `prediction_probability` field alongside prediction field in ml results.
-(See {ml-pull}818[#818].)
-* Reduce memory usage of {ml} native processes on Windows. (See {ml-pull}844[#844].)
-* Reduce runtime of classification and regression. (See {ml-pull}863[#863].)
+(See {
+    ml - pull}818[#818].)
+* Reduce memory usage of {ml} native processes on Windows. (See {
+    ml - pull}844[#844].)
+* Reduce runtime of classification and regression. (See {
+    ml - pull}863[#863].)
 * Stop early training a classification and regression forest when the validation error
-is no longer decreasing. (See {ml-pull}875[#875].)
+is no longer decreasing. (See {
+    ml - pull}875[#875].)
 * Emit `prediction_field_name` in ml results using the type provided as
-`prediction_field_type` parameter. (See {ml-pull}877[#877].)
-* Improve performance updating quantile estimates. (See {ml-pull}881[#881].)
+`prediction_field_type` parameter. (See {
+    ml - pull}877[#877].)
+* Improve performance updating quantile estimates. (See {
+    ml - pull}881[#881].)
 * Migrate to use Bayesian Optimisation for initial hyperparameter value line searches and
-stop early if the expected improvement is too small. (See {ml-pull}903[#903].)
+stop early if the expected improvement is too small. (See {
+    ml - pull}903[#903].)
 * Stop cross-validation early if the predicted test loss has a small chance of being
-smaller than for the best parameter values found so far. (See {ml-pull}915[#915].)
+smaller than for the best parameter values found so far. (See {
+    ml - pull}915[#915].)
 * Optimize decision threshold for classification to maximize minimum class recall.
-(See {ml-pull}926[#926].)
+(See {
+    ml - pull}926[#926].)
 * Include categorization memory usage in the `model_bytes` field in `model_size_stats`,
-so that it is taken into account in node assignment decisions. (See {ml-pull}927[#927],
-issue: {ml-issue}724[#724].)
+so that it is taken into account in node assignment decisions. (See {
+    ml - pull}927[#927],
+issue: {
+    ml - issue}724[#724].)
 
 === Bug Fixes
-* Fixes potential memory corruption when determining seasonality. (See {ml-pull}852[#852].)
+* Fixes potential memory corruption when determining seasonality. (See {
+    ml - pull}852[#852].)
 * Prevent prediction_field_name clashing with other fields in ml results.
-(See {ml-pull}861[#861].)
+(See {
+    ml - pull}861[#861].)
 * Include out-of-order as well as in-order terms in categorization reverse searches.
-(See {ml-pull}950[#950], issue: {ml-issue}949[#949].)
+(See {
+    ml - pull}950[#950], issue: {
+    ml - issue}949[#949].)
 
 == {es} version 7.5.2
 
 === Bug Fixes
 * Fixes potential memory corruption or inconsistent state when background persisting
-categorizer state. (See {ml-pull}921[#921].)
+categorizer state. (See {
+    ml - pull}921[#921].)
 
 == {es} version 7.5.0
 
@@ -156,47 +207,59 @@ categorizer state. (See {ml-pull}921[#921].)
 
 * Improve performance and concurrency training boosted tree regression models.
 For large data sets this change was observed to give a 10% to 20% decrease in
-train time. (See {ml-pull}622[#622].)
-* Upgrade Boost libraries to version 1.71. (See {ml-pull}638[#638].)
+train time. (See {
+    ml - pull}622[#622].)
+* Upgrade Boost libraries to version 1.71. (See {
+    ml - pull}638[#638].)
 * Improve initialisation of boosted tree training. This generally enables us to
-find lower loss models faster. (See {ml-pull}686[#686].)
+find lower loss models faster. (See {
+    ml - pull}686[#686].)
 * Include a smooth tree depth based penalty to regularized objective function for
 boosted tree training. Hard depth based regularization is often the strategy of
 choice to prevent over fitting for XGBoost. By smoothing we can make better tradeoffs.
 Also, the parameters of the penalty function are mode suited to optimising with our
-Bayesian optimisation based hyperparameter search. (See {ml-pull}698[#698].)
-* Binomial logistic regression targeting cross entropy. (See {ml-pull}713[#713].) 
+Bayesian optimisation based hyperparameter search. (See {
+    ml - pull}698[#698].)
+* Binomial logistic regression targeting cross entropy. (See {
+    ml - pull}713[#713].) 
 * Improvements to count and sum anomaly detection for sparse data. This primarily
 aims to improve handling of data which are predictably present: detecting when they
-are unexpectedly missing. (See {ml-pull}721[#721].)
+are unexpectedly missing. (See {
+    ml - pull}721[#721].)
 * Trap numeric errors causing bad hyperparameter search initialisation and repeated
-errors to be logged during boosted tree training. (See {ml-pull}732[#732].)
+errors to be logged during boosted tree training. (See {
+    ml - pull}732[#732].)
 
 === Bug Fixes
 
 * Restore from checkpoint could damage seasonality modeling. For example, it could
-cause seasonal components to be overwritten in error. (See {ml-pull}821[#821].)
+cause seasonal components to be overwritten in error. (See {
+    ml - pull}821[#821].)
 
 == {es} version 7.4.1
 
 === Enhancements
 
 * The {ml} native processes are now arranged in a .app directory structure on
-  macOS, to allow for notarization on macOS Catalina. (See {ml-pull}593[#593].)
+  macOS, to allow for notarization on macOS Catalina. (See {
+    ml - pull}593[#593].)
 
 === Bug Fixes
 
 * A reference to a temporary variable was causing forecast model restoration to fail.
-The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {ml-pull}688[#688].)
+The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {
+    ml - pull}688[#688].)
 
 == {es} version 7.4.0
 
 === Bug Fixes
 
 * Rename outlier detection method values knn and tnn to distance_kth_nn and distance_knn
-respectively to match the API. (See {ml-pull}598[#598].)
+respectively to match the API. (See {
+    ml - pull}598[#598].)
 * Fix occasional (non-deterministic) reinitialisation of modelling for the lat_long
-function. (See {ml-pull}641[#641].)
+function. (See {
+    ml - pull}641[#641].)
 
 == {es} version 7.3.1
 
@@ -206,93 +269,125 @@ function. (See {ml-pull}641[#641].)
 Previously, if rows were excluded from the data frame after supplying the row count
 in the configuration then we detected the inconsistency and failed outlier detection.
 However, this legitimately happens in case where the field values are non-numeric or
-array valued. (See {ml-pull}569[#569].)
+array valued. (See {
+    ml - pull}569[#569].)
 
 == {es} version 7.3.0
 
 === Enhancements
 
-* Upgrade to a newer version of the Apache Portable Runtime library. (See {ml-pull}495[#495].)
-* Improve stability of modelling around change points. (See {ml-pull}496[#496].)
+* Upgrade to a newer version of the Apache Portable Runtime library. (See {
+    ml - pull}495[#495].)
+* Improve stability of modelling around change points. (See {
+    ml - pull}496[#496].)
 
 === Bug Fixes
 
-* Reduce false positives associated with the multi-bucket feature. (See {ml-pull}491[#491].)
-* Reduce false positives for sum and count functions on sparse data. (See {ml-pull}492[#492].)
+* Reduce false positives associated with the multi-bucket feature. (See {
+    ml - pull}491[#491].)
+* Reduce false positives for sum and count functions on sparse data. (See {
+    ml - pull}492[#492].)
 
 == {es} version 7.2.1
 
 === Bug Fixes
 
 * Fix an edge case causing spurious anomalies (false positives) if the variance in the count of events
-changed significantly throughout the period of a seasonal quantity. (See {ml-pull}489[#489].)
+changed significantly throughout the period of a seasonal quantity. (See {
+    ml - pull}489[#489].)
 
 == {es} version 7.2.0
 
 === Enhancements
 
 * Remove hard limit for maximum forecast interval and limit based on the time interval of data added
-to the model. (See {ml-pull}214[#214].)
+to the model. (See {
+    ml - pull}214[#214].)
 
-* Use hardened compiler options to build 3rd party libraries. (See {ml-pull}453[#453].)
+* Use hardened compiler options to build 3rd party libraries. (See {
+    ml - pull}453[#453].)
 
 * Only select more complex trend models for forecasting if there is evidence that they are needed.
-(See {ml-pull}463[#463].)
+(See {
+    ml - pull}463[#463].)
 
-* Improve residual model selection. (See {ml-pull}468[#468].)
+* Improve residual model selection. (See {
+    ml - pull}468[#468].)
 
-* Stop linking to libcrypt on Linux. (See {ml-pull}480[#480].)
+* Stop linking to libcrypt on Linux. (See {
+    ml - pull}480[#480].)
 
-* Improvements to hard_limit audit message. (See {ml-pull}486[#486].)
-
-=== Bug Fixes
-
-* Handle NaNs when detrending seasonal components. {ml-pull}408[#408]
-
-== {es} version 7.0.0-alpha2
+* Improvements to hard_limit audit message. (See {
+    ml - pull}486[#486].)
 
 === Bug Fixes
 
-* Fixes CPoissonMeanConjugate sampling error. {ml-pull}335[#335]
-//NOTE: Remove from final 7.0.0 release notes if already in 6.x
+* Handle NaNs when detrending seasonal components. {
+    ml - pull
+}
+408 [#408]
 
-* Ensure statics are persisted in a consistent manner {ml-pull}360[#360]
+    == {es} version 7.0.0 - alpha2
 
-== {es} version 7.0.0-alpha1
+    ==
+    = Bug Fixes
 
-== {es} version 6.8.4
+      * Fixes CPoissonMeanConjugate sampling error.{
+    ml - pull
+}
+335 [#335]
+    //NOTE: Remove from final 7.0.0 release notes if already in 6.x
 
-=== Bug Fixes
+    * Ensure statics are persisted in a consistent manner {
+    ml - pull
+}
+360 [#360]
 
-* A reference to a temporary variable was causing forecast model restoration to fail.
-The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See {ml-pull}688[#688].)
+    == {es} version 7.0.0 - alpha1
 
-== {es} version 6.8.2
+    == {es} version 6.8.4
 
-=== Bug Fixes
+    == = Bug Fixes
 
-* Don't write model size stats when job is closed without any input {ml-pull}512[#512] (issue: {ml-issue}394[#394])
-* Don't persist model state at the end of lookback if the lookback did not generate any input {ml-pull}521[#521] (issue: {ml-issue}519[#519])
+                 * A reference to a temporary variable was causing forecast model restoration
+                       to fail.The bug exhibited itself on MacOS builds with versions of clangd >
+             10.0.0.(See { ml - pull } 688 [#688].)
 
-== {es} version 6.7.2
+         == {es} version 6.8.2
 
-=== Enhancements
+         == = Bug Fixes
 
-* Adjust seccomp filter to allow the "time" system call {ml-pull}459[#459]
+                  * Don't write model size stats when job is closed without any input {ml-pull}512[#512] (issue: {ml-issue}394[#394]) * Don't persist model state at the end of lookback if the lookback did not generate any input {ml-pull}521[#521] (issue: {ml-issue}519[#519])
+
+              == {es} version 6.7.2
+
+              == = Enhancements
+
+                   * Adjust seccomp filter to allow the "time" system call {
+    ml - pull
+}459[#459]
 
 == {es} version 6.7.0
 
 === Bug Fixes
 
-* Improve autodetect logic for persistence. {ml-pull}437[#437]
+* Improve autodetect logic for persistence. {
+    ml - pull
+}437[#437]
 
 == {es} version 6.6.2
 
 === Enhancements
 
-* Adjust seccomp filter for Fedora 29. {ml-pull}354[#354]
+* Adjust seccomp filter for Fedora 29. {
+    ml - pull
+}
+354 [#354]
 
-=== Bug Fixes
+    == = Bug Fixes
 
-* Fixes an issue where interim results would be calculated after advancing time into an empty bucket. {ml-pull}416[#416]
-
+         * Fixes an issue where interim results would be calculated after
+               advancing time into an empty bucket.{
+    ml - pull
+}
+416 [#416]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@
 * Improve robustness of anomaly detection to bad input data. (See {ml-pull}1114[#1114].)
 * Adds new `num_matches` and `preferred_to_categories` fields to category output.
   (See {ml-pull}1062[#1062])
+* Ensure classification and regression results agree for all our target operating systems.
+  (See {ml-pull}1127[1127].)
 
 == {es} version 7.7.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -49,7 +49,7 @@
 * Improve robustness of anomaly detection to bad input data. (See {ml-pull}1114[#1114].)
 * Adds new `num_matches` and `preferred_to_categories` fields to category output.
   (See {ml-pull}1062[#1062].)
-* Ensure classification and regression results agree for all our target operating systems.
+* Reduce variability of classification and regression results across our target operating systems.
   (See {ml-pull}1127[#1127].)
 
 == {es} version 7.7.0

--- a/include/core/CIEEE754.h
+++ b/include/core/CIEEE754.h
@@ -9,8 +9,8 @@
 
 #include <core/ImportExport.h>
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 namespace ml {
 namespace core {
@@ -40,14 +40,14 @@ public:
     //! as an integer.
     //! \note The actual "exponent" is "exponent - 1022" in two's complement.
     struct SDoubleRep {
-#ifdef __sparc                    // Add any other big endian architectures
-        uint64_t s_Sign : 1;      // sign bit
-        uint64_t s_Exponent : 11; // exponent
-        uint64_t s_Mantissa : 52; // mantissa
+#ifdef __sparc                         // Add any other big endian architectures
+        std::uint64_t s_Sign : 1;      // sign bit
+        std::uint64_t s_Exponent : 11; // exponent
+        std::uint64_t s_Mantissa : 52; // mantissa
 #else
-        uint64_t s_Mantissa : 52; // mantissa
-        uint64_t s_Exponent : 11; // exponent
-        uint64_t s_Sign : 1;      // sign bit
+        std::uint64_t s_Mantissa : 52; // mantissa
+        std::uint64_t s_Exponent : 11; // exponent
+        std::uint64_t s_Sign : 1;      // sign bit
 #endif
     };
 
@@ -57,15 +57,19 @@ public:
     //!
     //! \note This is closely related to std::frexp for double but returns
     //! the mantissa interpreted as an integer.
-    static void decompose(double value, uint64_t& mantissa, int& exponent) {
+    static void decompose(double value, std::uint64_t& mantissa, int& exponent) {
         SDoubleRep parsed;
         static_assert(sizeof(double) == sizeof(SDoubleRep),
                       "SDoubleRep definition unsuitable for memcpy to double");
         // Use memcpy() rather than union to adhere to strict aliasing rules
-        ::memcpy(&parsed, &value, sizeof(double));
+        std::memcpy(&parsed, &value, sizeof(double));
         exponent = static_cast<int>(parsed.s_Exponent) - 1022;
         mantissa = parsed.s_Mantissa;
     }
+
+    //! Drop \p bits trailing bits from the mantissa of \p value in a stable way
+    //! for different operating systems.
+    static double dropbits(double value, int bits);
 };
 }
 }

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -459,7 +459,8 @@ private:
 
         bool operator<(const SSplitStatistics& rhs) const {
             return COrderings::lexicographical_compare(
-                s_Gain, s_Curvature, s_Feature, rhs.s_Gain, rhs.s_Curvature, rhs.s_Feature);
+                s_Gain, s_Curvature, s_Feature, s_SplitAt, // <- lhs
+                rhs.s_Gain, rhs.s_Curvature, rhs.s_Feature, rhs.s_SplitAt);
         }
 
         std::string print() const {

--- a/include/maths/CLbfgs.h
+++ b/include/maths/CLbfgs.h
@@ -302,7 +302,7 @@ private:
         return m_BacktrackingMinDecrease * s * las::inner(m_Gx, m_P) / las::norm(m_P);
     }
 
-    constexpr double minimumStepSize() const {
+    double minimumStepSize() const {
         return std::pow(m_StepScale, static_cast<double>(MAXIMUM_BACK_TRACKING_ITERATIONS));
     }
 

--- a/include/maths/CLbfgs.h
+++ b/include/maths/CLbfgs.h
@@ -8,6 +8,7 @@
 #define INCLUDED_ml_maths_CLbfgs_h
 
 #include <maths/CLinearAlgebraShims.h>
+#include <maths/CTools.h>
 
 #include <boost/circular_buffer.hpp>
 
@@ -303,7 +304,8 @@ private:
     }
 
     double minimumStepSize() const {
-        return std::pow(m_StepScale, static_cast<double>(MAXIMUM_BACK_TRACKING_ITERATIONS));
+        return CTools::stable(std::pow(
+            m_StepScale, static_cast<double>(MAXIMUM_BACK_TRACKING_ITERATIONS)));
     }
 
 private:

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -22,6 +22,7 @@
 #include <boost/static_assert.hpp>
 
 #include <array>
+#include <cinttypes>
 #include <cmath>
 #include <cstring>
 #include <iosfwd>
@@ -456,7 +457,7 @@ private:
             //      (interpreted as an integer) to the corresponding
             //      double value and fastLog uses the same approach
             //      to extract the mantissa.
-            uint64_t dx = 0x10000000000000ull / BINS;
+            std::uint64_t dx = 0x10000000000000ull / BINS;
             core::CIEEE754::SDoubleRep x;
             x.s_Sign = 0;
             x.s_Mantissa = (dx / 2) & core::CIEEE754::IEEE754_MANTISSA_MASK;
@@ -469,12 +470,12 @@ private:
                 // Use memcpy() rather than union to adhere to strict
                 // aliasing rules
                 std::memcpy(&value, &x, sizeof(double));
-                m_Table[i] = std::log2(value);
+                m_Table[i] = stable(std::log2(value));
             }
         }
 
         //! Lookup log2 for a given mantissa.
-        const double& operator[](uint64_t mantissa) const {
+        const double& operator[](std::uint64_t mantissa) const {
             return m_Table[mantissa >> FAST_LOG_SHIFT];
         }
 
@@ -494,7 +495,7 @@ public:
     //! \note This is taken from the approach given in
     //! http://www.icsi.berkeley.edu/pubs/techreports/TR-07-002.pdf
     static double fastLog(double x) {
-        uint64_t mantissa;
+        std::uint64_t mantissa;
         int log2;
         core::CIEEE754::decompose(x, mantissa, log2);
         return 0.693147180559945 * (FAST_LOG_TABLE[mantissa] + log2);

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -669,9 +669,7 @@ public:
     static double pow2(double x) { return x * x; }
 
     //! Compute a value from \p x which will be stable across platforms.
-    static double stable(double x) {
-        return STABLE_EPS * std::floor(x / STABLE_EPS + 0.5);
-    }
+    static double stable(double x) { return core::CIEEE754::dropbits(x, 1); }
 
     //! A version of std::log which is stable across platforms.
     static double stableLog(double x) { return stable(std::log(x)); }
@@ -737,9 +735,6 @@ public:
 
     //! A wrapper around lgamma which handles corner cases if requested
     static bool lgamma(double value, double& result, bool checkForFinite = true);
-
-private:
-    static constexpr double STABLE_EPS{10.0 * std::numeric_limits<double>::epsilon()};
 };
 }
 }

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -668,6 +668,17 @@ public:
     //! Compute \f$x^2\f$.
     static double pow2(double x) { return x * x; }
 
+    //! Compute a value from \p x which will be stable across platforms.
+    static double stable(double x) {
+        return STABLE_EPS * std::floor(x / STABLE_EPS + 0.5);
+    }
+
+    //! A version of std::log which is stable across platforms.
+    static double stableLog(double x) { return stable(std::log(x)); }
+
+    //! A version of std::log which is stable across platforms.
+    static double stableExp(double x) { return stable(std::exp(x)); }
+
     //! Sigmoid function of \p p.
     static double sigmoid(double p) { return 1.0 / (1.0 + 1.0 / p); }
 
@@ -681,7 +692,7 @@ public:
     //! \param[in] sign Determines whether it's a step up or down.
     static double
     logisticFunction(double x, double width = 1.0, double x0 = 0.0, double sign = 1.0) {
-        return sigmoid(std::exp(std::copysign(1.0, sign) * (x - x0) / width));
+        return sigmoid(stableExp(std::copysign(1.0, sign) * (x - x0) / width));
     }
 
     //! Compute the softmax from the multinomial logit values \p logit.
@@ -695,7 +706,7 @@ public:
         double Z{0.0};
         double zmax{*std::max_element(z.begin(), z.end())};
         for (auto& zi : z) {
-            zi = std::exp(zi - zmax);
+            zi = stableExp(zi - zmax);
             Z += zi;
         }
         for (auto& zi : z) {
@@ -726,6 +737,9 @@ public:
 
     //! A wrapper around lgamma which handles corner cases if requested
     static bool lgamma(double value, double& result, bool checkForFinite = true);
+
+private:
+    static constexpr double STABLE_EPS{10.0 * std::numeric_limits<double>::epsilon()};
 };
 }
 }

--- a/include/maths/CTools.h
+++ b/include/maths/CTools.h
@@ -22,8 +22,8 @@
 #include <boost/static_assert.hpp>
 
 #include <array>
-#include <cinttypes>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <iosfwd>
 #include <limits>

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -485,8 +485,8 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoImportance, SFixture) {
             double c1{readShapValue(result, "c1")};
             double prediction{
                 result["row_results"]["results"]["ml"]["target_prediction"].GetDouble()};
-            // c1 explains 95% of the prediction value, i.e. the difference from the prediction is less than 2%.
-            BOOST_REQUIRE_CLOSE(c1, prediction, 5.0);
+            // c1 explains 94% of the prediction value, i.e. the difference from the prediction is less than 2%.
+            BOOST_REQUIRE_CLOSE(c1, prediction, 6.0);
             for (const auto& feature : {"c2", "c3", "c4"}) {
                 double c = readShapValue(result, feature);
                 BOOST_REQUIRE_SMALL(c, 2.0);

--- a/lib/core/CIEEE754.cc
+++ b/lib/core/CIEEE754.cc
@@ -45,7 +45,7 @@ double CIEEE754::dropbits(double value, int bits) {
     static_assert(sizeof(double) == sizeof(SDoubleRep),
                   "SDoubleRep definition unsuitable for memcpy to double");
     std::memcpy(&parsed, &value, sizeof(double));
-    parsed.s_Mantissa = parsed.s_Mantissa & (IEEE754_MANTISSA_MASK << bits);
+    parsed.s_Mantissa &= ((IEEE754_MANTISSA_MASK << bits) & IEEE754_MANTISSA_MASK);
     std::memcpy(&value, &parsed, sizeof(double));
     return value;
 }

--- a/lib/core/CIEEE754.cc
+++ b/lib/core/CIEEE754.cc
@@ -7,14 +7,14 @@
 #include <core/CIEEE754.h>
 
 #include <cmath>
+#include <cstring>
 
 namespace ml {
 namespace core {
 
 double CIEEE754::round(double value, EPrecision precision) {
-    // This first decomposes the value into the mantissa
-    // and exponent to avoid the problem with overflow if
-    // the values are close to max double.
+    // First decomposes the value into the mantissa and exponent to avoid the
+    // problem with overflow if the values are close to max double.
 
     int exponent;
     double mantissa = std::frexp(value, &exponent);
@@ -38,6 +38,16 @@ double CIEEE754::round(double value, EPrecision precision) {
     }
 
     return std::ldexp(mantissa, exponent);
+}
+
+double CIEEE754::dropbits(double value, int bits) {
+    SDoubleRep parsed;
+    static_assert(sizeof(double) == sizeof(SDoubleRep),
+                  "SDoubleRep definition unsuitable for memcpy to double");
+    std::memcpy(&parsed, &value, sizeof(double));
+    parsed.s_Mantissa = parsed.s_Mantissa & (IEEE754_MANTISSA_MASK << bits);
+    std::memcpy(&value, &parsed, sizeof(double));
+    return value;
 }
 }
 }

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -20,7 +20,7 @@
 #include <maths/CSampling.h>
 #include <maths/CTools.h>
 
-#include <boost/math/distributions/normal.hpp>
+#include <boost/math/constants/constants.hpp>
 #include <boost/optional/optional_io.hpp>
 
 #include <exception>
@@ -41,6 +41,16 @@ const std::string RANGE_SHIFT_TAG{"range_shift"};
 const std::string RANGE_SCALE_TAG{"range_scale"};
 const std::string RESTARTS_TAG{"restarts"};
 const std::string RNG_TAG{"rng"};
+
+//! A version of the normal c.d.f. which is stable across our target platforms.
+double stableNormCdf(double z) {
+    return (1.0 + CTools::stable(std::erf(z / boost::math::constants::root_two<double>()))) / 2.0;
+}
+
+//! A version of the normal p.d.f. which is stable across our target platforms.
+double stableNormPdf(double z) {
+    return CTools::stableExp(-z * z / 2.0) / boost::math::constants::root_two_pi<double>();
+}
 
 // The kernel we use is v * I + a(0)^2 * O(I). We fall back to random search when
 // a(0)^2 < eps * v since for small eps and a reasonable number of dimensions the
@@ -132,7 +142,7 @@ CBayesianOptimisation::maximumExpectedImprovement() {
             double fx{minusEI(x)};
             LOG_TRACE(<< "x = " << x.transpose() << " EI(x) = " << fx);
 
-            if (-fx > fmax) {
+            if (COrderings::lexicographical_compare(fmax, xmax, -fx, x)) {
                 xmax = x;
                 fmax = -fx;
             }
@@ -154,9 +164,8 @@ CBayesianOptimisation::maximumExpectedImprovement() {
             LOG_TRACE(<< "x0 = " << x0.second.transpose());
             std::tie(xcand, fcand) = lbfgs.constrainedMinimize(
                 minusEI, minusEIGradient, a, b, std::move(x0.second), rho);
-            LOG_TRACE(<< " xcand = " << xcand.transpose() << " EI(cand) = " << fcand);
-
-            if (-fcand > fmax) {
+            LOG_TRACE(<< "xcand = " << xcand.transpose() << " EI(cand) = " << fcand);
+            if (COrderings::lexicographical_compare(fmax, xmax, -fcand, xcand)) {
                 std::tie(xmax, fmax) = std::make_pair(std::move(xcand), -fcand);
             }
         }
@@ -174,10 +183,10 @@ CBayesianOptimisation::maximumExpectedImprovement() {
         expectedImprovement = fmax / m_RangeScale;
     }
 
-    LOG_TRACE(<< "best = " << xmax.cwiseProduct(m_MaxBoundary - m_MinBoundary).transpose()
-              << " EI(best) = " << expectedImprovement);
+    xmax = xmax.cwiseProduct(m_MaxBoundary - m_MinBoundary);
+    LOG_TRACE(<< "best = " << xmax.transpose() << " EI(best) = " << expectedImprovement);
 
-    return {xmax.cwiseProduct(m_MaxBoundary - m_MinBoundary), expectedImprovement};
+    return {std::move(xmax), expectedImprovement};
 }
 
 std::pair<CBayesianOptimisation::TLikelihoodFunc, CBayesianOptimisation::TLikelihoodGradientFunc>
@@ -185,10 +194,17 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
 
     TVector f{this->function()};
     double v{this->meanErrorVariance()};
+    TVector ones;
+    TVector gradient;
+    TMatrix K;
+    TVector Kinvf;
+    TMatrix Kinv;
+    TMatrix dKdai;
 
-    auto minusLogLikelihood = [f, v, this](const TVector& a) {
-        Eigen::LDLT<Eigen::MatrixXd> Kldl{this->kernel(a, v)};
-        TVector Kinvf{Kldl.solve(f)};
+    auto minusLogLikelihood = [=](const TVector& a) mutable {
+        K = this->kernel(a, v);
+        Eigen::LDLT<Eigen::MatrixXd> Kldl{K};
+        Kinvf = Kldl.solve(f);
         // We can only determine values up to eps * "max diagonal". If the diagonal
         // has a zero it blows up the determinant term. In practice, we know the
         // kernel can't be singular by construction so we perturb the diagonal by
@@ -199,31 +215,27 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
                (f.transpose() * Kinvf + (Kldl.vectorD().array() + eps).log().sum());
     };
 
-    auto minusLogLikelihoodGradient = [f, v, this](const TVector& a) {
-        TMatrix K{this->kernel(a, v)};
+    auto minusLogLikelihoodGradient = [=](const TVector& a) mutable {
+        K = this->kernel(a, v);
         Eigen::LDLT<Eigen::MatrixXd> Kldl{K};
 
-        TVector Kinvf{Kldl.solve(f)};
+        Kinvf = Kldl.solve(f);
 
-        TVector ones(f.size());
-        ones.setOnes();
-        TMatrix KInv{Kldl.solve(TMatrix{ones.asDiagonal()})};
+        ones = TVector::Ones(f.size());
+        Kinv = Kldl.solve(TMatrix::Identity(f.size(), f.size()));
 
         K.diagonal() -= v * ones;
 
-        TVector gradient{a.size()};
-        gradient.setZero();
-
+        gradient = TVector::Zero(a.size());
         for (int i = 0; i < Kinvf.size(); ++i) {
-            gradient(0) -=
-                1.0 / a(0) *
-                double{(Kinvf(i) * Kinvf.transpose() - KInv.row(i)) * K.col(i)};
+            double di{(Kinvf(i) * Kinvf.transpose() - Kinv.row(i)) * K.col(i)};
+            gradient(0) -= di / a(0);
         }
         for (int i = 1; i < a.size(); ++i) {
-            TMatrix dKdai{this->dKerneld(a, i)};
+            dKdai = this->dKerneld(a, i);
             for (int j = 0; j < Kinvf.size(); ++j) {
-                gradient(i) += 0.5 * double{(Kinvf(j) * Kinvf.transpose() - KInv.row(j)) *
-                                            dKdai.col(j)};
+                double di{(Kinvf(j) * Kinvf.transpose() - Kinv.row(j)) * dKdai.col(j)};
+                gradient(i) += 0.5 * di;
             }
         }
 
@@ -238,10 +250,15 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
 
     TMatrix K{this->kernel(m_KernelParameters, this->meanErrorVariance())};
     Eigen::LDLT<Eigen::MatrixXd> Kldl{K};
-
     TVector Kinvf{Kldl.solve(this->function())};
-
     double vx{this->meanErrorVariance()};
+
+    TVector Kxn;
+    TVector KinvKxn;
+    TVector muGradient;
+    TVector sigmaGradient;
+    TVector dKxndx;
+    TVector zGradient;
 
     double fmin{
         std::min_element(m_FunctionMeanValues.begin(), m_FunctionMeanValues.end(),
@@ -250,9 +267,8 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
                          })
             ->second};
 
-    auto EI = [Kldl, Kinvf, vx, fmin, this](const TVector& x) {
+    auto EI = [=](const TVector& x) mutable {
         double Kxx;
-        TVector Kxn;
         std::tie(Kxn, Kxx) = this->kernelCovariates(m_KernelParameters, x, vx);
 
         double sigma{Kxx - Kxn.transpose() * Kldl.solve(Kxn)};
@@ -264,17 +280,17 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
         double mu{Kxn.transpose() * Kinvf};
         sigma = std::sqrt(sigma);
 
-        boost::math::normal normal{0.0, 1.0};
         double z{(fmin - mu) / sigma};
-        return -sigma * (z * CTools::safeCdf(normal, z) + CTools::safePdf(normal, z));
+        double cdfz{stableNormCdf(z)};
+        double pdfz{stableNormPdf(z)};
+        return -sigma * (z * cdfz + pdfz);
     };
 
-    auto EIGradient = [Kldl, Kinvf, vx, fmin, this](const TVector& x) {
+    auto EIGradient = [=](const TVector& x) mutable {
         double Kxx;
-        TVector Kxn;
         std::tie(Kxn, Kxx) = this->kernelCovariates(m_KernelParameters, x, vx);
 
-        TVector KinvKxn{Kldl.solve(Kxn)};
+        KinvKxn = Kldl.solve(Kxn);
         double sigma{Kxx - Kxn.transpose() * KinvKxn};
 
         if (sigma <= 0.0) {
@@ -284,15 +300,14 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
         double mu{Kxn.transpose() * Kinvf};
         sigma = std::sqrt(sigma);
 
-        boost::math::normal normal{0.0, 1.0};
         double z{(fmin - mu) / sigma};
-        double cdfz{CTools::safeCdf(normal, z)};
-        double pdfz{CTools::safePdf(normal, z)};
+        double cdfz{stableNormCdf(z)};
+        double pdfz{stableNormPdf(z)};
 
-        TVector muGradient{x.size()};
-        TVector sigmaGradient{x.size()};
+        muGradient.resize(x.size());
+        sigmaGradient.resize(x.size());
         for (int i = 0; i < x.size(); ++i) {
-            TVector dKxndx{Kxn.size()};
+            dKxndx.resize(Kxn.size());
             for (int j = 0; j < Kxn.size(); ++j) {
                 const TVector& xj{m_FunctionMeanValues[j].first};
                 dKxndx(j) = 2.0 *
@@ -305,8 +320,7 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
         }
         sigmaGradient /= 2.0 * sigma;
 
-        TVector zGradient{((mu - fmin) / CTools::pow2(sigma)) * sigmaGradient -
-                          muGradient / sigma};
+        zGradient = ((mu - fmin) / CTools::pow2(sigma)) * sigmaGradient - muGradient / sigma;
 
         return TVector{-(z * cdfz + pdfz) * sigmaGradient - sigma * cdfz * zGradient};
     };
@@ -325,8 +339,8 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
     // We restart optimization with initial guess on different scales for global probing.
     TDoubleVec scales;
     scales.reserve((m_Restarts - 1) * n);
-    CSampling::uniformSample(m_Rng, CTools::stableLog(0.1),
-                             CTools::stableLog(4.0), (m_Restarts - 1) * n, scales);
+    CSampling::uniformSample(m_Rng, CTools::stableLog(0.2),
+                             CTools::stableLog(5.0), (m_Restarts - 1) * n, scales);
 
     TLikelihoodFunc l;
     TLikelihoodGradientFunc g;
@@ -345,12 +359,12 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
         for (std::size_t j = 0; j < n; ++j) {
             scale(j) = scales[(i - 1) * n + j];
         }
-        a.array() = scale.array().exp() * a.array();
+        a.array() *= scale.array().exp();
 
         double la;
         std::tie(a, la) = lbfgs.minimize(l, g, std::move(a), 1e-8, 75);
 
-        if (la < lmax) {
+        if (COrderings::lexicographical_compare(la, a, lmax, amax)) {
             lmax = la;
             amax = std::move(a);
         }
@@ -360,6 +374,7 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
     // but improves traceability.
     m_KernelParameters = amax.cwiseAbs();
     LOG_TRACE(<< "kernel parameters = " << m_KernelParameters.transpose());
+    LOG_TRACE(<< "likelihood = " << -lmax);
 
     return m_KernelParameters;
 }

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -325,8 +325,8 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
     // We restart optimization with initial guess on different scales for global probing.
     TDoubleVec scales;
     scales.reserve((m_Restarts - 1) * n);
-    CSampling::uniformSample(m_Rng, std::log(0.1), std::log(4.0),
-                             (m_Restarts - 1) * n, scales);
+    CSampling::uniformSample(m_Rng, CTools::stableLog(0.1),
+                             CTools::stableLog(4.0), (m_Restarts - 1) * n, scales);
 
     TLikelihoodFunc l;
     TLikelihoodGradientFunc g;
@@ -446,11 +446,12 @@ CBayesianOptimisation::kernelCovariates(const TVector& a, const TVector& x, doub
 }
 
 double CBayesianOptimisation::kernel(const TVector& a, const TVector& x, const TVector& y) const {
-    return CTools::pow2(a(0)) * std::exp(-(x - y).transpose() *
-                                         (m_MinimumKernelCoordinateDistanceScale +
-                                          a.tail(a.size() - 1).cwiseAbs2().matrix())
-                                             .asDiagonal() *
-                                         (x - y));
+    return CTools::pow2(a(0)) *
+           CTools::stableExp(-(x - y).transpose() *
+                             (m_MinimumKernelCoordinateDistanceScale +
+                              a.tail(a.size() - 1).cwiseAbs2().matrix())
+                                 .asDiagonal() *
+                             (x - y));
 }
 
 void CBayesianOptimisation::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -489,16 +489,16 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
     if (m_TreeImpl->m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
         if (gainPerNode90thPercentile > 0.0) {
             double searchIntervalSize{2.0 * gainPerNode90thPercentile / gainPerNode1stPercentile};
-            double logMaxDepthPenaltyMultiplier{std::log(gainPerNode90thPercentile)};
+            double logMaxDepthPenaltyMultiplier{CTools::stableLog(gainPerNode90thPercentile)};
             double logMinDepthPenaltyMultiplier{logMaxDepthPenaltyMultiplier -
-                                                std::log(searchIntervalSize)};
+                                                CTools::stableLog(searchIntervalSize)};
             double meanLogDepthPenaltyMultiplier{
                 (logMinDepthPenaltyMultiplier + logMaxDepthPenaltyMultiplier) / 2.0};
-            double mainLoopSearchInterval{std::log(searchIntervalSize) / 2.0};
+            double mainLoopSearchInterval{CTools::stableLog(searchIntervalSize) / 2.0};
             LOG_TRACE(<< "mean log depth penalty multiplier = " << meanLogDepthPenaltyMultiplier);
 
             auto applyDepthPenaltyMultiplier = [](CBoostedTreeImpl& tree, double logDepthPenalty) {
-                tree.m_Regularization.depthPenaltyMultiplier(std::exp(logDepthPenalty));
+                tree.m_Regularization.depthPenaltyMultiplier(CTools::stableExp(logDepthPenalty));
                 return true;
             };
 
@@ -516,7 +516,7 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
             LOG_TRACE(<< "log depth penalty multiplier search interval = ["
                       << m_LogDepthPenaltyMultiplierSearchInterval.toDelimited() << "]");
 
-            m_TreeImpl->m_Regularization.depthPenaltyMultiplier(std::exp(
+            m_TreeImpl->m_Regularization.depthPenaltyMultiplier(CTools::stableExp(
                 m_LogDepthPenaltyMultiplierSearchInterval(BEST_REGULARIZER_INDEX)));
         }
         if (gainPerNode90thPercentile <= 0.0 ||
@@ -531,18 +531,19 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
     if (m_TreeImpl->m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
         if (gainPerNode90thPercentile > 0.0) {
             double searchIntervalSize{2.0 * gainPerNode90thPercentile / gainPerNode1stPercentile};
-            double logMaxTreeSizePenaltyMultiplier{std::log(gainPerNode90thPercentile)};
-            double logMinTreeSizePenaltyMultiplier{logMaxTreeSizePenaltyMultiplier -
-                                                   std::log(searchIntervalSize)};
+            double logMaxTreeSizePenaltyMultiplier{CTools::stableLog(gainPerNode90thPercentile)};
+            double logMinTreeSizePenaltyMultiplier{
+                logMaxTreeSizePenaltyMultiplier - CTools::stableLog(searchIntervalSize)};
             double meanLogTreeSizePenaltyMultiplier{
                 (logMinTreeSizePenaltyMultiplier + logMaxTreeSizePenaltyMultiplier) / 2.0};
-            double mainLoopSearchInterval{0.5 * std::log(searchIntervalSize)};
+            double mainLoopSearchInterval{0.5 * CTools::stableLog(searchIntervalSize)};
             LOG_TRACE(<< "mean log tree size penalty multiplier = "
                       << meanLogTreeSizePenaltyMultiplier);
 
             auto applyTreeSizePenaltyMultiplier = [](CBoostedTreeImpl& tree,
                                                      double logTreeSizePenalty) {
-                tree.m_Regularization.treeSizePenaltyMultiplier(std::exp(logTreeSizePenalty));
+                tree.m_Regularization.treeSizePenaltyMultiplier(
+                    CTools::stableExp(logTreeSizePenalty));
                 return true;
             };
 
@@ -561,7 +562,7 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
             LOG_TRACE(<< "log tree size penalty multiplier search interval = ["
                       << m_LogTreeSizePenaltyMultiplierSearchInterval.toDelimited() << "]");
 
-            m_TreeImpl->m_Regularization.treeSizePenaltyMultiplier(std::exp(
+            m_TreeImpl->m_Regularization.treeSizePenaltyMultiplier(CTools::stableExp(
                 m_LogTreeSizePenaltyMultiplierSearchInterval(BEST_REGULARIZER_INDEX)));
         }
         if (gainPerNode90thPercentile <= 0.0 ||
@@ -577,18 +578,20 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
         if (totalCurvaturePerNode90thPercentile > 0.0) {
             double searchIntervalSize{2.0 * totalCurvaturePerNode90thPercentile /
                                       totalCurvaturePerNode1stPercentile};
-            double logMaxLeafWeightPenaltyMultiplier{std::log(totalCurvaturePerNode90thPercentile)};
+            double logMaxLeafWeightPenaltyMultiplier{
+                CTools::stableLog(totalCurvaturePerNode90thPercentile)};
             double logMinLeafWeightPenaltyMultiplier{
-                logMaxLeafWeightPenaltyMultiplier - std::log(searchIntervalSize)};
+                logMaxLeafWeightPenaltyMultiplier - CTools::stableLog(searchIntervalSize)};
             double meanLogLeafWeightPenaltyMultiplier{
                 (logMinLeafWeightPenaltyMultiplier + logMaxLeafWeightPenaltyMultiplier) / 2.0};
-            double mainLoopSearchInterval{0.5 * std::log(searchIntervalSize)};
+            double mainLoopSearchInterval{0.5 * CTools::stableLog(searchIntervalSize)};
             LOG_TRACE(<< "mean log leaf weight penalty multiplier = "
                       << meanLogLeafWeightPenaltyMultiplier);
 
             auto applyLeafWeightPenaltyMultiplier = [](CBoostedTreeImpl& tree,
                                                        double logLeafWeightPenalty) {
-                tree.m_Regularization.leafWeightPenaltyMultiplier(std::exp(logLeafWeightPenalty));
+                tree.m_Regularization.leafWeightPenaltyMultiplier(
+                    CTools::stableExp(logLeafWeightPenalty));
                 return true;
             };
 
@@ -607,7 +610,7 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
             LOG_TRACE(<< "log leaf weight penalty multiplier search interval = ["
                       << m_LogLeafWeightPenaltyMultiplierSearchInterval.toDelimited()
                       << "]");
-            m_TreeImpl->m_Regularization.leafWeightPenaltyMultiplier(std::exp(
+            m_TreeImpl->m_Regularization.leafWeightPenaltyMultiplier(CTools::stableExp(
                 m_LogLeafWeightPenaltyMultiplierSearchInterval(BEST_REGULARIZER_INDEX)));
         }
         if (totalCurvaturePerNode90thPercentile <= 0.0 ||
@@ -631,9 +634,10 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
         double searchIntervalSize{CTools::truncate(
             m_TreeImpl->m_TrainingRowMasks[0].manhattan() / 100.0,
             MIN_DOWNSAMPLE_LINE_SEARCH_RANGE, MAX_DOWNSAMPLE_LINE_SEARCH_RANGE)};
-        double logMaxDownsampleFactor{std::log(std::min(
+        double logMaxDownsampleFactor{CTools::stableLog(std::min(
             std::sqrt(searchIntervalSize) * m_TreeImpl->m_DownsampleFactor, 1.0))};
-        double logMinDownsampleFactor{logMaxDownsampleFactor - std::log(searchIntervalSize)};
+        double logMinDownsampleFactor{logMaxDownsampleFactor -
+                                      CTools::stableLog(searchIntervalSize)};
         double meanLogDownSampleFactor{(logMinDownsampleFactor + logMaxDownsampleFactor) / 2.0};
         LOG_TRACE(<< "mean log down sample factor = " << meanLogDownSampleFactor);
 
@@ -666,7 +670,7 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
         double numberTrainingRows{m_TreeImpl->m_TrainingRowMasks[0].manhattan()};
 
         auto applyDownsampleFactor = [&](CBoostedTreeImpl& tree, double logDownsampleFactor) {
-            double downsampleFactor{std::exp(logDownsampleFactor)};
+            double downsampleFactor{CTools::stableExp(logDownsampleFactor)};
             tree.m_DownsampleFactor = downsampleFactor;
             scaleRegularizers(tree, downsampleFactor);
             return tree.m_DownsampleFactor * numberTrainingRows > 10.0;
@@ -676,23 +680,24 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
         m_LogDownsampleFactorSearchInterval =
             this->testLossLineSearch(frame, applyDownsampleFactor,
                                      logMinDownsampleFactor, logMaxDownsampleFactor,
-                                     std::log(MIN_DOWNSAMPLE_FACTOR_SCALE),
-                                     std::log(MAX_DOWNSAMPLE_FACTOR_SCALE))
+                                     CTools::stableLog(MIN_DOWNSAMPLE_FACTOR_SCALE),
+                                     CTools::stableLog(MAX_DOWNSAMPLE_FACTOR_SCALE))
                 .value_or(fallback);
 
         // Truncate the log(scale) to be less than or equal to log(1.0) and the down
         // sampled set contains at least ten examples on average.
         m_LogDownsampleFactorSearchInterval =
             min(max(m_LogDownsampleFactorSearchInterval,
-                    TVector{std::log(10.0 / numberTrainingRows)}),
+                    TVector{CTools::stableLog(10.0 / numberTrainingRows)}),
                 TVector{0.0});
         LOG_TRACE(<< "log down sample factor search interval = ["
                   << m_LogDownsampleFactorSearchInterval.toDelimited() << "]");
 
-        m_TreeImpl->m_DownsampleFactor =
-            std::exp(m_LogDownsampleFactorSearchInterval(BEST_REGULARIZER_INDEX));
+        m_TreeImpl->m_DownsampleFactor = CTools::stableExp(
+            m_LogDownsampleFactorSearchInterval(BEST_REGULARIZER_INDEX));
 
-        TVector logScale{std::log(scaleRegularizers(*m_TreeImpl, m_TreeImpl->m_DownsampleFactor))};
+        TVector logScale{CTools::stableLog(
+            scaleRegularizers(*m_TreeImpl, m_TreeImpl->m_DownsampleFactor))};
         m_LogTreeSizePenaltyMultiplierSearchInterval += logScale;
         m_LogLeafWeightPenaltyMultiplierSearchInterval += logScale;
 
@@ -706,14 +711,15 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
 
     if (m_TreeImpl->m_EtaOverride == boost::none) {
         double searchIntervalSize{5.0 * MAX_ETA_SCALE / MIN_ETA_SCALE};
-        double logMaxEta{std::log(std::sqrt(searchIntervalSize) * m_TreeImpl->m_Eta)};
-        double logMinEta{logMaxEta - std::log(searchIntervalSize)};
+        double logMaxEta{
+            CTools::stableLog(std::sqrt(searchIntervalSize) * m_TreeImpl->m_Eta)};
+        double logMinEta{logMaxEta - CTools::stableLog(searchIntervalSize)};
         double meanLogEta{(logMaxEta + logMinEta) / 2.0};
-        double mainLoopSearchInterval{std::log(0.2 * searchIntervalSize)};
+        double mainLoopSearchInterval{CTools::stableLog(0.2 * searchIntervalSize)};
         LOG_TRACE(<< "mean log eta = " << meanLogEta);
 
         auto applyEta = [](CBoostedTreeImpl& tree, double eta) {
-            tree.m_Eta = std::exp(eta);
+            tree.m_Eta = CTools::stableExp(eta);
             tree.m_EtaGrowthRatePerTree = 1.0 + tree.m_Eta / 2.0;
             tree.m_MaximumNumberTrees = computeMaximumNumberTrees(tree.m_Eta);
             return true;

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1076,16 +1076,16 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     // Read parameters for last round.
     int i{0};
     if (m_DownsampleFactorOverride == boost::none) {
-        parameters(i++) = std::log(m_DownsampleFactor);
+        parameters(i++) = CTools::stableLog(m_DownsampleFactor);
     }
     if (m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
-        parameters(i++) = std::log(m_Regularization.depthPenaltyMultiplier());
+        parameters(i++) = CTools::stableLog(m_Regularization.depthPenaltyMultiplier());
     }
     if (m_RegularizationOverride.leafWeightPenaltyMultiplier() == boost::none) {
-        parameters(i++) = std::log(m_Regularization.leafWeightPenaltyMultiplier());
+        parameters(i++) = CTools::stableLog(m_Regularization.leafWeightPenaltyMultiplier());
     }
     if (m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
-        parameters(i++) = std::log(m_Regularization.treeSizePenaltyMultiplier());
+        parameters(i++) = CTools::stableLog(m_Regularization.treeSizePenaltyMultiplier());
     }
     if (m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
         parameters(i++) = m_Regularization.softTreeDepthLimit();
@@ -1094,7 +1094,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         parameters(i++) = m_Regularization.softTreeDepthTolerance();
     }
     if (m_EtaOverride == boost::none) {
-        parameters(i++) = std::log(m_Eta);
+        parameters(i++) = CTools::stableLog(m_Eta);
         parameters(i++) = m_EtaGrowthRatePerTree;
     }
     if (m_FeatureBagFractionOverride == boost::none) {
@@ -1131,21 +1131,24 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     // Write parameters for next round.
     i = 0;
     if (m_DownsampleFactorOverride == boost::none) {
-        m_DownsampleFactor = std::exp(parameters(i++));
+        m_DownsampleFactor = CTools::stableExp(parameters(i++));
         TVector minBoundary;
         TVector maxBoundary;
         std::tie(minBoundary, maxBoundary) = bopt.boundingBox();
         scale = std::min(scale, 2.0 * m_DownsampleFactor /
-                                    (std::exp(minBoundary(0)) + std::exp(maxBoundary(0))));
+                                    (CTools::stableExp(minBoundary(0)) +
+                                     CTools::stableExp(maxBoundary(0))));
     }
     if (m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
-        m_Regularization.depthPenaltyMultiplier(std::exp(parameters(i++)));
+        m_Regularization.depthPenaltyMultiplier(CTools::stableExp(parameters(i++)));
     }
     if (m_RegularizationOverride.leafWeightPenaltyMultiplier() == boost::none) {
-        m_Regularization.leafWeightPenaltyMultiplier(scale * std::exp(parameters(i++)));
+        m_Regularization.leafWeightPenaltyMultiplier(
+            scale * CTools::stableExp(parameters(i++)));
     }
     if (m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
-        m_Regularization.treeSizePenaltyMultiplier(scale * std::exp(parameters(i++)));
+        m_Regularization.treeSizePenaltyMultiplier(
+            scale * CTools::stableExp(parameters(i++)));
     }
     if (m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
         m_Regularization.softTreeDepthLimit(parameters(i++));
@@ -1154,7 +1157,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         m_Regularization.softTreeDepthTolerance(parameters(i++));
     }
     if (m_EtaOverride == boost::none) {
-        m_Eta = std::exp(scale * parameters(i++));
+        m_Eta = CTools::stableExp(scale * parameters(i++));
         m_EtaGrowthRatePerTree = parameters(i++);
     }
     if (m_FeatureBagFractionOverride == boost::none) {

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -126,7 +126,7 @@ CBoostedTreeLeafNodeStatistics::split(std::size_t leftChildId,
 }
 
 bool CBoostedTreeLeafNodeStatistics::operator<(const CBoostedTreeLeafNodeStatistics& rhs) const {
-    return m_BestSplit < rhs.m_BestSplit;
+    return COrderings::lexicographical_compare(m_BestSplit, m_Id, rhs.m_BestSplit, rhs.m_Id);
 }
 
 double CBoostedTreeLeafNodeStatistics::gain() const {

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -22,14 +22,15 @@ namespace maths {
 using namespace boosted_tree_detail;
 
 namespace {
-double LOG_EPSILON{std::log(100.0 * std::numeric_limits<double>::epsilon())};
+const double EPSILON{100.0 * std::numeric_limits<double>::epsilon()};
+const double LOG_EPSILON{CTools::stableLog(EPSILON)};
 
 double logOneMinusLogistic(double logOdds) {
     // For large x logistic(x) = 1 - e^(-x) + O(e^(-2x))
     if (logOdds > -LOG_EPSILON) {
         return -logOdds;
     }
-    return std::log(1.0 - CTools::logisticFunction(logOdds));
+    return CTools::stableLog(1.0 - CTools::logisticFunction(logOdds));
 }
 
 double logLogistic(double logOdds) {
@@ -37,7 +38,7 @@ double logLogistic(double logOdds) {
     if (logOdds < LOG_EPSILON) {
         return logOdds;
     }
-    return std::log(CTools::logisticFunction(logOdds));
+    return CTools::stableLog(CTools::logisticFunction(logOdds));
 }
 
 template<typename SCALAR>
@@ -46,7 +47,7 @@ void inplaceLogSoftmax(CDenseVector<SCALAR>& z) {
     double zmax{z.maxCoeff()};
     z.array() -= zmax;
     double Z{z.array().exp().sum()};
-    z.array() -= std::log(Z);
+    z.array() -= CTools::stableLog(Z);
 }
 }
 
@@ -179,8 +180,8 @@ CArgMinBinomialLogisticLossImpl::TDoubleVector CArgMinBinomialLogisticLossImpl::
         double c0{m_ClassCounts(0) + 1.0};
         double c1{m_ClassCounts(1) + 1.0};
         double empiricalProbabilityC1{c1 / (c0 + c1)};
-        double empiricalLogOddsC1{
-            std::log(empiricalProbabilityC1 / (1.0 - empiricalProbabilityC1))};
+        double empiricalLogOddsC1{CTools::stableLog(
+            empiricalProbabilityC1 / (1.0 - empiricalProbabilityC1))};
         minWeight = (empiricalProbabilityC1 < 0.5 ? empiricalLogOddsC1 : 0.0) - prediction;
         maxWeight = (empiricalProbabilityC1 < 0.5 ? 0.0 : empiricalLogOddsC1) - prediction;
 
@@ -485,7 +486,7 @@ void CBinomialLogisticLoss::gradient(const TMemoryMappedFloatVector& prediction,
                                      TWriter writer,
                                      double weight) const {
     if (prediction(0) > -LOG_EPSILON && actual == 1.0) {
-        writer(0, -weight * std::exp(-prediction(0)));
+        writer(0, -weight * CTools::stableExp(-prediction(0)));
     } else {
         writer(0, weight * (CTools::logisticFunction(prediction(0)) - actual));
     }
@@ -496,7 +497,7 @@ void CBinomialLogisticLoss::curvature(const TMemoryMappedFloatVector& prediction
                                       TWriter writer,
                                       double weight) const {
     if (prediction(0) > -LOG_EPSILON) {
-        writer(0, weight * std::exp(-prediction(0)));
+        writer(0, weight * CTools::stableExp(-prediction(0)));
     } else {
         double probability{CTools::logisticFunction(prediction(0))};
         writer(0, weight * probability * (1.0 - probability));
@@ -551,7 +552,7 @@ double CMultinomialLogisticLoss::value(const TMemoryMappedFloatVector& predictio
     for (int i = 0; i < predictions.size(); ++i) {
         logZ += std::exp(predictions(i) - zmax);
     }
-    logZ = zmax + std::log(logZ);
+    logZ = zmax + CTools::stableLog(logZ);
 
     // i.e. -log(z(actual))
     return weight * (logZ - predictions(static_cast<std::size_t>(actual)));
@@ -577,11 +578,12 @@ void CMultinomialLogisticLoss::gradient(const TMemoryMappedFloatVector& predicti
             logZ += std::exp(predictions(i) - zmax);
         }
     }
-    logZ = zmax + std::log(logZ);
+    eps = CTools::stable(eps);
+    logZ = zmax + CTools::stableLog(logZ);
 
     for (int i = 0; i < predictions.size(); ++i) {
         if (i == static_cast<int>(actual)) {
-            double probability{std::exp(predictions(i) - logZ)};
+            double probability{CTools::stableExp(predictions(i) - logZ)};
             if (probability == 1.0) {
                 // We have that p = 1 / (1 + eps) and the gradient is p - 1.
                 // Use a Taylor expansion and drop terms of O(eps^2) to get:
@@ -590,7 +592,7 @@ void CMultinomialLogisticLoss::gradient(const TMemoryMappedFloatVector& predicti
                 writer(i, weight * (probability - 1.0));
             }
         } else {
-            writer(i, weight * std::exp(predictions(i) - logZ));
+            writer(i, weight * CTools::stableExp(predictions(i) - logZ));
         }
     }
 }
@@ -617,10 +619,11 @@ void CMultinomialLogisticLoss::curvature(const TMemoryMappedFloatVector& predict
             logZ += std::exp(predictions(i) - zmax);
         }
     }
-    logZ = zmax + std::log(logZ);
+    eps = CTools::stable(eps);
+    logZ = zmax + CTools::stableLog(logZ);
 
     for (std::size_t i = 0, k = 0; i < m_NumberClasses; ++i) {
-        double probability{std::exp(predictions(i) - logZ)};
+        double probability{CTools::stableExp(predictions(i) - logZ)};
         if (probability == 1.0) {
             // We have that p = 1 / (1 + eps) and the curvature is p (1 - p).
             // Use a Taylor expansion and drop terms of O(eps^2) to get:
@@ -629,8 +632,8 @@ void CMultinomialLogisticLoss::curvature(const TMemoryMappedFloatVector& predict
             writer(k++, weight * probability * (1.0 - probability));
         }
         for (std::size_t j = i + 1; j < m_NumberClasses; ++j) {
-            double probabilities[]{std::exp(predictions(i) - logZ),
-                                   std::exp(predictions(j) - logZ)};
+            double probabilities[]{CTools::stableExp(predictions(i) - logZ),
+                                   CTools::stableExp(predictions(j) - logZ)};
             writer(k++, -weight * probabilities[0] * probabilities[1]);
         }
     }

--- a/lib/maths/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/unittest/CBayesianOptimisationTest.cc
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
         rng.generateUniformSamples(-10.0, 10.0, 12, centreCoordinates);
         rng.generateUniformSamples(0.3, 4.0, 12, coordinateScales);
 
-        // Use sum of some different quadratric functions.
+        // Use sum of some different quadratic functions.
         TVector centres[]{TVector{4}, TVector{4}, TVector{4}};
         TVector scales[]{TVector{4}, TVector{4}, TVector{4}};
         for (std::size_t i = 0; i < 3; ++i) {
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
                       (x - centres[1])};
             double f3{(x - centres[2]).transpose() * scales[2].asDiagonal() *
                       (x - centres[2])};
-            return f1 + f2 + f3;
+            return f1 - 0.2 * f2 + f3;
         };
 
         maths::CBayesianOptimisation bopt{

--- a/lib/maths/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/unittest/CBayesianOptimisationTest.cc
@@ -250,7 +250,8 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
     TVector a(vector({-10.0, -10.0, -10.0, -10.0}));
     TVector b(vector({10.0, 10.0, 10.0, 10.0}));
 
-    TMeanAccumulator gain;
+    TMeanAccumulator meanImprovementBopt;
+    TMeanAccumulator meanImprovementRs;
 
     for (std::size_t test = 0; test < 20; ++test) {
 
@@ -273,7 +274,7 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
                       (x - centres[1])};
             double f3{(x - centres[2]).transpose() * scales[2].asDiagonal() *
                       (x - centres[2])};
-            return f1 - 0.2 * f2 + f3;
+            return 100.0 + f1 - 0.2 * f2 + f3;
         };
 
         maths::CBayesianOptimisation bopt{
@@ -292,28 +293,39 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
         }
 
         LOG_TRACE(<< "Bayesian optimisation...");
-        for (std::size_t i = 0; i < 10; ++i) {
+        double f0Bopt{fminBopt};
+        for (std::size_t i = 0; i < 20; ++i) {
             TVector x;
             std::tie(x, std::ignore) = bopt.maximumExpectedImprovement();
             LOG_TRACE(<< "x = " << x.transpose() << ", f(x) = " << f(x));
             bopt.add(x, f(x), 10.0);
             fminBopt = std::min(fminBopt, f(x));
         }
+        double improvementBopt{(f0Bopt - fminBopt) / f0Bopt};
 
         LOG_TRACE(<< "random search...");
-        for (std::size_t i = 0; i < 10; ++i) {
+        double f0Rs{fminRs};
+        for (std::size_t i = 0; i < 20; ++i) {
             rng.generateUniformSamples(0.0, 1.0, 4, randomSearch);
             TVector x{a + vector(randomSearch).asDiagonal() * (b - a)};
             LOG_TRACE(<< "x = " << x.transpose() << ", f(x) = " << f(x));
             fminRs = std::min(fminRs, f(x));
         }
+        double improvementRs{(f0Rs - fminRs) / f0Rs};
 
-        LOG_TRACE(<< "gain = " << fminRs / fminBopt);
-        gain.add(fminRs / fminBopt);
+        LOG_DEBUG(<< "% improvement BO = " << 100.0 * improvementBopt
+                  << ", % improvement RS = " << 100.0 * improvementRs);
+        BOOST_TEST_REQUIRE(improvementBopt > improvementRs);
+        meanImprovementBopt.add(improvementBopt);
+        meanImprovementRs.add(improvementRs);
     }
 
-    LOG_DEBUG(<< "mean gain = " << maths::CBasicStatistics::mean(gain));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(gain) > 1.23);
+    LOG_DEBUG(<< "mean % improvement BO = "
+              << 100.0 * maths::CBasicStatistics::mean(meanImprovementBopt));
+    LOG_DEBUG(<< "mean % improvement RS = "
+              << 100.0 * maths::CBasicStatistics::mean(meanImprovementRs));
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanImprovementBopt) >
+                       1.8 * maths::CBasicStatistics::mean(meanImprovementRs)); // 80%
 }
 
 BOOST_AUTO_TEST_CASE(testPersistRestore) {

--- a/lib/maths/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/unittest/CBayesianOptimisationTest.cc
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
     }
 
     LOG_DEBUG(<< "mean gain = " << maths::CBasicStatistics::mean(gain));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(gain) > 1.26);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(gain) > 1.23);
 }
 
 BOOST_AUTO_TEST_CASE(testPersistRestore) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -980,7 +980,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.51);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -980,7 +980,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.51);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -294,9 +294,9 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
         // Unbiased...
         BOOST_REQUIRE_CLOSE_ABSOLUTE(
             0.0, modelBias[i][0],
-            9.1 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
             0.0, modelBias[i][0],
             5.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }

--- a/lib/maths/unittest/CToolsTest.cc
+++ b/lib/maths/unittest/CToolsTest.cc
@@ -28,6 +28,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <array>
+#include <bitset>
 #include <numeric>
 
 BOOST_AUTO_TEST_SUITE(CToolsTest)

--- a/lib/maths/unittest/CToolsTest.cc
+++ b/lib/maths/unittest/CToolsTest.cc
@@ -342,6 +342,20 @@ public:
 private:
     const maths::CMixtureDistribution<T>& m_Mixture;
 };
+
+void printByte(const unsigned char& byte, std::ostream& o) {
+    o << std::bitset<CHAR_BIT>{byte};
+}
+
+template<typename T>
+std::string printBits(const T& t) {
+    std::ostringstream o;
+    const unsigned char* byte{reinterpret_cast<const unsigned char*>(&t)};
+    for (std::size_t s = 0; s < sizeof(t); ++s, ++byte) {
+        printByte(*byte, o);
+    }
+    return o.str();
+}
 }
 
 BOOST_AUTO_TEST_CASE(testProbabilityOfLessLikelySample) {
@@ -1229,6 +1243,30 @@ BOOST_AUTO_TEST_CASE(testSoftMax) {
             BOOST_REQUIRE_CLOSE(p[i], p_[i], 1e-6);
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(testStable) {
+
+    // Test the bit representation of the stable log and exp of some random values.
+    // This will fail if they're different on any of our target platforms.
+
+    BOOST_REQUIRE_EQUAL("1001000010101011111010010001000011111110001100011111001110111111",
+                        printBits(CTools::stableLog(0.301283021)));
+    BOOST_REQUIRE_EQUAL("1001010011010100101100111011101001100110101100010010110101000000",
+                        printBits(CTools::stableLog(2803801.9332)));
+    BOOST_REQUIRE_EQUAL("1100010011111111100101000001110111100000001011010001001101000000",
+                        printBits(CTools::stableLog(120.880233)));
+    BOOST_REQUIRE_EQUAL("1110111001101001111010100000001100101010100100110000011001000000",
+                        printBits(CTools::stableLog(16.808042323)));
+
+    BOOST_REQUIRE_EQUAL("1000000001000110101011010011001110111111101111000001000101000000",
+                        printBits(CTools::stableExp(1.48937498342)));
+    BOOST_REQUIRE_EQUAL("1101111011000110011111000001010001101011111111000011000001000000",
+                        printBits(CTools::stableExp(2.832390)));
+    BOOST_REQUIRE_EQUAL("0101111001100101111110101101101100100100111001101001001100111111",
+                        printBits(CTools::stableExp(-3.94080233)));
+    BOOST_REQUIRE_EQUAL("1111100000011010010001001000000100011011010100100000010101000000",
+                        printBits(CTools::stableExp(0.98023840)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This addresses some of the underlying causes for variation in regression and classification results for different platforms: `std::log` and `std::exp` don't always agree in the last decimal place and our split order predicate wasn't a total order.