### PR TITLE
[ML] Add source URL to 3rd party info when we have to say how to get it

### DIFF
--- a/3rd_party/licenses/boost-INFO.csv
+++ b/3rd_party/licenses/boost-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-Boost C++ Libraries,1.71.0,,http://www.boost.org,BSL-1.0,
+name,version,revision,url,license,copyright,sourceURL
+Boost C++ Libraries,1.71.0,,http://www.boost.org,BSL-1.0,,

--- a/3rd_party/licenses/eigen-INFO.csv
+++ b/3rd_party/licenses/eigen-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-Eigen,3.3.7,21ae2afd4edaa1b69782c67a54182d34efe43f9c,http://eigen.tuxfamily.org,MPL-2.0,
+name,version,revision,url,license,copyright,sourceURL
+Eigen,3.3.7,21ae2afd4edaa1b69782c67a54182d34efe43f9c,http://eigen.tuxfamily.org,MPL-2.0,,https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip

--- a/3rd_party/licenses/gcc-runtime-INFO.csv
+++ b/3rd_party/licenses/gcc-runtime-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-GCC Runtime Library,7.5.0,b2d961e7342b5ba4e57adfa81cb189b738d10901,https://gcc.gnu.org,GPL-3.0 WITH GCC-exception-3.1,"Copyright (C) 2019 Free Software Foundation, Inc."
+name,version,revision,url,license,copyright,sourceURL
+GCC Runtime Library,9.3.0,4212a6a3e44f870412d9025eeb323fd4f50a61da,https://gcc.gnu.org,GPL-3.0 WITH GCC-exception-3.1,"Copyright (C) 2020 Free Software Foundation, Inc.",http://ftpmirror.gnu.org/gcc/gcc-9.3.0/gcc-9.3.0.tar.gz

--- a/3rd_party/licenses/libxml2-INFO.csv
+++ b/3rd_party/licenses/libxml2-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-Libxml2,2.9.7,,http://xmlsoft.org/,MIT,Copyright (C) 1998-2012 Daniel Veillard
+name,version,revision,url,license,copyright,sourceURL
+Libxml2,2.9.7,,http://xmlsoft.org/,MIT,Copyright (C) 1998-2012 Daniel Veillard,

--- a/3rd_party/licenses/moby-INFO.csv
+++ b/3rd_party/licenses/moby-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-Moby lexicon project,1,,http://icon.shef.ac.uk/Moby/,Public-Domain;http://icon.shef.ac.uk/Moby/,
+name,version,revision,url,license,copyright,sourceURL
+Moby lexicon project,1,,http://icon.shef.ac.uk/Moby/,Public-Domain;http://icon.shef.ac.uk/Moby/,,

--- a/3rd_party/licenses/msinttypes-INFO.csv
+++ b/3rd_party/licenses/msinttypes-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-The msinttypes,r29,,https://code.google.com/archive/p/msinttypes/,BSD-3-Clause,Copyright (c) 2006-2013 Alexander Chemeris
+name,version,revision,url,license,copyright,sourceURL
+The msinttypes,r29,,https://code.google.com/archive/p/msinttypes/,BSD-3-Clause,Copyright (c) 2006-2013 Alexander Chemeris,

--- a/3rd_party/licenses/rapidjson-INFO.csv
+++ b/3rd_party/licenses/rapidjson-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-RapidJSON,1.1.0,f05edc9296507a9864d99931e203631c2ffd8d4a,http://rapidjson.org,MIT,"Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip"
+name,version,revision,url,license,copyright,sourceURL
+RapidJSON,1.1.0,f05edc9296507a9864d99931e203631c2ffd8d4a,http://rapidjson.org,MIT,"Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip",

--- a/3rd_party/licenses/rapidxml-INFO.csv
+++ b/3rd_party/licenses/rapidxml-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-RapidXml,1.13,,http://rapidxml.sourceforge.net,MIT,"Copyright (c) 2006, 2007 Marcin Kalicinski"
+name,version,revision,url,license,copyright,sourceURL
+RapidXml,1.13,,http://rapidxml.sourceforge.net,MIT,"Copyright (c) 2006, 2007 Marcin Kalicinski",

--- a/3rd_party/licenses/scowl-INFO.csv
+++ b/3rd_party/licenses/scowl-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-SCOWL,7.1,,http://wordlist.aspell.net,Custom;https://raw.githubusercontent.com/en-wl/wordlist/scowl-7.1/scowl/Copyright,Copyright 2000-2011 by Kevin Atkinson
+name,version,revision,url,license,copyright,sourceURL
+SCOWL,7.1,,http://wordlist.aspell.net,Custom;https://raw.githubusercontent.com/en-wl/wordlist/scowl-7.1/scowl/Copyright,Copyright 2000-2011 by Kevin Atkinson,

--- a/3rd_party/licenses/strptime-INFO.csv
+++ b/3rd_party/licenses/strptime-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-strptime,1.35,,http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/time/strptime.c,BSD-2-Clause-NetBSD,"Copyright (c) 1997, 1998, 2005, 2008 The NetBSD Foundation, Inc."
+name,version,revision,url,license,copyright,sourceURL
+strptime,1.35,,http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/time/strptime.c,BSD-2-Clause-NetBSD,"Copyright (c) 1997, 1998, 2005, 2008 The NetBSD Foundation, Inc.",

--- a/3rd_party/licenses/visualstudio2017-INFO.csv
+++ b/3rd_party/licenses/visualstudio2017-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-Visual Studio 2017 Runtime Libraries,14.1,,https://www.visualstudio.com,Custom;https://www.visualstudio.com/license-terms/mlt687465/,Copyright (C) Microsoft Corporation
+name,version,revision,url,license,copyright,sourceURL
+Visual Studio 2017 Runtime Libraries,14.1,,https://www.visualstudio.com,Custom;https://www.visualstudio.com/license-terms/mlt687465/,Copyright (C) Microsoft Corporation,

--- a/3rd_party/licenses/zlib-INFO.csv
+++ b/3rd_party/licenses/zlib-INFO.csv
@@ -1,2 +1,2 @@
-name,version,revision,url,license,copyright
-zlib,1.2.11,,http://zlib.net,Zlib,Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+name,version,revision,url,license,copyright,sourceURL
+zlib,1.2.11,,http://zlib.net,Zlib,Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler,


### PR DESCRIPTION
Some third party licenses require that we tell people where they can
obtain the third party source code.

To integrate with the new solution Elastic is putting together to
meet this requirement, this PR adds a sourceURL field to the 3rd
party info files.  For licenses that require we tell people where
to get the code from this is set to the appropriate download URL.
For other licenses it is left blank.