### PR TITLE
[ML] Improve bit vector encoding efficiency for sparse vectors

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -62,6 +62,8 @@
   (See {ml-pull}1312[#1312].)
 * Performance improvements for classification and regression, particularly running
   multithreaded. (See {ml-pull}1317[#1317].)
+* Improve runtime and memory usage training deep trees for classification and
+  regression. (See {ml-pull}1340[#1340].)
 
 === Bug Fixes
 

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -38,14 +38,19 @@ namespace core {
 //!
 //! IMPLEMENTATION:\n
 //! The space optimal vector depends on the average run length. In particular, it
-//! is optimum to use around log2(E[run length]) bits to encode each run. We expect
-//! relative short runs in our target applications so stick with std::uint8_t to
-//! encode the run length.
+//! is optimum to use around log2(E[run length]) bits to encode each run. This
+//! approach uses run length encoding of the run lengths for efficiency over a
+//! broad range of average run lengths. This scheme also handles long tail runs
+//! of equal bits effectively. We use 2 bits to encode the number of bytes in the
+//! run and the remaining up to 30 bits to encode the run length.
 //!
 //! Because there are only two values we need only store the value of the first bit
 //! in the vector and can deduce all other values by the number of runs in between.
 //! In practice we store one extra bit, the vector parity to allow us to extend the
 //! vector efficiently.
+//!
+//! \warning Since it allows a more efficient implementation and covers our use cases
+//! this only supports vectors up to length 2^30.
 // clang-format off
 class CORE_EXPORT CPackedBitVector : private boost::equality_comparable<CPackedBitVector,
                                              boost::partially_ordered<CPackedBitVector,
@@ -54,6 +59,8 @@ class CORE_EXPORT CPackedBitVector : private boost::equality_comparable<CPackedB
 public:
     using TBoolVec = std::vector<bool>;
     using TUInt8Vec = std::vector<std::uint8_t>;
+    using TUInt8VecItr = TUInt8Vec::iterator;
+    using TUInt8VecCItr = TUInt8Vec::const_iterator;
 
     //! Operations which can be performed in the inner product.
     enum EOperation { E_AND, E_OR, E_XOR };
@@ -61,9 +68,6 @@ public:
     //! \brief A forward iterator over the indices of the one bits in bit vector.
     class CORE_EXPORT COneBitIndexConstIterator
         : public std::iterator<std::input_iterator_tag, std::size_t, std::ptrdiff_t> {
-    public:
-        using TUInt8VecCItr = TUInt8Vec::const_iterator;
-
     public:
         COneBitIndexConstIterator() = default;
         COneBitIndexConstIterator(bool first, TUInt8VecCItr runLengthsItr, TUInt8VecCItr endRunLengthsItr);
@@ -94,7 +98,6 @@ public:
 
     private:
         void skipRun();
-        std::size_t advanceToEndOfRun();
 
     private:
         std::size_t m_Current = 0;
@@ -102,11 +105,6 @@ public:
         TUInt8VecCItr m_RunLengthsItr;
         TUInt8VecCItr m_EndRunLengthsItr;
     };
-
-public:
-    //! The maximum permitted run length. Longer runs are encoded by stringing
-    //! together a number of maximum length runs.
-    static const std::uint8_t MAX_RUN_LENGTH;
 
 public:
     CPackedBitVector();
@@ -198,21 +196,37 @@ public:
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
-private:
+protected:
+    //! This is a mask of the bits which encode how many bytes the run length uses.
+    static constexpr int NUMBER_BYTES_MASK_BITS = 2;
+    static constexpr std::uint8_t NUMBER_BYTES_MASK = 0x3;
+    static constexpr std::size_t MAXIMUM_ONE_BYTE_RUN_LENGTH = 0x3F;
+    static constexpr std::size_t MAXIMUM_TWO_BYTE_RUN_LENGTH = 0x3FFF;
+    static constexpr std::size_t MAXIMUM_THREE_BYTE_RUN_LENGTH = 0x3FFFFF;
+    static constexpr std::size_t MAXIMUM_FOUR_BYTE_RUN_LENGTH = 0x3FFFFFFF;
+
+protected:
     void bitwise(EOperation op, const CPackedBitVector& other);
-    template<typename RUN_ACTION>
-    bool lineScan(const CPackedBitVector& covector, RUN_ACTION action) const;
-    static void appendRun(std::size_t run, TUInt8Vec& runLengths);
-    static void extendRun(std::size_t run, TUInt8Vec& runLengths);
+    template<typename RUN_OP>
+    bool lineScan(const CPackedBitVector& covector, RUN_OP op) const;
+    static void appendRun(std::size_t runLength, std::uint8_t& lastRunBytes, TUInt8Vec& runLengthBytes);
+    static void extendLastRun(std::size_t runLength,
+                              std::uint8_t& lastRunBytes,
+                              TUInt8Vec& runLengthBytes);
+    static std::uint8_t bytes(std::size_t runLength);
+    static std::size_t readLastRunLength(std::uint8_t lastRunBytes,
+                                         const TUInt8Vec& runLengthBytes);
+    static std::size_t readRunLength(TUInt8VecCItr runLengthBytes) {
+        return popRunLength(runLengthBytes);
+    }
+    static std::size_t popRunLength(TUInt8VecCItr& runLengthBytes);
+    static void writeRunLength(std::size_t runLength, TUInt8VecItr runLengthBytes);
     template<typename T>
     static T bit(EOperation op, T lhs, T rhs);
 
 private:
-    // Note that the bools are 1 byte aligned so the following three variables will
-    // be packed into the 64 bits.
-
     //! The dimension of the vector.
-    std::uint32_t m_Dimension;
+    std::size_t m_Dimension;
 
     //! The value of the first component in the vector.
     bool m_First;
@@ -222,9 +236,12 @@ private:
     //! value of the last component.
     bool m_Parity;
 
+    //! The number of needed to encode the last run length.
+    std::uint8_t m_LastRunBytes;
+
     //! The length of each run. Note that if the length of a run exceeds 255 then
     //! this is encoded in multiple run lengths.
-    TUInt8Vec m_RunLengths;
+    TUInt8Vec m_RunLengthBytes;
 };
 
 //! Output for debug.

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -107,7 +107,7 @@ public:
     };
 
 public:
-    CPackedBitVector();
+    CPackedBitVector() = default;
     explicit CPackedBitVector(bool bit);
     CPackedBitVector(std::size_t dimension, bool bit);
     CPackedBitVector(const TBoolVec& bits);
@@ -225,18 +225,18 @@ protected:
 
 private:
     //! The dimension of the vector.
-    std::size_t m_Dimension;
+    std::size_t m_Dimension = 0;
 
     //! The value of the first component in the vector.
-    bool m_First;
+    bool m_First = false;
 
     //! The parity of the vector: true indicates that there are an even number runs
     //! and false that there are an odd. Together with m_First this determines the
     //! value of the last component.
-    bool m_Parity;
+    bool m_Parity = true;
 
     //! The number of needed to encode the last run length.
-    std::uint8_t m_LastRunBytes;
+    std::uint8_t m_LastRunBytes = 0;
 
     //! The length of each run. Note that if the length of a run exceeds 255 then
     //! this is encoded in multiple run lengths.

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -133,6 +133,9 @@ public:
     //! Reset to zero length vector.
     void clear();
 
+    //! Get the maximum supported vector size.
+    static std::size_t maximumSize() { return MAXIMUM_FOUR_BYTE_RUN_LENGTH; }
+
     //! Wraps dimension.
     std::size_t size() const { return this->dimension(); }
 

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -206,7 +206,8 @@ protected:
     static constexpr std::size_t MAXIMUM_FOUR_BYTE_RUN_LENGTH = 0x3FFFFFFF;
 
 protected:
-    void bitwise(EOperation op, const CPackedBitVector& other);
+    template<typename RUN_OP>
+    void bitwise(RUN_OP op, const CPackedBitVector& other);
     template<typename RUN_OP>
     bool lineScan(const CPackedBitVector& covector, RUN_OP op) const;
     static void appendRun(std::size_t runLength, std::uint8_t& lastRunBytes, TUInt8Vec& runLengthBytes);
@@ -221,8 +222,6 @@ protected:
     }
     static std::size_t popRunLength(TUInt8VecCItr& runLengthBytes);
     static void writeRunLength(std::size_t runLength, TUInt8VecItr runLengthBytes);
-    template<typename T>
-    static T bit(EOperation op, T lhs, T rhs);
 
 private:
     //! The dimension of the vector.

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -61,6 +61,9 @@ public:
     //! \warning Throws runtime error on fail to restore.
     static CBoostedTreeFactory constructFromString(std::istream& jsonStream);
 
+    //! Get the maximum number of rows we'll train on.
+    static std::size_t maximumNumberRows();
+
     ~CBoostedTreeFactory();
     CBoostedTreeFactory(CBoostedTreeFactory&) = delete;
     CBoostedTreeFactory& operator=(CBoostedTreeFactory&) = delete;

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -560,10 +560,9 @@ public:
     std::size_t memoryUsage() const;
 
     //! Estimate the maximum leaf statistics' memory usage training on a data frame
-    //! with \p numberRows rows and \p numberCols columns using \p numberSplitsPerFeature
-    //! for a loss function with \p numberLossParameters parameters.
-    static std::size_t estimateMemoryUsage(std::size_t numberRows,
-                                           std::size_t numberCols,
+    //! with \p numberCols columns using \p numberSplitsPerFeature for a loss function
+    //! with \p numberLossParameters parameters.
+    static std::size_t estimateMemoryUsage(std::size_t numberCols,
                                            std::size_t numberSplitsPerFeature,
                                            std::size_t numberLossParameters);
 

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -112,9 +112,6 @@ inline double readActual(const TRowRef& row, std::size_t dependentVariable) {
     return row[dependentVariable];
 }
 
-// The maximum number of rows encoded by a single byte in the packed bit vector
-// assuming best compression.
-constexpr std::size_t PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE{256};
 constexpr double INF{std::numeric_limits<double>::max()};
 }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -219,6 +219,12 @@ bool CDataFrameTrainBoostedTreeRunner::validate(const core::CDataFrame& frame) c
         HANDLE_FATAL(<< "Input error: analysis need at least one regressor.")
         return false;
     }
+    if (frame.numberRows() > maths::CBoostedTreeFactory::maximumNumberRows()) {
+        HANDLE_FATAL(<< "Input error: no more than "
+                     << maths::CBoostedTreeFactory::maximumNumberRows()
+                     << " are supported. You need to downsample your data.")
+        return false;
+    }
     return true;
 }
 

--- a/lib/core/CPackedBitVector.cc
+++ b/lib/core/CPackedBitVector.cc
@@ -42,9 +42,7 @@ bool read(const std::string& str, std::size_t& last, std::size_t& pos, T& value)
 }
 }
 
