### PR TITLE
[ML] Fix some edge cases in new seasonal decomposition

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -95,4 +95,4 @@ export GIT_PREVIOUS_COMMIT="$GIT_COMMIT"
 
 IVY_REPO_URL="file://$2"
 ./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest
-./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:integTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}"
+./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:yamlRestTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}"

--- a/include/maths/CBasicStatistics.h
+++ b/include/maths/CBasicStatistics.h
@@ -1278,14 +1278,14 @@ public:
                                       const LESS& less = LESS{})
             : TImpl{std::vector<T>(std::max(n, std::size_t(1)), initial), less} {
             if (n == 0) {
-                LOG_ERROR(<< "Invalid size of 0 for order statistics accumulator");
+                LOG_DEBUG(<< "Invalid size of 0 for order statistics accumulator");
             }
         }
 
         //! Reset the number of statistics to gather to \p n.
         void resize(std::size_t n) {
             if (n == 0) {
-                LOG_ERROR(<< "Invalid resize to 0 for order statistics accumulator");
+                LOG_DEBUG(<< "Invalid resize to 0 for order statistics accumulator");
                 n = 1;
             }
             this->clear();

--- a/include/maths/CSignal.h
+++ b/include/maths/CSignal.h
@@ -216,10 +216,14 @@ public:
     //! \param[in] values The values for which to compute the autocorrelation.
     //! \param[in] transform Transforms \p values before computing the autocorrelation.
     //! \param[in] weight Weights \p values for computing the autocorrelation.
+    //! \param[in] eps The minimum variance we care about. This is added to the variance
+    //! when computing the autocorrelation so if the data variance is less than this it
+    //! drives the autocorrelation smoothly to zero.
     static double cyclicAutocorrelation(const SSeasonalComponentSummary& period,
                                         const TFloatMeanAccumulatorVec& values,
                                         const TMomentTransformFunc& transform = mean,
-                                        const TMomentWeightFunc& weight = count);
+                                        const TMomentWeightFunc& weight = count,
+                                        double eps = 0.0);
 
     //! Compute the discrete cyclic autocorrelation of \p values for the offset
     //! \p offset.
@@ -228,7 +232,8 @@ public:
     static double cyclicAutocorrelation(const SSeasonalComponentSummary& period,
                                         const TFloatMeanAccumulatorCRng& values,
                                         const TMomentTransformFunc& transform = mean,
-                                        const TMomentWeightFunc& weight = count);
+                                        const TMomentWeightFunc& weight = count,
+                                        double eps = 0.0);
 
     //! Get linear autocorrelations for all offsets up to the length of \p values.
     //!

--- a/include/maths/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/CTimeSeriesTestForSeasonality.h
@@ -536,6 +536,7 @@ private:
     static bool canTestPeriod(const TFloatMeanAccumulatorVec& values,
                               const TSeasonalComponent& period);
     static std::size_t observedRange(const TFloatMeanAccumulatorVec& values);
+    static std::size_t longestGap(const TFloatMeanAccumulatorVec& values);
     static void removePredictions(const TSeasonalComponentCRng& periodsToRemove,
                                   const TMeanAccumulatorVecCRng& componentsToRemove,
                                   TFloatMeanAccumulatorVec& values);

--- a/include/maths/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/CTimeSeriesTestForSeasonality.h
@@ -280,6 +280,7 @@ private:
     using TSegmentation = CTimeSeriesSegmentation;
     using TWeightFunc = TSegmentation::TWeightFunc;
     using TBucketPredictor = std::function<double(std::size_t)>;
+    using TTransform = std::function<double(const TFloatMeanAccumulator&)>;
     using TRemoveTrend =
         std::function<bool(const TSeasonalComponentVec&, TFloatMeanAccumulatorVec&, TSizeVec&)>;
 
@@ -508,8 +509,12 @@ private:
                    TFloatMeanAccumulatorVec& values,
                    TDoubleVec& scales) const;
     TVarianceStats residualVarianceStats(const TFloatMeanAccumulatorVec& values) const;
-    TMeanVarAccumulator truncatedMoments(double outlierFraction,
-                                         const TFloatMeanAccumulatorVec& residuals) const;
+    TMeanVarAccumulator
+    truncatedMoments(double outlierFraction,
+                     const TFloatMeanAccumulatorVec& residuals,
+                     const TTransform& transform = [](const TFloatMeanAccumulator& value) {
+                         return CBasicStatistics::mean(value);
+                     }) const;
     bool includesNewComponents(const TSeasonalComponentVec& periods) const;
     bool alreadyModelled(const TSeasonalComponentVec& periods) const;
     bool alreadyModelled(const TSeasonalComponent& period) const;
@@ -537,6 +542,7 @@ private:
                               const TSeasonalComponent& period);
     static std::size_t observedRange(const TFloatMeanAccumulatorVec& values);
     static std::size_t longestGap(const TFloatMeanAccumulatorVec& values);
