### PR TITLE
[7.x][ML] Write categorizer stats per categorizer to separate documents

### DIFF
--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -278,9 +278,14 @@ int main(int argc, char** argv) {
     ml::api::CJsonOutputWriter fieldDataCategorizerOutputWriter(jobId, wrappedOutputStream);
 
     // The categorizer knows how to assign categories to records
-    ml::api::CFieldDataCategorizer categorizer(jobId, fieldConfig, limits, outputChainer,
+    ml::api::CFieldDataCategorizer categorizer{jobId,
+                                               fieldConfig,
+                                               limits,
+                                               timeField,
+                                               timeFormat,
+                                               outputChainer,
                                                fieldDataCategorizerOutputWriter,
-                                               persistenceManager.get());
+                                               persistenceManager.get()};
 
     if (fieldConfig.fieldNameSuperset().count(
             ml::api::CFieldDataCategorizer::MLCATEGORY_NAME) > 0) {

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -54,18 +54,22 @@ int main(int argc, char** argv) {
     std::string jobId;
     std::string logProperties;
     std::string logPipe;
-    char delimiter('\t');
-    bool lengthEncodedInput(false);
-    ml::core_t::TTime persistInterval(-1);
+    char delimiter{'\t'};
+    bool lengthEncodedInput{false};
+    // Currently there aren't command line options for the time field/format
+    // TODO: add options to set these if this program is used in the future
+    std::string timeField;
+    std::string timeFormat;
+    ml::core_t::TTime persistInterval{-1};
     std::string inputFileName;
-    bool isInputFileNamedPipe(false);
+    bool isInputFileNamedPipe{false};
     std::string outputFileName;
-    bool isOutputFileNamedPipe(false);
+    bool isOutputFileNamedPipe{false};
     std::string restoreFileName;
-    bool isRestoreFileNamedPipe(false);
+    bool isRestoreFileNamedPipe{false};
     std::string persistFileName;
-    bool isPersistFileNamedPipe(false);
-    bool isPersistInForeground(false);
+    bool isPersistFileNamedPipe{false};
+    bool isPersistInForeground{false};
     std::string categorizationFieldName;
     if (ml::categorize::CCmdLineParser::parse(
             argc, argv, limitConfigFile, jobId, logProperties, logPipe, delimiter,
@@ -182,8 +186,9 @@ int main(int argc, char** argv) {
     ml::api::CJsonOutputWriter outputWriter(jobId, wrappedOutputStream);
 
     // The categorizer knows how to assign categories to records
-    ml::api::CFieldDataCategorizer categorizer(jobId, fieldConfig, limits, nullOutput,
-                                               outputWriter, persistenceManager.get());
+    ml::api::CFieldDataCategorizer categorizer{
+        jobId,      fieldConfig, limits,       timeField,
+        timeFormat, nullOutput,  outputWriter, persistenceManager.get()};
 
     if (persistenceManager != nullptr) {
         persistenceManager->firstProcessorBackgroundPeriodicPersistFunc(std::bind(

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@
 * Parallelize the feature importance calculation for classification and regression
   over trees. (See {ml-pull}1277[#1277].)
 * Add an option to do categorization independently for each partition.
-  (See {ml-pull}1293[#1293] and {pull}57683[#57683].)
+  (See {ml-pull}1293[#1293], {ml-pull}1318[#1318] and {pull}57683[#57683].)
 * Memory usage is reported during job initialization. (See {ml-pull}1294[#1294].)
 * More realistic memory estimation for classification and regression means that these
   analyses will require lower memory limits than before (See {ml-pull}1298[#1298].)

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -161,7 +161,7 @@ public:
 
     //! Receive a single record to be processed, and produce output
     //! with any required modifications
-    bool handleRecord(const TStrStrUMap& dataRowFields) override;
+    bool handleRecord(const TStrStrUMap& dataRowFields, TOptionalTime time) override;
 
     //! Perform any final processing once all input data has been seen.
     void finalise() override;
@@ -429,14 +429,6 @@ private:
 
     //! Optional function to be called when persistence is complete
     TPersistCompleteFunc m_PersistCompleteFunc;
-
-    //! Name of field holding the time
-    std::string m_TimeFieldName;
-
-    //! Time field format.  Blank means seconds since the epoch, i.e. the
-    //! time field can be converted to a time_t by simply converting the
-    //! string to a number.
-    std::string m_TimeFieldFormat;
 
     //! License restriction on the number of detectors allowed
     std::size_t m_MaxDetectors;

--- a/include/api/CCsvOutputWriter.h
+++ b/include/api/CCsvOutputWriter.h
@@ -77,7 +77,7 @@ public:
     //! present - this is only allowed once
     bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
-    // Bring the other overload of writeRow() into scope
+    // Bring the other overloads of writeRow() into scope
     using COutputHandler::writeRow;
 
     //! Write a row to the stream, optionally overriding some of the
@@ -85,7 +85,8 @@ public:
     //! overrideDataRowFields and dataRowFields, the value in
     //! overrideDataRowFields will be written.
     bool writeRow(const TStrStrUMap& dataRowFields,
-                  const TStrStrUMap& overrideDataRowFields) override;
+                  const TStrStrUMap& overrideDataRowFields,
+                  TOptionalTime time) override;
 
     //! Get the contents of the internal string stream - for use with the
     //! zero argument constructor

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -100,23 +100,26 @@ public:
 
 public:
     //! Construct without persistence capability
-    CFieldDataCategorizer(const std::string& jobId,
+    CFieldDataCategorizer(std::string jobId,
                           const CFieldConfig& config,
                           model::CLimits& limits,
+                          const std::string& timeFieldName,
+                          const std::string& timeFieldFormat,
                           COutputHandler& outputHandler,
                           CJsonOutputWriter& jsonOutputWriter,
                           CPersistenceManager* persistenceManager);
 
     ~CFieldDataCategorizer() override;
 
-    CGlobalCategoryId computeAndUpdateCategory(const TStrStrUMap& dataRowFields);
+    CGlobalCategoryId computeAndUpdateCategory(const TStrStrUMap& dataRowFields,
+                                               const TOptionalTime& time);
 
     //! We're going to be writing to a new output stream
     void newOutputStream() override;
 
     //! Receive a single record to be categorized, and output that record
     //! with its ML category field added
-    bool handleRecord(const TStrStrUMap& dataRowFields) override;
+    bool handleRecord(const TStrStrUMap& dataRowFields, TOptionalTime time) override;
 
     //! Perform any final processing once all input data has been seen.
     void finalise() override;
@@ -186,9 +189,9 @@ private:
     //! Acknowledge a flush request
     void acknowledgeFlush(const std::string& flushId, bool lastHandler);
 
-    //! Writes out to the JSON output writer any category that has changed
-    //! since the last time this method was called.
-    void writeOutChangedCategories();
+    //! Writes out to the JSON output writer any category definitions and stats
+    //! that have changed since they were last written.
+    void writeChanges();
 
     //! Get the next global ID to use.  This method only returns a useful
     //! result when per-partition categorization is being used.  When

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -188,9 +188,13 @@ public:
     //! always returns true
     bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
+    // Bring the other overloads of writeRow() into scope
+    using COutputHandler::writeRow;
+
     //! Write the data row fields as a JSON object
     bool writeRow(const TStrStrUMap& dataRowFields,
-                  const TStrStrUMap& overrideDataRowFields) override;
+                  const TStrStrUMap& overrideDataRowFields,
+                  TOptionalTime time) override;
 
     //! Limit the output to the top count anomalous records and influencers.
     //! Each detector will write no more than count records and influencers
@@ -235,6 +239,12 @@ public:
     //! Report the current levels of resource usage, as given to us
     //! from the CResourceMonitor via a callback
     void reportMemoryUsage(const model::CResourceMonitor::SModelSizeStats& modelSizeStats);
+
+    //! Write categorizer stats
+    void writeCategorizerStats(const std::string& partitionFieldName,
+                               const std::string& partitionFieldValue,
+                               const model::SCategorizerStats& categorizerStats,
+                               const TOptionalTime& timestamp);
 
     //! Acknowledge a flush request by echoing back the flush ID
     void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd);

--- a/include/api/CModelSizeStatsJsonWriter.h
+++ b/include/api/CModelSizeStatsJsonWriter.h
@@ -6,7 +6,6 @@
 #ifndef INCLUDED_ml_api_CModelSizeStatsJsonWriter_h
 #define INCLUDED_ml_api_CModelSizeStatsJsonWriter_h
 
-#include <core/CNonInstantiatable.h>
 #include <core/CRapidJsonConcurrentLineWriter.h>
 
 #include <model/CResourceMonitor.h>
@@ -16,16 +15,42 @@
 #include <string>
 
 namespace ml {
+namespace model {
+struct SCategorizerStats;
+}
 namespace api {
 
 //! \brief
 //! A static utility for writing the model_size_stats document in JSON.
-class API_EXPORT CModelSizeStatsJsonWriter : private core::CNonInstantiatable {
+class API_EXPORT CModelSizeStatsJsonWriter {
 public:
+    using TOptionalTime = boost::optional<core_t::TTime>;
+
+public:
+    //! Disallow instantiation.
+    CModelSizeStatsJsonWriter() = delete;
+    CModelSizeStatsJsonWriter(const CModelSizeStatsJsonWriter&) = delete;
+
     //! Writes the model size stats in the \p results in JSON format.
     static void write(const std::string& jobId,
                       const model::CResourceMonitor::SModelSizeStats& results,
                       core::CRapidJsonConcurrentLineWriter& writer);
+
+    //! Writes the categorizer stats in JSON format.
+    static void writeCategorizerStats(const std::string& jobId,
+                                      const std::string& partitionFieldName,
+                                      const std::string& partitionFieldValue,
+                                      const model::SCategorizerStats& categorizerStats,
+                                      const TOptionalTime& timestamp,
+                                      core::CRapidJsonConcurrentLineWriter& writer);
+
+private:
+    //! Writes fields common to both model size stats and categorizer stats in
+    //! JSON format.
+    static void writeCommonFields(const std::string& jobId,
+                                  const model::SCategorizerStats& categorizerStats,
+                                  const TOptionalTime& timestamp,
+                                  core::CRapidJsonConcurrentLineWriter& writer);
 };
 }
 }

--- a/include/api/CNdJsonOutputWriter.h
+++ b/include/api/CNdJsonOutputWriter.h
@@ -63,12 +63,13 @@ public:
     //! returns true
     virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames);
 
-    // Bring the other overload of writeRow() into scope
+    // Bring the other overloads of writeRow() into scope
     using COutputHandler::writeRow;
 
     //! Write the data row fields as a JSON object
     virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields);
+                          const TStrStrUMap& overrideDataRowFields,
+                          TOptionalTime time);
 
     //! Get the contents of the internal string stream - for use with the
     //! zero argument constructor

--- a/include/api/CNullOutput.h
+++ b/include/api/CNullOutput.h
@@ -40,9 +40,10 @@ public:
 
     //! Does nothing with the row provided.
     virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields);
+                          const TStrStrUMap& overrideDataRowFields,
+                          TOptionalTime time);
 
-    // Bring the other overload of writeRow() into scope
+    // Bring the other overloads of writeRow() into scope
     using COutputHandler::writeRow;
 };
 }

--- a/include/api/COutputChainer.h
+++ b/include/api/COutputChainer.h
@@ -50,7 +50,7 @@ public:
     //! present - this is only allowed once
     bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
-    // Bring the other overload of writeRow() into scope
+    // Bring the other overloads of writeRow() into scope
     using COutputHandler::writeRow;
 
     //! Call the next data processor's input function with some output
@@ -58,7 +58,8 @@ public:
     //! Where the same field is present in both overrideDataRowFields and
     //! dataRowFields, the value in overrideDataRowFields will be written.
     bool writeRow(const TStrStrUMap& dataRowFields,
-                  const TStrStrUMap& overrideDataRowFields) override;
+                  const TStrStrUMap& overrideDataRowFields,
+                  TOptionalTime time) override;
 
     //! Perform any final processing once all data for the current search
     //! has been seen.  Chained classes should NOT rely on this method being

--- a/include/api/COutputHandler.h
+++ b/include/api/COutputHandler.h
@@ -13,6 +13,7 @@
 
 #include <api/ImportExport.h>
 
+#include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
 #include <string>
@@ -52,6 +53,8 @@ public:
     using TStrStrUMapItr = TStrStrUMap::iterator;
     using TStrStrUMapCItr = TStrStrUMap::const_iterator;
 
+    using TOptionalTime = boost::optional<core_t::TTime>;
+
 public:
     //! Virtual destructor for abstract base class
     virtual ~COutputHandler() = default;
@@ -66,16 +69,21 @@ public:
     //! present - this is only allowed once
     virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) = 0;
 
-    //! Write a row to the stream.  The supplied map must contain every
-    //! field value.
-    virtual bool writeRow(const TStrStrUMap& dataRowFields);
+    //! Write a row to the stream.  The supplied map must contain every field
+    //! value.  The time will be passed as an empty optional, i.e. unknown.
+    bool writeRow(const TStrStrUMap& dataRowFields);
 
     //! Write a row to the stream, optionally overriding some of the
     //! original field values.  Where the same field is present in both
     //! overrideDataRowFields and dataRowFields, the value in
-    //! overrideDataRowFields will be written.
+    //! overrideDataRowFields will be written.  The time will be passed
+    //! as an empty optional, i.e. unknown.
+    bool writeRow(const TStrStrUMap& dataRowFields, const TStrStrUMap& overrideDataRowFields);
+
+    //! As above, but with a pre-parsed time.
     virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields) = 0;
+                          const TStrStrUMap& overrideDataRowFields,
+                          TOptionalTime time) = 0;
 
     //! Perform any final processing once all input data has been seen.
     virtual void finalise();

--- a/include/core/CTimeUtils.h
+++ b/include/core/CTimeUtils.h
@@ -13,6 +13,7 @@
 
 #include <boost/unordered_set.hpp>
 
+#include <cstdint>
 #include <string>
 
 namespace ml {
@@ -36,8 +37,11 @@ public:
     static const core_t::TTime MAX_CLOCK_DISCREPANCY;
 
 public:
-    //! Current time
+    //! Current time in seconds since the epoch
     static core_t::TTime now();
+
+    //! Current time in milliseconds since the epoch
+    static std::int64_t nowMs();
 
     //! Date and time to string according to http://www.w3.org/TR/NOTE-datetime
     //! E.g. 1997-07-16T19:20:30+01:00

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -17,10 +17,10 @@
 
 #include <model/CAnnotation.h>
 #include <model/CMemoryUsageEstimator.h>
-#include <model/CModelParams.h>
 #include <model/CPartitioningFields.h>
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>

--- a/include/model/CBucketGatherer.h
+++ b/include/model/CBucketGatherer.h
@@ -16,10 +16,10 @@
 
 #include <model/CBucketQueue.h>
 #include <model/CEventData.h>
-#include <model/CModelParams.h>
 #include <model/FunctionTypes.h>
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <boost/any.hpp>
 #include <boost/functional/hash.hpp>

--- a/include/model/CDataGatherer.h
+++ b/include/model/CDataGatherer.h
@@ -16,10 +16,10 @@
 #include <model/CBucketQueue.h>
 #include <model/CDynamicStringIdRegistry.h>
 #include <model/CEventData.h>
-#include <model/CModelParams.h>
 #include <model/FunctionTypes.h>
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <boost/any.hpp>
 #include <boost/optional.hpp>

--- a/include/model/CForecastDataSink.h
+++ b/include/model/CForecastDataSink.h
@@ -14,9 +14,9 @@
 
 #include <maths/CModel.h>
 
-#include <model/CModelParams.h>
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <rapidjson/allocators.h>
 #include <rapidjson/fwd.h>

--- a/include/model/CForecastModelPersist.h
+++ b/include/model/CForecastModelPersist.h
@@ -12,9 +12,9 @@
 
 #include <maths/CModel.h>
 
-#include <model/CModelParams.h>
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <boost/filesystem.hpp>
 

--- a/include/model/CModelFactory.h
+++ b/include/model/CModelFactory.h
@@ -13,10 +13,10 @@
 #include <maths/COrderings.h>
 #include <maths/MathsTypes.h>
 
-#include <model/CModelParams.h>
 #include <model/CSearchKey.h>
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>

--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -10,6 +10,7 @@
 
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SCategorizerStats.h>
 
 #include <boost/unordered_map.hpp>
 
@@ -49,13 +50,7 @@ public:
         core_t::TTime s_BucketStartTime = 0;
         std::size_t s_BytesExceeded = 0;
         std::size_t s_BytesMemoryLimit = 0;
-        std::size_t s_CategorizedMessages = 0;
-        std::size_t s_TotalCategories = 0;
-        std::size_t s_FrequentCategories = 0;
-        std::size_t s_RareCategories = 0;
-        std::size_t s_DeadCategories = 0;
-        std::size_t s_MemoryCategorizationFailures = 0;
-        model_t::ECategorizationStatus s_CategorizationStatus = model_t::E_CategorizationStatusOk;
+        SCategorizerStats s_OverallCategorizerStats;
     };
 
 public:

--- a/include/model/CSampleGatherer.h
+++ b/include/model/CSampleGatherer.h
@@ -24,11 +24,11 @@
 #include <model/CDataClassifier.h>
 #include <model/CMetricPartialStatistic.h>
 #include <model/CMetricStatisticWrappers.h>
-#include <model/CModelParams.h>
 #include <model/CSampleQueue.h>
 #include <model/CStringStore.h>
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <functional>
 #include <vector>

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -124,6 +124,23 @@ public:
         return true;
     }
 
+    //! Does the reverse search of this category match the reverse search find
+    //! everything that the reverse search for another category would find?
+    bool matchesSearchForCategory(const CTokenListCategory& other) const;
+
+    //! Does the reverse search of this category match the reverse search that
+    //! a category created from the supplied arguments would find?
+    template<typename PAIR_CONTAINER>
+    bool matchesSearchForCategory(std::size_t otherBaseWeight,
+                                  std::size_t otherStringLen,
+                                  const PAIR_CONTAINER& otherUniqueTokenIds,
+                                  const TSizeSizePrVec& otherBaseTokenIds) const {
+        return (m_BaseWeight == 0) == (otherBaseWeight == 0) &&
+               this->maxMatchingStringLen() >= otherStringLen &&
+               this->isMissingCommonTokenWeightZero(otherUniqueTokenIds) &&
+               this->containsCommonInOrderTokensInOrder(otherBaseTokenIds);
+    }
+
     //! Does the supplied token vector contain all our common tokens in the
     //! same order as our base token vector?
     bool containsCommonInOrderTokensInOrder(const TSizeSizePrVec& tokenIds) const;
@@ -137,11 +154,15 @@ public:
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
-    //! Attempt to get cached reverse search
-    bool cachedReverseSearch(std::string& part1, std::string& part2) const;
-
     //! Set the cached reverse search
-    void cacheReverseSearch(const std::string& part1, const std::string& part2);
+    void cacheReverseSearch(std::string part1, std::string part2);
+
+    //! Have we got a cached reverse search?
+    bool hasCachedReverseSearch() const;
+
+    //! Access the cached reverse search
+    const std::string& reverseSearchPart1() const;
+    const std::string& reverseSearchPart2() const;
 
     //! Debug the memory used by this category.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -20,17 +20,8 @@
 #include <string>
 #include <utility>
 
-#include <stdint.h>
-
 namespace ml {
-namespace core {
-class CStatePersistInserter;
-class CStateRestoreTraverser;
-}
 namespace maths {
-class CMultivariatePrior;
-class CPrior;
-class CTimeSeriesDecompositionInterface;
 template<typename>
 class CTimeSeriesMultibucketFeature;
 }
@@ -75,7 +66,7 @@ std::string print(EModelType type);
 //!   -# Conditional: if a result corresponds to a feature value which
 //!      is unusual only after conditioning on some other.
 //!
-//! IMPLEMENTATION:\n
+//! IMPLEMENTATION DECISIONS:\n
 //! Uses 1-of-n bitwise encoding of the different result binary descriptors
 //! so the size is just that of an unsigned int.
 class MODEL_EXPORT CResultType {

--- a/include/model/SCategorizerStats.h
+++ b/include/model/SCategorizerStats.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_model_SCategorizerStats_h
+#define INCLUDED_ml_model_SCategorizerStats_h
+
+#include <model/ImportExport.h>
+#include <model/ModelTypes.h>
+
+namespace ml {
+namespace model {
+//! \brief
+//! Stats that summarise what a categorizer has done.
+//!
+//! DESCIRIPTION:\n
+//! Stats that summarise what a categorizer has done.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! Timestamps are not stored.  When written as an output document,
+//! timestamps are expected to be added somewhere along the output
+//! path.
+//!
+struct MODEL_EXPORT SCategorizerStats {
+
+    std::size_t s_CategorizedMessages = 0;
+    std::size_t s_TotalCategories = 0;
+    std::size_t s_FrequentCategories = 0;
+    std::size_t s_RareCategories = 0;
+    std::size_t s_DeadCategories = 0;
+    std::size_t s_MemoryCategorizationFailures = 0;
+    model_t::ECategorizationStatus s_CategorizationStatus = model_t::E_CategorizationStatusOk;
+
+    //! Equality comparison
+    bool operator==(const SCategorizerStats& other) const {
+        return s_CategorizedMessages == other.s_CategorizedMessages &&
+               s_TotalCategories == other.s_TotalCategories &&
+               s_FrequentCategories == other.s_FrequentCategories &&
+               s_RareCategories == other.s_RareCategories &&
+               s_DeadCategories == other.s_DeadCategories &&
+               s_MemoryCategorizationFailures == other.s_MemoryCategorizationFailures &&
+               s_CategorizationStatus == other.s_CategorizationStatus;
+    }
+};
+}
+}
+
+#endif // INCLUDED_ml_model_SCategorizerStats_h

--- a/include/model/SModelParams.h
+++ b/include/model/SModelParams.h
@@ -4,8 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#ifndef INCLUDED_ml_model_CModelParams_h
-#define INCLUDED_ml_model_CModelParams_h
+#ifndef INCLUDED_ml_model_SModelParams_h
+#define INCLUDED_ml_model_SModelParams_h
 
 #include <core/CLogger.h>
 #include <core/CMemoryUsage.h>
@@ -33,7 +33,7 @@ namespace model {
 //! parameters to avoid the need of updating the constructor signatures
 //! of all the classes in the CModel hierarchy when new parameters added.
 //!
-//! IMPLEMENTATION:\n
+//! IMPLEMENTATION DECISIONS:\n
 //! This is purposely not implemented as a nested class so that it can
 //! be forward declared.
 struct MODEL_EXPORT SModelParams {
@@ -182,4 +182,4 @@ struct MODEL_EXPORT SModelParams {
 }
 }
 
-#endif // INCLUDED_ml_model_CModelParams_h
+#endif // INCLUDED_ml_model_SModelParams_h

--- a/lib/api/CAnnotationJsonWriter.cc
+++ b/lib/api/CAnnotationJsonWriter.cc
@@ -57,9 +57,9 @@ void CAnnotationJsonWriter::populateAnnotationObject(const std::string& jobId,
     m_Writer.addTimeFieldToObj(TIMESTAMP, annotation.time(), obj);
     m_Writer.addTimeFieldToObj(END_TIMESTAMP, annotation.time(), obj);
 
-    core_t::TTime currentTime(core::CTimeUtils::now());
-    m_Writer.addTimeFieldToObj(CREATE_TIME, currentTime, obj);
-    m_Writer.addTimeFieldToObj(MODIFIED_TIME, currentTime, obj);
+    std::int64_t currentTime(core::CTimeUtils::nowMs());
+    m_Writer.addIntFieldToObj(CREATE_TIME, currentTime, obj);
+    m_Writer.addIntFieldToObj(MODIFIED_TIME, currentTime, obj);
     m_Writer.addStringFieldCopyToObj(CREATE_USERNAME, "_xpack", obj);
     m_Writer.addStringFieldCopyToObj(MODIFIED_USERNAME, "_xpack", obj);
     m_Writer.addStringFieldCopyToObj(TYPE, "annotation", obj);

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -132,17 +132,16 @@ CAnomalyJob::CAnomalyJob(const std::string& jobId,
                          const std::string& timeFieldName,
                          const std::string& timeFieldFormat,
                          size_t maxAnomalyRecords)
-    : m_JobId(jobId), m_Limits(limits), m_OutputStream(outputStream),
-      m_ForecastRunner(m_JobId, m_OutputStream, limits.resourceMonitor()),
-      m_JsonOutputWriter(m_JobId, m_OutputStream), m_FieldConfig(fieldConfig),
-      m_ModelConfig(modelConfig), m_NumRecordsHandled(0),
-      m_LastFinalisedBucketEndTime(0), m_PersistCompleteFunc(persistCompleteFunc),
-      m_TimeFieldName(timeFieldName), m_TimeFieldFormat(timeFieldFormat),
-      m_MaxDetectors(std::numeric_limits<size_t>::max()),
-      m_PersistenceManager(persistenceManager),
-      m_MaxQuantileInterval(maxQuantileInterval),
-      m_LastNormalizerPersistTime(core::CTimeUtils::now()), m_LatestRecordTime(0),
-      m_LastResultsTime(0), m_Aggregator(modelConfig), m_Normalizer(modelConfig) {
+    : CDataProcessor{timeFieldName, timeFieldFormat}, m_JobId{jobId}, m_Limits{limits},
+      m_OutputStream{outputStream}, m_ForecastRunner{m_JobId, m_OutputStream,
+                                                     limits.resourceMonitor()},
+      m_JsonOutputWriter{m_JobId, m_OutputStream}, m_FieldConfig{fieldConfig},
+      m_ModelConfig{modelConfig}, m_NumRecordsHandled{0},
+      m_LastFinalisedBucketEndTime{0}, m_PersistCompleteFunc{persistCompleteFunc},
+      m_MaxDetectors{std::numeric_limits<size_t>::max()},
+      m_PersistenceManager{persistenceManager}, m_MaxQuantileInterval{maxQuantileInterval},
+      m_LastNormalizerPersistTime{core::CTimeUtils::now()}, m_LatestRecordTime{0},
+      m_LastResultsTime{0}, m_Aggregator{modelConfig}, m_Normalizer{modelConfig} {
     m_JsonOutputWriter.limitNumberRecords(maxAnomalyRecords);
 
     m_Limits.resourceMonitor().memoryUsageReporter(std::bind(
@@ -161,37 +160,19 @@ COutputHandler& CAnomalyJob::outputHandler() {
     return m_JsonOutputWriter;
 }
 
-bool CAnomalyJob::handleRecord(const TStrStrUMap& dataRowFields) {
+bool CAnomalyJob::handleRecord(const TStrStrUMap& dataRowFields, TOptionalTime time) {
     // Non-empty control fields take precedence over everything else
     TStrStrUMapCItr iter = dataRowFields.find(CONTROL_FIELD_NAME);
     if (iter != dataRowFields.end() && !iter->second.empty()) {
         return this->handleControlMessage(iter->second);
     }
 
-    core_t::TTime time(0);
-    iter = dataRowFields.find(m_TimeFieldName);
-    if (iter == dataRowFields.end()) {
-        ++core::CProgramCounters::counter(counter_t::E_TSADNumberRecordsNoTimeField);
-        LOG_ERROR(<< "Found record with no " << m_TimeFieldName << " field:"
-                  << core_t::LINE_ENDING << this->debugPrintRecord(dataRowFields));
-        return true;
-    }
-    if (m_TimeFieldFormat.empty()) {
-        if (core::CStringUtils::stringToType(iter->second, time) == false) {
-            ++core::CProgramCounters::counter(counter_t::E_TSADNumberTimeFieldConversionErrors);
-            LOG_ERROR(<< "Cannot interpret " << m_TimeFieldName
-                      << " field in record:" << core_t::LINE_ENDING
-                      << this->debugPrintRecord(dataRowFields));
-            return true;
-        }
-    } else {
-        // Use this library function instead of raw strptime() as it works
-        // around many operating system specific issues.
-        if (core::CTimeUtils::strptime(m_TimeFieldFormat, iter->second, time) == false) {
-            ++core::CProgramCounters::counter(counter_t::E_TSADNumberTimeFieldConversionErrors);
-            LOG_ERROR(<< "Cannot interpret " << m_TimeFieldName << " field using format "
-                      << m_TimeFieldFormat << " in record:" << core_t::LINE_ENDING
-                      << this->debugPrintRecord(dataRowFields));
+    // Time may have been parsed already further back along the chain
+    if (time == boost::none) {
+        time = this->parseTime(dataRowFields);
+        if (time == boost::none) {
+            // Time is compulsory for anomaly detection - the base class will
+            // have logged the parse error
             return true;
         }
     }
@@ -200,7 +181,7 @@ bool CAnomalyJob::handleRecord(const TStrStrUMap& dataRowFields) {
     // is zero, then it should be after the current bucket end. If
     // latency is non-zero, then it should be after the current bucket
     // end minus the latency.
-    if (time < m_LastFinalisedBucketEndTime) {
+    if (*time < m_LastFinalisedBucketEndTime) {
         ++core::CProgramCounters::counter(counter_t::E_TSADNumberTimeOrderErrors);
         std::ostringstream ss;
         ss << "Records must be in ascending time order. "
@@ -210,7 +191,7 @@ bool CAnomalyJob::handleRecord(const TStrStrUMap& dataRowFields) {
         return true;
     }
 
-    this->outputBucketResultsUntil(time);
+    this->outputBucketResultsUntil(*time);
 
     if (m_DetectorKeys.empty()) {
         this->populateDetectorKeys(m_FieldConfig, m_DetectorKeys);
@@ -230,19 +211,19 @@ bool CAnomalyJob::handleRecord(const TStrStrUMap& dataRowFields) {
 
         const TAnomalyDetectorPtr& detector = this->detectorForKey(
             false, // not restoring
-            time, m_DetectorKeys[i], partitionFieldValue, m_Limits.resourceMonitor());
+            *time, m_DetectorKeys[i], partitionFieldValue, m_Limits.resourceMonitor());
         if (detector == nullptr) {
             // There wasn't enough memory to create the detector
             continue;
         }
 
-        this->addRecord(detector, time, dataRowFields);
+        this->addRecord(detector, *time, dataRowFields);
     }
 
     ++core::CProgramCounters::counter(counter_t::E_TSADNumberApiRecordsHandled);
 
     ++m_NumRecordsHandled;
-    m_LatestRecordTime = std::max(m_LatestRecordTime, time);
+    m_LatestRecordTime = std::max(m_LatestRecordTime, *time);
 
     return true;
 }

--- a/lib/api/CCmdSkeleton.cc
+++ b/lib/api/CCmdSkeleton.cc
@@ -36,8 +36,9 @@ bool CCmdSkeleton::ioLoop() {
         }
     }
 
-    if (m_InputParser.readStreamIntoMaps(std::bind(&CDataProcessor::handleRecord, &m_Processor,
-                                                   std::placeholders::_1)) == false) {
+    if (m_InputParser.readStreamIntoMaps([this](const CDataProcessor::TStrStrUMap& dataRowFields) {
+            return m_Processor.handleRecord(dataRowFields, CDataProcessor::TOptionalTime{});
+        }) == false) {
         LOG_FATAL(<< "Failed to handle all input data");
         return false;
     }

--- a/lib/api/CCsvOutputWriter.cc
+++ b/lib/api/CCsvOutputWriter.cc
@@ -118,7 +118,8 @@ bool CCsvOutputWriter::fieldNames(const TStrVec& fieldNames, const TStrVec& extr
 }
 
 bool CCsvOutputWriter::writeRow(const TStrStrUMap& dataRowFields,
-                                const TStrStrUMap& overrideDataRowFields) {
+                                const TStrStrUMap& overrideDataRowFields,
+                                TOptionalTime /*time*/) {
     if (m_FieldNames.empty()) {
         LOG_ERROR(<< "Attempt to write data before field names");
         return false;

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -7,7 +7,6 @@
 
 #include <core/CTimeUtils.h>
 
-#include <iomanip>
 #include <maths/CBoostedTree.h>
 
 #include <api/CDataFrameOutliersRunner.h>
@@ -19,6 +18,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <iomanip>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -30,7 +30,6 @@ namespace api {
 namespace {
 using TStrVec = std::vector<std::string>;
 
-// clang-format off
 const double MEMORY_LIMIT_INCREMENT{2.0}; // request 100% more memory
 
 const std::string CLASSIFICATION_STATS_TAG{"classification_stats"};
@@ -65,7 +64,6 @@ const std::string NUM_SPLITS_PER_FEATURE_TAG{"num_splits_per_feature"};
 const std::string PHASE_PROGRESS{"phase_progress"};
 const std::string PHASE{"phase"};
 const std::string PROGRESS_PERCENT{"progress_percent"};
-// clang-format on
 
 const std::size_t MAXIMUM_FRACTIONAL_PROGRESS{std::size_t{1}
                                               << ((sizeof(std::size_t) - 2) * 8)};
@@ -210,10 +208,8 @@ CDataFrameAnalysisInstrumentation::TWriter* CDataFrameAnalysisInstrumentation::w
 }
 
 void CDataFrameAnalysisInstrumentation::writeMemoryAndAnalysisStats() {
-    std::int64_t timestamp{std::chrono::duration_cast<std::chrono::milliseconds>(
-                               std::chrono::system_clock::now().time_since_epoch())
-                               .count()};
     if (m_Writer != nullptr) {
+        std::int64_t timestamp{core::CTimeUtils::nowMs()};
         m_Writer->StartObject();
         this->writeMemory(timestamp);
         this->writeAnalysisStats(timestamp);

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -354,7 +354,8 @@ bool CJsonOutputWriter::fieldNames(const TStrVec& /*fieldNames*/,
 }
 
 bool CJsonOutputWriter::writeRow(const TStrStrUMap& dataRowFields,
-                                 const TStrStrUMap& overrideDataRowFields) {
+                                 const TStrStrUMap& overrideDataRowFields,
+                                 TOptionalTime /*time*/) {
     using TScopedAllocator =
         core::CScopedRapidJsonPoolAllocator<core::CRapidJsonConcurrentLineWriter>;
 
@@ -865,6 +866,17 @@ void CJsonOutputWriter::reportMemoryUsage(const model::CResourceMonitor::SModelS
     m_Writer.EndObject();
 
     LOG_TRACE(<< "Wrote memory usage results");
+}
+
+void CJsonOutputWriter::writeCategorizerStats(const std::string& partitionFieldName,
+                                              const std::string& partitionFieldValue,
+                                              const model::SCategorizerStats& categorizerStats,
+                                              const TOptionalTime& timestamp) {
+    m_Writer.StartObject();
+    CModelSizeStatsJsonWriter::writeCategorizerStats(m_JobId, partitionFieldName,
+                                                     partitionFieldValue, categorizerStats,
+                                                     timestamp, m_Writer);
+    m_Writer.EndObject();
 }
 
 void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,

--- a/lib/api/CNdJsonOutputWriter.cc
+++ b/lib/api/CNdJsonOutputWriter.cc
@@ -50,7 +50,8 @@ bool CNdJsonOutputWriter::fieldNames(const TStrVec& /*fieldNames*/,
 }
 
 bool CNdJsonOutputWriter::writeRow(const TStrStrUMap& dataRowFields,
-                                   const TStrStrUMap& overrideDataRowFields) {
+                                   const TStrStrUMap& overrideDataRowFields,
+                                   TOptionalTime /*time*/) {
     using TScopedAllocator = core::CScopedRapidJsonPoolAllocator<TGenericLineWriter>;
     TScopedAllocator scopedAllocator("CNdJsonOutputWriter::writeRow", m_Writer);
 

--- a/lib/api/CNullOutput.cc
+++ b/lib/api/CNullOutput.cc
@@ -17,7 +17,8 @@ const COutputHandler::TStrVec& CNullOutput::fieldNames() const {
 }
 
 bool CNullOutput::writeRow(const TStrStrUMap& /*dataRowFields*/,
-                           const TStrStrUMap& /*overrideDataRowFields*/) {
+                           const TStrStrUMap& /*overrideDataRowFields*/,
+                           TOptionalTime /*time*/) {
     return true;
 }
 }

--- a/lib/api/COutputChainer.cc
+++ b/lib/api/COutputChainer.cc
@@ -57,7 +57,8 @@ bool COutputChainer::fieldNames(const TStrVec& fieldNames, const TStrVec& extraF
 }
 
 bool COutputChainer::writeRow(const TStrStrUMap& dataRowFields,
-                              const TStrStrUMap& overrideDataRowFields) {
+                              const TStrStrUMap& overrideDataRowFields,
+                              TOptionalTime time) {
     if (m_FieldNames.empty()) {
         LOG_ERROR(<< "Attempt to output data before field names");
         return false;
@@ -89,7 +90,7 @@ bool COutputChainer::writeRow(const TStrStrUMap& dataRowFields,
                                    fieldValueIter->second.length());
     }
 
-    if (m_DataProcessor.handleRecord(m_WorkRecordFields) == false) {
+    if (m_DataProcessor.handleRecord(m_WorkRecordFields, std::move(time)) == false) {
         LOG_ERROR(<< "Chained data processor function returned false for record:" << core_t::LINE_ENDING
                   << CDataProcessor::debugPrintRecord(m_WorkRecordFields));
         return false;

--- a/lib/api/COutputHandler.cc
+++ b/lib/api/COutputHandler.cc
@@ -23,7 +23,12 @@ bool COutputHandler::fieldNames(const TStrVec& fieldNames) {
 bool COutputHandler::writeRow(const TStrStrUMap& dataRowFields) {
     // Since the overrides are checked first, but we know there aren't any, it's
     // most efficient to pretend everything's an override
-    return this->writeRow(EMPTY_FIELD_OVERRIDES, dataRowFields);
+    return this->writeRow(EMPTY_FIELD_OVERRIDES, dataRowFields, TOptionalTime{});
+}
+
+bool COutputHandler::writeRow(const TStrStrUMap& dataRowFields,
+                              const TStrStrUMap& overrideDataRowFields) {
+    return this->writeRow(dataRowFields, overrideDataRowFields, TOptionalTime{});
 }
 
 void COutputHandler::finalise() {

--- a/lib/api/CSingleFieldDataCategorizer.cc
+++ b/lib/api/CSingleFieldDataCategorizer.cc
@@ -43,6 +43,7 @@ void CSingleFieldDataCategorizer::dumpStats() const {
 CGlobalCategoryId CSingleFieldDataCategorizer::computeAndUpdateCategory(
     bool isDryRun,
     const model::CDataCategorizer::TStrStrUMap& fields,
+    const TOptionalTime& messageTime,
     const std::string& messageToCategorize,
     const std::string& rawMessage,
     model::CResourceMonitor& resourceMonitor,
@@ -54,25 +55,28 @@ CGlobalCategoryId CSingleFieldDataCategorizer::computeAndUpdateCategory(
         return globalCategoryId;
     }
 
-    bool exampleAdded{m_DataCategorizer->addExample(globalCategoryId.localId(), rawMessage)};
-    std::size_t maxMatchingLength{0};
-    bool searchTermsChanged{false};
-    if (m_DataCategorizer->createReverseSearch(
-            localCategoryId, m_SearchTermsScratchSpace, m_SearchTermsRegexScratchSpace,
-            maxMatchingLength, searchTermsChanged) == false) {
-        m_SearchTermsScratchSpace.clear();
-        m_SearchTermsRegexScratchSpace.clear();
+    if (messageTime.has_value()) {
+        m_LastMessageTime = messageTime;
     }
+    bool exampleAdded{m_DataCategorizer->addExample(localCategoryId, rawMessage)};
+    bool searchTermsChanged{m_DataCategorizer->cacheReverseSearch(localCategoryId)};
     if (exampleAdded || searchTermsChanged) {
-        //! signal that we noticed the change and are persisting here
-        m_DataCategorizer->categoryChangedAndReset(localCategoryId);
-        jsonOutputWriter.writeCategoryDefinition(
-            m_PartitionFieldName, m_CategoryIdMapper->categorizerKey(), globalCategoryId,
-            m_SearchTermsScratchSpace, m_SearchTermsRegexScratchSpace, maxMatchingLength,
-            m_DataCategorizer->examplesCollector().examples(localCategoryId),
-            m_DataCategorizer->numMatches(localCategoryId),
-            m_CategoryIdMapper->mapVec(m_DataCategorizer->usurpedCategories(localCategoryId)));
-        if (globalCategoryId.globalId() % 10 == 0) {
+        // In this case we are certain that there will have been a change, as
+        // the count of the chosen category will have been incremented
+        m_DataCategorizer->writeCategoryIfChanged(
+            localCategoryId,
+            [this, &jsonOutputWriter](
+                model::CLocalCategoryId localCategoryId_, const std::string& terms,
+                const std::string& regex, std::size_t maxMatchingFieldLength,
+                const model::CCategoryExamplesCollector::TStrFSet& examples, std::size_t numMatches,
+                const model::CDataCategorizer::TLocalCategoryIdVec& usurpedCategories) {
+                jsonOutputWriter.writeCategoryDefinition(
+                    m_PartitionFieldName, m_CategoryIdMapper->categorizerKey(),
+                    m_CategoryIdMapper->map(localCategoryId_), terms, regex,
+                    maxMatchingFieldLength, examples, numMatches,
+                    m_CategoryIdMapper->mapVec(usurpedCategories));
+            });
+        if (localCategoryId.id() % 10 == 0) {
             // Even if memory limiting is disabled, force a refresh occasionally
             // so the user has some idea what's going on with memory.
             resourceMonitor.forceRefresh(*m_DataCategorizer);
@@ -184,34 +188,29 @@ bool CSingleFieldDataCategorizer::acceptRestoreTraverser(core::CStateRestoreTrav
     return true;
 }
 
-void CSingleFieldDataCategorizer::writeOutChangedCategories(CJsonOutputWriter& jsonOutputWriter) {
-    std::size_t numCategories{m_DataCategorizer->numCategories()};
-    if (numCategories == 0) {
-        return;
-    }
-
-    std::size_t maxMatchingLength{0};
-    bool wasCached{false};
-    for (std::size_t index = 0; index < numCategories; ++index) {
-        model::CLocalCategoryId localCategoryId{index};
-        if (m_DataCategorizer->categoryChangedAndReset(localCategoryId)) {
-            CGlobalCategoryId globalCategoryId{m_CategoryIdMapper->map(localCategoryId)};
-            if (m_DataCategorizer->createReverseSearch(
-                    localCategoryId, m_SearchTermsScratchSpace, m_SearchTermsRegexScratchSpace,
-                    maxMatchingLength, wasCached) == false) {
-                LOG_WARN(<< "Unable to create or retrieve reverse search to store for category: "
-                         << globalCategoryId);
-                continue;
-            }
-            LOG_TRACE(<< "Writing out changed category: " << globalCategoryId);
+void CSingleFieldDataCategorizer::writeChanges(CJsonOutputWriter& jsonOutputWriter) {
+    std::size_t numWritten{m_DataCategorizer->writeChangedCategories(
+        [this, &jsonOutputWriter](
+            model::CLocalCategoryId localCategoryId, const std::string& terms,
+            const std::string& regex, std::size_t maxMatchingFieldLength,
+            const model::CCategoryExamplesCollector::TStrFSet& examples, std::size_t numMatches,
+            const model::CDataCategorizer::TLocalCategoryIdVec& usurpedCategories) {
             jsonOutputWriter.writeCategoryDefinition(
                 m_PartitionFieldName, m_CategoryIdMapper->categorizerKey(),
-                globalCategoryId, m_SearchTermsScratchSpace,
-                m_SearchTermsRegexScratchSpace, maxMatchingLength,
-                m_DataCategorizer->examplesCollector().examples(localCategoryId),
-                m_DataCategorizer->numMatches(localCategoryId),
-                m_CategoryIdMapper->mapVec(m_DataCategorizer->usurpedCategories(localCategoryId)));
-        }
+                m_CategoryIdMapper->map(localCategoryId), terms, regex,
+                maxMatchingFieldLength, examples, numMatches,
+                m_CategoryIdMapper->mapVec(usurpedCategories));
+        })};
+    LOG_TRACE(<< numWritten << " changed categories written for categorizer "
+              << m_CategoryIdMapper->categorizerKey());
+    if (m_DataCategorizer->writeCategorizerStatsIfChanged(
+            [this, &jsonOutputWriter](const model::SCategorizerStats& categorizerStats) {
+                jsonOutputWriter.writeCategorizerStats(
+                    m_PartitionFieldName, m_CategoryIdMapper->categorizerKey(),
+                    categorizerStats, m_LastMessageTime);
+            })) {
+        LOG_TRACE(<< "Wrote categorizer stats for categorizer "
+                  << m_CategoryIdMapper->categorizerKey());
     }
 }
 

--- a/lib/api/dump_state/Main.cc
+++ b/lib/api/dump_state/Main.cc
@@ -123,7 +123,8 @@ bool writeNormalizerState(const std::string& outputFileName) {
     return true;
 }
 
-bool persistCategorizerStateToFile(const std::string& outputFileName) {
+bool persistCategorizerStateToFile(const std::string& outputFileName,
+                                   const std::string& timeFormat = std::string()) {
     ml::model::CLimits limits(true);
     ml::api::CFieldConfig config("count", "mlcategory");
 
@@ -131,13 +132,14 @@ bool persistCategorizerStateToFile(const std::string& outputFileName) {
     ml::core::CJsonOutputStreamWrapper wrappendOutStream(outStream);
     ml::api::CJsonOutputWriter writer("job", wrappendOutStream);
 
-    ml::api::CFieldDataCategorizer categorizer("job", config, limits, writer, writer, nullptr);
+    ml::api::CFieldDataCategorizer categorizer("job", config, limits, "time",
+                                               timeFormat, writer, writer, nullptr);
 
     ml::api::CFieldDataCategorizer::TStrStrUMap dataRowFields;
     dataRowFields["_raw"] = "thing";
     dataRowFields["two"] = "other";
 
-    categorizer.handleRecord(dataRowFields);
+    categorizer.handleRecord(dataRowFields, ml::api::CFieldDataCategorizer::TOptionalTime{});
 
     // Persist the categorizer state to file
     {
@@ -199,8 +201,10 @@ bool persistAnomalyDetectorStateToFile(const std::string& configFileName,
         return std::make_unique<ml::api::CNdJsonInputParser>(inputStrm);
     }()};
 
-    if (!parser->readStreamIntoMaps(std::bind(&ml::api::CAnomalyJob::handleRecord,
-                                              &origJob, std::placeholders::_1))) {
+    if (parser->readStreamIntoMaps([&origJob](const ml::api::CAnomalyJob::TStrStrUMap& dataRowFields) {
+            return origJob.handleRecord(dataRowFields,
+                                        ml::api::CAnomalyJob::TOptionalTime{});
+        }) == false) {
         LOG_ERROR(<< "Failed to processs input");
         return false;
     }

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -126,8 +126,10 @@ BOOST_AUTO_TEST_CASE(testAccuracy) {
             api::CCsvInputParser parser(inputStrm);
 
             LOG_TRACE(<< "Reading file");
-            BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(std::bind(
-                &CTestAnomalyJob::handleRecord, &job, std::placeholders::_1)));
+            BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
+                [&job](const CTestAnomalyJob::TStrStrUMap& dataRowFields) {
+                    return job.handleRecord(dataRowFields);
+                }));
 
             LOG_TRACE(<< "Checking results");
 
@@ -169,8 +171,10 @@ BOOST_AUTO_TEST_CASE(testAccuracy) {
             api::CCsvInputParser parser(inputStrm);
 
             LOG_TRACE(<< "Reading file");
-            BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(std::bind(
-                &CTestAnomalyJob::handleRecord, &job, std::placeholders::_1)));
+            BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
+                [&job](const CTestAnomalyJob::TStrStrUMap& dataRowFields) {
+                    return job.handleRecord(dataRowFields);
+                }));
 
             LOG_TRACE(<< "Checking results");
 
@@ -219,7 +223,9 @@ BOOST_AUTO_TEST_CASE(testLimit) {
 
         LOG_TRACE(<< "Reading file");
         BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
-            std::bind(&CTestAnomalyJob::handleRecord, &job, std::placeholders::_1)));
+            [&job](const CTestAnomalyJob::TStrStrUMap& dataRowFields) {
+                return job.handleRecord(dataRowFields);
+            }));
         LOG_TRACE(<< "Checking results");
         BOOST_REQUIRE_EQUAL(uint64_t(1176), job.numRecordsHandled());
     }
@@ -265,7 +271,9 @@ BOOST_AUTO_TEST_CASE(testLimit) {
 
         LOG_TRACE(<< "Reading file");
         BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
-            std::bind(&CTestAnomalyJob::handleRecord, &job, std::placeholders::_1)));
+            [&job](const CTestAnomalyJob::TStrStrUMap& dataRowFields) {
+                return job.handleRecord(dataRowFields);
+            }));
         // Now turn on the resource limiting
         limits.resourceMonitor().m_ByteLimitHigh = 0;
         limits.resourceMonitor().m_ByteLimitLow = 0;
@@ -277,7 +285,9 @@ BOOST_AUTO_TEST_CASE(testLimit) {
 
         LOG_TRACE(<< "Reading second file");
         BOOST_TEST_REQUIRE(parser2.readStreamIntoMaps(
-            std::bind(&CTestAnomalyJob::handleRecord, &job, std::placeholders::_1)));
+            [&job](const CTestAnomalyJob::TStrStrUMap& dataRowFields) {
+                return job.handleRecord(dataRowFields);
+            }));
         LOG_TRACE(<< "Checking results");
         BOOST_REQUIRE_EQUAL(uint64_t(1180), job.numRecordsHandled());
     }

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -65,7 +65,8 @@ public:
     }
 
     virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields) {
+                          const TStrStrUMap& overrideDataRowFields,
+                          TOptionalTime /*time*/) {
         ++m_NumRows;
         std::string categoryIdStr;
         auto iter = overrideDataRowFields.find("mlcategory");

--- a/lib/api/unittest/CMockDataProcessor.cc
+++ b/lib/api/unittest/CMockDataProcessor.cc
@@ -17,7 +17,7 @@ void CMockDataProcessor::newOutputStream() {
     m_OutputHandler.newOutputStream();
 }
 
-bool CMockDataProcessor::handleRecord(const TStrStrUMap& dataRowFields) {
+bool CMockDataProcessor::handleRecord(const TStrStrUMap& dataRowFields, TOptionalTime time) {
     // First time through we output the field names
     if (m_WriteFieldNames) {
         TStrVec fieldNames;
@@ -34,7 +34,7 @@ bool CMockDataProcessor::handleRecord(const TStrStrUMap& dataRowFields) {
         m_WriteFieldNames = false;
     }
 
-    if (m_OutputHandler.writeRow(dataRowFields, m_FieldOverrides) == false) {
+    if (m_OutputHandler.writeRow(dataRowFields, m_FieldOverrides, std::move(time)) == false) {
         LOG_ERROR(<< "Unable to write output");
         return false;
     }

--- a/lib/api/unittest/CMockDataProcessor.h
+++ b/lib/api/unittest/CMockDataProcessor.h
@@ -29,14 +29,18 @@ class COutputHandler;
 //! IMPLEMENTATION DECISIONS:\n
 //! Only the minimal set of required functions are implemented.
 //!
-class CMockDataProcessor : public ml::api::CDataProcessor {
+class CMockDataProcessor final : public ml::api::CDataProcessor {
 public:
     CMockDataProcessor(ml::api::COutputHandler& outputHandler);
 
     //! We're going to be writing to a new output stream
     void newOutputStream() override;
 
-    bool handleRecord(const TStrStrUMap& dataRowFields) override;
+    bool handleRecord(const TStrStrUMap& dataRowFields, TOptionalTime time) override;
+
+    bool handleRecord(const TStrStrUMap& dataRowFields) {
+        return this->handleRecord(dataRowFields, TOptionalTime{});
+    }
 
     void finalise() override;
 

--- a/lib/api/unittest/CModelSnapshotJsonWriterTest.cc
+++ b/lib/api/unittest/CModelSnapshotJsonWriterTest.cc
@@ -39,13 +39,13 @@ BOOST_AUTO_TEST_CASE(testWrite) {
             core_t::TTime(1521046309), // bucket start time
             0,                         // model bytes exceeded
             50000,                     // model bytes memory limit
-            1000,                      // categorized messages
-            100,                       // total categories
-            7,                         // frequent categories
-            13,                        // rare categories
-            2,                         // dead categories
-            8,                         // failed categories
-            model_t::E_CategorizationStatusWarn};
+            {1000,                     // categorized messages
+             100,                      // total categories
+             7,                        // frequent categories
+             13,                       // rare categories
+             2,                        // dead categories
+             8,                        // failed categories
+             model_t::E_CategorizationStatusWarn}};
 
         CModelSnapshotJsonWriter::SModelSnapshotReport report{
             "6.3.0",

--- a/lib/api/unittest/CMultiFileDataAdderTest.cc
+++ b/lib/api/unittest/CMultiFileDataAdderTest.cc
@@ -91,7 +91,9 @@ void detectorPersistHelper(const std::string& configFileName,
     }()};
 
     BOOST_TEST_REQUIRE(parser->readStreamIntoMaps(
-        std::bind(&CTestAnomalyJob::handleRecord, &origJob, std::placeholders::_1)));
+        [&origJob](const CTestAnomalyJob::TStrStrUMap& dataRowFields) {
+            return origJob.handleRecord(dataRowFields);
+        }));
 
     // Persist the detector state to file(s)
 

--- a/lib/api/unittest/COutputChainerTest.cc
+++ b/lib/api/unittest/COutputChainerTest.cc
@@ -58,8 +58,10 @@ BOOST_AUTO_TEST_CASE(testChaining) {
 
         ml::api::CNdJsonInputParser parser(inputStrm);
 
-        BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(std::bind(
-            &CMockDataProcessor::handleRecord, &mockProcessor, std::placeholders::_1)));
+        BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
+            [&mockProcessor](const CMockDataProcessor::TStrStrUMap& dataRowFields) {
+                return mockProcessor.handleRecord(dataRowFields);
+            }));
     }
 
     // Check the results by re-reading the output file

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -123,8 +123,10 @@ protected:
             ml::api::CNdJsonInputParser parser(inputStrm);
 
             BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
-                std::bind(&ml::api::CDataProcessor::handleRecord,
-                          firstProcessor, std::placeholders::_1)));
+                [firstProcessor](const ml::api::CDataProcessor::TStrStrUMap& dataRowFields) {
+                    return firstProcessor->handleRecord(
+                        dataRowFields, ml::api::CDataProcessor::TOptionalTime{});
+                }));
 
             // Persist the processors' state in the background
             BOOST_TEST_REQUIRE(firstProcessor->periodicPersistStateInBackground());
@@ -232,8 +234,10 @@ protected:
             ml::api::CNdJsonInputParser parser(inputStrm);
 
             BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
-                std::bind(&ml::api::CDataProcessor::handleRecord,
-                          firstProcessor, std::placeholders::_1)));
+                [firstProcessor](const ml::api::CDataProcessor::TStrStrUMap& dataRowFields) {
+                    return firstProcessor->handleRecord(
+                        dataRowFields, ml::api::CDataProcessor::TOptionalTime{});
+                }));
 
             // Ensure the model size stats are up to date
             job.finalise();
@@ -328,8 +332,10 @@ BOOST_FIXTURE_TEST_CASE(testBackgroundPersistCategorizationConsistency, CTestFix
         std::istringstream inputStrm1{FIRST_INPUT};
         ml::api::CNdJsonInputParser parser1{inputStrm1};
 
-        BOOST_TEST_REQUIRE(parser1.readStreamIntoMaps(std::bind(
-            &ml::api::CDataProcessor::handleRecord, &categorizer, std::placeholders::_1)));
+        BOOST_TEST_REQUIRE(parser1.readStreamIntoMaps(
+            [&categorizer](const CTestFieldDataCategorizer::TStrStrUMap& dataRowFields) {
+                return categorizer.handleRecord(dataRowFields);
+            }));
 
         // Now persist the categorizer's state in the background
         BOOST_TEST_REQUIRE(categorizer.periodicPersistStateInBackground());
@@ -349,8 +355,10 @@ BOOST_FIXTURE_TEST_CASE(testBackgroundPersistCategorizationConsistency, CTestFix
         // persistence is complete.  This shouldn't be a problem if the
         // background persistence copied the state, but if it didn't then
         // it should fail the test.
-        BOOST_TEST_REQUIRE(parser2.readStreamIntoMaps(std::bind(
-            &ml::api::CDataProcessor::handleRecord, &categorizer, std::placeholders::_1)));
+        BOOST_TEST_REQUIRE(parser2.readStreamIntoMaps(
+            [&categorizer](const CTestFieldDataCategorizer::TStrStrUMap& dataRowFields) {
+                return categorizer.handleRecord(dataRowFields);
+            }));
 
         BOOST_TEST_REQUIRE(persistenceManager.waitForIdle());
 
@@ -413,8 +421,10 @@ BOOST_FIXTURE_TEST_CASE(testCategorizationOnlyPersist, CTestFixture) {
 
         ml::api::CNdJsonInputParser parser(inputStrm);
 
-        BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(std::bind(
-            &ml::api::CDataProcessor::handleRecord, &categorizer, std::placeholders::_1)));
+        BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
+            [&categorizer](const CTestFieldDataCategorizer::TStrStrUMap& dataRowFields) {
+                return categorizer.handleRecord(dataRowFields);
+            }));
 
         // Persist the processors' state in the background
         BOOST_TEST_REQUIRE(categorizer.periodicPersistStateInBackground());

--- a/lib/api/unittest/CSingleFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CSingleFieldDataCategorizerTest.cc
@@ -85,13 +85,15 @@ BOOST_AUTO_TEST_CASE(testPersistNotPerPartition) {
     fields["message"] = "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r";
     BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{1},
                         origGlobalCategorizer.computeAndUpdateCategory(
-                            false, fields, fields["message"], fields["message"],
+                            false, fields, ml::api::CSingleFieldDataCategorizer::TOptionalTime{},
+                            fields["message"], fields["message"],
                             limits.resourceMonitor(), jsonOutputWriter));
 
     fields["message"] = "2015-10-18 18:01:52,728 INFO [main] org.mortbay.log: Started HttpServer2$SelectChannelConnectorWithSafeStartup@0.0.0.0:62267\r";
     BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId{2},
                         origGlobalCategorizer.computeAndUpdateCategory(
-                            false, fields, fields["message"], fields["message"],
+                            false, fields, ml::api::CSingleFieldDataCategorizer::TOptionalTime{},
+                            fields["message"], fields["message"],
                             limits.resourceMonitor(), jsonOutputWriter));
 
     idMapper = std::make_shared<ml::api::CNoopCategoryIdMapper>();
@@ -137,18 +139,18 @@ BOOST_AUTO_TEST_CASE(testPersistPerPartition) {
     ml::model::CDataCategorizer::TStrStrUMap fields;
     fields["event.dataset"] = "vmware";
     fields["message"] = "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback";
-    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(1, fields["event.dataset"],
-                                                   ml::model::CLocalCategoryId{1}),
-                        origGlobalCategorizer.computeAndUpdateCategory(
-                            false, fields, fields["message"], fields["message"],
-                            limits.resourceMonitor(), jsonOutputWriter));
+    BOOST_REQUIRE_EQUAL(
+        ml::api::CGlobalCategoryId(1, fields["event.dataset"], ml::model::CLocalCategoryId{1}),
+        origGlobalCategorizer.computeAndUpdateCategory(
+            false, fields, ml::api::CSingleFieldDataCategorizer::TOptionalTime{},
+            fields["message"], fields["message"], limits.resourceMonitor(), jsonOutputWriter));
 
     fields["message"] = "Vpxa: [49EC0B90 verbose 'Default' opID=WFU-ddeadb59] [VpxaHalVmHostagent] 11: GuestInfo changed 'guest.disk";
-    BOOST_REQUIRE_EQUAL(ml::api::CGlobalCategoryId(2, fields["event.dataset"],
-                                                   ml::model::CLocalCategoryId{2}),
-                        origGlobalCategorizer.computeAndUpdateCategory(
-                            false, fields, fields["message"], fields["message"],
-                            limits.resourceMonitor(), jsonOutputWriter));
+    BOOST_REQUIRE_EQUAL(
+        ml::api::CGlobalCategoryId(2, fields["event.dataset"], ml::model::CLocalCategoryId{2}),
+        origGlobalCategorizer.computeAndUpdateCategory(
+            false, fields, ml::api::CSingleFieldDataCategorizer::TOptionalTime{},
+            fields["message"], fields["message"], limits.resourceMonitor(), jsonOutputWriter));
 
     idMapper = std::make_shared<ml::api::CPerPartitionCategoryIdMapper>(
         "event.dataset", [&highestGlobalId]() { return ++highestGlobalId; });

--- a/lib/api/unittest/CSingleStreamDataAdderTest.cc
+++ b/lib/api/unittest/CSingleStreamDataAdderTest.cc
@@ -106,8 +106,11 @@ void detectorPersistHelper(const std::string& configFileName,
             return std::make_unique<ml::api::CNdJsonInputParser>(inputStrm);
         }()};
 
-        BOOST_TEST_REQUIRE(parser->readStreamIntoMaps(std::bind(
-            &ml::api::CDataProcessor::handleRecord, firstProcessor, std::placeholders::_1)));
+        BOOST_TEST_REQUIRE(parser->readStreamIntoMaps(
+            [firstProcessor](const ml::api::CDataProcessor::TStrStrUMap& dataRowFields) {
+                return firstProcessor->handleRecord(
+                    dataRowFields, ml::api::CDataProcessor::TOptionalTime{});
+            }));
 
         // Persist the detector state to a stringstream
         std::ostringstream* strm(nullptr);

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -85,7 +85,9 @@ core_t::TTime playData(core_t::TTime start,
     api::CCsvInputParser parser(ss);
 
     BOOST_TEST_REQUIRE(parser.readStreamIntoMaps(
-        std::bind(&CTestAnomalyJob::handleRecord, &job, std::placeholders::_1)));
+        [&job](const CTestAnomalyJob::TStrStrUMap& dataRowFields) {
+            return job.handleRecord(dataRowFields);
+        }));
 
     return t;
 }

--- a/lib/api/unittest/CTestAnomalyJob.h
+++ b/lib/api/unittest/CTestAnomalyJob.h
@@ -34,6 +34,13 @@ public:
                     const std::string& timeFieldName = DEFAULT_TIME_FIELD_NAME,
                     const std::string& timeFieldFormat = EMPTY_STRING,
                     std::size_t maxAnomalyRecords = 0u);
+
+    //! Bring base class overload of handleRecord() into scope
+    using CAnomalyJob::handleRecord;
+
+    bool handleRecord(const TStrStrUMap& dataRowFields) {
+        return this->handleRecord(dataRowFields, TOptionalTime{});
+    }
 };
 
 #endif // INCLUDED_CTestAnomalyJob_h

--- a/lib/api/unittest/CTestFieldDataCategorizer.cc
+++ b/lib/api/unittest/CTestFieldDataCategorizer.cc
@@ -11,5 +11,30 @@ CTestFieldDataCategorizer::CTestFieldDataCategorizer(const std::string& jobId,
                                                      ml::api::COutputHandler& outputHandler,
                                                      ml::api::CJsonOutputWriter& jsonOutputWriter,
                                                      ml::api::CPersistenceManager* persistenceManager)
-    : ml::api::CFieldDataCategorizer(jobId, config, limits, outputHandler, jsonOutputWriter, persistenceManager) {
+    : ml::api::CFieldDataCategorizer(jobId,
+                                     config,
+                                     limits,
+                                     std::string(),
+                                     std::string(),
+                                     outputHandler,
+                                     jsonOutputWriter,
+                                     persistenceManager) {
+}
+
+CTestFieldDataCategorizer::CTestFieldDataCategorizer(const std::string& jobId,
+                                                     const ml::api::CFieldConfig& config,
+                                                     ml::model::CLimits& limits,
+                                                     const std::string& timeFieldName,
+                                                     const std::string& timeFieldFormat,
+                                                     ml::api::COutputHandler& outputHandler,
+                                                     ml::api::CJsonOutputWriter& jsonOutputWriter,
+                                                     ml::api::CPersistenceManager* persistenceManager)
+    : ml::api::CFieldDataCategorizer(jobId,
+                                     config,
+                                     limits,
+                                     timeFieldName,
+                                     timeFieldFormat,
+                                     outputHandler,
+                                     jsonOutputWriter,
+                                     persistenceManager) {
 }

--- a/lib/api/unittest/CTestFieldDataCategorizer.h
+++ b/lib/api/unittest/CTestFieldDataCategorizer.h
@@ -29,6 +29,22 @@ public:
                               ml::api::COutputHandler& outputHandler,
                               ml::api::CJsonOutputWriter& jsonOutputWriter,
                               ml::api::CPersistenceManager* persistenceManager = nullptr);
+
+    CTestFieldDataCategorizer(const std::string& jobId,
+                              const ml::api::CFieldConfig& config,
+                              ml::model::CLimits& limits,
+                              const std::string& timeFieldName,
+                              const std::string& timeFieldFormat,
+                              ml::api::COutputHandler& outputHandler,
+                              ml::api::CJsonOutputWriter& jsonOutputWriter,
+                              ml::api::CPersistenceManager* persistenceManager = nullptr);
+
+    //! Bring base class overload of handleRecord() into scope
+    using CFieldDataCategorizer::handleRecord;
+
+    bool handleRecord(const TStrStrUMap& dataRowFields) {
+        return this->handleRecord(dataRowFields, TOptionalTime{});
+    }
 };
 
 #endif // INCLUDED_CTestFieldDataCategorizer_h

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -12,6 +12,8 @@
 #include <core/CTimezone.h>
 #include <core/CoreTypes.h>
 
+#include <chrono>
+
 #include <errno.h>
 #include <string.h>
 
@@ -22,8 +24,13 @@ namespace core {
 const core_t::TTime CTimeUtils::MAX_CLOCK_DISCREPANCY(300);
 
 core_t::TTime CTimeUtils::now() {
-    // TODO use std::chrono functionality
     return ::time(nullptr);
+}
+
+std::int64_t CTimeUtils::nowMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
 }
 
 std::string CTimeUtils::toIso8601(core_t::TTime t) {

--- a/lib/core/unittest/CTimeUtilsTest.cc
+++ b/lib/core/unittest/CTimeUtilsTest.cc
@@ -10,18 +10,21 @@
 #include <core/CTimeUtils.h>
 #include <core/CTimezone.h>
 
-#include <time.h>
-
 #include <boost/test/unit_test.hpp>
+
+#include <time.h>
 
 BOOST_AUTO_TEST_SUITE(CTimeUtilsTest)
 
 BOOST_AUTO_TEST_CASE(testNow) {
     ml::core_t::TTime t1(ml::core::CTimeUtils::now());
+    std::int64_t t1Ms(ml::core::CTimeUtils::nowMs());
     ml::core::CSleep::sleep(1001);
     ml::core_t::TTime t2(ml::core::CTimeUtils::now());
+    std::int64_t t2Ms(ml::core::CTimeUtils::nowMs());
 
     BOOST_TEST_REQUIRE(t2 > t1);
+    BOOST_TEST_REQUIRE(t2Ms > t1Ms);
 }
 
 BOOST_AUTO_TEST_CASE(testToIso8601) {

--- a/lib/model/CDataCategorizer.cc
+++ b/lib/model/CDataCategorizer.cc
@@ -17,8 +17,7 @@ namespace model {
 const CDataCategorizer::TStrStrUMap CDataCategorizer::EMPTY_FIELDS;
 
 CDataCategorizer::CDataCategorizer(CLimits& limits, const std::string& fieldName)
-    : m_Limits{limits}, m_FieldName{fieldName},
-      m_ExamplesCollector{limits.maxExamples()}, m_LastPersistTime{0} {
+    : m_Limits{limits}, m_FieldName{fieldName}, m_ExamplesCollector{limits.maxExamples()} {
     m_Limits.resourceMonitor().registerComponent(*this);
 }
 
@@ -34,14 +33,6 @@ CLocalCategoryId CDataCategorizer::computeCategory(bool isDryRun,
 
 const std::string& CDataCategorizer::fieldName() const {
     return m_FieldName;
-}
-
-core_t::TTime CDataCategorizer::lastPersistTime() const {
-    return m_LastPersistTime;
-}
-
-void CDataCategorizer::lastPersistTime(core_t::TTime lastPersistTime) {
-    m_LastPersistTime = lastPersistTime;
 }
 
 void CDataCategorizer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -290,7 +290,7 @@ CResourceMonitor::createMemoryUsageReport(core_t::TTime bucketStartTime) {
         resource.first->updateModelSizeStats(res);
     }
     res.s_AllocationFailures += m_AllocationFailures.size();
-    res.s_MemoryCategorizationFailures += m_CategorizerAllocationFailures;
+    res.s_OverallCategorizerStats.s_MemoryCategorizationFailures += m_CategorizerAllocationFailures;
     return res;
 }
 

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -413,6 +413,12 @@ std::size_t CTokenListCategory::missingCommonTokenWeight(const TSizeSizeMap& uni
     return m_CommonUniqueTokenWeight - presentWeight;
 }
 
+bool CTokenListCategory::matchesSearchForCategory(const CTokenListCategory& other) const {
+    return this->matchesSearchForCategory(
+        other.m_BaseWeight, other.maxMatchingStringLen(),
+        other.commonUniqueTokenIds(), other.baseTokenIds());
+}
+
 bool CTokenListCategory::containsCommonInOrderTokensInOrder(const TSizeSizePrVec& tokenIds) const {
 
     auto testIter = tokenIds.begin();
@@ -469,26 +475,26 @@ void CTokenListCategory::acceptPersistInserter(core::CStatePersistInserter& inse
     inserter.insertValue(NUM_MATCHES, m_NumMatches);
 }
 
-bool CTokenListCategory::cachedReverseSearch(std::string& part1, std::string& part2) const {
-    part1 = m_ReverseSearchPart1;
-    part2 = m_ReverseSearchPart2;
+void CTokenListCategory::cacheReverseSearch(std::string part1, std::string part2) {
+    m_ReverseSearchPart1 = std::move(part1);
+    m_ReverseSearchPart2 = std::move(part2);
+}
 
+bool CTokenListCategory::hasCachedReverseSearch() const {
     // There's an assumption here that a valid reverse search will not have both
     // parts 1 and 2 being empty strings. If this assumption ceases to be true
     // for any type of reverse search in the future then an extra boolean member
     // should be added to indicate where the cached parts 1 and 2 represent
     // a valid reverse search.
-    bool missed(part1.empty() && part2.empty());
-
-    LOG_TRACE(<< "Reverse search cache " << (missed ? "miss" : "hit"));
-
-    return !missed;
+    return m_ReverseSearchPart1.empty() == false || m_ReverseSearchPart2.empty() == false;
 }
 
-void CTokenListCategory::cacheReverseSearch(const std::string& part1,
-                                            const std::string& part2) {
-    m_ReverseSearchPart1 = part1;
-    m_ReverseSearchPart2 = part2;
+const std::string& CTokenListCategory::reverseSearchPart1() const {
+    return m_ReverseSearchPart1;
+}
+
+const std::string& CTokenListCategory::reverseSearchPart2() const {
+    return m_ReverseSearchPart2;
 }
 
 void CTokenListCategory::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -42,8 +42,7 @@ CTokenListDataCategorizerBase::CTokenListDataCategorizerBase(CLimits& limits,
     : CDataCategorizer{limits, fieldName}, m_ReverseSearchCreator{reverseSearchCreator},
       m_LowerThreshold{std::min(0.99, std::max(0.01, threshold))},
       // Upper threshold is half way between the lower threshold and 1
-      m_UpperThreshold{(1.0 + m_LowerThreshold) / 2.0},
-      m_MemoryCategorizationFailures{0}, m_HasChanged{false} {
+      m_UpperThreshold{(1.0 + m_LowerThreshold) / 2.0}, m_MemoryCategorizationFailures{0} {
 }
 
 void CTokenListDataCategorizerBase::dumpStats(const TLocalCategoryIdFormatterFunc& idFormatter) const {
@@ -85,21 +84,18 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
     auto bestSoFarIter = m_CategoriesByCount.end();
     double bestSoFarSimilarity(m_LowerThreshold);
     for (auto iter = m_CategoriesByCount.begin(); iter != m_CategoriesByCount.end(); ++iter) {
-        const CTokenListCategory& compCategory = m_Categories[iter->second];
-        const TSizeSizePrVec& baseTokenIds = compCategory.baseTokenIds();
-        std::size_t baseWeight(compCategory.baseWeight());
+        const CTokenListCategory& compCategory{m_Categories[iter->second]};
+        const TSizeSizePrVec& baseTokenIds{compCategory.baseTokenIds()};
+        std::size_t baseWeight{compCategory.baseWeight()};
 
         // Check whether the current record matches the search for the existing
         // category - if it does then we'll put it in the existing category without any
         // further checks.  The first condition here ensures that we never say
         // a string with tokens matches the reverse search of a string with no
         // tokens (which the other criteria alone might say matched).
-        bool matchesSearch{
-            (baseWeight == 0) == (workWeight == 0) &&
-            compCategory.maxMatchingStringLen() >= rawStringLen &&
-            compCategory.isMissingCommonTokenWeightZero(m_WorkTokenUniqueIds) &&
-            compCategory.containsCommonInOrderTokensInOrder(m_WorkTokenIds)};
-        if (!matchesSearch) {
+        bool matchesSearch{compCategory.matchesSearchForCategory(
+            workWeight, rawStringLen, m_WorkTokenUniqueIds, m_WorkTokenIds)};
+        if (matchesSearch == false) {
             // Quickly rule out wildly different token weights prior to doing
             // the expensive similarity calculations
             if (baseWeight < minWeight || baseWeight > maxWeight) {
@@ -108,10 +104,10 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
 
             // Rule out categories where adding the current string would unacceptably
             // reduce the number of unique common tokens
-            std::size_t origUniqueTokenWeight(compCategory.origUniqueTokenWeight());
-            std::size_t commonUniqueTokenWeight(compCategory.commonUniqueTokenWeight());
-            std::size_t missingCommonTokenWeight(
-                compCategory.missingCommonTokenWeight(m_WorkTokenUniqueIds));
+            std::size_t origUniqueTokenWeight{compCategory.origUniqueTokenWeight()};
+            std::size_t commonUniqueTokenWeight{compCategory.commonUniqueTokenWeight()};
+            std::size_t missingCommonTokenWeight{
+                compCategory.missingCommonTokenWeight(m_WorkTokenUniqueIds)};
             double proportionOfOrig(double(commonUniqueTokenWeight - missingCommonTokenWeight) /
                                     double(origUniqueTokenWeight));
             if (proportionOfOrig < m_LowerThreshold) {
@@ -160,8 +156,6 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
         return categoryId;
     }
 
-    m_HasChanged = true;
-
     if (this->areNewCategoriesAllowed() == false) {
         // Only log once per job, as logging every time this happens could
         // generate enormous log spam
@@ -186,48 +180,34 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
     return CLocalCategoryId{m_Categories.size() - 1};
 }
 
-bool CTokenListDataCategorizerBase::createReverseSearch(CLocalCategoryId categoryId,
-                                                        std::string& part1,
-                                                        std::string& part2,
-                                                        std::size_t& maxMatchingLength,
-                                                        bool& wasCached) {
-    wasCached = false;
-    maxMatchingLength = 0;
+bool CTokenListDataCategorizerBase::cacheReverseSearch(CLocalCategoryId categoryId) {
 
     if (m_ReverseSearchCreator == nullptr) {
         LOG_ERROR(<< "Cannot create reverse search - no reverse search creator");
-
-        part1.clear();
-        part2.clear();
-
         return false;
     }
 
     // Find the correct category object
     if (categoryId.isValid() == false || categoryId.index() >= m_Categories.size()) {
-
-        part1.clear();
-        part2.clear();
-
         // Soft failure is supposed to be the only special value used for the
         // category ID that permits subsequent processing like asking for a
         // reverse search.
         if (categoryId.isSoftFailure() == false) {
             LOG_ERROR(<< "Programmatic error - unexpected ML local category: " << categoryId);
-            return false;
         }
 
-        return true;
+        return false;
     }
 
     CTokenListCategory& category{m_Categories[categoryId.index()]};
-    maxMatchingLength = category.maxMatchingStringLen();
 
     // If we can retrieve cached reverse search terms we'll save a lot of time
-    wasCached = category.cachedReverseSearch(part1, part2);
-    if (wasCached) {
-        return true;
+    if (category.hasCachedReverseSearch()) {
+        return false;
     }
+
+    std::string part1;
+    std::string part2;
 
     const TSizeSizePrVec& baseTokenIds{category.baseTokenIds()};
     const TSizeSizePrVec& commonUniqueTokenIds{category.commonUniqueTokenIds()};
@@ -238,14 +218,10 @@ bool CTokenListDataCategorizerBase::createReverseSearch(CLocalCategoryId categor
                 category.maxMatchingStringLen(), part1, part2) == false) {
             // More detail should have been logged by the failed call
             LOG_ERROR(<< "Could not create reverse search");
-
-            part1.clear();
-            part2.clear();
-
             return false;
         }
 
-        category.cacheReverseSearch(part1, part2);
+        category.cacheReverseSearch(std::move(part1), std::move(part2));
 
         return true;
     }
@@ -300,10 +276,6 @@ bool CTokenListDataCategorizerBase::createReverseSearch(CLocalCategoryId categor
                       << categoryId << " - cheapest token was "
                       << cheapestIter->second.first << " with cost " << cheapestCost);
         }
-
-        part1.clear();
-        part2.clear();
-
         return false;
     }
 
@@ -332,13 +304,9 @@ bool CTokenListDataCategorizerBase::createReverseSearch(CLocalCategoryId categor
 
     m_ReverseSearchCreator->closeStandardSearch(part1, part2);
 
-    category.cacheReverseSearch(part1, part2);
+    category.cacheReverseSearch(std::move(part1), std::move(part2));
 
     return true;
-}
-
-bool CTokenListDataCategorizerBase::hasChanged() const {
-    return m_HasChanged;
 }
 
 bool CTokenListDataCategorizerBase::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
@@ -348,12 +316,11 @@ bool CTokenListDataCategorizerBase::acceptRestoreTraverser(core::CStateRestoreTr
     m_WorkTokenIds.clear();
     m_WorkTokenUniqueIds.clear();
     m_MemoryCategorizationFailures = 0;
-    m_HasChanged = false;
 
     do {
         const std::string& name{traverser.name()};
         if (name == TOKEN_TAG) {
-            std::size_t nextIndex(m_TokenIdLookup.size());
+            std::size_t nextIndex{m_TokenIdLookup.size()};
             m_TokenIdLookup.push_back(CTokenInfoItem(traverser.value(), nextIndex));
         } else if (name == TOKEN_CATEGORY_COUNT_TAG) {
             if (m_TokenIdLookup.empty()) {
@@ -374,7 +341,7 @@ bool CTokenListDataCategorizerBase::acceptRestoreTraverser(core::CStateRestoreTr
         } else if (name == CATEGORY_TAG) {
             CTokenListCategory category{traverser};
             m_CategoriesByCount.emplace_back(category.numMatches(), m_Categories.size());
-            m_Categories.push_back(category);
+            m_Categories.emplace_back(std::move(category));
         } else if (name == MEMORY_CATEGORIZATION_FAILURES_TAG) {
             if (core::CStringUtils::stringToType(
                     traverser.value(), m_MemoryCategorizationFailures) == false) {
@@ -441,10 +408,7 @@ void CTokenListDataCategorizerBase::addCategoryMatch(bool isDryRun,
                                                      const TSizeSizePrVec& tokenIds,
                                                      const TSizeSizeMap& tokenUniqueIds,
                                                      TSizeSizePrVecItr& iter) {
-    if (m_Categories[iter->second].addString(isDryRun, str, rawStringLen,
-                                             tokenIds, tokenUniqueIds) == true) {
-        m_HasChanged = true;
-    }
+    m_Categories[iter->second].addString(isDryRun, str, rawStringLen, tokenIds, tokenUniqueIds);
 
     std::size_t& count{iter->first};
     ++count;
@@ -482,7 +446,9 @@ std::size_t CTokenListDataCategorizerBase::minMatchingWeight(std::size_t weight,
     // enforce this.  Using floor + 1 due to threshold check being exclusive.
     // If threshold check is changed to inclusive, change formula to ceil
     // (without the + 1).
-    return static_cast<std::size_t>(std::floor(double(weight) * threshold + EPSILON)) + 1;
+    return static_cast<std::size_t>(
+               std::floor(static_cast<double>(weight) * threshold + EPSILON)) +
+           1;
 }
 
 std::size_t CTokenListDataCategorizerBase::maxMatchingWeight(std::size_t weight,
@@ -500,7 +466,9 @@ std::size_t CTokenListDataCategorizerBase::maxMatchingWeight(std::size_t weight,
     // enforce this.  Using ceil - 1 due to threshold check being exclusive.
     // If threshold check is changed to inclusive, change formula to floor
     // (without the - 1).
-    return static_cast<std::size_t>(std::ceil(double(weight) / threshold - EPSILON)) - 1;
+    return static_cast<std::size_t>(
+               std::ceil(static_cast<double>(weight) / threshold - EPSILON)) -
+           1;
 }
 
 std::size_t CTokenListDataCategorizerBase::idForToken(const std::string& token) {
@@ -559,51 +527,54 @@ std::size_t CTokenListDataCategorizerBase::memoryUsage() const {
     return mem;
 }
 
-void CTokenListDataCategorizerBase::updateModelSizeStats(CResourceMonitor::SModelSizeStats& modelSizeStats) const {
+void CTokenListDataCategorizerBase::updateCategorizerStats(SCategorizerStats& categorizerStats) const {
 
-    modelSizeStats.s_TotalCategories = m_Categories.size();
+    categorizerStats.s_TotalCategories += m_Categories.size();
 
     std::size_t categorizedMessagesThisCategorizer{0};
     for (auto categoryByCount : m_CategoriesByCount) {
         categorizedMessagesThisCategorizer += categoryByCount.first;
     }
-    modelSizeStats.s_CategorizedMessages += categorizedMessagesThisCategorizer;
-    modelSizeStats.s_MemoryCategorizationFailures += m_MemoryCategorizationFailures;
+    categorizerStats.s_CategorizedMessages += categorizedMessagesThisCategorizer;
+    categorizerStats.s_MemoryCategorizationFailures += m_MemoryCategorizationFailures;
 
+    std::size_t rareCategoriesThisCategorizer{0};
+    std::size_t frequentCategoriesThisCategorizer{0};
+    std::size_t deadCategoriesThisCategorizer{0};
     for (std::size_t i = 0; i < m_CategoriesByCount.size(); ++i) {
         const CTokenListCategory& category{m_Categories[m_CategoriesByCount[i].second]};
         // Definitions for frequent/rare categories are:
         // - rare = single match
         // - frequent = matches more than 1% of messages
         if (category.numMatches() == 1) {
-            ++modelSizeStats.s_RareCategories;
+            ++rareCategoriesThisCategorizer;
         } else if (category.numMatches() * 100 > categorizedMessagesThisCategorizer) {
-            ++modelSizeStats.s_FrequentCategories;
+            ++frequentCategoriesThisCategorizer;
         }
         for (std::size_t j = 0; j < i; ++j) {
             const CTokenListCategory& moreFrequentCategory{
                 m_Categories[m_CategoriesByCount[j].second]};
-            bool matchesSearch{moreFrequentCategory.maxMatchingStringLen() >=
-                                   category.maxMatchingStringLen() &&
-                               moreFrequentCategory.isMissingCommonTokenWeightZero(
-                                   category.commonUniqueTokenIds()) &&
-                               moreFrequentCategory.containsCommonInOrderTokensInOrder(
-                                   category.baseTokenIds())};
-            if (matchesSearch) {
-                ++modelSizeStats.s_DeadCategories;
-                LOG_DEBUG(<< "Category " << (m_CategoriesByCount[i].second + 1)
-                          << " (" << category.baseString() << ") is killed by category "
-                          << (m_CategoriesByCount[j].second + 1) << " ("
-                          << moreFrequentCategory.baseString() << ")");
+            if (moreFrequentCategory.matchesSearchForCategory(category)) {
+                ++deadCategoriesThisCategorizer;
                 break;
             }
         }
     }
+    categorizerStats.s_FrequentCategories += frequentCategoriesThisCategorizer;
+    categorizerStats.s_RareCategories += rareCategoriesThisCategorizer;
+    categorizerStats.s_DeadCategories += deadCategoriesThisCategorizer;
 
-    modelSizeStats.s_CategorizationStatus = CTokenListDataCategorizerBase::calculateCategorizationStatus(
-        modelSizeStats.s_CategorizedMessages, modelSizeStats.s_TotalCategories,
-        modelSizeStats.s_FrequentCategories, modelSizeStats.s_RareCategories,
-        modelSizeStats.s_DeadCategories);
+    if (categorizerStats.s_CategorizationStatus != model_t::E_CategorizationStatusOk) {
+        categorizerStats.s_CategorizationStatus =
+            CTokenListDataCategorizerBase::calculateCategorizationStatus(
+                categorizedMessagesThisCategorizer, m_Categories.size(),
+                frequentCategoriesThisCategorizer,
+                rareCategoriesThisCategorizer, deadCategoriesThisCategorizer);
+    }
+}
+
+void CTokenListDataCategorizerBase::updateModelSizeStats(CResourceMonitor::SModelSizeStats& modelSizeStats) const {
+    this->updateCategorizerStats(modelSizeStats.s_OverallCategorizerStats);
 }
 
 model_t::ECategorizationStatus
@@ -659,48 +630,97 @@ std::size_t CTokenListDataCategorizerBase::numMatches(CLocalCategoryId categoryI
 }
 
 CDataCategorizer::TLocalCategoryIdVec
-CTokenListDataCategorizerBase::usurpedCategories(CLocalCategoryId categoryId) {
-    CDataCategorizer::TLocalCategoryIdVec usurped;
+CTokenListDataCategorizerBase::usurpedCategories(CLocalCategoryId categoryId) const {
     if (categoryId.isValid() == false || categoryId.index() >= m_Categories.size()) {
         LOG_ERROR(<< "Programmatic error - unexpected ML local category: " << categoryId);
-        return usurped;
+        return {};
     }
-    auto iter = std::find_if(m_CategoriesByCount.begin(), m_CategoriesByCount.end(),
-                             [categoryId](const TSizeSizePr& pr) {
-                                 return pr.second == categoryId.index();
-                             });
-    if (iter == m_CategoriesByCount.end()) {
-        LOG_WARN(<< "Could not find category definition for category: " << categoryId);
-        return usurped;
-    }
+    // If the category is not found it indicates a bug in other code in this
+    // class, as it means m_Categories and m_CategoriesByCount are inconsistent,
+    // so a class invariant is violated.  The next method will log this case.
+    return this->usurpedCategories(
+        std::find_if(m_CategoriesByCount.begin(), m_CategoriesByCount.end(),
+                     [categoryId](const TSizeSizePr& pr) {
+                         return pr.second == categoryId.index();
+                     }));
+}
 
-    const CTokenListCategory& category{m_Categories[categoryId.index()]};
+CDataCategorizer::TLocalCategoryIdVec
+CTokenListDataCategorizerBase::usurpedCategories(TSizeSizePrVecCItr iter) const {
+    CDataCategorizer::TLocalCategoryIdVec usurped;
+    if (iter == m_CategoriesByCount.end()) {
+        LOG_ERROR(<< "Programmatic error - categories and "
+                     "categories by count are inconsistent");
+        return usurped;
+    }
+    const CTokenListCategory& category{m_Categories[iter->second]};
     for (++iter; iter != m_CategoriesByCount.end(); ++iter) {
         const CTokenListCategory& lessFrequentCategory{m_Categories[iter->second]};
-        bool matchesSearch{category.maxMatchingStringLen() >=
-                               lessFrequentCategory.maxMatchingStringLen() &&
-                           category.isMissingCommonTokenWeightZero(
-                               lessFrequentCategory.commonUniqueTokenIds()) &&
-                           category.containsCommonInOrderTokensInOrder(
-                               lessFrequentCategory.baseTokenIds())};
-        if (matchesSearch) {
-            usurped.emplace_back(1 + static_cast<int>(iter->second));
+        if (category.matchesSearchForCategory(lessFrequentCategory)) {
+            usurped.emplace_back(iter->second);
         }
     }
     std::sort(usurped.begin(), usurped.end());
     return usurped;
 }
 
-std::size_t CTokenListDataCategorizerBase::numCategories() const {
-    return m_Categories.size();
-}
+bool CTokenListDataCategorizerBase::writeCategoryIfChanged(CLocalCategoryId categoryId,
+                                                           const TCategoryOutputFunc& outputFunc) {
 
-bool CTokenListDataCategorizerBase::categoryChangedAndReset(CLocalCategoryId categoryId) {
     if (categoryId.isValid() == false || categoryId.index() >= m_Categories.size()) {
         LOG_ERROR(<< "Programmatic error - unexpected ML local category: " << categoryId);
         return false;
     }
-    return m_Categories[categoryId.index()].isChangedAndReset();
+
+    CTokenListCategory& category{m_Categories[categoryId.index()]};
+    if (category.isChangedAndReset() == false) {
+        return false;
+    }
+
+    this->cacheReverseSearch(categoryId);
+    outputFunc(categoryId, category.reverseSearchPart1(),
+               category.reverseSearchPart2(), category.maxMatchingStringLen(),
+               this->examplesCollector().examples(categoryId),
+               category.numMatches(), this->usurpedCategories(categoryId));
+
+    return true;
+}
+
+std::size_t CTokenListDataCategorizerBase::writeChangedCategories(const TCategoryOutputFunc& outputFunc) {
+
+    std::size_t numWritten{0};
+
+    // Iterating m_CategoriesByCount rather than m_Categories means we can call
+    // the O(N) version of usurpedCategories() rather than the O(N^2) version
+    for (auto iter = m_CategoriesByCount.begin(); iter != m_CategoriesByCount.end(); ++iter) {
+        CTokenListCategory& category{m_Categories[iter->second]};
+        if (category.isChangedAndReset()) {
+            CLocalCategoryId categoryId{iter->second};
+            this->cacheReverseSearch(categoryId);
+            outputFunc(categoryId, category.reverseSearchPart1(),
+                       category.reverseSearchPart2(), category.maxMatchingStringLen(),
+                       this->examplesCollector().examples(categoryId),
+                       category.numMatches(), this->usurpedCategories(iter));
+        }
+    }
+
+    return numWritten;
+}
+
+bool CTokenListDataCategorizerBase::writeCategorizerStatsIfChanged(const TCategorizerStatsOutputFunc& outputFunc) {
+
+    SCategorizerStats newCategorizerStats;
+    this->updateCategorizerStats(newCategorizerStats);
+    if (newCategorizerStats == m_LastCategorizerStats) {
+        return false;
+    }
+    outputFunc(newCategorizerStats);
+    m_LastCategorizerStats = std::move(newCategorizerStats);
+    return true;
+}
+
+std::size_t CTokenListDataCategorizerBase::numCategories() const {
+    return m_Categories.size();
 }
 
 CTokenListDataCategorizerBase::CTokenInfoItem::CTokenInfoItem(const std::string& str,

--- a/lib/model/Makefile
+++ b/lib/model/Makefile
@@ -61,7 +61,6 @@ CMetricPopulationModelFactory.cc \
 CAnnotation.cc \
 CModelDetailsView.cc \
 CModelFactory.cc \
-CModelParams.cc \
 CModelPlotData.cc \
 CModelTools.cc \
 CMonitoredResource.cc \
@@ -81,6 +80,7 @@ CTokenListDataCategorizerBase.cc \
 CTokenListReverseSearchCreator.cc \
 FrequencyPredicates.cc \
 FunctionTypes.cc \
-ModelTypes.cc
+ModelTypes.cc \
+SModelParams.cc \
 
 include $(CPP_SRC_HOME)/mk/dynamiclib.mk

--- a/lib/model/ModelTypes.cc
+++ b/lib/model/ModelTypes.cc
@@ -8,14 +8,12 @@
 
 #include <core/Constants.h>
 
-#include <maths/CMultivariatePrior.h>
-#include <maths/CPrior.h>
 #include <maths/CTimeSeriesDecomposition.h>
 #include <maths/CTimeSeriesMultibucketFeatures.h>
 
 #include <model/CAnomalyDetector.h>
-#include <model/CModelParams.h>
 #include <model/CProbabilityAndInfluenceCalculator.h>
+#include <model/SModelParams.h>
 
 namespace ml {
 namespace model_t {

--- a/lib/model/SModelParams.cc
+++ b/lib/model/SModelParams.cc
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <model/CModelParams.h>
+#include <model/SModelParams.h>
 
 #include <core/CMemory.h>
 #include <core/Constants.h>

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -10,11 +10,11 @@
 #include <model/CAnomalyDetectorModel.h>
 #include <model/CDataGatherer.h>
 #include <model/CDetectionRule.h>
-#include <model/CModelParams.h>
 #include <model/CResourceMonitor.h>
 #include <model/CRuleCondition.h>
 #include <model/CSearchKey.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include "Mocks.h"
 

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -17,11 +17,11 @@
 #include <model/CDataGatherer.h>
 #include <model/CEventData.h>
 #include <model/CEventRateBucketGatherer.h>
-#include <model/CModelParams.h>
 #include <model/CResourceMonitor.h>
 #include <model/CSearchKey.h>
 #include <model/CStringStore.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -15,8 +15,8 @@
 #include <model/CEventData.h>
 #include <model/CEventRateBucketGatherer.h>
 #include <model/CEventRatePopulationModelFactory.h>
-#include <model/CModelParams.h>
 #include <model/CResourceMonitor.h>
+#include <model/SModelParams.h>
 
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>

--- a/lib/model/unittest/CGathererToolsTest.cc
+++ b/lib/model/unittest/CGathererToolsTest.cc
@@ -5,7 +5,7 @@
  */
 
 #include <model/CGathererTools.h>
-#include <model/CModelParams.h>
+#include <model/SModelParams.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -17,9 +17,9 @@
 #include <model/CEventData.h>
 #include <model/CGathererTools.h>
 #include <model/CMetricBucketGatherer.h>
-#include <model/CModelParams.h>
 #include <model/CResourceMonitor.h>
 #include <model/CSearchKey.h>
+#include <model/SModelParams.h>
 
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>

--- a/lib/model/unittest/CRuleConditionTest.cc
+++ b/lib/model/unittest/CRuleConditionTest.cc
@@ -9,10 +9,10 @@
 #include <model/CAnomalyDetectorModel.h>
 #include <model/CDataGatherer.h>
 #include <model/CDetectionRule.h>
-#include <model/CModelParams.h>
 #include <model/CRuleCondition.h>
 #include <model/CSearchKey.h>
 #include <model/ModelTypes.h>
+#include <model/SModelParams.h>
 
 #include "Mocks.h"
 

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -465,15 +465,22 @@ BOOST_FIXTURE_TEST_CASE(testLongReverseSearch, CTestFixture) {
 
     std::string terms;
     std::string regex;
-    size_t maxMatchingLength(0);
-    bool wasCached(false);
+    std::size_t maxMatchingLength{0};
+
+    BOOST_TEST_REQUIRE(categorizer.writeCategoryIfChanged(
+        categoryId,
+        [&terms, &regex, &maxMatchingLength](
+            ml::model::CLocalCategoryId /*localCategoryId*/, const std::string& terms_,
+            const std::string& regex_, std::size_t maxMatchingLength_,
+            const ml::model::CCategoryExamplesCollector::TStrFSet& /*examples*/, std::size_t /*numMatches*/,
+            const ml::model::CDataCategorizer::TLocalCategoryIdVec& /*usurpedCategories*/) {
+            terms = terms_;
+            regex = regex_;
+            maxMatchingLength = maxMatchingLength_;
+        }));
 
     // Only 1 message so the reverse search COULD include all the tokens, but
     // shouldn't because such a reverse search would be ridiculously long
-    BOOST_TEST_REQUIRE(categorizer.createReverseSearch(
-        categoryId, terms, regex, maxMatchingLength, wasCached));
-
-    BOOST_TEST_REQUIRE(!wasCached);
     LOG_DEBUG(<< "Terms length: " << terms.length());
     LOG_TRACE(<< "Terms: " << terms);
     LOG_DEBUG(<< "Regex length: " << regex.length());


### PR DESCRIPTION
This is working towards the functionality to stop categorizing
in partitions where it's working badly.

This PR contains the following groundwork:

1. Add support for writing a categorizer_stats document to the
   output stream.
2. Add support for the categorizer to know the timestamp of each
   input record if there is one, but still tolerate not having
   a timestamp (for the pure categorization use case).  This is
   done in such a way that the timestamp is only parsed once,
   by whichever of the categorizer and anomaly detector gets to
   it first, as timestamp parsing is expensive.
3. Refactor the output functions to be primarily in the model
   library with lambdas supplied by the api library joining them
   up to the JSON output classes.  This also allowed an O(N^3)
   loop in the old output code to be improved to O(N^2), removal
   of one of the two ways of recording which objects were
   changed since the last persist, and removal of one of the two
   layers of caching for terms and regex.

Items still outstanding are:

1. Write the categorizer stats more frequently - currently they're
   only written on flush and close.
2. Calculate the categorization status for individual categorizers
   more frequently, so that a status of "warn" is reported quickly.
3. Halt categorization when the categorization status changes to
   "warn" if that functionality is enabled.

Backport of #1318