### PR TITLE
[7.x] Report model change annotations via result stream (#1247)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,6 +30,11 @@
 
 == {es} version 7.9.0
 
+=== New Features
+
+* Report significant changes to anomaly detection models in annotations of the results.
+  (See {ml-pull}1247[#1247], {pull}56342[#56342], {pull}56417[#56417], {pull}57144[#57144], {pull}57278[#57278], {pull}57539[#57539].)
+
 === Enhancements
 
 * Add support for larger forecasts in memory via max_model_memory setting.

--- a/include/api/CAnnotationJsonWriter.h
+++ b/include/api/CAnnotationJsonWriter.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CAnnotationJsonWriter_h
+#define INCLUDED_ml_api_CAnnotationJsonWriter_h
+
+#include <core/CJsonOutputStreamWrapper.h>
+#include <core/CNonCopyable.h>
+#include <core/CRapidJsonConcurrentLineWriter.h>
+#include <core/CoreTypes.h>
+
+#include <api/ImportExport.h>
+
+#include <model/CAnnotation.h>
+
+#include <rapidjson/document.h>
+
+#include <iosfwd>
+#include <sstream>
+#include <string>
+
+#include <stdint.h>
+
+namespace ml {
+namespace api {
+
+//! \brief
+//! Write annotation result as a JSON document
+class API_EXPORT CAnnotationJsonWriter final : private core::CNonCopyable {
+public:
+    //! Constructor that causes to be written to the specified stream
+    explicit CAnnotationJsonWriter(core::CJsonOutputStreamWrapper& outStream);
+
+    void writeResult(const std::string& jobId, const model::CAnnotation& annotation);
+
+private:
+    void populateAnnotationObject(const std::string& jobId,
+                                  const model::CAnnotation& annotation,
+                                  rapidjson::Value& obj);
+
+private:
+    //! JSON line writer
+    core::CRapidJsonConcurrentLineWriter m_Writer;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CAnnotationJsonWriter_h

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -111,6 +111,7 @@ public:
         std::pair<model::CSearchKey::TStrCRefKeyCRefPr, TAnomalyDetectorPtr>;
     using TKeyCRefAnomalyDetectorPtrPrVec = std::vector<TKeyCRefAnomalyDetectorPtrPr>;
     using TModelPlotDataVec = model::CAnomalyDetector::TModelPlotDataVec;
+    using TAnnotationVec = model::CAnomalyDetector::TAnnotationVec;
 
     struct API_EXPORT SRestoredStateDetail {
         ERestoreStateStatus s_RestoredStateStatus;
@@ -333,6 +334,9 @@ private:
     //! Write the pre-generated model plot to the output stream of the user's
     //! choosing: either file or streamed to the API
     void writeOutModelPlot(const TModelPlotDataVec& modelPlotData);
+
+    //! Write the annotations to the output stream.
+    void writeOutAnnotations(const TAnnotationVec& annotations);
 
     //! Persist one detector to a stream.
     //! This method is static so that there is no danger of it accessing

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -121,6 +121,12 @@ public:
     //! Get the prior sample weights.
     const TDouble2VecWeightsAryVec& priorWeights() const;
 
+    //! Set the model annotation callback.
+    CModelAddSamplesParams&
+    annotationCallback(const maths_t::TModelAnnotationCallback& modelAnnotationCallback);
+    //! Get the model annotation callback.
+    const maths_t::TModelAnnotationCallback& annotationCallback() const;
+
 private:
     //! The data type.
     maths_t::EDataType m_Type = maths_t::E_MixedData;
@@ -132,6 +138,9 @@ private:
     const TDouble2VecWeightsAryVec* m_TrendWeights = nullptr;
     //! The prior sample weights.
     const TDouble2VecWeightsAryVec* m_PriorWeights = nullptr;
+    //! The model change callback.
+    maths_t::TModelAnnotationCallback m_ModelAnnotationCallback =
+        [](core_t::TTime, const std::string&) {};
 };
 
 //! \brief The extra parameters needed by CModel::probability.

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -106,10 +106,13 @@ public:
     //! and it's local variance.
     //! \param[in] componentChangeCallback Called if the components
     //! change as a result of adding the data point.
-    virtual void addPoint(core_t::TTime time,
-                          double value,
-                          const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT,
-                          const TComponentChangeCallback& componentChangeCallback = noop);
+    //! \param[in] modelAnnotationCallback Called if the model changes as a result of adding the data point.
+    virtual void
+    addPoint(core_t::TTime time,
+             double value,
+             const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT,
+             const TComponentChangeCallback& componentChangeCallback = noopComponentChange,
+             const maths_t::TModelAnnotationCallback& modelAnnotationCallback = noopModelAnnotation);
 
     //! Apply \p change at \p time.
     //!

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -359,7 +359,8 @@ public:
         class CScopeAttachComponentChangeCallback {
         public:
             CScopeAttachComponentChangeCallback(CComponents& components,
-                                                TComponentChangeCallback callback);
+                                                TComponentChangeCallback componentChangeCallback,
+                                                maths_t::TModelAnnotationCallback modelAnnotationCallback);
             ~CScopeAttachComponentChangeCallback();
             CScopeAttachComponentChangeCallback(const CScopeAttachComponentChangeCallback&) = delete;
             CScopeAttachComponentChangeCallback&
@@ -768,7 +769,8 @@ public:
         std::size_t maxSize() const;
 
         //! Add new seasonal components to \p components.
-        bool addSeasonalComponents(const CPeriodicityHypothesisTestsResult& result,
+        bool addSeasonalComponents(core_t::TTime time,
+                                   const CPeriodicityHypothesisTestsResult& result,
                                    const CExpandingWindow& window,
                                    const TPredictor& predictor);
 
@@ -864,6 +866,9 @@ public:
 
         //! Called if the components change.
         TComponentChangeCallback m_ComponentChangeCallback;
+
+        //! Called if the model change annotation is reported.
+        maths_t::TModelAnnotationCallback m_ModelAnnotationCallback;
 
         //! Set to true when testing for a change.
         bool m_TestingForChange = false;

--- a/include/maths/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/CTimeSeriesDecompositionInterface.h
@@ -96,7 +96,8 @@ public:
     addPoint(core_t::TTime time,
              double value,
              const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT,
-             const TComponentChangeCallback& componentChangeCallback = noop) = 0;
+             const TComponentChangeCallback& componentChangeCallback = noopComponentChange,
+             const maths_t::TModelAnnotationCallback& modelAnnotationCallback = noopModelAnnotation) = 0;
 
     //! Apply \p change at \p time.
     //!
@@ -193,7 +194,8 @@ public:
     virtual core_t::TTime lastValueTime() const = 0;
 
 protected:
-    static void noop(TFloatMeanAccumulatorVec) {}
+    static void noopComponentChange(TFloatMeanAccumulatorVec) {}
+    static void noopModelAnnotation(core_t::TTime, const std::string&) {}
 };
 }
 }

--- a/include/maths/CTimeSeriesDecompositionStub.h
+++ b/include/maths/CTimeSeriesDecompositionStub.h
@@ -41,10 +41,12 @@ public:
     virtual void testingForChange(bool value);
 
     //! No-op returning false.
-    virtual void addPoint(core_t::TTime time,
-                          double value,
-                          const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT,
-                          const TComponentChangeCallback& componentChangeCallback = noop);
+    virtual void
+    addPoint(core_t::TTime time,
+             double value,
+             const maths_t::TDoubleWeightsAry& weights = TWeights::UNIT,
+             const TComponentChangeCallback& componentChangeCallback = noopComponentChange,
+             const maths_t::TModelAnnotationCallback& modelAnnotationCallback = noopModelAnnotation);
 
     //! No-op returning false.
     virtual bool applyChange(core_t::TTime time, double value, const SChangeDescription& change);

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -234,8 +234,8 @@ private:
     EUpdateResult applyChange(const SChangeDescription& change);
 
     //! Update the trend with \p samples.
-    EUpdateResult updateTrend(const TTimeDouble2VecSizeTrVec& samples,
-                              const TDouble2VecWeightsAryVec& trendWeights);
+    EUpdateResult updateTrend(const CModelAddSamplesParams& params,
+                              const TTimeDouble2VecSizeTrVec& samples);
 
     //! Update the various model decay rates based on the prediction errors
     //! for \p samples.
@@ -689,8 +689,8 @@ private:
 
 private:
     //! Update the trend with \p samples.
-    EUpdateResult updateTrend(const TTimeDouble2VecSizeTrVec& samples,
-                              const TDouble2VecWeightsAryVec& trendWeights);
+    EUpdateResult updateTrend(const CModelAddSamplesParams& params,
+                              const TTimeDouble2VecSizeTrVec& samples);
 
     //! Update the various model decay rates based on the prediction errors
     //! for \p samples.

--- a/include/maths/MathsTypes.h
+++ b/include/maths/MathsTypes.h
@@ -9,6 +9,7 @@
 
 #include <core/CFloatStorage.h>
 #include <core/CSmallVector.h>
+#include <core/CoreTypes.h>
 
 #include <maths/ImportExport.h>
 
@@ -78,6 +79,9 @@ using TDouble2VecWeightsAry = TWeightsAry<TDouble2Vec>;
 using TDouble2VecWeightsAry1Vec = core::CSmallVector<TDouble2VecWeightsAry, 1>;
 using TDouble10VecWeightsAry = TWeightsAry<TDouble10Vec>;
 using TDouble10VecWeightsAry1Vec = core::CSmallVector<TDouble10VecWeightsAry, 1>;
+
+// Functional type used for reporting model change annotations to higher-level layers.
+using TModelAnnotationCallback = std::function<void(core_t::TTime, const std::string&)>;
 
 namespace maths_types_detail {
 

--- a/include/model/CAnnotation.h
+++ b/include/model/CAnnotation.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_model_CAnnotation_h
+#define INCLUDED_ml_model_CAnnotation_h
+
+#include <model/ImportExport.h>
+
+#include <model/ModelTypes.h>
+
+#include <string>
+
+namespace ml {
+namespace model {
+
+//! \brief Data necessary to create an annotation
+class MODEL_EXPORT CAnnotation {
+public:
+    CAnnotation() = default;
+    CAnnotation(core_t::TTime time,
+                const std::string& annotation,
+                int detectorIndex,
+                const std::string& partitionFieldName,
+                const std::string& partitionFieldValue,
+                const std::string& overFieldName,
+                const std::string& overFieldValue,
+                const std::string& byFieldName,
+                const std::string& byFieldValue);
+    core_t::TTime time() const;
+    const std::string& annotation() const;
+    const std::string& event() const;
+    int detectorIndex() const;
+    const std::string& partitionFieldName() const;
+    const std::string& partitionFieldValue() const;
+    const std::string& overFieldName() const;
+    const std::string& overFieldValue() const;
+    const std::string& byFieldName() const;
+    const std::string& byFieldValue() const;
+
+private:
+    core_t::TTime m_Time = 0;
+    std::string m_Annotation;
+    int m_DetectorIndex = -1;
+    std::string m_PartitionFieldName;
+    std::string m_PartitionFieldValue;
+    std::string m_OverFieldName;
+    std::string m_OverFieldValue;
+    std::string m_ByFieldName;
+    std::string m_ByFieldValue;
+};
+}
+}
+
+#endif // INCLUDED_ml_model_CAnnotation_h

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -63,6 +63,7 @@ public:
     using TStrVec = std::vector<std::string>;
     using TStrCPtrVec = std::vector<const std::string*>;
     using TModelPlotDataVec = std::vector<CModelPlotData>;
+    using TAnnotationVec = CAnomalyDetectorModel::TAnnotationVec;
     using TDataGathererPtr = std::shared_ptr<CDataGatherer>;
     using TModelFactoryCPtr = std::shared_ptr<const CModelFactory>;
     using TModelPtr = std::unique_ptr<CAnomalyDetectorModel>;
@@ -223,6 +224,11 @@ public:
                            double boundsPercentile,
                            const TStrSet& terms,
                            TModelPlotDataVec& modelPlots) const;
+
+    //! Generate the annotations.
+    void generateAnnotations(core_t::TTime bucketStartTime,
+                             core_t::TTime bucketEndTime,
+                             TAnnotationVec& annotations) const;
 
     //! Generate ForecastPrerequistes, e.g. memory requirements
     CForecastDataSink::SForecastModelPrerequisites getForecastPrerequisites() const;

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -15,6 +15,7 @@
 #include <maths/CTimeSeriesModel.h>
 #include <maths/MathsTypes.h>
 
+#include <model/CAnnotation.h>
 #include <model/CMemoryUsageEstimator.h>
 #include <model/CModelParams.h>
 #include <model/CPartitioningFields.h>
@@ -50,6 +51,7 @@ class CAttributeFrequencyGreaterThan;
 class CInterimBucketCorrector;
 class CDataGatherer;
 class CHierarchicalResults;
+class CAnnotation;
 class CModelDetailsView;
 class CPersonFrequencyGreaterThan;
 class CResourceMonitor;
@@ -164,6 +166,7 @@ public:
     using TDataGathererPtr = std::shared_ptr<CDataGatherer>;
     using TModelDetailsViewUPtr = std::unique_ptr<CModelDetailsView>;
     using TModelPtr = std::unique_ptr<CAnomalyDetectorModel>;
+    using TAnnotationVec = std::vector<CAnnotation>;
 
 public:
     //! A value used to indicate a time variable is unset
@@ -482,6 +485,9 @@ public:
 
     //! Get the descriptions of any occurring scheduled event descriptions for the bucket time
     virtual const TStr1Vec& scheduledEventDescriptions(core_t::TTime time) const;
+
+    //! Get the annotations produced by this model.
+    virtual const TAnnotationVec& annotations() const = 0;
 
 protected:
     using TStrCRef = std::reference_wrapper<const std::string>;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -219,6 +219,9 @@ public:
     //! Get the descriptions of any occurring scheduled event descriptions for the bucket time
     const TStr1Vec& scheduledEventDescriptions(core_t::TTime time) const override;
 
+    //! Get the annotations produced by this model.
+    const TAnnotationVec& annotations() const override;
+
 protected:
     //! Get the start time of the current bucket.
     core_t::TTime currentBucketStartTime() const override;
@@ -292,6 +295,9 @@ private:
 
     //! Calculates corrections for interim buckets.
     TInterimBucketCorrectorPtr m_InterimBucketCorrector;
+
+    //! Annotations produced by this model.
+    TAnnotationVec m_Annotations;
 
     friend struct CCountingModelTest::testCheckScheduledEvents;
 };

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -77,6 +77,8 @@ public:
         //! The key is <feature, pid, pid> for non-correlated corrections
         //! or <feature, pid, correlated_pid> for correlated corrections
         mutable TFeatureSizeSizeTripleDouble1VecUMap s_InterimCorrections;
+        //! Annotations produced by this model.
+        TAnnotationVec s_Annotations;
     };
 
 public:
@@ -269,6 +271,9 @@ public:
     //! by \p pid for the bucketing interval containing \p time.
     const TFeatureData*
     featureData(model_t::EFeature feature, std::size_t pid, core_t::TTime time) const;
+
+    //! Get the annotations produced by this model.
+    const TAnnotationVec& annotations() const override;
 
 private:
     //! Get the start time of the current bucket.

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -98,6 +98,8 @@ public:
         TFeatureSizeSizePrFeatureDataPrVecMap s_FeatureData;
         //! A cache of the corrections applied to interim results.
         mutable TCorrectionKeyDouble1VecUMap s_InterimCorrections;
+        //! Annotations produced by this model.
+        TAnnotationVec s_Annotations;
     };
 
     //! Lift the overloads of currentBucketValue into the class scope.
