### PR TITLE
[ML] Fixed errors identified by valgrind memcheck

### DIFF
--- a/lib/core/CPackedBitVector.cc
+++ b/lib/core/CPackedBitVector.cc
@@ -143,8 +143,9 @@ bool CPackedBitVector::fromDelimited(const std::string& str) {
             CPersistUtils::fromString(str.substr(pos + 1), runLengthBytes)) {
             m_First = (first != 0);
             m_Parity = (parity != 0);
+            runLengthBytes.push_back(0);
             for (std::size_t j = 0, runLength = read(runLengthBytes[j]);
-                 j < runLengthBytes.size(); runLength += read(runLengthBytes[++j])) {
+                 j + 1 < runLengthBytes.size(); runLength += read(runLengthBytes[++j])) {
                 if (complete(runLengthBytes[j])) {
                     appendRun(runLength, m_LastRunBytes, m_RunLengthBytes);
                     runLength = 0;

--- a/lib/core/unittest/CPackedBitVectorTest.cc
+++ b/lib/core/unittest/CPackedBitVectorTest.cc
@@ -234,8 +234,8 @@ BOOST_AUTO_TEST_CASE(testInternals) {
 
         auto byteItr = runLengthBytes.cbegin();
         for (std::size_t j = 0; j < allRunLengths.size(); ++j) {
-            BOOST_TEST_REQUIRE(allRunLengths[j],
-                               CPackedBitVectorInternals::popRunLength(byteItr));
+            std::size_t readLength{CPackedBitVectorInternals::popRunLength(byteItr)};
+            BOOST_REQUIRE_EQUAL(allRunLengths[j], readLength);
         }
     }
 }


### PR DESCRIPTION
`Valgrind`'s `memcheck` tool  was run over the unit test suite. The tool picked up
an error related to unit test code only and another in production code
itself. Labelling as a non-issue because of the relatively minor nature of the problems identified.