-CPackedBitVector::CPackedBitVector(bool bit)
-    : m_Dimension{1}, m_First{bit}, m_Parity{true}, m_LastRunBytes{1},
-      m_RunLengthBytes(1, 1) {
+CPackedBitVector::CPackedBitVector(bool bit) : CPackedBitVector{1, bit} {
 }
 
 CPackedBitVector::CPackedBitVector(std::size_t dimension, bool bit)
@@ -64,7 +62,9 @@ CPackedBitVector::CPackedBitVector(const TBoolVec& bits)
             run = 0;
         }
     }
-    appendRun(run, m_LastRunBytes, m_RunLengthBytes);
+    if (run > 0) {
+        appendRun(run, m_LastRunBytes, m_RunLengthBytes);
+    }
 }
 
 void CPackedBitVector::contract() {

--- a/lib/core/unittest/CPackedBitVectorTest.cc
+++ b/lib/core/unittest/CPackedBitVectorTest.cc
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <numeric>
 #include <vector>
@@ -42,6 +43,200 @@ std::string toBitString(const T& v) {
     }
     return result.str();
 }
+
+class CPackedBitVectorInternals : public core::CPackedBitVector {
+public:
+    static std::size_t maximumOneByteRunLength() {
+        return MAXIMUM_ONE_BYTE_RUN_LENGTH;
+    }
+    static std::size_t maximumTwoByteRunLength() {
+        return MAXIMUM_TWO_BYTE_RUN_LENGTH;
+    }
+    static std::size_t maximumThreeByteRunLength() {
+        return MAXIMUM_THREE_BYTE_RUN_LENGTH;
+    }
+    static std::size_t maximumFourByteRunLength() {
+        return MAXIMUM_FOUR_BYTE_RUN_LENGTH;
+    }
+    static void appendRun(std::size_t runLength, std::uint8_t& lastRunBytes, TUInt8Vec& runLengthBytes) {
+        core::CPackedBitVector::appendRun(runLength, lastRunBytes, runLengthBytes);
+    }
+    static void extendLastRun(std::size_t runLength, std::uint8_t& runBytes, TUInt8Vec& runLengthBytes) {
+        core::CPackedBitVector::extendLastRun(runLength, runBytes, runLengthBytes);
+    }
+    static std::uint8_t bytes(std::size_t runLength) {
+        return core::CPackedBitVector::bytes(runLength);
+    }
+    static std::size_t readLastRunLength(std::uint8_t lastRunBytes,
+                                         const TUInt8Vec& runLengthBytes) {
+        return core::CPackedBitVector::readLastRunLength(lastRunBytes, runLengthBytes);
+    }
+    static std::size_t readRunLength(TUInt8VecCItr runLengthBytes) {
+        return core::CPackedBitVector::readRunLength(runLengthBytes);
+    }
+    static std::size_t popRunLength(TUInt8VecCItr& runLengthBytes) {
+        return core::CPackedBitVector::popRunLength(runLengthBytes);
+    }
+    static void writeRunLength(std::size_t runLength, TUInt8VecItr runLengthBytes) {
+        core::CPackedBitVector::writeRunLength(runLength, runLengthBytes);
+    }
+};
+}
+
+BOOST_AUTO_TEST_CASE(testInternals) {
+
+    using TUInt8Vec = std::vector<std::uint8_t>;
+
+    LOG_DEBUG(<< "bytes");
+
+    BOOST_TEST_REQUIRE(1, CPackedBitVectorInternals::bytes(1));
+    BOOST_TEST_REQUIRE(1, CPackedBitVectorInternals::bytes(
+                              CPackedBitVectorInternals::maximumOneByteRunLength()));
+    BOOST_TEST_REQUIRE(2, CPackedBitVectorInternals::bytes(
+                              CPackedBitVectorInternals::maximumOneByteRunLength() + 1));
+    BOOST_TEST_REQUIRE(2, CPackedBitVectorInternals::bytes(
+                              CPackedBitVectorInternals::maximumTwoByteRunLength()));
+    BOOST_TEST_REQUIRE(3, CPackedBitVectorInternals::bytes(
+                              CPackedBitVectorInternals::maximumTwoByteRunLength() + 1));
+    BOOST_TEST_REQUIRE(2, CPackedBitVectorInternals::bytes(
+                              CPackedBitVectorInternals::maximumThreeByteRunLength()));
+    BOOST_TEST_REQUIRE(3, CPackedBitVectorInternals::bytes(
+                              CPackedBitVectorInternals::maximumThreeByteRunLength() + 1));
+    BOOST_TEST_REQUIRE(4, CPackedBitVectorInternals::bytes(
+                              CPackedBitVectorInternals::maximumFourByteRunLength()));
+
+    test::CRandomNumbers rng;
+    TSizeVec ranges{1, 1 << 8, 1 << 16, 1 << 24, 1 << 30};
+    TUInt8Vec runLengthBytes;
+    TSizeVec runLengths;
+
+    LOG_DEBUG(<< "read/writeRunLength");
+
+    // We test some edge cases and then do a randomized test that write followed
+    // by read is idempotent.
+
+    runLengthBytes.resize(4);
+    for (auto expectedRunLength :
+         {std::size_t{1}, CPackedBitVectorInternals::maximumOneByteRunLength(),
+          CPackedBitVectorInternals::maximumOneByteRunLength() + 1,
+          CPackedBitVectorInternals::maximumTwoByteRunLength(),
+          CPackedBitVectorInternals::maximumOneByteRunLength() + 1,
+          CPackedBitVectorInternals::maximumThreeByteRunLength(),
+          CPackedBitVectorInternals::maximumThreeByteRunLength() + 1,
+          CPackedBitVectorInternals::maximumFourByteRunLength()}) {
+        CPackedBitVectorInternals::writeRunLength(expectedRunLength,
+                                                  runLengthBytes.begin());
+        BOOST_REQUIRE_EQUAL(expectedRunLength, CPackedBitVectorInternals::readRunLength(
+                                                   runLengthBytes.begin()));
+    }
+
+    for (std::size_t i = 0; i < 1000; ++i) {
+        for (std::size_t j = 1; j < ranges.size(); ++j) {
+            rng.generateUniformSamples(ranges[j - 1], ranges[j], 20, runLengths);
+            for (auto expectedRunLength : runLengths) {
+                CPackedBitVectorInternals::writeRunLength(expectedRunLength,
+                                                          runLengthBytes.begin());
+                BOOST_REQUIRE_EQUAL(expectedRunLength, CPackedBitVectorInternals::readRunLength(
+                                                           runLengthBytes.begin()));
+            }
+        }
+    }
+
+    LOG_DEBUG(<< "readLastRunLength");
+
+    // Randomized test that write followed by read is idempotent.
+
+    for (std::size_t i = 0; i < 1000; ++i) {
+        for (std::size_t j = 1; j < ranges.size(); ++j) {
+            rng.generateUniformSamples(ranges[j - 1], ranges[j], 20, runLengths);
+            for (auto expectedRunLength : runLengths) {
+                std::uint8_t bytes{CPackedBitVectorInternals::bytes(expectedRunLength)};
+                runLengthBytes.resize(bytes);
+                CPackedBitVectorInternals::writeRunLength(expectedRunLength,
+                                                          runLengthBytes.begin());
+                BOOST_REQUIRE_EQUAL(expectedRunLength, CPackedBitVectorInternals::readLastRunLength(
+                                                           bytes, runLengthBytes));
+            }
+        }
+    }
+
+    LOG_DEBUG(<< "appendRun");
+
+    // Test we append the run length we actually added.
+
+    for (std::size_t i = 0; i < 1000; ++i) {
+        runLengthBytes.clear();
+        for (std::size_t j = 1; j < ranges.size(); ++j) {
+            rng.generateUniformSamples(ranges[j - 1], ranges[j], 1, runLengths);
+            std::uint8_t lastRunBytes;
+            CPackedBitVectorInternals::appendRun(runLengths[0], lastRunBytes, runLengthBytes);
+            BOOST_REQUIRE_EQUAL(CPackedBitVectorInternals::bytes(runLengths[0]), lastRunBytes);
+            BOOST_REQUIRE_EQUAL(runLengths[0], CPackedBitVectorInternals::readLastRunLength(
+                                                   lastRunBytes, runLengthBytes));
+        }
+    }
+
+    LOG_DEBUG(<< "extendRun");
+
+    // Test when we extend a range we get the new range we expect.
+
+    runLengthBytes.resize(4);
+
+    for (std::size_t i = 0; i < 1000; ++i) {
+        for (auto runLength :
+             {CPackedBitVectorInternals::maximumOneByteRunLength(),
+              CPackedBitVectorInternals::maximumTwoByteRunLength(),
+              CPackedBitVectorInternals::maximumThreeByteRunLength(),
+              CPackedBitVectorInternals::maximumFourByteRunLength() - 15}) {
+            runLengthBytes.clear();
+            for (int j = -10; j < 10; ++j) {
+                for (int k = 1; k < 5; ++k) {
+                    std::uint8_t lastRunBytes;
+                    CPackedBitVectorInternals::appendRun(runLength + j, lastRunBytes,
+                                                         runLengthBytes);
+                    CPackedBitVectorInternals::extendLastRun(k, lastRunBytes, runLengthBytes);
+                    BOOST_REQUIRE_EQUAL(runLength + j + k,
+                                        CPackedBitVectorInternals::readLastRunLength(
+                                            lastRunBytes, runLengthBytes));
+                }
+            }
+        }
+        for (std::size_t j = 1; j < ranges.size(); ++j) {
+            rng.generateUniformSamples(ranges[j - 1], ranges[j], 1, runLengths);
+            std::uint8_t lastRunBytes;
+            CPackedBitVectorInternals::appendRun(runLengths[0], lastRunBytes, runLengthBytes);
+            BOOST_REQUIRE_EQUAL(CPackedBitVectorInternals::bytes(runLengths[0]), lastRunBytes);
+            BOOST_REQUIRE_EQUAL(runLengths[0], CPackedBitVectorInternals::readLastRunLength(
+                                                   lastRunBytes, runLengthBytes));
+        }
+    }
+
+    LOG_DEBUG(<< "popRunLength");
+
+    // Test reading a sequence with pop run length.
+
+    TSizeVec allRunLengths;
+    for (std::size_t i = 0; i < 1000; ++i) {
+        allRunLengths.clear();
+        for (std::size_t j = 1; j < ranges.size(); ++j) {
+            rng.generateUniformSamples(ranges[j - 1], ranges[j], 10, runLengths);
+            allRunLengths.insert(allRunLengths.end(), runLengths.begin(),
+                                 runLengths.end());
+        }
+        rng.random_shuffle(allRunLengths.begin(), allRunLengths.end());
+
+        runLengthBytes.clear();
+        for (auto runLength : allRunLengths) {
+            std::uint8_t dummy;
+            CPackedBitVectorInternals::appendRun(runLength, dummy, runLengthBytes);
+        }
+
+        auto byteItr = runLengthBytes.cbegin();
+        for (std::size_t j = 0; j < allRunLengths.size(); ++j) {
+            BOOST_TEST_REQUIRE(allRunLengths[j],
+                               CPackedBitVectorInternals::popRunLength(byteItr));
+        }
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testCreation) {
@@ -115,50 +310,50 @@ BOOST_AUTO_TEST_CASE(testCreation) {
 BOOST_AUTO_TEST_CASE(testExtend) {
     core::CPackedBitVector test1;
     test1.extend(true);
-    LOG_DEBUG(<< "test1 = " << test1);
     BOOST_REQUIRE_EQUAL(std::size_t(1), test1.dimension());
     BOOST_REQUIRE_EQUAL(std::string("[1]"), print(test1));
 
     test1.extend(true);
-    LOG_DEBUG(<< "test1 = " << test1);
     BOOST_REQUIRE_EQUAL(std::size_t(2), test1.dimension());
     BOOST_REQUIRE_EQUAL(std::string("[1 1]"), print(test1));
 
     test1.extend(false);
-    LOG_DEBUG(<< "test1 = " << test1);
     BOOST_REQUIRE_EQUAL(std::size_t(3), test1.dimension());
     BOOST_REQUIRE_EQUAL(std::string("[1 1 0]"), print(test1));
 
     test1.extend(false);
-    LOG_DEBUG(<< "test1 = " << test1);
     BOOST_REQUIRE_EQUAL(std::size_t(4), test1.dimension());
     BOOST_REQUIRE_EQUAL(std::string("[1 1 0 0]"), print(test1));
 
     test1.extend(true);
-    LOG_DEBUG(<< "test1 = " << test1);
     BOOST_REQUIRE_EQUAL(std::size_t(5), test1.dimension());
     BOOST_REQUIRE_EQUAL(std::string("[1 1 0 0 1]"), print(test1));
 
-    core::CPackedBitVector test2(254, true);
-    test2.extend(true);
-    LOG_DEBUG(<< "test2 = " << test2);
-    BOOST_REQUIRE_EQUAL(std::size_t(255), test2.dimension());
-    TBoolVec bits1(255, true);
-    BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
-                        core::CContainerPrinter::print(test2.toBitVector()));
-    test2.extend(false);
-    bits1.push_back(false);
-    LOG_DEBUG(<< "test2 = " << test2);
-    BOOST_REQUIRE_EQUAL(std::size_t(256), test2.dimension());
-    BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
-                        core::CContainerPrinter::print(test2.toBitVector()));
+    for (auto runLength : {CPackedBitVectorInternals::maximumOneByteRunLength(),
+                           CPackedBitVectorInternals::maximumTwoByteRunLength()}) {
+        LOG_DEBUG(<< "run length = " << runLength);
 
-    core::CPackedBitVector test3(255, true);
-    test3.extend(false);
-    LOG_DEBUG(<< "test3 = " << test2);
-    BOOST_REQUIRE_EQUAL(std::size_t(256), test3.dimension());
-    BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
-                        core::CContainerPrinter::print(test3.toBitVector()));
+        core::CPackedBitVector test2(runLength, true);
+        test2.extend(true);
+        BOOST_REQUIRE_EQUAL(runLength + 1, test2.dimension());
+        TBoolVec bits1(runLength + 1, true);
+        BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
+                            core::CContainerPrinter::print(test2.toBitVector()));
+
+        test2.extend(false);
+        bits1.push_back(false);
+        BOOST_REQUIRE_EQUAL(runLength + 2, test2.dimension());
+        BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
+                            core::CContainerPrinter::print(test2.toBitVector()));
+
+        core::CPackedBitVector test3(runLength + 1, true);
+        test3.extend(false);
+        BOOST_REQUIRE_EQUAL(runLength + 2, test3.dimension());
+        BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
+                            core::CContainerPrinter::print(test3.toBitVector()));
+    }
+
+    LOG_DEBUG(<< "randomized");
 
     test::CRandomNumbers rng;
 
