### PR TITLE
[ML] Resolves the predicted class type when writing feature importance values

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -29,6 +29,12 @@ public:
     using TReadPredictionFunc = std::function<TDouble2Vec(const TRowRef&)>;
     using TReadClassScoresFunc = std::function<TDouble2Vec(const TRowRef&)>;
 
+    enum EPredictionFieldType {
+        E_PredictionFieldTypeString,
+        E_PredictionFieldTypeInt,
+        E_PredictionFieldTypeBool
+    };
+
 public:
     static const std::size_t MAX_NUMBER_CLASSES;
     static const std::string NUM_CLASSES;
@@ -69,11 +75,6 @@ public:
 
     //! \return A serialisable metadata of the trained regression model.
     TOptionalInferenceModelMetadata inferenceModelMetadata() const override;
-
-    static void
-    writePredictedCategoryValueForType(const std::string& categoryValue,
-                                       EPredictionFieldType predictionFieldType,
-                                       core::CRapidJsonConcurrentLineWriter& writer);
 
 private:
     static TLossFunctionUPtr loss(std::size_t numberClasses);

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -29,12 +29,6 @@ public:
     using TReadPredictionFunc = std::function<TDouble2Vec(const TRowRef&)>;
     using TReadClassScoresFunc = std::function<TDouble2Vec(const TRowRef&)>;
 
-    enum EPredictionFieldType {
-        E_PredictionFieldTypeString,
-        E_PredictionFieldTypeInt,
-        E_PredictionFieldTypeBool
-    };
-
 public:
     static const std::size_t MAX_NUMBER_CLASSES;
     static const std::string NUM_CLASSES;
@@ -75,6 +69,11 @@ public:
 
     //! \return A serialisable metadata of the trained regression model.
     TOptionalInferenceModelMetadata inferenceModelMetadata() const override;
