### PR TITLE
[7.x] Adjust JDK for running ES integration tests on aarch64

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -70,6 +70,11 @@ if [ -z "$ES_BUILD_JAVA" ]; then
     exit 1
 fi
 
+# On aarch64 adoptopenjdk is used in place of openjdk
+if [ `uname -m` = aarch64 ] ; then
+    export ES_BUILD_JAVA=adopt$ES_BUILD_JAVA
+fi
+
 echo "Setting JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA"
 export JAVA_HOME="$HOME/.java/$ES_BUILD_JAVA"
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1440,8 +1440,14 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
                 BOOST_REQUIRE_EQUAL("[0, 10, 20, 30, 40, 50, 60, 70, 80, 90]",
                                     core::CContainerPrinter::print(task.s_TenPercentProgressPoints));
             } else if (task.s_Name == maths::CBoostedTreeFactory::FINAL_TRAINING) {
-                BOOST_REQUIRE_EQUAL("[0, 10, 20, 30, 40, 50, 60, 70, 80, 90]",
-                                    core::CContainerPrinter::print(task.s_TenPercentProgressPoints));
+                // Progress might be 90% or 100% depending on whether the final
+                // progress update registered
+                if (task.s_TenPercentProgressPoints.size() != 11 ||
+                    task.s_TenPercentProgressPoints.front() != 0 ||
+                    task.s_TenPercentProgressPoints.back() != 100) {
+                    BOOST_REQUIRE_EQUAL("[0, 10, 20, 30, 40, 50, 60, 70, 80, 90]",
+                                        core::CContainerPrinter::print(task.s_TenPercentProgressPoints));
+                }
             }
             BOOST_TEST_REQUIRE(task.s_Monotonic);
         }


### PR DESCRIPTION
The JDK directories on x86_64 are openjdk11, openjdk14, etc.
On aarch64 they're adoptopenjdk11, adoptopenjdk14, etc.
This change works around the difference.

Backport of #1204