@@ -307,6 +309,9 @@ public:
     //! Get the feature data corresponding to \p feature at \p time.
     const TSizeSizePrFeatureDataPrVec& featureData(model_t::EFeature feature,
                                                    core_t::TTime time) const;
+
+    //! Get the annotations produced by this model.
+    const TAnnotationVec& annotations() const override;
 
 private:
     //! Initialize the feature models.

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -73,6 +73,8 @@ public:
         //! The key is <feature, pid, pid> for non-correlated corrections
         //! or <feature, pid, correlated_pid> for correlated corrections
         mutable TFeatureSizeSizeTripleDouble1VecUMap s_InterimCorrections;
+        //! Annotations produced by this model.
+        TAnnotationVec s_Annotations;
     };
 
 public:
@@ -264,6 +266,9 @@ public:
     //! by \p pid for the bucketing interval containing \p time.
     const TFeatureData*
     featureData(model_t::EFeature feature, std::size_t pid, core_t::TTime time) const;
+
+    //! Get the annotations produced by this model.
+    const TAnnotationVec& annotations() const override;
 
 private:
     using TOptionalSample = boost::optional<CSample>;

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -26,6 +26,7 @@ class CStatePersistInserter;
 class CStateRestoreTraverser;
 }
 namespace model {
+
 //! \brief The model for computing the anomalousness of the values
 //! each person in a population generates in a data stream.
 //!
@@ -74,6 +75,8 @@ public:
         TFeatureSizeSizePrFeatureDataPrVecMap s_FeatureData;
         //! A cache of the corrections applied to interim results.
         mutable TCorrectionKeyDouble1VecUMap s_InterimCorrections;
+        //! Annotations produced by this model.
+        TAnnotationVec s_Annotations;
     };
 
     //! Lift the overloads of currentBucketValue into the class scope.
