### PR TITLE
[7.x][ML] Activate model metadata output

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,10 @@
 
 * Calculate total feature importance to store with model metadata. (See {ml-pull}1387[#1387].)
 
+=== Enhancements
+
+* Calculate total feature importance to store with model metadata. (See {ml-pull}1387[#1387].)
+
 === Bug Fixes
 
 * Fix progress on resume after final training has completed for classification and regression.


### PR DESCRIPTION
Activate the output of the model metadata and the corresponding unit tests for total feature importance.

The implementation itself was introduced in #1387 however, I need to fix the documentation, it was originally attributed to v7.10. Hence, I mark this PR as enhancement to rectify the docs.

Backport of  #1456