### PR TITLE
[7.x][ML] Fix peak memory usage reporting

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -95,4 +95,4 @@ export GIT_PREVIOUS_COMMIT="$GIT_COMMIT"
 
 IVY_REPO_URL="file://$2"
 ./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest
-./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:integTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}"
+./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:yamlRestTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}"

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,6 +40,12 @@
 * Fix progress on resume after final training has completed for classification and regression.
   We previously showed progress stuck at zero for final training. (See {ml-pull}1443[#1443].)
 
+== {es} version 7.9.2
+
+=== Bug Fixes
+
+* Fix reporting of peak memory usage in memory stats for data frame analytics. (See {ml-pull}1468[#1468].)
+
 == {es} version 7.9.0
 
 === New Features

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -102,7 +102,7 @@ void addOutlierTestData(TStrVec fieldNames,
 BOOST_AUTO_TEST_CASE(testMemoryState) {
     std::string jobId{"testJob"};
     std::int64_t memoryLimit{1024 * 1024 * 1024}; //1gb default value
-    std::int64_t memoryUsage{1000};
+    std::int64_t memoryUsage{500000};
     std::int64_t timeBefore{std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count()};

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(testMemoryLimitHandling) {
         test::CDataFrameAnalysisSpecificationFactory{}
             .rows(numberSamples)
             .predictionMaximumNumberTrees(2)
-            .memoryLimit(10)
+            .memoryLimit(1000)
             .predicitionNumberRoundsPerHyperparameter(1)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
         outputWriterFactory};


### PR DESCRIPTION
In the memory stats we reported the current memory usage instead of the peak memory usage. This PR fixes this.

Furthermore, we now check if the memory usage exceeds memory limit every time memory usage is updated instead of ca. once every second like it was before.

Backport of #1468