### PR TITLE
[7.x] Adding forecast parameter max_model_memory  (#1238)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 7.9.0
+
+=== Enhancements
+
+* Add support for larger forecasts in memory via max_model_memory setting.
+  (See {ml-pull}1238[#1238] and {pull}57254[#57254].)
+
 == {es} version 7.8.0
 
 === Enhancements

--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -44,6 +44,8 @@ struct testValidateNoExpiry;
 struct testValidateInvalidExpiry;
 struct testValidateBrokenMessage;
 struct testValidateMissingId;
+struct testValidateProvidedMaxMemoryLimit;
+struct testValidateProvidedTooLargeMaxMemoryLimit;
 }
 
 namespace ml {
@@ -78,7 +80,7 @@ public:
     static const size_t DEFAULT_EXPIRY_TIME = 14 * core::constants::DAY;
 
     //! max memory allowed to use for forecast models
-    static const size_t MAX_FORECAST_MODEL_MEMORY = 20971520ull; // 20MB
+    static const size_t DEFAULT_MAX_FORECAST_MODEL_MEMORY = 20971520ull; // 20MB
 
     //! Note: This value measures the size in memory, not the size of the persistence,
     //! which is likely higher and would be hard to calculate upfront
@@ -103,7 +105,7 @@ private:
     static const std::string ERROR_NO_DATA_PROCESSED;
     static const std::string ERROR_NO_CREATE_TIME;
     static const std::string ERROR_BAD_MEMORY_STATUS;
-    static const std::string ERROR_MEMORY_LIMIT;
+    static const std::string ERROR_BAD_MODEL_MEMORY_LIMIT;
     static const std::string ERROR_MEMORY_LIMIT_DISK;
     static const std::string ERROR_MEMORY_LIMIT_DISKSPACE;
     static const std::string ERROR_NOT_SUPPORTED_FOR_POPULATION_MODELS;
@@ -211,6 +213,9 @@ private:
         //! total memory required for this forecasting job (only the models)
         size_t s_MemoryUsage;
 
+        //! maximum allowed memory (in bytes) that this forecast can use
+        size_t s_MaxForecastModelMemory;
+
         //! A collection storing important messages from forecasting
         TStrUSet s_Messages;
 
@@ -249,11 +254,12 @@ private:
     void sendMessage(WRITE write, const SForecast& forecastJob, const std::string& message) const;
 
     //! parse and validate a forecast request and turn it into a forecast job
-    static bool
-    parseAndValidateForecastRequest(const std::string& controlMessage,
-                                    SForecast& forecastJob,
-                                    const core_t::TTime lastResultsTime,
-                                    const TErrorFunc& errorFunction = TErrorFunc());
+    static bool parseAndValidateForecastRequest(
+        const std::string& controlMessage,
+        SForecast& forecastJob,
+        const core_t::TTime lastResultsTime,
+        std::size_t jobBytesSizeLimit = std::numeric_limits<std::size_t>::max() / 2,
+        const TErrorFunc& errorFunction = TErrorFunc());
 
 private:
     //! This job ID
@@ -292,6 +298,8 @@ private:
     friend struct CForecastRunnerTest::testValidateInvalidExpiry;
     friend struct CForecastRunnerTest::testValidateBrokenMessage;
     friend struct CForecastRunnerTest::testValidateMissingId;
+    friend struct CForecastRunnerTest::testValidateProvidedMaxMemoryLimit;
+    friend struct CForecastRunnerTest::testValidateProvidedTooLargeMaxMemoryLimit;
 };
 }
 }

--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -7,8 +7,6 @@
 #ifndef INCLUDED_ml_api_CForecastRunner_h
 #define INCLUDED_ml_api_CForecastRunner_h
 
-#include <api/ImportExport.h>
-
 #include <core/CConcurrentWrapper.h>
 #include <core/CJsonOutputStreamWrapper.h>
 #include <core/CNonCopyable.h>
@@ -21,10 +19,13 @@
 #include <model/CForecastDataSink.h>
 #include <model/CResourceMonitor.h>
 
+#include <api/ImportExport.h>
+
 #include <boost/filesystem.hpp>
 #include <boost/unordered_set.hpp>
 
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>
@@ -32,8 +33,6 @@
 #include <string>
 #include <thread>
 #include <vector>
