### PR TITLE
[ML] Restrict growth of max matching string length for categories

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -74,6 +74,7 @@
 * Fix numerical issues leading to blow up of the model plot bounds. (See {ml-pull}1268[#1268].)
 * Fix causes for inverted forecast confidence interval bounds. (See {ml-pull}1369[#1369],
   issue: {ml-issue}1357[#1357].)
+* Restrict growth of max matching string length for categories. (See {ml-pull}1406[#1406].)
 
 == {es} version 7.8.2
 

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -53,7 +53,7 @@ public:
 public:
     //! Create a new category
     CTokenListCategory(bool isDryRun,
-                       const std::string& baseString,
+                       std::string baseString,
                        std::size_t rawStringLen,
                        const TSizeSizePrVec& baseTokenIds,
                        std::size_t baseWeight,
@@ -195,44 +195,48 @@ private:
     TSizeSizePrVec m_BaseTokenIds;
 
     //! Cache the total weight of the base tokens
-    std::size_t m_BaseWeight;
+    std::size_t m_BaseWeight = 0;
+
+    //! The original length (i.e. before filtering) of the string this category
+    //! was originally based on
+    std::size_t m_BaseRawStringLen = 0;
 
     //! The maximum original length of all the strings that have been
     //! classified as this category.  The original length may be longer than the
     //! length of the strings in passed to the addString() method, because
     //! it will include the date.
-    std::size_t m_MaxStringLen;
+    std::size_t m_MaxStringLen = 0;
 
     //! The index into the base token IDs where the subsequence of tokens that
     //! are in the same order for all strings of this category begins.
-    std::size_t m_OrderedCommonTokenBeginIndex;
+    std::size_t m_OrderedCommonTokenBeginIndex = 0;
 
     //! One past the index into the base token IDs where the subsequence of
     //! tokens that are in the same order for all strings of this category ends.
-    std::size_t m_OrderedCommonTokenEndIndex;
+    std::size_t m_OrderedCommonTokenEndIndex = 0;
 
     //! The unique token IDs that all strings classified to be this category
     //! contain.  This vector must always be sorted into ascending order.
     TSizeSizePrVec m_CommonUniqueTokenIds;
 
     //! Cache the weight of the common unique tokens
-    std::size_t m_CommonUniqueTokenWeight;
+    std::size_t m_CommonUniqueTokenWeight = 0;
 
     //! What was the weight of the original unique tokens (i.e. when the category
     //! only represented one string)?  Remembering this means we can ensure
     //! that the degree of commonality doesn't fall below a certain level as
     //! the number of strings classified as this category grows.
-    std::size_t m_OrigUniqueTokenWeight;
+    std::size_t m_OrigUniqueTokenWeight = 0;
 
     //! Number of matched strings
-    std::size_t m_NumMatches;
+    std::size_t m_NumMatches = 0;
 
     //! Cache reverse searches to save repeated recalculations
     std::string m_ReverseSearchPart1;
     std::string m_ReverseSearchPart2;
 
     //! Has the category changed recently
-    bool m_Changed;
+    bool m_Changed = false;
 };
 }
 }

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -28,6 +28,7 @@ const std::string COMMON_UNIQUE_TOKEN_WEIGHT{"g"};
 const std::string ORIG_UNIQUE_TOKEN_WEIGHT{"h"};
 const std::string NUM_MATCHES{"i"};
 const std::string ORDERED_COMMON_TOKEN_BEGIN_INDEX{"j"};
+const std::string BASE_RAW_STRING_LENGTH{"k"};
 
 //! Functor for comparing token IDs that works for both simple token IDs and
 //! token ID/weight pairs.
@@ -50,27 +51,25 @@ public:
 }
 
 CTokenListCategory::CTokenListCategory(bool isDryRun,
-                                       const std::string& baseString,
+                                       std::string baseString,
                                        std::size_t rawStringLen,
                                        const TSizeSizePrVec& baseTokenIds,
                                        std::size_t baseWeight,
                                        const TSizeSizeMap& uniqueTokenIds)
-    : m_BaseString{baseString}, m_BaseTokenIds{baseTokenIds}, m_BaseWeight{baseWeight},
-      m_MaxStringLen{rawStringLen}, m_OrderedCommonTokenBeginIndex{0},
-      m_OrderedCommonTokenEndIndex{baseTokenIds.size()},
+    : m_BaseString{std::move(baseString)}, m_BaseTokenIds{baseTokenIds},
+      m_BaseWeight{baseWeight}, m_BaseRawStringLen{rawStringLen},
+      m_MaxStringLen{rawStringLen}, m_OrderedCommonTokenEndIndex{baseTokenIds.size()},
       // Note: m_CommonUniqueTokenIds is required to be in sorted order, and
       // this relies on uniqueTokenIds being in sorted order
-      m_CommonUniqueTokenIds{uniqueTokenIds.begin(), uniqueTokenIds.end()}, m_CommonUniqueTokenWeight{0},
-      m_OrigUniqueTokenWeight{0}, m_NumMatches{isDryRun ? 0u : 1u}, m_Changed{!isDryRun} {
+      m_CommonUniqueTokenIds{uniqueTokenIds.begin(), uniqueTokenIds.end()},
+      m_NumMatches{isDryRun ? 0u : 1u}, m_Changed{!isDryRun} {
     for (auto uniqueTokenId : uniqueTokenIds) {
         m_CommonUniqueTokenWeight += uniqueTokenId.second;
     }
     m_OrigUniqueTokenWeight = m_CommonUniqueTokenWeight;
 }
 
-CTokenListCategory::CTokenListCategory(core::CStateRestoreTraverser& traverser)
-    : m_BaseWeight{0}, m_MaxStringLen{0}, m_OrderedCommonTokenBeginIndex{0}, m_OrderedCommonTokenEndIndex{0},
-      m_CommonUniqueTokenWeight{0}, m_OrigUniqueTokenWeight{0}, m_NumMatches{0} {
+CTokenListCategory::CTokenListCategory(core::CStateRestoreTraverser& traverser) {
     traverser.traverseSubLevel(std::bind(&CTokenListCategory::acceptRestoreTraverser,
                                          this, std::placeholders::_1));
 }
@@ -81,6 +80,10 @@ bool CTokenListCategory::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
     // This won't be present in pre-7.7 state,
     // and for such versions it was always 0
     m_OrderedCommonTokenBeginIndex = 0;
+
+    // This won't be present in pre-7.9 state.
+    // This value means we guess at the end.
+    m_BaseRawStringLen = m_BaseString.max_size();
 
     do {
         const std::string& name{traverser.name()};
@@ -167,14 +170,25 @@ bool CTokenListCategory::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
                 LOG_ERROR(<< "Invalid maximum string length in " << traverser.value());
                 return false;
             }
+        } else if (name == BASE_RAW_STRING_LENGTH) {
+            if (core::CStringUtils::stringToType(traverser.value(), m_BaseRawStringLen) == false) {
+                LOG_ERROR(<< "Invalid base raw string length in " << traverser.value());
+                return false;
+            }
         }
     } while (traverser.next());
+
+    // m_BaseRawStringLen will only have been persisted by 7.9 and above.
+    // In this case the absolute maximum set at the beginning of the method
+    // will still be set.  A reasonable compromise that will result in
+    // behaviour no worse than 7.8 is to set it to m_MaxStringLen.
+    m_BaseRawStringLen = std::min(m_BaseRawStringLen, m_MaxStringLen);
 
     return true;
 }
 
 bool CTokenListCategory::addString(bool isDryRun,
-                                   const std::string& /* str */,
+                                   const std::string& str,
                                    std::size_t rawStringLen,
                                    const TSizeSizePrVec& tokenIds,
                                    const TSizeSizeMap& uniqueTokenIds) {
@@ -191,6 +205,8 @@ bool CTokenListCategory::addString(bool isDryRun,
 
     // Adjust the maximum observed string length for this category.
     if (rawStringLen > m_MaxStringLen) {
+        LOG_TRACE(<< "Growing max string length from " << m_MaxStringLen
+                  << " to " << rawStringLen << " due to '" << str << '\'');
         m_MaxStringLen = rawStringLen;
         changed = true;
     }
@@ -380,8 +396,19 @@ CTokenListCategory::TSizeSizePr CTokenListCategory::orderedCommonTokenBounds() c
 }
 
 std::size_t CTokenListCategory::maxMatchingStringLen() const {
-    // Add a 10% margin of error
-    return (m_MaxStringLen * 11) / 10;
+    // Add a 10% margin of error if this wouldn't result in a length much
+    // longer than the base string.  The broader the category (i.e. fewer
+    // tokens that must match) the lower the tolerance of length increases.
+    // The risk is that we end up with a category with just one or two tokens
+    // that matches every message.  The max matching length is designed to
+    // prevent categories that just require a few tokens to match from
+    // matching much longer messages, but the 10% growth here can cause
+    // progressively longer messages to be included in the category over time
+    // if no cap is applied.
+    std::size_t extendedLength{std::min(
+        (m_MaxStringLen * 11) / 10,
+        m_BaseRawStringLen * std::max(m_CommonUniqueTokenIds.size() / 2, std::size_t{2}))};
+    return std::max(m_MaxStringLen, extendedLength);
 }
 
 std::size_t CTokenListCategory::missingCommonTokenWeight(const TSizeSizeMap& uniqueTokenIds) const {

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -407,7 +407,9 @@ std::size_t CTokenListCategory::maxMatchingStringLen() const {
     // if no cap is applied.
     std::size_t extendedLength{std::min(
         (m_MaxStringLen * 11) / 10,
-        m_BaseRawStringLen * std::max(m_CommonUniqueTokenIds.size() / 2, std::size_t{2}))};
+        static_cast<std::size_t>(
+            static_cast<double>(m_BaseRawStringLen) *
+            std::max(static_cast<double>(m_CommonUniqueTokenIds.size()) / 1.5, 2.0)))};
     return std::max(m_MaxStringLen, extendedLength);
 }
 

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -443,9 +443,8 @@ std::size_t CTokenListCategory::missingCommonTokenWeight(const TSizeSizeMap& uni
 }
 
 bool CTokenListCategory::matchesSearchForCategory(const CTokenListCategory& other) const {
-    return this->matchesSearchForCategory(
-        other.m_BaseWeight, other.maxMatchingStringLen(),
-        other.commonUniqueTokenIds(), other.baseTokenIds());
+    return this->matchesSearchForCategory(other.m_BaseWeight, other.m_MaxStringLen,
+                                          other.m_CommonUniqueTokenIds, other.m_BaseTokenIds);
 }
 
 bool CTokenListCategory::containsCommonInOrderTokensInOrder(const TSizeSizePrVec& tokenIds) const {

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -500,6 +500,7 @@ void CTokenListCategory::acceptPersistInserter(core::CStatePersistInserter& inse
 
     inserter.insertValue(ORIG_UNIQUE_TOKEN_WEIGHT, m_OrigUniqueTokenWeight);
     inserter.insertValue(NUM_MATCHES, m_NumMatches);
+    inserter.insertValue(BASE_RAW_STRING_LENGTH, m_BaseRawStringLen);
 }
 
 void CTokenListCategory::cacheReverseSearch(std::string part1, std::string part2) {

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -108,8 +108,8 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
             std::size_t commonUniqueTokenWeight{compCategory.commonUniqueTokenWeight()};
             std::size_t missingCommonTokenWeight{
                 compCategory.missingCommonTokenWeight(m_WorkTokenUniqueIds)};
-            double proportionOfOrig(double(commonUniqueTokenWeight - missingCommonTokenWeight) /
-                                    double(origUniqueTokenWeight));
+            double proportionOfOrig{static_cast<double>(commonUniqueTokenWeight - missingCommonTokenWeight) /
+                                    static_cast<double>(origUniqueTokenWeight)};
             if (proportionOfOrig < m_LowerThreshold) {
                 continue;
             }

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -289,6 +289,54 @@ BOOST_FIXTURE_TEST_CASE(testVmwareData, CTestFixture) {
     checkMemoryUsageInstrumentation(categorizer);
 }
 
+BOOST_FIXTURE_TEST_CASE(testVmwareDataLengthGrowth, CTestFixture) {
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
+
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 11:10:54 prelert-esxi1.prelert.com Hostd: --> }",
+                                                    54));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 11:10:54 prelert-esxi1.prelert.com Hostd: --> \"5331582\"",
+                                                    62));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 11:10:54 prelert-esxi1.prelert.com Hostd: -->    msg = \"\",",
+                                                    65));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:39 prelert-esxi1.prelert.com Hostd: -->    userName = \"\"",
+                                                    70));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:39 prelert-esxi1.prelert.com Hostd: -->    changeTag = <unset>",
+                                                    76));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:39 prelert-esxi1.prelert.com Hostd: -->       (vmodl.KeyAnyValue) {",
+                                                    80));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:39 prelert-esxi1.prelert.com Hostd: -->          dynamicType = <unset>,",
+                                                    84));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:39 prelert-esxi1.prelert.com Hostd: -->    objectType = \"vim.HostSystem\",",
+                                                    86));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:39 prelert-esxi1.prelert.com Hostd: -->    fault = (vmodl.MethodFault) null,",
+                                                    89));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:45 prelert-esxi1.prelert.com Hostd: -->    createdTime = \"1970-01-01T00:00:00Z\",",
+                                                    93));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:45 prelert-esxi1.prelert.com Hostd: -->    host = (vim.event.HostEventArgument) {",
+                                                    94));
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "Jul 10 13:04:45 prelert-esxi1.prelert.com Hostd: -->    ds = (vim.event.DatastoreEventArgument) null,",
+                                                    101));
+    // This one would match the reverse search for category 1 if
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
+                        categorizer.computeCategory(false, "Jul 10 13:04:45 prelert-esxi1.prelert.com Hostd: -->          value = \"naa.644a84202f3712001d0c56a3304f87cf\",",
+                                                    109));
+
+    checkMemoryUsageInstrumentation(categorizer);
+}
+
 BOOST_FIXTURE_TEST_CASE(testBankData, CTestFixture) {
     TTokenListDataCategorizerKeepsFields categorizer{
         m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};


### PR DESCRIPTION
The max matching string length in a category definition is supposed
to stop a category created from a message with very few tokens from
matching messages with many more tokens that happen to include the
few tokens.  However, the 10% tolerance that was added to the length
when considering a match could cause the category to match slightly
longer messages over and over again until the max matching length
was an order of magnitude greater than it started off.

This change caps the increase in the max matching length to a
multiple of the length of the original message that caused the
category to be created.  The multiple is 2 for categories that have
few tokens, and progressively bigger as the number of tokens that
define the category increases (as the more tokens the category has
the less risk of it matching very broadly).