### PR TITLE
[7.x][ML] Remove dead code in simple output writers

### DIFF
--- a/include/api/CCsvOutputWriter.h
+++ b/include/api/CCsvOutputWriter.h
@@ -10,10 +10,8 @@
 #include <api/ImportExport.h>
 
 #include <iosfwd>
-#include <set>
 #include <sstream>
 #include <string>
-#include <utility>
 
 namespace ml {
 namespace api {
@@ -55,14 +53,10 @@ public:
 public:
     //! Constructor that causes output to be written to the internal string
     //! stream
-    CCsvOutputWriter(bool outputMessages = false,
-                     bool outputHeader = true,
-                     char escape = QUOTE,
-                     char separator = COMMA);
+    CCsvOutputWriter(bool outputHeader = true, char escape = QUOTE, char separator = COMMA);
 
     //! Constructor that causes output to be written to the specified stream
     CCsvOutputWriter(std::ostream& strmOut,
-                     bool outputMessages = false,
                      bool outputHeader = true,
                      char escape = QUOTE,
                      char separator = COMMA);
@@ -85,8 +79,7 @@ public:
     //! overrideDataRowFields and dataRowFields, the value in
     //! overrideDataRowFields will be written.
     bool writeRow(const TStrStrUMap& dataRowFields,
-                  const TStrStrUMap& overrideDataRowFields,
-                  TOptionalTime time) override;
+                  const TStrStrUMap& overrideDataRowFields) override;
 
     //! Get the contents of the internal string stream - for use with the
     //! zero argument constructor
@@ -109,9 +102,6 @@ private:
     //! Reference to the stream we're going to write to
     std::ostream& m_StrmOut;
 
-    //! Should we output a messages section before the CSV?
-    bool m_OutputMessages;
-
     //! Should we output a row containing the CSV column names?
     bool m_OutputHeader;
 
@@ -128,13 +118,6 @@ private:
     //! output stream.  Held as a member so that the capacity adjusts to
     //! an appropriate level, avoiding regular memory allocations.
     std::string m_WorkRecord;
-
-    using TStrStrPr = std::pair<std::string, std::string>;
-    using TStrStrPrSet = std::set<TStrStrPr>;
-    using TStrStrPrSetCItr = TStrStrPrSet::const_iterator;
-
-    //! Messages to be printed before the next lot of output
-    TStrStrPrSet m_Messages;
 
     //! Character to use for escaping quotes (const to allow compiler
     //! optimisations, since the value can't be changed after construction)

--- a/include/api/CNdJsonOutputWriter.h
+++ b/include/api/CNdJsonOutputWriter.h
@@ -45,31 +45,30 @@ public:
 
     //! Constructor that causes output to be written to the internal string
     //! stream, with some numeric fields
-    CNdJsonOutputWriter(const TStrSet& numericFields);
+    CNdJsonOutputWriter(TStrSet numericFields);
 
     //! Constructor that causes output to be written to the specified stream
     CNdJsonOutputWriter(std::ostream& strmOut);
 
     //! Constructor that causes output to be written to the specified stream
-    CNdJsonOutputWriter(const TStrSet& numericFields, std::ostream& strmOut);
+    CNdJsonOutputWriter(TStrSet numericFields, std::ostream& strmOut);
 
     //! Destructor flushes the stream
-    virtual ~CNdJsonOutputWriter();
+    ~CNdJsonOutputWriter() override;
 
     // Bring the other overload of fieldNames() into scope
     using CSimpleOutputWriter::fieldNames;
 
     //! Set field names - this function has no affect it always
     //! returns true
-    virtual bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames);
+    bool fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) override;
 
     // Bring the other overloads of writeRow() into scope
     using CSimpleOutputWriter::writeRow;
 
     //! Write the data row fields as a JSON object
-    virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields,
-                          TOptionalTime time);
+    bool writeRow(const TStrStrUMap& dataRowFields,
+                  const TStrStrUMap& overrideDataRowFields) override;
 
     //! Get the contents of the internal string stream - for use with the
     //! zero argument constructor