@@ -184,34 +379,24 @@ BOOST_AUTO_TEST_CASE(testContract) {
     test1.extend(true);
     std::string expected[] = {"[1 1 0 1]", "[1 0 1]", "[0 1]", "[1]"};
     for (const std::string* e = expected; test1.dimension() > 0; ++e) {
-        LOG_DEBUG(<< "test1 = " << test1);
         BOOST_REQUIRE_EQUAL(*e, print(test1));
         test1.contract();
     }
 
-    TBoolVec bits1(256, true);
-    bits1.push_back(false);
-    bits1.push_back(true);
-    bits1.push_back(false);
-    core::CPackedBitVector test2(bits1);
-    for (std::size_t i = 0; i < 10; ++i) {
-        bits1.erase(bits1.begin());
-        test2.contract();
-        LOG_DEBUG(<< "test2 = " << test2);
-        BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
-                            core::CContainerPrinter::print(test2.toBitVector()));
-    }
-
-    TBoolVec bits2(1024, true);
-    bits2.push_back(false);
-    core::CPackedBitVector test3(1024, true);
-    test3.extend(false);
-    for (std::size_t i = 0; i < 10; ++i) {
-        bits2.erase(bits2.begin());
-        test3.contract();
-        LOG_DEBUG(<< "test3 = " << test3);
-        BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits2),
-                            core::CContainerPrinter::print(test3.toBitVector()));
+    for (auto runLength : {CPackedBitVectorInternals::maximumOneByteRunLength() + 2,
+                           CPackedBitVectorInternals::maximumTwoByteRunLength() + 2}) {
+        LOG_DEBUG(<< "run length = " << runLength);
+        TBoolVec bits1(runLength, true);
+        bits1.push_back(false);
+        bits1.push_back(true);
+        bits1.push_back(false);
+        core::CPackedBitVector test2(bits1);
+        for (std::size_t i = 0; i < 10; ++i) {
+            bits1.erase(bits1.begin());
+            test2.contract();
+            BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(bits1),
+                                core::CContainerPrinter::print(test2.toBitVector()));
+        }
     }
 }
 
