### PR TITLE
[7.x][ML] Limit categorization memory usage

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -64,6 +64,8 @@
 * Trap and fail if insufficient features are supplied to data frame analyses. This
   caused classification and regression getting stuck at zero progress analyzing.
   (See {ml-pull}1160[#1160], issue: {issue}55593[#55593].)
+* Make categorization respect the `model_memory_limit`. (See {ml-pull}1167[#1167],
+  issue: {ml-issue}1130[#1130].)
 
 === Bug Fixes
 

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -164,10 +164,10 @@ private:
     TStrVec m_ExtraFieldNames;
 
     //! Should we write the field names before the next output?
-    bool m_WriteFieldNames;
+    bool m_WriteFieldNames = true;
 
     //! Keep count of how many records we've handled
-    std::uint64_t m_NumRecordsHandled;
+    std::uint64_t m_NumRecordsHandled = 0;
 
     //! Map holding fields to add/change in the output compared to the input
     TStrStrUMap m_Overrides;
@@ -183,7 +183,7 @@ private:
     std::string m_SearchTermsRegex;
 
     //! The max matching length of the current category
-    std::size_t m_MaxMatchingLength;
+    std::size_t m_MaxMatchingLength = 0;
 
     //! Pointer to the actual categorizer
     model::CDataCategorizer::TDataCategorizerP m_DataCategorizer;

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -53,6 +53,16 @@ public:
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
     using TIntVec = std::vector<int>;
 
+    //! A soft categorization failure means downstream components can continue,
+    //! by considering the input record to be in some "uncategorizable"
+    //! category.
+    static const int SOFT_CATEGORIZATION_FAILURE_ERROR;
+
+    //! A hard categorization failure means processing of the input record must
+    //! cease.  (This is generally used to prevent excessive memory
+    //! accumulation.)
+    static const int HARD_CATEGORIZATION_FAILURE_ERROR;
+
 public:
     CDataCategorizer(CLimits& limits, const std::string& fieldName);
 
@@ -142,6 +152,10 @@ public:
     //! Once called, the category is marked as unchanged, until the category
     //! changes again.
     virtual bool categoryChangedAndReset(int categoryId) = 0;
+
+    //! Is it permissable to create new categories?  New categories are
+    //! not permitted when memory use has exceeded the limit.
+    bool areNewCategoriesAllowed();
 
 protected:
     //! Used if no fields are supplied to the computeCategory() method.

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -54,6 +54,7 @@ public:
         std::size_t s_FrequentCategories = 0;
         std::size_t s_RareCategories = 0;
         std::size_t s_DeadCategories = 0;
+        std::size_t s_MemoryCategorizationFailures = 0;
         model_t::ECategorizationStatus s_CategorizationStatus = model_t::E_CategorizationStatusOk;
     };
 

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -293,6 +293,7 @@ private:
     //! Used by deferred persistence functions
     static void acceptPersistInserter(const TTokenMIndex& tokenIdLookup,
                                       const TTokenListCategoryVec& categories,
+                                      std::size_t memoryCategorizationFailures,
                                       core::CStatePersistInserter& inserter);
 
     //! Given a string containing comma separated pre-tokenised input, add
@@ -316,6 +317,9 @@ private:
     //! The upper threshold for comparison.  If another category matches this
     //! closely, we accept it immediately (i.e. don't look for a better one).
     double m_UpperThreshold;
+
+    //! How many messages have we failed to categorize due to lack of memory?
+    std::size_t m_MemoryCategorizationFailures;
 
     //! Has the data categorizer's state changed?
     bool m_HasChanged;

--- a/lib/api/CBenchMarker.cc
+++ b/lib/api/CBenchMarker.cc
@@ -8,6 +8,8 @@
 #include <core/CLogger.h>
 #include <core/CoreTypes.h>
 
+#include <model/CDataCategorizer.h>
+
 #include <algorithm>
 #include <fstream>
 #include <functional>
@@ -151,7 +153,7 @@ void CBenchMarker::dumpResults() const {
             // good (as long as it's not already used), and all other categories
             // are bad.
             size_t max{0};
-            int maxCategoryId{-1};
+            int maxCategoryId{model::CDataCategorizer::SOFT_CATEGORIZATION_FAILURE_ERROR};
             for (TIntSizeStrPrMapCItr mapIter = counts.begin();
                  mapIter != counts.end(); ++mapIter) {
                 int categoryId{mapIter->first};
@@ -169,7 +171,7 @@ void CBenchMarker::dumpResults() const {
                 }
                 strm << '\t' << example << core_t::LINE_ENDING;
             }
-            if (maxCategoryId > -1) {
+            if (maxCategoryId != model::CDataCategorizer::SOFT_CATEGORIZATION_FAILURE_ERROR) {
                 good += max;
                 usedCategories.insert(maxCategoryId);
             }

--- a/lib/api/CModelSizeStatsJsonWriter.cc
+++ b/lib/api/CModelSizeStatsJsonWriter.cc
@@ -28,6 +28,7 @@ const std::string TOTAL_CATEGORY_COUNT{"total_category_count"};
 const std::string FREQUENT_CATEGORY_COUNT{"frequent_category_count"};
 const std::string RARE_CATEGORY_COUNT{"rare_category_count"};
 const std::string DEAD_CATEGORY_COUNT{"dead_category_count"};
+const std::string FAILED_CATEGORY_COUNT{"failed_category_count"};
 const std::string CATEGORIZATION_STATUS{"categorization_status"};
 const std::string TIMESTAMP{"timestamp"};
 const std::string LOG_TIME{"log_time"};
@@ -36,58 +37,61 @@ const std::string LOG_TIME{"log_time"};
 void CModelSizeStatsJsonWriter::write(const std::string& jobId,
                                       const model::CResourceMonitor::SModelSizeStats& results,
                                       core::CRapidJsonConcurrentLineWriter& writer) {
-    writer.String(MODEL_SIZE_STATS);
+    writer.Key(MODEL_SIZE_STATS);
     writer.StartObject();
 
-    writer.String(JOB_ID);
+    writer.Key(JOB_ID);
     writer.String(jobId);
 
-    writer.String(MODEL_BYTES);
+    writer.Key(MODEL_BYTES);
     writer.Uint64(results.s_AdjustedUsage);
 
-    writer.String(MODEL_BYTES_EXCEEDED);
+    writer.Key(MODEL_BYTES_EXCEEDED);
     writer.Uint64(results.s_BytesExceeded);
 
-    writer.String(MODEL_BYTES_MEMORY_LIMIT);
+    writer.Key(MODEL_BYTES_MEMORY_LIMIT);
     writer.Uint64(results.s_BytesMemoryLimit);
 
-    writer.String(TOTAL_BY_FIELD_COUNT);
+    writer.Key(TOTAL_BY_FIELD_COUNT);
     writer.Uint64(results.s_ByFields);
 
-    writer.String(TOTAL_OVER_FIELD_COUNT);
+    writer.Key(TOTAL_OVER_FIELD_COUNT);
     writer.Uint64(results.s_OverFields);
 
-    writer.String(TOTAL_PARTITION_FIELD_COUNT);
+    writer.Key(TOTAL_PARTITION_FIELD_COUNT);
     writer.Uint64(results.s_PartitionFields);
 
-    writer.String(BUCKET_ALLOCATION_FAILURES_COUNT);
+    writer.Key(BUCKET_ALLOCATION_FAILURES_COUNT);
     writer.Uint64(results.s_AllocationFailures);
 
-    writer.String(MEMORY_STATUS);
+    writer.Key(MEMORY_STATUS);
     writer.String(print(results.s_MemoryStatus));
 
-    writer.String(CATEGORIZED_DOC_COUNT);
+    writer.Key(CATEGORIZED_DOC_COUNT);
     writer.Uint64(results.s_CategorizedMessages);
 
-    writer.String(TOTAL_CATEGORY_COUNT);
+    writer.Key(TOTAL_CATEGORY_COUNT);
     writer.Uint64(results.s_TotalCategories);
 
-    writer.String(FREQUENT_CATEGORY_COUNT);
+    writer.Key(FREQUENT_CATEGORY_COUNT);
     writer.Uint64(results.s_FrequentCategories);
 
-    writer.String(RARE_CATEGORY_COUNT);
+    writer.Key(RARE_CATEGORY_COUNT);
     writer.Uint64(results.s_RareCategories);
 
-    writer.String(DEAD_CATEGORY_COUNT);
+    writer.Key(DEAD_CATEGORY_COUNT);
     writer.Uint64(results.s_DeadCategories);
 
-    writer.String(CATEGORIZATION_STATUS);
+    writer.Key(FAILED_CATEGORY_COUNT);
+    writer.Uint64(results.s_MemoryCategorizationFailures);
+
+    writer.Key(CATEGORIZATION_STATUS);
     writer.String(print(results.s_CategorizationStatus));
 
-    writer.String(TIMESTAMP);
+    writer.Key(TIMESTAMP);
     writer.Time(results.s_BucketStartTime);
 
-    writer.String(LOG_TIME);
+    writer.Key(LOG_TIME);
     writer.Time(core::CTimeUtils::now());
 
     writer.EndObject();

--- a/lib/api/unittest/CModelSnapshotJsonWriterTest.cc
+++ b/lib/api/unittest/CModelSnapshotJsonWriterTest.cc
@@ -44,6 +44,7 @@ BOOST_AUTO_TEST_CASE(testWrite) {
             7,                         // frequent categories
             13,                        // rare categories
             2,                         // dead categories
+            8,                         // failed categories
             model_t::E_CategorizationStatusWarn};
 
         CModelSnapshotJsonWriter::SModelSnapshotReport report{
@@ -138,6 +139,9 @@ BOOST_AUTO_TEST_CASE(testWrite) {
                         modelSizeStats["rare_category_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("dead_category_count"));
     BOOST_REQUIRE_EQUAL(std::uint64_t(2), modelSizeStats["dead_category_count"].GetUint64());
+    BOOST_TEST_REQUIRE(modelSizeStats.HasMember("failed_category_count"));
+    BOOST_REQUIRE_EQUAL(std::uint64_t(8),
+                        modelSizeStats["failed_category_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("memory_status"));
     BOOST_REQUIRE_EQUAL(std::string("warn"),
                         std::string(modelSizeStats["categorization_status"].GetString()));

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -69,8 +69,31 @@ public:
         ml::core::CLogger::instance().setLoggingLevel(ml::core::CLogger::E_Debug);
     }
 
+    std::string makeUniqueToken() {
+        std::string token;
+        for (std::uint32_t workSeed = ++m_Seed; workSeed > 0; workSeed /= 20) {
+            // Use letters g-z only so that no tokens are valid hex numbers
+            token += static_cast<char>('g' + (workSeed - 1) % 20);
+        }
+        return token;
+    }
+
+    std::string makeUniqueMessage(std::size_t numTokens) {
+        std::string message;
+        for (std::size_t token = 0; token < numTokens; ++token) {
+            if (token > 0) {
+                message += ' ';
+            }
+            message += makeUniqueToken();
+        }
+        return message;
+    }
+
 protected:
     ml::model::CLimits m_Limits;
+
+private:
+    std::uint32_t m_Seed = 0;
 };
 
 BOOST_FIXTURE_TEST_CASE(testHexData, CTestFixture) {
@@ -551,6 +574,63 @@ BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {
     BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(expected),
                         ml::core::CContainerPrinter::print(actual));
     checkMemoryUsageInstrumentation(categorizer);
+}
+
+BOOST_FIXTURE_TEST_CASE(testSoftMemoryLimit, CTestFixture) {
+
+    TTokenListDataCategorizerKeepsFields categorizer(
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+
+    std::string baseMessage{"foo bar baz "};
+    std::string message{baseMessage + makeUniqueToken()};
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(1, message));
+    BOOST_REQUIRE_EQUAL(1, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    message = baseMessage + makeUniqueToken();
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(1, message));
+    // Since the messages are different, there should be two examples for the category now
+    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+
+    // Create a soft memory limit
+    m_Limits.resourceMonitor().acceptPruningResult();
+
+    message = baseMessage + makeUniqueToken();
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(1, message) == false);
+    // In soft limit we should stop accumulating examples, hence 2 instead of 3
+    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    message = baseMessage + makeUniqueToken();
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(1, message) == false);
+    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+
+    // TODO: once it's possible to escape from soft limit without
+    // a restart, test that we start accumulating examples again
+}
+
+BOOST_FIXTURE_TEST_CASE(testHardMemoryLimit, CTestFixture) {
+
+    // Set memory limit to 1MB so that it's quickly exhausted
+    m_Limits.resourceMonitor().memoryLimit(1);
+
+    TTokenListDataCategorizerKeepsFields categorizer(
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+
+    std::string nextMessage{makeUniqueMessage(10)};
+    int categoryId{0};
+    for (int nextExpectedCategoryId = 1; nextExpectedCategoryId < 100000;
+         ++nextExpectedCategoryId, nextMessage = makeUniqueMessage(10)) {
+        categoryId = categorizer.computeCategory(false, nextMessage, nextMessage.length());
+        if (categoryId == ml::model::CDataCategorizer::HARD_CATEGORIZATION_FAILURE_ERROR) {
+            LOG_INFO(<< "Hit hard limit after " << nextExpectedCategoryId << " messages");
+            break;
+        }
+        BOOST_REQUIRE_EQUAL(nextExpectedCategoryId, categoryId);
+        m_Limits.resourceMonitor().refresh(categorizer);
+    }
+    BOOST_REQUIRE_EQUAL(ml::model::CDataCategorizer::HARD_CATEGORIZATION_FAILURE_ERROR,
+                        categoryId);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Anomaly detection jobs have a model_memory_limit setting.  This is
supposed to restrict the amount of memory the job can use, however,
in the past the limit only applied to anomaly detection and not to
categorization.

This change applies memory limiting to categorization as follows:

- When a job is in hard_limit status no new categories will be
  created.  The input document that could not be categorized is
  discarded as it cannot take part in anomaly detection without a
  category.  The failed_category_count statistic is incremented
  each time this happens.
- When a job is in soft_limit status, we stop recording examples
  for the category.

Backport of #1167