### PR TITLE
[ML] Replace boost::size in model unit tests

### DIFF
--- a/lib/model/unittest/CCountingModelTest.cc
+++ b/lib/model/unittest/CCountingModelTest.cc
@@ -78,9 +78,9 @@ const std::string EMPTY_STRING;
 class CTestFixture : public CModelTestFixtureBase {};
 
 BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
-    core_t::TTime startTime(100);
-    core_t::TTime bucketLength(100);
-    std::size_t maxAgeBuckets(1);
+    core_t::TTime startTime{100};
+    core_t::TTime bucketLength{100};
+    std::size_t maxAgeBuckets{1};
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
@@ -144,8 +144,8 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testCheckScheduledEvents, CTestFixture) {
-    core_t::TTime startTime(100);
-    core_t::TTime bucketLength(100);
+    core_t::TTime startTime{100};
+    core_t::TTime bucketLength{100};
 
     SModelParams params(bucketLength);
 
@@ -247,8 +247,8 @@ BOOST_FIXTURE_TEST_CASE(testCheckScheduledEvents, CTestFixture) {
 BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
     // Check that we correctly update estimate bucket completeness.
 
-    core_t::TTime time(0);
-    core_t::TTime bucketLength(600);
+    core_t::TTime time{0};
+    core_t::TTime bucketLength{600};
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
@@ -270,7 +270,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
     TDoubleVec uniform01;
     TSizeVec offsets;
 
-    for (std::size_t i = 0; i < 10; ++i, time += bucketLength) {
+    for (std::size_t i = 0u; i < 10; ++i, time += bucketLength) {
         rng.generateUniformSamples(0, bucketLength, 10, offsets);
         std::sort(offsets.begin(), offsets.end());
         for (auto offset : offsets) {
@@ -285,7 +285,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
     rng.generateUniformSamples(0, bucketLength, 10, offsets);
     std::sort(offsets.begin(), offsets.end());
 
-    for (std::size_t i = 0; i < offsets.size(); ++i) {
+    for (std::size_t i = 0u; i < offsets.size(); ++i) {
         rng.generateUniformSamples(0.0, 1.0, 1, uniform01);
         addArrival(*gatherer, m_ResourceMonitor,
                    time + static_cast<core_t::TTime>(offsets[i]),

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -36,7 +36,6 @@
 
 #include "CModelTestFixtureBase.h"
 
-#include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <memory>
@@ -208,8 +207,8 @@ void testModelWithValueField(model_t::EFeature feature,
                              CResourceMonitor& resourceMonitor) {
     LOG_DEBUG(<< "  *** testing feature " << model_t::print(feature));
 
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
     SModelParams params(bucketLength);
     auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
     CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
@@ -219,12 +218,12 @@ void testModelWithValueField(model_t::EFeature feature,
     CModelFactory::TModelPtr model(factory.makeModel(gatherer));
     BOOST_TEST_REQUIRE(model);
 
-    std::size_t anomalousBucket = 20;
-    std::size_t numberBuckets = 30;
+    std::size_t anomalousBucket{20u};
+    std::size_t numberBuckets{30u};
 
     const core_t::TTime endTime = startTime + (numberBuckets * bucketLength);
 
-    std::size_t i = 0u;
+    std::size_t i{0u};
     for (core_t::TTime bucketStartTime = startTime; bucketStartTime < endTime;
          bucketStartTime += bucketLength, i++) {
         core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
@@ -300,6 +299,10 @@ protected:
     using TInterimBucketCorrectorPtr = std::shared_ptr<CInterimBucketCorrector>;
     using TEventRateModelFactoryPtr = std::shared_ptr<CEventRateModelFactory>;
 
+    using TDoubleSizeStrTr = core::CTriple<double, std::size_t, std::string>;
+    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizeStrTr>;
+    using TMinAccumulatorVec = std::vector<TMinAccumulator>;
+
 protected:
     TInterimBucketCorrectorPtr m_InterimBucketCorrector;
     TEventRateModelFactoryPtr m_Factory;
@@ -308,8 +311,8 @@ protected:
 };
 
 BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
     this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 1);
@@ -329,12 +332,13 @@ BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
     LOG_DEBUG(<< "startTime = " << startTime << ", endTime = " << endTime
               << ", # events = " << eventTimes.size());
 
-    std::size_t i = 0u, j = 0u;
+    std::size_t i{0u};
+    std::size_t j{0u};
     for (core_t::TTime bucketStartTime = startTime; bucketStartTime < endTime;
          bucketStartTime += bucketLength, ++j) {
         core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-        double count = 0.0;
+        double count{0.0};
         for (/**/; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
             addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
             count += 1.0;
@@ -401,8 +405,8 @@ BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
     this->makeModel(params, {model_t::E_IndividualNonZeroCountByBucketAndPerson},
@@ -423,12 +427,13 @@ BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
     LOG_DEBUG(<< "startTime = " << startTime << ", endTime = " << endTime
               << ", # events = " << eventTimes.size());
 
-    std::size_t i = 0u, j = 0u;
+    std::size_t i{0u};
+    std::size_t j{0u};
     for (core_t::TTime bucketStartTime = startTime; bucketStartTime < endTime;
          bucketStartTime += bucketLength) {
         core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-        double count = 0.0;
+        double count{0.0};
         for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
             addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
             count += 1.0;
@@ -469,8 +474,8 @@ BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testRare, CTestFixture) {
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
     SModelParams params(bucketLength);
     this->makeModel(params,
                     {model_t::E_IndividualTotalBucketCountByPerson,
@@ -478,7 +483,7 @@ BOOST_FIXTURE_TEST_CASE(testRare, CTestFixture) {
                     startTime, 5);
     CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
-    core_t::TTime time = startTime;
+    core_t::TTime time{startTime};
     for (/**/; time < startTime + 10 * bucketLength; time += bucketLength) {
         addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
         addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
@@ -551,11 +556,11 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculation, CTestFixture) {
         TDoubleSizeAnotatedProbabilityTr,
         std::function<bool(const TDoubleSizeAnotatedProbabilityTr&, const TDoubleSizeAnotatedProbabilityTr&)>>;
 
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
 
-    TSizeVec anomalousBuckets[]{TSizeVec{25}, TSizeVec{24, 25, 26, 27}};
-    double anomalousBucketsRateMultipliers[]{3.0, 1.3};
+    TSizeVecVec anomalousBuckets{{25}, {24, 25, 26, 27}};
+    TDoubleVec anomalousBucketsRateMultipliers{3.0, 1.3};
 
     for (std::size_t t = 0; t < 2; ++t) {
 
@@ -585,12 +590,12 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculation, CTestFixture) {
                                              return lhs.first < rhs.first;
                                          });
 
-        std::size_t i = 0;
+        std::size_t i{0u};
         for (core_t::TTime j = 0, bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
                 count += 1.0;
@@ -629,13 +634,12 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculation, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowNonZeroCount, CTestFixture) {
-    core_t::TTime startTime(0);
-    core_t::TTime bucketLength(100);
-    std::size_t lowNonZeroCountBucket = 6u;
-    std::size_t highNonZeroCountBucket = 8u;
+    core_t::TTime startTime{0};
+    core_t::TTime bucketLength{100};
+    std::size_t lowNonZeroCountBucket{6u};
+    std::size_t highNonZeroCountBucket{8u};
 
-    std::size_t bucketCounts[] = {50, 50, 50, 50, 50,  0,  0,
-                                  0,  50, 1,  50, 100, 50, 50};
+    TSizeVec bucketCounts{50, 50, 50, 50, 50, 0, 0, 0, 50, 1, 50, 100, 50, 50};
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
@@ -645,7 +649,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowNonZeroCount, CTestFixtu
 
     TDoubleVec probabilities;
 
-    core_t::TTime time = startTime;
+    core_t::TTime time{startTime};
     for (auto count : bucketCounts) {
         LOG_DEBUG(<< "Writing " << count << " values");
 
@@ -675,13 +679,12 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowNonZeroCount, CTestFixtu
 }
 
 BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighNonZeroCount, CTestFixture) {
-    core_t::TTime startTime(0);
-    core_t::TTime bucketLength(100);
-    std::size_t lowNonZeroCountBucket = 6u;
-    std::size_t highNonZeroCountBucket = 8u;
+    core_t::TTime startTime{0};
+    core_t::TTime bucketLength{100};
+    std::size_t lowNonZeroCountBucket{6u};
+    std::size_t highNonZeroCountBucket{8u};
 
-    std::size_t bucketCounts[] = {50, 50, 50,  50, 50, 0,  0,
-                                  0,  50, 100, 50, 1,  50, 50};
+    TSizeVec bucketCounts{50, 50, 50, 50, 50, 0, 0, 0, 50, 100, 50, 1, 50, 50};
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.001;
@@ -691,7 +694,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighNonZeroCount, CTestFixt
 
     TDoubleVec probabilities;
 
-    core_t::TTime time = startTime;
+    core_t::TTime time{startTime};
     for (auto count : bucketCounts) {
         LOG_DEBUG(<< "Writing " << count << " values");
 
@@ -724,26 +727,18 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
     // Check we find the correct correlated variables, and identify
     // correlate and marginal anomalies.
 
-    using TDoubleSizeStrTr = core::CTriple<double, std::size_t, std::string>;
-    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizeStrTr>;
-
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
 
     test::CRandomNumbers rng;
 
-    const std::size_t numberBuckets = 200;
-    const double means_[] = {20.0, 25.0, 100.0, 800.0};
-    const double covariances_[][4] = {{3.0, 2.5, 0.0, 0.0},
-                                      {2.5, 4.0, 0.0, 0.0},
-                                      {0.0, 0.0, 100.0, -500.0},
-                                      {0.0, 0.0, -500.0, 3000.0}};
+    const std::size_t numberBuckets{200};
+    const TDoubleVec means{20.0, 25.0, 100.0, 800.0};
+    const TDoubleVecVec covariances{{3.0, 2.5, 0.0, 0.0},
+                                    {2.5, 4.0, 0.0, 0.0},
+                                    {0.0, 0.0, 100.0, -500.0},
+                                    {0.0, 0.0, -500.0, 3000.0}};
 
-    TDoubleVec means(&means_[0], &means_[4]);
-    TDoubleVecVec covariances;
-    for (std::size_t i = 0u; i < 4; ++i) {
-        covariances.push_back(TDoubleVec(&covariances_[i][0], &covariances_[i][4]));
-    }
     TDoubleVecVec samples;
     rng.generateMultivariateNormalSamples(means, covariances, numberBuckets, samples);
 
@@ -760,15 +755,15 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
 
         LOG_DEBUG(<< "Test correlation anomalies");
 
-        std::size_t anomalyBuckets[]{100, 160, 190, numberBuckets};
-        double anomalies[][4]{{-5.73, 4.29, 0.0, 0.0},
-                              {0.0, 0.0, 89.99, 15.38},
-                              {-7.73, 5.59, 52.99, 9.03}};
+        TSizeVec anomalyBuckets{100, 160, 190, numberBuckets};
+        TDoubleVecVec anomalies{{-5.73, 4.29, 0.0, 0.0},
+                                {0.0, 0.0, 89.99, 15.38},
+                                {-7.73, 5.59, 52.99, 9.03}};
 
-        TMinAccumulator probabilities[4]{TMinAccumulator(2), TMinAccumulator(2),
-                                         TMinAccumulator(2), TMinAccumulator(2)};
+        TMinAccumulatorVec probabilities{TMinAccumulator{2}, TMinAccumulator{2},
+                                         TMinAccumulator{2}, TMinAccumulator{2}};
 
-        core_t::TTime time = startTime;
+        core_t::TTime time{startTime};
         for (std::size_t i = 0u, anomaly = 0u; i < numberBuckets; ++i) {
             for (std::size_t j = 0u; j < samples[i].size(); ++j) {
                 std::string person = std::string("p") +
@@ -803,9 +798,9 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
             time += bucketLength;
         }
 
-        std::string expectedResults[]{"[(100,p2), (190,p2)]", "[(100,p1), (190,p1)]",
-                                      "[(160,p4), (190,p4)]", "[(160,p3), (190,p3)]"};
-        for (std::size_t i = 0u; i < boost::size(probabilities); ++i) {
+        TStrVec expectedResults{"[(100,p2), (190,p2)]", "[(100,p1), (190,p1)]",
+                                "[(160,p4), (190,p4)]", "[(160,p3), (190,p3)]"};
+        for (std::size_t i = 0u; i < probabilities.size(); ++i) {
             LOG_DEBUG(<< "probabilities = " << probabilities[i].print());
             std::string results[2];
             for (std::size_t j = 0u; j < 2; ++j) {
@@ -856,15 +851,15 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
         BOOST_TEST_REQUIRE(model);
 
-        std::size_t anomalyBuckets[]{100, 160, 190, numberBuckets};
-        double anomalies[][4]{{11.07, 14.19, 0.0, 0.0},
-                              {0.0, 0.0, -66.9, 399.95},
-                              {11.07, 14.19, -48.15, 329.95}};
+        TSizeVec anomalyBuckets{100, 160, 190, numberBuckets};
+        TDoubleVecVec anomalies{{11.07, 14.19, 0.0, 0.0},
+                                {0.0, 0.0, -66.9, 399.95},
+                                {11.07, 14.19, -48.15, 329.95}};
 
-        TMinAccumulator probabilities[]{TMinAccumulator(3), TMinAccumulator(3),
-                                        TMinAccumulator(3), TMinAccumulator(3)};
+        TMinAccumulatorVec probabilities{TMinAccumulator{3}, TMinAccumulator{3},
+                                         TMinAccumulator{3}, TMinAccumulator{3}};
 
-        core_t::TTime time = startTime;
+        core_t::TTime time{startTime};
         for (std::size_t i = 0u, anomaly = 0u; i < numberBuckets; ++i) {
             for (std::size_t j = 0u; j < samples[i].size(); ++j) {
                 std::string person = std::string("p") +
@@ -900,9 +895,9 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
             time += bucketLength;
         }
 
-        std::string expectedResults[][2]{
+        TStrVecVec expectedResults{
             {"100,", "190,"}, {"100,", "190,"}, {"160,", "190,"}, {"160,", "190,"}};
-        for (std::size_t i = 0u; i < 4; ++i) {
+        for (std::size_t i = 0u; i < probabilities.size(); ++i) {
             LOG_DEBUG(<< "probabilities = " << probabilities[i].print());
             TStrVec results;
             for (const auto& result : probabilities[i]) {
@@ -921,22 +916,19 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
     // Check we find the correct correlated variables, and identify
     // correlate and marginal anomalies.
 
-    using TDoubleSizeStrTr = core::CTriple<double, std::size_t, std::string>;
-    using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizeStrTr>;
-
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{600};
 
     test::CRandomNumbers rng;
     rng.discard(200000);
 
-    const std::size_t numberBuckets = 2880;
-    const double means_[] = {20.0, 25.0, 50.0, 100.0};
-    const double covariances_[][4] = {{30.0, 20.0, 0.0, 0.0},
-                                      {20.0, 40.0, 0.0, 0.0},
-                                      {0.0, 0.0, 60.0, -50.0},
-                                      {0.0, 0.0, -50.0, 60.0}};
-    double trends[][24] = {
+    const std::size_t numberBuckets{2880};
+    const TDoubleVec means{20.0, 25.0, 50.0, 100.0};
+    const TDoubleVecVec covariances{{30.0, 20.0, 0.0, 0.0},
+                                    {20.0, 40.0, 0.0, 0.0},
+                                    {0.0, 0.0, 60.0, -50.0},
+                                    {0.0, 0.0, -50.0, 60.0}};
+    const TDoubleVecVec trends{
         {0.0, 0.0, 0.0,  1.0, 1.0, 2.0, 4.0, 10.0, 11.0, 10.0, 8.0, 8.0,
          7.0, 9.0, 12.0, 4.0, 3.0, 1.0, 1.0, 0.0,  0.0,  0.0,  0.0, 0.0},
         {0.0,  0.0,  0.0,  2.0, 2.0, 4.0, 8.0, 15.0, 18.0, 14.0, 12.0, 12.0,
@@ -949,19 +941,14 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
          40.0,  40.0,  30.0,  20.0,  10.0,  0.0,   0.0,   0.0},
     };
 
-    TDoubleVec means(&means_[0], &means_[4]);
-    TDoubleVecVec covariances;
-    for (std::size_t i = 0u; i < 4; ++i) {
-        covariances.push_back(TDoubleVec(&covariances_[i][0], &covariances_[i][4]));
-    }
     TDoubleVecVec samples;
     rng.generateMultivariateNormalSamples(means, covariances, numberBuckets, samples);
 
-    std::size_t anomalyBuckets[] = {1950, 2400, 2700, numberBuckets};
-    double anomalies[][4] = {
+    TSizeVec anomalyBuckets{1950, 2400, 2700, numberBuckets};
+    TDoubleVecVec anomalies{
         {-23.9, 19.7, 0.0, 0.0}, {0.0, 0.0, 36.4, 36.4}, {-28.7, 30.4, 36.4, 36.4}};
-    TMinAccumulator probabilities[4] = {TMinAccumulator(4), TMinAccumulator(4),
-                                        TMinAccumulator(4), TMinAccumulator(4)};
+    TMinAccumulatorVec probabilities{TMinAccumulator{4}, TMinAccumulator{4},
+                                     TMinAccumulator{4}, TMinAccumulator{4}};
 
     SModelParams params(bucketLength);
     params.s_DecayRate = 0.0002;
@@ -973,7 +960,7 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
     CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
     BOOST_TEST_REQUIRE(model);
 
-    core_t::TTime time = startTime;
+    core_t::TTime time{startTime};
     for (std::size_t i = 0u, anomaly = 0u; i < numberBuckets; ++i) {
         if (i % 10 == 0) {
             LOG_DEBUG(<< i << ") processing bucket [" << time << ", "
@@ -1020,10 +1007,10 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
         time += bucketLength;
     }
 
-    std::string expectedResults[][2]{{"1950,p2", "2700,p2"},
-                                     {"1950,p1", "2700,p1"},
-                                     {"2400,p4", "2700,p4"},
-                                     {"2400,p3", "2700,p3"}};
+    TStrVecVec expectedResults{{"1950,p2", "2700,p2"},
+                               {"1950,p1", "2700,p1"},
+                               {"2400,p4", "2700,p4"},
+                               {"2400,p3", "2700,p3"}};
     for (std::size_t i = 0u; i < 4; ++i) {
         LOG_DEBUG(<< "probabilities = " << probabilities[i].print());
         TStrVec results;
@@ -1043,12 +1030,10 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
     using TEventDataVec = std::vector<CEventData>;
     using TSizeSizeMap = std::map<std::size_t, std::size_t>;
 
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
 
-    const std::string people[] = {std::string("p1"), std::string("p2"),
-                                  std::string("p3"), std::string("p4"),
-                                  std::string("p5"), std::string("p6")};
+    const TStrVec people{"p1", "p2", "p3", "p4", "p5", "p6"};
 
     TUInt64VecVec eventCounts;
     eventCounts.push_back(TUInt64Vec(1000u, 0));
@@ -1186,27 +1171,26 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
-    function_t::EFunction countFunctions[] = {function_t::E_IndividualCount,
-                                              function_t::E_IndividualNonZeroCount,
-                                              function_t::E_IndividualRareCount,
-                                              function_t::E_IndividualRareNonZeroCount,
-                                              function_t::E_IndividualRare,
-                                              function_t::E_IndividualLowCounts,
-                                              function_t::E_IndividualHighCounts};
-    bool useNull[] = {true, false};
-    std::string byField[] = {"", "by"};
-    std::string partitionField[] = {"", "partition"};
+    function_t::TFunctionVec countFunctions{function_t::E_IndividualCount,
+                                            function_t::E_IndividualNonZeroCount,
+                                            function_t::E_IndividualRareCount,
+                                            function_t::E_IndividualRareNonZeroCount,
+                                            function_t::E_IndividualRare,
+                                            function_t::E_IndividualLowCounts,
+                                            function_t::E_IndividualHighCounts};
+    TBoolVec useNull{true, false};
+    TStrVec byFields{"", "by"};
+    TStrVec partitionFields{"", "partition"};
 
     CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
 
-    int detectorIndex = 0;
-    for (std::size_t i = 0u; i < boost::size(countFunctions); ++i) {
-        for (std::size_t j = 0u; j < boost::size(useNull); ++j) {
-            for (std::size_t k = 0u; k < boost::size(byField); ++k) {
-                for (std::size_t l = 0u; l < boost::size(partitionField); ++l) {
-                    CSearchKey key(++detectorIndex, countFunctions[i],
-                                   useNull[j], model_t::E_XF_None, "",
-                                   byField[k], "", partitionField[l]);
+    int detectorIndex{0};
+    for (const auto& countFunction : countFunctions) {
+        for (bool usingNull : useNull) {
+            for (const auto& byField : byFields) {
+                for (const auto& partitionField : partitionFields) {
+                    CSearchKey key(++detectorIndex, countFunction, usingNull,
+                                   model_t::E_XF_None, "", byField, "", partitionField);
 
                     CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
                         config.factory(key);
@@ -1229,13 +1213,13 @@ BOOST_FIXTURE_TEST_CASE(testModelsWithValueFields, CTestFixture) {
     LOG_DEBUG(<< "*** testModelsValueFields ***");
     {
         // check E_PopulationUniqueCountByBucketPersonAndAttribute
-        std::size_t anomalousBucket = 20;
-        std::size_t numberBuckets = 30;
+        std::size_t anomalousBucket{20u};
+        std::size_t numberBuckets{30u};
 
         TStrVec strings{"p1", "c1", "c2"};
         TSizeVecVecVec fieldsPerBucket;
 
-        for (std::size_t i = 0; i < numberBuckets; i++) {
+        for (std::size_t i = 0u; i < numberBuckets; i++) {
             TSizeVecVec fields;
             std::size_t attribute1Strings = 10;
             std::size_t attribute2Strings = 10;
@@ -1244,7 +1228,7 @@ BOOST_FIXTURE_TEST_CASE(testModelsWithValueFields, CTestFixture) {
                 attribute2Strings = 15;
             }
 
-            for (std::size_t j = 0;
+            for (std::size_t j = 0u;
                  j < std::max(attribute1Strings, attribute2Strings); j++) {
                 std::ostringstream ss1;
                 std::ostringstream ss2;
@@ -1276,8 +1260,8 @@ BOOST_FIXTURE_TEST_CASE(testModelsWithValueFields, CTestFixture) {
     }
     {
         // Check E_PopulationInfoContentByBucketPersonAndAttribute
-        std::size_t anomalousBucket = 20;
-        std::size_t numberBuckets = 30;
+        std::size_t anomalousBucket{20u};
+        std::size_t numberBuckets{30u};
 
         TStrVec strings{"p1",
                         "c1",
@@ -1289,7 +1273,7 @@ BOOST_FIXTURE_TEST_CASE(testModelsWithValueFields, CTestFixture) {
 
         TSizeVecVecVec fieldsPerBucket;
 
-        for (std::size_t i = 0; i < numberBuckets; i++) {
+        for (std::size_t i = 0u; i < numberBuckets; i++) {
             TSizeVecVec fields;
 
             TSizeVec fb;
@@ -1343,8 +1327,8 @@ BOOST_FIXTURE_TEST_CASE(testModelsWithValueFields, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixture) {
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
 
     {
         // Test single influence name, single influence value
@@ -1372,7 +1356,8 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
@@ -1429,12 +1414,13 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 std::stringstream ss;
                 ss << "inf" << (i % 2);
@@ -1492,12 +1478,13 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 std::stringstream ss;
                 ss << "inf" << (i % 2);
@@ -1556,12 +1543,13 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 std::stringstream ss;
                 ss << "inf";
@@ -1619,12 +1607,13 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 std::stringstream ss;
                 ss << "inf";
@@ -1694,10 +1683,10 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
         core_t::TTime bucketStartTime = startTime;
         core_t::TTime bucketEndTime = startTime + bucketLength;
-        for (std::size_t i = 0, j = 0; bucketStartTime < endTime;
+        for (std::size_t i = 0u, j = 0u; bucketStartTime < endTime;
              bucketStartTime += bucketLength, bucketEndTime += bucketLength, ++j) {
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
                            TOptionalStr("p"));
@@ -1725,8 +1714,8 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
 }
 
 BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CTestFixture) {
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
 
     {
         // Test single influence name, single influence value
@@ -1755,12 +1744,13 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
                            TOptionalStr("inf1"), TOptionalStr(uniqueValue));
@@ -1823,12 +1813,13 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
                            TOptionalStr("inf1"), TOptionalStr(uniqueValue));
@@ -1901,12 +1892,13 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
                            TOptionalStr("inf1"), TOptionalStr(uniqueValue));
@@ -1975,12 +1967,13 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                   << ", # events = " << eventTimes.size());
 
         SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
-        std::size_t i = 0u, j = 0u;
+        std::size_t i{0u};
+        std::size_t j{0u};
         for (core_t::TTime bucketStartTime = startTime;
              bucketStartTime < endTime; bucketStartTime += bucketLength, ++j) {
             core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
 
-            double count = 0.0;
+            double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
                 addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
                            TOptionalStr("inf1"), TOptionalStr("inf1"),
@@ -2040,8 +2033,8 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 }
 
 BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
-    const core_t::TTime startTime = 1346968800;
-    const core_t::TTime bucketLength = 3600;
+    const core_t::TTime startTime{1346968800};
+    const core_t::TTime bucketLength{3600};
     SModelParams params(bucketLength);
     auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
     CEventRateModelFactory factory(params, interimBucketCorrector);
@@ -2065,7 +2058,7 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
 
     SAnnotatedProbability::TStoredStringPtrStoredStringPtrPrDoublePrVec lastInfluencersResult;
 
-    core_t::TTime time = startTime;
+    core_t::TTime time{startTime};
 
     for (/**/; time < startTime + 50 * bucketLength; time += bucketLength) {
         addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1",
@@ -2145,9 +2138,9 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
-    core_t::TTime startTime(100);
-    std::size_t bucketLength(100);
-    std::size_t maxAgeBuckets(5);
+    core_t::TTime startTime{100};
+    std::size_t bucketLength{100};
+    std::size_t maxAgeBuckets{5};
 
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
@@ -2227,9 +2220,9 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
-    core_t::TTime startTime(100);
-    std::size_t bucketLength(100);
-    std::string summaryCountField("count");
+    core_t::TTime startTime{100};
+    std::size_t bucketLength{100};
+    std::string summaryCountField{"count"};
 
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
@@ -2326,9 +2319,9 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
-    core_t::TTime startTime(3600);
-    core_t::TTime bucketLength(3600);
-    core_t::TTime endTime(2 * 24 * bucketLength);
+    core_t::TTime startTime{3600};
+    core_t::TTime bucketLength{3600};
+    core_t::TTime endTime{2 * 24 * bucketLength};
     SModelParams params(bucketLength);
     params.s_InitialDecayRateMultiplier = 1.0;
     params.s_MultibucketFeaturesWindowLength = 0;
@@ -2337,7 +2330,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     CCountingModel countingModel(params, m_Gatherer, m_InterimBucketCorrector);
 
     test::CRandomNumbers rng;
-    core_t::TTime now = startTime;
+    core_t::TTime now{startTime};
     TDoubleVec samples(3, 0.0);
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
@@ -2452,16 +2445,16 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
-    core_t::TTime startTime(3600);
-    core_t::TTime bucketLength(3600);
+    core_t::TTime startTime{3600};
+    core_t::TTime bucketLength{3600};
 
     SModelParams params(bucketLength);
     params.s_MultivariateByFields = true;
     this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 3);
     CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
 
-    core_t::TTime now = startTime;
-    core_t::TTime endTime(now + 2 * 24 * bucketLength);
+    core_t::TTime now{startTime};
+    core_t::TTime endTime{now + 2 * 24 * bucketLength};
     test::CRandomNumbers rng;
     TDoubleVec samples(1, 0.0);
     while (now < endTime) {
@@ -2534,11 +2527,11 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testSummaryCountZeroRecordsAreIgnored, CTestFixture) {
-    core_t::TTime startTime(100);
-    core_t::TTime bucketLength(100);
+    core_t::TTime startTime{100};
+    core_t::TTime bucketLength{100};
 
     SModelParams params(bucketLength);
-    std::string summaryCountField("count");
+    std::string summaryCountField{"count"};
 
     CModelFactory::TDataGathererPtr gathererWithZeros;
     CModelFactory::TModelPtr modelWithZerosPtr;
@@ -2555,13 +2548,13 @@ BOOST_FIXTURE_TEST_CASE(testSummaryCountZeroRecordsAreIgnored, CTestFixture) {
     // The idea here is to compare a model that has records with summary count of zero
     // against a model that has no records at all where the first model had the zero-count records.
 
-    core_t::TTime now = 100;
-    core_t::TTime end = now + 50 * bucketLength;
+    core_t::TTime now{100};
+    core_t::TTime end{now + 50 * bucketLength};
     test::CRandomNumbers rng;
     TSizeVec samples;
     TDoubleVec zeroCountProbability;
-    std::string summaryCountZero("0");
-    std::string summaryCountOne("1");
+    std::string summaryCountZero{"0"};
+    std::string summaryCountOne{"1"};
     while (now < end) {
         rng.generateUniformSamples(1, 10, 1, samples);
         rng.generateUniformSamples(0.0, 1.0, 1, zeroCountProbability);
@@ -2592,9 +2585,9 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbabilityGivenDetectionRule, CTestFixture) 
     CDetectionRule rule;
     rule.addCondition(condition);
 
-    core_t::TTime startTime(3600);
-    core_t::TTime bucketLength(3600);
-    core_t::TTime endTime(24 * bucketLength);
+    core_t::TTime startTime{3600};
+    core_t::TTime bucketLength{3600};
+    core_t::TTime endTime{24 * bucketLength};
 
     SModelParams params(bucketLength);
     SModelParams::TDetectionRuleVec rules{rule};
@@ -2627,8 +2620,8 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbabilityGivenDetectionRule, CTestFixture) 
 }
 
 BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
-    core_t::TTime startTime = 0;
-    core_t::TTime bucketLength = 1800;
+    core_t::TTime startTime{0};
+    core_t::TTime bucketLength{1800};
 
     model_t::EFeature feature = model_t::E_IndividualCountByBucketAndPerson;
     model_t::TFeatureVec features{feature};
@@ -2849,8 +2842,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     rule.action(CDetectionRule::E_SkipModelUpdate);
     rule.addCondition(condition);
 
-    std::size_t bucketLength(100);
-    std::size_t startTime(100);
+    std::size_t bucketLength{100};
+    std::size_t startTime{100};
 
     // Model without the skip sampling rule
     SModelParams paramsNoRules(bucketLength);

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -36,7 +36,6 @@
 #include "CModelTestFixtureBase.h"
 
 #include <boost/optional/optional_io.hpp>
-#include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
@@ -104,13 +103,13 @@ struct SMessage {
 
 using TMessageVec = std::vector<SMessage>;
 
-const std::size_t numberAttributes = 5u;
-const std::size_t numberPeople = 10u;
+const std::size_t numberAttributes{5u};
+const std::size_t numberPeople{10u};
 
 double roundToNearestPersisted(double value) {
-    std::string valueAsString(core::CStringUtils::typeToStringPrecise(
-        value, core::CIEEE754::E_DoublePrecision));
-    double result = 0.0;
+    std::string valueAsString{core::CStringUtils::typeToStringPrecise(
+        value, core::CIEEE754::E_DoublePrecision)};
+    double result{0.0};
     core::CStringUtils::stringToType(valueAsString, result);
     return result;
 }
@@ -135,7 +134,7 @@ void generateTestMessages(std::size_t dimension,
     //
     // There are 10 people, 4 attributes and 100 buckets.
 
-    const std::size_t numberBuckets = 100u;
+    const std::size_t numberBuckets{100u};
 
     TStrVec people;
     for (std::size_t i = 0u; i < numberPeople; ++i) {
@@ -149,9 +148,9 @@ void generateTestMessages(std::size_t dimension,
     }
     LOG_DEBUG(<< "attributes = " << core::CContainerPrinter::print(attributes));
 
-    const double attributeRates[] = {10.0, 2.0, 15.0, 2.0, 1.0};
-    const double means[] = {5.0, 10.0, 7.0, 3.0, 15.0};
-    const double variances[] = {1.0, 0.5, 2.0, 0.1, 4.0};
+    const TDoubleVec attributeRates{10.0, 2.0, 15.0, 2.0, 1.0};
+    const TDoubleVec means{5.0, 10.0, 7.0, 3.0, 15.0};
+    const TDoubleVec variances{1.0, 0.5, 2.0, 0.1, 4.0};
 
     TSizeSizePrVecVec anomalies{{{40u, 6u}, {15u, 3u}, {12u, 2u}},
                                 {},
@@ -205,8 +204,8 @@ void generateTestMessages(std::size_t dimension,
 }
 
 std::string valueAsString(const TDouble1Vec& value) {
-    std::string result = core::CStringUtils::typeToStringPrecise(
-        value[0], core::CIEEE754::E_DoublePrecision);
+    std::string result{core::CStringUtils::typeToStringPrecise(
+        value[0], core::CIEEE754::E_DoublePrecision)};
     for (std::size_t i = 1u; i < value.size(); ++i) {
         result += CAnomalyDetectorModelConfig::DEFAULT_MULTIVARIATE_COMPONENT_DELIMITER +
                   core::CStringUtils::typeToStringPrecise(
@@ -228,22 +227,18 @@ CEventData addArrival(const SMessage& message,
 
 void processBucket(core_t::TTime time,
                    core_t::TTime bucketLength,
-                   std::size_t n,
-                   const double* bucket,
-                   const std::string* influencerValues,
+                   const TDoubleStrPrVec& bucket,
                    CDataGatherer& gatherer,
                    CResourceMonitor& resourceMonitor,
                    CMetricPopulationModel& model,
                    SAnnotatedProbability& probability) {
-    const std::string person("p");
-    const std::string attribute("a");
-    for (std::size_t i = 0u; i < n; ++i) {
-
+    const std::string person{"p"};
+    const std::string attribute{"a"};
+    for (auto& pr : bucket) {
         const std::string valueAsString{core::CStringUtils::typeToStringPrecise(
-            bucket[i], core::CIEEE754::E_DoublePrecision)};
+            pr.first, core::CIEEE754::E_DoublePrecision)};
 
-        CDataGatherer::TStrCPtrVec fieldValues{&person, &attribute,
-                                               &influencerValues[i], &valueAsString};
+        CDataGatherer::TStrCPtrVec fieldValues{&person, &attribute, &pr.second, &valueAsString};
 
         CEventData eventData;
         eventData.time(time);
@@ -264,14 +259,12 @@ BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
     // Check that the correct data is read retrieved by the
     // basic model accessors.
 
-    using TOptionalUInt64 = boost::optional<uint64_t>;
-    using TStrUInt64Map = std::map<std::string, uint64_t>;
     using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
     using TMinAccumulatorVec = std::vector<TMinAccumulator>;
     using TMaxAccumulatorVec = std::vector<TMaxAccumulator>;
 
-    core_t::TTime startTime = 1367280000;
-    const core_t::TTime bucketLength = 3600;
+    core_t::TTime startTime{1367280000};
+    const core_t::TTime bucketLength{3600};
 
     TMessageVec messages;
     generateTestMessages(1, startTime, bucketLength, messages);
@@ -429,8 +422,8 @@ BOOST_FIXTURE_TEST_CASE(testMinMaxAndMean, CTestFixture) {
     using TSizeSizeTimeDouble2VecSizeTrVecDouble2VecWeightAryVecPrMapMap =
         std::map<std::size_t, TSizeTimeDouble2VecSizeTrVecDouble2VecWeightsAryVecPrMap>;
 
-    core_t::TTime startTime = 1367280000;
-    const core_t::TTime bucketLength = 3600;
+    core_t::TTime startTime{1367280000};
+    const core_t::TTime bucketLength{3600};
 
     TMessageVec messages;
     generateTestMessages(1, startTime, bucketLength, messages);
@@ -568,13 +561,13 @@ BOOST_FIXTURE_TEST_CASE(testMinMaxAndMean, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
-    core_t::TTime startTime(3600);
-    core_t::TTime bucketLength(3600);
+    core_t::TTime startTime{3600};
+    core_t::TTime bucketLength{3600};
     SModelParams params(bucketLength);
     auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
     CMetricPopulationModelFactory factory(params, interimBucketCorrector);
     factory.features({model_t::E_PopulationVarianceByPersonAndAttribute});
-    factory.fieldNames("", "P", "", "V", TStrVec(1, "I"));
+    factory.fieldNames("", "P", "", "V", TStrVec{1, "I"});
     CModelFactory::SGathererInitializationData gathererInitData(startTime);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
     BOOST_TEST_REQUIRE(gatherer->isPopulation());
@@ -584,79 +577,71 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
     CMetricPopulationModel& model = static_cast<CMetricPopulationModel&>(*model_.get());
 
-    double bucket1[] = {1.0, 1.1, 1.01, 1.02};
-    std::string influencerValues1[] = {"i1", "i1", "i2", "i2"};
-    double bucket2[] = {10.0};
-    std::string influencerValues2[] = {"i1"};
-    double bucket3[] = {4.3, 4.4, 4.6, 4.2, 4.8};
-    std::string influencerValues3[] = {"i1", "i1", "i1", "i1", "i3"};
-    double bucket4[] = {3.2, 3.3};
-    std::string influencerValues4[] = {"i3", "i3"};
-    double bucket5[] = {20.1, 20.8, 20.9};
-    std::string influencerValues5[] = {"i2", "i1", "i1"};
-    double bucket6[] = {4.1, 4.2, 3.9, 4.2};
-    std::string influencerValues6[] = {"i1", "i2", "i2", "i2"};
-    double bucket7[] = {0.1, 0.3, 0.2};
-    std::string influencerValues7[] = {"i1", "i1", "i3"};
-    double bucket8[] = {12.5, 12.3};
-    std::string influencerValues8[] = {"i1", "i2"};
-    double bucket9[] = {6.9, 7.0, 7.1, 6.6, 7.1, 6.7};
-    std::string influencerValues9[] = {"i1", "i2", "i3", "i4", "i5", "i6"};
+    TDoubleStrPrVec b1{{1.0, "i1"}, {1.1, "i1"}, {1.01, "i2"}, {1.02, "i2"}};
+    TDoubleStrPrVec b2{{10.0, "i1"}};
+    TDoubleStrPrVec b3{{4.3, "i1"}, {4.4, "i1"}, {4.6, "i1"}, {4.2, "i1"}, {4.8, "i3"}};
+    TDoubleStrPrVec b4{{3.2, "i3"}, {3.3, "i3"}};
+    TDoubleStrPrVec b5{{20.1, "i2"}, {20.8, "i1"}, {20.9, "i1"}};
+    TDoubleStrPrVec b6{{4.1, "i1"}, {4.2, "i2"}, {3.9, "i2"}, {4.2, "i2"}};
+    TDoubleStrPrVec b7{{0.1, "i1"}, {0.3, "i1"}, {0.2, "i3"}};
+    TDoubleStrPrVec b8{{12.5, "i1"}, {12.3, "i2"}};
+    TDoubleStrPrVec b9{{6.9, "i1"}, {7.0, "i2"}, {7.1, "i3"},
+                       {6.6, "i4"}, {7.1, "i5"}, {6.7, "i6"}};
     // This last bucket is much more improbable, with influencer i2 being responsible
-    double bucket10[] = {0.3, 15.4, 77.62, 112.999, 5.1, 5.1, 5.1, 5.1, 5.1};
-    std::string influencerValues10[] = {"i2", "i2", "i2", "i2", "i1",
-                                        "i1", "i1", "i1", "i1"};
+    TDoubleStrPrVec b10{{0.3, "i2"},     {15.4, "i2"}, {77.62, "i2"},
+                        {112.999, "i2"}, {5.1, "i1"},  {5.1, "i1"},
+                        {5.1, "i1"},     {5.1, "i1"},  {5.1, "i1"}};
 
     SAnnotatedProbability annotatedProbability;
 
     core_t::TTime time = startTime;
-    processBucket(time, bucketLength, boost::size(bucket1), bucket1, influencerValues1,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b1, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket2), bucket2, influencerValues2,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b2, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket3), bucket3, influencerValues3,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b3, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket4), bucket4, influencerValues4,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b4, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket5), bucket5, influencerValues5,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b5, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket6), bucket6, influencerValues6,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b6, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket7), bucket7, influencerValues7,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b7, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket8), bucket8, influencerValues8,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b8, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket9), bucket9, influencerValues9,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b9, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability < 0.85);
 
     time += bucketLength;
-    processBucket(time, bucketLength, boost::size(bucket10), bucket10, influencerValues10,
-                  *gatherer, m_ResourceMonitor, model, annotatedProbability);
+    processBucket(time, bucketLength, b10, *gatherer, m_ResourceMonitor, model,
+                  annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability < 0.1);
     BOOST_REQUIRE_EQUAL(std::size_t(1), annotatedProbability.s_Influences.size());
     BOOST_REQUIRE_EQUAL(std::string("I"),
@@ -677,23 +662,22 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbability, CTestFixture) {
     using TAnomalyAccumulator =
         maths::CBasicStatistics::COrderStatisticsHeap<TDoubleAnomalyPr, maths::COrderings::SFirstLess>;
 
-    core_t::TTime startTime = 1367280000;
-    const core_t::TTime bucketLength = 3600;
+    core_t::TTime startTime{1367280000};
+    const core_t::TTime bucketLength{3600};
 
-    model_t::EFeature features_[] = {model_t::E_PopulationMaxByPersonAndAttribute,
-                                     model_t::E_PopulationMeanLatLongByPersonAndAttribute};
+    model_t::TFeatureVec features{model_t::E_PopulationMaxByPersonAndAttribute,
+                                  model_t::E_PopulationMeanLatLongByPersonAndAttribute};
 
-    for (std::size_t i = 0u; i < boost::size(features_); ++i) {
-        LOG_DEBUG(<< "Testing " << model_t::print(features_[i]));
+    for (auto& feature : features) {
+        LOG_DEBUG(<< "Testing " << model_t::print(feature));
 
         TMessageVec messages;
-        generateTestMessages(model_t::dimension(features_[i]), startTime,
-                             bucketLength, messages);
+        generateTestMessages(model_t::dimension(feature), startTime, bucketLength, messages);
 
         SModelParams params(bucketLength);
         auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
         CMetricPopulationModelFactory factory(params, interimBucketCorrector);
-        factory.features({features_[i]});
+        factory.features({feature});
         CModelFactory::SGathererInitializationData gathererInitData(startTime);
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
         CModelFactory::SModelInitializationData modelInitData(gatherer);
@@ -703,7 +687,7 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbability, CTestFixture) {
 
         TAnomalyAccumulator anomalies(7);
 
-        std::size_t bucket = 0u;
+        std::size_t bucket{0u};
         for (const auto& message : messages) {
             if (message.s_Time >= startTime + bucketLength) {
                 model->sample(startTime, startTime + bucketLength, m_ResourceMonitor);
@@ -750,13 +734,11 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbability, CTestFixture) {
         LOG_DEBUG(<< "orderedAnomalies = "
                   << core::CContainerPrinter::print(orderedAnomalies));
 
-        std::string expectedAnomalies[] = {
-            std::string("[12, p2, c0 c3]"), std::string("[15, p3, c0]"),
-            std::string("[30, p5, c2]"),    std::string("[40, p6, c0]"),
-            std::string("[44, p9, c2]"),    std::string("[60, p2, c4]"),
-            std::string("[80, p1, c3]")};
+        TStrVec expectedAnomalies{
+            "[12, p2, c0 c3]", "[15, p3, c0]", "[30, p5, c2]", "[40, p6, c0]",
+            "[44, p9, c2]",    "[60, p2, c4]", "[80, p1, c3]"};
 
-        BOOST_REQUIRE_EQUAL(boost::size(expectedAnomalies), orderedAnomalies.size());
+        BOOST_REQUIRE_EQUAL(expectedAnomalies.size(), orderedAnomalies.size());
         for (std::size_t j = 0u; j < orderedAnomalies.size(); ++j) {
             BOOST_REQUIRE_EQUAL(expectedAnomalies[j], orderedAnomalies[j].print());
         }
@@ -767,21 +749,14 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
     // This test has four people and five attributes. We expect
     // person 2 and attributes 1, 2 and 5 to be deleted.
 
-    using TStrSizePr = std::pair<std::string, std::size_t>;
-    using TStrSizePrVec = std::vector<TStrSizePr>;
-    using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
+    core_t::TTime startTime{1367280000};
+    const core_t::TTime bucketLength{3600};
+    const std::size_t numberBuckets{1000u};
 
-    core_t::TTime startTime = 1367280000;
-    const core_t::TTime bucketLength = 3600;
-    const std::size_t numberBuckets = 1000u;
+    TStrVec people{"p1", "p2", "p3", "p4"};
+    TStrVec attributes{"c1", "c2", "c3", "c4", "c5"};
+    TStrSizePrVecVecVec eventCounts{{}, {}, {}, {}};
 
-    std::string people[] = {std::string("p1"), std::string("p2"),
-                            std::string("p3"), std::string("p4")};
-    std::string attributes[] = {std::string("c1"), std::string("c2"), std::string("c3"),
-                                std::string("c4"), std::string("c5")};
-
-    TStrSizePrVecVec eventCounts[] = {TStrSizePrVecVec(), TStrSizePrVecVec(),
-                                      TStrSizePrVecVec(), TStrSizePrVecVec()};
     {
         TStrSizePrVec attributeCounts{{attributes[0], 0}, {attributes[4], 0}};
         eventCounts[0].resize(numberBuckets, attributeCounts);
@@ -860,27 +835,26 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
     test::CRandomNumbers rng;
 
     TMessageVec messages;
-    for (std::size_t i = 0u; i < boost::size(people); ++i) {
-        core_t::TTime bucketStart = startTime;
+    for (std::size_t i = 0u; i < people.size(); ++i) {
+        core_t::TTime bucketStart{startTime};
         for (std::size_t j = 0u; j < numberBuckets; ++j, bucketStart += bucketLength) {
             const TStrSizePrVec& attributeEventCounts = eventCounts[i][j];
-            for (std::size_t k = 0u; k < attributeEventCounts.size(); ++k) {
-                if (attributeEventCounts[k].second == 0) {
+            for (auto& attributeEventCount : attributeEventCounts) {
+                if (attributeEventCount.second == 0) {
                     continue;
                 }
 
-                std::size_t n = attributeEventCounts[k].second;
+                std::size_t n{attributeEventCount.second};
 
                 TDoubleVec samples;
                 rng.generateUniformSamples(0.0, 8.0, n, samples);
 
-                core_t::TTime time = bucketStart;
-                core_t::TTime dt = bucketLength / static_cast<core_t::TTime>(n);
+                core_t::TTime time{bucketStart};
+                core_t::TTime dt{bucketLength / static_cast<core_t::TTime>(n)};
 
                 for (std::size_t l = 0u; l < n; ++l, time += dt) {
-                    messages.push_back(SMessage(time, people[i],
-                                                attributeEventCounts[k].first,
-                                                TDouble1Vec(1, samples[l])));
+                    messages.emplace_back(time, people[i], attributeEventCount.first,
+                                          TDouble1Vec{1, samples[l]});
                 }
             }
         }
@@ -889,16 +863,16 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
 
     TMessageVec expectedMessages;
     expectedMessages.reserve(messages.size());
-    for (std::size_t i = 0u; i < messages.size(); ++i) {
+    for (const auto& message : messages) {
         if (std::binary_search(std::begin(expectedPeople),
-                               std::end(expectedPeople), messages[i].s_Person) &&
+                               std::end(expectedPeople), message.s_Person) &&
             std::binary_search(std::begin(expectedAttributes),
-                               std::end(expectedAttributes), messages[i].s_Attribute)) {
-            expectedMessages.push_back(messages[i]);
+                               std::end(expectedAttributes), message.s_Attribute)) {
+            expectedMessages.push_back(message);
         }
     }
 
-    core_t::TTime bucketStart = startTime;
+    core_t::TTime bucketStart{startTime};
     for (const auto& message : messages) {
         if (message.s_Time >= bucketStart + bucketLength) {
             model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -913,12 +887,12 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
     BOOST_REQUIRE_EQUAL(maxDimensionBeforePrune, maxDimensionAfterPrune);
 
     bucketStart = startTime;
-    for (std::size_t i = 0u; i < expectedMessages.size(); ++i) {
-        if (expectedMessages[i].s_Time >= bucketStart + bucketLength) {
+    for (const auto& expectedMessage : expectedMessages) {
+        if (expectedMessage.s_Time >= bucketStart + bucketLength) {
             expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(expectedMessages[i], expectedGatherer, m_ResourceMonitor);
+        addArrival(expectedMessage, expectedGatherer, m_ResourceMonitor);
     }
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
 
@@ -930,14 +904,13 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
 
     bucketStart = gatherer->currentBucketStartTime() + bucketLength;
 
-    SMessage newMessages[] = {
-        SMessage(bucketStart + 10, "p1", "c2", TDouble1Vec(1, 20.0)),
-        SMessage(bucketStart + 200, "p5", "c6", TDouble1Vec(1, 10.0)),
-        SMessage(bucketStart + 2100, "p5", "c6", TDouble1Vec(1, 15.0))};
+    TMessageVec newMessages{{bucketStart + 10, "p1", "c2", TDouble1Vec(1, 20.0)},
+                            {bucketStart + 200, "p5", "c6", TDouble1Vec(1, 10.0)},
+                            {bucketStart + 2100, "p5", "c6", TDouble1Vec(1, 15.0)}};
 
-    for (std::size_t i = 0u; i < boost::size(newMessages); ++i) {
-        addArrival(newMessages[i], gatherer, m_ResourceMonitor);
-        addArrival(newMessages[i], expectedGatherer, m_ResourceMonitor);
+    for (auto& newMessage : newMessages) {
+        addArrival(newMessage, gatherer, m_ResourceMonitor);
+        addArrival(newMessage, expectedGatherer, m_ResourceMonitor);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -957,25 +930,25 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
-    function_t::EFunction countFunctions[] = {
+    function_t::TFunctionVec countFunctions{
         function_t::E_PopulationMetric, function_t::E_PopulationMetricMean,
         function_t::E_PopulationMetricMin, function_t::E_PopulationMetricMax,
         function_t::E_PopulationMetricSum};
-    bool useNull[] = {true, false};
-    std::string byField[] = {"", "by"};
-    std::string partitionField[] = {"", "partition"};
+    TBoolVec useNull{true, false};
+    TStrVec byFields{"", "by"};
+    TStrVec partitionFields{"", "partition"};
 
     {
         CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
 
-        int detectorIndex = 0;
-        for (std::size_t i = 0u; i < boost::size(countFunctions); ++i) {
-            for (std::size_t j = 0u; j < boost::size(useNull); ++j) {
-                for (std::size_t k = 0u; k < boost::size(byField); ++k) {
-                    for (std::size_t l = 0u; l < boost::size(partitionField); ++l) {
-                        CSearchKey key(++detectorIndex, countFunctions[i],
-                                       useNull[j], model_t::E_XF_None, "value",
-                                       byField[k], "over", partitionField[l]);
+        int detectorIndex{0};
+        for (const auto& countFunction : countFunctions) {
+            for (bool usingNull : useNull) {
+                for (const auto& byField : byFields) {
+                    for (const auto& partitionField : partitionFields) {
+                        CSearchKey key(++detectorIndex, countFunction,
+                                       usingNull, model_t::E_XF_None, "value",
+                                       byField, "over", partitionField);
 
                         CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
                             config.factory(key);
@@ -993,26 +966,35 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
 BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
     // Test we correctly compute frequencies for people and attributes.
 
-    const core_t::TTime bucketLength = 600;
-    const std::string attributes[] = {"a1", "a2", "a3", "a4", "a5",
-                                      "a6", "a7", "a8", "a9", "a10"};
-    const std::string people[] = {"p1", "p2", "p3", "p4", "p5",
-                                  "p6", "p7", "p8", "p9", "p10"};
-    std::size_t period[] = {1u, 1u, 10u, 3u, 4u, 5u, 2u, 1u, 3u, 7u};
+    struct SDatum {
+        std::string s_Attribute;
+        std::string s_Person;
+        std::size_t s_Period{0};
+    };
 
-    core_t::TTime startTime = 0;
+    using TDataVec = std::vector<SDatum>;
+    TDataVec data{{"a1", "p1", 1u},  {"a2", "p2", 1u}, {"a3", "p3", 10u},
+                  {"a4", "p4", 3u},  {"a5", "p5", 4u}, {"a6", "p6", 5u},
+                  {"a7", "p7", 2u},  {"a8", "p8", 1u}, {"a9", "p9", 3u},
+                  {"a10", "p10", 7u}};
+
+    const core_t::TTime bucketLength{600};
+
+    core_t::TTime startTime{0};
 
     TMessageVec messages;
-    std::size_t bucket = 0u;
+    std::size_t bucket{0u};
     for (core_t::TTime bucketStart = startTime; bucketStart < 100 * bucketLength;
          bucketStart += bucketLength, ++bucket) {
-        for (std::size_t i = 0u; i < boost::size(people); ++i) {
-            if (bucket % period[i] == 0) {
+        std::size_t i{0u};
+        for (auto& datum : data) {
+            if (bucket % datum.s_Period == 0) {
                 for (std::size_t j = 0u; j < i + 1; ++j) {
-                    messages.push_back(SMessage(bucketStart + bucketLength / 2, people[i],
-                                                attributes[j], TDouble1Vec(1, 0.0)));
+                    messages.emplace_back(bucketStart + bucketLength / 2, datum.s_Person,
+                                          data[j].s_Attribute, TDouble1Vec{1, 0.0});
                 }
             }
+            ++i;
         }
     }
 
@@ -1036,7 +1018,7 @@ BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
         dynamic_cast<CMetricPopulationModel*>(model.get());
     BOOST_TEST_REQUIRE(populationModel);
 
-    core_t::TTime time = startTime;
+    core_t::TTime time{startTime};
     for (const auto& message : messages) {
         if (message.s_Time >= time + bucketLength) {
             populationModel->sample(time, time + bucketLength, m_ResourceMonitor);
@@ -1047,30 +1029,33 @@ BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
 
     {
         TMeanAccumulator meanError;
-        for (std::size_t i = 0u; i < boost::size(people); ++i) {
-            LOG_DEBUG(<< "*** person = " << people[i] << " ***");
+        for (auto& datum : data) {
+            LOG_DEBUG(<< "*** person = " << datum.s_Person << " ***");
             std::size_t pid;
-            BOOST_TEST_REQUIRE(gatherer->personId(people[i], pid));
+            BOOST_TEST_REQUIRE(gatherer->personId(datum.s_Person, pid));
             LOG_DEBUG(<< "frequency = " << populationModel->personFrequency(pid));
-            LOG_DEBUG(<< "expected frequency = " << 1.0 / static_cast<double>(period[i]));
-            BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0 / static_cast<double>(period[i]),
+            LOG_DEBUG(<< "expected frequency = "
+                      << 1.0 / static_cast<double>(datum.s_Period));
+            BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0 / static_cast<double>(datum.s_Period),
                                          populationModel->personFrequency(pid),
-                                         0.1 / static_cast<double>(period[i]));
+                                         0.1 / static_cast<double>(datum.s_Period));
             meanError.add(std::fabs(populationModel->personFrequency(pid) -
-                                    1.0 / static_cast<double>(period[i])));
+                                    1.0 / static_cast<double>(datum.s_Period)));
         }
         LOG_DEBUG(<< "error = " << maths::CBasicStatistics::mean(meanError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.002);
     }
     {
-        for (std::size_t i = 0u; i < boost::size(attributes); ++i) {
-            LOG_DEBUG(<< "*** attributes = " << attributes[i] << " ***");
+        std::size_t i{0};
+        for (auto& datum : data) {
+            LOG_DEBUG(<< "*** attributes = " << datum.s_Attribute << " ***");
             std::size_t cid;
-            BOOST_TEST_REQUIRE(populationGatherer.attributeId(attributes[i], cid));
+            BOOST_TEST_REQUIRE(populationGatherer.attributeId(datum.s_Attribute, cid));
             LOG_DEBUG(<< "frequency = " << populationModel->attributeFrequency(cid));
             LOG_DEBUG(<< "expected frequency = " << (10.0 - static_cast<double>(i)) / 10.0);
             BOOST_REQUIRE_EQUAL((10.0 - static_cast<double>(i)) / 10.0,
                                 populationModel->attributeFrequency(cid));
+            ++i;
         }
     }
 }
@@ -1084,22 +1069,22 @@ BOOST_FIXTURE_TEST_CASE(testSampleRateWeight, CTestFixture) {
     // The remaining 18 people only generate one message per bucket, i.e.
     // one message per attribute per 10 buckets.
 
-    const core_t::TTime bucketLength = 600;
-    const std::string attributes[] = {"a1", "a2", "a3", "a4", "a5",
-                                      "a6", "a7", "a8", "a9", "a10"};
-    const std::string people[] = {
-        "p1",  "p2",  "p3",  "p4",  "p5",  "p6",  "p7",  "p8",  "p9",  "p10",
-        "p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18", "p19", "p20"};
-    std::size_t heavyHitters[] = {0u, 4u};
-    std::size_t normal[] = {1u,  2u,  3u,  5u,  6u,  7u,  8u,  9u,  10u,
-                            11u, 12u, 13u, 14u, 15u, 16u, 17u, 18u, 19u};
+    const core_t::TTime bucketLength{600};
+    const TStrVec attributes{"a1", "a2", "a3", "a4", "a5",
+                             "a6", "a7", "a8", "a9", "a10"};
+    const TStrVec people{"p1",  "p2",  "p3",  "p4",  "p5",  "p6",  "p7",
+                         "p8",  "p9",  "p10", "p11", "p12", "p13", "p14",
+                         "p15", "p16", "p17", "p18", "p19", "p20"};
+    TSizeVec heavyHitters{0u, 4u};
+    TSizeVec normal{1u,  2u,  3u,  5u,  6u,  7u,  8u,  9u,  10u,
+                    11u, 12u, 13u, 14u, 15u, 16u, 17u, 18u, 19u};
 
-    std::size_t messagesPerBucket =
-        boost::size(heavyHitters) * boost::size(attributes) + boost::size(normal);
+    std::size_t messagesPerBucket = heavyHitters.size() * attributes.size() +
+                                    normal.size();
 
     test::CRandomNumbers rng;
 
-    core_t::TTime startTime = 0;
+    core_t::TTime startTime{0};
 
     TMessageVec messages;
     for (core_t::TTime bucketStart = startTime;
@@ -1109,22 +1094,22 @@ BOOST_FIXTURE_TEST_CASE(testSampleRateWeight, CTestFixture) {
                                    static_cast<std::size_t>(bucketStart + bucketLength),
                                    messagesPerBucket, times);
 
-        std::size_t m = 0u;
-        for (std::size_t i = 0u; i < boost::size(attributes); ++i) {
-            for (std::size_t j = 0u; j < boost::size(heavyHitters); ++j) {
-                messages.push_back(SMessage(static_cast<core_t::TTime>(times[m++]),
-                                            people[heavyHitters[j]],
-                                            attributes[i], TDouble1Vec(1, 0.0)));
+        std::size_t m{0u};
+        for (auto& attribute : attributes) {
+            for (auto& heavyHitter : heavyHitters) {
+                messages.emplace_back(static_cast<core_t::TTime>(times[m++]),
+                                      people[heavyHitter], attribute,
+                                      TDouble1Vec{1, 0.0});
             }
         }
 
         TSizeVec attributeIndexes;
-        rng.generateUniformSamples(0, boost::size(attributes),
-                                   boost::size(normal), attributeIndexes);
-        for (std::size_t i = 0u; i < boost::size(normal); ++i) {
-            messages.push_back(
-                SMessage(static_cast<core_t::TTime>(times[m++]), people[normal[i]],
-                         attributes[attributeIndexes[i]], TDouble1Vec(1, 0.0)));
+        rng.generateUniformSamples(0, attributes.size(), normal.size(), attributeIndexes);
+        std::size_t i{0};
+        for (auto& norm : normal) {
+            messages.emplace_back(static_cast<core_t::TTime>(times[m++]),
+                                  people[norm], attributes[attributeIndexes[i++]],
+                                  TDouble1Vec{1, 0.0});
         }
     }
 
@@ -1145,7 +1130,7 @@ BOOST_FIXTURE_TEST_CASE(testSampleRateWeight, CTestFixture) {
         dynamic_cast<CMetricPopulationModel*>(model.get());
     BOOST_TEST_REQUIRE(populationModel);
 
-    core_t::TTime time = startTime;
+    core_t::TTime time{startTime};
     for (const auto& message : messages) {
         if (message.s_Time >= time + bucketLength) {
             populationModel->sample(time, time + bucketLength, m_ResourceMonitor);
@@ -1161,17 +1146,17 @@ BOOST_FIXTURE_TEST_CASE(testSampleRateWeight, CTestFixture) {
     //      + ("# heavy hitters"))
     //   / "# people"
 
-    double expectedRateWeight = (static_cast<double>(boost::size(normal)) /
-                                     static_cast<double>(boost::size(attributes)) +
-                                 static_cast<double>(boost::size(heavyHitters))) /
-                                static_cast<double>(boost::size(people));
+    double expectedRateWeight = (static_cast<double>(normal.size()) /
+                                     static_cast<double>(attributes.size()) +
+                                 static_cast<double>(heavyHitters.size())) /
+                                static_cast<double>(people.size());
     LOG_DEBUG(<< "expectedRateWeight = " << expectedRateWeight);
 
-    for (std::size_t i = 0u; i < boost::size(heavyHitters); ++i) {
-        LOG_DEBUG(<< "*** person = " << people[heavyHitters[i]] << " ***");
+    for (auto& heavyHitter : heavyHitters) {
+        LOG_DEBUG(<< "*** person = " << people[heavyHitter] << " ***");
         std::size_t pid;
-        BOOST_TEST_REQUIRE(gatherer->personId(people[heavyHitters[i]], pid));
-        for (std::size_t cid = 0u; cid < boost::size(attributes); ++cid) {
+        BOOST_TEST_REQUIRE(gatherer->personId(people[heavyHitter], pid));
+        for (std::size_t cid = 0u; cid < attributes.size(); ++cid) {
             double sampleRateWeight = populationModel->sampleRateWeight(pid, cid);
             LOG_DEBUG(<< "attribute = " << populationModel->attributeName(cid)
                       << ", sampleRateWeight = " << sampleRateWeight);
@@ -1180,11 +1165,11 @@ BOOST_FIXTURE_TEST_CASE(testSampleRateWeight, CTestFixture) {
         }
     }
 
-    for (std::size_t i = 0u; i < boost::size(normal); ++i) {
-        LOG_DEBUG(<< "*** person = " << people[normal[i]] << " ***");
+    for (auto& norm : normal) {
+        LOG_DEBUG(<< "*** person = " << people[norm] << " ***");
         std::size_t pid;
-        BOOST_TEST_REQUIRE(gatherer->personId(people[normal[i]], pid));
-        for (std::size_t cid = 0u; cid < boost::size(attributes); ++cid) {
+        BOOST_TEST_REQUIRE(gatherer->personId(people[norm], pid));
+        for (std::size_t cid = 0u; cid < attributes.size(); ++cid) {
             double sampleRateWeight = populationModel->sampleRateWeight(pid, cid);
             LOG_DEBUG(<< "attribute = " << populationModel->attributeName(cid)
                       << ", sampleRateWeight = " << sampleRateWeight);
@@ -1199,35 +1184,37 @@ BOOST_FIXTURE_TEST_CASE(testPeriodicity, CTestFixture) {
 
     using TStrDoubleMap = std::map<std::string, double>;
 
-    static const core_t::TTime HOUR = 3600;
-    static const core_t::TTime DAY = 86400;
+    static const core_t::TTime HOUR{3600};
+    static const core_t::TTime DAY{86400};
 
-    const core_t::TTime bucketLength = 3600;
-    double baseline[] = {1, 1, 2, 2,  3, 5, 6, 6, 20, 21, 4, 3,
-                         4, 4, 8, 25, 7, 6, 5, 1, 1,  4,  1, 1};
-    const std::string attributes[] = {"a1", "a2"};
-    double scales[] = {2.0, 3.0};
-    const std::string people[] = {"p1", "p2", "p3", "p4", "p5",
-                                  "p6", "p7", "p8", "p9", "p10"};
+    const core_t::TTime bucketLength{3600};
+    TDoubleVec baseline{1, 1, 2, 2,  3, 5, 6, 6, 20, 21, 4, 3,
+                        4, 4, 8, 25, 7, 6, 5, 1, 1,  4,  1, 1};
+
+    TDoubleStrPrVec attribs{{2.0, "a1"}, {3.0, "a2"}};
+
+    const TStrVec people{"p1", "p2", "p3", "p4", "p5",
+                         "p6", "p7", "p8", "p9", "p10"};
 
     test::CRandomNumbers rng;
 
-    core_t::TTime startTime = 0;
-    core_t::TTime endTime = 604800;
+    core_t::TTime startTime{0};
+    core_t::TTime endTime{604800};
 
     TMessageVec messages;
     for (core_t::TTime time = startTime; time < endTime; time += bucketLength) {
-        for (std::size_t i = 0u; i < boost::size(attributes); ++i) {
+        for (const auto& attrib : attribs) {
             TDoubleVec values;
             rng.generateNormalSamples(baseline[(time % DAY) / HOUR],
-                                      scales[i] * scales[i], boost::size(people), values);
+                                      attrib.first * attrib.first, people.size(), values);
 
-            for (std::size_t j = 0u; j < values.size(); ++j) {
+            std::size_t j{0};
+            for (const auto& value : values) {
                 for (unsigned int t = 0; t < 4; ++t) {
-                    messages.push_back(SMessage(time + (t * bucketLength) / 4,
-                                                people[j], attributes[i],
-                                                TDouble1Vec(1, values[j])));
+                    messages.emplace_back(time + (t * bucketLength) / 4, people[j],
+                                          attrib.second, TDouble1Vec(1, value));
                 }
+                ++j;
             }
         }
     }
@@ -1252,13 +1239,13 @@ BOOST_FIXTURE_TEST_CASE(testPeriodicity, CTestFixture) {
     TStrDoubleMap personProbabilitiesWithPeriodicity;
 
     core_t::TTime time = startTime;
-    for (std::size_t i = 0u; i < messages.size(); ++i) {
-        if (messages[i].s_Time >= time + bucketLength) {
+    for (const auto& message : messages) {
+        if (message.s_Time >= time + bucketLength) {
             populationModel->sample(time, time + bucketLength, m_ResourceMonitor);
 
-            for (std::size_t j = 0u; j < boost::size(people); ++j) {
+            for (const auto& person : people) {
                 std::size_t pid;
-                if (!gatherer->personId(people[j], pid)) {
+                if (!gatherer->personId(person, pid)) {
                     continue;
                 }
 
@@ -1272,14 +1259,14 @@ BOOST_FIXTURE_TEST_CASE(testPeriodicity, CTestFixture) {
 
                 if (time < startTime + 3 * DAY) {
                     double& minimumProbability = personProbabilitiesWithoutPeriodicity
-                                                     .insert({people[j], 1.0})
+                                                     .insert({person, 1.0})
                                                      .first->second;
                     minimumProbability = std::min(
                         minimumProbability, annotatedProbability.s_Probability);
                 } else if (time > startTime + 5 * DAY) {
-                    double& minimumProbability = personProbabilitiesWithPeriodicity
-                                                     .insert({people[j], 1.0})
-                                                     .first->second;
+                    double& minimumProbability =
+                        personProbabilitiesWithPeriodicity.insert({person, 1.0})
+                            .first->second;
                     minimumProbability = std::min(
                         minimumProbability, annotatedProbability.s_Probability);
                 }
@@ -1287,16 +1274,16 @@ BOOST_FIXTURE_TEST_CASE(testPeriodicity, CTestFixture) {
             time += bucketLength;
         }
 
-        addArrival(messages[i], gatherer, m_ResourceMonitor);
+        addArrival(message, gatherer, m_ResourceMonitor);
     }
 
-    double totalw = 0.0;
-    double totalwo = 0.0;
+    double totalw{0.0};
+    double totalwo{0.0};
 
-    for (std::size_t i = 0u; i < boost::size(people); ++i) {
-        auto wo = personProbabilitiesWithoutPeriodicity.find(people[i]);
-        auto w = personProbabilitiesWithPeriodicity.find(people[i]);
-        LOG_DEBUG(<< "person = " << people[i]);
+    for (const auto& person : people) {
+        auto wo = personProbabilitiesWithoutPeriodicity.find(person);
+        auto w = personProbabilitiesWithPeriodicity.find(person);
+        LOG_DEBUG(<< "person = " << person);
         LOG_DEBUG(<< "minimum probability with periodicity    = " << w->second);
         LOG_DEBUG(<< "minimum probability without periodicity = " << wo->second);
         totalwo += wo->second;
@@ -1309,8 +1296,8 @@ BOOST_FIXTURE_TEST_CASE(testPeriodicity, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
-    core_t::TTime startTime = 1367280000;
-    const core_t::TTime bucketLength = 3600;
+    core_t::TTime startTime{1367280000};
+    const core_t::TTime bucketLength{3600};
 
     TMessageVec messages;
     generateTestMessages(1, startTime, bucketLength, messages);
@@ -1333,12 +1320,12 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
         dynamic_cast<CMetricPopulationModel*>(origModel.get());
     BOOST_TEST_REQUIRE(populationModel);
 
-    for (std::size_t i = 0u; i < messages.size(); ++i) {
-        if (messages[i].s_Time >= startTime + bucketLength) {
+    for (auto& message : messages) {
+        if (message.s_Time >= startTime + bucketLength) {
             origModel->sample(startTime, startTime + bucketLength, m_ResourceMonitor);
             startTime += bucketLength;
         }
-        addArrival(messages[i], gatherer, m_ResourceMonitor);
+        addArrival(message, gatherer, m_ResourceMonitor);
     }
 
     std::string origXml;
@@ -1382,8 +1369,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     // At the end the checksums for the underlying models should
     // be the same.
 
-    core_t::TTime startTime(100);
-    std::size_t bucketLength(100);
+    core_t::TTime startTime{100};
+    const std::size_t bucketLength{100};
     core_t::TTime endTime = startTime + bucketLength;
 
     // Create a categorical rule to filter out attribute a3
@@ -1421,10 +1408,10 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     CAnomalyDetectorModel::TModelPtr modelWithSkip(
         factoryWithSkip.makeModel(modelWithSkipInitData));
 
-    std::vector<SMessage> messages{{startTime + 10, "p1", "c1", {1, 20.0}},
-                                   {startTime + 10, "p1", "c2", {1, 22.0}},
-                                   {startTime + 10, "p2", "c1", {1, 20.0}},
-                                   {startTime + 10, "p2", "c2", {1, 22.0}}};
+    TMessageVec messages{{startTime + 10, "p1", "c1", {1, 20.0}},
+                         {startTime + 10, "p1", "c2", {1, 22.0}},
+                         {startTime + 10, "p2", "c1", {1, 20.0}},
+                         {startTime + 10, "p2", "c2", {1, 22.0}}};
 
     std::vector<CModelFactory::TDataGathererPtr> gatherers{gathererNoSkip, gathererWithSkip};
     for (auto& gatherer : gatherers) {

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -22,6 +22,8 @@
 #include <utility>
 #include <vector>
 
+using TBoolVec = std::vector<bool>;
+
 using TDouble1Vec = ml::core::CSmallVector<double, 1>;
 using TDouble2Vec = ml::core::CSmallVector<double, 2>;
 using TDouble4Vec = ml::core::CSmallVector<double, 4>;
@@ -54,11 +56,17 @@ using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
 using TSizeVec = std::vector<std::size_t>;
 using TSizeVecVec = std::vector<TSizeVec>;
 using TSizeVecVecVec = std::vector<TSizeVecVec>;
+using TStrSizePr = std::pair<std::string, std::size_t>;
+using TStrSizePrVec = std::vector<TStrSizePr>;
+using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
+using TStrSizePrVecVecVec = std::vector<TStrSizePrVecVec>;
+using TStrUInt64Map = std::map<std::string, uint64_t>;
 
 using TStrVec = std::vector<std::string>;
 using TStrVecVec = std::vector<TStrVec>;
 
 using TTimeDoublePr = std::pair<ml::core_t::TTime, double>;
+using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
 using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
 using TTimeStrVecPr = std::pair<ml::core_t::TTime, TStrVec>;
 using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;


### PR DESCRIPTION
Use modern C++ data structures, initialisation to remove the need for
boost::size.

Use uniform braced initialisation of variables consistently.

Relates to #1477 