### PR TITLE
[7.8][ML] Fix timestamp issue for instrumentation 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -90,6 +90,8 @@
   issue: {ml-issue}1136[#1136].)
 * Fix classification job failures when number of classes in configuration differs 
   from the number of classes present in the training data. (See {ml-pull}1144[#1144].)
+* Change data frame analytics instrumentation timestamp resolution to milliseconds. (See 
+  {ml-pull}1237[#1237].)
 
 == {es} version 7.7.0
 

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -175,7 +175,9 @@ CDataFrameAnalysisInstrumentation::TWriter* CDataFrameAnalysisInstrumentation::w
 }
 
 void CDataFrameAnalysisInstrumentation::writeMemoryAndAnalysisStats() {
-    std::int64_t timestamp{core::CTimeUtils::toEpochMs(core::CTimeUtils::now())};
+    std::int64_t timestamp{std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count()};
     if (m_Writer != nullptr) {
         m_Writer->StartObject();
         this->writeMemory(timestamp);

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -16,6 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <chrono>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -101,7 +102,9 @@ void addOutlierTestData(TStrVec fieldNames,
 BOOST_AUTO_TEST_CASE(testMemoryState) {
     std::string jobId{"testJob"};
     std::int64_t memoryUsage{1000};
-    std::int64_t timeBefore{core::CTimeUtils::toEpochMs(core::CTimeUtils::now())};
+    std::int64_t timeBefore{std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::system_clock::now().time_since_epoch())
+                                .count()};
     std::stringstream outputStream;
     {
         core::CJsonOutputStreamWrapper streamWrapper(outputStream);
@@ -112,7 +115,9 @@ BOOST_AUTO_TEST_CASE(testMemoryState) {
         instrumentation.flush();
         outputStream.flush();
     }
-    std::int64_t timeAfter{core::CTimeUtils::toEpochMs(core::CTimeUtils::now())};
+    std::int64_t timeAfter{std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count()};
 
     rapidjson::Document results;
     rapidjson::ParseResult ok(results.Parse(outputStream.str()));

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -22,6 +22,7 @@ namespace core {
 const core_t::TTime CTimeUtils::MAX_CLOCK_DISCREPANCY(300);
 
 core_t::TTime CTimeUtils::now() {
+    // TODO use std::chrono functionality
     return ::time(nullptr);
 }
 


### PR DESCRIPTION
This PR changes the resolution of the timestamps from seconds to milliseconds. This fixes #1234