### PR TITLE
[ML] Add a constant to the prediction which minimises the unregularised loss for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -65,6 +65,9 @@
 * Improve false positive rates from periodicity test for time series anomaly detection.
   (See {ml-pull}1177[#1177].)
 * Break progress reporting of data frame analyses into multiple phases. (See {ml-pull}1179[#1179].)
+* Really centre the data before training for classification and regression begins. This
+  means we can choose more optimal smoothing bias and should reduce the number of trees.
+  (See {ml-pull}1192[#1192].)
 
 === Bug Fixes
 

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -247,6 +247,7 @@ private:
                                               const core::CPackedBitVector& trainingRowMask,
                                               const core::CPackedBitVector& testingRowMask,
                                               double eta,
+                                              double lambda,
                                               TNodeVec& tree) const;
 
     //! Compute the mean of the loss function on the masked rows of \p frame.

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -485,11 +485,11 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoImportance, SFixture) {
             double c1{readShapValue(result, "c1")};
             double prediction{
                 result["row_results"]["results"]["ml"]["target_prediction"].GetDouble()};
-            // c1 explains 94% of the prediction value, i.e. the difference from the prediction is less than 2%.
+            // c1 explains 94% of the prediction value, i.e. the difference from the prediction is less than 6%.
             BOOST_REQUIRE_CLOSE(c1, prediction, 6.0);
             for (const auto& feature : {"c2", "c3", "c4"}) {
                 double c = readShapValue(result, feature);
-                BOOST_REQUIRE_SMALL(c, 2.0);
+                BOOST_REQUIRE_SMALL(c, 3.0);
                 cNoImportanceMean.add(std::fabs(c));
             }
         }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -523,8 +523,8 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
 
     // At the start we will centre the data w.r.t. the given loss function.
     TNodeVec tree{CBoostedTreeNode{m_Loss->numberParameters()}};
-    this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask,
-                                               testingRowMask, 1.0, tree);
+    this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask, testingRowMask,
+                                               1.0 /*eta*/, 0.0 /*lambda*/, tree);
 
     return tree;
 }
@@ -585,8 +585,9 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
 
         if (tree.size() > 1) {
             scopeMemoryUsage.add(tree);
-            this->refreshPredictionsAndLossDerivatives(frame, trainingRowMask,
-                                                       testingRowMask, eta, tree);
+            this->refreshPredictionsAndLossDerivatives(
+                frame, trainingRowMask, testingRowMask, eta,
+                m_Regularization.leafWeightPenaltyMultiplier(), tree);
             forest.push_back(std::move(tree));
             eta = std::min(1.0, m_EtaGrowthRatePerTree * eta);
             retries = 0;
@@ -990,13 +991,12 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
                                                             const core::CPackedBitVector& trainingRowMask,
                                                             const core::CPackedBitVector& testingRowMask,
                                                             double eta,
+                                                            double lambda,
                                                             TNodeVec& tree) const {
 
     using TArgMinLossVec = std::vector<CArgMinLoss>;
 
-    TArgMinLossVec leafValues(
-        tree.size(),
-        m_Loss->minimizer(m_Regularization.leafWeightPenaltyMultiplier(), m_Rng));
+    TArgMinLossVec leafValues(tree.size(), m_Loss->minimizer(lambda, m_Rng));
     auto nextPass = [&] {
         bool done{true};
         for (const auto& value : leafValues) {


### PR DESCRIPTION
We add on a constant weight to "centre" the data. (Strictly speaking this isn't centring the data in the conventional sense, it is finding a single weight which when added to the ensemble prediction minimises the loss.)

Currently, we choose to minimise regularised loss with this weight, i.e. respecting the weight shrinkage. First, there is no need to do this, shrinkage is used to impose a "smoothness" bias, but a constant function is flat. Second, the subsequent trees spend effort updating the mean predictions to be unbiased and means there is an unfortunate interplay between the degree of smoothing we can use (since it will create bias in the unregularised loss) and the centre of the data.