### PR TITLE
[ML] Improve seasonal component test parameterisation

### DIFF
--- a/include/core/Constants.h
+++ b/include/core/Constants.h
@@ -25,17 +25,21 @@ const core_t::TTime HOUR{3600};
 //! A day in seconds.
 const core_t::TTime DAY{86400};
 
-//! A (two day) weekend in seconds.
+//! Two days in seconds.
 const core_t::TTime WEEKEND{172800};
 
-//! Five weekdays in seconds.
+//! Five days in seconds.
 const core_t::TTime WEEKDAYS{432000};
 
 //! A week in seconds.
 const core_t::TTime WEEK{604800};
 
-//! A (364 day) year in seconds.
-const core_t::TTime YEAR{31449600};
+//! 365 days in seconds.
+//!
+//! Note that this doesn't use the more standard 365.2425 days average length
+//! of a Gregorian year because things work out slightly better if it is a
+//! multiple time series bucket length.
+const core_t::TTime YEAR{31536000};
 
 //! Log of min double.
 const double LOG_MIN_DOUBLE{std::log(std::numeric_limits<double>::min())};

--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -109,10 +109,10 @@ public:
     void trend(CTrendHypothesis value);
 
     //! Fit and remove the appropriate trend from \p values.
-    void removeTrend(TFloatMeanAccumulatorVec& values) const;
+    void removeTrendFrom(TFloatMeanAccumulatorVec& values) const;
 
     //! Remove any discontinuities in \p values.
-    void removeDiscontinuities(TFloatMeanAccumulatorVec& values) const;
+    void removeDiscontinuitiesFrom(TFloatMeanAccumulatorVec& values) const;
 
     //! Check if there are any periodic components.
     bool periodic() const;

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -239,13 +239,8 @@ public:
     private:
         using TTimeDoublePr = std::pair<core_t::TTime, double>;
         using TTimeDoublePrVec = std::vector<std::pair<core_t::TTime, double>>;
-        using TExpandingWindowPtr = std::unique_ptr<CExpandingWindow>;
-        using TExpandingWindowPtrAry = std::array<TExpandingWindowPtr, 2>;
-
-    private:
-        //! The longest bucket length at which we'll test for periodic
-        //! components.
-        static const core_t::TTime LONGEST_BUCKET_LENGTH;
+        using TExpandingWindowUPtr = std::unique_ptr<CExpandingWindow>;
+        using TExpandingWindowPtrAry = std::array<TExpandingWindowUPtr, 2>;
 
     private:
         //! Handle \p symbol.
@@ -255,7 +250,7 @@ public:
         bool shouldTest(ETest test, core_t::TTime time) const;
 
         //! Get a new \p test. (Warning: this is owned by the caller.)
