### PR TITLE
[DOCS] Adjust release note for reduced process priority

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,7 +43,8 @@
 
 * Speed up anomaly detection for the lat_long function. (See {ml-pull}1102[#1102].)
 * Reduce CPU scheduling priority of native analysis processes to favor the ES JVM
-  when CPU is constrained. (See {ml-pull}1109[#1109].)
+  when CPU is constrained. This change is only implemented for Linux and macOS, not
+  for Windows. (See {ml-pull}1109[#1109].)
 * Take `training_percent` into account when estimating memory usage for classification and regression. 
   (See {ml-pull}1111[#1111].)
 * Support maximize minimum recall when assigning class labels for multiclass classification.


### PR DESCRIPTION
The original release note omitted to mention that the feature
is only implemented for Linux and macOS.

Relates #1109