### PR TITLE
[ML] Fix a race in writing the memory usage message after circuit breaking

### DIFF
--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -183,15 +183,16 @@ void CDataFrameAnalysisInstrumentation::monitor(CDataFrameAnalysisInstrumentatio
             lastProgress = progress;
             writeProgress(lastTask, lastProgress, &writer);
         }
-        if (instrumentation.memory() > instrumentation.m_MemoryLimit) {
-            double memoryReestimateBytes{static_cast<double>(instrumentation.memory()) *
-                                         MEMORY_LIMIT_INCREMENT};
+        std::int64_t memory{instrumentation.memory()};
+        std::int64_t memoryLimit{instrumentation.m_MemoryLimit};
+        if (memory > memoryLimit) {
+            double memoryReestimateBytes{static_cast<double>(memory) * MEMORY_LIMIT_INCREMENT};
             instrumentation.memoryReestimate(static_cast<std::int64_t>(memoryReestimateBytes));
             instrumentation.memoryStatus(E_HardLimit);
             instrumentation.flush();
-            HANDLE_FATAL(<< "Input error: required memory "
-                         << bytesToString(instrumentation.memory()) << " exceeds the memory limit "
-                         << bytesToString(instrumentation.m_MemoryLimit) << ". Please increase the limit to at least "
+            HANDLE_FATAL(<< "Input error: required memory " << bytesToString(memory)
+                         << " exceeds the memory limit " << bytesToString(memoryLimit)
+                         << ". Please increase the limit to at least "
                          << bytesToString(memoryReestimateBytes) << " and restart.");
         }
 


### PR DESCRIPTION
This message is new to 7.9 so I've marked this PR as a non-issue.