### PR TITLE
[7.x][ML] UTF-16 String length computation

### DIFF
--- a/include/core/CStringUtils.h
+++ b/include/core/CStringUtils.h
@@ -43,6 +43,10 @@ public:
     //! character) return -1.
     static int utf8ByteType(char c);
 
+    //! Compute the length of a UTF-16 encoded string for a given UTF-8 encoded
+    //! \p str.
+    static std::size_t utf16LengthOfUtf8String(const std::string& str);
+
     //! Convert a type to a string
     template<typename T>
     static std::string typeToString(const T& type) {

--- a/lib/core/CStringUtils.cc
+++ b/lib/core/CStringUtils.cc
@@ -75,6 +75,23 @@ int CStringUtils::utf8ByteType(char c) {
     return 6;
 }
 
+std::size_t CStringUtils::utf16LengthOfUtf8String(const std::string& str) {
+    std::size_t result{0};
+    for (const auto& c : str) {
+        int byteType{utf8ByteType(c)};
+        if (byteType >= 1 && byteType <= 3) {
+            result += 1;
+        } else if (byteType >= 4 && byteType <= 6) {
+            result += 2;
+        } else if (byteType == -1) {
+            result += 0; // I guess this will optimized out
+        } else {
+            LOG_ERROR(<< "Input error: unexpected utf8ByteType " << byteType);
+        }
+    }
+    return result;
+}
+
 std::string CStringUtils::toLower(std::string str) {
     std::transform(str.begin(), str.end(), str.begin(), &::tolower);
     return str;

--- a/lib/core/unittest/CStringUtilsTest.cc
+++ b/lib/core/unittest/CStringUtilsTest.cc
@@ -925,6 +925,30 @@ BOOST_AUTO_TEST_CASE(testUtf8ByteType) {
     BOOST_REQUIRE_EQUAL(-1, ml::core::CStringUtils::utf8ByteType(testStr[9]));
 }
 
+BOOST_AUTO_TEST_CASE(testUtf16LengthOfUtf8String) {
+    // Every character in the UTF-8 string is pure ASCII - in this case UTF-8 byte count = UTF-16 length
+    {
+        std::string testStr{"qwerty"};
+        BOOST_REQUIRE_EQUAL(6, testStr.size());
+        BOOST_REQUIRE_EQUAL(6, ml::core::CStringUtils::utf16LengthOfUtf8String(testStr));
+    }
+    // The UTF-8 string contains some characters that need two bytes to represent in UTF-8, but only one UTF-16 character
+    {
+        std::string testChar{"é"};
+        BOOST_REQUIRE_EQUAL(2, testChar.size());
+        BOOST_REQUIRE_EQUAL(1, ml::core::CStringUtils::utf16LengthOfUtf8String(testChar));
+        std::string testStr{"café"};
+        BOOST_REQUIRE_EQUAL(5, testStr.size());
+        BOOST_REQUIRE_EQUAL(4, ml::core::CStringUtils::utf16LengthOfUtf8String(testStr));
+    }
+    // The UTF-8 string contains some characters that need two UTF-16 characters to represent, i.e. Unicode code points > 65535
+    {
+        std::string testChar{"𩸽"};
+        BOOST_REQUIRE_EQUAL(4, testChar.size());
+        BOOST_REQUIRE_EQUAL(2, ml::core::CStringUtils::utf16LengthOfUtf8String(testChar));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testRoundtripMaxDouble) {
     ml::core::CIEEE754::EPrecision precisions[] = {
         ml::core::CIEEE754::E_SinglePrecision, ml::core::CIEEE754::E_DoublePrecision};


### PR DESCRIPTION
This PR adds a utility to compute the length of a UTF-16 encoded string. This functionality is needed to improve compatibility with Java.

Since it's not a user-facing functionality, I mark it as a non-issue.

Backport of #1338.