### PR TITLE
[ML] Add state checkpoints during coarse parameter search for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -46,6 +46,8 @@
 * Don't lose precision when saving model state. (See {ml-pull}1274[#1274].)
 * Parallelize the feature importance calculation for classification and regression
   over trees. (See {ml-pull}1277[#1277].)
+* Checkpoint state to allow efficient failover during coarse parameter search
+  for classification and regression. (See {ml-pull}1300[#1300].)
 
 === Bug Fixes
 

--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -334,19 +334,20 @@ public:
         mutable std::string m_Token;
     };
 
-    //! Entry method for objects being restored
+    //! Restore \p collection reading state from \p inserter expecting \p tag for elements.
     template<typename T>
     static bool restore(const std::string& tag, T& collection, CStateRestoreTraverser& traverser) {
         return persist_utils_detail::restore(tag, collection, traverser);
     }
 
-    //! Entry method for objects being persisted
+    //! Persist \p collection passing state to \p inserter using \p tag for elements.
     template<typename T>
     static bool
     persist(const std::string& tag, const T& collection, CStatePersistInserter& inserter) {
         return persist_utils_detail::persist(tag, collection, inserter);
     }
 
+    //! Persist \p collection passing state to \p inserter using \p tag for elements.
     template<typename T>
     static bool
     persist(const TPersistenceTag& tag, const T& collection, CStatePersistInserter& inserter) {
@@ -603,7 +604,7 @@ private:
                 LOG_ERROR(<< "Invalid state " << state);
                 return false;
             }
-            *inserter = element;
+            *inserter = std::move(element);
             ++inserter;
             return true;
         }
@@ -617,7 +618,7 @@ private:
                 LOG_ERROR(<< "Invalid element 0 : element " << token << " in " << state);
                 return false;
             }
-            *inserter = element;
+            *inserter = std::move(element);
             ++inserter;
         }
 
@@ -637,7 +638,7 @@ private:
                           << " in " << state);
                 return false;
             }
-            *inserter = element;
+            *inserter = std::move(element);
 
             ++i;
             lastDelimPos = delimPos;
@@ -936,7 +937,7 @@ private:
                         LOG_ERROR(<< "Restoration error at " << traverser.name());
                         return false;
                     }
-                    container.insert(container.end(), value);
+                    container.insert(container.end(), std::move(value));
                 }
             } while (traverser.next());
             return true;
@@ -953,7 +954,7 @@ private:
                         LOG_ERROR(<< "Restoration error at " << traverser.name());
                         return false;
                     }
-                    *(i++) = value;
+                    *(i++) = std::move(value);
                 }
             } while (traverser.next());
             return true;

--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -334,7 +334,7 @@ public:
         mutable std::string m_Token;
     };
 
-    //! Restore \p collection reading state from \p inserter expecting \p tag for elements.
+    //! Restore \p collection reading state from \p traverser expecting \p tag for elements.
     template<typename T>
     static bool restore(const std::string& tag, T& collection, CStateRestoreTraverser& traverser) {
         return persist_utils_detail::restore(tag, collection, traverser);

--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -97,7 +97,7 @@ struct persist_selector<T, typename enable_if_is<std::string (T::*)() const, &T:
 };
 //@}
 
-//! Detail of the persist class selected by the object features
+//! \brief Specialisations of this class implement persist methods based on object features.
 template<typename SELECTOR>
 class CPersisterImpl {};
 
@@ -136,7 +136,7 @@ struct restore_selector<T, typename enable_if_is<bool (T::*)(const std::string&)
 };
 //@}
 
-//! Detail of the restorer implementation based on object features
+//! \brief Specialisations of this class implement restore methods based on object features.
 template<typename SELECTOR>
 class CRestorerImpl {};
 
@@ -342,17 +342,40 @@ public:
 
     //! Persist \p collection passing state to \p inserter using \p tag for elements.
     template<typename T>
-    static bool
+    static void
     persist(const std::string& tag, const T& collection, CStatePersistInserter& inserter) {
-        return persist_utils_detail::persist(tag, collection, inserter);
+        persist_utils_detail::persist(tag, collection, inserter);
     }
 
     //! Persist \p collection passing state to \p inserter using \p tag for elements.
     template<typename T>
