### PR TITLE
[7.x][ML] Reset memory status from soft limit to ok below threshold

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -74,6 +74,8 @@
   (See {ml-pull}1157[#1157].)
 * Respect user overrides for `max_trees` for classification and regression. (See
   {ml-pull}1185[#1185].)
+* Reset memory status from `soft_limit` to `ok` when pruning is no longer required.
+  (See {ml-pull}1193[#1193], issue: {ml-issue}1131[#1131].)
 
 == {es} version 7.7.1
 

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -368,10 +368,12 @@ public:
     //! sufficiently long period, based on the prior decay rates.
     void prune();
 
-    //! Calculate the maximum permitted prune window for this model
+    //! Calculate the maximum permitted prune window (measured in buckets)
+    //! for this model
     std::size_t defaultPruneWindow() const;
 
-    //! Calculate the minimum permitted prune window for this model
+    //! Calculate the minimum permitted prune window (measured in buckets)
+    //! for this model
     std::size_t minimumPruneWindow() const;
     //@}
 

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -127,12 +127,18 @@ public:
     //! We are being told that aggressive pruning has taken place
     //! to avoid hitting the resource limit, and we should report this
     //! to the user when we can
-    void acceptPruningResult();
+    void startPruning();
+
+    //! We are being told that aggressive pruning to avoid hitting the
+    //! resource limit is no longer necessary, and we should report this
+    //! to the user when we can
+    void endPruning();
 
     //! Accessor for no limit flag
     bool haveNoLimit() const;
 
     //! Prune models where necessary
+    //! \return Was pruning required?
     bool pruneIfRequired(core_t::TTime endTime);
 
     //! Accounts for any extra memory to the one
@@ -243,7 +249,7 @@ private:
     //! The largest that the prune window can grow to - determined from the models
     std::size_t m_PruneWindowMaximum;
 
-    //! The smallest that the prune window can shrink to - 4 weeks
+    //! The smallest that the prune window can shrink to - determined from the models
     std::size_t m_PruneWindowMinimum;
 
     //! Don't do any sort of memory checking if this is set

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -275,7 +275,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         BOOST_REQUIRE_EQUAL(std::size_t(0), m_ReportedModelSizeStats.s_AllocationFailures);
 
         // Set a soft-limit degraded status
-        mon.acceptPruningResult();
+        mon.startPruning();
 
         // This refresh should trigger a report
         mon.refresh(categorizer);
@@ -453,6 +453,16 @@ BOOST_FIXTURE_TEST_CASE(testPruning, CTestFixture) {
     // And finally that it grows again
     this->addTestData(bucket, BUCKET_LENGTH, 700, 0, startOffset, detector, monitor);
     BOOST_TEST_REQUIRE(monitor.m_PruneWindow > level);
+
+    // If it grows enough we will stop pruning and revert to memory status OK,
+    // and 7000 completely empty buckets (even without the all pervasive person)
+    // is the quickest way to achieve this.
+    bucket += BUCKET_LENGTH * 7000;
+    this->addTestData(bucket, BUCKET_LENGTH, 2, 0, startOffset, detector, monitor);
+    LOG_DEBUG(<< "Window is now: " << monitor.m_PruneWindow);
+    BOOST_REQUIRE_EQUAL(false, monitor.m_HasPruningStarted);
+    BOOST_REQUIRE_EQUAL(monitor.m_PruneWindowMaximum, monitor.m_PruneWindow);
+    BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusOk, monitor.m_MemoryStatus);
 }
 
 BOOST_FIXTURE_TEST_CASE(testExtraMemory, CTestFixture) {

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -593,7 +593,7 @@ BOOST_FIXTURE_TEST_CASE(testSoftMemoryLimit, CTestFixture) {
     BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
 
     // Create a soft memory limit
-    m_Limits.resourceMonitor().acceptPruningResult();
+    m_Limits.resourceMonitor().startPruning();
 
     message = baseMessage + makeUniqueToken();
     BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
@@ -605,8 +605,18 @@ BOOST_FIXTURE_TEST_CASE(testSoftMemoryLimit, CTestFixture) {
     BOOST_REQUIRE(categorizer.addExample(1, message) == false);
     BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
 
-    // TODO: once it's possible to escape from soft limit without
-    // a restart, test that we start accumulating examples again
+    // Clear the soft memory limit
+    m_Limits.resourceMonitor().endPruning();
+
+    message = baseMessage + makeUniqueToken();
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(1, message));
+    // Out of soft limit we have started accumulating examples again
+    BOOST_REQUIRE_EQUAL(3, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    message = baseMessage + makeUniqueToken();
+    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(1, message));
+    BOOST_REQUIRE_EQUAL(4, categorizer.examplesCollector().numberOfExamplesForCategory(1));
 }
 
 BOOST_FIXTURE_TEST_CASE(testHardMemoryLimit, CTestFixture) {


### PR DESCRIPTION
We start pruning models when the memory used goes above the
prune threshold, and set the job's memory status to soft
limit at the same time.  If you close and reopen the job and
memory usage is lower than the prune threshold then we don't
prune and the memory limit is ok.  Prior to this change there
was a discrepancy where if you didn't close and reopen the
job but memory usage dropped below the prune threshold then
we continued to prune and left the memory status in soft
limit.

This change makes the case of not closing and reopening the
job more consistent.  If memory usage drops below the prune
threshold and the prune window expands to the default level
then we stop pruning and set the memory status back to ok.

Backport of #1193