### PR TITLE
[7.x][ML] Remove volatile and update thread-safe static initialisation

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -7,7 +7,6 @@
 #ifndef INCLUDED_ml_api_CDataFrameAnalysisRunner_h
 #define INCLUDED_ml_api_CDataFrameAnalysisRunner_h
 
-#include <core/CFastMutex.h>
 #include <core/CProgramCounters.h>
 #include <core/CStatePersistInserter.h>
 

--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -24,6 +24,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/unordered_set.hpp>
 
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
@@ -276,7 +277,7 @@ private:
     std::thread m_Worker;
 
     //! indicator for worker
-    volatile bool m_Shutdown;
+    std::atomic_bool m_Shutdown;
 
     //! The 'queue' of forecast jobs to be executed
     std::list<SForecast> m_ForecastJobs;

--- a/include/core/CDualThreadStreamBuf.h
+++ b/include/core/CDualThreadStreamBuf.h
@@ -12,6 +12,7 @@
 
 #include <boost/scoped_array.hpp>
 
+#include <atomic>
 #include <streambuf>
 
 namespace ml {
@@ -175,11 +176,11 @@ private:
     //! Flag to indicate end-of-file.  When this is set, the reader will
     //! receive end-of-file notification once all the buffers are empty.
     //! The writer will not be allowed to add any more data.
-    volatile bool m_Eof;
+    std::atomic_bool m_Eof;
 
     //! A call to signalFatalError() chucks away all currently buffered data
     //! and prevents future data being added.
-    volatile bool m_FatalError;
+    std::atomic_bool m_FatalError;
 };
 }
 }

--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -175,11 +175,8 @@ private:
 private:
     TLevelSeverityLogger m_Logger;
 
-    //! Has the logger ever been reconfigured?  This is not protected by a
-    //! lock despite the fact that it may be accessed from different
-    //! threads.  It is declared volatile to prevent the compiler optimising
-    //! away reads of it.
-    volatile bool m_Reconfigured;
+    //! Has the logger ever been reconfigured?
+    std::atomic_bool m_Reconfigured;
 
     //! Custom Boost.Log attribute names
     boost::log::attribute_name m_FileAttributeName;

--- a/include/core/CTimeUtils.h
+++ b/include/core/CTimeUtils.h
@@ -6,7 +6,6 @@
 #ifndef INCLUDED_ml_core_CTimeUtils_h
 #define INCLUDED_ml_core_CTimeUtils_h
 
-#include <core/CFastMutex.h>
 #include <core/CNonInstantiatable.h>
 #include <core/CoreTypes.h>
 #include <core/ImportExport.h>
@@ -93,15 +92,11 @@ private:
         ~CDateWordCache();
 
     private:
-        //! Protect the singleton's initialisation, preventing it from
-        //! being constructed simultaneously in different threads.
-        static CFastMutex ms_InitMutex;
-
-        //! This pointer is set after the singleton object has been
-        //! constructed, and avoids the need to lock the mutex on
-        //! subsequent calls of the instance() method (once the updated
-        //! value of this variable has made its way into every thread).
-        static volatile CDateWordCache* ms_Instance;
+        //! This pointer is set after the singleton object has been constructed,
+        //! and avoids the need to lock the magic static initialisation mutex on
+        //! subsequent calls of the instance() method (once the updated value of
+        //! this variable is visible in every thread).
+        static CDateWordCache* ms_Instance;
 
         using TStrUSet = boost::unordered_set<std::string>;
 

--- a/include/core/CWordDictionary.h
+++ b/include/core/CWordDictionary.h
@@ -6,7 +6,6 @@
 #ifndef INCLUDED_ml_core_CWordDictionary_h
 #define INCLUDED_ml_core_CWordDictionary_h
 
-#include <core/CFastMutex.h>
 #include <core/CNonCopyable.h>
 #include <core/ImportExport.h>
 
@@ -150,16 +149,11 @@ private:
     //! Name of the file to load that contains the dictionary words.
     static const char* const DICTIONARY_FILE;
 
-    //! The constructor loads a file, and hence may take a while.  This
-    //! mutex prevents the singleton object being constructed simultaneously
-    //! in different threads.
-    static CFastMutex ms_LoadMutex;
-
     //! This pointer is set after the singleton object has been constructed,
