### PR TITLE
[7.7][ML] Fix periodic persistence of categorizer state

### DIFF
--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -221,7 +221,7 @@ int main(int argc, char** argv) {
     }
 
     using TPersistenceManagerUPtr = std::unique_ptr<ml::api::CPersistenceManager>;
-    const TPersistenceManagerUPtr periodicPersister{
+    const TPersistenceManagerUPtr persistenceManager{
         [persistInterval, isPersistInForeground, &persister,
          &bucketPersistInterval]() -> TPersistenceManagerUPtr {
             if (persistInterval >= 0 || bucketPersistInterval > 0) {
@@ -251,7 +251,7 @@ int main(int argc, char** argv) {
     ml::api::CAnomalyJob job(jobId, limits, fieldConfig, modelConfig, wrappedOutputStream,
                              std::bind(&ml::api::CModelSnapshotJsonWriter::write,
                                        &modelSnapshotWriter, std::placeholders::_1),
-                             periodicPersister.get(), maxQuantileInterval,
+                             persistenceManager.get(), maxQuantileInterval,
                              timeField, timeFormat, maxAnomalyRecords);
 
     if (!quantilesStateFile.empty()) {
@@ -273,7 +273,8 @@ int main(int argc, char** argv) {
 
     // The categorizer knows how to assign categories to records
     ml::api::CFieldDataCategorizer categorizer(jobId, fieldConfig, limits, outputChainer,
-                                               fieldDataCategorizerOutputWriter);
+                                               fieldDataCategorizerOutputWriter,
+                                               persistenceManager.get());
 
     if (fieldConfig.fieldNameSuperset().count(
             ml::api::CFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
@@ -281,11 +282,11 @@ int main(int argc, char** argv) {
         firstProcessor = &categorizer;
     }
 
-    if (periodicPersister != nullptr) {
-        periodicPersister->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
+    if (persistenceManager != nullptr) {
+        persistenceManager->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
             &ml::api::CDataProcessor::periodicPersistStateInBackground, firstProcessor));
 
-        periodicPersister->firstProcessorForegroundPeriodicPersistFunc(std::bind(
+        persistenceManager->firstProcessorForegroundPeriodicPersistFunc(std::bind(
             &ml::api::CDataProcessor::periodicPersistStateInForeground, firstProcessor));
     }
 

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -149,7 +149,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
     using TPersistenceManagerUPtr = std::unique_ptr<ml::api::CPersistenceManager>;
-    const TPersistenceManagerUPtr periodicPersister{
+    const TPersistenceManagerUPtr persistenceManager{
         [persistInterval, isPersistInForeground, &persister]() -> TPersistenceManagerUPtr {
             if (persistInterval >= 0) {
                 return std::make_unique<ml::api::CPersistenceManager>(
@@ -177,13 +177,13 @@ int main(int argc, char** argv) {
 
     // The categorizer knows how to assign categories to records
     ml::api::CFieldDataCategorizer categorizer(jobId, fieldConfig, limits, nullOutput,
-                                               outputWriter, periodicPersister.get());
+                                               outputWriter, persistenceManager.get());
 
-    if (periodicPersister != nullptr) {
-        periodicPersister->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
+    if (persistenceManager != nullptr) {
+        persistenceManager->firstProcessorBackgroundPeriodicPersistFunc(std::bind(
             &ml::api::CFieldDataCategorizer::periodicPersistStateInBackground, &categorizer));
 
-        periodicPersister->firstProcessorForegroundPeriodicPersistFunc(std::bind(
+        persistenceManager->firstProcessorForegroundPeriodicPersistFunc(std::bind(
             &ml::api::CFieldDataCategorizer::periodicPersistStateInForeground, &categorizer));
     }
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 7.7.1
+
+=== Bug Fixes
+
+* Fixed background persistence of categorizer state (See {ml-pull}1137[#1137],
+  issue: {ml-issue}1136[#1136].)
+
 == {es} version 7.7.0
 
 === New Features

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -27,14 +27,13 @@
 
 #include <boost/unordered_map.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -144,12 +143,12 @@ public:
                 CFieldConfig& fieldConfig,
                 model::CAnomalyDetectorModelConfig& modelConfig,
                 core::CJsonOutputStreamWrapper& outputBuffer,
-                const TPersistCompleteFunc& persistCompleteFunc = TPersistCompleteFunc(),
-                CPersistenceManager* periodicPersister = nullptr,
-                core_t::TTime maxQuantileInterval = -1,
-                const std::string& timeFieldName = DEFAULT_TIME_FIELD_NAME,
-                const std::string& timeFieldFormat = EMPTY_STRING,
-                size_t maxAnomalyRecords = 0u);
+                const TPersistCompleteFunc& persistCompleteFunc,
+                CPersistenceManager* persistenceManager,
+                core_t::TTime maxQuantileInterval,
+                const std::string& timeFieldName,
+                const std::string& timeFieldFormat,
+                std::size_t maxAnomalyRecords);
 
     ~CAnomalyJob() override;
 
@@ -182,7 +181,7 @@ public:
     virtual bool initNormalizer(const std::string& quantilesStateFile);
 
     //! How many records did we handle?
-    uint64_t numRecordsHandled() const override;
+    std::uint64_t numRecordsHandled() const override;
 
     //! Is persistence needed?
     bool isPersistenceNeeded(const std::string& description) const override;
@@ -225,7 +224,7 @@ private:
     void writeOutResults(bool interim,
                          model::CHierarchicalResults& results,
                          core_t::TTime bucketTime,
-                         uint64_t processingTime);
+                         std::uint64_t processingTime);
 
     //! Reset buckets in the range specified by the control message.
     void resetBuckets(const std::string& controlMessage);
@@ -413,7 +412,7 @@ private:
     model::CAnomalyDetectorModelConfig& m_ModelConfig;
 
     //! Keep count of how many records we've handled
-    uint64_t m_NumRecordsHandled;
+    std::uint64_t m_NumRecordsHandled;
 
     //! Detector keys.
     TKeyVec m_DetectorKeys;
@@ -436,12 +435,11 @@ private:
     std::string m_TimeFieldFormat;
 
     //! License restriction on the number of detectors allowed
-    size_t m_MaxDetectors;
+    std::size_t m_MaxDetectors;
 
-    //! Pointer to periodic persister that works in the background.  May be
-    //! nullptr if this object is not responsible for starting periodic
-    //! persistence.
-    CPersistenceManager* m_PeriodicPersister;
+    //! Pointer to the persistence manager. May be nullptr if state persistence
+    //! is not required, for example in unit tests.
+    CPersistenceManager* m_PersistenceManager;
 
     //! If we haven't output quantiles for this long due to a big anomaly
     //! we'll output them to reflect decay.  Non-positive values mean never.

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -79,7 +79,7 @@ public:
                           model::CLimits& limits,
                           COutputHandler& outputHandler,
                           CJsonOutputWriter& jsonOutputWriter,
-                          CPersistenceManager* periodicPersister = nullptr);
+                          CPersistenceManager* persistenceManager);
 
     ~CFieldDataCategorizer() override;
 
@@ -193,10 +193,9 @@ private:
     //! The categorization filter
     core::CRegexFilter m_CategorizationFilter;
 
-    //! Pointer to periodic persister that works in the background.  May be
-    //! nullptr if this object is not responsible for starting periodic
-    //! persistence.
-    CPersistenceManager* m_PeriodicPersister;
+    //! Pointer to the persistence manager. May be nullptr if state persistence
+    //! is not required, for example in unit tests.
+    CPersistenceManager* m_PersistenceManager;
 };
 }
 }

--- a/lib/api/dump_state/Main.cc
+++ b/lib/api/dump_state/Main.cc
@@ -131,7 +131,7 @@ bool persistCategorizerStateToFile(const std::string& outputFileName) {
     ml::core::CJsonOutputStreamWrapper wrappendOutStream(outStream);
     ml::api::CJsonOutputWriter writer("job", wrappendOutStream);
 
-    ml::api::CFieldDataCategorizer categorizer("job", config, limits, writer, writer);
+    ml::api::CFieldDataCategorizer categorizer("job", config, limits, writer, writer, nullptr);
 
     ml::api::CFieldDataCategorizer::TStrStrUMap dataRowFields;
     dataRowFields["_raw"] = "thing";
@@ -189,7 +189,7 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
 
     ml::api::CAnomalyJob origJob(jobId, limits, fieldConfig, modelConfig, wrappedOutputStream,
                                  std::bind(&reportPersistComplete, std::placeholders::_1),
-                                 nullptr, -1, "time", timeFormat);
+                                 nullptr, -1, "time", timeFormat, 0);
 
     using TInputParserUPtr = std::unique_ptr<ml::api::CInputParser>;
     const TInputParserUPtr parser{[&inputFilename, &inputStrm]() -> TInputParserUPtr {

--- a/lib/api/unittest/CAnomalyJobTest.cc
+++ b/lib/api/unittest/CAnomalyJobTest.cc
@@ -12,11 +12,12 @@
 #include <model/CDataGatherer.h>
 #include <model/CLimits.h>
 
-#include <api/CAnomalyJob.h>
 #include <api/CCsvInputParser.h>
 #include <api/CFieldConfig.h>
 #include <api/CHierarchicalResultsWriter.h>
 #include <api/CJsonOutputWriter.h>
+
+#include "CTestAnomalyJob.h"
 
 #include <rapidjson/document.h>
 
@@ -192,9 +193,9 @@ BOOST_AUTO_TEST_CASE(testBadTimes) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["wibble"] = "12345678";
         dataRows["value"] = "1.0";
         dataRows["greenhouse"] = "rhubarb";
@@ -215,9 +216,9 @@ BOOST_AUTO_TEST_CASE(testBadTimes) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["time"] = "hello";
         dataRows["value"] = "1.0";
         dataRows["greenhouse"] = "rhubarb";
@@ -238,11 +239,11 @@ BOOST_AUTO_TEST_CASE(testBadTimes) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                             api::CAnomalyJob::TPersistCompleteFunc(), nullptr,
-                             -1, "time", "%Y%m%m%H%M%S");
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc(), nullptr,
+                            -1, "time", "%Y%m%m%H%M%S");
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["time"] = "hello world";
         dataRows["value"] = "1.0";
         dataRows["greenhouse"] = "rhubarb";
@@ -266,13 +267,13 @@ BOOST_AUTO_TEST_CASE(testOutOfSequence) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
         job.description();
         job.descriptionAndDebugMemoryUsage();
 
         // add records which create partitions
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["time"] = "12345678";
         dataRows["value"] = "1.0";
         dataRows["greenhouse"] = "rhubarb";
@@ -302,9 +303,9 @@ BOOST_AUTO_TEST_CASE(testControlMessages) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["."] = " ";
         BOOST_TEST_REQUIRE(job.handleRecord(dataRows));
         BOOST_REQUIRE_EQUAL(uint64_t(0), job.numRecordsHandled());
@@ -332,14 +333,14 @@ BOOST_AUTO_TEST_CASE(testControlMessages) {
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["value"] = "2.0";
         dataRows["greenhouse"] = "rhubarb";
 
         std::stringstream outputStrm;
         {
             core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-            api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+            CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
             core_t::TTime time = 12345678;
             for (std::size_t i = 0; i < 50; i++, time += (BUCKET_SIZE / 2)) {
@@ -387,7 +388,7 @@ BOOST_AUTO_TEST_CASE(testControlMessages) {
         std::stringstream outputStrm2;
         {
             core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm2);
-            api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+            CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
             core_t::TTime time = 12345678;
             for (std::size_t i = 0; i < 50; i++, time += (BUCKET_SIZE / 2)) {
@@ -401,7 +402,7 @@ BOOST_AUTO_TEST_CASE(testControlMessages) {
                 }
                 BOOST_TEST_REQUIRE(job.handleRecord(dataRows));
                 if (i == 40) {
-                    api::CAnomalyJob::TStrStrUMap rows;
+                    CTestAnomalyJob::TStrStrUMap rows;
                     rows["."] = "r" + ss.str() + " " + ss.str();
                     BOOST_TEST_REQUIRE(job.handleRecord(rows));
                     for (std::size_t j = 0; j < 100; j++) {
@@ -449,9 +450,9 @@ BOOST_AUTO_TEST_CASE(testSkipTimeControlMessage) {
     std::stringstream outputStrm;
     core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-    api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+    CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
-    api::CAnomalyJob::TStrStrUMap dataRows;
+    CTestAnomalyJob::TStrStrUMap dataRows;
 
     core_t::TTime time = 3600;
     for (std::size_t i = 0; i < 10; ++i, time += BUCKET_SIZE) {
@@ -504,7 +505,7 @@ BOOST_AUTO_TEST_CASE(testIsPersistenceNeeded) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
         BOOST_REQUIRE_EQUAL(false, job.isPersistenceNeeded("test state"));
 
@@ -530,9 +531,9 @@ BOOST_AUTO_TEST_CASE(testIsPersistenceNeeded) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
 
         std::ostringstream ss;
         ss << time;
@@ -563,9 +564,9 @@ BOOST_AUTO_TEST_CASE(testIsPersistenceNeeded) {
         std::stringstream outputStrm;
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
 
         time = 39600;
         dataRows["."] = "t39600";
@@ -609,9 +610,9 @@ BOOST_AUTO_TEST_CASE(testModelPlot) {
     {
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
-        api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["time"] = "10000000";
         dataRows["value"] = "2.0";
         dataRows["animal"] = "baboon";
@@ -682,13 +683,13 @@ BOOST_AUTO_TEST_CASE(testInterimResultEdgeCases) {
 
     core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-    api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+    CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
     std::remove(logFile);
     BOOST_TEST_REQUIRE(ml::core::CLogger::instance().reconfigureFromFile(
         "testfiles/testLogErrors.boost.log.ini"));
 
-    api::CAnomalyJob::TStrStrUMap dataRows;
+    CTestAnomalyJob::TStrStrUMap dataRows;
     dataRows["time"] = "3610";
     dataRows["error"] = "e1";
     BOOST_TEST_REQUIRE(job.handleRecord(dataRows));
@@ -742,7 +743,7 @@ BOOST_AUTO_TEST_CASE(testRestoreFailsWithEmptyStream) {
     std::ostringstream outputStrm;
     core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-    api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+    CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
     core_t::TTime completeToTime(0);
     CEmptySearcher restoreSearcher;

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -11,13 +11,13 @@
 #include <model/CLimits.h>
 
 #include <api/CFieldConfig.h>
-#include <api/CFieldDataCategorizer.h>
 #include <api/CJsonOutputWriter.h>
 #include <api/CNullOutput.h>
 #include <api/COutputChainer.h>
 #include <api/COutputHandler.h>
 
 #include "CMockDataProcessor.h"
+#include "CTestFieldDataCategorizer.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(testAll) {
     core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
     CJsonOutputWriter writer("job", wrappedOutputStream);
 
-    CFieldDataCategorizer categorizer("job", config, limits, handler, writer);
+    CTestFieldDataCategorizer categorizer("job", config, limits, handler, writer);
     BOOST_REQUIRE_EQUAL(false, handler.isNewStream());
     categorizer.newOutputStream();
     BOOST_REQUIRE_EQUAL(true, handler.isNewStream());
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(testAll) {
         core::CJsonOutputStreamWrapper wrappedOutputStream2(outputStrm2);
         CJsonOutputWriter writer2("job", wrappedOutputStream2);
 
-        CFieldDataCategorizer newCategorizer("job", config2, limits2, handler2, writer2);
+        CTestFieldDataCategorizer newCategorizer("job", config2, limits2, handler2, writer2);
         CTestDataSearcher restorer(origJson);
         core_t::TTime time = 0;
         newCategorizer.restoreState(restorer, time);
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(testNodeReverseSearch) {
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
         CJsonOutputWriter writer("job", wrappedOutputStream);
 
-        CFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
+        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["message"] = "Node 1 started";
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(testJobKilledReverseSearch) {
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
         CJsonOutputWriter writer("job", wrappedOutputStream);
 
-        CFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
+        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["message"] = "[count_tweets] Killing job";
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(testPassOnControlMessages) {
 
         CMockDataProcessor mockProcessor(nullOutput);
         COutputChainer outputChainer(mockProcessor);
-        CFieldDataCategorizer categorizer("job", config, limits, outputChainer, writer);
+        CTestFieldDataCategorizer categorizer("job", config, limits, outputChainer, writer);
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["."] = "f7";
@@ -308,7 +308,8 @@ BOOST_AUTO_TEST_CASE(testHandleControlMessages) {
         core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
         CJsonOutputWriter writer("job", wrappedOutputStream);
 
-        CFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer, nullptr);
+        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput,
+                                              writer, nullptr);
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["."] = "f7";
@@ -333,7 +334,7 @@ BOOST_AUTO_TEST_CASE(testRestoreStateFailsWithEmptyState) {
     CNullOutput nullOutput;
     core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
     CJsonOutputWriter writer("job", wrappedOutputStream);
-    CFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer, nullptr);
+    CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer, nullptr);
 
     core_t::TTime completeToTime(0);
     CEmptySearcher restoreSearcher;

--- a/lib/api/unittest/CForecastRunnerTest.cc
+++ b/lib/api/unittest/CForecastRunnerTest.cc
@@ -11,8 +11,9 @@
 #include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CLimits.h>
 
-#include <api/CAnomalyJob.h>
 #include <api/CFieldConfig.h>
+
+#include "CTestAnomalyJob.h"
 
 #include <rapidjson/document.h>
 
@@ -27,40 +28,36 @@ BOOST_AUTO_TEST_SUITE(CForecastRunnerTest)
 namespace {
 
 using TGenerateRecord = void (*)(ml::core_t::TTime time,
-                                 ml::api::CAnomalyJob::TStrStrUMap& dataRows);
+                                 CTestAnomalyJob::TStrStrUMap& dataRows);
 
 const ml::core_t::TTime START_TIME{12000000};
 const ml::core_t::TTime BUCKET_LENGTH{3600};
 
-void generateRecord(ml::core_t::TTime time, ml::api::CAnomalyJob::TStrStrUMap& dataRows) {
+void generateRecord(ml::core_t::TTime time, CTestAnomalyJob::TStrStrUMap& dataRows) {
     dataRows["time"] = ml::core::CStringUtils::typeToString(time);
 }
 
 void generateRecordWithSummaryCount(ml::core_t::TTime time,
-                                    ml::api::CAnomalyJob::TStrStrUMap& dataRows) {
+                                    CTestAnomalyJob::TStrStrUMap& dataRows) {
     double x = static_cast<double>(time - START_TIME) / BUCKET_LENGTH;
     double count = (std::sin(x / 4.0) + 1.0) * 42.0 * std::pow(1.005, x);
     dataRows["time"] = ml::core::CStringUtils::typeToString(time);
     dataRows["count"] = ml::core::CStringUtils::typeToString(count);
 }
 
-void generateRecordWithStatus(ml::core_t::TTime time,
-                              ml::api::CAnomalyJob::TStrStrUMap& dataRows) {
+void generateRecordWithStatus(ml::core_t::TTime time, CTestAnomalyJob::TStrStrUMap& dataRows) {
     dataRows["time"] = ml::core::CStringUtils::typeToString(time);
     dataRows["status"] = (time / BUCKET_LENGTH) % 919 == 0 ? "404" : "200";
 }
 
-void generatePopulationRecord(ml::core_t::TTime time,
-                              ml::api::CAnomalyJob::TStrStrUMap& dataRows) {
+void generatePopulationRecord(ml::core_t::TTime time, CTestAnomalyJob::TStrStrUMap& dataRows) {
     dataRows["time"] = ml::core::CStringUtils::typeToString(time);
     dataRows["person"] = "jill";
 }
 
-void populateJob(TGenerateRecord generateRecord,
-                 ml::api::CAnomalyJob& job,
-                 std::size_t buckets = 1000) {
+void populateJob(TGenerateRecord generateRecord, CTestAnomalyJob& job, std::size_t buckets = 1000) {
     ml::core_t::TTime time = START_TIME;
-    ml::api::CAnomalyJob::TStrStrUMap dataRows;
+    CTestAnomalyJob::TStrStrUMap dataRows;
     for (std::size_t bucket = 0u; bucket < 2 * buckets;
          ++bucket, time += (BUCKET_LENGTH / 2)) {
         generateRecord(time, dataRows);
@@ -84,10 +81,10 @@ BOOST_AUTO_TEST_CASE(testSummaryCount) {
         ml::model::CAnomalyDetectorModelConfig modelConfig =
             ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
 
-        ml::api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
         populateJob(generateRecordWithSummaryCount, job);
 
-        ml::api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["."] = "p{\"duration\":" + std::to_string(13 * BUCKET_LENGTH) +
                         ",\"forecast_id\": \"42\"" + ",\"forecast_alias\": \"sumcount\"" +
                         ",\"create_time\": \"1511370819\"" + ",\"expires_in\": \"" +
@@ -156,10 +153,10 @@ BOOST_AUTO_TEST_CASE(testPopulation) {
         ml::model::CAnomalyDetectorModelConfig modelConfig =
             ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
 
-        ml::api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
         populateJob(generatePopulationRecord, job);
 
-        ml::api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["."] = "p{\"duration\":" + std::to_string(13 * BUCKET_LENGTH) +
                         ",\"forecast_id\": \"31\"" + ",\"create_time\": \"1511370819\" }";
         BOOST_TEST_REQUIRE(job.handleRecord(dataRows));
@@ -200,10 +197,10 @@ BOOST_AUTO_TEST_CASE(testRare) {
         ml::model::CAnomalyDetectorModelConfig modelConfig =
             ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
 
-        ml::api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
         populateJob(generateRecordWithStatus, job, 5000);
 
-        ml::api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["."] = "p{\"duration\":" + std::to_string(13 * BUCKET_LENGTH) +
                         ",\"forecast_id\": \"42\"" + ",\"create_time\": \"1511370819\"" +
                         ",\"expires_in\": \"8640000\" }";
@@ -241,10 +238,10 @@ BOOST_AUTO_TEST_CASE(testInsufficientData) {
         ml::model::CAnomalyDetectorModelConfig modelConfig =
             ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
 
-        ml::api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, streamWrapper);
         populateJob(generateRecord, job, 3);
 
-        ml::api::CAnomalyJob::TStrStrUMap dataRows;
+        CTestAnomalyJob::TStrStrUMap dataRows;
         dataRows["."] = "p{\"duration\":" + std::to_string(13 * BUCKET_LENGTH) +
                         ",\"forecast_id\": \"31\"" + ",\"create_time\": \"1511370819\" }";
         BOOST_TEST_REQUIRE(job.handleRecord(dataRows));

--- a/lib/api/unittest/COutputChainerTest.cc
+++ b/lib/api/unittest/COutputChainerTest.cc
@@ -8,7 +8,6 @@
 
 #include <model/CLimits.h>
 
-#include <api/CAnomalyJob.h>
 #include <api/CFieldConfig.h>
 #include <api/CJsonOutputWriter.h>
 #include <api/CNdJsonInputParser.h>
@@ -17,6 +16,7 @@
 #include <test/CTestTmpDir.h>
 
 #include "CMockDataProcessor.h"
+#include "CTestAnomalyJob.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -48,9 +48,9 @@ BOOST_AUTO_TEST_CASE(testChaining) {
         ml::model::CAnomalyDetectorModelConfig modelConfig =
             ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
 
-        ml::api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                                 ml::api::CAnomalyJob::TPersistCompleteFunc(),
-                                 nullptr, -1, "time", "%d/%b/%Y:%T %z");
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc(), nullptr,
+                            -1, "time", "%d/%b/%Y:%T %z");
 
         ml::api::COutputChainer outputChainer(job);
 

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -13,10 +13,8 @@
 #include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CLimits.h>
 
-#include <api/CAnomalyJob.h>
 #include <api/CDataProcessor.h>
 #include <api/CFieldConfig.h>
-#include <api/CFieldDataCategorizer.h>
 #include <api/CJsonOutputWriter.h>
 #include <api/CModelSnapshotJsonWriter.h>
 #include <api/CNdJsonInputParser.h>
@@ -24,6 +22,9 @@
 #include <api/COutputChainer.h>
 #include <api/CPersistenceManager.h>
 #include <api/CSingleStreamDataAdder.h>
+
+#include "CTestAnomalyJob.h"
+#include "CTestFieldDataCategorizer.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -99,11 +100,10 @@ protected:
             ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
             ml::api::CJsonOutputWriter outputWriter(JOB_ID, wrappedOutputStream);
 
-            ml::api::CAnomalyJob job(
-                JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
-                std::bind(&reportPersistComplete, std::placeholders::_1,
-                          std::ref(snapshotId), std::ref(numDocs)),
-                &persistenceManager, -1, "time", "%d/%b/%Y:%T %z");
+            CTestAnomalyJob job(JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
+                                std::bind(&reportPersistComplete, std::placeholders::_1,
+                                          std::ref(snapshotId), std::ref(numDocs)),
+                                &persistenceManager, -1, "time", "%d/%b/%Y:%T %z");
 
             ml::api::CDataProcessor* firstProcessor(&job);
 
@@ -111,12 +111,11 @@ protected:
             ml::api::COutputChainer outputChainer(job);
 
             // The categorizer knows how to assign categories to records
-            ml::api::CFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits,
-                                                       outputChainer, outputWriter,
-                                                       &persistenceManager);
+            CTestFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits, outputChainer,
+                                                  outputWriter, &persistenceManager);
 
             if (fieldConfig.fieldNameSuperset().count(
-                    ml::api::CFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
+                    CTestFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
                 LOG_DEBUG(<< "Applying the categorization categorizer for anomaly detection");
                 firstProcessor = &categorizer;
             }
@@ -223,11 +222,10 @@ protected:
             ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
             ml::api::CJsonOutputWriter outputWriter(JOB_ID, wrappedOutputStream);
 
-            ml::api::CAnomalyJob job(
-                JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
-                std::bind(&reportPersistComplete, std::placeholders::_1,
-                          std::ref(snapshotId), std::ref(numDocs)),
-                &persistenceManager, -1, "time", "%d/%b/%Y:%T %z");
+            CTestAnomalyJob job(JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
+                                std::bind(&reportPersistComplete, std::placeholders::_1,
+                                          std::ref(snapshotId), std::ref(numDocs)),
+                                &persistenceManager, -1, "time", "%d/%b/%Y:%T %z");
 
             ml::api::CDataProcessor* firstProcessor(&job);
 
@@ -324,8 +322,8 @@ BOOST_FIXTURE_TEST_CASE(testBackgroundPersistCategorizationConsistency, CTestFix
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
         ml::api::CJsonOutputWriter outputWriter(JOB_ID, wrappedOutputStream);
 
-        ml::api::CFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits, outputWriter,
-                                                   outputWriter, &persistenceManager);
+        CTestFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits, outputWriter,
+                                              outputWriter, &persistenceManager);
 
         std::istringstream inputStrm1{FIRST_INPUT};
         ml::api::CNdJsonInputParser parser1{inputStrm1};
@@ -410,8 +408,8 @@ BOOST_FIXTURE_TEST_CASE(testCategorizationOnlyPersist, CTestFixture) {
         ml::api::CNullOutput nullOutput;
 
         // The categorizer knows how to assign categories to records
-        ml::api::CFieldDataCategorizer categorizer(
-            JOB_ID, fieldConfig, limits, nullOutput, outputWriter, &persistenceManager);
+        CTestFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits, nullOutput,
+                                              outputWriter, &persistenceManager);
 
         ml::api::CNdJsonInputParser parser(inputStrm);
 

--- a/lib/api/unittest/CRestorePreviousStateTest.cc
+++ b/lib/api/unittest/CRestorePreviousStateTest.cc
@@ -11,15 +11,16 @@
 #include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CLimits.h>
 
-#include <api/CAnomalyJob.h>
 #include <api/CCsvOutputWriter.h>
 #include <api/CFieldConfig.h>
-#include <api/CFieldDataCategorizer.h>
 #include <api/CJsonOutputWriter.h>
 #include <api/CResultNormalizer.h>
 #include <api/CSingleStreamDataAdder.h>
 #include <api/CSingleStreamSearcher.h>
 #include <api/CStateRestoreStreamFilter.h>
+
+#include "CTestAnomalyJob.h"
+#include "CTestFieldDataCategorizer.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -82,7 +83,7 @@ void categorizerRestoreHelper(const std::string& stateFile, bool isSymmetric) {
     std::ostringstream outputStrm;
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
     ml::api::CJsonOutputWriter writer("job", wrappedOutputStream);
-    ml::api::CFieldDataCategorizer restoredCategorizer("job", config, limits, writer, writer);
+    CTestFieldDataCategorizer restoredCategorizer("job", config, limits, writer, writer);
 
     std::ifstream inputStrm(stateFile.c_str());
     BOOST_TEST_REQUIRE(inputStrm.is_open());
@@ -146,7 +147,7 @@ void anomalyDetectorRestoreHelper(const std::string& stateFile,
 
     std::string restoredSnapshotId;
     std::size_t numRestoredDocs(0);
-    ml::api::CAnomalyJob restoredJob(
+    CTestAnomalyJob restoredJob(
         JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
         std::bind(&reportPersistComplete, std::placeholders::_1,
                   std::ref(restoredSnapshotId), std::ref(numRestoredDocs)));

--- a/lib/api/unittest/CSingleStreamDataAdderTest.cc
+++ b/lib/api/unittest/CSingleStreamDataAdderTest.cc
@@ -14,16 +14,17 @@
 #include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CLimits.h>
 
-#include <api/CAnomalyJob.h>
 #include <api/CCsvInputParser.h>
 #include <api/CFieldConfig.h>
-#include <api/CFieldDataCategorizer.h>
 #include <api/CJsonOutputWriter.h>
 #include <api/CNdJsonInputParser.h>
 #include <api/COutputChainer.h>
 #include <api/CSingleStreamDataAdder.h>
 #include <api/CSingleStreamSearcher.h>
 #include <api/CStateRestoreStreamFilter.h>
+
+#include "CTestAnomalyJob.h"
+#include "CTestFieldDataCategorizer.h"
 
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/test/unit_test.hpp>
@@ -76,7 +77,7 @@ void detectorPersistHelper(const std::string& configFileName,
     std::string origPersistedState;
 
     {
-        ml::api::CAnomalyJob origJob(
+        CTestAnomalyJob origJob(
             JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
             std::bind(&reportPersistComplete, std::placeholders::_1,
                       std::ref(origSnapshotId), std::ref(numOrigDocs)),
@@ -88,11 +89,11 @@ void detectorPersistHelper(const std::string& configFileName,
         ml::api::COutputChainer outputChainer(origJob);
 
         // The categorizer knows how to assign categories to records
-        ml::api::CFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits,
-                                                   outputChainer, outputWriter);
+        CTestFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits,
+                                              outputChainer, outputWriter);
 
         if (fieldConfig.fieldNameSuperset().count(
-                ml::api::CFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
+                CTestFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
             LOG_DEBUG(<< "Applying the categorization categorizer for anomaly detection");
             firstProcessor = &categorizer;
         }
@@ -123,7 +124,7 @@ void detectorPersistHelper(const std::string& configFileName,
     std::string newPersistedState;
 
     {
-        ml::api::CAnomalyJob restoredJob(
+        CTestAnomalyJob restoredJob(
             JOB_ID, limits, fieldConfig, modelConfig, wrappedOutputStream,
             std::bind(&reportPersistComplete, std::placeholders::_1,
                       std::ref(restoredSnapshotId), std::ref(numRestoredDocs)));
@@ -134,13 +135,13 @@ void detectorPersistHelper(const std::string& configFileName,
         ml::api::COutputChainer restoredOutputChainer(restoredJob);
 
         // The categorizer knows how to assign categories to records
-        ml::api::CFieldDataCategorizer restoredCategorizer(
+        CTestFieldDataCategorizer restoredCategorizer(
             JOB_ID, fieldConfig, limits, restoredOutputChainer, outputWriter);
 
         size_t numCategorizerDocs(0);
 
         if (fieldConfig.fieldNameSuperset().count(
-                ml::api::CFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
+                CTestFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
             LOG_DEBUG(<< "Applying the categorization categorizer for anomaly detection");
             numCategorizerDocs = 1;
             restoredFirstProcessor = &restoredCategorizer;

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -11,7 +11,6 @@
 #include <model/CLimits.h>
 #include <model/CStringStore.h>
 
-#include <api/CAnomalyJob.h>
 #include <api/CCsvInputParser.h>
 #include <api/CFieldConfig.h>
 #include <api/CHierarchicalResultsWriter.h>
@@ -19,6 +18,7 @@
 
 #include "CMockDataAdder.h"
 #include "CMockSearcher.h"
+#include "CTestAnomalyJob.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -53,7 +53,7 @@ core_t::TTime playData(core_t::TTime start,
                        int numPeople,
                        int numPartitions,
                        int anomaly,
-                       api::CAnomalyJob& job) {
+                       CTestAnomalyJob& job) {
     std::string people[] = {"Elgar", "Holst",   "Delius", "Vaughan Williams",
                             "Bliss", "Warlock", "Walton"};
     if (numPeople > 7) {
@@ -85,7 +85,7 @@ core_t::TTime playData(core_t::TTime start,
     api::CCsvInputParser parser(ss);
 
     BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
-        std::bind(&api::CAnomalyJob::handleRecord, &job, std::placeholders::_1)));
+        std::bind(&CTestAnomalyJob::handleRecord, &job, std::placeholders::_1)));
 
     return t;
 }
@@ -156,7 +156,7 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
         wrappedOutputStream.syncFlush();
@@ -202,8 +202,8 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
 
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                             api::CAnomalyJob::TPersistCompleteFunc());
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc());
 
         core_t::TTime completeToTime(0);
         BOOST_TEST_REQUIRE(job.restoreState(searcher, completeToTime));
@@ -243,8 +243,8 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
 
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                             api::CAnomalyJob::TPersistCompleteFunc());
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc());
 
         core_t::TTime completeToTime(0);
         BOOST_TEST_REQUIRE(job.restoreState(searcher, completeToTime));
@@ -285,8 +285,8 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
 
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                             api::CAnomalyJob::TPersistCompleteFunc());
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc());
 
         core_t::TTime completeToTime(0);
         BOOST_TEST_REQUIRE(job.restoreState(searcher, completeToTime));
@@ -346,7 +346,7 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
         wrappedOutputStream.syncFlush();
@@ -391,8 +391,8 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                             api::CAnomalyJob::TPersistCompleteFunc());
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc());
 
         core_t::TTime completeToTime(0);
         BOOST_TEST_REQUIRE(job.restoreState(searcher, completeToTime));
@@ -433,8 +433,8 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                             api::CAnomalyJob::TPersistCompleteFunc());
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc());
 
         core_t::TTime completeToTime(0);
         BOOST_TEST_REQUIRE(job.restoreState(searcher, completeToTime));
@@ -476,8 +476,8 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
-                             api::CAnomalyJob::TPersistCompleteFunc());
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream,
+                            CTestAnomalyJob::TPersistCompleteFunc());
 
         core_t::TTime completeToTime(0);
         BOOST_TEST_REQUIRE(job.restoreState(searcher, completeToTime));
@@ -535,7 +535,7 @@ BOOST_FIXTURE_TEST_CASE(testInfluencerStringPruning, CTestFixture) {
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
 
-        api::CAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
+        CTestAnomalyJob job("job", limits, fieldConfig, modelConfig, wrappedOutputStream);
 
         // Play in a few buckets with influencers, and see that they stick around for
         // 3 buckets

--- a/lib/api/unittest/CTestAnomalyJob.cc
+++ b/lib/api/unittest/CTestAnomalyJob.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include "CTestAnomalyJob.h"
+
+CTestAnomalyJob::CTestAnomalyJob(const std::string& jobId,
+                                 ml::model::CLimits& limits,
+                                 ml::api::CFieldConfig& fieldConfig,
+                                 ml::model::CAnomalyDetectorModelConfig& modelConfig,
+                                 ml::core::CJsonOutputStreamWrapper& outputBuffer,
+                                 const TPersistCompleteFunc& persistCompleteFunc,
+                                 ml::api::CPersistenceManager* persistenceManager,
+                                 ml::core_t::TTime maxQuantileInterval,
+                                 const std::string& timeFieldName,
+                                 const std::string& timeFieldFormat,
+                                 std::size_t maxAnomalyRecords)
+    : ml::api::CAnomalyJob(jobId,
+                           limits,
+                           fieldConfig,
+                           modelConfig,
+                           outputBuffer,
+                           persistCompleteFunc,
+                           persistenceManager,
+                           maxQuantileInterval,
+                           timeFieldName,
+                           timeFieldFormat,
+                           maxAnomalyRecords) {
+}

--- a/lib/api/unittest/CTestAnomalyJob.h
+++ b/lib/api/unittest/CTestAnomalyJob.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_CTestAnomalyJob_h
+#define INCLUDED_CTestAnomalyJob_h
+
+#include <api/CAnomalyJob.h>
+
+//! \brief
+//! A test convenience wrapper for the ML anomaly  detector.
+//!
+//! DESCRIPTION:\n
+//! Defaults some constructor arguments to make unit tests less
+//! verbose.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! The base class requires all constructor arguments be provided
+//! to avoid accidental defaulting in production code, but for
+//! unit tests defaults are often fine.
+//!
+class CTestAnomalyJob : public ml::api::CAnomalyJob {
+
+public:
+    CTestAnomalyJob(const std::string& jobId,
+                    ml::model::CLimits& limits,
+                    ml::api::CFieldConfig& fieldConfig,
+                    ml::model::CAnomalyDetectorModelConfig& modelConfig,
+                    ml::core::CJsonOutputStreamWrapper& outputBuffer,
+                    const TPersistCompleteFunc& persistCompleteFunc = TPersistCompleteFunc(),
+                    ml::api::CPersistenceManager* persistenceManager = nullptr,
+                    ml::core_t::TTime maxQuantileInterval = -1,
+                    const std::string& timeFieldName = DEFAULT_TIME_FIELD_NAME,
+                    const std::string& timeFieldFormat = EMPTY_STRING,
+                    std::size_t maxAnomalyRecords = 0u);
+};
+
+#endif // INCLUDED_CTestAnomalyJob_h

--- a/lib/api/unittest/CTestFieldDataCategorizer.cc
+++ b/lib/api/unittest/CTestFieldDataCategorizer.cc
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include "CTestFieldDataCategorizer.h"
+
+CTestFieldDataCategorizer::CTestFieldDataCategorizer(const std::string& jobId,
+                                                     const ml::api::CFieldConfig& config,
+                                                     ml::model::CLimits& limits,
+                                                     ml::api::COutputHandler& outputHandler,
+                                                     ml::api::CJsonOutputWriter& jsonOutputWriter,
+                                                     ml::api::CPersistenceManager* persistenceManager)
+    : ml::api::CFieldDataCategorizer(jobId, config, limits, outputHandler, jsonOutputWriter, persistenceManager) {
+}

--- a/lib/api/unittest/CTestFieldDataCategorizer.h
+++ b/lib/api/unittest/CTestFieldDataCategorizer.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_CTestFieldDataCategorizer_h
+#define INCLUDED_CTestFieldDataCategorizer_h
+
+#include <api/CFieldDataCategorizer.h>
+
+//! \brief
+//! A test convenience wrapper for the ML categorizer.
+//!
+//! DESCRIPTION:\n
+//! Defaults some constructor arguments to make unit tests less
+//! verbose.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! The base class requires all constructor arguments be provided
+//! to avoid accidental defaulting in production code, but for
+//! unit tests defaults are often fine.
+//!
+class CTestFieldDataCategorizer : public ml::api::CFieldDataCategorizer {
+
+public:
+    CTestFieldDataCategorizer(const std::string& jobId,
+                              const ml::api::CFieldConfig& config,
+                              ml::model::CLimits& limits,
+                              ml::api::COutputHandler& outputHandler,
+                              ml::api::CJsonOutputWriter& jsonOutputWriter,
+                              ml::api::CPersistenceManager* persistenceManager = nullptr);
+};
+
+#endif // INCLUDED_CTestFieldDataCategorizer_h

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -58,7 +58,8 @@ SRCS=\
 	CSingleStreamDataAdderTest.cc \
 	CStateRestoreStreamFilterTest.cc \
 	CStringStoreTest.cc \
-
+	CTestAnomalyJob.cc \
+	CTestFieldDataCategorizer.cc \
 
 include $(CPP_SRC_HOME)/mk/stdboosttest.mk
 


### PR DESCRIPTION
Periodic persistence of categorizer state has not
worked since version 7.4.0.  This change makes it work
again.

Additionally, the persistence manager pointer argument
to the categorizer and anomaly detector classes is no
longer defaulted.  It can still be null, because it's
a major pain for unit tests to have to pass a real
persistence manager, but at least this must be
explicitly specified now, hopefully prompting anyone
who constructs such an object in production code to
pass a non-null persistence manager.

Backport of #1137