### PR TITLE
[ML] Consume restore state stream to end

### DIFF
--- a/include/api/CSingleStreamSearcher.h
+++ b/include/api/CSingleStreamSearcher.h
@@ -39,14 +39,14 @@ public:
     CSingleStreamSearcher(const TIStreamP& stream);
 
     //! Ensure destructor is called to consume stream to its end
-    ~CSingleStreamSearcher();
+    ~CSingleStreamSearcher() override;
 
     //! Get the stream to retrieve data from.
     //! \return Pointer to the input stream.
     //! Some errors cannot be detected by this call itself, and are
     //! indicated by the stream going into the "bad" state as it is
     //! read from.
-    virtual TIStreamP search(size_t currentDocNum, size_t limit);
+    TIStreamP search(size_t currentDocNum, size_t limit) override;
 
 private:
     void consumeStream();

--- a/include/api/CSingleStreamSearcher.h
+++ b/include/api/CSingleStreamSearcher.h
@@ -38,12 +38,18 @@ public:
     //! called.
     CSingleStreamSearcher(const TIStreamP& stream);
 
+    //! Ensure destructor is called to consume stream to its end
+    ~CSingleStreamSearcher();
+
     //! Get the stream to retrieve data from.
     //! \return Pointer to the input stream.
     //! Some errors cannot be detected by this call itself, and are
     //! indicated by the stream going into the "bad" state as it is
     //! read from.
     virtual TIStreamP search(size_t currentDocNum, size_t limit);
+
+private:
+    void consumeStream();
 
 private:
     //! The stream we're reading from.

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -283,13 +283,19 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
     std::size_t dependentVariableColumn(dependentVariablePos -
                                         frame.columnNames().begin());
 
-    auto restoreSearcher{this->spec().restoreSearcher()};
-    bool treeRestored{false};
-    if (restoreSearcher != nullptr) {
-        treeRestored = this->restoreBoostedTree(frame, dependentVariableColumn, restoreSearcher);
-    }
-    if (treeRestored == false) {
-        m_BoostedTree = m_BoostedTreeFactory->buildFor(frame, dependentVariableColumn);
+    // Create restore searcher and restore in a scope
+    // so that the restore searcher gets destructed
+    // and performs any cleanup necessary.
+    {
+        auto restoreSearcher{this->spec().restoreSearcher()};
+        bool treeRestored{false};
+        if (restoreSearcher != nullptr) {
+            treeRestored = this->restoreBoostedTree(frame, dependentVariableColumn,
+                                                    restoreSearcher);
+        }
+        if (treeRestored == false) {
+            m_BoostedTree = m_BoostedTreeFactory->buildFor(frame, dependentVariableColumn);
+        }
     }
 
     this->validate(frame, dependentVariableColumn);

--- a/lib/api/CSingleStreamSearcher.cc
+++ b/lib/api/CSingleStreamSearcher.cc
@@ -15,6 +15,12 @@ CSingleStreamSearcher::CSingleStreamSearcher(const TIStreamP& stream)
 }
 
 CSingleStreamSearcher::~CSingleStreamSearcher() {
+	// We have to ensure we consume the stream to its end
+	// as it is possible that we receive additional
+	// documents after the eos marker and we should not
+	// block the state streamer thread. We may receive
+	// additional documents in case the state reduces
+	// in size and spreads over less docs than prior state.
     this->consumeStream();
 }
 

--- a/lib/api/CSingleStreamSearcher.cc
+++ b/lib/api/CSingleStreamSearcher.cc
@@ -15,12 +15,12 @@ CSingleStreamSearcher::CSingleStreamSearcher(const TIStreamP& stream)
 }
 
 CSingleStreamSearcher::~CSingleStreamSearcher() {
-	// We have to ensure we consume the stream to its end
-	// as it is possible that we receive additional
-	// documents after the eos marker and we should not
-	// block the state streamer thread. We may receive
-	// additional documents in case the state reduces
-	// in size and spreads over less docs than prior state.
+    // We have to ensure we consume the stream to its end
+    // as it is possible that we receive additional
+    // documents after the eos marker and we should not
+    // block the state streamer thread. We may receive
+    // additional documents in case the state reduces
+    // in size and spreads over less docs than prior state.
     this->consumeStream();
 }
 

--- a/lib/api/CSingleStreamSearcher.cc
+++ b/lib/api/CSingleStreamSearcher.cc
@@ -14,6 +14,17 @@ CSingleStreamSearcher::CSingleStreamSearcher(const TIStreamP& stream)
     : m_Stream(stream) {
 }
 
+CSingleStreamSearcher::~CSingleStreamSearcher() {
+    this->consumeStream();
+}
+
+void CSingleStreamSearcher::consumeStream() {
+    char buf[512];
+    while (m_Stream->good()) {
+        m_Stream->read(buf, 512);
+    }
+}
+
 CSingleStreamSearcher::TIStreamP
 CSingleStreamSearcher::search(size_t /*currentDocNum*/, size_t /*limit*/) {
     // documents in a stream are separated by '\0', skip over it in case to not confuse clients (see #279)


### PR DESCRIPTION
Data frame analytics state may spread over multiple
documents. But unlike autodetect, where state is accompanied
by a model snapshot that allows us to know exactly how many
docs it comprises of, or categorizer, where we don't have
a snapshot equivalent but state can only grow, DFA state
may spread less docs than the previous one for a job.
This means that when the state is restored and streamed
into the c++ process, we might get more documents than
just the necessary ones.

We correctly restore state as we detect the `eos` marker.
However, we also need to consume the stream to its end
so that the thread writing to the stream may complete.