### PR TITLE
[7.x][ML] Make swap and move functions noexcept where possible

### DIFF
--- a/include/api/CFieldConfig.h
+++ b/include/api/CFieldConfig.h
@@ -274,7 +274,7 @@ public:
         std::ostream& debugPrintClause(std::ostream& strm) const;
 
         //! Efficient swap
-        void swap(CFieldOptions& other);
+        void swap(CFieldOptions& other) noexcept;
 
     private:
         std::string m_Description;

--- a/include/core/CDataFrameRowSlice.h
+++ b/include/core/CDataFrameRowSlice.h
@@ -53,10 +53,10 @@ public:
     CDataFrameRowSliceHandle() = default;
     CDataFrameRowSliceHandle(TImplPtr impl);
     CDataFrameRowSliceHandle(const CDataFrameRowSliceHandle& other);
-    CDataFrameRowSliceHandle(CDataFrameRowSliceHandle&& other);
+    CDataFrameRowSliceHandle(CDataFrameRowSliceHandle&& other) noexcept;
 
     CDataFrameRowSliceHandle& operator=(const CDataFrameRowSliceHandle& other);
-    CDataFrameRowSliceHandle& operator=(CDataFrameRowSliceHandle&& other);
+    CDataFrameRowSliceHandle& operator=(CDataFrameRowSliceHandle&& other) noexcept;
 
     //! The size of the slice in floats.
     std::size_t size() const;

--- a/include/maths/CAdaptiveBucketing.h
+++ b/include/maths/CAdaptiveBucketing.h
@@ -174,7 +174,7 @@ protected:
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
     //! Efficiently swap the contents of two bucketing objects.
-    void swap(CAdaptiveBucketing& other);
+    void swap(CAdaptiveBucketing& other) noexcept;
 
     //! Create a new uniform bucketing with \p n buckets on the
     //! interval [\p a, \p b].

--- a/include/maths/CBjkstUniqueValues.h
+++ b/include/maths/CBjkstUniqueValues.h
@@ -85,7 +85,7 @@ public:
     CBjkstUniqueValues(core::CStateRestoreTraverser& traverser);
 
     //! Efficiently swap the contents of two sketches.
-    void swap(CBjkstUniqueValues& other);
+    void swap(CBjkstUniqueValues& other) noexcept;
 
 private:
     //! Create by traversing a state document.
@@ -126,7 +126,7 @@ private:
         SSketch(std::size_t numberHashes);
 
         //! Efficiently swap the contents of two sketches.
-        void swap(SSketch& other);
+        void swap(SSketch& other) noexcept;
 
         //! Create by traversing a state document.
         bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser,

--- a/include/maths/CCountMinSketch.h
+++ b/include/maths/CCountMinSketch.h
@@ -54,7 +54,7 @@ public:
     CCountMinSketch(core::CStateRestoreTraverser& traverser);
 
     //! Efficient swap the contents of two sketches.
-    void swap(CCountMinSketch& sketch);
+    void swap(CCountMinSketch& sketch) noexcept;
 
 private:
     //! Create by traversing a state document.

--- a/include/maths/CDecompositionComponent.h
+++ b/include/maths/CDecompositionComponent.h
@@ -69,7 +69,7 @@ protected:
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
         //! An efficient swap of the contents of two packed splines.
-        void swap(CPackedSplines& other);
+        void swap(CPackedSplines& other) noexcept;
 
         //! Check if the splines have been initialized.
         bool initialized() const;

--- a/include/maths/CKMeansOnline.h
+++ b/include/maths/CKMeansOnline.h
@@ -181,7 +181,7 @@ public:
     }
 
     //! Efficiently swap the contents of this and \p other.
