### PR TITLE
[ML] Parallelise the feature importance calculation for classification and regression over trees

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,8 @@
 === Enhancements
 
 * Don't lose precision when saving model state. (See {ml-pull}1274[#1274].)
+* Parallelize the feature importance calculation for classification and regression
+  over trees. (See {ml-pull}1277[#1277].)
 
 == {es} version 7.8.0
 

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -233,19 +233,19 @@ void parallel_for_each(std::size_t start,
     for (std::size_t offset = 0, partitions = functions.size();
          offset < partitions; ++offset, ++start) {
 
-        // Note there is one copy of g for each thread so capture by reference
-        // is thread safe provided f is thread safe.
+        // Note there is one f for each thread so capture by reference is thread
+        // safe provided each f is thread safe.
 
         CLoopProgress progress{end - offset, recordProgress,
                                1.0 / static_cast<double>(partitions)};
 
-        auto& g = functions[offset];
+        auto& f = functions[offset];
         tasks.emplace_back(
             async(defaultAsyncExecutor(),
-                  [&g, partitions, progress](std::size_t start_, std::size_t end_) mutable {
+                  [&f, partitions, progress](std::size_t start_, std::size_t end_) mutable {
                       for (std::size_t i = start_; i < end_;
                            i += partitions, progress.increment(partitions)) {
-                          g(i);
+                          f(i);
                       }
                       return true; // So we can check for exceptions via get.
                   },
@@ -348,16 +348,17 @@ void parallel_for_each(ITR start,
 
     for (std::size_t offset = 0, partitions = functions.size();
          offset < partitions; ++offset, ++start) {
-        // Note there is one copy of g for each thread so capture by reference
-        // is thread safe provided f is thread safe.
+
+        // Note there is one f for each thread so capture by reference is thread
+        // safe provided each f is thread safe.
 
         CLoopProgress progress{size - offset, recordProgress,
                                1.0 / static_cast<double>(partitions)};
 
-        auto& g = functions[offset];
+        auto& f = functions[offset];
         tasks.emplace_back(async(
             defaultAsyncExecutor(),
-            [&g, partitions, offset, size, progress](ITR start_) mutable {
+            [&f, partitions, offset, size, progress](ITR start_) mutable {
 
                 std::size_t i{offset};
 
@@ -369,7 +370,7 @@ void parallel_for_each(ITR start,
 
                 for (ITR j = start_; i < size; i += partitions,
                          incrementByPartitions(j), progress.increment(partitions)) {
-                    g(*j);
+                    f(*j);
                 }
                 return true; // So we can check for exceptions via get.
             },

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -426,7 +426,7 @@ parallel_for_each(std::size_t partitions,
         return functions;
     }
 
-    std::vector<FUNCTION> functions{partitions, std::forward<FUNCTION>(f)};
+    std::vector<FUNCTION> functions(partitions, std::forward<FUNCTION>(f));
     parallel_for_each(start, size, functions, recordProgress);
     return functions;
 }

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -205,17 +205,12 @@ private:
 
 CORE_EXPORT
 void noop(double);
-}
 
-//! Run \p functions in parallel using async.
-//!
-//! This executes \p functions on a partition of the indices in the range
-//! [\p start, \p end) using the default async executor.
 template<typename FUNCTION>
 void parallel_for_each(std::size_t start,
                        std::size_t end,
                        std::vector<FUNCTION>& functions,
-                       const std::function<void(double)>& recordProgress = concurrency_detail::noop) {
+                       const std::function<void(double)>& recordProgress) {
 
     // Threads access the indices in the following pattern:
     //   [0, m,   2*m,   ...]
@@ -228,19 +223,22 @@ void parallel_for_each(std::size_t start,
     // ensure the best possible locality of reference for reads which occur
     // at a similar time in the different threads.
 
-    std::vector<std::future<bool>> tasks;
+    std::vector<std::future<bool>> finished;
+    finished.reserve(functions.size());
 
     for (std::size_t offset = 0, partitions = functions.size();
          offset < partitions; ++offset, ++start) {
 
         // Note there is one f for each thread so capture by reference is thread
-        // safe provided each f is thread safe.
+        // safe provided each f is thread safe. Also, we always wait until all
+        // calls are finished before returning so functions always live beyond
+        // these references.
 
         CLoopProgress progress{end - offset, recordProgress,
                                1.0 / static_cast<double>(partitions)};
 
         auto& f = functions[offset];
-        tasks.emplace_back(
+        finished.emplace_back(
             async(defaultAsyncExecutor(),
                   [&f, partitions, progress](std::size_t start_, std::size_t end_) mutable {
                       for (std::size_t i = start_; i < end_;
@@ -252,7 +250,107 @@ void parallel_for_each(std::size_t start,
                   start, end));
     }
 
-    get_conjunction_of_all(tasks);
+    get_conjunction_of_all(finished);
+}
+
+template<typename ITR, typename FUNCTION>
+void parallel_for_each(ITR start,
+                       std::size_t size,
+                       std::vector<FUNCTION>& functions,
+                       const std::function<void(double)>& recordProgress = concurrency_detail::noop) {
+
+    // See above for the rationale for this access pattern.
+
+    std::vector<std::future<bool>> finished;
+    finished.reserve(functions.size());
+
+    for (std::size_t offset = 0, partitions = functions.size();
+         offset < partitions; ++offset, ++start) {
+
+        // As above, capturing by reference here is  safe.
+
+        CLoopProgress progress{size - offset, recordProgress,
+                               1.0 / static_cast<double>(partitions)};
+
+        auto& f = functions[offset];
+        finished.emplace_back(async(
+            defaultAsyncExecutor(),
+            [&f, partitions, offset, size, progress](ITR start_) mutable {
+
+                std::size_t i{offset};
+
+                auto incrementByPartitions = [&i, partitions, size](ITR& j) {
+                    if (i < size) {
+                        std::advance(j, partitions);
+                    }
+                };
+
+                for (ITR j = start_; i < size; i += partitions,
+                         incrementByPartitions(j), progress.increment(partitions)) {
+                    f(*j);
+                }
+                return true; // So we can check for exceptions via get.
+            },
+            start));
+    }
+
+    get_conjunction_of_all(finished);
+}
+}
+
+//! Run \p functions in parallel using async.
+//!
+//! This executes \p functions on a partition of the indices in the range
+//! [\p start, \p end) using the default async executor.
+template<typename FUNCTION>
+bool parallel_for_each(std::size_t start,
+                       std::size_t end,
+                       std::vector<FUNCTION>& functions,
+                       const std::function<void(double)>& recordProgress = concurrency_detail::noop) {
+
+    if (end <= start) {
+        recordProgress(1.0);
+        return true;
+    }
+    if (functions.empty()) {
+        LOG_ERROR(<< "No task supplied");
+        recordProgress(1.0);
+        return false;
+    }
+
+    // This function is not re-entrant without the chance of deadlock if we always
+    // execute in parallel. In particular, we wait on the completion of tasks which
+    // are enqueued in the global thread pool. However, if this has already been
+    // called further up the stack we will enqueue functions which will wait on the
+    // results of these and will block the tasks they need to complete behind them
+    // in the queues. There are a couple strategies we could take, two obvious ones
+    // in order of increasing complexity and decreasing pessimism are:
+    //   1) Execute sequentially if there are any tasks in the thread pool, we then
+    //      won't wait here and nothing will block in the queue,
+    //   2) Assign tasks a priority and ensure in the queue that tasks are execute
+    //      in priority order. Then we can assign these tasks "highest priority in
+    //      queue" + 1.
+    //
+    // This implements 1) because it is significantly simpler to and in practice we
+    // probably don't actually need to nest parallel_for_each. We're just interested
+    // in guarding against accidental deadlock in the case someone inadvertantly calls
+    // parallelised code in the function to execute.
+
+    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
+
+    functions.resize(std::min(functions.size(), end - start));
+
+    if (functions.size() < 2 || scope.wasBusy()) {
+        functions.resize(1);
+        CLoopProgress progress{end - start, recordProgress};
+        for (std::size_t i = start; i < end; ++i, progress.increment()) {
+            functions[0](i);
+        }
+        return true;
+    }
+
+    concurrency_detail::parallel_for_each(start, end, functions, recordProgress);
+    return true;
 }
 
 //! Run \p f in parallel using async.
@@ -281,27 +379,11 @@ parallel_for_each(std::size_t partitions,
         return {std::forward<FUNCTION>(f)};
     }
 
-    partitions = std::min(partitions, end - start);
-
-    // This function is not re-entrant without the chance of deadlock if we always
-    // execute in parallel. In particular, we wait on the completion of tasks which
-    // are enqueued in the global thread pool. However, if this has already been
-    // called further up the stack we will enqueue functions which will wait on the
-    // results of these and will block the tasks they need to complete behind them
-    // in the queues. There are a couple strategies we could take, two obvious ones
-    // in order of increasing complexity and decreasing pessimism are:
-    //   1) Execute sequentially if there are any tasks in the thread pool, we then
-    //      won't wait here and nothing will block in the queue,
-    //   2) Assign tasks a priority and ensure in the queue that tasks are execute
-    //      in priority order. Then we can assign these tasks "highest priority in
-    //      queue" + 1.
-    //
-    // This implements 1) because it is significantly simpler to and in practice we
-    // probably don't actually need to nest parallel_for_each. We're just interested
-    // in guarding against accidental deadlock in the case someone inadvertantly calls
-    // parallelised code in the function to execute.
+    // See above for details.
 
     concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
+
+    partitions = std::min(partitions, end - start);
 
     if (partitions < 2 || scope.wasBusy()) {
         CLoopProgress progress{end - start, recordProgress};
@@ -317,7 +399,7 @@ parallel_for_each(std::size_t partitions,
     }
 
     std::vector<FUNCTION> functions(partitions, std::forward<FUNCTION>(f));
-    parallel_for_each(start, end, functions, recordProgress);
+    concurrency_detail::parallel_for_each(start, end, functions, recordProgress);
     return functions;
 }
 
@@ -335,49 +417,40 @@ parallel_for_each(std::size_t start,
 //! Run \p functions in parallel using async.
 //!
 //! This executes \p functions on a partition of the dereferenced iterators in
-//! the range [\p start, \p start + size) using the default async executor.
+//! the range [\p start, \p end) using the default async executor.
 template<typename ITR, typename FUNCTION>
-void parallel_for_each(ITR start,
-                       std::size_t size,
+bool parallel_for_each(ITR start,
+                       ITR end,
                        std::vector<FUNCTION>& functions,
                        const std::function<void(double)>& recordProgress = concurrency_detail::noop) {
 
-    // See above for the rationale for this access pattern.
-
-    std::vector<std::future<bool>> tasks;
-
-    for (std::size_t offset = 0, partitions = functions.size();
-         offset < partitions; ++offset, ++start) {
-
-        // Note there is one f for each thread so capture by reference is thread
-        // safe provided each f is thread safe.
-
-        CLoopProgress progress{size - offset, recordProgress,
-                               1.0 / static_cast<double>(partitions)};
-
-        auto& f = functions[offset];
-        tasks.emplace_back(async(
-            defaultAsyncExecutor(),
-            [&f, partitions, offset, size, progress](ITR start_) mutable {
-
-                std::size_t i{offset};
-
-                auto incrementByPartitions = [&i, partitions, size](ITR& j) {
-                    if (i < size) {
-                        std::advance(j, partitions);
-                    }
-                };
-
-                for (ITR j = start_; i < size; i += partitions,
-                         incrementByPartitions(j), progress.increment(partitions)) {
-                    f(*j);
-                }
-                return true; // So we can check for exceptions via get.
-            },
-            start));
+    std::size_t size(std::distance(start, end));
+    if (size == 0) {
+        recordProgress(1.0);
+        return true;
+    }
+    if (functions.empty()) {
+        LOG_ERROR(<< "No task supplied");
+        recordProgress(1.0);
+        return false;
     }
 
-    get_conjunction_of_all(tasks);
+    // See above for details.
+
+    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
+
+    functions.resize(std::min(functions.size(), size));
+
+    if (functions.size() < 2 || scope.wasBusy()) {
+        functions.resize(1);
+        CLoopProgress progress{size, recordProgress};
+        for (ITR i = start; i != end; ++i, progress.increment()) {
+            functions[0](*i);
+        }
+    }
+
+    concurrency_detail::parallel_for_each(start, size, functions, recordProgress);
+    return true;
 }
 
 //! Run \p f in parallel using async.
@@ -407,14 +480,13 @@ parallel_for_each(std::size_t partitions,
         return {std::forward<FUNCTION>(f)};
     }
 
-    partitions = std::min(partitions, size);
-
     // See above for details.
 
     concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
 
-    if (partitions < 2 || scope.wasBusy()) {
+    partitions = std::min(partitions, size);
 
+    if (partitions < 2 || scope.wasBusy()) {
         CLoopProgress progress{size, recordProgress};
         for (ITR i = start; i != end; ++i, progress.increment()) {
             f(*i);
@@ -428,7 +500,7 @@ parallel_for_each(std::size_t partitions,
     }
 
     std::vector<FUNCTION> functions(partitions, std::forward<FUNCTION>(f));
-    parallel_for_each(start, size, functions, recordProgress);
+    concurrency_detail::parallel_for_each(start, size, functions, recordProgress);
     return functions;
 }
 

--- a/include/maths/CTreeShapFeatureImportance.h
+++ b/include/maths/CTreeShapFeatureImportance.h
@@ -40,11 +40,13 @@ public:
     using TTreeVec = std::vector<TTree>;
     using TVector = CDenseVector<double>;
     using TVectorVec = std::vector<TVector>;
+    using TVectorVecVec = std::vector<TVectorVec>;
     using TShapWriter =
         std::function<void(const TSizeVec&, const TStrVec&, const TVectorVec&)>;
 
 public:
-    CTreeShapFeatureImportance(const core::CDataFrame& frame,
+    CTreeShapFeatureImportance(std::size_t numberThreads,
+                               const core::CDataFrame& frame,
                                const CDataFrameCategoryEncoder& encoder,
                                TTreeVec& trees,
                                std::size_t numberTopShapValues);
@@ -80,6 +82,7 @@ private:
     };
 
     using TElementVec = std::vector<SPathElement>;
+    using TElementVecVec = std::vector<TElementVec>;
     using TElementItr = TElementVec::iterator;
     using TDoubleVecItr = TDoubleVec::iterator;
 
@@ -186,9 +189,10 @@ private:
     const CDataFrameCategoryEncoder* m_Encoder;
     const TTreeVec* m_Forest;
     TStrVec m_ColumnNames;
-    TElementVec m_PathStorage;
-    TDoubleVec m_ScaleStorage;
-    TVectorVec m_ShapValues;
+    TElementVecVec m_PathStorage;
+    TDoubleVecVec m_ScaleStorage;
+    TVectorVecVec m_PerThreadShapValues;
+    TVectorVec m_ReducedShapValues;
     TSizeVec m_TopShapValues;
 };
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -436,7 +436,7 @@ void CBoostedTreeImpl::initializeTreeShap(const core::CDataFrame& frame) {
     if (m_NumberTopShapValues > 0) {
         // Create the SHAP calculator.
         m_TreeShap = std::make_unique<CTreeShapFeatureImportance>(
-            frame, *m_Encoder, m_BestForest, m_NumberTopShapValues);
+            m_NumberThreads, frame, *m_Encoder, m_BestForest, m_NumberTopShapValues);
     } else {
         // TODO these are not currently written into the inference model
         // but they would be nice to expose since they provide good insight

--- a/lib/maths/CTreeShapFeatureImportance.cc
+++ b/lib/maths/CTreeShapFeatureImportance.cc
@@ -8,6 +8,7 @@
 
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
+#include <core/Concurrency.h>
 
 #include <maths/CLinearAlgebraShims.h>
 #include <maths/COrderings.h>
@@ -19,12 +20,18 @@
 namespace ml {
 namespace maths {
 
-CTreeShapFeatureImportance::CTreeShapFeatureImportance(const core::CDataFrame& frame,
+CTreeShapFeatureImportance::CTreeShapFeatureImportance(std::size_t numberThreads,
+                                                       const core::CDataFrame& frame,
                                                        const CDataFrameCategoryEncoder& encoder,
                                                        TTreeVec& forest,
                                                        std::size_t numberTopShapValues)
     : m_NumberTopShapValues{numberTopShapValues}, m_Encoder{&encoder}, m_Forest{&forest},
       m_ColumnNames{frame.columnNames()} {
+
+    std::size_t concurrency{std::min(numberThreads, forest.size())};
+    m_PathStorage.resize(concurrency);
+    m_ScaleStorage.resize(concurrency);
+    m_PerThreadShapValues.resize(concurrency);
 
     // When traversing a tree, we successively copy the parent path and add one
     // new element to it. This means that if a tree has maxDepth depth, we store
@@ -32,8 +39,10 @@ CTreeShapFeatureImportance::CTreeShapFeatureImportance(const core::CDataFrame& f
     // the initial element in the path has split feature -1. Altogether it results
     // in ((maxDepth + 1) * (maxDepth + 2)) / 2 elements to be stored.
     std::size_t maxDepth{depth(forest)};
-    m_PathStorage.resize((maxDepth + 1) * (maxDepth + 2) / 2);
-    m_ScaleStorage.resize((maxDepth + 1) * (maxDepth + 2) / 2);
+    for (std::size_t i = 0; i < concurrency; ++i) {
+        m_PathStorage[i].resize((maxDepth + 1) * (maxDepth + 2) / 2);
+        m_ScaleStorage[i].resize((maxDepth + 1) * (maxDepth + 2) / 2);
+    }
 
     computeInternalNodeValues(forest);
 }
@@ -44,29 +53,57 @@ void CTreeShapFeatureImportance::shap(const TRowRef& row, TShapWriter writer) {
         return;
     }
 
+    using TTreeShapVec = std::vector<std::function<void(const TTree&)>>;
+
     auto encodedRow{m_Encoder->encode(row)};
-    m_ShapValues.assign(m_Encoder->numberInputColumns(),
-                        las::zero((*m_Forest)[0][0].value()));
-    for (const auto& tree : *m_Forest) {
-        this->shapRecursive(tree, encodedRow, 0, 1.0, 1.0, -1,
-                            CSplitPath{m_PathStorage.begin(), m_ScaleStorage.begin()},
-                            0, m_ShapValues);
+
+    if (m_PerThreadShapValues.size() == 1) {
+        m_ReducedShapValues.assign(m_Encoder->numberInputColumns(),
+                                   las::zero((*m_Forest)[0][0].value()));
+        for (const auto& tree : *m_Forest) {
+            this->shapRecursive(
+                tree, encodedRow, 0, 1.0, 1.0, -1,
+                CSplitPath{m_PathStorage[0].begin(), m_ScaleStorage[0].begin()},
+                0, m_ReducedShapValues);
+        }
+    } else {
+        TTreeShapVec computeTreeShap;
+        computeTreeShap.reserve(m_PerThreadShapValues.size());
+        for (std::size_t i = 0; i < m_PerThreadShapValues.size(); ++i) {
+            m_PerThreadShapValues[i].assign(m_Encoder->numberInputColumns(),
+                                            las::zero((*m_Forest)[0][0].value()));
+            computeTreeShap.push_back([&encodedRow, i, this](const TTree& tree) {
+                this->shapRecursive(tree, encodedRow, 0, 1.0, 1.0, -1,
+                                    CSplitPath{m_PathStorage[i].begin(),
+                                               m_ScaleStorage[i].begin()},
+                                    0, m_PerThreadShapValues[i]);
+            });
+        }
+
+        core::parallel_for_each(m_Forest->begin(), m_Forest->size(), computeTreeShap);
+
+        m_ReducedShapValues = m_PerThreadShapValues[0];
+        for (std::size_t i = 1; i < m_PerThreadShapValues.size(); ++i) {
+            for (std::size_t j = 0; j < m_ReducedShapValues.size(); ++j) {
+                m_ReducedShapValues[j] += m_PerThreadShapValues[i][j];
+            }
+        }
     }
 
-    m_TopShapValues.resize(m_ShapValues.size());
+    m_TopShapValues.resize(m_ReducedShapValues.size());
     std::iota(m_TopShapValues.begin(), m_TopShapValues.end(), 0);
     if (m_NumberTopShapValues < m_TopShapValues.size()) {
-        std::nth_element(
-            m_TopShapValues.begin(), m_TopShapValues.begin() + m_NumberTopShapValues,
-            m_TopShapValues.end(), [this](std::size_t lhs, std::size_t rhs) {
-                return COrderings::lexicographical_compare(
-                    -las::L1(m_ShapValues[lhs]), lhs, -las::L1(m_ShapValues[rhs]), rhs);
-            });
+        std::nth_element(m_TopShapValues.begin(), m_TopShapValues.begin() + m_NumberTopShapValues,
+                         m_TopShapValues.end(), [this](std::size_t lhs, std::size_t rhs) {
+                             return COrderings::lexicographical_compare(
+                                 -las::L1(m_ReducedShapValues[lhs]), lhs,
+                                 -las::L1(m_ReducedShapValues[rhs]), rhs);
+                         });
         m_TopShapValues.resize(m_NumberTopShapValues);
         std::sort(m_TopShapValues.begin(), m_TopShapValues.end());
     }
 
-    writer(m_TopShapValues, m_ColumnNames, m_ShapValues);
+    writer(m_TopShapValues, m_ColumnNames, m_ReducedShapValues);
 }
 
 void CTreeShapFeatureImportance::computeNumberSamples(std::size_t numberThreads,
@@ -159,24 +196,31 @@ void CTreeShapFeatureImportance::shapRecursive(const TTree& tree,
                                                TVectorVec& shap) const {
     CSplitPath splitPath{parentSplitPath, nextIndex};
 
-    CTreeShapFeatureImportance::extendPath(splitPath, parentFractionZero, parentFractionOne,
-                                           parentFeatureIndex, nextIndex);
+    extendPath(splitPath, parentFractionZero, parentFractionOne, parentFeatureIndex, nextIndex);
     if (tree[nodeIndex].isLeaf()) {
         const TVector& leafValue{tree[nodeIndex].value()};
         for (int i = 1; i < nextIndex; ++i) {
-            double scale{CTreeShapFeatureImportance::sumUnwoundPath(splitPath, i, nextIndex)};
+            double scale{sumUnwoundPath(splitPath, i, nextIndex)};
             std::size_t inputColumnIndex{
                 m_Encoder->encoding(splitPath.featureIndex(i)).inputColumnIndex()};
-            // inputColumnIndex is read by seeing what the feature at position i is on the path to this leaf.
-            // fractionOnes(i) is an indicator variable which tells us if we condition on this variable
-            // do we visit this path from that node or not, fractionZeros(i) tells us what proportion of
-            // all training data which reaches that node visits this path, i.e. the case we're averaging
-            // over that feature. So this is telling us exactly about the difference in E[f | S U {i}] -
-            // E[f | S] given we're examining only that part of the sample space concerned with this leaf.
+
+            // Consider that:
+            //   1. inputColumnIndex is read by seeing what the split feature at position
+            //      i is on the path to this leaf,
+            //   2. fractionOnes(i) is an indicator variable which tells us if we condition
+            //      on this feature do we visit this path from that node or not,
+            //   3. fractionZeros(i) tells us what proportion of all training data which
+            //      reaches that node visits this path.
+            //
+            // So for the feature g identified by inputColumnIndex, fractionOnes(i) minus
+            // fractionZeros(i) is proportional to E[f | S U {g}] - E[f | S], where f is the
+            // model prediction, restricted to that part of the sample space concerned with
+            // this leaf.
             //
             // The key observation is that the leaves form a disjoint partition of the
-            // sample space (set of all training data) so we can compute the full
-            // expectation as a simple sum over the contributions of the individual leaves.
+            // sample space (set of all training data) so we can compute the full expectation
+            // as a simple sum over the contributions of the individual leaves.
+
             shap[inputColumnIndex] +=
                 scale * (splitPath.fractionOnes(i) - splitPath.fractionZeros(i)) * leafValue;
         }
@@ -197,7 +241,7 @@ void CTreeShapFeatureImportance::shapRecursive(const TTree& tree,
         if (pathIndex >= 0) {
             incomingFractionZero = splitPath.fractionZeros(pathIndex);
             incomingFractionOne = splitPath.fractionOnes(pathIndex);
-            CTreeShapFeatureImportance::unwindPath(splitPath, pathIndex, nextIndex);
+            unwindPath(splitPath, pathIndex, nextIndex);
         }
 
         double hotFractionZero{incomingFractionZero *
@@ -218,14 +262,26 @@ void CTreeShapFeatureImportance::extendPath(CSplitPath& splitPath,
                                             double fractionOne,
                                             int featureIndex,
                                             int& nextIndex) {
-    // Update binomial coefficients to be able to compute Equation (2) from the paper.  In particular,
-    // we have in the line path.s_Scale[i + 1] += fractionOne * path.s_Scale[i] * (i + 1.0) / (pathDepth +
-    // 1.0) that if we're on the "one" path, i.e. if the last feature selects this path if we include that
-    // feature in S (then fractionOne is 1), and we need to consider all the additional ways we now have of
-    // constructing each S of each given cardinality i + 1. Each of these come by adding the last feature
-    // to sets of size i and we **also** need to scale by the difference in binomial coefficients as both M
-    // increases by one and i increases by one. So we get additive term 1{last feature selects path if in S}
-    // * scale(i) * (i+1)! (M+1-(i+1)-1)!/(M+1)! / (i! (M-i-1)!/ M!), whence += scale(i) * (i+1) / (M+1).
+
+    // Update binomial coefficients to be able to compute Equation (2) from the paper.
+    // In particular, in the for loop we effectively have:
+    //
+    //   path.s_Scale[i + 1] += fractionOne * path.s_Scale[i] * (i + 1.0) / (pathDepth + 1.0)
+    //
+    // To understand this consider the following. If we're on the "one" path - i.e. if
+    // we include the node's split feature in S then the example's feature value selects
+    // this path and fractionOne is 1 - we need to consider all the additional ways we
+    // now have of constructing S for each cardinality i + 1. These come from adding
+    // the feature to sets of cardinality i. We also need to scale by the difference in
+    // binomial coefficients as both M increases by one and i increases by one. Putting
+    // this together, we need to add the term
+    //
+    //   1{last feature selects path if in S} * scale(i) * ((i+1)!(M+1-(i+1)-1)! / (M+1)!) /
+    //                                                     (i!(M-i-1)! / M!)
+    //   = fractionOne * scale(i) * (i+1) / (M+1)
+    //
+    // to the path scale for each i + 1.
+
     splitPath.setValues(nextIndex, fractionOne, fractionZero, featureIndex);
     auto scalePath{splitPath.scale()};
     if (nextIndex == 0) {
@@ -246,7 +302,7 @@ void CTreeShapFeatureImportance::extendPath(CSplitPath& splitPath,
 }
 
 double CTreeShapFeatureImportance::sumUnwoundPath(const CSplitPath& path, int pathIndex, int nextIndex) {
-    const auto& scalePath{path.scale()};
+    const auto& scalePath = path.scale();
     double total{0.0};
     int pathDepth{nextIndex - 1};
     double nextFractionOne{scalePath[pathDepth]};
@@ -276,7 +332,7 @@ double CTreeShapFeatureImportance::sumUnwoundPath(const CSplitPath& path, int pa
 }
 
 void CTreeShapFeatureImportance::unwindPath(CSplitPath& path, int pathIndex, int& nextIndex) {
-    auto& scalePath{path.scale()};
+    auto& scalePath = path.scale();
     int pathDepth{nextIndex - 1};
     double nextFractionOne{scalePath[pathDepth]};
     double fractionOne{path.fractionOnes(pathIndex)};

--- a/lib/maths/CTreeShapFeatureImportance.cc
+++ b/lib/maths/CTreeShapFeatureImportance.cc
@@ -80,7 +80,7 @@ void CTreeShapFeatureImportance::shap(const TRowRef& row, TShapWriter writer) {
             });
         }
 
-        core::parallel_for_each(m_Forest->begin(), m_Forest->size(), computeTreeShap);
+        core::parallel_for_each(m_Forest->begin(), m_Forest->end(), computeTreeShap);
 
         m_ReducedShapValues = m_PerThreadShapValues[0];
         for (std::size_t i = 1; i < m_PerThreadShapValues.size(); ++i) {

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include "core/Concurrency.h"
+#include <boost/test/tools/old/interface.hpp>
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 
@@ -118,9 +120,9 @@ struct SFixtureSingleTree {
         tree[6].numberSamples(1);
 
         s_TreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
-            *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
+            1, *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
         s_TopTreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
-            *s_Frame, *s_Encoder, s_Trees, 1);
+            1, *s_Frame, *s_Encoder, s_Trees, 1);
     }
 
     TDataFrameUPtr s_Frame;
@@ -130,112 +132,6 @@ struct SFixtureSingleTree {
     TTreeShapFeatureImportanceUPtr s_TopTreeFeatureImportance;
     TEncoderUPtr s_Encoder;
     mutable TTreeVec s_Trees;
-};
-
-struct SFixtureSingleTreeRandom {
-    SFixtureSingleTreeRandom() {
-        test::CRandomNumbers rng;
-        this->initFrame(rng);
-        CStubMakeDataFrameCategoryEncoder stubParameters{1, *s_Frame, 0, s_NumberFeatures};
-        s_Encoder = std::make_unique<maths::CDataFrameCategoryEncoder>(stubParameters);
-        this->initTree(rng);
-        s_TreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
-            *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
-        s_TopTwoTreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
-            *s_Frame, *s_Encoder, s_Trees, 2);
-    }
-
-    void initFrame(test::CRandomNumbers& rng) {
-        TDoubleVec values;
-        rng.generateUniformSamples(-10.0, 10.0, s_NumberRows * s_NumberFeatures, values);
-
-        s_Frame = core::makeMainStorageDataFrame(s_NumberFeatures, s_NumberRows).first;
-        s_Frame->columnNames(columnNames(s_NumberFeatures));
-        for (std::size_t i = 0; i < s_NumberRows; ++i) {
-            s_Frame->writeRow([&](core::CDataFrame::TFloatVecItr column, int32_t&) {
-                for (std::size_t j = 0; j < s_NumberFeatures; ++j, ++column) {
-                    *column = values[i * s_NumberFeatures + j];
-                }
-            });
-        }
-        s_Frame->finishWritingRows();
-    }
-
-    void initTree(test::CRandomNumbers& rng) {
-        s_Trees.resize(1);
-        auto& tree = s_Trees[0];
-
-        tree.reserve(s_NumberInnerNodes * 2 + 1);
-        TDoubleVecVec bottom;
-        bottom.reserve(s_NumberInnerNodes);
-        TDoubleVecVec top;
-        top.reserve(s_NumberInnerNodes);
-        TSizeVec splitFeature(1);
-        TDoubleVec splitThreshold(1);
-
-        tree.emplace_back();
-        bottom.emplace_back(s_NumberFeatures, -10);
-        top.emplace_back(s_NumberFeatures, 10);
-        for (std::size_t nodeIndex = 0; nodeIndex < s_NumberInnerNodes; ++nodeIndex) {
-            rng.generateUniformSamples(0, s_NumberFeatures, 1, splitFeature);
-            rng.generateUniformSamples(bottom[nodeIndex][splitFeature[0]],
-                                       top[nodeIndex][splitFeature[0]], 1, splitThreshold);
-            tree[nodeIndex].split(splitFeature[0], splitThreshold[0], true, 0.0, 0.0, tree);
-            // keep the management of the boundaries, to make sure the generated thresholds are realistic
-            TDoubleVec leftChildBottom{bottom[nodeIndex]};
-            TDoubleVec rightChildBottom{bottom[nodeIndex]};
-            TDoubleVec leftChildTop{top[nodeIndex]};
-            TDoubleVec rightChildTop{top[nodeIndex]};
-            leftChildTop[splitFeature[0]] = splitThreshold[0];
-            rightChildBottom[splitFeature[0]] = splitThreshold[0];
-            bottom.push_back(std::move(leftChildBottom));
-            bottom.push_back(std::move(rightChildBottom));
-            top.push_back(std::move(leftChildTop));
-            top.push_back(std::move(rightChildTop));
-        }
-
-        std::size_t numberLeafs{s_NumberInnerNodes + 1};
-        TDoubleVec leafValues(numberLeafs);
-        rng.generateUniformSamples(-5, 5, numberLeafs, leafValues);
-        for (std::size_t i = 0; i < numberLeafs; ++i) {
-            tree[s_NumberInnerNodes + i].value(toVector(leafValues[i]));
-        }
-
-        // set correct number samples
-        auto result = s_Frame->readRows(
-            1, core::bindRetrievableState(
-                   [&](TSizeVec& numberSamples, const TRowItr& beginRows, const TRowItr& endRows) {
-                       for (auto row = beginRows; row != endRows; ++row) {
-                           auto node{&(tree[0])};
-                           auto encodedRow{s_Encoder->encode(*row)};
-                           numberSamples[0] += 1;
-                           std::size_t nextIndex;
-                           while (node->isLeaf() == false) {
-                               if (node->assignToLeft(encodedRow)) {
-                                   nextIndex = node->leftChildIndex();
-                               } else {
-                                   nextIndex = node->rightChildIndex();
-                               }
-                               numberSamples[nextIndex] += 1;
-                               node = &(tree[nextIndex]);
-                           }
-                       }
-                   },
-                   TSizeVec(tree.size())));
-        TSizeVec numberSamples{std::move(result.first[0].s_FunctionState)};
-        for (std::size_t i = 0; i < numberSamples.size(); ++i) {
-            tree[i].numberSamples(numberSamples[i]);
-        }
-    }
-
-    TDataFrameUPtr s_Frame;
-    std::size_t s_NumberFeatures{5};
-    std::size_t s_NumberRows{1000};
-    std::size_t s_NumberInnerNodes{15};
-    TTreeShapFeatureImportanceUPtr s_TreeFeatureImportance;
-    TTreeShapFeatureImportanceUPtr s_TopTwoTreeFeatureImportance;
-    TEncoderUPtr s_Encoder;
-    TTreeVec s_Trees;
 };
 
 struct SFixtureMultipleTrees {
@@ -295,9 +191,9 @@ struct SFixtureMultipleTrees {
         tree2[6].numberSamples(4);
 
         s_TreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
-            *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
+            1, *s_Frame, *s_Encoder, s_Trees, s_NumberFeatures);
         s_TopTreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
-            *s_Frame, *s_Encoder, s_Trees, 1);
+            1, *s_Frame, *s_Encoder, s_Trees, 1);
     }
 
     TDataFrameUPtr s_Frame;
@@ -307,6 +203,125 @@ struct SFixtureMultipleTrees {
     TTreeShapFeatureImportanceUPtr s_TopTreeFeatureImportance;
     TEncoderUPtr s_Encoder;
     TTreeVec s_Trees;
+};
+
+struct SFixtureRandomTrees {
+    SFixtureRandomTrees() {
+        test::CRandomNumbers rng;
+        this->initFrame(rng);
+        CStubMakeDataFrameCategoryEncoder stubParameters{1, *s_Frame, 0, s_NumberFeatures};
+        s_Encoder = std::make_unique<maths::CDataFrameCategoryEncoder>(stubParameters);
+        this->initTrees(rng);
+        s_TreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            1, *s_Frame, *s_Encoder, s_SingleTree, s_NumberFeatures);
+        s_TopTwoTreeFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            1, *s_Frame, *s_Encoder, s_SingleTree, 2);
+        s_ForestFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            1, *s_Frame, *s_Encoder, s_MultipleTrees, s_NumberFeatures);
+        s_ThreadedForestFeatureImportance = std::make_unique<maths::CTreeShapFeatureImportance>(
+            2, *s_Frame, *s_Encoder, s_MultipleTrees, s_NumberFeatures);
+    }
+
+    void initFrame(test::CRandomNumbers& rng) {
+        TDoubleVec values;
+        rng.generateUniformSamples(-10.0, 10.0, s_NumberRows * s_NumberFeatures, values);
+
+        s_Frame = core::makeMainStorageDataFrame(s_NumberFeatures, s_NumberRows).first;
+        s_Frame->columnNames(columnNames(s_NumberFeatures));
+        for (std::size_t i = 0; i < s_NumberRows; ++i) {
+            s_Frame->writeRow([&](core::CDataFrame::TFloatVecItr column, int32_t&) {
+                for (std::size_t j = 0; j < s_NumberFeatures; ++j, ++column) {
+                    *column = values[i * s_NumberFeatures + j];
+                }
+            });
+        }
+        s_Frame->finishWritingRows();
+    }
+
+    void initTrees(test::CRandomNumbers& rng) {
+        s_SingleTree.resize(1);
+        s_MultipleTrees.resize(2);
+        initTree(rng, s_SingleTree[0]);
+        for (auto& tree : s_MultipleTrees) {
+            initTree(rng, tree);
+        }
+    }
+
+    void initTree(test::CRandomNumbers& rng, TTree& tree) {
+        tree.reserve(2 * s_NumberInnerNodes + 1);
+        TDoubleVecVec bottom;
+        bottom.reserve(s_NumberInnerNodes);
+        TDoubleVecVec top;
+        top.reserve(s_NumberInnerNodes);
+        TSizeVec splitFeature(1);
+        TDoubleVec splitThreshold(1);
+
+        tree.emplace_back();
+        bottom.emplace_back(s_NumberFeatures, -10);
+        top.emplace_back(s_NumberFeatures, 10);
+        for (std::size_t nodeIndex = 0; nodeIndex < s_NumberInnerNodes; ++nodeIndex) {
+            rng.generateUniformSamples(0, s_NumberFeatures, 1, splitFeature);
+            rng.generateUniformSamples(bottom[nodeIndex][splitFeature[0]],
+                                       top[nodeIndex][splitFeature[0]], 1, splitThreshold);
+            tree[nodeIndex].split(splitFeature[0], splitThreshold[0], true, 0.0, 0.0, tree);
+            // keep the management of the boundaries, to make sure the generated thresholds are realistic
+            TDoubleVec leftChildBottom{bottom[nodeIndex]};
+            TDoubleVec rightChildBottom{bottom[nodeIndex]};
+            TDoubleVec leftChildTop{top[nodeIndex]};
+            TDoubleVec rightChildTop{top[nodeIndex]};
+            leftChildTop[splitFeature[0]] = splitThreshold[0];
+            rightChildBottom[splitFeature[0]] = splitThreshold[0];
+            bottom.push_back(std::move(leftChildBottom));
+            bottom.push_back(std::move(rightChildBottom));
+            top.push_back(std::move(leftChildTop));
+            top.push_back(std::move(rightChildTop));
+        }
+
+        std::size_t numberLeafs{s_NumberInnerNodes + 1};
+        TDoubleVec leafValues(numberLeafs);
+        rng.generateUniformSamples(-5, 5, numberLeafs, leafValues);
+        for (std::size_t i = 0; i < numberLeafs; ++i) {
+            tree[s_NumberInnerNodes + i].value(toVector(leafValues[i]));
+        }
+
+        // set correct number samples
+        auto result = s_Frame->readRows(
+            1, core::bindRetrievableState(
+                   [&](TSizeVec& numberSamples, const TRowItr& beginRows, const TRowItr& endRows) {
+                       for (auto row = beginRows; row != endRows; ++row) {
+                           auto node{&(tree[0])};
+                           auto encodedRow{s_Encoder->encode(*row)};
+                           numberSamples[0] += 1;
+                           std::size_t nextIndex;
+                           while (node->isLeaf() == false) {
+                               if (node->assignToLeft(encodedRow)) {
+                                   nextIndex = node->leftChildIndex();
+                               } else {
+                                   nextIndex = node->rightChildIndex();
+                               }
+                               numberSamples[nextIndex] += 1;
+                               node = &(tree[nextIndex]);
+                           }
+                       }
+                   },
+                   TSizeVec(tree.size())));
+        TSizeVec numberSamples{std::move(result.first[0].s_FunctionState)};
+        for (std::size_t i = 0; i < numberSamples.size(); ++i) {
+            tree[i].numberSamples(std::max(numberSamples[i], std::size_t{1}));
+        }
+    }
+
+    TDataFrameUPtr s_Frame;
+    std::size_t s_NumberFeatures{5};
+    std::size_t s_NumberRows{1000};
+    std::size_t s_NumberInnerNodes{15};
+    TTreeShapFeatureImportanceUPtr s_TreeFeatureImportance;
+    TTreeShapFeatureImportanceUPtr s_TopTwoTreeFeatureImportance;
+    TTreeShapFeatureImportanceUPtr s_ForestFeatureImportance;
+    TTreeShapFeatureImportanceUPtr s_ThreadedForestFeatureImportance;
+    TEncoderUPtr s_Encoder;
+    TTreeVec s_SingleTree;
+    TTreeVec s_MultipleTrees;
 };
 
 class CBruteForceTreeShap {
@@ -499,14 +514,14 @@ BOOST_FIXTURE_TEST_CASE(testSingleTreeBruteForceShap, SFixtureSingleTree) {
     }
 }
 
-BOOST_FIXTURE_TEST_CASE(testSingleTreeShapRandomDataFrame, SFixtureSingleTreeRandom) {
+BOOST_FIXTURE_TEST_CASE(testSingleRandomTreeShap, SFixtureRandomTrees) {
 
     // Compare tree shap algorithm with the brute force approach (Algorithm
     // 1 in paper by Lundberg et al.) on a random data set with a random tree.
 
     TStrVec expectedNames{s_Frame->columnNames()};
 
-    CBruteForceTreeShap bfShap(s_Trees[0], s_NumberFeatures);
+    CBruteForceTreeShap bfShap(s_SingleTree[0], s_NumberFeatures);
     auto expectedPhi = bfShap.shap(*s_Frame, *s_Encoder, 1);
 
     TSizeVecVec expectedIndices(expectedPhi.size());
@@ -543,6 +558,40 @@ BOOST_FIXTURE_TEST_CASE(testSingleTreeShapRandomDataFrame, SFixtureSingleTreeRan
                 });
         }
     });
+}
+
+BOOST_FIXTURE_TEST_CASE(testThreadedRandomTreeShap, SFixtureRandomTrees) {
+
+    // Test that threaded and non-threaded implementations agree.
+
+    core::startDefaultAsyncExecutor();
+
+    s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        TSizeVec expectedIndices;
+        TStrVec expectedNames;
+        TVectorVec expectedShap;
+        for (auto row = beginRows; row != endRows; ++row) {
+            s_ForestFeatureImportance->shap(*row, [&](const TSizeVec& indices,
+                                                      const TStrVec& names,
+                                                      const TVectorVec& shap) {
+                expectedIndices = indices;
+                expectedNames = names;
+                expectedShap = shap;
+            });
+            s_ThreadedForestFeatureImportance->shap(*row, [&](const TSizeVec& indices,
+                                                              const TStrVec& names,
+                                                              const TVectorVec& shap) {
+                BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(expectedIndices),
+                                    core::CContainerPrinter::print(indices));
+                BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(expectedNames),
+                                    core::CContainerPrinter::print(names));
+                BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(expectedShap),
+                                    core::CContainerPrinter::print(shap));
+            });
+        }
+    });
+
+    core::stopDefaultAsyncExecutor();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -4,10 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include "core/Concurrency.h"
-#include <boost/test/tools/old/interface.hpp>
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
+#include <core/Concurrency.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>


### PR DESCRIPTION
We can split the work to compute feature importance up over the trees in the forest since we just sum up the per tree feature importances at the end.

In order to do this, I needed to expose an interface to `parallel_for_each` which takes a list of functions to run on subsets of the iterator range because we use member variables for the algorithm state to avoid reallocating for each training example, which I need to bind to each function upfront.