### PR TITLE
[ML] Don't require time is supplied when adding an annotation

### DIFF
--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -138,9 +138,8 @@ private:
     const TDouble2VecWeightsAryVec* m_TrendWeights = nullptr;
     //! The prior sample weights.
     const TDouble2VecWeightsAryVec* m_PriorWeights = nullptr;
-    //! The model change callback.
-    maths_t::TModelAnnotationCallback m_ModelAnnotationCallback =
-        [](core_t::TTime, const std::string&) {};
+    //! The add annotation callback.
+    maths_t::TModelAnnotationCallback m_ModelAnnotationCallback = [](const std::string&) {};
 };
 
 //! \brief The extra parameters needed by CModel::probability.

--- a/include/maths/CTimeSeriesDecomposition.h
+++ b/include/maths/CTimeSeriesDecomposition.h
@@ -104,9 +104,11 @@ public:
     //! \param[in] weights The weights of \p value. The smaller
     //! the count weight the less influence \p value has on the trend
     //! and it's local variance.
-    //! \param[in] componentChangeCallback Called if the components
-    //! change as a result of adding the data point.
-    //! \param[in] modelAnnotationCallback Called if the model changes as a result of adding the data point.
+    //! \param[in] componentChangeCallback Supplied with prediction
+    //! residuals if a new component is added as a result of adding the
+    //! data point.
+    //! \param[in] modelAnnotationCallback Supplied with an annotation
+    //! if a new component is added as a result of adding the data point.
     virtual void
     addPoint(core_t::TTime time,
              double value,

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -769,13 +769,12 @@ public:
         std::size_t maxSize() const;
 
         //! Add new seasonal components to \p components.
-        bool addSeasonalComponents(core_t::TTime time,
-                                   const CPeriodicityHypothesisTestsResult& result,
+        bool addSeasonalComponents(const CPeriodicityHypothesisTestsResult& result,
                                    const CExpandingWindow& window,
                                    const TPredictor& predictor);
 
         //! Add a new calendar component to \p components.
-        bool addCalendarComponent(const CCalendarFeature& feature, core_t::TTime time);
+        bool addCalendarComponent(const CCalendarFeature& feature);
 
         //! Adjust the values to remove any piecewise constant linear scales
         //! of the component with period \p period.
@@ -864,10 +863,10 @@ public:
         //! The moments of the error in the predictions including the trend.
         TMeanVarAccumulator m_PredictionErrorWithTrend;
 
-        //! Called if the components change.
+        //! Supplied with the prediction residuals if a component is added.
         TComponentChangeCallback m_ComponentChangeCallback;
 
-        //! Called if the model change annotation is reported.
+        //! Supplied with an annotation if a component is added.
         maths_t::TModelAnnotationCallback m_ModelAnnotationCallback;
 
         //! Set to true when testing for a change.

--- a/include/maths/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/CTimeSeriesDecompositionInterface.h
@@ -90,8 +90,11 @@ public:
     //! \param[in] weights The weights of \p value. The smaller
     //! the product count weight the less influence \p value has
     //! on the trend and it's local variance.
-    //! \param[in] componentChangeCallback Called if the components
-    //! change as a result of adding the data point.
+    //! \param[in] componentChangeCallback Supplied with prediction
+    //! residuals if a new component is added as a result of adding the
+    //! data point.
+    //! \param[in] modelAnnotationCallback Supplied with an annotation
+    //! if a new component is added as a result of adding the data point.
     virtual void
     addPoint(core_t::TTime time,
              double value,
@@ -195,7 +198,7 @@ public:
 
 protected:
     static void noopComponentChange(TFloatMeanAccumulatorVec) {}
-    static void noopModelAnnotation(core_t::TTime, const std::string&) {}
+    static void noopModelAnnotation(const std::string&) {}
 };
 }
 }

--- a/include/maths/MathsTypes.h
+++ b/include/maths/MathsTypes.h
@@ -80,8 +80,8 @@ using TDouble2VecWeightsAry1Vec = core::CSmallVector<TDouble2VecWeightsAry, 1>;
 using TDouble10VecWeightsAry = TWeightsAry<TDouble10Vec>;
 using TDouble10VecWeightsAry1Vec = core::CSmallVector<TDouble10VecWeightsAry, 1>;
 
-// Functional type used for reporting model change annotations to higher-level layers.
-using TModelAnnotationCallback = std::function<void(core_t::TTime, const std::string&)>;
+//! Functional type used for reporting model annotations to higher-level layers.
+using TModelAnnotationCallback = std::function<void(const std::string&)>;
 
 namespace maths_types_detail {
 

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1289,7 +1289,7 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SAddValue& messag
         if (testForTrend && this->shouldUseTrendForPrediction()) {
             LOG_DEBUG(<< "Detected trend at " << time);
             m_ComponentChangeCallback({});
-            m_ModelAnnotationCallback(time, "Detected trend");
+            m_ModelAnnotationCallback("Detected trend");
         }
     } break;
     case SC_DISABLED:
