### PR TITLE
[ML] Upgrade to clang 8/Apple clang 11.3.1 for macOS compilation

### DIFF
--- a/3rd_party/3rd_party.sh
+++ b/3rd_party/3rd_party.sh
@@ -65,7 +65,7 @@ case `uname` in
             STL_EXTENSION=.so.6
             ZLIB_LOCATION=
         elif [ "$CPP_CROSS_COMPILE" = macosx ] ; then
-            SYSROOT=/usr/local/sysroot-x86_64-apple-macosx10.13
+            SYSROOT=/usr/local/sysroot-x86_64-apple-macosx10.14
             BOOST_LOCATION=$SYSROOT/usr/local/lib
             BOOST_COMPILER=clang
             BOOST_EXTENSION=mt-x64-1_71.dylib

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -50,7 +50,7 @@ For C++17 Xcode 10 is required, and this requires macOS High Sierra or above. Th
 
 - If you are using High Sierra, you must install Xcode 10.1.x
 - If you are using Mojave, you must install Xcode 11.3.x
-- If you are using Catalina, you must install Xcode 11.4.x or above
+- If you are using Catalina, you must install Xcode 11.6.x or above
 
 Xcode is distributed as a `.xip` file; simply double click the `.xip` file to expand it, then drag `Xcode.app` to your `/Applications` directory.
 (Older versions of Xcode can be downloaded from [here](https://developer.apple.com/download/more/), provided you are signed in with your Apple ID.)

--- a/build-setup/macos_cross_compiled.md
+++ b/build-setup/macos_cross_compiled.md
@@ -21,31 +21,33 @@ export CPP_CROSS_COMPILE=macosx
 
 Start by configuring a native macOS build server as described in [macos.md](macos.md).
 
-The remainder of these instructions assume the macOS build server you have configured is for macOS 10.13 (High Sierra).  This is what builds for distribution are currently built on.
+The remainder of these instructions assume the macOS build server you have configured is for macOS 10.14 (Mojave).  This is what builds for distribution are currently built on.
 
 On the fully configured macOS build server, run the following commands:
 
 ```
 cd /usr
-tar jcvf ~/usr-x86_64-apple-macosx10.13.tar.bz2 include lib local
+tar jcvf ~/usr-x86_64-apple-macosx10.14.tar.bz2 include lib local
 cd /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr
-tar jcvf ~/xcode-x86_64-apple-macosx10.13.tar.bz2 include
+tar jcvf ~/xcode-x86_64-apple-macosx10.14.tar.bz2 include
+cd `xcrun --show-sdk-path`/usr
+tar jcvf ~/sdk-x86_64-apple-macosx10.14.tar.bz2 include lib
 ```
 
 These instructions also assume the host platform is Ubuntu 18.04.  It makes life much easier if the host platform is a version of Ubuntu that's new enough to run the official binary distribution of clang/LLVM (otherwise it would be necessary to build clang/LLVM from source).
 
-Transfer the two archives created in your home directory on the macOS build server, `usr-x86_64-apple-macosx10.13.tar.bz2` and `xcode-x86_64-apple-macosx10.13.tar.bz2`, to your home directory on the cross compilation host build server.
+Transfer the three archives created in your home directory on the macOS build server, `usr-x86_64-apple-macosx10.14.tar.bz2`, `xcode-x86_64-apple-macosx10.14.tar.bz2` and `sdk-x86_64-apple-macosx10.14.tar.bz2`, to your home directory on the cross compilation host build server.
 
 ### OS Packages
 
-You need clang 6.0, plus a number of other build tools.  They can be installed on modern Ubuntu as follows:
+You need clang 8, plus a number of other build tools.  They can be installed on modern Ubuntu as follows:
 
 ```
 sudo apt-get install automake autogen build-essential bzip2 git gobjc libtool software-properties-common unzip wget
 
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
-sudo apt-get install clang-6.0 clang-6.0-doc libclang1-6.0 libllvm6.0 lldb-6.0 llvm-6.0 llvm-6.0-doc llvm-6.0-runtime
+sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
+sudo apt-get install clang-8 clang-8-doc libclang1-8 libllvm8 lldb-8 llvm-8 llvm-8-doc llvm-8-runtime
 ```
 
 (It is strongly recommended NOT to attempt to create a cross compile environment on an old version of Linux, because you will have to build clang from source and you need a modern C++ compiler to build clang.  So you would probably end up first building a modern version of gcc using the system default gcc, then building clang using the modern gcc.)
@@ -55,10 +57,11 @@ sudo apt-get install clang-6.0 clang-6.0-doc libclang1-6.0 libllvm6.0 lldb-6.0 l
 Add the dependencies that you copied from the fully configured macOS build server in the "Initial Preparation" step.
 
 ```
-sudo mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.13/usr
-cd /usr/local/sysroot-x86_64-apple-macosx10.13/usr
-sudo tar jxvf ~/usr-x86_64-apple-macosx10.13.tar.bz2
-sudo tar jxvf ~/xcode-x86_64-apple-macosx10.13.tar.bz2
+sudo mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.14/usr
+cd /usr/local/sysroot-x86_64-apple-macosx10.14/usr
+sudo tar jxvf ~/usr-x86_64-apple-macosx10.14.tar.bz2
+sudo tar jxvf ~/xcode-x86_64-apple-macosx10.14.tar.bz2
+sudo tar jxvf ~/sdk-x86_64-apple-macosx10.14.tar.bz2
 ```
 
 ### cctools-port
@@ -68,15 +71,14 @@ You need to obtain Linux ports of several Apple development tools.  The easiest 
 ```
 git clone https://github.com/tpoechtrager/cctools-port.git
 cd cctools-port/cctools
-git checkout 921-ld64-409.12
-sed -i -e 's/autoconf/autoreconf -fi/' autogen.sh
-export CC=clang-6.0
-export CXX=clang++-6.0
+git checkout 949.0.1-ld64-530
+export CC=clang-8
+export CXX=clang++-8
 ./autogen.sh
-./configure --target=x86_64-apple-macosx10.13 --with-llvm-config=/usr/bin/llvm-config-6.0
+./configure --target=x86_64-apple-macosx10.14 --with-llvm-config=/usr/bin/llvm-config-8
 make
 sudo make install
 ```
 
-The "921-ld64-409.12" branch in the [cctools-port repository](https://github.com/tpoechtrager/cctools-port) corresponds to the tools for macOS 10.13 High Sierra and clang 6.0.  (A different branch would be required for newer versions of the OS/compiler.)
+The "949.0.1-ld64-530" branch in the [cctools-port repository](https://github.com/tpoechtrager/cctools-port) corresponds to the tools for macOS 10.14 Mojave and clang 8.  (A different branch would be required for newer versions of the OS/compiler.)
 

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -17,7 +17,7 @@
 HOST=push.docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-macosx-build
-VERSION=8
+VERSION=9
 
 set -e
 

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-macosx-build:8
+FROM docker.elastic.co/ml-dev/ml-macosx-build:9
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/macosx_image/Dockerfile
+++ b/dev-tools/docker/macosx_image/Dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # This is basically automating the setup instructions in build-setup/macos_cross_compiled.md
 
@@ -12,32 +12,33 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 
 # Make sure apt-get is up to date and required packages are installed
 RUN \
+  export DEBIAN_FRONTEND=noninteractive && \
   apt-get update && \
   apt-get install --no-install-recommends -y apt-utils automake autogen build-essential bzip2 git gobjc gpg-agent libtool software-properties-common unzip wget zip
 
 # Install clang
 RUN \
   wget --quiet -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-  apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" && \
-  apt-get install --no-install-recommends -y clang-6.0 libclang1-6.0 libllvm6.0 llvm-6.0 llvm-6.0-runtime
+  apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" && \
+  apt-get install --no-install-recommends -y clang-8 libclang1-8 libllvm8 llvm-8 llvm-8-runtime
 
 # Add build dependencies transferred from native Mac build server
 RUN \
-  mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.13/usr && \
-  cd /usr/local/sysroot-x86_64-apple-macosx10.13/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.13-1.tar.bz2 | tar jxf - && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/xcode-x86_64-apple-macosx10.13-1.tar.bz2 | tar jxf -
+  mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
+  cd /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/xcode-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/sdk-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf -
 
 # Build cctools-port
 RUN \
   git clone https://github.com/tpoechtrager/cctools-port.git && \
   cd cctools-port/cctools && \
-  git checkout 921-ld64-409.12 && \
-  sed -i -e 's/autoconf/autoreconf -fi/' autogen.sh && \
-  export CC=clang-6.0 && \
-  export CXX=clang++-6.0 && \
+  git checkout 949.0.1-ld64-530 && \
+  export CC=clang-8 && \
+  export CXX=clang++-8 && \
   ./autogen.sh && \
-  ./configure --target=x86_64-apple-macosx10.13 --with-llvm-config=/usr/bin/llvm-config-6.0 && \
+  ./configure --target=x86_64-apple-macosx10.14 --with-llvm-config=/usr/bin/llvm-config-8 && \
   make -j`nproc` && \
   make install && \
   cd ../.. && \

--- a/dev-tools/strip_binaries.sh
+++ b/dev-tools/strip_binaries.sh
@@ -87,11 +87,11 @@ case `uname` in
                 objcopy --add-gnu-debuglink="$LIBRARY-debug" "$LIBRARY"
             done
         elif [ "$CPP_CROSS_COMPILE" = macosx ] ; then
-            CROSS_TARGET_PLATFORM=x86_64-apple-macosx10.13
+            CROSS_TARGET_PLATFORM=x86_64-apple-macosx10.14
             for PROGRAM in `ls -1d "$EXE_DIR"/* | grep -v '\.dSYM$'`
             do
                 echo "Stripping $PROGRAM"
-                llvm-dsymutil-6.0 $PROGRAM
+                dsymutil-8 $PROGRAM
                 /usr/local/bin/$CROSS_TARGET_PLATFORM-strip -u -r $PROGRAM
             done
             for LIBRARY in `ls -1d "$DYNAMIC_LIB_DIR"/* | grep -v '\.dSYM$'`
@@ -99,7 +99,7 @@ case `uname` in
                 echo "Stripping $LIBRARY"
                 case $LIBRARY in
                     *Ml*)
-                        llvm-dsymutil-6.0 $LIBRARY
+                        dsymutil-8 $LIBRARY
                 esac
                 /usr/local/bin/$CROSS_TARGET_PLATFORM-strip -x $LIBRARY
             done

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,8 +34,8 @@
 
 * The Windows build platform for the {ml} C++ code now uses Visual Studio 2019. (See
   {ml-pull}1352[#1352].)
-* The macOS build platform for the {ml} C++ code is now High Sierra running Xcode 10.1,
-  or Ubuntu 18.04 running clang 6.0 for cross compilation. (See {ml-pull}867[#867].)
+* The macOS build platform for the {ml} C++ code is now Mojave running Xcode 11.3.1,
+  or Ubuntu 20.04 running clang 8 for cross compilation. (See {ml-pull}1429[#1429].)
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3. (See
   {ml-pull}1170[#1170].)
 

--- a/mk/linux_crosscompile_macosx.mk
+++ b/mk/linux_crosscompile_macosx.mk
@@ -10,9 +10,9 @@ CPP_PLATFORM_HOME=$(CPP_DISTRIBUTION_HOME)/platform/darwin-x86_64
 ML_APP_NAME=controller
 APP_CONTENTS=$(ML_APP_NAME).app/Contents
 
-CROSS_TARGET_PLATFORM=x86_64-apple-macosx10.13
+CROSS_TARGET_PLATFORM=x86_64-apple-macosx10.14
 SYSROOT=/usr/local/sysroot-$(CROSS_TARGET_PLATFORM)
-CLANGVER=6.0
+CLANGVER=8
 # We use a natively compiled Boost even when cross compiling our own source
 # code, and Apple's clang versions are different to LLVM's clang versions, so
 # the natively built library file names will contain different versions.  Then
@@ -20,7 +20,8 @@ CLANGVER=6.0
 # 3.8 -> 70 (Xcode 7.2)
 # 3.9 -> 80 (Xcode 8.2)
 # 6.0 -> 100 (Xcode 10.1)
-BOOSTCLANGVER=100
+# 8 -> 110 (Xcode 11.3)
+BOOSTCLANGVER=110
 CROSS_FLAGS=--sysroot=$(SYSROOT) -B /usr/local/bin -target $(CROSS_TARGET_PLATFORM)
 CC=clang-$(CLANGVER) $(CROSS_FLAGS)
 CXX=clang++-$(CLANGVER) $(CROSS_FLAGS) -std=c++17 -stdlib=libc++
@@ -37,7 +38,7 @@ endif
 endif
 
 # Start by enabling all warnings and then disable the really pointless/annoying ones
-CFLAGS=-g $(OPTCFLAGS) -msse4.2 -fstack-protector -Weverything -Werror-switch -Wno-deprecated -Wno-disabled-macro-expansion -Wno-documentation-deprecated-sync -Wno-documentation-unknown-command -Wno-float-equal -Wno-missing-prototypes -Wno-padded -Wno-sign-conversion -Wno-unreachable-code -Wno-used-but-marked-unused $(COVERAGE)
+CFLAGS=-g $(OPTCFLAGS) -msse4.2 -fstack-protector -Weverything -Werror-switch -Wno-deprecated -Wno-disabled-macro-expansion -Wno-documentation-deprecated-sync -Wno-documentation-unknown-command -Wno-extra-semi-stmt -Wno-float-equal -Wno-missing-prototypes -Wno-padded -Wno-sign-conversion -Wno-unreachable-code -Wno-used-but-marked-unused $(COVERAGE)
 CXXFLAGS=$(CFLAGS) -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors -Wno-global-constructors -Wno-return-std-move-in-c++11 -Wno-unused-member-function -Wno-weak-vtables
 CPPFLAGS=-isystem $(SYSROOT)/usr/include/c++/v1 -isystem $(CPP_SRC_HOME)/3rd_party/include -isystem $(SYSROOT)/usr/local/include -D$(OS) $(OPTCPPFLAGS)
 ANALYZEFLAGS=--analyze


### PR DESCRIPTION
Upgrade to build the macOS version 8.x of the ML C++
using Apple clang 11.3.1 on Mojave or cross-compiling
using clang 8 on Ubuntu 20.04.