### PR TITLE
Fix deprecated Gradle API usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,11 +126,11 @@ def zipSpec = copySpec {
 
 task buildZip(type: Zip) {
   dependsOn strip
-  baseName = artifactName
+  archiveBaseName = artifactName
   with zipSpec
-  destinationDir = file("${buildDir}/distributions")
-  version = project.version
-  classifier = artifactClassifier
+  destinationDirectory = file("${buildDir}/distributions")
+  archiveVersion = project.version
+  archiveClassifier = artifactClassifier
 }
 
 def zipSpecSymbols = copySpec {
@@ -145,11 +145,11 @@ def zipSpecSymbols = copySpec {
 
 task buildZipSymbols(type: Zip) {
   dependsOn strip
-  baseName = "$artifactName-debug"
+  archiveBaseName = "$artifactName-debug"
   with zipSpecSymbols
-  destinationDir = file("${buildDir}/distributions")
-  version = project.version
-  classifier = artifactClassifier
+  destinationDirectory = file("${buildDir}/distributions")
+  archiveVersion = project.version
+  archiveClassifier = artifactClassifier
 }
 
 // The uber zip contains C++ binaries for as many platforms as possible
@@ -171,10 +171,10 @@ def uberZipSpec = copySpec {
 
 task buildUberZip(type: Zip) {
   dependsOn buildZip
-  baseName = "$artifactName"
+  archiveBaseName = "$artifactName"
   with uberZipSpec
-  destinationDir = file("${buildDir}/distributions")
-  version = project.version
+  destinationDirectory = file("${buildDir}/distributions")
+  archiveVersion = project.version
 }
 
 configurations.create('default')

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,10 +12,10 @@ repositories {
 GradleVersion logVersion = GradleVersion.current() > GradleVersion.version('4.3') ? GradleVersion.version('4.3') : GradleVersion.current()
 
 dependencies {
-  compile gradleApi()
-  compile localGroovy()
-  compile 'com.amazonaws:aws-java-sdk-s3:1.10.33'
-  compile 'org.apache.velocity:velocity:1.7'
+  compileOnly gradleApi()
+  compileOnly localGroovy()
+  implementation 'com.amazonaws:aws-java-sdk-s3:1.10.33'
+  implementation 'org.apache.velocity:velocity:1.7'
   compileOnly "org.gradle:gradle-logging:${logVersion.getVersion()}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ org.gradle.daemon=false
 elasticsearchVersion=8.0.0
 
 artifactName=ml-cpp
+
+# Enforce the build to fail on deprecated gradle api usage
+systemProp.org.gradle.warning.mode=fail

--- a/upload.gradle
+++ b/upload.gradle
@@ -42,17 +42,22 @@ if (envMlAwsSecretKey != null) {
  */
 class DownloadPlatformSpecific extends DefaultTask {
 
+  @Input
   String version = project.version
+
+  @Input
   String artifactGroupPath = project.group.replaceAll("\\.", "/")
 
   /**
    * Base name for the artifacts
    */
+  @Input
   String baseName
 
   /**
    * Directory to download platform specific zip files into
    */
+  @InputDirectory
   File downloadDirectory
 
   /**
@@ -61,6 +66,7 @@ class DownloadPlatformSpecific extends DefaultTask {
   @OutputDirectory
   File extractDirectory
 
+  @Input
   List<String> platforms = [ 'darwin-x86_64', 'linux-aarch64', 'linux-x86_64', 'windows-x86_64' ]
 
   DownloadPlatformSpecific() {
@@ -120,8 +126,8 @@ task downloadPlatformSpecific(type: DownloadPlatformSpecific) {
 }
 
 task buildUberZip(type: Zip, dependsOn: downloadPlatformSpecific) {
-  baseName = artifactName
-  version = project.version
+  archiveBaseName = artifactName
+  archiveVersion = project.version
   destinationDirectory = file("${buildDir}/distributions")
   from(fileTree(downloadPlatformSpecific.outputs.files.singleFile))
   description = 'Create an uber zip from combined platform-specific C++ distributions'


### PR DESCRIPTION
This PR fixes some deprecated gradle api usages in the gradle build. It also enforces the failure of the build from now on if a deprecated api is used. That makes it easy to keep the build clean and not let deprecations sneak into the build over time. 

This PR is related to a discussion with the elasticsearch infra team at https://elastic.slack.com/archives/C8UUBNASY/p1595288611366200 after a failure in a 7.8.1 BC 