### PR TITLE
[ML] New memory estimation correction function

### DIFF
--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -366,9 +366,13 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
 std::size_t CBoostedTreeImpl::correctedMemoryUsage(double memoryUsageBytes) {
     // We use a piecewise linear function of the estimated memory usage to compute
     // the corrected value. The values are selected in a way to reduce over-estimation
-    // on small jobs to improve the behaviour on the trial nodes in the cloud.
-    TDoubleVec estimatedMemoryUsageMB{0., 1024., 4096., 8192., 12288., 16384.};
-    TDoubleVec correctedMemoryUsageMB{0., 179.2, 512., 819.2, 1088., 1280.};
+    // and to improve the behaviour on the trial nodes in the cloud. The high level strategy
+    // also ensures that corrected memory usage is a monotonic function of estimated memory
+    // usage and any change to the approach should preserve this property.
+    TDoubleVec estimatedMemoryUsageMB{0.0,    20.0,    1024.0, 4096.0,
+                                      8192.0, 12288.0, 16384.0};
+    TDoubleVec correctedMemoryUsageMB{0.0,   20.0,   179.2, 512.0,
+                                      819.2, 1088.0, 1280.0};
     maths::CSpline<> spline(maths::CSplineTypes::E_Linear);
     spline.interpolate(estimatedMemoryUsageMB, correctedMemoryUsageMB,
                        maths::CSplineTypes::E_ParabolicRunout);

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -26,6 +26,7 @@
 #include <maths/CQuantileSketch.h>
 #include <maths/CSampling.h>
 #include <maths/CSetTools.h>
+#include <maths/CSpline.h>
 #include <maths/CTreeShapFeatureImportance.h>
 
 #include <boost/circular_buffer.hpp>
@@ -50,6 +51,7 @@ namespace {
 const double MINIMUM_SPLIT_REFRESH_INTERVAL{3.0};
 const std::string HYPERPARAMETER_OPTIMIZATION_ROUND{"hyperparameter_optimization_round_"};
 const std::string TRAIN_FINAL_FOREST{"train_final_forest"};
+const int BYTES_IN_MB{1024 * 1024};
 
 //! \brief Record the memory used by a supplied object using the RAII idiom.
 class CScopeRecordMemoryUsage {
@@ -362,12 +364,15 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
 }
 
 std::size_t CBoostedTreeImpl::correctedMemoryUsage(double memoryUsageBytes) {
-    // We compute the correction coefficient as a sigmoid function: ca. 1.0 until
-    // 10mb, ca 16.0 after 1000mb to this end we need to shift and scale using the
-    // magic numbers below.
-    double correctionCoefficient{
-        CTools::logisticFunction(memoryUsageBytes / (1024 * 1024), 100, 550) * 15 + 1};
-    return static_cast<std::size_t>(memoryUsageBytes / correctionCoefficient);
+    // We use a piecewise linear function of the estimated memory usage to compute
+    // the corrected value. The values are selected in a way to reduce over-estimation
+    // on small jobs to improve the behaviour on the trial nodes in the cloud.
+    TDoubleVec estimatedMemoryUsageMB{0., 1024., 4096., 8192., 12288., 16384.};
+    TDoubleVec correctedMemoryUsageMB{0., 179.2, 512., 819.2, 1088., 1280.};
+    maths::CSpline<> spline(maths::CSplineTypes::E_Linear);
+    spline.interpolate(estimatedMemoryUsageMB, correctedMemoryUsageMB,
+                       maths::CSplineTypes::E_ParabolicRunout);
+    return static_cast<std::size_t>(spline.value(memoryUsageBytes / BYTES_IN_MB) * BYTES_IN_MB);
 }
 
 bool CBoostedTreeImpl::canTrain() const {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -4,8 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include "core/CContainerPrinter.h"
-#include "maths/CSpline.h"
 #include <core/CDataFrame.h>
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CLogger.h>

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
- 
+
 #include <core/CDataFrame.h>
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CLogger.h>
@@ -1849,7 +1849,9 @@ BOOST_AUTO_TEST_CASE(testWorstCaseMemoryCorrection) {
         179.2, 1.0);
     // test for 18000mb
     BOOST_REQUIRE_CLOSE(static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(
-                            18000.0 * BYTES_IN_MB)) / BYTES_IN_MB, 1355.75, 1.0);
+                            18000.0 * BYTES_IN_MB)) /
+                            BYTES_IN_MB,
+                        1355.75, 1.0);
 
     // test for monotonicity
     std::size_t numberSamples{1000};

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-
+ 
 #include <core/CDataFrame.h>
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CLogger.h>
@@ -1831,23 +1831,39 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
 }
 
 BOOST_AUTO_TEST_CASE(testWorstCaseMemoryCorrection) {
+    // test for 15mb
+    BOOST_REQUIRE_CLOSE(
+        static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(15.0 * BYTES_IN_MB)) / BYTES_IN_MB,
+        15.0, 1.0);
     // test for 50mb
     BOOST_REQUIRE_CLOSE(
         static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(50.0 * BYTES_IN_MB)) / BYTES_IN_MB,
