### PR TITLE
[7.x][ML] Report analytics progress as phase_progress (#1159)

### DIFF
--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -35,8 +35,15 @@ const char FINISHED_DATA_CONTROL_MESSAGE_FIELD_VALUE{'$'};
 
 // Result types
 const std::string ROW_RESULTS{"row_results"};
-const std::string PROGRESS_PERCENT{"progress_percent"};
 const std::string ANALYZER_STATE{"analyzer_state"};
+
+// Phase progress
+const std::string PHASE_PROGRESS{"phase_progress"};
+const std::string PHASE{"phase"};
+const std::string PROGRESS_PERCENT{"progress_percent"};
+
+// Progress phases
+const std::string ANALYZING{"analyzing"};
 
 // Row result fields
 const std::string CHECKSUM{"checksum"};
@@ -294,8 +301,13 @@ void CDataFrameAnalyzer::monitorProgress(const CDataFrameAnalysisRunner& analysi
 void CDataFrameAnalyzer::writeProgress(int progress,
                                        core::CRapidJsonConcurrentLineWriter& writer) const {
     writer.StartObject();
+    writer.Key(PHASE_PROGRESS);
+    writer.StartObject();
+    writer.Key(PHASE);
+    writer.String(ANALYZING);
     writer.Key(PROGRESS_PERCENT);
     writer.Int(progress);
+    writer.EndObject();
     writer.EndObject();
     writer.flush();
 }

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -140,11 +140,11 @@ BOOST_AUTO_TEST_CASE(testWithoutControlMessages) {
                 *expectedScore,
                 result["row_results"]["results"]["ml"]["outlier_score"].GetDouble(),
                 1e-4 * *expectedScore);
-            BOOST_TEST_REQUIRE(result.HasMember("progress_percent") == false);
+            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
             ++expectedScore;
-        } else if (result.HasMember("progress_percent")) {
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() >= 0);
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() <= 100);
+        } else if (result.HasMember("phase_progress")) {
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() >= 0);
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() <= 100);
             BOOST_TEST_REQUIRE(result.HasMember("row_results") == false);
         }
     }
@@ -187,12 +187,12 @@ BOOST_AUTO_TEST_CASE(testRunOutlierDetection) {
                 result["row_results"]["results"]["ml"]["outlier_score"].GetDouble(),
                 1e-4 * *expectedScore);
             ++expectedScore;
-            BOOST_TEST_REQUIRE(result.HasMember("progress_percent") == false);
-        } else if (result.HasMember("progress_percent")) {
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() >= 0);
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() <= 100);
+            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
+        } else if (result.HasMember("phase_progress")) {
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() >= 0);
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() <= 100);
             BOOST_TEST_REQUIRE(result.HasMember("row_results") == false);
-            progressCompleted = result["progress_percent"].GetInt() == 100;
+            progressCompleted = result["phase_progress"]["progress_percent"].GetInt() == 100;
         }
     }
     BOOST_TEST_REQUIRE(expectedScore == expectedScores.end());

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -311,12 +311,12 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingMse) {
                 result["row_results"]["results"]["ml"]["target_prediction"].GetDouble(),
                 1e-4 * std::fabs(*expectedPrediction));
             ++expectedPrediction;
-            BOOST_TEST_REQUIRE(result.HasMember("progress_percent") == false);
-        } else if (result.HasMember("progress_percent")) {
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() >= 0);
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() <= 100);
+            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
+        } else if (result.HasMember("phase_progress")) {
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() >= 0);
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() <= 100);
             BOOST_TEST_REQUIRE(result.HasMember("row_results") == false);
-            progressCompleted = result["progress_percent"].GetInt() == 100;
+            progressCompleted = result["phase_progress"]["progress_percent"].GetInt() == 100;
         }
     }
     BOOST_TEST_REQUIRE(expectedPrediction == expectedPredictions.end());
@@ -440,12 +440,12 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithParams) {
                 result["row_results"]["results"]["ml"]["target_prediction"].GetDouble(),
                 1e-4 * std::fabs(*expectedPrediction));
             ++expectedPrediction;
-            BOOST_TEST_REQUIRE(result.HasMember("progress_percent") == false);
-        } else if (result.HasMember("progress_percent")) {
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() >= 0);
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() <= 100);
+            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
+        } else if (result.HasMember("phase_progress")) {
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() >= 0);
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() <= 100);
             BOOST_TEST_REQUIRE(result.HasMember("row_results") == false);
-            progressCompleted = result["progress_percent"].GetInt() == 100;
+            progressCompleted = result["phase_progress"]["progress_percent"].GetInt() == 100;
         }
     }
     BOOST_TEST_REQUIRE(expectedPrediction == expectedPredictions.end());
@@ -641,7 +641,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingMsle) {
                 result["row_results"]["results"]["ml"]["target_prediction"].GetDouble(),
                 1e-4 * std::fabs(*expectedPrediction));
             ++expectedPrediction;
-            BOOST_TEST_REQUIRE(result.HasMember("progress_percent") == false);
+            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
         }
     }
     BOOST_TEST_REQUIRE(expectedPrediction == expectedPredictions.end());
@@ -701,12 +701,12 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
                 result["row_results"]["results"]["ml"]["top_classes"][0]["class_score"]
                     .GetDouble());
             ++expectedPrediction;
-            BOOST_TEST_REQUIRE(result.HasMember("progress_percent") == false);
-        } else if (result.HasMember("progress_percent")) {
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() >= 0);
-            BOOST_TEST_REQUIRE(result["progress_percent"].GetInt() <= 100);
+            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
+        } else if (result.HasMember("phase_progress")) {
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() >= 0);
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() <= 100);
             BOOST_TEST_REQUIRE(result.HasMember("row_results") == false);
-            progressCompleted = result["progress_percent"].GetInt() == 100;
+            progressCompleted = result["phase_progress"]["progress_percent"].GetInt() == 100;
         }
     }
     BOOST_TEST_REQUIRE(expectedPrediction == expectedPredictions.end());


### PR DESCRIPTION
Changes the way we report progress for data frame analytics
from a plain integer `progress_percent` to an object called
`phase_progress` which contains an integer `progress_percent`
and the `phase` name. In this commit we only have one phase
called `analyzing` but this change allows us to introduce new
phases.

Backport of #1159