### PR TITLE
[ML] Changing the message for memory limit failure

### DIFF
--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -193,9 +193,9 @@ void CDataFrameAnalysisInstrumentation::monitor(CDataFrameAnalysisInstrumentatio
             LOG_ERROR(<< "Input error: required memory " << bytesToString(memory) << " exceeds the memory limit "
                       << bytesToString(memoryLimit) << ". New estimated limit is "
                       << bytesToString(memoryReestimateBytes) << ".");
-            HANDLE_FATAL(<< "Input error: Memory limit " << bytesToString(memoryLimit)
-                         << " has been exceeded. Please force stop the job, increase to new estimated limit "
-                         << bytesToString(memoryReestimateBytes) << " and restart.")
+            HANDLE_FATAL(<< "Input error: Memory limit [" << bytesToString(memoryLimit)
+                         << "] has been exceeded. Please force stop the job, increase to new estimated limit ["
+                         << bytesToString(memoryReestimateBytes) << "] and restart.")
         }
 
         wait = std::min(2 * wait, 1024);

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -190,9 +190,11 @@ void CDataFrameAnalysisInstrumentation::monitor(CDataFrameAnalysisInstrumentatio
             instrumentation.memoryReestimate(static_cast<std::int64_t>(memoryReestimateBytes));
             instrumentation.memoryStatus(E_HardLimit);
             instrumentation.flush();
-            HANDLE_FATAL(<< "Input error: required memory " << bytesToString(memory)
-                         << " exceeds the memory limit " << bytesToString(memoryLimit)
-                         << ". Please force-stop the analysis job, increase the limit to at least "
+            LOG_ERROR(<< "Input error: required memory " << bytesToString(memory) << " exceeds the memory limit "
+                      << bytesToString(memoryLimit) << ". New estimated limit is "
+                      << bytesToString(memoryReestimateBytes) << ".");
+            HANDLE_FATAL(<< "Input error: Memory limit " << bytesToString(memoryLimit)
+                         << " has been exceeded. Please force stop the job, increase to new estimated limit "
                          << bytesToString(memoryReestimateBytes) << " and restart.")
         }
 


### PR DESCRIPTION
When the job fails due to exceeded memory limit, I issue a `LOG_ERROR` with the details about the final memory usage and a `HANDLE_FATAL` message which is more concise and will be used as an audit message for the user. 

The original message is confusing for the user since they would need to double memory requirement even though the limit might be exceed by a few megs.