@@ -1319,7 +1319,7 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SDetectedSeasonal
         const CExpandingWindow& window{message.s_Window};
         const TPredictor& predictor{message.s_Predictor};
 
-        if (this->addSeasonalComponents(time, result, window, predictor)) {
+        if (this->addSeasonalComponents(result, window, predictor)) {
             LOG_DEBUG(<< "Detected seasonal components at " << time);
             m_UsingTrendForPrediction = true;
             this->clearComponentErrors();
@@ -1358,7 +1358,8 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SDetectedCalendar
             break;
         }
 
-        this->addCalendarComponent(feature, time);
+        LOG_DEBUG(<< "Detected feature '" << feature.print() << "' at " << time);
+        this->addCalendarComponent(feature);
         this->apply(SC_ADDED_COMPONENTS, message);
         this->mediator()->forward(
             SNewComponents(time, lastTime, SNewComponents::E_CalendarCyclic));
@@ -1545,7 +1546,6 @@ std::size_t CTimeSeriesDecompositionDetail::CComponents::maxSize() const {
 }
 
 bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
-    core_t::TTime time,
     const CPeriodicityHypothesisTestsResult& result,
     const CExpandingWindow& window,
     const TPredictor& predictor) {
@@ -1564,8 +1564,8 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
                              return component.time().excludes(*seasonalTime);
                          }) == components.end()) {
             LOG_DEBUG(<< "Detected '" << candidate.s_Description << "'");
-            m_ModelAnnotationCallback(time, "Detected periodicity with period " +
-                                                std::to_string(candidate.s_Period));
+            m_ModelAnnotationCallback("Detected periodicity with period " +
+                                      std::to_string(candidate.s_Period));
             newComponents.emplace_back(std::move(seasonalTime), candidate.s_PiecewiseScaled);
         }
     }