@@ -283,6 +286,9 @@ public:
 
     //! Get the non-estimated memory used by this model.
     std::size_t computeMemoryUsage() const override;
+
+    //! Get the annotations produced by this model.
+    const TAnnotationVec& annotations() const override;
 
 private:
     //! Initialize the feature models.

--- a/include/model/CModelFactory.h
+++ b/include/model/CModelFactory.h
@@ -349,6 +349,9 @@ public:
     //! Update the bucket length, for ModelAutoConfig's benefit
     void updateBucketLength(core_t::TTime length);
 
+    //! Set whether model annotations should be reported.
+    void annotationsEnabled(bool enabled);
+
     //! Get global model configuration parameters.
     const SModelParams& modelParams() const;
 

--- a/include/model/CModelParams.h
+++ b/include/model/CModelParams.h
@@ -175,6 +175,9 @@ struct MODEL_EXPORT SModelParams {
     //! If true then cache the results of the probability calculation.
     bool s_CacheProbabilities;
     //@}
+
+    //! If true then model change annotations should be reported.
+    bool s_AnnotationsEnabled;
 };
 }
 }

--- a/lib/api/CAnnotationJsonWriter.cc
+++ b/lib/api/CAnnotationJsonWriter.cc
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include <api/CAnnotationJsonWriter.h>
+#include <core/CLogger.h>
+#include <core/CTimeUtils.h>
+
+namespace ml {
+namespace api {
+namespace {
+// JSON field names
+const std::string ANNOTATION_RESULT_TYPE{"annotation"};
+const std::string TIMESTAMP{"timestamp"};
+const std::string END_TIMESTAMP{"end_timestamp"};
+const std::string ANNOTATION{"annotation"};
+const std::string CREATE_TIME{"create_time"};
+const std::string CREATE_USERNAME{"create_username"};
+const std::string MODIFIED_TIME{"modified_time"};
+const std::string MODIFIED_USERNAME{"modified_username"};
+const std::string TYPE{"type"};
+const std::string EVENT{"event"};
+const std::string JOB_ID{"job_id"};
+const std::string DETECTOR_INDEX{"detector_index"};
+const std::string PARTITION_FIELD_NAME{"partition_field_name"};
+const std::string PARTITION_FIELD_VALUE{"partition_field_value"};
+const std::string OVER_FIELD_NAME{"over_field_name"};
+const std::string OVER_FIELD_VALUE{"over_field_value"};
+const std::string BY_FIELD_NAME{"by_field_name"};
+const std::string BY_FIELD_VALUE{"by_field_value"};
+}
+
+CAnnotationJsonWriter::CAnnotationJsonWriter(core::CJsonOutputStreamWrapper& outStream)
+    : m_Writer(outStream) {
+}
+
+void CAnnotationJsonWriter::writeResult(const std::string& jobId,
+                                        const model::CAnnotation& annotation) {
+
+    rapidjson::Value obj = m_Writer.makeObject();
+    populateAnnotationObject(jobId, annotation, obj);
+
+    rapidjson::Value wrapper = m_Writer.makeObject();
+    m_Writer.addMember(ANNOTATION_RESULT_TYPE, obj, wrapper);
+    m_Writer.write(wrapper);
+    m_Writer.Flush();
+}
+
+void CAnnotationJsonWriter::populateAnnotationObject(const std::string& jobId,
+                                                     const model::CAnnotation& annotation,
+                                                     rapidjson::Value& obj) {
+
+    m_Writer.addStringFieldCopyToObj(JOB_ID, jobId, obj, true);
+    m_Writer.addStringFieldCopyToObj(ANNOTATION, annotation.annotation(), obj);
+    // time is in Java format - milliseconds since the epoch
+    m_Writer.addTimeFieldToObj(TIMESTAMP, annotation.time(), obj);
+    m_Writer.addTimeFieldToObj(END_TIMESTAMP, annotation.time(), obj);
+
+    core_t::TTime currentTime(core::CTimeUtils::now());
+    m_Writer.addTimeFieldToObj(CREATE_TIME, currentTime, obj);
+    m_Writer.addTimeFieldToObj(MODIFIED_TIME, currentTime, obj);
+    m_Writer.addStringFieldCopyToObj(CREATE_USERNAME, "_xpack", obj);
+    m_Writer.addStringFieldCopyToObj(MODIFIED_USERNAME, "_xpack", obj);
+    m_Writer.addStringFieldCopyToObj(TYPE, "annotation", obj);
+    m_Writer.addStringFieldCopyToObj(EVENT, annotation.event(), obj);
+
+    m_Writer.addIntFieldToObj(DETECTOR_INDEX, annotation.detectorIndex(), obj);
+    if (annotation.partitionFieldName().empty() == false) {
+        m_Writer.addStringFieldCopyToObj(PARTITION_FIELD_NAME,
+                                         annotation.partitionFieldName(), obj);
+        m_Writer.addStringFieldCopyToObj(
+            PARTITION_FIELD_VALUE, annotation.partitionFieldValue(), obj, true);
+    }
+    if (annotation.overFieldName().empty() == false) {
+        m_Writer.addStringFieldCopyToObj(OVER_FIELD_NAME, annotation.overFieldName(), obj);
+        m_Writer.addStringFieldCopyToObj(OVER_FIELD_VALUE,
+                                         annotation.overFieldValue(), obj, true);
+    }
+    if (annotation.byFieldName().empty() == false) {
+        m_Writer.addStringFieldCopyToObj(BY_FIELD_NAME, annotation.byFieldName(), obj);
+        m_Writer.addStringFieldCopyToObj(BY_FIELD_VALUE,
+                                         annotation.byFieldValue(), obj, true);
+    }
+}
+}
+}

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -36,6 +36,7 @@
 #include <model/CSimpleCountDetector.h>
 #include <model/CStringStore.h>
 
