### PR TITLE
[7.7] Make ES integration tests work on reused Jenkins workers

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -61,6 +61,7 @@ function pickCloneTarget {
 pickCloneTarget
 
 cd "$1"
+rm -rf elasticsearch
 git clone -b "$SELECTED_BRANCH" "git@github.com:${SELECTED_FORK}/elasticsearch.git" --depth=1
 cd elasticsearch
 


### PR DESCRIPTION
The code to run ES integration tests on ml-cpp PR builds was
assuming the PR build would be on a completely clean Jenkins
worker.  This is not always the case, and for a reused worker
the old clone of the elasticsearch repo needs to be deleted
before doing the shallow (single commit) clone for the current
build.

Backport of #1213