### PR TITLE
[ML] Threading speedups for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -59,7 +59,9 @@
 * Checkpoint state to allow efficient failover during coarse parameter search
   for classification and regression. (See {ml-pull}1300[#1300].)
 * Improve data access patterns to speed up classification and regression.
-  (See {ml-pull}1312[#1312].) 
+  (See {ml-pull}1312[#1312].)
+* Performance improvements for classification and regression, particularly running
+  multithreaded. (See {ml-pull}1317[#1317].)
 
 === Bug Fixes
 

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -345,6 +345,17 @@ public:
         return this->readRows(numberThreads, 0, this->numberRows(), std::move(reader));
     }
 
+    //! Overload taking a collection of functions to run, using one thread to
+    //! run each function.
+    //!
+    //! \note This is intented for stateful readers whose state is large and
+    //! provides a mechanism for reading multi-threaded without having to copy
+    //! that state.
+    bool readRows(std::size_t beginRows,
+                  std::size_t endRows,
+                  TRowFuncVec& readers,
+                  const CPackedBitVector* rowMask) const;
+
     //! Convenience overload for typed readers.
     //!
     //! The reason for this is to wrap up the code to extract the typed readers
@@ -546,17 +557,16 @@ private:
     using TRowSliceWriterPtr = std::unique_ptr<CDataFrameRowSliceWriter>;
 
 private:
-    TRowFuncVecBoolPr parallelApplyToAllRows(std::size_t numberThreads,
-                                             std::size_t beginRows,
-                                             std::size_t endRows,
-                                             TRowFunc&& func,
-                                             const CPackedBitVector* rowMask,
-                                             bool commitResult) const;
-    TRowFuncVecBoolPr sequentialApplyToAllRows(std::size_t beginRows,
-                                               std::size_t endRows,
-                                               TRowFunc& func,
-                                               const CPackedBitVector* rowMask,
-                                               bool commitResult) const;
+    bool parallelApplyToAllRows(std::size_t beginRows,
+                                std::size_t endRows,
+                                TRowFuncVec& funcs,
+                                const CPackedBitVector* rowMask,
+                                bool commitResult) const;
+    bool sequentialApplyToAllRows(std::size_t beginRows,
+                                  std::size_t endRows,
+                                  TRowFuncVec& func,
+                                  const CPackedBitVector* rowMask,
+                                  bool commitResult) const;
 
     void applyToRowsOfOneSlice(TRowFunc& func,
                                std::size_t firstRowToRead,

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -81,9 +81,7 @@ public:
     CRowRef(std::size_t index, TFloatVecItr beginColumns, TFloatVecItr endColumns, std::int32_t docHash);
 
     //! Get column \p i value.
-    CFloatStorage operator[](std::size_t i) const {
-        return m_BeginColumns[i];
-    }
+    CFloatStorage operator[](std::size_t i) const { return m_BeginColumns[i]; }
 
     //! Get the row's index.
     std::size_t index() const;

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -348,7 +348,7 @@ public:
     //! Overload taking a collection of functions to run, using one thread to
     //! run each function.
     //!
-    //! \note This is intented for stateful readers whose state is large and
+    //! \note This is intended for stateful readers whose state is large and
     //! provides a mechanism for reading multi-threaded without having to copy
     //! that state.
     bool readRows(std::size_t beginRows,

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -81,7 +81,9 @@ public:
     CRowRef(std::size_t index, TFloatVecItr beginColumns, TFloatVecItr endColumns, std::int32_t docHash);
 
     //! Get column \p i value.
-    CFloatStorage operator[](std::size_t i) const;
+    CFloatStorage operator[](std::size_t i) const {
+        return m_BeginColumns[i];
+    }
 
     //! Get the row's index.
     std::size_t index() const;

--- a/include/core/CImmutableRadixSet.h
+++ b/include/core/CImmutableRadixSet.h
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <limits>
 #include <numeric>
+#include <string>
+#include <type_traits>
 #include <vector>
 
 namespace ml {
@@ -66,8 +68,8 @@ public:
 
     //! \name Lookup
     //@{
-    const T& operator[](std::size_t i) const { return m_Values[i]; }
-    std::ptrdiff_t upperBound(const T& value) const {
+    T operator[](std::size_t i) const { return m_Values[i]; }
+    std::ptrdiff_t upperBound(T value) const {
         // This branch is predictable so essentially free.
         if (m_Values.size() < 2) {
             return std::distance(m_Values.begin(),
@@ -81,11 +83,9 @@ public:
         if (bucket >= static_cast<std::ptrdiff_t>(m_Buckets.size())) {
             return static_cast<std::ptrdiff_t>(m_Values.size());
         }
-        TCItr beginBucket;
-        TCItr endBucket;
-        std::tie(beginBucket, endBucket) = m_Buckets[bucket];
+        TCItrCItrPr bucket_{m_Buckets[bucket]};
         return std::distance(m_Values.begin(),
-                             std::upper_bound(beginBucket, endBucket, value));
+                             std::upper_bound(bucket_.first, bucket_.second, value));
     }
     //@}
 

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -132,6 +132,9 @@ public:
 
     //! \name Container Semantics
     //@{
+    //! Reset to zero length vector.
+    void clear();
+
     //! Wraps dimension.
     std::size_t size() const { return this->dimension(); }
 

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -341,7 +341,7 @@ bool parallel_for_each(std::size_t start,
     functions.resize(std::min(functions.size(), end - start));
 
     if (functions.size() < 2 || scope.wasBusy()) {
-        functions.resize(1);
+        functions.resize(1); // For the case scope was busy.
         CLoopProgress progress{end - start, recordProgress};
         for (std::size_t i = start; i < end; ++i, progress.increment()) {
             functions[0](i);
@@ -442,11 +442,12 @@ bool parallel_for_each(ITR start,
     functions.resize(std::min(functions.size(), size));
 
     if (functions.size() < 2 || scope.wasBusy()) {
-        functions.resize(1);
+        functions.resize(1); // For the case scope was busy.
         CLoopProgress progress{size, recordProgress};
         for (ITR i = start; i != end; ++i, progress.increment()) {
             functions[0](*i);
         }
+        return true;
     }
 
     concurrency_detail::parallel_for_each(start, size, functions, recordProgress);

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -17,6 +17,7 @@
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeHyperparameters.h>
+#include <maths/CBoostedTreeLeafNodeStatistics.h>
 #include <maths/CBoostedTreeLoss.h>
 #include <maths/CBoostedTreeUtils.h>
 #include <maths/CDataFrameAnalysisInstrumentationInterface.h>
@@ -168,6 +169,7 @@ private:
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
     using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
+    using TWorkspace = CBoostedTreeLeafNodeStatistics::CWorkspace;
 
     //! Tag progress through initialization.
     enum EInitializationStage {

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -234,7 +234,8 @@ private:
     TNodeVec trainTree(core::CDataFrame& frame,
                        const core::CPackedBitVector& trainingRowMask,
                        const TImmutableRadixSetVec& candidateSplits,
-                       const std::size_t maximumTreeSize) const;
+                       const std::size_t maximumTreeSize,
+                       TWorkspace& workspace) const;
 
     //! Compute the minimum mean test loss per fold for any round.
     double minimumTestLoss() const;

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -425,22 +425,16 @@ public:
         using TSplitsDerivativesVec = std::vector<CSplitsDerivatives>;
 
     public:
-        CWorkspace(std::size_t numberThreads,
-                   const TImmutableRadixSetVec& candidateSplits,
-                   std::size_t numberLossParameters) {
-            m_Masks.resize(numberThreads);
-            m_Derivatives.reserve(numberThreads);
-            for (std::size_t i = 0; i < numberThreads; ++i) {
-                m_Derivatives.emplace_back(candidateSplits, numberLossParameters);
-            }
-        }
-
         //! Re-initialize the masks and derivatives.
         void reinitialize(std::size_t numberThreads,
                           const TImmutableRadixSetVec& candidateSplits,
                           std::size_t numberLossParameters) {
+            m_MinimumGain = 0.0;
             m_Masks.resize(numberThreads);
             m_Derivatives.reserve(numberThreads);
+            for (auto& mask : m_Masks) {
+                mask.clear();
+            }
             for (auto& derivatives : m_Derivatives) {
                 derivatives.reinitialize(candidateSplits, numberLossParameters);
             }

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -425,6 +425,11 @@ public:
         using TSplitsDerivativesVec = std::vector<CSplitsDerivatives>;
 
     public:
+        CWorkspace() = default;
+        CWorkspace(CWorkspace&&) = default;
+        CWorkspace& operator=(const CWorkspace& other) = delete;
+        CWorkspace& operator=(CWorkspace&&) = default;
+
         //! Re-initialize the masks and derivatives.
         void reinitialize(std::size_t numberThreads,
                           const TImmutableRadixSetVec& candidateSplits,

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -88,6 +88,12 @@ public:
             return m_Curvature;
         }
 
+        //! Zero all values.
+        void zero() {
+            m_Count = 0;
+            this->flatView().setZero();
+        }
+
         //! Add \p count and \p derivatives to the accumulator.
         void add(std::size_t count, const TMemoryMappedFloatVector& derivatives) {
             m_Count += count;
@@ -194,6 +200,26 @@ public:
         CSplitsDerivatives& operator=(const CSplitsDerivatives& other) = delete;
         CSplitsDerivatives& operator=(CSplitsDerivatives&&) = default;
 
+        //! Re-initialize recycling the allocated memory.
+        void reinitialize(const TImmutableRadixSetVec& candidateSplits,
+                          std::size_t numberLossParameters) {
+            m_NumberLossParameters = numberLossParameters;
+            for (auto& derivatives : m_Derivatives) {
+                derivatives.clear();
+            }
+            m_MissingDerivatives.clear();
+            m_Storage.clear();
+            this->map(candidateSplits);
+        }
+
+        //! Efficiently swap this and \p other.
+        void swap(CSplitsDerivatives& other) {
+            std::swap(m_NumberLossParameters, other.m_NumberLossParameters);
+            m_Derivatives.swap(other.m_Derivatives);
+            m_MissingDerivatives.swap(other.m_MissingDerivatives);
+            m_Storage.swap(other.m_Storage);
+        }
+
         //! \return The aggregate count for \p feature and \p split.
         std::size_t count(std::size_t feature, std::size_t split) const {
             return m_Derivatives[feature][split].count();
@@ -242,6 +268,16 @@ public:
         void addMissingDerivatives(std::size_t feature,
                                    const TMemoryMappedFloatVector& derivatives) {
             m_MissingDerivatives[feature].add(1, derivatives);
+        }
+
+        //! Zero all values.
+        void zero() {
+            for (std::size_t i = 0; i < m_Derivatives.size(); ++i) {
+                for (std::size_t j = 0; j < m_Derivatives[i].size(); ++j) {
+                    m_Derivatives[i][j].zero();
+                }
+                m_MissingDerivatives[i].zero();
+            }
         }
 
         //! Compute the accumulation of both collections of per split derivatives.
@@ -376,6 +412,72 @@ public:
         TAlignedDoubleVec m_Storage;
     };
 
+    //! \brief The derivatives and row masks objects to use for computations.
+    //!
+    //! DESCRIPTION:\n
+    //! These are heavyweight objects and get passed in to minimise the number of
+    //! times they need to be allocated. This has the added advantage of keeping
+    //! the cache warm since the critical path is always working on the derivatives
+    //! objects stored in this class.
+    class MATHS_EXPORT CWorkspace {
+    public:
+        using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+        using TSplitsDerivativesVec = std::vector<CSplitsDerivatives>;
+
+    public:
+        CWorkspace(std::size_t numberThreads,
+                   const TImmutableRadixSetVec& candidateSplits,
+                   std::size_t numberLossParameters) {
+            m_Masks.resize(numberThreads);
+            m_Derivatives.reserve(numberThreads);
+            for (std::size_t i = 0; i < numberThreads; ++i) {
+                m_Derivatives.emplace_back(candidateSplits, numberLossParameters);
+            }
+        }
+
+        //! Re-initialize the masks and derivatives.
+        void reinitialize(std::size_t numberThreads,
+                          const TImmutableRadixSetVec& candidateSplits,
+                          std::size_t numberLossParameters) {
+            m_Masks.resize(numberThreads);
+            m_Derivatives.reserve(numberThreads);
+            for (auto& derivatives : m_Derivatives) {
+                derivatives.reinitialize(candidateSplits, numberLossParameters);
+            }
+            for (std::size_t i = m_Derivatives.size(); i < numberThreads; ++i) {
+                m_Derivatives.emplace_back(candidateSplits, numberLossParameters);
+            }
+        }
+
+        //! Get the minimum leaf gain which will generate a split.
+        double minimumGain() const { return m_MinimumGain; }
+
+        //! Update the minimum gain to be at least \p gain.
+        void minimumGain(double gain) {
+            m_MinimumGain = std::max(m_MinimumGain, gain);
+        }
+
+        //! Reset the minimum gain to its initial value.
+        void resetMinimumGain() { m_MinimumGain = 0.0; }
+
+        //! Get the workspace row masks.
+        TPackedBitVectorVec& masks() { return m_Masks; }
+
+        //! Get the workspace derivatives.
+        TSplitsDerivativesVec& derivatives() { return m_Derivatives; }
+
+        //! Get the memory used by this object.
+        std::size_t memoryUsage() const {
+            return core::CMemory::dynamicSize(m_Masks) +
+                   core::CMemory::dynamicSize(m_Derivatives);
+        }
+
+    private:
+        double m_MinimumGain = 0.0;
+        TPackedBitVectorVec m_Masks;
+        TSplitsDerivativesVec m_Derivatives;
+    };
+
 public:
     CBoostedTreeLeafNodeStatistics(std::size_t id,
                                    const TSizeVec& extraColumns,
@@ -387,30 +489,28 @@ public:
                                    const TImmutableRadixSetVec& candidateSplits,
                                    const TSizeVec& featureBag,
                                    std::size_t depth,
-                                   const core::CPackedBitVector& rowMask);
+                                   const core::CPackedBitVector& rowMask,
+                                   CWorkspace& workspace);
 
     //! Only called by split but is public so it's accessible to std::make_shared.
     CBoostedTreeLeafNodeStatistics(std::size_t id,
-                                   const TSizeVec& extraColumns,
-                                   std::size_t numberLossParameters,
+                                   const CBoostedTreeLeafNodeStatistics& parent,
                                    std::size_t numberThreads,
                                    const core::CDataFrame& frame,
                                    const CDataFrameCategoryEncoder& encoder,
                                    const TRegularization& regularization,
-                                   const TImmutableRadixSetVec& candidateSplits,
                                    const TSizeVec& featureBag,
                                    bool isLeftChild,
-                                   std::size_t depth,
                                    const CBoostedTreeNode& split,
-                                   const core::CPackedBitVector& parentRowMask);
+                                   CWorkspace& workspace);
 
     //! Only called by split but is public so it's accessible to std::make_shared.
     CBoostedTreeLeafNodeStatistics(std::size_t id,
                                    CBoostedTreeLeafNodeStatistics&& parent,
-                                   const CBoostedTreeLeafNodeStatistics& sibling,
                                    const TRegularization& regularization,
                                    const TSizeVec& featureBag,
-                                   core::CPackedBitVector rowMask);
+                                   core::CPackedBitVector rowMask,
+                                   CWorkspace& workspace);
 
     CBoostedTreeLeafNodeStatistics(const CBoostedTreeLeafNodeStatistics&) = delete;
     CBoostedTreeLeafNodeStatistics& operator=(const CBoostedTreeLeafNodeStatistics&) = delete;
@@ -426,9 +526,9 @@ public:
                     const core::CDataFrame& frame,
                     const CDataFrameCategoryEncoder& encoder,
                     const TRegularization& regularization,
-                    const TImmutableRadixSetVec& candidateSplits,
                     const TSizeVec& featureBag,
-                    const CBoostedTreeNode& split);
+                    const CBoostedTreeNode& split,
+                    CWorkspace& workspace);
 
     //! Order two leaves by decreasing gain in splitting them.
     bool operator<(const CBoostedTreeLeafNodeStatistics& rhs) const;
@@ -508,13 +608,16 @@ private:
 private:
     void computeAggregateLossDerivatives(std::size_t numberThreads,
                                          const core::CDataFrame& frame,
-                                         const CDataFrameCategoryEncoder& encoder);
+                                         const CDataFrameCategoryEncoder& encoder,
+                                         const core::CPackedBitVector& rowMask,
+                                         CWorkspace& workspace) const;
     void computeRowMaskAndAggregateLossDerivatives(std::size_t numberThreads,
                                                    const core::CDataFrame& frame,
                                                    const CDataFrameCategoryEncoder& encoder,
                                                    bool isLeftChild,
                                                    const CBoostedTreeNode& split,
-                                                   const core::CPackedBitVector& parentRowMask);
+                                                   const core::CPackedBitVector& parentRowMask,
+                                                   CWorkspace& workspace) const;
     void addRowDerivatives(const CEncodedDataFrameRowRef& row,
                            CSplitsDerivatives& splitsDerivatives) const;
     SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -535,6 +535,9 @@ public:
     //! Get the best (feature, feature value) split.
     TSizeDoublePr bestSplit() const;
 
+    //! Get the row count of the child node with the fewest rows.
+    std::size_t minimumChildRowCount() const;
+
     //! Check if the left child has fewer rows than the right child.
     bool leftChildHasFewerRows() const;
 
@@ -570,10 +573,12 @@ private:
                          double curvature,
                          std::size_t feature,
                          double splitAt,
+                         std::size_t minimumChildRowCount,
                          bool leftChildHasFewerRows,
                          bool assignMissingToLeft)
             : s_Gain{CMathsFuncs::isNan(gain) ? -boosted_tree_detail::INF : gain},
               s_Curvature{curvature}, s_Feature{feature}, s_SplitAt{splitAt},
+              s_MinimumChildRowCount{static_cast<std::uint32_t>(minimumChildRowCount)},
               s_LeftChildHasFewerRows{leftChildHasFewerRows}, s_AssignMissingToLeft{assignMissingToLeft} {
         }
 
@@ -594,6 +599,7 @@ private:
         double s_Curvature = 0.0;
         std::size_t s_Feature = -1;
         double s_SplitAt = boosted_tree_detail::INF;
+        std::uint32_t s_MinimumChildRowCount = 0;
         bool s_LeftChildHasFewerRows = true;
         bool s_AssignMissingToLeft = true;
     };

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -503,7 +503,6 @@ public:
                                    CBoostedTreeLeafNodeStatistics&& parent,
                                    const TRegularization& regularization,
                                    const TSizeVec& featureBag,
-                                   core::CPackedBitVector rowMask,
                                    CWorkspace& workspace);
 
     CBoostedTreeLeafNodeStatistics(const CBoostedTreeLeafNodeStatistics&) = delete;

--- a/include/maths/CDataFrameCategoryEncoder.h
+++ b/include/maths/CDataFrameCategoryEncoder.h
@@ -106,19 +106,27 @@ public:
     public:
         CEncoding(std::size_t inputColumnIndex, double mic);
         virtual ~CEncoding() = default;
+        //! Get the encoding type.
         virtual EEncoding type() const = 0;
+        //! Encode \p value.
         virtual double encode(double value) const = 0;
-        virtual std::uint64_t checksum() const = 0;
+        //! \return True if this is a binary feature.
         virtual bool isBinary() const = 0;
         //! \return The encoding type as string.
         virtual const std::string& typeString() const = 0;
+        //! \return A checksum for this object.
+        virtual std::uint64_t checksum() const = 0;
 
+        //! \return The data frame column index this encodes.
         std::size_t inputColumnIndex() const;
+        //! \return Encode \p row.
         double encode(const TRowRef& row) const;
+        //! \return The MICe of this feature with the target variable.
         double mic() const;
+
         //! Persist by passing information to \p inserter.
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
-        //! Populate the object from serialized data.
+        //! Initialize the object reading state from \p traverser.
         bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     private:
@@ -142,8 +150,8 @@ public:
         EEncoding type() const override;
         double encode(double value) const override;
         bool isBinary() const override;
-        std::uint64_t checksum() const override;
         const std::string& typeString() const override;
+        std::uint64_t checksum() const override;
 
     private:
         void acceptPersistInserterForDerivedTypeState(core::CStatePersistInserter& inserter) const override;
@@ -157,9 +165,9 @@ public:
         EEncoding type() const override;
         double encode(double value) const override;
         bool isBinary() const override;
-        std::uint64_t checksum() const override;
         const std::string& typeString() const override;
-        size_t hotCategory() const;
+        std::uint64_t checksum() const override;
+        std::size_t hotCategory() const;
 
     private:
         void acceptPersistInserterForDerivedTypeState(core::CStatePersistInserter& inserter) const override;
@@ -180,8 +188,8 @@ public:
         EEncoding type() const override;
         double encode(double value) const override;
         bool isBinary() const override;
-        std::uint64_t checksum() const override;
         const std::string& typeString() const override;
+        std::uint64_t checksum() const override;
         const TDoubleVec& map() const;
         double fallback() const;
 

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -462,7 +462,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1800000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1900000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -654,7 +654,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1800000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1900000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -195,10 +195,30 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::readRows(std::size_t numberThreads,
         return {{std::move(reader)}, true};
     }
 
-    return numberThreads > 1
-               ? this->parallelApplyToAllRows(numberThreads, beginRows, endRows,
-                                              std::move(reader), rowMask, false)
-               : this->sequentialApplyToAllRows(beginRows, endRows, reader, rowMask, false);
+    TRowFuncVec readers(numberThreads, std::move(reader));
+    bool successful{
+        numberThreads > 1
+            ? this->parallelApplyToAllRows(beginRows, endRows, readers, rowMask, false)
+            : this->sequentialApplyToAllRows(beginRows, endRows, readers, rowMask, false)};
+
+    return {std::move(readers), successful};
+}
+
+bool CDataFrame::readRows(std::size_t beginRows,
+                          std::size_t endRows,
+                          TRowFuncVec& readers,
+                          const CPackedBitVector* rowMask) const {
+
+    beginRows = std::min(beginRows, m_NumberRows);
+    endRows = std::min(endRows, m_NumberRows);
+
+    if (beginRows >= endRows) {
+        return true;
+    }
+
+    return readers.size() > 1
+               ? this->parallelApplyToAllRows(beginRows, endRows, readers, rowMask, false)
+               : this->sequentialApplyToAllRows(beginRows, endRows, readers, rowMask, false);
 }
 
 CDataFrame::TRowFuncVecBoolPr CDataFrame::writeColumns(std::size_t numberThreads,
@@ -214,10 +234,12 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::writeColumns(std::size_t numberThreads
         return {{std::move(writer)}, true};
     }
 
-    return numberThreads > 1
-               ? this->parallelApplyToAllRows(numberThreads, beginRows, endRows,
-                                              std::move(writer), rowMask, true)
-               : this->sequentialApplyToAllRows(beginRows, endRows, writer, rowMask, true);
+    TRowFuncVec writers(numberThreads, std::move(writer));
+    bool successful{
+        numberThreads > 1
+            ? this->parallelApplyToAllRows(beginRows, endRows, writers, rowMask, true)
+            : this->sequentialApplyToAllRows(beginRows, endRows, writers, rowMask, true)};
+    return {std::move(writers), successful};
 }
 
 void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues, const std::string* hash) {
@@ -403,21 +425,21 @@ std::size_t CDataFrame::estimateMemoryUsage(bool inMainMemory,
                : 0;
 }
 
-CDataFrame::TRowFuncVecBoolPr
-CDataFrame::parallelApplyToAllRows(std::size_t numberThreads,
-                                   std::size_t beginRows,
-                                   std::size_t endRows,
-                                   TRowFunc&& func,
-                                   const CPackedBitVector* rowMask,
-                                   bool commitResult) const {
+bool CDataFrame::parallelApplyToAllRows(std::size_t beginRows,
+                                        std::size_t endRows,
+                                        TRowFuncVec& funcs,
+                                        const CPackedBitVector* rowMask,
+                                        bool commitResult) const {
 
-    // If we're reading in parallel then we don't want to interleave
-    // reads from storage and applying the function because we're
-    // already fully balancing our work across the slices.
+    // If we're reading in parallel then we don't want to interleave reads
+    // from storage and applying the function because we're already fully
+    // balancing our work across the slices.
+
+    using TSliceFuncVec = std::vector<std::function<void(const TRowSlicePtr&)>>;
 
     CPackedBitVector::COneBitIndexConstIterator maskedRow;
     CPackedBitVector::COneBitIndexConstIterator endMaskedRows;
-    if (rowMask) {
+    if (rowMask != nullptr) {
         maskedRow = rowMask->beginOneBits();
         endMaskedRows = rowMask->endOneBits();
     }
@@ -425,59 +447,55 @@ CDataFrame::parallelApplyToAllRows(std::size_t numberThreads,
     std::atomic_bool successful{true};
     CDataFrameRowSliceHandle readSlice;
 
-    auto results = parallel_for_each(
-        numberThreads, this->beginSlices(beginRows), this->endSlices(endRows),
-        bindRetrievableState(
-            [=, &successful](TRowFunc& func_, const TRowSlicePtr& slice) mutable {
-                if (successful.load() == false) {
-                    return;
-                }
+    TSliceFuncVec sliceFuncs;
+    sliceFuncs.reserve(funcs.size());
 
-                std::size_t beginSliceRows{std::max(slice->indexOfFirstRow(), beginRows)};
-                std::size_t endSliceRows{
-                    std::min(slice->indexOfLastRow(m_RowCapacity) + 1, endRows)};
+    for (auto& func : funcs) {
+        sliceFuncs.push_back([=, &func, &successful](const TRowSlicePtr& slice) mutable {
+            if (successful.load() == false) {
+                return;
+            }
 
-                if (rowMask != nullptr &&
-                    this->maskedRowsInSlice(maskedRow, endMaskedRows, beginSliceRows,
-                                            endSliceRows) == false) {
-                    return;
-                }
+            std::size_t beginSliceRows{std::max(slice->indexOfFirstRow(), beginRows)};
+            std::size_t endSliceRows{
+                std::min(slice->indexOfLastRow(m_RowCapacity) + 1, endRows)};
 
-                readSlice = slice->read();
-                if (readSlice.bad()) {
-                    successful.store(false);
-                    return;
-                }
+            if (rowMask != nullptr &&
+                this->maskedRowsInSlice(maskedRow, endMaskedRows,
+                                        beginSliceRows, endSliceRows) == false) {
+                return;
+            }
 
-                TOptionalPopMaskedRow popMaskedRow;
-                if (rowMask != nullptr) {
-                    beginSliceRows = *maskedRow;
-                    popMaskedRow = CPopMaskedRow{endSliceRows, maskedRow, endMaskedRows};
-                }
+            readSlice = slice->read();
+            if (readSlice.bad()) {
+                successful.store(false);
+                return;
+            }
 
-                this->applyToRowsOfOneSlice(func_, beginSliceRows, endSliceRows,
-                                            popMaskedRow, readSlice);
-                if (commitResult) {
-                    slice->write(readSlice.rows(), readSlice.docHashes());
-                }
-            },
-            std::move(func)));
+            TOptionalPopMaskedRow popMaskedRow;
+            if (rowMask != nullptr) {
+                beginSliceRows = *maskedRow;
+                popMaskedRow = CPopMaskedRow{endSliceRows, maskedRow, endMaskedRows};
+            }
 
-    TRowFuncVec funcs;
-    funcs.reserve(results.size());
-    for (auto& result : results) {
-        funcs.emplace_back(std::move(result.s_FunctionState));
+            this->applyToRowsOfOneSlice(func, beginSliceRows, endSliceRows,
+                                        popMaskedRow, readSlice);
+            if (commitResult) {
+                slice->write(readSlice.rows(), readSlice.docHashes());
+            }
+        });
     }
 
-    return {std::move(funcs), successful.load()};
+    parallel_for_each(this->beginSlices(beginRows), this->endSlices(endRows), sliceFuncs);
+
+    return successful.load();
 }
 
-CDataFrame::TRowFuncVecBoolPr
-CDataFrame::sequentialApplyToAllRows(std::size_t beginRows,
-                                     std::size_t endRows,
-                                     TRowFunc& func,
-                                     const CPackedBitVector* rowMask,
-                                     bool commitResult) const {
+bool CDataFrame::sequentialApplyToAllRows(std::size_t beginRows,
+                                          std::size_t endRows,
+                                          TRowFuncVec& func,
+                                          const CPackedBitVector* rowMask,
+                                          bool commitResult) const {
 
     CPackedBitVector::COneBitIndexConstIterator maskedRow;
     CPackedBitVector::COneBitIndexConstIterator endMaskedRows;
@@ -514,7 +532,7 @@ CDataFrame::sequentialApplyToAllRows(std::size_t beginRows,
 
             readSlice = (*slice)->read();
             if (readSlice.bad()) {
-                return {{std::move(func)}, false};
+                return false;
             }
 
             // We wait here so at most one slice is copied into memory.
@@ -530,7 +548,7 @@ CDataFrame::sequentialApplyToAllRows(std::size_t beginRows,
                         popMaskedRow = CPopMaskedRow{endSliceRows, maskedRow, endMaskedRows};
                     }
 
-                    this->applyToRowsOfOneSlice(func, beginSliceRows, endSliceRows,
+                    this->applyToRowsOfOneSlice(func[0], beginSliceRows, endSliceRows,
                                                 popMaskedRow, readSlice_);
 
                     if (commitResult) {
@@ -556,7 +574,7 @@ CDataFrame::sequentialApplyToAllRows(std::size_t beginRows,
 
             readSlice = (*slice)->read();
             if (readSlice.bad()) {
-                return {{std::move(func)}, false};
+                return false;
             }
 
             TOptionalPopMaskedRow popMaskedRow;
@@ -565,7 +583,7 @@ CDataFrame::sequentialApplyToAllRows(std::size_t beginRows,
                 popMaskedRow = CPopMaskedRow{endSliceRows, maskedRow, endMaskedRows};
             }
 
-            this->applyToRowsOfOneSlice(func, beginSliceRows, endSliceRows,
+            this->applyToRowsOfOneSlice(func[0], beginSliceRows, endSliceRows,
                                         popMaskedRow, readSlice);
 
             if (commitResult) {
@@ -575,14 +593,7 @@ CDataFrame::sequentialApplyToAllRows(std::size_t beginRows,
         break;
     }
 
-    // TRowFuncVec funcs{std::move(func)}; moves func into an std::inializer_list
-    // but then *copies* from the list because the standard requires its elements
-    // are treated as constant, see 8.5.4/5.
-    TRowFuncVec funcs;
-    funcs.reserve(1);
-    funcs.emplace_back(std::move(func));
-
-    return TRowFuncVecBoolPr{std::move(funcs), true};
+    return true;
 }
 
 void CDataFrame::applyToRowsOfOneSlice(TRowFunc& func,

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -35,10 +35,6 @@ CRowRef::CRowRef(std::size_t index, TFloatVecItr beginColumns, TFloatVecItr endC
     : m_Index{index}, m_BeginColumns{beginColumns}, m_EndColumns{endColumns}, m_DocHash{docHash} {
 }
 
-CFloatStorage CRowRef::operator[](std::size_t i) const {
-    return *(m_BeginColumns + i);
-}
-
 std::size_t CRowRef::index() const {
     return m_Index;
 }
@@ -70,11 +66,11 @@ CRowIterator::CRowIterator(std::size_t numberColumns,
 }
 
 bool CRowIterator::operator==(const CRowIterator& rhs) const {
-    return m_RowItr == rhs.m_RowItr && m_DocHashItr == rhs.m_DocHashItr;
+    return m_RowItr == rhs.m_RowItr;
 }
 
 bool CRowIterator::operator!=(const CRowIterator& rhs) const {
-    return m_RowItr != rhs.m_RowItr || m_DocHashItr != rhs.m_DocHashItr;
+    return m_RowItr != rhs.m_RowItr;
 }
 
 CRowRef CRowIterator::operator*() const {

--- a/lib/core/CPackedBitVector.cc
+++ b/lib/core/CPackedBitVector.cc
@@ -150,6 +150,13 @@ std::string CPackedBitVector::toDelimited() const {
     return result;
 }
 
+void CPackedBitVector::clear() {
+    m_Dimension = 0;
+    m_First = false;
+    m_Parity = true;
+    m_RunLengths.clear();
+}
+
 bool CPackedBitVector::operator==(const CPackedBitVector& other) const {
     return m_Dimension == other.m_Dimension && m_First == other.m_First &&
            m_Parity == other.m_Parity && m_RunLengths == other.m_RunLengths;

--- a/lib/core/unittest/CConcurrencyTest.cc
+++ b/lib/core/unittest/CConcurrencyTest.cc
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(testAsyncWithExecutorsAndExceptions) {
 
 BOOST_AUTO_TEST_CASE(testParallelForEachWithEmpty) {
 
-    core::stopDefaultAsyncExecutor();
+    core::startDefaultAsyncExecutor();
 
     TIntVec values;
     auto result = core::parallel_for_each(0, values.size(),
@@ -107,6 +107,8 @@ BOOST_AUTO_TEST_CASE(testParallelForEachWithEmpty) {
                                               0.0));
     BOOST_REQUIRE_EQUAL(std::size_t{1}, result.size());
     BOOST_REQUIRE_EQUAL(0.0, result[0].s_FunctionState);
+
+    core::stopDefaultAsyncExecutor();
 }
 
 BOOST_AUTO_TEST_CASE(testParallelForEach) {
@@ -253,6 +255,58 @@ BOOST_AUTO_TEST_CASE(testParallelForEachReentry) {
         }
         BOOST_REQUIRE_EQUAL(expected, actual);
     }
+
+    core::stopDefaultAsyncExecutor();
+}
+
+BOOST_AUTO_TEST_CASE(testParallelForEachFunctionVector) {
+
+    // Test we get identical results if we supply a number of threads and single
+    // function or a vector of functions.
+
+    core::startDefaultAsyncExecutor(4);
+
+    {
+        using TFuncVec = std::vector<std::function<void (std::size_t)>>;
+
+        for (auto size : {1, 4}) {
+            std::atomic_size_t counter{0};
+            TFuncVec funcs(size, [&](std::size_t i) { counter.fetch_add(i); });
+            core::parallel_for_each(std::size_t{0}, std::size_t{100}, funcs);
+            BOOST_REQUIRE_EQUAL(4950, counter.load());
+
+            BOOST_TEST_REQUIRE(core::parallel_for_each(std::size_t{0}, std::size_t{0}, funcs));
+            BOOST_REQUIRE_EQUAL(4950, counter.load());
+        }
+
+        TFuncVec empty;
+        BOOST_TEST_REQUIRE(core::parallel_for_each(std::size_t{0}, std::size_t{100}, empty) == false);
+    }
+
+    {
+        using TFuncVec = std::vector<std::function<void (int)>>;
+
+        for (auto size : {1, 4}) {
+            TIntVec ints(100);
+            std::iota(ints.begin(), ints.end(), 0);
+
+            std::atomic_size_t counter{0};
+            TFuncVec funcs(size, [&](int i) { counter.fetch_add(i); });
+            core::parallel_for_each(ints.begin(), ints.end(), funcs);
+            BOOST_REQUIRE_EQUAL(4950, counter.load());
+
+            ints.clear();
+            BOOST_TEST_REQUIRE(core::parallel_for_each(ints.begin(), ints.end(), funcs));
+            BOOST_REQUIRE_EQUAL(4950, counter.load());
+        }
+
+        TIntVec ints(100);
+        std::iota(ints.begin(), ints.end(), 0);
+        TFuncVec funcs;
+        BOOST_TEST_REQUIRE(core::parallel_for_each(ints.begin(), ints.end(), funcs) == false);
+    }
+
+    core::stopDefaultAsyncExecutor();
 }
 
 BOOST_AUTO_TEST_CASE(testProgressMonitoring) {

--- a/lib/core/unittest/CConcurrencyTest.cc
+++ b/lib/core/unittest/CConcurrencyTest.cc
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(testParallelForEachFunctionVector) {
     core::startDefaultAsyncExecutor(4);
 
     {
-        using TFuncVec = std::vector<std::function<void (std::size_t)>>;
+        using TFuncVec = std::vector<std::function<void(std::size_t)>>;
 
         for (auto size : {1, 4}) {
             std::atomic_size_t counter{0};
@@ -280,11 +280,12 @@ BOOST_AUTO_TEST_CASE(testParallelForEachFunctionVector) {
         }
 
         TFuncVec empty;
-        BOOST_TEST_REQUIRE(core::parallel_for_each(std::size_t{0}, std::size_t{100}, empty) == false);
+        BOOST_TEST_REQUIRE(core::parallel_for_each(std::size_t{0}, std::size_t{100},
+                                                   empty) == false);
     }
 
     {
-        using TFuncVec = std::vector<std::function<void (int)>>;
+        using TFuncVec = std::vector<std::function<void(int)>>;
 
         for (auto size : {1, 4}) {
             TIntVec ints(100);
@@ -302,8 +303,8 @@ BOOST_AUTO_TEST_CASE(testParallelForEachFunctionVector) {
 
         TIntVec ints(100);
         std::iota(ints.begin(), ints.end(), 0);
-        TFuncVec funcs;
-        BOOST_TEST_REQUIRE(core::parallel_for_each(ints.begin(), ints.end(), funcs) == false);
+        TFuncVec empty;
+        BOOST_TEST_REQUIRE(core::parallel_for_each(ints.begin(), ints.end(), empty) == false);
     }
 
     core::stopDefaultAsyncExecutor();

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -528,7 +528,8 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                         m_TreeImpl->m_Regularization.softTreeDepthLimit());
                 }
             })) {
-            m_TreeImpl->m_TrainingProgress.increment(lineSearchMaximumNumberIterations(frame));
+            m_TreeImpl->m_TrainingProgress.increment(
+                this->lineSearchMaximumNumberIterations(frame));
         }
     }
 
@@ -581,7 +582,8 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                         m_TreeImpl->m_Regularization.depthPenaltyMultiplier());
                 }
             })) {
-            m_TreeImpl->m_TrainingProgress.increment(lineSearchMaximumNumberIterations(frame));
+            m_TreeImpl->m_TrainingProgress.increment(
+                this->lineSearchMaximumNumberIterations(frame));
         }
     }
 
@@ -634,7 +636,8 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                         m_TreeImpl->m_Regularization.treeSizePenaltyMultiplier());
                 }
             })) {
-            m_TreeImpl->m_TrainingProgress.increment(lineSearchMaximumNumberIterations(frame));
+            m_TreeImpl->m_TrainingProgress.increment(
+                this->lineSearchMaximumNumberIterations(frame));
         }
     }
 
@@ -688,7 +691,8 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                         m_TreeImpl->m_Regularization.leafWeightPenaltyMultiplier());
                 }
             })) {
-            m_TreeImpl->m_TrainingProgress.increment(lineSearchMaximumNumberIterations(frame));
+            m_TreeImpl->m_TrainingProgress.increment(
+                this->lineSearchMaximumNumberIterations(frame));
         }
     }
 
@@ -785,7 +789,8 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
                     m_TreeImpl->m_DownsampleFactorOverride = m_TreeImpl->m_DownsampleFactor;
                 }
             })) {
-            m_TreeImpl->m_TrainingProgress.increment(lineSearchMaximumNumberIterations(frame));
+            m_TreeImpl->m_TrainingProgress.increment(
+                this->lineSearchMaximumNumberIterations(frame));
         }
     }
 }
