### PR TITLE
[ML] Fix override of maximum permitted trees for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -64,8 +64,6 @@
   periods of time. (See {ml-pull}1158[#1158].)
 * Break progress reporting of data frame analyses into multiple phases. (See {ml-pull}1179[#1179].)
 
-== {es} version 7.8.0
-
 === Bug Fixes
 
 * Trap and fail if insufficient features are supplied to data frame analyses. This
@@ -73,11 +71,10 @@
   (See {ml-pull}1160[#1160], issue: {issue}55593[#55593].)
 * Make categorization respect the `model_memory_limit`. (See {ml-pull}1167[#1167],
   issue: {ml-issue}1130[#1130].)
-
-=== Bug Fixes
-
 * Fix underlying cause for "Failed to calculate splitting significance" log errors.
   (See {ml-pull}1157[#1157].)
+* Respect user overrides for `max_trees` for classification and regression. (See
+  {ml-pull}1185[#1185].)
 
 == {es} version 7.7.1
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -717,7 +717,9 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
         auto applyEta = [](CBoostedTreeImpl& tree, double eta) {
             tree.m_Eta = CTools::stableExp(eta);
             tree.m_EtaGrowthRatePerTree = 1.0 + tree.m_Eta / 2.0;
-            tree.m_MaximumNumberTrees = computeMaximumNumberTrees(tree.m_Eta);
+            if (tree.m_MaximumNumberTreesOverride == boost::none) {
+                tree.m_MaximumNumberTrees = computeMaximumNumberTrees(tree.m_Eta);
+            }
             return true;
         };
 
@@ -738,7 +740,7 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
 
         if (intervalIsEmpty(m_LogEtaSearchInterval)) {
             m_TreeImpl->m_EtaOverride = m_TreeImpl->m_Eta;
-        } else {
+        } else if (m_TreeImpl->m_MaximumNumberTreesOverride == boost::none) {
             m_TreeImpl->m_MaximumNumberTrees =
                 computeMaximumNumberTrees(MIN_ETA_SCALE * m_TreeImpl->m_Eta);
         }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -4,8 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <atomic>
-#include <boost/test/tools/interface.hpp>
 #include <core/CDataFrame.h>
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CLogger.h>
@@ -28,6 +26,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <fstream>
 #include <functional>
 #include <limits>
@@ -1467,6 +1466,81 @@ BOOST_AUTO_TEST_CASE(testMissingFeatures) {
     BOOST_REQUIRE_EQUAL(expectedPredictions.size(), actualPredictions.size());
     for (std::size_t i = 0; i < expectedPredictions.size(); ++i) {
         BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedPredictions[i], actualPredictions[i], 0.8);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
+
+    // Test hyperparameter overrides are respected.
+
+    test::CRandomNumbers rng;
+
+    std::size_t rows{300};
+    std::size_t cols{6};
+    std::size_t capacity{600};
+
+    TDoubleVecVec x(cols);
+    for (std::size_t i = 0; i < cols; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    auto target = [](const TRowRef& row) { return row[0] + 3.0 * row[3]; };
+
+    auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+
+    fillDataFrame(rows, 0, cols, x, TDoubleVec(rows, 0.0), target, *frame);
+
+    CTestInstrumentation instrumentation;
+    {
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(instrumentation)
+                              .maximumNumberTrees(10)
+                              .treeSizePenaltyMultiplier(0.1)
+                              .leafWeightPenaltyMultiplier(0.01)
+                              .buildFor(*frame, cols - 1);
+
+        regression->train();
+
+        // We use a single leaf to centre the data so end up with limit + 1 trees.
+        BOOST_REQUIRE_EQUAL(11, regression->bestHyperparameters().maximumNumberTrees());
+        BOOST_REQUIRE_EQUAL(
+            0.1, regression->bestHyperparameters().regularization().treeSizePenaltyMultiplier());
+        BOOST_REQUIRE_EQUAL(
+            0.01, regression->bestHyperparameters().regularization().leafWeightPenaltyMultiplier());
+    }
+    {
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(instrumentation)
+                              .eta(0.2)
+                              .softTreeDepthLimit(2.0)
+                              .softTreeDepthTolerance(0.1)
+                              .buildFor(*frame, cols - 1);
+
+        regression->train();
+
+        BOOST_REQUIRE_EQUAL(0.2, regression->bestHyperparameters().eta());
+        BOOST_REQUIRE_EQUAL(
+            2.0, regression->bestHyperparameters().regularization().softTreeDepthLimit());
+        BOOST_REQUIRE_EQUAL(
+            0.1, regression->bestHyperparameters().regularization().softTreeDepthTolerance());
+    }
+    {
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(instrumentation)
+                              .depthPenaltyMultiplier(1.0)
+                              .featureBagFraction(0.4)
+                              .downsampleFactor(0.6)
+                              .buildFor(*frame, cols - 1);
+
+        regression->train();
+
+        BOOST_REQUIRE_EQUAL(
+            1.0, regression->bestHyperparameters().regularization().depthPenaltyMultiplier());
+        BOOST_REQUIRE_EQUAL(0.4, regression->bestHyperparameters().featureBagFraction());
+        BOOST_REQUIRE_EQUAL(0.6, regression->bestHyperparameters().downsampleFactor());
     }
 }
 


### PR DESCRIPTION
This was being reset when searching for the best learn rate. We were also missing a unit test that user overrides for hyperparameters are respected.