### PR TITLE
[7.x][ML] Add per-partition categorization option

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,8 @@
 * Don't lose precision when saving model state. (See {ml-pull}1274[#1274].)
 * Parallelize the feature importance calculation for classification and regression
   over trees. (See {ml-pull}1277[#1277].)
+* Add an option to do categorization independently for each partition.
+  (See {ml-pull}1293[#1293] and {pull}57683[#57683].)
 * Memory usage is reported during job initialization. (See {ml-pull}1294[#1294].)
 * Checkpoint state to allow efficient failover during coarse parameter search
   for classification and regression. (See {ml-pull}1300[#1300].)

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -171,7 +171,8 @@ public:
                       core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
+    bool persistStateInForeground(core::CDataAdder& persister,
+                                  const std::string& descriptionPrefix) override;
 
     //! Persist state of the residual models only
     bool persistModelsState(core::CDataAdder& persister,

--- a/include/api/CBenchMarker.h
+++ b/include/api/CBenchMarker.h
@@ -8,6 +8,8 @@
 
 #include <core/CRegex.h>
 
+#include <model/CLocalCategoryId.h>
+
 #include <api/ImportExport.h>
 
 #include <map>
@@ -35,20 +37,24 @@ namespace api {
 class API_EXPORT CBenchMarker {
 public:
     //! A count and and example string
-    using TSizeStrPr = std::pair<size_t, std::string>;
+    using TSizeStrPr = std::pair<std::size_t, std::string>;
 
-    //! Used for mapping Ml type to count and example
-    using TIntSizeStrPrMap = std::map<int, TSizeStrPr>;
-    using TIntSizeStrPrMapItr = TIntSizeStrPrMap::iterator;
-    using TIntSizeStrPrMapCItr = TIntSizeStrPrMap::const_iterator;
+    //! Used for mapping ML category to count and example
+    using TLocalCategoryIdSizeStrPrMap = std::map<model::CLocalCategoryId, TSizeStrPr>;
+    using TLocalCategoryIdSizeStrPrMapItr = TLocalCategoryIdSizeStrPrMap::iterator;
+    using TLocalCategoryIdSizeStrPrMapCItr = TLocalCategoryIdSizeStrPrMap::const_iterator;
 
-    //! A regex and its corresponding type count map
-    using TRegexIntSizeStrPrMapPr = std::pair<core::CRegex, TIntSizeStrPrMap>;
+    //! A regex and its corresponding category count map
+    using TRegexLocalCategoryIdSizeStrPrMapPr =
+        std::pair<core::CRegex, TLocalCategoryIdSizeStrPrMap>;
 
-    //! Vector of regexes with corresponding type count maps
-    using TRegexIntSizeStrPrMapPrVec = std::vector<TRegexIntSizeStrPrMapPr>;
-    using TRegexIntSizeStrPrMapPrVecItr = TRegexIntSizeStrPrMapPrVec::iterator;
-    using TRegexIntSizeStrPrMapPrVecCItr = TRegexIntSizeStrPrMapPrVec::const_iterator;
+    //! Vector of regexes with corresponding category count maps
+    using TRegexLocalCategoryIdSizeStrPrMapPrVec =
+        std::vector<TRegexLocalCategoryIdSizeStrPrMapPr>;
+    using TRegexLocalCategoryIdSizeStrPrMapPrVecItr =
+        TRegexLocalCategoryIdSizeStrPrMapPrVec::iterator;
+    using TRegexLocalCategoryIdSizeStrPrMapPrVecCItr =
+        TRegexLocalCategoryIdSizeStrPrMapPrVec::const_iterator;
 
 public:
     CBenchMarker();
@@ -56,21 +62,21 @@ public:
     //! Initialise from a file
     bool init(const std::string& regexFilename);
 
-    //! Add a message together with the type Ml assigned to it
-    void addResult(const std::string& message, int type);
+    //! Add a message together with the category ML assigned to it
+    void addResult(const std::string& message, model::CLocalCategoryId categoryId);
 
     void dumpResults() const;
 
 private:
     //! Number of messages passed to the benchmarker
-    size_t m_TotalMessages;
+    std::size_t m_TotalMessages;
 
     //! Number of messages that matched one of the regexes, and hence
     //! contribute to the scoring
-    size_t m_ScoredMessages;
+    std::size_t m_ScoredMessages;
 
-    //! The string and tokens we base this type on
-    TRegexIntSizeStrPrMapPrVec m_Measures;
+    //! The string and tokens we base this category on
+    TRegexLocalCategoryIdSizeStrPrMapPrVec m_Measures;
 };
 }
 }

--- a/include/api/CCategoryIdMapper.h
+++ b/include/api/CCategoryIdMapper.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CCategoryIdMapper_h
+#define INCLUDED_ml_api_CCategoryIdMapper_h
+
+#include <model/CLocalCategoryId.h>
+
+#include <api/CGlobalCategoryId.h>
+#include <api/ImportExport.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ml {
+namespace core {
+class CStatePersistInserter;
+class CStateRestoreTraverser;
+}
+namespace api {
+
+//! \brief
+//! Interface for mappers between local and global category IDs.
+//!
+//! DESCRIPTION:\n
+//! Classes that map between local and global category IDs should
+//! derive from this interface.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! By default persist/restore is a no-op.  Derived classes must
+//! override if required.
+//!
+class API_EXPORT CCategoryIdMapper {
+public:
+    using TCategoryIdMapperPtr = std::shared_ptr<CCategoryIdMapper>;
+
+    using TLocalCategoryIdVec = std::vector<model::CLocalCategoryId>;
+    using TGlobalCategoryIdVec = std::vector<CGlobalCategoryId>;
+
+public:
+    virtual ~CCategoryIdMapper() = default;
+
+    //! Map from a local category ID local to a global category ID.  This method
+    //! is not const, as it will create a new global ID if one does not exist.
+    virtual CGlobalCategoryId map(model::CLocalCategoryId localCategoryId) = 0;
+
+    //! Map from a vector of local category IDs to a vector of global category
+    //! IDs.  This method is not const, as it will create new global IDs if any
+    //! that are required do not already exist.
+    TGlobalCategoryIdVec mapVec(const TLocalCategoryIdVec& localCategoryIds);
+
+    //! Get the categorizer key for this mapper.
+    virtual const std::string& categorizerKey() const = 0;
+
+    //! Create a clone.
+    virtual TCategoryIdMapperPtr clone() const = 0;
+
+    //! Persist the mapper passing information to \p inserter.
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Restore the mapper reading state from \p traverser.
+    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CCategoryIdMapper_h

--- a/include/api/CCmdSkeleton.h
+++ b/include/api/CCmdSkeleton.h
@@ -44,7 +44,7 @@ public:
 
 private:
     //! Persists the state of the models
-    bool persistState();
+    bool persistStateInForeground();
 
 private:
     //! NULL if state restoration is not required.

--- a/include/api/CDataProcessor.h
+++ b/include/api/CDataProcessor.h
@@ -71,8 +71,8 @@ public:
                               core_t::TTime& completeToTime) = 0;
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister,
-                              const std::string& descriptionPrefix) = 0;
+    virtual bool persistStateInForeground(core::CDataAdder& persister,
+                                          const std::string& descriptionPrefix) = 0;
 
     //! Persist current state in the background due to the periodic persistence being triggered.
     virtual bool periodicPersistStateInBackground();

--- a/include/api/CFieldConfig.h
+++ b/include/api/CFieldConfig.h
@@ -114,32 +114,9 @@ public:
     //! Character to look for to distinguish setting names
     static const char SUFFIX_SEPARATOR;
 
-    //! Character to look for to split field names out of complete config keys
-    static const char FIELDNAME_SEPARATOR;
-
-    //! Suffix applied to field names for the setting that indicates whether
-    //! they're enabled
-    static const std::string IS_ENABLED_SUFFIX;
-
-    //! Suffix applied to field names for the setting that indicates whether
-    //! they're metrics
-    static const std::string BY_SUFFIX;
-
-    //! Suffix applied to field names for the setting that indicates whether
-    //! they're metrics
-    static const std::string OVER_SUFFIX;
-
-    //! Suffix applied to field names for the setting that indicates whether
-    //! they're metrics
-    static const std::string PARTITION_SUFFIX;
-
     //! Option to look for in the command line clause to indicate that the
     //! "partitionfield" parameter is specified (case-insensitive)
     static const std::string PARTITION_FIELD_OPTION;
-
-    //! Suffix applied to field names for the setting that indicates whether
-    //! empty/missing values of the "by" field should be ignored
-    static const std::string USE_NULL_SUFFIX;
 
     //! Option to look for in the command line clause to indicate that the
     //! "usenull" parameter is specified (case-insensitive)
@@ -156,18 +133,6 @@ public:
     //! Magic field name used to indicate that event rate should be
     //! analysed rather than a field value
     static const std::string COUNT_NAME;
-
-    //! A default string value that our string utilities will convert to
-    //! boolean false
-    static const std::string FALSE_VALUE;
-
-    //! A default string value that our string utilities will convert to
-    //! boolean true
-    static const std::string TRUE_VALUE;
-
-    //! Token to look in the config file to indicate a list of field
-    //! names that are used to indicate an influence pivot relationship
-    static const std::string INFLUENCER_FIELD_NAMES_OPTION;
 
     //! Option to specify an influencer field
     static const std::string INFLUENCER_FIELD_OPTION;
@@ -234,8 +199,10 @@ public:
     static const std::string FUNCTION_MEAN_VELOCITY;
     static const std::string FUNCTION_SUM_VELOCITY;
 
+    //! String that defines whether to do per-partition categorization
+    static const std::string PER_PARTITION_CATEGORIZATION_OPTION;
+
     //! String that defines whether to exclude frequent results
-    static const std::string EXCLUDE_FREQUENT_SUFFIX;
     static const std::string EXCLUDE_FREQUENT_OPTION;
     static const std::string ALL_TOKEN;
     static const std::string NONE_TOKEN;
@@ -458,6 +425,7 @@ public:
     const TFieldOptionsMIndex& fieldOptions() const;
 
     const std::string& categorizationFieldName() const;
+    const std::string& categorizationPartitionFieldName() const;
 
     const TStrPatternSetUMap& ruleFilters() const;
 
@@ -475,6 +443,7 @@ private:
                      TStrVec& copyTokens,
                      TFieldOptionsMIndex& optionsIndex,
                      std::string& categorizationFieldName,
+                     std::string& categorizationPartitionFieldName,
                      std::string& summaryCountFieldName);
 
     //! Helper method for initFromFile().  Because multiple config
@@ -570,6 +539,9 @@ private:
 
     //! The categorization field name.
     std::string m_CategorizationFieldName;
+
+    //! The partition field name to use with categorization.
+    std::string m_CategorizationPartitionFieldName;
 
     //! The filters to be applied to values of the categorization field.
     TStrVec m_CategorizationFilters;

--- a/include/api/CGlobalCategoryId.h
+++ b/include/api/CGlobalCategoryId.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CGlobalCategoryId_h
+#define INCLUDED_ml_api_CGlobalCategoryId_h
+
+#include <model/CLocalCategoryId.h>
+
+#include <api/ImportExport.h>
+
+#include <iosfwd>
+#include <string>
+
+namespace ml {
+namespace api {
+
+//! \brief
+//! Adds type safety to a global category ID.
+//!
+//! DESCRIPTION:\n
+//! Global category IDs are the IDs reported externally by the
+//! categorization functionality.  Global category IDs run from 1 to
+//! the total number of categories across all model library
+//! categorizers.
+//!
+//! Every global ID corresponds to a unique value of the pair
+//! (categorizer key, local category ID).
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! Global ID objects remember which categorizer key and local
+//! category ID they correspond to.  This avoids the need to map
+//! in both directions between local and global IDs; once a local
+//! ID has been mapped to a global ID all the information is kept
+//! together.
+//!
+//! Categorizer keys are held by pointer to avoid excessive string
+//! copying.  Global ID objects are expected to be relatively
+//! short-lived so that there is little risk of the string that is
+//! pointed to being destroyed before this object.
+//!
+class API_EXPORT CGlobalCategoryId {
+public:
+    //! Create a category representing a soft failure.
+    CGlobalCategoryId();
+
+    //! Create a new category from its numeric ID in the case where local ID is
+    //! the same and categorizer key is unimportant.
+    explicit CGlobalCategoryId(int globalId);
+
+    //! Create a new category from its numeric ID, also storing the
+    //! corresponding categorizer key and local ID.
+    CGlobalCategoryId(int globalId,
+                      const std::string& categorizerKey,
+                      model::CLocalCategoryId localCategoryId);
+
+    //! Get an object representing a soft failure.
+    static CGlobalCategoryId softFailure();
+
+    //! Get an object representing a hard failure.
+    static CGlobalCategoryId hardFailure();
+
+    //! Accessor for numeric global ID.
+    int globalId() const { return m_GlobalId; }
+
+    //! Accessor for categorizer key.  Returns an empty string if unimportant.
+    const std::string& categorizerKey() const;
+
+    //! Accessor for numeric local ID.
+    model::CLocalCategoryId localId() const { return m_LocalId; }
+
+    //! Does the object represent a valid category?
+    bool isValid() const { return m_GlobalId >= 1; }
+
+    //! Does the object represent a soft failure?
+    bool isSoftFailure() const {
+        return m_GlobalId == model::CLocalCategoryId::SOFT_CATEGORIZATION_FAILURE_ERROR;
+    }
+
+    //! Does the object represent a hard failure?
+    bool isHardFailure() const {
+        return m_GlobalId == model::CLocalCategoryId::HARD_CATEGORIZATION_FAILURE_ERROR;
+    }
+
+    //! Comparison operators only consider the global ID, as that is supposed to
+    //! be globally unique.
+    bool operator==(const CGlobalCategoryId& other) const;
+    bool operator!=(const CGlobalCategoryId& other) const;
+    bool operator<(const CGlobalCategoryId& other) const;
+
+    //! Print for debug.
+    std::string print() const;
+
+    friend API_EXPORT std::ostream& operator<<(std::ostream&, const CGlobalCategoryId&);
+
+private:
+    //! Overload that aborts to prevent string literals being passed as the
+    //! categorizer key (since we store a pointer to the string object, which
+    //! would be a temporary if converted from const char*).  This is mainly an
+    //! aid to unit test writers.
+    [[noreturn]] CGlobalCategoryId(int globalId,
+                                   const char* categorizerKey,
+                                   model::CLocalCategoryId localCategoryId);
+
+private:
+    //! The numeric global ID.
+    int m_GlobalId;
+
+    //! The key of the categorizer that the local ID corresponds to.
+    //! This may be NULL if it's unimportant (for example in failure
+    //! cases or when it is known that there will only ever be one
+    //! categorizer program-wide).
+    const std::string* m_CategorizerKey;
+
+    //! The corresponding local ID.
+    model::CLocalCategoryId m_LocalId;
+};
+
+//! The hash only considers the global ID, as that is supposed to be globally
+//! unique.
+inline std::size_t hash_value(const CGlobalCategoryId& categoryId) {
+    return static_cast<std::size_t>(categoryId.globalId());
+}
+
+API_EXPORT
+std::ostream& operator<<(std::ostream& strm, const CGlobalCategoryId& categoryId);
+}
+}
+
+#endif // INCLUDED_ml_api_CGlobalCategoryId_h

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -15,6 +15,7 @@
 #include <model/CHierarchicalResults.h>
 #include <model/CResourceMonitor.h>
 
+#include <api/CGlobalCategoryId.h>
 #include <api/CHierarchicalResultsWriter.h>
 #include <api/COutputHandler.h>
 #include <api/ImportExport.h>
@@ -111,8 +112,7 @@ public:
     using TStrVec = std::vector<std::string>;
     using TStr1Vec = core::CSmallVector<std::string, 1>;
     using TTimeVec = std::vector<core_t::TTime>;
-    using TIntVec = std::vector<int>;
-    using TIntVecCIter = std::vector<int>::const_iterator;
+    using TGlobalCategoryIdVec = std::vector<CGlobalCategoryId>;
     using TDoubleVec = std::vector<double>;
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
@@ -240,13 +240,15 @@ public:
     void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd);
 
     //! Write a category definition
-    void writeCategoryDefinition(int categoryId,
+    void writeCategoryDefinition(const std::string& partitionFieldName,
+                                 const std::string& partitionFieldValue,
+                                 const CGlobalCategoryId& categoryId,
                                  const std::string& terms,
                                  const std::string& regex,
                                  std::size_t maxMatchingFieldLength,
                                  const TStrFSet& examples,
                                  std::size_t numMatches,
-                                 const TIntVec& usurpedCategories);
+                                 const TGlobalCategoryIdVec& usurpedCategories);
 
     //! Persist a normalizer by writing its state to the output
     void persistNormalizer(const model::CHierarchicalResultsNormalizer& normalizer,

--- a/include/api/CNdInputParser.h
+++ b/include/api/CNdInputParser.h
@@ -88,4 +88,4 @@ private:
 }
 }
 
-#endif // INCLUDED_ml_api_CNdJsonInputParser_h
+#endif // INCLUDED_ml_api_CNdInputParser_h

--- a/include/api/CNoopCategoryIdMapper.h
+++ b/include/api/CNoopCategoryIdMapper.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CNoopCategoryIdMapper_h
+#define INCLUDED_ml_api_CNoopCategoryIdMapper_h
+
+#include <api/CCategoryIdMapper.h>
+#include <api/ImportExport.h>
+
+namespace ml {
+namespace api {
+
+//! \brief
+//! Category ID mapper for use when local and global category IDs
+//! are the same.
+//!
+//! DESCRIPTION:\n
+//! All mappings are no-ops and the categorizer key is the empty
+//! string.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! This mapper is designed for the case where there is a single
+//! categorizer, which includes all jobs created before 7.9.
+//!
+class API_EXPORT CNoopCategoryIdMapper : public CCategoryIdMapper {
+public:
+    //! Map from a local category ID local to a global category ID.  This method
+    //! is not const, as it will create a new global ID if one does not exist.
+    CGlobalCategoryId map(model::CLocalCategoryId localCategoryId) override;
+
+    //! Get the categorizer key for this mapper.
+    const std::string& categorizerKey() const override;
+
+    //! Create a clone.
+    TCategoryIdMapperPtr clone() const override;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CNoopCategoryIdMapper_h

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -72,7 +72,8 @@ public:
                       core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) override;
+    bool persistStateInForeground(core::CDataAdder& persister,
+                                  const std::string& descriptionPrefix) override;
 
     //! Persist current state due to the periodic persistence being triggered.
     bool periodicPersistStateInBackground() override;

--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -85,7 +85,8 @@ public:
                               core_t::TTime& completeToTime);
 
     //! Persist current state
-    virtual bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix);
+    virtual bool persistStateInForeground(core::CDataAdder& persister,
+                                          const std::string& descriptionPrefix);
 
     //! Persist current state due to the periodic persistence being triggered.
     virtual bool periodicPersistStateInBackground();

--- a/include/api/CPerPartitionCategoryIdMapper.h
+++ b/include/api/CPerPartitionCategoryIdMapper.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CPerPartitionCategoryIdMapper_h
+#define INCLUDED_ml_api_CPerPartitionCategoryIdMapper_h
+
+#include <api/CCategoryIdMapper.h>
+#include <api/ImportExport.h>
+
+#include <functional>
+#include <vector>
+
+namespace ml {
+namespace api {
+
+//! \brief
+//! Category ID mapper for use with per-partition categorization.
+//!
+//! DESCRIPTION:\n
+//! Maps between local category ID and global category ID.
+//!
+//! Each partition will have a separate instance of this class.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! This mapper is designed for jobs that do per-partition
+//! categorization.
+//!
+//! The mappings are stored in a vector of global IDs that is
+//! stored ordered by local ID.  Since local ID is vector
+//! index plus one in vectors of all local IDs this means that
+//! the lookup just involves getting the element at the
+//! desired index from the vector.
+//!
+//! The highest ever global ID is obtained from a supplied
+//! function, as it needs to increment across all partitions,
+//! not just for the partition one object of this class is
+//! mapping for.
+//!
+//! This class is not thread-safe.  Each object should only
+//! be used within a single thread.
+//!
+class API_EXPORT CPerPartitionCategoryIdMapper : public CCategoryIdMapper {
+public:
+    using TNextGlobalIdSupplier = std::function<int()>;
+
+public:
+    CPerPartitionCategoryIdMapper(std::string categorizerKey,
+                                  TNextGlobalIdSupplier nextGlobalIdSupplier);
+
+    //! Map from a local category ID local to a global category ID.  This method
+    //! is not const, as it will create a new global ID if one does not exist.
+    CGlobalCategoryId map(model::CLocalCategoryId localCategoryId) override;
+
+    //! Get the categorizer key for this mapper.
+    const std::string& categorizerKey() const override;
+
+    //! Create a clone.
+    TCategoryIdMapperPtr clone() const override;
+
+    //! Persist the mapper passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+
+    //! Restore the mapper reading state from \p traverser.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
+
+private:
+    //! Key specifiers for the multi-index
+    using TGlobalCategoryIdVec = std::vector<CGlobalCategoryId>;
+
+private:
+    //! Highest previously used global ID.
+    const std::string m_CategorizerKey;
+
+    //! Supplier for next global ID.
+    TNextGlobalIdSupplier m_NextGlobalIdSupplier;
+
+    //! Index of local to global category IDs.  Each global ID is at the index
+    //! of the index() method of the corresponding local ID.  The string
+    //! pointers inside the global category IDs point to m_CategorizerKey.
+    TGlobalCategoryIdVec m_Mappings;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CPerPartitionCategoryIdMapper_h

--- a/include/api/CSingleFieldDataCategorizer.h
+++ b/include/api/CSingleFieldDataCategorizer.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CSingleFieldDataCategorizer_h
+#define INCLUDED_ml_api_CSingleFieldDataCategorizer_h
+
+#include <model/CDataCategorizer.h>
+
+#include <api/CCategoryIdMapper.h>
+#include <api/CGlobalCategoryId.h>
+#include <api/ImportExport.h>
+
+#include <functional>
+#include <string>
+
+namespace ml {
+namespace core {
+class CStatePersistInserter;
+class CStateRestoreTraverser;
+}
+namespace model {
+class CCategoryExamplesCollector;
+}
+namespace api {
+class CJsonOutputWriter;
+
+//! \brief
+//! Wraps a categorizer, mapping local IDs to global IDs.
+//!
+//! DESCRIPTION:\n
+//! Exposes the functionality of the model library data categorizer
+//! classes, but with local category IDs mapped to the corresponding
+//! global category IDs.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! The persistence for this class is unusual in that it is not
+//! persisted within a new sub-level in the state.  The reason for
+//! this is that the objects it contains used to be persisted by
+//! the CFieldDataCategorizer when there was only one low level
+//! categorizer.  An extra level cannot be introduced now, as that
+//! would break backwards compatibility of the state.
+//!
+class API_EXPORT CSingleFieldDataCategorizer {
+public:
+    //! Function used for persisting objects of this class
+    using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
+
+public:
+    CSingleFieldDataCategorizer(std::string partitionFieldName,
+                                model::CDataCategorizer::TDataCategorizerUPtr dataCategorizer,
+                                CCategoryIdMapper::TCategoryIdMapperPtr categoryIdMapper);
+
+    //! Dump stats
+    void dumpStats() const;
+
+    //! Compute a category from a string.  The raw string length may be longer
+    //! than the length of the passed string, because the passed string may
+    //! have the date stripped out of it.  If the category changes as a result
+    //! write it to the output.
+    CGlobalCategoryId
+    computeAndUpdateCategory(bool isDryRun,
+                             const model::CDataCategorizer::TStrStrUMap& fields,
+                             const std::string& messageToCategorize,
+                             const std::string& rawMessage,
+                             model::CResourceMonitor& resourceMonitor,
+                             CJsonOutputWriter& jsonOutputWriter);
+
+    //! Make a function that can be called later to persist state in the
+    //! foreground, i.e. in the knowledge that no other thread will be
+    //! accessing the data structures this method accesses.
+    TPersistFunc makeForegroundPersistFunc() const;
+
+    //! Make a function that can be called later to persist state in the
+    //! background, i.e. copying any required data such that other threads
+    //! may modify the original data structures while persistence is taking
+    //! place.
+    TPersistFunc makeBackgroundPersistFunc() const;
+
+    //! Populate the object from part of a state document
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
+    //! Access to the categorizer key.
+    const std::string& categorizerKey() const {
+        return m_CategoryIdMapper->categorizerKey();
+    }
+
+    //! Writes out to the JSON output writer any category that has changed
+    //! since the last time this method was called.
+    void writeOutChangedCategories(CJsonOutputWriter& jsonOutputWriter);
+
+    //! Force an update of the resource monitor.
+    void forceResourceRefresh(model::CResourceMonitor& resourceMonitor);
+
+private:
+    //! Used by deferred persistence functions
+    static void acceptPersistInserter(const model::CDataCategorizer::TPersistFunc& dataCategorizerPersistFunc,
+                                      const model::CCategoryExamplesCollector& examplesCollector,
+                                      const CCategoryIdMapper& categoryIdMapper,
+                                      core::CStatePersistInserter& inserter);
+
+private:
+    //! Which field name are we partitioning on?  If empty, this means
+    //! per-partition categorization is disabled and categories are
+    //! determined across the entire data set.
+    std::string m_PartitionFieldName;
+
+    //! Pointer to the wrapped data categorizer.
+    model::CDataCategorizer::TDataCategorizerUPtr m_DataCategorizer;
+
+    //! Pointer to the category ID mapper.
+    CCategoryIdMapper::TCategoryIdMapperPtr m_CategoryIdMapper;
+
+    //! String to store search terms.  By keeping this as a member variable
+    //! instead of repeatedly creating local strings the buffer can learn the
+    //! appropriate size and won't need to be reallocated repeatedly, this
+    //! saving memory allocations.
+    std::string m_SearchTermsScratchSpace;
+
+    //! Regex to match values of the current category.  As with
+    //! m_SearchTermsScratchSpace, this is a member to avoid repeated memory
+    //! allocations.
+    std::string m_SearchTermsRegexScratchSpace;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CSingleFieldDataCategorizer_h

--- a/include/config/CAutoconfigurer.h
+++ b/include/config/CAutoconfigurer.h
@@ -38,29 +38,30 @@ public:
     CAutoconfigurer(const CAutoconfigurerParams& params, CReportWriter& reportWriter);
 
     //! We're going to be writing to a new output stream.
-    virtual void newOutputStream();
+    void newOutputStream() override;
 
     //! Receive a single record to be processed.
-    virtual bool handleRecord(const TStrStrUMap& fieldValues);
+    bool handleRecord(const TStrStrUMap& fieldValues) override;
 
     //! Generate the report.
-    virtual void finalise();
+    void finalise() override;
 
     //! Is persistence needed?
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! No-op.
-    virtual bool restoreState(core::CDataSearcher& restoreSearcher,
-                              core_t::TTime& completeToTime);
+    bool restoreState(core::CDataSearcher& restoreSearcher,
+                      core_t::TTime& completeToTime) override;
 
     //! No-op.
-    virtual bool persistState(core::CDataAdder& persister, const std::string& descriptionPrefix);
+    virtual bool persistStateInForeground(core::CDataAdder& persister,
+                                          const std::string& descriptionPrefix) override;
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const;
+    uint64_t numRecordsHandled() const override;
 
     //! Access the output handler.
-    virtual api::COutputHandler& outputHandler();
+    api::COutputHandler& outputHandler() override;
 
 private:
     using TImplPtr = std::shared_ptr<CAutoconfigurerImpl>;

--- a/include/model/CCategoryExamplesCollector.h
+++ b/include/model/CCategoryExamplesCollector.h
@@ -8,6 +8,7 @@
 
 #include <core/CMemoryUsage.h>
 
+#include <model/CLocalCategoryId.h>
 #include <model/ImportExport.h>
 
 #include <boost/container/flat_set.hpp>
@@ -48,12 +49,12 @@ public:
     //! distinct example and if there are less than the maximum
     //! number of examples for the given category.
     //! Returns true if the example was added or false otherwise.
-    bool add(int categoryId, const std::string& example);
+    bool add(CLocalCategoryId categoryId, const std::string& example);
 
     //! Returns the number of examples currently stored for a given category.
-    std::size_t numberOfExamplesForCategory(int categoryId) const;
+    std::size_t numberOfExamplesForCategory(CLocalCategoryId categoryId) const;
 
-    const TStrFSet& examples(int categoryId) const;
+    const TStrFSet& examples(CLocalCategoryId categoryId) const;
 
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
@@ -71,10 +72,10 @@ public:
     std::size_t memoryUsage() const;
 
 private:
-    using TIntStrFSetUMap = boost::unordered_map<int, TStrFSet>;
+    using TLocalCategoryIdStrFSetUMap = boost::unordered_map<CLocalCategoryId, TStrFSet>;
 
 private:
-    void persistExamples(int categoryId,
+    void persistExamples(CLocalCategoryId categoryId,
                          const TStrFSet& examples,
                          core::CStatePersistInserter& inserter) const;
     bool restoreExamples(core::CStateRestoreTraverser& traverser);
@@ -88,7 +89,7 @@ private:
     std::size_t m_MaxExamples;
 
     //! A map from categories to the set that contains the examples
-    TIntStrFSetUMap m_ExamplesByCategory;
+    TLocalCategoryIdStrFSetUMap m_ExamplesByCategory;
 };
 }
 }

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -10,6 +10,7 @@
 #include <core/CoreTypes.h>
 
 #include <model/CCategoryExamplesCollector.h>
+#include <model/CLocalCategoryId.h>
 #include <model/CMonitoredResource.h>
 #include <model/ImportExport.h>
 
@@ -42,26 +43,21 @@ class CLimits;
 //!
 class MODEL_EXPORT CDataCategorizer : public CMonitoredResource {
 public:
+    //! Used for formatting category IDs in the debug dump
+    using TLocalCategoryIdFormatterFunc = std::function<std::string(CLocalCategoryId)>;
+
     //! Used for storing distinct token IDs
     using TStrStrUMap = boost::unordered_map<std::string, std::string>;
     using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
-    //! Shared pointer to an instance of this class
-    using TDataCategorizerP = std::shared_ptr<CDataCategorizer>;
+    //! Unique pointer to an instance of this class
+    using TDataCategorizerUPtr = std::unique_ptr<CDataCategorizer>;
 
-    //! Shared pointer to an instance of this class
+    //! Function used for persisting objects of this class
     using TPersistFunc = std::function<void(core::CStatePersistInserter&)>;
-    using TIntVec = std::vector<int>;
 
-    //! A soft categorization failure means downstream components can continue,
-    //! by considering the input record to be in some "uncategorizable"
-    //! category.
-    static const int SOFT_CATEGORIZATION_FAILURE_ERROR;
-
-    //! A hard categorization failure means processing of the input record must
-    //! cease.  (This is generally used to prevent excessive memory
-    //! accumulation.)
-    static const int HARD_CATEGORIZATION_FAILURE_ERROR;
+    //! Vector of local category IDs
+    using TLocalCategoryIdVec = std::vector<CLocalCategoryId>;
 
 public:
     CDataCategorizer(CLimits& limits, const std::string& fieldName);
@@ -73,25 +69,25 @@ public:
     ~CDataCategorizer() override;
 
     //! Dump stats
-    virtual void dumpStats() const = 0;
+    virtual void dumpStats(const TLocalCategoryIdFormatterFunc& formatterFunc) const = 0;
 
     //! Compute a category from a string.  The raw string length may be longer
     //! than the length of the passed string, because the passed string may
     //! have the date stripped out of it.
-    int computeCategory(bool isDryRun, const std::string& str, std::size_t rawStringLen);
+    CLocalCategoryId computeCategory(bool isDryRun, const std::string& str, std::size_t rawStringLen);
 
     //! As above, but also take into account field names/values.
-    virtual int computeCategory(bool isDryRun,
-                                const TStrStrUMap& fields,
-                                const std::string& str,
-                                std::size_t rawStringLen) = 0;
+    virtual CLocalCategoryId computeCategory(bool isDryRun,
+                                             const TStrStrUMap& fields,
+                                             const std::string& str,
+                                             std::size_t rawStringLen) = 0;
 
     //! Create reverse search commands that will (more or less) just
     //! select the records that are classified as the given category when
     //! combined with the original search.  Note that the reverse search is
     //! only approximate - it may select more records than have actually
     //! been classified as the returned category.
-    virtual bool createReverseSearch(int categoryId,
+    virtual bool createReverseSearch(CLocalCategoryId categoryId,
                                      std::string& part1,
                                      std::string& part2,
                                      std::size_t& maxMatchingLength,
@@ -134,7 +130,7 @@ public:
 
     //! Add an example if the limit for the category has not be reached.
     //! \return true if the example was added, false if not.
-    bool addExample(int categoryId, const std::string& example);
+    bool addExample(CLocalCategoryId categoryId, const std::string& example);
 
     //! Access to the examples collector
     const CCategoryExamplesCollector& examplesCollector() const;
@@ -142,16 +138,20 @@ public:
     //! Restore the examples collector
     bool restoreExamplesCollector(core::CStateRestoreTraverser& traverser);
 
-    virtual std::size_t numMatches(int categoryId) = 0;
+    //! Number of matches for the specified category.
+    virtual std::size_t numMatches(CLocalCategoryId categoryId) = 0;
 
-    virtual TIntVec usurpedCategories(int categoryId) = 0;
+    //! Get the categories that will never be detected again because the
+    //! specified category will always be returned instead.
+    virtual TLocalCategoryIdVec usurpedCategories(CLocalCategoryId categoryId) = 0;
 
+    //! Number of categories this categorizer has detected.
     virtual std::size_t numCategories() const = 0;
 
-    //! Has the passed category changed since this method was called last?
+    //! Has the specified category changed since this method was called last?
     //! Once called, the category is marked as unchanged, until the category
     //! changes again.
-    virtual bool categoryChangedAndReset(int categoryId) = 0;
+    virtual bool categoryChangedAndReset(CLocalCategoryId categoryId) = 0;
 
     //! Is it permissable to create new categories?  New categories are
     //! not permitted when memory use has exceeded the limit.

--- a/include/model/CLocalCategoryId.h
+++ b/include/model/CLocalCategoryId.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_model_CLocalCategoryId_h
+#define INCLUDED_ml_model_CLocalCategoryId_h
+
+#include <model/ImportExport.h>
+
+#include <iosfwd>
+#include <string>
+
+namespace ml {
+namespace model {
+
+//! \brief
+//! Adds type safety to a local category ID.
+//!
+//! DESCRIPTION:\n
+//! Local category IDs are the IDs used by the categorization classes
+//! in the model library.  Each model library categorizer will have
+//! local category IDs running from 1 to the number of categories
+//! found.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! This is basically a wrapper around an int, but by using a dedicated
+//! class there is less risk of accidentally confusing other ints.
+//!
+class MODEL_EXPORT CLocalCategoryId {
+public:
+    //! A soft categorization failure means downstream components can continue,
+    //! by considering the input record to be in some "uncategorizable"
+    //! category.
+    static const int SOFT_CATEGORIZATION_FAILURE_ERROR;
+
+    //! A hard categorization failure means processing of the input record must
+    //! cease.  (This is generally used to prevent excessive memory
+    //! accumulation.)
+    static const int HARD_CATEGORIZATION_FAILURE_ERROR;
+
+public:
+    //! Create a category representing a soft failure.
+    CLocalCategoryId();
+
+    //! Create a new category from its numeric ID.
+    explicit CLocalCategoryId(int id);
+
+    //! Create a new category based on a vector index.
+    explicit CLocalCategoryId(std::size_t index);
+
+    //! Get an object representing a soft failure.
+    static CLocalCategoryId softFailure();
+
+    //! Get an object representing a hard failure.
+    static CLocalCategoryId hardFailure();
+
+    //! Accessor for numeric ID.
+    int id() const { return m_Id; }
+
+    //! The appropriate vector index for the category.  The caller should
+    //! ensure the object represents a valid category before calling this.
+    std::size_t index() const { return static_cast<std::size_t>(m_Id - 1); }
+
+    //! Does the object represent a valid category?
+    bool isValid() const { return m_Id >= 1; }
+
+    //! Does the object represent a soft failure?
+    bool isSoftFailure() const {
+        return m_Id == SOFT_CATEGORIZATION_FAILURE_ERROR;
+    }
+
+    //! Does the object represent a hard failure?
+    bool isHardFailure() const {
+        return m_Id == HARD_CATEGORIZATION_FAILURE_ERROR;
+    }
+
+    //! Comparison operators.
+    bool operator==(const CLocalCategoryId& other) const;
+    bool operator!=(const CLocalCategoryId& other) const;
+    bool operator<(const CLocalCategoryId& other) const;
+
+    //! Convert to string.
+    std::string toString() const;
+
+    //! Parse from string.  Returns false if unsuccessful.
+    bool fromString(const std::string& str);
+
+private:
+    //! The numeric ID.
+    int m_Id;
+};
+
+inline std::size_t hash_value(const CLocalCategoryId& categoryId) {
+    return static_cast<std::size_t>(categoryId.id());
+}
+
+MODEL_EXPORT
+std::ostream& operator<<(std::ostream& strm, const CLocalCategoryId& categoryId);
+}
+}
+
+#endif // INCLUDED_ml_model_CLocalCategoryId_h

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -110,7 +110,13 @@ public:
     std::size_t getBytesMemoryLimit() const;
 
     //! Get the memory status
-    model_t::EMemoryStatus getMemoryStatus();
+    model_t::EMemoryStatus memoryStatus() const;
+
+    //! Get categorizer allocation failures
+    std::size_t categorizerAllocationFailures() const;
+
+    //! Set categorizer allocation failures
+    void categorizerAllocationFailures(std::size_t categorizerAllocationFailures);
 
     //! Send a memory usage report if it's changed by more than a certain percentage
     void sendMemoryUsageReportIfSignificantlyChanged(core_t::TTime bucketStartTime);
@@ -226,7 +232,7 @@ private:
     //! Callback function to fire when memory usage increases by 1%
     TMemoryUsageReporterFunc m_MemoryUsageReporter;
 
-    //! Keep track of classes telling us about allocation failures
+    //! Keep track of times of anomaly detector allocation failures
     TTimeSizeMap m_AllocationFailures;
 
     //! The time at which the last allocation failure was reported
@@ -262,6 +268,9 @@ private:
 
     //! Is persistence occurring in the foreground?
     bool m_PersistenceInForeground;
+
+    //! Number of categorizer allocation failures to date
+    std::size_t m_CategorizerAllocationFailures = 0;
 
     //! Test friends
     friend struct CResourceMonitorTest::testMonitor;

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -108,16 +108,16 @@ public:
     CTokenListDataCategorizerBase& operator=(const CTokenListDataCategorizerBase&) = delete;
 
     //! Dump stats
-    void dumpStats() const override;
+    void dumpStats(const TLocalCategoryIdFormatterFunc& formatterFunc) const override;
 
     //! Compute a category from a string.  The raw string length may be longer
     //! than the length of the passed string, because the passed string may
     //! have the date stripped out of it.  Field names/values are available
     //! to the category computation.
-    int computeCategory(bool dryRun,
-                        const TStrStrUMap& fields,
-                        const std::string& str,
-                        std::size_t rawStringLen) override;
+    CLocalCategoryId computeCategory(bool dryRun,
+                                     const TStrStrUMap& fields,
+                                     const std::string& str,
+                                     std::size_t rawStringLen) override;
 
     // Bring the other overload of computeCategory() into scope
     using CDataCategorizer::computeCategory;
@@ -126,7 +126,7 @@ public:
     //! that are classified as the given category.  Note that the reverse search
     //! is only approximate - it may select more records than have actually
     //! been classified as the returned category.
-    bool createReverseSearch(int categoryId,
+    bool createReverseSearch(CLocalCategoryId categoryId,
                              std::string& part1,
                              std::string& part2,
                              std::size_t& maxMatchingLength,
@@ -176,13 +176,13 @@ public:
                                   std::size_t rareCategories,
                                   std::size_t deadCategories);
 
-    std::size_t numMatches(int categoryId) override;
+    std::size_t numMatches(CLocalCategoryId categoryId) override;
 
-    CDataCategorizer::TIntVec usurpedCategories(int categoryId) override;
+    CDataCategorizer::TLocalCategoryIdVec usurpedCategories(CLocalCategoryId categoryId) override;
 
     std::size_t numCategories() const override;
 
-    bool categoryChangedAndReset(int categoryId) override;
+    bool categoryChangedAndReset(CLocalCategoryId categoryId) override;
 
 protected:
     //! Split the string into a list of tokens.  The result of the

--- a/include/model/CTokenListReverseSearchCreator.h
+++ b/include/model/CTokenListReverseSearchCreator.h
@@ -8,6 +8,7 @@
 
 #include <core/CMemoryUsage.h>
 
+#include <model/CLocalCategoryId.h>
 #include <model/ImportExport.h>
 
 #include <string>
@@ -47,7 +48,7 @@ public:
     //! If possible, create a reverse search for the case where there are no
     //! unique tokens identifying the category.  (If this is not possible return
     //! false.)
-    bool createNoUniqueTokenSearch(int categoryId,
+    bool createNoUniqueTokenSearch(CLocalCategoryId categoryId,
                                    const std::string& example,
                                    std::size_t maxMatchingStringLen,
                                    std::string& terms,
@@ -56,7 +57,7 @@ public:
     //! Initialise the two strings that form a reverse search.  For example,
     //! this could be as simple as clearing the strings or setting them to
     //! some sort of one-off preamble.
-    void initStandardSearch(int categoryId,
+    void initStandardSearch(CLocalCategoryId categoryId,
                             const std::string& example,
                             std::size_t maxMatchingStringLen,
                             std::string& terms,

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1018,7 +1018,8 @@ bool CAnomalyJob::persistModelsState(core::CDataAdder& persister,
     return this->persistModelsState(detectors, persister, timestamp, outputFormat);
 }
 
-bool CAnomalyJob::persistState(core::CDataAdder& persister, const std::string& descriptionPrefix) {
+bool CAnomalyJob::persistStateInForeground(core::CDataAdder& persister,
+                                           const std::string& descriptionPrefix) {
     if (m_PersistenceManager != nullptr) {
         // This will not happen if finalise() was called before persisting state
         if (m_PersistenceManager->isBusy()) {
@@ -1029,7 +1030,7 @@ bool CAnomalyJob::persistState(core::CDataAdder& persister, const std::string& d
     }
 
     // Pass on the request in case we're chained
-    if (this->outputHandler().persistState(persister, descriptionPrefix) == false) {
+    if (this->outputHandler().persistStateInForeground(persister, descriptionPrefix) == false) {
         return false;
     }
 
@@ -1118,7 +1119,7 @@ bool CAnomalyJob::runForegroundPersist(core::CDataAdder& persister) {
     // Prune the models so that the persisted state is as neat as possible
     this->pruneAllModels();
 
-    return this->persistState(persister, "Periodic foreground persist at ");
+    return this->persistStateInForeground(persister, "Periodic foreground persist at ");
 }
 
 bool CAnomalyJob::runBackgroundPersist(TBackgroundPersistArgsPtr args,
@@ -1290,7 +1291,8 @@ bool CAnomalyJob::periodicPersistStateInBackground() {
 }
 
 bool CAnomalyJob::periodicPersistStateInForeground() {
-    // Do NOT pass this request on to the output chainer. That logic is already present in persistState.
+    // Do NOT pass this request on to the output chainer.
+    // That logic is already present in persistStateInForeground.
 
     if (m_PersistenceManager == nullptr) {
         return false;

--- a/lib/api/CCategoryIdMapper.cc
+++ b/lib/api/CCategoryIdMapper.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CCategoryIdMapper.h>
+
+namespace ml {
+namespace api {
+
+CCategoryIdMapper::TGlobalCategoryIdVec
+CCategoryIdMapper::mapVec(const TLocalCategoryIdVec& localCategoryIds) {
+    TGlobalCategoryIdVec mapped;
+    mapped.reserve(localCategoryIds.size());
+
+    for (const auto& localCategoryId : localCategoryIds) {
+        mapped.emplace_back(this->map(localCategoryId));
+    }
+
+    return mapped;
+}
+
+void CCategoryIdMapper::acceptPersistInserter(core::CStatePersistInserter& /*inserter*/) const {
+    // No-op
+}
+
+bool CCategoryIdMapper::acceptRestoreTraverser(core::CStateRestoreTraverser& /*traverser*/) {
+    // No-op
+    return true;
+}
+}
+}

--- a/lib/api/CCmdSkeleton.cc
+++ b/lib/api/CCmdSkeleton.cc
@@ -47,10 +47,10 @@ bool CCmdSkeleton::ioLoop() {
     // Finalise the processor so it gets a chance to write any remaining results
     m_Processor.finalise();
 
-    return this->persistState();
+    return this->persistStateInForeground();
 }
 
-bool CCmdSkeleton::persistState() {
+bool CCmdSkeleton::persistStateInForeground() {
     if (m_Persister == nullptr) {
         LOG_DEBUG(<< "No persistence sink specified - will not attempt to persist state");
         return true;
@@ -61,7 +61,8 @@ bool CCmdSkeleton::persistState() {
     }
 
     // Attempt to persist state
-    if (m_Processor.persistState(*m_Persister, "State persisted due to job close at ") == false) {
+    if (m_Processor.persistStateInForeground(
+            *m_Persister, "State persisted due to job close at ") == false) {
         LOG_FATAL(<< "Failed to persist state");
         return false;
     }

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -274,7 +274,7 @@ bool CForecastRunner::pushForecastJob(const std::string& controlMessage,
         return false;
     }
 
-    if (m_ResourceMonitor.getMemoryStatus() != model_t::E_MemoryStatusOk) {
+    if (m_ResourceMonitor.memoryStatus() != model_t::E_MemoryStatusOk) {
         this->sendErrorMessage(forecastJob, ERROR_BAD_MEMORY_STATUS);
         return false;
     }

--- a/lib/api/CGlobalCategoryId.cc
+++ b/lib/api/CGlobalCategoryId.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CGlobalCategoryId.h>
+
+#include <core/CLogger.h>
+
+#include <sstream>
+
+namespace {
+const std::string EMPTY_STRING;
+}
+
+namespace ml {
+namespace api {
+
+CGlobalCategoryId::CGlobalCategoryId()
+    : m_GlobalId{model::CLocalCategoryId::SOFT_CATEGORIZATION_FAILURE_ERROR},
+      m_CategorizerKey{nullptr}, m_LocalId{model::CLocalCategoryId::softFailure()} {
+}
+
+CGlobalCategoryId::CGlobalCategoryId(int globalId)
+    : m_GlobalId{globalId}, m_CategorizerKey{nullptr}, m_LocalId{globalId} {
+}
+
+CGlobalCategoryId::CGlobalCategoryId(int globalId,
+                                     const std::string& categorizerKey,
+                                     model::CLocalCategoryId localCategoryId)
+    : m_GlobalId{globalId}, m_CategorizerKey{&categorizerKey}, m_LocalId{localCategoryId} {
+    // Enforce the invariant that global ID and local ID are the same for
+    // failure states
+    if (this->isValid() == false) {
+        m_CategorizerKey = nullptr;
+        m_LocalId = model::CLocalCategoryId{m_GlobalId};
+    }
+}
+
+CGlobalCategoryId::CGlobalCategoryId(int globalId,
+                                     const char* /*categorizerKey*/,
+                                     model::CLocalCategoryId localCategoryId)
+    : m_GlobalId{globalId}, m_CategorizerKey{nullptr}, m_LocalId{localCategoryId} {
+    LOG_ABORT(<< "Programmatic error: CGlobalCategoryId called with const char* categorizer key");
+}
+
+CGlobalCategoryId CGlobalCategoryId::softFailure() {
+    return CGlobalCategoryId{};
+}
+
+CGlobalCategoryId CGlobalCategoryId::hardFailure() {
+    return CGlobalCategoryId{model::CLocalCategoryId::HARD_CATEGORIZATION_FAILURE_ERROR};
+}
+
+const std::string& CGlobalCategoryId::categorizerKey() const {
+    return (m_CategorizerKey == nullptr) ? EMPTY_STRING : *m_CategorizerKey;
+}
+
+bool CGlobalCategoryId::operator==(const CGlobalCategoryId& other) const {
+    return m_GlobalId == other.m_GlobalId;
+}
+
+bool CGlobalCategoryId::operator!=(const CGlobalCategoryId& other) const {
+    return m_GlobalId != other.m_GlobalId;
+}
+
+bool CGlobalCategoryId::operator<(const CGlobalCategoryId& other) const {
+    return m_GlobalId < other.m_GlobalId;
+}
+
+std::string CGlobalCategoryId::print() const {
+    if (m_CategorizerKey == nullptr) {
+        return std::to_string(m_GlobalId);
+    }
+    std::ostringstream strm;
+    strm << *m_CategorizerKey << '/' << m_LocalId << ';' << m_GlobalId;
+    return strm.str();
+}
+
+std::ostream& operator<<(std::ostream& strm, const CGlobalCategoryId& categoryId) {
+    if (categoryId.m_CategorizerKey != nullptr) {
+        strm << *categoryId.m_CategorizerKey << '/' << categoryId.m_LocalId << ';';
+    }
+    return strm << categoryId.m_GlobalId;
+}
+}
+}

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -886,39 +886,47 @@ void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,
     LOG_TRACE(<< "Wrote flush with ID " << flushId);
 }
 
-void CJsonOutputWriter::writeCategoryDefinition(int categoryId,
+void CJsonOutputWriter::writeCategoryDefinition(const std::string& partitionFieldName,
+                                                const std::string& partitionFieldValue,
+                                                const CGlobalCategoryId& categoryId,
                                                 const std::string& terms,
                                                 const std::string& regex,
                                                 std::size_t maxMatchingFieldLength,
                                                 const TStrFSet& examples,
                                                 std::size_t numMatches,
-                                                const TIntVec& usurpedCategories) {
+                                                const TGlobalCategoryIdVec& usurpedCategories) {
     m_Writer.StartObject();
-    m_Writer.String(CATEGORY_DEFINITION);
+    m_Writer.Key(CATEGORY_DEFINITION);
     m_Writer.StartObject();
-    m_Writer.String(JOB_ID);
+    m_Writer.Key(JOB_ID);
     m_Writer.String(m_JobId);
-    m_Writer.String(CATEGORY_ID);
-    m_Writer.Int(categoryId);
-    m_Writer.String(TERMS);
+    if (partitionFieldName.empty() == false) {
+        m_Writer.Key(PARTITION_FIELD_NAME);
+        m_Writer.String(partitionFieldName);
+        m_Writer.Key(PARTITION_FIELD_VALUE);
+        m_Writer.String(partitionFieldValue);
+    }
+    m_Writer.Key(CATEGORY_ID);
+    m_Writer.Int(categoryId.globalId());
+    m_Writer.Key(TERMS);
     m_Writer.String(terms);
-    m_Writer.String(REGEX);
+    m_Writer.Key(REGEX);
     m_Writer.String(regex);
-    m_Writer.String(MAX_MATCHING_LENGTH);
+    m_Writer.Key(MAX_MATCHING_LENGTH);
     m_Writer.Uint64(maxMatchingFieldLength);
-    m_Writer.String(EXAMPLES);
+    m_Writer.Key(EXAMPLES);
     m_Writer.StartArray();
     for (TStrFSetCItr itr = examples.begin(); itr != examples.end(); ++itr) {
         const std::string& example = *itr;
         m_Writer.String(example);
     }
     m_Writer.EndArray();
-    m_Writer.String(NUM_MATCHES);
+    m_Writer.Key(NUM_MATCHES);
     m_Writer.Uint64(numMatches);
-    m_Writer.String(PREFERRED_TO_CATEGORIES);
+    m_Writer.Key(PREFERRED_TO_CATEGORIES);
     m_Writer.StartArray();
-    for (int id : usurpedCategories) {
-        m_Writer.Int(id);
+    for (const auto& globalCategoryId : usurpedCategories) {
+        m_Writer.Int(globalCategoryId.globalId());
     }
     m_Writer.EndArray();
     m_Writer.EndObject();

--- a/lib/api/CNoopCategoryIdMapper.cc
+++ b/lib/api/CNoopCategoryIdMapper.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CNoopCategoryIdMapper.h>
+
+namespace {
+std::string EMPTY_STRING;
+}
+
+namespace ml {
+namespace api {
+
+CGlobalCategoryId CNoopCategoryIdMapper::map(model::CLocalCategoryId localCategoryId) {
+    return CGlobalCategoryId{localCategoryId.id()};
+}
+
+const std::string& CNoopCategoryIdMapper::categorizerKey() const {
+    return EMPTY_STRING;
+}
+
+CCategoryIdMapper::TCategoryIdMapperPtr CNoopCategoryIdMapper::clone() const {
+    return std::make_shared<CNoopCategoryIdMapper>(*this);
+}
+}
+}

--- a/lib/api/COutputChainer.cc
+++ b/lib/api/COutputChainer.cc
@@ -107,9 +107,9 @@ bool COutputChainer::restoreState(core::CDataSearcher& restoreSearcher,
     return m_DataProcessor.restoreState(restoreSearcher, completeToTime);
 }
 
-bool COutputChainer::persistState(core::CDataAdder& persister,
-                                  const std::string& descriptionPrefix) {
-    return m_DataProcessor.persistState(persister, descriptionPrefix);
+bool COutputChainer::persistStateInForeground(core::CDataAdder& persister,
+                                              const std::string& descriptionPrefix) {
+    return m_DataProcessor.persistStateInForeground(persister, descriptionPrefix);
 }
 
 bool COutputChainer::periodicPersistStateInBackground() {

--- a/lib/api/COutputHandler.cc
+++ b/lib/api/COutputHandler.cc
@@ -36,8 +36,8 @@ bool COutputHandler::restoreState(core::CDataSearcher& /* restoreSearcher */,
     return true;
 }
 
-bool COutputHandler::persistState(core::CDataAdder& /* persister */,
-                                  const std::string& /*descriptionPrefix*/) {
+bool COutputHandler::persistStateInForeground(core::CDataAdder& /* persister */,
+                                              const std::string& /*descriptionPrefix*/) {
     // NOOP unless overridden
     return true;
 }

--- a/lib/api/CPerPartitionCategoryIdMapper.cc
+++ b/lib/api/CPerPartitionCategoryIdMapper.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CPerPartitionCategoryIdMapper.h>
+
+#include <core/CLogger.h>
+#include <core/CStatePersistInserter.h>
+#include <core/CStateRestoreTraverser.h>
+
+namespace {
+const std::string GLOBAL_ID_TAG{"a"};
+}
+
+namespace ml {
+namespace api {
+
+CPerPartitionCategoryIdMapper::CPerPartitionCategoryIdMapper(std::string categorizerKey,
+                                                             TNextGlobalIdSupplier nextGlobalIdSupplier)
+    : m_CategorizerKey{std::move(categorizerKey)}, m_NextGlobalIdSupplier{
+                                                       std::move(nextGlobalIdSupplier)} {
+}
+
+CGlobalCategoryId CPerPartitionCategoryIdMapper::map(model::CLocalCategoryId localCategoryId) {
+    if (localCategoryId.isValid() == false) {
+        return CGlobalCategoryId{localCategoryId.id()};
+    }
+    std::size_t index{localCategoryId.index()};
+    if (index > m_Mappings.size()) {
+        LOG_ERROR(<< "Bad category mappings: " << (index - m_Mappings.size())
+                  << " local to global category ID mappings missing for partition "
+                  << m_CategorizerKey);
+        m_Mappings.resize(index);
+    }
+    if (index == m_Mappings.size()) {
+        m_Mappings.emplace_back(m_NextGlobalIdSupplier(), m_CategorizerKey, localCategoryId);
+    }
+    return m_Mappings[index];
+}
+
+const std::string& CPerPartitionCategoryIdMapper::categorizerKey() const {
+    return m_CategorizerKey;
+}
+
+CCategoryIdMapper::TCategoryIdMapperPtr CPerPartitionCategoryIdMapper::clone() const {
+    return std::make_shared<CPerPartitionCategoryIdMapper>(*this);
+}
+
+void CPerPartitionCategoryIdMapper::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    for (const auto& globalCategoryId : m_Mappings) {
+        inserter.insertValue(GLOBAL_ID_TAG, globalCategoryId.globalId());
+    }
+}
+
+bool CPerPartitionCategoryIdMapper::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+
+    m_Mappings.clear();
+
+    do {
+        const std::string& name{traverser.name()};
+        if (name == GLOBAL_ID_TAG) {
+            int globalId{model::CLocalCategoryId::SOFT_CATEGORIZATION_FAILURE_ERROR};
+            if (core::CStringUtils::stringToType(traverser.value(), globalId) == false) {
+                LOG_ERROR(<< "Invalid global ID in " << traverser.value());
+                return false;
+            }
+            m_Mappings.emplace_back(globalId, m_CategorizerKey,
+                                    model::CLocalCategoryId{m_Mappings.size()});
+        }
+    } while (traverser.next());
+
+    return true;
+}
+}
+}

--- a/lib/api/CSingleFieldDataCategorizer.cc
+++ b/lib/api/CSingleFieldDataCategorizer.cc
@@ -1,0 +1,238 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CSingleFieldDataCategorizer.h>
+
+#include <core/CStatePersistInserter.h>
+#include <core/CStateRestoreTraverser.h>
+
+#include <model/CCategoryExamplesCollector.h>
+
+#include <api/CJsonOutputWriter.h>
+
+namespace {
+// For historical reasons, these tags must not duplicate those used in
+// CFieldDataCategorizer.cc
+// a used in CFieldDataCategorizer.cc
+const std::string CATEGORIZER_TAG{"b"};
+const std::string EXAMPLES_COLLECTOR_TAG{"c"};
+const std::string CATEGORY_ID_MAPPER_TAG{"d"};
+// e, f, g used in CFieldDataCategorizer.cc
+}
+
+namespace ml {
+namespace api {
+
+CSingleFieldDataCategorizer::CSingleFieldDataCategorizer(
+    std::string partitionFieldName,
+    model::CDataCategorizer::TDataCategorizerUPtr dataCategorizer,
+    CCategoryIdMapper::TCategoryIdMapperPtr categoryIdMapper)
+    : m_PartitionFieldName{std::move(partitionFieldName)},
+      m_DataCategorizer{std::move(dataCategorizer)}, m_CategoryIdMapper{std::move(categoryIdMapper)} {
+}
+
+void CSingleFieldDataCategorizer::dumpStats() const {
+    m_DataCategorizer->dumpStats([this](model::CLocalCategoryId localCategoryId) {
+        return m_CategoryIdMapper->map(localCategoryId).print();
+    });
+}
+
+CGlobalCategoryId CSingleFieldDataCategorizer::computeAndUpdateCategory(
+    bool isDryRun,
+    const model::CDataCategorizer::TStrStrUMap& fields,
+    const std::string& messageToCategorize,
+    const std::string& rawMessage,
+    model::CResourceMonitor& resourceMonitor,
+    CJsonOutputWriter& jsonOutputWriter) {
+    model::CLocalCategoryId localCategoryId{m_DataCategorizer->computeCategory(
+        isDryRun, fields, messageToCategorize, rawMessage.length())};
+    CGlobalCategoryId globalCategoryId{m_CategoryIdMapper->map(localCategoryId)};
+    if (globalCategoryId.isValid() == false) {
+        return globalCategoryId;
+    }
+
+    bool exampleAdded{m_DataCategorizer->addExample(globalCategoryId.localId(), rawMessage)};
+    std::size_t maxMatchingLength{0};
+    bool searchTermsChanged{false};
+    if (m_DataCategorizer->createReverseSearch(
+            localCategoryId, m_SearchTermsScratchSpace, m_SearchTermsRegexScratchSpace,
+            maxMatchingLength, searchTermsChanged) == false) {
+        m_SearchTermsScratchSpace.clear();
+        m_SearchTermsRegexScratchSpace.clear();
+    }
+    if (exampleAdded || searchTermsChanged) {
+        //! signal that we noticed the change and are persisting here
+        m_DataCategorizer->categoryChangedAndReset(localCategoryId);
+        jsonOutputWriter.writeCategoryDefinition(
+            m_PartitionFieldName, m_CategoryIdMapper->categorizerKey(), globalCategoryId,
+            m_SearchTermsScratchSpace, m_SearchTermsRegexScratchSpace, maxMatchingLength,
+            m_DataCategorizer->examplesCollector().examples(localCategoryId),
+            m_DataCategorizer->numMatches(localCategoryId),
+            m_CategoryIdMapper->mapVec(m_DataCategorizer->usurpedCategories(localCategoryId)));
+        if (globalCategoryId.globalId() % 10 == 0) {
+            // Even if memory limiting is disabled, force a refresh occasionally
+            // so the user has some idea what's going on with memory.
+            resourceMonitor.forceRefresh(*m_DataCategorizer);
+        } else {
+            resourceMonitor.refresh(*m_DataCategorizer);
+        }
+    }
+    return globalCategoryId;
+}
+
+CSingleFieldDataCategorizer::TPersistFunc
+CSingleFieldDataCategorizer::makeForegroundPersistFunc() const {
+    model::CDataCategorizer::TPersistFunc categorizerPersistFunc{
+        m_DataCategorizer->makeForegroundPersistFunc()};
+
+    return [ categorizerPersistFunc = std::move(categorizerPersistFunc),
+             this ](core::CStatePersistInserter & inserter) {
+        CSingleFieldDataCategorizer::acceptPersistInserter(
+            categorizerPersistFunc, m_DataCategorizer->examplesCollector(),
+            *m_CategoryIdMapper, inserter);
+    };
+}
+
+CSingleFieldDataCategorizer::TPersistFunc
+CSingleFieldDataCategorizer::makeBackgroundPersistFunc() const {
+    model::CDataCategorizer::TPersistFunc categorizerPersistFunc{
+        m_DataCategorizer->makeBackgroundPersistFunc()};
+    model::CCategoryExamplesCollector examplesCollector{m_DataCategorizer->examplesCollector()};
+    CCategoryIdMapper::TCategoryIdMapperPtr categoryIdMapperClone{
+        m_CategoryIdMapper->clone()};
+
+    // IMPORTANT: here we are moving the local variables into the lambda, but
+    // the local variables must be copies of the underlying data structures.
+    // Do NOT change this to avoid the copying.  The background persist
+    // function must be able to operate in a different thread on a snapshot of
+    // the data at the time it was created.
+    return [
+        categorizerPersistFunc = std::move(categorizerPersistFunc),
+        examplesCollector = std::move(examplesCollector),
+        categoryIdMapperClone = std::move(categoryIdMapperClone)
+    ](core::CStatePersistInserter & inserter) {
+        CSingleFieldDataCategorizer::acceptPersistInserter(
+            categorizerPersistFunc, examplesCollector, *categoryIdMapperClone, inserter);
+    };
+}
+
+bool CSingleFieldDataCategorizer::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    if (traverser.next() == false) {
+        LOG_ERROR(<< "Cannot restore categorizer - end of object reached when "
+                  << CATEGORIZER_TAG << " was expected");
+        return false;
+    }
+
+    if (traverser.name() == CATEGORIZER_TAG) {
+        if (traverser.traverseSubLevel([this](core::CStateRestoreTraverser& traverser_) {
+                return m_DataCategorizer->acceptRestoreTraverser(traverser_);
+            }) == false) {
+            LOG_ERROR(<< "Cannot restore categorizer, unexpected element: "
+                      << traverser.value());
+            return false;
+        }
+    } else {
+        LOG_ERROR(<< "Cannot restore categorizer - " << CATEGORIZER_TAG << " element expected but found "
+                  << traverser.name() << '=' << traverser.value());
+        return false;
+    }
+
+    if (traverser.next() == false) {
+        LOG_ERROR(<< "Cannot restore categorizer - end of object reached when "
+                  << EXAMPLES_COLLECTOR_TAG << " was expected");
+        return false;
+    }
+
+    if (traverser.name() == EXAMPLES_COLLECTOR_TAG) {
+        if (m_DataCategorizer->restoreExamplesCollector(traverser) == false) {
+            return false;
+        }
+    } else {
+        LOG_ERROR(<< "Cannot restore categorizer - " << EXAMPLES_COLLECTOR_TAG << " element expected but found "
+                  << traverser.name() << '=' << traverser.value());
+        return false;
+    }
+
+    // Only expect a category ID mapper when per-partition categorization
+    // is being used
+    if (m_PartitionFieldName.empty() == false) {
+        if (traverser.next() == false) {
+            LOG_ERROR(<< "Cannot restore categorizer - end of object reached when "
+                      << CATEGORY_ID_MAPPER_TAG << " was expected");
+            return false;
+        }
+
+        if (traverser.name() == CATEGORY_ID_MAPPER_TAG) {
+            if (traverser.traverseSubLevel([this](core::CStateRestoreTraverser& traverser_) {
+                    return m_CategoryIdMapper->acceptRestoreTraverser(traverser_);
+                }) == false ||
+                traverser.haveBadState()) {
+                LOG_ERROR(<< "Cannot restore category ID mapper, unexpected element: "
+                          << traverser.value());
+                return false;
+            }
+        } else {
+            LOG_ERROR(<< "Cannot restore categorizer - " << CATEGORY_ID_MAPPER_TAG << " element expected but found "
+                      << traverser.name() << '=' << traverser.value());
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void CSingleFieldDataCategorizer::writeOutChangedCategories(CJsonOutputWriter& jsonOutputWriter) {
+    std::size_t numCategories{m_DataCategorizer->numCategories()};
+    if (numCategories == 0) {
+        return;
+    }
+
+    std::size_t maxMatchingLength{0};
+    bool wasCached{false};
+    for (std::size_t index = 0; index < numCategories; ++index) {
+        model::CLocalCategoryId localCategoryId{index};
+        if (m_DataCategorizer->categoryChangedAndReset(localCategoryId)) {
+            CGlobalCategoryId globalCategoryId{m_CategoryIdMapper->map(localCategoryId)};
+            if (m_DataCategorizer->createReverseSearch(
+                    localCategoryId, m_SearchTermsScratchSpace, m_SearchTermsRegexScratchSpace,
+                    maxMatchingLength, wasCached) == false) {
+                LOG_WARN(<< "Unable to create or retrieve reverse search to store for category: "
+                         << globalCategoryId);
+                continue;
+            }
+            LOG_TRACE(<< "Writing out changed category: " << globalCategoryId);
+            jsonOutputWriter.writeCategoryDefinition(
+                m_PartitionFieldName, m_CategoryIdMapper->categorizerKey(),
+                globalCategoryId, m_SearchTermsScratchSpace,
+                m_SearchTermsRegexScratchSpace, maxMatchingLength,
+                m_DataCategorizer->examplesCollector().examples(localCategoryId),
+                m_DataCategorizer->numMatches(localCategoryId),
+                m_CategoryIdMapper->mapVec(m_DataCategorizer->usurpedCategories(localCategoryId)));
+        }
+    }
+}
+
+void CSingleFieldDataCategorizer::forceResourceRefresh(model::CResourceMonitor& resourceMonitor) {
+    resourceMonitor.forceRefresh(*m_DataCategorizer);
+}
+
+void CSingleFieldDataCategorizer::acceptPersistInserter(
+    const model::CDataCategorizer::TPersistFunc& dataCategorizerPersistFunc,
+    const model::CCategoryExamplesCollector& examplesCollector,
+    const CCategoryIdMapper& categoryIdMapper,
+    core::CStatePersistInserter& inserter) {
+    inserter.insertLevel(CATEGORIZER_TAG, dataCategorizerPersistFunc);
+    inserter.insertLevel(EXAMPLES_COLLECTOR_TAG,
+                         [&examplesCollector](core::CStatePersistInserter& inserter_) {
+                             examplesCollector.acceptPersistInserter(inserter_);
+                         });
+    inserter.insertLevel(CATEGORY_ID_MAPPER_TAG,
+                         [&categoryIdMapper](core::CStatePersistInserter& inserter_) {
+                             categoryIdMapper.acceptPersistInserter(inserter_);
+                         });
+}
+}
+}

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -21,6 +21,7 @@ SRCS= \
 CAnomalyJob.cc \
 CBenchMarker.cc \
 CBoostedTreeInferenceModelBuilder.cc \
+CCategoryIdMapper.cc \
 CCmdSkeleton.cc \
 CConfigUpdater.cc \
 CCsvInputParser.cc \
@@ -40,6 +41,7 @@ CDetectionRulesJsonParser.cc \
 CFieldConfig.cc \
 CFieldDataCategorizer.cc \
 CForecastRunner.cc \
+CGlobalCategoryId.cc \
 CHierarchicalResultsWriter.cc \
 CInferenceModelDefinition.cc \
 CInputParser.cc \
@@ -54,11 +56,14 @@ CModelSnapshotJsonWriter.cc \
 CNdInputParser.cc \
 CNdJsonInputParser.cc \
 CNdJsonOutputWriter.cc \
+CNoopCategoryIdMapper.cc \
 CNullOutput.cc \
 COutputChainer.cc \
 COutputHandler.cc \
+CPerPartitionCategoryIdMapper.cc \
 CPersistenceManager.cc \
 CResultNormalizer.cc \
+CSingleFieldDataCategorizer.cc \
 CSingleStreamDataAdder.cc \
 CSingleStreamSearcher.cc \
 CStateRestoreStreamFilter.cc \

--- a/lib/api/dump_state/Main.cc
+++ b/lib/api/dump_state/Main.cc
@@ -149,7 +149,7 @@ bool persistCategorizerStateToFile(const std::string& outputFileName) {
         }
 
         ml::api::CSingleStreamDataAdder persister(ptr);
-        if (!categorizer.persistState(persister, "State persisted due to job close at ")) {
+        if (!categorizer.persistStateInForeground(persister, "State persisted due to job close at ")) {
             LOG_ERROR(<< "Error persisting state to " << outputFileName);
             return false;
         }
@@ -215,7 +215,7 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
         }
 
         ml::api::CSingleStreamDataAdder persister(ptr);
-        if (!origJob.persistState(persister, "State persisted due to job close at ")) {
+        if (!origJob.persistStateInForeground(persister, "State persisted due to job close at ")) {
             LOG_ERROR(<< "Error persisting state to " << outputFileName);
             return false;
         }

--- a/lib/api/unittest/CGlobalCategoryIdTest.cc
+++ b/lib/api/unittest/CGlobalCategoryIdTest.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <model/CLocalCategoryId.h>
+
+#include <api/CGlobalCategoryId.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(CGlobalCategoryIdTest)
+
+BOOST_AUTO_TEST_CASE(testDefaultConstructor) {
+    ml::api::CGlobalCategoryId globalCategoryId;
+    BOOST_TEST_REQUIRE(globalCategoryId.isValid() == false);
+    BOOST_TEST_REQUIRE(globalCategoryId.isSoftFailure());
+    BOOST_TEST_REQUIRE(globalCategoryId.isHardFailure() == false);
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId::SOFT_CATEGORIZATION_FAILURE_ERROR,
+                        globalCategoryId.globalId());
+    BOOST_REQUIRE_EQUAL("-1", globalCategoryId.print());
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId::softFailure(), globalCategoryId);
+}
+
+BOOST_AUTO_TEST_CASE(testIdConstructor) {
+    ml::api::CGlobalCategoryId globalCategoryId{7};
+    BOOST_TEST_REQUIRE(globalCategoryId.isValid());
+    BOOST_TEST_REQUIRE(globalCategoryId.isSoftFailure() == false);
+    BOOST_TEST_REQUIRE(globalCategoryId.isHardFailure() == false);
+    BOOST_REQUIRE_EQUAL(7, globalCategoryId.globalId());
+    BOOST_REQUIRE_EQUAL("", globalCategoryId.categorizerKey());
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{7}, globalCategoryId.localId());
+    BOOST_REQUIRE_EQUAL("7", globalCategoryId.print());
+}
+
+BOOST_AUTO_TEST_CASE(testIdKeyIdConstructor) {
+    std::string categorizerKey{"foo"};
+    ml::api::CGlobalCategoryId globalCategoryId{5, categorizerKey,
+                                                ml::model::CLocalCategoryId{2}};
+    BOOST_TEST_REQUIRE(globalCategoryId.isValid());
+    BOOST_TEST_REQUIRE(globalCategoryId.isSoftFailure() == false);
+    BOOST_TEST_REQUIRE(globalCategoryId.isHardFailure() == false);
+    BOOST_REQUIRE_EQUAL(5, globalCategoryId.globalId());
+    BOOST_REQUIRE_EQUAL("foo", globalCategoryId.categorizerKey());
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2}, globalCategoryId.localId());
+    BOOST_REQUIRE_EQUAL("foo/2;5", globalCategoryId.print());
+}
+
+BOOST_AUTO_TEST_CASE(testFailureHelpers) {
+    ml::api::CGlobalCategoryId softFailure{ml::api::CGlobalCategoryId::softFailure()};
+    BOOST_TEST_REQUIRE(softFailure.isValid() == false);
+    BOOST_TEST_REQUIRE(softFailure.isSoftFailure());
+    BOOST_TEST_REQUIRE(softFailure.isHardFailure() == false);
+
+    ml::api::CGlobalCategoryId hardFailure{ml::api::CGlobalCategoryId::hardFailure()};
+    BOOST_TEST_REQUIRE(hardFailure.isValid() == false);
+    BOOST_TEST_REQUIRE(hardFailure.isSoftFailure() == false);
+    BOOST_TEST_REQUIRE(hardFailure.isHardFailure());
+
+    BOOST_TEST_REQUIRE(softFailure != hardFailure);
+    BOOST_TEST_REQUIRE((softFailure == hardFailure) == false);
+    BOOST_TEST_REQUIRE(softFailure.print() != hardFailure.print());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -19,6 +19,7 @@
 #include <model/CStringStore.h>
 #include <model/ModelTypes.h>
 
+#include <api/CGlobalCategoryId.h>
 #include <api/CJsonOutputWriter.h>
 
 #include <test/BoostTestCloseAbsolute.h>
@@ -1284,7 +1285,7 @@ BOOST_AUTO_TEST_CASE(testFlush) {
 }
 
 BOOST_AUTO_TEST_CASE(testWriteCategoryDefinition) {
-    int categoryId(42);
+    ml::api::CGlobalCategoryId categoryId{42};
     std::string terms("foo bar");
     std::string regex(".*?foo.+?bar.*");
     std::size_t maxMatchingLength(132);
@@ -1298,7 +1299,7 @@ BOOST_AUTO_TEST_CASE(testWriteCategoryDefinition) {
         ml::core::CJsonOutputStreamWrapper outputStream(sstream);
         ml::api::CJsonOutputWriter writer("job", outputStream);
 
-        writer.writeCategoryDefinition(categoryId, terms, regex,
+        writer.writeCategoryDefinition("", "", categoryId, terms, regex,
                                        maxMatchingLength, examples, 0, {});
     }
 
@@ -1321,9 +1322,75 @@ BOOST_AUTO_TEST_CASE(testWriteCategoryDefinition) {
     const rapidjson::Value& category = categoryWrapper["category_definition"];
     BOOST_TEST_REQUIRE(category.HasMember("job_id"));
     BOOST_REQUIRE_EQUAL(std::string("job"), std::string(category["job_id"].GetString()));
+    BOOST_TEST_REQUIRE(category.HasMember("partition_field_name") == false);
+    BOOST_TEST_REQUIRE(category.HasMember("partition_field_value") == false);
     BOOST_TEST_REQUIRE(category.IsObject());
     BOOST_TEST_REQUIRE(category.HasMember("category_id"));
-    BOOST_REQUIRE_EQUAL(categoryId, category["category_id"].GetInt());
+    BOOST_REQUIRE_EQUAL(categoryId.globalId(), category["category_id"].GetInt());
+    BOOST_TEST_REQUIRE(category.HasMember("terms"));
+    BOOST_REQUIRE_EQUAL(terms, std::string(category["terms"].GetString()));
+    BOOST_TEST_REQUIRE(category.HasMember("regex"));
+    BOOST_REQUIRE_EQUAL(regex, std::string(category["regex"].GetString()));
+    BOOST_TEST_REQUIRE(category.HasMember("max_matching_length"));
+    BOOST_REQUIRE_EQUAL(maxMatchingLength,
+                        static_cast<std::size_t>(category["max_matching_length"].GetInt()));
+    BOOST_TEST_REQUIRE(category.HasMember("examples"));
+
+    ml::api::CJsonOutputWriter::TStrFSet writtenExamplesSet;
+    const rapidjson::Value& writtenExamples = category["examples"];
+    for (rapidjson::SizeType i = 0; i < writtenExamples.Size(); i++) {
+        writtenExamplesSet.insert(std::string(writtenExamples[i].GetString()));
+    }
+    BOOST_TEST_REQUIRE(writtenExamplesSet == examples);
+}
+
+BOOST_AUTO_TEST_CASE(testWritePerPartitionCategoryDefinition) {
+    ml::api::CGlobalCategoryId categoryId{42};
+    std::string terms("foo bar");
+    std::string regex(".*?foo.+?bar.*");
+    std::size_t maxMatchingLength(132);
+    ml::api::CJsonOutputWriter::TStrFSet examples;
+    examples.insert("User foo failed to log in");
+    examples.insert("User bar failed to log in");
+
+    std::ostringstream sstream;
+
+    {
+        ml::core::CJsonOutputStreamWrapper outputStream(sstream);
+        ml::api::CJsonOutputWriter writer("job", outputStream);
+
+        writer.writeCategoryDefinition("event.dataset", "elasticsearch", categoryId, terms,
+                                       regex, maxMatchingLength, examples, 0, {});
+    }
+
+    rapidjson::Document arrayDoc;
+    arrayDoc.Parse<rapidjson::kParseDefaultFlags>(sstream.str().c_str());
+
+    BOOST_TEST_REQUIRE(arrayDoc.IsArray());
+    BOOST_REQUIRE_EQUAL(rapidjson::SizeType(1), arrayDoc.Size());
+
+    rapidjson::StringBuffer strbuf;
+    using TStringBufferPrettyWriter = rapidjson::PrettyWriter<rapidjson::StringBuffer>;
+    TStringBufferPrettyWriter writer(strbuf);
+    arrayDoc.Accept(writer);
+    LOG_DEBUG(<< "CategoryDefinition:\n" << strbuf.GetString());
+
+    const rapidjson::Value& categoryWrapper = arrayDoc[rapidjson::SizeType(0)];
+    BOOST_TEST_REQUIRE(categoryWrapper.IsObject());
+    BOOST_TEST_REQUIRE(categoryWrapper.HasMember("category_definition"));
+
+    const rapidjson::Value& category = categoryWrapper["category_definition"];
+    BOOST_TEST_REQUIRE(category.HasMember("job_id"));
+    BOOST_REQUIRE_EQUAL(std::string("job"), std::string(category["job_id"].GetString()));
+    BOOST_TEST_REQUIRE(category.HasMember("partition_field_name"));
+    BOOST_REQUIRE_EQUAL("event.dataset",
+                        std::string(category["partition_field_name"].GetString()));
+    BOOST_TEST_REQUIRE(category.HasMember("partition_field_value"));
+    BOOST_REQUIRE_EQUAL("elasticsearch",
+                        std::string(category["partition_field_value"].GetString()));
+    BOOST_TEST_REQUIRE(category.IsObject());
+    BOOST_TEST_REQUIRE(category.HasMember("category_id"));
+    BOOST_REQUIRE_EQUAL(categoryId.globalId(), category["category_id"].GetInt());
     BOOST_TEST_REQUIRE(category.HasMember("terms"));
     BOOST_REQUIRE_EQUAL(terms, std::string(category["terms"].GetString()));
     BOOST_TEST_REQUIRE(category.HasMember("regex"));

--- a/lib/api/unittest/CMockDataProcessor.cc
+++ b/lib/api/unittest/CMockDataProcessor.cc
@@ -66,10 +66,10 @@ bool CMockDataProcessor::restoreState(ml::core::CDataSearcher& restoreSearcher,
     return true;
 }
 
-bool CMockDataProcessor::persistState(ml::core::CDataAdder& persister,
-                                      const std::string& descriptionPrefix) {
+bool CMockDataProcessor::persistStateInForeground(ml::core::CDataAdder& persister,
+                                                  const std::string& descriptionPrefix) {
     // Pass on the request in case we're chained
-    if (m_OutputHandler.persistState(persister, descriptionPrefix) == false) {
+    if (m_OutputHandler.persistStateInForeground(persister, descriptionPrefix) == false) {
         return false;
     }
 

--- a/lib/api/unittest/CMockDataProcessor.h
+++ b/lib/api/unittest/CMockDataProcessor.h
@@ -34,27 +34,27 @@ public:
     CMockDataProcessor(ml::api::COutputHandler& outputHandler);
 
     //! We're going to be writing to a new output stream
-    virtual void newOutputStream();
+    void newOutputStream() override;
 
-    virtual bool handleRecord(const TStrStrUMap& dataRowFields);
+    bool handleRecord(const TStrStrUMap& dataRowFields) override;
 
-    virtual void finalise();
+    void finalise() override;
 
-    virtual bool isPersistenceNeeded(const std::string& description) const;
+    bool isPersistenceNeeded(const std::string& description) const override;
 
     //! Restore previously saved state
-    virtual bool restoreState(ml::core::CDataSearcher& restoreSearcher,
-                              ml::core_t::TTime& completeToTime);
+    bool restoreState(ml::core::CDataSearcher& restoreSearcher,
+                      ml::core_t::TTime& completeToTime) override;
 
     //! Persist current state
-    virtual bool persistState(ml::core::CDataAdder& persister,
-                              const std::string& descriptionPrefix);
+    bool persistStateInForeground(ml::core::CDataAdder& persister,
+                                  const std::string& descriptionPrefix) override;
 
     //! How many records did we handle?
-    virtual uint64_t numRecordsHandled() const;
+    uint64_t numRecordsHandled() const override;
 
     //! Access the output handler
-    virtual ml::api::COutputHandler& outputHandler();
+    ml::api::COutputHandler& outputHandler() override;
 
 private:
     ml::api::COutputHandler& m_OutputHandler;

--- a/lib/api/unittest/CMultiFileDataAdderTest.cc
+++ b/lib/api/unittest/CMultiFileDataAdderTest.cc
@@ -102,7 +102,7 @@ void detectorPersistHelper(const std::string& configFileName,
         BOOST_REQUIRE_NO_THROW(boost::filesystem::remove_all(origDir));
 
         ml::test::CMultiFileDataAdder persister(baseOrigOutputFilename);
-        BOOST_TEST_REQUIRE(origJob.persistState(persister, ""));
+        BOOST_TEST_REQUIRE(origJob.persistStateInForeground(persister, ""));
     }
 
     std::string origBaseDocId(JOB_ID + '_' + CTestAnomalyJob::STATE_TYPE + '_' + origSnapshotId);
@@ -156,7 +156,7 @@ void detectorPersistHelper(const std::string& configFileName,
         BOOST_REQUIRE_NO_THROW(boost::filesystem::remove_all(restoredDir));
 
         ml::test::CMultiFileDataAdder persister(baseRestoredOutputFilename);
-        BOOST_TEST_REQUIRE(restoredJob.persistState(persister, ""));
+        BOOST_TEST_REQUIRE(restoredJob.persistStateInForeground(persister, ""));
     }
 
     std::string restoredBaseDocId(JOB_ID + '_' + CTestAnomalyJob::STATE_TYPE +

--- a/lib/api/unittest/CNoopCategoryIdMapperTest.cc
+++ b/lib/api/unittest/CNoopCategoryIdMapperTest.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CNoopCategoryIdMapper.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(CNoopCategoryIdMapperTest)
+
+BOOST_AUTO_TEST_CASE(testLocalToGlobal) {
+    ml::api::CNoopCategoryIdMapper categoryIdMapper;
+
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{-2},
+                        categoryIdMapper.map(ml::model::CLocalCategoryId{-2}));
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{-1},
+                        categoryIdMapper.map(ml::model::CLocalCategoryId{-1}));
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{1},
+                        categoryIdMapper.map(ml::model::CLocalCategoryId{1}));
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{2},
+                        categoryIdMapper.map(ml::model::CLocalCategoryId{2}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CPerPartitionCategoryIdMapperTest.cc
+++ b/lib/api/unittest/CPerPartitionCategoryIdMapperTest.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CJsonStatePersistInserter.h>
+#include <core/CJsonStateRestoreTraverser.h>
+#include <core/CLogger.h>
+
+#include <api/CPerPartitionCategoryIdMapper.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+
+BOOST_AUTO_TEST_SUITE(CPerPartitionCategoryIdMapperTest)
+
+namespace {
+void persistAndRestore(const ml::api::CPerPartitionCategoryIdMapper& persistFrom,
+                       ml::api::CPerPartitionCategoryIdMapper& restoreTo) {
+    std::stringstream jsonStrm;
+    {
+        ml::core::CJsonStatePersistInserter inserter(jsonStrm);
+        persistFrom.acceptPersistInserter(inserter);
+    }
+
+    LOG_DEBUG(<< "JSON representation is: " << jsonStrm.str());
+
+    jsonStrm.seekg(0);
+    ml::core::CJsonStateRestoreTraverser traverser(jsonStrm);
+    BOOST_TEST_REQUIRE(restoreTo.acceptRestoreTraverser(traverser));
+}
+}
+
+BOOST_AUTO_TEST_CASE(testLocalToGlobal) {
+
+    const std::string partitionFieldValue1{"p1"};
+    const std::string partitionFieldValue2{"p1"};
+
+    int highestGlobalId{0};
+    ml::api::CPerPartitionCategoryIdMapper::TNextGlobalIdSupplier nextGlobalIdSupplier{
+        [&highestGlobalId]() { return ++highestGlobalId; }};
+
+    auto assertions = [&partitionFieldValue1, &partitionFieldValue2](
+                          ml::api::CPerPartitionCategoryIdMapper& categoryIdMapper1,
+                          ml::api::CPerPartitionCategoryIdMapper& categoryIdMapper2) {
+        BOOST_REQUIRE_EQUAL(
+            ml::api::CGlobalCategoryId::hardFailure(),
+            categoryIdMapper1.map(ml::model::CLocalCategoryId::hardFailure()));
+        BOOST_REQUIRE_EQUAL(
+            ml::api::CGlobalCategoryId::hardFailure(),
+            categoryIdMapper2.map(ml::model::CLocalCategoryId::hardFailure()));
+        BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(1, partitionFieldValue1,
+                                                       ml::model::CLocalCategoryId{1}),
+                            categoryIdMapper1.map(ml::model::CLocalCategoryId{1}));
+        BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(2, partitionFieldValue1,
+                                                       ml::model::CLocalCategoryId{2}),
+                            categoryIdMapper1.map(ml::model::CLocalCategoryId{2}));
+        BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(3, partitionFieldValue2,
+                                                       ml::model::CLocalCategoryId{1}),
+                            categoryIdMapper2.map(ml::model::CLocalCategoryId{1}));
+        BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(2, partitionFieldValue1,
+                                                       ml::model::CLocalCategoryId{2}),
+                            categoryIdMapper1.map(ml::model::CLocalCategoryId{2}));
+        BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(3, partitionFieldValue2,
+                                                       ml::model::CLocalCategoryId{1}),
+                            categoryIdMapper2.map(ml::model::CLocalCategoryId{1}));
+        BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(4, partitionFieldValue1,
+                                                       ml::model::CLocalCategoryId{3}),
+                            categoryIdMapper1.map(ml::model::CLocalCategoryId{3}));
+        BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(5, partitionFieldValue2,
+                                                       ml::model::CLocalCategoryId{2}),
+                            categoryIdMapper2.map(ml::model::CLocalCategoryId{2}));
+        BOOST_REQUIRE_EQUAL(
+            ml::api::CGlobalCategoryId::softFailure(),
+            categoryIdMapper2.map(ml::model::CLocalCategoryId::softFailure()));
+        BOOST_REQUIRE_EQUAL(
+            ml::api::CGlobalCategoryId::softFailure(),
+            categoryIdMapper1.map(ml::model::CLocalCategoryId::softFailure()));
+    };
+
+    ml::api::CPerPartitionCategoryIdMapper origCategoryIdMapper1{
+        partitionFieldValue1, nextGlobalIdSupplier};
+    ml::api::CPerPartitionCategoryIdMapper origCategoryIdMapper2{
+        partitionFieldValue2, nextGlobalIdSupplier};
+
+    assertions(origCategoryIdMapper1, origCategoryIdMapper2);
+
+    ml::api::CPerPartitionCategoryIdMapper restoredCategoryIdMapper1{
+        partitionFieldValue1, nextGlobalIdSupplier};
+    persistAndRestore(origCategoryIdMapper1, restoredCategoryIdMapper1);
+    ml::api::CPerPartitionCategoryIdMapper restoredCategoryIdMapper2{
+        partitionFieldValue2, nextGlobalIdSupplier};
+    persistAndRestore(origCategoryIdMapper2, restoredCategoryIdMapper2);
+
+    assertions(restoredCategoryIdMapper1, restoredCategoryIdMapper2);
+
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(6, partitionFieldValue2,
+                                                   ml::model::CLocalCategoryId{3}),
+                        restoredCategoryIdMapper2.map(ml::model::CLocalCategoryId{3}));
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(7, partitionFieldValue1,
+                                                   ml::model::CLocalCategoryId{4}),
+                        restoredCategoryIdMapper1.map(ml::model::CLocalCategoryId{4}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -141,9 +141,9 @@ protected:
             persistenceManager.startPersist();
             foregroundSnapshotId = snapshotId;
 
-            // ... persist in foreground again by directly calling persistState
+            // ... persist in foreground again by directly calling persistStateInForeground
             ml::api::CSingleStreamDataAdder foregroundDataAdder2(foregroundStreamPtr2);
-            BOOST_TEST_REQUIRE(firstProcessor->persistState(
+            BOOST_TEST_REQUIRE(firstProcessor->persistStateInForeground(
                 foregroundDataAdder2, "Periodic foreground persistence at "));
             foregroundSnapshotId2 = snapshotId;
         }

--- a/lib/api/unittest/CRestorePreviousStateTest.cc
+++ b/lib/api/unittest/CRestorePreviousStateTest.cc
@@ -111,7 +111,7 @@ void categorizerRestoreHelper(const std::string& stateFile, bool isSymmetric) {
             std::ostringstream* strm(nullptr);
             ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
             ml::api::CSingleStreamDataAdder persister(ptr);
-            BOOST_TEST_REQUIRE(restoredCategorizer.persistState(persister, ""));
+            BOOST_TEST_REQUIRE(restoredCategorizer.persistStateInForeground(persister, ""));
             newPersistedState = strm->str();
         }
         BOOST_REQUIRE_EQUAL(stripDocIds(origPersistedState), stripDocIds(newPersistedState));
@@ -180,7 +180,7 @@ void anomalyDetectorRestoreHelper(const std::string& stateFile,
             std::ostringstream* strm(nullptr);
             ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
             ml::api::CSingleStreamDataAdder persister(ptr);
-            BOOST_TEST_REQUIRE(restoredJob.persistState(persister, ""));
+            BOOST_TEST_REQUIRE(restoredJob.persistStateInForeground(persister, ""));
             newPersistedState = strm->str();
         }
 

--- a/lib/api/unittest/CSingleFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CSingleFieldDataCategorizerTest.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CJsonOutputStreamWrapper.h>
+#include <core/CJsonStatePersistInserter.h>
+#include <core/CJsonStateRestoreTraverser.h>
+
+#include <model/CLimits.h>
+#include <model/CTokenListDataCategorizer.h>
+#include <model/CTokenListReverseSearchCreator.h>
+
+#include <api/CCategoryIdMapper.h>
+#include <api/CFieldDataCategorizer.h>
+#include <api/CJsonOutputWriter.h>
+#include <api/CNoopCategoryIdMapper.h>
+#include <api/CPerPartitionCategoryIdMapper.h>
+#include <api/CSingleFieldDataCategorizer.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <sstream>
+
+BOOST_AUTO_TEST_SUITE(CSingleFieldDataCategorizerTest)
+
+namespace {
+
+void checkPersistAndRestore(bool inBackgroundFirst,
+                            const ml::api::CSingleFieldDataCategorizer& persistFrom,
+                            ml::api::CSingleFieldDataCategorizer& restoreTo) {
+    std::stringstream origJsonStrm;
+    {
+        ml::core::CJsonStatePersistInserter inserter{origJsonStrm};
+        auto persistFunc = inBackgroundFirst
+                               ? persistFrom.makeBackgroundPersistFunc()
+                               : persistFrom.makeForegroundPersistFunc();
+        // This is a quirk of the fact that the CSingleFieldDataCategorizer
+        // is persisted at the same level as other tags - it cannot be
+        // first in the object it's part of.
+        inserter.insertValue("a", "1");
+        persistFunc(inserter);
+    }
+
+    std::string origJson{origJsonStrm.str()};
+
+    origJsonStrm.seekg(0);
+    ml::core::CJsonStateRestoreTraverser traverser(origJsonStrm);
+    BOOST_TEST_REQUIRE(restoreTo.acceptRestoreTraverser(traverser));
+
+    std::stringstream rePersistJsonStrm;
+    {
+        ml::core::CJsonStatePersistInserter inserter{rePersistJsonStrm};
+        auto persistFunc = inBackgroundFirst ? restoreTo.makeForegroundPersistFunc()
+                                             : restoreTo.makeBackgroundPersistFunc();
+        inserter.insertValue("a", "1");
+        persistFunc(inserter);
+    }
+
+    std::string rePersistedJson{rePersistJsonStrm.str()};
+
+    BOOST_REQUIRE_EQUAL(origJson, rePersistedJson);
+}
+}
+
+BOOST_AUTO_TEST_CASE(testPersistNotPerPartition) {
+
+    ml::model::CLimits limits;
+    std::ostringstream outputStrm;
+    ml::core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
+    ml::api::CJsonOutputWriter jsonOutputWriter{"job", wrappedOutputStream};
+
+    ml::api::CCategoryIdMapper::TCategoryIdMapperPtr idMapper{
+        std::make_shared<ml::api::CNoopCategoryIdMapper>()};
+    auto localCategorizer = std::make_unique<ml::api::CFieldDataCategorizer::TTokenListDataCategorizerKeepsFields>(
+        limits, std::make_shared<ml::model::CTokenListReverseSearchCreator>("message"),
+        0.7, "message");
+
+    ml::api::CSingleFieldDataCategorizer origGlobalCategorizer{
+        "", std::move(localCategorizer), std::move(idMapper)};
+
+    ml::model::CDataCategorizer::TStrStrUMap fields;
+    fields["message"] = "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r";
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{1},
+                        origGlobalCategorizer.computeAndUpdateCategory(
+                            false, fields, fields["message"], fields["message"],
+                            limits.resourceMonitor(), jsonOutputWriter));
+
+    fields["message"] = "2015-10-18 18:01:52,728 INFO [main] org.mortbay.log: Started HttpServer2$SelectChannelConnectorWithSafeStartup@0.0.0.0:62267\r";
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{2},
+                        origGlobalCategorizer.computeAndUpdateCategory(
+                            false, fields, fields["message"], fields["message"],
+                            limits.resourceMonitor(), jsonOutputWriter));
+
+    idMapper = std::make_shared<ml::api::CNoopCategoryIdMapper>();
+    localCategorizer = std::make_unique<ml::api::CFieldDataCategorizer::TTokenListDataCategorizerKeepsFields>(
+        limits, std::make_shared<ml::model::CTokenListReverseSearchCreator>("message"),
+        0.7, "message");
+    ml::api::CSingleFieldDataCategorizer restoredFromBackgroundStateGlobalCategorizer{
+        "", std::move(localCategorizer), std::move(idMapper)};
+
+    checkPersistAndRestore(true, origGlobalCategorizer,
+                           restoredFromBackgroundStateGlobalCategorizer);
+
+    idMapper = std::make_shared<ml::api::CNoopCategoryIdMapper>();
+    localCategorizer = std::make_unique<ml::api::CFieldDataCategorizer::TTokenListDataCategorizerKeepsFields>(
+        limits, std::make_shared<ml::model::CTokenListReverseSearchCreator>("message"),
+        0.7, "message");
+    ml::api::CSingleFieldDataCategorizer restoredFromForegroundStateGlobalCategorizer{
+        "", std::move(localCategorizer), std::move(idMapper)};
+
+    checkPersistAndRestore(false, origGlobalCategorizer,
+                           restoredFromForegroundStateGlobalCategorizer);
+}
+
+BOOST_AUTO_TEST_CASE(testPersistPerPartition) {
+
+    ml::model::CLimits limits;
+    std::ostringstream outputStrm;
+    ml::core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
+    ml::api::CJsonOutputWriter jsonOutputWriter{"job", wrappedOutputStream};
+
+    int highestGlobalId{0};
+
+    ml::api::CCategoryIdMapper::TCategoryIdMapperPtr idMapper{
+        std::make_shared<ml::api::CPerPartitionCategoryIdMapper>(
+            "vmware", [&highestGlobalId]() { return ++highestGlobalId; })};
+    auto localCategorizer = std::make_unique<ml::api::CFieldDataCategorizer::TTokenListDataCategorizerKeepsFields>(
+        limits, std::make_shared<ml::model::CTokenListReverseSearchCreator>("message"),
+        0.7, "message");
+
+    ml::api::CSingleFieldDataCategorizer origGlobalCategorizer{
+        "event.dataset", std::move(localCategorizer), std::move(idMapper)};
+
+    ml::model::CDataCategorizer::TStrStrUMap fields;
+    fields["event.dataset"] = "vmware";
+    fields["message"] = "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback";
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(1, fields["event.dataset"],
+                                                   ml::model::CLocalCategoryId{1}),
+                        origGlobalCategorizer.computeAndUpdateCategory(
+                            false, fields, fields["message"], fields["message"],
+                            limits.resourceMonitor(), jsonOutputWriter));
+
+    fields["message"] = "Vpxa: [49EC0B90 verbose 'Default' opID=WFU-ddeadb59] [VpxaHalVmHostagent] 11: GuestInfo changed 'guest.disk";
+    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(2, fields["event.dataset"],
+                                                   ml::model::CLocalCategoryId{2}),
+                        origGlobalCategorizer.computeAndUpdateCategory(
+                            false, fields, fields["message"], fields["message"],
+                            limits.resourceMonitor(), jsonOutputWriter));
+
+    idMapper = std::make_shared<ml::api::CPerPartitionCategoryIdMapper>(
+        "event.dataset", [&highestGlobalId]() { return ++highestGlobalId; });
+    localCategorizer = std::make_unique<ml::api::CFieldDataCategorizer::TTokenListDataCategorizerKeepsFields>(
+        limits, std::make_shared<ml::model::CTokenListReverseSearchCreator>("message"),
+        0.7, "message");
+    ml::api::CSingleFieldDataCategorizer restoredFromBackgroundStateGlobalCategorizer{
+        "event.dataset", std::move(localCategorizer), std::move(idMapper)};
+
+    checkPersistAndRestore(true, origGlobalCategorizer,
+                           restoredFromBackgroundStateGlobalCategorizer);
+
+    idMapper = std::make_shared<ml::api::CPerPartitionCategoryIdMapper>(
+        "event.dataset", [&highestGlobalId]() { return ++highestGlobalId; });
+    localCategorizer = std::make_unique<ml::api::CFieldDataCategorizer::TTokenListDataCategorizerKeepsFields>(
+        limits, std::make_shared<ml::model::CTokenListReverseSearchCreator>("message"),
+        0.7, "message");
+    ml::api::CSingleFieldDataCategorizer restoredFromForegroundStateGlobalCategorizer{
+        "event.dataset", std::move(localCategorizer), std::move(idMapper)};
+
+    checkPersistAndRestore(false, origGlobalCategorizer,
+                           restoredFromForegroundStateGlobalCategorizer);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CSingleStreamDataAdderTest.cc
+++ b/lib/api/unittest/CSingleStreamDataAdderTest.cc
@@ -113,7 +113,7 @@ void detectorPersistHelper(const std::string& configFileName,
         std::ostringstream* strm(nullptr);
         ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
         ml::api::CSingleStreamDataAdder persister(ptr);
-        BOOST_TEST_REQUIRE(firstProcessor->persistState(persister, ""));
+        BOOST_TEST_REQUIRE(firstProcessor->persistStateInForeground(persister, ""));
         origPersistedState = strm->str();
     }
 
@@ -168,7 +168,7 @@ void detectorPersistHelper(const std::string& configFileName,
         std::ostringstream* strm(nullptr);
         ml::api::CSingleStreamDataAdder::TOStreamP ptr(strm = new std::ostringstream());
         ml::api::CSingleStreamDataAdder persister(ptr);
-        BOOST_TEST_REQUIRE(restoredFirstProcessor->persistState(persister, ""));
+        BOOST_TEST_REQUIRE(restoredFirstProcessor->persistStateInForeground(persister, ""));
         newPersistedState = strm->str();
     }
 

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -183,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         time += BUCKET_SPAN * 100;
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
 
-        BOOST_TEST_REQUIRE(job.persistState(adder, ""));
+        BOOST_TEST_REQUIRE(job.persistStateInForeground(adder, ""));
         wrappedOutputStream.syncFlush();
 
         BOOST_REQUIRE_EQUAL(std::size_t(1),
@@ -229,7 +229,7 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         time = playData(time, BUCKET_SPAN, 100, 3, 1, 101, job);
 
         job.finalise();
-        BOOST_TEST_REQUIRE(job.persistState(adder, ""));
+        BOOST_TEST_REQUIRE(job.persistStateInForeground(adder, ""));
     }
     LOG_DEBUG(<< "Restoring job again");
     {
@@ -271,7 +271,7 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         time = playData(time, BUCKET_SPAN, 100, 2, 2, 101, job);
 
         job.finalise();
-        BOOST_TEST_REQUIRE(job.persistState(adder, ""));
+        BOOST_TEST_REQUIRE(job.persistStateInForeground(adder, ""));
     }
     LOG_DEBUG(<< "Restoring yet again");
     {
@@ -373,7 +373,7 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         time += BUCKET_SPAN * 100;
         time = playData(time, BUCKET_SPAN, 100, 3, 2, 99, job);
 
-        BOOST_TEST_REQUIRE(job.persistState(adder, ""));
+        BOOST_TEST_REQUIRE(job.persistStateInForeground(adder, ""));
         wrappedOutputStream.syncFlush();
         BOOST_REQUIRE_EQUAL(std::size_t(1),
                             countBuckets("records", outputStrm.str() + "]"));
@@ -418,7 +418,7 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         time = playData(time, BUCKET_SPAN, 100, 3, 1, 101, job);
 
         job.finalise();
-        BOOST_TEST_REQUIRE(job.persistState(adder, ""));
+        BOOST_TEST_REQUIRE(job.persistStateInForeground(adder, ""));
     }
     LOG_DEBUG(<< "Restoring job again");
     {
@@ -461,7 +461,7 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         time = playData(time, BUCKET_SPAN, 100, 2, 2, 101, job);
 
         job.finalise();
-        BOOST_TEST_REQUIRE(job.persistState(adder, ""));
+        BOOST_TEST_REQUIRE(job.persistStateInForeground(adder, ""));
     }
     LOG_DEBUG(<< "Restoring yet again");
     {

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -39,6 +39,7 @@ SRCS=\
 	CFieldConfigTest.cc \
 	CFieldDataCategorizerTest.cc \
 	CForecastRunnerTest.cc \
+	CGlobalCategoryIdTest.cc \
 	CIoManagerTest.cc \
 	CJsonOutputWriterTest.cc \
 	CLengthEncodedInputParserTest.cc \
@@ -52,10 +53,13 @@ SRCS=\
 	CMultiFileDataAdderTest.cc \
 	CNdJsonInputParserTest.cc \
 	CNdJsonOutputWriterTest.cc \
+	CNoopCategoryIdMapperTest.cc \
 	COutputChainerTest.cc \
+	CPerPartitionCategoryIdMapperTest.cc \
 	CPersistenceManagerTest.cc \
 	CRestorePreviousStateTest.cc \
 	CResultNormalizerTest.cc \
+	CSingleFieldDataCategorizerTest.cc \
 	CSingleStreamDataAdderTest.cc \
 	CStateRestoreStreamFilterTest.cc \
 	CStringStoreTest.cc \

--- a/lib/api/unittest/testfiles/new_persist_per_partition_categorization.conf
+++ b/lib/api/unittest/testfiles/new_persist_per_partition_categorization.conf
@@ -1,0 +1,1 @@
+detector.0.clause = count by mlcategory categorizationfield=message partitionfield=event.dataset perpartitioncategorization=true

--- a/lib/config/CAutoconfigurer.cc
+++ b/lib/config/CAutoconfigurer.cc
@@ -174,7 +174,7 @@ bool CAutoconfigurer::restoreState(core::CDataSearcher& /*restoreSearcher*/,
     return true;
 }
 
-bool CAutoconfigurer::persistState(core::CDataAdder&, const std::string&) {
+bool CAutoconfigurer::persistStateInForeground(core::CDataAdder&, const std::string&) {
     return true;
 }
 

--- a/lib/model/CDataCategorizer.cc
+++ b/lib/model/CDataCategorizer.cc
@@ -14,8 +14,6 @@ namespace ml {
 namespace model {
 
 // Initialise statics
-const int CDataCategorizer::SOFT_CATEGORIZATION_FAILURE_ERROR{-1};
-const int CDataCategorizer::HARD_CATEGORIZATION_FAILURE_ERROR{-2};
 const CDataCategorizer::TStrStrUMap CDataCategorizer::EMPTY_FIELDS;
 
 CDataCategorizer::CDataCategorizer(CLimits& limits, const std::string& fieldName)
@@ -28,7 +26,9 @@ CDataCategorizer::~CDataCategorizer() {
     m_Limits.resourceMonitor().unRegisterComponent(*this);
 }
 
-int CDataCategorizer::computeCategory(bool isDryRun, const std::string& str, std::size_t rawStringLen) {
+CLocalCategoryId CDataCategorizer::computeCategory(bool isDryRun,
+                                                   const std::string& str,
+                                                   std::size_t rawStringLen) {
     return this->computeCategory(isDryRun, EMPTY_FIELDS, str, rawStringLen);
 }
 
@@ -57,14 +57,14 @@ std::size_t CDataCategorizer::memoryUsage() const {
     return mem;
 }
 
-bool CDataCategorizer::addExample(int categoryId, const std::string& example) {
+bool CDataCategorizer::addExample(CLocalCategoryId categoryId, const std::string& example) {
     // Don't add examples if we're in any way memory-constrained.
     // We stop adding examples when the memory status is either
     // E_MemoryStatusSoftLimit or E_MemoryStatusHardLimit, but only
     // stop adding completely new categories in E_MemoryStatusHardLimit.
-    if (m_Limits.resourceMonitor().getMemoryStatus() != model_t::E_MemoryStatusOk) {
+    if (m_Limits.resourceMonitor().memoryStatus() != model_t::E_MemoryStatusOk) {
         LOG_TRACE(<< "Not adding example as memory status is "
-                  << m_Limits.resourceMonitor().getMemoryStatus());
+                  << m_Limits.resourceMonitor().memoryStatus());
         return false;
     }
     return m_ExamplesCollector.add(categoryId, example);

--- a/lib/model/CLocalCategoryId.cc
+++ b/lib/model/CLocalCategoryId.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <model/CLocalCategoryId.h>
+
+#include <core/CStringUtils.h>
+
+#include <ostream>
+
+namespace ml {
+namespace model {
+
+// Initialise statics
+const int CLocalCategoryId::SOFT_CATEGORIZATION_FAILURE_ERROR{-1};
+const int CLocalCategoryId::HARD_CATEGORIZATION_FAILURE_ERROR{-2};
+
+CLocalCategoryId::CLocalCategoryId() : m_Id{SOFT_CATEGORIZATION_FAILURE_ERROR} {
+}
+
+CLocalCategoryId::CLocalCategoryId(int id) : m_Id{id} {
+}
+
+CLocalCategoryId::CLocalCategoryId(std::size_t index)
+    : m_Id{static_cast<int>(index + 1)} {
+}
+
+CLocalCategoryId CLocalCategoryId::softFailure() {
+    return CLocalCategoryId{SOFT_CATEGORIZATION_FAILURE_ERROR};
+}
+CLocalCategoryId CLocalCategoryId::hardFailure() {
+    return CLocalCategoryId{HARD_CATEGORIZATION_FAILURE_ERROR};
+}
+
+bool CLocalCategoryId::operator==(const CLocalCategoryId& other) const {
+    return m_Id == other.m_Id;
+}
+
+bool CLocalCategoryId::operator!=(const CLocalCategoryId& other) const {
+    return m_Id != other.m_Id;
+}
+
+bool CLocalCategoryId::operator<(const CLocalCategoryId& other) const {
+    return m_Id < other.m_Id;
+}
+
+std::string CLocalCategoryId::toString() const {
+    return std::to_string(m_Id);
+}
+
+bool CLocalCategoryId::fromString(const std::string& str) {
+    return core::CStringUtils::stringToType(str, m_Id);
+}
+
+std::ostream& operator<<(std::ostream& strm, const CLocalCategoryId& categoryId) {
+    return strm << categoryId.id();
+}
+}
+}

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -93,8 +93,16 @@ void CResourceMonitor::updateMemoryLimitsAndPruneThreshold(std::size_t limitMBs)
     m_PruneThreshold = (m_ByteLimitHigh * 3) / 5;
 }
 
-model_t::EMemoryStatus CResourceMonitor::getMemoryStatus() {
+model_t::EMemoryStatus CResourceMonitor::memoryStatus() const {
     return m_MemoryStatus;
+}
+
+std::size_t CResourceMonitor::categorizerAllocationFailures() const {
+    return m_CategorizerAllocationFailures;
+}
+
+void CResourceMonitor::categorizerAllocationFailures(std::size_t categorizerAllocationFailures) {
+    m_CategorizerAllocationFailures = categorizerAllocationFailures;
 }
 
 void CResourceMonitor::refresh(CMonitoredResource& resource) {
@@ -274,7 +282,7 @@ CResourceMonitor::createMemoryUsageReport(core_t::TTime bucketStartTime) {
     SModelSizeStats res;
     res.s_Usage = this->totalMemory();
     res.s_AdjustedUsage = this->adjustedUsage(res.s_Usage);
-    res.s_BytesMemoryLimit = 2 * m_ByteLimitHigh;
+    res.s_BytesMemoryLimit = this->persistenceMemoryIncreaseFactor() * m_ByteLimitHigh;
     res.s_BytesExceeded = m_CurrentBytesExceeded;
     res.s_MemoryStatus = m_MemoryStatus;
     res.s_BucketStartTime = bucketStartTime;
@@ -282,6 +290,7 @@ CResourceMonitor::createMemoryUsageReport(core_t::TTime bucketStartTime) {
         resource.first->updateModelSizeStats(res);
     }
     res.s_AllocationFailures += m_AllocationFailures.size();
+    res.s_MemoryCategorizationFailures += m_CategorizerAllocationFailures;
     return res;
 }
 

--- a/lib/model/CTokenListReverseSearchCreator.cc
+++ b/lib/model/CTokenListReverseSearchCreator.cc
@@ -31,7 +31,7 @@ std::size_t CTokenListReverseSearchCreator::costOfToken(const std::string& token
            numOccurrences;
 }
 
-bool CTokenListReverseSearchCreator::createNoUniqueTokenSearch(int /*categoryId*/,
+bool CTokenListReverseSearchCreator::createNoUniqueTokenSearch(CLocalCategoryId /*categoryId*/,
                                                                const std::string& /*example*/,
                                                                std::size_t /*maxMatchingStringLen*/,
                                                                std::string& terms,
@@ -41,7 +41,7 @@ bool CTokenListReverseSearchCreator::createNoUniqueTokenSearch(int /*categoryId*
     return true;
 }
 
-void CTokenListReverseSearchCreator::initStandardSearch(int /*categoryId*/,
+void CTokenListReverseSearchCreator::initStandardSearch(CLocalCategoryId /*categoryId*/,
                                                         const std::string& /*example*/,
                                                         std::size_t /*maxMatchingStringLen*/,
                                                         std::string& terms,

--- a/lib/model/Makefile
+++ b/lib/model/Makefile
@@ -51,6 +51,7 @@ CHierarchicalResultsProbabilityFinalizer.cc \
 CIndividualModel.cc \
 CInterimBucketCorrector.cc \
 CLimits.cc \
+CLocalCategoryId.cc \
 CMemoryUsageEstimator.cc \
 CMetricBucketGatherer.cc \
 CMetricModel.cc \

--- a/lib/model/unittest/CCategoryExamplesCollectorTest.cc
+++ b/lib/model/unittest/CCategoryExamplesCollectorTest.cc
@@ -21,63 +21,74 @@ using namespace model;
 
 BOOST_AUTO_TEST_CASE(testAddGivenMaxExamplesIsZero) {
     CCategoryExamplesCollector examplesCollector(0);
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo") == false);
-    BOOST_TEST_REQUIRE(examplesCollector.add(2, "foo") == false);
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(1), std::size_t(0));
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(2), std::size_t(0));
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo") == false);
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{2}, "foo") == false);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{1}) == 0);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{2}) == 0);
 }
 
 BOOST_AUTO_TEST_CASE(testAddGivenSameCategoryExamplePairAddedTwice) {
     CCategoryExamplesCollector examplesCollector(4);
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo") == true);
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo") == false);
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo") == true);
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo") == false);
 }
 
 BOOST_AUTO_TEST_CASE(testAddGivenMoreThanMaxExamplesAreAddedForSameCategory) {
     CCategoryExamplesCollector examplesCollector(3);
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo1") == true);
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(1), std::size_t(1));
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo2") == true);
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(1), std::size_t(2));
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo3") == true);
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(1), std::size_t(3));
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo4") == false);
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(1), std::size_t(3));
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo1") == true);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{1}) == 1);
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo2") == true);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{1}) == 2);
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo3") == true);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{1}) == 3);
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo4") == false);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{1}) == 3);
 }
 
 BOOST_AUTO_TEST_CASE(testAddGivenCategoryAddedIsNotSubsequent) {
     CCategoryExamplesCollector examplesCollector(2);
-    BOOST_TEST_REQUIRE(examplesCollector.add(1, "foo") == true);
-    BOOST_TEST_REQUIRE(examplesCollector.add(3, "bar") == true);
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(1), std::size_t(1));
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(2), std::size_t(0));
-    BOOST_REQUIRE_EQUAL(examplesCollector.numberOfExamplesForCategory(3), std::size_t(1));
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{1}, "foo") == true);
+    BOOST_TEST_REQUIRE(examplesCollector.add(CLocalCategoryId{3}, "bar") == true);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{1}) == 1);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{2}) == 0);
+    BOOST_TEST_REQUIRE(
+        examplesCollector.numberOfExamplesForCategory(CLocalCategoryId{3}) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(testExamples) {
     CCategoryExamplesCollector examplesCollector(3);
-    examplesCollector.add(1, "foo");
-    examplesCollector.add(1, "bar");
-    examplesCollector.add(2, "foo");
+    examplesCollector.add(CLocalCategoryId{1}, "foo");
+    examplesCollector.add(CLocalCategoryId{1}, "bar");
+    examplesCollector.add(CLocalCategoryId{2}, "foo");
 
-    CCategoryExamplesCollector::TStrFSet examples1 = examplesCollector.examples(1);
+    CCategoryExamplesCollector::TStrFSet examples1 =
+        examplesCollector.examples(CLocalCategoryId{1});
     BOOST_TEST_REQUIRE(examples1.find("foo") != examples1.end());
     BOOST_TEST_REQUIRE(examples1.find("bar") != examples1.end());
     BOOST_TEST_REQUIRE(examples1.find("invalid") == examples1.end());
 
-    CCategoryExamplesCollector::TStrFSet examples2 = examplesCollector.examples(2);
+    CCategoryExamplesCollector::TStrFSet examples2 =
+        examplesCollector.examples(CLocalCategoryId{2});
     BOOST_TEST_REQUIRE(examples2.find("foo") != examples2.end());
     BOOST_TEST_REQUIRE(examples2.find("invalid") == examples2.end());
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {
     CCategoryExamplesCollector examplesCollector(3);
-    examplesCollector.add(1, "foo");
-    examplesCollector.add(1, "bar");
-    examplesCollector.add(1, "foobar");
-    examplesCollector.add(2, "baz");
-    examplesCollector.add(2, "qux");
-    examplesCollector.add(3, "quux");
+    examplesCollector.add(CLocalCategoryId{1}, "foo");
+    examplesCollector.add(CLocalCategoryId{1}, "bar");
+    examplesCollector.add(CLocalCategoryId{1}, "foobar");
+    examplesCollector.add(CLocalCategoryId{2}, "baz");
+    examplesCollector.add(CLocalCategoryId{2}, "qux");
+    examplesCollector.add(CLocalCategoryId{3}, "quux");
 
     std::string origXml;
     {
@@ -93,14 +104,17 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
     CCategoryExamplesCollector restoredExamplesCollector(3, traverser);
 
-    BOOST_TEST_REQUIRE(restoredExamplesCollector.numberOfExamplesForCategory(1) == 3);
+    BOOST_TEST_REQUIRE(restoredExamplesCollector.numberOfExamplesForCategory(
+                           CLocalCategoryId{1}) == 3);
 
-    BOOST_TEST_REQUIRE(restoredExamplesCollector.add(2, "baz") == false);
-    BOOST_TEST_REQUIRE(restoredExamplesCollector.add(2, "qux") == false);
-    BOOST_TEST_REQUIRE(restoredExamplesCollector.numberOfExamplesForCategory(2) == 2);
+    BOOST_TEST_REQUIRE(restoredExamplesCollector.add(CLocalCategoryId{2}, "baz") == false);
+    BOOST_TEST_REQUIRE(restoredExamplesCollector.add(CLocalCategoryId{2}, "qux") == false);
+    BOOST_TEST_REQUIRE(restoredExamplesCollector.numberOfExamplesForCategory(
+                           CLocalCategoryId{2}) == 2);
 
-    BOOST_TEST_REQUIRE(restoredExamplesCollector.add(3, "quux") == false);
-    BOOST_TEST_REQUIRE(restoredExamplesCollector.numberOfExamplesForCategory(3) == 1);
+    BOOST_TEST_REQUIRE(restoredExamplesCollector.add(CLocalCategoryId{3}, "quux") == false);
+    BOOST_TEST_REQUIRE(restoredExamplesCollector.numberOfExamplesForCategory(
+                           CLocalCategoryId{3}) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(testTruncation) {
@@ -113,44 +127,44 @@ BOOST_AUTO_TEST_CASE(testTruncation) {
     {
         // All single byte characters
         std::string example = baseExample + "bbbbbb";
-        examplesCollector.add(1, example);
+        examplesCollector.add(CLocalCategoryId{1}, example);
         BOOST_REQUIRE_EQUAL(baseExample + "bb" + ellipsis,
-                            *examplesCollector.examples(1).begin());
+                            *examplesCollector.examples(CLocalCategoryId{1}).begin());
     }
     {
         // Two byte character crosses truncation boundary
         std::string example = baseExample + "bébbb";
-        examplesCollector.add(2, example);
+        examplesCollector.add(CLocalCategoryId{2}, example);
         BOOST_REQUIRE_EQUAL(baseExample + "b" + ellipsis,
-                            *examplesCollector.examples(2).begin());
+                            *examplesCollector.examples(CLocalCategoryId{2}).begin());
     }
     {
         // Two byte characters either side of truncation boundary
         std::string example = baseExample + "éébbb";
-        examplesCollector.add(3, example);
+        examplesCollector.add(CLocalCategoryId{3}, example);
         BOOST_REQUIRE_EQUAL(baseExample + "é" + ellipsis,
-                            *examplesCollector.examples(3).begin());
+                            *examplesCollector.examples(CLocalCategoryId{3}).begin());
     }
     {
         // Two byte character before truncation boundary, single byte immediately after
         std::string example = baseExample + "ébbbb";
-        examplesCollector.add(4, example);
+        examplesCollector.add(CLocalCategoryId{4}, example);
         BOOST_REQUIRE_EQUAL(baseExample + "é" + ellipsis,
-                            *examplesCollector.examples(4).begin());
+                            *examplesCollector.examples(CLocalCategoryId{4}).begin());
     }
     {
         // Three byte character crosses truncation boundary with start character before
         std::string example = baseExample + "b中bbb";
-        examplesCollector.add(5, example);
+        examplesCollector.add(CLocalCategoryId{5}, example);
         BOOST_REQUIRE_EQUAL(baseExample + "b" + ellipsis,
-                            *examplesCollector.examples(5).begin());
+                            *examplesCollector.examples(CLocalCategoryId{5}).begin());
     }
     {
         // Three byte character crosses truncation boundary with continuation character before
         std::string example = baseExample + "中bbb";
-        examplesCollector.add(6, example);
+        examplesCollector.add(CLocalCategoryId{6}, example);
         BOOST_REQUIRE_EQUAL(baseExample + ellipsis,
-                            *examplesCollector.examples(6).begin());
+                            *examplesCollector.examples(CLocalCategoryId{6}).begin());
     }
 }
 

--- a/lib/model/unittest/CLocalCategoryIdTest.cc
+++ b/lib/model/unittest/CLocalCategoryIdTest.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <model/CLocalCategoryId.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(CLocalCategoryIdTest)
+
+BOOST_AUTO_TEST_CASE(testDefaultConstructor) {
+    ml::model::CLocalCategoryId localCategoryId;
+    BOOST_TEST_REQUIRE(localCategoryId.isValid() == false);
+    BOOST_TEST_REQUIRE(localCategoryId.isSoftFailure());
+    BOOST_TEST_REQUIRE(localCategoryId.isHardFailure() == false);
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId::SOFT_CATEGORIZATION_FAILURE_ERROR,
+                        localCategoryId.id());
+    BOOST_REQUIRE_EQUAL("-1", localCategoryId.toString());
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId::softFailure(), localCategoryId);
+}
+
+BOOST_AUTO_TEST_CASE(testIdConstructor) {
+    ml::model::CLocalCategoryId localCategoryId{7};
+    BOOST_TEST_REQUIRE(localCategoryId.isValid());
+    BOOST_TEST_REQUIRE(localCategoryId.isSoftFailure() == false);
+    BOOST_TEST_REQUIRE(localCategoryId.isHardFailure() == false);
+    BOOST_REQUIRE_EQUAL(7, localCategoryId.id());
+    BOOST_REQUIRE_EQUAL(6, localCategoryId.index());
+    BOOST_REQUIRE_EQUAL("7", localCategoryId.toString());
+    ml::model::CLocalCategoryId otherLocalCategoryId;
+    BOOST_TEST_REQUIRE(otherLocalCategoryId.fromString("7"));
+    BOOST_REQUIRE_EQUAL(localCategoryId, otherLocalCategoryId);
+}
+
+BOOST_AUTO_TEST_CASE(testIndexConstructor) {
+    ml::model::CLocalCategoryId localCategoryId{std::size_t(3)};
+    BOOST_TEST_REQUIRE(localCategoryId.isValid());
+    BOOST_TEST_REQUIRE(localCategoryId.isSoftFailure() == false);
+    BOOST_TEST_REQUIRE(localCategoryId.isHardFailure() == false);
+    BOOST_REQUIRE_EQUAL(4, localCategoryId.id());
+    BOOST_REQUIRE_EQUAL(3, localCategoryId.index());
+    BOOST_REQUIRE_EQUAL("4", localCategoryId.toString());
+}
+
+BOOST_AUTO_TEST_CASE(testFailureHelpers) {
+    ml::model::CLocalCategoryId softFailure{ml::model::CLocalCategoryId::softFailure()};
+    BOOST_TEST_REQUIRE(softFailure.isValid() == false);
+    BOOST_TEST_REQUIRE(softFailure.isSoftFailure());
+    BOOST_TEST_REQUIRE(softFailure.isHardFailure() == false);
+
+    ml::model::CLocalCategoryId hardFailure{ml::model::CLocalCategoryId::hardFailure()};
+    BOOST_TEST_REQUIRE(hardFailure.isValid() == false);
+    BOOST_TEST_REQUIRE(hardFailure.isSoftFailure() == false);
+    BOOST_TEST_REQUIRE(hardFailure.isHardFailure());
+
+    BOOST_TEST_REQUIRE(softFailure != hardFailure);
+    BOOST_TEST_REQUIRE((softFailure == hardFailure) == false);
+    BOOST_TEST_REQUIRE(softFailure.toString() != hardFailure.toString());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -42,7 +42,7 @@ const TTokenListDataCategorizerKeepsFields::TTokenListReverseSearchCreatorCPtr N
 void checkMemoryUsageInstrumentation(const TTokenListDataCategorizerKeepsFields& categorizer) {
 
     std::size_t memoryUsage{categorizer.memoryUsage()};
-    auto mem{std::make_shared<ml::core::CMemoryUsage>()};
+    auto mem = std::make_shared<ml::core::CMemoryUsage>();
     categorizer.debugMemoryUsage(mem);
 
     std::ostringstream strm;
@@ -100,11 +100,16 @@ BOOST_FIXTURE_TEST_CASE(testHexData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "[0x0000000800000000 ", 500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "0x0000000800000000", 500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, " 0x0000000800000000,", 500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "0x0000000800000000)", 500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, " 0x0000000800000000,", 500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "[0x0000000800000000 ", 500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "0x0000000800000000", 500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, " 0x0000000800000000,", 500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "0x0000000800000000)", 500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, " 0x0000000800000000,", 500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -113,26 +118,36 @@ BOOST_FIXTURE_TEST_CASE(testRmdsData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4606.1.p2ps: Info: > Source CUBE_LIQUID on 13188:2010 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML SERVICE2 on 13122:867 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX, id of 132, has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4606.1.p2ps: Info: > Source CUBE_LIQUID on 13188:2010 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML SERVICE2 on 13122:867 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX, id of 132, has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+                        categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
+                                                    500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -141,30 +156,37 @@ BOOST_FIXTURE_TEST_CASE(testProxyData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false,
-                                                       " [1094662464] INFO  transaction <3c26701d3140-kn8n1c8f5d2o> - Transaction TID: "
-                                                       "z9hG4bKy6aEy6aEy6aEaUgi!UmU-Ma.9-6bf50ea0192.168.251.8SUBSCRIBE deleted",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false,
-                                                       " [1091504448] INFO  transaction <3c26701ad775-1cref2zy3w9e> - Transaction TID: "
-                                                       "z9hG4bK_UQA_UQA_UQAsO0i!OG!yYK.25-5bee09e0192.168.251.8SUBSCRIBE deleted",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false,
-                                                       " [1094662464] INFO  transactionuser <6508700927200972648@10.10.18.82> - ---------------- "
-                                                       "DESTROYING RegistrationServer ---------------",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, " [1111529792] INFO  proxy <45409105041220090733@192.168.251.123> - +++++++++++++++ CREATING ProxyCore ++++++++++++++++",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(false, " [1091504448] INFO  transactionuser <3c26709ab9f0-iih26eh8pxxa> - +++++++++++++++ CREATING PresenceAgent ++++++++++++++++",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(5, categorizer.computeCategory(false,
-                                                       " [1111529792] INFO  session <45409105041220090733@192.168.251.123> - ----------------- PROXY "
-                                                       "Session DESTROYED --------------------",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(5, categorizer.computeCategory(false,
-                                                       " [1094662464] INFO  session <ch6z1bho8xeprb3z4ty604iktl6c@dave.proxy.uk> - ----------------- "
-                                                       "PROXY Session DESTROYED --------------------",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false,
+                                                    " [1094662464] INFO  transaction <3c26701d3140-kn8n1c8f5d2o> - Transaction TID: "
+                                                    "z9hG4bKy6aEy6aEy6aEaUgi!UmU-Ma.9-6bf50ea0192.168.251.8SUBSCRIBE deleted",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false,
+                                                    " [1091504448] INFO  transaction <3c26701ad775-1cref2zy3w9e> - Transaction TID: "
+                                                    "z9hG4bK_UQA_UQA_UQAsO0i!OG!yYK.25-5bee09e0192.168.251.8SUBSCRIBE deleted",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false,
+                                                    " [1094662464] INFO  transactionuser <6508700927200972648@10.10.18.82> - ---------------- "
+                                                    "DESTROYING RegistrationServer ---------------",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, " [1111529792] INFO  proxy <45409105041220090733@192.168.251.123> - +++++++++++++++ CREATING ProxyCore ++++++++++++++++",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+                        categorizer.computeCategory(false, " [1091504448] INFO  transactionuser <3c26709ab9f0-iih26eh8pxxa> - +++++++++++++++ CREATING PresenceAgent ++++++++++++++++",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{5},
+                        categorizer.computeCategory(false,
+                                                    " [1111529792] INFO  session <45409105041220090733@192.168.251.123> - ----------------- PROXY "
+                                                    "Session DESTROYED --------------------",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{5},
+                        categorizer.computeCategory(false,
+                                                    " [1094662464] INFO  session <ch6z1bho8xeprb3z4ty604iktl6c@dave.proxy.uk> - ----------------- "
+                                                    "PROXY Session DESTROYED --------------------",
+                                                    500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -173,16 +195,18 @@ BOOST_FIXTURE_TEST_CASE(testFxData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false,
-                                                       "<L_MSG MN=\"ml12220\" PID=\"ml010_managed4\" TID=\"asyncDelivery41\" DT=\"\" PT=\"ERROR\" AP=\"wts\" DN=\"\" "
-                                                       "SN=\"\" SR=\"co.elastic.session.ejb.FxCoverSessionBean\">javax.ejb.FinderException - findFxCover([]): "
-                                                       "null</L_MSG>",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false,
-                                                       "<L_MSG MN=\"ml12213\" PID=\"ml010_managed2\" TID=\"asyncDelivery44\" DT=\"\" PT=\"ERROR\" AP=\"wts\" DN=\"\" "
-                                                       "SN=\"\" SR=\"co.elastic.session.ejb.FxCoverSessionBean\">javax.ejb.FinderException - findFxCover([]): "
-                                                       "null</L_MSG>",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false,
+                                                    "<L_MSG MN=\"ml12220\" PID=\"ml010_managed4\" TID=\"asyncDelivery41\" DT=\"\" PT=\"ERROR\" AP=\"wts\" DN=\"\" "
+                                                    "SN=\"\" SR=\"co.elastic.session.ejb.FxCoverSessionBean\">javax.ejb.FinderException - findFxCover([]): "
+                                                    "null</L_MSG>",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false,
+                                                    "<L_MSG MN=\"ml12213\" PID=\"ml010_managed2\" TID=\"asyncDelivery44\" DT=\"\" PT=\"ERROR\" AP=\"wts\" DN=\"\" "
+                                                    "SN=\"\" SR=\"co.elastic.session.ejb.FxCoverSessionBean\">javax.ejb.FinderException - findFxCover([]): "
+                                                    "null</L_MSG>",
+                                                    500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -191,14 +215,18 @@ BOOST_FIXTURE_TEST_CASE(testApacheData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol destroy",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol init",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol start",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol stop",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol destroy",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol init",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol start",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+                        categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol stop",
+                                                    500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -207,25 +235,28 @@ BOOST_FIXTURE_TEST_CASE(testBrokerageData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(
-                               false,
-                               "AUDIT  ; tomcat-http--16; ee96c0c4567c0c11d6b90f9bc8b54aaa77; REQ4e42023e0a0328d020003e460005aa33; "
-                               "applnx911.elastic.co; ; Request Complete: /mlgw/mlb/ofsummary/summary "
-                               "[T=283ms,CUSTPREF-WEB_ACCOUNT_PREFERENCES=95,MAUI-ETSPROF2=155,NBMSG-NB_MESSAGING_SERVICE=164,CustAcctProfile="
-                               "BRK=2;NB=0;FILI=0;CESG=0;CC=0;AcctTotal=2,migrated=2]",
-                               500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(
-                               false,
-                               "AUDIT  ; tomcat-http--39; ee763e95747c0b11d6b90f9bc8b54aaa77; REQ4e42023e0a0429a020000c6f0002aa33; "
-                               "applnx811.elastic.co; ; Request Complete: /mlgw/mlb/ofaccounts/brokerageAccountHistory "
-                               "[T=414ms,CUSTPREF-INS_PERSON_WEB_ACCT_PREFERENCES=298,MAUI-PSL04XD=108]",
-                               500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(
-                               false,
-                               "AUDIT  ; tomcat-http--39; ee256201da7c0c11d6b90f9bc8b54aaa77; REQ4e42023b0a022925200027180002aa33; "
-                               "applnx711.elastic.co; ; Request Complete: /mlgw/mlb/ofpositions/brokerageAccountPositionsIframe "
-                               "[T=90ms,CacheStore-GetAttribute=5,MAUI-ECAPPOS=50,RR-QUOTE_TRANSACTION=11]",
-                               500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false,
+                            "AUDIT  ; tomcat-http--16; ee96c0c4567c0c11d6b90f9bc8b54aaa77; REQ4e42023e0a0328d020003e460005aa33; "
+                            "applnx911.elastic.co; ; Request Complete: /mlgw/mlb/ofsummary/summary "
+                            "[T=283ms,CUSTPREF-WEB_ACCOUNT_PREFERENCES=95,MAUI-ETSPROF2=155,NBMSG-NB_MESSAGING_SERVICE=164,CustAcctProfile="
+                            "BRK=2;NB=0;FILI=0;CESG=0;CC=0;AcctTotal=2,migrated=2]",
+                            500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(
+                            false,
+                            "AUDIT  ; tomcat-http--39; ee763e95747c0b11d6b90f9bc8b54aaa77; REQ4e42023e0a0429a020000c6f0002aa33; "
+                            "applnx811.elastic.co; ; Request Complete: /mlgw/mlb/ofaccounts/brokerageAccountHistory "
+                            "[T=414ms,CUSTPREF-INS_PERSON_WEB_ACCT_PREFERENCES=298,MAUI-PSL04XD=108]",
+                            500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(
+                            false,
+                            "AUDIT  ; tomcat-http--39; ee256201da7c0c11d6b90f9bc8b54aaa77; REQ4e42023b0a022925200027180002aa33; "
+                            "applnx711.elastic.co; ; Request Complete: /mlgw/mlb/ofpositions/brokerageAccountPositionsIframe "
+                            "[T=90ms,CacheStore-GetAttribute=5,MAUI-ECAPPOS=50,RR-QUOTE_TRANSACTION=11]",
+                            500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -234,18 +265,24 @@ BOOST_FIXTURE_TEST_CASE(testVmwareData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
-                                                       103));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'Default' opID=WFU-ddeadb59] [VpxaHalVmHostagent] 11: GuestInfo changed 'guest.disk",
-                                                       107));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Completed callback",
-                                                       104));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-35689729] [WaitForUpdatesDone] Received callback",
-                                                       103));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'Default' opID=WFU-35689729] [VpxaHalVmHostagent] 15: GuestInfo changed 'guest.disk",
-                                                       107));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-35689729] [WaitForUpdatesDone] Completed callback",
-                                                       104));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
+                                                    103));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'Default' opID=WFU-ddeadb59] [VpxaHalVmHostagent] 11: GuestInfo changed 'guest.disk",
+                                                    107));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Completed callback",
+                                                    104));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-35689729] [WaitForUpdatesDone] Received callback",
+                                                    103));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'Default' opID=WFU-35689729] [VpxaHalVmHostagent] 15: GuestInfo changed 'guest.disk",
+                                                    107));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-35689729] [WaitForUpdatesDone] Completed callback",
+                                                    104));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -254,21 +291,24 @@ BOOST_FIXTURE_TEST_CASE(testBankData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false,
-                                                       "INFO  [co.elastic.settlement.synchronization.PaymentFlowProcessorImpl] Process payment flow "
-                                                       "for tradeId=80894728 and backOfficeId=9354474",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false,
-                                                       "INFO  [co.elastic.settlement.synchronization.PaymentFlowProcessorImpl] Synchronization of "
-                                                       "payment flow is complete for tradeId=80013186 and backOfficeId=265573",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false,
+                                                    "INFO  [co.elastic.settlement.synchronization.PaymentFlowProcessorImpl] Process payment flow "
+                                                    "for tradeId=80894728 and backOfficeId=9354474",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false,
+                                                    "INFO  [co.elastic.settlement.synchronization.PaymentFlowProcessorImpl] Synchronization of "
+                                                    "payment flow is complete for tradeId=80013186 and backOfficeId=265573",
+                                                    500));
 
     // This is not great, but it's tricky when only 1 word differs from the
     // first category
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false,
-                                                       "INFO  [co.elastic.settlement.synchronization.PaymentFlowProcessorImpl] Synchronize payment "
-                                                       "flow for tradeId=80894721 and backOfficeId=9354469",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false,
+                                                    "INFO  [co.elastic.settlement.synchronization.PaymentFlowProcessorImpl] Synchronize payment "
+                                                    "flow for tradeId=80894721 and backOfficeId=9354469",
+                                                    500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -277,47 +317,67 @@ BOOST_FIXTURE_TEST_CASE(testJavaGcData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-27T19:57:43.644-0700: 1922084.903: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-28T19:57:43.644-0700: 1922084.903: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-29T19:57:43.644-0700: 1922084.903: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.644-0700: 1922084.903: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.644-0700: 1922084.904: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.644-0700: 1922084.905: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.644-0700: 1922084.906: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.644-0700: 1922085.906: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.644-0700: 1922086.906: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.644-0700: 1922087.906: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.645-0700: 1922087.906: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.646-0700: 1922087.906: [GC",
-                                                       46));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2016-04-30T19:57:43.647-0700: 1922087.906: [GC",
-                                                       46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-27T19:57:43.644-0700: 1922084.903: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-28T19:57:43.644-0700: 1922084.903: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-29T19:57:43.644-0700: 1922084.903: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.644-0700: 1922084.903: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.644-0700: 1922084.904: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.644-0700: 1922084.905: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.644-0700: 1922084.906: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.644-0700: 1922085.906: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.644-0700: 1922086.906: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.644-0700: 1922087.906: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.645-0700: 1922087.906: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.646-0700: 1922087.906: [GC", 46));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(
+                            false, "2016-04-30T19:57:43.647-0700: 1922087.906: [GC", 46));
 
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "PSYoungGen      total 2572800K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
-                                                       106));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "PSYoungGen      total 2572801K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
-                                                       106));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "PSYoungGen      total 2572802K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
-                                                       106));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
-                                                       106));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759600000, 0x0000000800000000, 0x0000000800000000)",
-                                                       106));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759700000, 0x0000000800000000, 0x0000000800000000)",
-                                                       106));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759800000, 0x0000000800000000, 0x0000000800000000)",
-                                                       106));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "PSYoungGen      total 2572800K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
+                                                    106));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "PSYoungGen      total 2572801K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
+                                                    106));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "PSYoungGen      total 2572802K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
+                                                    106));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759500000, 0x0000000800000000, 0x0000000800000000)",
+                                                    106));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759600000, 0x0000000800000000, 0x0000000800000000)",
+                                                    106));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759700000, 0x0000000800000000, 0x0000000800000000)",
+                                                    106));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "PSYoungGen      total 2572803K, used 1759355K [0x0000000759800000, 0x0000000800000000, 0x0000000800000000)",
+                                                    106));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -399,8 +459,9 @@ BOOST_FIXTURE_TEST_CASE(testLongReverseSearch, CTestFixture) {
     LOG_DEBUG(<< "Long message is: " << longMessage);
 
     // Only 1 message so must be category 1
-    int categoryId = categorizer.computeCategory(false, longMessage, longMessage.length());
-    BOOST_REQUIRE_EQUAL(1, categoryId);
+    ml::model::CLocalCategoryId categoryId{
+        categorizer.computeCategory(false, longMessage, longMessage.length())};
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1}, categoryId);
 
     std::string terms;
     std::string regex;
