### PR TITLE
[ML] Don't lose precision when persisting state

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,12 @@
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3. (See
   {ml-pull}1170[#1170].)
 
+== {es} version 7.9.0
+
+=== Enhancements
+
+* Don't lose precision when saving model state. (See {ml-pull}1274[#1274].)
+
 == {es} version 7.8.0
 
 === Enhancements

--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -21,7 +21,7 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -257,9 +257,7 @@ public:
     class CORE_EXPORT CBuiltinFromString {
     public:
         CBuiltinFromString(const char pairDelimiter)
-            : m_PairDelimiter(pairDelimiter) {
-            m_Token.reserve(17);
-        }
+            : m_PairDelimiter(pairDelimiter) {}
 
         template<typename T>
         bool operator()(const std::string& token, T& value) const {
@@ -503,8 +501,7 @@ public:
                            std::array<T, N>& collection,
                            const char delimiter = DELIMITER) {
         if (state.empty()) {
-            LOG_ERROR(<< "Unexpected number of elements 0"
-                      << ", expected " << N);
+            LOG_ERROR(<< "Unexpected number of elements 0, expected " << N);
             return false;
         }
 
@@ -612,11 +609,7 @@ private:
         }
 
         // Reuse this same string to avoid as many allocations as possible.
-        //
-        // Reserve 17 chars because for string implementations using the short
-        // string optimisation we don't want to cause an unnecessary allocation.
         std::string token;
-        token.reserve(17);
         token.assign(state, 0, delimPos);
         {
             T element;

--- a/include/maths/CChecksum.h
+++ b/include/maths/CChecksum.h
@@ -16,7 +16,7 @@
 #include <maths/ImportExport.h>
 #include <maths/MathsTypes.h>
 
-#include <boost/optional/optional_fwd.hpp>
+#include <boost/optional/optional.hpp>
 #include <boost/unordered/unordered_map_fwd.hpp>
 #include <boost/unordered/unordered_set_fwd.hpp>
 

--- a/include/maths/CChecksum.h
+++ b/include/maths/CChecksum.h
@@ -165,7 +165,7 @@ public:
     //! Checksum of a optional.
     template<typename T>
     static std::uint64_t dispatch(std::uint64_t seed, const boost::optional<T>& target) {
-        return target != boost::none
+        return target == boost::none
                    ? seed
                    : CChecksumImpl<typename selector<T>::value>::dispatch(seed, *target);
     }
@@ -173,7 +173,7 @@ public:
     //! Checksum a shared pointer.
     template<typename T>
     static std::uint64_t dispatch(std::uint64_t seed, const std::shared_ptr<T>& target) {
-        return target != nullptr
+        return target == nullptr
                    ? seed
                    : CChecksumImpl<typename selector<T>::value>::dispatch(seed, *target);
     }
@@ -181,7 +181,7 @@ public:
     //! Checksum a unique pointer.
     template<typename T>
     static std::uint64_t dispatch(std::uint64_t seed, const std::unique_ptr<T>& target) {
-        return target != nullptr
+        return target == nullptr
                    ? seed
                    : CChecksumImpl<typename selector<T>::value>::dispatch(seed, *target);
     }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -216,7 +216,6 @@ void testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType lossFuncti
     double eta{0.9};
     std::size_t maximumNumberTrees{1};
     double featureBagFraction{0.3};
-    double downsampleFactor{0.7};
 
     std::stringstream output;
     auto outputWriterFactory = [&output]() {
@@ -233,7 +232,6 @@ void testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType lossFuncti
             .predictionEta(eta)
             .predictionMaximumNumberTrees(maximumNumberTrees)
             .predictionFeatureBagFraction(featureBagFraction)
-            .predictionDownsampleFactor(downsampleFactor)
             .regressionLossFunction(lossFunction)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
         outputWriterFactory};
@@ -255,8 +253,8 @@ void testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType lossFuncti
     const auto& bestHyperparameters{boostedTree.bestHyperparameters()};
     BOOST_TEST_REQUIRE(bestHyperparameters.eta() == eta);
     BOOST_TEST_REQUIRE(bestHyperparameters.featureBagFraction() == featureBagFraction);
-    BOOST_TEST_REQUIRE(bestHyperparameters.downsampleFactor() == downsampleFactor);
-    // TODO extend to support setting etaGrowthRatePerTree
+    // TODO extend to support setting downsampleFactor and etaGrowthRatePerTree
+    //    BOOST_TEST_REQUIRE(bestHyperparameters.downsampleFactor() == downsampleFactor);
     //    BOOST_TEST_REQUIRE(bestHyperparameters.etaGrowthRatePerTree() == etaGrowthRatePerTree);
     BOOST_TEST_REQUIRE(bestHyperparameters.regularization().depthPenaltyMultiplier() == alpha);
     BOOST_TEST_REQUIRE(

--- a/lib/core/unittest/CJsonStatePersistInserterTest.cc
+++ b/lib/core/unittest/CJsonStatePersistInserterTest.cc
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include <core/CIEEE754.h>
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CLogger.h>
 #include <core/CStringUtils.h>
@@ -53,7 +54,10 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
         LOG_DEBUG(<< "JSON is: " << json);
 
-        BOOST_REQUIRE_EQUAL(std::string("{\"a\":\"a\",\"b\":\"25\",\"c\":{\"a\":\"3.14\",\"b\":\"z\"}}"),
+        BOOST_REQUIRE_EQUAL(std::string("{\"a\":\"a\",\"b\":\"25\",\"c\":{\"a\":\"" +
+                                        ml::core::CStringUtils::typeToStringPrecise(
+                                            3.14, ml::core::CIEEE754::E_SinglePrecision) +
+                                        "\",\"b\":\"z\"}}"),
                             json);
     }
 
@@ -74,7 +78,10 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
         LOG_DEBUG(<< "JSON is: " << json);
 
-        BOOST_REQUIRE_EQUAL(std::string("{\"level1A\":\"a\",\"level1B\":\"25\",\"level1C\":{\"level2A\":\"3.14\",\"level2B\":\"z\"}}"),
+        BOOST_REQUIRE_EQUAL(std::string("{\"level1A\":\"a\",\"level1B\":\"25\",\"level1C\":{\"level2A\":\"" +
+                                        ml::core::CStringUtils::typeToStringPrecise(
+                                            3.14, ml::core::CIEEE754::E_SinglePrecision) +
+                                        "\",\"level2B\":\"z\"}}"),
                             json);
     }
 }

--- a/lib/core/unittest/CPersistUtilsTest.cc
+++ b/lib/core/unittest/CPersistUtilsTest.cc
@@ -10,6 +10,8 @@
 #include <core/CLogger.h>
 #include <core/CPersistUtils.h>
 
+#include <test/CRandomNumbers.h>
+
 #include <boost/circular_buffer.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/unordered_map.hpp>
@@ -577,6 +579,22 @@ BOOST_AUTO_TEST_CASE(testAppend) {
         core::CPersistUtils::fromString(state, restored, core::CPersistUtils::DELIMITER,
                                         core::CPersistUtils::PAIR_DELIMITER, true);
         BOOST_TEST_REQUIRE(equal(collection, restored));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testFloatingPoint) {
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec doubles;
+    TDoubleVec restoredDoubles;
+    for (std::size_t i = 0; i < 100; ++i) {
+        rng.generateUniformSamples(-1000.0, 1000.0, 10, doubles);
+        std::string serialized{core::CPersistUtils::toString(doubles)};
+        core::CPersistUtils::fromString(serialized, restoredDoubles);
+        for (std::size_t j = 0; j < doubles.size(); ++j) {
+            BOOST_REQUIRE_EQUAL(doubles[j], restoredDoubles[j]);
+        }
     }
 }
 

--- a/lib/core/unittest/CRapidXmlStatePersistInserterTest.cc
+++ b/lib/core/unittest/CRapidXmlStatePersistInserterTest.cc
@@ -53,8 +53,10 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
         inserter.toXml(false, xml);
         BOOST_REQUIRE_EQUAL(std::string("<root attr1=\"attrVal1\" "
-                                        "attr2=\"attrVal2\"><a>a</a><b>25</b><c><a>3.14</"
-                                        "a><b>z</b></c></root>"),
+                                        "attr2=\"attrVal2\"><a>a</a><b>25</b><c><a>") +
+                                ml::core::CStringUtils::typeToStringPrecise(
+                                    3.14, ml::core::CIEEE754::E_SinglePrecision) +
+                                "</a><b>z</b></c></root>",
                             xml);
     }
 
@@ -74,9 +76,11 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
         inserter.toXml(false, xml);
 
-        BOOST_REQUIRE_EQUAL(std::string("<root attr1=\"attrVal1\" "
-                                        "attr2=\"attrVal2\"><level1A>a</level1A><level1B>25</level1B><level1C><level2A>3.14</"
-                                        "level2A><level2B>z</level2B></level1C></root>"),
+        BOOST_REQUIRE_EQUAL(std::string("<root attr1=\"attrVal1\" attr2=\"attrVal2\">"
+                                        "<level1A>a</level1A><level1B>25</level1B><level1C><level2A>") +
+                                ml::core::CStringUtils::typeToStringPrecise(
+                                    3.14, ml::core::CIEEE754::E_SinglePrecision) +
+                                "</level2A><level2B>z</level2B></level1C></root>",
                             xml);
     }
 }

--- a/lib/core/unittest/CStringUtilsTest.cc
+++ b/lib/core/unittest/CStringUtilsTest.cc
@@ -200,99 +200,111 @@ BOOST_AUTO_TEST_CASE(testTypeToStringPrecise) {
     }
     {
         double i(0.123456);
-        std::string expected("1.23456e-1");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_SinglePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_SinglePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(
+            ml::core::CIEEE754::round(i, ml::core::CIEEE754::E_SinglePrecision),
+            ml::core::CIEEE754::round(o, ml::core::CIEEE754::E_SinglePrecision));
     }
     {
         double i(0.123456);
-        std::string expected("1.23456e-1");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_DoublePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_DoublePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(i, o);
     }
     {
         double i(0.123456e10);
-        std::string expected("1.23456e9");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_SinglePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_SinglePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(
+            ml::core::CIEEE754::round(i, ml::core::CIEEE754::E_SinglePrecision),
+            ml::core::CIEEE754::round(o, ml::core::CIEEE754::E_SinglePrecision));
     }
     {
         double i(0.123456e10);
-        std::string expected("1234560000");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_DoublePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_DoublePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(i, o);
     }
     {
         double i(0.123456e-10);
-        std::string expected("1.23456e-11");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_SinglePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_SinglePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(
+            ml::core::CIEEE754::round(i, ml::core::CIEEE754::E_SinglePrecision),
+            ml::core::CIEEE754::round(o, ml::core::CIEEE754::E_SinglePrecision));
     }
     {
         double i(0.123456e-10);
-        std::string expected("1.23456e-11");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_DoublePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_DoublePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(i, o);
     }
     {
         double i(0.123456787654321e-10);
-        std::string expected("1.234568e-11");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_SinglePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_SinglePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(
+            ml::core::CIEEE754::round(i, ml::core::CIEEE754::E_SinglePrecision),
+            ml::core::CIEEE754::round(o, ml::core::CIEEE754::E_SinglePrecision));
     }
     {
         double i(0.123456787654321e-10);
-        std::string expected("1.23456787654321e-11");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_DoublePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_DoublePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(i, o);
     }
     {
         double i(0.00000000012345678765432123456);
-        std::string expected("1.234568e-10");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_SinglePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_SinglePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(
+            ml::core::CIEEE754::round(i, ml::core::CIEEE754::E_SinglePrecision),
+            ml::core::CIEEE754::round(o, ml::core::CIEEE754::E_SinglePrecision));
     }
     {
         double i(0.00000000012345678765432123456);
-        std::string expected("1.23456787654321e-10");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_DoublePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_DoublePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(i, o);
     }
     {
         double i(123456787654321.23456);
-        std::string expected("1.234568e14");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_SinglePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_SinglePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(
+            ml::core::CIEEE754::round(i, ml::core::CIEEE754::E_SinglePrecision),
+            ml::core::CIEEE754::round(o, ml::core::CIEEE754::E_SinglePrecision));
     }
     {
         double i(123456787654321.23456);
-        std::string expected("123456787654321");
-
-        std::string actual = ml::core::CStringUtils::typeToStringPrecise(
-            i, ml::core::CIEEE754::E_DoublePrecision);
-        BOOST_REQUIRE_EQUAL(expected, actual);
+        double o;
+        std::string string{ml::core::CStringUtils::typeToStringPrecise(
+            i, ml::core::CIEEE754::E_DoublePrecision)};
+        ml::core::CStringUtils::stringToType(string, o);
+        BOOST_REQUIRE_EQUAL(i, o);
     }
 }
 

