### PR TITLE
[7.x] Add description (e.g.: "daily", "weekend weekly") to the annotation text (#1373)

### DIFF
--- a/include/maths/CPeriodicityHypothesisTests.h
+++ b/include/maths/CPeriodicityHypothesisTests.h
@@ -68,6 +68,9 @@ public:
         //! \warning The caller owns the returned object.
         CSeasonalTime* seasonalTime() const;
 
+        //! Get an annotation text appropriate for this component.
+        std::string annotationText() const;
+
         //! An identifier for the component used by the test.
         std::string s_Description;
         //! True if this is a diurnal component false otherwise.

--- a/lib/maths/CPeriodicityHypothesisTests.cc
+++ b/lib/maths/CPeriodicityHypothesisTests.cc
@@ -11,6 +11,7 @@
 #include <core/CPersistUtils.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
+#include <core/CTimeUtils.h>
 #include <core/Constants.h>
 #include <core/RestoreMacros.h>
 
@@ -618,6 +619,11 @@ CSeasonalTime* CPeriodicityHypothesisTestsResult::SComponent::seasonalTime() con
                                 s_Window.second, s_Period, s_Precedence);
     }
     return new CGeneralPeriodTime(s_Period, s_Precedence);
+}
+
+std::string CPeriodicityHypothesisTestsResult::SComponent::annotationText() const {
+    return "Detected periodicity with period " +
+           core::CTimeUtils::durationToString(s_Period) + " (" + s_Description + ")";
 }
 
 void CPeriodicityHypothesisTestsConfig::disableDiurnal() {

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -12,7 +12,6 @@
 #include <core/CPersistUtils.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
-#include <core/CTimeUtils.h>
 #include <core/CTimezone.h>
 #include <core/Constants.h>
 #include <core/RestoreMacros.h>
@@ -1564,10 +1563,9 @@ bool CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(
                          [&seasonalTime](const CSeasonalComponent& component) {
                              return component.time().excludes(*seasonalTime);
                          }) == components.end()) {
-            LOG_DEBUG(<< "Detected '" << candidate.s_Description << "'");
-            m_ModelAnnotationCallback(
-                "Detected periodicity with period " +
-                core::CTimeUtils::durationToString(candidate.s_Period));
+            std::string annotationText{candidate.annotationText()};
+            LOG_DEBUG(<< annotationText);
+            m_ModelAnnotationCallback(annotationText);
             newComponents.emplace_back(std::move(seasonalTime), candidate.s_PiecewiseScaled);
         }
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add description (e.g.: "daily", "weekend weekly") to the annotation text  (#1373)