--- a/include/api/CSimpleOutputWriter.h
+++ b/include/api/CSimpleOutputWriter.h
@@ -6,11 +6,8 @@
 #ifndef INCLUDED_ml_api_CSimpleOutputWriter_h
 #define INCLUDED_ml_api_CSimpleOutputWriter_h
 
-#include <core/CoreTypes.h>
-
 #include <api/ImportExport.h>
 
-#include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
 #include <string>
@@ -38,8 +35,6 @@ public:
     using TStrVec = std::vector<std::string>;
     using TStrStrUMap = boost::unordered_map<std::string, std::string>;
 
-    using TOptionalTime = boost::optional<core_t::TTime>;
-
 public:
     CSimpleOutputWriter() = default;
 
@@ -66,12 +61,8 @@ public:
     //! overrideDataRowFields and dataRowFields, the value in
     //! overrideDataRowFields will be written.  The time will be passed
     //! as an empty optional, i.e. unknown.
-    bool writeRow(const TStrStrUMap& dataRowFields, const TStrStrUMap& overrideDataRowFields);
-
-    //! As above, but with a pre-parsed time.
     virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields,
-                          TOptionalTime time) = 0;
+                          const TStrStrUMap& overrideDataRowFields) = 0;
 
 protected:
     //! Class to cache a hash value so that it doesn't have to be repeatedly

--- a/lib/api/CCsvOutputWriter.cc
+++ b/lib/api/CCsvOutputWriter.cc
@@ -6,7 +6,6 @@
 #include <api/CCsvOutputWriter.h>
 
 #include <core/CLogger.h>
-#include <core/CSleep.h>
 
 #include <algorithm>
 #include <ostream>
