### PR TITLE
[ML] Fix flakey progress monitoring test

### DIFF
--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -576,7 +576,8 @@ BOOST_AUTO_TEST_CASE(testProgress) {
             LOG_DEBUG(<< sb.GetString());
             if (result["phase_progress"]["phase"] == maths::COutliers::COMPUTING_OUTLIERS) {
                 computingOutliersProgress =
-                    result["phase_progress"]["progress_percent"].GetInt();
+                    std::max(computingOutliersProgress,
+                             result["phase_progress"]["progress_percent"].GetInt());
             }
         }
     }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -963,13 +963,15 @@ BOOST_AUTO_TEST_CASE(testProgress) {
             std::string phase{result["phase_progress"]["phase"].GetString()};
             int progress{result["phase_progress"]["progress_percent"].GetInt()};
             if (phase == maths::CBoostedTreeFactory::FEATURE_SELECTION) {
-                featureSelectionLastProgress = progress;
+                featureSelectionLastProgress = std::max(featureSelectionLastProgress, progress);
             } else if (phase == maths::CBoostedTreeFactory::COARSE_PARAMETER_SEARCH) {
-                coarseParameterSearchLastProgress = progress;
+                coarseParameterSearchLastProgress =
+                    std::max(coarseParameterSearchLastProgress, progress);
             } else if (phase == maths::CBoostedTreeFactory::FINE_TUNING_PARAMETERS) {
-                fineTuneParametersLastProgress = progress;
+                fineTuneParametersLastProgress =
+                    std::max(fineTuneParametersLastProgress, progress);
             } else if (phase == maths::CBoostedTreeFactory::FINAL_TRAINING) {
-                finalTrainLastProgress = progress;
+                finalTrainLastProgress = std::max(finalTrainLastProgress, progress);
             }
         }
     }
@@ -1052,17 +1054,19 @@ BOOST_AUTO_TEST_CASE(testProgressFromRestart) {
             std::string phase{result["phase_progress"]["phase"].GetString()};
             int progress{result["phase_progress"]["progress_percent"].GetInt()};
             if (phase == maths::CBoostedTreeFactory::FEATURE_SELECTION) {
-                featureSelectionLastProgress = progress;
+                featureSelectionLastProgress = std::max(featureSelectionLastProgress, progress);
             } else if (phase == maths::CBoostedTreeFactory::COARSE_PARAMETER_SEARCH) {
-                coarseParameterSearchLastProgress = progress;
+                coarseParameterSearchLastProgress =
+                    std::max(coarseParameterSearchLastProgress, progress);
             } else if (phase == maths::CBoostedTreeFactory::FINE_TUNING_PARAMETERS) {
                 if (progress > 0) {
                     fineTuneParametersFirstProgress =
                         std::min(fineTuneParametersFirstProgress, progress);
                 }
-                fineTuneParametersLastProgress = progress;
+                fineTuneParametersLastProgress =
+                    std::max(fineTuneParametersLastProgress, progress);
             } else if (phase == maths::CBoostedTreeFactory::FINAL_TRAINING) {
-                finalTrainLastProgress = progress;
+                finalTrainLastProgress = std::max(finalTrainLastProgress, progress);
             }
         }
     }


### PR DESCRIPTION
Fix an intermittent test failure.

The concurrent queue doesn't guaranty the order messages are written out so we can only asset that each phase gets a 100% complete message not that it is also the last message.