### PR TITLE
[7.8][ML] Switch off CDS archive for ES test Gradle on aarch64

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -71,9 +71,11 @@ if [ -z "$ES_BUILD_JAVA" ]; then
     exit 1
 fi
 
-# On aarch64 adoptopenjdk is used in place of openjdk
+# On aarch64 adoptopenjdk is used in place of openjdk,
+# and the CDS archive can cause problems with Gradle
 if [ `uname -m` = aarch64 ] ; then
     export ES_BUILD_JAVA=adopt$ES_BUILD_JAVA
+    export GRADLE_OPTS=-Xshare:off
 fi
 
 echo "Setting JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA"


### PR DESCRIPTION
Having the CDS archive enabled on aarch64 was observed to cause an
error in the Gradle used for the ES integration tests:

```
[0.003s][error][cds] Unable to map CDS archive -- os::vm_allocation_granularity() expected: 65536 actual: 4096
```

Backport of #1257