### PR TITLE
[ML] Improve data access pattern computing best splits for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -58,6 +58,8 @@
   analyses will require lower memory limits than before (See {ml-pull}1298[#1298].)
 * Checkpoint state to allow efficient failover during coarse parameter search
   for classification and regression. (See {ml-pull}1300[#1300].)
+* Improve data access patterns to speed up classification and regression.
+  (See {ml-pull}1312[#1312].) 
 
 === Bug Fixes
 

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -251,7 +251,10 @@ private:
     std::size_t featureBagSize() const;
 
     //! Sample the features according to their categorical distribution.
-    TSizeVec featureBag() const;
+    void featureBag(TSizeVec& features) const;
+
+    //! Get a column mask of the suitable regressor features.
+    void candidateRegressorFeatures(TSizeVec& features) const;
 
     //! Refresh the predictions and loss function derivatives for the masked
     //! rows in \p frame with predictions of \p tree.
@@ -264,9 +267,6 @@ private:
 
     //! Compute the mean of the loss function on the masked rows of \p frame.
     double meanLoss(const core::CDataFrame& frame, const core::CPackedBitVector& rowMask) const;
-
-    //! Get a column mask of the suitable regressor features.
-    TSizeVec candidateRegressorFeatures() const;
 
     //! Get the root node of \p tree.
     static const CBoostedTreeNode& root(const TNodeVec& tree);

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -251,10 +251,10 @@ private:
     std::size_t featureBagSize() const;
 
     //! Sample the features according to their categorical distribution.
-    void featureBag(TSizeVec& features) const;
+    void featureBag(TDoubleVec& probabilities, TSizeVec& features) const;
 
     //! Get a column mask of the suitable regressor features.
-    void candidateRegressorFeatures(TSizeVec& features) const;
+    void candidateRegressorFeatures(const TDoubleVec& probabilities, TSizeVec& features) const;
 
     //! Refresh the predictions and loss function derivatives for the masked
     //! rows in \p frame with predictions of \p tree.

--- a/lib/maths/CSampling.cc
+++ b/lib/maths/CSampling.cc
@@ -200,7 +200,7 @@ void doCategoricalSampleWithoutReplacement(RNG& rng,
     }
 
     // Construct the transform function.
-    for (std::size_t i = 1; i < probabilities.size(); ++i) {
+    for (std::size_t i = 1; i < m; ++i) {
         probabilities[i] += probabilities[i - 1];
     }
 
@@ -226,9 +226,8 @@ void doCategoricalSampleWithoutReplacement(RNG& rng,
         }
     }
 
-    // The sampled values are at the end of the vector so copy into place.
-    std::copy(result.begin() + m, result.end(), result.begin());
-    result.resize(n);
+    // The sampled values are at the end of the vector.
+    result.erase(result.begin(), result.begin() + m);
 }
 
 //! Implementation of multivariate normal sampling.

--- a/lib/maths/CSampling.cc
+++ b/lib/maths/CSampling.cc
@@ -153,25 +153,25 @@ void doCategoricalSampleWithReplacement(RNG& rng,
         return;
     }
 
-    std::size_t p = probabilities.size();
+    std::size_t m{probabilities.size()};
 
     // Construct the transform function.
-    for (std::size_t i = 1u; i < p; ++i) {
+    for (std::size_t i = 1; i < m; ++i) {
         probabilities[i] += probabilities[i - 1];
     }
 
-    if (probabilities[p - 1] == 0.0) {
-        doUniformSample(rng, std::size_t(0), p, n, result);
+    if (probabilities[m - 1] == 0.0) {
+        doUniformSample(rng, std::size_t(0), m, n, result);
     } else {
         result.reserve(n);
-        boost::random::uniform_real_distribution<> uniform(0.0, probabilities[p - 1]);
+        boost::random::uniform_real_distribution<> uniform(0.0, probabilities[m - 1]);
         for (std::size_t i = 0u; i < n; ++i) {
-            double uniform0X = uniform(rng);
+            double u0X{uniform(rng)};
             result.push_back(std::min(
                 static_cast<std::size_t>(std::lower_bound(probabilities.begin(),
-                                                          probabilities.end(), uniform0X) -
+                                                          probabilities.end(), u0X) -
                                          probabilities.begin()),
-                probabilities.size() - 1));
+                m - 1));
         }
     }
 }
@@ -191,45 +191,44 @@ void doCategoricalSampleWithoutReplacement(RNG& rng,
         return;
     }
 
-    std::size_t p = probabilities.size();
-    if (n >= p) {
-        result.assign(boost::counting_iterator<std::size_t>(0),
-                      boost::counting_iterator<std::size_t>(p));
+    std::size_t m{probabilities.size()};
+    result.assign(boost::counting_iterator<std::size_t>(0),
+                  boost::counting_iterator<std::size_t>(m));
+
+    if (n >= m) {
+        return;
     }
 
     // Construct the transform function.
-    for (std::size_t i = 1u; i < p; ++i) {
+    for (std::size_t i = 1; i < probabilities.size(); ++i) {
         probabilities[i] += probabilities[i - 1];
     }
 
-    result.reserve(n);
-    TSizeVec indices(boost::counting_iterator<std::size_t>(0),
-                     boost::counting_iterator<std::size_t>(p));
-    TSizeVec s(1);
-
-    for (std::size_t i = 0u; i < n; ++i, --p) {
-        if (probabilities[p - 1] <= 0.0) {
-            doUniformSample(rng, std::size_t(0), indices.size(), 1, s);
-            result.push_back(indices[s[0]]);
+    for (std::size_t i = 0; i < n; ++i, --m) {
+        std::size_t s{0};
+        double x{probabilities[m - 1]};
+        if (x <= 0.0) {
+            s = doUniformSample(rng, std::size_t{0}, m);
         } else {
-            boost::random::uniform_real_distribution<> uniform(0.0, probabilities[p - 1]);
-            double uniform0X = uniform(rng);
-            s[0] = std::min(static_cast<std::size_t>(
-                                std::lower_bound(probabilities.begin(),
-                                                 probabilities.end(), uniform0X) -
-                                probabilities.begin()),
-                            probabilities.size() - 1);
-
-            result.push_back(indices[s[0]]);
-
-            double ps = probabilities[s[0]] - (s[0] == 0 ? 0.0 : probabilities[s[0] - 1]);
-            for (std::size_t j = s[0] + 1; j < p; ++j) {
-                probabilities[j - 1] = probabilities[j] - ps;
-            }
-            probabilities.pop_back();
+            boost::random::uniform_real_distribution<> uniform{0.0, x};
+            double u0X{uniform(rng)};
+            s = std::min(static_cast<std::size_t>(
+                             std::lower_bound(probabilities.begin(),
+                                              probabilities.begin() + m, u0X) -
+                             probabilities.begin()),
+                         m - 1);
         }
-        indices.erase(indices.begin() + s[0]);
+
+        double ps{probabilities[s] - (s == 0 ? 0.0 : probabilities[s - 1])};
+        for (std::size_t j = s + 1; j < m; ++j) {
+            probabilities[j - 1] = probabilities[j] - ps;
+            std::swap(result[j - 1], result[j]);
+        }
     }
+
+    // The sampled values are at the end of the vector so copy into place.
+    std::copy(result.begin() + m, result.end(), result.begin());
+    result.resize(n);
 }
 
 //! Implementation of multivariate normal sampling.

--- a/lib/maths/unittest/CSamplingTest.cc
+++ b/lib/maths/unittest/CSamplingTest.cc
@@ -8,11 +8,15 @@
 #include <core/CLogger.h>
 
 #include <maths/CBasicStatistics.h>
+#include <maths/CBasicStatisticsCovariances.h>
+#include <maths/CLinearAlgebra.h>
 #include <maths/CLinearAlgebraEigen.h>
+#include <maths/CLinearAlgebraPersist.h>
 #include <maths/CPRNG.h>
 #include <maths/CSampling.h>
 #include <maths/CStatisticalTests.h>
 
+#include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
 
 #include <boost/test/unit_test.hpp>
@@ -118,36 +122,112 @@ double frobenius(const TDoubleVecVec& m) {
 }
 }
 
-BOOST_AUTO_TEST_CASE(testMultinomialSample) {
-    using TSizeVecDoubleMap = std::map<TSizeVec, double>;
-    using TSizeVecDoubleMapCItr = TSizeVecDoubleMap::const_iterator;
+BOOST_AUTO_TEST_CASE(testCategoricalSampleWithoutReplacement) {
+
+    using TVector = maths::CVectorNx1<double, 6>;
+    using TMatrix = maths::CSymmetricMatrixNxN<double, 6>;
 
     maths::CSampling::seed();
 
-    double probabilities_[] = {0.4, 0.25, 0.2, 0.15};
+    // Edge cases:
+    //   1. All values
+    //   2. No values
+    //   3. All zero probabilities
+
+    TSizeVec samples;
+    TDoubleVec probabilities{0.2, 0.2, 0.2, 0.2, 0.2};
+
+    maths::CSampling::categoricalSampleWithoutReplacement(probabilities, 6, samples);
+    BOOST_REQUIRE_EQUAL("[0, 1, 2, 3, 4]", core::CContainerPrinter::print(samples));
+
+    maths::CSampling::categoricalSampleWithoutReplacement(probabilities, 0, samples);
+    BOOST_TEST_REQUIRE(samples.empty());
+
+    {
+        TDoubleVec counts(5, 0);
+        for (std::size_t i = 0; i < 500; ++i) {
+            std::fill_n(probabilities.begin(), 5, 0.0);
+            maths::CSampling::categoricalSampleWithoutReplacement(probabilities, 2, samples);
+            for (auto j : samples) {
+                BOOST_TEST_REQUIRE(j < counts.size());
+                counts[j] += 1.0;
+            }
+        }
+        LOG_DEBUG(<< "counts = " << core::CContainerPrinter::print(counts));
+
+        // We should get a random sample.
+        for (auto count : counts) {
+            BOOST_REQUIRE_CLOSE_ABSOLUTE(200.0, count, 20.0);
+        }
+    }
+
+    // For n draws without replacement the distribution of the counts is multivariate
+    // hypergeometric. We test that the mean and variance converge to their expected
+    // values.
+    TSizeVec colours{0, 1, 0, 3, 0, 2, 4, 5, 3, 2, 3};
+    auto accumulator = maths::CBasicStatistics::covariancesAccumulator(
+        TVector{0}, TVector{0}, TMatrix{0});
+    for (std::size_t i = 0; i < 500; ++i) {
+        TVector counts{0.0};
+        for (std::size_t j = 0; j < 100; ++j) {
+            probabilities.assign(11, 1.0);
+            maths::CSampling::categoricalSampleWithoutReplacement(probabilities, 4, samples);
+            for (auto k : samples) {
+                BOOST_TEST_REQUIRE(k < probabilities.size());
+                counts(colours[k]) += 1.0;
+            }
+        }
+        accumulator.add(counts);
+    }
+
+    TDoubleVec k{3.0, 1.0, 2.0, 3.0, 1.0, 1.0};
+    for (std::size_t i = 0; i < k.size(); ++i) {
+        LOG_DEBUG(<< "mean expected = " << 100.0 * 4.0 * k[i] / 11.0);
+        LOG_DEBUG(<< "mean actual   = " << maths::CBasicStatistics::mean(accumulator)(i));
+        BOOST_REQUIRE_CLOSE(100.0 * 4.0 * k[i] / 11.0,
+                            maths::CBasicStatistics::mean(accumulator)(i), 2.0 /*%*/);
+    }
+    for (std::size_t i = 0; i < k.size(); ++i) {
+        LOG_DEBUG(<< "variance expected = "
+                  << 100.0 * 4.0 * (11.0 - 4.0) / (11.0 - 1.0) * k[i] / 11.0 *
+                         (1.0 - k[i] / 11.0));
+        LOG_DEBUG(<< "variance actual   = "
+                  << maths::CBasicStatistics::covariances(accumulator)(i, i));
+        BOOST_REQUIRE_CLOSE(
+            100.0 * 4.0 * (11.0 - 4.0) / (11.0 - 1.0) * k[i] / 11.0 * (1.0 - k[i] / 11.0),
+            maths::CBasicStatistics::covariances(accumulator)(i, i), 15.0 /*%*/);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testMultinomialSample) {
+    using TSizeVecDoubleMap = std::map<TSizeVec, double>;
+
+    maths::CSampling::seed();
+
+    double probabilities_[]{0.4, 0.25, 0.2, 0.15};
 
     TDoubleVec probabilities(std::begin(probabilities_), std::end(probabilities_));
 
     TSizeVecDoubleMap empiricalProbabilities;
 
-    std::size_t n = 1000000u;
+    std::size_t n{1000000};
 
     TSizeVec sample;
-    for (std::size_t i = 0u; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
         maths::CSampling::multinomialSampleFast(probabilities, 20, sample);
         empiricalProbabilities[sample] += 1.0 / static_cast<double>(n);
     }
 
     double error = 0.0;
     double pTotal = 0.0;
-    for (TSizeVecDoubleMapCItr pItr = empiricalProbabilities.begin();
-         pItr != empiricalProbabilities.end(); ++pItr) {
-        LOG_DEBUG(<< "counts = " << core::CContainerPrinter::print(pItr->first));
-        BOOST_REQUIRE_EQUAL(size_t(20), std::accumulate(pItr->first.begin(),
-                                                        pItr->first.end(), size_t(0)));
+    for (const auto& p_ : empiricalProbabilities) {
+        LOG_DEBUG(<< "counts = " << core::CContainerPrinter::print(p_.first));
+        BOOST_REQUIRE_EQUAL(
+            std::size_t(20),
+            std::accumulate(p_.first.begin(), p_.first.end(), std::size_t(0)));
 
-        double p = multinomialProbability(probabilities, pItr->first);
-        double pe = pItr->second;
+        double p{multinomialProbability(probabilities, p_.first)};
+        double pe{p_.second};
         LOG_DEBUG(<< "p  = " << p << ", pe = " << pe);
         BOOST_TEST_REQUIRE(std::fabs(pe - p) < std::max(0.27 * p, 3e-5));
         error += std::fabs(pe - p);
@@ -164,41 +244,36 @@ BOOST_AUTO_TEST_CASE(testMultivariateNormalSample) {
     maths::CSampling::seed();
 
     {
-        double m[] = {1.0, 3.0, 5.0};
-        TDoubleVec m_(std::begin(m), std::end(m));
-        double C[][3] = {{3.0, 1.0, 0.1}, {1.0, 2.0, -0.3}, {0.1, -0.3, 1.0}};
-        TDoubleVecVec C_;
-        C_.push_back(TDoubleVec(std::begin(C[0]), std::end(C[0])));
-        C_.push_back(TDoubleVec(std::begin(C[1]), std::end(C[1])));
-        C_.push_back(TDoubleVec(std::begin(C[2]), std::end(C[2])));
+        TDoubleVec m{1.0, 3.0, 5.0};
+        TDoubleVecVec C{{3.0, 1.0, 0.1}, {1.0, 2.0, -0.3}, {0.1, -0.3, 1.0}};
 
         TDoubleVecVec samples;
-        maths::CSampling::multivariateNormalSample(m_, C_, 1000, samples);
+        maths::CSampling::multivariateNormalSample(m, C, 1000, samples);
 
         TMeanAccumulator mean[3];
-        for (std::size_t i = 0u; i < samples.size(); ++i) {
+        for (std::size_t i = 0; i < samples.size(); ++i) {
             mean[0].add(samples[i][0]);
             mean[1].add(samples[i][1]);
             mean[2].add(samples[i][2]);
         }
 
         TDoubleVec mean_;
-        for (std::size_t i = 0u; i < 3; ++i) {
+        for (std::size_t i = 0; i < 3; ++i) {
             mean_.push_back(maths::CBasicStatistics::mean(mean[i]));
         }
-        LOG_DEBUG(<< "actual mean = " << core::CContainerPrinter::print(m_));
+        LOG_DEBUG(<< "actual mean = " << core::CContainerPrinter::print(m));
         LOG_DEBUG(<< "sample mean = " << core::CContainerPrinter::print(mean_));
         {
-            TDoubleVec error = test_detail::minus(mean_, m_);
+            TDoubleVec error{test_detail::minus(mean_, m)};
             LOG_DEBUG(<< "||error|| = " << test_detail::euclidean(error));
-            LOG_DEBUG(<< "||m|| = " << test_detail::euclidean(m_));
+            LOG_DEBUG(<< "||m|| = " << test_detail::euclidean(m));
             BOOST_TEST_REQUIRE(test_detail::euclidean(error) <
-                               0.02 * test_detail::euclidean(m_));
+                               0.02 * test_detail::euclidean(m));
         }
 
         // Get the sample covariance matrix.
         TDoubleVecVec covariance(3, TDoubleVec(3, 0.0));
-        for (std::size_t i = 0u; i < samples.size(); ++i) {
+        for (std::size_t i = 0; i < samples.size(); ++i) {
             test_detail::add(test_detail::outer(test_detail::minus(samples[i], mean_),
                                                 test_detail::minus(samples[i], mean_)),
                              covariance);
@@ -207,14 +282,11 @@ BOOST_AUTO_TEST_CASE(testMultivariateNormalSample) {
         LOG_DEBUG(<< "actual covariance = " << core::CContainerPrinter::print(covariance));
         LOG_DEBUG(<< "sample covariance = " << core::CContainerPrinter::print(covariance));
         {
-            // The cast of the minus() function is necessary to avoid overload
-            // ambiguity with std::minus (found via ADL if <functional> is
-            // indirectly included)
-            TDoubleVecVec error = test_detail::minus(covariance, C_);
+            TDoubleVecVec error{test_detail::minus(covariance, C)};
             LOG_DEBUG(<< "||error|| = " << test_detail::frobenius(error));
-            LOG_DEBUG(<< "||C|| = " << test_detail::frobenius(C_));
+            LOG_DEBUG(<< "||C|| = " << test_detail::frobenius(C));
             BOOST_TEST_REQUIRE(test_detail::frobenius(error) <
-                               0.1 * test_detail::frobenius(C_));
+                               0.1 * test_detail::frobenius(C));
         }
     }
 }


### PR DESCRIPTION
The feature derivatives for boosted tree splits are laid out in increasing feature index order, but when we sample a feature bag we don't ensure it is sorted. This means we are getting random access rather than linear scan over the derivatives when computing the best split. This switches to sorting the feature bag after sampling and rejigs the function signatures to avoid allocating a vector for every node.