### PR TITLE
[ML] Fix cause of SIGSEGV for classification and regression

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -66,10 +66,17 @@
   regression. (See {ml-pull}1340[#1340].)
 * Improvement in handling large inference model definitions. (See {ml-pull}1349[#1349].)
 
-
 === Bug Fixes
 
 * Fix numerical issues leading to blow up of the model plot bounds. (See {ml-pull}1268[#1268].)
+
+== {es} version 7.8.1
+
+=== Bug Fixes
+
+== {es} version 7.8.2
+
+* Fix cause of SIGSEGV of classification and regression. (See {ml-pull}1379[#1379].)
 
 == {es} version 7.8.1
 

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -220,6 +220,7 @@ class CORE_EXPORT CDataFrame final {
 public:
     using TBoolVec = std::vector<bool>;
     using TSizeVec = std::vector<std::size_t>;
+    using TSizeVecSizePr = std::pair<TSizeVec, std::size_t>;
     using TStrVec = std::vector<std::string>;
     using TStrVecVec = std::vector<TStrVec>;
     using TStrCRng = CVectorRange<const TStrVec>;
@@ -309,9 +310,11 @@ public:
     //!
     //! \param[in] numberThreads The target number of threads to use.
     //! \param[in] extraColumns The desired additional columns.
-    //! \return The index of each (block of) columns in \p extraColumns.
+    //! \return The index of each (block of) columns in \p extraColumns and the
+    //! number of columns added to the data frame.
     //! \warning This only supports alignments less than or equal the row alignment.
-    TSizeVec resizeColumns(std::size_t numberThreads, const TSizeAlignmentPrVec& extraColumns);
+    TSizeVecSizePr resizeColumns(std::size_t numberThreads,
+                                 const TSizeAlignmentPrVec& extraColumns);
 
     //! This reads rows using one or more readers.
     //!

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -326,6 +326,7 @@ private:
     EInitializationStage m_InitializationStage = E_NotInitialized;
     std::size_t m_NumberThreads;
     std::size_t m_DependentVariable = std::numeric_limits<std::size_t>::max();
+    TOptionalSize m_PaddedExtraColumns;
     TSizeVec m_ExtraColumns;
     TLossFunctionUPtr m_Loss;
     CBoostedTree::EClassAssignmentObjective m_ClassAssignmentObjective =

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -158,8 +158,8 @@ void CDataFrame::resizeColumns(std::size_t numberThreads, std::size_t numberColu
     m_NumberColumns = numberColumns;
 }
 
-CDataFrame::TSizeVec CDataFrame::resizeColumns(std::size_t numberThreads,
-                                               const TSizeAlignmentPrVec& extraColumns) {
+CDataFrame::TSizeVecSizePr CDataFrame::resizeColumns(std::size_t numberThreads,
+                                                     const TSizeAlignmentPrVec& extraColumns) {
     TSizeVec result;
     result.reserve(extraColumns.size());
     std::size_t index{m_NumberColumns};
@@ -174,8 +174,9 @@ CDataFrame::TSizeVec CDataFrame::resizeColumns(std::size_t numberThreads,
         result.push_back(index);
         index += count;
     }
+    std::size_t numberExtraColumns{index - m_NumberColumns};
     this->resizeColumns(numberThreads, index);
-    return result;
+    return {result, numberExtraColumns};
 }
 
 CDataFrame::TRowFuncVecBoolPr CDataFrame::readRows(std::size_t numberThreads,

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -30,6 +30,7 @@ using namespace ml;
 namespace {
 using TBoolVec = std::vector<bool>;
 using TDoubleVec = std::vector<double>;
+using TSizeVec = std::vector<std::size_t>;
 using TFloatVec =
     std::vector<core::CFloatStorage, core::CAlignedAllocator<core::CFloatStorage>>;
 using TFloatVecItr = TFloatVec::iterator;
@@ -703,8 +704,6 @@ BOOST_FIXTURE_TEST_CASE(testRowMask, CTestFixture) {
 
     // Test we read only the rows in a mask.
 
-    using TSizeVec = std::vector<std::size_t>;
-
     TSizeVec rowsRead;
 
     std::size_t rows{5000};
@@ -926,7 +925,13 @@ BOOST_FIXTURE_TEST_CASE(testAlignedExtraColumns, CTestFixture) {
             }
             frame->finishWritingRows();
 
-            auto offsets = frame->resizeColumns(1, extraCols);
+            std::size_t numberColumns{frame->numberColumns()};
+
+            TSizeVec offsets;
+            std::size_t extraColumns;
+            std::tie(offsets, extraColumns) = frame->resizeColumns(1, extraCols);
+
+            BOOST_REQUIRE_EQUAL(frame->numberColumns() - frame->numberColumns(), extraColumns);
             for (std::size_t i = 1; i < offsets.size(); ++i) {
                 BOOST_TEST_REQUIRE(offsets[i] - offsets[i - 1] >=
                                    extraCols[i - 1].first);

--- a/lib/core/unittest/CDataFrameTest.cc
+++ b/lib/core/unittest/CDataFrameTest.cc
@@ -931,7 +931,7 @@ BOOST_FIXTURE_TEST_CASE(testAlignedExtraColumns, CTestFixture) {
             std::size_t extraColumns;
             std::tie(offsets, extraColumns) = frame->resizeColumns(1, extraCols);
 
-            BOOST_REQUIRE_EQUAL(frame->numberColumns() - frame->numberColumns(), extraColumns);
+            BOOST_REQUIRE_EQUAL(frame->numberColumns() - numberColumns, extraColumns);
             for (std::size_t i = 1; i < offsets.size(); ++i) {
                 BOOST_TEST_REQUIRE(offsets[i] - offsets[i - 1] >=
                                    extraCols[i - 1].first);

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -307,8 +307,8 @@ void CBoostedTreeFactory::resizeDataFrame(core::CDataFrame& frame) const {
 
     std::size_t numberLossParameters{m_TreeImpl->m_Loss->numberParameters()};
     std::size_t frameMemory{core::CMemory::dynamicSize(frame)};
-    m_TreeImpl->m_ExtraColumns = frame.resizeColumns(
-        m_TreeImpl->m_NumberThreads, extraColumns(numberLossParameters));
+    std::tie(m_TreeImpl->m_ExtraColumns, m_TreeImpl->m_PaddedExtraColumns) =
+        frame.resizeColumns(m_TreeImpl->m_NumberThreads, extraColumns(numberLossParameters));
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(
         core::CMemory::dynamicSize(frame) - frameMemory);
     m_TreeImpl->m_Instrumentation->flush();
@@ -1267,7 +1267,10 @@ std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
 }
 
 std::size_t CBoostedTreeFactory::numberExtraColumnsForTrain() const {
-    return CBoostedTreeImpl::numberExtraColumnsForTrain(m_TreeImpl->m_Loss->numberParameters());
+    return m_TreeImpl->m_PaddedExtraColumns == boost::none
+               ? CBoostedTreeImpl::numberExtraColumnsForTrain(
+                     m_TreeImpl->m_Loss->numberParameters())
+               : *m_TreeImpl->m_PaddedExtraColumns;
 }
 
 void CBoostedTreeFactory::startProgressMonitoringFeatureSelection() {


### PR DESCRIPTION
We weren't accounting for the padding we include since we memory aligned columns, #1142, in `CBoostedTreeFactory` when computing the number of extra columns. This meant we were using presenting extra columns to feature selection (which would nearly always ignore them) and occasionally changing the initialisation of the learn rate.

The problem we hit which caused the SIGSEGV was when there was only one feature which itself carried no information, i.e. it was a constant. We could then erroneously select an extra column as a feature.