### PR TITLE
[7.x][ML] Generate memory size info for compressed model definition

### DIFF
--- a/lib/api/CInferenceModelDefinition.cc
+++ b/lib/api/CInferenceModelDefinition.cc
@@ -6,7 +6,10 @@
 #include <api/CInferenceModelDefinition.h>
 
 #include <core/CPersistUtils.h>
+#include <core/CStringUtils.h>
 
+#include <cmath>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -14,18 +17,23 @@ namespace ml {
 namespace api {
 
 namespace {
-
+// clang-format off
 const std::string JSON_AGGREGATE_OUTPUT_TAG{"aggregate_output"};
 const std::string JSON_CLASSIFICATION_LABELS_TAG{"classification_labels"};
 const std::string JSON_CLASSIFICATION_WEIGHTS_TAG{"classification_weights"};
 const std::string JSON_DECISION_TYPE_TAG{"decision_type"};
 const std::string JSON_DEFAULT_LEFT_TAG{"default_left"};
 const std::string JSON_DEFAULT_VALUE_TAG{"default_value"};
+const std::string JSON_ENSEMBLE_MODEL_SIZE_TAG{"ensemble_model_size"};
 const std::string JSON_ENSEMBLE_TAG{"ensemble"};
+const std::string JSON_FEATURE_NAME_LENGTH_TAG{"feature_name_length"};
+const std::string JSON_FEATURE_NAME_LENGTHS_TAG{"feature_name_lengths"};
 const std::string JSON_FEATURE_NAME_TAG{"feature_name"};
 const std::string JSON_FEATURE_NAMES_TAG{"feature_names"};
+const std::string JSON_FIELD_LENGTH_TAG{"field_length"};
 const std::string JSON_FIELD_NAMES_TAG{"field_names"};
 const std::string JSON_FIELD_TAG{"field"};
+const std::string JSON_FIELD_VALUE_LENGTHS_TAG{"field_value_lengths"};
 const std::string JSON_FREQUENCY_ENCODING_TAG{"frequency_encoding"};
 const std::string JSON_FREQUENCY_MAP_TAG{"frequency_map"};
 const std::string JSON_HOT_MAP_TAG{"hot_map"};
@@ -34,6 +42,12 @@ const std::string JSON_LEFT_CHILD_TAG{"left_child"};
 const std::string JSON_LOGISTIC_REGRESSION_TAG{"logistic_regression"};
 const std::string JSON_LT{"lt"};
 const std::string JSON_NODE_INDEX_TAG{"node_index"};
+const std::string JSON_NUM_CLASSES_TAG{"num_classes"};
+const std::string JSON_NUM_CLASSIFICATION_WEIGHTS_TAG{"num_classification_weights"};
+const std::string JSON_NUM_LEAVES_TAG{"num_leaves"};
+const std::string JSON_NUM_NODES_TAG{"num_nodes"};
+const std::string JSON_NUM_OPERATIONS_TAG{"num_operations"};
+const std::string JSON_NUM_OUTPUT_PROCESSOR_WEIGHTS_TAG{"num_output_processor_weights"};
 const std::string JSON_NUMBER_SAMPLES_TAG{"number_samples"};
 const std::string JSON_ONE_HOT_ENCODING_TAG{"one_hot_encoding"};
 const std::string JSON_PREPROCESSORS_TAG{"preprocessors"};
@@ -46,13 +60,16 @@ const std::string JSON_TARGET_TYPE_CLASSIFICATION{"classification"};
 const std::string JSON_TARGET_TYPE_REGRESSION{"regression"};
 const std::string JSON_TARGET_TYPE_TAG{"target_type"};
 const std::string JSON_THRESHOLD_TAG{"threshold"};
+const std::string JSON_TRAINED_MODEL_SIZE_TAG{"trained_model_size"};
 const std::string JSON_TRAINED_MODEL_TAG{"trained_model"};
 const std::string JSON_TRAINED_MODELS_TAG{"trained_models"};
 const std::string JSON_TREE_STRUCTURE_TAG{"tree_structure"};
 const std::string JSON_TREE_TAG{"tree"};
+const std::string JSON_TREE_SIZES_TAG{"tree_sizes"};
 const std::string JSON_WEIGHTED_MODE_TAG{"weighted_mode"};
 const std::string JSON_WEIGHTED_SUM_TAG{"weighted_sum"};
 const std::string JSON_WEIGHTS_TAG{"weights"};
+// clang-format on
 
 auto toJson(const std::string& value, CSerializableToJson::TRapidJsonWriter& writer) {
     rapidjson::Value result;
@@ -62,6 +79,14 @@ auto toJson(const std::string& value, CSerializableToJson::TRapidJsonWriter& wri
 
 auto toJson(double value, CSerializableToJson::TRapidJsonWriter&) {
     return rapidjson::Value{value};
+}
+
+auto toJson(std::size_t value) {
+    return rapidjson::Value{static_cast<std::uint64_t>(value)};
+}
+
+auto toJson(std::size_t value, CSerializableToJson::TRapidJsonWriter&) {
+    return toJson(value);
 }
 
 template<typename T>
@@ -80,16 +105,11 @@ void addJsonArray(const std::string& tag,
 void CTree::CTreeNode::addToDocument(rapidjson::Value& parentObject,
                                      TRapidJsonWriter& writer) const {
     writer.addMember(JSON_NODE_INDEX_TAG, rapidjson::Value(m_NodeIndex).Move(), parentObject);
-    writer.addMember(
-        JSON_NUMBER_SAMPLES_TAG,
-        rapidjson::Value(static_cast<std::uint64_t>(m_NumberSamples)).Move(), parentObject);
+    writer.addMember(JSON_NUMBER_SAMPLES_TAG, toJson(m_NumberSamples).Move(), parentObject);
 
     if (m_LeftChild) {
         // internal node
-        writer.addMember(
-            JSON_SPLIT_FEATURE_TAG,
-            rapidjson::Value(static_cast<std::uint64_t>(m_SplitFeature)).Move(),
-            parentObject);
+        writer.addMember(JSON_SPLIT_FEATURE_TAG, toJson(m_SplitFeature).Move(), parentObject);
         if (m_SplitGain.is_initialized()) {
             writer.addMember(JSON_SPLIT_GAIN_TAG,
                              rapidjson::Value(m_SplitGain.get()).Move(), parentObject);
@@ -102,14 +122,8 @@ void CTree::CTreeNode::addToDocument(rapidjson::Value& parentObject,
             writer.addMember(JSON_DECISION_TYPE_TAG, JSON_LT, parentObject);
             break;
         }
-        writer.addMember(
-            JSON_LEFT_CHILD_TAG,
-            rapidjson::Value(static_cast<std::uint64_t>(m_LeftChild.get())).Move(),
-            parentObject);
-        writer.addMember(
-            JSON_RIGHT_CHILD_TAG,
-            rapidjson::Value(static_cast<std::uint64_t>(m_RightChild.get())).Move(),
-            parentObject);
+        writer.addMember(JSON_LEFT_CHILD_TAG, toJson(m_LeftChild.get()).Move(), parentObject);
+        writer.addMember(JSON_RIGHT_CHILD_TAG, toJson(m_RightChild.get()).Move(), parentObject);
     } else if (m_LeafValue.size() > 1) {
         // leaf node
         addJsonArray(JSON_LEAF_VALUE_TAG, m_LeafValue, parentObject, writer);
@@ -145,6 +159,44 @@ void CTree::CTreeNode::splitFeature(std::size_t splitFeature) {
 
 bool CTree::CTreeNode::leaf() const {
     return m_LeftChild.is_initialized() == false;
+}
+
+CTrainedModel::TSizeInfoUPtr CTree::sizeInfo() const {
+    return std::make_unique<CSizeInfo>(*this);
+}
+
+CTree::CSizeInfo::CSizeInfo(const CTree& tree)
+    : CTrainedModel::CSizeInfo(tree), m_Tree{tree} {
+}
+
+void CTree::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                     TRapidJsonWriter& writer) const {
+    std::size_t numLeaves{0};
+    std::size_t numNodes{0};
+    for (const auto& node : m_Tree.m_TreeStructure) {
+        if (node.leaf()) {
+            ++numLeaves;
+        } else {
+            ++numNodes;
+        }
+    }
+    writer.addMember(JSON_NUM_NODES_TAG, toJson(numNodes).Move(), parentObject);
+    writer.addMember(JSON_NUM_LEAVES_TAG, toJson(numLeaves).Move(), parentObject);
+}
+
+std::size_t CTree::CSizeInfo::numOperations() const {
+    std::size_t numLeaves{0};
+    std::size_t numNodes{0};
+    for (const auto& node : m_Tree.m_TreeStructure) {
+        if (node.leaf()) {
+            ++numLeaves;
+        } else {
+            ++numNodes;
+        }
+    }
+    // Strictly speaking, this formula is correct only for balanced trees, but it will
+    // give a good average estimate for other binary trees as well.
+    return static_cast<std::size_t>(std::ceil(std::log2(numNodes + numLeaves + 1)));
 }
 
 void CEnsemble::addToDocument(rapidjson::Value& parentObject, TRapidJsonWriter& writer) const {
@@ -227,12 +279,55 @@ void CEnsemble::classificationWeights(TDoubleVec classificationWeights) {
     this->CTrainedModel::classificationWeights(std::move(classificationWeights));
 }
 
+CTrainedModel::TSizeInfoUPtr CEnsemble::sizeInfo() const {
+    return std::make_unique<CSizeInfo>(*this);
+}
+
+CEnsemble::CSizeInfo::CSizeInfo(const CEnsemble& ensemble)
+    : CTrainedModel::CSizeInfo(ensemble), m_Ensemble{&ensemble} {
+}
+
+std::size_t CEnsemble::CSizeInfo::numOperations() const {
+    std::size_t numOperations{0};
+    for (const auto& model : m_Ensemble->m_TrainedModels) {
+        numOperations += model->sizeInfo()->numOperations();
+    }
+    return numOperations;
+}
+
+void CEnsemble::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                         TRapidJsonWriter& writer) const {
+    this->CTrainedModel::CSizeInfo::addToDocument(parentObject, writer);
+    rapidjson::Value featureNameLengthsArray{
+        writer.makeArray(m_Ensemble->featureNames().size())};
+    for (const auto& featureName : m_Ensemble->featureNames()) {
+        featureNameLengthsArray.PushBack(
+            toJson(core::CStringUtils::utf16LengthOfUtf8String(featureName)).Move(),
+            writer.getRawAllocator());
+    }
+    writer.addMember(JSON_FEATURE_NAME_LENGTHS_TAG, featureNameLengthsArray, parentObject);
+
+    rapidjson::Value treeSizesArray{writer.makeArray(m_Ensemble->m_TrainedModels.size())};
+    for (const auto& trainedModel : m_Ensemble->m_TrainedModels) {
+        rapidjson::Value item{writer.makeObject()};
+        trainedModel->sizeInfo()->addToDocument(item, writer);
+        treeSizesArray.PushBack(item, writer.getRawAllocator());
+    }
+    writer.addMember(JSON_TREE_SIZES_TAG, treeSizesArray, parentObject);
+
+    std::size_t numOutputProcessorWeights{m_Ensemble->m_TrainedModels.size()};
+    writer.addMember(JSON_NUM_OUTPUT_PROCESSOR_WEIGHTS_TAG,
+                     toJson(numOutputProcessorWeights).Move(), parentObject);
+    std::size_t numOperations{this->numOperations()};
+    writer.addMember(JSON_NUM_OPERATIONS_TAG, toJson(numOperations).Move(), parentObject);
+}
+
 void CTree::addToDocument(rapidjson::Value& parentObject, TRapidJsonWriter& writer) const {
-    rapidjson::Value object = writer.makeObject();
+    rapidjson::Value object{writer.makeObject()};
     this->CTrainedModel::addToDocument(object, writer);
-    rapidjson::Value treeStructureArray = writer.makeArray(m_TreeStructure.size());
+    rapidjson::Value treeStructureArray{writer.makeArray(m_TreeStructure.size())};
     for (const auto& treeNode : m_TreeStructure) {
-        rapidjson::Value treeNodeObject = writer.makeObject();
+        rapidjson::Value treeNodeObject{writer.makeObject()};
         treeNode.addToDocument(treeNodeObject, writer);
         treeStructureArray.PushBack(treeNodeObject, writer.getRawAllocator());
     }
@@ -274,7 +369,7 @@ std::string CInferenceModelDefinition::jsonString() {
     {
         core::CJsonOutputStreamWrapper wrapper{stream};
         CSerializableToJson::TRapidJsonWriter writer{wrapper};
-        rapidjson::Value doc = writer.makeObject();
+        rapidjson::Value doc{writer.makeObject()};
         this->addToDocument(doc, writer);
         writer.write(doc);
         stream.flush();
@@ -288,11 +383,11 @@ std::string CInferenceModelDefinition::jsonString() {
 void CInferenceModelDefinition::addToDocument(rapidjson::Value& parentObject,
                                               TRapidJsonWriter& writer) const {
     // preprocessors
-    rapidjson::Value preprocessingArray = writer.makeArray();
+    rapidjson::Value preprocessingArray{writer.makeArray()};
     for (const auto& encoding : m_Preprocessors) {
-        rapidjson::Value encodingValue = writer.makeObject();
+        rapidjson::Value encodingValue{writer.makeObject()};
         encoding->addToDocument(encodingValue, writer);
-        rapidjson::Value encodingEnclosingObject = writer.makeObject();
+        rapidjson::Value encodingEnclosingObject{writer.makeObject()};
         writer.addMember(encoding->typeString(), encodingValue, encodingEnclosingObject);
         preprocessingArray.PushBack(encodingEnclosingObject, writer.getRawAllocator());
     }
@@ -300,7 +395,7 @@ void CInferenceModelDefinition::addToDocument(rapidjson::Value& parentObject,
 
     // trained_model
     if (m_TrainedModel) {
-        rapidjson::Value trainedModelValue = writer.makeObject();
+        rapidjson::Value trainedModelValue{writer.makeObject()};
         m_TrainedModel->addToDocument(trainedModelValue, writer);
         writer.addMember(JSON_TRAINED_MODEL_TAG, trainedModelValue, parentObject);
     } else {
@@ -372,15 +467,36 @@ void CTrainedModel::classificationWeights(TDoubleVec classificationWeights) {
     m_ClassificationWeights = std::move(classificationWeights);
 }
 
+CTrainedModel::CSizeInfo::CSizeInfo(const CTrainedModel& trainedModel)
+    : m_TrainedModel{trainedModel} {
+}
+
+void CTrainedModel::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                             TRapidJsonWriter& writer) const {
+    if (m_TrainedModel.targetType() == E_Classification) {
+        writer.addMember(JSON_NUM_CLASSIFICATION_WEIGHTS_TAG,
+                         toJson(m_TrainedModel.classificationWeights()->size()).Move(),
+                         parentObject);
+        writer.addMember(JSON_NUM_CLASSES_TAG,
+                         toJson(m_TrainedModel.classificationLabels()->size()).Move(),
+                         parentObject);
+    }
+}
+
 void CInferenceModelDefinition::fieldNames(TStringVec&& fieldNames) {
     m_FieldNames = std::move(fieldNames);
 }
 
-void CInferenceModelDefinition::trainedModel(CEnsemble::TTrainedModelUPtr&& trainedModel) {
+void CInferenceModelDefinition::trainedModel(TTrainedModelUPtr&& trainedModel) {
     m_TrainedModel = std::move(trainedModel);
 }
 
-CEnsemble::TTrainedModelUPtr& CInferenceModelDefinition::trainedModel() {
+CInferenceModelDefinition::TTrainedModelUPtr& CInferenceModelDefinition::trainedModel() {
+    return m_TrainedModel;
+}
+
+const CInferenceModelDefinition::TTrainedModelUPtr&
+CInferenceModelDefinition::trainedModel() const {
     return m_TrainedModel;
 }
 
@@ -408,6 +524,60 @@ void CInferenceModelDefinition::dependentVariableColumnIndex(std::size_t depende
     m_DependentVariableColumnIndex = dependentVariableColumnIndex;
 }
 
+CInferenceModelDefinition::TSizeInfoUPtr CInferenceModelDefinition::sizeInfo() const {
+    return std::make_unique<CSizeInfo>(*this);
+}
+
+CInferenceModelDefinition::CSizeInfo::CSizeInfo(const CInferenceModelDefinition& definition)
+    : m_Definition{definition} {
+}
+
+std::string CInferenceModelDefinition::CSizeInfo::jsonString() {
+    std::ostringstream stream;
+    {
+        // we use this scope to finish writing the object in the CJsonOutputStreamWrapper destructor
+        core::CJsonOutputStreamWrapper wrapper{stream};
+        CSerializableToJson::TRapidJsonWriter writer{wrapper};
+        rapidjson::Value doc{writer.makeObject()};
+        this->addToDocument(doc, writer);
+        writer.write(doc);
+        stream.flush();
+    }
+    // string writer puts the json object in an array, so we strip the external brackets
+    std::string jsonStr{stream.str()};
+    std::string resultString(jsonStr, 1, jsonStr.size() - 2);
+    return resultString;
+}
+
+void CInferenceModelDefinition::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                                         TRapidJsonWriter& writer) const {
+    using TTrainedModelSizeUPtr = std::unique_ptr<CTrainedModel::CSizeInfo>;
+
+    // parse trained models
+    TTrainedModelSizeUPtr trainedModelSize;
+    if (m_Definition.trainedModel()) {
+        m_Definition.trainedModel()->sizeInfo().swap(trainedModelSize);
+    }
+
+    // preprocessors
+    rapidjson::Value preprocessingArray{writer.makeArray()};
+    for (const auto& preprocessor : m_Definition.preprocessors()) {
+        auto encodingSizeInfo = preprocessor->sizeInfo();
+        rapidjson::Value encodingValue{writer.makeObject()};
+        encodingSizeInfo->addToDocument(encodingValue, writer);
+        rapidjson::Value encodingEnclosingObject{writer.makeObject()};
+        writer.addMember(encodingSizeInfo->typeString(), encodingValue, encodingEnclosingObject);
+        preprocessingArray.PushBack(encodingEnclosingObject, writer.getRawAllocator());
+    }
+    writer.addMember(JSON_PREPROCESSORS_TAG, preprocessingArray, parentObject);
+    rapidjson::Value trainedModelSizeObject{writer.makeObject()};
+    rapidjson::Value ensembleModelSizeObject{writer.makeObject()};
+    trainedModelSize->addToDocument(ensembleModelSizeObject, writer);
+    writer.addMember(JSON_ENSEMBLE_MODEL_SIZE_TAG, ensembleModelSizeObject,
+                     trainedModelSizeObject);
+    writer.addMember(JSON_TRAINED_MODEL_SIZE_TAG, trainedModelSizeObject, parentObject);
+}
+
 const std::string& CTargetMeanEncoding::typeString() const {
     return JSON_TARGET_MEAN_ENCODING_TAG;
 }
@@ -419,7 +589,7 @@ void CTargetMeanEncoding::addToDocument(rapidjson::Value& parentObject,
                      rapidjson::Value(m_DefaultValue).Move(), parentObject);
     writer.addMember(JSON_FEATURE_NAME_TAG, m_FeatureName, parentObject);
 
-    rapidjson::Value map = writer.makeObject();
+    rapidjson::Value map{writer.makeObject()};
     for (const auto& mapping : m_TargetMap) {
         writer.addMember(mapping.first, rapidjson::Value(mapping.second).Move(), map);
     }
@@ -446,6 +616,33 @@ const CTargetMeanEncoding::TStringDoubleUMap& CTargetMeanEncoding::targetMap() c
     return m_TargetMap;
 }
 
+CTargetMeanEncoding::CSizeInfo::CSizeInfo(const CTargetMeanEncoding& encoding)
+    : CEncoding::CSizeInfo::CSizeInfo(&encoding), m_Encoding{encoding} {
+}
+
+void CTargetMeanEncoding::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                                   TRapidJsonWriter& writer) const {
+    this->CEncoding::CSizeInfo::addToDocument(parentObject, writer);
+    std::size_t featureNameLength{
+        core::CStringUtils::utf16LengthOfUtf8String(m_Encoding.featureName())};
+    TSizeVec fieldValueLengths;
+    fieldValueLengths.reserve(m_Encoding.targetMap().size());
+    for (const auto& item : m_Encoding.targetMap()) {
+        fieldValueLengths.push_back(core::CStringUtils::utf16LengthOfUtf8String(item.first));
+    }
+    writer.addMember(JSON_FEATURE_NAME_LENGTH_TAG,
+                     toJson(featureNameLength).Move(), parentObject);
+    addJsonArray(JSON_FIELD_VALUE_LENGTHS_TAG, fieldValueLengths, parentObject, writer);
+}
+
+CEncoding::TSizeInfoUPtr CTargetMeanEncoding::sizeInfo() const {
+    return std::make_unique<CTargetMeanEncoding::CSizeInfo>(*this);
+}
+
+const std::string& CTargetMeanEncoding::CSizeInfo::typeString() const {
+    return JSON_TARGET_MEAN_ENCODING_TAG;
+}
+
 CFrequencyEncoding::CFrequencyEncoding(const std::string& field,
                                        std::string featureName,
                                        TStringDoubleUMap frequencyMap)
@@ -468,18 +665,34 @@ const std::string& CEncoding::field() const {
     return m_Field;
 }
 
+CEncoding::CSizeInfo::CSizeInfo(const CEncoding* encoding)
+    : m_Encoding(encoding) {
+}
+
+void CEncoding::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                         TRapidJsonWriter& writer) const {
+    writer.addMember(
+        JSON_FIELD_LENGTH_TAG,
+        toJson(core::CStringUtils::utf16LengthOfUtf8String(m_Encoding->field())).Move(),
+        parentObject);
+}
+
+const CEncoding* CEncoding::CSizeInfo::encoding() const {
+    return m_Encoding;
+}
+
 void CFrequencyEncoding::addToDocument(rapidjson::Value& parentObject,
                                        CSerializableToJson::TRapidJsonWriter& writer) const {
     this->CEncoding::addToDocument(parentObject, writer);
     writer.addMember(JSON_FEATURE_NAME_TAG, m_FeatureName, parentObject);
-    rapidjson::Value frequencyMap = writer.makeObject();
+    rapidjson::Value frequencyMap{writer.makeObject()};
     for (const auto& mapping : m_FrequencyMap) {
         writer.addMember(mapping.first, rapidjson::Value(mapping.second).Move(), frequencyMap);
     }
     writer.addMember(JSON_FREQUENCY_MAP_TAG, frequencyMap, parentObject);
 }
 
-const std::string& CFrequencyEncoding::typeString() const {
+const std::string& CFrequencyEncoding::CSizeInfo::typeString() const {
     return JSON_FREQUENCY_ENCODING_TAG;
 }
 
@@ -491,7 +704,38 @@ const CFrequencyEncoding::TStringDoubleUMap& CFrequencyEncoding::frequencyMap() 
     return m_FrequencyMap;
 }
 
+CFrequencyEncoding::CSizeInfo::CSizeInfo(const CFrequencyEncoding& encoding)
+    : CEncoding::CSizeInfo::CSizeInfo(&encoding), m_Encoding{encoding} {
+}
+
+void CFrequencyEncoding::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                                  TRapidJsonWriter& writer) const {
+    this->CEncoding::CSizeInfo::addToDocument(parentObject, writer);
+    std::size_t featureNameLength{
+        core::CStringUtils::utf16LengthOfUtf8String(m_Encoding.featureName())};
+    TSizeVec fieldValueLengths;
+    fieldValueLengths.reserve(m_Encoding.frequencyMap().size());
+    for (const auto& item : m_Encoding.frequencyMap()) {
+        fieldValueLengths.push_back(core::CStringUtils::utf16LengthOfUtf8String(item.first));
+    }
+    writer.addMember(JSON_FEATURE_NAME_LENGTH_TAG,
+                     toJson(featureNameLength).Move(), parentObject);
+    addJsonArray(JSON_FIELD_VALUE_LENGTHS_TAG, fieldValueLengths, parentObject, writer);
+}
+
+const std::string& CFrequencyEncoding::typeString() const {
+    return JSON_FREQUENCY_ENCODING_TAG;
+}
+
+CEncoding::TSizeInfoUPtr CFrequencyEncoding::sizeInfo() const {
+    return std::make_unique<CFrequencyEncoding::CSizeInfo>(*this);
+}
+
 COneHotEncoding::TStringStringUMap& COneHotEncoding::hotMap() {
+    return m_HotMap;
+}
+
+const COneHotEncoding::TStringStringUMap& COneHotEncoding::hotMap() const {
     return m_HotMap;
 }
 
@@ -502,15 +746,42 @@ const std::string& COneHotEncoding::typeString() const {
 void COneHotEncoding::addToDocument(rapidjson::Value& parentObject,
                                     CSerializableToJson::TRapidJsonWriter& writer) const {
     this->CEncoding::addToDocument(parentObject, writer);
-    rapidjson::Value hotMap = writer.makeObject();
+    rapidjson::Value hotMap{writer.makeObject()};
     for (const auto& mapping : m_HotMap) {
         writer.addMember(mapping.first, mapping.second, hotMap);
     }
     writer.addMember(JSON_HOT_MAP_TAG, hotMap, parentObject);
 }
 
+COneHotEncoding::CSizeInfo::CSizeInfo(const COneHotEncoding& encoding)
+    : CEncoding::CSizeInfo::CSizeInfo(&encoding), m_Encoding{encoding} {
+}
+
 COneHotEncoding::COneHotEncoding(const std::string& field, TStringStringUMap hotMap)
     : CEncoding(field), m_HotMap(std::move(hotMap)) {
+}
+
+void COneHotEncoding::CSizeInfo::addToDocument(rapidjson::Value& parentObject,
+                                               TRapidJsonWriter& writer) const {
+    this->CEncoding::CSizeInfo::addToDocument(parentObject, writer);
+    TSizeVec fieldValueLengths;
+    fieldValueLengths.reserve(m_Encoding.hotMap().size());
+    TSizeVec featureNameLengths;
+    featureNameLengths.reserve(m_Encoding.hotMap().size());
+    for (const auto& item : m_Encoding.hotMap()) {
+        fieldValueLengths.push_back(core::CStringUtils::utf16LengthOfUtf8String(item.first));
+        featureNameLengths.push_back(core::CStringUtils::utf16LengthOfUtf8String(item.second));
+    }
+    addJsonArray(JSON_FIELD_VALUE_LENGTHS_TAG, fieldValueLengths, parentObject, writer);
+    addJsonArray(JSON_FEATURE_NAME_LENGTHS_TAG, featureNameLengths, parentObject, writer);
+}
+
+const std::string& COneHotEncoding::CSizeInfo::typeString() const {
+    return JSON_ONE_HOT_ENCODING_TAG;
+}
+
+CEncoding::TSizeInfoUPtr COneHotEncoding::sizeInfo() const {
+    return std::make_unique<COneHotEncoding::CSizeInfo>(*this);
 }
 
 CWeightedSum::CWeightedSum(TDoubleVec&& weights)
@@ -522,7 +793,7 @@ CWeightedSum::CWeightedSum(std::size_t size, double weight)
 
 void CWeightedSum::addToDocument(rapidjson::Value& parentObject,
                                  CSerializableToJson::TRapidJsonWriter& writer) const {
-    rapidjson::Value object = writer.makeObject();
+    rapidjson::Value object{writer.makeObject()};
     addJsonArray(JSON_WEIGHTS_TAG, m_Weights, object, writer);
     writer.addMember(this->stringType(), object, parentObject);
 }
@@ -541,7 +812,7 @@ const std::string& CWeightedMode::stringType() const {
 
 void CWeightedMode::addToDocument(rapidjson::Value& parentObject,
                                   CSerializableToJson::TRapidJsonWriter& writer) const {
-    rapidjson::Value object = writer.makeObject();
+    rapidjson::Value object{writer.makeObject()};
     addJsonArray(JSON_WEIGHTS_TAG, m_Weights, object, writer);
     writer.addMember(this->stringType(), object, parentObject);
 }
@@ -560,7 +831,7 @@ CLogisticRegression::CLogisticRegression(std::size_t size, double weight)
 
 void CLogisticRegression::addToDocument(rapidjson::Value& parentObject,
                                         TRapidJsonWriter& writer) const {
-    rapidjson::Value object = writer.makeObject();
+    rapidjson::Value object{writer.makeObject()};
     addJsonArray(JSON_WEIGHTS_TAG, m_Weights, object, writer);
     writer.addMember(this->stringType(), object, parentObject);
 }

--- a/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
+++ b/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
@@ -25,6 +25,7 @@
 #include <test/CRandomNumbers.h>
 #include <test/CTestTmpDir.h>
 
+#include <rapidjson/document.h>
 #include <rapidjson/schema.h>
 
 #include <boost/test/unit_test.hpp>
@@ -117,46 +118,123 @@ BOOST_AUTO_TEST_CASE(testIntegrationRegression) {
     TStrVecVec categoryMappingVector{{}, {"cat1", "cat2", "cat3"}, {}};
     auto definition = analysisRunner->inferenceModelDefinition(fieldNames, categoryMappingVector);
 
-    // test pre-processing
-    BOOST_REQUIRE_EQUAL(std::size_t(3), definition->preprocessors().size());
-    bool frequency = false;
-    bool target = false;
-    bool oneHot = false;
+    LOG_DEBUG(<< "Inference model definition: " << definition->jsonString());
+    std::string modelSizeDefinition{definition->sizeInfo()->jsonString()};
+    LOG_DEBUG(<< "Model size definition: " << modelSizeDefinition);
 
-    for (const auto& encoding : definition->preprocessors()) {
-        if (encoding->typeString() == "frequency_encoding") {
-            auto enc = static_cast<ml::api::CFrequencyEncoding*>(encoding.get());
-            BOOST_REQUIRE_EQUAL(std::size_t(3), enc->frequencyMap().size());
-            BOOST_TEST_REQUIRE("categorical_col_frequency" == enc->featureName());
-            frequency = true;
-        } else if (encoding->typeString() == "target_mean_encoding") {
-            auto enc = static_cast<ml::api::CTargetMeanEncoding*>(encoding.get());
-            BOOST_REQUIRE_EQUAL(std::size_t(3), enc->targetMap().size());
-            BOOST_TEST_REQUIRE("categorical_col_targetmean" == enc->featureName());
-            BOOST_REQUIRE_CLOSE_ABSOLUTE(100.0177288, enc->defaultValue(), 1e-6);
-            target = true;
-        } else if (encoding->typeString() == "one_hot_encoding") {
-            auto enc = static_cast<ml::api::COneHotEncoding*>(encoding.get());
-            BOOST_REQUIRE_EQUAL(std::size_t(3), enc->hotMap().size());
-            BOOST_TEST_REQUIRE("categorical_col_cat1" == enc->hotMap()["cat1"]);
-            BOOST_TEST_REQUIRE("categorical_col_cat2" == enc->hotMap()["cat2"]);
-            BOOST_TEST_REQUIRE("categorical_col_cat3" == enc->hotMap()["cat3"]);
-            oneHot = true;
+    // verify model definition
+    {
+        // test pre-processing
+        BOOST_REQUIRE_EQUAL(std::size_t(3), definition->preprocessors().size());
+        bool frequency = false;
+        bool target = false;
+        bool oneHot = false;
+
+        for (const auto& encoding : definition->preprocessors()) {
+            if (encoding->typeString() == "frequency_encoding") {
+                auto enc = static_cast<ml::api::CFrequencyEncoding*>(encoding.get());
+                BOOST_REQUIRE_EQUAL(std::size_t(3), enc->frequencyMap().size());
+                BOOST_TEST_REQUIRE("categorical_col_frequency" == enc->featureName());
+                frequency = true;
+            } else if (encoding->typeString() == "target_mean_encoding") {
+                auto enc = static_cast<ml::api::CTargetMeanEncoding*>(encoding.get());
+                BOOST_REQUIRE_EQUAL(std::size_t(3), enc->targetMap().size());
+                BOOST_TEST_REQUIRE("categorical_col_targetmean" == enc->featureName());
+                BOOST_REQUIRE_CLOSE_ABSOLUTE(100.0177288, enc->defaultValue(), 1e-6);
+                target = true;
+            } else if (encoding->typeString() == "one_hot_encoding") {
+                auto enc = static_cast<ml::api::COneHotEncoding*>(encoding.get());
+                BOOST_REQUIRE_EQUAL(std::size_t(3), enc->hotMap().size());
+                BOOST_TEST_REQUIRE("categorical_col_cat1" == enc->hotMap()["cat1"]);
+                BOOST_TEST_REQUIRE("categorical_col_cat2" == enc->hotMap()["cat2"]);
+                BOOST_TEST_REQUIRE("categorical_col_cat3" == enc->hotMap()["cat3"]);
+                oneHot = true;
+            }
         }
+
+        BOOST_TEST_REQUIRE(oneHot);
+        BOOST_TEST_REQUIRE(target);
+        BOOST_TEST_REQUIRE(frequency);
+
+        // assert trained model
+        auto* trainedModel =
+            dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
+        BOOST_REQUIRE_EQUAL(api::CTrainedModel::E_Regression, trainedModel->targetType());
+        std::size_t expectedSize{core::CProgramCounters::counter(
+            ml::counter_t::E_DFTPMTrainedForestNumberTrees)};
+        BOOST_REQUIRE_EQUAL(expectedSize, trainedModel->size());
+        BOOST_TEST_REQUIRE("weighted_sum" == trainedModel->aggregateOutput()->stringType());
     }
 
-    BOOST_TEST_REQUIRE(oneHot);
-    BOOST_TEST_REQUIRE(target);
-    BOOST_TEST_REQUIRE(frequency);
+    // verify model size info
+    {
+        rapidjson::Document result;
+        rapidjson::ParseResult ok(result.Parse(modelSizeDefinition));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        bool hasFrequencyEncoding{false};
+        bool hasTargetMeanEncoding{false};
+        bool hasOneHotEncoding{false};
+        std::size_t expectedFieldLength{
+            core::CStringUtils::utf16LengthOfUtf8String("categorical_col")};
 
-    // assert trained model
-    auto* trainedModel =
-        dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
-    BOOST_REQUIRE_EQUAL(api::CTrainedModel::E_Regression, trainedModel->targetType());
-    std::size_t expectedSize{core::CProgramCounters::counter(
-        ml::counter_t::E_DFTPMTrainedForestNumberTrees)};
-    BOOST_REQUIRE_EQUAL(expectedSize, trainedModel->size());
-    BOOST_TEST_REQUIRE("weighted_sum" == trainedModel->aggregateOutput()->stringType());
+        if (result.HasMember("preprocessors")) {
+            for (const auto& preprocessor : result["preprocessors"].GetArray()) {
+                if (preprocessor.HasMember("frequency_encoding")) {
+                    hasFrequencyEncoding = true;
+                    std::size_t fieldLength{
+                        preprocessor["frequency_encoding"]["field_length"].GetUint64()};
+                    BOOST_REQUIRE_EQUAL(fieldLength, expectedFieldLength);
+                    std::size_t featureNameLength{preprocessor["frequency_encoding"]["feature_name_length"]
+                                                      .GetUint64()};
+                    BOOST_REQUIRE_EQUAL(featureNameLength,
+                                        core::CStringUtils::utf16LengthOfUtf8String(
+                                            "categorical_col_frequency"));
+                }
+                if (preprocessor.HasMember("target_mean_encoding")) {
+                    hasTargetMeanEncoding = true;
+                    std::size_t fieldLength{
+                        preprocessor["target_mean_encoding"]["field_length"].GetUint64()};
+                    BOOST_REQUIRE_EQUAL(fieldLength, expectedFieldLength);
+                    std::size_t featureNameLength{preprocessor["target_mean_encoding"]["feature_name_length"]
+                                                      .GetUint64()};
+                    BOOST_REQUIRE_EQUAL(featureNameLength,
+                                        core::CStringUtils::utf16LengthOfUtf8String(
+                                            "categorical_col_targetmean"));
+                }
+                if (preprocessor.HasMember("one_hot_encoding")) {
+                    hasOneHotEncoding = true;
+                    std::size_t fieldLength{
+                        preprocessor["one_hot_encoding"]["field_length"].GetUint64()};
+                    BOOST_REQUIRE_EQUAL(fieldLength, expectedFieldLength);
+                    BOOST_REQUIRE_EQUAL(preprocessor["one_hot_encoding"]["field_value_lengths"]
+                                            .GetArray()
+                                            .Size(),
+                                        3);
+                    BOOST_REQUIRE_EQUAL(preprocessor["one_hot_encoding"]["feature_name_lengths"]
+                                            .GetArray()
+                                            .Size(),
+                                        3);
+                }
+            }
+        }
+        BOOST_TEST_REQUIRE(hasFrequencyEncoding);
+        BOOST_TEST_REQUIRE(hasTargetMeanEncoding);
+        BOOST_TEST_REQUIRE(hasOneHotEncoding);
+
+        bool hasTreeSizes{false};
+        if (result.HasMember("trained_model_size") &&
+            result["trained_model_size"].HasMember("ensemble_model_size") &&
+            result["trained_model_size"]["ensemble_model_size"].HasMember("tree_sizes")) {
+            hasTreeSizes = true;
+            std::size_t numTrees{result["trained_model_size"]["ensemble_model_size"]["tree_sizes"]
+                                     .GetArray()
+                                     .Size()};
+            auto* trainedModel =
+                dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
+            BOOST_TEST_REQUIRE(numTrees, trainedModel->size());
+        }
+        BOOST_TEST_REQUIRE(hasTreeSizes);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testIntegrationClassification) {
@@ -206,49 +284,112 @@ BOOST_AUTO_TEST_CASE(testIntegrationClassification) {
     auto definition = analysisRunner->inferenceModelDefinition(fieldNames, categoryMappingVector);
 
     LOG_DEBUG(<< "Inference model definition: " << definition->jsonString());
+    auto modelSizeDefinition{definition->sizeInfo()->jsonString()};
+    LOG_DEBUG(<< "Model size definition: " << modelSizeDefinition);
 
-    // assert trained model
-    auto trainedModel = dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
-    BOOST_REQUIRE_EQUAL(api::CTrainedModel::E_Classification, trainedModel->targetType());
-    std::size_t expectedSize{
-        core::CProgramCounters::counter(counter_t::E_DFTPMTrainedForestNumberTrees)};
-    BOOST_REQUIRE_EQUAL(expectedSize, trainedModel->size());
-    BOOST_TEST_REQUIRE("logistic_regression" ==
-                       trainedModel->aggregateOutput()->stringType());
-    const auto& classificationLabels = trainedModel->classificationLabels();
-    BOOST_TEST_REQUIRE(classificationLabels.is_initialized());
-    BOOST_REQUIRE_EQUAL_COLLECTIONS(
-        classificationLabels->begin(), classificationLabels->end(),
-        expectedClassificationLabels.begin(), expectedClassificationLabels.end());
+    {
+        // assert trained model
+        auto trainedModel =
+            dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
+        BOOST_REQUIRE_EQUAL(api::CTrainedModel::E_Classification,
+                            trainedModel->targetType());
+        std::size_t expectedSize{core::CProgramCounters::counter(
+            counter_t::E_DFTPMTrainedForestNumberTrees)};
+        BOOST_REQUIRE_EQUAL(expectedSize, trainedModel->size());
+        BOOST_TEST_REQUIRE("logistic_regression" ==
+                           trainedModel->aggregateOutput()->stringType());
+        const auto& classificationLabels = trainedModel->classificationLabels();
+        BOOST_TEST_REQUIRE(classificationLabels.is_initialized());
+        BOOST_REQUIRE_EQUAL_COLLECTIONS(classificationLabels->begin(),
+                                        classificationLabels->end(),
+                                        expectedClassificationLabels.begin(),
+                                        expectedClassificationLabels.end());
 
-    const auto& classificationWeights = trainedModel->classificationWeights();
-    BOOST_TEST_REQUIRE(classificationWeights.is_initialized());
+        const auto& classificationWeights = trainedModel->classificationWeights();
+        BOOST_TEST_REQUIRE(classificationWeights.is_initialized());
 
-    // Check that predicted score matches the value calculated from the inference
-    // classification weights.
-    std::map<bool, std::size_t> classLookup;
-    for (std::size_t i = 0; i < classificationLabels->size(); ++i) {
-        bool labelAsBool;
-        core::CStringUtils::stringToType((*classificationLabels)[i], labelAsBool);
-        classLookup[labelAsBool] = i;
-    }
-    rapidjson::Document results;
-    rapidjson::ParseResult ok(results.Parse(output.str()));
-    BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
-    for (const auto& result : results.GetArray()) {
-        if (result.HasMember("row_results")) {
-            std::string prediction{
-                result["row_results"]["results"]["ml"]["target_col_prediction"].GetString()};
-            double probability{
-                result["row_results"]["results"]["ml"]["prediction_probability"].GetDouble()};
-            double score{
-                result["row_results"]["results"]["ml"]["prediction_score"].GetDouble()};
-            bool predictionAsBool;
-            core::CStringUtils::stringToType(prediction, predictionAsBool);
-            std::size_t weight{classLookup[predictionAsBool]};
-            BOOST_REQUIRE_CLOSE((*classificationWeights)[weight] * probability,
-                                score, 1e-3); // 0.001%
+        // Check that predicted score matches the value calculated from the inference
+        // classification weights.
+        std::map<bool, std::size_t> classLookup;
+        for (std::size_t i = 0; i < classificationLabels->size(); ++i) {
+            bool labelAsBool;
+            core::CStringUtils::stringToType((*classificationLabels)[i], labelAsBool);
+            classLookup[labelAsBool] = i;
         }
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(output.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("row_results")) {
+                std::string prediction{result["row_results"]["results"]["ml"]["target_col_prediction"]
+                                           .GetString()};
+                double probability{result["row_results"]["results"]["ml"]["prediction_probability"]
+                                       .GetDouble()};
+                double score{
+                    result["row_results"]["results"]["ml"]["prediction_score"].GetDouble()};
+                bool predictionAsBool;
+                core::CStringUtils::stringToType(prediction, predictionAsBool);
+                std::size_t weight{classLookup[predictionAsBool]};
+                BOOST_REQUIRE_CLOSE((*classificationWeights)[weight] * probability,
+                                    score, 1e-3); // 0.001%
+            }
+        }
+    }
+    // verify model size info
+    {
+        rapidjson::Document result;
+        rapidjson::ParseResult ok(result.Parse(modelSizeDefinition));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        bool hasFrequencyEncoding{false};
+        bool hasOneHotEncoding{false};
+        std::size_t expectedFieldLength{
+            core::CStringUtils::utf16LengthOfUtf8String("categorical_col")};
+        if (result.HasMember("preprocessors")) {
+            for (const auto& preprocessor : result["preprocessors"].GetArray()) {
+                if (preprocessor.HasMember("frequency_encoding")) {
+                    hasFrequencyEncoding = true;
+                    std::size_t fieldLength{
+                        preprocessor["frequency_encoding"]["field_length"].GetUint64()};
+                    BOOST_REQUIRE_EQUAL(fieldLength, expectedFieldLength);
+                    std::size_t featureNameLength{preprocessor["frequency_encoding"]["feature_name_length"]
+                                                      .GetUint64()};
+                    BOOST_REQUIRE_EQUAL(featureNameLength,
+                                        core::CStringUtils::utf16LengthOfUtf8String(
+                                            "categorical_col_frequency"));
+                }
+                if (preprocessor.HasMember("one_hot_encoding")) {
+                    hasOneHotEncoding = true;
+                    std::size_t fieldLength{
+                        preprocessor["one_hot_encoding"]["field_length"].GetUint64()};
+                    BOOST_REQUIRE_EQUAL(fieldLength, expectedFieldLength);
+                    BOOST_REQUIRE_EQUAL(preprocessor["one_hot_encoding"]["field_value_lengths"]
+                                            .GetArray()
+                                            .Size(),
+                                        2);
+                    BOOST_REQUIRE_EQUAL(preprocessor["one_hot_encoding"]["feature_name_lengths"]
+                                            .GetArray()
+                                            .Size(),
+                                        2);
+                }
+            }
+        }
+
+        BOOST_TEST_REQUIRE(hasFrequencyEncoding);
+        BOOST_TEST_REQUIRE(hasOneHotEncoding);
+
+        bool hasTreeSizes{false};
+        if (result.HasMember("trained_model_size") &&
+            result["trained_model_size"].HasMember("ensemble_model_size") &&
+            result["trained_model_size"]["ensemble_model_size"].HasMember("tree_sizes")) {
+            hasTreeSizes = true;
+            std::size_t numTrees{result["trained_model_size"]["ensemble_model_size"]["tree_sizes"]
+                                     .GetArray()
+                                     .Size()};
+            auto* trainedModel =
+                dynamic_cast<api::CEnsemble*>(definition->trainedModel().get());
+            BOOST_TEST_REQUIRE(numTrees, trainedModel->size());
+        }
+        BOOST_TEST_REQUIRE(hasTreeSizes);
     }
 }
 
@@ -299,30 +440,63 @@ BOOST_AUTO_TEST_CASE(testJsonSchema) {
     TStrVecVec categoryMappingVector{{}, {"cat1", "cat2", "cat3"}, {}};
     auto definition = analysisRunner->inferenceModelDefinition(fieldNames, categoryMappingVector);
 
-    std::ifstream schemaFileStream("testfiles/inference_json_schema/model_definition.schema.json");
-    BOOST_REQUIRE_MESSAGE(schemaFileStream.is_open(), "Cannot open test file!");
-    std::string schemaJson((std::istreambuf_iterator<char>(schemaFileStream)),
-                           std::istreambuf_iterator<char>());
-    rapidjson::Document schemaDocument;
-    BOOST_REQUIRE_MESSAGE(schemaDocument.Parse(schemaJson).HasParseError() == false,
-                          "Cannot parse JSON schema!");
-    rapidjson::SchemaDocument schema(schemaDocument);
+    // validating inference model definition
+    {
+        std::ifstream schemaFileStream("testfiles/inference_json_schema/model_definition.schema.json");
+        BOOST_REQUIRE_MESSAGE(schemaFileStream.is_open(), "Cannot open test file!");
+        std::string schemaJson((std::istreambuf_iterator<char>(schemaFileStream)),
+                               std::istreambuf_iterator<char>());
+        rapidjson::Document schemaDocument;
+        BOOST_REQUIRE_MESSAGE(schemaDocument.Parse(schemaJson).HasParseError() == false,
+                              "Cannot parse JSON schema!");
+        rapidjson::SchemaDocument schema(schemaDocument);
 
-    rapidjson::Document doc;
-    BOOST_REQUIRE_MESSAGE(doc.Parse(definition->jsonString()).HasParseError() == false,
-                          "Error parsing JSON definition!");
+        rapidjson::Document doc;
+        BOOST_REQUIRE_MESSAGE(doc.Parse(definition->jsonString()).HasParseError() == false,
+                              "Error parsing JSON definition!");
 
-    rapidjson::SchemaValidator validator(schema);
-    if (doc.Accept(validator) == false) {
-        rapidjson::StringBuffer sb;
-        validator.GetInvalidSchemaPointer().StringifyUriFragment(sb);
-        LOG_ERROR(<< "Invalid schema: " << sb.GetString());
-        LOG_ERROR(<< "Invalid keyword: " << validator.GetInvalidSchemaKeyword());
-        sb.Clear();
-        validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
-        LOG_ERROR(<< "Invalid document: " << sb.GetString());
-        LOG_DEBUG(<< "Document: " << definition->jsonString());
-        BOOST_FAIL("Schema validation failed");
+        rapidjson::SchemaValidator validator(schema);
+        if (doc.Accept(validator) == false) {
+            rapidjson::StringBuffer sb;
+            validator.GetInvalidSchemaPointer().StringifyUriFragment(sb);
+            LOG_ERROR(<< "Invalid schema: " << sb.GetString());
+            LOG_ERROR(<< "Invalid keyword: " << validator.GetInvalidSchemaKeyword());
+            sb.Clear();
+            validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
+            LOG_ERROR(<< "Invalid document: " << sb.GetString());
+            LOG_DEBUG(<< "Document: " << definition->jsonString());
+            BOOST_FAIL("Schema validation failed");
+        }
+    }
+
+    // validating model size info
+    {
+        std::ifstream schemaFileStream("testfiles/model_size_info/model_size_info.schema.json");
+        BOOST_REQUIRE_MESSAGE(schemaFileStream.is_open(), "Cannot open test file!");
+        std::string schemaJson((std::istreambuf_iterator<char>(schemaFileStream)),
+                               std::istreambuf_iterator<char>());
+        rapidjson::Document schemaDocument;
+        BOOST_REQUIRE_MESSAGE(schemaDocument.Parse(schemaJson).HasParseError() == false,
+                              "Cannot parse JSON schema!");
+        rapidjson::SchemaDocument schema(schemaDocument);
+
+        rapidjson::Document doc;
+        BOOST_REQUIRE_MESSAGE(
+            doc.Parse(definition->sizeInfo()->jsonString()).HasParseError() == false,
+            "Error parsing JSON definition!");
+
+        rapidjson::SchemaValidator validator(schema);
+        if (doc.Accept(validator) == false) {
+            rapidjson::StringBuffer sb;
+            validator.GetInvalidSchemaPointer().StringifyUriFragment(sb);
+            LOG_ERROR(<< "Invalid schema: " << sb.GetString());
+            LOG_ERROR(<< "Invalid keyword: " << validator.GetInvalidSchemaKeyword());
+            sb.Clear();
+            validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
+            LOG_ERROR(<< "Invalid document: " << sb.GetString());
+            LOG_DEBUG(<< "Document: " << definition->sizeInfo()->jsonString());
+            BOOST_FAIL("Schema validation failed");
+        }
     }
 
     // TODO add multivalued leaf test.

--- a/lib/api/unittest/testfiles/model_size_info/model_size_info.schema.json
+++ b/lib/api/unittest/testfiles/model_size_info/model_size_info.schema.json
@@ -1,0 +1,214 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/elastic/ml-json-schemas-private/master/schemas/model_size/model_size_info.schema.json",
+    "description": "Model size info for calculating an JVM heap size estimate",
+    "title": "model_size_info",
+    "type": "object",
+    "definitions": {
+        "ensemble_model_size": {
+            "$id": "#ensemble_model_size",
+            "description": "Size information for a model",
+            "properties": {
+                "tree_sizes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "num_nodes": {
+                                "description": "number of non-leaf nodes in the tree",
+                                "type": "integer"
+                            },
+                            "num_leaves": {
+                                "description": "number of leaf nodes in the tree",
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "num_leaves"
+                        ]
+                    },
+                    "minItems": 1,
+                    "uniqueItems": false
+                },
+                "feature_name_lengths": {
+                    "description": "UTF-16 length of each feature name for the model",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": false
+                },
+                "num_output_processor_weights": {
+                    "type": "integer"
+                },
+                "num_classification_weights": {
+                    "type": "integer"
+                },
+                "num_operations": {
+                    "type": "integer"
+                },
+                "num_classes": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "tree_sizes",
+                "num_operations",
+                "feature_name_lengths"
+            ]
+        },
+        "one_hot_encoding": {
+            "description": "one hot encoding size information",
+            "type": "object",
+            "properties": {
+                "field_length": {
+                    "description": "UTF-16 length of input field",
+                    "type": "integer"
+                },
+                "feature_name_lengths": {
+                    "description": "UTF-16 length of each destination feature name used in the one hot map",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "minItems": 1
+                },
+                "field_value_lengths": {
+                    "description": "UTF-16 length of each field value used in the one hot map",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "field_length",
+                "feature_name_lengths",
+                "field_value_lengths"
+            ]
+        },
+        "target_mean_encoding": {
+            "description": "target mean encoding size information",
+            "type": "object",
+            "properties": {
+                "field_length": {
+                    "description": "UTF-16 length of input field",
+                    "type": "integer"
+                },
+                "feature_name_length": {
+                    "description": "UTF-16 length of feature_name field",
+                    "type": "integer"
+                },
+                "field_value_lengths": {
+                    "description": "UTF-16 length of field values used in the target mean map",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "field_length",
+                "feature_name_length",
+                "field_value_lengths"
+            ]
+        },
+        "frequency_encoding": {
+            "description": "frequency encoding size information",
+            "type": "object",
+            "properties": {
+                "field_length": {
+                    "description": "Character length of input field",
+                    "type": "integer"
+                },
+                "feature_name_length": {
+                    "description": "Character length of feature_name field",
+                    "type": "integer"
+                },
+                "field_value_lengths": {
+                    "description": "UTF-16 length of field values used in the frequency encoding map",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "field_length",
+                "feature_name_length",
+                "field_value_lengths"
+            ]
+        }
+    },
+    "properties": {
+        "preprocessors": {
+            "description": "Optional step for pre-processing data, e.g. vector embedding, one-hot-encoding, etc.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "oneOf": [
+                    {
+                        "properties": {
+                            "one_hot_encoding": {
+                                "$ref": "#/definitions/one_hot_encoding"
+                            }
+                        },
+                        "required": [
+                            "one_hot_encoding"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "properties": {
+                            "target_mean_encoding": {
+                                "$ref": "#/definitions/target_mean_encoding"
+                            }
+                        },
+                        "required": [
+                            "target_mean_encoding"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "properties": {
+                            "frequency_encoding": {
+                                "$ref": "#/definitions/frequency_encoding"
+                            }
+                        },
+                        "required": [
+                            "frequency_encoding"
+                        ],
+                        "additionalProperties": false
+                    }
+                ]
+            },
+            "minItems": 0,
+            "uniqueItems": true
+        },
+        "trained_model_size": {
+            "description": "Details of the model evaluation step with a trained_model.",
+            "type": "object",
+            "oneOf": [
+                {
+                    "properties": {
+                        "ensemble_model_size": {
+                            "$ref": "#/definitions/ensemble_model_size"
+                        }
+                    },
+                    "required": [
+                        "ensemble_model_size"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    },
+    "required": [
+        "trained_model_size"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
This PR adds the ability to generate model_size_info objects used in Java to estimate the heap size for the inference models. I added a slim subclass CSizeInfo to all relevant classes which contains reference to the definition objects and generates Json with the necessary information when called.

We do a double work for counting nodes and leaves of the tree when computing numOperations and generating JSON. I did it to avoid memory overhead.

I am not writing the model_size_info in the results yet, I intend to do it in a subsequent PR. Hence this PR is marked as a non-issue.

Backport of #1316.