### PR TITLE
[ML] Fix undefined behaviour

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -14,7 +14,7 @@
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/ImportExport.h>
 
-#include <rapidjson/fwd.h>
+#include <rapidjson/document.h>
 
 #include <memory>
 
@@ -81,8 +81,6 @@ public:
     CDataFrameAnalysisInstrumentation& instrumentation() override;
 
 protected:
-    using TOptionalRapidJsonDocument = boost::optional<rapidjson::Document>;
-    using TBoostedTreeUPtr = std::unique_ptr<maths::CBoostedTree>;
     using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
 
 protected:
@@ -107,6 +105,7 @@ protected:
 
 private:
     using TBoostedTreeFactoryUPtr = std::unique_ptr<maths::CBoostedTreeFactory>;
+    using TBoostedTreeUPtr = std::unique_ptr<maths::CBoostedTree>;
     using TDataSearcherUPtr = CDataFrameAnalysisSpecification::TDataSearcherUPtr;
 
 private:
@@ -125,7 +124,7 @@ private:
 private:
     // Note custom config is written directly to the factory object.
 
-    TOptionalRapidJsonDocument m_CustomProcessors;
+    rapidjson::Document m_CustomProcessors;
     std::string m_DependentVariableFieldName;
     std::string m_PredictionFieldName;
     double m_TrainingPercent;

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -339,9 +339,7 @@ private:
     std::string m_Field;
 };
 