@@ -1698,12 +1698,10 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
     return newComponents.size() > 0;
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::addCalendarComponent(const CCalendarFeature& feature,
-                                                                       core_t::TTime time) {
+bool CTimeSeriesDecompositionDetail::CComponents::addCalendarComponent(const CCalendarFeature& feature) {
     double bucketLength{static_cast<double>(m_BucketLength)};
     m_Calendar->add(feature, m_CalendarComponentSize, m_DecayRate, bucketLength);
-    LOG_DEBUG(<< "Detected feature '" << feature.print() << "' at " << time);
-    m_ModelAnnotationCallback(time, "Detected calendar feature: " + feature.print());
+    m_ModelAnnotationCallback("Detected calendar feature: " + feature.print());
     return true;
 }
 

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1501,16 +1501,14 @@ CUnivariateTimeSeriesModel::testAndApplyChange(const CModelAddSamplesParams& par
     }
 
     if (m_ChangeDetector != nullptr) {
-        const maths_t::TModelAnnotationCallback& modelAnnotationCallback =
-            params.annotationCallback();
+        const auto& modelAnnotationCallback = params.annotationCallback();
         m_ChangeDetector->addSamples({{time, values[median].second[0]}}, {weights});
         if (m_ChangeDetector->stopTesting()) {
             m_ChangeDetector.reset();
             m_TrendModel->testingForChange(false);
         } else if (auto change = m_ChangeDetector->change()) {
-            std::string annotation{"Detected " + change->print()};
-            LOG_DEBUG(<< annotation << " at " << time);
-            modelAnnotationCallback(time, annotation);
+            LOG_DEBUG(<< "Detected " << change->print() << " at " << time);
+            modelAnnotationCallback("Detected " + change->print());
             m_ChangeDetector.reset();
             m_TrendModel->testingForChange(false);
             return this->applyChange(*change);
@@ -1550,8 +1548,7 @@ CUnivariateTimeSeriesModel::updateTrend(const CModelAddSamplesParams& params,
                                         const TTimeDouble2VecSizeTrVec& samples) {
 
     const TDouble2VecWeightsAryVec& weights = params.trendWeights();
-    const maths_t::TModelAnnotationCallback& modelAnnotationCallback =
-        params.annotationCallback();
+    const auto& modelAnnotationCallback = params.annotationCallback();
 
     for (const auto& sample : samples) {
         if (sample.second.size() != 1) {
@@ -2869,8 +2866,7 @@ CMultivariateTimeSeriesModel::updateTrend(const CModelAddSamplesParams& params,
                                           const TTimeDouble2VecSizeTrVec& samples) {
 
     const TDouble2VecWeightsAryVec& weights = params.trendWeights();
-    const maths_t::TModelAnnotationCallback& modelAnnotationCallback =
-        params.annotationCallback();
+    const auto& modelAnnotationCallback = params.annotationCallback();
 
     std::size_t dimension{this->dimension()};
 

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -332,16 +332,14 @@ void CEventRateModel::sample(core_t::TTime startTime,
                     .trendWeights(trendWeights)
                     .priorWeights(priorWeights);
                 if (this->params().s_AnnotationsEnabled) {
-                    const auto modelAnnotationCallback =
-                        [&](core_t::TTime t, const std::string& annotation) {
-                            m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
-                                gatherer.searchKey().partitionFieldName(),
-                                gatherer.partitionFieldValue(),
-                                gatherer.searchKey().overFieldName(),
-                                EMPTY_STRING, gatherer.searchKey().byFieldName(),
-                                gatherer.personName(pid));
-                        };
+                    const auto modelAnnotationCallback = [&](const std::string& annotation) {
+                        m_CurrentBucketStats.s_Annotations.emplace_back(
+                            time, annotation, gatherer.searchKey().detectorIndex(),
+                            gatherer.searchKey().partitionFieldName(),
+                            gatherer.partitionFieldValue(),
+                            gatherer.searchKey().overFieldName(), EMPTY_STRING,
+                            gatherer.searchKey().byFieldName(), gatherer.personName(pid));
+                    };
                     params.annotationCallback(modelAnnotationCallback);
                 }
 

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -325,23 +325,26 @@ void CEventRateModel::sample(core_t::TTime startTime,
                                   priorWeights[0]);
                 maths_t::setWinsorisationWeight(winsorisationWeight, priorWeights[0]);
 
-                maths::CModelAddSamplesParams params;
-                params.integer(true)
-                    .nonNegative(true)
-                    .propagationInterval(deratedInterval)
-                    .trendWeights(trendWeights)
-                    .priorWeights(priorWeights);
-                if (this->params().s_AnnotationsEnabled) {
-                    const auto modelAnnotationCallback = [&](const std::string& annotation) {
+                auto annotationCallback = [&](const std::string& annotation) {
+                    if (this->params().s_AnnotationsEnabled) {
                         m_CurrentBucketStats.s_Annotations.emplace_back(
                             time, annotation, gatherer.searchKey().detectorIndex(),
                             gatherer.searchKey().partitionFieldName(),
                             gatherer.partitionFieldValue(),
                             gatherer.searchKey().overFieldName(), EMPTY_STRING,
                             gatherer.searchKey().byFieldName(), gatherer.personName(pid));
-                    };
-                    params.annotationCallback(modelAnnotationCallback);
-                }
+                    }
+                };
+
+                maths::CModelAddSamplesParams params;
+                params.integer(true)
+                    .nonNegative(true)
+                    .propagationInterval(deratedInterval)
+                    .trendWeights(trendWeights)
+                    .priorWeights(priorWeights)
+                    .annotationCallback([&](const std::string& annotation) {
+                        annotationCallback(annotation);
+                    });
 
                 if (model->addSamples(params, values) == maths::CModel::E_Reset) {
                     gatherer.resetSampleCount(pid);

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -469,16 +469,15 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                     .trendWeights(attribute.second.s_Weights)
                     .priorWeights(attribute.second.s_Weights);
                 if (this->params().s_AnnotationsEnabled) {
-                    const auto modelAnnotationCallback =
-                        [&](core_t::TTime t, const std::string& annotation) {
-                            m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
-                                gatherer.searchKey().partitionFieldName(),
-                                gatherer.partitionFieldValue(),
-                                gatherer.searchKey().overFieldName(),
-                                gatherer.attributeName(cid),
-                                gatherer.searchKey().byFieldName(), EMPTY_STRING);
-                        };
+                    const auto modelAnnotationCallback = [&](const std::string& annotation) {
+                        m_CurrentBucketStats.s_Annotations.emplace_back(
+                            time, annotation, gatherer.searchKey().detectorIndex(),
+                            gatherer.searchKey().partitionFieldName(),
+                            gatherer.partitionFieldValue(),
+                            gatherer.searchKey().overFieldName(),
+                            gatherer.attributeName(cid),
+                            gatherer.searchKey().byFieldName(), EMPTY_STRING);
+                    };
                     params.annotationCallback(modelAnnotationCallback);
                 }
 

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -315,16 +315,14 @@ void CMetricModel::sample(core_t::TTime startTime,
                     .trendWeights(trendWeights)
                     .priorWeights(priorWeights);
                 if (this->params().s_AnnotationsEnabled) {
-                    const auto modelAnnotationCallback =
-                        [&](core_t::TTime t, const std::string& annotation) {
-                            m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
-                                gatherer.searchKey().partitionFieldName(),
-                                gatherer.partitionFieldValue(),
-                                gatherer.searchKey().overFieldName(),
-                                EMPTY_STRING, gatherer.searchKey().byFieldName(),
-                                gatherer.personName(pid));
-                        };
+                    const auto modelAnnotationCallback = [&](const std::string& annotation) {
+                        m_CurrentBucketStats.s_Annotations.emplace_back(
+                            time, annotation, gatherer.searchKey().detectorIndex(),
+                            gatherer.searchKey().partitionFieldName(),
+                            gatherer.partitionFieldValue(),
+                            gatherer.searchKey().overFieldName(), EMPTY_STRING,
+                            gatherer.searchKey().byFieldName(), gatherer.personName(pid));
+                    };
                     params.annotationCallback(modelAnnotationCallback);
                 }
 

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -308,23 +308,26 @@ void CMetricModel::sample(core_t::TTime startTime,
                                                    priorWeights[i]);
                 }
 
-                maths::CModelAddSamplesParams params;
-                params.integer(data_.second.s_IsInteger)
-                    .nonNegative(data_.second.s_IsNonNegative)
-                    .propagationInterval(deratedInterval)
-                    .trendWeights(trendWeights)
-                    .priorWeights(priorWeights);
-                if (this->params().s_AnnotationsEnabled) {
-                    const auto modelAnnotationCallback = [&](const std::string& annotation) {
+                auto annotationCallback = [&](const std::string& annotation) {
+                    if (this->params().s_AnnotationsEnabled) {
                         m_CurrentBucketStats.s_Annotations.emplace_back(
                             time, annotation, gatherer.searchKey().detectorIndex(),
                             gatherer.searchKey().partitionFieldName(),
                             gatherer.partitionFieldValue(),
                             gatherer.searchKey().overFieldName(), EMPTY_STRING,
                             gatherer.searchKey().byFieldName(), gatherer.personName(pid));
-                    };
-                    params.annotationCallback(modelAnnotationCallback);
-                }
+                    }
+                };
+
+                maths::CModelAddSamplesParams params;
+                params.integer(data_.second.s_IsInteger)
+                    .nonNegative(data_.second.s_IsNonNegative)
+                    .propagationInterval(deratedInterval)
+                    .trendWeights(trendWeights)
+                    .priorWeights(priorWeights)
+                    .annotationCallback([&](const std::string& annotation) {
+                        annotationCallback(annotation);
+                    });
 
                 if (model->addSamples(params, values) == maths::CModel::E_Reset) {
                     gatherer.resetSampleCount(pid);

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -466,16 +466,15 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                     .trendWeights(attribute.second.s_TrendWeights)
                     .priorWeights(attribute.second.s_PriorWeights);
                 if (this->params().s_AnnotationsEnabled) {
-                    const auto modelAnnotationCallback =
-                        [&](core_t::TTime t, const std::string& annotation) {
-                            m_CurrentBucketStats.s_Annotations.emplace_back(
-                                t, annotation, gatherer.searchKey().detectorIndex(),
-                                gatherer.searchKey().partitionFieldName(),
-                                gatherer.partitionFieldValue(),
-                                gatherer.searchKey().overFieldName(),
-                                gatherer.attributeName(cid),
-                                gatherer.searchKey().byFieldName(), EMPTY_STRING);
-                        };
+                    const auto modelAnnotationCallback = [&](const std::string& annotation) {
+                        m_CurrentBucketStats.s_Annotations.emplace_back(
+                            time, annotation, gatherer.searchKey().detectorIndex(),
+                            gatherer.searchKey().partitionFieldName(),
+                            gatherer.partitionFieldValue(),
+                            gatherer.searchKey().overFieldName(),
+                            gatherer.attributeName(cid),
+                            gatherer.searchKey().byFieldName(), EMPTY_STRING);
+                    };
                     params.annotationCallback(modelAnnotationCallback);
                 }
 


### PR DESCRIPTION
All annotations can use the start time of the bucket in which they are added. This means that it is not necessary to pass in a time when adding an annotation it can be captured in the lambda.

This is important because there are places we may want to generate annotations, such as when the residual distribution model changes, where time is unavailable. It will be undesirable to have to make it available just for annotations.

I also made a small tweak to the way the callback is passed to `std::function`. The size of this object means it won't be able to take advantage of the small object optimisation. This triggers an allocation on every single bucket and time series update which we try to avoid. By passing the callback by reference we avoid this.