### PR TITLE
[ML] Fix bad function call exception in anomaly detection

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -99,6 +99,9 @@
   issue: {ml-issue}1136[#1136].)
 * Fix classification job failures when number of classes in configuration differs 
   from the number of classes present in the training data. (See {ml-pull}1144[#1144].)
+* Fix "autodetect process stopped unexpectedly: Fatal error: 'terminate called after
+  throwing an instance of 'std::bad_function_call'". (See {ml-pull}1246[#1246],
+  issue: {ml-issue}1245[#1245].)
 
 == {es} version 7.7.0
 

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -62,8 +62,7 @@ public:
                   double seasonal,
                   double calendar,
                   const TPredictor& predictor,
-                  const CPeriodicityHypothesisTestsConfig& periodicityTestConfig,
-                  TComponentChangeCallback componentChangeCallback);
+                  const CPeriodicityHypothesisTestsConfig& periodicityTestConfig);
         SAddValue(const SAddValue&) = delete;
         SAddValue& operator=(const SAddValue&) = delete;
 
@@ -81,8 +80,6 @@ public:
         TPredictor s_Predictor;
         //! The periodicity test configuration.
         CPeriodicityHypothesisTestsConfig s_PeriodicityTestConfig;
-        //! Called if the components change.
-        TComponentChangeCallback s_ComponentChangeCallback;
     };
 
     //! \brief The message passed to indicate periodic components have
@@ -358,6 +355,20 @@ public:
 
     //! \brief Holds and updates the components of the decomposition.
     class MATHS_EXPORT CComponents : public CHandler {
+    public:
+        class CScopeAttachComponentChangeCallback {
+        public:
+            CScopeAttachComponentChangeCallback(CComponents& components,
+                                                TComponentChangeCallback callback);
+            ~CScopeAttachComponentChangeCallback();
+            CScopeAttachComponentChangeCallback(const CScopeAttachComponentChangeCallback&) = delete;
+            CScopeAttachComponentChangeCallback&
+            operator=(const CScopeAttachComponentChangeCallback&) = delete;
+
+        private:
+            CComponents& m_Components;
+        };
+
     public:
         CComponents(double decayRate, core_t::TTime bucketLength, std::size_t seasonalComponentSize);
         CComponents(const CComponents& other);

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -227,6 +227,9 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
         return;
     }
 
+    // Make sure that we always attach this as the first thing we do.
+    CComponents::CScopeAttachComponentChangeCallback attach{m_Components, componentChangeCallback};
+
     time += m_TimeShift;
 
     core_t::TTime lastTime{std::max(m_LastValueTime, m_LastPropagationTime)};
@@ -245,8 +248,7 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                           return CBasicStatistics::mean(
                               this->value(time_, 0.0, E_Seasonal | E_Calendar));
                       },
-                      m_Components.periodicityTestConfig(),
-                      componentChangeCallback};
+                      m_Components.periodicityTestConfig()};
 
     m_Components.handle(message);
     m_PeriodicityTest.handle(message);

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1568,7 +1568,9 @@ CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
     TFloatMeanAccumulatorVec window;
     EUpdateResult result{E_Success};
     auto componentChangeCallback = [&window, &result](TFloatMeanAccumulatorVec window_) {
-        window = std::move(window_);
+        if (window_.empty() == false) {
+            window = std::move(window_);
+        }
         result = E_Reset;
     };
     for (auto i : timeorder) {


### PR DESCRIPTION
This would manifest as a `autodetect process stopped unexpectedly: Fatal error: 'terminate called after throwing an instance of 'std::bad_function_call'` error. The issue was introduced in 7.2.

The problem was we were using a callback before it was set. This makes sure that the callback is always set (as a no-op if one isn't provided) and attaches it as the first action in `CTimeSeriesDecomposition::addPoint` and resets it again afterwards. Not reseting it is also a bad idea since it would keep around a reference to a stack variable.

Fixes #1245.