### PR TITLE
[7.x][ML] Add memory_status to memory_stats

### DIFF
--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -41,6 +41,9 @@ namespace api {
 class API_EXPORT CDataFrameAnalysisInstrumentation
     : virtual public maths::CDataFrameAnalysisInstrumentationInterface {
 public:
+    //!\brief Memory status
+    enum EMemoryStatus { E_Ok, E_HardLimit };
+
     //! \brief Set the output stream for the lifetime of this object.
     class API_EXPORT CScopeSetOutputStream {
     public:
@@ -103,16 +106,19 @@ public:
     //! Start polling and writing progress updates.
     //!
     //! \note This doesn't return until instrumentation.setToFinished() is called.
-    static void monitor(const CDataFrameAnalysisInstrumentation& instrumentation,
+    static void monitor(CDataFrameAnalysisInstrumentation& instrumentation,
                         core::CRapidJsonConcurrentLineWriter& writer);
 
 protected:
     using TWriter = core::CRapidJsonConcurrentLineWriter;
     using TWriterUPtr = std::unique_ptr<TWriter>;
+    using TOptionalInt64 = boost::optional<std::int64_t>;
 
 protected:
     virtual counter_t::ECounterTypes memoryCounterType() = 0;
     TWriter* writer();
+    void memoryReestimate(std::int64_t memoryReestimate);
+    void memoryStatus(EMemoryStatus status);
 
 private:
     static const std::string NO_TASK;
@@ -136,6 +142,8 @@ private:
     std::atomic<std::int64_t> m_Memory;
     mutable std::mutex m_ProgressMutex;
     TWriterUPtr m_Writer;
+    EMemoryStatus m_MemoryStatus;
+    TOptionalInt64 m_MemoryReestimate;
 };
 
 //! \brief Instrumentation class for Outlier Detection jobs.

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -428,9 +428,7 @@ public:
 
 public:
     TApiEncodingUPtrVec& preprocessors();
-    const TApiEncodingUPtrVec& preprocessors() const {
-        return m_Preprocessors;
-    };
+    const TApiEncodingUPtrVec& preprocessors() const { return m_Preprocessors; }
     void trainedModel(TTrainedModelUPtr&& trainedModel);
     TTrainedModelUPtr& trainedModel();
     const TTrainedModelUPtr& trainedModel() const;

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -31,11 +31,18 @@ namespace {
 using TStrVec = std::vector<std::string>;
 
 const double MEMORY_LIMIT_INCREMENT{2.0}; // request 100% more memory
+const std::size_t MAXIMUM_FRACTIONAL_PROGRESS{std::size_t{1}
+                                              << ((sizeof(std::size_t) - 2) * 8)};
 
+// clang-format off
 const std::string CLASSIFICATION_STATS_TAG{"classification_stats"};
 const std::string HYPERPARAMETERS_TAG{"hyperparameters"};
+const std::string MEMORY_REESTIMATE_TAG{"memory_reestimate_bytes"};
 const std::string ITERATION_TAG{"iteration"};
 const std::string JOB_ID_TAG{"job_id"};
+const std::string MEMORY_STATUS_HARD_LIMIT_TAG{"hard-limit"};
+const std::string MEMORY_STATUS_OK_TAG{"ok"};
+const std::string MEMORY_STATUS_TAG{"status"};
 const std::string MEMORY_TYPE_TAG{"analytics_memory_usage"};
 const std::string OUTLIER_DETECTION_STATS{"outlier_detection_stats"};
 const std::string PARAMETERS_TAG{"parameters"};
@@ -64,9 +71,7 @@ const std::string NUM_SPLITS_PER_FEATURE_TAG{"num_splits_per_feature"};
 const std::string PHASE_PROGRESS{"phase_progress"};
 const std::string PHASE{"phase"};
 const std::string PROGRESS_PERCENT{"progress_percent"};
-
-const std::size_t MAXIMUM_FRACTIONAL_PROGRESS{std::size_t{1}
-                                              << ((sizeof(std::size_t) - 2) * 8)};
+// clang-format on
 
 std::string bytesToString(double value) {
     std::ostringstream stream;
@@ -94,7 +99,7 @@ CDataFrameAnalysisInstrumentation::CDataFrameAnalysisInstrumentation(const std::
                                                                      std::size_t memoryLimit)
     : m_JobId{jobId}, m_ProgressMonitoredTask{NO_TASK},
       m_MemoryLimit{static_cast<std::int64_t>(memoryLimit)}, m_Finished{false},
-      m_FractionalProgress{0}, m_Memory{0}, m_Writer{nullptr} {
+      m_FractionalProgress{0}, m_Memory{0}, m_Writer{nullptr}, m_MemoryStatus(E_Ok) {
 }
 
 void CDataFrameAnalysisInstrumentation::updateMemoryUsage(std::int64_t delta) {
@@ -162,7 +167,7 @@ const std::string& CDataFrameAnalysisInstrumentation::jobId() const {
     return m_JobId;
 }
 
-void CDataFrameAnalysisInstrumentation::monitor(const CDataFrameAnalysisInstrumentation& instrumentation,
+void CDataFrameAnalysisInstrumentation::monitor(CDataFrameAnalysisInstrumentation& instrumentation,
                                                 core::CRapidJsonConcurrentLineWriter& writer) {
 
     std::string lastTask{NO_TASK};
@@ -179,11 +184,15 @@ void CDataFrameAnalysisInstrumentation::monitor(const CDataFrameAnalysisInstrume
             writeProgress(lastTask, lastProgress, &writer);
         }
         if (instrumentation.memory() > instrumentation.m_MemoryLimit) {
+            double memoryReestimateBytes{static_cast<double>(instrumentation.memory()) *
+                                         MEMORY_LIMIT_INCREMENT};
+            instrumentation.memoryReestimate(static_cast<std::int64_t>(memoryReestimateBytes));
+            instrumentation.memoryStatus(E_HardLimit);
+            instrumentation.flush();
             HANDLE_FATAL(<< "Input error: required memory "
                          << bytesToString(instrumentation.memory()) << " exceeds the memory limit "
                          << bytesToString(instrumentation.m_MemoryLimit) << ". Please increase the limit to at least "
-                         << bytesToString(static_cast<double>(instrumentation.memory()) * MEMORY_LIMIT_INCREMENT)
-                         << " and restart.");
+                         << bytesToString(memoryReestimateBytes) << " and restart.");
         }
 
         wait = std::min(2 * wait, 1024);
@@ -192,6 +201,14 @@ void CDataFrameAnalysisInstrumentation::monitor(const CDataFrameAnalysisInstrume
     lastTask = instrumentation.readProgressMonitoredTask();
     lastProgress = instrumentation.percentageProgress();
     writeProgress(lastTask, lastProgress, &writer);
+}
+
+void CDataFrameAnalysisInstrumentation::memoryReestimate(std::int64_t memoryReestimate) {
+    m_MemoryReestimate = memoryReestimate;
+}
+
+void CDataFrameAnalysisInstrumentation::memoryStatus(EMemoryStatus status) {
+    m_MemoryStatus = status;
 }
 
 std::string CDataFrameAnalysisInstrumentation::readProgressMonitoredTask() const {
@@ -227,6 +244,19 @@ void CDataFrameAnalysisInstrumentation::writeMemory(std::int64_t timestamp) {
         m_Writer->Int64(timestamp);
         m_Writer->Key(PEAK_MEMORY_USAGE_TAG);
         m_Writer->Int64(m_Memory.load());
+        m_Writer->Key(MEMORY_STATUS_TAG);
+        switch (m_MemoryStatus) {
+        case E_Ok:
+            m_Writer->String(MEMORY_STATUS_OK_TAG);
+            break;
+        case E_HardLimit:
+            m_Writer->String(MEMORY_STATUS_HARD_LIMIT_TAG);
+            break;
+        }
+        if (m_MemoryReestimate) {
+            m_Writer->Key(MEMORY_REESTIMATE_TAG);
+            m_Writer->Int64(m_MemoryReestimate.get());
+        }
         m_Writer->EndObject();
     }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -514,6 +514,7 @@ BOOST_AUTO_TEST_CASE(testErrors) {
 
     // Memory limit exceeded.
     {
+        output.str("");
         errors.clear();
         api::CDataFrameAnalyzer analyzer{
             test::CDataFrameAnalysisSpecificationFactory{}.memoryLimit(10000).outlierSpec(),
@@ -535,6 +536,32 @@ BOOST_AUTO_TEST_CASE(testErrors) {
             }
         }
         BOOST_TEST_REQUIRE(memoryLimitExceed);
+
+        // verify memory status change
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(output.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        bool memoryStatusOk{false};
+        bool memoryStatusHardLimit{false};
+        bool memoryReestimateAvailable{false};
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("analytics_memory_usage")) {
+                std::string status{result["analytics_memory_usage"]["status"].GetString()};
+                if (status == "ok") {
+                    memoryStatusOk = true;
+                } else if (status == "hard-limit") {
+                    memoryStatusHardLimit = true;
+                    if (result["analytics_memory_usage"].HasMember("memory_reestimate_bytes") &&
+                        result["analytics_memory_usage"]["memory_reestimate_bytes"]
+                                .GetInt() > 0) {
+                        memoryReestimateAvailable = true;
+                    }
+                }
+            }
+        }
+        BOOST_TEST_REQUIRE(memoryStatusOk);
+        BOOST_TEST_REQUIRE(memoryStatusHardLimit);
+        BOOST_TEST_REQUIRE(memoryReestimateAvailable);
     }
 }
 

--- a/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
+++ b/lib/api/unittest/testfiles/instrumentation/memory_usage.schema.json
@@ -16,10 +16,20 @@
     "peak_usage_bytes": {
       "description": "Peak memory usage for the data frame analytics job in bytes",
       "type": "integer"
+    },
+    "status": {
+      "type":"string",
+      "enum": ["ok", "hard-limit"],
+      "description": "Describes how current memory usage relates to the configured memory limit. If the limit is exceeded, 'status' is 'hard-limit'."
+    },
+    "memory_reestimate_bytes": {
+      "type": "integer",
+      "description": "If 'status' is set to 'hard-limit', this optional field provides the new advised memory limit."
     }
   },
   "required": [
-    "peak_usage_bytes"
+    "peak_usage_bytes",
+    "status"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
This PR adds status field to the analytics_memory_usage instrumentation object for DGA. The status can be "ok" and "hard-limit". Additionally I added the field advised_limit_bytes containing new recommended memory limit for simple usage, e.g. by UI.

Since this is closely related to #1298, I don't document this separately and mark as non-issue.

Backport of #1345.