### PR TITLE
[ML] Output progress for final training even if we don't have this step

### DIFF
--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -195,6 +195,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
         // Fallback to using the constant predictor which minimises the loss.
 
+        this->startProgressMonitoringFinalTrain();
         m_BestForest.assign(1, this->initializePredictionsAndLossDerivatives(
                                    frame, allTrainingRowsMask, noRowsMask));
         m_BestForestTestLoss = this->meanLoss(frame, allTrainingRowsMask);


### PR DESCRIPTION
It is expected by Java. This is unreleased and related to #1179 so marking as a non-issue.