### PR TITLE
[ML] Update user instructions for memory limit surpass

### DIFF
--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -191,7 +191,8 @@ void CDataFrameAnalysisInstrumentation::monitor(CDataFrameAnalysisInstrumentatio
             instrumentation.flush();
             HANDLE_FATAL(<< "Input error: required memory "
                          << bytesToString(instrumentation.memory()) << " exceeds the memory limit "
-                         << bytesToString(instrumentation.m_MemoryLimit) << ". Please increase the limit to at least "
+                         << bytesToString(instrumentation.m_MemoryLimit)
+                         << ". Please force-stop the analysis job, increase the limit to at least "
                          << bytesToString(memoryReestimateBytes) << " and restart.");
         }
 


### PR DESCRIPTION
This tiny PR updates the instructions for the user stating explicitly that the analysis job has to be force-stop before the memory setting can be updated.