### PR TITLE
[7.x][ML] Fix printing values for multiclass feature importance 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -52,6 +52,8 @@
 
 * Fixed background persistence of categorizer state (See {ml-pull}1137[#1137],
   issue: {ml-issue}1136[#1136].)
+* Fix classification job failures when number of classes in configuration differs from the number of classes present in the training data. (See {ml-pull}1144[#1144].)
+  identified one. (See {ml-pull}1144[#1144].)
 
 == {es} version 7.7.0
 
@@ -298,4 +300,3 @@ The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0. (See 
 === Bug Fixes
 
 * Fixes an issue where interim results would be calculated after advancing time into an empty bucket. {ml-pull}416[#416]
-

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -178,7 +178,8 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
                             writer.Key(CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME);
                             writer.Double(shap[i](0));
                         } else {
-                            for (int j = 0; j < shap[i].size(); ++j) {
+                            for (int j = 0;
+                                 j < shap[i].size() && j < classValues.size(); ++j) {
                                 writer.Key(classValues[j]);
                                 writer.Double(shap[i](j));
                             }


### PR DESCRIPTION
Fix classification job failures when number of classes in configuration differs from the number of classes present in the training data.

Backport to #1144.