### PR TITLE
[ML] Parse enhanced persist control message

### DIFF
--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -35,6 +35,11 @@
 #include <utility>
 #include <vector>
 
+namespace CAnomalyJobTest {
+class CTestFixture;
+struct testParsePersistControlMessage;
+}
+
 namespace ml {
 namespace core {
 class CDataAdder;
@@ -376,6 +381,17 @@ private:
                    core_t::TTime time,
                    const TStrStrUMap& dataRowFields);
 
+    //! Parses a control message requesting that model state be persisted.
+    //! Extracts optional arguments to be used for persistence.
+    static bool parsePersistControlMessage(const std::string& controlMessage,
+                                           core_t::TTime& snapshotTimestamp,
+                                           std::string& snapshotId,
+                                           std::string& snapshotDescription);
+
+    //! Perform foreground persistence if control message contains valid optional
+    //! arguments else request a background persist
+    void doPersist(const std::string& controlMessage);
+
 protected:
     //! Get all the detectors.
     void detectors(TAnomalyDetectorPtrVec& detectors) const;
@@ -468,6 +484,10 @@ private:
 
     //! Flag indicating whether or not time has been advanced.
     bool m_TimeAdvanced{false};
+
+    // Test case access
+    friend class CAnomalyJobTest::CTestFixture;
+    friend struct CAnomalyJobTest::testParsePersistControlMessage;
 };
 }
 }

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -36,8 +36,7 @@
 #include <vector>
 
 namespace CAnomalyJobTest {
-class CTestFixture;
-struct testParsePersistControlMessage;
+struct testParsePersistControlMessageArgs;
 }
 
 namespace ml {
@@ -383,14 +382,14 @@ private:
 
     //! Parses a control message requesting that model state be persisted.
     //! Extracts optional arguments to be used for persistence.
-    static bool parsePersistControlMessage(const std::string& controlMessage,
-                                           core_t::TTime& snapshotTimestamp,
-                                           std::string& snapshotId,
-                                           std::string& snapshotDescription);
+    static bool parsePersistControlMessageArgs(const std::string& controlMessageArgs,
+                                               core_t::TTime& snapshotTimestamp,
+                                               std::string& snapshotId,
+                                               std::string& snapshotDescription);
 
     //! Perform foreground persistence if control message contains valid optional
     //! arguments else request a background persist
-    void doPersist(const std::string& controlMessage);
+    void processPersistControlMessage(const std::string& controlMessageArgs);
 
 protected:
     //! Get all the detectors.
@@ -486,8 +485,7 @@ private:
     bool m_TimeAdvanced{false};
 
     // Test case access
-    friend class CAnomalyJobTest::CTestFixture;
-    friend struct CAnomalyJobTest::testParsePersistControlMessage;
+    friend struct CAnomalyJobTest::testParsePersistControlMessageArgs;
 };
 }
 }

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -133,6 +133,10 @@ public:
     //! Concurrent calls to this method are not threadsafe.
     bool startPersist(core_t::TTime timeOfPersistence);
 
+    //! Start a foreground persist if a background one is not running,
+    //! using the provided persistence function.
+    bool doForegroundPersist(core::CDataAdder::TPersistFunc persistFunc);
+
 private:
     //! Implementation of the background thread
     class CBackgroundThread : public core::CThread {

--- a/lib/api/unittest/CAnomalyJobTest.cc
+++ b/lib/api/unittest/CAnomalyJobTest.cc
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE(testRestoreFailsWithEmptyStream) {
     BOOST_TEST_REQUIRE(job.restoreState(restoreSearcher, completeToTime) == false);
 }
 
-BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
+BOOST_AUTO_TEST_CASE(testParsePersistControlMessageArgs) {
     {
         const ml::core_t::TTime expectedSnapshotTimestamp{1283524206};
         const std::string expectedSnapshotId{"my_special_snapshot"};
@@ -768,7 +768,7 @@ BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
         ml::core_t::TTime snapshotTimestamp;
         std::string snapshotId;
         std::string snapshotDescription;
-        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessageArgs(
             validPersistControlMessage, snapshotTimestamp, snapshotId, snapshotDescription));
 
         BOOST_TEST_REQUIRE(expectedSnapshotTimestamp == snapshotTimestamp);
@@ -782,7 +782,7 @@ BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
         ml::core_t::TTime snapshotTimestamp;
         std::string snapshotId;
         std::string snapshotDescription;
-        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessageArgs(
                                invalidPersistControlMessage, snapshotTimestamp,
                                snapshotId, snapshotDescription) == false);
     }