+#include <api/CAnnotationJsonWriter.h>
 #include <api/CConfigUpdater.h>
 #include <api/CFieldConfig.h>
 #include <api/CHierarchicalResultsWriter.h>
@@ -587,6 +588,7 @@ void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
 
     model::CHierarchicalResults results;
     TModelPlotDataVec modelPlotData;
+    TAnnotationVec annotations;
 
     TKeyCRefAnomalyDetectorPtrPrVec detectors;
     this->sortedDetectors(detectors);
@@ -603,6 +605,8 @@ void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
 
         this->generateModelPlot(bucketStartTime, bucketStartTime + bucketLength,
                                 *detector, modelPlotData);
+        detector->generateAnnotations(bucketStartTime,
+                                      bucketStartTime + bucketLength, annotations);
     }
 
     if (!results.empty()) {
@@ -626,6 +630,7 @@ void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
     // Model plots must be written first so the Java persists them
     // once the bucket result is processed
     this->writeOutModelPlot(modelPlotData);
+    this->writeOutAnnotations(annotations);
     this->writeOutResults(false, results, bucketStartTime, processingTime);
 
     m_Limits.resourceMonitor().pruneIfRequired(bucketStartTime);
@@ -1386,6 +1391,13 @@ void CAnomalyJob::writeOutModelPlot(const TModelPlotDataVec& modelPlotData) {
     CModelPlotDataJsonWriter modelPlotWriter(m_OutputStream);
     for (const auto& plot : modelPlotData) {
         modelPlotWriter.writeFlat(m_JobId, plot);
+    }
+}
+
+void CAnomalyJob::writeOutAnnotations(const TAnnotationVec& annotations) {
+    CAnnotationJsonWriter annotationWriter(m_OutputStream);
+    for (const auto& annotation : annotations) {
+        annotationWriter.writeResult(m_JobId, annotation);
     }
 }
 

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -47,6 +47,7 @@ CIoManager.cc \
 CJsonOutputWriter.cc \
 CLengthEncodedInputParser.cc \
 CMemoryUsageEstimationResultJsonWriter.cc \
+CAnnotationJsonWriter.cc \
 CModelPlotDataJsonWriter.cc \
 CModelSizeStatsJsonWriter.cc \
 CModelSnapshotJsonWriter.cc \

--- a/lib/api/unittest/CAnnotationJsonWriterTest.cc
+++ b/lib/api/unittest/CAnnotationJsonWriterTest.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CJsonOutputStreamWrapper.h>
+
+#include <model/CAnnotation.h>
+#include <model/ModelTypes.h>
+
+#include <api/CAnnotationJsonWriter.h>
+
+#include <test/BoostTestCloseAbsolute.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+
+BOOST_AUTO_TEST_SUITE(CAnnotationJsonWriterTest)
+
+BOOST_AUTO_TEST_CASE(testWrite) {
+    std::ostringstream sstream;
+
+    {
+        ml::core::CJsonOutputStreamWrapper outputStream(sstream);
+        ml::api::CAnnotationJsonWriter writer(outputStream);
+
+        ml::model::CAnnotation annotation(1, "annotation text", 2, "pName", "pValue",
+                                          "oName", "oValue", "bName", "bValue");
+        writer.writeResult("job-id", annotation);
+    }
+
+    rapidjson::Document doc;
+    doc.Parse<rapidjson::kParseDefaultFlags>(sstream.str());
+    BOOST_TEST_REQUIRE(doc.HasParseError() == false);
+    const rapidjson::Value& firstElement = doc[0];
+    BOOST_TEST_REQUIRE(firstElement.HasMember("annotation"));
+    const rapidjson::Value& annotation = firstElement["annotation"];
+    BOOST_TEST_REQUIRE(annotation.HasMember("job_id"));
+    BOOST_REQUIRE_EQUAL(std::string("job-id"),
+                        std::string(annotation["job_id"].GetString()));
+    BOOST_TEST_REQUIRE(annotation.HasMember("timestamp"));
+    BOOST_REQUIRE_EQUAL(1000, annotation["timestamp"].GetInt64());
+    BOOST_TEST_REQUIRE(annotation.HasMember("detector_index"));
+    BOOST_REQUIRE_EQUAL(2, annotation["detector_index"].GetInt());
+    BOOST_TEST_REQUIRE(annotation.HasMember("partition_field_name"));
+    BOOST_REQUIRE_EQUAL(std::string("pName"),
+                        std::string(annotation["partition_field_name"].GetString()));
+    BOOST_TEST_REQUIRE(annotation.HasMember("partition_field_value"));
+    BOOST_REQUIRE_EQUAL(std::string("pValue"),
+                        std::string(annotation["partition_field_value"].GetString()));
+    BOOST_TEST_REQUIRE(annotation.HasMember("over_field_name"));
+    BOOST_REQUIRE_EQUAL(std::string("oName"),
+                        std::string(annotation["over_field_name"].GetString()));
+    BOOST_TEST_REQUIRE(annotation.HasMember("over_field_value"));
+    BOOST_REQUIRE_EQUAL(std::string("oValue"),
+                        std::string(annotation["over_field_value"].GetString()));
+    BOOST_TEST_REQUIRE(annotation.HasMember("by_field_name"));
+    BOOST_REQUIRE_EQUAL(std::string("bName"),
+                        std::string(annotation["by_field_name"].GetString()));
+    BOOST_TEST_REQUIRE(annotation.HasMember("by_field_value"));
+    BOOST_REQUIRE_EQUAL(std::string("bValue"),
+                        std::string(annotation["by_field_value"].GetString()));
+    BOOST_TEST_REQUIRE(annotation.HasMember("annotation"));
+    BOOST_REQUIRE_EQUAL(std::string("annotation text"),
+                        std::string(annotation["annotation"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string("model_change"),
+                        std::string(annotation["event"].GetString()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CConfigUpdaterTest.cc
+++ b/lib/api/unittest/CConfigUpdaterTest.cc
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(testUpdateGivenModelPlotConfig) {
     terms.insert(std::string("b"));
     modelConfig.modelPlotTerms(terms);
 
-    std::string configUpdate("[modelPlotConfig]\nboundspercentile = 83.5\nterms = c,d\n");
+    std::string configUpdate("[modelPlotConfig]\nboundspercentile = 83.5\nterms = c,d\nannotations_enabled = false\n");
 
     CConfigUpdater configUpdater(fieldConfig, modelConfig);
 

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -46,6 +46,7 @@ SRCS=\
 	CMockDataAdder.cc \
 	CMockDataProcessor.cc \
 	CMockSearcher.cc \
+	CAnnotationJsonWriterTest.cc \
 	CModelPlotDataJsonWriterTest.cc \
 	CModelSnapshotJsonWriterTest.cc \
 	CMultiFileDataAdderTest.cc \

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -130,6 +130,16 @@ CModelAddSamplesParams::priorWeights() const {
     return *m_PriorWeights;
 }
 
+CModelAddSamplesParams&
+CModelAddSamplesParams::annotationCallback(const maths_t::TModelAnnotationCallback& modelAnnotationCallback) {
+    m_ModelAnnotationCallback = modelAnnotationCallback;
+    return *this;
+}
+
+const maths_t::TModelAnnotationCallback& CModelAddSamplesParams::annotationCallback() const {
+    return m_ModelAnnotationCallback;
+}
+
 //////// CModelProbabilityParams ////////
 
 CModelProbabilityParams::CModelProbabilityParams()

--- a/lib/maths/CTimeSeriesDecomposition.cc
+++ b/lib/maths/CTimeSeriesDecomposition.cc
@@ -220,7 +220,8 @@ void CTimeSeriesDecomposition::testingForChange(bool value) {
 void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                                         double value,
                                         const maths_t::TDoubleWeightsAry& weights,
-                                        const TComponentChangeCallback& componentChangeCallback) {
+                                        const TComponentChangeCallback& componentChangeCallback,
+                                        const maths_t::TModelAnnotationCallback& modelAnnotationCallback) {
 
     if (CMathsFuncs::isFinite(value) == false) {
         LOG_ERROR(<< "Discarding invalid value.");
@@ -228,7 +229,8 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
     }
 
     // Make sure that we always attach this as the first thing we do.
-    CComponents::CScopeAttachComponentChangeCallback attach{m_Components, componentChangeCallback};
+    CComponents::CScopeAttachComponentChangeCallback attach{
+        m_Components, componentChangeCallback, modelAnnotationCallback};
 
     time += m_TimeShift;
 

--- a/lib/maths/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/CTimeSeriesDecompositionStub.cc
@@ -36,10 +36,12 @@ bool CTimeSeriesDecompositionStub::initialized() const {
 void CTimeSeriesDecompositionStub::testingForChange(bool /*value*/) {
 }
 
-void CTimeSeriesDecompositionStub::addPoint(core_t::TTime /*time*/,
-                                            double /*value*/,
-                                            const maths_t::TDoubleWeightsAry& /*weights*/,
-                                            const TComponentChangeCallback& /*componentChangeCallback*/) {
+void CTimeSeriesDecompositionStub::addPoint(
+    core_t::TTime /*time*/,
+    double /*value*/,
+    const maths_t::TDoubleWeightsAry& /*weights*/,
+    const TComponentChangeCallback& /*componentChangeCallback*/,
+    const maths_t::TModelAnnotationCallback& /*modelAnnotationCallback*/) {
 }
 
 bool CTimeSeriesDecompositionStub::applyChange(core_t::TTime /*time*/,

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -738,7 +738,7 @@ CUnivariateTimeSeriesModel::addSamples(const CModelAddSamplesParams& params,
     }
     m_TrendModel->dataType(type);
 
-    result = CModel::combine(result, this->updateTrend(samples, params.trendWeights()));
+    result = CModel::combine(result, this->updateTrend(params, samples));
 
     for (auto& sample : samples) {
         sample.second[0] = m_TrendModel->detrend(sample.first, sample.second[0], 0.0);
@@ -1501,12 +1501,16 @@ CUnivariateTimeSeriesModel::testAndApplyChange(const CModelAddSamplesParams& par
     }
 
     if (m_ChangeDetector != nullptr) {
+        const maths_t::TModelAnnotationCallback& modelAnnotationCallback =
+            params.annotationCallback();
         m_ChangeDetector->addSamples({{time, values[median].second[0]}}, {weights});
         if (m_ChangeDetector->stopTesting()) {
             m_ChangeDetector.reset();
             m_TrendModel->testingForChange(false);
         } else if (auto change = m_ChangeDetector->change()) {
-            LOG_DEBUG(<< "Detected " << change->print() << " at " << time);
+            std::string annotation{"Detected " + change->print()};
+            LOG_DEBUG(<< annotation << " at " << time);
+            modelAnnotationCallback(time, annotation);
             m_ChangeDetector.reset();
             m_TrendModel->testingForChange(false);
             return this->applyChange(*change);
@@ -1542,8 +1546,13 @@ CUnivariateTimeSeriesModel::applyChange(const SChangeDescription& change) {
 }
 
 CUnivariateTimeSeriesModel::EUpdateResult
-CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
-                                        const TDouble2VecWeightsAryVec& weights) {
+CUnivariateTimeSeriesModel::updateTrend(const CModelAddSamplesParams& params,
+                                        const TTimeDouble2VecSizeTrVec& samples) {
+
+    const TDouble2VecWeightsAryVec& weights = params.trendWeights();
+    const maths_t::TModelAnnotationCallback& modelAnnotationCallback =
+        params.annotationCallback();
+
     for (const auto& sample : samples) {
         if (sample.second.size() != 1) {
             LOG_ERROR(<< "Dimension mismatch: '" << sample.second.size() << " != 1'");
@@ -1577,7 +1586,8 @@ CUnivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
         core_t::TTime time{samples[i].first};
         double value{samples[i].second[0]};
         TDoubleWeightsAry weight{unpack(weights[i])};
-        m_TrendModel->addPoint(time, value, weight, componentChangeCallback);
+        m_TrendModel->addPoint(time, value, weight, componentChangeCallback,
+                               modelAnnotationCallback);
     }
 
     if (result == E_Reset) {
@@ -2296,7 +2306,7 @@ CMultivariateTimeSeriesModel::addSamples(const CModelAddSamplesParams& params,
         trendModel->dataType(type);
     }
 
-    EUpdateResult result{this->updateTrend(samples, params.trendWeights())};
+    EUpdateResult result{this->updateTrend(params, samples)};
 
     std::size_t dimension{this->dimension()};
     for (auto& sample : samples) {
@@ -2855,8 +2865,13 @@ const CMultivariatePrior& CMultivariateTimeSeriesModel::residualModel() const {
 }
 
 CMultivariateTimeSeriesModel::EUpdateResult
-CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& samples,
-                                          const TDouble2VecWeightsAryVec& weights) {
+CMultivariateTimeSeriesModel::updateTrend(const CModelAddSamplesParams& params,
+                                          const TTimeDouble2VecSizeTrVec& samples) {
+
+    const TDouble2VecWeightsAryVec& weights = params.trendWeights();
+    const maths_t::TModelAnnotationCallback& modelAnnotationCallback =
+        params.annotationCallback();
+
     std::size_t dimension{this->dimension()};
 
     for (const auto& sample : samples) {
@@ -2894,7 +2909,8 @@ CMultivariateTimeSeriesModel::updateTrend(const TTimeDouble2VecSizeTrVec& sample
             for (std::size_t j = 0; j < maths_t::NUMBER_WEIGHT_STYLES; ++j) {
                 weight[j] = weights[i][j][d];
             }
-            m_TrendModel[d]->addPoint(time, value[d], weight, componentChangeCallback);
+            m_TrendModel[d]->addPoint(time, value[d], weight, componentChangeCallback,
+                                      modelAnnotationCallback);
         }
     }
 

--- a/lib/model/CAnnotation.cc
+++ b/lib/model/CAnnotation.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include <model/CAnnotation.h>
+
+namespace ml {
+namespace model {
+namespace {
+const std::string EVENT_MODEL_CHANGE{"model_change"};
+}
+
+CAnnotation::CAnnotation(core_t::TTime time,
+                         const std::string& annotation,
+                         int detectorIndex,
+                         const std::string& partitionFieldName,
+                         const std::string& partitionFieldValue,
+                         const std::string& overFieldName,
+                         const std::string& overFieldValue,
+                         const std::string& byFieldName,
+                         const std::string& byFieldValue)
+    : m_Time{time}, m_Annotation{annotation}, m_DetectorIndex{detectorIndex},
+      m_PartitionFieldName{partitionFieldName}, m_PartitionFieldValue{partitionFieldValue},
+      m_OverFieldName{overFieldName}, m_OverFieldValue{overFieldValue},
+      m_ByFieldName{byFieldName}, m_ByFieldValue{byFieldValue} {
+}
+
+core_t::TTime CAnnotation::time() const {
+    return m_Time;
+}
+
+const std::string& CAnnotation::annotation() const {
+    return m_Annotation;
+}
+
+const std::string& CAnnotation::event() const {
+    // If we start reporting some other event type, we should return m_Event instead of a constant here.
+    return EVENT_MODEL_CHANGE;
+}
+
+int CAnnotation::detectorIndex() const {
+    return m_DetectorIndex;
+}
+
+const std::string& CAnnotation::partitionFieldName() const {
+    return m_PartitionFieldName;
+}
+
+const std::string& CAnnotation::partitionFieldValue() const {
+    return m_PartitionFieldValue;
+}
+
+const std::string& CAnnotation::overFieldName() const {
+    return m_OverFieldName;
+}
+
+const std::string& CAnnotation::overFieldValue() const {
+    return m_OverFieldValue;
+}
+
+const std::string& CAnnotation::byFieldName() const {
+    return m_ByFieldName;
+}
+
+const std::string& CAnnotation::byFieldValue() const {
+    return m_ByFieldValue;
+}
+}
+}

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -17,6 +17,7 @@
 #include <maths/COrderings.h>
 #include <maths/CSampling.h>
 
+#include <model/CAnnotation.h>
 #include <model/CAnomalyDetectorModel.h>
 #include <model/CDataGatherer.h>
 #include <model/CForecastModelPersist.h>
@@ -439,6 +440,19 @@ void CAnomalyDetector::generateModelPlot(core_t::TTime bucketStartTime,
                                         bucketLength, key.detectorIndex());
                 view->modelPlot(time, boundsPercentile, terms, modelPlots.back());
             }
+        }
+    }
+}
+
+void CAnomalyDetector::generateAnnotations(core_t::TTime bucketStartTime,
+                                           core_t::TTime bucketEndTime,
+                                           TAnnotationVec& annotations) const {
+    if (bucketEndTime <= bucketStartTime) {
+        return;
+    }
+    for (const auto& annotation : m_Model->annotations()) {
+        if (annotation.time() >= bucketStartTime && annotation.time() < bucketEndTime) {
+            annotations.push_back(annotation);
         }
     }
 }

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -403,6 +403,7 @@ namespace {
 // Model debug config properties
 const std::string BOUNDS_PERCENTILE_PROPERTY("boundspercentile");
 const std::string TERMS_PROPERTY("terms");
+const std::string ANNOTATIONS_ENABLED_PROPERTY("annotations_enabled");
 }
 
 bool CAnomalyDetectorModelConfig::configureModelPlot(const boost::property_tree::ptree& propTree) {
@@ -434,6 +435,22 @@ bool CAnomalyDetectorModelConfig::configureModelPlot(const boost::property_tree:
     } catch (boost::property_tree::ptree_error&) {
         LOG_ERROR(<< "Error reading model debug config. Property '"
                   << TERMS_PROPERTY << "' is missing");
+        return false;
+    }
+
+    try {
+        std::string valueStr(propTree.get<std::string>(ANNOTATIONS_ENABLED_PROPERTY));
+        bool annotationsEnabled = false;
+        if (core::CStringUtils::stringToType(valueStr, annotationsEnabled) == false) {
+            LOG_ERROR(<< "Cannot parse as bool: " << valueStr);
+            return false;
+        }
+        for (auto& factory : m_Factories) {
+            factory.second->annotationsEnabled(annotationsEnabled);
+        }
+    } catch (boost::property_tree::ptree_error&) {
+        LOG_ERROR(<< "Error reading model debug config. Property '"
+                  << ANNOTATIONS_ENABLED_PROPERTY << "' is missing");
         return false;
     }
 

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -350,6 +350,10 @@ CCountingModel::scheduledEventDescriptions(core_t::TTime time) const {
     return it->second;
 }
 
+const CCountingModel::TAnnotationVec& CCountingModel::annotations() const {
+    return m_Annotations;
+}
+
 double CCountingModel::attributeFrequency(std::size_t /*cid*/) const {
     return 1.0;
 }

--- a/lib/model/CModelFactory.cc
+++ b/lib/model/CModelFactory.cc
@@ -284,6 +284,10 @@ void CModelFactory::updateBucketLength(core_t::TTime length) {
     m_ModelParams.s_BucketLength = length;
 }
 
+void CModelFactory::annotationsEnabled(bool enabled) {
+    m_ModelParams.s_AnnotationsEnabled = enabled;
+}
+
 CModelFactory::TInterimBucketCorrectorPtr CModelFactory::interimBucketCorrector() const {
     TInterimBucketCorrectorPtr result{m_InterimBucketCorrector.lock()};
     if (result == nullptr) {

--- a/lib/model/CModelParams.cc
+++ b/lib/model/CModelParams.cc
@@ -52,7 +52,8 @@ SModelParams::SModelParams(core_t::TTime bucketLength)
       s_PruneWindowScaleMaximum(CAnomalyDetectorModelConfig::DEFAULT_PRUNE_WINDOW_SCALE_MAXIMUM),
       s_DetectionRules(EMPTY_RULES), s_ScheduledEvents(EMPTY_SCHEDULED_EVENTS),
       s_InfluenceCutoff(CAnomalyDetectorModelConfig::DEFAULT_INFLUENCE_CUTOFF),
-      s_MinimumToFuzzyDeduplicate(10000), s_CacheProbabilities(true) {
+      s_MinimumToFuzzyDeduplicate(10000), s_CacheProbabilities(true),
+      s_AnnotationsEnabled(false) {
 }
 
 void SModelParams::configureLatency(core_t::TTime latency, core_t::TTime bucketLength) {

--- a/lib/model/Makefile
+++ b/lib/model/Makefile
@@ -57,6 +57,7 @@ CMetricModel.cc \
 CMetricModelFactory.cc \
 CMetricPopulationModel.cc \
 CMetricPopulationModelFactory.cc \
+CAnnotation.cc \
 CModelDetailsView.cc \
 CModelFactory.cc \
 CModelParams.cc \

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -128,6 +128,10 @@ std::size_t CMockModel::computeMemoryUsage() const {
     return 0;
 }
 
+const CMockModel::TAnnotationVec& CMockModel::annotations() const {
+    return m_Annotations;
+}
+
 std::size_t CMockModel::staticSize() const {
     return 0;
 }

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -92,6 +92,8 @@ public:
 
     std::size_t computeMemoryUsage() const override;
 
+    const TAnnotationVec& annotations() const override;
+
     std::size_t staticSize() const override;
 
     TModelDetailsViewUPtr details() const override;
@@ -141,6 +143,7 @@ private:
     TFeatureSizeSizeTimeTriplePrDouble1VecUMap m_BucketBaselineMeans;
     TMathsModelUPtrVec m_Models;
     model::CInterimBucketCorrector m_InterimBucketCorrector;
+    TAnnotationVec m_Annotations;
 };
 
 //! \brief A details view for a mock model.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Report model change annotations via result stream  (#1247)