### PR TITLE
Adding forecast parameter max_model_memory 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,13 @@
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3. (See
   {ml-pull}1170[#1170].)
 
+== {es} version 7.9.0
+
+=== Enhancements
+
+* Add support for larger forecasts in memory via max_model_memory setting.
+  (See {ml-pull}1238[#1238].)
+  
 == {es} version 7.8.0
 
 === Enhancements

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@
 
 * Don't lose precision when saving model state. (See {ml-pull}1274[#1274].)
 * Add support for larger forecasts in memory via max_model_memory setting.
-  (See {ml-pull}1238[#1238].)
+  (See {ml-pull}1238[#1238] and {pull}57254[#57254].)
 
 == {es} version 7.8.0
 

--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -103,7 +103,7 @@ private:
     static const std::string ERROR_NO_DATA_PROCESSED;
     static const std::string ERROR_NO_CREATE_TIME;
     static const std::string ERROR_BAD_MEMORY_STATUS;
-    static const std::string ERROR_MEMORY_LIMIT;
+    static const std::string ERROR_BAD_MODEL_MEMORY_LIMIT;
     static const std::string ERROR_MEMORY_LIMIT_DISK;
     static const std::string ERROR_MEMORY_LIMIT_DISKSPACE;
     static const std::string ERROR_NOT_SUPPORTED_FOR_POPULATION_MODELS;
@@ -210,6 +210,9 @@ private:
 
         //! total memory required for this forecasting job (only the models)
         size_t s_MemoryUsage;
+
+        //! maximum allowed memory (in bytes) that this forecast can use
+        size_t s_MaxForecastModelMemory;
 
         //! A collection storing important messages from forecasting
         TStrUSet s_Messages;

--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -44,6 +44,8 @@ struct testValidateNoExpiry;
 struct testValidateInvalidExpiry;
 struct testValidateBrokenMessage;
 struct testValidateMissingId;
+struct testValidateProvidedMaxMemoryLimit;
+struct testValidateProvidedTooLargeMaxMemoryLimit;
 }
 
 namespace ml {
@@ -295,6 +297,8 @@ private:
     friend struct CForecastRunnerTest::testValidateInvalidExpiry;
     friend struct CForecastRunnerTest::testValidateBrokenMessage;
     friend struct CForecastRunnerTest::testValidateMissingId;
+    friend struct CForecastRunnerTest::testValidateProvidedMaxMemoryLimit;
+    friend struct CForecastRunnerTest::testValidateProvidedTooLargeMaxMemoryLimit;
 };
 }
 }

--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -80,7 +80,7 @@ public:
     static const size_t DEFAULT_EXPIRY_TIME = 14 * core::constants::DAY;
 
     //! max memory allowed to use for forecast models
-    static const size_t MAX_FORECAST_MODEL_MEMORY = 20971520ull; // 20MB
+    static const size_t DEFAULT_MAX_FORECAST_MODEL_MEMORY = 20971520ull; // 20MB
 
     //! Note: This value measures the size in memory, not the size of the persistence,
     //! which is likely higher and would be hard to calculate upfront
@@ -254,11 +254,12 @@ private:
     void sendMessage(WRITE write, const SForecast& forecastJob, const std::string& message) const;
 
     //! parse and validate a forecast request and turn it into a forecast job
-    static bool
-    parseAndValidateForecastRequest(const std::string& controlMessage,
-                                    SForecast& forecastJob,
-                                    const core_t::TTime lastResultsTime,
-                                    const TErrorFunc& errorFunction = TErrorFunc());
+    static bool parseAndValidateForecastRequest(
+        const std::string& controlMessage,
+        SForecast& forecastJob,
+        const core_t::TTime lastResultsTime,
+        std::size_t jobBytesSizeLimit = std::numeric_limits<std::size_t>::max() / 2,
+        const TErrorFunc& errorFunction = TErrorFunc());
 
 private:
     //! This job ID

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -107,6 +107,8 @@ public:
     //! Set the internal memory limit, as specified in a limits config file
     void memoryLimit(std::size_t limitMBs);
 
+    std::size_t getBytesMemoryLimit() const;
+
     //! Get the memory status
     model_t::EMemoryStatus getMemoryStatus();
 

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -350,9 +350,8 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
         }
 
         LOG_WARN(<< "Forecast [" << forecastJob.s_ForecastId << "] memory usage exceeds configured byte limit ["
-                 << std::to_string(forecastJob.s_MaxForecastModelMemory)
-                 << "] (requires " << std::to_string(1 + (totalMemoryUsage >> 20))
-                 << " MB), using disk.");
+                 << std::to_string(forecastJob.s_MaxForecastModelMemory) << "] (requires "
+                 << std::to_string(1 + (totalMemoryUsage >> 20)) << " MB), using disk.");
 
         // create a subdirectory using the unique forecast id
         temporaryFolder /= forecastJob.s_ForecastId;

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -349,8 +349,10 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
             return false;
         }
 
-        LOG_INFO(<< "Forecast of large model requested (requires "
-                 << std::to_string(1 + (totalMemoryUsage >> 20)) << " MB), using disk.");
+        LOG_WARN(<< "Forecast [" << forecastJob.s_ForecastId << "] memory usage exceeds configured byte limit ["
+                 << std::to_string(forecastJob.s_MaxForecastModelMemory)
+                 << "] (requires " << std::to_string(1 + (totalMemoryUsage >> 20))
+                 << " MB), using disk.");
 
         // create a subdirectory using the unique forecast id
         temporaryFolder /= forecastJob.s_ForecastId;

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -307,7 +307,7 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
             this->sendErrorMessage(
                 forecastJob, "Forecast cannot be executed as forecast memory usage is predicted to exceed " +
                                  std::to_string(forecastJob.s_MaxForecastModelMemory) +
-                                 " while disk space is exceeded");
+                                 " bytes while disk space is exceeded");
             return false;
         }
     }

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -436,17 +436,17 @@ bool CForecastRunner::parseAndValidateForecastRequest(const std::string& control
         return false;
     }
 
