### PR TITLE
[7.8][ML] Only remove discontinuities initialising seasonal components if they were part of the hypothesis we selected

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -78,6 +78,8 @@
   (See {ml-pull}1193[#1193], issue: {ml-issue}1131[#1131].)
 * Fix restore from training state for classification and regression. (See
   {ml-pull}1197[#1197].)
+* Improve the initialization of seasonal components for anomaly detection. (See
+  {ml-pull}1201[#1201], issue: {ml-issue}#1178[#1178].)
 
 == {es} version 7.7.1
 

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -571,9 +571,11 @@ void CPeriodicityHypothesisTestsResult::removeTrend(TFloatMeanAccumulatorVec& va
 }
 
 void CPeriodicityHypothesisTestsResult::removeDiscontinuities(TFloatMeanAccumulatorVec& values) const {
-    TSizeVec segmentation(CTimeSeriesSegmentation::piecewiseLinear(values));
-    values = CTimeSeriesSegmentation::removePiecewiseLinearDiscontinuities(
-        std::move(values), segmentation);
+    if (m_Trend.type() == CTrendHypothesis::E_PiecewiseLinear) {
+        TSizeVec segmentation(CTimeSeriesSegmentation::piecewiseLinear(values));
+        values = CTimeSeriesSegmentation::removePiecewiseLinearDiscontinuities(
+            std::move(values), segmentation);
+    }
 }
 
 bool CPeriodicityHypothesisTestsResult::periodic() const {


### PR DESCRIPTION
Backport #1201.