### PR TITLE
[ML] Fix macOS sandbox rules

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -63,9 +63,9 @@
 
 === Bug Fixes
 
-* Fixed background persistence of categorizer state. (See {ml-pull}1137[#1137],
+* Fixed background persistence of categorizer state (See {ml-pull}1137[#1137],
   issue: {ml-issue}1136[#1136].)
-* Fixed macOS sandbox rules. (See {ml-pull}1146[#1146].)
+
 
 == {es} version 7.7.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -63,9 +63,9 @@
 
 === Bug Fixes
 
-* Fixed background persistence of categorizer state (See {ml-pull}1137[#1137],
+* Fixed background persistence of categorizer state. (See {ml-pull}1137[#1137],
   issue: {ml-issue}1136[#1136].)
-
+* Fixed macOS sandbox rules. (See {ml-pull}1146[#1146].)
 
 == {es} version 7.7.0
 

--- a/lib/seccomp/CSystemCallFilter_MacOSX.cc
+++ b/lib/seccomp/CSystemCallFilter_MacOSX.cc
@@ -88,7 +88,7 @@ void CSystemCallFilter::installSystemCallFilter() {
         if (errorbuf != nullptr) {
             msg += ": ";
             msg += errorbuf;
-            sandbox_free_error(errorbuf);
+            ::sandbox_free_error(errorbuf);
         }
         LOG_ERROR(<< msg);
     } else {

--- a/lib/seccomp/CSystemCallFilter_MacOSX.cc
+++ b/lib/seccomp/CSystemCallFilter_MacOSX.cc
@@ -18,29 +18,39 @@ namespace ml {
 namespace seccomp {
 
 namespace {
-// The Sandbox rules deny all actions apart from creating fifos,
-// opening files, reading and writing.
+// The Sandbox rules deny all actions not explicitly listed.
+// (allow signal (target self)) is required for the SIGIO used
+// to wake up blocking reads.
+// (allow system-sched (target self)) is required for "nice".
+// (allow file-read*) is required for reading config files.
+// (allow file-read*) is required for reading config files.
 // (allow file-write*) is required for mkfifo and that permission
 // can not be set using the more granular controls.
-const std::string SANDBOX_RULES("\
+// (debug deny) makes it easier to see which calls need adding
+// when one that is required is not in the list - they show up in
+// the macOS console.
+const std::string SANDBOX_RULES{"\
     (version 1) \
     (deny default) \
+    (allow signal (target self)) \
+    (allow system-sched (target self)) \
     (allow file-read*) \
     (allow file-read-data) \
     (allow file-write*) \
-    (allow file-write-data)");
+    (allow file-write-data) \
+    (debug deny)"};
 
 // mkstemps will replace the Xs with random characters
-const std::string FILE_NAME_TEMPLATE("ml.XXXXXX.sb");
+const std::string FILE_NAME_TEMPLATE{"ml.XXXXXX.sb"};
 // The length of the suffix '.sb'
-const int FILE_NAME_TEMPLATE_SUFFIX_LEN = 3;
+const int FILE_NAME_TEMPLATE_SUFFIX_LEN{3};
 
 std::string getTempDir() {
     // Prefer to use the temporary directory set by the Elasticsearch JVM
-    const char* tmpDir(::getenv("TMPDIR"));
+    const char* tmpDir{::getenv("TMPDIR")};
 
     // If TMPDIR is not set use _PATH_VARTMP
-    std::string path((tmpDir == nullptr) ? _PATH_VARTMP : tmpDir);
+    std::string path{(tmpDir == nullptr) ? _PATH_VARTMP : tmpDir};
     // Make sure path ends with a slash so it's ready to have a file name appended
     if (path[path.length() - 1] != '/') {
         path += '/';
@@ -49,32 +59,32 @@ std::string getTempDir() {
 }
 
 std::string writeTempRulesFile() {
-    std::string profileFilename = getTempDir() + FILE_NAME_TEMPLATE;
+    std::string profileFilename{getTempDir() + FILE_NAME_TEMPLATE};
 
     // Create and open a temporary file with a random name
     // profileFilename is updated with the new filename.
-    int fd = mkstemps(&profileFilename[0], FILE_NAME_TEMPLATE_SUFFIX_LEN);
+    int fd{::mkstemps(&profileFilename[0], FILE_NAME_TEMPLATE_SUFFIX_LEN)};
     if (fd == -1) {
         LOG_ERROR(<< "Opening a temporary file with mkstemps failed: "
                   << std::strerror(errno));
         return std::string();
     }
-    write(fd, SANDBOX_RULES.c_str(), SANDBOX_RULES.size());
-    close(fd);
+    ::write(fd, SANDBOX_RULES.c_str(), SANDBOX_RULES.size());
+    ::close(fd);
 
     return profileFilename;
 }
 }
 
 void CSystemCallFilter::installSystemCallFilter() {
-    std::string profileFilename = writeTempRulesFile();
+    std::string profileFilename{writeTempRulesFile()};
     if (profileFilename.empty()) {
         LOG_WARN(<< "Cannot write sandbox rules. macOS sandbox will not be initialized");
         return;
     }
 
-    char* errorbuf = nullptr;
-    if (sandbox_init(profileFilename.c_str(), SANDBOX_NAMED, &errorbuf) != 0) {
+    char* errorbuf{nullptr};
+    if (::sandbox_init(profileFilename.c_str(), SANDBOX_NAMED, &errorbuf) != 0) {
         std::string msg("Error initializing macOS sandbox");
         if (errorbuf != nullptr) {
             msg += ": ";

--- a/lib/seccomp/CSystemCallFilter_MacOSX.cc
+++ b/lib/seccomp/CSystemCallFilter_MacOSX.cc
@@ -23,7 +23,6 @@ namespace {
 // to wake up blocking reads.
 // (allow system-sched (target self)) is required for "nice".
 // (allow file-read*) is required for reading config files.
-// (allow file-read*) is required for reading config files.
 // (allow file-write*) is required for mkfifo and that permission
 // can not be set using the more granular controls.
 // (debug deny) makes it easier to see which calls need adding


### PR DESCRIPTION
Two rules were missing:

1. We were blocking our own SIGIO signals used to wake up blocking
   file reads.  (This is quite nasty as this functionality is only
   used in edge cases.)
2. We were blocking the setpriority() calls made by nice().

I added the (debug deny) rule so that any blocked calls get logged
to the system console.  This makes it easier to see which rules are
required but missing.

I also changed the code style to match what our current style guide
says.