### PR TITLE
[7.x][ML] Refactor model lib unit tests (#1499)

### DIFF
--- a/lib/model/unittest/CCountingModelTest.cc
+++ b/lib/model/unittest/CCountingModelTest.cc
@@ -18,6 +18,8 @@
 
 #include <test/CRandomNumbers.h>
 
+#include "CModelTestFixtureBase.h"
+
 #include <boost/test/unit_test.hpp>
 
 #include <string>
@@ -74,10 +76,7 @@ makeScheduledEvent(const std::string& description, double start, double end) {
 const std::string EMPTY_STRING;
 }
 
-class CTestFixture {
-protected:
-    CResourceMonitor m_ResourceMonitor;
-};
+class CTestFixture : public CModelTestFixtureBase {};
 
 BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     core_t::TTime startTime(100);

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -39,6 +39,8 @@
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
 
+#include "CModelTestFixtureBase.h"
+
 #include <boost/foreach.hpp>
 #include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>
@@ -49,8 +51,6 @@
 
 #include <stdint.h>
 
-using TStrVec = std::vector<std::string>;
-
 BOOST_TEST_DONT_PRINT_LOG_VALUE(TStrVec::iterator)
 
 BOOST_AUTO_TEST_SUITE(CEventRateModelTest)
@@ -59,26 +59,6 @@ using namespace ml;
 using namespace model;
 
 namespace {
-
-using TDoubleVec = std::vector<double>;
-using TDoubleVecVec = std::vector<TDoubleVec>;
-using TDoubleDoublePr = std::pair<double, double>;
-using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
-using TUInt64Vec = std::vector<uint64_t>;
-using TTimeVec = std::vector<core_t::TTime>;
-using TSizeVec = std::vector<std::size_t>;
-using TSizeVecVec = std::vector<TSizeVec>;
-using TSizeVecVecVec = std::vector<TSizeVecVec>;
-using TDouble1Vec = core::CSmallVector<double, 1>;
-using TDouble2Vec = core::CSmallVector<double, 2>;
-using TSizeDoublePr = std::pair<std::size_t, double>;
-using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
-using TOptionalStr = boost::optional<std::string>;
-using TOptionalUInt64 = boost::optional<uint64_t>;
-using TOptionalDouble = boost::optional<double>;
-using TOptionalDoubleVec = std::vector<TOptionalDouble>;
-using TMathsModelPtr = std::shared_ptr<maths::CModel>;
-using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
 const std::string EMPTY_STRING;
 
@@ -285,7 +265,7 @@ const TSizeDoublePr1Vec NO_CORRELATES;
 
 } // unnamed::
 
-class CTestFixture {
+class CTestFixture : public CModelTestFixtureBase {
 public:
     void makeModel(const SModelParams& params,
                    const model_t::TFeatureVec& features,
@@ -335,7 +315,6 @@ protected:
     TEventRateModelFactoryPtr m_Factory;
     ml::model::CModelFactory::TDataGathererPtr m_Gatherer;
     ml::model::CModelFactory::TModelPtr m_Model;
-    ml::model::CResourceMonitor m_ResourceMonitor;
 };
 
 BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -33,6 +33,8 @@
 #include <test/BoostTestPointerOutput.h>
 #include <test/CRandomNumbers.h>
 
+#include "CModelTestFixtureBase.h"
+
 #include <boost/lexical_cast.hpp>
 #include <boost/optional/optional_io.hpp>
 #include <boost/range.hpp>
@@ -54,19 +56,6 @@ using namespace ml;
 using namespace model;
 
 namespace {
-
-using TDoubleVec = std::vector<double>;
-using TDoubleVecVec = std::vector<TDoubleVec>;
-using TDouble1Vec = core::CSmallVector<double, 1>;
-using TUIntVec = std::vector<unsigned int>;
-using TSizeVec = std::vector<std::size_t>;
-using TSizeVecVec = std::vector<TSizeVec>;
-using TDoubleStrPr = std::pair<double, std::string>;
-using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
-using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
-using TSizeDoublePr = std::pair<std::size_t, double>;
-using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
 
 const std::string EMPTY_STRING;
 
@@ -213,10 +202,7 @@ void addArrival(const SMessage& message,
 const TSizeDoublePr1Vec NO_CORRELATES;
 }
 
-class CTestFixture {
-protected:
-    CResourceMonitor m_ResourceMonitor;
-};
+class CTestFixture : public CModelTestFixtureBase {};
 
 BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
     // Check that the correct data is read retrieved by the

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -41,6 +41,8 @@
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
 
+#include "CModelTestFixtureBase.h"
+
 #include <boost/optional.hpp>
 #include <boost/optional/optional_io.hpp>
 #include <boost/range.hpp>
@@ -59,36 +61,8 @@ using namespace model;
 
 namespace {
 
-using TDoubleDoublePr = std::pair<double, double>;
-using TSizeDoublePr = std::pair<std::size_t, double>;
-using TDoubleSizePr = std::pair<double, std::size_t>;
-using TDoubleVec = std::vector<double>;
-using TDoubleVecVec = std::vector<TDoubleVec>;
-using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
-using TStrVec = std::vector<std::string>;
-using TStrVecVec = std::vector<TStrVec>;
-using TOptionalUInt64 = boost::optional<uint64_t>;
-using TOptionalDouble = boost::optional<double>;
-using TOptionalDoubleVec = std::vector<TOptionalDouble>;
-using TOptionalStr = boost::optional<std::string>;
-using TTimeDoublePr = std::pair<core_t::TTime, double>;
-using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
-using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TMinAccumulator = maths::CBasicStatistics::SMin<double>::TAccumulator;
 using TMaxAccumulator = maths::CBasicStatistics::SMax<double>::TAccumulator;
-using TMathsModelPtr = std::shared_ptr<maths::CModel>;
-using TPriorPtr = std::shared_ptr<maths::CPrior>;
-using TMultivariatePriorPtr = std::shared_ptr<maths::CMultivariatePrior>;
-using TDoubleStrPr = std::pair<double, std::string>;
-using TDouble1Vec = core::CSmallVector<double, 1>;
-using TDouble2Vec = core::CSmallVector<double, 2>;
-using TDouble4Vec = core::CSmallVector<double, 4>;
-using TDouble4Vec1Vec = core::CSmallVector<TDouble4Vec, 1>;
-using TSizeDoublePr = std::pair<std::size_t, double>;
-using TSizeDoublePr1Vec = core::CSmallVector<TSizeDoublePr, 1>;
-using TStrVec = std::vector<std::string>;
-using TTimeStrVecPr = std::pair<core_t::TTime, TStrVec>;
-using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
 
 const std::string EMPTY_STRING;
 
@@ -259,7 +233,7 @@ void processBucket(core_t::TTime time,
 const TSizeDoublePr1Vec NO_CORRELATES;
 }
 
-class CTestFixture {
+class CTestFixture : public CModelTestFixtureBase {
 public:
     void makeModel(const SModelParams& params,
                    const model_t::TFeatureVec& features,
@@ -302,7 +276,6 @@ protected:
     TMetricModelFactoryPtr m_Factory;
     ml::model::CModelFactory::TDataGathererPtr m_Gatherer;
     ml::model::CModelFactory::TModelPtr m_Model;
-    ml::model::CResourceMonitor m_ResourceMonitor;
 };
 
 BOOST_FIXTURE_TEST_CASE(testSample, CTestFixture) {

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -36,6 +36,8 @@
 #include <test/BoostTestPointerOutput.h>
 #include <test/CRandomNumbers.h>
 
+#include "CModelTestFixtureBase.h"
+
 #include <boost/optional/optional_io.hpp>
 #include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>
@@ -53,24 +55,9 @@ using namespace model;
 
 namespace {
 
-using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-using TSizeSizePrVec = std::vector<TSizeSizePr>;
-using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
-using TDoubleDoublePr = std::pair<double, double>;
-using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
-using TDoubleStrPr = std::pair<double, std::string>;
-using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
-using TStrVec = std::vector<std::string>;
-using TUIntVec = std::vector<unsigned int>;
-using TDoubleVec = std::vector<double>;
-using TSizeVec = std::vector<std::size_t>;
-using TSizeVecVec = std::vector<TSizeVec>;
-using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1u>;
 using TMaxAccumulator =
     maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>>;
-using TDouble1Vec = core::CSmallVector<double, 1>;
-using TDouble2Vec = core::CSmallVector<double, 2>;
 
 const std::string EMPTY_STRING;
 
@@ -291,10 +278,7 @@ void processBucket(core_t::TTime time,
 }
 }
 
-class CTestFixture {
-protected:
-    CResourceMonitor m_ResourceMonitor;
-};
+class CTestFixture : public CModelTestFixtureBase {};
 
 BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
     // Check that the correct data is read retrieved by the

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_CModelTestFixtureBase_h
+#define INCLUDED_CModelTestFixtureBase_h
+
+#include <core/CoreTypes.h>
+
+#include <maths/CBasicStatistics.h>
+#include <maths/CModel.h>
+#include <maths/CMultivariatePrior.h>
+
+#include <model/CResourceMonitor.h>
+
+#include <boost/optional.hpp>
+
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+using TDouble1Vec = ml::core::CSmallVector<double, 1>;
+using TDouble2Vec = ml::core::CSmallVector<double, 2>;
+using TDouble4Vec = ml::core::CSmallVector<double, 4>;
+using TDouble4Vec1Vec = ml::core::CSmallVector<TDouble4Vec, 1>;
+using TDoubleDoublePr = std::pair<double, double>;
+using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+using TDoubleSizePr = std::pair<double, std::size_t>;
+using TDoubleStrPr = std::pair<double, std::string>;
+using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+
+using TMathsModelPtr = std::shared_ptr<ml::maths::CModel>;
+using TMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TMultivariatePriorPtr = std::shared_ptr<ml::maths::CMultivariatePrior>;
+
+using TOptionalDouble = boost::optional<double>;
+using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+using TOptionalStr = boost::optional<std::string>;
+using TOptionalUInt64 = boost::optional<uint64_t>;
+
+using TPriorPtr = std::shared_ptr<ml::maths::CPrior>;
+
+using TSizeDoublePr = std::pair<std::size_t, double>;
+using TSizeDoublePr1Vec = ml::core::CSmallVector<TSizeDoublePr, 1>;
+using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+using TSizeSizePrVec = std::vector<TSizeSizePr>;
+using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
+using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+using TSizeVec = std::vector<std::size_t>;
+using TSizeVecVec = std::vector<TSizeVec>;
+using TSizeVecVecVec = std::vector<TSizeVecVec>;
+
+using TStrVec = std::vector<std::string>;
+using TStrVecVec = std::vector<TStrVec>;
+
+using TTimeDoublePr = std::pair<ml::core_t::TTime, double>;
+using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
+using TTimeStrVecPr = std::pair<ml::core_t::TTime, TStrVec>;
+using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
+using TTimeVec = std::vector<ml::core_t::TTime>;
+
+using TUInt64Vec = std::vector<uint64_t>;
+using TUIntVec = std::vector<unsigned int>;
+
+class CModelTestFixtureBase {
+protected:
+    ml::model::CResourceMonitor m_ResourceMonitor;
+};
+
+#endif //INCLUDED_CModelTestFixtureBase_h


### PR DESCRIPTION
Create a common base for the test fixture class used by a number of model test suites.
Refactor the test fixtures to move the resource monitor and common type definitions to the new base class.

Backports #1499 