### PR TITLE
[ML] Fix custom processor tests

### DIFF
--- a/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
+++ b/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(testIntegrationRegression) {
             .columns(cols)
             .memoryLimit(30000000)
             .predictionCategoricalFieldNames({"categorical_col"})
-            .predictionCustomProcessor(customProcessors.GetObject())
+            .predictionCustomProcessor(customProcessors)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target_col"),
         outputWriterFactory};
 
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(testIntegrationClassification) {
             .columns(cols)
             .memoryLimit(30000000)
             .predictionCategoricalFieldNames({"categorical_col", "target_col"})
-            .predictionCustomProcessor(customProcessors.GetObject())
+            .predictionCustomProcessor(customProcessors)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(), "target_col"),
         outputWriterFactory};
 


### PR DESCRIPTION
These tests expect the custom processors to be an array, which
is what the test document gets parsed as.  Interpreting it as
an object trips an assertion if they are enabled, though works
by pure luck as the array and object are both just pointers
and are members of a union so you get the same address even
after calling the wrong method.