### PR TITLE
[7.x][ML] Better interrupt handling during named pipe connection

### DIFF
--- a/bin/controller/CBlockingCallCancellerThread.cc
+++ b/bin/controller/CBlockingCallCancellerThread.cc
@@ -14,25 +14,30 @@ namespace controller {
 
 CBlockingCallCancellerThread::CBlockingCallCancellerThread(core::CThread::TThreadId potentiallyBlockedThreadId,
                                                            std::istream& monitorStream)
-    : m_PotentiallyBlockedThreadId(potentiallyBlockedThreadId),
-      m_MonitorStream(monitorStream), m_Shutdown(false) {
+    : m_PotentiallyBlockedThreadId{potentiallyBlockedThreadId},
+      m_MonitorStream{monitorStream}, m_Shutdown{false}, m_HasCancelledBlockingCall{false} {
+}
+
+const std::atomic_bool& CBlockingCallCancellerThread::hasCancelledBlockingCall() const {
+    return m_HasCancelledBlockingCall;
 }
 
 void CBlockingCallCancellerThread::run() {
     char c;
     while (m_MonitorStream >> c) {
-        if (m_Shutdown) {
+        if (m_Shutdown.load()) {
             return;
         }
     }
 
+    m_HasCancelledBlockingCall.store(true);
     if (core::CThread::cancelBlockedIo(m_PotentiallyBlockedThreadId) == false) {
         LOG_WARN(<< "Failed to cancel blocked IO in thread " << m_PotentiallyBlockedThreadId);
     }
 }
 
 void CBlockingCallCancellerThread::shutdown() {
-    m_Shutdown = true;
+    m_Shutdown.store(true);
 
     // This is to wake up the stream reading in the run() method of this object.
     // If this has an effect then the assumption is that the program is exiting

--- a/bin/controller/CBlockingCallCancellerThread.h
+++ b/bin/controller/CBlockingCallCancellerThread.h
@@ -8,6 +8,7 @@
 
 #include <core/CThread.h>
 
+#include <atomic>
 #include <iosfwd>
 
 namespace ml {
@@ -39,12 +40,14 @@ public:
     CBlockingCallCancellerThread(core::CThread::TThreadId potentiallyBlockedThreadId,
                                  std::istream& monitorStream);
 
+    const std::atomic_bool& hasCancelledBlockingCall() const;
+
 protected:
     //! Called when the thread is started.
-    virtual void run();
+    void run() override;
 
     //! Called when the thread is stopped.
-    virtual void shutdown();
+    void shutdown() override;
 
 private:
     //! Thread ID of the thread that this object will cancel blocking IO in
@@ -54,8 +57,12 @@ private:
     //! Stream to monitor for end-of-file.
     std::istream& m_MonitorStream;
 
-    //! Flag to indicate the thread should shut down
-    volatile bool m_Shutdown;
+    //! Flag to indicate the monitoring thread should shut down
+    std::atomic_bool m_Shutdown;
+
+    //! Flag to indicate that an attempt to cancel blocking calls in the
+    //! monitored thread has been made
+    std::atomic_bool m_HasCancelledBlockingCall;
 };
 }
 }

--- a/bin/controller/Main.cc
+++ b/bin/controller/Main.cc
@@ -4,10 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 //! \brief
-//! Controller to start other Ml processes.
+//! Controller to start other ML processes.
 //!
 //! DESCRIPTION:\n
-//! Starts other Ml processes based on commands sent to it
+//! Starts other ML processes based on commands sent to it
 //! through a named pipe.
 //!
 //! Each command has the following format:
@@ -59,12 +59,12 @@
 #include <string.h>
 
 int main(int argc, char** argv) {
-    const std::string& defaultNamedPipePath = ml::core::CNamedPipeFactory::defaultPath();
-    const std::string& progName = ml::core::CProgName::progName();
+    const std::string& defaultNamedPipePath{ml::core::CNamedPipeFactory::defaultPath()};
+    const std::string& progName{ml::core::CProgName::progName()};
 
     // Read command line options
-    std::string jvmPidStr = ml::core::CStringUtils::typeToString(
-        ml::core::CProcess::instance().parentId());
+    std::string jvmPidStr{ml::core::CStringUtils::typeToString(
+        ml::core::CProcess::instance().parentId())};
     std::string logPipe;
     std::string commandPipe;
     if (ml::controller::CCmdLineParser::parse(argc, argv, jvmPidStr, logPipe,
@@ -88,8 +88,8 @@ int main(int argc, char** argv) {
     // 4) No plugin code ever runs
     // This thread will detect the death of the parent process because this
     // process's STDIN will be closed.
-    ml::controller::CBlockingCallCancellerThread cancellerThread(
-        ml::core::CThread::currentThreadId(), std::cin);
+    ml::controller::CBlockingCallCancellerThread cancellerThread{
+        ml::core::CThread::currentThreadId(), std::cin};
     if (cancellerThread.start() == false) {
         // This log message will probably never been seen as it will go to the
         // real stderr of this process rather than the log pipe...
@@ -97,8 +97,13 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (ml::core::CLogger::instance().reconfigureLogToNamedPipe(logPipe) == false) {
-        LOG_FATAL(<< "Could not reconfigure logging");
+    if (ml::core::CLogger::instance().reconfigureLogToNamedPipe(
+            logPipe, cancellerThread.hasCancelledBlockingCall()) == false) {
+        if (cancellerThread.hasCancelledBlockingCall().load()) {
+            LOG_INFO(<< "Parent process died - ML controller exiting");
+        } else {
+            LOG_FATAL(<< "Could not reconfigure logging");
+        }
         cancellerThread.stop();
         return EXIT_FAILURE;
     }
@@ -112,10 +117,14 @@ int main(int argc, char** argv) {
     // the controller is critical to the overall system.  Also its resource
     // requirements should always be very low.
 
-    ml::core::CNamedPipeFactory::TIStreamP commandStream =
-        ml::core::CNamedPipeFactory::openPipeStreamRead(commandPipe);
+    ml::core::CNamedPipeFactory::TIStreamP commandStream{ml::core::CNamedPipeFactory::openPipeStreamRead(
+        commandPipe, cancellerThread.hasCancelledBlockingCall())};
     if (commandStream == nullptr) {
-        LOG_FATAL(<< "Could not open command pipe");
+        if (cancellerThread.hasCancelledBlockingCall().load()) {
+            LOG_INFO(<< "Parent process died - ML controller exiting");
+        } else {
+            LOG_FATAL(<< "Could not open command pipe");
+        }
         cancellerThread.stop();
         return EXIT_FAILURE;
     }
@@ -123,7 +132,7 @@ int main(int argc, char** argv) {
     // Change directory to the directory containing this program, because the
     // permitted paths all assume the current working directory contains the
     // permitted programs
-    const std::string& progDir = ml::core::CProgName::progDir();
+    const std::string& progDir{ml::core::CProgName::progDir()};
     if (ml::core::COsFileFuncs::chdir(progDir.c_str()) == -1) {
         LOG_FATAL(<< "Could not change directory to '" << progDir
                   << "': " << ::strerror(errno));
@@ -131,13 +140,10 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    ml::controller::CCommandProcessor::TStrVec permittedProcessPaths;
-    permittedProcessPaths.push_back("./autodetect");
-    permittedProcessPaths.push_back("./categorize");
-    permittedProcessPaths.push_back("./data_frame_analyzer");
-    permittedProcessPaths.push_back("./normalize");
+    ml::controller::CCommandProcessor::TStrVec permittedProcessPaths{
+        "./autodetect", "./categorize", "./data_frame_analyzer", "./normalize"};
 
-    ml::controller::CCommandProcessor processor(permittedProcessPaths);
+    ml::controller::CCommandProcessor processor{permittedProcessPaths};
     processor.processCommands(*commandStream);
 
     cancellerThread.stop();
@@ -145,7 +151,7 @@ int main(int argc, char** argv) {
     // This message makes it easier to spot process crashes in a log file - if
     // this isn't present in the log for a given PID and there's no other log
     // message indicating early exit then the process has probably core dumped
-    LOG_INFO(<< "Ml controller exiting");
+    LOG_INFO(<< "ML controller exiting");
 
     return EXIT_SUCCESS;
 }

--- a/bin/controller/unittest/CBlockingCallCancellerThreadTest.cc
+++ b/bin/controller/unittest/CBlockingCallCancellerThreadTest.cc
@@ -21,16 +21,16 @@ namespace {
 
 class CEofThread : public ml::core::CThread {
 public:
-    CEofThread(ml::core::CDualThreadStreamBuf& buf) : m_Buf(buf) {}
+    CEofThread(ml::core::CDualThreadStreamBuf& buf) : m_Buf{buf} {}
 
 protected:
-    virtual void run() {
+    void run() override {
         ml::core::CSleep::sleep(200);
 
         m_Buf.signalEndOfFile();
     }
 
-    virtual void shutdown() {}
+    void shutdown() override {}
 
 private:
     ml::core::CDualThreadStreamBuf& m_Buf;
@@ -39,10 +39,10 @@ private:
 
 BOOST_AUTO_TEST_CASE(testCancelBlock) {
     ml::core::CDualThreadStreamBuf buf;
-    std::istream monStrm(&buf);
+    std::istream monStrm{&buf};
 
-    ml::controller::CBlockingCallCancellerThread cancellerThread(
-        ml::core::CThread::currentThreadId(), monStrm);
+    ml::controller::CBlockingCallCancellerThread cancellerThread{
+        ml::core::CThread::currentThreadId(), monStrm};
     BOOST_TEST_REQUIRE(cancellerThread.start());
 
     // The CBlockingCallCancellerThread should wake up the blocking open of the
@@ -52,11 +52,12 @@ BOOST_AUTO_TEST_CASE(testCancelBlock) {
     // real program this would be STDIN, but in this test another thread is the
     // source, and it runs out of data after 0.2 seconds.
 
-    CEofThread eofThread(buf);
+    CEofThread eofThread{buf};
     BOOST_TEST_REQUIRE(eofThread.start());
 
-    ml::core::CNamedPipeFactory::TIStreamP pipeStrm = ml::core::CNamedPipeFactory::openPipeStreamRead(
-        ml::core::CNamedPipeFactory::defaultPath() + "test_pipe");
+    ml::core::CNamedPipeFactory::TIStreamP pipeStrm{ml::core::CNamedPipeFactory::openPipeStreamRead(
+        ml::core::CNamedPipeFactory::defaultPath() + "test_pipe",
+        cancellerThread.hasCancelledBlockingCall())};
     BOOST_TEST_REQUIRE(pipeStrm == nullptr);
 
     BOOST_TEST_REQUIRE(cancellerThread.stop());

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -56,6 +56,12 @@
 
 * Fix numerical issues leading to blow up of the model plot bounds. (See {ml-pull}1268[#1268].)
 
+== {es} version 7.8.1
+
+=== Bug Fixes
+
+* Better interrupt handling during named pipe connection. (See {ml-pull}1311[#1311].)
+
 == {es} version 7.8.0
 
 === Enhancements

--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -13,6 +13,7 @@
 
 #include <boost/log/sources/severity_logger.hpp>
 
+#include <atomic>
 #include <functional>
 #include <iosfwd>
 
@@ -90,11 +91,22 @@ public:
     //! If both are supplied the named pipe takes precedence.
     bool reconfigure(const std::string& pipeName, const std::string& propertiesFile);
 
+    //! As above, but with a flag to indicate named pipe connection attempts
+    //! should be cancelled.
+    bool reconfigure(const std::string& pipeName,
+                     const std::string& propertiesFile,
+                     const std::atomic_bool& isCancelled);
+
     //! Reconfigure to use provided stream.
     bool reconfigure(boost::shared_ptr<std::ostream> streamPtr);
 
     //! Tell the logger to log to a named pipe rather than a file.
     bool reconfigureLogToNamedPipe(const std::string& pipeName);
+
+    //! As above, but with a flag to indicate named pipe connection attempts
+    //! should be cancelled.
+    bool reconfigureLogToNamedPipe(const std::string& pipeName,
+                                   const std::atomic_bool& isCancelled);
 
     //! Tell the logger to reconfigure itself by reading a specified
     //! properties file, if the file exists.

--- a/include/core/CNamedPipeFactory.h
+++ b/include/core/CNamedPipeFactory.h
@@ -10,11 +10,12 @@
 #include <core/ImportExport.h>
 #include <core/WindowsSafe.h>
 
+#include <atomic>
 #include <iosfwd>
 #include <memory>
 #include <string>
 
-#include <stdio.h>
+#include <stdio.h> // fdopen() is not C++ so need the C header
 
 namespace ml {
 namespace core {
@@ -69,20 +70,24 @@ public:
     //! Initialise and open a named pipe for reading, returning a C++ stream
     //! that can be used to read from it.  Returns a NULL pointer on
     //! failure.
-    static TIStreamP openPipeStreamRead(const std::string& fileName);
+    static TIStreamP openPipeStreamRead(const std::string& fileName,
+                                        const std::atomic_bool& isCancelled);
 
     //! Initialise and open a named pipe for writing, returning a C++ stream
     //! that can be used to write to it.  Returns a NULL pointer on failure.
-    static TOStreamP openPipeStreamWrite(const std::string& fileName);
+    static TOStreamP openPipeStreamWrite(const std::string& fileName,
+                                         const std::atomic_bool& isCancelled);
 
     //! Initialise and open a named pipe for writing, returning a C FILE
     //! that can be used to read from it.  Returns a NULL pointer on
     //! failure.
-    static TFileP openPipeFileRead(const std::string& fileName);
+    static TFileP openPipeFileRead(const std::string& fileName,
+                                   const std::atomic_bool& isCancelled);
 
     //! Initialise and open a named pipe for writing, returning a C FILE
     //! that can be used to write to it.  Returns a NULL pointer on failure.
-    static TFileP openPipeFileWrite(const std::string& fileName);
+    static TFileP openPipeFileWrite(const std::string& fileName,
+                                    const std::atomic_bool& isCancelled);
 
     //! Does the supplied file name refer to a named pipe?
     static bool isNamedPipe(const std::string& fileName);
@@ -107,7 +112,9 @@ private:
     //! file descriptor that can be used to access it.  This is the core
     //! implementation of the higher level encapsulations that the public
     //! interface provides.
-    static TPipeHandle initPipeHandle(const std::string& fileName, bool forWrite);
+    static TPipeHandle initPipeHandle(const std::string& fileName,
+                                      bool forWrite,
+                                      const std::atomic_bool& isCancelled);
 };
 }
 }

--- a/lib/api/CIoManager.cc
+++ b/lib/api/CIoManager.cc
@@ -7,6 +7,7 @@
 
 #include <core/CLogger.h>
 
+#include <atomic>
 #include <fstream>
 #include <ios>
 #include <iostream>
@@ -24,7 +25,8 @@ bool setUpIStream(const std::string& fileName,
         return true;
     }
     if (isFileNamedPipe) {
-        stream = core::CNamedPipeFactory::openPipeStreamRead(fileName);
+        std::atomic_bool dummy{false};
+        stream = core::CNamedPipeFactory::openPipeStreamRead(fileName, dummy);
         return stream != nullptr && !stream->bad();
     }
     std::ifstream* fileStream(nullptr);
@@ -40,7 +42,8 @@ bool setUpOStream(const std::string& fileName,
         return true;
     }
     if (isFileNamedPipe) {
-        stream = core::CNamedPipeFactory::openPipeStreamWrite(fileName);
+        std::atomic_bool dummy{false};
+        stream = core::CNamedPipeFactory::openPipeStreamWrite(fileName, dummy);
         return stream != nullptr && !stream->bad();
     }
     std::ofstream* fileStream(nullptr);

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -266,6 +266,13 @@ const std::string& CLogger::levelToString(ELevel level) {
 }
 
 bool CLogger::reconfigure(const std::string& pipeName, const std::string& propertiesFile) {
+    std::atomic_bool dummy{false};
+    return this->reconfigure(pipeName, propertiesFile, dummy);
+}
+
+bool CLogger::reconfigure(const std::string& pipeName,
+                          const std::string& propertiesFile,
+                          const std::atomic_bool& isCancelled) {
     if (pipeName.empty()) {
         if (propertiesFile.empty()) {
             // Both empty is OK - it just means we keep logging to stderr
@@ -273,7 +280,7 @@ bool CLogger::reconfigure(const std::string& pipeName, const std::string& proper
         }
         return this->reconfigureFromFile(propertiesFile);
     }
-    return this->reconfigureLogToNamedPipe(pipeName);
+    return this->reconfigureLogToNamedPipe(pipeName, isCancelled);
 }
 
 bool CLogger::reconfigure(boost::shared_ptr<std::ostream> streamPtr) {
@@ -287,12 +294,18 @@ bool CLogger::reconfigure(boost::shared_ptr<std::ostream> streamPtr) {
 }
 
 bool CLogger::reconfigureLogToNamedPipe(const std::string& pipeName) {
+    std::atomic_bool dummy{false};
+    return this->reconfigureLogToNamedPipe(pipeName, dummy);
+}
+
+bool CLogger::reconfigureLogToNamedPipe(const std::string& pipeName,
+                                        const std::atomic_bool& isCancelled) {
     if (m_Reconfigured) {
         LOG_ERROR(<< "Cannot log to a named pipe after logger reconfiguration");
         return false;
     }
 
-    m_PipeFile = CNamedPipeFactory::openPipeFileWrite(pipeName);
+    m_PipeFile = CNamedPipeFactory::openPipeFileWrite(pipeName, isCancelled);
     if (m_PipeFile == nullptr) {
         LOG_ERROR(<< "Cannot log to named pipe " << pipeName
                   << " as it could not be opened for writing");

--- a/lib/core/CNamedPipeFactory.cc
+++ b/lib/core/CNamedPipeFactory.cc
@@ -44,7 +44,7 @@ bool ignoreSigPipe() {
     return ::sigaction(SIGPIPE, &sa, nullptr) == 0;
 }
 
-const bool SIGPIPE_IGNORED(ignoreSigPipe());
+const bool SIGPIPE_IGNORED{ignoreSigPipe()};
 
 //! \brief
 //! Replacement for boost::iostreams::file_descriptor_sink that retries on EINTR.
@@ -78,12 +78,12 @@ public:
     //! in the event of an interrupted system call.  The method signature is
     //! defined by Boost's Sink concept.
     std::streamsize write(const char* s, std::streamsize n) {
-        std::streamsize totalBytesWritten = 0;
+        std::streamsize totalBytesWritten{0};
         while (n > 0) {
-            ssize_t ret = ::write(this->handle(), s, static_cast<size_t>(n));
+            ssize_t ret{::write(this->handle(), s, static_cast<size_t>(n))};
             if (ret == -1) {
                 if (errno != EINTR) {
-                    std::string reason("Failed writing to named pipe: ");
+                    std::string reason{"Failed writing to named pipe: "};
                     reason += ::strerror(errno);
                     LOG_ERROR(<< reason);
                     // We don't usually throw exceptions, but Boost.Iostreams
@@ -107,42 +107,50 @@ namespace core {
 // Initialise static
 const char CNamedPipeFactory::TEST_CHAR('\n');
 
-CNamedPipeFactory::TIStreamP CNamedPipeFactory::openPipeStreamRead(const std::string& fileName) {
-    TPipeHandle fd = CNamedPipeFactory::initPipeHandle(fileName, false);
+CNamedPipeFactory::TIStreamP
+CNamedPipeFactory::openPipeStreamRead(const std::string& fileName,
+                                      const std::atomic_bool& isCancelled) {
+    TPipeHandle fd{CNamedPipeFactory::initPipeHandle(fileName, false, isCancelled)};
     if (fd == -1) {
-        return TIStreamP();
+        return TIStreamP{};
     }
     using TFileDescriptorSourceStream =
         boost::iostreams::stream<boost::iostreams::file_descriptor_source>;
-    return TIStreamP(new TFileDescriptorSourceStream(
-        boost::iostreams::file_descriptor_source(fd, boost::iostreams::close_handle)));
+    return TIStreamP{new TFileDescriptorSourceStream(
+        boost::iostreams::file_descriptor_source(fd, boost::iostreams::close_handle))};
 }
 
-CNamedPipeFactory::TOStreamP CNamedPipeFactory::openPipeStreamWrite(const std::string& fileName) {
-    TPipeHandle fd = CNamedPipeFactory::initPipeHandle(fileName, true);
+CNamedPipeFactory::TOStreamP
+CNamedPipeFactory::openPipeStreamWrite(const std::string& fileName,
+                                       const std::atomic_bool& isCancelled) {
+    TPipeHandle fd{CNamedPipeFactory::initPipeHandle(fileName, true, isCancelled)};
     if (fd == -1) {
-        return TOStreamP();
+        return TOStreamP{};
     }
     using TRetryingFileDescriptorSinkStream =
         boost::iostreams::stream<CRetryingFileDescriptorSink>;
-    return TOStreamP(new TRetryingFileDescriptorSinkStream(
-        CRetryingFileDescriptorSink(fd, boost::iostreams::close_handle)));
+    return TOStreamP{new TRetryingFileDescriptorSinkStream(
+        CRetryingFileDescriptorSink(fd, boost::iostreams::close_handle))};
 }
 
-CNamedPipeFactory::TFileP CNamedPipeFactory::openPipeFileRead(const std::string& fileName) {
-    TPipeHandle fd = CNamedPipeFactory::initPipeHandle(fileName, false);
+CNamedPipeFactory::TFileP
+CNamedPipeFactory::openPipeFileRead(const std::string& fileName,
+                                    const std::atomic_bool& isCancelled) {
+    TPipeHandle fd{CNamedPipeFactory::initPipeHandle(fileName, false, isCancelled)};
     if (fd == -1) {
-        return TFileP();
+        return TFileP{};
     }
-    return TFileP(::fdopen(fd, "r"), safeFClose);
+    return TFileP{::fdopen(fd, "r"), safeFClose};
 }
 
-CNamedPipeFactory::TFileP CNamedPipeFactory::openPipeFileWrite(const std::string& fileName) {
-    TPipeHandle fd = CNamedPipeFactory::initPipeHandle(fileName, true);
+CNamedPipeFactory::TFileP
+CNamedPipeFactory::openPipeFileWrite(const std::string& fileName,
+                                     const std::atomic_bool& isCancelled) {
+    TPipeHandle fd{CNamedPipeFactory::initPipeHandle(fileName, true, isCancelled)};
     if (fd == -1) {
-        return TFileP();
+        return TFileP{};
     }
-    return TFileP(::fdopen(fd, "w"), safeFClose);
+    return TFileP{::fdopen(fd, "w"), safeFClose};
 }
 
 bool CNamedPipeFactory::isNamedPipe(const std::string& fileName) {
@@ -161,12 +169,12 @@ std::string CNamedPipeFactory::defaultPath() {
     // $TMPDIR is generally set on Mac OS X (to something like
     // /var/folders/k5/5sqcdlps5sg3cvlp783gcz740000h0/T/) and not set on other
     // platforms.
-    const char* tmpDir(::getenv("TMPDIR"));
+    const char* tmpDir{::getenv("TMPDIR")};
 
     // Make sure path ends with a slash so it's ready to have a file name
     // appended.  (_PATH_VARTMP already has this on all platforms I've seen,
     // but a user-defined $TMPDIR might not.)
-    std::string path((tmpDir == nullptr) ? _PATH_VARTMP : tmpDir);
+    std::string path{(tmpDir == nullptr) ? _PATH_VARTMP : tmpDir};
     if (path[path.length() - 1] != '/') {
         path += '/';
     }
@@ -181,13 +189,27 @@ void CNamedPipeFactory::logDeferredWarnings() {
 }
 
 CNamedPipeFactory::TPipeHandle
-CNamedPipeFactory::initPipeHandle(const std::string& fileName, bool forWrite) {
-    bool madeFifo(false);
+CNamedPipeFactory::initPipeHandle(const std::string& fileName,
+                                  bool forWrite,
+                                  const std::atomic_bool& isCancelled) {
+    bool madeFifo{false};
+
+    auto retrySyscallOnInterruptUnlessCancelled = [&isCancelled](std::function<int()> fn) {
+        int ret{-1};
+        if (isCancelled.load() == false) {
+            do {
+                ret = fn();
+            } while (ret == -1 && errno == EINTR && isCancelled.load() == false);
+        }
+        return ret;
+    };
 
     // If the name already exists, ensure it refers directly (i.e. not via a
     // symlink) to a named pipe
     COsFileFuncs::TStat statbuf;
-    if (COsFileFuncs::lstat(fileName.c_str(), &statbuf) == 0) {
+    if (retrySyscallOnInterruptUnlessCancelled([&fileName, &statbuf]() {
+            return COsFileFuncs::lstat(fileName.c_str(), &statbuf);
+        }) == 0) {
         if ((statbuf.st_mode & S_IFMT) != S_IFIFO) {
             LOG_ERROR(<< "Unable to create named pipe " << fileName
                       << " - a file "
@@ -201,36 +223,52 @@ CNamedPipeFactory::initPipeHandle(const std::string& fileName, bool forWrite) {
             return -1;
         }
     } else {
-        if (errno != ENOENT) {
+        if (errno != ENOENT && isCancelled.load() == false) {
             LOG_WARN(<< "lstat of named pipe " << fileName
                      << " failed with unexpected error " << ::strerror(errno));
         }
 
         // The file didn't exist, so create a new FIFO for it, with permissions
         // for the current user only
-        if (::mkfifo(fileName.c_str(), S_IRUSR | S_IWUSR) == -1) {
-            LOG_ERROR(<< "Unable to create named pipe " << fileName << ": "
-                      << ::strerror(errno));
+        if (retrySyscallOnInterruptUnlessCancelled([&fileName]() {
+                return ::mkfifo(fileName.c_str(), S_IRUSR | S_IWUSR);
+            }) == -1) {
+            if (isCancelled.load() == false) {
+                LOG_ERROR(<< "Unable to create named pipe " << fileName << ": "
+                          << ::strerror(errno));
+            }
             return -1;
         }
         madeFifo = true;
     }
 
+    if (isCancelled.load()) {
+        return -1;
+    }
+
     // The open call here will block if there is no other connection to the
     // named pipe
-    int fd = COsFileFuncs::open(fileName.c_str(), forWrite ? COsFileFuncs::WRONLY
-                                                           : COsFileFuncs::RDONLY);
+    int fd{retrySyscallOnInterruptUnlessCancelled([&fileName, forWrite]() {
+        return COsFileFuncs::open(fileName.c_str(), forWrite ? COsFileFuncs::WRONLY
+                                                             : COsFileFuncs::RDONLY);
+    })};
     if (fd == -1) {
-        LOG_ERROR(<< "Unable to open named pipe " << fileName
-                  << (forWrite ? " for writing: " : " for reading: ")
-                  << ::strerror(errno));
+        if (isCancelled.load() == false) {
+            LOG_ERROR(<< "Unable to open named pipe " << fileName
+                      << (forWrite ? " for writing: " : " for reading: ")
+                      << ::strerror(errno));
+        }
     } else {
         // Write a test character to the pipe - this is really only necessary on
         // Windows, but doing it on *nix too will mean the inability of the Java
         // code to tolerate the test character will be discovered sooner.
-        if (forWrite && COsFileFuncs::write(fd, &TEST_CHAR, sizeof(TEST_CHAR)) <= 0) {
-            LOG_ERROR(<< "Unable to test named pipe " << fileName << ": "
-                      << ::strerror(errno));
+        if (forWrite && retrySyscallOnInterruptUnlessCancelled([fd]() {
+                            return COsFileFuncs::write(fd, &TEST_CHAR, sizeof(TEST_CHAR));
+                        }) <= 0) {
+            if (isCancelled.load() == false) {
+                LOG_ERROR(<< "Unable to test named pipe " << fileName << ": "
+                          << ::strerror(errno));
+            }
             COsFileFuncs::close(fd);
             fd = -1;
         }

--- a/lib/core/CThread.cc
+++ b/lib/core/CThread.cc
@@ -27,7 +27,7 @@ void noOpHandler(int /*sig*/) {
 //! Use SIGIO for waking up blocking calls.  The same handler will be used in
 //! all threads, so there's an assumption here that having some other sort of
 //! handling for SIGIO is not important to any other thread in the process.
-//! That will be true of Ml code.  If a 3rd party library relied on SIGIO
+//! That will be true of ML code.  If a 3rd party library relied on SIGIO
 //! handling then we could change the signal we use in this class to another
 //! (maybe SIGURG).  However, it's bad practice for reusable libraries to
 //! unconditionally install signal handlers, so unlikely to be a problem.


### PR DESCRIPTION
This change fixes two related issues with named pipe connection
when the controller process first starts up:

1. If the ES JVM dies before the controller connects its logging
   named pipe then since elastic/elasticsearch#56491 the resulting
   errors from the controller process will be seen in the ES
   stderr file.  There is a change to the logging to make it
   clearer that the controller didn't fail, but exited due to
   the ES JVM disappearing.
2. Interrupted system calls while connecting the named pipes
   could cause the pipes to unnecessarily fail to connect.  There
   is a change to retry the calls on getting an EINTR error unless
   the interrupt was caused by the functionality of controller
   that kills off the connection attempts if the ES JVM dies (i.e.
   the scenario described in point 1).

Backport of #1311