### PR TITLE
[ML] Reduce false positives for the periodic component test for anomaly detection

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -62,17 +62,14 @@
   operations. (See {ml-pull}1142[#1142].)
 * Fix spurious anomalies for count and sum functions after no data are received for long
   periods of time. (See {ml-pull}1158[#1158].)
-
-== {es} version 7.8.0
+* Improve false positive rates from periodicity test for time series anomaly detection.
+  (See {ml-pull}1177[#1177].)
 
 === Bug Fixes
 
 * Trap and fail if insufficient features are supplied to data frame analyses. This
   caused classification and regression getting stuck at zero progress analyzing.
   (See {ml-pull}1160[#1160], issue: {issue}55593[#55593].)
-
-=== Bug Fixes
-
 * Fix underlying cause for "Failed to calculate splitting significance" log errors.
   (See {ml-pull}1157[#1157].)
 

--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -441,7 +441,7 @@ private:
                       STestStats& stats,
                       double& R,
                       double& meanRepeats,
-                      double& pVariance,
+                      double& truthVariance,
                       const TSizeVec& segmentation = TSizeVec{}) const;
 
     //! Run the component amplitude test on the alternative hypothesis.
@@ -452,7 +452,7 @@ private:
                        double v,
                        double R,
                        double meanRepeats,
-                       double pVariance,
+                       double truthVariance,
                        STestStats& stats) const;
 
 private:

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -2095,7 +2095,7 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
         return CBasicStatistics::mean(result);
     };
 
-    CSmoothCondition condition;
+    CSmoothCondition correlationCondition;
     double R{-1.0};
 
     TFloatMeanAccumulatorVec partitionValues;
@@ -2121,9 +2121,10 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
                                      MINIMUM_REPEATS_TO_TEST_VARIANCE};
         LOG_TRACE(<< "  mean repeats per segment = " << meanRepeatsPerSegment);
 
-        condition = std::max(
-            condition, softGreaterThan(R, stats.s_AutocorrelationThreshold, 0.1) &&
-                           softGreaterThan(meanRepeatsPerSegment, 1.0, 0.2));
+        correlationCondition =
+            std::max(correlationCondition,
+                     softGreaterThan(R, stats.s_AutocorrelationThreshold, 0.1) &&
+                         softGreaterThan(meanRepeatsPerSegment, 1.0, 0.2));
         R = std::max(R, RW);
     }
 
@@ -2131,7 +2132,7 @@ bool CPeriodicityHypothesisTests::testPartition(const TTimeTimePr2Vec& partition
         CTools::fastLog(CStatisticalTests::leftTailFTest(v1 / v0, df1, df0)) /
         LOG_COMPONENT_STATISTICALLY_SIGNIFICANCE};
 
-    if (condition && softGreaterThan(logSignificance, 1.0, 0.1) &&
+    if (correlationCondition && softGreaterThan(logSignificance, 1.0, 0.1) &&
         (vt > v1 ? softGreaterThan(vt / v1, 1.0, 1.0) : softLessThan(v1 / vt, 1.0, 0.1))) {
         stats.s_StartOfPartition = startOfPartition;
         stats.s_R0 = R;

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -1276,13 +1276,12 @@ CPeriodicityHypothesisTests::best(const TNestedHypothesesVec& hypotheses) const 
             v = v == summary.s_VarianceThreshold * vmin[0]
                     ? 1.0
                     : v / summary.s_VarianceThreshold / vmin[0];
-            double R{summary.s_R / summary.s_AutocorrelationThreshold};
-            double DF{summary.s_DF / DFmin[0]};
-            double p{CTools::logisticFunction(v, 0.2, 1.0, -1.0) *
-                     CTools::logisticFunction(R, 0.2, 1.0, +1.0) *
-                     CTools::logisticFunction(DF, 0.2, 1.0, +1.0) *
-                     CTools::logisticFunction(summary.s_TrendSegments, 0.3, 0.0, -1.0) *
-                     CTools::logisticFunction(summary.s_ScaleSegments, 0.3, 0.0, -1.0)};
+            double p{(softLessThan(v, 1.0, 0.2) &&
+                      softGreaterThan(summary.s_R, summary.s_AutocorrelationThreshold, 0.1) &&
+                      softGreaterThan(summary.s_DF / DFmin[0], 1.0, 0.2) &&
+                      softLessThan(summary.s_TrendSegments, 0.0, 0.3) &&
+                      softLessThan(summary.s_ScaleSegments, 0.0, 0.3))
+                         .p()};
             LOG_TRACE(<< "p = " << p);
             if (pmin.add(-p)) {
                 result = summary.s_H;

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -1263,17 +1263,19 @@ CPeriodicityHypothesisTests::best(const TNestedHypothesesVec& hypotheses) const 
         TMinAccumulator vmin;
         TMinAccumulator DFmin;
         for (const auto& summary : summaries) {
-            vmin.add(varianceAtPercentile(summary.s_V, summary.s_DF,
-                                          50.0 + CONFIDENCE_INTERVAL / 2.0) /
-                     summary.s_VarianceThreshold);
+            double v{varianceAtPercentile(summary.s_V, summary.s_DF,
+                                          50.0 + CONFIDENCE_INTERVAL / 2.0)};
+            vmin.add(v == summary.s_VarianceThreshold ? 1.0 : v / summary.s_VarianceThreshold);
             DFmin.add(summary.s_DF);
         }
 
         TMinAccumulator pmin;
         for (const auto& summary : summaries) {
             double v{varianceAtPercentile(summary.s_V, summary.s_DF,
-                                          50.0 - CONFIDENCE_INTERVAL / 2.0) /
-                     summary.s_VarianceThreshold / vmin[0]};
+                                          50.0 - CONFIDENCE_INTERVAL / 2.0)};
+            v = v == summary.s_VarianceThreshold * vmin[0]
+                    ? 1.0
+                    : v / summary.s_VarianceThreshold / vmin[0];
             double R{summary.s_R / summary.s_AutocorrelationThreshold};
             double DF{summary.s_DF / DFmin[0]};
             double p{CTools::logisticFunction(v, 0.2, 1.0, -1.0) *

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1667,7 +1667,6 @@ void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAc
                                  [](double weight, const TFloatMeanAccumulator& sample) {
                                      return weight + CBasicStatistics::count(sample);
                                  })};
-        LOG_INFO(<< 10.0 * std::max(this->params().learnRate(), 1.0) << " vs " << numberSamples);
         double weightScale{
             std::min(10.0 * std::max(this->params().learnRate(), 1.0), numberSamples) / Z};
         maths_t::TDoubleWeightsAry1Vec weights(1);

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1551,8 +1551,9 @@ CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
         }
     }
 
-    // Time order is not reliable, for example if the data are polled
-    // or for count feature, the times of all samples will be the same.
+    // Time order is not a total order, for example if the data are polled
+    // the times of all samples will be the same. So break ties using the
+    // sample value.
     TSizeVec timeorder(samples.size());
     std::iota(timeorder.begin(), timeorder.end(), 0);
     std::stable_sort(timeorder.begin(), timeorder.end(),
@@ -1656,6 +1657,7 @@ void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAc
     // We can't properly handle periodicity in the variance of the rate if
     // using a Poisson process so remove it from model detectio if we detect
     // seasonality.
+    double numberSamples{m_ResidualModel->numberSamples()};
     m_ResidualModel->removeModels(
         maths::CPrior::CModelFilter().remove(maths::CPrior::E_Poisson));
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
@@ -1665,7 +1667,9 @@ void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAc
                                  [](double weight, const TFloatMeanAccumulator& sample) {
                                      return weight + CBasicStatistics::count(sample);
                                  })};
-        double weightScale{10.0 * std::max(this->params().learnRate(), 1.0) / Z};
+        LOG_INFO(<< 10.0 * std::max(this->params().learnRate(), 1.0) << " vs " << numberSamples);
+        double weightScale{
+            std::min(10.0 * std::max(this->params().learnRate(), 1.0), numberSamples) / Z};
         maths_t::TDoubleWeightsAry1Vec weights(1);
         for (const auto& residual : residuals) {
             double weight(CBasicStatistics::count(residual));
@@ -2862,8 +2866,9 @@ CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& sample
         }
     }
 
-    // Time order is not reliable, for example if the data are polled
-    // or for count feature, the times of all samples will be the same.
+    // Time order is not a total order, for example if the data are polled
+    // the times of all samples will be the same. So break ties using the
+    // sample value.
     TSizeVec timeorder(samples.size());
     std::iota(timeorder.begin(), timeorder.end(), 0);
     std::stable_sort(timeorder.begin(), timeorder.end(),
@@ -2965,6 +2970,7 @@ void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMean
     // re-weight so that the total sample weight corresponds to the sample
     // weight the model receives from a fixed (shortish) time interval.
 
+    double numberSamples{m_ResidualModel->numberSamples()};
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
 
     if (residuals.size() > 0) {
@@ -2988,7 +2994,8 @@ void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMean
         }
 
         double Z{std::accumulate(weights.begin(), weights.end(), 0.0)};
-        double weightScale{10.0 * std::max(this->params().learnRate(), 1.0) / Z};
+        double weightScale{
+            std::min(10.0 * std::max(this->params().learnRate(), 1.0), numberSamples) / Z};
         maths_t::TDouble10VecWeightsAry1Vec weight(1);
         for (std::size_t i = 0; i < samples.size(); ++i) {
             if (weights[i] > 0.0) {

--- a/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
+++ b/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(testDiurnal) {
         }
 
         LOG_DEBUG(<< "Recall = " << TP / (TP + FN));
-        BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.99);
+        BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.98);
     }
 
     LOG_DEBUG(<< "");
@@ -249,7 +249,8 @@ BOOST_AUTO_TEST_CASE(testDiurnal) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
                 LOG_DEBUG(<< "result = " << result.print());
                 BOOST_TEST_REQUIRE(
-                    (result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' }" ||
+                    (result.print() == "{ 'daily' 'weekly' }" ||
+                     result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' }" ||
                      result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }"));
                 hypotheses = maths::CPeriodicityHypothesisTests();
                 hypotheses.initialize(0 /*startTime*/, HOUR, window, DAY);
@@ -322,11 +323,9 @@ BOOST_AUTO_TEST_CASE(testDiurnal) {
             core_t::TTime time{timeseries[i].first};
             if (time > lastTest + window) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
-                const std::string& printedResult{result.print()};
-                LOG_DEBUG(<< "result = " << printedResult);
-                if (printedResult != "{ 'weekend daily' 'weekday daily' 'weekend weekly' }") {
-                    BOOST_TEST_REQUIRE(printedResult == "{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }");
-                }
+                LOG_DEBUG(<< "result = " << result.print());
+                BOOST_TEST_REQUIRE((result.print() == "{ 'daily' 'weekly' }" ||
+                                    result.print() == "{ 'weekend daily' 'weekday daily' 'weekend weekly' 'weekday weekly' }"));
                 hypotheses = maths::CPeriodicityHypothesisTests();
                 hypotheses.initialize(0 /*startTime*/, HOUR, window, DAY);
                 lastTest += window;
@@ -510,7 +509,9 @@ BOOST_AUTO_TEST_CASE(testWithSparseData) {
             if (t >= 2) {
                 maths::CPeriodicityHypothesisTestsResult result{hypotheses.test()};
                 LOG_DEBUG(<< "result = " << result.print());
-                BOOST_REQUIRE_EQUAL(std::string("{ 'daily' 'weekly' }"), result.print());
+                BOOST_TEST_REQUIRE(
+                    (result.print() == "{ 'daily' 'weekly' }" ||
+                     result.print() == std::string("{ 'weekend daily' 'weekday daily' }")));
             }
         }
     }
@@ -666,8 +667,9 @@ BOOST_AUTO_TEST_CASE(testWithOutliers) {
             maths::CPeriodicityHypothesisTestsResult result{
                 maths::testForPeriods(config, startTime, bucketLength, values)};
             LOG_DEBUG(<< "result = " << result.print());
-            BOOST_TEST_REQUIRE(result.print() ==
-                               std::string("{ 'weekend daily' 'weekday daily' 'weekend weekly' }"));
+            BOOST_TEST_REQUIRE(
+                (result.print() == std::string("{ 'daily' 'weekly' }") ||
+                 result.print() == std::string("{ 'weekend daily' 'weekday daily' 'weekend weekly' }")));
         }
     }
 }
@@ -947,7 +949,7 @@ BOOST_AUTO_TEST_CASE(testWithPiecewiseLinearTrend) {
     }
 
     LOG_DEBUG(<< "Recall = " << TP / (TP + FN));
-    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.8);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.9);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -294,7 +294,7 @@ BOOST_FIXTURE_TEST_CASE(testDistortedPeriodic, CTestFixture) {
             LOG_TRACE(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                BOOST_TEST_REQUIRE(sumResidual < 0.27 * sumValue);
+                BOOST_TEST_REQUIRE(sumResidual < 0.28 * sumValue);
                 BOOST_TEST_REQUIRE(maxResidual < 0.56 * maxValue);
                 BOOST_TEST_REQUIRE(percentileError < 0.22 * sumValue);
 
@@ -313,7 +313,7 @@ BOOST_FIXTURE_TEST_CASE(testDistortedPeriodic, CTestFixture) {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.18 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.20 * totalSumValue);
     BOOST_TEST_REQUIRE(totalMaxResidual < 0.28 * totalMaxValue);
     BOOST_TEST_REQUIRE(totalPercentileError < 0.1 * totalSumValue);
 }
@@ -412,9 +412,9 @@ BOOST_FIXTURE_TEST_CASE(testMinimizeLongComponents, CTestFixture) {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.05 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.06 * totalSumValue);
     BOOST_TEST_REQUIRE(totalMaxResidual < 0.20 * totalMaxValue);
-    BOOST_TEST_REQUIRE(totalPercentileError < 0.02 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalPercentileError < 0.03 * totalSumValue);
 
     meanSlope /= refinements;
     LOG_DEBUG(<< "mean weekly |slope| = " << meanSlope);
@@ -744,12 +744,12 @@ BOOST_FIXTURE_TEST_CASE(testSeasonalOnset, CTestFixture) {
             totalPercentileError += percentileError;
 
             const TSeasonalComponentVec& components = decomposition.seasonalComponents();
-            if (time > 12 * WEEK) {
+            if (time > 13 * WEEK) {
                 // Check that there are at two least components.
                 BOOST_TEST_REQUIRE(components.size() >= 2);
                 BOOST_TEST_REQUIRE(components[0].initialized());
                 BOOST_TEST_REQUIRE(components[1].initialized());
-            } else if (time > 11 * WEEK) {
+            } else if (time > 12 * WEEK) {
                 // Check that there is at least one component.
                 BOOST_REQUIRE_EQUAL(std::size_t(1), components.size());
                 BOOST_TEST_REQUIRE(components[0].initialized());
@@ -764,9 +764,9 @@ BOOST_FIXTURE_TEST_CASE(testSeasonalOnset, CTestFixture) {
     LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.07 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.08 * totalMaxValue);
-    BOOST_TEST_REQUIRE(totalPercentileError < 0.03 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.08 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.1 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalPercentileError < 0.05 * totalSumValue);
 }
 
 BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -315,7 +315,7 @@ BOOST_FIXTURE_TEST_CASE(testDistortedPeriodic, CTestFixture) {
 
     BOOST_TEST_REQUIRE(totalSumResidual < 0.20 * totalSumValue);
     BOOST_TEST_REQUIRE(totalMaxResidual < 0.28 * totalMaxValue);
-    BOOST_TEST_REQUIRE(totalPercentileError < 0.1 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalPercentileError < 0.11 * totalSumValue);
 }
 
 BOOST_FIXTURE_TEST_CASE(testMinimizeLongComponents, CTestFixture) {


### PR DESCRIPTION
While investigating changes in our QA suite from #1158, I noticed, particularly for sparse data, the periodicity test generates false positives.

These turn out to be because of how we account for piecewise scaling of the periodic component. We allow piecewise linear scaling of the periodic component in the time window we test. However, we didn't directly impose a limit on the minimum number of repeats we require per scale. This change requires (as with unscaled periodicity testing) that we have at least three repeats *per* scale selected. I also took the opportunity to slightly rework the combination of soft conditions we check to make it clearer what is happening. 

The downside of detecting periodicity when none is present is that the model is generally less robust to anomalous behaviour. Also, the periodic component tends to be unstable. Both these effects tend to lead to poor estimation of anomaly severity: in particular, less significant anomalies are scored more highly than more significant anomalies by chance because of model instability.