### PR TITLE
[6.8][ML] Fix change detector restore

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 6.8.12
+
+=== Bug Fixes
+
+* Fix restoration of change detectors after seasonality change. (See {ml-pull}1391[#1391].)
+
 == {es} version 6.8.11
 
 === Bug Fixes

--- a/include/maths/CTimeSeriesChangeDetector.h
+++ b/include/maths/CTimeSeriesChangeDetector.h
@@ -136,6 +136,9 @@ private:
     using TMinMaxAccumulator = CBasicStatistics::CMinMax<core_t::TTime>;
     using TRegression = CRegression::CLeastSquaresOnline<1, double>;
 
+    //! Initialise the m_ChangeModels vector
+    void initChangeModels(TPriorPtr residualModel);
+
 private:
     //! The minimum amount of time we need to observe before
     //! selecting a change model.
@@ -227,6 +230,9 @@ public:
     //! Get a checksum for this object.
     virtual uint64_t checksum(uint64_t seed) const = 0;
 
+    //! Get the time series residual model member variable.
+    const TPriorPtr& residualModelPtr() const;
+
 protected:
     CUnivariateChangeModel(const CUnivariateChangeModel& other,
                            const TDecompositionPtr& trendModel,
@@ -257,8 +263,6 @@ protected:
     const CPrior& residualModel() const;
     //! Get the time series residual model.
     CPrior& residualModel();
-    //! Get the time series residual model member variable.
-    const TPriorPtr& residualModelPtr() const;
 
 private:
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;


### PR DESCRIPTION
The change detector would crash during restoration if seasonal
components existed at the time it was originally created, but
had been discarded by the time it was persisted.

This change ensures that the change models within the change
detector reflect the status of seasonality at the time of
restoration from state.

Backport of #1391