-    void swap(CKMeansOnline& other) {
+    void swap(CKMeansOnline& other) noexcept {
         std::swap(m_Rng, other.m_Rng);
         std::swap(m_K, other.m_K);
         std::swap(m_BufferSize, other.m_BufferSize);

--- a/include/maths/CLassoLogisticRegression.h
+++ b/include/maths/CLassoLogisticRegression.h
@@ -40,7 +40,7 @@ public:
     CLrDenseMatrix(TDoubleVecVec& elements);
 
     //! Efficiently swap the contents of two matrices.
-    void swap(CLrDenseMatrix& other);
+    void swap(CLrDenseMatrix& other) noexcept;
 
     //! Get the number of rows.
     std::size_t rows() const {
@@ -77,7 +77,7 @@ public:
     CLrSparseMatrix(std::size_t rows, std::size_t columns, TSizeSizePrDoublePrVec& elements);
 
     //! Efficiently swap the contents of two matrices.
-    void swap(CLrSparseMatrix& other);
+    void swap(CLrSparseMatrix& other) noexcept;
 
     //! Get the number of rows.
     std::size_t rows() const { return m_Rows; }
@@ -250,7 +250,7 @@ public:
     CLogisticRegressionModel(double beta0, TSizeDoublePrVec& beta);
 
     //! Efficiently swap the contents of two models.
-    void swap(CLogisticRegressionModel& other);
+    void swap(CLogisticRegressionModel& other) noexcept;
 
     //! Get the probability of the dense feature vector \p x.
     bool operator()(const TDoubleVec& x, double& probability) const;

--- a/include/maths/CMultinomialConjugate.h
+++ b/include/maths/CMultinomialConjugate.h
@@ -69,7 +69,7 @@ public:
     // Default copy constructor and assignment operator work.
 
     //! Efficient swap of the contents of this prior and \p other.
-    void swap(CMultinomialConjugate& other);
+    void swap(CMultinomialConjugate& other) noexcept;
 
     //! Create an instance of a non-informative prior.
     //!

--- a/include/maths/CMultivariatePrior.h
+++ b/include/maths/CMultivariatePrior.h
@@ -82,7 +82,7 @@ public:
     virtual ~CMultivariatePrior() = default;
 
     //! Swap the contents of this prior and \p other.
-    void swap(CMultivariatePrior& other);
+    void swap(CMultivariatePrior& other) noexcept;
     //@}
 
     //! Mark the prior as being used for forecasting.

--- a/include/maths/CPrior.h
+++ b/include/maths/CPrior.h
@@ -127,7 +127,7 @@ public:
     virtual ~CPrior() = default;
 
     //! Swap the contents of this prior and \p other.
-    void swap(CPrior& other);
+    void swap(CPrior& other) noexcept;
     //@}
 
     //! Check if the prior is being used to model discrete data.

--- a/include/model/CAnnotatedProbability.h
+++ b/include/model/CAnnotatedProbability.h
@@ -122,7 +122,7 @@ struct MODEL_EXPORT SAnnotatedProbability {
     void addDescriptiveData(annotated_probability::EDescriptiveData key, double value);
 
     //! Efficiently swap the contents of this and \p other.
-    void swap(SAnnotatedProbability& other);
+    void swap(SAnnotatedProbability& other) noexcept;
 
     //! Is the result type interim?
     bool isInterim() const;

--- a/include/model/CHierarchicalResults.h
+++ b/include/model/CHierarchicalResults.h
@@ -143,7 +143,7 @@ struct MODEL_EXPORT SNode {
     std::string print() const;
 
     //! Efficient swap
-    void swap(SNode& other);
+    void swap(SNode& other) noexcept;
 
     //! \name Connectivity
     //@{
@@ -194,7 +194,7 @@ struct MODEL_EXPORT SNode {
 
 //! Non-member node swap to work with standard algorithms
 MODEL_EXPORT
-void swap(SNode& node1, SNode& node2);
+void swap(SNode& node1, SNode& node2) noexcept;
 
 } // hierarchical_results_detail::
 

--- a/include/model/CSearchKey.h
+++ b/include/model/CSearchKey.h
@@ -125,7 +125,7 @@ public:
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
     //! Efficiently swap the contents of two objects of this class.
-    void swap(CSearchKey& other);
+    void swap(CSearchKey& other) noexcept;
 
     //! Check if this and \p rhs are equal.
     bool operator==(const CSearchKey& rhs) const;

--- a/lib/api/CFieldConfig.cc
+++ b/lib/api/CFieldConfig.cc
@@ -1774,7 +1774,7 @@ std::ostream& CFieldConfig::CFieldOptions::debugPrintClause(std::ostream& strm) 
     return strm;
 }
 
-void CFieldConfig::CFieldOptions::swap(CFieldOptions& other) {
+void CFieldConfig::CFieldOptions::swap(CFieldOptions& other) noexcept {
     m_Description.swap(other.m_Description);
     std::swap(m_Function, other.m_Function);
     m_FieldName.swap(other.m_FieldName);

--- a/lib/core/CDataFrameRowSlice.cc
+++ b/lib/core/CDataFrameRowSlice.cc
@@ -125,7 +125,7 @@ CDataFrameRowSliceHandle::CDataFrameRowSliceHandle(const CDataFrameRowSliceHandl
     : m_Impl{other.m_Impl != nullptr ? other.m_Impl->clone() : nullptr} {
 }
 
-CDataFrameRowSliceHandle::CDataFrameRowSliceHandle(CDataFrameRowSliceHandle&& other)
+CDataFrameRowSliceHandle::CDataFrameRowSliceHandle(CDataFrameRowSliceHandle&& other) noexcept
     : m_Impl{std::move(other.m_Impl)} {
 }
 
@@ -138,7 +138,7 @@ operator=(const CDataFrameRowSliceHandle& other) {
 }
 
 CDataFrameRowSliceHandle& CDataFrameRowSliceHandle::
-operator=(CDataFrameRowSliceHandle&& other) = default;
+operator=(CDataFrameRowSliceHandle&& other) noexcept = default;
 
 std::size_t CDataFrameRowSliceHandle::size() const {
     return m_Impl->rows().size();

--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -196,7 +196,7 @@ void CAdaptiveBucketing::acceptPersistInserter(core::CStatePersistInserter& inse
                          m_MeanAbsDesiredDisplacement.toDelimited());
 }
 
-void CAdaptiveBucketing::swap(CAdaptiveBucketing& other) {
+void CAdaptiveBucketing::swap(CAdaptiveBucketing& other) noexcept {
     std::swap(m_DecayRate, other.m_DecayRate);
     std::swap(m_MinimumBucketLength, other.m_MinimumBucketLength);
     std::swap(m_TargetSize, other.m_TargetSize);

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -257,7 +257,7 @@ CBjkstUniqueValues::CBjkstUniqueValues(core::CStateRestoreTraverser& traverser)
                                          this, std::placeholders::_1));
 }
 
-void CBjkstUniqueValues::swap(CBjkstUniqueValues& other) {
+void CBjkstUniqueValues::swap(CBjkstUniqueValues& other) noexcept {
     if (this == &other) {
         return;
     }
@@ -502,7 +502,7 @@ CBjkstUniqueValues::SSketch::SSketch(std::size_t numberHashes) {
     s_B.resize(numberHashes, TUInt8Vec());
 }
 
-void CBjkstUniqueValues::SSketch::swap(SSketch& other) {
+void CBjkstUniqueValues::SSketch::swap(SSketch& other) noexcept {
     s_G.swap(other.s_G);
     s_H.swap(other.s_H);
     s_Z.swap(other.s_Z);

--- a/lib/maths/CCountMinSketch.cc
+++ b/lib/maths/CCountMinSketch.cc
@@ -47,7 +47,7 @@ CCountMinSketch::CCountMinSketch(core::CStateRestoreTraverser& traverser)
                                          this, std::placeholders::_1));
 }
 
-void CCountMinSketch::swap(CCountMinSketch& other) {
+void CCountMinSketch::swap(CCountMinSketch& other) noexcept {
     if (this == &other) {
         return;
     }

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -257,7 +257,7 @@ void CDecompositionComponent::CPackedSplines::acceptPersistInserter(core::CState
     }
 }
 
-void CDecompositionComponent::CPackedSplines::swap(CPackedSplines& other) {
+void CDecompositionComponent::CPackedSplines::swap(CPackedSplines& other) noexcept {
     std::swap(m_Types, other.m_Types);
     m_Knots.swap(other.m_Knots);
     m_Values[0].swap(other.m_Values[0]);

--- a/lib/maths/CLassoLogisticRegression.cc
+++ b/lib/maths/CLassoLogisticRegression.cc
@@ -213,7 +213,7 @@ CLrDenseMatrix::CLrDenseMatrix(TDoubleVecVec& elements) {
     m_Elements.swap(elements);
 }
 
-void CLrDenseMatrix::swap(CLrDenseMatrix& other) {
+void CLrDenseMatrix::swap(CLrDenseMatrix& other) noexcept {
     m_Elements.swap(other.m_Elements);
 }
 
@@ -228,7 +228,7 @@ CLrSparseMatrix::CLrSparseMatrix(std::size_t rows, std::size_t columns, TSizeSiz
     std::sort(m_Elements.begin(), m_Elements.end(), COrderings::SFirstLess());
 }
 
-void CLrSparseMatrix::swap(CLrSparseMatrix& other) {
+void CLrSparseMatrix::swap(CLrSparseMatrix& other) noexcept {
     std::swap(m_Rows, other.m_Rows);
     std::swap(m_Columns, other.m_Columns);
     m_Elements.swap(other.m_Elements);
@@ -361,7 +361,7 @@ CLogisticRegressionModel::CLogisticRegressionModel(double beta0, TSizeDoublePrVe
     m_Beta.swap(beta);
 }
 
-void CLogisticRegressionModel::swap(CLogisticRegressionModel& other) {
+void CLogisticRegressionModel::swap(CLogisticRegressionModel& other) noexcept {
     std::swap(m_Beta0, other.m_Beta0);
     m_Beta.swap(other.m_Beta);
 }

--- a/lib/maths/CMultinomialConjugate.cc
+++ b/lib/maths/CMultinomialConjugate.cc
@@ -318,7 +318,7 @@ bool CMultinomialConjugate::acceptRestoreTraverser(core::CStateRestoreTraverser&
     return true;
 }
 
-void CMultinomialConjugate::swap(CMultinomialConjugate& other) {
+void CMultinomialConjugate::swap(CMultinomialConjugate& other) noexcept {
     this->CPrior::swap(other);
     std::swap(m_NumberAvailableCategories, other.m_NumberAvailableCategories);
     m_Categories.swap(other.m_Categories);

--- a/lib/maths/CMultivariatePrior.cc
+++ b/lib/maths/CMultivariatePrior.cc
@@ -44,7 +44,7 @@ CMultivariatePrior::CMultivariatePrior(maths_t::EDataType dataType, double decay
     setDecayRate(decayRate, FALLBACK_DECAY_RATE, m_DecayRate);
 }
 
-void CMultivariatePrior::swap(CMultivariatePrior& other) {
+void CMultivariatePrior::swap(CMultivariatePrior& other) noexcept {
     std::swap(m_Forecasting, other.m_Forecasting);
     std::swap(m_DataType, other.m_DataType);
     std::swap(m_DecayRate, other.m_DecayRate);

--- a/lib/maths/CPrior.cc
+++ b/lib/maths/CPrior.cc
@@ -55,7 +55,7 @@ CPrior::CPrior(maths_t::EDataType dataType, double decayRate)
     detail::setDecayRate(decayRate, FALLBACK_DECAY_RATE, m_DecayRate);
 }
 
-void CPrior::swap(CPrior& other) {
+void CPrior::swap(CPrior& other) noexcept {
     std::swap(m_DataType, other.m_DataType);
     std::swap(m_DecayRate, other.m_DecayRate);
     std::swap(m_NumberSamples, other.m_NumberSamples);

--- a/lib/model/CAnnotatedProbability.cc
+++ b/lib/model/CAnnotatedProbability.cc
@@ -153,7 +153,7 @@ void SAnnotatedProbability::addDescriptiveData(annotated_probability::EDescripti
     s_DescriptiveData.emplace_back(key, value);
 }
 
-void SAnnotatedProbability::swap(SAnnotatedProbability& other) {
+void SAnnotatedProbability::swap(SAnnotatedProbability& other) noexcept {
     std::swap(s_Probability, other.s_Probability);
     std::swap(s_MultiBucketImpact, other.s_MultiBucketImpact);
     s_AttributeProbabilities.swap(other.s_AttributeProbabilities);

--- a/lib/model/CHierarchicalResults.cc
+++ b/lib/model/CHierarchicalResults.cc
@@ -274,7 +274,7 @@ std::string SNode::print() const {
                 : ", " + core::CContainerPrinter::print(s_AnnotatedProbability.s_Influences));
 }
 
-void SNode::swap(SNode& other) {
+void SNode::swap(SNode& other) noexcept {
     std::swap(s_Parent, other.s_Parent);
     s_Children.swap(other.s_Children);
     std::swap(s_Spec, other.s_Spec);
@@ -290,7 +290,7 @@ void SNode::swap(SNode& other) {
     std::swap(s_BucketLength, other.s_BucketLength);
 }
 
-void swap(SNode& node1, SNode& node2) {
+void swap(SNode& node1, SNode& node2) noexcept {
     node1.swap(node2);
 }
 

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -140,7 +140,7 @@ void CSearchKey::acceptPersistInserter(core::CStatePersistInserter& inserter) co
     }
 }
 
-void CSearchKey::swap(CSearchKey& other) {
+void CSearchKey::swap(CSearchKey& other) noexcept {
     std::swap(m_DetectorIndex, other.m_DetectorIndex);
     std::swap(m_Function, other.m_Function);
     std::swap(m_UseNull, other.m_UseNull);


### PR DESCRIPTION
The standard library can use more efficient algorithms when it
is certain that swap functions, move constructors and move
assignment operators do no throw exceptions.

This change adds noexcept to the majority of such functions that
didn't already have it.

(There are still a few that I didn't add it to, as it was hard
to be sure whether the complicated layers of containers of
Eigen data structures held within them might throw exceptions.)

Backport of #1339