### PR TITLE
[ML] Tailor the data frame slice size per analysis type

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -103,6 +103,9 @@ public:
     //! \return The number of columns this analysis appends.
     virtual std::size_t numberExtraColumns() const = 0;
 
+    //! \return The capacity of the data frame slice to use.
+    virtual std::size_t dataFrameSliceCapacity() const = 0;
+
     //! Write the extra columns of \p row added by the analysis to \p writer.
     //!
     //! This should create a new object of the form:

--- a/include/api/CDataFrameOutliersRunner.h
+++ b/include/api/CDataFrameOutliersRunner.h
@@ -38,6 +38,9 @@ public:
     //! \return The number of columns this adds to the data frame.
     std::size_t numberExtraColumns() const override;
 
+    //! \return The capacity of the data frame slice to use.
+    std::size_t dataFrameSliceCapacity() const override;
+
     //! Write the extra columns of \p row added by outlier analysis to \p writer.
     void writeOneRow(const core::CDataFrame& frame,
                      const TRowRef& row,

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -64,6 +64,9 @@ public:
     //! \return The number of columns this adds to the data frame.
     std::size_t numberExtraColumns() const override;
 
+    //! \return The capacity of the data frame slice to use.
+    std::size_t dataFrameSliceCapacity() const override;
+
     //! The boosted tree.
     const maths::CBoostedTree& boostedTree() const;
 

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -270,13 +270,6 @@ public:
                EReadWriteToStorage readAndWriteToStoreSyncStrategy,
                const TWriteSliceToStoreFunc& writeSliceToStore);
 
-    //! Overload which manages the setting of slice capacity to a sensible default.
-    CDataFrame(bool inMainMemory,
-               std::size_t numberColumns,
-               CAlignment::EType rowAlignment,
-               EReadWriteToStorage readAndWriteToStoreSyncStrategy,
-               const TWriteSliceToStoreFunc& writeSliceToStore);
-
     ~CDataFrame();
 
     CDataFrame(const CDataFrame&) = delete;
@@ -628,6 +621,12 @@ private:
     //! The slice writer which is currently active.
     TRowSliceWriterPtr m_Writer;
 };
