### PR TITLE
[ML] Fix memory usage estimation for vectors with a custom allocator

### DIFF
--- a/include/core/CMemory.h
+++ b/include/core/CMemory.h
@@ -327,8 +327,8 @@ public:
     }
 
     //! Overload for std::vector.
-    template<typename T>
-    static std::size_t dynamicSize(const std::vector<T>& t) {
+    template<typename T, typename A>
+    static std::size_t dynamicSize(const std::vector<T, A>& t) {
         std::size_t mem = 0;
         if (!memory_detail::SDynamicSizeAlwaysZero<T>::value()) {
             for (auto i = t.begin(); i != t.end(); ++i) {
@@ -781,9 +781,9 @@ public:
     }
 
     //! Overload for std::vector.
-    template<typename T>
+    template<typename T, typename A>
     static void dynamicSize(const char* name,
-                            const std::vector<T>& t,
+                            const std::vector<T, A>& t,
                             const CMemoryUsage::TMemoryUsagePtr& mem) {
         std::string componentName(name);
 

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -162,9 +162,9 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     }
 
     if (featureImportance != nullptr) {
+        int numberClasses{static_cast<int>(classValues.size())};
         featureImportance->shap(
-            row, [&writer, &classValues](
-                     const maths::CTreeShapFeatureImportance::TSizeVec& indices,
+            row, [&](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
                      const TStrVec& featureNames,
                      const maths::CTreeShapFeatureImportance::TVectorVec& shap) {
                 writer.Key(FEATURE_IMPORTANCE_FIELD_NAME);
@@ -178,8 +178,7 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
                             writer.Key(IMPORTANCE_FIELD_NAME);
                             writer.Double(shap[i](0));
                         } else {
-                            for (int j = 0;
-                                 j < shap[i].size() && j < classValues.size(); ++j) {
+                            for (int j = 0; j < shap[i].size() && j < numberClasses; ++j) {
                                 writer.Key(classValues[j]);
                                 writer.Double(shap[i](j));
                             }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingMse) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1600000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1800000);
     BOOST_TEST_REQUIRE(
         core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
         core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
@@ -721,7 +721,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1600000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1800000);
     BOOST_TEST_REQUIRE(
         core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
         core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -427,7 +427,8 @@ BOOST_FIXTURE_TEST_CASE(testMemoryUsage, CTestFixture) {
 
     // Memory usage should be less than:
     //   1) 1075 + 4 times the root directory length bytes for on disk, and
-    //   2) data size + doc ids size + 900 byte overhead in main memory.
+    //   2) data size + doc ids size + 900 byte overhead in main memory. Note that
+    //      we round up the number of columns to the next multiple of the alignment.
     std::size_t maximumMemory[]{1075 + 4 * rootDirectory.length(),
                                 rows * (4 * ((cols + 3) / 4) + 1) * 4 + 900};
 

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -429,7 +429,7 @@ BOOST_FIXTURE_TEST_CASE(testMemoryUsage, CTestFixture) {
     //   1) 1075 + 4 times the root directory length bytes for on disk, and
     //   2) data size + doc ids size + 900 byte overhead in main memory.
     std::size_t maximumMemory[]{1075 + 4 * rootDirectory.length(),
-                                rows * (cols + 1) * 4 + 900};
+                                rows * (4 * ((cols + 3) / 4) + 1) * 4 + 900};
 
     std::string type[]{"on disk", "main memory"};
     std::size_t t{0};


### PR DESCRIPTION
#1142 showed up that we weren't accounting for memory used by vector with a custom allocator. This is a pre-existing bug in memory estimation, but the aligned allocator was the first code to expose it. Since this is not released I've marked this as a non-issue.