-    //! and avoids the need to lock the mutex on subsequent calls of the
-    //! instance() method (once the updated value of this variable has made
-    //! its way into every thread).
-    static volatile CWordDictionary* ms_Instance;
+    //! and avoids the need to lock the magic static initialisation mutex on
+    //! subsequent calls of the instance() method (once the updated value of
+    //! this variable is visible in every thread).
+    static CWordDictionary* ms_Instance;
 
     //! Stores the dictionary words - using a multi-index even though
     //! there's only one index, because of its flexible key extractors.

--- a/lib/core/CDualThreadStreamBuf.cc
+++ b/lib/core/CDualThreadStreamBuf.cc
@@ -19,13 +19,11 @@ namespace core {
 const size_t CDualThreadStreamBuf::DEFAULT_BUFFER_CAPACITY(65536);
 
 CDualThreadStreamBuf::CDualThreadStreamBuf(size_t bufferCapacity)
-    : m_WriteBuffer(new char[bufferCapacity]), m_WriteBufferCapacity(bufferCapacity),
-      m_ReadBuffer(new char[bufferCapacity]), m_ReadBufferCapacity(bufferCapacity),
-      m_IntermediateBuffer(new char[bufferCapacity]),
-      m_IntermediateBufferCapacity(bufferCapacity),
-      m_IntermediateBufferEnd(m_IntermediateBuffer.get()), m_ReadBytesSwapped(0),
-      m_WriteBytesSwapped(0), m_IntermediateBufferCondition(m_IntermediateBufferMutex),
-      m_Eof(false), m_FatalError(false) {
+    : m_WriteBuffer{new char[bufferCapacity]}, m_WriteBufferCapacity{bufferCapacity},
+      m_ReadBuffer{new char[bufferCapacity]}, m_ReadBufferCapacity{bufferCapacity},
+      m_IntermediateBuffer{new char[bufferCapacity]}, m_IntermediateBufferCapacity{bufferCapacity},
+      m_IntermediateBufferEnd{m_IntermediateBuffer.get()}, m_ReadBytesSwapped{0}, m_WriteBytesSwapped{0},
+      m_IntermediateBufferCondition{m_IntermediateBufferMutex}, m_Eof{false}, m_FatalError{false} {
     // Initialise write buffer pointers to indicate an empty buffer
     char* begin(m_WriteBuffer.get());
     char* end(begin + m_WriteBufferCapacity);
@@ -40,14 +38,14 @@ CDualThreadStreamBuf::CDualThreadStreamBuf(size_t bufferCapacity)
 void CDualThreadStreamBuf::signalEndOfFile() {
     CScopedLock lock(m_IntermediateBufferMutex);
 
-    if (m_Eof) {
+    if (m_Eof.load()) {
         return;
     }
 
-    if (m_FatalError) {
+    if (m_FatalError.load()) {
         // If there's been a fatal error we don't care about losing data, so
         // just set the end-of-file flag and return
-        m_Eof = true;
+        m_Eof.store(true);
 
         return;
     }
@@ -67,11 +65,11 @@ void CDualThreadStreamBuf::signalEndOfFile() {
     // end-of-file flag isn't set until the write buffer has been swapped,
     // because otherwise the reader can act on it while the swapWriteBuffer()
     // method is waiting on m_IntermediateBufferCondition
-    m_Eof = true;
+    m_Eof.store(true);
 }
 
 bool CDualThreadStreamBuf::endOfFile() const {
-    return m_Eof;
+    return m_Eof.load();
 }
 
 void CDualThreadStreamBuf::signalFatalError() {
@@ -82,13 +80,13 @@ void CDualThreadStreamBuf::signalFatalError() {
     this->setg(begin, begin, begin);
 
     // Set a flag to indicate that future reads and writes should fail
-    m_FatalError = true;
+    m_FatalError.store(true);
 
     m_IntermediateBufferCondition.signal();
 }
 
 bool CDualThreadStreamBuf::hasFatalError() const {
-    return m_FatalError;
+    return m_FatalError.load();
 }
 
 std::streamsize CDualThreadStreamBuf::showmanyc() {
@@ -100,7 +98,7 @@ std::streamsize CDualThreadStreamBuf::showmanyc() {
 
     CScopedLock lock(m_IntermediateBufferMutex);
 
-    if (!m_FatalError) {
+    if (m_FatalError.load() == false) {
         // Add on unread contents of intermediate buffer
         ret += (m_IntermediateBufferEnd - m_IntermediateBuffer.get());
     }
@@ -111,7 +109,7 @@ std::streamsize CDualThreadStreamBuf::showmanyc() {
 int CDualThreadStreamBuf::sync() {
     CScopedLock lock(m_IntermediateBufferMutex);
 
-    if (m_FatalError) {
+    if (m_FatalError.load()) {
         return -1;
     }
 
@@ -132,7 +130,7 @@ std::streamsize CDualThreadStreamBuf::xsgetn(char* s, std::streamsize n) {
     // comments)
 
     std::streamsize ret(0);
-    if (m_FatalError) {
+    if (m_FatalError.load()) {
         return ret;
     }
 
@@ -163,7 +161,7 @@ std::streamsize CDualThreadStreamBuf::xsgetn(char* s, std::streamsize n) {
 int CDualThreadStreamBuf::underflow() {
     CScopedLock lock(m_IntermediateBufferMutex);
 
-    if (m_FatalError || this->swapReadBuffer() == false) {
+    if (m_FatalError.load() || this->swapReadBuffer() == false) {
         return traits_type::eof();
     }
 
@@ -215,12 +213,12 @@ std::streamsize CDualThreadStreamBuf::xsputn(const char* s, std::streamsize n) {
 
     std::streamsize ret(0);
 
-    if (m_Eof) {
+    if (m_Eof.load()) {
         LOG_ERROR(<< "Inconsistency - trying to add data to stream buffer after end-of-file");
         return ret;
     }
 
-    if (m_FatalError) {
+    if (m_FatalError.load()) {
         return ret;
     }
 
@@ -252,12 +250,12 @@ int CDualThreadStreamBuf::overflow(int c) {
 
     CScopedLock lock(m_IntermediateBufferMutex);
 
-    if (m_Eof || m_FatalError || this->swapWriteBuffer() == false) {
+    if (m_Eof.load() || m_FatalError.load() || this->swapWriteBuffer() == false) {
         return ret;
     }
 
     if (c == ret) {
-        m_Eof = true;
+        m_Eof.store(true);
         // If the argument indicated EOF, we don't put it in the new buffer
         ret = traits_type::not_eof(c);
     } else {
@@ -304,7 +302,7 @@ bool CDualThreadStreamBuf::swapWriteBuffer() {
     // Wait until the intermediate buffer is empty
     while (m_IntermediateBufferEnd > m_IntermediateBuffer.get()) {
         m_IntermediateBufferCondition.wait();
-        if (m_FatalError) {
+        if (m_FatalError.load()) {
             return false;
         }
     }
@@ -328,9 +326,10 @@ bool CDualThreadStreamBuf::swapWriteBuffer() {
 // NB: m_IntermediateBufferMutex MUST be locked when this method is called
 bool CDualThreadStreamBuf::swapReadBuffer() {
     // Wait until the intermediate buffer contains data
-    while (!m_Eof && m_IntermediateBufferEnd == m_IntermediateBuffer.get()) {
+    while (m_Eof.load() == false &&
+           m_IntermediateBufferEnd == m_IntermediateBuffer.get()) {
         m_IntermediateBufferCondition.wait();
-        if (m_FatalError) {
+        if (m_FatalError.load()) {
             return false;
         }
     }
@@ -338,7 +337,7 @@ bool CDualThreadStreamBuf::swapReadBuffer() {
     char* begin(m_IntermediateBuffer.get());
     char* end(m_IntermediateBufferEnd);
     if (begin >= end) {
-        if (!m_Eof) {
+        if (m_Eof.load() == false) {
             LOG_ERROR(<< "Inconsistency - intermediate buffer empty after wait "
                          "when not at end-of-file: begin = "
                       << static_cast<void*>(begin)

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -95,9 +95,8 @@ namespace ml {
 namespace core {
 
 CLogger::CLogger()
-    : m_Reconfigured(false), m_FileAttributeName("File"),
-      m_LineAttributeName("Line"), m_FunctionAttributeName("Function"),
-      m_OrigStderrFd(-1), m_FatalErrorHandler(defaultFatalErrorHandler) {
+    : m_Reconfigured{false}, m_FileAttributeName{"File"}, m_LineAttributeName{"Line"},
+      m_FunctionAttributeName{"Function"}, m_OrigStderrFd{-1}, m_FatalErrorHandler{defaultFatalErrorHandler} {
     CCrashHandler::installCrashHandler();
     // These formatter factories are not needed for programmatic configuration
     // of the format, but without them formats defined in settings files don't
@@ -175,7 +174,7 @@ void CLogger::reset() {
         boost::log::expressions::attr<ELevel>(
             boost::log::aux::default_attribute_names::severity()) >= E_Debug);
 
-    m_Reconfigured = false;
+    m_Reconfigured.store(false);
 }
 
 CLogger& CLogger::instance() {
@@ -184,7 +183,7 @@ CLogger& CLogger::instance() {
 }
 
 bool CLogger::hasBeenReconfigured() const {
-    return m_Reconfigured;
+    return m_Reconfigured.load();
 }
 
 void CLogger::logEnvironment() const {
@@ -300,7 +299,7 @@ bool CLogger::reconfigureLogToNamedPipe(const std::string& pipeName) {
 
 bool CLogger::reconfigureLogToNamedPipe(const std::string& pipeName,
                                         const std::atomic_bool& isCancelled) {
-    if (m_Reconfigured) {
+    if (m_Reconfigured.load()) {
         LOG_ERROR(<< "Cannot log to a named pipe after logger reconfiguration");
         return false;
     }
@@ -387,7 +386,7 @@ bool CLogger::reconfigureFromSettings(std::istream& settingsStrm) {
         return false;
     }
 
-    m_Reconfigured = true;
+    m_Reconfigured.store(true);
 
     // Start the new log off with "uname -a" information so we know what
     // hardware any subsequent problems occurred on

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -149,24 +149,19 @@ bool CTimeUtils::isDateWord(const std::string& word) {
 }
 
 // Initialise statics for the inner class CDateWordCache
-CFastMutex CTimeUtils::CDateWordCache::ms_InitMutex;
-volatile CTimeUtils::CDateWordCache* CTimeUtils::CDateWordCache::ms_Instance(nullptr);
+CTimeUtils::CDateWordCache* CTimeUtils::CDateWordCache::ms_Instance{nullptr};
 
 const CTimeUtils::CDateWordCache& CTimeUtils::CDateWordCache::instance() {
     if (ms_Instance == nullptr) {
-        CScopedFastLock lock(ms_InitMutex);
-
-        // Even if we get into this code block in more than one thread, whatever
-        // measures the compiler is taking to ensure this variable is only
-        // constructed once should be fine given that the block is protected by
-        // a mutex.
-        static volatile CDateWordCache instance;
+        // This initialisation is thread safe due to the "magic statics" feature
+        // introduced in C++11.  This is implemented in Visual Studio 2015 and
+        // above.
+        static CDateWordCache instance;
 
         ms_Instance = &instance;
     }
 
-    // Need to explicitly cast away volatility
-    return *const_cast<const CDateWordCache*>(ms_Instance);
+    return *ms_Instance;
 }
 
 bool CTimeUtils::CDateWordCache::isDateWord(const std::string& word) const {

--- a/lib/core/CWordDictionary.cc
+++ b/lib/core/CWordDictionary.cc
@@ -67,24 +67,19 @@ CWordDictionary::EPartOfSpeech partOfSpeechFromCode(char partOfSpeechCode) {
 
 const char* const CWordDictionary::DICTIONARY_FILE("ml-en.dict");
 
-CFastMutex CWordDictionary::ms_LoadMutex;
-volatile CWordDictionary* CWordDictionary::ms_Instance(nullptr);
+CWordDictionary* CWordDictionary::ms_Instance{nullptr};
 
 const CWordDictionary& CWordDictionary::instance() {
     if (ms_Instance == nullptr) {
-        CScopedFastLock lock(ms_LoadMutex);
-
-        // Even if we get into this code block in more than one thread, whatever
-        // measures the compiler is taking to ensure this variable is only
-        // constructed once should be fine given that the block is protected by
-        // a mutex.
-        static volatile CWordDictionary instance;
+        // This initialisation is thread safe due to the "magic statics" feature
+        // introduced in C++11.  This is implemented in Visual Studio 2015 and
+        // above.
+        static CWordDictionary instance;
 
         ms_Instance = &instance;
     }
 
-    // Need to explicitly cast away volatility
-    return *const_cast<const CWordDictionary*>(ms_Instance);
+    return *ms_Instance;
 }
 
 bool CWordDictionary::isInDictionary(const std::string& str) const {


### PR DESCRIPTION
There were a few places in the code where we were inappropriately
using the volatile keyword.  Some of these should have been using
atomics, and others were simply unnecessary.

Additionally, the "magic statics" feature of C++11 finally made it
into Visual Studio 2015.  We were using Visual Studio 2013 in 5.x
and 6.x, so could not use this feature.  However, 7.x is using
Visual Studio 2017, so we can adapt our code to take advantage of
automatic protection of static variable initialisation instead of
having to write custom code for this.

Backport of #1323