### PR TITLE
[7.x][ML] Pseudo-Huber loss function 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@
 * Adds new `num_matches` and `preferred_to_categories` fields to category output.
   (See {ml-pull}1062[#1062].)
 * Adds mean squared logarithmic error (MSLE) for regression. (See {ml-pull}1101[#1101].)
-* Improve robustness of anomaly detection to bad input data. (See {ml-pull}1114[#1114].)
+* Adds pseudo-Huber loss for regression. (See {ml-pull}1168[#1168].)
 * Reduce peak memory usage and memory estimates for classification and regression.
   (See {ml-pull}1125[#1125].)
 * Reduce variability of classification and regression results across our target operating systems.

--- a/include/api/CDataFrameTrainBoostedTreeRegressionRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRegressionRunner.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDED_ml_api_CDataFrameTrainBoostedTreeRegressionRunner_h
 #define INCLUDED_ml_api_CDataFrameTrainBoostedTreeRegressionRunner_h
 
+#include <maths/CBoostedTreeLoss.h>
+
 #include <api/CDataFrameTrainBoostedTreeRunner.h>
 #include <api/ImportExport.h>
 
@@ -21,13 +23,15 @@ class API_EXPORT CDataFrameTrainBoostedTreeRegressionRunner final
 
 public:
     using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
-    enum ELossFunctionType { E_Mse, E_Msle };
+    using TLossFunctionType = maths::boosted_tree::ELossType;
 
 public:
     static const std::string STRATIFIED_CROSS_VALIDATION;
     static const std::string LOSS_FUNCTION;
+    static const std::string LOSS_FUNCTION_PARAMETER;
     static const std::string MSE;
     static const std::string MSLE;
+    static const std::string PSEUDO_HUBER;
 
 public:
     static const CDataFrameAnalysisConfigReader& parameterReader();

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -297,9 +297,6 @@ private:
     //! Start monitoring the final model training.
     void startProgressMonitoringFinalTrain();
 
-    //! Restore \p loss function pointer from the \p traverser.
-    static bool restoreLoss(TLossFunctionUPtr& loss, core::CStateRestoreTraverser& traverser);
-
     //! Record the training state using the \p recordTrainState callback function
     void recordState(const TTrainingStateCallback& recordTrainState) const;
 

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -10,6 +10,8 @@
 #include <core/CDataAdder.h>
 #include <core/CDataSearcher.h>
 
+#include <maths/CBoostedTreeLoss.h>
+
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataFrameTrainBoostedTreeRegressionRunner.h>
 
@@ -33,7 +35,7 @@ public:
     using TDataSearcherUPtr = std::unique_ptr<core::CDataSearcher>;
     using TRestoreSearcherSupplier = std::function<TDataSearcherUPtr()>;
     using TSpecificationUPtr = std::unique_ptr<api::CDataFrameAnalysisSpecification>;
-    using TRegressionLossFunction = api::CDataFrameTrainBoostedTreeRegressionRunner::ELossFunctionType;
+    using TLossFunctionType = maths::boosted_tree::ELossType;
 
 public:
     CDataFrameAnalysisSpecificationFactory();
@@ -76,8 +78,9 @@ public:
     predictionRestoreSearcherSupplier(TRestoreSearcherSupplier* restoreSearcherSupplier);
 
     // Regression
+    CDataFrameAnalysisSpecificationFactory& regressionLossFunction(TLossFunctionType lossFunction);
     CDataFrameAnalysisSpecificationFactory&
-    regressionLossFunction(TRegressionLossFunction lossFunction);
+    regressionLossFunctionParameter(double lossFunctionParameter);
 
     // Classification
     CDataFrameAnalysisSpecificationFactory& numberClasses(std::size_t number);
@@ -94,6 +97,8 @@ public:
 
 private:
     using TOptionalSize = boost::optional<std::size_t>;
+    using TOptionalDouble = boost::optional<double>;
+    using TOptionalLossFunctionType = boost::optional<TLossFunctionType>;
 
 private:
     // Shared
@@ -123,7 +128,8 @@ private:
     TPersisterSupplier* m_PersisterSupplier = nullptr;
     TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
     // Regression
-    TRegressionLossFunction m_RegressionLossFunction = TRegressionLossFunction::E_Mse;
+    TOptionalLossFunctionType m_RegressionLossFunction;
+    TOptionalDouble m_RegressionLossFunctionParameter;
     // Classification
     std::size_t m_NumberClasses = 2;
     std::size_t m_NumberTopClasses = 0;

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -28,21 +28,16 @@ namespace test {
 //! \brief Collection of helping methods to create regression and classification data for tests.
 class TEST_EXPORT CDataFrameAnalyzerTrainingFactory {
 public:
-    enum EPredictionType {
-        E_MsleRegression,
-        E_Regression,
-        E_BinaryClassification,
-        E_MulticlassClassification
-    };
     using TStrVec = std::vector<std::string>;
     using TDoubleVec = std::vector<double>;
     using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
     using TLossUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
     using TTargetTransformer = std::function<double(double)>;
+    using TLossFunctionType = maths::boosted_tree::ELossType;
 
 public:
     template<typename T>
-    static void addPredictionTestData(EPredictionType type,
+    static void addPredictionTestData(TLossFunctionType type,
                                       const TStrVec& fieldNames,
                                       TStrVec fieldValues,
                                       api::CDataFrameAnalyzer& analyzer,
@@ -55,7 +50,8 @@ public:
                                       double softTreeDepthTolerance = -1.0,
                                       double eta = 0.0,
                                       std::size_t maximumNumberTrees = 0,
-                                      double featureBagFraction = 0.0) {
+                                      double featureBagFraction = 0.0,
+                                      double lossFunctionParameter = 1.0) {
 
         test::CRandomNumbers rng;
 
@@ -67,17 +63,20 @@ public:
         TStrVec targets;
         auto frame = [&] {
             switch (type) {
-            case E_Regression:
+            case TLossFunctionType::E_MseRegression:
                 return setupLinearRegressionData(fieldNames, fieldValues, analyzer,
                                                  weights, regressors, targets);
-            case E_MsleRegression:
+            case TLossFunctionType::E_HuberRegression:
+                return setupLinearRegressionData(fieldNames, fieldValues, analyzer,
+                                                 weights, regressors, targets);
+            case TLossFunctionType::E_MsleRegression:
                 return setupLinearRegressionData(fieldNames, fieldValues, analyzer,
                                                  weights, regressors, targets,
                                                  [](double x) { return x * x; });
-            case E_BinaryClassification:
+            case TLossFunctionType::E_BinaryClassification:
                 return setupBinaryClassificationData(fieldNames, fieldValues, analyzer,
                                                      weights, regressors, targets);
-            case E_MulticlassClassification:
+            case TLossFunctionType::E_MulticlassClassification:
                 // TODO
                 return TDataFrameUPtr{};
             }
@@ -86,16 +85,19 @@ public:
 
         TLossUPtr loss;
         switch (type) {
-        case E_Regression:
+        case TLossFunctionType::E_MseRegression:
             loss = std::make_unique<maths::boosted_tree::CMse>();
             break;
-        case E_MsleRegression:
-            loss = std::make_unique<maths::boosted_tree::CMsle>();
+        case TLossFunctionType::E_MsleRegression:
+            loss = std::make_unique<maths::boosted_tree::CMsle>(lossFunctionParameter);
             break;
-        case E_BinaryClassification:
+        case TLossFunctionType::E_HuberRegression:
+            loss = std::make_unique<maths::boosted_tree::CPseudoHuber>(lossFunctionParameter);
+            break;
+        case TLossFunctionType::E_BinaryClassification:
             loss = std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>();
             break;
-        case E_MulticlassClassification:
+        case TLossFunctionType::E_MulticlassClassification:
             // TODO
             loss = TLossUPtr{};
             break;

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -29,6 +29,7 @@ using TStrVec = std::vector<std::string>;
 using TRowItr = core::CDataFrame::TRowItr;
 using TDoubleVec = std::vector<double>;
 using TDoubleVecVec = std::vector<TDoubleVec>;
+using TLossFunctionType = maths::boosted_tree::ELossType;
 
 void addOutlierTestData(TStrVec fieldNames,
                         TStrVec fieldValues,
@@ -150,8 +151,8 @@ BOOST_AUTO_TEST_CASE(testTrainingRegression) {
             test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
         outputWriterFactory};
     test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
-        test::CDataFrameAnalyzerTrainingFactory::E_Regression, fieldNames,
-        fieldValues, analyzer, expectedPredictions);
+        TLossFunctionType::E_MseRegression, fieldNames, fieldValues, analyzer,
+        expectedPredictions);
 
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
@@ -240,8 +241,8 @@ BOOST_AUTO_TEST_CASE(testTrainingClassification) {
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(), "target"),
         outputWriterFactory};
     test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
-        test::CDataFrameAnalyzerTrainingFactory::E_BinaryClassification,
-        fieldNames, fieldValues, analyzer, expectedPredictions);
+        TLossFunctionType::E_BinaryClassification, fieldNames, fieldValues,
+        analyzer, expectedPredictions);
 
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -54,7 +54,7 @@ using TDataAdderUPtr = std::unique_ptr<core::CDataAdder>;
 using TPersisterSupplier = std::function<TDataAdderUPtr()>;
 using TDataSearcherUPtr = std::unique_ptr<core::CDataSearcher>;
 using TRestoreSearcherSupplier = std::function<TDataSearcherUPtr()>;
-using TRegressionLossFunction = test::CDataFrameAnalysisSpecificationFactory::TRegressionLossFunction;
+using TLossFunctionType = maths::boosted_tree::ELossType;
 
 class CTestDataSearcher : public core::CDataSearcher {
 public:
@@ -111,7 +111,7 @@ template<typename F>
 void testOneRunOfBoostedTreeTrainingWithStateRecovery(
     F makeSpec,
     std::size_t iterationToRestartFrom,
-    TRegressionLossFunction lossFunction = TRegressionLossFunction::E_Mse) {
+    TLossFunctionType lossFunction = TLossFunctionType::E_MseRegression) {
 
     std::stringstream outputStream;
     auto outputWriterFactory = [&outputStream]() {
@@ -141,7 +141,7 @@ void testOneRunOfBoostedTreeTrainingWithStateRecovery(
     TStrVec targets;
     // avoid negative targets
     auto targetTransformer = [&lossFunction](double x) {
-        return (lossFunction == TRegressionLossFunction::E_Msle) ? x * x : x;
+        return (lossFunction == TLossFunctionType::E_MsleRegression) ? x * x : x;
     };
     auto frame = test::CDataFrameAnalyzerTrainingFactory::setupLinearRegressionData(
         fieldNames, fieldValues, analyzer, weights, regressors, targets, targetTransformer);
@@ -199,6 +199,94 @@ void testOneRunOfBoostedTreeTrainingWithStateRecovery(
             BOOST_FAIL("Missing " + key);
         }
     }
+}
+
+void testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType lossFunction) {
+
+    // Test the regression hyperparameter settings are correctly propagated to the
+    // analysis runner.
+
+    double alpha{2.0};
+    double lambda{1.0};
+    double gamma{10.0};
+    double softTreeDepthLimit{3.0};
+    double softTreeDepthTolerance{0.1};
+    double eta{0.9};
+    std::size_t maximumNumberTrees{1};
+    double featureBagFraction{0.3};
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    test::CDataFrameAnalysisSpecificationFactory specFactory;
+    api::CDataFrameAnalyzer analyzer{
+        specFactory.predictionAlpha(alpha)
+            .predictionLambda(lambda)
+            .predictionGamma(gamma)
+            .predictionSoftTreeDepthLimit(softTreeDepthLimit)
+            .predictionSoftTreeDepthTolerance(softTreeDepthTolerance)
+            .predictionEta(eta)
+            .predictionMaximumNumberTrees(maximumNumberTrees)
+            .predictionFeatureBagFraction(featureBagFraction)
+            .regressionLossFunction(lossFunction)
+            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
+        outputWriterFactory};
+
+    TDoubleVec expectedPredictions;
+
+    TStrVec fieldNames{"f1", "f2", "f3", "f4", "target", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
+        lossFunction, fieldNames, fieldValues, analyzer, expectedPredictions,
+        100, alpha, lambda, gamma, softTreeDepthLimit, softTreeDepthTolerance,
+        eta, maximumNumberTrees, featureBagFraction);
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    // Check best hyperparameters
+    const auto* runner{dynamic_cast<const api::CDataFrameTrainBoostedTreeRegressionRunner*>(
+        analyzer.runner())};
+    const auto& boostedTree{runner->boostedTree()};
+    const auto& bestHyperparameters{boostedTree.bestHyperparameters()};
+    BOOST_TEST_REQUIRE(bestHyperparameters.eta() == eta);
+    BOOST_TEST_REQUIRE(bestHyperparameters.featureBagFraction() == featureBagFraction);
+    // TODO extend the test to add the checks for downsampleFactor and etaGrowthRatePerTree
+    //    BOOST_TEST_REQUIRE(bestHyperparameters.downsampleFactor() == downsampleFactor);
+    //    BOOST_TEST_REQUIRE(bestHyperparameters.etaGrowthRatePerTree() == etaGrowthRatePerTree);
+    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().depthPenaltyMultiplier() == alpha);
+    BOOST_TEST_REQUIRE(
+        bestHyperparameters.regularization().leafWeightPenaltyMultiplier() == lambda);
+    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().treeSizePenaltyMultiplier() == gamma);
+    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().softTreeDepthLimit() ==
+                       softTreeDepthLimit);
+    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().softTreeDepthTolerance() ==
+                       softTreeDepthTolerance);
+
+    rapidjson::Document results;
+    rapidjson::ParseResult ok(results.Parse(output.str()));
+    BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+
+    auto expectedPrediction = expectedPredictions.begin();
+    bool progressCompleted{false};
+    for (const auto& result : results.GetArray()) {
+        if (result.HasMember("row_results")) {
+            BOOST_TEST_REQUIRE(expectedPrediction != expectedPredictions.end());
+            BOOST_REQUIRE_CLOSE_ABSOLUTE(
+                *expectedPrediction,
+                result["row_results"]["results"]["ml"]["target_prediction"].GetDouble(),
+                1e-4 * std::fabs(*expectedPrediction));
+            ++expectedPrediction;
+            BOOST_TEST_REQUIRE(result.HasMember("progress_percent") == false);
+        } else if (result.HasMember("phase_progress")) {
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() >= 0);
+            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() <= 100);
+            BOOST_TEST_REQUIRE(result.HasMember("row_results") == false);
+            progressCompleted = result["phase_progress"]["progress_percent"].GetInt() == 100;
+        }
+    }
+    BOOST_TEST_REQUIRE(expectedPrediction == expectedPredictions.end());
+    BOOST_TEST_REQUIRE(progressCompleted);
 }
 }
 
@@ -275,7 +363,7 @@ BOOST_AUTO_TEST_CASE(testMissingString) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingMse) {
+BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
 
     // Test the results the analyzer produces match running the regression directly.
 
@@ -293,8 +381,8 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingMse) {
             test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
         outputWriterFactory};
     test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
-        test::CDataFrameAnalyzerTrainingFactory::E_Regression, fieldNames,
-        fieldValues, analyzer, expectedPredictions);
+        TLossFunctionType::E_MseRegression, fieldNames, fieldValues, analyzer,
+        expectedPredictions);
 
     core::CStopWatch watch{true};
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
@@ -342,91 +430,23 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingMse) {
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
 
-BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithParams) {
+BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithMse) {
 
     // Test the regression hyperparameter settings are correctly propagated to the
     // analysis runner.
+    testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType::E_MseRegression);
+}
 
-    double alpha{2.0};
-    double lambda{1.0};
-    double gamma{10.0};
-    double softTreeDepthLimit{3.0};
-    double softTreeDepthTolerance{0.1};
-    double eta{0.9};
-    std::size_t maximumNumberTrees{1};
-    double featureBagFraction{0.3};
+BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithParamsMsle) {
+    // Test the regression hyperparameter settings are correctly propagated to the
+    // analysis runner.
+    testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType::E_MsleRegression);
+}
 
