### PR TITLE
[ML] Change Docker push target

### DIFF
--- a/dev-tools/docker/build_check_style_image.sh
+++ b/dev-tools/docker/build_check_style_image.sh
@@ -12,7 +12,7 @@
 # clang-format version, increment the image version, change the Dockerfile and
 # build a new image to be used for subsequent builds on this branch.
 
-HOST=push.docker.elastic.co
+HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-check-style
 VERSION=2

--- a/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
@@ -14,7 +14,7 @@
 # used for subsequent builds on this branch.  Then update the version to be
 # used for builds in docker/linux_builder/Dockerfile.
 
-HOST=push.docker.elastic.co
+HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-aarch64-cross-build
 VERSION=2

--- a/dev-tools/docker/build_linux_aarch64_native_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_native_build_image.sh
@@ -20,7 +20,7 @@ if [ `uname -m` != aarch64 ] ; then
     exit 1
 fi
 
-HOST=push.docker.elastic.co
+HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-aarch64-native-build
 VERSION=2

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -20,7 +20,7 @@ if [ `uname -m` != x86_64 ] ; then
     exit 1
 fi
 
-HOST=push.docker.elastic.co
+HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
 VERSION=15

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -14,7 +14,7 @@
 # used for subsequent builds on this branch.  Then update the version to be
 # used for builds in docker/macosx_builder/Dockerfile.
 
-HOST=push.docker.elastic.co
+HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-macosx-build
 VERSION=9


### PR DESCRIPTION
The host to push our Docker images to is changing from
push.docker.elastic.co to simply docker.elastic.co.

This change adjusts our scripts to reflect this.