### PR TITLE
[ML] Implement stop-on-warn for per-partition categorization

### DIFF
--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -50,9 +50,10 @@ bool CCmdLineParser::parse(int argc,
                            std::string& persistFileName,
                            bool& isPersistFileNamedPipe,
                            bool& isPersistInForeground,
-                           size_t& maxAnomalyRecords,
+                           std::size_t& maxAnomalyRecords,
                            bool& memoryUsage,
                            bool& multivariateByFields,
+                           bool& stopCategorizationOnWarnStatus,
                            TStrVec& clauseTokens) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
@@ -111,12 +112,14 @@ bool CCmdLineParser::parse(int argc,
                         "Optional number of buckets after which to periodically persist model state (Mutually exclusive with persistInterval)")
             ("maxQuantileInterval", boost::program_options::value<core_t::TTime>(),
                         "Optional interval at which to periodically output quantiles if they have not been output due to an anomaly - if not specified then quantiles will only be output following a big anomaly")
-            ("maxAnomalyRecords", boost::program_options::value<size_t>(),
+            ("maxAnomalyRecords", boost::program_options::value<std::size_t>(),
                         "The maximum number of records to be outputted for each bucket. Defaults to 100, a value 0 removes the limit.")
             ("memoryUsage",
                         "Log the model memory usage at the end of the job")
             ("multivariateByFields",
                         "Optional flag to enable multi-variate analysis of correlated by fields")
+            ("stopCategorizationOnWarnStatus",
+                        "Optional flag to stop categorization for partitions where the status is 'warn'.")
         ;
         // clang-format on
 
@@ -234,13 +237,16 @@ bool CCmdLineParser::parse(int argc,
             isPersistInForeground = true;
         }
         if (vm.count("maxAnomalyRecords") > 0) {
-            maxAnomalyRecords = vm["maxAnomalyRecords"].as<size_t>();
+            maxAnomalyRecords = vm["maxAnomalyRecords"].as<std::size_t>();
         }
         if (vm.count("memoryUsage") > 0) {
             memoryUsage = true;
         }
         if (vm.count("multivariateByFields") > 0) {
             multivariateByFields = true;
+        }
+        if (vm.count("stopCategorizationOnWarnStatus") > 0) {
+            stopCategorizationOnWarnStatus = true;
         }
 
         boost::program_options::collect_unrecognized(

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -62,9 +62,10 @@ public:
                       std::string& persistFileName,
                       bool& isPersistFileNamedPipe,
                       bool& isPersistInForeground,
-                      size_t& maxAnomalyRecords,
+                      std::size_t& maxAnomalyRecords,
                       bool& memoryUsage,
                       bool& multivariateByFields,
+                      bool& stopCategorizationOnWarnStatus,
                       TStrVec& clauseTokens);
 
 private:

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -52,7 +52,7 @@
 * Parallelize the feature importance calculation for classification and regression
   over trees. (See {ml-pull}1277[#1277].)
 * Add an option to do categorization independently for each partition.
-  (See {ml-pull}1293[#1293], {ml-pull}1318[#1318] and {pull}57683[#57683].)
+  (See {ml-pull}1293[#1293], {ml-pull}1318[#1318], {ml-pull}1356[#1356] and {pull}57683[#57683].)
 * Memory usage is reported during job initialization. (See {ml-pull}1294[#1294].)
 * More realistic memory estimation for classification and regression means that these
   analyses will require lower memory limits than before (See {ml-pull}1298[#1298].)

--- a/include/api/CAnnotationJsonWriter.h
+++ b/include/api/CAnnotationJsonWriter.h
@@ -6,32 +6,33 @@
 #ifndef INCLUDED_ml_api_CAnnotationJsonWriter_h
 #define INCLUDED_ml_api_CAnnotationJsonWriter_h
 
-#include <core/CJsonOutputStreamWrapper.h>
-#include <core/CNonCopyable.h>
 #include <core/CRapidJsonConcurrentLineWriter.h>
-#include <core/CoreTypes.h>
 
 #include <api/ImportExport.h>
 
-#include <model/CAnnotation.h>
-
 #include <rapidjson/document.h>
 
-#include <iosfwd>
-#include <sstream>
 #include <string>
 
-#include <stdint.h>
-
 namespace ml {
+namespace core {
+class CJsonOutputStreamWrapper;
+}
+namespace model {
+class CAnnotation;
+}
 namespace api {
 
 //! \brief
 //! Write annotation result as a JSON document
-class API_EXPORT CAnnotationJsonWriter final : private core::CNonCopyable {
+class API_EXPORT CAnnotationJsonWriter final {
 public:
     //! Constructor that causes to be written to the specified stream
     explicit CAnnotationJsonWriter(core::CJsonOutputStreamWrapper& outStream);
+
+    //! No copying
+    CAnnotationJsonWriter(const CAnnotationJsonWriter&) = delete;
+    CAnnotationJsonWriter& operator=(const CAnnotationJsonWriter&) = delete;
 
     void writeResult(const std::string& jobId, const model::CAnnotation& annotation);
 

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -13,9 +13,11 @@
 #include <model/CDataCategorizer.h>
 #include <model/CTokenListDataCategorizer.h>
 
+#include <api/CAnnotationJsonWriter.h>
 #include <api/CCategoryIdMapper.h>
 #include <api/CDataProcessor.h>
 #include <api/CGlobalCategoryId.h>
+#include <api/CJsonOutputWriter.h>
 #include <api/CSingleFieldDataCategorizer.h>
 #include <api/ImportExport.h>
 
@@ -31,6 +33,7 @@ namespace ml {
 namespace core {
 class CDataAdder;
 class CDataSearcher;
+class CJsonOutputStreamWrapper;
 class CStatePersistInserter;
 class CStateRestoreTraverser;
 }
@@ -39,7 +42,6 @@ class CLimits;
 }
 namespace api {
 class CFieldConfig;
-class CJsonOutputWriter;
 class COutputHandler;
 class CPersistenceManager;
 
@@ -106,8 +108,9 @@ public:
                           const std::string& timeFieldName,
                           const std::string& timeFieldFormat,
                           COutputHandler& outputHandler,
-                          CJsonOutputWriter& jsonOutputWriter,
-                          CPersistenceManager* persistenceManager);
+                          core::CJsonOutputStreamWrapper& outputStream,
+                          CPersistenceManager* persistenceManager,
+                          bool stopCategorizationOnWarnStatus);
 
     ~CFieldDataCategorizer() override;
 
@@ -189,6 +192,9 @@ private:
     //! Acknowledge a flush request
     void acknowledgeFlush(const std::string& flushId, bool lastHandler);
 
+    //! Parse a stop-on-warn control message
+    void parseStopOnWarnControlMessage(const std::string& enabledStr);
+
     //! Writes out to the JSON output writer any category definitions and stats
     //! that have changed since they were last written.
     void writeChanges();
@@ -206,14 +212,21 @@ private:
     //! Configurable limits
     model::CLimits& m_Limits;
 
-    //! Object to which the output is passed
+    //! Object to which the processed input is passed
     COutputHandler& m_OutputHandler;
+
+    //! Stream used by the output writer
+    core::CJsonOutputStreamWrapper& m_OutputStream;
 
     //! Cache extra field names to be added
     TStrVec m_ExtraFieldNames;
 
     //! Should we write the field names before the next output?
     bool m_WriteFieldNames = true;
+
+    //! Should we stop categorizing when a model library categorizer's
+    //! categorization status is "warn"?
+    bool m_StopCategorizationOnWarnStatus;
 
     //! Highest previously used global ID.
     int m_HighestGlobalId = 0;
@@ -233,8 +246,11 @@ private:
     //! the empty string.
     TStrSingleFieldDataCategorizerUPtrMap m_DataCategorizers;
 
-    //! Reference to the json output writer so that examples can be written
-    CJsonOutputWriter& m_JsonOutputWriter;
+    //! Object to which the overall process output is passed
+    CJsonOutputWriter m_JsonOutputWriter;
+
+    //! Writer for annotations
+    CAnnotationJsonWriter m_AnnotationJsonWriter;
 
     //! Which field name are we partitioning on?  If empty, this means
     //! per-partition categorization is disabled and categories are

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -226,7 +226,7 @@ private:
 
     //! Should we stop categorizing when a model library categorizer's
     //! categorization status is "warn"?
-    bool m_StopCategorizationOnWarnStatus;
+    bool m_StopCategorizationOnWarnStatus = false;
 
     //! Highest previously used global ID.
     int m_HighestGlobalId = 0;

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -181,6 +181,9 @@ public:
     //! Destructor flushes the stream
     ~CJsonOutputWriter() override;
 
+    //! Access to job ID
+    const std::string& jobId() const;
+
     // Bring the other overload of fieldNames() into scope
     using COutputHandler::fieldNames;
 

--- a/include/api/CSingleFieldDataCategorizer.h
+++ b/include/api/CSingleFieldDataCategorizer.h
@@ -26,6 +26,7 @@ namespace model {
 class CCategoryExamplesCollector;
 }
 namespace api {
+class CAnnotationJsonWriter;
 class CJsonOutputWriter;
 
 //! \brief
@@ -91,9 +92,21 @@ public:
         return m_CategoryIdMapper->categorizerKey();
     }
 
+    //! Get the most recent categorization status.
+    model_t::ECategorizationStatus categorizationStatus() const {
+        return m_DataCategorizer->categorizationStatus();
+    }
+
     //! Writes out to the JSON output writer any category definitions and stats
     //! that have changed since they were last written.
-    void writeChanges(CJsonOutputWriter& jsonOutputWriter);
+    void writeChanges(CJsonOutputWriter& jsonOutputWriter,
+                      CAnnotationJsonWriter& annotationJsonWriter);
+
+    //! If the lower level categorizer thinks it urgent, write the latest
+    //! categorizer stats, plus an annotation if the categorization status has
+    //! changed.
+    void writeStatsIfUrgent(CJsonOutputWriter& jsonOutputWriter,
+                            CAnnotationJsonWriter& annotationJsonWriter);
 
     //! Force an update of the resource monitor.
     void forceResourceRefresh(model::CResourceMonitor& resourceMonitor);
@@ -104,6 +117,11 @@ private:
                                       const model::CCategoryExamplesCollector& examplesCollector,
                                       const CCategoryIdMapper& categoryIdMapper,
                                       core::CStatePersistInserter& inserter);
+
+    //! Write the latest categorizer stats, plus an annotation if the
+    //! categorization status has changed.
+    void writeStats(CJsonOutputWriter& jsonOutputWriter,
+                    CAnnotationJsonWriter& annotationJsonWriter);
 
 private:
     //! Which field name are we partitioning on?  If empty, this means

--- a/include/api/CSingleFieldDataCategorizer.h
+++ b/include/api/CSingleFieldDataCategorizer.h
@@ -120,8 +120,8 @@ private:
 
     //! Write the latest categorizer stats, plus an annotation if the
     //! categorization status has changed.
-    void writeStats(CJsonOutputWriter& jsonOutputWriter,
-                    CAnnotationJsonWriter& annotationJsonWriter);
+    void writeStatsIfChanged(CJsonOutputWriter& jsonOutputWriter,
+                             CAnnotationJsonWriter& annotationJsonWriter);
 
 private:
     //! Which field name are we partitioning on?  If empty, this means

--- a/include/model/CAnnotation.h
+++ b/include/model/CAnnotation.h
@@ -7,9 +7,9 @@
 #ifndef INCLUDED_ml_model_CAnnotation_h
 #define INCLUDED_ml_model_CAnnotation_h
 
-#include <model/ImportExport.h>
+#include <core/CoreTypes.h>
 
-#include <model/ModelTypes.h>
+#include <model/ImportExport.h>
 
 #include <string>
 
@@ -19,8 +19,18 @@ namespace model {
 //! \brief Data necessary to create an annotation
 class MODEL_EXPORT CAnnotation {
 public:
+    //! The values of this enum must correspond to a subset of the values of the
+    //! Event enum of org.elasticsearch.xpack.core.ml.annotations.Annotation in
+    //! the Java code.
+    enum EEvent { E_ModelChange = 0, E_CategorizationStatusChange = 1 };
+
+    //! Detector index will not be written to the output if this value is used.
+    static const int DETECTOR_INDEX_NOT_APPLICABLE = -1;
+
+public:
     CAnnotation() = default;
     CAnnotation(core_t::TTime time,
+                EEvent event,
                 const std::string& annotation,
                 int detectorIndex,
                 const std::string& partitionFieldName,
@@ -42,8 +52,9 @@ public:
 
 private:
     core_t::TTime m_Time = 0;
+    EEvent m_Event = E_ModelChange;
     std::string m_Annotation;
-    int m_DetectorIndex = -1;
+    int m_DetectorIndex = DETECTOR_INDEX_NOT_APPLICABLE;
     std::string m_PartitionFieldName;
     std::string m_PartitionFieldValue;
     std::string m_OverFieldName;

--- a/include/model/CDataCategorizer.h
+++ b/include/model/CDataCategorizer.h
@@ -64,7 +64,7 @@ public:
         std::function<void(CLocalCategoryId, const std::string&, const std::string&, std::size_t, const CCategoryExamplesCollector::TStrFSet&, std::size_t, TLocalCategoryIdVec)>;
 
     //! Callback for categorizer stats output
-    using TCategorizerStatsOutputFunc = std::function<void(const SCategorizerStats&)>;
+    using TCategorizerStatsOutputFunc = std::function<void(const SCategorizerStats&, bool)>;
 
 public:
     CDataCategorizer(CLimits& limits, const std::string& fieldName);
@@ -116,6 +116,9 @@ public:
     //! Access to the field name
     const std::string& fieldName() const;
 
+    //! Get the most recent categorization status.
+    virtual model_t::ECategorizationStatus categorizationStatus() const = 0;
+
     //! Debug the memory used by this categorizer.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
@@ -155,6 +158,10 @@ public:
     //! \return Were the stats written?
     virtual bool
     writeCategorizerStatsIfChanged(const TCategorizerStatsOutputFunc& outputFunc) = 0;
+
+    //! Quickly check if a stats write is important at this time.  This method
+    //! is called frequently, so should not do costly processing.
+    virtual bool isStatsWriteUrgent() const = 0;
 
     //! Number of categories this categorizer has detected.
     virtual std::size_t numCategories() const = 0;

--- a/lib/api/CAnnotationJsonWriter.cc
+++ b/lib/api/CAnnotationJsonWriter.cc
@@ -4,8 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 #include <api/CAnnotationJsonWriter.h>
-#include <core/CLogger.h>
+
 #include <core/CTimeUtils.h>
+
+#include <model/CAnnotation.h>
 
 namespace ml {
 namespace api {
@@ -29,19 +31,24 @@ const std::string OVER_FIELD_NAME{"over_field_name"};
 const std::string OVER_FIELD_VALUE{"over_field_value"};
 const std::string BY_FIELD_NAME{"by_field_name"};
 const std::string BY_FIELD_VALUE{"by_field_value"};
+
+// Type can be annotation or comment, but from the C++ always annotation
+const std::string ANNOTATION_TYPE{"annotation"};
+// Internal user name
+const std::string XPACK_USER{"_xpack"};
 }
 
 CAnnotationJsonWriter::CAnnotationJsonWriter(core::CJsonOutputStreamWrapper& outStream)
-    : m_Writer(outStream) {
+    : m_Writer{outStream} {
 }
 
 void CAnnotationJsonWriter::writeResult(const std::string& jobId,
                                         const model::CAnnotation& annotation) {
 
-    rapidjson::Value obj = m_Writer.makeObject();
-    populateAnnotationObject(jobId, annotation, obj);
+    rapidjson::Value obj{m_Writer.makeObject()};
+    this->populateAnnotationObject(jobId, annotation, obj);
 
-    rapidjson::Value wrapper = m_Writer.makeObject();
+    rapidjson::Value wrapper{m_Writer.makeObject()};
     m_Writer.addMember(ANNOTATION_RESULT_TYPE, obj, wrapper);
     m_Writer.write(wrapper);
     m_Writer.Flush();
@@ -51,36 +58,43 @@ void CAnnotationJsonWriter::populateAnnotationObject(const std::string& jobId,
                                                      const model::CAnnotation& annotation,
                                                      rapidjson::Value& obj) {
 
-    m_Writer.addStringFieldCopyToObj(JOB_ID, jobId, obj, true);
-    m_Writer.addStringFieldCopyToObj(ANNOTATION, annotation.annotation(), obj);
-    // time is in Java format - milliseconds since the epoch
+    // There is no need to copy the strings, as this is a private method and the
+    // rapidjson::Value it's populating will have a shorter lifetime than the
+    // CAnnotation object the string references rely on.
+    m_Writer.addStringFieldReferenceToObj(JOB_ID, jobId, obj);
+    m_Writer.addStringFieldReferenceToObj(ANNOTATION, annotation.annotation(), obj, true);
+    m_Writer.addStringFieldReferenceToObj(EVENT, annotation.event(), obj);
+
+    // In the JSON the time is in Java format - milliseconds since the epoch
     m_Writer.addTimeFieldToObj(TIMESTAMP, annotation.time(), obj);
     m_Writer.addTimeFieldToObj(END_TIMESTAMP, annotation.time(), obj);
 
-    std::int64_t currentTime(core::CTimeUtils::nowMs());
+    std::int64_t currentTime{core::CTimeUtils::nowMs()};
     m_Writer.addIntFieldToObj(CREATE_TIME, currentTime, obj);
     m_Writer.addIntFieldToObj(MODIFIED_TIME, currentTime, obj);
-    m_Writer.addStringFieldCopyToObj(CREATE_USERNAME, "_xpack", obj);
-    m_Writer.addStringFieldCopyToObj(MODIFIED_USERNAME, "_xpack", obj);
-    m_Writer.addStringFieldCopyToObj(TYPE, "annotation", obj);
-    m_Writer.addStringFieldCopyToObj(EVENT, annotation.event(), obj);
+    m_Writer.addStringFieldReferenceToObj(CREATE_USERNAME, XPACK_USER, obj);
+    m_Writer.addStringFieldReferenceToObj(MODIFIED_USERNAME, XPACK_USER, obj);
+    m_Writer.addStringFieldReferenceToObj(TYPE, ANNOTATION_TYPE, obj);
 
-    m_Writer.addIntFieldToObj(DETECTOR_INDEX, annotation.detectorIndex(), obj);
+    if (annotation.detectorIndex() != model::CAnnotation::DETECTOR_INDEX_NOT_APPLICABLE) {
+        m_Writer.addIntFieldToObj(DETECTOR_INDEX, annotation.detectorIndex(), obj);
+    }
     if (annotation.partitionFieldName().empty() == false) {
-        m_Writer.addStringFieldCopyToObj(PARTITION_FIELD_NAME,
-                                         annotation.partitionFieldName(), obj);
-        m_Writer.addStringFieldCopyToObj(
+        m_Writer.addStringFieldReferenceToObj(PARTITION_FIELD_NAME,
+                                              annotation.partitionFieldName(), obj);
+        m_Writer.addStringFieldReferenceToObj(
             PARTITION_FIELD_VALUE, annotation.partitionFieldValue(), obj, true);
     }
     if (annotation.overFieldName().empty() == false) {
-        m_Writer.addStringFieldCopyToObj(OVER_FIELD_NAME, annotation.overFieldName(), obj);
-        m_Writer.addStringFieldCopyToObj(OVER_FIELD_VALUE,
-                                         annotation.overFieldValue(), obj, true);
+        m_Writer.addStringFieldReferenceToObj(OVER_FIELD_NAME,
+                                              annotation.overFieldName(), obj);
+        m_Writer.addStringFieldReferenceToObj(
+            OVER_FIELD_VALUE, annotation.overFieldValue(), obj, true);
     }
     if (annotation.byFieldName().empty() == false) {
-        m_Writer.addStringFieldCopyToObj(BY_FIELD_NAME, annotation.byFieldName(), obj);
-        m_Writer.addStringFieldCopyToObj(BY_FIELD_VALUE,
-                                         annotation.byFieldValue(), obj, true);
+        m_Writer.addStringFieldReferenceToObj(BY_FIELD_NAME, annotation.byFieldName(), obj);
+        m_Writer.addStringFieldReferenceToObj(BY_FIELD_VALUE,
+                                              annotation.byFieldValue(), obj, true);
     }
 }
 }

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -245,6 +245,8 @@ void CAnomalyJob::finalise() {
     if (m_PersistenceManager != nullptr) {
         m_PersistenceManager->waitForIdle();
     }
+
+    m_JsonOutputWriter.finalise();
 }
 
 bool CAnomalyJob::initNormalizer(const std::string& quantilesStateFile) {

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -59,7 +59,7 @@ CFieldDataCategorizer::CFieldDataCategorizer(std::string jobId,
                                              bool stopCategorizationOnWarnStatus)
     : CDataProcessor{timeFieldName, timeFieldFormat}, m_JobId{std::move(jobId)},
       m_Limits{limits}, m_OutputHandler{outputHandler}, m_OutputStream{outputStream},
-      m_ExtraFieldNames{1, MLCATEGORY_NAME}, m_StopCategorizationOnWarnStatus{stopCategorizationOnWarnStatus},
+      m_ExtraFieldNames{MLCATEGORY_NAME}, m_StopCategorizationOnWarnStatus{stopCategorizationOnWarnStatus},
       m_OutputFieldCategory{m_Overrides[MLCATEGORY_NAME]},
       m_JsonOutputWriter{m_JobId, m_OutputStream}, m_AnnotationJsonWriter{m_OutputStream},
       m_PartitionFieldName{config.categorizationPartitionFieldName()},
@@ -700,7 +700,7 @@ void CFieldDataCategorizer::parseStopOnWarnControlMessage(const std::string& ena
         return;
     }
     if (m_StopCategorizationOnWarnStatus != enabled) {
-        LOG_INFO(<< "Stop-on-warn now: " << std::boolalpha << enabled);
+        LOG_INFO(<< "Categorization stop-on-warn now: " << std::boolalpha << enabled);
         m_StopCategorizationOnWarnStatus = enabled;
     }
 }

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -162,6 +162,10 @@ CJsonOutputWriter::~CJsonOutputWriter() {
     finalise();
 }
 
+const std::string& CJsonOutputWriter::jobId() const {
+    return m_JobId;
+}
+
 void CJsonOutputWriter::finalise() {
     if (m_Finalised) {
         return;

--- a/lib/api/CSingleFieldDataCategorizer.cc
+++ b/lib/api/CSingleFieldDataCategorizer.cc
@@ -211,18 +211,18 @@ void CSingleFieldDataCategorizer::writeChanges(CJsonOutputWriter& jsonOutputWrit
         })};
     LOG_TRACE(<< numWritten << " changed categories written for categorizer "
               << m_CategoryIdMapper->categorizerKey());
-    this->writeStats(jsonOutputWriter, annotationJsonWriter);
+    this->writeStatsIfChanged(jsonOutputWriter, annotationJsonWriter);
 }
 
 void CSingleFieldDataCategorizer::writeStatsIfUrgent(CJsonOutputWriter& jsonOutputWriter,
                                                      CAnnotationJsonWriter& annotationJsonWriter) {
     if (m_DataCategorizer->isStatsWriteUrgent()) {
-        this->writeStats(jsonOutputWriter, annotationJsonWriter);
+        this->writeStatsIfChanged(jsonOutputWriter, annotationJsonWriter);
     }
 }
 
-void CSingleFieldDataCategorizer::writeStats(CJsonOutputWriter& jsonOutputWriter,
-                                             CAnnotationJsonWriter& annotationJsonWriter) {
+void CSingleFieldDataCategorizer::writeStatsIfChanged(CJsonOutputWriter& jsonOutputWriter,
+                                                      CAnnotationJsonWriter& annotationJsonWriter) {
     if (m_DataCategorizer->writeCategorizerStatsIfChanged(
             [this, &jsonOutputWriter, &annotationJsonWriter](
                 const model::SCategorizerStats& categorizerStats, bool statusChanged) {

--- a/lib/api/CSingleFieldDataCategorizer.cc
+++ b/lib/api/CSingleFieldDataCategorizer.cc
@@ -8,10 +8,15 @@
 
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
+#include <core/CTimeUtils.h>
 
 #include <model/CCategoryExamplesCollector.h>
+#include <model/ModelTypes.h>
 
+#include <api/CAnnotationJsonWriter.h>
 #include <api/CJsonOutputWriter.h>
+
+#include <sstream>
 
 namespace {
 // For historical reasons, these tags must not duplicate those used in
@@ -21,6 +26,8 @@ const std::string CATEGORIZER_TAG{"b"};
 const std::string EXAMPLES_COLLECTOR_TAG{"c"};
 const std::string CATEGORY_ID_MAPPER_TAG{"d"};
 // e, f, g used in CFieldDataCategorizer.cc
+
+const std::string EMPTY_STRING;
 }
 
 namespace ml {
@@ -188,7 +195,8 @@ bool CSingleFieldDataCategorizer::acceptRestoreTraverser(core::CStateRestoreTrav
     return true;
 }
 
-void CSingleFieldDataCategorizer::writeChanges(CJsonOutputWriter& jsonOutputWriter) {
+void CSingleFieldDataCategorizer::writeChanges(CJsonOutputWriter& jsonOutputWriter,
+                                               CAnnotationJsonWriter& annotationJsonWriter) {
     std::size_t numWritten{m_DataCategorizer->writeChangedCategories(
         [this, &jsonOutputWriter](
             model::CLocalCategoryId localCategoryId, const std::string& terms,
@@ -203,11 +211,47 @@ void CSingleFieldDataCategorizer::writeChanges(CJsonOutputWriter& jsonOutputWrit
         })};
     LOG_TRACE(<< numWritten << " changed categories written for categorizer "
               << m_CategoryIdMapper->categorizerKey());
+    this->writeStats(jsonOutputWriter, annotationJsonWriter);
+}
+
+void CSingleFieldDataCategorizer::writeStatsIfUrgent(CJsonOutputWriter& jsonOutputWriter,
+                                                     CAnnotationJsonWriter& annotationJsonWriter) {
+    if (m_DataCategorizer->isStatsWriteUrgent()) {
+        this->writeStats(jsonOutputWriter, annotationJsonWriter);
+    }
+}
+
+void CSingleFieldDataCategorizer::writeStats(CJsonOutputWriter& jsonOutputWriter,
+                                             CAnnotationJsonWriter& annotationJsonWriter) {
     if (m_DataCategorizer->writeCategorizerStatsIfChanged(
-            [this, &jsonOutputWriter](const model::SCategorizerStats& categorizerStats) {
+            [this, &jsonOutputWriter, &annotationJsonWriter](
+                const model::SCategorizerStats& categorizerStats, bool statusChanged) {
                 jsonOutputWriter.writeCategorizerStats(
                     m_PartitionFieldName, m_CategoryIdMapper->categorizerKey(),
                     categorizerStats, m_LastMessageTime);
+                if (statusChanged) {
+                    std::ostringstream text;
+                    text << "Categorization status changed to '"
+                         << model_t::print(categorizerStats.s_CategorizationStatus)
+                         << '\'';
+                    if (m_PartitionFieldName.empty() == false) {
+                        text << " for '" << m_PartitionFieldName << "' '"
+                             << m_CategoryIdMapper->categorizerKey() << '\'';
+                    }
+                    model::CAnnotation annotation{
+                        m_LastMessageTime.has_value() ? *m_LastMessageTime
+                                                      : core::CTimeUtils::now(),
+                        model::CAnnotation::E_CategorizationStatusChange,
+                        text.str(),
+                        model::CAnnotation::DETECTOR_INDEX_NOT_APPLICABLE,
+                        m_PartitionFieldName,
+                        m_CategoryIdMapper->categorizerKey(),
+                        EMPTY_STRING,
+                        EMPTY_STRING,
+                        EMPTY_STRING,
+                        EMPTY_STRING};
+                    annotationJsonWriter.writeResult(jsonOutputWriter.jobId(), annotation);
+                }
             })) {
         LOG_TRACE(<< "Wrote categorizer stats for categorizer "
                   << m_CategoryIdMapper->categorizerKey());

--- a/lib/api/dump_state/Main.cc
+++ b/lib/api/dump_state/Main.cc
@@ -37,6 +37,7 @@
 #include <api/CJsonOutputWriter.h>
 #include <api/CModelSnapshotJsonWriter.h>
 #include <api/CNdJsonInputParser.h>
+#include <api/CNullOutput.h>
 #include <api/CSingleStreamDataAdder.h>
 #include <api/CSingleStreamSearcher.h>
 
@@ -129,11 +130,12 @@ bool persistCategorizerStateToFile(const std::string& outputFileName,
     ml::api::CFieldConfig config("count", "mlcategory");
 
     std::ofstream outStream(ml::core::COsFileFuncs::NULL_FILENAME);
-    ml::core::CJsonOutputStreamWrapper wrappendOutStream(outStream);
-    ml::api::CJsonOutputWriter writer("job", wrappendOutStream);
+    ml::core::CJsonOutputStreamWrapper wrappedOutStream(outStream);
+    ml::api::CNullOutput nullOutput;
 
-    ml::api::CFieldDataCategorizer categorizer("job", config, limits, "time",
-                                               timeFormat, writer, writer, nullptr);
+    ml::api::CFieldDataCategorizer categorizer{
+        "job",      config,           limits,  "time", timeFormat,
+        nullOutput, wrappedOutStream, nullptr, false};
 
     ml::api::CFieldDataCategorizer::TStrStrUMap dataRowFields;
     dataRowFields["_raw"] = "thing";

--- a/lib/api/unittest/CAnnotationJsonWriterTest.cc
+++ b/lib/api/unittest/CAnnotationJsonWriterTest.cc
@@ -7,14 +7,10 @@
 #include <core/CJsonOutputStreamWrapper.h>
 
 #include <model/CAnnotation.h>
-#include <model/ModelTypes.h>
 
 #include <api/CAnnotationJsonWriter.h>
 
-#include <test/BoostTestCloseAbsolute.h>
-
 #include <rapidjson/document.h>
-#include <rapidjson/prettywriter.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -26,50 +22,53 @@ BOOST_AUTO_TEST_CASE(testWrite) {
     std::ostringstream sstream;
 
     {
-        ml::core::CJsonOutputStreamWrapper outputStream(sstream);
-        ml::api::CAnnotationJsonWriter writer(outputStream);
+        ml::core::CJsonOutputStreamWrapper outputStream{sstream};
+        ml::api::CAnnotationJsonWriter writer{outputStream};
 
-        ml::model::CAnnotation annotation(1, "annotation text", 2, "pName", "pValue",
-                                          "oName", "oValue", "bName", "bValue");
+        ml::model::CAnnotation annotation{1,
+                                          ml::model::CAnnotation::E_ModelChange,
+                                          "annotation text",
+                                          2,
+                                          "pName",
+                                          "pValue",
+                                          "oName",
+                                          "oValue",
+                                          "bName",
+                                          "bValue"};
         writer.writeResult("job-id", annotation);
     }
 
     rapidjson::Document doc;
     doc.Parse<rapidjson::kParseDefaultFlags>(sstream.str());
     BOOST_TEST_REQUIRE(doc.HasParseError() == false);
-    const rapidjson::Value& firstElement = doc[0];
+    const rapidjson::Value& firstElement{doc[0]};
     BOOST_TEST_REQUIRE(firstElement.HasMember("annotation"));
-    const rapidjson::Value& annotation = firstElement["annotation"];
+    const rapidjson::Value& annotation{firstElement["annotation"]};
     BOOST_TEST_REQUIRE(annotation.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job-id"),
-                        std::string(annotation["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"job-id"}, annotation["job_id"].GetString());
     BOOST_TEST_REQUIRE(annotation.HasMember("timestamp"));
     BOOST_REQUIRE_EQUAL(1000, annotation["timestamp"].GetInt64());
     BOOST_TEST_REQUIRE(annotation.HasMember("detector_index"));
     BOOST_REQUIRE_EQUAL(2, annotation["detector_index"].GetInt());
     BOOST_TEST_REQUIRE(annotation.HasMember("partition_field_name"));
-    BOOST_REQUIRE_EQUAL(std::string("pName"),
-                        std::string(annotation["partition_field_name"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"pName"},
+                        annotation["partition_field_name"].GetString());
     BOOST_TEST_REQUIRE(annotation.HasMember("partition_field_value"));
-    BOOST_REQUIRE_EQUAL(std::string("pValue"),
-                        std::string(annotation["partition_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"pValue"},
+                        annotation["partition_field_value"].GetString());
     BOOST_TEST_REQUIRE(annotation.HasMember("over_field_name"));
-    BOOST_REQUIRE_EQUAL(std::string("oName"),
-                        std::string(annotation["over_field_name"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"oName"}, annotation["over_field_name"].GetString());
     BOOST_TEST_REQUIRE(annotation.HasMember("over_field_value"));
-    BOOST_REQUIRE_EQUAL(std::string("oValue"),
-                        std::string(annotation["over_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"oValue"}, annotation["over_field_value"].GetString());
     BOOST_TEST_REQUIRE(annotation.HasMember("by_field_name"));
-    BOOST_REQUIRE_EQUAL(std::string("bName"),
-                        std::string(annotation["by_field_name"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"bName"}, annotation["by_field_name"].GetString());
     BOOST_TEST_REQUIRE(annotation.HasMember("by_field_value"));
-    BOOST_REQUIRE_EQUAL(std::string("bValue"),
-                        std::string(annotation["by_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"bValue"}, annotation["by_field_value"].GetString());
     BOOST_TEST_REQUIRE(annotation.HasMember("annotation"));
-    BOOST_REQUIRE_EQUAL(std::string("annotation text"),
-                        std::string(annotation["annotation"].GetString()));
-    BOOST_REQUIRE_EQUAL(std::string("model_change"),
-                        std::string(annotation["event"].GetString()));
+    BOOST_REQUIRE_EQUAL(std::string{"annotation text"},
+                        annotation["annotation"].GetString());
+    BOOST_TEST_REQUIRE(annotation.HasMember("event"));
+    BOOST_REQUIRE_EQUAL(std::string{"model_change"}, annotation["event"].GetString());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -763,7 +763,8 @@ BOOST_AUTO_TEST_CASE(testStopCategorizingOnWarnStatusPerPartition) {
     // All these combinations of initial state and control message changes
     // should result in the same behaviour
     using TBoolBoolBoolTuple = std::tuple<bool, bool, bool>;
-    auto combinations = {TBoolBoolBoolTuple{true, false, false}, TBoolBoolBoolTuple{true, true, true},
+    auto combinations = {TBoolBoolBoolTuple{true, false, false},
+                         TBoolBoolBoolTuple{true, true, true},
                          TBoolBoolBoolTuple{false, true, true}};
     for (const auto& args : combinations) {
         const std::string& output{setupPerPartitionStopOnWarnTest(

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -762,8 +762,9 @@ BOOST_AUTO_TEST_CASE(testStopCategorizingOnWarnStatusPerPartition) {
 
     // All these combinations of initial state and control message changes
     // should result in the same behaviour
-    auto combinations = {std::tuple{true, false, false}, std::tuple{true, true, true},
-                         std::tuple{false, true, true}};
+    using TBoolBoolBoolTuple = std::tuple<bool, bool, bool>;
+    auto combinations = {TBoolBoolBoolTuple{true, false, false}, TBoolBoolBoolTuple{true, true, true},
+                         TBoolBoolBoolTuple{false, true, true}};
     for (const auto& args : combinations) {
         const std::string& output{setupPerPartitionStopOnWarnTest(
             std::get<0>(args), std::get<1>(args), std::get<2>(args))};

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -13,7 +13,6 @@
 #include <model/CLimits.h>
 
 #include <api/CFieldConfig.h>
-#include <api/CJsonOutputWriter.h>
 #include <api/CNullOutput.h>
 #include <api/COutputChainer.h>
 #include <api/COutputHandler.h>
@@ -23,8 +22,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <set>
 #include <sstream>
+#include <tuple>
 
 BOOST_AUTO_TEST_SUITE(CFieldDataCategorizerTest)
 
@@ -42,7 +43,7 @@ namespace {
 class CEmptySearcher : public ml::core::CDataSearcher {
 public:
     //! Do a search that results in an empty input stream.
-    virtual TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) {
+    TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) override {
         return TIStreamP(new std::istringstream());
     }
 };
@@ -52,21 +53,21 @@ public:
     using TIntSet = std::set<int>;
 
 public:
-    virtual void finalise() { m_Finalised = true; }
+    void finalise() override { m_Finalised = true; }
 
     bool hasFinalised() const { return m_Finalised; }
 
-    virtual void newOutputStream() { m_NewStream = true; }
+    void newOutputStream() override { m_NewStream = true; }
 
     bool isNewStream() const { return m_NewStream; }
 
-    virtual bool fieldNames(const TStrVec& /*fieldNames*/, const TStrVec& /*extraFieldNames*/) {
+    bool fieldNames(const TStrVec& /*fieldNames*/, const TStrVec& /*extraFieldNames*/) override {
         return true;
     }
 
-    virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields,
-                          TOptionalTime /*time*/) {
+    bool writeRow(const TStrStrUMap& dataRowFields,
+                  const TStrStrUMap& overrideDataRowFields,
+                  TOptionalTime /*time*/) override {
         ++m_NumRows;
         std::string categoryIdStr;
         auto iter = overrideDataRowFields.find("mlcategory");
@@ -87,7 +88,7 @@ public:
         return true;
     }
 
-    uint64_t numRows() const { return m_NumRows; }
+    std::uint64_t numRows() const { return m_NumRows; }
 
     const TIntSet& categoryIdsHandled() const { return m_CategoryIdsHandled; }
 
@@ -96,7 +97,7 @@ private:
 
     bool m_Finalised = false;
 
-    uint64_t m_NumRows = 0;
+    std::uint64_t m_NumRows = 0;
 
     TIntSet m_CategoryIdsHandled;
 };
@@ -106,7 +107,7 @@ public:
     CTestDataSearcher(const std::string& data)
         : m_Stream(new std::istringstream(data)) {}
 
-    virtual TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) {
+    TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) override {
         return m_Stream;
     }
 
@@ -118,11 +119,11 @@ class CTestDataAdder : public core::CDataAdder {
 public:
     CTestDataAdder() : m_Stream(new std::ostringstream) {}
 
-    virtual TOStreamP addStreamed(const std::string& /*index*/, const std::string& /*id*/) {
+    TOStreamP addStreamed(const std::string& /*index*/, const std::string& /*id*/) override {
         return m_Stream;
     }
 
-    virtual bool streamComplete(TOStreamP& /*strm*/, bool /*force*/) {
+    bool streamComplete(TOStreamP& /*strm*/, bool /*force*/) override {
         return true;
     }
 
@@ -131,6 +132,68 @@ public:
 private:
     TOStreamP m_Stream;
 };
+
+std::size_t countOccurrences(const std::string& str, const std::string& substr) {
+    std::size_t occurrences{0};
+    for (std::size_t start = str.find(substr); start != std::string::npos;
+         start = str.find(substr, start + substr.length())) {
+        ++occurrences;
+    }
+    return occurrences;
+}
+
+std::string setupPerPartitionStopOnWarnTest(bool stopOnWarnAtInit,
+                                            bool sendControlMessageAfter50,
+                                            bool controlMessageContent) {
+    model::CLimits limits;
+    CFieldConfig config;
+    BOOST_TEST_REQUIRE(config.initFromFile("testfiles/new_persist_per_partition_categorization.conf"));
+
+    std::ostringstream outputStrm;
+    {
+        CNullOutput nullOutput;
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
+
+        CTestFieldDataCategorizer categorizer{
+            "job",   config,          limits, nullOutput, wrappedOutputStream,
+            nullptr, stopOnWarnAtInit};
+
+        CFieldDataCategorizer::TStrStrUMap dataRowFieldsPartition1;
+        dataRowFieldsPartition1["event.dataset"] = "nodes";
+        dataRowFieldsPartition1["message"] = "Node 1 started";
+
+        CFieldDataCategorizer::TStrStrUMap dataRowFieldsPartition2;
+        dataRowFieldsPartition2["event.dataset"] = "random but changing";
+        dataRowFieldsPartition2["message"] = "fff fff fff";
+
+        // The 100th message in partition "nodes" should cause the
+        // categorization status to change to "warn" for that partition.  This
+        // is because there is only one category, which is a red flag, but we
+        // don't report warning status until we've seen 100 messages.  Then we
+        // should stop categorizing in partition "nodes" if stop-on-warn is in
+        // force at that time.  However, since the "random but changing"
+        // partition does not enter "warn" status, categorization should
+        // continue for it.
+        for (std::size_t count = 1; count <= 200; ++count) {
+            BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFieldsPartition1));
+            if (count % 10 == 1) {
+                std::string& message{dataRowFieldsPartition2["message"]};
+                char oldChar{message[0]};
+                char newChar{static_cast<char>(oldChar + 1)};
+                std::replace(message.begin(), message.end(), oldChar, newChar);
+            }
+            BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFieldsPartition2));
+            if (count == 50 && sendControlMessageAfter50) {
+                CFieldDataCategorizer::TStrStrUMap control;
+                control["."] = "c" + ml::core::CStringUtils::typeToString(controlMessageContent);
+                BOOST_TEST_REQUIRE(categorizer.handleRecord(control));
+            }
+        }
+
+        categorizer.finalise();
+    }
+    return outputStrm.str();
+}
 }
 
 BOOST_AUTO_TEST_CASE(testWithoutPerPartitionCategorization) {
@@ -140,16 +203,15 @@ BOOST_AUTO_TEST_CASE(testWithoutPerPartitionCategorization) {
     CTestOutputHandler handler;
 
     std::ostringstream outputStrm;
-    core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-    CJsonOutputWriter writer("job", wrappedOutputStream);
+    core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-    CTestFieldDataCategorizer categorizer("job", config, limits, handler, writer);
+    CTestFieldDataCategorizer categorizer{"job", config, limits, handler, wrappedOutputStream};
     BOOST_REQUIRE_EQUAL(false, handler.isNewStream());
     categorizer.newOutputStream();
     BOOST_REQUIRE_EQUAL(true, handler.isNewStream());
 
     BOOST_REQUIRE_EQUAL(false, handler.hasFinalised());
-    BOOST_REQUIRE_EQUAL(uint64_t(0), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(0, categorizer.numRecordsHandled());
 
     CFieldDataCategorizer::TStrStrUMap dataRowFields;
     dataRowFields["message"] = "thing";
@@ -157,7 +219,7 @@ BOOST_AUTO_TEST_CASE(testWithoutPerPartitionCategorization) {
 
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(1), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(1, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     BOOST_REQUIRE_EQUAL("[1]", core::CContainerPrinter::print(handler.categoryIdsHandled()));
 
@@ -172,7 +234,7 @@ BOOST_AUTO_TEST_CASE(testWithoutPerPartitionCategorization) {
     dataRowFields["message"] = "";
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(4), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(4, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     // Still only 1, as all the other input was invalid
     BOOST_REQUIRE_EQUAL("[1]", core::CContainerPrinter::print(handler.categoryIdsHandled()));
@@ -180,7 +242,7 @@ BOOST_AUTO_TEST_CASE(testWithoutPerPartitionCategorization) {
     dataRowFields["message"] = "and another thing";
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(5), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(5, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     BOOST_REQUIRE_EQUAL(
         "[1, 2]", core::CContainerPrinter::print(handler.categoryIdsHandled()));
@@ -203,17 +265,17 @@ BOOST_AUTO_TEST_CASE(testWithoutPerPartitionCategorization) {
         model::CLimits limits2;
         CTestOutputHandler handler2;
         std::ostringstream outputStrm2;
-        core::CJsonOutputStreamWrapper wrappedOutputStream2(outputStrm2);
-        CJsonOutputWriter writer2("job", wrappedOutputStream2);
+        core::CJsonOutputStreamWrapper wrappedOutputStream2{outputStrm2};
 
-        CTestFieldDataCategorizer newCategorizer("job", config, limits2, handler2, writer2);
-        CTestDataSearcher restorer(origJson);
-        core_t::TTime time = 0;
+        CTestFieldDataCategorizer newCategorizer{"job", config, limits2,
+                                                 handler2, wrappedOutputStream2};
+        CTestDataSearcher restorer{origJson};
+        core_t::TTime time{0};
         newCategorizer.restoreState(restorer, time);
 
         CTestDataAdder adder;
         newCategorizer.persistStateInForeground(adder, "");
-        std::ostringstream& ss = dynamic_cast<std::ostringstream&>(*adder.getStream());
+        std::ostringstream& ss{dynamic_cast<std::ostringstream&>(*adder.getStream())};
         newJson = ss.str();
     }
     BOOST_REQUIRE_EQUAL(origJson, newJson);
@@ -226,16 +288,15 @@ BOOST_AUTO_TEST_CASE(testWithPerPartitionCategorization) {
     CTestOutputHandler handler;
 
     std::ostringstream outputStrm;
-    core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-    CJsonOutputWriter writer("job", wrappedOutputStream);
+    core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-    CTestFieldDataCategorizer categorizer("job", config, limits, handler, writer);
+    CTestFieldDataCategorizer categorizer{"job", config, limits, handler, wrappedOutputStream};
     BOOST_REQUIRE_EQUAL(false, handler.isNewStream());
     categorizer.newOutputStream();
     BOOST_REQUIRE_EQUAL(true, handler.isNewStream());
 
     BOOST_REQUIRE_EQUAL(false, handler.hasFinalised());
-    BOOST_REQUIRE_EQUAL(uint64_t(0), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(0, categorizer.numRecordsHandled());
 
     CFieldDataCategorizer::TStrStrUMap dataRowFields;
     dataRowFields["message"] = "thing";
@@ -244,14 +305,14 @@ BOOST_AUTO_TEST_CASE(testWithPerPartitionCategorization) {
 
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(1), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(1, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     BOOST_REQUIRE_EQUAL("[1]", core::CContainerPrinter::print(handler.categoryIdsHandled()));
 
     dataRowFields["event.dataset"] = "kibana";
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(2), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(2, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     // Now two categories, because even though message was identical, the
     // partition was different
@@ -269,7 +330,7 @@ BOOST_AUTO_TEST_CASE(testWithPerPartitionCategorization) {
     dataRowFields["message"] = "";
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(5), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(5, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     // Still only 2, as all the other input was invalid
     BOOST_REQUIRE_EQUAL(
@@ -279,14 +340,14 @@ BOOST_AUTO_TEST_CASE(testWithPerPartitionCategorization) {
     dataRowFields["event.dataset"] = "elasticsearch";
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(6), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(6, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     BOOST_REQUIRE_EQUAL(
         "[1, 2, 3]", core::CContainerPrinter::print(handler.categoryIdsHandled()));
 
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(7), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(7, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     // Still 3, as the message and partition were identical so won't have
     // created a new category
@@ -296,7 +357,7 @@ BOOST_AUTO_TEST_CASE(testWithPerPartitionCategorization) {
     dataRowFields["event.dataset"] = "kibana";
     BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
-    BOOST_REQUIRE_EQUAL(uint64_t(8), categorizer.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(8, categorizer.numRecordsHandled());
     BOOST_REQUIRE_EQUAL(categorizer.numRecordsHandled(), handler.numRows());
     // Now 4, as the message was the same but the partition changed
     BOOST_REQUIRE_EQUAL("[1, 2, 3, 4]",
@@ -310,7 +371,7 @@ BOOST_AUTO_TEST_CASE(testWithPerPartitionCategorization) {
     {
         CTestDataAdder adder;
         categorizer.persistStateInForeground(adder, "");
-        std::ostringstream& ss = dynamic_cast<std::ostringstream&>(*adder.getStream());
+        std::ostringstream& ss{dynamic_cast<std::ostringstream&>(*adder.getStream())};
         origJson = ss.str();
     }
 
@@ -320,17 +381,17 @@ BOOST_AUTO_TEST_CASE(testWithPerPartitionCategorization) {
         model::CLimits limits2;
         CTestOutputHandler handler2;
         std::ostringstream outputStrm2;
-        core::CJsonOutputStreamWrapper wrappedOutputStream2(outputStrm2);
-        CJsonOutputWriter writer2("job", wrappedOutputStream2);
+        core::CJsonOutputStreamWrapper wrappedOutputStream2{outputStrm2};
 
-        CTestFieldDataCategorizer newCategorizer("job", config, limits2, handler2, writer2);
-        CTestDataSearcher restorer(origJson);
-        core_t::TTime time = 0;
+        CTestFieldDataCategorizer newCategorizer{"job", config, limits2,
+                                                 handler2, wrappedOutputStream2};
+        CTestDataSearcher restorer{origJson};
+        core_t::TTime time{0};
         newCategorizer.restoreState(restorer, time);
 
         CTestDataAdder adder;
         newCategorizer.persistStateInForeground(adder, "");
-        std::ostringstream& ss = dynamic_cast<std::ostringstream&>(*adder.getStream());
+        std::ostringstream& ss{dynamic_cast<std::ostringstream&>(*adder.getStream())};
         newJson = ss.str();
     }
     BOOST_REQUIRE_EQUAL(origJson, newJson);
@@ -344,10 +405,10 @@ BOOST_AUTO_TEST_CASE(testNodeReverseSearch) {
     std::ostringstream outputStrm;
     {
         CNullOutput nullOutput;
-        core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        CJsonOutputWriter writer("job", wrappedOutputStream);
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
+        CTestFieldDataCategorizer categorizer{"job", config, limits, nullOutput,
+                                              wrappedOutputStream};
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["message"] = "Node 1 started";
@@ -361,7 +422,7 @@ BOOST_AUTO_TEST_CASE(testNodeReverseSearch) {
         categorizer.finalise();
     }
 
-    const std::string& output = outputStrm.str();
+    const std::string& output{outputStrm.str()};
     LOG_DEBUG(<< "Output is: " << output);
 
     // Assert that the reverse search contains all expected tokens when
@@ -383,10 +444,10 @@ BOOST_AUTO_TEST_CASE(testJobKilledReverseSearch) {
     std::ostringstream outputStrm;
     {
         CNullOutput nullOutput;
-        core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        CJsonOutputWriter writer("job", wrappedOutputStream);
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
+        CTestFieldDataCategorizer categorizer{"job", config, limits, nullOutput,
+                                              wrappedOutputStream};
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["message"] = "[count_tweets] Killing job";
@@ -408,7 +469,7 @@ BOOST_AUTO_TEST_CASE(testJobKilledReverseSearch) {
         categorizer.finalise();
     }
 
-    const std::string& output = outputStrm.str();
+    const std::string& output{outputStrm.str()};
     LOG_DEBUG(<< "Output is: " << output);
 
     // Assert that the reverse search contains all expected tokens when
@@ -430,12 +491,12 @@ BOOST_AUTO_TEST_CASE(testPassOnControlMessages) {
     std::ostringstream outputStrm;
     {
         CNullOutput nullOutput;
-        core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        CJsonOutputWriter writer("job", wrappedOutputStream);
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-        CMockDataProcessor mockProcessor(nullOutput);
-        COutputChainer outputChainer(mockProcessor);
-        CTestFieldDataCategorizer categorizer("job", config, limits, outputChainer, writer);
+        CMockDataProcessor mockProcessor{nullOutput};
+        COutputChainer outputChainer{mockProcessor};
+        CTestFieldDataCategorizer categorizer{"job", config, limits,
+                                              outputChainer, wrappedOutputStream};
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["."] = "f7";
@@ -445,9 +506,9 @@ BOOST_AUTO_TEST_CASE(testPassOnControlMessages) {
         categorizer.finalise();
     }
 
-    const std::string& output = outputStrm.str();
+    const std::string& output{outputStrm.str()};
     LOG_DEBUG(<< "Output is: " << output);
-    BOOST_REQUIRE_EQUAL(std::string("[]"), output);
+    BOOST_REQUIRE_EQUAL("[]", output);
 }
 
 BOOST_AUTO_TEST_CASE(testHandleControlMessages) {
@@ -458,11 +519,10 @@ BOOST_AUTO_TEST_CASE(testHandleControlMessages) {
     std::ostringstream outputStrm;
     {
         CNullOutput nullOutput;
-        core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        CJsonOutputWriter writer("job", wrappedOutputStream);
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput,
-                                              writer, nullptr);
+        CTestFieldDataCategorizer categorizer{"job", config, limits, nullOutput,
+                                              wrappedOutputStream};
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["."] = "f7";
@@ -472,10 +532,9 @@ BOOST_AUTO_TEST_CASE(testHandleControlMessages) {
         categorizer.finalise();
     }
 
-    const std::string& output = outputStrm.str();
+    const std::string& output{outputStrm.str()};
     LOG_DEBUG(<< "Output is: " << output);
-    BOOST_REQUIRE_EQUAL(std::string::size_type(0),
-                        output.find("[{\"flush\":{\"id\":\"7\",\"last_finalized_bucket_end\":0}}"));
+    BOOST_REQUIRE_EQUAL(0, output.find("[{\"flush\":{\"id\":\"7\",\"last_finalized_bucket_end\":0}}"));
 }
 
 BOOST_AUTO_TEST_CASE(testRestoreStateFailsWithEmptyState) {
@@ -485,16 +544,15 @@ BOOST_AUTO_TEST_CASE(testRestoreStateFailsWithEmptyState) {
 
     std::ostringstream outputStrm;
     CNullOutput nullOutput;
-    core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-    CJsonOutputWriter writer("job", wrappedOutputStream);
-    CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer, nullptr);
+    core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
+    CTestFieldDataCategorizer categorizer{"job", config, limits, nullOutput, wrappedOutputStream};
 
-    core_t::TTime completeToTime(0);
+    core_t::TTime completeToTime{0};
     CEmptySearcher restoreSearcher;
     BOOST_TEST_REQUIRE(categorizer.restoreState(restoreSearcher, completeToTime) == false);
 }
 
-BOOST_AUTO_TEST_CASE(flushWritesOnlyChangedCategories) {
+BOOST_AUTO_TEST_CASE(testFlushWritesOnlyChangedCategories) {
     model::CLimits limits;
     CFieldConfig config;
     BOOST_TEST_REQUIRE(config.initFromFile("testfiles/new_persist_categorization.conf"));
@@ -502,10 +560,10 @@ BOOST_AUTO_TEST_CASE(flushWritesOnlyChangedCategories) {
     std::ostringstream outputStrm;
     {
         CNullOutput nullOutput;
-        core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        CJsonOutputWriter writer("job", wrappedOutputStream);
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
+        CTestFieldDataCategorizer categorizer{"job", config, limits, nullOutput,
+                                              wrappedOutputStream};
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["message"] = "Node 1 started";
@@ -521,37 +579,45 @@ BOOST_AUTO_TEST_CASE(flushWritesOnlyChangedCategories) {
         BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
         CFieldDataCategorizer::TStrStrUMap flush;
-        flush["."] = "f42";
+        flush["."] = "f1";
 
-        //! should write to the output buffer and the num_matches will end up being 2
         BOOST_TEST_REQUIRE(categorizer.handleRecord(flush));
 
         dataRowFields["message"] = "Node 2 started";
 
+        // This will not add a new example, as the message is exactly the
+        // same as a previous example.  So the number of matches for
+        // category_id 1 will increase to 3, but the category will not
+        // immediately be updated.
         BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
 
+        flush["."] = "f2";
+
+        // Should write the updated category_id 1 to the output again with
+        // num_matches: 3
         BOOST_TEST_REQUIRE(categorizer.handleRecord(flush));
     }
-    const std::string& output = outputStrm.str();
+    const std::string& output{outputStrm.str()};
     LOG_DEBUG(<< "Output is: " << output);
 
-    auto findOccurrences = [](const std::string& str, const std::string& substr) {
-        int occurrences = 0;
-        std::string::size_type start = 0;
-        while ((start = str.find(substr, start)) != std::string::npos) {
-            ++occurrences;
-            start += substr.length();
-        }
-        return occurrences;
-    };
-    //! Output should have category_id 1 3 times. 2 for the first two calls, and one for the flush
-    BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":1"), 3);
+    // Output should have a category definition for category_id 1 three times:
+    // two for the first two calls, and one for the flush
+    BOOST_REQUIRE_EQUAL(3, countOccurrences(output, "\"category_id\":1"));
 
-    //! Output should only have the initial persistence as it did not change after the flush
-    BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":2"), 1);
+    // Stats object on first flush should have been written when there were
+    // a total of 3 categorized messages
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":3"));
+
+    // Output should only have the initial write of category definition for
+    // category_id 2 as it did not change after the flush
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"category_id\":2"));
+
+    // Stats object on second flush should have been written when there were
+    // a total of 4 categorized messages
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":4"));
 }
 
-BOOST_AUTO_TEST_CASE(finalizeWritesOnlyChangedCategories) {
+BOOST_AUTO_TEST_CASE(testFinalizeWritesOnlyChangedCategories) {
     model::CLimits limits;
     CFieldConfig config;
     BOOST_TEST_REQUIRE(config.initFromFile("testfiles/new_persist_categorization.conf"));
@@ -559,10 +625,10 @@ BOOST_AUTO_TEST_CASE(finalizeWritesOnlyChangedCategories) {
     std::ostringstream outputStrm;
     {
         CNullOutput nullOutput;
-        core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-        CJsonOutputWriter writer("job", wrappedOutputStream);
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
 
-        CTestFieldDataCategorizer categorizer("job", config, limits, nullOutput, writer);
+        CTestFieldDataCategorizer categorizer{"job", config, limits, nullOutput,
+                                              wrappedOutputStream};
 
         CFieldDataCategorizer::TStrStrUMap dataRowFields;
         dataRowFields["message"] = "Node 1 started";
@@ -576,7 +642,6 @@ BOOST_AUTO_TEST_CASE(finalizeWritesOnlyChangedCategories) {
         dataRowFields["message"] = "Somethingelse my message";
 
         BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
-        categorizer.finalise();
 
         dataRowFields["message"] = "Node 2 started";
 
@@ -584,22 +649,192 @@ BOOST_AUTO_TEST_CASE(finalizeWritesOnlyChangedCategories) {
 
         categorizer.finalise();
     }
-    auto findOccurrences = [](const std::string& str, const std::string& substr) {
-        int occurrences = 0;
-        std::string::size_type start = 0;
-        while ((start = str.find(substr, start)) != std::string::npos) {
-            ++occurrences;
-            start += substr.length();
-        }
-        return occurrences;
-    };
-    const std::string& output = outputStrm.str();
+    const std::string& output{outputStrm.str()};
     LOG_DEBUG(<< "Output is: " << output);
-    //! Output should have category_id 1 3 times. 2 for the first two calls, and one for the finalize
-    BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":1"), 3);
 
-    //! Output should only have the initial persistence as it did not change after the finalize
-    BOOST_REQUIRE_EQUAL(findOccurrences(output, "\"category_id\":2"), 1);
+    // Output should have a category definition for category_id 1 three times:
+    // two for the first two calls, and one for the finalise
+    BOOST_REQUIRE_EQUAL(3, countOccurrences(output, "\"category_id\":1"));
+
+    // Output should only have the initial write of category definition for
+    // category_id 2 as it was completely up-to-date when finalise was called
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"category_id\":2"));
+
+    // Stats object on finalize should have been written when there were
+    // a total of 4 categorized messages
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":4"));
+}
+
+BOOST_AUTO_TEST_CASE(testWarnStatusCausesUrgentStatsWrite) {
+    model::CLimits limits;
+    CFieldConfig config;
+    BOOST_TEST_REQUIRE(config.initFromFile("testfiles/new_persist_categorization.conf"));
+
+    std::ostringstream outputStrm;
+    {
+        CNullOutput nullOutput;
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
+
+        CTestFieldDataCategorizer categorizer{"job", config, limits, nullOutput,
+                                              wrappedOutputStream};
+
+        CFieldDataCategorizer::TStrStrUMap dataRowFields;
+        dataRowFields["message"] = "Node 1 started";
+
+        // The 100th message should cause an urgent stats write with a
+        // categorization status of "warn".  This is because there is only one
+        // category, which is a red flag, but we don't report warning status
+        // until we've seen 100 messages.
+        for (std::size_t count = 1; count <= 101; ++count) {
+            BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
+        }
+
+        // This should cause another stats write, as the total number of messages
+        // categorized has increased to 101 since the previous stats write.
+        categorizer.finalise();
+    }
+    const std::string& output{outputStrm.str()};
+    LOG_DEBUG(<< "Output is: " << output);
+
+    // Output should have a category definition for category_id 1 twice:
+    // one for the first time it was seen, and another for the finalise
+    BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"category_id\":1"));
+
+    // Both stats objects should have categorization status warn
+    BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"categorization_status\":\"warn\""));
+
+    // One stats object should have 100 total count and the other 101
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":100"));
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":101"));
+
+    // We should have got an annotation on the change to "warn" status
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"annotation\":\"Categorization status changed to 'warn'\""));
+}
+
+BOOST_AUTO_TEST_CASE(testStopCategorizingOnWarnStatusSingleCategorizer) {
+    model::CLimits limits;
+    CFieldConfig config;
+    BOOST_TEST_REQUIRE(config.initFromFile("testfiles/new_persist_categorization.conf"));
+
+    std::ostringstream outputStrm;
+    {
+        CNullOutput nullOutput;
+        core::CJsonOutputStreamWrapper wrappedOutputStream{outputStrm};
+
+        CTestFieldDataCategorizer categorizer{
+            "job",   config, limits, nullOutput, wrappedOutputStream,
+            nullptr, true};
+
+        CFieldDataCategorizer::TStrStrUMap dataRowFields;
+        dataRowFields["message"] = "Node 1 started";
+
+        // The 100th message should cause the categorization status to change to
+        // "warn".  This is because there is only one category, which is a red
+        // flag, but we don't report warning status until we've seen 100
+        // messages.  Then we should stop categorizing, as we passed
+        // stop-on-warn=true to the constructor in this test.
+        for (std::size_t count = 1; count < 200; ++count) {
+            BOOST_TEST_REQUIRE(categorizer.handleRecord(dataRowFields));
+        }
+
+        categorizer.finalise();
+    }
+    const std::string& output{outputStrm.str()};
+    LOG_DEBUG(<< "Output is: " << output);
+
+    // Output should have a category definition for category_id 1 twice:
+    // one for the first time it was seen, and another for the finalise
+    BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"category_id\":1"));
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"num_matches\":1,"));
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"num_matches\":100"));
+
+    // The only stats object should have 100 total count and categorization
+    // status "warn"; the stats should not have changed again when finalise()
+    // was called because we should have stopped categorizing
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorization_status\":\"warn\""));
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":100"));
+
+    // We should have got an annotation on the change to "warn" status
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"annotation\":\"Categorization status changed to 'warn'\""));
+}
+
+BOOST_AUTO_TEST_CASE(testStopCategorizingOnWarnStatusPerPartition) {
+
+    // All these combinations of initial state and control message changes
+    // should result in the same behaviour
+    auto combinations = {std::tuple{true, false, false}, std::tuple{true, true, true},
+                         std::tuple{false, true, true}};
+    for (const auto& args : combinations) {
+        const std::string& output{setupPerPartitionStopOnWarnTest(
+            std::get<0>(args), std::get<1>(args), std::get<2>(args))};
+        LOG_DEBUG(<< "Output is: " << output);
+
+        // We should have a total of 21 categories, each written when they had a
+        // count of one
+        BOOST_REQUIRE_EQUAL(21, countOccurrences(output, "\"num_matches\":1,"));
+
+        // Output should have a category definition for category_id 1 twice:
+        // one for the first time it was seen, and another for the finalise
+        BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"category_id\":1,"));
+        BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"num_matches\":100"));
+
+        // The categories for partition "random but changing" should have also been
+        // updated on finalise()
+        BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"category_id\":21"));
+        BOOST_REQUIRE_EQUAL(20, countOccurrences(output, "\"num_matches\":10,"));
+
+        // The stats object for partition "nodes" should have 100 total count and
+        // categorization status "warn"; the stats should not have changed again
+        // when finalise() was called because we should have stopped categorizing
+        BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorization_status\":\"warn\""));
+        BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":100"));
+
+        // The stats object for partition "random but changing" should have 200
+        // total count and categorization status "ok"
+        BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorization_status\":\"ok\""));
+        BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":200"));
+
+        // We should have got an annotation on the change to "warn" status
+        BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"annotation\":\"Categorization status changed to 'warn' for 'event.dataset' 'nodes'\""));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testStopCategorizingOnWarnStatusPerPartitionDisabledByControlMessage) {
+
+    const std::string& output{setupPerPartitionStopOnWarnTest(true, true, false)};
+    LOG_DEBUG(<< "Output is: " << output);
+
+    // We should have a total of 21 categories, each written when they had a
+    // count of one
+    BOOST_REQUIRE_EQUAL(21, countOccurrences(output, "\"num_matches\":1,"));
+
+    // Output should have a category definition for category_id 1 twice:
+    // one for the first time it was seen, and another for the finalise
+    BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"category_id\":1,"));
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"num_matches\":200"));
+
+    // The categories for partition "random but changing" should have also been
+    // updated on finalise()
+    BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"category_id\":21"));
+    BOOST_REQUIRE_EQUAL(20, countOccurrences(output, "\"num_matches\":10,"));
+
+    // A stats object for partition "nodes" should have been written with 100
+    // total count and categorization status "warn"; the stats should have
+    // changed again when finalise() was called because we should have kept
+    // categorizing despite the "warn" status, due to the control message
+    // disabling stop-on-warn
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorized_doc_count\":100"));
+    BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"categorization_status\":\"warn\""));
+
+    // The stats object for partition "random but changing" should have
+    // categorization status "ok"
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"categorization_status\":\"ok\""));
+
+    // The final stats objects for both partitiosn should have 200 total count
+    BOOST_REQUIRE_EQUAL(2, countOccurrences(output, "\"categorized_doc_count\":200"));
+
+    // We should have got an annotation on the change to "warn" status
+    BOOST_REQUIRE_EQUAL(1, countOccurrences(output, "\"annotation\":\"Categorization status changed to 'warn' for 'event.dataset' 'nodes'\""));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/CRestorePreviousStateTest.cc
+++ b/lib/api/unittest/CRestorePreviousStateTest.cc
@@ -13,7 +13,7 @@
 
 #include <api/CCsvOutputWriter.h>
 #include <api/CFieldConfig.h>
-#include <api/CJsonOutputWriter.h>
+#include <api/CNullOutput.h>
 #include <api/CResultNormalizer.h>
 #include <api/CSingleStreamDataAdder.h>
 #include <api/CSingleStreamSearcher.h>
@@ -82,8 +82,9 @@ void categorizerRestoreHelper(const std::string& stateFile, bool isSymmetric) {
 
     std::ostringstream outputStrm;
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-    ml::api::CJsonOutputWriter writer("job", wrappedOutputStream);
-    CTestFieldDataCategorizer restoredCategorizer("job", config, limits, writer, writer);
+    ml::api::CNullOutput nullOutput;
+    CTestFieldDataCategorizer restoredCategorizer("job", config, limits,
+                                                  nullOutput, wrappedOutputStream);
 
     std::ifstream inputStrm(stateFile.c_str());
     BOOST_TEST_REQUIRE(inputStrm.is_open());

--- a/lib/api/unittest/CSingleStreamDataAdderTest.cc
+++ b/lib/api/unittest/CSingleStreamDataAdderTest.cc
@@ -16,7 +16,6 @@
 
 #include <api/CCsvInputParser.h>
 #include <api/CFieldConfig.h>
-#include <api/CJsonOutputWriter.h>
 #include <api/CNdJsonInputParser.h>
 #include <api/COutputChainer.h>
 #include <api/CSingleStreamDataAdder.h>
@@ -70,7 +69,6 @@ void detectorPersistHelper(const std::string& configFileName,
             BUCKET_SIZE, ml::model_t::E_None, "", BUCKET_SIZE * latencyBuckets, false);
 
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
-    ml::api::CJsonOutputWriter outputWriter(JOB_ID, wrappedOutputStream);
 
     std::string origSnapshotId;
     std::size_t numOrigDocs(0);
@@ -90,7 +88,7 @@ void detectorPersistHelper(const std::string& configFileName,
 
         // The categorizer knows how to assign categories to records
         CTestFieldDataCategorizer categorizer(JOB_ID, fieldConfig, limits,
-                                              outputChainer, outputWriter);
+                                              outputChainer, wrappedOutputStream);
 
         if (fieldConfig.fieldNameSuperset().count(
                 CTestFieldDataCategorizer::MLCATEGORY_NAME) > 0) {
@@ -139,7 +137,7 @@ void detectorPersistHelper(const std::string& configFileName,
 
         // The categorizer knows how to assign categories to records
         CTestFieldDataCategorizer restoredCategorizer(
-            JOB_ID, fieldConfig, limits, restoredOutputChainer, outputWriter);
+            JOB_ID, fieldConfig, limits, restoredOutputChainer, wrappedOutputStream);
 
         size_t numCategorizerDocs(0);
 

--- a/lib/api/unittest/CTestFieldDataCategorizer.cc
+++ b/lib/api/unittest/CTestFieldDataCategorizer.cc
@@ -5,36 +5,42 @@
  */
 #include "CTestFieldDataCategorizer.h"
 
-CTestFieldDataCategorizer::CTestFieldDataCategorizer(const std::string& jobId,
-                                                     const ml::api::CFieldConfig& config,
-                                                     ml::model::CLimits& limits,
-                                                     ml::api::COutputHandler& outputHandler,
-                                                     ml::api::CJsonOutputWriter& jsonOutputWriter,
-                                                     ml::api::CPersistenceManager* persistenceManager)
-    : ml::api::CFieldDataCategorizer(jobId,
+CTestFieldDataCategorizer::CTestFieldDataCategorizer(
+    const std::string& jobId,
+    const ml::api::CFieldConfig& config,
+    ml::model::CLimits& limits,
+    ml::api::COutputHandler& outputHandler,
+    ml::core::CJsonOutputStreamWrapper& outputStream,
+    ml::api::CPersistenceManager* persistenceManager,
+    bool stopCategorizationOnWarnStatus)
+    : ml::api::CFieldDataCategorizer{jobId,
                                      config,
                                      limits,
                                      std::string(),
                                      std::string(),
                                      outputHandler,
-                                     jsonOutputWriter,
-                                     persistenceManager) {
+                                     outputStream,
+                                     persistenceManager,
+                                     stopCategorizationOnWarnStatus} {
 }
 
-CTestFieldDataCategorizer::CTestFieldDataCategorizer(const std::string& jobId,
-                                                     const ml::api::CFieldConfig& config,
-                                                     ml::model::CLimits& limits,
-                                                     const std::string& timeFieldName,
-                                                     const std::string& timeFieldFormat,
-                                                     ml::api::COutputHandler& outputHandler,
-                                                     ml::api::CJsonOutputWriter& jsonOutputWriter,
-                                                     ml::api::CPersistenceManager* persistenceManager)
-    : ml::api::CFieldDataCategorizer(jobId,
+CTestFieldDataCategorizer::CTestFieldDataCategorizer(
+    const std::string& jobId,
+    const ml::api::CFieldConfig& config,
+    ml::model::CLimits& limits,
+    const std::string& timeFieldName,
+    const std::string& timeFieldFormat,
+    ml::api::COutputHandler& outputHandler,
+    ml::core::CJsonOutputStreamWrapper& outputStream,
+    ml::api::CPersistenceManager* persistenceManager,
+    bool stopCategorizationOnWarnStatus)
+    : ml::api::CFieldDataCategorizer{jobId,
                                      config,
                                      limits,
                                      timeFieldName,
                                      timeFieldFormat,
                                      outputHandler,
-                                     jsonOutputWriter,
-                                     persistenceManager) {
+                                     outputStream,
+                                     persistenceManager,
+                                     stopCategorizationOnWarnStatus} {
 }

--- a/lib/api/unittest/CTestFieldDataCategorizer.h
+++ b/lib/api/unittest/CTestFieldDataCategorizer.h
@@ -27,8 +27,9 @@ public:
                               const ml::api::CFieldConfig& config,
                               ml::model::CLimits& limits,
                               ml::api::COutputHandler& outputHandler,
-                              ml::api::CJsonOutputWriter& jsonOutputWriter,
-                              ml::api::CPersistenceManager* persistenceManager = nullptr);
+                              ml::core::CJsonOutputStreamWrapper& outputStream,
+                              ml::api::CPersistenceManager* persistenceManager = nullptr,
+                              bool stopCategorizationOnWarnStatus = false);
 
     CTestFieldDataCategorizer(const std::string& jobId,
                               const ml::api::CFieldConfig& config,
@@ -36,8 +37,9 @@ public:
                               const std::string& timeFieldName,
                               const std::string& timeFieldFormat,
                               ml::api::COutputHandler& outputHandler,
-                              ml::api::CJsonOutputWriter& jsonOutputWriter,
-                              ml::api::CPersistenceManager* persistenceManager = nullptr);
+                              ml::core::CJsonOutputStreamWrapper& outputStream,
+                              ml::api::CPersistenceManager* persistenceManager = nullptr,
+                              bool stopCategorizationOnWarnStatus = false);
 
     //! Bring base class overload of handleRecord() into scope
     using CFieldDataCategorizer::handleRecord;

--- a/lib/model/CAnnotation.cc
+++ b/lib/model/CAnnotation.cc
@@ -8,10 +8,14 @@
 namespace ml {
 namespace model {
 namespace {
+// These strings must correspond exactly to lowercased values of the Event enum
+// of org.elasticsearch.xpack.core.ml.annotations.Annotation in the Java code.
 const std::string EVENT_MODEL_CHANGE{"model_change"};
+const std::string EVENT_CATEGORIZATION_STATUS_CHANGE{"categorization_status_change"};
 }
 
 CAnnotation::CAnnotation(core_t::TTime time,
+                         EEvent event,
                          const std::string& annotation,
                          int detectorIndex,
                          const std::string& partitionFieldName,
@@ -20,10 +24,10 @@ CAnnotation::CAnnotation(core_t::TTime time,
                          const std::string& overFieldValue,
                          const std::string& byFieldName,
                          const std::string& byFieldValue)
-    : m_Time{time}, m_Annotation{annotation}, m_DetectorIndex{detectorIndex},
-      m_PartitionFieldName{partitionFieldName}, m_PartitionFieldValue{partitionFieldValue},
-      m_OverFieldName{overFieldName}, m_OverFieldValue{overFieldValue},
-      m_ByFieldName{byFieldName}, m_ByFieldValue{byFieldValue} {
+    : m_Time{time}, m_Event{event}, m_Annotation{annotation},
+      m_DetectorIndex{detectorIndex}, m_PartitionFieldName{partitionFieldName},
+      m_PartitionFieldValue{partitionFieldValue}, m_OverFieldName{overFieldName},
+      m_OverFieldValue{overFieldValue}, m_ByFieldName{byFieldName}, m_ByFieldValue{byFieldValue} {
 }
 
 core_t::TTime CAnnotation::time() const {
@@ -35,7 +39,12 @@ const std::string& CAnnotation::annotation() const {
 }
 
 const std::string& CAnnotation::event() const {
-    // If we start reporting some other event type, we should return m_Event instead of a constant here.
+    switch (m_Event) {
+    case E_ModelChange:
+        return EVENT_MODEL_CHANGE;
+    case E_CategorizationStatusChange:
+        return EVENT_CATEGORIZATION_STATUS_CHANGE;
+    }
     return EVENT_MODEL_CHANGE;
 }
 

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -335,7 +335,8 @@ void CEventRateModel::sample(core_t::TTime startTime,
                     const auto modelAnnotationCallback =
                         [&](core_t::TTime t, const std::string& annotation) {
                             m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
+                                t, CAnnotation::E_ModelChange, annotation,
+                                gatherer.searchKey().detectorIndex(),
                                 gatherer.searchKey().partitionFieldName(),
                                 gatherer.partitionFieldValue(),
                                 gatherer.searchKey().overFieldName(),

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -472,7 +472,8 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                     const auto modelAnnotationCallback =
                         [&](core_t::TTime t, const std::string& annotation) {
                             m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
+                                t, CAnnotation::E_ModelChange, annotation,
+                                gatherer.searchKey().detectorIndex(),
                                 gatherer.searchKey().partitionFieldName(),
                                 gatherer.partitionFieldValue(),
                                 gatherer.searchKey().overFieldName(),

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -318,7 +318,8 @@ void CMetricModel::sample(core_t::TTime startTime,
                     const auto modelAnnotationCallback =
                         [&](core_t::TTime t, const std::string& annotation) {
                             m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
+                                t, CAnnotation::E_ModelChange, annotation,
+                                gatherer.searchKey().detectorIndex(),
                                 gatherer.searchKey().partitionFieldName(),
                                 gatherer.partitionFieldValue(),
                                 gatherer.searchKey().overFieldName(),

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -469,7 +469,8 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                     const auto modelAnnotationCallback =
                         [&](core_t::TTime t, const std::string& annotation) {
                             m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
+                                t, CAnnotation::E_ModelChange, annotation,
+                                gatherer.searchKey().detectorIndex(),
                                 gatherer.searchKey().partitionFieldName(),
                                 gatherer.partitionFieldValue(),
                                 gatherer.searchKey().overFieldName(),

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -429,23 +429,31 @@ void CTokenListDataCategorizerBase::addCategoryMatch(bool isDryRun,
     bool wasCountRare{this->isCategoryCountRare(count)};
     ++count;
     ++m_TotalCount;
-    if (wasCountRare && this->isCategoryCountRare(count) == false) {
-        --m_NumRareCategories;
+    bool isCountRare{this->isCategoryCountRare(count)};
+    if (isCountRare != wasCountRare) {
+        if (isCountRare) {
+            ++m_NumRareCategories;
+        } else {
+            --m_NumRareCategories;
+        }
     }
 
     // Search backwards for the point where the incremented count belongs
-    auto swapIter = m_CategoriesByCount.end();
-    while (iter != m_CategoriesByCount.begin()) {
-        --iter;
-        if (count <= iter->first) {
+    auto swapIter = iter;
+    while (swapIter != m_CategoriesByCount.begin()) {
+        --swapIter;
+        if (count <= swapIter->first) {
+            // Move the changed category as little as possible - if its
+            // incremented count is equal to another category's count then
+            // leave that other category nearer the beginning of the vector
+            ++swapIter;
             break;
         }
-        swapIter = iter;
     }
 
     // Move the iterator we've matched nearer the front of the list if it
     // deserves this
-    if (swapIter != m_CategoriesByCount.end()) {
+    if (swapIter != iter) {
         std::iter_swap(swapIter, iter);
     }
 }

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -18,8 +18,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <sstream>
+#include <vector>
 
 BOOST_AUTO_TEST_SUITE(CTokenListDataCategorizerTest)
 
@@ -97,8 +99,8 @@ private:
 };
 
 BOOST_FIXTURE_TEST_CASE(testHexData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, "[0x0000000800000000 ", 500));
@@ -115,8 +117,8 @@ BOOST_FIXTURE_TEST_CASE(testHexData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testRmdsData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has shut down.",
@@ -153,8 +155,8 @@ BOOST_FIXTURE_TEST_CASE(testRmdsData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testProxyData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false,
@@ -192,8 +194,8 @@ BOOST_FIXTURE_TEST_CASE(testProxyData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testFxData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false,
@@ -212,8 +214,8 @@ BOOST_FIXTURE_TEST_CASE(testFxData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testApacheData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, " org.apache.coyote.http11.Http11BaseProtocol destroy",
@@ -232,8 +234,8 @@ BOOST_FIXTURE_TEST_CASE(testApacheData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testBrokerageData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(
@@ -262,8 +264,8 @@ BOOST_FIXTURE_TEST_CASE(testBrokerageData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testVmwareData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
@@ -288,8 +290,8 @@ BOOST_FIXTURE_TEST_CASE(testVmwareData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testBankData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false,
@@ -314,8 +316,8 @@ BOOST_FIXTURE_TEST_CASE(testBankData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testJavaGcData, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(
@@ -383,8 +385,8 @@ BOOST_FIXTURE_TEST_CASE(testJavaGcData, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields origCategorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields origCategorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     origCategorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has shut down.",
                                     500);
@@ -409,7 +411,7 @@ BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
 
     std::string origXml;
     {
-        ml::core::CRapidXmlStatePersistInserter inserter("root");
+        ml::core::CRapidXmlStatePersistInserter inserter{"root"};
         origCategorizer.acceptPersistInserter(inserter);
         inserter.toXml(origXml);
     }
@@ -417,12 +419,12 @@ BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
     LOG_DEBUG(<< "Categorizer XML representation:\n" << origXml);
 
     // Restore the XML into a new categorizer
-    TTokenListDataCategorizerKeepsFields restoredCategorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields restoredCategorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
     {
         ml::core::CRapidXmlParser parser;
         BOOST_TEST_REQUIRE(parser.parseStringIgnoreCdata(origXml));
-        ml::core::CRapidXmlStateRestoreTraverser traverser(parser);
+        ml::core::CRapidXmlStateRestoreTraverser traverser{parser};
         BOOST_TEST_REQUIRE(traverser.traverseSubLevel(
             std::bind(&TTokenListDataCategorizerKeepsFields::acceptRestoreTraverser,
                       &restoredCategorizer, std::placeholders::_1)));
@@ -442,16 +444,16 @@ BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testLongReverseSearch, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields::TTokenListReverseSearchCreatorCPtr reverseSearchCreator(
-        new ml::model::CTokenListReverseSearchCreator("_raw"));
-    TTokenListDataCategorizerKeepsFields categorizer(m_Limits, reverseSearchCreator,
-                                                     0.7, "_raw");
+    TTokenListDataCategorizerKeepsFields::TTokenListReverseSearchCreatorCPtr reverseSearchCreator{
+        new ml::model::CTokenListReverseSearchCreator{"_raw"}};
+    TTokenListDataCategorizerKeepsFields categorizer{m_Limits, reverseSearchCreator,
+                                                     0.7, "_raw"};
 
     // Create a long message with lots of junk that will create a ridiculous
     // reverse search if not constrained
     std::string longMessage("a few dictionary words to start off");
-    for (size_t i = 1; i < 26; ++i) {
-        for (size_t j = 0; j <= i; ++j) {
+    for (std::size_t i = 1; i < 26; ++i) {
+        for (std::size_t j = 0; j <= i; ++j) {
             longMessage += ' ';
             longMessage.append(20, char('a' + j));
         }
@@ -501,8 +503,8 @@ BOOST_FIXTURE_TEST_CASE(testLongReverseSearch, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testPreTokenised, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has shut down.",
@@ -569,18 +571,18 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenised, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
-    static const size_t TEST_SIZE(100000);
+    static const std::size_t TEST_SIZE{100000};
     ml::core::CStopWatch stopWatch;
 
-    uint64_t inlineTokenisationTime(0);
+    std::uint64_t inlineTokenisationTime{0};
     {
-        TTokenListDataCategorizerKeepsFields categorizer(
-            m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+        TTokenListDataCategorizerKeepsFields categorizer{
+            m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
         LOG_DEBUG(<< "Before test with inline tokenisation");
 
         stopWatch.start();
-        for (size_t count = 0; count < TEST_SIZE; ++count) {
+        for (std::size_t count = 0; count < TEST_SIZE; ++count) {
             BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                                 categorizer.computeCategory(false, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
                                                             103));
@@ -597,15 +599,15 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
     fields[TTokenListDataCategorizerKeepsFields::PRETOKENISED_TOKEN_FIELD] =
         "Vpxa,verbose,VpxaHalCnxHostagent,opID,WFU-ddeadb59,WaitForUpdatesDone,Received,callback";
 
-    uint64_t preTokenisationTime(0);
+    std::uint64_t preTokenisationTime{0};
     {
-        TTokenListDataCategorizerKeepsFields categorizer(
-            m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+        TTokenListDataCategorizerKeepsFields categorizer{
+            m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
         LOG_DEBUG(<< "Before test with pre-tokenisation");
 
         stopWatch.start();
-        for (size_t count = 0; count < TEST_SIZE; ++count) {
+        for (std::size_t count = 0; count < TEST_SIZE; ++count) {
             BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                                 categorizer.computeCategory(false, fields, "Vpxa: [49EC0B90 verbose 'VpxaHalCnxHostagent' opID=WFU-ddeadb59] [WaitForUpdatesDone] Received callback",
                                                             103));
@@ -617,7 +619,7 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
     }
 
     const char* keepGoingEnvVar{std::getenv("ML_KEEP_GOING")};
-    bool likelyInCi = (keepGoingEnvVar != nullptr && *keepGoingEnvVar != '\0');
+    bool likelyInCi{keepGoingEnvVar != nullptr && *keepGoingEnvVar != '\0'};
     if (likelyInCi) {
         // CI is most likely running on a VM, and this test can fail quite often
         // due to the VM stalling or being slowed down by noisy neighbours
@@ -628,8 +630,8 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, "2015-10-18 18:01:51,963 INFO [main] org.mortbay.log: jetty-6.1.26\r",
@@ -673,8 +675,8 @@ BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testSoftMemoryLimit, CTestFixture) {
 
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     std::string baseMessage{"foo bar baz "};
     std::string message{baseMessage + makeUniqueToken()};
@@ -731,8 +733,8 @@ BOOST_FIXTURE_TEST_CASE(testHardMemoryLimit, CTestFixture) {
     // Set memory limit to 1MB so that it's quickly exhausted
     m_Limits.resourceMonitor().memoryLimit(1);
 
-    TTokenListDataCategorizerKeepsFields categorizer(
-        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
 
     std::string nextMessage{makeUniqueMessage(10)};
     ml::model::CLocalCategoryId categoryId;
@@ -747,6 +749,127 @@ BOOST_FIXTURE_TEST_CASE(testHardMemoryLimit, CTestFixture) {
         m_Limits.resourceMonitor().refresh(categorizer);
     }
     BOOST_TEST_REQUIRE(categoryId.isHardFailure());
+}
+
+BOOST_FIXTURE_TEST_CASE(testStatsWriteUrgentDueToRareCategories, CTestFixture) {
+
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
+
+    // If more than 90% of categories are found to be rare after we have
+    // categorized 100 messages then that should trigger categorization status
+    // "warn" and an urgent stats write.  (We must be careful not to cause the
+    // categorization status to flip to "warn" earlier due to only having one
+    // category in the build up.)
+
+    std::string baseMessage{makeUniqueToken() + ' '};
+    std::string frequentMessage1{baseMessage + makeUniqueToken()};
+    std::string frequentMessage2{baseMessage + makeUniqueToken()};
+    for (std::size_t i = 0; i < 50; ++i) {
+        BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                            categorizer.computeCategory(false, frequentMessage1,
+                                                        frequentMessage1.length()));
+        BOOST_REQUIRE_EQUAL(false, categorizer.isStatsWriteUrgent());
+        BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                            categorizer.computeCategory(false, frequentMessage2,
+                                                        frequentMessage2.length()));
+    }
+
+    // 2 frequent categories and 19 rare categories makes for more than 90% rare
+    for (std::size_t i = 0; i < 19; ++i) {
+        BOOST_REQUIRE_EQUAL(false, categorizer.isStatsWriteUrgent());
+        std::string rareMessage{baseMessage + makeUniqueToken()};
+        BOOST_REQUIRE_EQUAL(
+            ml::model::CLocalCategoryId{3 + static_cast<int>(i)},
+            categorizer.computeCategory(false, rareMessage, rareMessage.length()));
+    }
+
+    BOOST_REQUIRE_EQUAL(true, categorizer.isStatsWriteUrgent());
+
+    ml::model::SCategorizerStats categorizerStats;
+    categorizer.updateCategorizerStats(categorizerStats);
+    BOOST_REQUIRE_EQUAL(119, categorizerStats.s_CategorizedMessages);
+    BOOST_REQUIRE_EQUAL(21, categorizerStats.s_TotalCategories);
+    BOOST_REQUIRE_EQUAL(2, categorizerStats.s_FrequentCategories);
+    BOOST_REQUIRE_EQUAL(19, categorizerStats.s_RareCategories);
+    BOOST_REQUIRE_EQUAL(0, categorizerStats.s_DeadCategories);
+    BOOST_REQUIRE_EQUAL(0, categorizerStats.s_MemoryCategorizationFailures);
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        categorizerStats.s_CategorizationStatus);
+}
+
+BOOST_FIXTURE_TEST_CASE(testStatsWriteUrgentDueToSingleCategory, CTestFixture) {
+
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
+
+    // If there is only 1 category after we have categorized 100 messages then
+    // that should trigger categorization status "warn" and an urgent stats
+    // write.
+
+    std::string singleMessage{makeUniqueMessage(3)};
+    for (std::size_t i = 0; i < 100; ++i) {
+        BOOST_REQUIRE_EQUAL(false, categorizer.isStatsWriteUrgent());
+        BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                            categorizer.computeCategory(false, singleMessage,
+                                                        singleMessage.length()));
+    }
+
+    // This is the first time we have 100 messages for the check
+    BOOST_REQUIRE_EQUAL(true, categorizer.isStatsWriteUrgent());
+
+    ml::model::SCategorizerStats categorizerStats;
+    categorizer.updateCategorizerStats(categorizerStats);
+    BOOST_REQUIRE_EQUAL(100, categorizerStats.s_CategorizedMessages);
+    BOOST_REQUIRE_EQUAL(1, categorizerStats.s_TotalCategories);
+    BOOST_REQUIRE_EQUAL(1, categorizerStats.s_FrequentCategories);
+    BOOST_REQUIRE_EQUAL(0, categorizerStats.s_RareCategories);
+    BOOST_REQUIRE_EQUAL(0, categorizerStats.s_DeadCategories);
+    BOOST_REQUIRE_EQUAL(0, categorizerStats.s_MemoryCategorizationFailures);
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        categorizerStats.s_CategorizationStatus);
+}
+
+BOOST_FIXTURE_TEST_CASE(testStatsWriteUrgentDueToManyCategories, CTestFixture) {
+
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
+
+    // If the number of categories is more than half the number of messages
+    // after we have categorized 100 messages then that should trigger
+    // categorization status "warn" and an urgent stats write.
+
+    using TStrVec = std::vector<std::string>;
+    TStrVec messages{51};
+    std::generate(messages.begin(), messages.end(),
+                  [this]() { return makeUniqueMessage(3); });
+
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 50; ++j) {
+            BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{j},
+                                categorizer.computeCategory(false, messages[j],
+                                                            messages[j].length()));
+            BOOST_REQUIRE_EQUAL(false, categorizer.isStatsWriteUrgent());
+        }
+    }
+
+    // After this we'll have 51 categories from 101 messages, so the number of
+    // categories is more than 50% of the number of messages
+    BOOST_REQUIRE_EQUAL(
+        ml::model::CLocalCategoryId{51},
+        categorizer.computeCategory(false, messages[50], messages[50].length()));
+    BOOST_REQUIRE_EQUAL(true, categorizer.isStatsWriteUrgent());
+
+    ml::model::SCategorizerStats categorizerStats;
+    categorizer.updateCategorizerStats(categorizerStats);
+    BOOST_REQUIRE_EQUAL(101, categorizerStats.s_CategorizedMessages);
+    BOOST_REQUIRE_EQUAL(51, categorizerStats.s_TotalCategories);
+    BOOST_REQUIRE_EQUAL(50, categorizerStats.s_FrequentCategories);
+    BOOST_REQUIRE_EQUAL(1, categorizerStats.s_RareCategories);
+    BOOST_REQUIRE_EQUAL(0, categorizerStats.s_DeadCategories);
+    BOOST_REQUIRE_EQUAL(0, categorizerStats.s_MemoryCategorizationFailures);
+    BOOST_REQUIRE_EQUAL(ml::model_t::E_CategorizationStatusWarn,
+                        categorizerStats.s_CategorizationStatus);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change adds:

1. More frequent writes of categorization stats - categorizers
   now know when it's "urgent" that they update their stats,
   which is basically when their status has just changed to
   "warn".
2. Caching of some of the values used to determine whether a
   categorizer's status is "warn".  This is important because
   we now calculate this a lot more frequently, to know whether
   stats writes are "urgent".
3. Functionality to stop categorizing on "warn" status, if the
   corresponding option is set.  The option can be set by a
   command line argument when the program is started, or by a
   control message while it is running.