+
+    static void
+    writePredictedCategoryValueForType(const std::string& categoryValue,
+                                       EPredictionFieldType predictionFieldType,
+                                       core::CRapidJsonConcurrentLineWriter& writer);
 
 private:
     static TLossFunctionUPtr loss(std::size_t numberClasses);

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -17,12 +17,6 @@
 namespace ml {
 namespace api {
 
-enum EPredictionFieldType {
-    E_PredictionFieldTypeString,
-    E_PredictionFieldTypeInt,
-    E_PredictionFieldTypeBool
-};
-
 //! \brief Class controls the serialization of the model meta information
 //! (such as totol feature importance) into JSON format.
 class API_EXPORT CInferenceModelMetadata {
@@ -42,14 +36,13 @@ public:
     using TStrVec = std::vector<std::string>;
     using TRapidJsonWriter = core::CRapidJsonConcurrentLineWriter;
     using TPredictionFieldTypeResolverWriter =
-        std::function<void(const std::string&, EPredictionFieldType, TRapidJsonWriter&)>;
+        std::function<void(const std::string&, TRapidJsonWriter&)>;
 
 public:
     //! Writes metadata using \p writer.
     void write(TRapidJsonWriter& writer) const;
     void columnNames(const TStrVec& columnNames);
     void classValues(const TStrVec& classValues);
-    void predictionFieldType(EPredictionFieldType predictionFieldType);
     void predictionFieldTypeResolverWriter(const TPredictionFieldTypeResolverWriter& resolverWriter);
     const std::string& typeString() const;
     //! Add importances \p values to the feature with index \p i to calculate total feature importance.
@@ -70,8 +63,10 @@ private:
     TSizeMinMaxAccumulatorUMap m_TotalShapValuesMinMax;
     TStrVec m_ColumnNames;
     TStrVec m_ClassValues;
-    EPredictionFieldType m_PredictionFieldType;
-    TPredictionFieldTypeResolverWriter m_PredictionFieldTypeResolverWriter;
+    TPredictionFieldTypeResolverWriter m_PredictionFieldTypeResolverWriter =
+        [](const std::string& value, TRapidJsonWriter& writer) {
+            writer.String(value);
+        };
 };
 }
 }

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -17,6 +17,12 @@
 namespace ml {
 namespace api {
 
+enum EPredictionFieldType {
+    E_PredictionFieldTypeString,
+    E_PredictionFieldTypeInt,
+    E_PredictionFieldTypeBool
+};
+
 //! \brief Class controls the serialization of the model meta information
 //! (such as totol feature importance) into JSON format.
 class API_EXPORT CInferenceModelMetadata {
@@ -35,12 +41,16 @@ public:
     using TVector = maths::CDenseVector<double>;
     using TStrVec = std::vector<std::string>;
     using TRapidJsonWriter = core::CRapidJsonConcurrentLineWriter;
+    using TPredictionFieldTypeResolverWriter =
+        std::function<void(const std::string&, EPredictionFieldType, TRapidJsonWriter&)>;
 
 public:
     //! Writes metadata using \p writer.
     void write(TRapidJsonWriter& writer) const;
     void columnNames(const TStrVec& columnNames);
     void classValues(const TStrVec& classValues);
+    void predictionFieldType(EPredictionFieldType predictionFieldType);
+    void predictionFieldTypeResolverWriter(const TPredictionFieldTypeResolverWriter& resolverWriter);
     const std::string& typeString() const;
     //! Add importances \p values to the feature with index \p i to calculate total feature importance.
     //! Total feature importance is the mean of the magnitudes of importances for individual data points.
@@ -60,6 +70,8 @@ private:
     TSizeMinMaxAccumulatorUMap m_TotalShapValuesMinMax;
     TStrVec m_ColumnNames;
     TStrVec m_ClassValues;
+    EPredictionFieldType m_PredictionFieldType;
+    TPredictionFieldTypeResolverWriter m_PredictionFieldTypeResolverWriter;
 };
 }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -165,9 +165,10 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
         std::size_t numberClasses{classValues.size()};
         m_InferenceModelMetadata.columnNames(featureImportance->columnNames());
         m_InferenceModelMetadata.classValues(classValues);
-        m_InferenceModelMetadata.predictionFieldType(m_PredictionFieldType);
         m_InferenceModelMetadata.predictionFieldTypeResolverWriter(
-            CDataFrameTrainBoostedTreeClassifierRunner::writePredictedCategoryValueForType);
+            [this](const std::string& categoryValue, core::CRapidJsonConcurrentLineWriter& writer) {
+                this->writePredictedCategoryValue(categoryValue, writer);
+            });
         featureImportance->shap(
             row, [&](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
                      const TStrVec& featureNames,
@@ -226,13 +227,12 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     writer.EndObject();
 }
 
-void CDataFrameTrainBoostedTreeClassifierRunner::writePredictedCategoryValueForType(
+void CDataFrameTrainBoostedTreeClassifierRunner::writePredictedCategoryValue(
     const std::string& categoryValue,
-    EPredictionFieldType predictionFieldType,
-    core::CRapidJsonConcurrentLineWriter& writer) {
+    core::CRapidJsonConcurrentLineWriter& writer) const {
 
     double doubleValue;
-    switch (predictionFieldType) {
+    switch (m_PredictionFieldType) {
     case E_PredictionFieldTypeString:
         writer.String(categoryValue);
         break;
@@ -251,12 +251,6 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writePredictedCategoryValueForT
         }
         break;
     }
-}
-void CDataFrameTrainBoostedTreeClassifierRunner::writePredictedCategoryValue(
-    const std::string& categoryValue,
-    core::CRapidJsonConcurrentLineWriter& writer) const {
-    CDataFrameTrainBoostedTreeClassifierRunner::writePredictedCategoryValueForType(
-        categoryValue, m_PredictionFieldType, writer);
 }
 
 CDataFrameTrainBoostedTreeClassifierRunner::TLossFunctionUPtr

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -128,7 +128,7 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
                 }
                 writer.EndArray();
 
-                for (int i = 0; i < shap.size(); ++i) {
+                for (int i = 0; i < static_cast<int>(shap.size()); ++i) {
                     if (shap[i].lpNorm<1>() != 0) {
                         const_cast<CDataFrameTrainBoostedTreeRegressionRunner*>(this)
                             ->m_InferenceModelMetadata.addToFeatureImportance(i, shap[i]);

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -43,7 +43,12 @@ void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writ
             for (std::size_t j = 0; j < m_ClassValues.size(); ++j) {
                 writer.StartObject();
                 writer.Key(JSON_CLASS_NAME_TAG);
-                writer.String(m_ClassValues[j]);
+                if (m_PredictionFieldTypeResolverWriter) {
+                    m_PredictionFieldTypeResolverWriter(
+                        m_ClassValues[j], m_PredictionFieldType, writer);
+                } else {
+                    writer.String(m_ClassValues[j]);
+                }
                 writer.Key(JSON_IMPORTANCE_TAG);
                 writer.StartObject();
                 writer.Key(JSON_MEAN_MAGNITUDE_TAG);
@@ -65,7 +70,12 @@ void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writ
                  j < meanFeatureImportance.size() && j < m_ClassValues.size(); ++j) {
                 writer.StartObject();
                 writer.Key(JSON_CLASS_NAME_TAG);
-                writer.String(m_ClassValues[j]);
+                if (m_PredictionFieldTypeResolverWriter) {
+                    m_PredictionFieldTypeResolverWriter(
+                        m_ClassValues[j], m_PredictionFieldType, writer);
+                } else {
+                    writer.String(m_ClassValues[j]);
+                }
                 writer.Key(JSON_IMPORTANCE_TAG);
                 writer.StartObject();
                 writer.Key(JSON_MEAN_MAGNITUDE_TAG);
@@ -94,6 +104,15 @@ void CInferenceModelMetadata::columnNames(const TStrVec& columnNames) {
 
 void CInferenceModelMetadata::classValues(const TStrVec& classValues) {
     m_ClassValues = classValues;
+}
+
+void CInferenceModelMetadata::predictionFieldType(EPredictionFieldType predictionFieldType) {
+    m_PredictionFieldType = predictionFieldType;
+}
+
+void CInferenceModelMetadata::predictionFieldTypeResolverWriter(
+    const TPredictionFieldTypeResolverWriter& resolverWriter) {
+    m_PredictionFieldTypeResolverWriter = resolverWriter;
 }
 
 void CInferenceModelMetadata::addToFeatureImportance(std::size_t i, const TVector& values) {

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -43,12 +43,7 @@ void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writ
             for (std::size_t j = 0; j < m_ClassValues.size(); ++j) {
                 writer.StartObject();
                 writer.Key(JSON_CLASS_NAME_TAG);
-                if (m_PredictionFieldTypeResolverWriter) {
-                    m_PredictionFieldTypeResolverWriter(
-                        m_ClassValues[j], m_PredictionFieldType, writer);
-                } else {
-                    writer.String(m_ClassValues[j]);
-                }
+                m_PredictionFieldTypeResolverWriter(m_ClassValues[j], writer);
                 writer.Key(JSON_IMPORTANCE_TAG);
                 writer.StartObject();
                 writer.Key(JSON_MEAN_MAGNITUDE_TAG);
@@ -67,15 +62,12 @@ void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writ
             writer.Key(JSON_CLASSES_TAG);
             writer.StartArray();
             for (std::size_t j = 0;
-                 j < meanFeatureImportance.size() && j < m_ClassValues.size(); ++j) {
+                 j < static_cast<std::size_t>(meanFeatureImportance.size()) &&
+                 j < m_ClassValues.size();
+                 ++j) {
                 writer.StartObject();
                 writer.Key(JSON_CLASS_NAME_TAG);
-                if (m_PredictionFieldTypeResolverWriter) {
-                    m_PredictionFieldTypeResolverWriter(
-                        m_ClassValues[j], m_PredictionFieldType, writer);
-                } else {
-                    writer.String(m_ClassValues[j]);
-                }
+                m_PredictionFieldTypeResolverWriter(m_ClassValues[j], writer);
                 writer.Key(JSON_IMPORTANCE_TAG);
                 writer.StartObject();
                 writer.Key(JSON_MEAN_MAGNITUDE_TAG);
@@ -104,10 +96,6 @@ void CInferenceModelMetadata::columnNames(const TStrVec& columnNames) {
 
 void CInferenceModelMetadata::classValues(const TStrVec& classValues) {
     m_ClassValues = classValues;
-}
-
-void CInferenceModelMetadata::predictionFieldType(EPredictionFieldType predictionFieldType) {
-    m_PredictionFieldType = predictionFieldType;
 }
 
 void CInferenceModelMetadata::predictionFieldTypeResolverWriter(


### PR DESCRIPTION
This commit addresses two bugs:

- For individual class feature importance values, we now resolve the predicted class type name. e.g. we will now write JSON boolean `true` instead of `"1"`.
- For total feature importance, the predicted class type is now resolved as well.