### PR TITLE
[ML] Some move related optimisations

### DIFF
--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -166,8 +166,8 @@ private:
     struct API_EXPORT SForecast {
         SForecast();
 
-        SForecast(SForecast&& other);
-        SForecast& operator=(SForecast&& other);
+        SForecast(SForecast&& other) noexcept;
+        SForecast& operator=(SForecast&& other) noexcept;
 
         SForecast(const SForecast& that) = delete;
         SForecast& operator=(const SForecast&) = delete;

--- a/include/core/CSmallVector.h
+++ b/include/core/CSmallVector.h
@@ -97,7 +97,7 @@ public:
     //@{
     CSmallVector() {}
     CSmallVector(const CSmallVector& other) : TBase(other) {}
-    CSmallVector(CSmallVector&& other) noexcept(std::is_nothrow_move_assignable<TBase>::value)
+    CSmallVector(CSmallVector&& other) noexcept(std::is_nothrow_move_constructible<TBase>::value)
         : TBase(std::move(other.baseRef())) {}
     explicit CSmallVector(size_type n, const value_type& val = value_type())
         : TBase(n, val) {}

--- a/include/core/CSmallVector.h
+++ b/include/core/CSmallVector.h
@@ -97,7 +97,7 @@ public:
     //@{
     CSmallVector() {}
     CSmallVector(const CSmallVector& other) : TBase(other) {}
-    CSmallVector(CSmallVector&& other) noexcept(std::is_nothrow_move_assignable<T>::value)
+    CSmallVector(CSmallVector&& other) noexcept(std::is_nothrow_move_assignable<TBase>::value)
         : TBase(std::move(other.baseRef())) {}
     explicit CSmallVector(size_type n, const value_type& val = value_type())
         : TBase(n, val) {}
@@ -117,7 +117,7 @@ public:
         : TBase(other.begin(), other.end()) {}
 
     CSmallVector&
-    operator=(CSmallVector&& rhs) noexcept(std::is_nothrow_move_assignable<T>::value) {
+    operator=(CSmallVector&& rhs) noexcept(std::is_nothrow_move_assignable<TBase>::value) {
         this->baseRef() = std::move(rhs.baseRef());
         return *this;
     }

--- a/include/core/CSmallVector.h
+++ b/include/core/CSmallVector.h
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <initializer_list>
 #include <ostream>
+#include <type_traits>
 #include <vector>
 
 namespace ml {
@@ -96,7 +97,8 @@ public:
     //@{
     CSmallVector() {}
     CSmallVector(const CSmallVector& other) : TBase(other) {}
-    CSmallVector(CSmallVector&& other) : TBase(std::move(other.baseRef())) {}
+    CSmallVector(CSmallVector&& other) noexcept(std::is_nothrow_move_assignable<T>::value)
+        : TBase(std::move(other.baseRef())) {}
     explicit CSmallVector(size_type n, const value_type& val = value_type())
         : TBase(n, val) {}
     CSmallVector(std::initializer_list<value_type> list)
@@ -114,7 +116,8 @@ public:
     CSmallVector(const std::vector<U>& other)
         : TBase(other.begin(), other.end()) {}
 
-    CSmallVector& operator=(CSmallVector&& rhs) {
+    CSmallVector&
+    operator=(CSmallVector&& rhs) noexcept(std::is_nothrow_move_assignable<T>::value) {
         this->baseRef() = std::move(rhs.baseRef());
         return *this;
     }

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -260,7 +260,12 @@ parallel_for_each(std::size_t partitions,
         for (std::size_t i = start; i < end; ++i, progress.increment()) {
             f(i);
         }
-        return {std::forward<FUNCTION>(f)};
+
+        // Avoid the copy from an initializer_list.
+        std::vector<FUNCTION> functions;
+        functions.reserve(1);
+        functions.push_back(std::forward<FUNCTION>(f));
+        return functions;
     }
 
     std::vector<FUNCTION> functions{partitions, std::forward<FUNCTION>(f)};
@@ -353,7 +358,12 @@ parallel_for_each(std::size_t partitions,
         for (ITR i = start; i != end; ++i, progress.increment()) {
             f(*i);
         }
-        return {std::forward<FUNCTION>(f)};
+
+        // Avoid the copy from an initializer_list.
+        std::vector<FUNCTION> functions;
+        functions.reserve(1);
+        functions.push_back(std::forward<FUNCTION>(f));
+        return functions;
     }
 
     std::vector<FUNCTION> functions{partitions, std::forward<FUNCTION>(f)};

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -42,7 +42,7 @@ public:
     using TRowRef = core::CDataFrame::TRowRef;
 
 public:
-    CEncodedDataFrameRowRef(TRowRef row, const CDataFrameCategoryEncoder& encoder);
+    CEncodedDataFrameRowRef(const TRowRef& row, const CDataFrameCategoryEncoder& encoder);
 
     //! Get column \p i value.
     CFloatStorage operator[](std::size_t encodedColumnIndex) const;
@@ -221,7 +221,7 @@ public:
     CDataFrameCategoryEncoder& operator=(const CDataFrameCategoryEncoder&) = delete;
 
     //! Get a row reference which encodes the categories in \p row.
-    CEncodedDataFrameRowRef encode(TRowRef row) const;
+    CEncodedDataFrameRowRef encode(const TRowRef& row) const;
 
     //! Get the MICs of the selected features.
     TDoubleVec encodedColumnMics() const;

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -385,7 +385,7 @@ public:
         this->reseat(other);
     }
     CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix&& other) noexcept(
-        std::is_nothrow_move_assignable<TBase>::value)
+        std::is_nothrow_constructible<TBase>::value)
         : TBase{nullptr, 1, 1} {
         this->reseat(other);
     }
@@ -396,7 +396,7 @@ public:
         return *this;
     }
     CMemoryMappedDenseMatrix& operator=(CMemoryMappedDenseMatrix&& other) noexcept(
-        std::is_nothrow_move_assignable<TBase>::value) {
+        std::is_nothrow_constructible<TBase>::value) {
         if (this != &other) {
             this->reseat(other);
         }
@@ -509,7 +509,7 @@ public:
         this->reseat(other);
     }
     CMemoryMappedDenseVector(CMemoryMappedDenseVector&& other) noexcept(
-        std::is_nothrow_move_assignable<TBase>::value)
+        std::is_nothrow_constructible<TBase>::value)
         : TBase{nullptr, 1} {
         this->reseat(other);
     }