-    std::stringstream output;
-    auto outputWriterFactory = [&output]() {
-        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
-    };
-
-    test::CDataFrameAnalysisSpecificationFactory specFactory;
-    api::CDataFrameAnalyzer analyzer{
-        specFactory.predictionAlpha(alpha)
-            .predictionLambda(lambda)
-            .predictionGamma(gamma)
-            .predictionSoftTreeDepthLimit(softTreeDepthLimit)
-            .predictionSoftTreeDepthTolerance(softTreeDepthTolerance)
-            .predictionEta(eta)
-            .predictionMaximumNumberTrees(maximumNumberTrees)
-            .predictionFeatureBagFraction(featureBagFraction)
-            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
-        outputWriterFactory};
-
-    TDoubleVec expectedPredictions;
-
-    TStrVec fieldNames{"f1", "f2", "f3", "f4", "target", ".", "."};
-    TStrVec fieldValues{"", "", "", "", "", "0", ""};
-    test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
-        test::CDataFrameAnalyzerTrainingFactory::E_Regression, fieldNames, fieldValues,
-        analyzer, expectedPredictions, 100, alpha, lambda, gamma, softTreeDepthLimit,
-        softTreeDepthTolerance, eta, maximumNumberTrees, featureBagFraction);
-    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
-
-    // Check best hyperparameters
-    const auto* runner{dynamic_cast<const api::CDataFrameTrainBoostedTreeRegressionRunner*>(
-        analyzer.runner())};
-    const auto& boostedTree{runner->boostedTree()};
-    const auto& bestHyperparameters{boostedTree.bestHyperparameters()};
-    BOOST_TEST_REQUIRE(bestHyperparameters.eta() == eta);
-    BOOST_TEST_REQUIRE(bestHyperparameters.featureBagFraction() == featureBagFraction);
-    // TODO extend the test to add the checks for downsampleFactor and etaGrowthRatePerTree
-    //    BOOST_TEST_REQUIRE(bestHyperparameters.downsampleFactor() == downsampleFactor);
-    //    BOOST_TEST_REQUIRE(bestHyperparameters.etaGrowthRatePerTree() == etaGrowthRatePerTree);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().depthPenaltyMultiplier() == alpha);
-    BOOST_TEST_REQUIRE(
-        bestHyperparameters.regularization().leafWeightPenaltyMultiplier() == lambda);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().treeSizePenaltyMultiplier() == gamma);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().softTreeDepthLimit() ==
-                       softTreeDepthLimit);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().softTreeDepthTolerance() ==
-                       softTreeDepthTolerance);
-
-    rapidjson::Document results;
-    rapidjson::ParseResult ok(results.Parse(output.str()));
-    BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
-
-    auto expectedPrediction = expectedPredictions.begin();
-    bool progressCompleted{false};
-    for (const auto& result : results.GetArray()) {
-        if (result.HasMember("row_results")) {
-            BOOST_TEST_REQUIRE(expectedPrediction != expectedPredictions.end());
-            BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                *expectedPrediction,
-                result["row_results"]["results"]["ml"]["target_prediction"].GetDouble(),
-                1e-4 * std::fabs(*expectedPrediction));
-            ++expectedPrediction;
-            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
-        } else if (result.HasMember("phase_progress")) {
-            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() >= 0);
-            BOOST_TEST_REQUIRE(result["phase_progress"]["progress_percent"].GetInt() <= 100);
-            BOOST_TEST_REQUIRE(result.HasMember("row_results") == false);
-            progressCompleted = result["phase_progress"]["progress_percent"].GetInt() == 100;
-        }
-    }
-    BOOST_TEST_REQUIRE(expectedPrediction == expectedPredictions.end());
-    BOOST_TEST_REQUIRE(progressCompleted);
+BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithParamsPseudoHuber) {
+    // Test the regression hyperparameter settings are correctly propagated to the
+    // analysis runner.
+    testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType::E_HuberRegression);
 }
 
 BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithRowsMissingTargetValue) {
@@ -525,8 +545,9 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
 
         LOG_DEBUG(<< "Number parameters to search = " << params.numberUnset());
 
-        for (const auto& lossFunction :
-             {TRegressionLossFunction::E_Mse, TRegressionLossFunction::E_Msle}) {
+        for (const auto& lossFunction : {TLossFunctionType::E_MseRegression,
+                                         TLossFunctionType::E_MsleRegression,
+                                         TLossFunctionType::E_HuberRegression}) {
             LOG_DEBUG(<< "Loss function type " << lossFunction);
 
             auto makeSpec = [&](const std::string& dependentVariable, std::size_t numberExamples,
@@ -563,68 +584,6 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingMsle) {
-
-    // Test running the analyser supplying the MSLE objective produces similar results
-    // to running the regression directly.
-
-    double alpha{2.0};
-    double lambda{1.0};
-    double gamma{10.0};
-    double softTreeDepthLimit{3.0};
-    double softTreeDepthTolerance{0.1};
-    double eta{0.9};
-    std::size_t maximumNumberTrees{1};
-    double featureBagFraction{0.3};
-
-    std::stringstream output;
-    auto outputWriterFactory = [&output]() {
-        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
-    };
-
-    test::CDataFrameAnalysisSpecificationFactory specFactory;
-    api::CDataFrameAnalyzer analyzerMsle{
-        specFactory.predictionAlpha(alpha)
-            .predictionLambda(lambda)
-            .predictionGamma(gamma)
-            .predictionSoftTreeDepthLimit(softTreeDepthLimit)
-            .predictionSoftTreeDepthTolerance(softTreeDepthTolerance)
-            .predictionEta(eta)
-            .predictionMaximumNumberTrees(maximumNumberTrees)
-            .predictionFeatureBagFraction(featureBagFraction)
-            .regressionLossFunction(test::CDataFrameAnalysisSpecificationFactory::TRegressionLossFunction::E_Msle)
-            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
-        outputWriterFactory};
-
-    TDoubleVec expectedPredictions;
-
-    TStrVec fieldNames{"f1", "f2", "f3", "f4", "target", ".", "."};
-    TStrVec fieldValues{"", "", "", "", "", "0", ""};
-    test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
-        test::CDataFrameAnalyzerTrainingFactory::E_MsleRegression, fieldNames, fieldValues,
-        analyzerMsle, expectedPredictions, 100, alpha, lambda, gamma, softTreeDepthLimit,
-        softTreeDepthTolerance, eta, maximumNumberTrees, featureBagFraction);
-    analyzerMsle.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
-
-    rapidjson::Document results;
-    rapidjson::ParseResult ok(results.Parse(output.str()));
-    BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
-
-    auto expectedPrediction = expectedPredictions.begin();
-    for (const auto& result : results.GetArray()) {
-        if (result.HasMember("row_results")) {
-            BOOST_TEST_REQUIRE(expectedPrediction != expectedPredictions.end());
-            BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                *expectedPrediction,
-                result["row_results"]["results"]["ml"]["target_prediction"].GetDouble(),
-                1e-4 * std::fabs(*expectedPrediction));
-            ++expectedPrediction;
-            BOOST_TEST_REQUIRE(result.HasMember("phase_progress") == false);
-        }
-    }
-    BOOST_TEST_REQUIRE(expectedPrediction == expectedPredictions.end());
-}
-
 BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
 
     // Test the results the analyzer produces match running classification directly.
@@ -646,8 +605,8 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(), "target"),
         outputWriterFactory};
     test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
