### PR TITLE
[ML] Improve stability of trend decomposition for very sparse data

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -60,6 +60,8 @@
   {ml-pull}1135[#1135].)
 * Improve data frame analysis runtime by optimising memory alignment for intrinsic
   operations. (See {ml-pull}1142[#1142].)
+* Fix spurious anomalies for count and sum functions after no data are received for long
+  periods of time. (See {ml-pull}1158[#1158].)
 
 == {es} version 7.7.1
 

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -545,7 +545,7 @@ double CIndividualModel::emptyBucketWeight(model_t::EFeature feature,
         if (count == boost::none || *count == 0) {
             // We smoothly transition to modelling non-zero count when the bucket
             // occupancy is less than 0.5.
-            weight = std::min(2.0 * this->personFrequency(pid), 1.0);
+            weight = maths::CTools::truncate(2.0 * this->personFrequency(pid), 1e-6, 1.0);
         }
     }
     return weight;


### PR DESCRIPTION
For sparse data with count and sum features (which assign zero values to empty buckets) we smoothly transition to modelling only values in non-empty buckets. This is important so we don't raise anomalies for every non-empty bucket. We also adjust the rate at which we decay out old data so the model isn't based on too little data.

This works fine for the residual distribution model, but the time dependent parts of the model decay out old data on a different schedule and can become unstable as a result. Normally, sparse data doesn't have significant time dependencies. However, this has caused problems when we no longer receive data for a time series. In these cases, it can result in spurious anomalies long after the last "real" data point was received.

This change makes the least intrusive fix: we only need to discard empty buckets for the residual distribution from an anomaly detection perspective and so switch to only down weight empty bucket values for the residual model update.