### PR TITLE
[7.x][ML] Memory limit circuit breaker

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,6 +43,8 @@
 * Parallelize the feature importance calculation for classification and regression
   over trees. (See {ml-pull}1277[#1277].)
 * Memory usage is reported during job initialization. (See {ml-pull}1294[#1294].)
+* More realistic memory estimation for classification and regression means that these
+  analyses will require lower memory limits than before (See {ml-pull}1298[#1298].)
 * Checkpoint state to allow efficient failover during coarse parameter search
   for classification and regression. (See {ml-pull}1300[#1300].)
 

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -57,7 +57,7 @@ public:
 
 public:
     //! Constructs an instrumentation object an analytics job with a given \p jobId.
-    explicit CDataFrameAnalysisInstrumentation(const std::string& jobId);
+    CDataFrameAnalysisInstrumentation(const std::string& jobId, std::size_t memoryLimit);
 
     //! Adds \p delta to the memory usage statistics.
     void updateMemoryUsage(std::int64_t delta) override;
@@ -103,8 +103,8 @@ public:
     //! Start polling and writing progress updates.
     //!
     //! \note This doesn't return until instrumentation.setToFinished() is called.
-    static void monitorProgress(const CDataFrameAnalysisInstrumentation& instrumentation,
-                                core::CRapidJsonConcurrentLineWriter& writer);
+    static void monitor(const CDataFrameAnalysisInstrumentation& instrumentation,
+                        core::CRapidJsonConcurrentLineWriter& writer);
 
 protected:
     using TWriter = core::CRapidJsonConcurrentLineWriter;
@@ -130,6 +130,7 @@ private:
 private:
     std::string m_JobId;
     std::string m_ProgressMonitoredTask;
+    std::int64_t m_MemoryLimit;
     std::atomic_bool m_Finished;
     std::atomic_size_t m_FractionalProgress;
     std::atomic<std::int64_t> m_Memory;
@@ -142,8 +143,8 @@ class API_EXPORT CDataFrameOutliersInstrumentation final
     : public CDataFrameAnalysisInstrumentation,
       public maths::CDataFrameOutliersInstrumentationInterface {
 public:
-    explicit CDataFrameOutliersInstrumentation(const std::string& jobId)
-        : CDataFrameAnalysisInstrumentation(jobId) {}
+    CDataFrameOutliersInstrumentation(const std::string& jobId, std::size_t memoryLimit)
+        : CDataFrameAnalysisInstrumentation(jobId, memoryLimit) {}
     void parameters(const maths::COutliers::SComputeParameters& parameters) override;
     void elapsedTime(std::uint64_t time) override;
     void featureInfluenceThreshold(double featureInfluenceThreshold) override;
@@ -172,7 +173,8 @@ class API_EXPORT CDataFrameTrainBoostedTreeInstrumentation final
     : public CDataFrameAnalysisInstrumentation,
       public maths::CDataFrameTrainBoostedTreeInstrumentationInterface {
 public:
-    explicit CDataFrameTrainBoostedTreeInstrumentation(const std::string& jobId);
+    CDataFrameTrainBoostedTreeInstrumentation(const std::string& jobId, std::size_t memoryLimit)
+        : CDataFrameAnalysisInstrumentation(jobId, memoryLimit) {}
 
     //! Supervised learning job \p type, can be E_Regression or E_Classification.
     void type(EStatsType type) override;

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -162,7 +162,8 @@ public:
             treeFactory.featureBagFraction(featureBagFraction);
         }
 
-        ml::api::CDataFrameTrainBoostedTreeInstrumentation instrumentation("testJob");
+        const std::int64_t memoryLimit{1024 * 1024 * 1024}; // 1gb default value
+        ml::api::CDataFrameTrainBoostedTreeInstrumentation instrumentation("testJob", memoryLimit);
         treeFactory.analysisInstrumentation(instrumentation);
 
         auto tree = treeFactory.buildFor(*frame, weights.size());

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -139,7 +139,7 @@ void CDataFrameAnalyzer::run() {
 
         core::CRapidJsonConcurrentLineWriter outputWriter{*outStream};
 
-        CDataFrameAnalysisInstrumentation::monitorProgress(instrumentation, outputWriter);
+        CDataFrameAnalysisInstrumentation::monitor(instrumentation, outputWriter);
 
         analysisRunner->waitToFinish();
         this->writeResultsOf(*analysisRunner, outputWriter);

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -72,7 +72,7 @@ CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpeci
 CDataFrameOutliersRunner::CDataFrameOutliersRunner(const CDataFrameAnalysisSpecification& spec)
     : CDataFrameAnalysisRunner{spec}, m_Method{static_cast<std::size_t>(
                                           maths::COutliers::E_Ensemble)},
-      m_Instrumentation{spec.jobId()} {
+      m_Instrumentation{spec.jobId(), spec.memoryLimit()} {
 }
 
 std::size_t CDataFrameOutliersRunner::numberExtraColumns() const {

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -72,7 +72,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     const CDataFrameAnalysisSpecification& spec,
     const CDataFrameAnalysisParameters& parameters,
     TLossFunctionUPtr loss)
-    : CDataFrameAnalysisRunner{spec}, m_Instrumentation{spec.jobId()} {
+    : CDataFrameAnalysisRunner{spec}, m_Instrumentation{spec.jobId(), spec.memoryLimit()} {
 
     m_DependentVariableFieldName = parameters[DEPENDENT_VARIABLE_NAME].as<std::string>();
 

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -101,6 +101,7 @@ void addOutlierTestData(TStrVec fieldNames,
 
 BOOST_AUTO_TEST_CASE(testMemoryState) {
     std::string jobId{"testJob"};
+    std::int64_t memoryLimit{1024 * 1024 * 1024}; //1gb default value
     std::int64_t memoryUsage{1000};
     std::int64_t timeBefore{std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::system_clock::now().time_since_epoch())
@@ -108,7 +109,8 @@ BOOST_AUTO_TEST_CASE(testMemoryState) {
     std::stringstream outputStream;
     {
         core::CJsonOutputStreamWrapper streamWrapper(outputStream);
-        api::CDataFrameTrainBoostedTreeInstrumentation instrumentation{jobId};
+        api::CDataFrameTrainBoostedTreeInstrumentation instrumentation{
+            jobId, static_cast<std::size_t>(memoryLimit)};
         api::CDataFrameTrainBoostedTreeInstrumentation::CScopeSetOutputStream setStream{
             instrumentation, streamWrapper};
         instrumentation.updateMemoryUsage(memoryUsage);

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -365,6 +365,44 @@ BOOST_AUTO_TEST_CASE(testMissingString) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testMemoryLimitHandling) {
+    TStrVec errors;
+    auto errorHandler = [&errors](std::string error) { errors.push_back(error); };
+    core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
+
+    // Test the results the analyzer produces match running the regression directly.
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    TDoubleVec expectedPredictions;
+
+    TStrVec fieldNames{"f1", "f2", "f3", "f4", "target", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    api::CDataFrameAnalyzer analyzer{
+        test::CDataFrameAnalysisSpecificationFactory{}.memoryLimit(1000).predictionSpec(
+            test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
+        outputWriterFactory};
+    test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
+        TLossFunctionType::E_MseRegression, fieldNames, fieldValues, analyzer,
+        expectedPredictions);
+
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+    BOOST_TEST_REQUIRE(errors.size() > 0);
+    bool memoryLimitExceed{false};
+    for (const auto& error : errors) {
+        if (error.find("Input error: required memory") != std::string::npos) {
+            memoryLimitExceed = true;
+            break;
+        }
+    }
+    BOOST_TEST_REQUIRE(memoryLimitExceed);
+}
+
 BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
 
     // Test the results the analyzer produces match running the regression directly.
@@ -425,9 +463,6 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1800000);
-    BOOST_TEST_REQUIRE(
-        core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
-        core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -620,9 +655,6 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1800000);
-    BOOST_TEST_REQUIRE(
-        core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) <
-        core::CProgramCounters::counter(counter_t::E_DFTPMEstimatedPeakMemoryUsage));
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.h
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.h
@@ -21,7 +21,7 @@
 class CDataFrameMockAnalysisState final : public ml::api::CDataFrameAnalysisInstrumentation {
 public:
     CDataFrameMockAnalysisState(const std::string& jobId)
-        : ml::api::CDataFrameAnalysisInstrumentation(jobId) {}
+        : ml::api::CDataFrameAnalysisInstrumentation(jobId, 0ul) {}
     void writeAnalysisStats(std::int64_t /* timestamp */) override {}
 
 protected:

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1306,7 +1306,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {
         BOOST_TEST_REQUIRE(instrumentation.maxMemoryUsage() < estimatedMemory);
     }
 }
-
+// TODO: test for handle fatal (memory-limit-circuit-breaker)
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrainWithTestRows) {
 
     // Test estimation of the memory used training a model.


### PR DESCRIPTION
This PR introduces a less restrictive memory estimation. Instead of returning the possible worst case number, which often overestimates the actual memory usage by the factor of 20, we establish a scaling multiplier which goes from 1 of the worst case for smaller jobs (<100mb) to 1/16th for larger jobs (>1000mb).

Since now we can potentially hit the memory limit at the runtime, the used memory is now monitored and if the memory limit is exceeded, we generate a HANDLE_FATAL with a meaningful message.

Backport of #1298