### PR TITLE
[ML] Silence gcc warnings

### DIFF
--- a/include/maths/COutliers.h
+++ b/include/maths/COutliers.h
@@ -719,7 +719,7 @@ public:
                                                    std::size_t dimension);
 
     //! Return string representation of the \p method.
-    static std::string print(EMethod method);
+    static const std::string& print(EMethod method);
 
     //! \name Test Interface
     //@{

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -81,6 +81,7 @@ public:
                 // TODO
                 return TDataFrameUPtr{};
             }
+            return nullptr;
         }();
 
         TLossUPtr loss;

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -81,7 +81,7 @@ public:
                 // TODO
                 return TDataFrameUPtr{};
             }
-            return nullptr;
+            return TDataFrameUPtr{};
         }();
 
         TLossUPtr loss;

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -56,6 +56,7 @@ CDataFrameTrainBoostedTreeRegressionRunner::lossFunction(const CDataFrameAnalysi
     case E_Mse:
         return std::make_unique<maths::boosted_tree::CMse>();
     }
+    return nullptr;
 }
 
 CDataFrameTrainBoostedTreeRegressionRunner::CDataFrameTrainBoostedTreeRegressionRunner(

--- a/lib/config/unittest/CReportWriterTest.cc
+++ b/lib/config/unittest/CReportWriterTest.cc
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(testPretty) {
     TDoubleVec weight;
     TSizeVec index;
     for (core_t::TTime time = startTime; time < endTime;
-         time += static_cast<double>(dt[0])) {
+         time += static_cast<core_t::TTime>(dt[0])) {
         double progress = static_cast<double>(time - startTime) /
                           static_cast<double>((endTime - startTime));
         if (progress > lastProgress + 0.05) {

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -20,8 +20,10 @@
 
 #include <boost/math/distributions/lognormal.hpp>
 
+#include <cmath>
 #include <numeric>
 #include <sstream>
+#include <string>
 #include <tuple>
 
 namespace ml {
@@ -31,6 +33,7 @@ using namespace outliers_detail;
 namespace {
 
 const std::string COMPUTE_OUTLIER_SCORES{"compute_outlier_scores"};
+const std::string EMPTY_STRING;
 
 using TRowItr = core::CDataFrame::TRowItr;
 using TStepCallback = std::function<void(const std::string&)>;
@@ -1121,19 +1124,20 @@ void COutliers::noopRecordProgress(double) {
 void COutliers::noopRecordMemoryUsage(std::int64_t) {
 }
 
-std::string COutliers::print(EMethod method) {
+const std::string& COutliers::print(EMethod method) {
     switch (method) {
     case E_Lof:
         return LOF;
-    case maths::COutliers::E_Ldof:
+    case E_Ldof:
         return LDOF;
-    case maths::COutliers::E_DistancekNN:
+    case E_DistancekNN:
         return DISTANCE_KNN;
-    case maths::COutliers::E_TotalDistancekNN:
+    case E_TotalDistancekNN:
         return TOTAL_DISTANCE_KNN;
-    case maths::COutliers::E_Ensemble:
+    case E_Ensemble:
         return ENSEMBLE;
     }
+    return EMPTY_STRING;
 }
 
 const std::string COutliers::LOF{"lof"};

--- a/lib/maths/unittest/CMicTest.cc
+++ b/lib/maths/unittest/CMicTest.cc
@@ -87,7 +87,8 @@ BOOST_AUTO_TEST_CASE(testOptimizeXAxis) {
     mic.setup();
 
     std::size_t k{5};
-    std::size_t ck{static_cast<std::size_t>(k * mic.maximumXAxisPartitionSizeToSearch())};
+    std::size_t ck{static_cast<std::size_t>(
+        static_cast<double>(k) * mic.maximumXAxisPartitionSizeToSearch())};
 
     TDoubleVec pi(mic.equipartitionAxis(0, ck));
     TDoubleVec q(mic.equipartitionAxis(1, k));

--- a/lib/maths/unittest/CMultivariateMultimodalPriorTest.cc
+++ b/lib/maths/unittest/CMultivariateMultimodalPriorTest.cc
@@ -318,14 +318,14 @@ BOOST_AUTO_TEST_CASE(testMultipleModes) {
     LOG_DEBUG(<< "Mixture Normals");
     {
         const TSizeVec n{400, 600};
-        const double means[][2] = {{10.0, 10.0}, {20.0, 20.0}};
-        const double covariances[][3] = {{4.0, 1.0, 4.0}, {10.0, -4.0, 6.0}};
+        const double means[][2]{{10.0, 10.0}, {20.0, 20.0}};
+        const double covariances[][3]{{4.0, 1.0, 4.0}, {10.0, -4.0, 6.0}};
 
         TDouble10Vec1Vec samples;
         gaussianSamples(rng, n, means, covariances, samples);
 
-        double w[] = {n[0] / static_cast<double>(n[0] + n[1]),
-                      n[1] / static_cast<double>(n[0] + n[1])};
+        double w[]{static_cast<double>(n[0]) / static_cast<double>(n[0] + n[1]),
+                   static_cast<double>(n[1]) / static_cast<double>(n[0] + n[1])};
 
         double loss = 0.0;
         TMeanAccumulator differentialEntropy_;

--- a/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
+++ b/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
@@ -582,7 +582,8 @@ BOOST_AUTO_TEST_CASE(testWithOutliers) {
 
             for (const auto& bucketLength : bucketLengths) {
                 core_t::TTime buckets{window / bucketLength};
-                std::size_t numberOutliers{static_cast<std::size_t>(0.12 * buckets)};
+                std::size_t numberOutliers{
+                    static_cast<std::size_t>(0.12 * static_cast<double>(buckets))};
                 rng.generateUniformSamples(0, buckets, numberOutliers, outliers);
                 rng.generateUniformSamples(0, 1.0, numberOutliers, spikeOrTroughSelector);
                 rng.generateNormalSamples(0.0, 9.0, buckets, noise);
@@ -632,7 +633,8 @@ BOOST_AUTO_TEST_CASE(testWithOutliers) {
 
         for (const auto& bucketLength : bucketLengths) {
             core_t::TTime buckets{window / bucketLength};
-            std::size_t numberOutliers{static_cast<std::size_t>(0.12 * buckets)};
+            std::size_t numberOutliers{
+                static_cast<std::size_t>(0.12 * static_cast<double>(buckets))};
             rng.generateUniformSamples(0, buckets, numberOutliers, outliers);
             rng.generateUniformSamples(0, 1.0, numberOutliers, spikeOrTroughSelector);
             rng.generateNormalSamples(0.0, 9.0, buckets, noise);

--- a/lib/maths/unittest/CRandomizedPeriodicityTestTest.cc
+++ b/lib/maths/unittest/CRandomizedPeriodicityTestTest.cc
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(testAccuracy) {
                                           : falseNegatives[j - 3]) += 1.0;
                         if (rtests[j].test()) {
                             timeToDetectionMoments[j - 3].add(
-                                time - lastTruePositive[j - 3]);
+                                static_cast<double>(time - lastTruePositive[j - 3]));
                             timeToDetectionMax[j - 3].add(
                                 static_cast<double>(time - lastTruePositive[j - 3]));
                             lastTruePositive[j - 3] = time;

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -1776,7 +1776,7 @@ BOOST_FIXTURE_TEST_CASE(testWithOutliers, CTestFixture) {
     TDoubleVec spikeOrTroughSelector;
 
     core_t::TTime buckets{WEEK / TEN_MINS};
-    std::size_t numberOutliers{static_cast<std::size_t>(0.1 * buckets)};
+    std::size_t numberOutliers{static_cast<std::size_t>(0.1 * static_cast<double>(buckets))};
     rng.generateUniformSamples(0, buckets, numberOutliers, outliers);
     rng.generateUniformSamples(0, 1.0, numberOutliers, spikeOrTroughSelector);
     rng.generateNormalSamples(0.0, 9.0, buckets, noise);
@@ -1920,19 +1920,25 @@ BOOST_FIXTURE_TEST_CASE(testComponentLifecycle, CTestFixture) {
     test::CRandomNumbers rng;
 
     auto trend = [](core_t::TTime time) {
-        return 20.0 + 10.0 * std::sin(boost::math::double_constants::two_pi * time / DAY) +
+        return 20.0 +
+               10.0 * std::sin(boost::math::double_constants::two_pi *
+                               static_cast<double>(time) / static_cast<double>(DAY)) +
                3.0 * (time > 4 * WEEK
-                          ? std::sin(boost::math::double_constants::two_pi * time / HOUR)
+                          ? std::sin(boost::math::double_constants::two_pi *
+                                     static_cast<double>(time) / static_cast<double>(HOUR))
                           : 0.0) -
                3.0 * (time > 9 * WEEK
-                          ? std::sin(boost::math::double_constants::two_pi * time / HOUR)
+                          ? std::sin(boost::math::double_constants::two_pi *
+                                     static_cast<double>(time) / static_cast<double>(HOUR))
                           : 0.0) +
-               8.0 * (time > 16 * WEEK
-                          ? std::sin(boost::math::double_constants::two_pi * time / 4 / DAY)
-                          : 0.0) -
-               8.0 * (time > 21 * WEEK
-                          ? std::sin(boost::math::double_constants::two_pi * time / 4 / DAY)
-                          : 0.0);
+               8.0 * (time > 16 * WEEK ? std::sin(boost::math::double_constants::two_pi *
+                                                  static_cast<double>(time) /
+                                                  4.0 / static_cast<double>(DAY))
+                                       : 0.0) -
+               8.0 * (time > 21 * WEEK ? std::sin(boost::math::double_constants::two_pi *
+                                                  static_cast<double>(time) /
+                                                  4.0 / static_cast<double>(DAY))
+                                       : 0.0);
     };
 
     maths::CTimeSeriesDecomposition decomposition(0.012, FIVE_MINS);

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -386,8 +386,8 @@ private:
         if (m_Tree[nodeIndex].isLeaf()) {
             return weight * m_Tree[nodeIndex].value();
         } else {
-            auto leftChildIndex{m_Tree[nodeIndex].leftChildIndex()};
-            auto rightChildIndex{m_Tree[nodeIndex].rightChildIndex()};
+            auto leftChildIndex = m_Tree[nodeIndex].leftChildIndex();
+            auto rightChildIndex = m_Tree[nodeIndex].rightChildIndex();
             if (S.find(m_Tree[nodeIndex].splitFeature()) != S.end()) {
                 if (m_Tree[nodeIndex].assignToLeft(x)) {
                     return this->conditionalExpectation(x, S, leftChildIndex, weight);
@@ -397,12 +397,12 @@ private:
             } else {
                 return this->conditionalExpectation(
                            x, S, leftChildIndex,
-                           weight * m_Tree[leftChildIndex].numberSamples() /
-                               m_Tree[nodeIndex].numberSamples()) +
+                           weight * static_cast<double>(m_Tree[leftChildIndex].numberSamples()) /
+                               static_cast<double>(m_Tree[nodeIndex].numberSamples())) +
                        this->conditionalExpectation(
                            x, S, rightChildIndex,
-                           weight * m_Tree[rightChildIndex].numberSamples() /
-                               m_Tree[nodeIndex].numberSamples());
+                           weight * static_cast<double>(m_Tree[rightChildIndex].numberSamples()) /
+                               static_cast<double>(m_Tree[nodeIndex].numberSamples()));
             }
         }
     }

--- a/lib/maths/unittest/CTrendComponentTest.cc
+++ b/lib/maths/unittest/CTrendComponentTest.cc
@@ -280,9 +280,9 @@ BOOST_AUTO_TEST_CASE(testDecayRate) {
     for (core_t::TTime time = start; time < end; time += BUCKET_LENGTH) {
         double value{values[(time - start) / BUCKET_LENGTH]};
         component.add(time, value);
-        regression.add(time / 604800.0, value);
+        regression.add(static_cast<double>(time) / 604800.0, value);
 
-        double expectedPrediction{regression.predict(time / 604800.0)};
+        double expectedPrediction{regression.predict(static_cast<double>(time) / 604800.0)};
         double prediction{maths::CBasicStatistics::mean(component.value(time, 0.0))};
         error.add(std::fabs(prediction - expectedPrediction));
         level.add(value);

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -281,7 +281,8 @@ std::size_t CResourceMonitor::adjustedUsage(std::size_t usage) const {
     // This gives the user a fairer indication of how close the job is to hitting
     // the model memory limit in a concise manner (as the limit is scaled down by
     // the margin during the beginning period of the job's existence).
-    size_t adjustedUsage{static_cast<std::size_t>(usage / m_ByteLimitMargin)};
+    std::size_t adjustedUsage{
+        static_cast<std::size_t>(static_cast<double>(usage) / m_ByteLimitMargin)};
 
     adjustedUsage *= this->persistenceMemoryIncreaseFactor();
 

--- a/lib/model/CRuleCondition.cc
+++ b/lib/model/CRuleCondition.cc
@@ -76,7 +76,7 @@ bool CRuleCondition::test(const CAnomalyDetectorModel& model,
         break;
     }
     case E_Time: {
-        value.push_back(time);
+        value.push_back(static_cast<double>(time));
         break;
     }
     }

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -528,7 +528,7 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
                                     uniqueValues.begin(), uniqueValues.end(),
                                     std::bind(&core::CCompressUtil::addString,
                                               &compressor, std::placeholders::_1))));
-            size_t length(0);
+            std::size_t length(0);
             BOOST_TEST_REQUIRE(compressor.length(true, length));
             expectedBucketCompressedLengthPerPerson[key] = length;
         }
@@ -539,8 +539,9 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
         for (TSizeSizePrFeatureDataPrVec::const_iterator j =
                  bucketCompressedLengthPerPerson.begin();
              j != bucketCompressedLengthPerPerson.end(); ++j) {
-            double expectedLength = expectedBucketCompressedLengthPerPerson[j->first];
-            double actual = j->second.s_Count;
+            double expectedLength = static_cast<double>(
+                expectedBucketCompressedLengthPerPerson[j->first]);
+            double actual = static_cast<double>(j->second.s_Count);
             BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedLength, actual, expectedLength * 0.1);
         }
 

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -308,7 +308,7 @@ BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
         BOOST_TEST_REQUIRE(gatherer->personId(message.s_Person, pid));
         BOOST_TEST_REQUIRE(gatherer->attributeId(message.s_Attribute, cid));
         ++expectedBucketPersonCounts[pid];
-        expectedBucketPersonAttributeCounts[{pid, cid}] += 1.0;
+        ++expectedBucketPersonAttributeCounts[{pid, cid}];
     }
 }
 

--- a/lib/model/unittest/CSampleQueueTest.cc
+++ b/lib/model/unittest/CSampleQueueTest.cc
@@ -1019,7 +1019,7 @@ BOOST_AUTO_TEST_CASE(testQualityOfSamplesGivenConstantRate) {
             core_t::TTime measurementTime = static_cast<core_t::TTime>(testData[0]);
             queue.add(measurementTime, {1.0}, 1u, sampleCount);
         }
-        meanQueueSize.add(queue.size());
+        meanQueueSize.add(static_cast<double>(queue.size()));
         queue.sample(latestTime, sampleCount, model_t::E_IndividualMeanByPerson, samples);
 
         maths::CBasicStatistics::SSampleMeanVar<double>::TAccumulator varianceStat;


### PR DESCRIPTION
This fixes warnings being generated by gcc I noticed while working on #1127. These are harmless and mainly `-Wconversion`.