-class API_EXPORT CCustomEncoding : public CSerializableToJsonStream {
-public:
-};
+class API_EXPORT CCustomEncoding : public CSerializableToJsonStream {};
 
 //! \brief Mapping from categorical columns to numerical values related to categorical value distribution.
 class API_EXPORT CFrequencyEncoding final : public CEncoding {

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -103,6 +103,7 @@ private:
     using TOptionalSize = boost::optional<std::size_t>;
     using TOptionalDouble = boost::optional<double>;
     using TOptionalLossFunctionType = boost::optional<TLossFunctionType>;
+    using TOptionalRapidjsonDocument = boost::optional<rapidjson::Document>;
 
 private:
     // Shared
@@ -132,7 +133,7 @@ private:
     std::size_t m_NumberTopShapValues = 0;
     TPersisterSupplier* m_PersisterSupplier = nullptr;
     TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
-    rapidjson::Document m_CustomProcessors;
+    TOptionalRapidjsonDocument m_CustomProcessors;
     // Regression
     TOptionalLossFunctionType m_RegressionLossFunction;
     TOptionalDouble m_RegressionLossFunctionParameter;

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -17,8 +17,9 @@
 
 #include <test/ImportExport.h>
 
-#include <boost/optional.hpp>
 #include <rapidjson/document.h>
+
+#include <boost/optional.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -40,6 +41,10 @@ public:
 
 public:
     CDataFrameAnalysisSpecificationFactory();
+
+    CDataFrameAnalysisSpecificationFactory(const CDataFrameAnalysisSpecificationFactory&) = delete;
+    CDataFrameAnalysisSpecificationFactory&
+    operator=(const CDataFrameAnalysisSpecificationFactory&) = delete;
 
     static const std::string& classification();
     static const std::string& regression();
@@ -103,7 +108,6 @@ private:
     using TOptionalSize = boost::optional<std::size_t>;
     using TOptionalDouble = boost::optional<double>;
     using TOptionalLossFunctionType = boost::optional<TLossFunctionType>;
-    using TOptionalRapidjsonDocument = boost::optional<rapidjson::Document>;
 
 private:
     // Shared
@@ -133,7 +137,7 @@ private:
     std::size_t m_NumberTopShapValues = 0;
     TPersisterSupplier* m_PersisterSupplier = nullptr;
     TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
-    TOptionalRapidjsonDocument m_CustomProcessors;
+    rapidjson::Document m_CustomProcessors;
     // Regression
     TOptionalLossFunctionType m_RegressionLossFunction;
     TOptionalDouble m_RegressionLossFunctionParameter;

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -104,9 +104,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double softTreeDepthTolerance{parameters[SOFT_TREE_DEPTH_TOLERANCE].fallback(-1.0)};
     double featureBagFraction{parameters[FEATURE_BAG_FRACTION].fallback(-1.0)};
     if (parameters[FEATURE_PROCESSORS].jsonObject() != nullptr) {
-        m_CustomProcessors = rapidjson::Document{};
-        m_CustomProcessors->CopyFrom(*parameters[FEATURE_PROCESSORS].jsonObject(),
-                                     m_CustomProcessors->GetAllocator());
+        m_CustomProcessors.CopyFrom(*parameters[FEATURE_PROCESSORS].jsonObject(),
+                                    m_CustomProcessors.GetAllocator());
     }
     if (alpha != -1.0 && alpha < 0.0) {
         HANDLE_FATAL(<< "Input error: '" << ALPHA << "' should be non-negative.")
@@ -236,8 +235,8 @@ bool CDataFrameTrainBoostedTreeRunner::validate(const core::CDataFrame& frame) c
 }
 
 void CDataFrameTrainBoostedTreeRunner::accept(CBoostedTreeInferenceModelBuilder& builder) const {
-    if (m_CustomProcessors != boost::none) {
-        builder.addCustomProcessor(std::make_unique<COpaqueEncoding>(*m_CustomProcessors));
+    if (m_CustomProcessors.IsNull() == false) {
+        builder.addCustomProcessor(std::make_unique<COpaqueEncoding>(m_CustomProcessors));
     }
     this->boostedTree().accept(builder);
 }

--- a/lib/api/CInferenceModelDefinition.cc
+++ b/lib/api/CInferenceModelDefinition.cc
@@ -885,16 +885,13 @@ COpaqueEncoding::COpaqueEncoding(const rapidjson::Document& object) {
 
 void COpaqueEncoding::addToJsonStream(TGenericLineWriter& writer) const {
 
-    if (m_Object.Empty()) {
-        return;
-    }
     if (m_Object.IsArray()) {
         // These are prepended to the array of other encoders so we don't wrap in
         // a StartArray and EndArray.
         for (const auto& val : m_Object.GetArray()) {
             writer.write(val);
         }
-    } else {
+    } else if (m_Object.IsObject() && m_Object.ObjectEmpty() == false) {
         writer.write(m_Object);
     }
 }

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -207,7 +207,8 @@ CDataFrameAnalysisSpecificationFactory::regressionLossFunction(TLossFunctionType
 
 CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::predictionCustomProcessor(const rapidjson::Value& value) {
-    m_CustomProcessors.CopyFrom(value, m_CustomProcessors.GetAllocator());
+    m_CustomProcessors = rapidjson::Document{};
+    m_CustomProcessors->CopyFrom(value, m_CustomProcessors->GetAllocator());
     return *this;
 }
 
@@ -335,9 +336,9 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
         writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES);
         writer.Uint64(m_NumberTopClasses);
     }
-    if (m_CustomProcessors.Empty() == false) {
+    if (m_CustomProcessors != boost::none) {
         writer.Key(api::CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS);
-        writer.write(m_CustomProcessors);
+        writer.write(*m_CustomProcessors);
     }
 
     if (analysis == regression()) {

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -207,8 +207,7 @@ CDataFrameAnalysisSpecificationFactory::regressionLossFunction(TLossFunctionType
 
 CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::predictionCustomProcessor(const rapidjson::Value& value) {
-    m_CustomProcessors = rapidjson::Document{};
-    m_CustomProcessors->CopyFrom(value, m_CustomProcessors->GetAllocator());
+    m_CustomProcessors.CopyFrom(value, m_CustomProcessors.GetAllocator());
     return *this;
 }
 
@@ -336,9 +335,9 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
         writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES);
         writer.Uint64(m_NumberTopClasses);
     }
-    if (m_CustomProcessors != boost::none) {
+    if (m_CustomProcessors.IsNull() == false) {
         writer.Key(api::CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS);
-        writer.write(*m_CustomProcessors);
+        writer.write(m_CustomProcessors);
     }
 
     if (analysis == regression()) {


### PR DESCRIPTION
`IsEmpty` can only be called on an `rapidjson::Array` object. This fixes some fallout from #1408 by checking types first and migrating to an optional `rapidjson::Document` on `CDataFrameAnalysisSpecificationFactory`. Since the code hasn't been released I've marked this as a non-issue.