+
+//! Compute the default data frame slice capacity in rows.
+//!
+//! \param[in] numberColumns The number of columns in the data frame created.
+CORE_EXPORT
+std::size_t dataFrameDefaultSliceCapacity(std::size_t numberColumns);
 
 //! Make a data frame which uses main memory storage for its slices.
 //!

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -336,7 +336,7 @@ bool parallel_for_each(std::size_t start,
     // in guarding against accidental deadlock in the case someone inadvertantly calls
     // parallelised code in the function to execute.
 
-    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
+    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope;
 
     functions.resize(std::min(functions.size(), end - start));
 
@@ -381,7 +381,7 @@ parallel_for_each(std::size_t partitions,
 
     // See above for details.
 
-    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
+    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope;
 
     partitions = std::min(partitions, end - start);
 
@@ -437,7 +437,7 @@ bool parallel_for_each(ITR start,
 
     // See above for details.
 
-    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
+    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope;
 
     functions.resize(std::min(functions.size(), size));
 
@@ -482,7 +482,7 @@ parallel_for_each(std::size_t partitions,
 
     // See above for details.
 
-    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope{};
+    concurrency_detail::CDefaultAsyncExecutorBusyForScope scope;
 
     partitions = std::min(partitions, size);
 

--- a/lib/api/CDataFrameAnalysisSpecification.cc
+++ b/lib/api/CDataFrameAnalysisSpecification.cc
@@ -198,9 +198,11 @@ CDataFrameAnalysisSpecification::makeDataFrame() {
     }
 
     auto result = m_Runner->storeDataFrameInMainMemory()
-                      ? core::makeMainStorageDataFrame(m_NumberColumns)
-                      : core::makeDiskStorageDataFrame(m_TemporaryDirectory,
-                                                       m_NumberColumns, m_NumberRows);
+                      ? core::makeMainStorageDataFrame(
+                            m_NumberColumns, m_Runner->dataFrameSliceCapacity())
+                      : core::makeDiskStorageDataFrame(
+                            m_TemporaryDirectory, m_NumberColumns, m_NumberRows,
+                            m_Runner->dataFrameSliceCapacity());
     result.first->missingString(m_MissingFieldValue);
     result.first->reserve(m_NumberThreads, m_NumberColumns + this->numberExtraColumns());
 

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -79,6 +79,11 @@ std::size_t CDataFrameOutliersRunner::numberExtraColumns() const {
     return m_ComputeFeatureInfluence ? this->spec().numberColumns() + 1 : 1;
 }
 
+std::size_t CDataFrameOutliersRunner::dataFrameSliceCapacity() const {
+    return core::dataFrameDefaultSliceCapacity(this->spec().numberColumns() +
+                                               this->numberExtraColumns());
+}
+
 void CDataFrameOutliersRunner::writeOneRow(const core::CDataFrame& frame,
                                            const TRowRef& row,
                                            core::CRapidJsonConcurrentLineWriter& writer) const {

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -187,6 +187,19 @@ std::size_t CDataFrameTrainBoostedTreeRunner::numberExtraColumns() const {
     return m_BoostedTreeFactory->numberExtraColumnsForTrain();
 }
 
+std::size_t CDataFrameTrainBoostedTreeRunner::dataFrameSliceCapacity() const {
+    std::size_t sliceCapacity{core::dataFrameDefaultSliceCapacity(
+        this->spec().numberColumns() + this->numberExtraColumns())};
+    std::size_t numberThreads{this->spec().numberThreads()};
+    if (numberThreads > 1) {
+        // Use at least one slice per thread because we parallelize work over slices.
+        std::size_t capacityForTwoSlicesPerThread{
+            (this->spec().numberRows() + numberThreads - 1) / numberThreads};
+        sliceCapacity = std::min(sliceCapacity, capacityForTwoSlicesPerThread);
+    }
+    return std::max(sliceCapacity, std::size_t{128});
+}
+
 const std::string& CDataFrameTrainBoostedTreeRunner::dependentVariableFieldName() const {
     return m_DependentVariableFieldName;
 }

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -17,6 +17,10 @@ std::size_t CDataFrameMockAnalysisRunner::numberExtraColumns() const {
     return 2;
 }
 
+std::size_t CDataFrameMockAnalysisRunner::dataFrameSliceCapacity() const {
+    return 10000;
+}
+
 void CDataFrameMockAnalysisRunner::writeOneRow(const ml::core::CDataFrame&,
                                                const TRowRef&,
                                                ml::core::CRapidJsonConcurrentLineWriter&) const {

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -33,6 +33,7 @@ public:
     CDataFrameMockAnalysisRunner(const ml::api::CDataFrameAnalysisSpecification& spec);
 
     std::size_t numberExtraColumns() const override;
+    std::size_t dataFrameSliceCapacity() const override;
     void writeOneRow(const ml::core::CDataFrame&,
                      const TRowRef&,
                      ml::core::CRapidJsonConcurrentLineWriter&) const override;

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -183,11 +183,13 @@ CBoostedTree::TDouble2Vec CBoostedTree::readAndAdjustPrediction(const TRowRef& r
         row, m_Impl->extraColumns(), loss.numberParameters()));
 
     switch (loss.type()) {
-    case CLoss::E_BinaryClassification:
-    case CLoss::E_MulticlassClassification:
+    case E_BinaryClassification:
+    case E_MulticlassClassification:
         prediction = m_Impl->classificationWeights().array() * prediction.array();
         break;
-    case CLoss::E_Regression:
+    case E_MseRegression:
+    case E_MsleRegression:
+    case E_HuberRegression:
         break;
     }
 

--- a/lib/maths/CBoostedTreeLoss.cc
+++ b/lib/maths/CBoostedTreeLoss.cc
@@ -698,8 +698,8 @@ std::unique_ptr<CLoss> CMse::clone() const {
     return std::make_unique<CMse>(*this);
 }
 
-CMse::EType CMse::type() const {
-    return E_Regression;
+ELossType CMse::type() const {
+    return E_MseRegression;
 }
 
 std::size_t CMse::numberParameters() const {
@@ -762,8 +762,8 @@ CMsle::CMsle(core::CStateRestoreTraverser& traverser) {
     }
 }
 
-CLoss::EType CMsle::type() const {
-    return E_Regression;
+ELossType CMsle::type() const {
+    return E_MsleRegression;
 }
 
 std::unique_ptr<CLoss> CMsle::clone() const {
@@ -854,8 +854,8 @@ CPseudoHuber::CPseudoHuber(core::CStateRestoreTraverser& traverser) {
     }
 }
 
-CLoss::EType CPseudoHuber::type() const {
-    return E_Regression;
+ELossType CPseudoHuber::type() const {
+    return E_HuberRegression;
 }
 
 std::unique_ptr<CLoss> CPseudoHuber::clone() const {
@@ -941,7 +941,7 @@ std::unique_ptr<CLoss> CBinomialLogisticLoss::clone() const {
     return std::make_unique<CBinomialLogisticLoss>(*this);
 }
 
-CBinomialLogisticLoss::EType CBinomialLogisticLoss::type() const {
+ELossType CBinomialLogisticLoss::type() const {
     return E_BinaryClassification;
 }
 
@@ -1028,7 +1028,7 @@ std::unique_ptr<CLoss> CMultinomialLogisticLoss::clone() const {
     return std::make_unique<CMultinomialLogisticLoss>(m_NumberClasses);
 }
 
-CMultinomialLogisticLoss::EType CMultinomialLogisticLoss::type() const {
+ELossType CMultinomialLogisticLoss::type() const {
     return E_MulticlassClassification;
 }
 


### PR DESCRIPTION
When a data frame is sliced by memory it should have been accounting for the additional columns that each analysis type will require. Additionally, now we support threading analyses, it is useful to set the slice size based on the thread count for boosted tree training, since we parallelise work by splitting it over the data frame slices.

I'm marking this as a non-issue because it is a low level detail which is mainly only visible when threading is enabled for classification and regression. Since this is new in 7.9, I don't think it needs documenting separately.