### PR TITLE
[ML] Trap potential causes of inverted forecast bounds

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -66,10 +66,11 @@
   regression. (See {ml-pull}1340[#1340].)
 * Improvement in handling large inference model definitions. (See {ml-pull}1349[#1349].)
 
-
 === Bug Fixes
 
 * Fix numerical issues leading to blow up of the model plot bounds. (See {ml-pull}1268[#1268].)
+* Fix causes for inverted forecast confidence interval bounds. (See {ml-pull}1369[#1369],
+  issue: {ml-issue}1357[#1357].)
 
 == {es} version 7.8.1
 

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -137,7 +137,7 @@ TDoubleDoublePr CDecompositionComponent::value(double offset, double n, double c
         }
 
         try {
-            boost::math::normal_distribution<> normal{m, sd};
+            boost::math::normal normal{m, sd};
             double ql{boost::math::quantile(normal, (100.0 - confidence) / 200.0)};
             double qu{boost::math::quantile(normal, (100.0 + confidence) / 200.0)};
             return {ql, qu};
@@ -170,7 +170,7 @@ TDoubleDoublePr CDecompositionComponent::variance(double offset, double n, doubl
             return {v, v};
         }
         try {
-            boost::math::chi_squared_distribution<> chi{n - 1.0};
+            boost::math::chi_squared chi{n - 1.0};
             double ql{boost::math::quantile(chi, (100.0 - confidence) / 200.0)};
             double qu{boost::math::quantile(chi, (100.0 + confidence) / 200.0)};
             return std::make_pair(ql * v / (n - 1.0), qu * v / (n - 1.0));

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -726,10 +726,6 @@ CTrendComponent::CForecastLevel::forecast(core_t::TTime time, double prediction,
         result[0] = m_Levels[lower];
         result[1] = CBasicStatistics::median(m_Levels);
         result[2] = m_Levels[upper];
-
-        // This should never happen, but trap the case that the bounds are out-of-order.
-        result[0] = CBasicStatistics::min(result[0], result[1], result[2]);
-        result[2] = CBasicStatistics::max(result[0], result[1], result[2]);
     }
 
     return result;

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(testDailyNoLongTermTrend) {
         return 40.0 + alpha * y[i / 6] + beta * y[(i / 6 + 1) % y.size()] + noise;
     };
 
-    test(trend, bucketLength, 63, 64.0, 4.5, 0.15);
+    test(trend, bucketLength, 63, 64.0, 10.0, 0.15);
 }
 
 BOOST_AUTO_TEST_CASE(testDailyConstantLongTermTrend) {
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(testDailyConstantLongTermTrend) {
                y[i] + noise;
     };
 
-    test(trend, bucketLength, 63, 64.0, 10.0, 0.016);
+    test(trend, bucketLength, 63, 64.0, 12.0, 0.016);
 }
 
 BOOST_AUTO_TEST_CASE(testDailyVaryingLongTermTrend) {
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(testComplexNoLongTermTrend) {
         return scale[d] * (20.0 + y[h] + noise);
     };
 
-    test(trend, bucketLength, 63, 24.0, 5.0, 0.14);
+    test(trend, bucketLength, 63, 24.0, 10.0, 0.14);
 }
 
 BOOST_AUTO_TEST_CASE(testComplexConstantLongTermTrend) {
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(testComplexConstantLongTermTrend) {
                scale[d] * (20.0 + y[h] + noise);
     };
 
-    test(trend, bucketLength, 63, 24.0, 5.0, 0.01);
+    test(trend, bucketLength, 63, 24.0, 10.0, 0.01);
 }
 
 BOOST_AUTO_TEST_CASE(testComplexVaryingLongTermTrend) {


### PR DESCRIPTION
This addresses the potential causes for empty forecast confidence intervals.

In particular, we weren't ensuring that the smoothing we perform where we join the predictions of models for distinct time intervals doesn't invert the confidence interval bounds (although this should be very unlikely, it is theoretically possible). It also reworks the handling of heteroskedasticity so we scale the forecasted seasonal confidence interval. By construction, this transform will never invert the confidence interval bounds.

Closes #1357.