### PR TITLE
[ML] Improve adaption to periodic anomalies for longer bucket lengths

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,13 @@
 * The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
   or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
 
+== {es} version 7.9.0
+
+=== Enhancements
+
+* Speed up how quickly we'll learn new periodic patterns for longer bucket lengths.
+  (See {ml-pull})1224[#1224].)
+
 == {es} version 7.8.0
 
 === Enhancements

--- a/include/maths/CAdaptiveBucketing.h
+++ b/include/maths/CAdaptiveBucketing.h
@@ -295,7 +295,7 @@ private:
     core_t::TTime m_LastLargeErrorPeriod = 0;
 
     //! The p-values of the most significant large error counts.
-    TFloatUInt32PrMinAccumulator m_LargeErrorCountSignificances;
+    TFloatUInt32PrMinAccumulator m_LargeErrorCountPValues;
 
     //! The mean weight of values added.
     TFloatMeanAccumulator m_MeanWeight;

--- a/include/maths/CAdaptiveBucketing.h
+++ b/include/maths/CAdaptiveBucketing.h
@@ -264,6 +264,9 @@ private:
     //! Implements split of \p bucket for derived state.
     virtual void split(std::size_t bucket) = 0;
 
+    //! Compute the p-value of the large error count for \p bucket.
+    double bucketLargeErrorCountPValue(double totalLargeErrorCount, std::size_t bucket) const;
+
     //! Check if there is evidence of systematically large errors in a
     //! bucket and split it if there is.
     void maybeSplitBucket();

--- a/include/maths/CLeastSquaresOnlineRegressionDetail.h
+++ b/include/maths/CLeastSquaresOnlineRegressionDetail.h
@@ -55,8 +55,8 @@ void CLeastSquaresOnlineRegression<N, T>::shiftAbscissa(double dx) {
     //   -> 1/n * (  sum_i{ t(i)^i * y(i) }
     //             + sum_j{ (i j) * dx^(i - j) * sum_i{ t(i)^j y(i) } } )
 
-    double d[2 * N - 2] = {dx};
-    for (std::size_t i = 1u; i < 2 * N - 2; ++i) {
+    double d[2 * N - 2]{dx};
+    for (std::size_t i = 1; i < 2 * N - 2; ++i) {
         d[i] = d[i - 1] * dx;
     }
     LOG_TRACE(<< "d = " << core::CContainerPrinter::print(d));
@@ -65,14 +65,14 @@ void CLeastSquaresOnlineRegression<N, T>::shiftAbscissa(double dx) {
     for (std::size_t i = 2 * N - 2; i > 0; --i) {
         LOG_TRACE(<< "i = " << i);
         for (std::size_t j = 0; j < i; ++j) {
-            double bij = CCategoricalTools::binomialCoefficient(i, j) * d[i - j - 1];
+            double bij{CCategoricalTools::binomialCoefficient(i, j) * d[i - j - 1]};
             LOG_TRACE(<< "bij = " << bij);
             CBasicStatistics::moment<0>(m_S)(i) += bij * CBasicStatistics::mean(m_S)(j);
             if (i >= N) {
                 continue;
             }
-            std::size_t yi = i + 2 * N - 1;
-            std::size_t yj = j + 2 * N - 1;
+            std::size_t yi{i + 2 * N - 1};
+            std::size_t yj{j + 2 * N - 1};
             LOG_TRACE(<< "yi = " << yi << ", yj = " << yj);
             CBasicStatistics::moment<0>(m_S)(yi) += bij * CBasicStatistics::mean(m_S)(yj);
         }
@@ -146,14 +146,14 @@ bool CLeastSquaresOnlineRegression<N, T>::covariances(std::size_t n,
         case N: {
             constexpr int N_{static_cast<int>(N)};
             Eigen::Matrix<double, N_, N_> x;
-            if (!this->covariances(N, x, variance, maxCondition, result)) {
+            if (this->covariances(N, x, variance, maxCondition, result) == false) {
                 continue;
             }
             break;
         }
         default: {
             CDenseMatrix<double> x(n, n);
-            if (!this->covariances(n, x, variance, maxCondition, result)) {
+            if (this->covariances(n, x, variance, maxCondition, result) == false) {
                 continue;
             }
             break;
@@ -208,7 +208,7 @@ bool CLeastSquaresOnlineRegression<N, T>::parameters(std::size_t n,
 
     // Don't bother checking the solution since we check the matrix
     // condition above.
-    VECTOR r = svd.solve(y);
+    VECTOR r{svd.solve(y)};
     for (std::size_t i = 0; i < n; ++i) {
         result[i] = r(i);
     }

--- a/include/maths/CSeasonalComponent.h
+++ b/include/maths/CSeasonalComponent.h
@@ -129,7 +129,11 @@ public:
     void decayRate(double decayRate);
 
     //! Age out old data to account for elapsed \p time.
-    void propagateForwardsByTime(double time, bool meanRevert = false);
+    //!
+    //! \param[in] meanRevertFactor Controls how quicly the components mean
+    //! revert as a multiplier of the rate at which data is aged out of the
+    //! component. By default components don't mean revert.
+    void propagateForwardsByTime(double time, double meanRevertFactor = 0.0);
 
     //! Get the time provider.
     const CSeasonalTime& time() const;

--- a/include/maths/CSeasonalComponentAdaptiveBucketing.h
+++ b/include/maths/CSeasonalComponentAdaptiveBucketing.h
@@ -108,7 +108,11 @@ public:
     void add(core_t::TTime time, double value, double prediction, double weight = 1.0);
 
     //! Age the bucket values to account for \p time elapsed time.
-    void propagateForwardsByTime(double time, bool meanRevert = false);
+    //!
+    //! \param[in] meanRevertFactor Controls how quicly the components mean
+    //! revert as a multiplier of the rate at which data is aged out of the
+    //! component. By default components don't mean revert.
+    void propagateForwardsByTime(double time, double meanRevertFactor = 0.0);
 
     //! Get the time provider.
     const CSeasonalTime& time() const;

--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -814,8 +814,8 @@ void CAdaptiveBucketing::maybeSplitBucket() {
         significance.first = CTools::oneMinusPowOneMinusX(
             significance.first, static_cast<double>(this->size()));
         LOG_TRACE(<< "bucket [" << m_Endpoints[significance.second] << ","
-                 << m_Endpoints[significance.second + 1]
-                 << ") split significance = " << significance.first);
+                  << m_Endpoints[significance.second + 1]
+                  << ") split significance = " << significance.first);
     }
     m_LargeErrorCountSignificances.sort();
 

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -170,8 +170,8 @@ void CSeasonalComponent::decayRate(double decayRate) {
     return m_Bucketing.decayRate(decayRate);
 }
 
-void CSeasonalComponent::propagateForwardsByTime(double time, bool meanRevert) {
-    m_Bucketing.propagateForwardsByTime(time, meanRevert);
+void CSeasonalComponent::propagateForwardsByTime(double time, double meanRevertFactor) {
+    m_Bucketing.propagateForwardsByTime(time, meanRevertFactor);
 }
 
 const CSeasonalTime& CSeasonalComponent::time() const {

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -240,14 +240,14 @@ const CSeasonalTime& CSeasonalComponentAdaptiveBucketing::time() const {
     return *m_Time;
 }
 
-void CSeasonalComponentAdaptiveBucketing::propagateForwardsByTime(double time, bool meanRevert) {
+void CSeasonalComponentAdaptiveBucketing::propagateForwardsByTime(double time, double meanRevertFactor) {
     if (time < 0.0) {
         LOG_ERROR(<< "Can't propagate bucketing backwards in time");
     } else if (this->initialized()) {
         double factor{std::exp(-this->decayRate() * m_Time->fractionInWindow() * time)};
         this->age(factor);
         for (auto& bucket : m_Buckets) {
-            bucket.s_Regression.age(factor, meanRevert);
+            bucket.s_Regression.age(factor, meanRevertFactor);
         }
     }
 }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -2183,7 +2183,7 @@ void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::propagateForwards(c
     for (std::size_t i = 0; i < m_Components.size(); ++i) {
         core_t::TTime period{m_Components[i].time().period()};
         stepwisePropagateForwards(start, end, period, [&](double time) {
-            m_Components[i].propagateForwardsByTime(time / 4.0, 0.25);
+            m_Components[i].propagateForwardsByTime(time / 3.0, 0.3);
             m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
         });
     }
@@ -2484,7 +2484,7 @@ void CTimeSeriesDecompositionDetail::CComponents::CCalendar::propagateForwards(c
                                                                                core_t::TTime end) {
     for (std::size_t i = 0; i < m_Components.size(); ++i) {
         stepwisePropagateForwards(start, end, MONTH, [&](double time) {
-            m_Components[i].propagateForwardsByTime(time / 4.0);
+            m_Components[i].propagateForwardsByTime(time / 3.0);
             m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
         });
     }

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(testDailyNoLongTermTrend) {
         return 40.0 + alpha * y[i / 6] + beta * y[(i / 6 + 1) % y.size()] + noise;
     };
 
-    test(trend, bucketLength, 63, 64.0, 4.5, 0.15);
+    test(trend, bucketLength, 63, 64.0, 5.0, 0.15);
 }
 
 BOOST_AUTO_TEST_CASE(testDailyConstantLongTermTrend) {
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(testDailyVaryingLongTermTrend) {
                8.0 * std::sin(boost::math::double_constants::two_pi * time_ / 43200.0) + noise;
     };
 
-    test(trend, bucketLength, 98, 9.0, 7.0, 0.043);
+    test(trend, bucketLength, 98, 9.0, 9.0, 0.04);
 }
 
 BOOST_AUTO_TEST_CASE(testComplexNoLongTermTrend) {
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(testComplexVaryingLongTermTrend) {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    test(trend, bucketLength, 63, 4.0, 19.0, 0.04);
+    test(trend, bucketLength, 63, 4.0, 15.0, 0.04);
 }
 
 BOOST_AUTO_TEST_CASE(testNonNegative) {

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -1544,8 +1544,8 @@ BOOST_FIXTURE_TEST_CASE(testLongTermTrendAndPeriodicity, CTestFixture) {
                 totalSumValue += sumValue;
                 totalMaxValue += maxValue;
 
-                BOOST_TEST_REQUIRE(sumResidual / sumValue < 0.42);
-                BOOST_TEST_REQUIRE(maxResidual / maxValue < 0.46);
+                BOOST_TEST_REQUIRE(sumResidual / sumValue < 0.48);
+                BOOST_TEST_REQUIRE(maxResidual / maxValue < 0.50);
             }
             lastDay += DAY;
         }
@@ -1554,8 +1554,8 @@ BOOST_FIXTURE_TEST_CASE(testLongTermTrendAndPeriodicity, CTestFixture) {
     LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
 
-    BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.04);
-    BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.05);
+    BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.045);
+    BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.050);
 }
 
 BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {


### PR DESCRIPTION
We track where anomalies occur for each seasonal component and increase the rate at which we learn them if there is strong evidence they're occurring periodically. However, we were only doing this for shorter bucket lengths, meaning we could take much longer than intended to adapt for long buckets.

This makes a related change to improve the stability of the adaption of seasonal components by including some mean reversion. The vast majority of signals we model tend to have stable periodic patterns and so mean reverting as we age out old data we better match their expected behaviour.

This is a step towards #1202.