### PR TITLE
Format time period in model change annotation using CTimeUtils::durationToString

### DIFF
--- a/include/core/CTimeUtils.h
+++ b/include/core/CTimeUtils.h
@@ -71,6 +71,7 @@ public:
     //! whitespace before calling this function.
     static bool isDateWord(const std::string& word);
 
+    //! Formats the given duration as human-readable string.
     static std::string durationToString(core_t::TTime duration);
 
 private:

--- a/include/core/CTimeUtils.h
+++ b/include/core/CTimeUtils.h
@@ -71,6 +71,8 @@ public:
     //! whitespace before calling this function.
     static bool isDateWord(const std::string& word);
 
+    static std::string durationToString(core_t::TTime duration);
+
 private:
     //! Factor out common code from the three string conversion methods
     static void toStringCommon(core_t::TTime t, const std::string& format, std::string& result);

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -156,21 +156,19 @@ std::string CTimeUtils::durationToString(core_t::TTime duration) {
     duration -= hours * constants::HOUR;
     core_t::TTime minutes = duration / constants::MINUTE;
     duration -= minutes * constants::MINUTE;
-    bool seenNonZero = false;
     std::string res;
-    if (seenNonZero || days > 0) {
+    if (days > 0) {
         res += std::to_string(days) + "d";
-        seenNonZero = true;
     }
-    if (seenNonZero || hours > 0) {
+    if (hours > 0) {
         res += std::to_string(hours) + "h";
-        seenNonZero = true;
     }
-    if (seenNonZero || minutes > 0) {
+    if (minutes > 0) {
         res += std::to_string(minutes) + "m";
-        seenNonZero = true;
     }
-    res += std::to_string(duration) + "s";
+    if ((duration > 0) || res.empty()) {
+        res += std::to_string(duration) + "s";
+    }
     return res;
 }
 

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -10,6 +10,7 @@
 #include <core/CStrFTime.h>
 #include <core/CStrPTime.h>
 #include <core/CTimezone.h>
+#include <core/Constants.h>
 #include <core/CoreTypes.h>
 
 #include <chrono>
@@ -146,6 +147,31 @@ void CTimeUtils::toStringCommon(core_t::TTime t, const std::string& format, std:
 
 bool CTimeUtils::isDateWord(const std::string& word) {
     return CDateWordCache::instance().isDateWord(word);
+}
+
+std::string CTimeUtils::durationToString(core_t::TTime duration) {
+    core_t::TTime days = duration / constants::DAY;
+    duration -= days * constants::DAY;
+    core_t::TTime hours = duration / constants::HOUR;
+    duration -= hours * constants::HOUR;
+    core_t::TTime minutes = duration / constants::MINUTE;
+    duration -= minutes * constants::MINUTE;
+    bool seenNonZero = false;
+    std::string res;
+    if (seenNonZero || days > 0) {
+        res += std::to_string(days) + "d";
+        seenNonZero = true;
+    }
+    if (seenNonZero || hours > 0) {
+        res += std::to_string(hours) + "h";
+        seenNonZero = true;
+    }
+    if (seenNonZero || minutes > 0) {
+        res += std::to_string(minutes) + "m";
+        seenNonZero = true;
+    }
+    res += std::to_string(duration) + "s";
+    return res;
 }
 
 // Initialise statics for the inner class CDateWordCache

--- a/lib/core/unittest/CTimeUtilsTest.cc
+++ b/lib/core/unittest/CTimeUtilsTest.cc
@@ -488,4 +488,25 @@ BOOST_AUTO_TEST_CASE(testDateWords) {
     BOOST_TEST_REQUIRE(!ml::core::CTimeUtils::isDateWord(" \t"));
 }
 
+BOOST_AUTO_TEST_CASE(testDurationToString) {
+    ml::core_t::TTime s = 1;
+    ml::core_t::TTime m = 60 * s;
+    ml::core_t::TTime h = 60 * m;
+    ml::core_t::TTime d = 24 * h;
+    BOOST_REQUIRE_EQUAL("0s", ml::core::CTimeUtils::durationToString(0));
+    BOOST_REQUIRE_EQUAL("1s", ml::core::CTimeUtils::durationToString(s));
+    BOOST_REQUIRE_EQUAL("1m0s", ml::core::CTimeUtils::durationToString(m));
+    BOOST_REQUIRE_EQUAL("1h0m0s", ml::core::CTimeUtils::durationToString(h));
+    BOOST_REQUIRE_EQUAL("1d0h0m0s", ml::core::CTimeUtils::durationToString(d));
+    BOOST_REQUIRE_EQUAL("1m1s", ml::core::CTimeUtils::durationToString(m + s));
+    BOOST_REQUIRE_EQUAL("1h1m0s", ml::core::CTimeUtils::durationToString(h + m));
+    BOOST_REQUIRE_EQUAL("1h0m1s", ml::core::CTimeUtils::durationToString(h + s));
+    BOOST_REQUIRE_EQUAL("1h1m1s", ml::core::CTimeUtils::durationToString(h + m + s));
+    BOOST_REQUIRE_EQUAL("1d1h1m1s", ml::core::CTimeUtils::durationToString(d + h + m + s));
+    BOOST_REQUIRE_EQUAL("7d12h0m0s",
+                        ml::core::CTimeUtils::durationToString(7 * d + 12 * h));
+    BOOST_REQUIRE_EQUAL("365d5h48m46s", ml::core::CTimeUtils::durationToString(
+                                            365 * d + 5 * h + 48 * m + 46 * s));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/unittest/CTimeUtilsTest.cc
+++ b/lib/core/unittest/CTimeUtilsTest.cc
@@ -495,16 +495,15 @@ BOOST_AUTO_TEST_CASE(testDurationToString) {
     ml::core_t::TTime d = 24 * h;
     BOOST_REQUIRE_EQUAL("0s", ml::core::CTimeUtils::durationToString(0));
     BOOST_REQUIRE_EQUAL("1s", ml::core::CTimeUtils::durationToString(s));
-    BOOST_REQUIRE_EQUAL("1m0s", ml::core::CTimeUtils::durationToString(m));
-    BOOST_REQUIRE_EQUAL("1h0m0s", ml::core::CTimeUtils::durationToString(h));
-    BOOST_REQUIRE_EQUAL("1d0h0m0s", ml::core::CTimeUtils::durationToString(d));
+    BOOST_REQUIRE_EQUAL("1m", ml::core::CTimeUtils::durationToString(m));
+    BOOST_REQUIRE_EQUAL("1h", ml::core::CTimeUtils::durationToString(h));
+    BOOST_REQUIRE_EQUAL("1d", ml::core::CTimeUtils::durationToString(d));
     BOOST_REQUIRE_EQUAL("1m1s", ml::core::CTimeUtils::durationToString(m + s));
-    BOOST_REQUIRE_EQUAL("1h1m0s", ml::core::CTimeUtils::durationToString(h + m));
-    BOOST_REQUIRE_EQUAL("1h0m1s", ml::core::CTimeUtils::durationToString(h + s));
+    BOOST_REQUIRE_EQUAL("1h1m", ml::core::CTimeUtils::durationToString(h + m));
+    BOOST_REQUIRE_EQUAL("1h1s", ml::core::CTimeUtils::durationToString(h + s));
     BOOST_REQUIRE_EQUAL("1h1m1s", ml::core::CTimeUtils::durationToString(h + m + s));
     BOOST_REQUIRE_EQUAL("1d1h1m1s", ml::core::CTimeUtils::durationToString(d + h + m + s));
-    BOOST_REQUIRE_EQUAL("7d12h0m0s",
-                        ml::core::CTimeUtils::durationToString(7 * d + 12 * h));
+    BOOST_REQUIRE_EQUAL("7d12h", ml::core::CTimeUtils::durationToString(7 * d + 12 * h));
     BOOST_REQUIRE_EQUAL("365d5h48m46s", ml::core::CTimeUtils::durationToString(
                                             365 * d + 5 * h + 48 * m + 46 * s));
 }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -12,6 +12,7 @@
 #include <core/CPersistUtils.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
+#include <core/CTimeUtils.h>
 #include <core/CTimezone.h>
 #include <core/Constants.h>
 #include <core/RestoreMacros.h>
@@ -1564,8 +1565,9 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
                              return component.time().excludes(*seasonalTime);
                          }) == components.end()) {
             LOG_DEBUG(<< "Detected '" << candidate.s_Description << "'");
-            m_ModelAnnotationCallback(time, "Detected periodicity with period " +
-                                                std::to_string(candidate.s_Period));
+            m_ModelAnnotationCallback(
+                time, "Detected periodicity with period " +
+                          core::CTimeUtils::durationToString(candidate.s_Period));
             newComponents.emplace_back(std::move(seasonalTime), candidate.s_PiecewiseScaled);
         }
     }


### PR DESCRIPTION
This PR makes time period used in model change annotation formatted using newly introduced `CTimeUtils::durationToString`.
The goal is to make the annotation text human-readable.

Relates https://github.com/elastic/elasticsearch/issues/55781