@@ -251,7 +436,7 @@ BOOST_AUTO_TEST_CASE(testBitwiseComplement) {
 }
 
 BOOST_AUTO_TEST_CASE(testBitwise) {
-    std::size_t run(core::CPackedBitVector::MAX_RUN_LENGTH);
+    std::size_t run{CPackedBitVectorInternals::maximumOneByteRunLength()};
 
     // Test some run length edge cases.
     {
@@ -304,16 +489,16 @@ BOOST_AUTO_TEST_CASE(testBitwise) {
         reference.push_back(std::move(bits));
     }
 
+    TBoolVec expectedBitwiseAnd(500);
+    TBoolVec expectedBitwiseOr(500);
+    TBoolVec expectedBitwiseXor(500);
+
     for (std::size_t i = 0; i < test.size(); ++i) {
         for (std::size_t j = 0; j < test.size(); ++j) {
             core::CPackedBitVector actualBitwiseAnd{test[i] & test[j]};
-            TBoolVec expectedBitwiseAnd(500);
             std::transform(reference[i].begin(), reference[i].end(),
                            reference[j].begin(), expectedBitwiseAnd.begin(),
                            std::logical_and<bool>());
-            if (j % 500 == 0) {
-                LOG_DEBUG(<< "and = " << toBitString(expectedBitwiseAnd));
-            }
             BOOST_REQUIRE_EQUAL(toBitString(expectedBitwiseAnd),
                                 toBitString(actualBitwiseAnd));
             // Also check hidden state...
@@ -321,26 +506,18 @@ BOOST_AUTO_TEST_CASE(testBitwise) {
                                 actualBitwiseAnd.checksum());
 
             core::CPackedBitVector actualBitwiseOr{test[i] | test[j]};
-            TBoolVec expectedBitwiseOr(500);
             std::transform(reference[i].begin(), reference[i].end(),
                            reference[j].begin(), expectedBitwiseOr.begin(),
                            std::logical_or<bool>());
-            if (j % 100 == 0) {
-                LOG_DEBUG(<< "or = " << toBitString(expectedBitwiseOr));
-            }
             BOOST_REQUIRE_EQUAL(toBitString(expectedBitwiseOr), toBitString(actualBitwiseOr));
             // Also check hidden state...
             BOOST_REQUIRE_EQUAL(core::CPackedBitVector{expectedBitwiseOr}.checksum(),
                                 actualBitwiseOr.checksum());
 
             core::CPackedBitVector actualBitwiseXor{test[i] ^ test[j]};
-            TBoolVec expectedBitwiseXor(500);
             std::transform(reference[i].begin(), reference[i].end(),
                            reference[j].begin(), expectedBitwiseXor.begin(),
                            [](bool lhs, bool rhs) { return lhs ^ rhs; });
-            if (j % 100 == 0) {
-                LOG_DEBUG(<< "xor = " << toBitString(expectedBitwiseXor));
-            }
             BOOST_REQUIRE_EQUAL(toBitString(expectedBitwiseXor),
                                 toBitString(actualBitwiseXor));
             // Also check hidden state...
@@ -352,8 +529,14 @@ BOOST_AUTO_TEST_CASE(testBitwise) {
 
 BOOST_AUTO_TEST_CASE(testOneBitIterators) {
     {
+        // Empty.
+        core::CPackedBitVector test;
+        TSizeVec indices{test.beginOneBits(), test.endOneBits()};
+        BOOST_TEST_REQUIRE(indices.empty());
+    }
+    {
         // All ones.
-        core::CPackedBitVector test(2000, true);
+        core::CPackedBitVector test{2000, true};
         TSizeVec actualIndices{test.beginOneBits(), test.endOneBits()};
         TSizeVec expectedIndices(2000);
         std::iota(expectedIndices.begin(), expectedIndices.end(), 0);
@@ -361,22 +544,21 @@ BOOST_AUTO_TEST_CASE(testOneBitIterators) {
     }
     {
         // All zeros.
-        core::CPackedBitVector test(1000, false);
+        core::CPackedBitVector test{1000, false};
         TSizeVec actualIndices{test.beginOneBits(), test.endOneBits()};
         BOOST_TEST_REQUIRE(actualIndices.empty());
     }
-    {
-        // Test end edge cases.
-
-        std::size_t run(core::CPackedBitVector::MAX_RUN_LENGTH);
+    // Test end edge cases.
+    for (auto runLength : {CPackedBitVectorInternals::maximumOneByteRunLength(),
+                           CPackedBitVectorInternals::maximumTwoByteRunLength()}) {
 
         core::CPackedBitVector test;
-        test.extend(false, run);
-        test.extend(true, 2 * run);
+        test.extend(false, runLength);
+        test.extend(true, 2 * runLength);
 
         TSizeVec actualIndices{test.beginOneBits(), test.endOneBits()};
         TSizeVec expectedIndices;
-        for (std::size_t i = run; i < 3 * run; ++i) {
+        for (std::size_t i = runLength; i < 3 * runLength; ++i) {
             expectedIndices.push_back(i);
         }
         BOOST_TEST_REQUIRE(actualIndices == expectedIndices);
@@ -404,7 +586,7 @@ BOOST_AUTO_TEST_CASE(testOneBitIterators) {
         if (actualIndices != expectedIndices) {
             LOG_ERROR(<< "expected = " << core::CContainerPrinter::print(expectedIndices));
             LOG_ERROR(<< "actual   = " << core::CContainerPrinter::print(actualIndices));
-        } else if (t % 100 == 0) {
+        } else if (t % 200 == 0) {
             LOG_DEBUG(<< "indices = " << core::CContainerPrinter::print(expectedIndices));
         }
         BOOST_TEST_REQUIRE(actualIndices == expectedIndices);
@@ -412,6 +594,7 @@ BOOST_AUTO_TEST_CASE(testOneBitIterators) {
 }
 
 BOOST_AUTO_TEST_CASE(testInnerProductBitwiseAnd) {
+
     core::CPackedBitVector test1(10, true);
     core::CPackedBitVector test2(10, false);
     TBoolVec bits1{true,  true,  false, false, true,
@@ -476,6 +659,7 @@ BOOST_AUTO_TEST_CASE(testInnerProductBitwiseAnd) {
 }
 
 BOOST_AUTO_TEST_CASE(testInnerProductBitwiseOr) {
+
     test::CRandomNumbers rng;
 
     TPackedBitVectorVec test;
@@ -490,30 +674,19 @@ BOOST_AUTO_TEST_CASE(testInnerProductBitwiseOr) {
     }
 
     for (std::size_t i = 0; i < test.size(); ++i) {
-        LOG_DEBUG(<< "Testing " << test[i]);
         for (std::size_t j = 0; j < test.size(); ++j) {
-            {
-                double expected = 0.0;
-                for (std::size_t k = 0; k < 50; ++k) {
-                    expected += (reference[i][k] || reference[j][k] ? 1.0 : 0.0);
-                }
-                if (j % 100 == 0) {
-                    LOG_DEBUG(<< "or  = " << expected);
-                }
-                BOOST_REQUIRE_EQUAL(
-                    expected, test[i].inner(test[j], core::CPackedBitVector::E_OR));
+            double expected{0.0};
+            for (std::size_t k = 0; k < 50; ++k) {
+                expected += (reference[i][k] || reference[j][k] ? 1.0 : 0.0);
             }
-            {
-                double expected = 0.0;
-                for (std::size_t k = 0; k < 50; ++k) {
-                    expected += (reference[i][k] != reference[j][k] ? 1.0 : 0.0);
-                }
-                if (j % 100 == 0) {
-                    LOG_DEBUG(<< "xor = " << expected);
-                }
-                BOOST_REQUIRE_EQUAL(
-                    expected, test[i].inner(test[j], core::CPackedBitVector::E_XOR));
+            BOOST_REQUIRE_EQUAL(
+                expected, test[i].inner(test[j], core::CPackedBitVector::E_OR));
+            expected = 0.0;
+            for (std::size_t k = 0; k < 50; ++k) {
+                expected += (reference[i][k] != reference[j][k] ? 1.0 : 0.0);
             }
+            BOOST_REQUIRE_EQUAL(
+                expected, test[i].inner(test[j], core::CPackedBitVector::E_XOR));
         }
     }
 }
@@ -587,8 +760,7 @@ BOOST_AUTO_TEST_CASE(testZeroLengthRunProblemCase) {
     auto toBits = [](const TSizeVec& components) {
         TBoolVec result;
         for (auto component : components) {
-            std::fill_n(std::back_inserter(result),
-                        core::CPackedBitVector::MAX_RUN_LENGTH, component);
+            std::fill_n(std::back_inserter(result), 255, component);
         }
         return result;
     };
@@ -621,6 +793,53 @@ BOOST_AUTO_TEST_CASE(testZeroLengthRunProblemCase) {
         BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(expectedIndices),
                             core::CContainerPrinter::print(actualIndices));
     }
+}
+
+BOOST_AUTO_TEST_CASE(testCompression) {
+
+    // Check the number of bytes we use per bit for a range of different one-bit
+    // densities.
+
+    using TDoubleVec = std::vector<double>;
+
+    test::CRandomNumbers rng;
+
+    double averageOverhead{0.0};
+
+    for (auto density : {0.5, 0.1, 0.01, 0.001, 0.0002}) {
+
+        std::size_t meanMemoryUsage{0};
+        for (std::size_t i = 0; i < 100; ++i) {
+            TDoubleVec u01;
+            rng.generateUniformSamples(0.0, 1.0, 100000, u01);
+            core::CPackedBitVector vector;
+            bool parity{true};
+            for (auto selector : u01) {
+                parity = selector < density ? !parity : parity;
+                vector.extend(parity);
+            }
+            meanMemoryUsage += vector.memoryUsage();
+        }
+        meanMemoryUsage /= 100;
+
+        // Optimal encoding uses log2(E[run length]) bits per run. This gives
+        // expected memory usage of log2(E[run length]) / E[run length] / 8
+        // bytes per vector bit.
+
+        double minimumMeanBytesPerBit{density * std::log2(1.0 / density) / 8.0};
+        double meanBytesPerBit{static_cast<double>(meanMemoryUsage) / 100000.0};
+        LOG_DEBUG(<< "minimum bytes per bit = " << minimumMeanBytesPerBit);
+        LOG_DEBUG(<< "bytes per bit         = " << meanBytesPerBit);
+
+        averageOverhead += meanBytesPerBit / minimumMeanBytesPerBit;
+        BOOST_TEST_REQUIRE(meanBytesPerBit < 15.0 * minimumMeanBytesPerBit);
+    }
+
+    averageOverhead /= 4.0;
+
+    LOG_DEBUG(<< "average overhead = " << averageOverhead);
+
+    BOOST_TEST_REQUIRE(averageOverhead < 6.0);
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {

--- a/lib/core/unittest/CPackedBitVectorTest.cc
+++ b/lib/core/unittest/CPackedBitVectorTest.cc
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include "core/CStopWatch.h"
+#include <boost/test/tools/old/interface.hpp>
 #include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
 #include <core/CPackedBitVector.h>
@@ -24,6 +26,7 @@ using namespace ml;
 
 using TBoolVec = std::vector<bool>;
 using TBoolVecVec = std::vector<TBoolVec>;
+using TDoubleVec = std::vector<double>;
 using TSizeVec = std::vector<std::size_t>;
 using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
@@ -799,8 +802,6 @@ BOOST_AUTO_TEST_CASE(testCompression) {
 
     // Check the number of bytes we use per bit for a range of different one-bit
     // densities.
-
-    using TDoubleVec = std::vector<double>;
 
     test::CRandomNumbers rng;
 

--- a/lib/core/unittest/CPackedBitVectorTest.cc
+++ b/lib/core/unittest/CPackedBitVectorTest.cc
@@ -90,21 +90,21 @@ BOOST_AUTO_TEST_CASE(testInternals) {
 
     LOG_DEBUG(<< "bytes");
 
-    BOOST_TEST_REQUIRE(1, CPackedBitVectorInternals::bytes(1));
-    BOOST_TEST_REQUIRE(1, CPackedBitVectorInternals::bytes(
-                              CPackedBitVectorInternals::maximumOneByteRunLength()));
-    BOOST_TEST_REQUIRE(2, CPackedBitVectorInternals::bytes(
-                              CPackedBitVectorInternals::maximumOneByteRunLength() + 1));
-    BOOST_TEST_REQUIRE(2, CPackedBitVectorInternals::bytes(
-                              CPackedBitVectorInternals::maximumTwoByteRunLength()));
-    BOOST_TEST_REQUIRE(3, CPackedBitVectorInternals::bytes(
-                              CPackedBitVectorInternals::maximumTwoByteRunLength() + 1));
-    BOOST_TEST_REQUIRE(2, CPackedBitVectorInternals::bytes(
-                              CPackedBitVectorInternals::maximumThreeByteRunLength()));
-    BOOST_TEST_REQUIRE(3, CPackedBitVectorInternals::bytes(
-                              CPackedBitVectorInternals::maximumThreeByteRunLength() + 1));
-    BOOST_TEST_REQUIRE(4, CPackedBitVectorInternals::bytes(
-                              CPackedBitVectorInternals::maximumFourByteRunLength()));
+    BOOST_REQUIRE_EQUAL(1, CPackedBitVectorInternals::bytes(1));
+    BOOST_REQUIRE_EQUAL(1, CPackedBitVectorInternals::bytes(
+                               CPackedBitVectorInternals::maximumOneByteRunLength()));
+    BOOST_REQUIRE_EQUAL(2, CPackedBitVectorInternals::bytes(
+                               CPackedBitVectorInternals::maximumOneByteRunLength() + 1));
+    BOOST_REQUIRE_EQUAL(2, CPackedBitVectorInternals::bytes(
+                               CPackedBitVectorInternals::maximumTwoByteRunLength()));
+    BOOST_REQUIRE_EQUAL(3, CPackedBitVectorInternals::bytes(
+                               CPackedBitVectorInternals::maximumTwoByteRunLength() + 1));
+    BOOST_REQUIRE_EQUAL(3, CPackedBitVectorInternals::bytes(
+                               CPackedBitVectorInternals::maximumThreeByteRunLength()));
+    BOOST_REQUIRE_EQUAL(4, CPackedBitVectorInternals::bytes(
+                               CPackedBitVectorInternals::maximumThreeByteRunLength() + 1));
+    BOOST_REQUIRE_EQUAL(4, CPackedBitVectorInternals::bytes(
+                               CPackedBitVectorInternals::maximumFourByteRunLength()));
 
     test::CRandomNumbers rng;
     TSizeVec ranges{1, 1 << 8, 1 << 16, 1 << 24, 1 << 30};

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1068,6 +1068,10 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromString(std::istream& jsonS
     return result;
 }
 
+std::size_t CBoostedTreeFactory::maximumNumberRows() {
+    return core::CPackedBitVector::maximumSize();
+}
+
 CBoostedTreeFactory::CBoostedTreeFactory(std::size_t numberThreads, TLossFunctionUPtr loss)
     : m_NumberThreads{numberThreads},
       m_TreeImpl{std::make_unique<CBoostedTreeImpl>(numberThreads, std::move(loss))},

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -194,18 +194,14 @@ std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
 }
 
 std::size_t
-CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(std::size_t numberRows,
-                                                    std::size_t numberFeatures,
+CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(std::size_t numberFeatures,
                                                     std::size_t numberSplitsPerFeature,
                                                     std::size_t numberLossParameters) {
-    // We will typically get the close to the best compression for most of the
-    // leaves when the set of splits becomes large, corresponding to the worst
-    // case for memory usage. This is because the rows will be spread over many
-    // rows so the masks will mainly contain 0 bits in this case.
-    std::size_t rowMaskSize{numberRows / PACKED_BIT_VECTOR_MAXIMUM_ROWS_PER_BYTE};
+    // See CBoostedTreeImpl::estimateMemoryUsage for a discussion of the cost
+    // of the row mask.
     std::size_t splitsDerivativesSize{CSplitsDerivatives::estimateMemoryUsage(
         numberFeatures, numberSplitsPerFeature, numberLossParameters)};
-    return sizeof(CBoostedTreeLeafNodeStatistics) + rowMaskSize + splitsDerivativesSize;
+    return sizeof(CBoostedTreeLeafNodeStatistics) + splitsDerivativesSize;
 }
 
 void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivatives(

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1311,6 +1311,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {
         BOOST_TEST_REQUIRE(instrumentation.maxMemoryUsage() < estimatedMemory);
     }
 }
+
 // TODO: test for handle fatal (memory-limit-circuit-breaker)
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrainWithTestRows) {
 


### PR DESCRIPTION
We use run length encoding for the bit masks we use to cache the rows for each leaf of the boosted tree. The scheme we were previously using was to use a fixed 1 byte to encode each run length. Long runs were then represented by "run length" / 256 bytes. This scheme works well while the expected run length < 256, but becomes highly suboptimal when the expected run length >> 256.

As we grow a tree we are partitioning rows between leaves, so naturally induce sparseness into the bit masks which corresponds to longer expected run lengths (of zero bits). For roughly balanced splits, our current scheme works well until the tree depth is 8 and then performance tails off for deeper trees. And in particular, the worst case for both memory usage and run time, many deep trees, are when the encoding scheme is least effective.

This switches to using 1-4 bytes to encode each run length with two header bits to define the number bytes used to encode each run. This gives similar performance to the current approach for short runs. In the worst case it uses around 50% more bytes when the expected run length is 256. However, it gives dramatically better performance for longer runs. The figure below summarises the behaviour. The black line represents optimal run length encoding using log2(E[run length]) / E[run length] / 8 bytes per bit and the green line represents a std::bitset, i.e. one bit per bit. The current scheme is shown in red and the new scheme in blue. (We see new scheme asymptotes towards optimal for very long expected runs.)

<img width="783" alt="Screenshot 2020-06-23 at 10 59 52" src="https://user-images.githubusercontent.com/7591487/85390414-b6585c80-b540-11ea-83eb-179a787a56ca.png">

Because we use 2 bits out of 32 for the header we can only represent vectors up to length 2^30 = 1.07B. This comfortably exceeds the maximum size of training data we'd want to have on a single node, so doesn't represent a significant limitation. Using 3 bits for encoding the run length bytes represents a significant degradation in performance for the typical case.

This doesn't change the results, but represents a memory and performance (since operations on the bit vector are O(number bytes)) improvement for classification and regression.