@@ -834,7 +839,7 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
                 }
             })) {
             m_TreeImpl->m_TrainingProgress.increment(
-                lineSearchMaximumNumberIterations(frame, 0.5));
+                this->lineSearchMaximumNumberIterations(frame, 0.5));
         }
     }
 }
@@ -1284,22 +1289,22 @@ void CBoostedTreeFactory::startProgressMonitoringInitializeHyperparameters(const
 
     std::size_t totalNumberSteps{0};
     if (m_TreeImpl->m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
-        totalNumberSteps += lineSearchMaximumNumberIterations(frame);
+        totalNumberSteps += this->lineSearchMaximumNumberIterations(frame);
     }
     if (m_TreeImpl->m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
-        totalNumberSteps += lineSearchMaximumNumberIterations(frame);
+        totalNumberSteps += this->lineSearchMaximumNumberIterations(frame);
     }
     if (m_TreeImpl->m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
-        totalNumberSteps += lineSearchMaximumNumberIterations(frame);
+        totalNumberSteps += this->lineSearchMaximumNumberIterations(frame);
     }
     if (m_TreeImpl->m_RegularizationOverride.leafWeightPenaltyMultiplier() == boost::none) {
-        totalNumberSteps += lineSearchMaximumNumberIterations(frame);
+        totalNumberSteps += this->lineSearchMaximumNumberIterations(frame);
     }
     if (m_TreeImpl->m_DownsampleFactorOverride == boost::none) {
-        totalNumberSteps += lineSearchMaximumNumberIterations(frame);
+        totalNumberSteps += this->lineSearchMaximumNumberIterations(frame);
     }
     if (m_TreeImpl->m_EtaOverride == boost::none) {
-        totalNumberSteps += lineSearchMaximumNumberIterations(frame, 0.5);
+        totalNumberSteps += this->lineSearchMaximumNumberIterations(frame, 0.5);
     }
 
     LOG_TRACE(<< "initial search total number steps = " << totalNumberSteps);

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -13,41 +13,11 @@ namespace ml {
 namespace maths {
 namespace boosted_tree_detail {
 using namespace boosted_tree;
-namespace {
-enum EExtraColumn { E_Prediction = 0, E_Gradient, E_Curvature, E_Weight };
-}
-
-TSizeAlignmentPrVec extraColumns(std::size_t numberLossParameters) {
-    return {{numberLossParameters, core::CAlignment::E_Unaligned},
-            {numberLossParameters, core::CAlignment::E_Aligned16},
-            {numberLossParameters * numberLossParameters, core::CAlignment::E_Unaligned},
-            {1, core::CAlignment::E_Unaligned}};
-}
-
-TMemoryMappedFloatVector readPrediction(const TRowRef& row,
-                                        const TSizeVec& extraColumns,
-                                        std::size_t numberLossParameters) {
-    return {row.data() + extraColumns[E_Prediction], static_cast<int>(numberLossParameters)};
-}
 
 void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
     for (std::size_t i = 0; i < numberLossParameters; ++i) {
         row.writeColumn(extraColumns[E_Prediction] + i, 0.0);
     }
-}
-
-TAlignedMemoryMappedFloatVector readLossDerivatives(const TRowRef& row,
-                                                    const TSizeVec& extraColumns,
-                                                    std::size_t numberLossParameters) {
-    return {row.data() + extraColumns[E_Gradient],
-            static_cast<int>(numberLossParameters +
-                             lossHessianUpperTriangleSize(numberLossParameters))};
-}
-
-TMemoryMappedFloatVector readLossGradient(const TRowRef& row,
-                                          const TSizeVec& extraColumns,
-                                          std::size_t numberLossParameters) {
-    return {row.data() + extraColumns[E_Gradient], static_cast<int>(numberLossParameters)};
 }
 
 void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
@@ -71,13 +41,6 @@ void writeLossGradient(const TRowRef& row,
                   [&writer](std::size_t i, double value) { writer(i, value); }, weight);
 }
 
-TMemoryMappedFloatVector readLossCurvature(const TRowRef& row,
-                                           const TSizeVec& extraColumns,
-                                           std::size_t numberLossParameters) {
-    return {row.data() + extraColumns[E_Curvature],
-            static_cast<int>(lossHessianUpperTriangleSize(numberLossParameters))};
-}
-
 void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
     for (std::size_t i = 0, size = lossHessianUpperTriangleSize(numberLossParameters);
          i < size; ++i) {
@@ -98,18 +61,6 @@ void writeLossCurvature(const TRowRef& row,
     // of std::function small size optimization to avoid heap allocations.
     loss.curvature(prediction, actual,
                    [&writer](std::size_t i, double value) { writer(i, value); }, weight);
-}
-
-double readExampleWeight(const TRowRef& row, const TSizeVec& extraColumns) {
-    return row[extraColumns[E_Weight]];
-}
-
-void writeExampleWeight(const TRowRef& row, const TSizeVec& extraColumns, double weight) {
-    row.writeColumn(extraColumns[E_Weight], weight);
-}
-
-double readActual(const TRowRef& row, std::size_t dependentVariable) {
-    return row[dependentVariable];
 }
 }
 }

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -15,7 +15,6 @@
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CLbfgs.h>
 #include <maths/CLinearAlgebraEigen.h>
-#include <maths/CMathsFuncs.h>
 #include <maths/CMic.h>
 #include <maths/COrderings.h>
 #include <maths/CPRNG.h>
@@ -27,6 +26,7 @@
 
 #include <boost/unordered_map.hpp>
 
+#include <cmath>
 #include <limits>
 #include <memory>
 #include <numeric>
@@ -743,8 +743,8 @@ CDataFrameUtils::maximumMinimumRecallClassWeights(std::size_t numberThreads,
                                                     targetColumn, readPrediction);
 }
 