@@ -436,26 +497,36 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenised, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4606.1.p2ps: Info: > Source CUBE_LIQUID on 13188:2010 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML SERVICE2 on 13122:867 has shut down.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX, id of 132, has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4606.1.p2ps: Info: > Source CUBE_LIQUID on 13188:2010 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML SERVICE2 on 13122:867 has shut down.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "<ml13-4602.1.p2ps: Info: > Source MONEYBROKER on 13112:736 has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX, id of 132, has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+                        categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
+                                                    500));
 
     TTokenListDataCategorizerKeepsFields::TStrStrUMap fields;
 
@@ -463,8 +534,9 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenised, CTestFixture) {
     // category 4, so this should get put it category 4
     fields[TTokenListDataCategorizerKeepsFields::PRETOKENISED_TOKEN_FIELD] =
         "ml00-4201.1.p2ps,Info,Service,CUBE_CHIX,has,shut,down";
-    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+                        categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
+                                                    500));
 
     // Here we cheat.  The pre-tokenised tokens exactly match those of the
     // first message, so this should get put in category 1.  But the full
@@ -475,14 +547,16 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenised, CTestFixture) {
     // pre-tokenised tokens and the full message.)
     fields[TTokenListDataCategorizerKeepsFields::PRETOKENISED_TOKEN_FIELD] =
         "ml13-4608.1.p2ps,Info,Source,ML_SERVICE2,on,has,shut,down";
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
+                                                    500));
 
     // Similar principle, but with Chinese, Japanese and Korean tokens, so
     // should go in a new category.
     fields[TTokenListDataCategorizerKeepsFields::PRETOKENISED_TOKEN_FIELD] = "编码,コーディング,코딩";
