### PR TITLE
[ML] Memory correction coefficient fixed

### DIFF
--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -127,6 +127,9 @@ public:
     //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
 
+    //! Correct from worst case memory usage to a more realistic estimate.
+    static std::size_t correctedMemoryUsage(double memoryUsageBytes);
+
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -357,15 +357,17 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
         hyperparametersMemoryUsage + leafNodeStatisticsMemoryUsage +
         dataTypeMemoryUsage + featureSampleProbabilities + missingFeatureMaskMemoryUsage +
         trainTestMaskMemoryUsage + bayesianOptimisationMemoryUsage};
+
+    return CBoostedTreeImpl::correctedMemoryUsage(static_cast<double>(worstCaseMemoryUsage));
+}
+
+std::size_t CBoostedTreeImpl::correctedMemoryUsage(double memoryUsageBytes) {
     // We compute the correction coefficient as a sigmoid function: ca. 1.0 until
-    // 10mb, 16.0 after 1000mb to this end we need to shift and scale using the
+    // 10mb, ca 16.0 after 1000mb to this end we need to shift and scale using the
     // magic numbers below.
     double correctionCoefficient{
-        CTools::logisticFunction(
-            static_cast<double>(worstCaseMemoryUsage) / (1024 * 1024), 10, 550) *
-            15 +
-        1};
-    return static_cast<std::size_t>(static_cast<double>(worstCaseMemoryUsage) / correctionCoefficient);
+        CTools::logisticFunction(memoryUsageBytes / (1024 * 1024), 100, 550) * 15 + 1};
+    return static_cast<std::size_t>(memoryUsageBytes / correctionCoefficient);
 }
 
 bool CBoostedTreeImpl::canTrain() const {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -13,6 +13,7 @@
 #include <maths/CBasicStatistics.h>
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeFactory.h>
+#include <maths/CBoostedTreeImpl.h>
 #include <maths/CBoostedTreeLoss.h>
 #include <maths/CPRNG.h>
 #include <maths/CSampling.h>
@@ -1825,6 +1826,32 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
     }
     BOOST_TEST_REQUIRE(throwsExceptions);
     ml::core::CLogger::instance().reset();
+}
+
+BOOST_AUTO_TEST_CASE(testWorstCaseMemoryCorrection) {
+    // We compute the correction coefficient as a sigmoid function: ca. 1.0 until
+    // 10mb, ca 16.0 after 1000mb to this end we need to shift and scale using the
+    // magic numbers below.
+    // test for 10mb
+    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(
+                            10.0 * 1024 * 1024)) /
+                            (1024 * 1024),
+                        10 / 1.07, 2.0);
+    // test for 300mb
+    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(
+                            300.0 * 1024 * 1024)) /
+                            (1024 * 1024),
+                        300.0 / 2.14, 2.0);
+    // test for 550mb
+    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(
+                            550.0 * 1024 * 1024)) /
+                            (1024 * 1024),
+                        550.0 / 8.50, 2.0);
+    // test for 1000mb
+    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(
+                            1000.0 * 1024 * 1024)) /
+                            (1024 * 1024),
+                        1000.0 / 15.84, 2.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
There was an error in how we were computing the correction coefficient which led to wrong scaling. This PR fixes the issues and adds a unit test to check the values.

Since memory correction is not released yet I am marking this as a non-issue.