-    if (forecastJob.s_MaxForecastModelMemory >= MAX_FORECAST_MODEL_PERSISTANCE_MEMORY) {
-        errorFunction(forecastJob, ERROR_BAD_MODEL_MEMORY_LIMIT);
-        return false;
-    }
-
     if (forecastJob.s_ForecastId.empty()) {
         LOG_ERROR(<< ERROR_NO_FORECAST_ID);
         return false;
     }
 
     // from now we have a forecast ID and can send error messages
+    if (forecastJob.s_MaxForecastModelMemory >= MAX_FORECAST_MODEL_PERSISTANCE_MEMORY) {
+        errorFunction(forecastJob, ERROR_BAD_MODEL_MEMORY_LIMIT);
+        return false;
+    }
+
     if (lastResultsTime == 0l) {
         errorFunction(forecastJob, ERROR_NO_DATA_PROCESSED);
         return false;

--- a/lib/api/unittest/CForecastRunnerTest.cc
+++ b/lib/api/unittest/CForecastRunnerTest.cc
@@ -333,4 +333,37 @@ BOOST_AUTO_TEST_CASE(testValidateMissingId) {
                            message, forecastJob, 1400000000) == false);
 }
 
+BOOST_AUTO_TEST_CASE(testValidateProvidedMaxMemoryLimit) {
+    ml::api::CForecastRunner::SForecast forecastJob;
+
+    std::string message(
+        "p{\"duration\":" + std::to_string(3 * ml::core::constants::WEEK) +
+        ",\"forecast_id\": \"42\",\"create_time\": \"1511370819\",\"max_model_memory\": 10000000}");
+
+    BOOST_TEST_REQUIRE(ml::api::CForecastRunner::parseAndValidateForecastRequest(
+        message, forecastJob, 1400000000));
+    BOOST_REQUIRE_EQUAL(forecastJob.s_MaxForecastModelMemory, static_cast<size_t>(10000000));
+
+    std::string message2("p{\"duration\":" + std::to_string(3 * ml::core::constants::WEEK) +
+                         ",\"forecast_id\": \"42\",\"create_time\": \"1511370819\"}");
+
+    BOOST_TEST_REQUIRE(ml::api::CForecastRunner::parseAndValidateForecastRequest(
+        message2, forecastJob, 1400000000));
+    BOOST_REQUIRE_EQUAL(forecastJob.s_MaxForecastModelMemory,
+                        ml::api::CForecastRunner::MAX_FORECAST_MODEL_MEMORY);
+}
+
+BOOST_AUTO_TEST_CASE(testValidateProvidedTooLargeMaxMemoryLimit) {
+    ml::api::CForecastRunner::SForecast forecastJob;
+
+    std::string message(
+        "p{\"duration\":" + std::to_string(3 * ml::core::constants::WEEK) +
+        ",\"forecast_id\": \"42\",\"create_time\": \"1511370819\",\"max_model_memory\":" +
+        std::to_string(ml::api::CForecastRunner::MAX_FORECAST_MODEL_PERSISTANCE_MEMORY + 10) +
+        "}");
+
+    BOOST_TEST_REQUIRE(ml::api::CForecastRunner::parseAndValidateForecastRequest(
+                           message, forecastJob, 1400000000) == false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CForecastRunnerTest.cc
+++ b/lib/api/unittest/CForecastRunnerTest.cc
@@ -349,21 +349,20 @@ BOOST_AUTO_TEST_CASE(testValidateProvidedMaxMemoryLimit) {
 
     BOOST_TEST_REQUIRE(ml::api::CForecastRunner::parseAndValidateForecastRequest(
         message2, forecastJob, 1400000000));
-    BOOST_REQUIRE_EQUAL(forecastJob.s_MaxForecastModelMemory,
-                        ml::api::CForecastRunner::MAX_FORECAST_MODEL_MEMORY);
+    BOOST_REQUIRE_EQUAL(forecastJob.s_MaxForecastModelMemory, 20971520ull);
 }
 
 BOOST_AUTO_TEST_CASE(testValidateProvidedTooLargeMaxMemoryLimit) {
     ml::api::CForecastRunner::SForecast forecastJob;
 
-    std::string message(
-        "p{\"duration\":" + std::to_string(3 * ml::core::constants::WEEK) +
-        ",\"forecast_id\": \"42\",\"create_time\": \"1511370819\",\"max_model_memory\":" +
-        std::to_string(ml::api::CForecastRunner::MAX_FORECAST_MODEL_PERSISTANCE_MEMORY + 10) +
-        "}");
+    std::string message("p{\"duration\":" + std::to_string(3 * ml::core::constants::WEEK) +
+                        ",\"forecast_id\": \"42\",\"create_time\": \"1511370819\",\"max_model_memory\":" +
+                        std::to_string(524288000ull + 10ull) + "}");
 
     BOOST_TEST_REQUIRE(ml::api::CForecastRunner::parseAndValidateForecastRequest(
-                           message, forecastJob, 1400000000) == false);
+                           message, forecastJob, 1400000000,
+                           [](const ml::api::CForecastRunner::SForecast&,
+                              const std::string&) { return; }) == false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CForecastRunnerTest.cc
+++ b/lib/api/unittest/CForecastRunnerTest.cc
@@ -378,10 +378,8 @@ BOOST_AUTO_TEST_CASE(testValidateProvidedTooLargeMaxMemoryLimit) {
 
     // Less than 40% of the configured job memory should NOT fail
     BOOST_TEST_REQUIRE(ml::api::CForecastRunner::parseAndValidateForecastRequest(
-        message2, forecastJob, 1400000000, static_cast<std::size_t>(31457280ull * 2.5) + 1,
-        [](const ml::api::CForecastRunner::SForecast& f, const std::string& val) {
-            LOG_ERROR(<< "message: [" << val << "]"
-                      << "forecast limit: " << f.s_MaxForecastModelMemory);
+        message2, forecastJob, 1400000000, static_cast<std::size_t>(31457280ull * 3),
+        [](const ml::api::CForecastRunner::SForecast&, const std::string&) {
             return;
         }));
 }

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -71,6 +71,10 @@ void CResourceMonitor::memoryLimit(std::size_t limitMBs) {
     }
 }
 
+std::size_t CResourceMonitor::getBytesMemoryLimit() const {
+    return m_ByteLimitHigh * this->persistenceMemoryIncreaseFactor();
+}
+
 void CResourceMonitor::updateMemoryLimitsAndPruneThreshold(std::size_t limitMBs) {
     // The threshold for no limit is set such that any negative limit cast to
     // a size_t (which is unsigned) will be taken to mean no limit


### PR DESCRIPTION
This commit adds new parameter max_model_memory.

This parameter is defaulted to `20mb` (the previous static setting). 
Some larger forecasts can take a very long time to run. But if a user
has enough memory, they may opt to run more of the forecast in memory
without spooling to disk.

elasticsearch change https://github.com/elastic/elasticsearch/pull/57254

