### PR TITLE
[ML] Improve time series decomposition adaption

### DIFF
--- a/include/maths/CAdaptiveBucketing.h
+++ b/include/maths/CAdaptiveBucketing.h
@@ -264,6 +264,9 @@ private:
     //! Implements split of \p bucket for derived state.
     virtual void split(std::size_t bucket) = 0;
 
+    //! Compute the p-value of the large error count for \p bucket.
+    double bucketLargeErrorCountPValue(double totalLargeErrorCount, std::size_t bucket) const;
+
     //! Check if there is evidence of systematically large errors in a
     //! bucket and split it if there is.
     void maybeSplitBucket();
@@ -292,7 +295,7 @@ private:
     core_t::TTime m_LastLargeErrorPeriod = 0;
 
     //! The p-values of the most significant large error counts.
-    TFloatUInt32PrMinAccumulator m_LargeErrorCountSignificances;
+    TFloatUInt32PrMinAccumulator m_LargeErrorCountPValues;
 
     //! The mean weight of values added.
     TFloatMeanAccumulator m_MeanWeight;

--- a/include/maths/CLeastSquaresOnlineRegressionDetail.h
+++ b/include/maths/CLeastSquaresOnlineRegressionDetail.h
@@ -55,8 +55,8 @@ void CLeastSquaresOnlineRegression<N, T>::shiftAbscissa(double dx) {
     //   -> 1/n * (  sum_i{ t(i)^i * y(i) }
     //             + sum_j{ (i j) * dx^(i - j) * sum_i{ t(i)^j y(i) } } )
 
-    double d[2 * N - 2] = {dx};
-    for (std::size_t i = 1u; i < 2 * N - 2; ++i) {
+    double d[2 * N - 2]{dx};
+    for (std::size_t i = 1; i < 2 * N - 2; ++i) {
         d[i] = d[i - 1] * dx;
     }
     LOG_TRACE(<< "d = " << core::CContainerPrinter::print(d));
@@ -65,14 +65,14 @@ void CLeastSquaresOnlineRegression<N, T>::shiftAbscissa(double dx) {
     for (std::size_t i = 2 * N - 2; i > 0; --i) {
         LOG_TRACE(<< "i = " << i);
         for (std::size_t j = 0; j < i; ++j) {
-            double bij = CCategoricalTools::binomialCoefficient(i, j) * d[i - j - 1];
+            double bij{CCategoricalTools::binomialCoefficient(i, j) * d[i - j - 1]};
             LOG_TRACE(<< "bij = " << bij);
             CBasicStatistics::moment<0>(m_S)(i) += bij * CBasicStatistics::mean(m_S)(j);
             if (i >= N) {
                 continue;
             }
-            std::size_t yi = i + 2 * N - 1;
-            std::size_t yj = j + 2 * N - 1;
+            std::size_t yi{i + 2 * N - 1};
+            std::size_t yj{j + 2 * N - 1};
             LOG_TRACE(<< "yi = " << yi << ", yj = " << yj);
             CBasicStatistics::moment<0>(m_S)(yi) += bij * CBasicStatistics::mean(m_S)(yj);
         }
@@ -146,14 +146,14 @@ bool CLeastSquaresOnlineRegression<N, T>::covariances(std::size_t n,
         case N: {
             constexpr int N_{static_cast<int>(N)};
             Eigen::Matrix<double, N_, N_> x;
-            if (!this->covariances(N, x, variance, maxCondition, result)) {
+            if (this->covariances(N, x, variance, maxCondition, result) == false) {
                 continue;
             }
             break;
         }
         default: {
             CDenseMatrix<double> x(n, n);
-            if (!this->covariances(n, x, variance, maxCondition, result)) {
+            if (this->covariances(n, x, variance, maxCondition, result) == false) {
                 continue;
             }
             break;
@@ -208,7 +208,7 @@ bool CLeastSquaresOnlineRegression<N, T>::parameters(std::size_t n,
 
     // Don't bother checking the solution since we check the matrix
     // condition above.
-    VECTOR r = svd.solve(y);
+    VECTOR r{svd.solve(y)};
     for (std::size_t i = 0; i < n; ++i) {
         result[i] = r(i);
     }

--- a/include/maths/CSeasonalComponent.h
+++ b/include/maths/CSeasonalComponent.h
@@ -129,7 +129,11 @@ public:
     void decayRate(double decayRate);
 
     //! Age out old data to account for elapsed \p time.
-    void propagateForwardsByTime(double time, bool meanRevert = false);
+    //!
+    //! \param[in] meanRevertFactor Controls how quicly the components mean
+    //! revert as a multiplier of the rate at which data is aged out of the
+    //! component. By default components don't mean revert.
+    void propagateForwardsByTime(double time, double meanRevertFactor = 0.0);
 
     //! Get the time provider.
     const CSeasonalTime& time() const;

--- a/include/maths/CSeasonalComponentAdaptiveBucketing.h
+++ b/include/maths/CSeasonalComponentAdaptiveBucketing.h
@@ -108,7 +108,11 @@ public:
     void add(core_t::TTime time, double value, double prediction, double weight = 1.0);
 
     //! Age the bucket values to account for \p time elapsed time.
-    void propagateForwardsByTime(double time, bool meanRevert = false);
+    //!
+    //! \param[in] meanRevertFactor Controls how quicly the components mean
+    //! revert as a multiplier of the rate at which data is aged out of the
+    //! component. By default components don't mean revert.
+    void propagateForwardsByTime(double time, double meanRevertFactor = 0.0);
 
     //! Get the time provider.
     const CSeasonalTime& time() const;

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -346,8 +346,8 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
         std::size_t s_ExpectedByMemoryUsageRelativeErrorDivisor;
         std::size_t s_ExpectedPartitionUsageRelativeErrorDivisor;
         std::size_t s_ExpectedOverUsageRelativeErrorDivisor;
-    } testParams[]{{600, 550, 6000, 300, 33, 40, 40},
-                   {3600, 550, 5500, 300, 27, 20, 20},
+    } testParams[]{{600, 550, 6000, 300, 33, 37, 40},
+                   {3600, 550, 5500, 300, 27, 25, 20},
                    {172800, 150, 850, 110, 6, 6, 3}};
 
     for (const auto& testParam : testParams) {
@@ -449,6 +449,7 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             LOG_DEBUG(<< "# partition = " << used.s_PartitionFields);
             LOG_DEBUG(<< "Memory status = " << used.s_MemoryStatus);
             LOG_DEBUG(<< "Memory usage = " << used.s_Usage);
+            LOG_DEBUG(<< "Memory limit bytes = " << memoryLimit * 1024 * 1024);
             BOOST_TEST_REQUIRE(used.s_PartitionFields > testParam.s_ExpectedPartitionFields);
             BOOST_TEST_REQUIRE(used.s_PartitionFields < 450);
             BOOST_TEST_REQUIRE(static_cast<double>(used.s_ByFields) >
@@ -498,6 +499,7 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             LOG_DEBUG(<< "# over = " << used.s_OverFields);
             LOG_DEBUG(<< "Memory status = " << used.s_MemoryStatus);
             LOG_DEBUG(<< "Memory usage = " << used.s_Usage);
+            LOG_DEBUG(<< "Memory limit bytes = " << memoryLimit * 1024 * 1024);
             BOOST_TEST_REQUIRE(used.s_OverFields > testParam.s_ExpectedOverFields);
             BOOST_TEST_REQUIRE(used.s_OverFields < 7000);
             BOOST_REQUIRE_CLOSE_ABSOLUTE(

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
         std::size_t s_ExpectedPartitionUsageRelativeErrorDivisor;
         std::size_t s_ExpectedOverUsageRelativeErrorDivisor;
     } testParams[]{{600, 550, 6000, 300, 33, 40, 40},
-                   {3600, 550, 5500, 300, 27, 25, 18},
+                   {3600, 550, 5500, 300, 27, 20, 20},
                    {172800, 150, 850, 110, 6, 6, 3}};
 
     for (const auto& testParam : testParams) {

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
         std::size_t s_ExpectedPartitionUsageRelativeErrorDivisor;
         std::size_t s_ExpectedOverUsageRelativeErrorDivisor;
     } testParams[]{{600, 550, 6000, 300, 33, 40, 40},
-                   {3600, 550, 5500, 300, 27, 25, 20},
+                   {3600, 550, 5500, 300, 27, 25, 18},
                    {172800, 150, 850, 110, 6, 6, 3}};
 
     for (const auto& testParam : testParams) {

--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -81,13 +81,13 @@ private:
 };
 
 //! Convert to a delimited string.
-std::string significanceToDelimited(const TFloatUInt32Pr& value) {
+std::string pValueToDelimited(const TFloatUInt32Pr& value) {
     return value.first.toString() + CBasicStatistics::EXTERNAL_DELIMITER +
            core::CStringUtils::typeToString(value.second);
 }
 
 //! Initialize from a delimited string.
-bool significanceFromDelimited(const std::string& delimited, TFloatUInt32Pr& value) {
+bool pValueFromDelimited(const std::string& delimited, TFloatUInt32Pr& value) {
     std::size_t pos{delimited.find(CBasicStatistics::EXTERNAL_DELIMITER)};
     if (pos == std::string::npos) {
         LOG_ERROR(<< "Failed to delimiter in '" << delimited << "'");
@@ -119,13 +119,13 @@ const core::TPersistenceTag LARGE_ERROR_COUNTS_TAG{"f", "large_error_counts"};
 const core::TPersistenceTag TARGET_SIZE_TAG{"g", "target size"};
 const core::TPersistenceTag LAST_LARGE_ERROR_BUCKET_TAG{"h", "last_large_error_bucket"};
 const core::TPersistenceTag LAST_LARGE_ERROR_PERIOD_TAG{"i", "last_large_error_period"};
-const core::TPersistenceTag LARGE_ERROR_COUNT_SIGNIFICANCES_TAG{"j", "large_error_counts_significance"};
+const core::TPersistenceTag LARGE_ERROR_COUNT_P_VALUES_TAG{"j", "large_error_counts_p_values"};
 const core::TPersistenceTag MEAN_WEIGHT_TAG{"k", "mean weight"};
 const std::string EMPTY_STRING;
 
 const double SMOOTHING_FUNCTION[]{0.25, 0.5, 0.25};
 const std::size_t WIDTH{boost::size(SMOOTHING_FUNCTION) / 2};
-const double ALPHA{0.25};
+const double ALPHA{0.35};
 const double EPS{std::numeric_limits<double>::epsilon()};
 const double WEIGHTS[]{1.0, 1.0, 1.0, 0.75, 0.5};
 const double MINIMUM_DECAY_RATE{0.001};
@@ -157,8 +157,8 @@ bool CAdaptiveBucketing::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
         RESTORE_BUILT_IN(TARGET_SIZE_TAG, m_TargetSize)
         RESTORE_BUILT_IN(LAST_LARGE_ERROR_BUCKET_TAG, m_LastLargeErrorBucket)
         RESTORE_BUILT_IN(LAST_LARGE_ERROR_PERIOD_TAG, m_LastLargeErrorPeriod)
-        RESTORE(LARGE_ERROR_COUNT_SIGNIFICANCES_TAG,
-                m_LargeErrorCountSignificances.fromDelimited(traverser.value(), significanceFromDelimited))
+        RESTORE(LARGE_ERROR_COUNT_P_VALUES_TAG,
+                m_LargeErrorCountPValues.fromDelimited(traverser.value(), pValueFromDelimited))
         RESTORE(MEAN_WEIGHT_TAG, m_MeanWeight.fromDelimited(traverser.value()))
         RESTORE(ENDPOINT_TAG, core::CPersistUtils::fromString(traverser.value(), m_Endpoints))
         RESTORE(CENTRES_TAG, core::CPersistUtils::fromString(traverser.value(), m_Centres))
@@ -183,8 +183,8 @@ void CAdaptiveBucketing::acceptPersistInserter(core::CStatePersistInserter& inse
     inserter.insertValue(TARGET_SIZE_TAG, m_TargetSize);
     inserter.insertValue(LAST_LARGE_ERROR_BUCKET_TAG, m_LastLargeErrorBucket);
     inserter.insertValue(LAST_LARGE_ERROR_PERIOD_TAG, m_LastLargeErrorPeriod);
-    inserter.insertValue(LARGE_ERROR_COUNT_SIGNIFICANCES_TAG,
-                         m_LargeErrorCountSignificances.toDelimited(significanceToDelimited));
+    inserter.insertValue(LARGE_ERROR_COUNT_P_VALUES_TAG,
+                         m_LargeErrorCountPValues.toDelimited(pValueToDelimited));
     inserter.insertValue(MEAN_WEIGHT_TAG, m_MeanWeight.toDelimited());
     inserter.insertValue(ENDPOINT_TAG, core::CPersistUtils::toString(m_Endpoints));
     inserter.insertValue(CENTRES_TAG, core::CPersistUtils::toString(m_Centres));
@@ -202,7 +202,7 @@ void CAdaptiveBucketing::swap(CAdaptiveBucketing& other) {
     std::swap(m_TargetSize, other.m_TargetSize);
     std::swap(m_LastLargeErrorBucket, other.m_LastLargeErrorBucket);
     std::swap(m_LastLargeErrorPeriod, other.m_LastLargeErrorPeriod);
-    std::swap(m_LargeErrorCountSignificances, other.m_LargeErrorCountSignificances);
+    std::swap(m_LargeErrorCountPValues, other.m_LargeErrorCountPValues);
     std::swap(m_MeanWeight, other.m_MeanWeight);
     m_Endpoints.swap(other.m_Endpoints);
     m_Centres.swap(other.m_Centres);
@@ -250,24 +250,31 @@ void CAdaptiveBucketing::initialValues(core_t::TTime start,
         return;
     }
 
-    core_t::TTime size{static_cast<core_t::TTime>(values.size())};
-    core_t::TTime dT{(end - start) / size};
+    std::size_t n{values.size()};
+    core_t::TTime dT{(end - start) / static_cast<core_t::TTime>(n)};
     core_t::TTime dt{static_cast<core_t::TTime>(
         CTools::truncate(m_MinimumBucketLength, 1.0, static_cast<double>(dT)))};
+    core_t::TTime repeat{static_cast<core_t::TTime>(
+        m_Endpoints[m_Endpoints.size() - 1] - m_Endpoints[0])};
 
     double scale{std::pow(static_cast<double>(dt) / static_cast<double>(dT), 2.0)};
 
+    core_t::TTime lastRefined{start + dt / 2};
     for (core_t::TTime time = start + dt / 2; time < end; time += dt) {
         if (this->inWindow(time)) {
             core_t::TTime i{(time - start) / dT};
             double value{CBasicStatistics::mean(values[i])};
             double weight{scale * CBasicStatistics::count(values[i])};
-            if (weight > 0.0) {
-                std::size_t bucket;
-                if (this->bucket(time, bucket)) {
+            std::size_t bucket;
+            if (this->bucket(time, bucket)) {
+                if (weight > 0.0) {
                     this->add(bucket, time, weight);
                     this->add(bucket, time, value, weight);
                 }
+            }
+            if (time - start >= lastRefined + repeat) {
+                this->refine(time);
+                lastRefined += repeat;
             }
         }
     }
@@ -345,7 +352,7 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
     // Extract the bucket means.
     TDoubleDoublePrVec values;
     values.reserve(n);
-    for (std::size_t i = 0u; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
         values.emplace_back(this->bucketCount(i), this->predict(i, time, m_Centres[i]));
     }
     LOG_TRACE(<< "values = " << core::CContainerPrinter::print(values));
@@ -354,13 +361,13 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
     // boundary conditions at the start and end of the interval.
     TDoubleVec ranges;
     ranges.reserve(n);
-    for (std::size_t i = 0u; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
         TDoubleDoublePr v[]{values[(n + i - 2) % n], values[(n + i - 1) % n],
                             values[(n + i + 0) % n], // centre
                             values[(n + i + 1) % n], values[(n + i + 2) % n]};
 
         TMinMaxAccumulator minmax;
-        for (std::size_t j = 0u; j < sizeof(v) / sizeof(v[0]); ++j) {
+        for (std::size_t j = 0; j < sizeof(v) / sizeof(v[0]); ++j) {
             if (v[j].first > 0.0) {
                 minmax.add({v[j].second, j});
             }
@@ -382,11 +389,11 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
     // bucket by multiplying the smoothed range by the bucket width.
     TDoubleVec averagingErrors;
     averagingErrors.reserve(n);
-    for (std::size_t i = 0u; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
         double ai{m_Endpoints[i]};
         double bi{m_Endpoints[i + 1]};
         double error{0.0};
-        for (std::size_t j = 0u; j < boost::size(SMOOTHING_FUNCTION); ++j) {
+        for (std::size_t j = 0; j < boost::size(SMOOTHING_FUNCTION); ++j) {
             error += SMOOTHING_FUNCTION[j] * ranges[(n + i + j - WIDTH) % n];
         }
         double h{bi - ai};
@@ -395,9 +402,9 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
     }
     double maxAveragingError{
         *std::max_element(averagingErrors.begin(), averagingErrors.end())};
-    for (const auto& significance : m_LargeErrorCountSignificances) {
-        if (significance.first < MODERATE_SIGNIFICANCE) {
-            averagingErrors[significance.second] = maxAveragingError;
+    for (const auto& pValue : m_LargeErrorCountPValues) {
+        if (pValue.first < MODERATE_SIGNIFICANCE) {
+            averagingErrors[pValue.second] = maxAveragingError;
         }
     }
     double totalAveragingError{
@@ -414,7 +421,7 @@ void CAdaptiveBucketing::refine(core_t::TTime time) {
     // should be equidistant. We check step in case of underflow.
     if (step == 0.0) {
         m_Endpoints[0] = a;
-        for (std::size_t i = 0u; i < n; ++i) {
+        for (std::size_t i = 0; i < n; ++i) {
             m_Endpoints[i] = (b - a) * static_cast<double>(i) / n_;
         }
         m_Endpoints[n] = b;
@@ -489,7 +496,7 @@ bool CAdaptiveBucketing::knots(core_t::TTime time,
     variances.clear();
 
     std::size_t n{m_Centres.size()};
-    for (std::size_t i = 0u; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
         if (this->bucketCount(i) > 0.0) {
             double wide{3.0 * (m_Endpoints[n] - m_Endpoints[0]) / static_cast<double>(n)};
             LOG_TRACE(<< "period " << m_Endpoints[n] - m_Endpoints[0]
@@ -502,8 +509,6 @@ bool CAdaptiveBucketing::knots(core_t::TTime time,
             values.reserve(4 * n / 3);
             variances.reserve(4 * n / 3);
 
-            double a{m_Endpoints[i]};
-            double b{m_Endpoints[i + 1]};
             double c{m_Centres[i]};
             double c0{c - m_Endpoints[0]};
             knots.push_back(m_Endpoints[0]);
@@ -511,20 +516,22 @@ bool CAdaptiveBucketing::knots(core_t::TTime time,
             variances.push_back(this->variance(i));
             for (/**/; i < n; ++i) {
                 if (this->bucketCount(i) > 0.0) {
-                    a = m_Endpoints[i];
-                    b = m_Endpoints[i + 1];
+                    double a{m_Endpoints[i]};
+                    double b{m_Endpoints[i + 1]};
+                    double min{(9.0 * a + b) / 10.0};
+                    double max{(a + 9.0 * b) / 10.0};
                     c = m_Centres[i];
                     double m{this->predict(i, time, c)};
                     double v{this->variance(i)};
                     if (b - a > wide) {
-                        knots.push_back(std::max(c - (b - a) / 4.0, a));
+                        knots.push_back(std::max(c - (b - a) / 4.0, min));
                         values.push_back(m);
                         variances.push_back(v);
-                        knots.push_back(std::min(c + (b - a) / 4.0, b));
+                        knots.push_back(std::min(c + (b - a) / 4.0, max));
                         values.push_back(m);
                         variances.push_back(v);
                     } else {
-                        knots.push_back(c);
+                        knots.push_back(std::min(std::max(c, min), max));
                         values.push_back(m);
                         variances.push_back(v);
                     }
@@ -663,7 +670,7 @@ void CAdaptiveBucketing::spread(double a, double b, double separation, TFloatVec
         contiguousPoints.emplace_back(point);
     }
 
-    for (std::size_t previousSize{0}; contiguousPoints.size() != previousSize;
+    for (std::size_t previousSize = 0; contiguousPoints.size() != previousSize;
          /**/) {
         previousSize = contiguousPoints.size();
         std::size_t last{0};
@@ -709,20 +716,20 @@ CAdaptiveBucketing::TFloatVec& CAdaptiveBucketing::largeErrorCounts() {
 }
 
 double CAdaptiveBucketing::adjustedWeight(std::size_t bucket, double weight) const {
-    for (const auto& significance : m_LargeErrorCountSignificances) {
-        if (bucket == significance.second) {
-            double maxWeight{CBasicStatistics::mean(m_MeanWeight)};
-            double logSignificance{CTools::fastLog(significance.first)};
+    for (const auto& pValue : m_LargeErrorCountPValues) {
+        if (bucket == pValue.second) {
+            double largeWeight{2.0 * CBasicStatistics::mean(m_MeanWeight)};
+            double logPValue{CTools::fastLog(pValue.first)};
             return CTools::linearlyInterpolate(LOG_HIGH_SIGNIFICANCE, LOG_MODERATE_SIGNIFICANCE,
-                                               maxWeight, weight, logSignificance);
+                                               largeWeight, weight, logPValue);
         }
     }
     return weight;
 }
 
 double CAdaptiveBucketing::count() const {
-    double result = 0.0;
-    for (std::size_t i = 0u; i < m_Centres.size(); ++i) {
+    double result{0.0};
+    for (std::size_t i = 0; i < m_Centres.size(); ++i) {
         result += this->bucketCount(i);
     }
     return result;
@@ -731,7 +738,7 @@ double CAdaptiveBucketing::count() const {
 CAdaptiveBucketing::TDoubleVec CAdaptiveBucketing::values(core_t::TTime time) const {
     TDoubleVec result;
     result.reserve(m_Centres.size());
-    for (std::size_t i = 0u; i < m_Centres.size(); ++i) {
+    for (std::size_t i = 0; i < m_Centres.size(); ++i) {
         result.push_back(this->predict(i, time, m_Centres[i]));
     }
     return result;
@@ -740,7 +747,7 @@ CAdaptiveBucketing::TDoubleVec CAdaptiveBucketing::values(core_t::TTime time) co
 CAdaptiveBucketing::TDoubleVec CAdaptiveBucketing::variances() const {
     TDoubleVec result;
     result.reserve(m_Centres.size());
-    for (std::size_t i = 0u; i < m_Centres.size(); ++i) {
+    for (std::size_t i = 0; i < m_Centres.size(); ++i) {
         result.push_back(this->variance(i));
     }
     return result;
@@ -766,8 +773,7 @@ uint64_t CAdaptiveBucketing::checksum(uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_TargetSize);
     seed = CChecksum::calculate(seed, m_LastLargeErrorBucket);
     seed = CChecksum::calculate(seed, m_LastLargeErrorPeriod);
-    seed = CChecksum::calculate(
-        seed, m_LargeErrorCountSignificances.toDelimited(significanceToDelimited));
+    seed = CChecksum::calculate(seed, m_LargeErrorCountPValues.toDelimited(pValueToDelimited));
     seed = CChecksum::calculate(seed, m_MeanWeight);
     seed = CChecksum::calculate(seed, m_Endpoints);
     seed = CChecksum::calculate(seed, m_Centres);
@@ -783,54 +789,66 @@ std::size_t CAdaptiveBucketing::memoryUsage() const {
     return mem;
 }
 
+double CAdaptiveBucketing::bucketLargeErrorCountPValue(double totalLargeErrorCount,
+                                                       std::size_t bucket) const {
+    // We compute the right tail p-value of the count of large errors
+    // in a bucket for the null hypothesis that they are uniformly
+    // distributed on the total bucketed period, i.e. that there is
+    // not some poorly modelled periodic pattern.
+
+    if (m_LargeErrorCounts[bucket] > 2.0) { // Are there repeats?
+        double interval{m_Endpoints[bucket + 1] - m_Endpoints[bucket]};
+        double period{m_Endpoints[m_Endpoints.size() - 1] - m_Endpoints[0]};
+        try {
+            boost::math::binomial binomial{totalLargeErrorCount, interval / period};
+            return CTools::safeCdfComplement(binomial, m_LargeErrorCounts[bucket]);
+        } catch (const std::exception& e) {
+            LOG_ERROR(<< "Failed to calculate splitting significance: '" << e.what()
+                      << "' interval = " << interval << " period = " << period
+                      << " buckets = " << core::CContainerPrinter::print(m_Endpoints)
+                      << " type = " << this->name());
+        }
+    }
+    return 1.0;
+}
+
 void CAdaptiveBucketing::maybeSplitBucket() {
-    double largeErrorCount{std::accumulate(m_LargeErrorCounts.begin(),
-                                           m_LargeErrorCounts.end(), 0.0)};
+
+    double totalLargeErrorCount{std::accumulate(m_LargeErrorCounts.begin(),
+                                                m_LargeErrorCounts.end(), 0.0)};
+
+    // We do this indepedent of whether we'll split because we also use the
+    // significances to adjust the bucket update weight.
+    m_LargeErrorCountPValues = TFloatUInt32PrMinAccumulator{};
+    for (std::size_t i = 0; i + 1 < m_Endpoints.size(); ++i) {
+        m_LargeErrorCountPValues.add(
+            {this->bucketLargeErrorCountPValue(totalLargeErrorCount, i), i});
+    }
+
+    // We're choosing the minimum p-value of number of buckets independent
+    // statistics so the significance is one minus the chance that all of
+    // them are greater than the observation.
+    for (auto& candidateSplit : m_LargeErrorCountPValues) {
+        candidateSplit.first = CTools::oneMinusPowOneMinusX(
+            candidateSplit.first, static_cast<double>(this->size()));
+        LOG_TRACE(<< "bucket [" << m_Endpoints[candidateSplit.second] << ","
+                  << m_Endpoints[candidateSplit.second + 1]
+                  << ") split p-value = " << candidateSplit.first);
+    }
+    m_LargeErrorCountPValues.sort();
+
     double period{m_Endpoints[m_Endpoints.size() - 1] - m_Endpoints[0]};
+    double pValue;
+    std::size_t bucketToSplit;
+    std::tie(pValue, bucketToSplit) = m_LargeErrorCountPValues[0];
 
-    if (static_cast<double>(this->size() + 1) * m_MinimumBucketLength <= period &&
-        largeErrorCount >= MINIMUM_LARGE_ERROR_COUNT_TO_SPLIT) {
-
-        m_LargeErrorCountSignificances = TFloatUInt32PrMinAccumulator{};
-
-        // We compute the right tail p-value of the count of large errors
-        // in a bucket for the null hypothesis that they are uniformly
-        // distributed on the total bucketed period and split if this is
-        // less than a specified threshold.
-        for (std::size_t i = 1; i < m_Endpoints.size(); ++i) {
-            double interval{m_Endpoints[i] - m_Endpoints[i - 1]};
-            try {
-                boost::math::binomial binomial{largeErrorCount, interval / period};
-                double oneMinusCdf{
-                    CTools::safeCdfComplement(binomial, m_LargeErrorCounts[i - 1])};
-                m_LargeErrorCountSignificances.add({oneMinusCdf, i - 1});
-            } catch (const std::exception& e) {
-                LOG_ERROR(<< "Failed to calculate splitting significance: '"
-                          << e.what() << "' interval = " << interval << " period = " << period
-                          << " buckets = " << core::CContainerPrinter::print(m_Endpoints)
-                          << " type = " << this->name());
-            }
-        }
-        if (m_LargeErrorCountSignificances.count() > 0) {
-            // We're choosing the minimum p-value of number of buckets
-            // independent statistics so the significance is one minus
-            // the chance that all of them are greater than the observation.
-            for (auto& significance : m_LargeErrorCountSignificances) {
-                significance.first = CTools::oneMinusPowOneMinusX(
-                    significance.first, static_cast<double>(this->size()));
-                LOG_TRACE(<< "bucket [" << m_Endpoints[significance.second]
-                          << "," << m_Endpoints[significance.second + 1]
-                          << ") split significance = " << significance.first);
-            }
-            m_LargeErrorCountSignificances.sort();
-        }
-
-        if (2 * this->size() < 3 * m_TargetSize &&
-            largeErrorCount > MINIMUM_LARGE_ERROR_COUNT_TO_SPLIT &&
-            m_LargeErrorCountSignificances.count() > 0 &&
-            m_LargeErrorCountSignificances[0].first < HIGH_SIGNIFICANCE) {
-            this->splitBucket(m_LargeErrorCountSignificances[0].second);
-        }
+    // Split if we have received enough data, can divide the interval further
+    // and the significance is high.
+    if (totalLargeErrorCount >= MINIMUM_LARGE_ERROR_COUNT_TO_SPLIT &&
+        m_LargeErrorCountPValues.count() > 0 &&
+        static_cast<double>(this->size() + 1) * m_MinimumBucketLength < period &&
+        2 * this->size() < 3 * m_TargetSize && pValue < HIGH_SIGNIFICANCE) {
+        this->splitBucket(bucketToSplit);
     }
 }
 

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -170,8 +170,8 @@ void CSeasonalComponent::decayRate(double decayRate) {
     return m_Bucketing.decayRate(decayRate);
 }
 
-void CSeasonalComponent::propagateForwardsByTime(double time, bool meanRevert) {
-    m_Bucketing.propagateForwardsByTime(time, meanRevert);
+void CSeasonalComponent::propagateForwardsByTime(double time, double meanRevertFactor) {
+    m_Bucketing.propagateForwardsByTime(time, meanRevertFactor);
 }
 
 const CSeasonalTime& CSeasonalComponent::time() const {

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -240,14 +240,14 @@ const CSeasonalTime& CSeasonalComponentAdaptiveBucketing::time() const {
     return *m_Time;
 }
 
-void CSeasonalComponentAdaptiveBucketing::propagateForwardsByTime(double time, bool meanRevert) {
+void CSeasonalComponentAdaptiveBucketing::propagateForwardsByTime(double time, double meanRevertFactor) {
     if (time < 0.0) {
         LOG_ERROR(<< "Can't propagate bucketing backwards in time");
     } else if (this->initialized()) {
         double factor{std::exp(-this->decayRate() * m_Time->fractionInWindow() * time)};
         this->age(factor);
         for (auto& bucket : m_Buckets) {
-            bucket.s_Regression.age(factor, meanRevert);
+            bucket.s_Regression.age(factor, meanRevertFactor);
         }
     }
 }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -200,22 +200,17 @@ void decompose(double trend,
 
 //! Propagate \p target forwards to account for \p end - \p start elapsed
 //! time in steps or size \p step.
-template<typename PTR>
-double stepwisePropagateForwards(const PTR& target,
-                                 core_t::TTime start,
-                                 core_t::TTime end,
-                                 core_t::TTime step,
-                                 double scale = 1.0) {
-    double time{0.0};
-    if (target) {
-        start = CIntegerTools::floor(start, step);
-        end = CIntegerTools::floor(end, step);
-        if (end > start) {
-            time = scale * static_cast<double>(end - start) / static_cast<double>(step);
-            target->propagateForwardsByTime(time);
-        }
+template<typename F>
+void stepwisePropagateForwards(core_t::TTime start,
+                               core_t::TTime end,
+                               core_t::TTime step,
+                               const F& propagateForwardsByTime) {
+    start = CIntegerTools::floor(start, step);
+    end = CIntegerTools::floor(end, step);
+    if (end > start) {
+        double time{static_cast<double>(end - start) / static_cast<double>(step)};
+        propagateForwardsByTime(time);
     }
-    return time;
 }
 
 // Periodicity Test State Machine
@@ -556,7 +551,9 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::handle(const SAddValue& m
     core_t::TTime time{message.s_Time};
     double value{message.s_Value};
     const maths_t::TDoubleWeightsAry& weights{message.s_Weights};
-    double weight{maths_t::countForUpdate(weights)};
+    // We have explicit handling of outliers and we can't accurately assess
+    // them anyway before we've detected periodicity.
+    double weight{maths_t::count(weights)};
 
     this->test(message);
 
@@ -645,8 +642,16 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::shiftTime(core_t::TTime d
 
 void CTimeSeriesDecompositionDetail::CPeriodicityTest::propagateForwards(core_t::TTime start,
                                                                          core_t::TTime end) {
-    stepwisePropagateForwards(m_Windows[E_Short], start, end, DAY);
-    stepwisePropagateForwards(m_Windows[E_Long], start, end, WEEK);
+    if (m_Windows[E_Short] != nullptr) {
+        stepwisePropagateForwards(start, end, DAY, [this](double time) {
+            m_Windows[E_Short]->propagateForwardsByTime(time);
+        });
+    }
+    if (m_Windows[E_Long] != nullptr) {
+        stepwisePropagateForwards(start, end, WEEK, [this](double time) {
+            m_Windows[E_Long]->propagateForwardsByTime(time);
+        });
+    }
 }
 
 CTimeSeriesDecompositionDetail::TFloatMeanAccumulatorVec
@@ -977,7 +982,11 @@ void CTimeSeriesDecompositionDetail::CCalendarTest::test(const SMessage& message
 
 void CTimeSeriesDecompositionDetail::CCalendarTest::propagateForwards(core_t::TTime start,
                                                                       core_t::TTime end) {
-    stepwisePropagateForwards(m_Test, start, end, DAY);
+    if (m_Test != nullptr) {
+        stepwisePropagateForwards(start, end, DAY, [this](double time) {
+            m_Test->propagateForwardsByTime(time);
+        });
+    }
 }
 
 uint64_t CTimeSeriesDecompositionDetail::CCalendarTest::checksum(uint64_t seed) const {
@@ -2183,13 +2192,12 @@ bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::removeComponentsWit
 
 void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::propagateForwards(core_t::TTime start,
                                                                                core_t::TTime end) {
-    for (std::size_t i = 0u; i < m_Components.size(); ++i) {
+    for (std::size_t i = 0; i < m_Components.size(); ++i) {
         core_t::TTime period{m_Components[i].time().period()};
-        double time{stepwisePropagateForwards(
-            &m_Components[i], start, end, CTools::truncate(period, DAY, WEEK), 1.0 / 3.0)};
-        if (time > 0.0) {
+        stepwisePropagateForwards(start, end, period, [&](double time) {
+            m_Components[i].propagateForwardsByTime(time / 4.0, 0.25);
             m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
-        }
+        });
     }
 }
 
@@ -2486,11 +2494,11 @@ void CTimeSeriesDecompositionDetail::CComponents::CCalendar::decayRate(double de
 
 void CTimeSeriesDecompositionDetail::CComponents::CCalendar::propagateForwards(core_t::TTime start,
                                                                                core_t::TTime end) {
-    for (std::size_t i = 0u; i < m_Components.size(); ++i) {
-        double time{stepwisePropagateForwards(&m_Components[i], start, end, MONTH, 1.0 / 3.0)};
-        if (time > 0.0) {
+    for (std::size_t i = 0; i < m_Components.size(); ++i) {
+        stepwisePropagateForwards(start, end, MONTH, [&](double time) {
+            m_Components[i].propagateForwardsByTime(time / 4.0);
             m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
-        }
+        });
     }
 }
 

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -158,12 +158,12 @@ void test(TTrend trend,
 
     core_t::TTime time{0};
     TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
-    for (std::size_t d = 0u; d < daysToLearn; ++d) {
+    for (std::size_t d = 0; d < daysToLearn; ++d) {
         TDoubleVec noise;
         rng.generateNormalSamples(0.0, noiseVariance,
                                   core::constants::DAY / bucketLength, noise);
 
-        for (std::size_t i = 0u; i < noise.size(); ++i, time += bucketLength) {
+        for (std::size_t i = 0; i < noise.size(); ++i, time += bucketLength) {
             maths::CModelAddSamplesParams params;
             params.integer(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
             double yi{trend(time, noise[i])};
@@ -188,12 +188,12 @@ void test(TTrend trend,
     std::size_t count{0};
     TMeanAccumulator error;
 
-    for (std::size_t i = 0u; i < prediction.size(); /**/) {
+    for (std::size_t i = 0; i < prediction.size(); /**/) {
         TDoubleVec noise;
         rng.generateNormalSamples(0.0, noiseVariance,
                                   core::constants::DAY / bucketLength, noise);
         TDoubleVec day;
-        for (std::size_t j = 0u; i < prediction.size() && j < noise.size();
+        for (std::size_t j = 0; i < prediction.size() && j < noise.size();
              ++i, ++j, time += bucketLength) {
             double yj{trend(time, noise[j])};
             day.push_back(yj);
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(testDailyNoLongTermTrend) {
         return 40.0 + alpha * y[i / 6] + beta * y[(i / 6 + 1) % y.size()] + noise;
     };
 
-    test(trend, bucketLength, 63, 64.0, 4.5, 0.15);
+    test(trend, bucketLength, 63, 64.0, 6.0, 0.15);
 }
 
 BOOST_AUTO_TEST_CASE(testDailyConstantLongTermTrend) {
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(testComplexNoLongTermTrend) {
         return scale[d] * (20.0 + y[h] + noise);
     };
 
-    test(trend, bucketLength, 63, 24.0, 5.0, 0.14);
+    test(trend, bucketLength, 63, 24.0, 5.0, 0.13);
 }
 
 BOOST_AUTO_TEST_CASE(testComplexConstantLongTermTrend) {
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(testComplexVaryingLongTermTrend) {
         return trend_.value(time_) + scale[d] * (20.0 + y[h] + noise);
     };
 
-    test(trend, bucketLength, 63, 4.0, 19.0, 0.04);
+    test(trend, bucketLength, 63, 4.0, 5.0, 0.03);
 }
 
 BOOST_AUTO_TEST_CASE(testNonNegative) {
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(testFinancialIndex) {
     core_t::TTime endTime;
     BOOST_TEST_REQUIRE(test::CTimeSeriesTestData::parse(
         "testfiles/financial_index.csv", timeseries, startTime, endTime, "^([0-9]+),([0-9\\.]+)"));
-    BOOST_TEST_REQUIRE(!timeseries.empty());
+    BOOST_TEST_REQUIRE(timeseries.empty() == false);
 
     LOG_DEBUG(<< "timeseries = "
               << core::CContainerPrinter::print(timeseries.begin(), timeseries.begin() + 10)

--- a/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
+++ b/lib/maths/unittest/CPeriodicityHypothesisTestsTest.cc
@@ -949,7 +949,7 @@ BOOST_AUTO_TEST_CASE(testWithPiecewiseLinearTrend) {
     }
 
     LOG_DEBUG(<< "Recall = " << TP / (TP + FN));
-    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.9);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.89);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentTest.cc
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
         totalError2 /= 30.0;
         LOG_DEBUG(<< "totalError1 = " << totalError1);
         LOG_DEBUG(<< "totalError2 = " << totalError2);
-        BOOST_TEST_REQUIRE(totalError1 < 0.42);
+        BOOST_TEST_REQUIRE(totalError1 < 0.46);
         BOOST_TEST_REQUIRE(totalError2 < 0.01);
     }
 
@@ -511,7 +511,7 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
                           << mean(seasonal.value(time + core::constants::DAY - 1, 0.0)));
                 BOOST_REQUIRE_CLOSE_ABSOLUTE(
                     mean(seasonal.value(time, 0.0)),
-                    mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.2);
+                    mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.4);
             }
 
             error1 /= static_cast<double>(function.size());

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -210,8 +210,8 @@ BOOST_FIXTURE_TEST_CASE(testSuperpositionOfSines, CTestFixture) {
             LOG_TRACE(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                BOOST_TEST_REQUIRE(sumResidual < 0.055 * sumValue);
-                BOOST_TEST_REQUIRE(maxResidual < 0.10 * maxValue);
+                BOOST_TEST_REQUIRE(sumResidual < 0.06 * sumValue);
+                BOOST_TEST_REQUIRE(maxResidual < 0.12 * maxValue);
                 BOOST_TEST_REQUIRE(percentileError < 0.03 * sumValue);
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -229,7 +229,7 @@ BOOST_FIXTURE_TEST_CASE(testSuperpositionOfSines, CTestFixture) {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     BOOST_TEST_REQUIRE(totalSumResidual < 0.016 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.02 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.021 * totalMaxValue);
     BOOST_TEST_REQUIRE(totalPercentileError < 0.01 * totalSumValue);
 }
 
@@ -413,7 +413,7 @@ BOOST_FIXTURE_TEST_CASE(testMinimizeLongComponents, CTestFixture) {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     BOOST_TEST_REQUIRE(totalSumResidual < 0.06 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.20 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.19 * totalMaxValue);
     BOOST_TEST_REQUIRE(totalPercentileError < 0.03 * totalSumValue);
 
     meanSlope /= refinements;
@@ -635,7 +635,7 @@ BOOST_FIXTURE_TEST_CASE(testSinglePeriodicity, CTestFixture) {
 
             if (time >= 1 * WEEK) {
                 BOOST_TEST_REQUIRE(sumResidual < 0.025 * sumValue);
-                BOOST_TEST_REQUIRE(maxResidual < 0.035 * maxValue);
+                BOOST_TEST_REQUIRE(maxResidual < 0.040 * maxValue);
                 BOOST_TEST_REQUIRE(percentileError < 0.01 * sumValue);
 
                 totalSumResidual += sumResidual;
@@ -764,9 +764,9 @@ BOOST_FIXTURE_TEST_CASE(testSeasonalOnset, CTestFixture) {
     LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.08 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.1 * totalMaxValue);
-    BOOST_TEST_REQUIRE(totalPercentileError < 0.05 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.10 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.12 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalPercentileError < 0.06 * totalSumValue);
 }
 
 BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {
@@ -819,7 +819,7 @@ BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError));
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.3);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.38);
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentileError) < 0.05);
         BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, maths::CBasicStatistics::mean(meanScale), 0.04);
     }
@@ -1240,7 +1240,7 @@ BOOST_FIXTURE_TEST_CASE(testMixedSmoothAndSpikeyDataProblemCase, CTestFixture) {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.2 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.21 * totalSumValue);
     BOOST_TEST_REQUIRE(totalMaxResidual < 0.44 * totalMaxValue);
     BOOST_TEST_REQUIRE(totalPercentileError < 0.06 * totalSumValue);
 }
@@ -1633,8 +1633,8 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
         LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
         LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
 
-        BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.14);
-        BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.12);
+        BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.17);
+        BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.15);
     }
 
     LOG_DEBUG(<< "Two daily");
@@ -1977,7 +1977,7 @@ BOOST_FIXTURE_TEST_CASE(testComponentLifecycle, CTestFixture) {
         debug.addPrediction(time, prediction, trend(time) + noise[0] - prediction);
     }
 
-    double bounds[]{0.01, 0.018, 0.025, 0.06};
+    double bounds[]{0.01, 0.016, 0.01, 0.07};
     for (std::size_t i = 0; i < 4; ++i) {
         double error{maths::CBasicStatistics::mean(errors[i])};
         LOG_DEBUG(<< "error = " << error);

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -984,12 +984,12 @@ BOOST_AUTO_TEST_CASE(testPredict) {
             LOG_DEBUG(<< "expected = " << expected << " predicted = " << predicted
                       << " (trend = " << trend_ << ")");
             BOOST_REQUIRE_CLOSE_ABSOLUTE(expected, predicted, 1e-3 * expected);
-            BOOST_TEST_REQUIRE(std::fabs(trend_ - predicted) / trend_ < 0.2);
+            BOOST_TEST_REQUIRE(std::fabs(trend_ - predicted) / trend_ < 0.35);
             meanError.add(std::fabs(trend_ - predicted) / trend_);
         }
 
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.05);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.06);
     }
 
     LOG_DEBUG(<< "Univariate nearest mode");
@@ -1078,6 +1078,7 @@ BOOST_AUTO_TEST_CASE(testPredict) {
             time += bucketLength;
         }
 
+        TMeanAccumulator meanError;
         for (core_t::TTime time_ = time; time_ < time + 86400; time_ += 3600) {
             maths::CMultivariatePrior::TSize10Vec marginalize{1, 2};
             maths::CMultivariatePrior::TSizeDoublePr10Vec condition;
@@ -1095,9 +1096,13 @@ BOOST_AUTO_TEST_CASE(testPredict) {
                 LOG_DEBUG(<< "expected = " << expected << " predicted = " << predicted
                           << " (trend = " << trend_ << ")");
                 BOOST_REQUIRE_CLOSE_ABSOLUTE(expected, predicted, 1e-3 * expected);
-                BOOST_TEST_REQUIRE(std::fabs(trend_ - predicted) / trend_ < 0.25);
+                BOOST_TEST_REQUIRE(std::fabs(trend_ - predicted) / trend_ < 0.35);
+                meanError.add(std::fabs(trend_ - predicted) / trend_);
             }
         }
+
+        LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.06);
     }
 
     LOG_DEBUG(<< "Multivariate nearest mode");

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2868,7 +2868,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanPredictionError) <
-                           0.76 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                           0.82 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2338,7 +2338,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanPredictionError) <
-                           0.72 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                           0.78 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 


### PR DESCRIPTION
This makes a couple of enhancements aimed at #1202.

In particular, we track where anomalies occur for each seasonal component and increase the rate at which we learn from them if there is strong evidence they're occurring periodically. However, we were only doing this for shorter bucket lengths, meaning we could take much longer than intended to adapt for long buckets.

This also reworks mean reversion of seasonal components to be have a continuous parameterisation. Together with how quickly we adjust the position of the local regression model and how quickly we age out old data, this gives us three parameters which control how fast we'll adapt to changes and stability. I did a grid search over these parameters for a range of different QA data sets and chose the values to with the best "calibration", i.e. comparing the bucket predicted distribution to actual error distribution.

I also made a couple of small tidy ups and improved some function naming.

@droberts195 this is largely #1224 modulo some small tweaks and the parameter search. As discussed I'm raising this against a feature branch so we can do a full assessment with a couple of related changes I have planned. Marking as a non-issue since I'll add documentation only for the collection of changes.