@@ -15,35 +14,27 @@ namespace ml {
 namespace api {
 
 // Initialise statics
-const char CCsvOutputWriter::COMMA(',');
-const char CCsvOutputWriter::QUOTE('"');
-const char CCsvOutputWriter::RECORD_END('\n');
+const char CCsvOutputWriter::COMMA{','};
+const char CCsvOutputWriter::QUOTE{'"'};
+const char CCsvOutputWriter::RECORD_END{'\n'};
 
-CCsvOutputWriter::CCsvOutputWriter(bool outputMessages, bool outputHeader, char escape, char separator)
-    : m_StrmOut(m_StringOutputBuf), m_OutputMessages(outputMessages),
-      m_OutputHeader(outputHeader), m_Escape(escape), m_Separator(separator) {
+CCsvOutputWriter::CCsvOutputWriter(bool outputHeader, char escape, char separator)
+    : m_StrmOut{m_StringOutputBuf}, m_OutputHeader{outputHeader}, m_Escape{escape}, m_Separator{separator} {
     if (m_Separator == QUOTE || m_Separator == m_Escape || m_Separator == RECORD_END) {
         LOG_ERROR(<< "CSV output writer will not generate parsable output because "
                      "separator character ("
                   << m_Separator
-                  << ") is the same as "
-                     "the quote, escape and/or record end characters");
+                  << ") is the same as the quote, escape and/or record end characters");
     }
 }
 
-CCsvOutputWriter::CCsvOutputWriter(std::ostream& strmOut,
-                                   bool outputMessages,
-                                   bool outputHeader,
-                                   char escape,
-                                   char separator)
-    : m_StrmOut(strmOut), m_OutputMessages(outputMessages),
-      m_OutputHeader(outputHeader), m_Escape(escape), m_Separator(separator) {
+CCsvOutputWriter::CCsvOutputWriter(std::ostream& strmOut, bool outputHeader, char escape, char separator)
+    : m_StrmOut{strmOut}, m_OutputHeader{outputHeader}, m_Escape{escape}, m_Separator{separator} {
     if (m_Separator == QUOTE || m_Separator == m_Escape || m_Separator == RECORD_END) {
         LOG_ERROR(<< "CSV output writer will not generate parsable output because "
                      "separator character ("
                   << m_Separator
-                  << ") is the same as "
-                     "the quote, escape and/or record end characters");
+                  << ") is the same as the quote, escape and/or record end characters");
     }
 }
 
@@ -51,11 +42,6 @@ CCsvOutputWriter::~CCsvOutputWriter() {
     // Since we didn't flush the stream whilst working, we flush it on
     // destruction
     m_StrmOut.flush();
-
-    // We don't want the program to die before the remote end of the link has
-    // had a chance to read from any pipe to which our output stream might be
-    // connected, so sleep briefly here
-    core::CSleep::sleep(20);
 }
 
 bool CCsvOutputWriter::fieldNames(const TStrVec& fieldNames, const TStrVec& extraFieldNames) {
@@ -96,19 +82,6 @@ bool CCsvOutputWriter::fieldNames(const TStrVec& fieldNames, const TStrVec& extr
 
     m_WorkRecord += RECORD_END;
 
-    // Messages are output in arrears - this is not ideal - TODO
-    if (m_OutputMessages) {
-        for (const auto& message : m_Messages) {
-            m_StrmOut << message.first << '=' << message.second << RECORD_END;
-            LOG_DEBUG(<< "Forwarded " << message.first << '=' << message.second);
-        }
-
-        // Only output each message once
-        m_Messages.clear();
-
-        m_StrmOut << RECORD_END;
-    }
-
     if (m_OutputHeader) {
         m_StrmOut << m_WorkRecord;
     }
@@ -117,8 +90,7 @@ bool CCsvOutputWriter::fieldNames(const TStrVec& fieldNames, const TStrVec& extr
 }
 
 bool CCsvOutputWriter::writeRow(const TStrStrUMap& dataRowFields,
-                                const TStrStrUMap& overrideDataRowFields,
-                                TOptionalTime /*time*/) {
+                                const TStrStrUMap& overrideDataRowFields) {
     if (m_FieldNames.empty()) {
         LOG_ERROR(<< "Attempt to write data before field names");
         return false;
@@ -187,9 +159,8 @@ void CCsvOutputWriter::appendField(const std::string& field) {
     // per character of the string on which the find_first_of() method is
     // called.  This is not sensible when we're only checking for a small number
     // of possible characters.
-    bool needOuterQuotes(false);
-    for (std::string::const_iterator iter = field.begin(); iter != field.end(); ++iter) {
-        char curChar(*iter);
+    bool needOuterQuotes{false};
+    for (const char curChar : field) {
         if (curChar == m_Separator || curChar == QUOTE ||
             curChar == RECORD_END || curChar == m_Escape) {
             needOuterQuotes = true;
@@ -200,8 +171,7 @@ void CCsvOutputWriter::appendField(const std::string& field) {
     if (needOuterQuotes) {
         m_WorkRecord += QUOTE;
 
-        for (std::string::const_iterator iter = field.begin(); iter != field.end(); ++iter) {
-            char curChar(*iter);
+        for (const char curChar : field) {
             if (curChar == QUOTE || curChar == m_Escape) {
                 m_WorkRecord += m_Escape;
             }

--- a/lib/api/CSimpleOutputWriter.cc
+++ b/lib/api/CSimpleOutputWriter.cc
@@ -19,12 +19,7 @@ bool CSimpleOutputWriter::fieldNames(const TStrVec& fieldNames) {
 bool CSimpleOutputWriter::writeRow(const TStrStrUMap& dataRowFields) {
     // Since the overrides are checked first, but we know there aren't any, it's
     // most efficient to pretend everything's an override
-    return this->writeRow(EMPTY_FIELD_OVERRIDES, dataRowFields, TOptionalTime{});
-}
-
-bool CSimpleOutputWriter::writeRow(const TStrStrUMap& dataRowFields,
-                                   const TStrStrUMap& overrideDataRowFields) {
-    return this->writeRow(dataRowFields, overrideDataRowFields, TOptionalTime{});
+    return this->writeRow(EMPTY_FIELD_OVERRIDES, dataRowFields);
 }
 }
 }

--- a/lib/api/unittest/CCsvOutputWriterTest.cc
+++ b/lib/api/unittest/CCsvOutputWriterTest.cc
@@ -24,36 +24,15 @@ BOOST_AUTO_TEST_CASE(testAdd) {
 
     ml::api::CCsvOutputWriter writer;
 
-    ml::api::CCsvOutputWriter::TStrVec fieldNames;
-    fieldNames.push_back("_cd");
-    fieldNames.push_back("_indextime");
-    fieldNames.push_back("_kv");
-    fieldNames.push_back("_raw");
-    fieldNames.push_back("_serial");
-    fieldNames.push_back("_si");
-    fieldNames.push_back("_sourcetype");
-    fieldNames.push_back("_time");
-    fieldNames.push_back("date_hour");
-    fieldNames.push_back("date_mday");
-    fieldNames.push_back("date_minute");
-    fieldNames.push_back("date_month");
-    fieldNames.push_back("date_second");
-    fieldNames.push_back("date_wday");
-    fieldNames.push_back("date_year");
-    fieldNames.push_back("date_zone");
-    fieldNames.push_back("eventtype");
-    fieldNames.push_back("host");
-    fieldNames.push_back("index");
-    fieldNames.push_back("linecount");
-    fieldNames.push_back("punct");
-    fieldNames.push_back("source");
-    fieldNames.push_back("sourcetype");
-    fieldNames.push_back("server");
-    fieldNames.push_back("timeendpos");
-    fieldNames.push_back("timestartpos");
+    ml::api::CCsvOutputWriter::TStrVec fieldNames{
+        "_cd",         "_indextime",  "_kv",         "_raw",      "_serial",
+        "_si",         "_sourcetype", "_time",       "date_hour", "date_mday",
+        "date_minute", "date_month",  "date_second", "date_wday", "date_year",
+        "date_zone",   "eventtype",   "host",        "index",     "linecount",
+        "punct",       "source",      "sourcetype",  "server",    "timeendpos",
+        "timestartpos"};
 
-    ml::api::CCsvOutputWriter::TStrVec mlFieldNames;
-    mlFieldNames.push_back("mlcategory");
+    ml::api::CCsvOutputWriter::TStrVec mlFieldNames{"mlcategory"};
 
     BOOST_TEST_REQUIRE(writer.fieldNames(fieldNames, mlFieldNames));
 
@@ -90,28 +69,24 @@ BOOST_AUTO_TEST_CASE(testAdd) {
 
     BOOST_TEST_REQUIRE(writer.writeRow(originalFields, mlFields));
 
-    std::string output(writer.internalString());
+    std::string output{writer.internalString()};
 
     LOG_DEBUG(<< "Output is:\n" << output);
 
-    for (auto iter = fieldNames.begin(); iter != fieldNames.end(); ++iter) {
-        LOG_DEBUG(<< "Checking output contains '" << *iter << "'");
-        BOOST_TEST_REQUIRE(output.find(*iter) != std::string::npos);
+    for (const auto& fieldName : fieldNames) {
+        BOOST_TEST_REQUIRE(output.find(fieldName) != std::string::npos);
     }
 
-    for (auto iter = mlFieldNames.begin(); iter != mlFieldNames.end(); ++iter) {
-        LOG_DEBUG(<< "Checking output contains '" << *iter << "'");
-        BOOST_TEST_REQUIRE(output.find(*iter) != std::string::npos);
+    for (const auto& fieldName : mlFieldNames) {
+        BOOST_TEST_REQUIRE(output.find(fieldName) != std::string::npos);
     }
 
-    for (auto iter = originalFields.begin(); iter != originalFields.end(); ++iter) {
-        LOG_DEBUG(<< "Checking output contains '" << iter->second << "'");
-        BOOST_TEST_REQUIRE(output.find(iter->second) != std::string::npos);
+    for (const auto& field : originalFields) {
+        BOOST_TEST_REQUIRE(output.find(field.second) != std::string::npos);
     }
 
-    for (auto iter = mlFields.begin(); iter != mlFields.end(); ++iter) {
-        LOG_DEBUG(<< "Checking output contains '" << iter->second << "'");
-        BOOST_TEST_REQUIRE(output.find(iter->second) != std::string::npos);
+    for (const auto& field : mlFields) {
+        BOOST_TEST_REQUIRE(output.find(field.second) != std::string::npos);
     }
 }
 
@@ -120,37 +95,15 @@ BOOST_AUTO_TEST_CASE(testOverwrite) {
 
     ml::api::CCsvOutputWriter writer;
 
-    ml::api::CCsvOutputWriter::TStrVec fieldNames;
-    fieldNames.push_back("_cd");
-    fieldNames.push_back("_indextime");
-    fieldNames.push_back("_kv");
-    fieldNames.push_back("_raw");
-    fieldNames.push_back("_serial");
-    fieldNames.push_back("_si");
-    fieldNames.push_back("_sourcetype");
-    fieldNames.push_back("_time");
-    fieldNames.push_back("date_hour");
-    fieldNames.push_back("date_mday");
-    fieldNames.push_back("date_minute");
-    fieldNames.push_back("date_month");
-    fieldNames.push_back("date_second");
-    fieldNames.push_back("date_wday");
-    fieldNames.push_back("date_year");
-    fieldNames.push_back("date_zone");
-    fieldNames.push_back("eventtype");
-    fieldNames.push_back("host");
-    fieldNames.push_back("index");
-    fieldNames.push_back("linecount");
-    fieldNames.push_back("punct");
-    fieldNames.push_back("source");
-    fieldNames.push_back("sourcetype");
-    fieldNames.push_back("server");
-    fieldNames.push_back("timeendpos");
-    fieldNames.push_back("timestartpos");
+    ml::api::CCsvOutputWriter::TStrVec fieldNames{
+        "_cd",         "_indextime",  "_kv",         "_raw",      "_serial",
+        "_si",         "_sourcetype", "_time",       "date_hour", "date_mday",
+        "date_minute", "date_month",  "date_second", "date_wday", "date_year",
+        "date_zone",   "eventtype",   "host",        "index",     "linecount",
+        "punct",       "source",      "sourcetype",  "server",    "timeendpos",
+        "timestartpos"};
 
-    ml::api::CCsvOutputWriter::TStrVec mlFieldNames;
-    mlFieldNames.push_back("eventtype");
-    mlFieldNames.push_back("mlcategory");
+    ml::api::CCsvOutputWriter::TStrVec mlFieldNames{"eventtype", "mlcategory"};
 
     BOOST_TEST_REQUIRE(writer.fieldNames(fieldNames, mlFieldNames));
 
@@ -189,34 +142,29 @@ BOOST_AUTO_TEST_CASE(testOverwrite) {
 
     BOOST_TEST_REQUIRE(writer.writeRow(originalFields, mlFields));
 
-    std::string output(writer.internalString());
+    std::string output{writer.internalString()};
 
     LOG_DEBUG(<< "Output is:\n" << output);
 
-    for (auto iter = fieldNames.begin(); iter != fieldNames.end(); ++iter) {
-        LOG_DEBUG(<< "Checking output contains '" << *iter << "'");
-        BOOST_TEST_REQUIRE(output.find(*iter) != std::string::npos);
+    for (const auto& fieldName : fieldNames) {
+        BOOST_TEST_REQUIRE(output.find(fieldName) != std::string::npos);
     }
 
-    for (auto iter = mlFieldNames.begin(); iter != mlFieldNames.end(); ++iter) {
-        LOG_DEBUG(<< "Checking output contains '" << *iter << "'");
-        BOOST_TEST_REQUIRE(output.find(*iter) != std::string::npos);
+    for (const auto& fieldName : mlFieldNames) {
+        BOOST_TEST_REQUIRE(output.find(fieldName) != std::string::npos);
     }
 
-    for (auto iter = originalFields.begin(); iter != originalFields.end(); ++iter) {
-        // The Ml fields should override the originals
-        if (mlFields.find(iter->first) == mlFields.end()) {
-            LOG_DEBUG(<< "Checking output contains '" << iter->second << "'");
-            BOOST_TEST_REQUIRE(output.find(iter->second) != std::string::npos);
+    for (const auto& field : originalFields) {
+        // The ML fields should override the originals
+        if (mlFields.find(field.first) == mlFields.end()) {
+            BOOST_TEST_REQUIRE(output.find(field.second) != std::string::npos);
         } else {
-            LOG_DEBUG(<< "Checking output does not contain '" << iter->second << "'");
-            BOOST_TEST_REQUIRE(output.find(iter->second) == std::string::npos);
+            BOOST_TEST_REQUIRE(output.find(field.second) == std::string::npos);
         }
     }
 
-    for (auto iter = mlFields.begin(); iter != mlFields.end(); ++iter) {
-        LOG_DEBUG(<< "Checking output contains '" << iter->second << "'");
-        BOOST_TEST_REQUIRE(output.find(iter->second) != std::string::npos);
+    for (const auto& field : mlFields) {
+        BOOST_TEST_REQUIRE(output.find(field.second) != std::string::npos);
     }
 }
 
@@ -224,42 +172,20 @@ BOOST_AUTO_TEST_CASE(testThroughput) {
     // In this test, some fields from the input are changed in the output
 
     // Write to /dev/null (Unix) or nul (Windows)
-    std::ofstream ofs(ml::core::COsFileFuncs::NULL_FILENAME);
+    std::ofstream ofs{ml::core::COsFileFuncs::NULL_FILENAME};
     BOOST_TEST_REQUIRE(ofs.is_open());
 
-    ml::api::CCsvOutputWriter writer(ofs);
+    ml::api::CCsvOutputWriter writer{ofs};
 
-    ml::api::CCsvOutputWriter::TStrVec fieldNames;
-    fieldNames.push_back("_cd");
-    fieldNames.push_back("_indextime");
-    fieldNames.push_back("_kv");
-    fieldNames.push_back("_raw");
-    fieldNames.push_back("_serial");
-    fieldNames.push_back("_si");
-    fieldNames.push_back("_sourcetype");
-    fieldNames.push_back("_time");
-    fieldNames.push_back("date_hour");
-    fieldNames.push_back("date_mday");
-    fieldNames.push_back("date_minute");
-    fieldNames.push_back("date_month");
-    fieldNames.push_back("date_second");
-    fieldNames.push_back("date_wday");
-    fieldNames.push_back("date_year");
-    fieldNames.push_back("date_zone");
-    fieldNames.push_back("eventtype");
-    fieldNames.push_back("host");
-    fieldNames.push_back("index");
-    fieldNames.push_back("linecount");
-    fieldNames.push_back("punct");
-    fieldNames.push_back("source");
-    fieldNames.push_back("sourcetype");
-    fieldNames.push_back("server");
-    fieldNames.push_back("timeendpos");
-    fieldNames.push_back("timestartpos");
+    ml::api::CCsvOutputWriter::TStrVec fieldNames{
+        "_cd",         "_indextime",  "_kv",         "_raw",      "_serial",
+        "_si",         "_sourcetype", "_time",       "date_hour", "date_mday",
+        "date_minute", "date_month",  "date_second", "date_wday", "date_year",
+        "date_zone",   "eventtype",   "host",        "index",     "linecount",
+        "punct",       "source",      "sourcetype",  "server",    "timeendpos",
+        "timestartpos"};
 
-    ml::api::CCsvOutputWriter::TStrVec mlFieldNames;
-    mlFieldNames.push_back("eventtype");
-    mlFieldNames.push_back("mlcategory");
+    ml::api::CCsvOutputWriter::TStrVec mlFieldNames{"eventtype", "mlcategory"};
 
     ml::api::CCsvOutputWriter::TStrStrUMap originalFields;
     originalFields["_cd"] = "0:3933689";
@@ -295,18 +221,18 @@ BOOST_AUTO_TEST_CASE(testThroughput) {
     mlFields["mlcategory"] = "42";
 
     // Write the record this many times
-    static const size_t TEST_SIZE(75000);
+    static const std::size_t TEST_SIZE{75000};
 
-    ml::core_t::TTime start(ml::core::CTimeUtils::now());
+    ml::core_t::TTime start{ml::core::CTimeUtils::now()};
     LOG_INFO(<< "Starting throughput test at " << ml::core::CTimeUtils::toTimeString(start));
 
     BOOST_TEST_REQUIRE(writer.fieldNames(fieldNames, mlFieldNames));
 
-    for (size_t count = 0; count < TEST_SIZE; ++count) {
+    for (std::size_t count = 0; count < TEST_SIZE; ++count) {
         BOOST_TEST_REQUIRE(writer.writeRow(originalFields, mlFields));
     }
 
-    ml::core_t::TTime end(ml::core::CTimeUtils::now());
+    ml::core_t::TTime end{ml::core::CTimeUtils::now()};
     LOG_INFO(<< "Finished throughput test at " << ml::core::CTimeUtils::toTimeString(end));
 
     LOG_INFO(<< "Writing " << TEST_SIZE << " records took " << (end - start) << " seconds");
@@ -315,14 +241,13 @@ BOOST_AUTO_TEST_CASE(testThroughput) {
 BOOST_AUTO_TEST_CASE(testExcelQuoting) {
     ml::api::CCsvOutputWriter writer;
 
-    ml::api::CCsvOutputWriter::TStrVec fieldNames;
-    fieldNames.push_back("no_special");
-    fieldNames.push_back("contains_quote");
-    fieldNames.push_back("contains_quote_quote");
-    fieldNames.push_back("contains_separator");
-    fieldNames.push_back("contains_quote_separator");
-    fieldNames.push_back("contains_newline");
-    fieldNames.push_back("contains_quote_newline");
+    ml::api::CCsvOutputWriter::TStrVec fieldNames{"no_special",
+                                                  "contains_quote",
+                                                  "contains_quote_quote",
+                                                  "contains_separator",
+                                                  "contains_quote_separator",
+                                                  "contains_newline",
+                                                  "contains_quote_newline"};
 
     BOOST_TEST_REQUIRE(writer.fieldNames(fieldNames));
 
@@ -337,39 +262,35 @@ BOOST_AUTO_TEST_CASE(testExcelQuoting) {
 
     BOOST_TEST_REQUIRE(writer.writeRow(fieldValues));
 
-    std::string output(writer.internalString());
+    std::string output{writer.internalString()};
 
     LOG_DEBUG(<< "Output is:\n" << output);
 
-    BOOST_REQUIRE_EQUAL(std::string("no_special,"
-                                    "contains_quote,"
-                                    "contains_quote_quote,"
-                                    "contains_separator,"
-                                    "contains_quote_separator,"
-                                    "contains_newline,"
-                                    "contains_quote_newline\n"
-                                    "a,"
-                                    "\"\"\"\","
-                                    "\"\"\"\"\"\","
-                                    "\",\","
-                                    "\"\"\",\","
-                                    "\"\n\","
-                                    "\"\"\"\n\"\n"),
+    BOOST_REQUIRE_EQUAL("no_special,"
+                        "contains_quote,"
+                        "contains_quote_quote,"
+                        "contains_separator,"
+                        "contains_quote_separator,"
+                        "contains_newline,"
+                        "contains_quote_newline\n"
+                        "a,"
+                        "\"\"\"\","
+                        "\"\"\"\"\"\","
+                        "\",\","
+                        "\"\"\",\","
+                        "\"\n\","
+                        "\"\"\"\n\"\n",
                         output);
 }
 
 BOOST_AUTO_TEST_CASE(testNonExcelQuoting) {
-    ml::api::CCsvOutputWriter writer(false, true, '\\');
+    ml::api::CCsvOutputWriter writer{true, '\\'};
 
-    ml::api::CCsvOutputWriter::TStrVec fieldNames;
-    fieldNames.push_back("no_special");
-    fieldNames.push_back("contains_quote");
-    fieldNames.push_back("contains_escape");
-    fieldNames.push_back("contains_escape_quote");
-    fieldNames.push_back("contains_separator");
-    fieldNames.push_back("contains_escape_separator");
-    fieldNames.push_back("contains_newline");
-    fieldNames.push_back("contains_escape_newline");
+    ml::api::CCsvOutputWriter::TStrVec fieldNames{
+        "no_special",         "contains_quote",
+        "contains_escape",    "contains_escape_quote",
+        "contains_separator", "contains_escape_separator",
+        "contains_newline",   "contains_escape_newline"};
 
     BOOST_TEST_REQUIRE(writer.fieldNames(fieldNames));
 
@@ -385,26 +306,26 @@ BOOST_AUTO_TEST_CASE(testNonExcelQuoting) {
 
     BOOST_TEST_REQUIRE(writer.writeRow(fieldValues));
 
-    std::string output(writer.internalString());
+    std::string output{writer.internalString()};
 
     LOG_DEBUG(<< "Output is:\n" << output);
 
-    BOOST_REQUIRE_EQUAL(std::string("no_special,"
-                                    "contains_quote,"
-                                    "contains_escape,"
-                                    "contains_escape_quote,"
-                                    "contains_separator,"
-                                    "contains_escape_separator,"
-                                    "contains_newline,"
-                                    "contains_escape_newline\n"
-                                    "a,"
-                                    "\"\\\"\","
-                                    "\"\\\\\","
-                                    "\"\\\\\\\"\","
-                                    "\",\","
-                                    "\"\\\\,\","
-                                    "\"\n\","
-                                    "\"\\\\\n\"\n"),
+    BOOST_REQUIRE_EQUAL("no_special,"
+                        "contains_quote,"
+                        "contains_escape,"
+                        "contains_escape_quote,"
+                        "contains_separator,"
+                        "contains_escape_separator,"
+                        "contains_newline,"
+                        "contains_escape_newline\n"
+                        "a,"
+                        "\"\\\"\","
+                        "\"\\\\\","
+                        "\"\\\\\\\"\","
+                        "\",\","
+                        "\"\\\\,\","
+                        "\"\n\","
+                        "\"\\\\\n\"\n",
                         output);
 }
 

--- a/lib/api/unittest/CNdJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CNdJsonOutputWriterTest.cc
@@ -4,13 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <core/CLogger.h>
-
 #include <api/CNdJsonOutputWriter.h>
 
 #include <boost/test/unit_test.hpp>
-
-#include <sstream>
 
 BOOST_AUTO_TEST_SUITE(CNdJsonOutputWriterTest)
 
@@ -24,10 +20,9 @@ BOOST_AUTO_TEST_CASE(testStringOutput) {
     ml::api::CNdJsonOutputWriter writer;
     BOOST_TEST_REQUIRE(writer.writeRow(dataRowFields, overrideDataRowFields));
 
-    const std::string& output = writer.internalString();
+    const std::string& output{writer.internalString()};
 
-    BOOST_REQUIRE_EQUAL(
-        std::string("{\"probability\":\"0.01\",\"normalized_score\":\"3.3\"}\n"), output);
+    BOOST_REQUIRE_EQUAL("{\"probability\":\"0.01\",\"normalized_score\":\"3.3\"}\n", output);
 }
 
 BOOST_AUTO_TEST_CASE(testNumericOutput) {
@@ -37,13 +32,12 @@ BOOST_AUTO_TEST_CASE(testNumericOutput) {
     ml::api::CNdJsonOutputWriter::TStrStrUMap overrideDataRowFields;
     overrideDataRowFields["normalized_score"] = "3.3";
 
-    ml::api::CNdJsonOutputWriter writer({"probability", "normalized_score"});
+    ml::api::CNdJsonOutputWriter writer{{"probability", "normalized_score"}};
     BOOST_TEST_REQUIRE(writer.writeRow(dataRowFields, overrideDataRowFields));
 
-    const std::string& output = writer.internalString();
+    const std::string& output{writer.internalString()};
 
-    BOOST_REQUIRE_EQUAL(
-        std::string("{\"probability\":0.01,\"normalized_score\":3.3}\n"), output);
+    BOOST_REQUIRE_EQUAL("{\"probability\":0.01,\"normalized_score\":3.3}\n", output);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- The "messages" functionality in the CSV output writer was
  obsolete (related to the old Prelert app for Splunk)
- The optional time passed to the output methods was never used
- Unit tests could be simplified using modern syntax, and taking
  advantage of the fact that Boost.Test automatically prints
  what was compared when assertions fail
- The sleeps in destructors related to some dodgy behaviour with
  Python and named pipes on Solaris - no longer relevant

Backport of #1422