### PR TITLE
[7.x][ML] Work around gcc alignas bug

### DIFF
--- a/lib/core/unittest/CAlignmentTest.cc
+++ b/lib/core/unittest/CAlignmentTest.cc
@@ -12,6 +12,14 @@
 #include <array>
 #include <vector>
 
+// TODO: revert this when we upgrade to gcc 9.3
+#ifdef __GNUC__
+// gcc's alignas is unreliable prior to gcc 9.3, so use the old style attribute
+#define ALIGNAS(x) __attribute__((aligned(x)))
+#else
+#define ALIGNAS(x) alignas(x)
+#endif
+
 BOOST_AUTO_TEST_SUITE(CAlignmentTest)
 
 using namespace ml;
@@ -20,7 +28,7 @@ BOOST_AUTO_TEST_CASE(testMaxAlignment) {
 
     // Test some known alignments.
 
-    alignas(32) const char addresses[64]{};
+    ALIGNAS(32) const char addresses[64]{};
     for (std::size_t i = 0; i < 64; ++i) {
         if (i % 32 == 0) {
             BOOST_TEST_REQUIRE(core::CAlignment::maxAlignment(&addresses[i]) ==
@@ -42,7 +50,7 @@ BOOST_AUTO_TEST_CASE(testIsAligned) {
 
     // Test some known alignments.
 
-    alignas(32) const char addresses[64]{};
+    ALIGNAS(32) const char addresses[64]{};
     for (std::size_t i = 0; i < 64; ++i) {
         if (i % 32 == 0) {
             BOOST_TEST_REQUIRE(core::CAlignment::isAligned(
@@ -81,7 +89,7 @@ BOOST_AUTO_TEST_CASE(testNextAligned) {
     // Test that next aligned is the first position with the required alignment
     // after the current index.
 
-    alignas(32) std::array<double, 8> addresses;
+    ALIGNAS(32) std::array<double, 8> addresses;
 
     for (std::size_t i = 0; i < 8; ++i) {
         std::size_t i32{core::CAlignment::nextAligned(addresses, i, core::CAlignment::E_Aligned32)};


### PR DESCRIPTION
Prior to gcc 9.3 there is a bug where alignas wrongly caps alignment
requests of more than 16 bytes at 16 bytes.

The old style alignment attribute does not suffer this problem so
the workaround is to use that instead.

This change will be reverted when we upgrade to gcc 9.3.

Backport of #1220