### PR TITLE
[7.9][ML] Fix peak memory usage reporting

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 7.9.2
+
+=== Bug Fixes
+
+* Fix reporting of peak memory usage in memory stats for data frame analytics. (See {ml-pull}1468[#1468].)
+
 == {es} version 7.9.0
 
 === New Features

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -102,7 +102,7 @@ void addOutlierTestData(TStrVec fieldNames,
 BOOST_AUTO_TEST_CASE(testMemoryState) {
     std::string jobId{"testJob"};
     std::int64_t memoryLimit{1024 * 1024 * 1024}; //1gb default value
-    std::int64_t memoryUsage{1000};
+    std::int64_t memoryUsage{500000};
     std::int64_t timeBefore{std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count()};

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(testMemoryLimitHandling) {
         test::CDataFrameAnalysisSpecificationFactory{}
             .rows(numberSamples)
             .predictionMaximumNumberTrees(2)
-            .memoryLimit(10)
+            .memoryLimit(1000)
             .predicitionNumberRoundsPerHyperparameter(1)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
         outputWriterFactory};


### PR DESCRIPTION
In the memory stats we reported the current memory usage instead of the peak memory usage. This PR fixes this.

Furthermore, we now check if the memory usage exceeds memory limit every time memory usage is updated instead of ca. once every second like it was before.

Backport of #1468