### PR TITLE
[7.8][ML] Only log failure to ignore SIGPIPE once

### DIFF
--- a/include/core/CNamedPipeFactory.h
+++ b/include/core/CNamedPipeFactory.h
@@ -90,6 +90,11 @@ public:
     //! Default path for named pipes.
     static std::string defaultPath();
 
+    //! Log warnings that have been stored because they were detected very
+    //! early in the program lifecycle.  Programs using named pipes should
+    //! call this method once, after setting up logging.
+    static void logDeferredWarnings();
+
 private:
 #ifdef Windows
     using TPipeHandle = HANDLE;

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -314,6 +314,8 @@ bool CLogger::reconfigureLogToNamedPipe(const std::string& pipeName) {
 
     LOG_DEBUG(<< "Logger is logging to named pipe " << pipeName);
 
+    CNamedPipeFactory::logDeferredWarnings();
+
     return true;
 }
 

--- a/lib/core/CNamedPipeFactory.cc
+++ b/lib/core/CNamedPipeFactory.cc
@@ -173,13 +173,15 @@ std::string CNamedPipeFactory::defaultPath() {
     return path;
 }
 
-CNamedPipeFactory::TPipeHandle
-CNamedPipeFactory::initPipeHandle(const std::string& fileName, bool forWrite) {
-    if (!SIGPIPE_IGNORED) {
+void CNamedPipeFactory::logDeferredWarnings() {
+    if (SIGPIPE_IGNORED == false) {
         LOG_WARN(<< "Failed to ignore SIGPIPE - this process will not terminate "
                     "gracefully if a process it is writing to via a named pipe dies");
     }
+}
 
+CNamedPipeFactory::TPipeHandle
+CNamedPipeFactory::initPipeHandle(const std::string& fileName, bool forWrite) {
     bool madeFifo(false);
 
     // If the name already exists, ensure it refers directly (i.e. not via a

--- a/lib/core/CNamedPipeFactory_Windows.cc
+++ b/lib/core/CNamedPipeFactory_Windows.cc
@@ -83,6 +83,10 @@ std::string CNamedPipeFactory::defaultPath() {
     return PIPE_PREFIX;
 }
 
+void CNamedPipeFactory::logDeferredWarnings() {
+    // No-op
+}
+
 CNamedPipeFactory::TPipeHandle
 CNamedPipeFactory::initPipeHandle(const std::string& fileName, bool forWrite) {
     // Size of named pipe buffer


### PR DESCRIPTION
The warning if something stops SIGPIPE being ignored has
always been deferred as the signal calls are made before
main() has run.  However, the place the warning was deferred
to could result in it being logged many times because the
deferred logging was in a method that could be called many
times.

This change moves that deferred logging to a dedicated
method that can just be called once.

Backport of #1221