### PR TITLE
[ML] Avoid log spam when we only have missing values for a feature computing candidate splits for regression and classification

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -50,6 +50,9 @@
 
 * Fix progress on resume after final training has completed for classification and regression.
   We previously showed progress stuck at zero for final training. (See {ml-pull}1443[#1443].)
+* Avoid potential "Failed to compute quantile" and "No values added to quantile sketch" log errors
+  training regression and classification models if there are features with mostly missing values.
+  (See {ml-pull}1500[#1500].)
 
 == {es} version 7.9.2
 


### PR DESCRIPTION
Since we downsample the rows when computing candidate splits it's possible that a feature with non-zero probability of being selected ends up with no non-missing feature values when we compute candidate splits. This is harmless and we can happily initialise the candidate splits to an empty set in this case. However, it was generating log spam when trying to compute quantiles. In particular, we'd get repeated errors and warnings during training of the form:

```
[CBoostedTreeImpl.cc@737] Failed to compute quantile 86.7027: ignoring split
[CQuantileSketch.cc@295] No values added to quantile sketch
```

This change simply checks that there are values before trying to compute quantiles.