-
-#include <stdint.h>
 
 namespace CForecastRunnerTest {
 struct testPopulation;
@@ -74,28 +73,29 @@ class API_EXPORT CForecastRunner final : private core::CNonCopyable {
 public:
     //! max open forecast requests
     //! if you change this, also change the ERROR_TOO_MANY_JOBS message accordingly
-    static const size_t MAX_FORECAST_JOBS_IN_QUEUE = 3;
+    static const std::size_t MAX_FORECAST_JOBS_IN_QUEUE = 3;
 
     //! default expiry time
-    static const size_t DEFAULT_EXPIRY_TIME = 14 * core::constants::DAY;
+    static const std::size_t DEFAULT_EXPIRY_TIME = 14 * core::constants::DAY;
 
     //! max memory allowed to use for forecast models
-    static const size_t DEFAULT_MAX_FORECAST_MODEL_MEMORY = 20971520ull; // 20MB
+    //! (not defined inline because we need its address)
+    static const std::size_t DEFAULT_MAX_FORECAST_MODEL_MEMORY;
 
     //! Note: This value measures the size in memory, not the size of the persistence,
     //! which is likely higher and would be hard to calculate upfront
     //! max memory allowed to use for forecast models persisting to disk
-    static const size_t MAX_FORECAST_MODEL_PERSISTANCE_MEMORY = 524288000ull; // 500MB
+    static const std::size_t MAX_FORECAST_MODEL_PERSISTANCE_MEMORY = 524288000ull; // 500MB
 
     //! Note: This value is lower than in the ML Java code to prevent side-effects.
     //! If you change this value also change the limit in the ML Java code.
     //! The purpose of this value is to guard the rest of the system against
     //! running out of disk space.
     //! minimum disk space required for disk persistence
-    static const size_t MIN_FORECAST_AVAILABLE_DISK_SPACE = 4294967296ull; // 4GB
+    static const std::size_t MIN_FORECAST_AVAILABLE_DISK_SPACE = 4294967296ull; // 4GB
 
     //! minimum time between stat updates to prevent to many updates in a short time
-    static const uint64_t MINIMUM_TIME_ELAPSED_FOR_STATS_UPDATE = 3000ul; // 3s
+    static const std::uint64_t MINIMUM_TIME_ELAPSED_FOR_STATS_UPDATE = 3000ul; // 3s
 
 private:
     static const std::string ERROR_FORECAST_REQUEST_FAILED_TO_PARSE;
@@ -205,16 +205,16 @@ private:
         double s_BoundsPercentile;
 
         //! total number of models
-        size_t s_NumberOfModels;
+        std::size_t s_NumberOfModels;
 
         //! total number of models able to forecast
-        size_t s_NumberOfForecastableModels;
+        std::size_t s_NumberOfForecastableModels;
 
         //! total memory required for this forecasting job (only the models)
-        size_t s_MemoryUsage;
+        std::size_t s_MemoryUsage;
 
         //! maximum allowed memory (in bytes) that this forecast can use
-        size_t s_MaxForecastModelMemory;
+        std::size_t s_MaxForecastModelMemory;
 
         //! A collection storing important messages from forecasting
         TStrUSet s_Messages;

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -107,6 +107,8 @@ public:
     //! Set the internal memory limit, as specified in a limits config file
     void memoryLimit(std::size_t limitMBs);
 
+    std::size_t getBytesMemoryLimit() const;
+
     //! Get the memory status
     model_t::EMemoryStatus getMemoryStatus();
 

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -35,7 +35,8 @@ const std::string CForecastRunner::ERROR_NO_DATA_PROCESSED(
     "Forecast cannot be executed as job requires data to have been processed and modeled");
 const std::string CForecastRunner::ERROR_NO_CREATE_TIME("Forecast create time must be specified and non zero");
 const std::string CForecastRunner::ERROR_BAD_MEMORY_STATUS("Forecast cannot be executed as model memory status is not OK");
-const std::string CForecastRunner::ERROR_MEMORY_LIMIT("Forecast cannot be executed as forecast memory usage is predicted to exceed 20MB while disk space is exceeded");
+const std::string CForecastRunner::ERROR_BAD_MODEL_MEMORY_LIMIT(
+    "Forecast max_model_memory must be below 500MB and must not exceed 40% of the job's configured model memory limit.");
 const std::string CForecastRunner::ERROR_MEMORY_LIMIT_DISK(
     "Forecast cannot be executed as forecast memory usage is predicted to exceed 500MB");
 const std::string CForecastRunner::ERROR_MEMORY_LIMIT_DISKSPACE(
@@ -266,6 +267,7 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
     SForecast forecastJob;
     if (parseAndValidateForecastRequest(
             controlMessage, forecastJob, lastResultsTime,
+            m_ResourceMonitor.getBytesMemoryLimit(),
             std::bind(&CForecastRunner::sendErrorMessage, this,
                       std::placeholders::_1, std::placeholders::_2)) == false) {
         return false;
@@ -300,10 +302,12 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
                                       prerequisites.s_IsSupportedFunction;
         totalMemoryUsage += prerequisites.s_MemoryUsageForDetector;
 
-        if (totalMemoryUsage >= MAX_FORECAST_MODEL_MEMORY &&
+        if (totalMemoryUsage >= forecastJob.s_MaxForecastModelMemory &&
             forecastJob.s_TemporaryFolder.empty()) {
-            // note: for now MAX_FORECAST_MODEL_MEMORY is a static limit, a user can not change it
-            this->sendErrorMessage(forecastJob, ERROR_MEMORY_LIMIT);
+            this->sendErrorMessage(
+                forecastJob, "Forecast cannot be executed as forecast memory usage is predicted to exceed " +
+                                 std::to_string(forecastJob.s_MaxForecastModelMemory) +
+                                 " bytes while disk space is exceeded");
             return false;
         }
     }
@@ -337,7 +341,7 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
 
     // 2nd loop over the detectors to clone models for forecasting
     bool persistOnDisk = false;
-    if (totalMemoryUsage >= MAX_FORECAST_MODEL_MEMORY) {
+    if (totalMemoryUsage >= forecastJob.s_MaxForecastModelMemory) {
         boost::filesystem::path temporaryFolder(forecastJob.s_TemporaryFolder);
 
         if (this->sufficientAvailableDiskSpace(temporaryFolder) == false) {
@@ -345,7 +349,8 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
             return false;
         }
 
-        LOG_INFO(<< "Forecast of large model requested (requires "
+        LOG_WARN(<< "Forecast [" << forecastJob.s_ForecastId << "] memory usage exceeds configured byte limit ["
+                 << std::to_string(forecastJob.s_MaxForecastModelMemory) << "] (requires "
                  << std::to_string(1 + (totalMemoryUsage >> 20)) << " MB), using disk.");
 
         // create a subdirectory using the unique forecast id
@@ -404,6 +409,7 @@ bool CForecastRunner::push(SForecast& forecastJob) {
 bool CForecastRunner::parseAndValidateForecastRequest(const std::string& controlMessage,
                                                       SForecast& forecastJob,
                                                       const core_t::TTime lastResultsTime,
+                                                      std::size_t jobBytesSizeLimit,
                                                       const TErrorFunc& errorFunction) {
     std::istringstream stringStream(controlMessage.substr(1));
     forecastJob.s_StartTime = lastResultsTime;
@@ -418,6 +424,8 @@ bool CForecastRunner::parseAndValidateForecastRequest(const std::string& control
             properties.get<std::string>("forecast_alias", EMPTY_STRING);
         forecastJob.s_Duration = properties.get<core_t::TTime>("duration", 0);
         forecastJob.s_CreateTime = properties.get<core_t::TTime>("create_time", 0);
+        forecastJob.s_MaxForecastModelMemory = properties.get<size_t>(
+            "max_model_memory", DEFAULT_MAX_FORECAST_MODEL_MEMORY);
 
         // tmp storage if available
         forecastJob.s_TemporaryFolder = properties.get<std::string>("tmp_storage", EMPTY_STRING);
@@ -437,6 +445,14 @@ bool CForecastRunner::parseAndValidateForecastRequest(const std::string& control
     }
 
     // from now we have a forecast ID and can send error messages
+    if (forecastJob.s_MaxForecastModelMemory != DEFAULT_MAX_FORECAST_MODEL_MEMORY &&
+        (forecastJob.s_MaxForecastModelMemory >= MAX_FORECAST_MODEL_PERSISTANCE_MEMORY ||
+         forecastJob.s_MaxForecastModelMemory >=
+             static_cast<std::size_t>(jobBytesSizeLimit * 0.40))) {
+        errorFunction(forecastJob, ERROR_BAD_MODEL_MEMORY_LIMIT);
+        return false;
+    }
+
     if (lastResultsTime == 0l) {
         errorFunction(forecastJob, ERROR_NO_DATA_PROCESSED);
         return false;

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -71,6 +71,10 @@ void CResourceMonitor::memoryLimit(std::size_t limitMBs) {
     }
 }
 
+std::size_t CResourceMonitor::getBytesMemoryLimit() const {
+    return m_ByteLimitHigh * this->persistenceMemoryIncreaseFactor();
+}
+
 void CResourceMonitor::updateMemoryLimitsAndPruneThreshold(std::size_t limitMBs) {
     // The threshold for no limit is set such that any negative limit cast to
     // a size_t (which is unsigned) will be taken to mean no limit


### PR DESCRIPTION
This commit adds new parameter max_model_memory.

This parameter is defaulted to `20mb` (the previous static setting).
Some larger forecasts can take a very long time to run. But if a user
has enough memory, they may opt to run more of the forecast in memory
without spooling to disk.

elasticsearch change https://github.com/elastic/elasticsearch/pull/57254