### PR TITLE
Fix combine script used with search state splitter program

### DIFF
--- a/devbin/state_search_splitter/Main.cc
+++ b/devbin/state_search_splitter/Main.cc
@@ -10,7 +10,7 @@
 //! Utility to take the output of a search of a .ml-state index that
 //! returns all state documents for a given model snapshot and reformat
 //! it as the multiple chunks that are streamed to the autodetect
-//! process (separated by \\0 characters).
+//! process (separated by \0 characters).
 //!
 //! IMPLEMENTATION DECISIONS:\n
 //! Standalone dev program, not shipped with the product.

--- a/devbin/state_search_splitter/combine.sh
+++ b/devbin/state_search_splitter/combine.sh
@@ -50,11 +50,11 @@ if [ $# -ne 3 ] ; then
 fi
 
 JOB_ID="$1"
+SNAPSHOT_ID=$2
 DOC_NUM=1
-HIGHEST_DOC_NUM=$2
+HIGHEST_DOC_NUM=$3
 OUTPUT_FILE="$JOB_ID.combined_state.bin"
 rm -f "$OUTPUT_FILE"
-
 
 while [ $DOC_NUM -le $HIGHEST_DOC_NUM ]
 do


### PR DESCRIPTION
The version originally committed in #1180 was not the debugged
version.  Doh!