### PR TITLE
[ML] Fix for SIGSEGV forecasting

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -79,6 +79,7 @@
 === Bug Fixes
 
 * Fix restoration of change detectors after seasonality change. (See {ml-pull}1391[#1391].)
+* Fix potential SIGSEGV when forecasting. (See {ml-pull}1402[#1402], issue: {ml-issue}1401[#1401].)
 
 == {es} version 7.8.1
 

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -511,14 +511,14 @@ CAnomalyDetector::getForecastModels(bool persistOnDisk,
         return series;
     }
 
-    TModelDetailsViewUPtr view = m_Model.get()->details();
+    TModelDetailsViewUPtr view{m_Model.get()->details()};
 
     // The view can be empty, e.g. for the counting model.
     if (view.get() == nullptr) {
         return series;
     }
 
-    const CSearchKey& key = m_DataGatherer->searchKey();
+    const CSearchKey& key{m_DataGatherer->searchKey()};
     series.s_ByFieldName = key.byFieldName();
     series.s_DetectorIndex = key.detectorIndex();
     series.s_PartitionFieldName = key.partitionFieldName();
@@ -528,16 +528,15 @@ CAnomalyDetector::getForecastModels(bool persistOnDisk,
     if (persistOnDisk) {
         CForecastModelPersist::CPersist persister(persistenceFolder);
 
-        for (std::size_t pid = 0u, maxPid = m_DataGatherer->numberPeople();
-             pid < maxPid; ++pid) {
+        for (std::size_t pid = 0; pid < m_DataGatherer->numberPeople(); ++pid) {
             // todo: Add terms filtering here
             if (m_DataGatherer->isPersonActive(pid)) {
                 for (auto feature : view->features()) {
-                    const maths::CModel* model = view->model(feature, pid);
-                    core_t::TTime firstDataTime;
-                    core_t::TTime lastDataTime;
-                    std::tie(firstDataTime, lastDataTime) = view->dataTimeInterval(pid);
+                    const maths::CModel* model{view->model(feature, pid)};
                     if (model != nullptr && model->isForecastPossible()) {
+                        core_t::TTime firstDataTime;
+                        core_t::TTime lastDataTime;
+                        std::tie(firstDataTime, lastDataTime) = view->dataTimeInterval(pid);
                         persister.addModel(model, firstDataTime, lastDataTime, feature,
                                            m_DataGatherer->personName(pid));
                     }
@@ -547,16 +546,16 @@ CAnomalyDetector::getForecastModels(bool persistOnDisk,
 
         series.s_ToForecastPersisted = persister.finalizePersistAndGetFile();
     } else {
-        for (std::size_t pid = 0u, maxPid = m_DataGatherer->numberPeople();
-             pid < maxPid; ++pid) {
+
+        for (std::size_t pid = 0; pid < m_DataGatherer->numberPeople(); ++pid) {
             // todo: Add terms filtering here
             if (m_DataGatherer->isPersonActive(pid)) {
                 for (auto feature : view->features()) {
-                    const maths::CModel* model = view->model(feature, pid);
-                    core_t::TTime firstDataTime;
-                    core_t::TTime lastDataTime;
-                    std::tie(firstDataTime, lastDataTime) = view->dataTimeInterval(pid);
+                    const maths::CModel* model{view->model(feature, pid)};
                     if (model != nullptr && model->isForecastPossible()) {
+                        core_t::TTime firstDataTime;
+                        core_t::TTime lastDataTime;
+                        std::tie(firstDataTime, lastDataTime) = view->dataTimeInterval(pid);
                         series.s_ToForecast.emplace_back(
                             feature, m_DataGatherer->personName(pid),
                             CForecastDataSink::TMathsModelPtr(model->cloneForForecast()),


### PR DESCRIPTION
It is possible that a model which hasn't received any recent updates is removed. In this case, when forecasting we'd hit a null pointer dereference. This moves the offending code under the check that the model still exists.

Fixes #1401.