### PR TITLE
[7.x] Rename identifier to detectorIndex so that the naming is consistent between C++ and Java (#1251)

### DIFF
--- a/include/model/CCountingModelFactory.h
+++ b/include/model/CCountingModelFactory.h
@@ -103,7 +103,7 @@ public:
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void identifier(int identifier);
+    virtual void detectorIndex(int detectorIndex);
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
@@ -128,7 +128,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier;
+    int m_DetectorIndex;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process.

--- a/include/model/CEventRateModelFactory.h
+++ b/include/model/CEventRateModelFactory.h
@@ -113,7 +113,7 @@ public:
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void identifier(int identifier);
+    virtual void detectorIndex(int detectorIndex);
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
@@ -138,7 +138,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier = 0;
+    int m_DetectorIndex = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process

--- a/include/model/CEventRatePopulationModelFactory.h
+++ b/include/model/CEventRatePopulationModelFactory.h
@@ -114,7 +114,7 @@ public:
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void identifier(int identifier);
+    virtual void detectorIndex(int detectorIndex);
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
@@ -140,7 +140,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier = 0;
+    int m_DetectorIndex = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process.

--- a/include/model/CMetricModelFactory.h
+++ b/include/model/CMetricModelFactory.h
@@ -113,7 +113,7 @@ public:
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void identifier(int identifier);
+    virtual void detectorIndex(int detectorIndex);
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
@@ -141,7 +141,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier = 0;
+    int m_DetectorIndex = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process.

--- a/include/model/CMetricPopulationModelFactory.h
+++ b/include/model/CMetricPopulationModelFactory.h
@@ -114,7 +114,7 @@ public:
     //! \name Customization
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void identifier(int identifier);
+    virtual void detectorIndex(int detectorIndex);
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
@@ -145,7 +145,7 @@ private:
 
 private:
     //! The identifier of the search for which this generates models.
-    int m_Identifier = 0;
+    int m_DetectorIndex = 0;
 
     //! Indicates whether the data being gathered are already summarized
     //! by an external aggregation process

--- a/include/model/CModelFactory.h
+++ b/include/model/CModelFactory.h
@@ -267,7 +267,7 @@ public:
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void identifier(int identifier) = 0;
+    virtual void detectorIndex(int detectorIndex) = 0;
 
     //! Set the record field names which will be modeled.
     virtual void fieldNames(const std::string& partitionFieldName,

--- a/include/model/CSearchKey.h
+++ b/include/model/CSearchKey.h
@@ -99,7 +99,7 @@ public:
     //!
     //! \note Use the pass-by-value-and-swap trick to improve performance
     //! when the arguments are temporaries.
-    explicit CSearchKey(int identifier = 0,
+    explicit CSearchKey(int detectorIndex = 0,
                         function_t::EFunction function = function_t::E_IndividualCount,
                         bool useNull = false,
                         model_t::EExcludeFrequent excludeFrequent = model_t::E_XF_None,
@@ -134,7 +134,7 @@ public:
     bool operator<(const CSearchKey& rhs) const;
 
     //! Get an identifier for this search.
-    int identifier() const;
+    int detectorIndex() const;
 
     //! Get the unique simple counting search key.
     //!
@@ -194,7 +194,7 @@ public:
     uint64_t hash() const;
 
 private:
-    int m_Identifier;
+    int m_DetectorIndex;
     function_t::EFunction m_Function;
     bool m_UseNull;
     model_t::EExcludeFrequent m_ExcludeFrequent;

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1471,7 +1471,7 @@ CAnomalyJob::detectorForKey(bool isRestoring,
                   << partition << '\'' << ", time " << time);
         LOG_TRACE(<< "Detector count " << m_Detectors.size());
 
-        detector = this->makeDetector(key.identifier(), m_ModelConfig, m_Limits,
+        detector = this->makeDetector(key.detectorIndex(), m_ModelConfig, m_Limits,
                                       partition, time, m_ModelConfig.factory(key));
         if (detector == nullptr) {
             // This should never happen as CAnomalyDetectorUtils::makeDetector()

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -445,11 +445,11 @@ CAnomalyDetectorModelConfig::factory(const CSearchKey& key) const {
     TModelFactoryCPtr result = m_FactoryCache[key];
     if (!result) {
         result = key.isSimpleCount()
-                     ? this->factory(key.identifier(), key.function(), true,
+                     ? this->factory(key.detectorIndex(), key.function(), true,
                                      key.excludeFrequent(), key.partitionFieldName(),
                                      key.overFieldName(), key.byFieldName(),
                                      key.fieldName(), key.influenceFieldNames())
-                     : this->factory(key.identifier(), key.function(), key.useNull(),
+                     : this->factory(key.detectorIndex(), key.function(), key.useNull(),
                                      key.excludeFrequent(), key.partitionFieldName(),
                                      key.overFieldName(), key.byFieldName(),
                                      key.fieldName(), key.influenceFieldNames());
@@ -458,7 +458,7 @@ CAnomalyDetectorModelConfig::factory(const CSearchKey& key) const {
 }
 
 CAnomalyDetectorModelConfig::TModelFactoryCPtr
-CAnomalyDetectorModelConfig::factory(int identifier,
+CAnomalyDetectorModelConfig::factory(int detectorIndex,
                                      function_t::EFunction function,
                                      bool useNull,
                                      model_t::EExcludeFrequent excludeFrequent,
@@ -604,7 +604,7 @@ CAnomalyDetectorModelConfig::factory(int identifier,
     }
 
     TModelFactoryPtr result(prototype->second->clone());
-    result->identifier(identifier);
+    result->detectorIndex(detectorIndex);
     TStrVec influences;
     influences.reserve(influenceFieldNames.size());
     for (const auto& influenceFieldName : influenceFieldNames) {
@@ -616,7 +616,7 @@ CAnomalyDetectorModelConfig::factory(int identifier,
     result->excludeFrequent(excludeFrequent);
     result->features(features);
     result->multivariateByFields(m_MultivariateByFields);
-    TIntDetectionRuleVecUMapCItr rulesItr = m_DetectionRules.get().find(identifier);
+    TIntDetectionRuleVecUMapCItr rulesItr = m_DetectionRules.get().find(detectorIndex);
     if (rulesItr != m_DetectionRules.get().end()) {
         result->detectionRules(TDetectionRuleVecCRef(rulesItr->second));
     }

--- a/lib/model/CCountingModelFactory.cc
+++ b/lib/model/CCountingModelFactory.cc
@@ -25,7 +25,7 @@ CCountingModelFactory::CCountingModelFactory(const SModelParams& params,
                                              const TInterimBucketCorrectorWPtr& interimBucketCorrector,
                                              model_t::ESummaryMode summaryMode,
                                              const std::string& summaryCountFieldName)
-    : CModelFactory(params, interimBucketCorrector), m_Identifier(),
+    : CModelFactory(params, interimBucketCorrector), m_DetectorIndex(),
       m_SummaryMode(summaryMode),
       m_SummaryCountFieldName(summaryCountFieldName), m_UseNull(false) {
 }
@@ -94,7 +94,7 @@ CCountingModelFactory::defaultCorrelatePrior(model_t::EFeature /*feature*/,
 
 const CSearchKey& CCountingModelFactory::searchKey() const {
     if (!m_SearchKeyCache) {
-        m_SearchKeyCache.emplace(m_Identifier, function_t::function(m_Features),
+        m_SearchKeyCache.emplace(m_DetectorIndex, function_t::function(m_Features),
                                  m_UseNull, this->modelParams().s_ExcludeFrequent,
                                  "", m_PersonFieldName, "", m_PartitionFieldName);
     }
@@ -113,8 +113,8 @@ maths_t::EDataType CCountingModelFactory::dataType() const {
     return maths_t::E_IntegerData;
 }
 
-void CCountingModelFactory::identifier(int identifier) {
-    m_Identifier = identifier;
+void CCountingModelFactory::detectorIndex(int detectorIndex) {
+    m_DetectorIndex = detectorIndex;
     m_SearchKeyCache.reset();
 }
 

--- a/lib/model/CEventRateModelFactory.cc
+++ b/lib/model/CEventRateModelFactory.cc
@@ -209,7 +209,7 @@ CEventRateModelFactory::defaultCorrelatePrior(model_t::EFeature /*feature*/,
 
 const CSearchKey& CEventRateModelFactory::searchKey() const {
     if (!m_SearchKeyCache) {
-        m_SearchKeyCache.emplace(m_Identifier, function_t::function(m_Features),
+        m_SearchKeyCache.emplace(m_DetectorIndex, function_t::function(m_Features),
                                  m_UseNull, this->modelParams().s_ExcludeFrequent,
                                  m_ValueFieldName, m_PersonFieldName, "",
                                  m_PartitionFieldName, m_InfluenceFieldNames);
@@ -229,8 +229,8 @@ maths_t::EDataType CEventRateModelFactory::dataType() const {
     return maths_t::E_IntegerData;
 }
 
-void CEventRateModelFactory::identifier(int identifier) {
-    m_Identifier = identifier;
+void CEventRateModelFactory::detectorIndex(int detectorIndex) {
+    m_DetectorIndex = detectorIndex;
     m_SearchKeyCache.reset();
 }
 

--- a/lib/model/CEventRatePopulationModelFactory.cc
+++ b/lib/model/CEventRatePopulationModelFactory.cc
@@ -207,7 +207,7 @@ CEventRatePopulationModelFactory::defaultCorrelatePrior(model_t::EFeature /*feat
 
 const CSearchKey& CEventRatePopulationModelFactory::searchKey() const {
     if (!m_SearchKeyCache) {
-        m_SearchKeyCache.emplace(m_Identifier, function_t::function(m_Features),
+        m_SearchKeyCache.emplace(m_DetectorIndex, function_t::function(m_Features),
                                  m_UseNull, this->modelParams().s_ExcludeFrequent,
                                  m_ValueFieldName, m_AttributeFieldName, m_PersonFieldName,
                                  m_PartitionFieldName, m_InfluenceFieldNames);
@@ -227,8 +227,8 @@ maths_t::EDataType CEventRatePopulationModelFactory::dataType() const {
     return maths_t::E_IntegerData;
 }
 
-void CEventRatePopulationModelFactory::identifier(int identifier) {
-    m_Identifier = identifier;
+void CEventRatePopulationModelFactory::detectorIndex(int detectorIndex) {
+    m_DetectorIndex = detectorIndex;
     m_SearchKeyCache.reset();
 }
 

--- a/lib/model/CMetricModelFactory.cc
+++ b/lib/model/CMetricModelFactory.cc
@@ -203,7 +203,7 @@ CMetricModelFactory::defaultCorrelatePrior(model_t::EFeature /*feature*/,
 
 const CSearchKey& CMetricModelFactory::searchKey() const {
     if (!m_SearchKeyCache) {
-        m_SearchKeyCache.emplace(m_Identifier, function_t::function(m_Features),
+        m_SearchKeyCache.emplace(m_DetectorIndex, function_t::function(m_Features),
                                  m_UseNull, this->modelParams().s_ExcludeFrequent,
                                  m_ValueFieldName, m_PersonFieldName, "",
                                  m_PartitionFieldName, m_InfluenceFieldNames);
@@ -223,8 +223,8 @@ maths_t::EDataType CMetricModelFactory::dataType() const {
     return maths_t::E_ContinuousData;
 }
 
-void CMetricModelFactory::identifier(int identifier) {
-    m_Identifier = identifier;
+void CMetricModelFactory::detectorIndex(int detectorIndex) {
+    m_DetectorIndex = detectorIndex;
     m_SearchKeyCache.reset();
 }
 

--- a/lib/model/CMetricPopulationModelFactory.cc
+++ b/lib/model/CMetricPopulationModelFactory.cc
@@ -205,7 +205,7 @@ CMetricPopulationModelFactory::defaultCorrelatePrior(model_t::EFeature /*feature
 
 const CSearchKey& CMetricPopulationModelFactory::searchKey() const {
     if (!m_SearchKeyCache) {
-        m_SearchKeyCache.emplace(m_Identifier, function_t::function(m_Features),
+        m_SearchKeyCache.emplace(m_DetectorIndex, function_t::function(m_Features),
                                  m_UseNull, this->modelParams().s_ExcludeFrequent,
                                  m_ValueFieldName, m_AttributeFieldName, m_PersonFieldName,
                                  m_PartitionFieldName, m_InfluenceFieldNames);
@@ -225,8 +225,8 @@ maths_t::EDataType CMetricPopulationModelFactory::dataType() const {
     return maths_t::E_ContinuousData;
 }
 
-void CMetricPopulationModelFactory::identifier(int identifier) {
-    m_Identifier = identifier;
+void CMetricPopulationModelFactory::detectorIndex(int detectorIndex) {
+    m_DetectorIndex = detectorIndex;
     m_SearchKeyCache.reset();
 }
 

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -59,7 +59,7 @@ CSearchKey::CSearchKey(int identifier,
                        std::string overFieldName,
                        std::string partitionFieldName,
                        const TStrVec& influenceFieldNames)
-    : m_Identifier(identifier), m_Function(function), m_UseNull(useNull),
+    : m_DetectorIndex(identifier), m_Function(function), m_UseNull(useNull),
       m_ExcludeFrequent(excludeFrequent), m_Hash(0) {
     m_FieldName = CStringStore::names().get(fieldName);
     m_ByFieldName = CStringStore::names().get(byFieldName);
@@ -72,7 +72,7 @@ CSearchKey::CSearchKey(int identifier,
 }
 
 CSearchKey::CSearchKey(core::CStateRestoreTraverser& traverser, bool& successful)
-    : m_Identifier(0), m_Function(function_t::E_IndividualCount),
+    : m_DetectorIndex(0), m_Function(function_t::E_IndividualCount),
       m_UseNull(false), m_ExcludeFrequent(model_t::E_XF_None), m_Hash(0) {
     successful = traverser.traverseSubLevel(
         std::bind(&CSearchKey::acceptRestoreTraverser, this, std::placeholders::_1));
@@ -82,7 +82,7 @@ bool CSearchKey::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser)
     do {
         const std::string& name = traverser.name();
         if (name == IDENTIFIER_TAG) {
-            if (core::CStringUtils::stringToType(traverser.value(), m_Identifier) == false) {
+            if (core::CStringUtils::stringToType(traverser.value(), m_DetectorIndex) == false) {
                 LOG_ERROR(<< "Invalid identifier in " << traverser.value());
                 return false;
             }
@@ -127,7 +127,7 @@ bool CSearchKey::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser)
 }
 
 void CSearchKey::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    inserter.insertValue(IDENTIFIER_TAG, m_Identifier);
+    inserter.insertValue(IDENTIFIER_TAG, m_DetectorIndex);
     inserter.insertValue(FUNCTION_NAME_TAG, static_cast<int>(m_Function));
     inserter.insertValue(USE_NULL_TAG, static_cast<int>(m_UseNull));
     inserter.insertValue(EXCLUDE_FREQUENT_TAG, static_cast<int>(m_ExcludeFrequent));
@@ -141,7 +141,7 @@ void CSearchKey::acceptPersistInserter(core::CStatePersistInserter& inserter) co
 }
 
 void CSearchKey::swap(CSearchKey& other) {
-    std::swap(m_Identifier, other.m_Identifier);
+    std::swap(m_DetectorIndex, other.m_DetectorIndex);
     std::swap(m_Function, other.m_Function);
     std::swap(m_UseNull, other.m_UseNull);
     std::swap(m_ExcludeFrequent, other.m_ExcludeFrequent);
@@ -156,7 +156,7 @@ void CSearchKey::swap(CSearchKey& other) {
 bool CSearchKey::operator==(const CSearchKey& rhs) const {
     using TStrEqualTo = std::equal_to<std::string>;
 
-    return this->hash() == rhs.hash() && m_Identifier == rhs.m_Identifier &&
+    return this->hash() == rhs.hash() && m_DetectorIndex == rhs.m_DetectorIndex &&
            m_Function == rhs.m_Function && m_UseNull == rhs.m_UseNull &&
            m_ExcludeFrequent == rhs.m_ExcludeFrequent &&
            m_FieldName == rhs.m_FieldName && m_ByFieldName == rhs.m_ByFieldName &&
@@ -178,7 +178,7 @@ bool CSearchKey::operator<(const CSearchKey& rhs) const {
     }
 
     if (this->hash() == rhs.hash()) {
-        if (m_Identifier == rhs.m_Identifier) {
+        if (m_DetectorIndex == rhs.m_DetectorIndex) {
             if (m_Function == rhs.m_Function) {
                 if (m_UseNull == rhs.m_UseNull) {
                     if (m_ExcludeFrequent == rhs.m_ExcludeFrequent) {
@@ -226,7 +226,7 @@ bool CSearchKey::operator<(const CSearchKey& rhs) const {
             return m_Function < rhs.m_Function;
         }
 
-        return m_Identifier < rhs.m_Identifier;
+        return m_DetectorIndex < rhs.m_DetectorIndex;
     }
 
     return this->hash() < rhs.hash();
@@ -295,8 +295,8 @@ std::string CSearchKey::debug() const {
     return strm.str();
 }
 
-int CSearchKey::identifier() const {
-    return m_Identifier;
+int CSearchKey::detectorIndex() const {
+    return m_DetectorIndex;
 }
 
 function_t::EFunction CSearchKey::function() const {
@@ -342,7 +342,7 @@ uint64_t CSearchKey::hash() const {
     }
     m_Hash = m_UseNull ? 1 : 0;
     m_Hash = 4 * m_Hash + static_cast<uint64_t>(m_ExcludeFrequent);
-    m_Hash = core::CHashing::hashCombine(m_Hash, static_cast<uint64_t>(m_Identifier));
+    m_Hash = core::CHashing::hashCombine(m_Hash, static_cast<uint64_t>(m_DetectorIndex));
     m_Hash = core::CHashing::hashCombine(m_Hash, static_cast<uint64_t>(m_Function));
     m_Hash = maths::CChecksum::calculate(m_Hash, *m_FieldName);
     m_Hash = maths::CChecksum::calculate(m_Hash, *m_ByFieldName);
@@ -357,7 +357,7 @@ std::ostream& operator<<(std::ostream& strm, const CSearchKey& key) {
     // The format for this is very similar to the format used by toCue() at the
     // time of writing.  However, do NOT combine the code because the intention
     // is to simplify toCue() in the future.
-    strm << key.m_Identifier << "==" << function_t::print(key.m_Function) << '/'
+    strm << key.m_DetectorIndex << "==" << function_t::print(key.m_Function) << '/'
          << (key.m_UseNull ? '1' : '0') << '/' << static_cast<int>(key.m_ExcludeFrequent)
          << '/' << *key.m_FieldName << '/' << *key.m_ByFieldName << '/'
          << *key.m_OverFieldName << '/' << *key.m_PartitionFieldName << '/';

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -1230,14 +1230,14 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
 
     CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
 
-    int identifier = 0;
+    int detectorIndex = 0;
     for (std::size_t i = 0u; i < boost::size(countFunctions); ++i) {
         for (std::size_t j = 0u; j < boost::size(useNull); ++j) {
             for (std::size_t k = 0u; k < boost::size(byField); ++k) {
                 for (std::size_t l = 0u; l < boost::size(partitionField); ++l) {
-                    CSearchKey key(++identifier, countFunctions[i], useNull[j],
-                                   model_t::E_XF_None, "", byField[k], "",
-                                   partitionField[l]);
+                    CSearchKey key(++detectorIndex, countFunctions[i],
+                                   useNull[j], model_t::E_XF_None, "",
+                                   byField[k], "", partitionField[l]);
 
                     CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
                         config.factory(key);

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -756,12 +756,12 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
     {
         CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
 
-        int identifier = 0;
+        int detectorIndex = 0;
         for (std::size_t i = 0u; i < boost::size(countFunctions); ++i) {
             for (std::size_t j = 0u; j < boost::size(useNull); ++j) {
                 for (std::size_t k = 0u; k < boost::size(byField); ++k) {
                     for (std::size_t l = 0u; l < boost::size(partitionField); ++l) {
-                        CSearchKey key(++identifier, countFunctions[i],
+                        CSearchKey key(++detectorIndex, countFunctions[i],
                                        useNull[j], model_t::E_XF_None, "",
                                        byField[k], "over", partitionField[l]);
 

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -1505,14 +1505,14 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
 
     CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
 
-    int identifier = 0;
+    int detectorIndex = 0;
     for (std::size_t i = 0u; i < boost::size(countFunctions); ++i) {
         for (std::size_t j = 0u; j < boost::size(useNull); ++j) {
             for (std::size_t k = 0u; k < boost::size(byField); ++k) {
                 for (std::size_t l = 0u; l < boost::size(partitionField); ++l) {
-                    CSearchKey key(++identifier, countFunctions[i], useNull[j],
-                                   model_t::E_XF_None, "value", byField[k], "",
-                                   partitionField[l]);
+                    CSearchKey key(++detectorIndex, countFunctions[i],
+                                   useNull[j], model_t::E_XF_None, "value",
+                                   byField[k], "", partitionField[l]);
 
                     CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
                         config.factory(key);

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -1015,12 +1015,12 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
     {
         CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
 
-        int identifier = 0;
+        int detectorIndex = 0;
         for (std::size_t i = 0u; i < boost::size(countFunctions); ++i) {
             for (std::size_t j = 0u; j < boost::size(useNull); ++j) {
                 for (std::size_t k = 0u; k < boost::size(byField); ++k) {
                     for (std::size_t l = 0u; l < boost::size(partitionField); ++l) {
-                        CSearchKey key(++identifier, countFunctions[i],
+                        CSearchKey key(++detectorIndex, countFunctions[i],
                                        useNull[j], model_t::E_XF_None, "value",
                                        byField[k], "over", partitionField[l]);
 

--- a/lib/model/unittest/CResourceLimitTest.cc
+++ b/lib/model/unittest/CResourceLimitTest.cc
@@ -281,7 +281,7 @@ TAddPersonDataFunc createModel(model_t::EModelType modelType,
         auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
 
         factory = std::make_shared<CEventRateModelFactory>(params, interimBucketCorrector);
-        factory->identifier(1);
+        factory->detectorIndex(1);
         factory->fieldNames(emptyString, emptyString, "pers", emptyString, TStrVec());
         CModelFactory::TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
@@ -309,7 +309,7 @@ TAddPersonDataFunc createModel(model_t::EModelType modelType,
         params.s_DecayRate = 0.001;
         auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
         factory = std::make_shared<CMetricModelFactory>(params, interimBucketCorrector);
-        factory->identifier(1);
+        factory->detectorIndex(1);
         factory->fieldNames(emptyString, emptyString, "peep", "val", TStrVec());
         factory->useNull(true);
         CModelFactory::TFeatureVec features;
@@ -482,10 +482,10 @@ BOOST_FIXTURE_TEST_CASE(testLimitBy, CTestFixture) {
             CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
         modelConfig.useMultibucketFeatures(false);
         CLimits limits;
-        CSearchKey key(1, // identifier
+        CSearchKey key(1, // detectorIndex
                        function_t::E_IndividualMetric, false,
                        model_t::E_XF_None, "value", "colour");
-        CAnomalyDetector detector(1, // identifier
+        CAnomalyDetector detector(1, // detectorIndex
                                   limits, modelConfig, "", FIRST_TIME,
                                   modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits);
@@ -509,10 +509,10 @@ BOOST_FIXTURE_TEST_CASE(testLimitBy, CTestFixture) {
         CAnomalyDetectorModelConfig modelConfig =
             CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
         CLimits limits;
-        CSearchKey key(1, // identifier
+        CSearchKey key(1, // detectorIndex
                        function_t::E_IndividualMetric, false,
                        model_t::E_XF_None, "value", "colour");
-        CAnomalyDetector detector(1, // identifier
+        CAnomalyDetector detector(1, // detectorIndex
                                   limits, modelConfig, "", FIRST_TIME,
                                   modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits);
@@ -541,10 +541,10 @@ BOOST_FIXTURE_TEST_CASE(testLimitByOver, CTestFixture) {
         CAnomalyDetectorModelConfig modelConfig =
             CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
         CLimits limits;
-        CSearchKey key(1, // identifier
+        CSearchKey key(1, // detectorIndex
                        function_t::E_PopulationMetric, false,
                        model_t::E_XF_None, "value", "colour", "species");
-        CAnomalyDetector detector(1, // identifier
+        CAnomalyDetector detector(1, // detectorIndex
                                   limits, modelConfig, "", FIRST_TIME,
                                   modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits);
@@ -566,10 +566,10 @@ BOOST_FIXTURE_TEST_CASE(testLimitByOver, CTestFixture) {
     CAnomalyDetectorModelConfig modelConfig =
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
     CLimits limits;
-    CSearchKey key(1, // identifier
+    CSearchKey key(1, // detectorIndex
                    function_t::E_PopulationMetric, false, model_t::E_XF_None,
                    "value", "colour", "species");
-    CAnomalyDetector detector(1, // identifier
+    CAnomalyDetector detector(1, // detectorIndex
                               limits, modelConfig, "", FIRST_TIME,
                               modelConfig.factory(key));
     CResultWriter writer(modelConfig, limits);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Rename identifier to detectorIndex so that the naming is consistent between C++ and Java  (#1251)