-        CExpandingWindow* newWindow(ETest test, bool deflate = true) const;
+        TExpandingWindowUPtr newWindow(ETest test, bool deflate = true) const;
 
         //! Account for memory that is not allocated by initialisation.
         std::size_t extraMemoryOnInitialization() const;

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -2370,7 +2370,15 @@ CPeriodicityHypothesisTests::CNestedHypotheses::CBuilder::finishedNested() {
 namespace {
 
 //! Apply selection bias for known common periods.
+//!
+//! The estimated repeat can be in error. The larger the error the less effective
+//! the modelling will be, since the pattern will precess over time. We therefore
+//! bias towards selecting known common periods by applying a multiplier > 1 to
+//! their correlation.
 double applySelectionBias(std::size_t periodBuckets, core_t::TTime bucketLength, double correlation) {
+    // Daily and weekly periods are explicitly handled when testing for periodicity
+    // and we add calendar predictive features to deal with cyclic monthly effects.
+    // This therefore only biases for annual periodicity.
     core_t::TTime period{static_cast<core_t::TTime>(periodBuckets) * bucketLength};
     if (std::abs(period - core::constants::YEAR) <= bucketLength) {
         return 1.1 * correlation;
@@ -2378,7 +2386,7 @@ double applySelectionBias(std::size_t periodBuckets, core_t::TTime bucketLength,
     return correlation;
 }
 
-//! Compute the period snapping close periods to the selection bias.
+//! If the period is close snap it to a common period.
 core_t::TTime selectPeriod(std::size_t periodBuckets, core_t::TTime bucketLength) {
     core_t::TTime period{static_cast<core_t::TTime>(periodBuckets) * bucketLength};
     if (std::abs(period - core::constants::YEAR) <= bucketLength) {

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -561,7 +561,7 @@ void CPeriodicityHypothesisTestsResult::trend(CTrendHypothesis value) {
     m_Trend = value;
 }
 
-void CPeriodicityHypothesisTestsResult::removeTrend(TFloatMeanAccumulatorVec& values) const {
+void CPeriodicityHypothesisTestsResult::removeTrendFrom(TFloatMeanAccumulatorVec& values) const {
     if (m_Trend.type() == CTrendHypothesis::E_Linear) {
         removeLinearTrend(values);
     } else if (m_Trend.type() == CTrendHypothesis::E_PiecewiseLinear) {
@@ -570,7 +570,7 @@ void CPeriodicityHypothesisTestsResult::removeTrend(TFloatMeanAccumulatorVec& va
     }
 }
 
-void CPeriodicityHypothesisTestsResult::removeDiscontinuities(TFloatMeanAccumulatorVec& values) const {
+void CPeriodicityHypothesisTestsResult::removeDiscontinuitiesFrom(TFloatMeanAccumulatorVec& values) const {
     if (m_Trend.type() == CTrendHypothesis::E_PiecewiseLinear) {
         TSizeVec segmentation(CTimeSeriesSegmentation::piecewiseLinear(values));
         values = CTimeSeriesSegmentation::removePiecewiseLinearDiscontinuities(
@@ -2369,6 +2369,24 @@ CPeriodicityHypothesisTests::CNestedHypotheses::CBuilder::finishedNested() {
 
 namespace {
 
+//! Apply selection bias for known common periods.
+double applySelectionBias(std::size_t periodBuckets, core_t::TTime bucketLength, double correlation) {
+    core_t::TTime period{static_cast<core_t::TTime>(periodBuckets) * bucketLength};
+    if (std::abs(period - core::constants::YEAR) <= bucketLength) {
+        return 1.1 * correlation;
+    }
+    return correlation;
+}
+
+//! Compute the period snapping close periods to the selection bias.
+core_t::TTime selectPeriod(std::size_t periodBuckets, core_t::TTime bucketLength) {
+    core_t::TTime period{static_cast<core_t::TTime>(periodBuckets) * bucketLength};
+    if (std::abs(period - core::constants::YEAR) <= bucketLength) {
+        return core::constants::YEAR;
+    }
+    return period;
+}
+
 //! Compute the mean of the autocorrelation for \f${P, 2P, ...}\f$
 //! where \f$P\f$ is \p period.
 double meanAutocorrelationForPeriodicOffsets(const TDoubleVec& correlations,
@@ -2387,7 +2405,8 @@ double meanAutocorrelationForPeriodicOffsets(const TDoubleVec& correlations,
 
 //! Find the single periodic component which explains the most
 //! cyclic autocorrelation.
-std::size_t mostSignificantPeriodicComponent(TFloatMeanAccumulatorVec values) {
+std::size_t mostSignificantPeriodicComponent(core_t::TTime bucketLength,
+                                             TFloatMeanAccumulatorVec values) {
     using TDoubleSizePr = std::pair<double, std::size_t>;
     using TMaxAccumulator =
         CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr, std::greater<TDoubleSizePr>>;
@@ -2410,10 +2429,12 @@ std::size_t mostSignificantPeriodicComponent(TFloatMeanAccumulatorVec values) {
     // periodic.
     TMaxAccumulator candidates(15);
     correlations.resize(pad);
-    for (std::size_t p = 4u; p < correlations.size(); ++p) {
-        double correlation{meanAutocorrelationForPeriodicOffsets(correlations, n, p)};
-        LOG_TRACE(<< "correlation(" << p << ") = " << correlation);
-        candidates.add({correlation, p});
+    for (std::size_t period = 4; period < correlations.size(); ++period) {
+        double correlation{applySelectionBias(
+            period, bucketLength,
+            meanAutocorrelationForPeriodicOffsets(correlations, n, period))};
+        LOG_TRACE(<< "correlation(" << period << ") = " << correlation);
+        candidates.add({correlation, period});
     }
 
     // Sort by decreasing cyclic autocorrelation.
@@ -2422,9 +2443,11 @@ std::size_t mostSignificantPeriodicComponent(TFloatMeanAccumulatorVec values) {
         candidates.begin(), candidates.end(), candidatePeriods.begin(),
         [](const TDoubleSizePr& candidate_) { return candidate_.second; });
     candidates.clear();
-    for (const auto period : candidatePeriods) {
+    for (const auto& period : candidatePeriods) {
         TFloatMeanAccumulatorCRng window(values, 0, period * (n / period));
-        candidates.add({CSignal::autocorrelation(period, window), period});
+        candidates.add({applySelectionBias(period, bucketLength,
+                                           CSignal::autocorrelation(period, window)),
+                        period});
     }
     candidates.sort();
     LOG_TRACE(<< "candidate periods = " << candidates.print());
@@ -2453,9 +2476,9 @@ testForPeriods(const CPeriodicityHypothesisTestsConfig& config,
 
     // Find the single periodic component which explains the
     // most cyclic autocorrelation.
-    std::size_t period_{mostSignificantPeriodicComponent(values)};
+    std::size_t periodBuckets{mostSignificantPeriodicComponent(bucketLength, values)};
     core_t::TTime windowLength{static_cast<core_t::TTime>(values.size()) * bucketLength};
-    core_t::TTime period{static_cast<core_t::TTime>(period_) * bucketLength};
+    core_t::TTime period{selectPeriod(periodBuckets, bucketLength)};
     LOG_TRACE(<< "bucket length = " << bucketLength << ", windowLength = " << windowLength
               << ", periods to test = " << period << ", # values = " << values.size());
 

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -270,6 +270,10 @@ const std::string VERSION_6_3_TAG("6.3");
 const std::string VERSION_6_4_TAG("6.4");
 
 // Periodicity Test Tags
+// Version 7.9
+const core::TPersistenceTag SHORT_WINDOW_7_9_TAG{"e", "short_window"};
+const core::TPersistenceTag LONG_WINDOW_7_9_TAG{"f", "long_window"};
+// Version 7.2
 const core::TPersistenceTag LINEAR_SCALES_7_2_TAG{"d", "linear_scales"};
 // Version 6.3
 const core::TPersistenceTag PERIODICITY_TEST_MACHINE_6_3_TAG{"a", "periodicity_test_machine"};
@@ -472,13 +476,130 @@ std::size_t CTimeSeriesDecompositionDetail::CMediator::memoryUsage() const {
 
 //////// CPeriodicityTest ////////
 
+namespace {
+
+using TTimeTimeVecPrVec = std::vector<std::pair<core_t::TTime, TTimeVec>>;
+
+//! \brief Manages the choice of the tests' window parameters as a function
+//! of the job's bucket length.
+//!
+//! DESCRIPTION:\n
+//! The exact choice of window parameters is a tradeoff between the number
+//! of points used in the test and how quickly it finds periodic components.
+//! The fewer points the higher the chance of the false positives, but for
+//! long bucket lengths using many buckets means it takes a long time to
+//! find significant periodic components.
+class CPeriodicityTestWindowParameters {
+public:
+    static core_t::TTime maxBucketLength() { return 604800; }
+
+    static std::size_t numberBuckets(int window, core_t::TTime bucketLength) {
+        auto result = windowParameters(window, bucketLength);
+        return result != nullptr ? result->s_NumberBuckets : 0;
+    }
+
+    static const TTimeVec* bucketLengths(int window, core_t::TTime bucketLength) {
+        auto result = windowParameters(window, bucketLength);
+        return result != nullptr ? &result->s_BucketLengths : nullptr;
+    }
+
+    static const TTimeVec& testSchedule(int window, core_t::TTime bucketLength) {
+        return windowParameters(window, bucketLength)->s_TestSchedule;
+    }
+
+    static core_t::TTime shortestComponent(int window, core_t::TTime bucketLength) {
+        return windowParameters(window, bucketLength)->s_ShortestComponent;
+    }
+
+private:
+    struct CParameters {
+        CParameters() = default;
+        CParameters(core_t::TTime bucketLength,
+                    core_t::TTime shortestComponent,
+                    std::size_t numberBuckets,
+                    const std::initializer_list<core_t::TTime>& bucketLengths,
+                    const std::initializer_list<core_t::TTime>& testSchedule)
+            : s_BucketLength{bucketLength}, s_ShortestComponent{shortestComponent},
+              s_NumberBuckets{numberBuckets}, s_BucketLengths{bucketLengths}, s_TestSchedule{testSchedule} {
+        }
+        bool operator<(core_t::TTime rhs) const { return s_BucketLength < rhs; }
+
+        core_t::TTime s_BucketLength = 0;
+        core_t::TTime s_ShortestComponent = 0;
+        std::size_t s_NumberBuckets = 0;
+        TTimeVec s_BucketLengths;
+        TTimeVec s_TestSchedule;
+    };
+    using TParametersVecVec = std::vector<std::vector<CParameters>>;
+    using TTimeParametersUMap = boost::unordered_map<core_t::TTime, CParameters>;
+
+private:
+    static const CParameters* windowParameters(int window, core_t::TTime bucketLength) {
+        auto result = std::lower_bound(WINDOW_PARAMETERS[window].begin(),
+                                       WINDOW_PARAMETERS[window].end(), bucketLength);
+        return result != WINDOW_PARAMETERS[window].end() ? &(*result) : nullptr;
+    }
+
+private:
+    static const TParametersVecVec WINDOW_PARAMETERS;
+};
+
+// These parameterise the windows used to test for periodic components. From
+// left to right the parameters are:
+//   1. The job bucket length,
+//   2. The minimum period seasonal component we'll accept testing on the window,
+//   3. The number buckets in the window,
+//   4. The bucket lengths we'll cycle through as we test progressively longer
+//      windows,
+//   5. The times, in addition to "number buckets" * "window bucket lengths",
+//      when we'll test for seasonal components.
+const CPeriodicityTestWindowParameters::TParametersVecVec CPeriodicityTestWindowParameters::WINDOW_PARAMETERS{
+    {/*  SHORT WINDOW  */
+     {1, 1, 336, {1, 5, 10, 30, 60}, {}},
+     {5, 1, 336, {5, 10, 30, 60, 300}, {}},
+     {10, 1, 336, {10, 30, 60, 300, 600}, {}},
+     {30, 1, 336, {30, 60, 300, 600, 1800}, {3 * 86400}},
+     {60, 1, 336, {60, 300, 600, 1800, 3600}, {3 * 86400}},
+     {300, 1, 336, {300, 600, 1800, 3600}, {3 * 86400}},
+     {600, 1, 336, {600, 1800, 3600}, {3 * 86400}},
+     {900, 1, 336, {900, 1800, 3600, 7200}, {3 * 86400}},
+     {1200, 1, 336, {1200, 3600, 7200}, {3 * 86400}},
+     {1800, 1, 336, {1800, 3600, 7200}, {3 * 86400}},
+     {3600, 1, 336, {3600, 7200}, {3 * 86400, 7 * 86400}},
+     {7200, 1, 336, {7200}, {3 * 86400, 7 * 86400}},
+     {14400, 1, 168, {14400}, {7 * 86400, 21 * 86400}},
+     {21600, 1, 112, {21600}, {7 * 86400, 21 * 86400}},
+     {28800, 1, 84, {28800}, {21 * 86400}},
+     {43200, 1, 56, {43200}, {28 * 86400}},
+     {86400, 1, 56, {86400}, {}}},
+    /*  LONG WINDOW  */
+    {{1, 86401, 336, {600, 1800, 3600, 7200}, {3 * 86400}},
+     {5, 86401, 336, {1800, 3600, 7200}, {3 * 86400}},
+     {10, 86401, 336, {3600, 7200}, {3 * 86400, 7 * 86400}},
+     {30, 86401, 336, {3600, 7200}, {3 * 86400, 7 * 86400}},
+     {60, 86401, 336, {7200}, {21 * 86400}},
+     {300, 86401, 336, {7200, 14400}, {21 * 86400}},
+     {600, 86401, 336, {7200, 14400}, {21 * 86400}},
+     {900, 604801, 365, {7200, 14400, 28800, 86400, 259200}, {}},
+     {1200, 604801, 365, {7200, 14400, 28800, 86400, 259200}, {}},
+     {1800, 604801, 365, {14400, 28800, 86400, 259200}, {}},
+     {3600, 604801, 365, {14400, 28800, 86400, 259200}, {}},
+     {7200, 604801, 365, {14400, 28800, 86400, 259200}, {}},
+     {14400, 604801, 365, {28800, 86400, 259200}, {}},
+     {28800, 604801, 365, {86400, 259200}, {}},
+     {43200, 604801, 365, {86400, 259200}, {}},
+     {86400, 604801, 365, {86400, 259200}, {}},
+     {604800, 604801, 365, {604800}, {168 * 604800}}}};
+}
+
 CTimeSeriesDecompositionDetail::CPeriodicityTest::CPeriodicityTest(double decayRate,
                                                                    core_t::TTime bucketLength)
     : m_Machine{core::CStateMachine::create(
           PT_ALPHABET,
           PT_STATES,
           PT_TRANSITION_FUNCTION,
-          bucketLength > LONGEST_BUCKET_LENGTH ? PT_NOT_TESTING : PT_INITIAL)},
+          bucketLength > CPeriodicityTestWindowParameters::maxBucketLength() ? PT_NOT_TESTING
+                                                                             : PT_INITIAL)},
       m_DecayRate{decayRate}, m_BucketLength{bucketLength} {
 }
 
@@ -502,14 +623,16 @@ bool CTimeSeriesDecompositionDetail::CPeriodicityTest::acceptRestoreTraverser(
                 traverser.traverseSubLevel([this](core::CStateRestoreTraverser& traverser_) {
                     return m_Machine.acceptRestoreTraverser(traverser_);
                 }))
+        RESTORE_NO_ERROR(SHORT_WINDOW_6_3_TAG, m_Windows[E_Short] = this->newWindow(E_Short))
         RESTORE_SETUP_TEARDOWN(
-            SHORT_WINDOW_6_3_TAG, m_Windows[E_Short].reset(this->newWindow(E_Short)),
+            SHORT_WINDOW_7_9_TAG, m_Windows[E_Short] = this->newWindow(E_Short),
             m_Windows[E_Short] && traverser.traverseSubLevel(std::bind(
                                       &CExpandingWindow::acceptRestoreTraverser,
                                       m_Windows[E_Short].get(), std::placeholders::_1)),
             /**/)
+        RESTORE_NO_ERROR(LONG_WINDOW_6_3_TAG, m_Windows[E_Long] = this->newWindow(E_Long))
         RESTORE_SETUP_TEARDOWN(
-            LONG_WINDOW_6_3_TAG, m_Windows[E_Long].reset(this->newWindow(E_Long)),
+            LONG_WINDOW_7_9_TAG, m_Windows[E_Long] = this->newWindow(E_Long),
             m_Windows[E_Long] && traverser.traverseSubLevel(std::bind(
                                      &CExpandingWindow::acceptRestoreTraverser,
                                      m_Windows[E_Long].get(), std::placeholders::_1)),
@@ -526,12 +649,12 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::acceptPersistInserter(
                          std::bind(&core::CStateMachine::acceptPersistInserter,
                                    &m_Machine, std::placeholders::_1));
     if (m_Windows[E_Short] != nullptr) {
-        inserter.insertLevel(SHORT_WINDOW_6_3_TAG,
+        inserter.insertLevel(SHORT_WINDOW_7_9_TAG,
                              std::bind(&CExpandingWindow::acceptPersistInserter,
                                        m_Windows[E_Short].get(), std::placeholders::_1));
     }
     if (m_Windows[E_Long] != nullptr) {
-        inserter.insertLevel(LONG_WINDOW_6_3_TAG,
+        inserter.insertLevel(LONG_WINDOW_7_9_TAG,
                              std::bind(&CExpandingWindow::acceptPersistInserter,
                                        m_Windows[E_Long].get(), std::placeholders::_1));
     }
@@ -606,8 +729,9 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::test(const SAddValue& mes
                 core_t::TTime bucketLength{window->bucketLength()};
                 CPeriodicityHypothesisTestsResult result{
                     testForPeriods(config, start, bucketLength, values)};
-                result.remove([i](const CPeriodicityHypothesisTestsResult::SComponent& component) {
-                    return i == E_Long && component.s_Period <= WEEK;
+                result.remove([&](const CPeriodicityHypothesisTestsResult::SComponent& component) {
+                    return component.s_Period <
+                           CPeriodicityTestWindowParameters::shortestComponent(i, m_BucketLength);
                 });
 
                 if (result.periodic()) {
@@ -693,7 +817,7 @@ std::size_t CTimeSeriesDecompositionDetail::CPeriodicityTest::extraMemoryOnIniti
     static std::size_t result{0};
     if (result == 0) {
         for (auto i : {E_Short, E_Long}) {
-            TExpandingWindowPtr window(this->newWindow(i, false));
+            auto window = this->newWindow(i, false);
             // The 0.3 is a rule-of-thumb estimate of the worst case
             // compression ratio we achieve on the test state.
             result += static_cast<std::size_t>(
@@ -717,7 +841,7 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::apply(std::size_t symbol,
 
         auto initialize = [this](core_t::TTime time_) {
             for (auto i : {E_Short, E_Long}) {
-                m_Windows[i].reset(this->newWindow(i));
+                m_Windows[i] = this->newWindow(i);
                 if (m_Windows[i] != nullptr) {
                     // Since all permitted bucket lengths are divisors
                     // of longer ones, this finds the unique rightmost
@@ -738,9 +862,7 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::apply(std::size_t symbol,
         switch (state) {
         case PT_TEST:
             if (std::all_of(m_Windows.begin(), m_Windows.end(),
-                            [](const TExpandingWindowPtr& window) {
-                                return window == nullptr;
-                            })) {
+                            [](const auto& window) { return window == nullptr; })) {
                 initialize(time);
             }
             break;
@@ -759,55 +881,23 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::apply(std::size_t symbol,
     }
 }
 
-CExpandingWindow*
+CTimeSeriesDecompositionDetail::CPeriodicityTest::TExpandingWindowUPtr
 CTimeSeriesDecompositionDetail::CPeriodicityTest::newWindow(ETest test, bool deflate) const {
 
     using TTimeCRng = CExpandingWindow::TTimeCRng;
 
-    // The choice of 336 is somewhat arbitrary since we scan over a
-    // range of bucket lengths so consider multiple window durations.
-    // However, this is divisible by 6 and is the number of hours in
-    // two weeks. Together with the bucket lengths we use this means
-    // we will typically get window lengths which are a whole number
-    // of hours and are usually a multiple of one weeks. The testing
-    // makes the best use of data when the true period is a divisor
-    // of the window length and this improves the odds for the most
-    // common seasonalities we observe.
-    static const core_t::TTime TARGET_SIZE{336};
-    static const TTimeVec SHORT{1,    5,    10,   30,    60,    300,  600,
-                                1800, 3600, 7200, 21600, 43200, 86400};
-    static const TTimeVec LONG{7200,  21600,  43200,
-                               86400, 172800, LONGEST_BUCKET_LENGTH};
+    std::size_t numberBuckets{
+        CPeriodicityTestWindowParameters::numberBuckets(test, m_BucketLength)};
+    const TTimeVec* bucketLengths{
+        CPeriodicityTestWindowParameters::bucketLengths(test, m_BucketLength)};
 
-    auto newWindow = [&](const TTimeVec& buckets, core_t::TTime maxLength) {
-        if (m_BucketLength <= buckets.back()) {
-            // Find the next longer permitted bucket length.
-            auto a = std::lower_bound(buckets.begin(), buckets.end(), m_BucketLength);
-            // Compute the window length in buckets which doesn't exceed
-            // the maximum length and is great than the minimum number of
-            // buckets to test.
-            core_t::TTime size{
-                std::min(TARGET_SIZE, maxLength / buckets[a - buckets.begin()])};
-            // Find the longest bucket length such that the window length
-            // doesn't exceed the maximum length.
-            auto b = std::find_if(a + 1, buckets.end(), [&](core_t::TTime l) {
-                return size * l > maxLength;
-            });
-            return new CExpandingWindow(
-                m_BucketLength,
-                TTimeCRng(buckets, a - buckets.begin(), b - buckets.begin()),
-                size, m_DecayRate, deflate);
-        }
-        return static_cast<CExpandingWindow*>(nullptr);
-    };
-
-    switch (test) {
-    case E_Short:
-        return newWindow(SHORT, 7200 * TARGET_SIZE);
-    case E_Long:
-        return newWindow(LONG, LONGEST_BUCKET_LENGTH * TARGET_SIZE);
+    if (bucketLengths != nullptr) {
+        return std::make_unique<CExpandingWindow>(
+            m_BucketLength, TTimeCRng{*bucketLengths, 0, bucketLengths->size()},
+            numberBuckets, m_DecayRate, deflate);
     }
-    return nullptr;
+
+    return {};
 }
 
 bool CTimeSeriesDecompositionDetail::CPeriodicityTest::shouldTest(ETest test,
@@ -816,12 +906,11 @@ bool CTimeSeriesDecompositionDetail::CPeriodicityTest::shouldTest(ETest test,
     // would significantly delay when we first detect short periodic
     // components for longer bucket lengths otherwise.
     auto scheduledTest = [&]() {
-        if (test == E_Short) {
-            core_t::TTime length{time - m_Windows[test]->startTime()};
-            for (auto schedule : {3 * DAY, 1 * WEEK, 2 * WEEK}) {
-                if (length >= schedule && length < schedule + m_BucketLength) {
-                    return true;
-                }
+        core_t::TTime length{time - m_Windows[test]->startTime()};
+        for (auto schedule :
+             CPeriodicityTestWindowParameters::testSchedule(test, m_BucketLength)) {
+            if (length >= schedule && length < schedule + m_BucketLength) {
+                return true;
             }
         }
         return false;
@@ -858,8 +947,6 @@ void CTimeSeriesDecompositionDetail::CPeriodicityTest::pruneLinearScales() {
                                         }),
                          m_LinearScales.end());
 }
-
-const core_t::TTime CTimeSeriesDecompositionDetail::CPeriodicityTest::LONGEST_BUCKET_LENGTH{345600};
 
 //////// CCalendarCyclic ////////
 
@@ -1593,7 +1680,7 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
                        [](const TFloatMeanAccumulator& value) {
                            return CBasicStatistics::mean(value);
                        });
-        result.removeTrend(values);
+        result.removeTrendFrom(values);
         TFloatMeanAccumulator level{std::accumulate(values.begin(), values.end(),
                                                     TFloatMeanAccumulator{})};
         for (std::size_t i = 0; i < shifts.size(); ++i) {
@@ -1673,7 +1760,7 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
         }
 
         values = window.valuesMinusPrediction(predictor);
-        result.removeDiscontinuities(values);
+        result.removeDiscontinuitiesFrom(values);
         CTrendComponent newTrend{m_Trend.defaultDecayRate()};
         this->fitTrend(startTime, dt, values, newTrend);
         this->reweightOutliers(startTime, dt,


### PR DESCRIPTION
There is a short window and a long window to test for "fast" and "slow" seasonal components, respectively. Currently, these are not particularly well parameterised as a function of the job's bucket length: 
1. The parameterisation isn't tuned for very short or long job bucket lengths. This can degrade both the speed with which seasonality is detected and increase error in the components' estimated periods.
2. The window bucket lengths aren't a multiple of the job's bucket length for all the common cases. This causes beating in the assignment of values to buckets which can degrade detection and lead to poor component initialisation. 
3. There is redundancy: the sets of bucket lengths the two windows use "intersect"; this wastes time by running the same tests for both the short and long windows when the bucket lengths match.
4. The common long periodic component is annual and the tests aren't optimised for detecting this.

To address the first two deficiencies this change switches to using appropriate parameters for each of the common job bucket lengths. These choices ensure that the short and long windows don't have any overlap in the bucket lengths they consider. Finally, it uses better parameterisation for detecting annual periodicity and introduces a small selection bias when the estimated period is nearly one year.

I've marked as a non-issue because this is a feature branch.