@@ -792,9 +792,9 @@ BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
         ml::core_t::TTime snapshotTimestamp;
         std::string snapshotId;
         std::string snapshotDescription;
-        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
-            invalidPersistControlMessage, snapshotTimestamp,
-            snapshotId, snapshotDescription) == false);
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessageArgs(
+                               invalidPersistControlMessage, snapshotTimestamp,
+                               snapshotId, snapshotDescription) == false);
     }
     {
         const std::string invalidPersistControlMessage;
@@ -802,27 +802,29 @@ BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
         ml::core_t::TTime snapshotTimestamp;
         std::string snapshotId;
         std::string snapshotDescription;
-        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
-            invalidPersistControlMessage, snapshotTimestamp,
-            snapshotId, snapshotDescription) == false);
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessageArgs(
+                               invalidPersistControlMessage, snapshotTimestamp,
+                               snapshotId, snapshotDescription) == false);
     }
     {
         const ml::core_t::TTime expectedSnapshotTimestamp{1283524206};
         const std::string expectedSnapshotId{"my_special_snapshot"};
+
+        // Empty description is valid.
         const std::string expectedSnapshotDescription;
 
         std::ostringstream ostrm;
         ostrm << expectedSnapshotTimestamp << " " << expectedSnapshotId << " "
               << expectedSnapshotDescription;
 
-        const std::string& invalidPersistControlMessage{ostrm.str()};
+        const std::string& validPersistControlMessage{ostrm.str()};
 
         ml::core_t::TTime snapshotTimestamp;
         std::string snapshotId;
         std::string snapshotDescription;
-        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
-                               invalidPersistControlMessage, snapshotTimestamp,
-                               snapshotId, snapshotDescription) == false);
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessageArgs(
+                               validPersistControlMessage, snapshotTimestamp,
+                               snapshotId, snapshotDescription) == true);
     }
     {
         const ml::core_t::TTime expectedSnapshotTimestamp{1283524206};
@@ -838,7 +840,7 @@ BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
         ml::core_t::TTime snapshotTimestamp;
         std::string snapshotId;
         std::string snapshotDescription;
-        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessageArgs(
                                invalidPersistControlMessage, snapshotTimestamp,
                                snapshotId, snapshotDescription) == false);
     }
@@ -847,7 +849,7 @@ BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
         std::string snapshotId;
         std::string snapshotDescription;
         const std::string invalidPersistControlMessage{"invalid_control_message"};
-        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessageArgs(
                                invalidPersistControlMessage, snapshotTimestamp,
                                snapshotId, snapshotDescription) == false);
     }

--- a/lib/api/unittest/CAnomalyJobTest.cc
+++ b/lib/api/unittest/CAnomalyJobTest.cc
@@ -751,4 +751,106 @@ BOOST_AUTO_TEST_CASE(testRestoreFailsWithEmptyStream) {
     BOOST_TEST_REQUIRE(job.restoreState(restoreSearcher, completeToTime) == false);
 }
 
