### PR TITLE
[7.8][ML] Adding /usr/local/bin to the Linux PATH for FOSSA

### DIFF
--- a/set_env.sh
+++ b/set_env.sh
@@ -88,7 +88,7 @@ fi
 case $SIMPLE_PLATFORM in
 
     linux)
-        PATH=/usr/local/gcc75/bin:/usr/bin:/bin:/usr/local/gcc75/sbin:/usr/sbin:/sbin
+        PATH=/usr/local/gcc75/bin:/usr/bin:/bin:/usr/local/gcc75/sbin:/usr/sbin:/sbin:/usr/local/bin
         ;;
 
     linux-musl)


### PR DESCRIPTION
Most of our Linux tools go under /usr/local/gcc\<ver\>/bin
as we build them ourselves with a specific version of gcc.
But some, e.g. FOSSA, are in /usr/local/bin, so this
directory needs adding to the PATH as a last resort.

Backport of #1441