### PR TITLE
[ML] Silence some gcc warnings

### DIFF
--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -327,7 +327,7 @@ bool parallel_for_each(std::size_t start,
     // in order of increasing complexity and decreasing pessimism are:
     //   1) Execute sequentially if there are any tasks in the thread pool, we then
     //      won't wait here and nothing will block in the queue,
-    //   2) Assign tasks a priority and ensure in the queue that tasks are execute
+    //   2) Assign tasks a priority and ensure in the queue that tasks are executed
     //      in priority order. Then we can assign these tasks "highest priority in
     //      queue" + 1.
     //

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -151,7 +151,7 @@ async(CExecutor& executor, FUNCTION&& f, ARGS&&... args) {
     // Schedule the task to compute the result.
     executor.schedule(std::move(task));
 
-    return std::move(result);
+    return result;
 }
 
 //! Wait for all \p futures to be available.

--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -239,7 +239,8 @@ private:
 //! minimises regularised cross entropy loss w.r.t. the actual classes.
 //!
 //! DESCRIPTION:\n
-//! We want to find the weight which minimizes the log-loss, i.e. which satisfies
+//! We want to find the weight which minimizes the cross entropy, i.e. which
+//! satisfies:
 //! <pre class="fragment">
 //!   \f$\displaystyle arg\min_w{ \lambda \|w\|^2 -\sum_i{ \log([softmax(p_i + w)]_{a_i}) } }\f$
 //! </pre>
@@ -254,7 +255,7 @@ private:
 //!
 //! Here, \f$P\f$ ranges over the subsets of the partition, \f$\bar{p}_P\f$ denotes
 //! the mean of the predictions in the P'th subset and \f$c_{a_i, P}\f$ denote the
-//! counts of each classes \f$\{a_i\}\f$ in the subset \f$P\f$. We compute this
+//! counts of each classes \f$\{a_i\}\f$ in the P'th subset. We compute this
 //! partition via a weighted random sample where the weights are proportional to
 //! the mean distance between each point and the rest of the sample set.
 class MATHS_EXPORT CArgMinMultinomialLogisticLossImpl final : public CArgMinLossImpl {

--- a/lib/core/unittest/CImmutableRadixSetTest.cc
+++ b/lib/core/unittest/CImmutableRadixSetTest.cc
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(testUpperBound) {
         for (auto probe : probes) {
             BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) -
                                     values.begin(),
-                                set.upperBound(probe));
+                                set.upperBound(static_cast<double>(probe)));
         }
     }
 
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(testUpperBound) {
         for (auto probe : probes) {
             BOOST_REQUIRE_EQUAL(std::upper_bound(values.begin(), values.end(), probe) -
                                     values.begin(),
-                                set.upperBound(probe));
+                                set.upperBound(static_cast<double>(probe)));
         }
     }
 }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1070,7 +1070,7 @@ CTimeSeriesDecompositionDetail::CComponents::CComponents(double decayRate,
 }
 
 CTimeSeriesDecompositionDetail::CComponents::CComponents(const CComponents& other)
-    : m_Machine{other.m_Machine}, m_DecayRate{other.m_DecayRate},
+    : CHandler{}, m_Machine{other.m_Machine}, m_DecayRate{other.m_DecayRate},
       m_BucketLength{other.m_BucketLength}, m_GainController{other.m_GainController},
       m_SeasonalComponentSize{other.m_SeasonalComponentSize},
       m_CalendarComponentSize{other.m_CalendarComponentSize}, m_Trend{other.m_Trend},

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -1565,9 +1565,9 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
             3 * sizeof(maths::CNormalMeanPrecConjugate) +
             sizeof(maths::CUnivariateTimeSeriesModel::TDecayRateController2Ary) +
             2 * controllers[0].memoryUsage() + 16 * 12 /*Recent samples*/};
-        std::size_t size = model->memoryUsage();
+        std::size_t size{model->memoryUsage()};
         LOG_DEBUG(<< "size " << size << " expected " << expectedSize);
-        BOOST_TEST_REQUIRE(size < 1.1 * expectedSize);
+        BOOST_TEST_REQUIRE(static_cast<double>(size) < 1.1 * static_cast<double>(expectedSize));
     }
 
     LOG_DEBUG(<< "Multivariate");
@@ -1601,9 +1601,9 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
             2 * sizeof(maths::CMultivariateNormalConjugate<3>) +
             sizeof(maths::CUnivariateTimeSeriesModel::TDecayRateController2Ary) +
             2 * controllers[0].memoryUsage() + 32 * 12 /*Recent samples*/};
-        std::size_t size = model->memoryUsage();
+        std::size_t size{model->memoryUsage()};
         LOG_DEBUG(<< "size " << size << " expected " << expectedSize);
-        BOOST_TEST_REQUIRE(size < 1.1 * expectedSize);
+        BOOST_TEST_REQUIRE(static_cast<double>(size) < 1.1 * static_cast<double>(expectedSize));
     }
 
     // TODO LOG_DEBUG(<< "Correlates");


### PR DESCRIPTION
We still have a few gcc warnings mainly about type coercion. This silences those and also corrects a couple of comment typos.