-    static bool
+    static void
     persist(const TPersistenceTag& tag, const T& collection, CStatePersistInserter& inserter) {
-        return persist_utils_detail::persist(tag.name(inserter.readableTags()),
-                                             collection, inserter);
+        persist_utils_detail::persist(tag.name(inserter.readableTags()), collection, inserter);
+    }
+
+    //! A convenience function for optionally persisting types which convert to null.
+    //!
+    //! \tparam DEREFERENCEABLE Must support conversion to bool and operator*.
+    template<typename DEREFERENCEABLE>
+    static void persistIfNotNull(const std::string& tag,
+                                 const DEREFERENCEABLE& target,
+                                 CStatePersistInserter& inserter) {
+        if (target) {
+            persist_utils_detail::persist(tag, *target, inserter);
+        }
+    }
+
+    //! A convenience function for optionally persisting types which convert to null.
+    //!
+    //! \tparam DEREFERENCEABLE Must support conversion to bool and operator*.
+    template<typename DEREFERENCEABLE>
+    static void persistIfNotNull(const TPersistenceTag& tag,
+                                 const DEREFERENCEABLE& target,
+                                 CStatePersistInserter& inserter) {
+        if (target) {
+            persist_utils_detail::persist(tag.name(inserter.readableTags()), *target, inserter);
+        }
     }
 
     //! Wrapper for containers of built in types.

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -24,6 +24,8 @@
 namespace ml {
 namespace core {
 class CPackedBitVector;
+class CStatePersistInserter;
+class CStateRestoreTraverser;
 }
 namespace maths {
 
@@ -137,31 +139,14 @@ private:
     using TBoostedTreeImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
     using TApplyRegularizer = std::function<bool(CBoostedTreeImpl&, double)>;
 
-    //! \brief Attach a callback to the tree implementation for persisting factory state.
-    class CScopeAttachPersistState : core::CNonCopyable {
-    public:
-        CScopeAttachPersistState(CBoostedTreeFactory& factory);
-        ~CScopeAttachPersistState();
-
-    private:
-        CBoostedTreeImpl* m_TreeImpl;
-    };
-
-    //! \brief Attach a callback to the tree implementation for restoring factory state.
-    class CScopeAttachRestoreState : core::CNonCopyable {
-    public:
-        CScopeAttachRestoreState(CBoostedTreeFactory& factory);
-        ~CScopeAttachRestoreState();
-
-    private:
-        CBoostedTreeImpl* m_TreeImpl;
-    };
-
 private:
     CBoostedTreeFactory(std::size_t numberThreads, TLossFunctionUPtr loss);
 
     //! Persist state writing to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Restore readining state from \p traverser.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Compute the row masks for the missing values for each feature.
     void initializeMissingFeatureMasks(const core::CDataFrame& frame) const;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -7,7 +7,6 @@
 #ifndef INCLUDED_ml_maths_CBoostedTreeFactory_h
 #define INCLUDED_ml_maths_CBoostedTreeFactory_h
 
-#include "core/CStateMachine.h"
 #include <core/CDataFrame.h>
 
 #include <maths/CBoostedTree.h>

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -168,6 +168,20 @@ private:
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
     using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
+    using TPersistFactoryStateCallback = std::function<void(core::CStatePersistInserter&)>;
+    using TRestoreFactoryStateCallback = std::function<bool(core::CStateRestoreTraverser&)>;
+
+    //! Tag progress through initialization.
+    enum EInitializationStage {
+        E_NotInitialized = 0,
+        E_SoftTreeDepthLimitInitialized = 1,
+        E_DepthPenaltyMultiplierInitialized = 2,
+        E_TreeSizePenaltyMultiplierInitialized = 3,
+        E_LeafWeightPenaltyMultiplierInitialized = 4,
+        E_DownsampleFactorInitialized = 5,
+        E_EtaInitialized = 6,
+        E_FullyInitialized = 7
+    };
 
 private:
     CBoostedTreeImpl();
@@ -305,6 +319,7 @@ private:
 
 private:
     mutable CPRNG::CXorOShiro128Plus m_Rng;
+    EInitializationStage m_InitializationStage = E_NotInitialized;
     std::size_t m_NumberThreads;
     std::size_t m_DependentVariable = std::numeric_limits<std::size_t>::max();
     TSizeVec m_ExtraColumns;
@@ -346,7 +361,10 @@ private:
     core::CLoopProgress m_TrainingProgress;
     std::size_t m_NumberTopShapValues = 0;
     TTreeShapFeatureImportanceUPtr m_TreeShap;
-    TAnalysisInstrumentationPtr m_Instrumentation; // no persist/restore
+    TAnalysisInstrumentationPtr m_Instrumentation;
+    TPersistFactoryStateCallback m_PersistFactoryState = [](core::CStatePersistInserter&) {};
+    TRestoreFactoryStateCallback m_RestoreFactoryState =
+        [](core::CStateRestoreTraverser&) { return true; };
 
 private:
     friend class CBoostedTreeFactory;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -168,8 +168,6 @@ private:
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
     using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
-    using TPersistFactoryStateCallback = std::function<void(core::CStatePersistInserter&)>;
-    using TRestoreFactoryStateCallback = std::function<bool(core::CStateRestoreTraverser&)>;
 
     //! Tag progress through initialization.
     enum EInitializationStage {
@@ -362,9 +360,6 @@ private:
     std::size_t m_NumberTopShapValues = 0;
     TTreeShapFeatureImportanceUPtr m_TreeShap;
     TAnalysisInstrumentationPtr m_Instrumentation;
-    TPersistFactoryStateCallback m_PersistFactoryState = [](core::CStatePersistInserter&) {};
-    TRestoreFactoryStateCallback m_RestoreFactoryState =
-        [](core::CStateRestoreTraverser&) { return true; };
 
 private:
     friend class CBoostedTreeFactory;

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -523,7 +523,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
 
         LOG_DEBUG(<< "Loss function type " << lossFunction);
 
-        for (std::size_t restart = 1; restart < 10; restart += 2) {
+        for (std::size_t restart = 6; restart < 16; restart += 2) {
 
             auto makeSpec = [&](const std::string& dependentVariable, std::size_t numberExamples,
                                 TPersisterSupplier* persisterSupplier,
@@ -980,7 +980,8 @@ BOOST_AUTO_TEST_CASE(testProgressFromRestart) {
     output.str("");
     persistenceStream->str("");
 
-    std::istringstream intermediateStateStream{persistedStates[persistedStates.size() / 2]};
+    std::istringstream intermediateStateStream{
+        persistedStates[2 * persistedStates.size() / 3]};
     TRestoreSearcherSupplier restoreSearcherSupplier{[&intermediateStateStream]() {
         return std::make_unique<CTestDataSearcher>(intermediateStateStream.str());
     }};

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1371,7 +1371,8 @@ CBoostedTreeImpl::TStrVec CBoostedTreeImpl::bestHyperparameterNames() {
 
 void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     core::CPersistUtils::persist(VERSION_7_8_TAG, "", inserter);
-    core::CPersistUtils::persist(BAYESIAN_OPTIMIZATION_TAG, *m_BayesianOptimization, inserter);
+    core::CPersistUtils::persistIfNotNull(BAYESIAN_OPTIMIZATION_TAG,
+                                          m_BayesianOptimization, inserter);
     core::CPersistUtils::persist(BEST_FOREST_TEST_LOSS_TAG, m_BestForestTestLoss, inserter);
     core::CPersistUtils::persist(BEST_FOREST_TAG, m_BestForest, inserter);
     core::CPersistUtils::persist(BEST_HYPERPARAMETERS_TAG, m_BestHyperparameters, inserter);
@@ -1380,7 +1381,7 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persist(DOWNSAMPLE_FACTOR_OVERRIDE_TAG,
                                  m_DownsampleFactorOverride, inserter);
     core::CPersistUtils::persist(DOWNSAMPLE_FACTOR_TAG, m_DownsampleFactor, inserter);
-    core::CPersistUtils::persist(ENCODER_TAG, *m_Encoder, inserter);
+    core::CPersistUtils::persistIfNotNull(ENCODER_TAG, m_Encoder, inserter);
     core::CPersistUtils::persist(ETA_GROWTH_RATE_PER_TREE_TAG,
                                  m_EtaGrowthRatePerTree, inserter);
     core::CPersistUtils::persist(ETA_TAG, m_Eta, inserter);
@@ -1395,9 +1396,11 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persist(INITIALIZATION_STAGE_TAG,
                                  static_cast<int>(m_InitializationStage), inserter);
     inserter.insertLevel(INITIALIZATION_STATE_TAG, m_PersistFactoryState);
-    inserter.insertLevel(LOSS_TAG, [this](core::CStatePersistInserter& inserter_) {
-        m_Loss->persistLoss(inserter_);
-    });
+    if (m_Loss != nullptr) {
+        inserter.insertLevel(LOSS_TAG, [this](core::CStatePersistInserter& inserter_) {
+            m_Loss->persistLoss(inserter_);
+        });
+    }
     core::CPersistUtils::persist(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
                                  m_MaximumAttemptsToAddTree, inserter);
     core::CPersistUtils::persist(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1325,7 +1325,6 @@ const std::string FEATURE_DATA_TYPES_TAG{"feature_data_types"};
 const std::string FEATURE_SAMPLE_PROBABILITIES_TAG{"feature_sample_probabilities"};
 const std::string FOLD_ROUND_TEST_LOSSES_TAG{"fold_round_test_losses"};
 const std::string INITIALIZATION_STAGE_TAG{"initialization_progress"};
-const std::string INITIALIZATION_STATE_TAG{"initialization_state"};
 const std::string LOSS_TAG{"loss"};
 const std::string LOSS_NAME_TAG{"loss_name"};
 const std::string MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG{"maximum_attempts_to_add_tree"};
@@ -1395,7 +1394,6 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persist(FOLD_ROUND_TEST_LOSSES_TAG, m_FoldRoundTestLosses, inserter);
     core::CPersistUtils::persist(INITIALIZATION_STAGE_TAG,
                                  static_cast<int>(m_InitializationStage), inserter);
-    inserter.insertLevel(INITIALIZATION_STATE_TAG, m_PersistFactoryState);
     if (m_Loss != nullptr) {
         inserter.insertLevel(LOSS_TAG, [this](core::CStatePersistInserter& inserter_) {
             m_Loss->persistLoss(inserter_);
@@ -1492,7 +1490,6 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
         RESTORE(INITIALIZATION_STAGE_TAG,
                 core::CPersistUtils::restore(INITIALIZATION_STAGE_TAG,
                                              initializationStage, traverser))
-        RESTORE(INITIALIZATION_STATE_TAG, traverser.traverseSubLevel(m_RestoreFactoryState))
         RESTORE(LOSS_TAG, traverser.traverseSubLevel(restoreLoss))
         RESTORE(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,
                 core::CPersistUtils::restore(MAXIMUM_ATTEMPTS_TO_ADD_TREE_TAG,

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1668,7 +1668,7 @@ BOOST_AUTO_TEST_CASE(testPersistRestore) {
 BOOST_AUTO_TEST_CASE(testPersistRestoreDuringInitialization) {
 
     // Grab checkpoints during initialization and check they all produce the
-    // same result after restoring.
+    // same initialized tree after restoring.
 
     using TSStreamVec = std::vector<std::stringstream>;
 
@@ -1723,6 +1723,9 @@ BOOST_AUTO_TEST_CASE(testPersistRestoreDuringInitialization) {
         boostedTree->acceptPersistInserter(inserter);
         expectedState.flush();
     }
+
+    // Make sure this test fails if there aren't any checkpoints.
+    BOOST_TEST_REQUIRE(checkpoints.size() > 0);
 
     for (auto& checkpoint : checkpoints) {
         auto frame = makeFrame();

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1612,15 +1612,15 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
 
 BOOST_AUTO_TEST_CASE(testPersistRestore) {
 
-    // Check persist/restore is idempotent.
+    // Check persist + restore is idempotent.
 
     std::size_t rows{50};
     std::size_t cols{3};
     std::size_t capacity{50};
     test::CRandomNumbers rng;
 
-    std::stringstream persistOnceSStream;
-    std::stringstream persistTwiceSStream;
+    std::stringstream persistOnceState;
+    std::stringstream persistTwiceState;
 
     // Generate completely random data.
     TDoubleVecVec x(cols);
@@ -1638,7 +1638,7 @@ BOOST_AUTO_TEST_CASE(testPersistRestore) {
     }
     frame->finishWritingRows();
 
-    // persist
+    // Persist.
     {
         auto boostedTree = maths::CBoostedTreeFactory::constructFromParameters(
                                1, std::make_unique<maths::boosted_tree::CMse>())
@@ -1647,21 +1647,95 @@ BOOST_AUTO_TEST_CASE(testPersistRestore) {
                                .maximumOptimisationRoundsPerHyperparameter(3)
                                .buildFor(*frame, cols - 1);
         boostedTree->train();
-        core::CJsonStatePersistInserter inserter(persistOnceSStream);
+        core::CJsonStatePersistInserter inserter(persistOnceState);
         boostedTree->acceptPersistInserter(inserter);
-        persistOnceSStream.flush();
+        persistOnceState.flush();
     }
-    // restore
-    auto boostedTree = maths::CBoostedTreeFactory::constructFromString(persistOnceSStream)
-                           .restoreFor(*frame, cols - 1);
+    // Restore.
+    auto boostedTree =
+        maths::CBoostedTreeFactory::constructFromString(persistOnceState).restoreFor(*frame, cols - 1);
     {
-        core::CJsonStatePersistInserter inserter(persistTwiceSStream);
+        // We need to call the inserter destructor to finish writing the state.
+        core::CJsonStatePersistInserter inserter(persistTwiceState);
         boostedTree->acceptPersistInserter(inserter);
-        persistTwiceSStream.flush();
+        persistTwiceState.flush();
     }
-    LOG_DEBUG(<< "State " << persistOnceSStream.str());
-    LOG_DEBUG(<< "State after restore " << persistTwiceSStream.str());
-    BOOST_REQUIRE_EQUAL(persistOnceSStream.str(), persistTwiceSStream.str());
+    LOG_DEBUG(<< "State " << persistOnceState.str());
+    LOG_DEBUG(<< "State after restore " << persistTwiceState.str());
+    BOOST_REQUIRE_EQUAL(persistOnceState.str(), persistTwiceState.str());
+}
+
+BOOST_AUTO_TEST_CASE(testPersistRestoreDuringInitialization) {
+
+    // Grab checkpoints during initialization and check they all produce the
+    // same result after restoring.
+
+    using TSStreamVec = std::vector<std::stringstream>;
+
+    std::size_t rows{50};
+    std::size_t cols{3};
+    std::size_t capacity{50};
+    test::CRandomNumbers rng;
+
+    // Generate completely random data.
+    TDoubleVecVec x(cols);
+    for (std::size_t i = 0; i < cols; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    auto makeFrame = [&] {
+        auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
+        for (std::size_t i = 0; i < rows; ++i) {
+            frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                for (std::size_t j = 0; j < cols; ++j, ++column) {
+                    *column = x[j][i];
+                }
+            });
+        }
+        frame->finishWritingRows();
+        return frame;
+    };
+
+    TSStreamVec checkpoints;
+
+    auto writeTrainingState = [&checkpoints](maths::CBoostedTree::TPersistFunc persist) {
+        std::stringstream state;
+        {
+            // We need to call the inserter destructor to finish writing the state.
+            core::CJsonStatePersistInserter inserter(state);
+            persist(inserter);
+            state.flush();
+        }
+        checkpoints.push_back(std::move(state));
+    };
+
+    std::ostringstream expectedState;
+    {
+        auto frame = makeFrame();
+        auto boostedTree = maths::CBoostedTreeFactory::constructFromParameters(
+                               1, std::make_unique<maths::boosted_tree::CMse>())
+                               .numberFolds(2)
+                               .maximumNumberTrees(2)
+                               .maximumOptimisationRoundsPerHyperparameter(3)
+                               .trainingStateCallback(writeTrainingState)
+                               .buildFor(*frame, cols - 1);
+        core::CJsonStatePersistInserter inserter(expectedState);
+        boostedTree->acceptPersistInserter(inserter);
+        expectedState.flush();
+    }
+
+    for (auto& checkpoint : checkpoints) {
+        auto frame = makeFrame();
+        auto boostedTree =
+            maths::CBoostedTreeFactory::constructFromString(checkpoint).restoreFor(*frame, cols - 1);
+
+        std::ostringstream actualState;
+        core::CJsonStatePersistInserter inserter(actualState);
+        boostedTree->acceptPersistInserter(inserter);
+        actualState.flush();
+
+        BOOST_REQUIRE_EQUAL(expectedState.str(), actualState.str());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {


### PR DESCRIPTION
Searching for initial parameters for boosted tree training is an expensive operation and it is possible to save state to allow this to resume with minimal loss of work. This PR adds checkpointing of sufficient state to resume after failure during this step. It also makes some tweaks to `CPersistUtils`. These include moving values into place where possible and adding some convenience functions to persist pointers.

The basic strategy is to introduce an initialisation stage variable to `CBoostedTreeImpl`. This tracks where initialisation reached at each checkpoint, so that it is possible to resume, skipping stages which have already been performed. It is necessary to additionally persist and restore some factory state.

Closes #1275.