-        8.75, 1.0);
+        24.76, 1.0);
     // test for 300mb
     BOOST_REQUIRE_CLOSE(
         static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(300.0 * BYTES_IN_MB)) / BYTES_IN_MB,
-        52.5, 1.0);
-    // test for 550mb
-    BOOST_REQUIRE_CLOSE(
-        static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(550.0 * BYTES_IN_MB)) /
-            (BYTES_IN_MB),
-        96.25, 2.0);
-    // test for 1000mb
+        64.4, 1.0);
+    // test for 1024mb
     BOOST_REQUIRE_CLOSE(
         static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(1024.0 * BYTES_IN_MB)) / BYTES_IN_MB,
-        179.2, 2.0);
+        179.2, 1.0);
+    // test for 18000mb
+    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::CBoostedTreeImpl::correctedMemoryUsage(
+                            18000.0 * BYTES_IN_MB)) / BYTES_IN_MB, 1355.75, 1.0);
+
+    // test for monotonicity
+    std::size_t numberSamples{1000};
+    TDoubleVec lhs;
+    lhs.reserve(numberSamples);
+    TDoubleVec rhs;
+    rhs.reserve(numberSamples);
+    test::CRandomNumbers rng;
+    rng.generateUniformSamples(0, 20000, numberSamples, lhs);
+    for (int i = 0; i < numberSamples; ++i) {
+        BOOST_TEST_REQUIRE((lhs[i] <= rhs[i]) ==
+                           (maths::CBoostedTreeImpl::correctedMemoryUsage(lhs[i]) <=
+                            maths::CBoostedTreeImpl::correctedMemoryUsage(rhs[i])));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1860,7 +1860,8 @@ BOOST_AUTO_TEST_CASE(testWorstCaseMemoryCorrection) {
     TDoubleVec rhs;
     rhs.reserve(numberSamples);
     test::CRandomNumbers rng;
-    rng.generateUniformSamples(0, 20000, numberSamples, lhs);
+    rng.generateUniformSamples(0.0, 20000.0, numberSamples, lhs);
+    rng.generateUniformSamples(0.0, 20000.0, numberSamples, rhs);
     for (int i = 0; i < numberSamples; ++i) {
         BOOST_TEST_REQUIRE((lhs[i] <= rhs[i]) ==
                            (maths::CBoostedTreeImpl::correctedMemoryUsage(lhs[i]) <=


### PR DESCRIPTION
This PR changes the memory correction strategy to enforce the strongly monotonic behavior of the corrected values. Previously, the correction could leave to the situation where memory estimations could be swapped (bigger job could have a smaller memory estimation), this is not possible now. 