-        test::CDataFrameAnalyzerTrainingFactory::E_BinaryClassification,
-        fieldNames, fieldValues, analyzer, expectedPredictions);
+        TLossFunctionType::E_BinaryClassification, fieldNames, fieldValues,
+        analyzer, expectedPredictions);
 
     core::CStopWatch watch{true};
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
@@ -980,8 +939,8 @@ BOOST_AUTO_TEST_CASE(testProgress) {
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
         outputWriterFactory};
     test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
-        test::CDataFrameAnalyzerTrainingFactory::E_Regression, fieldNames,
-        fieldValues, analyzer, expectedPredictions, 200);
+        TLossFunctionType::E_MseRegression, fieldNames, fieldValues, analyzer,
+        expectedPredictions, 200);
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "", "$"});
 
     rapidjson::Document results;

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -4,7 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include <exception>
 #include <maths/CBoostedTreeLoss.h>
+
+#include <core/CPersistUtils.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CLbfgs.h>
@@ -25,11 +28,22 @@ namespace {
 const double EPSILON{100.0 * std::numeric_limits<double>::epsilon()};
 const double LOG_EPSILON{CTools::stableLog(EPSILON)};
 
-// MSLE CONSTANTS
+// MSLE constants
 const std::size_t MSLE_PREDICTION_INDEX{0};
 const std::size_t MSLE_ACTUAL_INDEX{1};
 const std::size_t MSLE_ERROR_INDEX{2};
 const std::size_t MSLE_BUCKET_SIZE{32};
+const std::size_t MSLE_OPTIMIZATION_ITERATIONS{15};
+
+// Pseudo-Huber constants
+const std::size_t HUBER_BUCKET_SIZE{128};
+const std::size_t HUBER_OPTIMIZATION_ITERATIONS{15};
+
+// Persistence and restoration
+const std::string NUMBER_CLASSES_TAG{"number_classes"};
+const std::string OFFSET_TAG{"offset"};
+const std::string DELTA_TAG{"delta"};
+const std::string NAME_TAG{"name"};
 
 double logOneMinusLogistic(double logOdds) {
     // For large x logistic(x) = 1 - e^(-x) + O(e^(-2x))
@@ -467,7 +481,7 @@ CArgMinMsleImpl::TDoubleVector CArgMinMsleImpl::value() const {
 
     double minimizer;
     double objectiveAtMinimum;
-    std::size_t maxIterations{15};
+    std::size_t maxIterations{MSLE_OPTIMIZATION_ITERATIONS};
     CSolvers::minimize(minLogWeight, maxLogWeight, objective(minLogWeight),
                        objective(maxLogWeight), objective, 1e-5, maxIterations,
                        minimizer, objectiveAtMinimum);
@@ -512,9 +526,135 @@ CArgMinMsleImpl::TObjective CArgMinMsleImpl::objective() const {
         }
     };
 }
+
+CArgMinPseudoHuberImpl::CArgMinPseudoHuberImpl(double lambda, double delta)
+    : CArgMinLossImpl{lambda}, m_DeltaSquared{CTools::pow2(delta)},
+      m_Buckets(HUBER_BUCKET_SIZE) {
+}
+
+std::unique_ptr<CArgMinLossImpl> CArgMinPseudoHuberImpl::clone() const {
+    return std::make_unique<CArgMinPseudoHuberImpl>(*this);
+}
+
+bool CArgMinPseudoHuberImpl::nextPass() {
+    ++m_CurrentPass;
+    return this->bucketWidth() > 0.0 && m_CurrentPass < 2;
+}
+
+void CArgMinPseudoHuberImpl::add(const TMemoryMappedFloatVector& predictionVector,
+                                 double actual,
+                                 double weight) {
+    double prediction{predictionVector[0]};
+    switch (m_CurrentPass) {
+    case 0: {
+        m_ErrorMinMax.add(actual - prediction);
+        break;
+    }
+    case 1: {
+        double error{actual - prediction};
+        auto bucketIndex{this->bucket(error)};
+        m_Buckets[bucketIndex].add(error, weight);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void CArgMinPseudoHuberImpl::merge(const CArgMinLossImpl& other) {
+    const auto* huber = dynamic_cast<const CArgMinPseudoHuberImpl*>(&other);
+    if (huber != nullptr) {
+        switch (m_CurrentPass) {
+        case 0:
+            m_ErrorMinMax += huber->m_ErrorMinMax;
+            break;
+        case 1:
+            for (std::size_t i = 0; i < m_Buckets.size(); ++i) {
+                m_Buckets[i] += huber->m_Buckets[i];
+            }
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+CArgMinPseudoHuberImpl::TDoubleVector CArgMinPseudoHuberImpl::value() const {
+    // Set the lower (upper) bounds for minimisation such that every example will have the same sign
+    // error if the weight is smaller (larger) than this bound and so would only increase the loss.
+    double minWeight = m_ErrorMinMax.min();
+    double maxWeight = m_ErrorMinMax.max();
+
+    TObjective objective{this->objective()};
+    double minimizer;
+    double objectiveAtMinimum;
+    std::size_t maxIterations{HUBER_OPTIMIZATION_ITERATIONS};
+    CSolvers::minimize(minWeight, maxWeight, objective(minWeight), objective(maxWeight),
+                       objective, 1e-5, maxIterations, minimizer, objectiveAtMinimum);
+    LOG_TRACE(<< "minimum = " << minimizer << " objective(minimum) = " << objectiveAtMinimum);
+
+    TDoubleVector result(1);
+    result(0) = minimizer;
+    return result;
+}
+
+CArgMinPseudoHuberImpl::TObjective CArgMinPseudoHuberImpl::objective() const {
+    return [this](double weight) {
+        if (m_DeltaSquared > 0) {
+
+            double loss{0.0};
+            double totalCount{0.0};
+            for (const auto& bucket : m_Buckets) {
+                double count{CBasicStatistics::count(bucket)};
+                if (count > 0.0) {
+                    double error{CBasicStatistics::mean(bucket)};
+                    loss += count * m_DeltaSquared *
+                            (std::sqrt(1.0 + CTools::pow2(error - weight) / m_DeltaSquared) - 1.0);
+                    totalCount += count;
+                }
+            }
+            return loss / totalCount + this->lambda() * CTools::pow2(weight);
+        } else {
+            return 0.0;
+        }
+    };
+}
 }
 
 namespace boosted_tree {
+
+CLoss::TLossUPtr CLoss::restoreLoss(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& lossFunctionName = traverser.name();
+        try {
+            if (lossFunctionName == CMse::NAME) {
+                return std::make_unique<CMse>(traverser);
+            } else if (lossFunctionName == CMsle::NAME) {
+                return std::make_unique<CMsle>(traverser);
+            } else if (lossFunctionName == CPseudoHuber::NAME) {
+                return std::make_unique<CPseudoHuber>(traverser);
+            } else if (lossFunctionName == CBinomialLogisticLoss::NAME) {
+                return std::make_unique<CBinomialLogisticLoss>(traverser);
+            } else if (lossFunctionName == CMultinomialLogisticLoss::NAME) {
+                return std::make_unique<CMultinomialLogisticLoss>(traverser);
+            }
+        } catch (const std::exception& e) {
+            LOG_ERROR(<< "Error restoring loss function " << lossFunctionName
+                      << " " << e.what());
+            return nullptr;
+        }
+        LOG_ERROR(<< "Error restoring loss function. Unknown loss function type '"
+                  << lossFunctionName << "'.");
+        return nullptr;
+    } while (traverser.next());
+}
+
+void CLoss::persistLoss(core::CStatePersistInserter& inserter) const {
+    auto persist = [this](core::CStatePersistInserter& inserter_) {
+        this->acceptPersistInserter(inserter_);
+    };
+    inserter.insertLevel(this->name(), persist);
+}
 
 CArgMinLoss::CArgMinLoss(const CArgMinLoss& other)
     : m_Impl{other.m_Impl->clone()} {
@@ -548,6 +688,13 @@ CArgMinLoss::CArgMinLoss(const CArgMinLossImpl& impl) : m_Impl{impl.clone()} {
 
 CArgMinLoss CLoss::makeMinimizer(const boosted_tree_detail::CArgMinLossImpl& impl) const {
     return {impl};
+}
+
+CMse::CMse(core::CStateRestoreTraverser& traverser) {
+    if (traverser.traverseSubLevel(std::bind(&CMse::acceptRestoreTraverser, this,
+                                             std::placeholders::_1)) == false) {
+        throw std::runtime_error{"failed to restore CMse"};
+    }
 }
 
 std::unique_ptr<CLoss> CMse::clone() const {
@@ -600,7 +747,23 @@ bool CMse::isRegression() const {
     return true;
 }
 
+void CMse::acceptPersistInserter(core::CStatePersistInserter& /* inserter */) const {
+}
+bool CMse::acceptRestoreTraverser(core::CStateRestoreTraverser& /* traverser */) {
+    return true;
+}
+
 const std::string CMse::NAME{"mse"};
+
+CMsle::CMsle(double offset) : m_Offset{offset} {
+}
+
+CMsle::CMsle(core::CStateRestoreTraverser& traverser) {
+    if (traverser.traverseSubLevel(std::bind(&CMsle::acceptRestoreTraverser, this,
+                                             std::placeholders::_1)) == false) {
+        throw std::runtime_error{"failed to restore CMsle"};
+    }
+}
 
 CLoss::EType CMsle::type() const {
     return E_Regression;
@@ -670,7 +833,111 @@ bool CMsle::isRegression() const {
     return true;
 }
 
+void CMsle::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(OFFSET_TAG, m_Offset, inserter);
+}
+
+bool CMsle::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(OFFSET_TAG, core::CPersistUtils::restore(OFFSET_TAG, m_Offset, traverser))
+    } while (traverser.next());
+    return true;
+}
+
 const std::string CMsle::NAME{"msle"};
+
+CPseudoHuber::CPseudoHuber(double delta) : m_Delta{delta} {};
+
+CPseudoHuber::CPseudoHuber(core::CStateRestoreTraverser& traverser) {
+    if (traverser.traverseSubLevel(std::bind(&CPseudoHuber::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        throw std::runtime_error{"failed to restore CPseudoHuber"};
+    }
+}
+
+CLoss::EType CPseudoHuber::type() const {
+    return E_Regression;
+}
+
+std::unique_ptr<CLoss> CPseudoHuber::clone() const {
+    return std::make_unique<CPseudoHuber>(*this);
+}
+
+std::size_t CPseudoHuber::numberParameters() const {
+    return 1;
+}
+
+double CPseudoHuber::value(const TMemoryMappedFloatVector& predictionVec,
+                           double actual,
+                           double weight) const {
+    double delta2{CTools::pow2(m_Delta)};
+    double prediction{predictionVec[0]};
+    return weight * delta2 *
+           (std::sqrt(1.0 + CTools::pow2(actual - prediction) / delta2) - 1.0);
+}
+
+void CPseudoHuber::gradient(const TMemoryMappedFloatVector& predictionVec,
+                            double actual,
+                            TWriter writer,
+                            double weight) const {
+    double prediction{predictionVec(0)};
+    writer(0, weight * (prediction - actual) /
+                  (std::sqrt(1.0 + CTools::pow2((actual - prediction) / m_Delta))));
+}
+
+void CPseudoHuber::curvature(const TMemoryMappedFloatVector& predictionVec,
+                             double actual,
+                             TWriter writer,
+                             double weight) const {
+    double prediction{predictionVec(0)};
+    double result{1.0 / (std::sqrt(1.0 + CTools::pow2((actual - prediction) / m_Delta)))};
+    writer(0, weight * result);
+}
+
+bool CPseudoHuber::isCurvatureConstant() const {
+    return false;
+}
+
+CMsle::TDoubleVector CPseudoHuber::transform(const TMemoryMappedFloatVector& prediction) const {
+    TDoubleVector result{1};
+    result(0) = prediction(0);
+    return result;
+}
+
+CArgMinLoss CPseudoHuber::minimizer(double lambda,
+                                    const CPRNG::CXorOShiro128Plus& /* rng */) const {
+    return this->makeMinimizer(CArgMinPseudoHuberImpl{lambda, m_Delta});
+}
+
+const std::string& CPseudoHuber::name() const {
+    return NAME;
+}
+
+bool CPseudoHuber::isRegression() const {
+    return true;
+}
+
+void CPseudoHuber::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(DELTA_TAG, m_Delta, inserter);
+}
+
+bool CPseudoHuber::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(DELTA_TAG, core::CPersistUtils::restore(DELTA_TAG, m_Delta, traverser))
+    } while (traverser.next());
+    return true;
+}
+
+const std::string CPseudoHuber::NAME{"pseudo_huber"};
+
+CBinomialLogisticLoss::CBinomialLogisticLoss(core::CStateRestoreTraverser& traverser) {
+    if (traverser.traverseSubLevel(std::bind(&CBinomialLogisticLoss::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        throw std::runtime_error{"failed to restore CBinomialLogisticLoss"};
+    }
+}
 
 std::unique_ptr<CLoss> CBinomialLogisticLoss::clone() const {
     return std::make_unique<CBinomialLogisticLoss>(*this);
@@ -740,10 +1007,23 @@ bool CBinomialLogisticLoss::isRegression() const {
     return false;
 }
 
+void CBinomialLogisticLoss::acceptPersistInserter(core::CStatePersistInserter& /* inserter */) const {
+}
+bool CBinomialLogisticLoss::acceptRestoreTraverser(core::CStateRestoreTraverser& /* traverser */) {
+    return true;
+}
+
 const std::string CBinomialLogisticLoss::NAME{"binomial_logistic"};
 
 CMultinomialLogisticLoss::CMultinomialLogisticLoss(std::size_t numberClasses)
     : m_NumberClasses{numberClasses} {
+}
+
+CMultinomialLogisticLoss::CMultinomialLogisticLoss(core::CStateRestoreTraverser& traverser) {
+    if (traverser.traverseSubLevel(std::bind(&CMultinomialLogisticLoss::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        throw std::runtime_error{"failed to restore CMultinomialLogisticLoss"};
+    }
 }
 
 std::unique_ptr<CLoss> CMultinomialLogisticLoss::clone() const {
@@ -876,6 +1156,19 @@ const std::string& CMultinomialLogisticLoss::name() const {
 
 bool CMultinomialLogisticLoss::isRegression() const {
     return false;
+}
+
+void CMultinomialLogisticLoss::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    core::CPersistUtils::persist(NUMBER_CLASSES_TAG, m_NumberClasses, inserter);
+}
+
+bool CMultinomialLogisticLoss::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    do {
+        const std::string& name = traverser.name();
+        RESTORE(NUMBER_CLASSES_TAG,
+                core::CPersistUtils::restore(NUMBER_CLASSES_TAG, m_NumberClasses, traverser))
+    } while (traverser.next());
+    return true;
 }
 
 const std::string CMultinomialLogisticLoss::NAME{"multinomial_logistic"};

--- a/lib/maths/unittest/CBoostedTreeLossTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLossTest.cc
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 #include <core/CContainerPrinter.h>
 
 #include <maths/CBasicStatistics.h>
@@ -19,6 +20,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <utility>
@@ -37,6 +39,7 @@ using maths::boosted_tree::CMultinomialLogisticLoss;
 using maths::boosted_tree_detail::CArgMinBinomialLogisticLossImpl;
 using maths::boosted_tree_detail::CArgMinMsleImpl;
 using maths::boosted_tree_detail::CArgMinMultinomialLogisticLossImpl;
+using maths::boosted_tree_detail::CArgMinPseudoHuberImpl;
 
 namespace {
 void minimizeGridSearch(std::function<double(const TDoubleVector&)> objective,
@@ -969,6 +972,134 @@ BOOST_AUTO_TEST_CASE(testMsleArgminValue) {
         LOG_DEBUG(<< "Estimated objective " << estimatedObjective
                   << " optimal objective " << optimalObjective);
         LOG_DEBUG(<< "Estimated weight " << estimatedWeight << " true weight " << optimalWeight);
+        BOOST_REQUIRE_CLOSE_ABSOLUTE(optimalObjective, estimatedObjective, 1e-5);
+        BOOST_REQUIRE_CLOSE_ABSOLUTE(optimalWeight, estimatedWeight, 1e-2);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPseudoHuberArgminObjective) {
+    // Test that the calculated objective function is close to the correct value.
+    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+    maths::CPRNG::CXorOShiro128Plus rng;
+    test::CRandomNumbers testRng;
+    std::size_t numberSamples{10000};
+
+    {
+        for (std::size_t t = 0; t < 3; ++t) {
+            double lambda{0.1 * static_cast<double>(t + 1)};
+            double delta{lambda * 10}; // try different delta's without the second loop
+            CArgMinPseudoHuberImpl argmin{lambda, delta};
+
+            TDoubleVec targets;
+            targets.resize(numberSamples, 0.0);
+            testRng.generateUniformSamples(0.0, 10000.0, numberSamples, targets);
+
+            double trueWeight{20.0};
+            TDoubleVec predictionErrors;
+            predictionErrors.resize(targets.size(), 0.0);
+            testRng.generateNormalSamples(-trueWeight, 10.0, targets.size(), predictionErrors);
+
+            do {
+                for (std::size_t i = 0; i < targets.size(); ++i) {
+                    maths::CFloatStorage storage[]{targets[i] + predictionErrors[i]};
+                    TMemoryMappedFloatVector prediction{storage, 1};
+                    argmin.add(prediction, targets[i]);
+                }
+            } while (argmin.nextPass());
+
+            auto objective = argmin.objective();
+            double expectedMin{std::numeric_limits<double>::infinity()};
+            double expectedArgmin{-100};
+            double estimatedMin{std::numeric_limits<double>::infinity()};
+            double estimatedArgmin{100};
+            for (double weight = -10.0; weight <= 30.0; weight += 0.1) {
+                TMeanAccumulator expectedErrorAccumulator;
+                for (std::size_t i = 0; i < targets.size(); ++i) {
+                    double p{targets[i] + predictionErrors[i]};
+                    double error{
+                        maths::CTools::pow2(delta) *
+                        (std::sqrt(1.0 + maths::CTools::pow2((targets[i] - p - weight) / delta)) -
+                         1.0)};
+                    expectedErrorAccumulator.add(error);
+                }
+                double expectedObjectiveValue{maths::CBasicStatistics::mean(expectedErrorAccumulator) +
+                                              lambda * maths::CTools::pow2(weight)};
+                double estimatedObjectiveValue{objective(weight)};
+                if (expectedObjectiveValue < expectedMin) {
+                    expectedMin = expectedObjectiveValue;
+                    expectedArgmin = weight;
+                }
+                if (estimatedObjectiveValue < estimatedMin) {
+                    estimatedMin = estimatedObjectiveValue;
+                    estimatedArgmin = weight;
+                }
+            }
+            BOOST_REQUIRE_CLOSE_ABSOLUTE(estimatedArgmin, expectedArgmin, 0.11);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPseudoHuberArgminValue) {
+    // test on a single data point with known output
+    {
+        double lambda{0.0};
+        double delta{1.0};
+        CArgMinPseudoHuberImpl argmin{lambda, delta};
+        TDoubleVec targets;
+        maths::CPRNG::CXorOShiro128Plus rng;
+        test::CRandomNumbers testRng;
+        std::size_t numberSamples{1};
+
+        testRng.generateUniformSamples(0.0, 10000.0, numberSamples, targets);
+
+        TDoubleVec predictions;
+        predictions.resize(targets.size(), 0.0);
+        testRng.generateUniformSamples(0.0, 10000.0, numberSamples, targets);
+
+        do {
+            for (std::size_t i = 0; i < targets.size(); ++i) {
+                maths::CFloatStorage storage[]{predictions[i]};
+                TMemoryMappedFloatVector prediction{storage, 1};
+                argmin.add(prediction, targets[i]);
+            }
+        } while (argmin.nextPass());
+        double expectedWeight{targets[0] - predictions[0]};
+        double estimatedWeight{argmin.value()[0]};
+        LOG_DEBUG(<< "Estimate weight " << estimatedWeight << " true weight " << expectedWeight);
+        BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedWeight, estimatedWeight, 1e-3);
+    }
+
+    // test against scipy and scikit learn
+    // To reproduce run in Python:
+    // from sklearn.metrics import mean_squared_log_error
+    // import numpy as np
+    // from scipy.optimize import minimize
+    // y_true = [3, 5, 2.5, 7]
+    // y_pred = [2.5, 5, 4, 8]
+    // def pseudo_huber(a, p, delta=1.0):
+    //     return np.mean(delta**2*(np.sqrt(1+((a-p)/delta)**2)-1))
+    // def objective(weight):
+    //     return pseudo_huber(y_true, y_pred + weight)
+    // minimize(objective, 0.0)
+    {
+        double lambda{0.0};
+        double delta{1.0};
+        CArgMinPseudoHuberImpl argmin{lambda, delta};
+        TDoubleVec targets{3, 5, 2.5, 7};
+        TDoubleVec predictions{2.5, 5, 4, 8};
+
+        do {
+            for (std::size_t i = 0; i < targets.size(); ++i) {
+                maths::CFloatStorage storage[]{predictions[i]};
+                TMemoryMappedFloatVector prediction{storage, 1};
+                argmin.add(prediction, targets[i]);
+            }
+        } while (argmin.nextPass());
+        double optimalWeight{-0.5};
+        double optimalObjective{0.266123775};
+        double estimatedWeight{argmin.value()[0]};
+        double estimatedObjective{argmin.objective()(estimatedWeight)};
         BOOST_REQUIRE_CLOSE_ABSOLUTE(optimalObjective, estimatedObjective, 1e-5);
         BOOST_REQUIRE_CLOSE_ABSOLUTE(optimalWeight, estimatedWeight, 1e-2);
     }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -287,8 +287,9 @@ TLossFunctionUPtr createLossFunction(TLossFunctionType lossFunctionType,
     case TLossFunctionType::E_BinaryClassification:
     case TLossFunctionType::E_MulticlassClassification:
         LOG_ERROR(<< "Input error: regression loss type is expected but classification type is provided.");
-        return nullptr;
+        break;
     }
+    return nullptr;
 }
 }
 
@@ -346,7 +347,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
             if (lossFunctionType != TLossFunctionType::E_MsleRegression) {
                 BOOST_REQUIRE_CLOSE_ABSOLUTE(
                     0.0, modelBias[i][0],
-                    7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+                    7.3 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
             }
             // Good R^2...
             BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.90);

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -194,8 +194,14 @@ CDataFrameAnalysisSpecificationFactory::predictionFieldType(const std::string& t
 }
 
 CDataFrameAnalysisSpecificationFactory&
-CDataFrameAnalysisSpecificationFactory::regressionLossFunction(TRegressionLossFunction lossFunction) {
+CDataFrameAnalysisSpecificationFactory::regressionLossFunction(TLossFunctionType lossFunction) {
     m_RegressionLossFunction = lossFunction;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::regressionLossFunctionParameter(double lossFunctionParameter) {
+    m_RegressionLossFunctionParameter = lossFunctionParameter;
     return *this;
 }
 
@@ -315,14 +321,28 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
     }
 
     if (analysis == regression()) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRegressionRunner::LOSS_FUNCTION);
-        switch (m_RegressionLossFunction) {
-        case TRegressionLossFunction::E_Msle:
-            writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::MSLE);
-            break;
-        case TRegressionLossFunction::E_Mse:
-            writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::MSE);
-            break;
+
+        if (m_RegressionLossFunction) {
+            writer.Key(api::CDataFrameTrainBoostedTreeRegressionRunner::LOSS_FUNCTION);
+            switch (m_RegressionLossFunction.get()) {
+            case TLossFunctionType::E_MsleRegression:
+                writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::MSLE);
+                break;
+            case TLossFunctionType::E_MseRegression:
+                writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::MSE);
+                break;
+            case TLossFunctionType::E_HuberRegression:
+                writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::PSEUDO_HUBER);
+                break;
+            case TLossFunctionType::E_BinaryClassification:
+            case TLossFunctionType::E_MulticlassClassification:
+                LOG_ERROR(<< "Input error: regression loss type is expected but classification type is provided.");
+                break;
+            }
+        }
+        if (m_RegressionLossFunctionParameter) {
+            writer.Key(api::CDataFrameTrainBoostedTreeRegressionRunner::LOSS_FUNCTION_PARAMETER);
+            writer.Double(m_RegressionLossFunctionParameter.get());
         }
     }
 


### PR DESCRIPTION
This PR implements Pseudo-Huber loss function and integrates it into the RegressionRunner. Since it has a parameter, I needed to reimplement the persist and restore functionality in order to be able to save the state of the loss functions (the same functionality is useful for MSLE and multiclass classification). I also did some refactoring of unit tests avoid code duplication.

Backport for #1168 and #1195