+    static TSizeSizePr observedInterval(const TFloatMeanAccumulatorVec& values);
     static void removePredictions(const TSeasonalComponentCRng& periodsToRemove,
                                   const TMeanAccumulatorVecCRng& componentsToRemove,
                                   TFloatMeanAccumulatorVec& values);

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -238,6 +238,9 @@ CTimeSeriesTestForSeasonality::CTimeSeriesTestForSeasonality(core_t::TTime value
             meanAbs.add(std::fabs(CBasicStatistics::mean(value)));
         }
     }
+    // Note we don't bother modelling seasonality which is too small compared to the
+    // absolute values. We won't raise anomalies for differences from our predictions
+    // less than this anyway.
     m_EpsVariance = std::max(
         CTools::pow2(1000.0 * std::numeric_limits<double>::epsilon()) *
             CBasicStatistics::maximumLikelihoodVariance(moments),

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -238,9 +238,9 @@ CTimeSeriesTestForSeasonality::CTimeSeriesTestForSeasonality(core_t::TTime value
             meanAbs.add(std::fabs(CBasicStatistics::mean(value)));
         }
     }
-    // Note we don't bother modelling seasonality which is too small compared to the
-    // absolute values. We won't raise anomalies for differences from our predictions
-    // less than this anyway.
+    // Note we don't bother modelling seasonality whose amplitude is too small
+    // compared to the absolute values. We won't raise anomalies for differences
+    // from our predictions which are smaller than this anyway.
     m_EpsVariance = std::max(
         CTools::pow2(1000.0 * std::numeric_limits<double>::epsilon()) *
             CBasicStatistics::maximumLikelihoodVariance(moments),

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -1281,10 +1281,11 @@ CTimeSeriesTestForSeasonality::truncatedMoments(double outlierFraction,
                                                 const TFloatMeanAccumulatorVec& residuals) const {
     double cutoff{std::numeric_limits<double>::max()};
     std::size_t count{CSignal::countNotMissing(residuals)};
-    if (outlierFraction > 0.0) {
+    std::size_t numberOutliers{
+        static_cast<std::size_t>(outlierFraction * static_cast<double>(count) + 0.5)};
+    if (numberOutliers > 0) {
         m_Outliers.clear();
-        m_Outliers.resize(static_cast<std::size_t>(
-            outlierFraction * static_cast<double>(CSignal::countNotMissing(residuals)) + 0.5));
+        m_Outliers.resize(numberOutliers);
         for (const auto& value : residuals) {
             if (CBasicStatistics::count(value) > 0.0) {
                 m_Outliers.add(std::fabs(CBasicStatistics::mean(value)));
@@ -1302,7 +1303,7 @@ CTimeSeriesTestForSeasonality::truncatedMoments(double outlierFraction,
             moments.add(CBasicStatistics::mean(value));
         }
     }
-    if (m_OutlierFraction > 0.0) {
+    if (numberOutliers > 0) {
         moments.add(cutoff, static_cast<double>(count) - CBasicStatistics::count(moments));
     }
     CBasicStatistics::moment<1>(moments) += m_EpsVariance;

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE(testDailyConstantLongTermTrend) {
     test.bucketLength(bucketLength)
         .daysToLearn(63)
         .noiseVariance(64.0)
-        .maximumPercentageOutOfBounds(13.0)
+        .maximumPercentageOutOfBounds(14.0)
         .maximumError(0.016)
         .run(trend);
 }
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(testComplexVaryingLongTermTrend) {
     test.bucketLength(bucketLength)
         .daysToLearn(98)
         .noiseVariance(4.0)
-        .maximumPercentageOutOfBounds(6.0)
+        .maximumPercentageOutOfBounds(8.0)
         .maximumError(0.03)
         .run(trend);
 }

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -1605,8 +1605,8 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
         }
 
         std::size_t expectedSize{
-            3 * sizeof(maths::CTimeSeriesDecomposition) +
-            trend[0].memoryUsage() + trend[1].memoryUsage() + trend[2].memoryUsage() +
+            3 * sizeof(maths::CTimeSeriesDecomposition) + trend[0].memoryUsage() +
+            trend[1].memoryUsage() + trend[2].memoryUsage() +
             2 * sizeof(maths::CMultivariateNormalConjugate<3>) +
             sizeof(maths::CUnivariateTimeSeriesModel::TDecayRateController2Ary) +
             2 * controllers[0].memoryUsage() + 32 * 12 /*Recent samples*/};


### PR DESCRIPTION
Testing on our full QA suite showed up some edge cases, mainly around numerics, which were generating log errors.

We had some cases of 0/0 in the test statistics. Also we weren't checking the denominator degrees freedom for the F distribution was > 4 before getting variance (for which it is undefined). Finally, I've improved handling of the case that almost all values are either missing or constant in the test window.

Follow on from #1451.