### PR TITLE
[ML] Report memory usage during DFA job initialization (#1294)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 * Don't lose precision when saving model state. (See {ml-pull}1274[#1274].)
 * Parallelize the feature importance calculation for classification and regression
   over trees. (See {ml-pull}1277[#1277].)
+* Memory usage is reported during job initialization. (See {ml-pull}1294[#1294].)
 
 === Bug Fixes
 

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -160,6 +160,7 @@ private:
     maths::COutliers::SComputeParameters m_Parameters;
     std::uint64_t m_ElapsedTime;
     double m_FeatureInfluenceThreshold = -1.0;
+    bool m_AnalysisStatsInitialized = false;
 };
 
 //! \brief Instrumentation class for Supervised Learning jobs.
@@ -204,6 +205,7 @@ private:
     std::size_t m_Iteration = 0;
     std::uint64_t m_IterationTime = 0;
     std::uint64_t m_ElapsedTime = 0;
+    bool m_AnalysisStatsInitialized = false;
     std::string m_LossType;
     TLossVec m_LossValues;
     SHyperparameters m_Hyperparameters;

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -229,7 +229,7 @@ counter_t::ECounterTypes CDataFrameTrainBoostedTreeInstrumentation::memoryCounte
 
 void CDataFrameOutliersInstrumentation::writeAnalysisStats(std::int64_t timestamp) {
     auto writer = this->writer();
-    if (writer != nullptr) {
+    if (writer != nullptr && m_AnalysisStatsInitialized == true) {
         writer->Key(OUTLIER_DETECTION_STATS);
         writer->StartObject();
         writer->Key(JOB_ID_TAG);
@@ -252,6 +252,9 @@ void CDataFrameOutliersInstrumentation::writeAnalysisStats(std::int64_t timestam
 }
 
 void CDataFrameOutliersInstrumentation::parameters(const maths::COutliers::SComputeParameters& parameters) {
+    if (m_AnalysisStatsInitialized == false) {
+        m_AnalysisStatsInitialized = true;
+    }
     m_Parameters = parameters;
 }
 
@@ -308,6 +311,9 @@ void CDataFrameTrainBoostedTreeInstrumentation::type(EStatsType type) {
 }
 
 void CDataFrameTrainBoostedTreeInstrumentation::iteration(std::size_t iteration) {
+    if (m_AnalysisStatsInitialized == false) {
+        m_AnalysisStatsInitialized = true;
+    }
     m_Iteration = iteration;
 }
 
@@ -327,7 +333,7 @@ void CDataFrameTrainBoostedTreeInstrumentation::lossValues(std::size_t fold,
 
 void CDataFrameTrainBoostedTreeInstrumentation::writeAnalysisStats(std::int64_t timestamp) {
     auto* writer = this->writer();
-    if (writer != nullptr) {
+    if (writer != nullptr && m_AnalysisStatsInitialized == true) {
         switch (m_Type) {
         case E_Regression:
             writer->Key(REGRESSION_STATS_TAG);

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -131,6 +131,9 @@ void CDataFrameAnalyzer::run() {
         auto& instrumentation = analysisRunner->instrumentation();
         CDataFrameAnalysisInstrumentation::CScopeSetOutputStream setStream{
             instrumentation, *outStream};
+        instrumentation.updateMemoryUsage(
+            static_cast<std::int64_t>(m_DataFrame->memoryUsage()));
+        instrumentation.flush();
 
         analysisRunner->run(*m_DataFrame);
 

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -177,7 +177,12 @@ BOOST_AUTO_TEST_CASE(testTrainingRegression) {
     rapidjson::SchemaValidator regressionValidator(regressionSchema);
 
     bool hasRegressionStats{false};
+    bool initialMemoryReport{false};
     for (const auto& result : results.GetArray()) {
+        if (result.HasMember("analytics_memory_usage") == true &&
+            result.HasMember("regression_stats") == false) {
+            initialMemoryReport = true;
+        }
         if (result.HasMember("regression_stats")) {
             hasRegressionStats = true;
             BOOST_TEST_REQUIRE(result["regression_stats"].IsObject() == true);
@@ -195,6 +200,7 @@ BOOST_AUTO_TEST_CASE(testTrainingRegression) {
         }
     }
     BOOST_TEST_REQUIRE(hasRegressionStats);
+    BOOST_TEST_REQUIRE(initialMemoryReport);
 
     std::ifstream memorySchemaFileStream("testfiles/instrumentation/memory_usage.schema.json");
     BOOST_REQUIRE_MESSAGE(memorySchemaFileStream.is_open(), "Cannot open test file!");
@@ -266,7 +272,12 @@ BOOST_AUTO_TEST_CASE(testTrainingClassification) {
     rapidjson::SchemaValidator validator(schema);
 
     bool hasClassificationStats{false};
+    bool initialMemoryReport{false};
     for (const auto& result : results.GetArray()) {
+        if (result.HasMember("analytics_memory_usage") == true &&
+            result.HasMember("classification_stats") == false) {
+            initialMemoryReport = true;
+        }
         if (result.HasMember("classification_stats")) {
             hasClassificationStats = true;
             BOOST_TEST_REQUIRE(result["classification_stats"].IsObject() == true);
@@ -283,6 +294,7 @@ BOOST_AUTO_TEST_CASE(testTrainingClassification) {
         }
     }
     BOOST_TEST_REQUIRE(hasClassificationStats);
+    BOOST_TEST_REQUIRE(initialMemoryReport);
 }
 
 BOOST_AUTO_TEST_CASE(testOutlierDetection) {
@@ -318,7 +330,12 @@ BOOST_AUTO_TEST_CASE(testOutlierDetection) {
     rapidjson::SchemaValidator validator(schema);
 
     bool hasOutlierDetectionStats{false};
+    bool initialMemoryReport{false};
     for (const auto& result : results.GetArray()) {
+        if (result.HasMember("analytics_memory_usage") == true &&
+            result.HasMember("outlier_detection_stats") == false) {
+            initialMemoryReport = true;
+        }
         if (result.HasMember("outlier_detection_stats")) {
             hasOutlierDetectionStats = true;
             BOOST_TEST_REQUIRE(result["outlier_detection_stats"].IsObject() == true);
@@ -335,6 +352,7 @@ BOOST_AUTO_TEST_CASE(testOutlierDetection) {
         }
     }
     BOOST_TEST_REQUIRE(hasOutlierDetectionStats);
+    BOOST_TEST_REQUIRE(initialMemoryReport);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -96,6 +96,7 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
     this->determineFeatureDataTypes(frame);
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
     m_TreeImpl->m_Instrumentation->lossType(m_TreeImpl->m_Loss->name());
+    m_TreeImpl->m_Instrumentation->flush();
 
     this->startProgressMonitoringInitializeHyperparameters(frame);
 
@@ -123,6 +124,7 @@ CBoostedTreeFactory::restoreFor(core::CDataFrame& frame, std::size_t dependentVa
     this->resizeDataFrame(frame);
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
     m_TreeImpl->m_Instrumentation->lossType(m_TreeImpl->m_Loss->name());
+    m_TreeImpl->m_Instrumentation->flush();
 
     this->skipProgressMonitoringFeatureSelection();
     this->skipProgressMonitoringInitializeHyperparameters();
@@ -275,9 +277,12 @@ void CBoostedTreeFactory::initializeNumberFolds(core::CDataFrame& frame) const {
 void CBoostedTreeFactory::resizeDataFrame(core::CDataFrame& frame) const {
 
     std::size_t numberLossParameters{m_TreeImpl->m_Loss->numberParameters()};
+    std::size_t frameMemory{core::CMemory::dynamicSize(frame)};
     m_TreeImpl->m_ExtraColumns = frame.resizeColumns(
         m_TreeImpl->m_NumberThreads, extraColumns(numberLossParameters));
-    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(frame));
+    m_TreeImpl->m_Instrumentation->updateMemoryUsage(
+        core::CMemory::dynamicSize(frame) - frameMemory);
+    m_TreeImpl->m_Instrumentation->flush();
 
     core::CPackedBitVector allTrainingRowsMask{m_TreeImpl->allTrainingRowsMask()};
     frame.writeColumns(m_NumberThreads, 0, frame.numberRows(),

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -886,9 +886,6 @@ bool computeOutliersNoPartitions(const COutliers::SComputeParameters& params,
     using TPoint = TMemoryMappedFloatVector;
     using TPointVec = std::vector<TPoint>;
 
-    std::int64_t frameMemory{signedMemoryUsage(frame)};
-    instrumentation.updateMemoryUsage(frameMemory);
-
     CEnsemble<TPoint>::TScorerVec scores;
 
     // Use scoping to recover memory before resizing the data frame.
@@ -952,6 +949,7 @@ bool computeOutliersNoPartitions(const COutliers::SComputeParameters& params,
         }
     };
 
+    std::int64_t frameMemory{signedMemoryUsage(frame)};
     frame.resizeColumns(params.s_NumberThreads,
                         (params.s_ComputeFeatureInfluence ? 2 : 1) * dimension + 1);
     instrumentation.updateMemoryUsage(signedMemoryUsage(frame) - frameMemory);
@@ -985,10 +983,10 @@ bool computeOutliersPartitioned(const COutliers::SComputeParameters& params,
     LOG_TRACE(<< "Ensemble = " << ensemble.print());
 
     std::size_t dimension{frame.numberColumns()};
-
+    std::int64_t frameMemory{signedMemoryUsage(frame)};
     frame.resizeColumns(params.s_NumberThreads,
                         (params.s_ComputeFeatureInfluence ? 2 : 1) * dimension + 1);
-    instrumentation.updateMemoryUsage(signedMemoryUsage(frame));
+    instrumentation.updateMemoryUsage(signedMemoryUsage(frame) - frameMemory);
 
     std::size_t rowsPerPartition{(frame.numberRows() + params.s_NumberPartitions - 1) /
                                  params.s_NumberPartitions};


### PR DESCRIPTION
This PR adds memory usage report in two new cases:

    right after data frame is loaded in the DataFrameAnalyzer
    in the initialization routines on CBoostedTreeFactory when memory usage is updated

Backport to #1294 