### PR TITLE
[7.x] Do not pass detectorIndex to CAnomalyDetector (#1259)

### DIFF
--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -350,8 +350,7 @@ private:
     void doForecast(const std::string& controlMessage);
 
     TAnomalyDetectorPtr
-    makeDetector(int identifier,
-                 const model::CAnomalyDetectorModelConfig& modelConfig,
+    makeDetector(const model::CAnomalyDetectorModelConfig& modelConfig,
                  model::CLimits& limits,
                  const std::string& partitionFieldValue,
                  core_t::TTime firstTime,

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -105,8 +105,7 @@ public:
     static const std::string EMPTY_STRING;
 
 public:
-    CAnomalyDetector(int detectorIndex,
-                     CLimits& limits,
+    CAnomalyDetector(CLimits& limits,
                      const CAnomalyDetectorModelConfig& modelConfig,
                      const std::string& partitionFieldValue,
                      core_t::TTime firstTime,
@@ -350,9 +349,6 @@ private:
     void legacyModelsAcceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
 private:
-    //! An identifier for the search for which this is detecting anomalies.
-    int m_DetectorIndex;
-
     //! Configurable limits
     CLimits& m_Limits;
 

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -402,15 +402,12 @@ public:
 
     //! Update the results with this model's probability.
     //!
-    //! \param[in] detector An identifier of the detector generating this
-    //! result.
     //! \param[in] startTime The start of the time interval of interest.
     //! \param[in] endTime The end of the time interval of interest.
     //! \param[in] numberAttributeProbabilities The maximum number of
     //! attribute probabilities to retrieve.
     //! \param[in,out] results The model results are added.
-    bool addResults(int detector,
-                    core_t::TTime startTime,
+    bool addResults(core_t::TTime startTime,
                     core_t::TTime endTime,
                     std::size_t numberAttributeProbabilities,
                     CHierarchicalResults& results) const;

--- a/include/model/CSimpleCountDetector.h
+++ b/include/model/CSimpleCountDetector.h
@@ -39,8 +39,7 @@ class CLimits;
 //!
 class MODEL_EXPORT CSimpleCountDetector : public CAnomalyDetector {
 public:
-    CSimpleCountDetector(int identifier,
-                         model_t::ESummaryMode summaryMode,
+    CSimpleCountDetector(model_t::ESummaryMode summaryMode,
                          const CAnomalyDetectorModelConfig& modelConfig,
                          CLimits& limits,
                          const std::string& partitionFieldValue,

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1471,8 +1471,8 @@ CAnomalyJob::detectorForKey(bool isRestoring,
                   << partition << '\'' << ", time " << time);
         LOG_TRACE(<< "Detector count " << m_Detectors.size());
 
-        detector = this->makeDetector(key.detectorIndex(), m_ModelConfig, m_Limits,
-                                      partition, time, m_ModelConfig.factory(key));
+        detector = this->makeDetector(m_ModelConfig, m_Limits, partition, time,
+                                      m_ModelConfig.factory(key));
         if (detector == nullptr) {
             // This should never happen as CAnomalyDetectorUtils::makeDetector()
             // contracts to never return NULL
@@ -1510,19 +1510,18 @@ void CAnomalyJob::pruneAllModels() {
 }
 
 CAnomalyJob::TAnomalyDetectorPtr
-CAnomalyJob::makeDetector(int identifier,
-                          const model::CAnomalyDetectorModelConfig& modelConfig,
+CAnomalyJob::makeDetector(const model::CAnomalyDetectorModelConfig& modelConfig,
                           model::CLimits& limits,
                           const std::string& partitionFieldValue,
                           core_t::TTime firstTime,
                           const model::CAnomalyDetector::TModelFactoryCPtr& modelFactory) {
     return modelFactory->isSimpleCount()
                ? std::make_shared<model::CSimpleCountDetector>(
-                     identifier, modelFactory->summaryMode(), modelConfig,
-                     std::ref(limits), partitionFieldValue, firstTime, modelFactory)
-               : std::make_shared<model::CAnomalyDetector>(
-                     identifier, std::ref(limits), modelConfig,
-                     partitionFieldValue, firstTime, modelFactory);
+                     modelFactory->summaryMode(), modelConfig, std::ref(limits),
+                     partitionFieldValue, firstTime, modelFactory)
+               : std::make_shared<model::CAnomalyDetector>(std::ref(limits), modelConfig,
+                                                           partitionFieldValue,
+                                                           firstTime, modelFactory);
 }
 
 void CAnomalyJob::populateDetectorKeys(const CFieldConfig& fieldConfig, TKeyVec& keys) {

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -346,7 +346,7 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
         std::size_t s_ExpectedByMemoryUsageRelativeErrorDivisor;
         std::size_t s_ExpectedPartitionUsageRelativeErrorDivisor;
         std::size_t s_ExpectedOverUsageRelativeErrorDivisor;
-    } testParams[]{{600, 550, 6000, 300, 33, 40, 40},
+    } testParams[]{{600, 550, 6000, 300, 33, 39, 40},
                    {3600, 550, 5500, 300, 27, 25, 20},
                    {172800, 150, 850, 110, 6, 6, 3}};
 

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -89,13 +89,12 @@ const std::string CAnomalyDetector::SUM_NAME("sum");
 const std::string CAnomalyDetector::LAT_LONG_NAME("lat_long");
 const std::string CAnomalyDetector::EMPTY_STRING;
 
-CAnomalyDetector::CAnomalyDetector(int detectorIndex,
-                                   CLimits& limits,
+CAnomalyDetector::CAnomalyDetector(CLimits& limits,
                                    const CAnomalyDetectorModelConfig& modelConfig,
                                    const std::string& partitionFieldValue,
                                    core_t::TTime firstTime,
                                    const TModelFactoryCPtr& modelFactory)
-    : m_DetectorIndex(detectorIndex), m_Limits(limits), m_ModelConfig(modelConfig),
+    : m_Limits(limits), m_ModelConfig(modelConfig),
       m_LastBucketEndTime(maths::CIntegerTools::ceil(firstTime, modelConfig.bucketLength())),
       m_DataGatherer(makeDataGatherer(modelFactory, m_LastBucketEndTime, partitionFieldValue)),
       m_ModelFactory(modelFactory),
@@ -116,8 +115,7 @@ CAnomalyDetector::CAnomalyDetector(int detectorIndex,
 }
 
 CAnomalyDetector::CAnomalyDetector(bool isForPersistence, const CAnomalyDetector& other)
-    : m_DetectorIndex(other.m_DetectorIndex), m_Limits(other.m_Limits),
-      m_ModelConfig(other.m_ModelConfig),
+    : m_Limits(other.m_Limits), m_ModelConfig(other.m_ModelConfig),
       // Empty result function is fine in this case
       // Empty result count function is fine in this case
       m_LastBucketEndTime(other.m_LastBucketEndTime),
@@ -438,7 +436,7 @@ void CAnomalyDetector::generateModelPlot(core_t::TTime bucketStartTime,
                 modelPlots.emplace_back(time, key.partitionFieldName(),
                                         m_DataGatherer->partitionFieldValue(),
                                         key.overFieldName(), key.byFieldName(),
-                                        bucketLength, m_DetectorIndex);
+                                        bucketLength, key.detectorIndex());
                 view->modelPlot(time, boundsPercentile, terms, modelPlots.back());
             }
         }
@@ -508,7 +506,7 @@ CAnomalyDetector::getForecastModels(bool persistOnDisk,
 
     const CSearchKey& key = m_DataGatherer->searchKey();
     series.s_ByFieldName = key.byFieldName();
-    series.s_DetectorIndex = m_DetectorIndex;
+    series.s_DetectorIndex = key.detectorIndex();
     series.s_PartitionFieldName = key.partitionFieldName();
     series.s_PartitionFieldValue = m_DataGatherer->partitionFieldValue();
     series.s_MinimumSeasonalVarianceScale = m_ModelFactory->minimumSeasonalVarianceScale();
@@ -685,7 +683,7 @@ void CAnomalyDetector::buildResultsHelper(core_t::TTime bucketStartTime,
     CSearchKey key = m_DataGatherer->searchKey();
     LOG_TRACE(<< "OutputResults, for " << key.toCue());
 
-    if (m_Model->addResults(m_DetectorIndex, bucketStartTime, bucketEndTime,
+    if (m_Model->addResults(bucketStartTime, bucketEndTime,
                             10, // TODO max number of attributes
                             results)) {
         if (bucketEndTime % bucketLength == 0) {

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -212,8 +212,7 @@ void CAnomalyDetectorModel::skipSampling(core_t::TTime endTime) {
     this->currentBucketStartTime(endTime - gatherer.bucketLength());
 }
 
-bool CAnomalyDetectorModel::addResults(int detector,
-                                       core_t::TTime startTime,
+bool CAnomalyDetectorModel::addResults(core_t::TTime startTime,
                                        core_t::TTime endTime,
                                        std::size_t numberAttributeProbabilities,
                                        CHierarchicalResults& results) const {
@@ -249,8 +248,9 @@ bool CAnomalyDetectorModel::addResults(int detector,
                                          numberAttributeProbabilities, annotatedProbability)) {
                 function_t::EFunction function{m_DataGatherer->function()};
                 results.addModelResult(
-                    detector, this->isPopulation(), function_t::name(function),
-                    function, m_DataGatherer->partitionFieldName(),
+                    m_DataGatherer->searchKey().detectorIndex(),
+                    this->isPopulation(), function_t::name(function), function,
+                    m_DataGatherer->partitionFieldName(),
                     m_DataGatherer->partitionFieldValue(),
                     m_DataGatherer->personFieldName(), this->personName(pid),
                     m_DataGatherer->valueFieldName(), annotatedProbability, this, startTime);

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -50,7 +50,7 @@ const std::string CSearchKey::COUNT_NAME("count");
 const char CSearchKey::CUE_DELIMITER('/');
 const std::string CSearchKey::EMPTY_STRING;
 
-CSearchKey::CSearchKey(int identifier,
+CSearchKey::CSearchKey(int detectorIndex,
                        function_t::EFunction function,
                        bool useNull,
                        model_t::EExcludeFrequent excludeFrequent,
@@ -59,7 +59,7 @@ CSearchKey::CSearchKey(int identifier,
                        std::string overFieldName,
                        std::string partitionFieldName,
                        const TStrVec& influenceFieldNames)
-    : m_DetectorIndex(identifier), m_Function(function), m_UseNull(useNull),
+    : m_DetectorIndex(detectorIndex), m_Function(function), m_UseNull(useNull),
       m_ExcludeFrequent(excludeFrequent), m_Hash(0) {
     m_FieldName = CStringStore::names().get(fieldName);
     m_ByFieldName = CStringStore::names().get(byFieldName);
@@ -236,7 +236,7 @@ namespace {
 
 // This is keyed on a 'by' field name of 'count', which isn't allowed
 // in a real field config, as it doesn't make sense.
-const CSearchKey SIMPLE_COUNT_KEY(0, // identifier
+const CSearchKey SIMPLE_COUNT_KEY(0, // detectorIndex
                                   function_t::E_IndividualCount,
                                   true,
                                   model_t::E_XF_None,

--- a/lib/model/CSimpleCountDetector.cc
+++ b/lib/model/CSimpleCountDetector.cc
@@ -12,14 +12,13 @@
 namespace ml {
 namespace model {
 
-CSimpleCountDetector::CSimpleCountDetector(int detectorIndex,
-                                           model_t::ESummaryMode summaryMode,
+CSimpleCountDetector::CSimpleCountDetector(model_t::ESummaryMode summaryMode,
                                            const CAnomalyDetectorModelConfig& modelConfig,
                                            CLimits& limits,
                                            const std::string& partitionFieldValue,
                                            core_t::TTime firstTime,
                                            const TModelFactoryCPtr& modelFactory)
-    : CAnomalyDetector(detectorIndex, limits, modelConfig, partitionFieldValue, firstTime, modelFactory),
+    : CAnomalyDetector(limits, modelConfig, partitionFieldValue, firstTime, modelFactory),
       m_FieldValues(summaryMode == model_t::E_None ? 1 : 2) {
     // We use a single event rate detector to maintain the counts, and for the
     // special case of the simple count detector, we'll create it before we've

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -184,11 +184,10 @@ BOOST_AUTO_TEST_CASE(testAnomalies) {
         ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
     ml::model::CLimits limits;
 
-    ml::model::CSearchKey key(1, // identifier
+    ml::model::CSearchKey key(1, // detectorIndex
                               ml::model::function_t::E_IndividualRare, false,
                               ml::model_t::E_XF_None, EMPTY_STRING, "status");
-    ml::model::CAnomalyDetector detector(1, // identifier
-                                         limits, modelConfig, EMPTY_STRING,
+    ml::model::CAnomalyDetector detector(limits, modelConfig, EMPTY_STRING,
                                          FIRST_TIME, modelConfig.factory(key));
     CResultWriter writer(modelConfig, limits);
     TStrVec files;
@@ -236,12 +235,11 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
     ml::model::CLimits limits;
 
-    ml::model::CSearchKey key(1, // identifier
+    ml::model::CSearchKey key(1, // detectorIndex
                               ml::model::function_t::E_IndividualCount, false,
                               ml::model_t::E_XF_None, EMPTY_STRING, "status");
 
-    ml::model::CAnomalyDetector origDetector(1, // identifier
-                                             limits, modelConfig, EMPTY_STRING,
+    ml::model::CAnomalyDetector origDetector(limits, modelConfig, EMPTY_STRING,
                                              FIRST_TIME, modelConfig.factory(key));
     CResultWriter writer(modelConfig, limits);
     TStrVec files;
@@ -259,8 +257,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     LOG_TRACE(<< "Event rate detector XML representation:\n" << origXml);
 
     // Restore the XML into a new detector
-    ml::model::CAnomalyDetector restoredDetector(1, // identifier
-                                                 limits, modelConfig, "", 0,
+    ml::model::CAnomalyDetector restoredDetector(limits, modelConfig, "", 0,
                                                  modelConfig.factory(key));
     {
         ml::core::CRapidXmlParser parser;

--- a/lib/model/unittest/CMetricAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CMetricAnomalyDetectorTest.cc
@@ -265,11 +265,10 @@ BOOST_AUTO_TEST_CASE(testAnomalies) {
             model::CAnomalyDetectorModelConfig::defaultConfig(bucketLength);
         modelConfig.useMultibucketFeatures(false);
         model::CLimits limits;
-        model::CSearchKey key(1, // identifier
+        model::CSearchKey key(1, // detectorIndex
                               model::function_t::E_IndividualMetric, false,
                               model_t::E_XF_None, "n/a", "n/a");
-        model::CAnomalyDetector detector(1, // identifier
-                                         limits, modelConfig, "", FIRST_TIME,
+        model::CAnomalyDetector detector(limits, modelConfig, "", FIRST_TIME,
                                          modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits, bucketLength);
 
@@ -344,11 +343,10 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
     model::CLimits limits;
-    model::CSearchKey key(1, // identifier
+    model::CSearchKey key(1, // detectorIndex
                           model::function_t::E_IndividualMetric, false,
                           model_t::E_XF_None, "responsetime", "Airline");
-    model::CAnomalyDetector origDetector(1, // identifier
-                                         limits, modelConfig, EMPTY_STRING,
+    model::CAnomalyDetector origDetector(limits, modelConfig, EMPTY_STRING,
                                          FIRST_TIME, modelConfig.factory(key));
     CResultWriter writer(modelConfig, limits, BUCKET_LENGTH);
 
@@ -365,8 +363,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     LOG_TRACE(<< "Event rate detector XML representation:\n" << origXml);
 
     // Restore the XML into a new detector
-    model::CAnomalyDetector restoredDetector(1, // identifier
-                                             limits, modelConfig, EMPTY_STRING,
+    model::CAnomalyDetector restoredDetector(limits, modelConfig, EMPTY_STRING,
                                              0, modelConfig.factory(key));
     {
         core::CRapidXmlParser parser;
@@ -396,11 +393,10 @@ BOOST_AUTO_TEST_CASE(testExcludeFrequent) {
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
         modelConfig.useMultibucketFeatures(false);
         model::CLimits limits;
-        model::CSearchKey key(1, // identifier
+        model::CSearchKey key(1, // detectorIndex
                               model::function_t::E_IndividualMetric, false,
                               model_t::E_XF_None, "bytes", "host");
-        model::CAnomalyDetector detector(1, // identifier
-                                         limits, modelConfig, "", FIRST_TIME,
+        model::CAnomalyDetector detector(limits, modelConfig, "", FIRST_TIME,
                                          modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits, BUCKET_LENGTH);
 
@@ -424,11 +420,10 @@ BOOST_AUTO_TEST_CASE(testExcludeFrequent) {
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
         modelConfig.useMultibucketFeatures(false);
         model::CLimits limits;
-        model::CSearchKey key(1, // identifier
+        model::CSearchKey key(1, // detectorIndex
                               model::function_t::E_IndividualMetric, false,
                               model_t::E_XF_By, "bytes", "host");
-        model::CAnomalyDetector detector(1, // identifier
-                                         limits, modelConfig, "", FIRST_TIME,
+        model::CAnomalyDetector detector(limits, modelConfig, "", FIRST_TIME,
                                          modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits, BUCKET_LENGTH);
 

--- a/lib/model/unittest/CResourceLimitTest.cc
+++ b/lib/model/unittest/CResourceLimitTest.cc
@@ -485,8 +485,7 @@ BOOST_FIXTURE_TEST_CASE(testLimitBy, CTestFixture) {
         CSearchKey key(1, // detectorIndex
                        function_t::E_IndividualMetric, false,
                        model_t::E_XF_None, "value", "colour");
-        CAnomalyDetector detector(1, // detectorIndex
-                                  limits, modelConfig, "", FIRST_TIME,
+        CAnomalyDetector detector(limits, modelConfig, "", FIRST_TIME,
                                   modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits);
 
@@ -512,8 +511,7 @@ BOOST_FIXTURE_TEST_CASE(testLimitBy, CTestFixture) {
         CSearchKey key(1, // detectorIndex
                        function_t::E_IndividualMetric, false,
                        model_t::E_XF_None, "value", "colour");
-        CAnomalyDetector detector(1, // detectorIndex
-                                  limits, modelConfig, "", FIRST_TIME,
+        CAnomalyDetector detector(limits, modelConfig, "", FIRST_TIME,
                                   modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits);
 
@@ -544,8 +542,7 @@ BOOST_FIXTURE_TEST_CASE(testLimitByOver, CTestFixture) {
         CSearchKey key(1, // detectorIndex
                        function_t::E_PopulationMetric, false,
                        model_t::E_XF_None, "value", "colour", "species");
-        CAnomalyDetector detector(1, // detectorIndex
-                                  limits, modelConfig, "", FIRST_TIME,
+        CAnomalyDetector detector(limits, modelConfig, "", FIRST_TIME,
                                   modelConfig.factory(key));
         CResultWriter writer(modelConfig, limits);
 
@@ -569,8 +566,7 @@ BOOST_FIXTURE_TEST_CASE(testLimitByOver, CTestFixture) {
     CSearchKey key(1, // detectorIndex
                    function_t::E_PopulationMetric, false, model_t::E_XF_None,
                    "value", "colour", "species");
-    CAnomalyDetector detector(1, // detectorIndex
-                              limits, modelConfig, "", FIRST_TIME,
+    CAnomalyDetector detector(limits, modelConfig, "", FIRST_TIME,
                               modelConfig.factory(key));
     CResultWriter writer(modelConfig, limits);
 

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -97,17 +97,19 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
 
     model::CTokenListDataCategorizer<> categorizer(limits, nullptr, 0.7, "whatever");
 
-    CSearchKey key(1, // identifier
-                   function_t::E_IndividualMetric, false, model_t::E_XF_None,
-                   "value", "colour");
+    CSearchKey key1(1, // detectorIndex
+                    function_t::E_IndividualMetric, false, model_t::E_XF_None,
+                    "value", "colour");
 
-    CAnomalyDetector detector1(1, // identifier
-                               limits, modelConfig, EMPTY_STRING, FIRST_TIME,
-                               modelConfig.factory(key));
+    CAnomalyDetector detector1(limits, modelConfig, EMPTY_STRING, FIRST_TIME,
+                               modelConfig.factory(key1));
 
-    CAnomalyDetector detector2(2, // identifier
-                               limits, modelConfig, EMPTY_STRING, FIRST_TIME,
-                               modelConfig.factory(key));
+    CSearchKey key2(2, // detectorIndex
+                    function_t::E_IndividualMetric, false, model_t::E_XF_None,
+                    "value", "colour");
+
+    CAnomalyDetector detector2(limits, modelConfig, EMPTY_STRING, FIRST_TIME,
+                               modelConfig.factory(key2));
 
     std::size_t mem = core::CMemory::dynamicSize(&categorizer) +
                       core::CMemory::dynamicSize(&detector1) +
@@ -397,15 +399,14 @@ BOOST_FIXTURE_TEST_CASE(testPruning, CTestFixture) {
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
     CLimits limits(false, 1.0);
 
-    CSearchKey key(1, // identifier
+    CSearchKey key(1, // detectorIndex
                    function_t::E_IndividualMetric, false, model_t::E_XF_None,
                    "value", "colour");
 
     CResourceMonitor& monitor = limits.resourceMonitor();
     monitor.memoryLimit(140);
 
-    CAnomalyDetector detector(1, // identifier
-                              limits, modelConfig, EMPTY_STRING, FIRST_TIME,
+    CAnomalyDetector detector(limits, modelConfig, EMPTY_STRING, FIRST_TIME,
                               modelConfig.factory(key));
 
     core_t::TTime bucket = FIRST_TIME;
@@ -474,7 +475,7 @@ BOOST_FIXTURE_TEST_CASE(testExtraMemory, CTestFixture) {
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
     CLimits limits;
 
-    CSearchKey key(1, // identifier
+    CSearchKey key(1, // detectorIndex
                    function_t::E_IndividualMetric, false, model_t::E_XF_None,
                    "value", "colour");
 
@@ -482,8 +483,7 @@ BOOST_FIXTURE_TEST_CASE(testExtraMemory, CTestFixture) {
     // set the limit to 1 MB
     monitor.memoryLimit(1);
 
-    CAnomalyDetector detector(1, // identifier
-                              limits, modelConfig, EMPTY_STRING, FIRST_TIME,
+    CAnomalyDetector detector(limits, modelConfig, EMPTY_STRING, FIRST_TIME,
                               modelConfig.factory(key));
 
     monitor.forceRefresh(detector);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Do not pass detectorIndex to CAnomalyDetector  (#1259)