### PR TITLE
[ML] Only compute boosted tree leaf row masks if they are needed

### DIFF
--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -481,10 +481,9 @@ public:
         //! Get the reduction of the per thread masks.
         const core::CPackedBitVector& reducedMask(std::size_t size) {
             if (m_ReducedMasks == false) {
-                for (auto& mask : m_Masks) {
-                    mask.extend(false, size - mask.size());
-                }
+                m_Masks[0].extend(false, size - m_Masks[0].size());
                 for (std::size_t i = 1; i < m_NumberThreads; ++i) {
+                    m_Masks[i].extend(false, size - m_Masks[i].size());
                     m_Masks[0] |= m_Masks[i];
                 }
                 m_ReducedMasks = true;

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -459,6 +459,39 @@ public:
         //! Reset the minimum gain to its initial value.
         void resetMinimumGain() { m_MinimumGain = 0.0; }
 
+        //! Start working on a new leaf.
+        void newLeaf(std::size_t numberThreads) {
+            m_NumberThreads = numberThreads;
+            m_ReducedMasks = false;
+            m_ReducedDerivatives = false;
+        }
+
+        //! Get the reduction of the per thread aggregate derivatives.
+        CSplitsDerivatives& reducedDerivatives() {
+            if (m_ReducedDerivatives == false) {
+                for (std::size_t i = 1; i < m_NumberThreads; ++i) {
+                    m_Derivatives[0].add(m_Derivatives[i]);
+                }
+                m_Derivatives[0].remapCurvature();
+                m_ReducedDerivatives = true;
+            }
+            return m_Derivatives[0];
+        }
+
+        //! Get the reduction of the per thread masks.
+        const core::CPackedBitVector& reducedMask(std::size_t size) {
+            if (m_ReducedMasks == false) {
+                for (auto& mask : m_Masks) {
+                    mask.extend(false, size - mask.size());
+                }
+                for (std::size_t i = 1; i < m_NumberThreads; ++i) {
+                    m_Masks[0] |= m_Masks[i];
+                }
+                m_ReducedMasks = true;
+            }
+            return m_Masks[0];
+        }
+
         //! Get the workspace row masks.
         TPackedBitVectorVec& masks() { return m_Masks; }
 
@@ -472,7 +505,10 @@ public:
         }
 
     private:
+        std::size_t m_NumberThreads = 0;
         double m_MinimumGain = 0.0;
+        bool m_ReducedMasks = false;
+        bool m_ReducedDerivatives = false;
         TPackedBitVectorVec m_Masks;
         TSplitsDerivativesVec m_Derivatives;
     };


### PR DESCRIPTION
Following on from #1317, we can delay computing the bitwise or of the different thread row masks until we know we can split the leaf. This operation is serial and can be expensive for many threads and rows.

I've decided not to document this separately from #1317, since it is a natural optimisation I missed in that change; so I've marked it as a non-issue.