### PR TITLE
[ML] Add memory_status to memory_stats

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -62,6 +62,8 @@
   (See {ml-pull}1312[#1312].)
 * Performance improvements for classification and regression, particularly running
   multithreaded. (See {ml-pull}1317[#1317].)
+* Memory usage reports for data frame analytics contain status and the new memory limit 
+  recommendation if necessary. (See {ml-pull}1345[#1345].)
 
 === Bug Fixes
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -62,8 +62,6 @@
   (See {ml-pull}1312[#1312].)
 * Performance improvements for classification and regression, particularly running
   multithreaded. (See {ml-pull}1317[#1317].)
-* Memory usage reports for data frame analytics contain status and the new memory limit 
-  recommendation if necessary. (See {ml-pull}1345[#1345].)
 
 === Bug Fixes
 

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -109,9 +109,6 @@ public:
     static void monitor(CDataFrameAnalysisInstrumentation& instrumentation,
                         core::CRapidJsonConcurrentLineWriter& writer);
 
-    std::int64_t advisedMemoryLimit() const;
-    EMemoryStatus memoryStatus() const;
-
 protected:
     using TWriter = core::CRapidJsonConcurrentLineWriter;
     using TWriterUPtr = std::unique_ptr<TWriter>;

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -41,6 +41,9 @@ namespace api {
 class API_EXPORT CDataFrameAnalysisInstrumentation
     : virtual public maths::CDataFrameAnalysisInstrumentationInterface {
 public:
+    //!\brief Memory status
+    enum EMemoryStatus { E_Ok, E_HardLimit };
+
     //! \brief Set the output stream for the lifetime of this object.
     class API_EXPORT CScopeSetOutputStream {
     public:
@@ -103,16 +106,22 @@ public:
     //! Start polling and writing progress updates.
     //!
     //! \note This doesn't return until instrumentation.setToFinished() is called.
-    static void monitor(const CDataFrameAnalysisInstrumentation& instrumentation,
+    static void monitor(CDataFrameAnalysisInstrumentation& instrumentation,
                         core::CRapidJsonConcurrentLineWriter& writer);
+
+    std::int64_t advisedMemoryLimit() const;
+    EMemoryStatus memoryStatus() const;
 
 protected:
     using TWriter = core::CRapidJsonConcurrentLineWriter;
     using TWriterUPtr = std::unique_ptr<TWriter>;
+    using TOptionalInt64 = boost::optional<std::int64_t>;
 
 protected:
     virtual counter_t::ECounterTypes memoryCounterType() = 0;
     TWriter* writer();
+    void advisedMemoryLimit(std::int64_t advisedMemoryLimit);
+    void memoryStatus(EMemoryStatus status);
 
 private:
     static const std::string NO_TASK;
@@ -136,6 +145,8 @@ private:
     std::atomic<std::int64_t> m_Memory;
     mutable std::mutex m_ProgressMutex;
     TWriterUPtr m_Writer;
+    EMemoryStatus m_MemoryStatus;
+    TOptionalInt64 m_AdvisedMemoryLimit;
 };
 
 //! \brief Instrumentation class for Outlier Detection jobs.

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -117,7 +117,7 @@ protected:
 protected:
     virtual counter_t::ECounterTypes memoryCounterType() = 0;
     TWriter* writer();
-    void advisedMemoryLimit(std::int64_t advisedMemoryLimit);
+    void increasedMemoryEstimate(std::int64_t increasedMemoryEstimate);
     void memoryStatus(EMemoryStatus status);
 
 private:
@@ -143,7 +143,7 @@ private:
     mutable std::mutex m_ProgressMutex;
     TWriterUPtr m_Writer;
     EMemoryStatus m_MemoryStatus;
-    TOptionalInt64 m_AdvisedMemoryLimit;
+    TOptionalInt64 m_IncreasedMemoryEstimate;
 };
 
 //! \brief Instrumentation class for Outlier Detection jobs.

--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -117,7 +117,7 @@ protected:
 protected:
     virtual counter_t::ECounterTypes memoryCounterType() = 0;
     TWriter* writer();
-    void increasedMemoryEstimate(std::int64_t increasedMemoryEstimate);
+    void memoryReestimate(std::int64_t memoryReestimate);
     void memoryStatus(EMemoryStatus status);
 
 private:
@@ -143,7 +143,7 @@ private:
     mutable std::mutex m_ProgressMutex;
     TWriterUPtr m_Writer;
     EMemoryStatus m_MemoryStatus;
-    TOptionalInt64 m_IncreasedMemoryEstimate;
+    TOptionalInt64 m_MemoryReestimate;
 };
 
 //! \brief Instrumentation class for Outlier Detection jobs.

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -428,9 +428,7 @@ public:
 
 public:
     TApiEncodingUPtrVec& preprocessors();
-    const TApiEncodingUPtrVec& preprocessors() const {
-        return m_Preprocessors;
-    };
+    const TApiEncodingUPtrVec& preprocessors() const { return m_Preprocessors; }
     void trainedModel(TTrainedModelUPtr&& trainedModel);
     TTrainedModelUPtr& trainedModel();
     const TTrainedModelUPtr& trainedModel() const;

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -203,15 +203,6 @@ void CDataFrameAnalysisInstrumentation::monitor(CDataFrameAnalysisInstrumentatio
     writeProgress(lastTask, lastProgress, &writer);
 }
 
-std::int64_t CDataFrameAnalysisInstrumentation::advisedMemoryLimit() const {
-    return m_AdvisedMemoryLimit.get();
-}
-
-CDataFrameAnalysisInstrumentation::EMemoryStatus
-CDataFrameAnalysisInstrumentation::memoryStatus() const {
-    return m_MemoryStatus;
-}
-
 void CDataFrameAnalysisInstrumentation::advisedMemoryLimit(std::int64_t advisedMemoryLimit) {
     m_AdvisedMemoryLimit = advisedMemoryLimit;
 }

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -514,6 +514,7 @@ BOOST_AUTO_TEST_CASE(testErrors) {
 
     // Memory limit exceeded.
     {
+        output.str("");
         errors.clear();
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory{}.memoryLimit(10000).outlierSpec(),
@@ -535,6 +536,31 @@ BOOST_AUTO_TEST_CASE(testErrors) {
             }
         }
         BOOST_TEST_REQUIRE(memoryLimitExceed);
+
+        // verify memory status change
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(output.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        bool memoryStatusOk{false};
+        bool memoryStatusHardLimit{false};
+        bool advisedMemoryLimitAvailable{false};
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("analytics_memory_usage")) {
+                std::string status{result["analytics_memory_usage"]["status"].GetString()};
+                if (status == "ok") {
+                    memoryStatusOk = true;
+                } else if (status == "hard-limit") {
+                    memoryStatusHardLimit = true;
+                    if (result["analytics_memory_usage"].HasMember("advised_limit_bytes") &&
+                        result["analytics_memory_usage"]["advised_limit_bytes"].GetInt() > 0) {
+                        advisedMemoryLimitAvailable = true;
+                    }
+                }
+            }
+        }
+        BOOST_TEST_REQUIRE(memoryStatusOk);
+        BOOST_TEST_REQUIRE(memoryStatusHardLimit);
+        BOOST_TEST_REQUIRE(advisedMemoryLimitAvailable);
     }
 }
 

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -543,7 +543,7 @@ BOOST_AUTO_TEST_CASE(testErrors) {
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
         bool memoryStatusOk{false};
         bool memoryStatusHardLimit{false};
-        bool advisedMemoryLimitAvailable{false};
+        bool memoryReestimateAvailable{false};
         for (const auto& result : results.GetArray()) {
             if (result.HasMember("analytics_memory_usage")) {
                 std::string status{result["analytics_memory_usage"]["status"].GetString()};
@@ -551,16 +551,17 @@ BOOST_AUTO_TEST_CASE(testErrors) {
                     memoryStatusOk = true;
                 } else if (status == "hard-limit") {
                     memoryStatusHardLimit = true;
-                    if (result["analytics_memory_usage"].HasMember("advised_limit_bytes") &&
-                        result["analytics_memory_usage"]["advised_limit_bytes"].GetInt() > 0) {
-                        advisedMemoryLimitAvailable = true;
+                    if (result["analytics_memory_usage"].HasMember("memory_reestimate_bytes") &&
+                        result["analytics_memory_usage"]["memory_reestimate_bytes"]
+                                .GetInt() > 0) {
+                        memoryReestimateAvailable = true;
                     }
                 }
             }
         }
         BOOST_TEST_REQUIRE(memoryStatusOk);
         BOOST_TEST_REQUIRE(memoryStatusHardLimit);
-        BOOST_TEST_REQUIRE(advisedMemoryLimitAvailable);
+        BOOST_TEST_REQUIRE(memoryReestimateAvailable);
     }
 }
 

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -407,7 +407,7 @@ BOOST_AUTO_TEST_CASE(testMemoryLimitHandling) {
     BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
     bool memoryStatusOk{false};
     bool memoryStatusHardLimit{false};
-    bool advisedMemoryLimitAvailable{false};
+    bool memoryReestimateAvailable{false};
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("analytics_memory_usage")) {
             std::string status{result["analytics_memory_usage"]["status"].GetString()};
@@ -415,16 +415,16 @@ BOOST_AUTO_TEST_CASE(testMemoryLimitHandling) {
                 memoryStatusOk = true;
             } else if (status == "hard-limit") {
                 memoryStatusHardLimit = true;
-                if (result["analytics_memory_usage"].HasMember("advised_limit_bytes") &&
-                    result["analytics_memory_usage"]["advised_limit_bytes"].GetInt() > 0) {
-                    advisedMemoryLimitAvailable = true;
+                if (result["analytics_memory_usage"].HasMember("memory_reestimate_bytes") &&
+                    result["analytics_memory_usage"]["memory_reestimate_bytes"].GetInt() > 0) {
+                    memoryReestimateAvailable = true;
                 }
             }
         }
     }
     BOOST_TEST_REQUIRE(memoryStatusOk);
     BOOST_TEST_REQUIRE(memoryStatusHardLimit);
-    BOOST_TEST_REQUIRE(advisedMemoryLimitAvailable);
+    BOOST_TEST_REQUIRE(memoryReestimateAvailable);
 }
 
 BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {

--- a/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
+++ b/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
@@ -16,10 +16,20 @@
     "peak_usage_bytes": {
       "description": "Peak memory usage for the data frame analytics job in bytes",
       "type": "integer"
+    },
+    "status": {
+      "type":"string",
+      "enum": ["ok", "hard-limit"],
+      "description": "Describes how current memory usage relates to the configured memory limit. If the limit is exceeded, 'status' is 'hard-limit'."
+    },
+    "advised_limit_bytes": {
+      "type": "integer",
+      "description": "If 'status' is set to 'hard-limit', this optional field provides the new advised memory limit."
     }
   },
   "required": [
-    "peak_usage_bytes"
+    "peak_usage_bytes",
+    "status"
   ],
   "additionalProperties": false
 }

--- a/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
+++ b/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
@@ -22,7 +22,7 @@
       "enum": ["ok", "hard-limit"],
       "description": "Describes how current memory usage relates to the configured memory limit. If the limit is exceeded, 'status' is 'hard-limit'."
     },
-    "advised_limit_bytes": {
+    "increased_memory_estimate_bytes": {
       "type": "integer",
       "description": "If 'status' is set to 'hard-limit', this optional field provides the new advised memory limit."
     }

--- a/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
+++ b/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
@@ -22,7 +22,7 @@
       "enum": ["ok", "hard-limit"],
       "description": "Describes how current memory usage relates to the configured memory limit. If the limit is exceeded, 'status' is 'hard-limit'."
     },
-    "increased_memory_estimate_bytes": {
+    "memory_reestimate_bytes": {
       "type": "integer",
       "description": "If 'status' is set to 'hard-limit', this optional field provides the new advised memory limit."
     }


### PR DESCRIPTION
This PR adds `status` field to the `analytics_memory_usage` instrumentation object for DGA. The status can be "ok" and "hard-limit". Additionally I added the field `advised_limit_bytes` containing new recommended memory limit for simple usage, e.g. by UI.

Since this is closely related to #1298, I don't document this separately and mark as non-issue.

Closes #1310.