--- a/lib/model/unittest/CAnomalyScoreTest.cc
+++ b/lib/model/unittest/CAnomalyScoreTest.cc
@@ -746,8 +746,9 @@ BOOST_AUTO_TEST_CASE(testJsonConversion) {
         partitionMaxScoreStr.erase(std::remove(partitionMaxScoreStr.begin(),
                                                partitionMaxScoreStr.end(), '\n'),
                                    partitionMaxScoreStr.end());
-        BOOST_REQUIRE_EQUAL("\"" + core::CStringUtils::typeToStringPretty(maxScore) + "\"",
-                            partitionMaxScoreStr);
+        BOOST_REQUIRE_EQUAL(
+            "\"" + core::CStringUtils::typeToStringPrecise(maxScore, core::CIEEE754::E_SinglePrecision) + "\"",
+            partitionMaxScoreStr);
     }
 
     rapidjson::StringBuffer buffer;

--- a/lib/model/unittest/CSampleQueueTest.cc
+++ b/lib/model/unittest/CSampleQueueTest.cc
@@ -38,7 +38,7 @@ using TTestSampleQueue = CSampleQueue<TMeanAccumulator>;
 BOOST_AUTO_TEST_CASE(testSampleToString) {
     CSample sample(10, {3.0}, 0.8, 1.0);
 
-    BOOST_REQUIRE_EQUAL(std::string("10;8e-1;1;3"), CSample::SToString()(sample));
+    BOOST_REQUIRE_EQUAL(std::string("10;0.800000012;1;3"), CSample::SToString()(sample));
 }
 
 BOOST_AUTO_TEST_CASE(testSampleFromString) {


### PR DESCRIPTION
Following on from #1197, this reworks persistence to not lose precision.

Since we chunk and compress state when persisting, using sufficient decimal places to not lose precision doesn't cost us much in terms of model size, and persisting and restoring state is not a performance bottleneck. 

This has the nice property that we can test restore from state produces the same results much more stably, so I simplified and extended `testRunBoostedTreeRegressionTrainingWithStateRecovery` accordingly.

I also took the opportunity to tidy up `CPersistUtils` and in particular fix violations of our coding guidelines.

This affects results for both anomaly detection and data frame analyses, but only after restoring from state.