-    BOOST_REQUIRE_EQUAL(5, categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{5},
+                        categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
+                                                    500));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -500,8 +574,9 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
 
         stopWatch.start();
         for (size_t count = 0; count < TEST_SIZE; ++count) {
-            BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
-                                                               103));
+            BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                                categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
+                                                            103));
         }
         inlineTokenisationTime = stopWatch.stop();
 
@@ -524,8 +599,9 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
 
         stopWatch.start();
         for (size_t count = 0; count < TEST_SIZE; ++count) {
-            BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, fields, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
-                                                               103));
+            BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                                categorizer.computeCategory(false, fields, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
+                                                            103));
         }
         preTokenisationTime = stopWatch.stop();
 
@@ -548,28 +624,40 @@ BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer(
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(2, categorizer.computeCategory(false, "2015-10-18 18:01:52,728 INFO [main] org.mortbay.log: Started HttpServer2$SelectChannelConnectorWithSafeStartup@0.0.0.0:62267\r",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(3, categorizer.computeCategory(false, "2015-10-18 18:01:53,400 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Registered webapp guice modules\r",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(4, categorizer.computeCategory(false, "2015-10-18 18:01:53,447 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerRequestor: nodeBlacklistingEnabled:true\r",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(5, categorizer.computeCategory(false, "2015-10-18 18:01:52,728 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Web app /mapreduce started at 62267\r",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(6, categorizer.computeCategory(false, "2015-10-18 18:01:53,557 INFO [main] org.apache.hadoop.yarn.client.RMProxy: Connecting to ResourceManager at msra-sa-41/10.190.173.170:8030\r",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(7, categorizer.computeCategory(false, "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator: maxContainerCapability: <memory:8192, vCores:32>\r",
-                                                       500));
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.yarn.client.api.impl.ContainerManagementProtocolProxy: yarn.client.max-cached-nodemanagers-proxies : 0\r",
-                                                       500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:52,728 INFO [main] org.mortbay.log: Started HttpServer2$SelectChannelConnectorWithSafeStartup@0.0.0.0:62267\r",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:53,400 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Registered webapp guice modules\r",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:53,447 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerRequestor: nodeBlacklistingEnabled:true\r",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{5},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:52,728 INFO [main] org.apache.hadoop.yarn.webapp.WebApps: Web app /mapreduce started at 62267\r",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{6},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:53,557 INFO [main] org.apache.hadoop.yarn.client.RMProxy: Connecting to ResourceManager at msra-sa-41/10.190.173.170:8030\r",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{7},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator: maxContainerCapability: <memory:8192, vCores:32>\r",
+                                                    500));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "2015-10-18 18:01:53,713 INFO [main] org.apache.hadoop.yarn.client.api.impl.ContainerManagementProtocolProxy: yarn.client.max-cached-nodemanagers-proxies : 0\r",
+                                                    500));
 
-    BOOST_REQUIRE_EQUAL(2, categorizer.numMatches(1));
+    BOOST_REQUIRE_EQUAL(2, categorizer.numMatches(ml::model::CLocalCategoryId{1}));
 
-    using TIntVec = std::vector<int>;
-    TIntVec expected{2, 3, 4, 5, 6, 7};
-    TIntVec actual{categorizer.usurpedCategories(1)};
+    using TLocalCategoryIdVec = std::vector<ml::model::CLocalCategoryId>;
+    TLocalCategoryIdVec expected{
+        ml::model::CLocalCategoryId{2}, ml::model::CLocalCategoryId{3},
+        ml::model::CLocalCategoryId{4}, ml::model::CLocalCategoryId{5},
+        ml::model::CLocalCategoryId{6}, ml::model::CLocalCategoryId{7}};
+    TLocalCategoryIdVec actual{
+        categorizer.usurpedCategories(ml::model::CLocalCategoryId{1})};
 
     BOOST_REQUIRE_EQUAL(ml::core::CContainerPrinter::print(expected),
                         ml::core::CContainerPrinter::print(actual));
@@ -583,40 +671,52 @@ BOOST_FIXTURE_TEST_CASE(testSoftMemoryLimit, CTestFixture) {
 
     std::string baseMessage{"foo bar baz "};
     std::string message{baseMessage + makeUniqueToken()};
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
-    BOOST_REQUIRE(categorizer.addExample(1, message));
-    BOOST_REQUIRE_EQUAL(1, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(ml::model::CLocalCategoryId{1}, message));
+    BOOST_REQUIRE_EQUAL(1, categorizer.examplesCollector().numberOfExamplesForCategory(
+                               ml::model::CLocalCategoryId{1}));
     message = baseMessage + makeUniqueToken();
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
-    BOOST_REQUIRE(categorizer.addExample(1, message));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(ml::model::CLocalCategoryId{1}, message));
     // Since the messages are different, there should be two examples for the category now
-    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(
+                               ml::model::CLocalCategoryId{1}));
 
     // Create a soft memory limit
     m_Limits.resourceMonitor().startPruning();
 
     message = baseMessage + makeUniqueToken();
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
-    BOOST_REQUIRE(categorizer.addExample(1, message) == false);
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(ml::model::CLocalCategoryId{1}, message) == false);
     // In soft limit we should stop accumulating examples, hence 2 instead of 3
-    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(
+                               ml::model::CLocalCategoryId{1}));
     message = baseMessage + makeUniqueToken();
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
-    BOOST_REQUIRE(categorizer.addExample(1, message) == false);
-    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(ml::model::CLocalCategoryId{1}, message) == false);
+    BOOST_REQUIRE_EQUAL(2, categorizer.examplesCollector().numberOfExamplesForCategory(
+                               ml::model::CLocalCategoryId{1}));
 
     // Clear the soft memory limit
     m_Limits.resourceMonitor().endPruning();
 
     message = baseMessage + makeUniqueToken();
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
-    BOOST_REQUIRE(categorizer.addExample(1, message));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(ml::model::CLocalCategoryId{1}, message));
     // Out of soft limit we have started accumulating examples again
-    BOOST_REQUIRE_EQUAL(3, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    BOOST_REQUIRE_EQUAL(3, categorizer.examplesCollector().numberOfExamplesForCategory(
+                               ml::model::CLocalCategoryId{1}));
     message = baseMessage + makeUniqueToken();
-    BOOST_REQUIRE_EQUAL(1, categorizer.computeCategory(false, message, message.length()));
-    BOOST_REQUIRE(categorizer.addExample(1, message));
-    BOOST_REQUIRE_EQUAL(4, categorizer.examplesCollector().numberOfExamplesForCategory(1));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, message, message.length()));
+    BOOST_REQUIRE(categorizer.addExample(ml::model::CLocalCategoryId{1}, message));
+    BOOST_REQUIRE_EQUAL(4, categorizer.examplesCollector().numberOfExamplesForCategory(
+                               ml::model::CLocalCategoryId{1}));
 }
 
 BOOST_FIXTURE_TEST_CASE(testHardMemoryLimit, CTestFixture) {
@@ -628,19 +728,18 @@ BOOST_FIXTURE_TEST_CASE(testHardMemoryLimit, CTestFixture) {
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
 
     std::string nextMessage{makeUniqueMessage(10)};
-    int categoryId{0};
+    ml::model::CLocalCategoryId categoryId;
     for (int nextExpectedCategoryId = 1; nextExpectedCategoryId < 100000;
          ++nextExpectedCategoryId, nextMessage = makeUniqueMessage(10)) {
         categoryId = categorizer.computeCategory(false, nextMessage, nextMessage.length());
-        if (categoryId == ml::model::CDataCategorizer::HARD_CATEGORIZATION_FAILURE_ERROR) {
+        if (categoryId.isHardFailure()) {
             LOG_INFO(<< "Hit hard limit after " << nextExpectedCategoryId << " messages");
             break;
         }
-        BOOST_REQUIRE_EQUAL(nextExpectedCategoryId, categoryId);
+        BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{nextExpectedCategoryId}, categoryId);
         m_Limits.resourceMonitor().refresh(categorizer);
     }
-    BOOST_REQUIRE_EQUAL(ml::model::CDataCategorizer::HARD_CATEGORIZATION_FAILURE_ERROR,
-                        categoryId);
+    BOOST_TEST_REQUIRE(categoryId.isHardFailure());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/model/unittest/CTokenListReverseSearchCreatorTest.cc
+++ b/lib/model/unittest/CTokenListReverseSearchCreatorTest.cc
@@ -24,8 +24,8 @@ BOOST_AUTO_TEST_CASE(testCreateNoUniqueTokenSearch) {
     std::string terms;
     std::string regex;
 
-    BOOST_TEST_REQUIRE(
-        reverseSearchCreator.createNoUniqueTokenSearch(1, "404", 4, terms, regex));
+    BOOST_TEST_REQUIRE(reverseSearchCreator.createNoUniqueTokenSearch(
+        CLocalCategoryId{1}, "404", 4, terms, regex));
 
     BOOST_REQUIRE_EQUAL(std::string(), terms);
     BOOST_REQUIRE_EQUAL(std::string(".*"), regex);
@@ -37,8 +37,8 @@ BOOST_AUTO_TEST_CASE(testInitStandardSearch) {
     std::string terms;
     std::string regex;
 
-    reverseSearchCreator.initStandardSearch(1, "User 'foo' logged in host '0.0.0.0'",
-                                            1, terms, regex);
+    reverseSearchCreator.initStandardSearch(
+        CLocalCategoryId{1}, "User 'foo' logged in host '0.0.0.0'", 1, terms, regex);
 
     BOOST_REQUIRE_EQUAL(std::string(), terms);
     BOOST_REQUIRE_EQUAL(std::string(), regex);

--- a/lib/model/unittest/Makefile
+++ b/lib/model/unittest/Makefile
@@ -40,6 +40,7 @@ SRCS=\
 	CHierarchicalResultsLevelSetTest.cc \
 	CInterimBucketCorrectorTest.cc \
 	CLimitsTest.cc \
+	CLocalCategoryIdTest.cc \
 	CMemoryUsageEstimatorTest.cc \
 	CMetricAnomalyDetectorTest.cc \
 	CMetricDataGathererTest.cc \


### PR DESCRIPTION
This change adds the option to do categorization separately
for every value of a partition field.

When per-partition categorization is enabled, multiple low
level categorizers are created, one per value of the partition
field, such that each works entirely independently.

When per-partition categorization is not enabled (which will
be the case for every job created prior to 7.9) categorization
works in exactly the way it used to.

In both cases category IDs (referred to as the "mlcategory"
field) in anomalies are unique across the job.

Backport of #1293