@@ -520,7 +520,7 @@ public:
         return *this;
     }
     CMemoryMappedDenseVector& operator=(CMemoryMappedDenseVector&& other) noexcept(
-        std::is_nothrow_move_assignable<TBase>::value) {
+        std::is_nothrow_constructible<TBase>::value) {
         if (this != &other) {
             this->reseat(other);
         }

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 namespace Eigen {
 #define LESS_OR_GREATER(l, r)                                                  \
@@ -383,7 +384,8 @@ public:
         : TBase{nullptr, 1, 1} {
         this->reseat(other);
     }
-    CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix&& other)
+    CMemoryMappedDenseMatrix(CMemoryMappedDenseMatrix&& other) noexcept(
+        std::is_nothrow_move_assignable<TBase>::value)
         : TBase{nullptr, 1, 1} {
         this->reseat(other);
     }
@@ -393,7 +395,8 @@ public:
         }
         return *this;
     }
-    CMemoryMappedDenseMatrix& operator=(CMemoryMappedDenseMatrix&& other) {
+    CMemoryMappedDenseMatrix& operator=(CMemoryMappedDenseMatrix&& other) noexcept(
+        std::is_nothrow_move_assignable<TBase>::value) {
         if (this != &other) {
             this->reseat(other);
         }
@@ -505,7 +508,8 @@ public:
         : TBase{nullptr, 1} {
         this->reseat(other);
     }
-    CMemoryMappedDenseVector(CMemoryMappedDenseVector&& other)
+    CMemoryMappedDenseVector(CMemoryMappedDenseVector&& other) noexcept(
+        std::is_nothrow_move_assignable<TBase>::value)
         : TBase{nullptr, 1} {
         this->reseat(other);
     }
@@ -515,7 +519,8 @@ public:
         }
         return *this;
     }