+BOOST_AUTO_TEST_CASE(testParsePersistControlMessage) {
+    {
+        const ml::core_t::TTime expectedSnapshotTimestamp{1283524206};
+        const std::string expectedSnapshotId{"my_special_snapshot"};
+        const std::string expectedSnapshotDescription{
+            "Supplied description for snapshot at " +
+            ml::core::CTimeUtils::toIso8601(expectedSnapshotTimestamp)};
+
+        std::ostringstream ostrm;
+        ostrm << expectedSnapshotTimestamp << " " << expectedSnapshotId << " "
+              << expectedSnapshotDescription;
+
+        const std::string& validPersistControlMessage{ostrm.str()};
+
+        ml::core_t::TTime snapshotTimestamp;
+        std::string snapshotId;
+        std::string snapshotDescription;
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+            validPersistControlMessage, snapshotTimestamp, snapshotId, snapshotDescription));
+
+        BOOST_TEST_REQUIRE(expectedSnapshotTimestamp == snapshotTimestamp);
+        BOOST_TEST_REQUIRE(expectedSnapshotId == snapshotId);
+        BOOST_TEST_REQUIRE(expectedSnapshotDescription == snapshotDescription);
+    }
+    {
+        const std::string invalidPersistControlMessage{
+            "junk_timestamp snapshot_id invalid snapshot control message"};
+
+        ml::core_t::TTime snapshotTimestamp;
+        std::string snapshotId;
+        std::string snapshotDescription;
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+                               invalidPersistControlMessage, snapshotTimestamp,
+                               snapshotId, snapshotDescription) == false);
+    }
+    {
+        const std::string invalidPersistControlMessage{" "};
+
+        ml::core_t::TTime snapshotTimestamp;
+        std::string snapshotId;
+        std::string snapshotDescription;
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+            invalidPersistControlMessage, snapshotTimestamp,
+            snapshotId, snapshotDescription) == false);
+    }
+    {
+        const std::string invalidPersistControlMessage;
+
+        ml::core_t::TTime snapshotTimestamp;
+        std::string snapshotId;
+        std::string snapshotDescription;
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+            invalidPersistControlMessage, snapshotTimestamp,
+            snapshotId, snapshotDescription) == false);
+    }
+    {
+        const ml::core_t::TTime expectedSnapshotTimestamp{1283524206};
+        const std::string expectedSnapshotId{"my_special_snapshot"};
+        const std::string expectedSnapshotDescription;
+
+        std::ostringstream ostrm;
+        ostrm << expectedSnapshotTimestamp << " " << expectedSnapshotId << " "
+              << expectedSnapshotDescription;
+
+        const std::string& invalidPersistControlMessage{ostrm.str()};
+
+        ml::core_t::TTime snapshotTimestamp;
+        std::string snapshotId;
+        std::string snapshotDescription;
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+                               invalidPersistControlMessage, snapshotTimestamp,
+                               snapshotId, snapshotDescription) == false);
+    }
+    {
+        const ml::core_t::TTime expectedSnapshotTimestamp{1283524206};
+        const std::string expectedSnapshotId;
+        const std::string expectedSnapshotDescription;
+
+        std::ostringstream ostrm;
+        ostrm << expectedSnapshotTimestamp << " " << expectedSnapshotId << " "
+              << expectedSnapshotDescription;
+
+        const std::string& invalidPersistControlMessage{ostrm.str()};
+
+        ml::core_t::TTime snapshotTimestamp;
+        std::string snapshotId;
+        std::string snapshotDescription;
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+                               invalidPersistControlMessage, snapshotTimestamp,
+                               snapshotId, snapshotDescription) == false);
+    }
+    {
+        ml::core_t::TTime snapshotTimestamp;
+        std::string snapshotId;
+        std::string snapshotDescription;
+        const std::string invalidPersistControlMessage{"invalid_control_message"};
+        BOOST_TEST_REQUIRE(ml::api::CAnomalyJob::parsePersistControlMessage(
+                               invalidPersistControlMessage, snapshotTimestamp,
+                               snapshotId, snapshotDescription) == false);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Parse and validate optional arguments to the 'persist' control message.
If present these arguments are used to perform foreground persistence,
else background persistence is requested.

As further work is still required to compose and send such a message from a suitable API, labelling this PR as a non-issue.