### PR TITLE
[ML] Fix memory estimation for outlier detections

### DIFF
--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -193,11 +193,11 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor10000Rows) {
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor100000Rows) {
-    testEstimateMemoryUsage(100000, "41mb", "10mb", 0);
+    testEstimateMemoryUsage(100000, "48mb", "11mb", 0);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor10000000Rows) {
-    testEstimateMemoryUsage(10000000, "4511mb", "88mb", 0);
+    testEstimateMemoryUsage(10000000, "6440mb", "147mb", 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -405,7 +405,6 @@ std::size_t CEnsemble<POINT>::estimateMemoryUsage(TMethodSize methodSize,
     std::size_t numberModels{(ensembleSize + numberMethodsPerModel - 1) / numberMethodsPerModel};
     std::size_t maxNumberNeighbours{computeNumberNeighbours(sampleSize)};
     std::size_t projectionDimension{computeProjectionDimension(sampleSize, dimension)};
-    std::size_t numberNeighbours{(3 + maxNumberNeighbours) / 2};
 
     std::size_t pointsMemory{partitionNumberPoints *
                              (sizeof(TPoint) + las::estimateMemoryUsage<TPoint>(dimension))};
@@ -413,13 +412,13 @@ std::size_t CEnsemble<POINT>::estimateMemoryUsage(TMethodSize methodSize,
         partitionNumberPoints *
         CScorer::estimateMemoryUsage(computeFeatureInfluence ? dimension : 0)};
     std::size_t modelMemory{CModel::estimateMemoryUsage(
-        methodSize, sampleSize, numberNeighbours, projectionDimension, dimension)};
+        methodSize, sampleSize, maxNumberNeighbours, projectionDimension, dimension)};
     // The scores for a single method plus bookkeeping overhead for a single partition.
     std::size_t partitionScoringMemory{
         numberMethodsPerModel * partitionNumberPoints *
             (sizeof(TDouble1Vec) +
              (computeFeatureInfluence ? projectionDimension * sizeof(double) : 0)) +
-        methodSize(numberNeighbours, partitionNumberPoints, projectionDimension)};
+        methodSize(maxNumberNeighbours, partitionNumberPoints, projectionDimension)};
 
     return pointsMemory + scorersMemory + numberModels * modelMemory + partitionScoringMemory;
 }

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByCompute) {
         LOG_DEBUG(<< "estimated peak memory = " << estimatedMemoryUsage);
         LOG_DEBUG(<< "high water mark = " << maxMemoryUsage);
         BOOST_TEST_REQUIRE(std::abs(maxMemoryUsage - estimatedMemoryUsage) <
-                           std::max(maxMemoryUsage.load(), estimatedMemoryUsage) / 6);
+                           std::max(maxMemoryUsage.load(), estimatedMemoryUsage) / 4);
     }
 }
 


### PR DESCRIPTION
In order to estimate the memory requirement we now use the maximum number of nearest neighbors instead of the expected average of the neighbors. This makes the new model memory estimation more robust.

I also adjusted the unit test assertions since now the estimated memory is higher.