-bool CDataFrameUtils::isMissing(double x) {
-    return CMathsFuncs::isFinite(x) == false;
+bool CDataFrameUtils::isMissing(double value) {
+    return std::isfinite(value) == false;
 }
 
 CDataFrameUtils::TSizeDoublePrVecVecVec CDataFrameUtils::categoricalMicWithColumnDataFrameInMemory(

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -523,9 +523,9 @@ BOOST_AUTO_TEST_CASE(testThreading) {
     // with and without starting the thread pool.
 
     test::CRandomNumbers rng;
-    std::size_t rows{500};
-    std::size_t cols{6};
-    std::size_t capacity{100};
+    std::size_t rows{4000};
+    std::size_t cols{12};
+    std::size_t capacity{400};
 
     auto target = [&] {
         TDoubleVec m;
@@ -556,9 +556,11 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
     std::string tests[]{"serial", "parallel"};
 
-    for (std::size_t test = 0; test < 2; ++test) {
+    for (std::size_t test = 0; test < 1; ++test) {
 
         LOG_DEBUG(<< tests[test]);
+
+        core::startDefaultAsyncExecutor(2);
 
         auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
 
@@ -584,8 +586,6 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
         modelBias.push_back(maths::CBasicStatistics::mean(modelPredictionErrorMoments));
         modelMse.push_back(maths::CBasicStatistics::variance(modelPredictionErrorMoments));
-
-        core::startDefaultAsyncExecutor();
     }
 
     BOOST_REQUIRE_EQUAL(modelBias[0], modelBias[1]);

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -523,9 +523,9 @@ BOOST_AUTO_TEST_CASE(testThreading) {
     // with and without starting the thread pool.
 
     test::CRandomNumbers rng;
-    std::size_t rows{4000};
-    std::size_t cols{12};
-    std::size_t capacity{400};
+    std::size_t rows{500};
+    std::size_t cols{6};
+    std::size_t capacity{100};
 
     auto target = [&] {
         TDoubleVec m;
@@ -556,11 +556,9 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
     std::string tests[]{"serial", "parallel"};
 
-    for (std::size_t test = 0; test < 1; ++test) {
+    for (std::size_t test = 0; test < 2; ++test) {
 
         LOG_DEBUG(<< tests[test]);
-
-        core::startDefaultAsyncExecutor(2);
 
         auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
 
@@ -586,6 +584,8 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
         modelBias.push_back(maths::CBasicStatistics::mean(modelPredictionErrorMoments));
         modelMse.push_back(maths::CBasicStatistics::variance(modelPredictionErrorMoments));
+
+        core::startDefaultAsyncExecutor(2);
     }
 
     BOOST_REQUIRE_EQUAL(modelBias[0], modelBias[1]);

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -8,6 +8,7 @@
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CLogger.h>
 #include <core/CRegex.h>
+#include <core/CStopWatch.h>
 
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
@@ -564,12 +565,16 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
         fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
+        core::CStopWatch watch{true};
+
         auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                               2, std::make_unique<maths::boosted_tree::CMse>())
                               .buildFor(*frame, cols - 1);
 
         regression->train();
         regression->predict();
+
+        LOG_DEBUG(<< "took " << watch.lap() << "ms");
 
         TMeanVarAccumulator modelPredictionErrorMoments;
 


### PR DESCRIPTION
Testing showed up we are often I/O bound during boosted tree training on larger data sets. This change introduces a placeholder for the large aggregate derivatives objects which is allocated once upfront at the start of training a forest. This is particularly relevant for running multithreaded because we use one copy of this data per thread. In order to do this it was necessary to change the `CDataFrame` interface to take in a vector of functions to bind to each task so the placeholders can be bound by reference.

We also now pass in information about the minimum gain of a node that we'll keep. This allows us to lazily create storage for these and avoid some work if they aren't needed. 

Testing also showed up degraded performance running multi-threaded when the thread count was set too high. One factor effecting this is the amount of work performed per thread when computing aggregate derivatives. I've introduced a minimum amount of work we'll perform per thread and this operation uses fewer threads accordingly. 

Finally, I've inlined some functions for which it is worthwhile. 