-    CMemoryMappedDenseVector& operator=(CMemoryMappedDenseVector&& other) {
+    CMemoryMappedDenseVector& operator=(CMemoryMappedDenseVector&& other) noexcept(
+        std::is_nothrow_move_assignable<TBase>::value) {
         if (this != &other) {
             this->reseat(other);
         }

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -54,7 +54,7 @@ CForecastRunner::SForecast::SForecast()
       s_Messages(), s_TemporaryFolder() {
 }
 
-CForecastRunner::SForecast::SForecast(SForecast&& other)
+CForecastRunner::SForecast::SForecast(SForecast&& other) noexcept
     : s_ForecastId(std::move(other.s_ForecastId)),
       s_ForecastAlias(std::move(other.s_ForecastAlias)),
       s_ForecastSeries(std::move(other.s_ForecastSeries)),
@@ -67,7 +67,7 @@ CForecastRunner::SForecast::SForecast(SForecast&& other)
       s_TemporaryFolder(std::move(other.s_TemporaryFolder)) {
 }
 
-CForecastRunner::SForecast& CForecastRunner::SForecast::operator=(SForecast&& other) {
+CForecastRunner::SForecast& CForecastRunner::SForecast::operator=(SForecast&& other) noexcept {
     s_ForecastId = std::move(other.s_ForecastId);
     s_ForecastAlias = std::move(other.s_ForecastAlias);
     s_ForecastSeries = std::move(other.s_ForecastSeries);

--- a/lib/core/CDataFrameRowSlice.cc
+++ b/lib/core/CDataFrameRowSlice.cc
@@ -137,10 +137,8 @@ operator=(const CDataFrameRowSliceHandle& other) {
     return *this;
 }
 
-CDataFrameRowSliceHandle& CDataFrameRowSliceHandle::operator=(CDataFrameRowSliceHandle&& other) {
-    m_Impl = std::move(other.m_Impl);
-    return *this;
-}
+CDataFrameRowSliceHandle& CDataFrameRowSliceHandle::
+operator=(CDataFrameRowSliceHandle&& other) = default;
 
 std::size_t CDataFrameRowSliceHandle::size() const {
     return m_Impl->rows().size();
@@ -183,7 +181,7 @@ bool CDataFrameRowSliceHandle::bad() const {
 CMainMemoryDataFrameRowSlice::CMainMemoryDataFrameRowSlice(std::size_t firstRow,
                                                            TFloatVec rows,
                                                            TInt32Vec docHashes)
-    : m_FirstRow{firstRow}, m_Rows{std::move(rows)}, m_DocHashes(docHashes) {
+    : m_FirstRow{firstRow}, m_Rows{std::move(rows)}, m_DocHashes{std::move(docHashes)} {
     LOG_TRACE(<< "slice size = " << m_Rows.size() << " capacity = " << m_Rows.capacity());
     m_Rows.shrink_to_fit();
     m_DocHashes.shrink_to_fit();

--- a/lib/core/CStaticThreadPool.cc
+++ b/lib/core/CStaticThreadPool.cc
@@ -79,7 +79,7 @@ void CStaticThreadPool::shutdown() {
     // Signal to each thread that it is finished. We bind each task to a thread so
     // so each thread executes exactly one shutdown task.
     for (std::size_t id = 0; id < m_TaskQueues.size(); ++id) {
-        TTask done{[&] { m_Done = true; }};
+        TTask done{[this] { m_Done = true; }};
         m_TaskQueues[id].push(CWrappedTask{std::move(done), id});
     }
 

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -216,7 +216,8 @@ private:
 };
 }
 
-CEncodedDataFrameRowRef::CEncodedDataFrameRowRef(const TRowRef& row, const CDataFrameCategoryEncoder& encoder)
+CEncodedDataFrameRowRef::CEncodedDataFrameRowRef(const TRowRef& row,
+                                                 const CDataFrameCategoryEncoder& encoder)
     : m_Row{row}, m_Encoder{&encoder} {
 }
 

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -216,8 +216,8 @@ private:
 };
 }
 
-CEncodedDataFrameRowRef::CEncodedDataFrameRowRef(TRowRef row, const CDataFrameCategoryEncoder& encoder)
-    : m_Row{std::move(row)}, m_Encoder{&encoder} {
+CEncodedDataFrameRowRef::CEncodedDataFrameRowRef(const TRowRef& row, const CDataFrameCategoryEncoder& encoder)
+    : m_Row{row}, m_Encoder{&encoder} {
 }
 
 CFloatStorage CEncodedDataFrameRowRef::operator[](std::size_t encodedColumnIndex) const {
@@ -247,8 +247,8 @@ CDataFrameCategoryEncoder::CDataFrameCategoryEncoder(core::CStateRestoreTraverse
     }
 }
 
-CEncodedDataFrameRowRef CDataFrameCategoryEncoder::encode(TRowRef row) const {
-    return {std::move(row), *this};
+CEncodedDataFrameRowRef CDataFrameCategoryEncoder::encode(const TRowRef& row) const {
+    return {row, *this};
 }
 
 CDataFrameCategoryEncoder::TDoubleVec CDataFrameCategoryEncoder::encodedColumnMics() const {


### PR DESCRIPTION
There are some places where we implement our own move operations which should be marked as `noexcept`. This allows the standard library to better optimise code with strong exception guaranties. There was also another place where we falling into the "can't move from a std::initialization_list" trap. Finally, `CRowRef` move is equivalent to a copy. Since it is 32 bytes we should instead prefer to pass this by constant reference when creating an encoded row.