### PR TITLE
[7.x] [ML] do not fail to start analytics process if memory estimate is lower than predicted memory usage (#1465)

### DIFF
--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -99,14 +99,14 @@ void CDataFrameAnalysisRunner::computeAndSaveExecutionStrategy() {
         auto roundMb = [](std::size_t memory) {
             return 0.01 * static_cast<double>((100 * memory) / BYTES_IN_MB);
         };
-
-        // Report rounded up to the nearest MB.
-        HANDLE_FATAL(<< "Input error: memory limit " << roundMb(memoryLimit)
-                     << "MB is too low to perform analysis. You need to give the process"
-                     << " at least " << std::ceil(roundMb(memoryUsage))
-                     << "MB, but preferably more.");
-
-    } else if (m_NumberPartitions > 1) {
+        // Simply log the limit being configured too low.
+        // If we exceed the limit during the process, we will fail and the user
+        // will have to update the limit and attempt to re-run
+        LOG_DEBUG(<< "Memory limit " << roundMb(memoryLimit) << "MB is configured lower than estimate "
+                  << std::ceil(roundMb(memoryUsage)) << "MB."
+                  << "Analytics process may fail due to low memory limit");
+    }
+    if (m_NumberPartitions > 1) {
         // The maximum number of rows is found by binary search in the interval
         // [numberRows / m_NumberPartitions, numberRows / (m_NumberPartitions - 1)).
 

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -95,12 +95,8 @@ BOOST_AUTO_TEST_CASE(testComputeAndSaveExecutionStrategyDiskUsageFlag) {
                         .diskUsageAllowed(false)
                         .outlierSpec();
 
-        // single error is registered that the memory limit is to low
-        LOG_DEBUG(<< "errors = " << core::CContainerPrinter::print(errors));
-        core::CRegex re;
-        re.init("Input error: memory limit.*");
-        BOOST_REQUIRE_EQUAL(1, static_cast<int>(errors.size()));
-        BOOST_TEST_REQUIRE(re.matches(errors[0]));
+        // no error should be registered
+        BOOST_REQUIRE_EQUAL(0, static_cast<int>(errors.size()));
     }
 
     // Test large memory requirement with disk usage


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] do not fail to start analytics process if memory estimate is lower than predicted memory usage (#1465)