### PR TITLE
[ML] Move model test helper functions to base class

### DIFF
--- a/lib/model/unittest/CCountingModelTest.cc
+++ b/lib/model/unittest/CCountingModelTest.cc
@@ -29,10 +29,6 @@ BOOST_AUTO_TEST_SUITE(CCountingModelTest)
 using namespace ml;
 using namespace model;
 
-namespace {
-const std::string EMPTY_STRING;
-}
-
 class CTestFixture : public CModelTestFixtureBase {
 protected:
     SModelParams::TStrDetectionRulePr

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -1110,9 +1110,6 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
                         clonedModel->dataGatherer().numberActivePeople());
 }
 
-
-
-
 BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
     function_t::TFunctionVec countFunctions{function_t::E_IndividualCount,
                                             function_t::E_IndividualNonZeroCount,
@@ -1126,8 +1123,9 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
     std::string overFieldName;
 
     generateAndCompareKey(countFunctions, fieldName, overFieldName,
-                          [](CSearchKey expectedKey, CSearchKey actualKey){
-                              BOOST_TEST_REQUIRE(expectedKey == actualKey);});
+                          [](CSearchKey expectedKey, CSearchKey actualKey) {
+                              BOOST_TEST_REQUIRE(expectedKey == actualKey);
+                          });
 }
 
 BOOST_FIXTURE_TEST_CASE(testModelsWithValueFields, CTestFixture) {

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -124,25 +124,6 @@ public:
         }
     }
 
-    CEventData makeEventData(core_t::TTime time, std::size_t pid) {
-        CEventData eventData;
-        eventData.time(time);
-        eventData.person(pid);
-        eventData.addAttribute(std::size_t(0));
-        eventData.addValue(TDoubleVec(1, 0.0));
-        return eventData;
-    }
-
-    CEventData makeEventData(core_t::TTime time, std::size_t pid, const std::string value) {
-        CEventData eventData;
-        eventData.time(time);
-        eventData.person(pid);
-        eventData.addAttribute(std::size_t(0));
-        eventData.addValue(TDoubleVec(1, 0.0));
-        eventData.stringValue(value);
-        return eventData;
-    }
-
     void handleEvent(const CDataGatherer::TStrCPtrVec& fields,
                      core_t::TTime time,
                      CModelFactory::TDataGathererPtr& gatherer,
@@ -1745,7 +1726,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                 for (std::size_t k = 1; k < 20; k++) {
                     std::stringstream ss;
                     ss << uniqueValue << "_" << k;
-                    CEventData d = makeEventData(eventTimes[i - 1], 0, ss.str());
+                    CEventData d = makeEventData(eventTimes[i - 1], 0, {}, ss.str());
                     if (k % 2 == 0) {
                         this->addArrival(*gatherer, eventTimes[i - 1], "p",
                                          TOptionalStr("inf1"), TOptionalStr(ss.str()));

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -54,7 +54,6 @@ using namespace ml;
 using namespace model;
 
 namespace {
-const std::string EMPTY_STRING;
 const CModelTestFixtureBase::TSizeDoublePr1Vec NO_CORRELATES;
 }
 
@@ -624,12 +623,13 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
     std::string overFieldName{"over"};
 
     generateAndCompareKey(countFunctions, fieldName, overFieldName,
-                          [](CSearchKey expectedKey, CSearchKey actualKey){
-                            BOOST_TEST_REQUIRE(expectedKey == actualKey);});
+                          [](CSearchKey expectedKey, CSearchKey actualKey) {
+                              BOOST_TEST_REQUIRE(expectedKey == actualKey);
+                          });
 }
 
 BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
-   // Test we correctly compute frequencies for people and attributes.
+    // Test we correctly compute frequencies for people and attributes.
 
     struct SDatum {
         std::string s_Attribute;

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -57,7 +57,6 @@ namespace {
 using TMinAccumulator = maths::CBasicStatistics::SMin<double>::TAccumulator;
 using TMaxAccumulator = maths::CBasicStatistics::SMax<double>::TAccumulator;
 
-const std::string EMPTY_STRING;
 const CModelTestFixtureBase::TSizeDoublePr1Vec NO_CORRELATES;
 }
 
@@ -1319,8 +1318,9 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
     std::string overFieldName;
 
     generateAndCompareKey(countFunctions, fieldName, overFieldName,
-                          [](CSearchKey expectedKey, CSearchKey actualKey){
-                            BOOST_TEST_REQUIRE(expectedKey == actualKey);});
+                          [](CSearchKey expectedKey, CSearchKey actualKey) {
+                              BOOST_TEST_REQUIRE(expectedKey == actualKey);
+                          });
 }
 
 BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -58,175 +58,35 @@ using TMinAccumulator = maths::CBasicStatistics::SMin<double>::TAccumulator;
 using TMaxAccumulator = maths::CBasicStatistics::SMax<double>::TAccumulator;
 
 const std::string EMPTY_STRING;
-
-class CTimeLess {
-public:
-    bool operator()(const CEventData& lhs, const CEventData& rhs) const {
-        return lhs.time() < rhs.time();
-    }
-};
-
-std::size_t addPerson(const std::string& p,
-                      const CModelFactory::TDataGathererPtr& gatherer,
-                      CResourceMonitor& resourceMonitor) {
-    CDataGatherer::TStrCPtrVec person{&p};
-    person.resize(gatherer->fieldsOfInterest().size(), nullptr);
-    CEventData result;
-    gatherer->processFields(person, result, resourceMonitor);
-    return *result.personId();
-}
-
-void addArrival(CDataGatherer& gatherer,
-                CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
-                const std::string& person,
-                double value,
-                const TOptionalStr& inf1 = TOptionalStr(),
-                const TOptionalStr& inf2 = TOptionalStr(),
-                const TOptionalStr& count = TOptionalStr()) {
-    CDataGatherer::TStrCPtrVec fieldValues;
-    fieldValues.push_back(&person);
-    if (inf1) {
-        fieldValues.push_back(&(inf1.get()));
-    }
-    if (inf2) {
-        fieldValues.push_back(&(inf2.get()));
-    }
-    if (count) {
-        fieldValues.push_back(&(count.get()));
-    }
-    std::string valueAsString(core::CStringUtils::typeToStringPrecise(
-        value, core::CIEEE754::E_DoublePrecision));
-    fieldValues.push_back(&valueAsString);
-
-    CEventData eventData;
-    eventData.time(time);
-
-    gatherer.addArrival(fieldValues, eventData, resourceMonitor);
-}
-
-void addArrival(CDataGatherer& gatherer,
-                CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
-                const std::string& person,
-                double lat,
-                double lng,
-                const TOptionalStr& inf1 = TOptionalStr(),
-                const TOptionalStr& inf2 = TOptionalStr()) {
-    CDataGatherer::TStrCPtrVec fieldValues;
-    fieldValues.push_back(&person);
-    if (inf1) {
-        fieldValues.push_back(&(inf1.get()));
-    }
-    if (inf2) {
-        fieldValues.push_back(&(inf2.get()));
-    }
-    std::string valueAsString;
-    valueAsString += core::CStringUtils::typeToStringPrecise(lat, core::CIEEE754::E_DoublePrecision);
-    valueAsString += model::CAnomalyDetectorModelConfig::DEFAULT_MULTIVARIATE_COMPONENT_DELIMITER;
-    valueAsString += core::CStringUtils::typeToStringPrecise(lng, core::CIEEE754::E_DoublePrecision);
-    fieldValues.push_back(&valueAsString);
-
-    CEventData eventData;
-    eventData.time(time);
-
-    gatherer.addArrival(fieldValues, eventData, resourceMonitor);
-}
-
-CEventData makeEventData(core_t::TTime time,
-                         std::size_t pid,
-                         double value,
-                         const TOptionalStr& influence = TOptionalStr()) {
-    CEventData result;
-    result.time(time);
-    result.person(pid);
-    result.addAttribute(std::size_t(0));
-    result.addValue({value});
-    result.addInfluence(influence);
-    return result;
-}
-
-TDouble1Vec featureData(const CMetricModel& model,
-                        model_t::EFeature feature,
-                        std::size_t pid,
-                        core_t::TTime time) {
-    const CMetricModel::TFeatureData* data = model.featureData(feature, pid, time);
-    if (!data) {
-        return TDouble1Vec();
-    }
-    return data->s_BucketValue ? data->s_BucketValue->value() : TDouble1Vec();
-}
-
-TDouble1Vec multivariateFeatureData(const CMetricModel& model,
-                                    model_t::EFeature feature,
-                                    std::size_t pid,
-                                    core_t::TTime time) {
-    const CMetricModel::TFeatureData* data = model.featureData(feature, pid, time);
-    if (!data) {
-        return TDouble1Vec();
-    }
-    return data->s_BucketValue ? data->s_BucketValue->value() : TDouble1Vec();
-}
-
-void processBucket(core_t::TTime time,
-                   core_t::TTime bucketLength,
-                   const TDoubleVec& bucket,
-                   const TStrVec& influencerValues,
-                   CDataGatherer& gatherer,
-                   CResourceMonitor& resourceMonitor,
-                   CMetricModel& model,
-                   SAnnotatedProbability& probability) {
-    for (std::size_t i = 0u; i < bucket.size(); ++i) {
-        addArrival(gatherer, resourceMonitor, time, "p", bucket[i],
-                   TOptionalStr(influencerValues[i]));
-    }
-    model.sample(time, time + bucketLength, resourceMonitor);
-    CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
-    model.computeProbability(0 /*pid*/, time, time + bucketLength,
-                             partitioningFields, 1, probability);
-    LOG_DEBUG(<< "influences = " << core::CContainerPrinter::print(probability.s_Influences));
-}
-
-void processBucket(core_t::TTime time,
-                   core_t::TTime bucketLength,
-                   const TDoubleVec& bucket,
-                   CDataGatherer& gatherer,
-                   CResourceMonitor& resourceMonitor,
-                   CMetricModel& model,
-                   SAnnotatedProbability& probability,
-                   SAnnotatedProbability& probability2) {
-    const std::string person("p");
-    const std::string person2("q");
-    for (std::size_t i = 0u; i < bucket.size(); ++i) {
-        CDataGatherer::TStrCPtrVec fieldValues;
-        if (i % 2 == 0) {
-            fieldValues.push_back(&person);
-        } else {
-            fieldValues.push_back(&person2);
-        }
-
-        std::string valueAsString(core::CStringUtils::typeToStringPrecise(
-            bucket[i], core::CIEEE754::E_DoublePrecision));
-        fieldValues.push_back(&valueAsString);
-
-        CEventData eventData;
-        eventData.time(time);
-
-        gatherer.addArrival(fieldValues, eventData, resourceMonitor);
-    }
-    model.sample(time, time + bucketLength, resourceMonitor);
-    CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
-    model.computeProbability(0 /*pid*/, time, time + bucketLength,
-                             partitioningFields, 1, probability);
-    model.computeProbability(1 /*pid*/, time, time + bucketLength,
-                             partitioningFields, 1, probability2);
-}
-
-const TSizeDoublePr1Vec NO_CORRELATES;
+const CModelTestFixtureBase::TSizeDoublePr1Vec NO_CORRELATES;
 }
 
 class CTestFixture : public CModelTestFixtureBase {
 public:
+    CEventData makeEventData(core_t::TTime time,
+                             std::size_t pid,
+                             double value,
+                             const TOptionalStr& influence = TOptionalStr()) {
+        CEventData result;
+        result.time(time);
+        result.person(pid);
+        result.addAttribute(std::size_t(0));
+        result.addValue({value});
+        result.addInfluence(influence);
+        return result;
+    }
+
+    TDouble1Vec featureData(const CMetricModel& model,
+                            model_t::EFeature feature,
+                            std::size_t pid,
+                            core_t::TTime time) {
+        const CMetricModel::TFeatureData* data = model.featureData(feature, pid, time);
+        if (!data) {
+            return TDouble1Vec();
+        }
+        return data->s_BucketValue ? data->s_BucketValue->value() : TDouble1Vec();
+    }
+
     void makeModel(const SModelParams& params,
                    const model_t::TFeatureVec& features,
                    core_t::TTime startTime,
@@ -294,7 +154,7 @@ BOOST_FIXTURE_TEST_CASE(testSample, CTestFixture) {
 
             this->makeModel(params, features, startTime, &sampleCount);
             CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-            BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+            BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
             // Bucket values.
             uint64_t expectedCount{0};
@@ -329,8 +189,7 @@ BOOST_FIXTURE_TEST_CASE(testSample, CTestFixture) {
                     LOG_DEBUG(<< "Adding " << data[j].second << " at "
                               << data[j].first);
 
-                    addArrival(*m_Gatherer, m_ResourceMonitor, data[j].first,
-                               "p", data[j].second);
+                    this->addArrival(*m_Gatherer, data[j].first, "p", data[j].second);
 
                     ++expectedCount;
                     expectedMean.add(data[j].second);
@@ -544,7 +403,7 @@ BOOST_FIXTURE_TEST_CASE(testMultivariateSample, CTestFixture) {
         this->makeModel(params, {model_t::E_IndividualMeanLatLongByPerson},
                         startTime, &sampleCount);
         CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-        BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
         // Bucket values.
         uint64_t expectedCount{0};
@@ -566,8 +425,8 @@ BOOST_FIXTURE_TEST_CASE(testMultivariateSample, CTestFixture) {
                 LOG_DEBUG(<< "Adding " << data[j].second[0] << ","
                           << data[j].second[1] << " at " << data[j].first);
 
-                addArrival(*m_Gatherer, m_ResourceMonitor, data[j].first, "p",
-                           data[j].second[0], data[j].second[1]);
+                this->addArrival(*m_Gatherer, data[j].first, "p",
+                                 data[j].second[0], data[j].second[1]);
 
                 ++expectedCount;
                 expectedLatLong.add(TVector2(data[j].second));
@@ -611,7 +470,7 @@ BOOST_FIXTURE_TEST_CASE(testMultivariateSample, CTestFixture) {
                 TDouble1Vec baselineLatLong =
                     model.baselineBucketMean(model_t::E_IndividualMeanLatLongByPerson,
                                              0, 0, type, NO_CORRELATES, time);
-                TDouble1Vec featureLatLong = multivariateFeatureData(
+                TDouble1Vec featureLatLong = featureData(
                     model, model_t::E_IndividualMeanLatLongByPerson, 0, time);
                 const auto& prior =
                     dynamic_cast<const maths::CMultivariateTimeSeriesModel*>(
@@ -708,7 +567,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMetric, CTestFixture) {
 
     this->makeModel(params, features, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr> minProbabilities(2u);
     test::CRandomNumbers rng;
@@ -722,9 +581,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMetric, CTestFixture) {
                   << ", offset = " << (i == anomalousBucket ? anomaly : 0.0));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p",
-                       values[j] + (i == anomalousBucket ? anomaly : 0.0));
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j), "p",
+                             values[j] + (i == anomalousBucket ? anomaly : 0.0));
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -760,7 +618,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualMedianByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr> minProbabilities(2u);
     test::CRandomNumbers rng;
@@ -781,8 +639,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p", values[j]);
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
+                             "p", values[j]);
         }
 
         model.sample(time, time + bucketLength, m_ResourceMonitor);
@@ -832,7 +690,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMean, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualLowMeanByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -850,8 +708,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMean, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p", values[j]);
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
+                             "p", values[j]);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -888,7 +746,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMean, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualHighMeanByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -906,8 +764,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMean, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p", values[j]);
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
+                             "p", values[j]);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -942,7 +800,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowSum, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualLowSumByBucketAndPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -960,8 +818,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowSum, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p", values[j]);
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
+                             "p", values[j]);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -995,7 +853,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighSum, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualHighSumByBucketAndPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -1013,8 +871,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighSum, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p", values[j]);
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
+                             "p", values[j]);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -1064,7 +922,7 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
         factory.bucketLength(bucketLength);
         factory.fieldNames("", "", "P", "V", TStrVec{"I"});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", gatherer, m_ResourceMonitor));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
         CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
         BOOST_TEST_REQUIRE(model_);
         BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
@@ -1079,8 +937,8 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
             maths::CBasicStatistics::SMin<TDoubleStrPr>::TAccumulator min;
             maths::CBasicStatistics::SMax<TDoubleStrPr>::TAccumulator max;
             for (std::size_t j = 0u; j < samples.size(); ++j) {
-                addArrival(*gatherer, m_ResourceMonitor, time, "p", samples[j],
-                           TOptionalStr(influencerValues[j]));
+                this->addArrival(*gatherer, time, "p", samples[j],
+                                 TOptionalStr(influencerValues[j]));
                 min.add(TDoubleStrPr(samples[j], influencerValues[j]));
                 max.add(TDoubleStrPr(samples[j], influencerValues[j]));
             }
@@ -1130,7 +988,7 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
         factory.fieldNames("", "", "P", "V", TStrVec(1, "I"));
         CModelFactory::SGathererInitializationData gathererInitData(startTime);
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", gatherer, m_ResourceMonitor));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
         CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
         BOOST_TEST_REQUIRE(model_);
         BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
@@ -1140,8 +998,8 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
 
         core_t::TTime time{startTime};
         for (std::size_t i = 0u; i < values.size(); ++i) {
-            processBucket(time, bucketLength, values[i], influencers[i], *gatherer,
-                          m_ResourceMonitor, model, annotatedProbability);
+            processBucket(time, bucketLength, values[i], influencers[i],
+                          *gatherer, model, annotatedProbability);
             BOOST_REQUIRE_EQUAL(influences[i].size(),
                                 annotatedProbability.s_Influences.size());
             if (influences[i].size() > 0) {
@@ -1356,20 +1214,22 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
 
                 for (core_t::TTime k = 0, time = bucketStart, dt = bucketLength / n;
                      k < n; ++k, time += dt) {
-                    std::size_t pid = addPerson(people[i], gatherer, m_ResourceMonitor);
+                    std::size_t pid = this->addPerson(people[i], gatherer);
                     events.push_back(
                         makeEventData(time, pid, samples[static_cast<size_t>(k)]));
                 }
             }
         }
     }
-    std::sort(events.begin(), events.end(), CTimeLess());
+    std::sort(events.begin(), events.end(), [](const CEventData& lhs, const CEventData& rhs) {
+        return lhs.time() < rhs.time();
+    });
 
     TEventDataVec expectedEvents;
     expectedEvents.reserve(events.size());
     TSizeSizeMap mapping;
     for (const auto& expectedPerson : expectedPeople) {
-        std::size_t pid = addPerson(people[expectedPerson], expectedGatherer, m_ResourceMonitor);
+        std::size_t pid = this->addPerson(people[expectedPerson], expectedGatherer);
         mapping[expectedPerson] = pid;
     }
     for (std::size_t i = 0u; i < events.size(); ++i) {
@@ -1387,9 +1247,9 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(*gatherer, m_ResourceMonitor, events[i].time(),
-                   gatherer->personName(events[i].personId().get()),
-                   events[i].values()[0][0]);
+        this->addArrival(*gatherer, events[i].time(),
+                         gatherer->personName(events[i].personId().get()),
+                         events[i].values()[0][0]);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     size_t maxDimensionBeforePrune(model->dataGatherer().maxDimension());
@@ -1404,9 +1264,10 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             bucketStart += bucketLength;
         }
 
-        addArrival(*expectedGatherer, m_ResourceMonitor, expectedEvents[i].time(),
-                   expectedGatherer->personName(expectedEvents[i].personId().get()),
-                   expectedEvents[i].values()[0][0]);
+        this->addArrival(
+            *expectedGatherer, expectedEvents[i].time(),
+            expectedGatherer->personName(expectedEvents[i].personId().get()),
+            expectedEvents[i].values()[0][0]);
     }
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
 
@@ -1419,19 +1280,17 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
     bucketStart = gatherer->currentBucketStartTime() + bucketLength;
     TStrVec newPersons{"p9", "p10", "p11", "p12", "13"};
     for (const auto& newPerson : newPersons) {
-        std::size_t newPid = addPerson(newPerson, gatherer, m_ResourceMonitor);
+        std::size_t newPid = this->addPerson(newPerson, gatherer);
         BOOST_TEST_REQUIRE(newPid < 8);
 
-        std::size_t expectedNewPid = addPerson(newPerson, expectedGatherer, m_ResourceMonitor);
+        std::size_t expectedNewPid = this->addPerson(newPerson, expectedGatherer);
 
-        addArrival(*gatherer, m_ResourceMonitor, bucketStart + 1,
-                   gatherer->personName(newPid), 10.0);
-        addArrival(*gatherer, m_ResourceMonitor, bucketStart + 2000,
-                   gatherer->personName(newPid), 15.0);
-        addArrival(*expectedGatherer, m_ResourceMonitor, bucketStart + 1,
-                   expectedGatherer->personName(expectedNewPid), 10.0);
-        addArrival(*expectedGatherer, m_ResourceMonitor, bucketStart + 2000,
-                   expectedGatherer->personName(expectedNewPid), 15.0);
+        this->addArrival(*gatherer, bucketStart + 1, gatherer->personName(newPid), 10.0);
+        this->addArrival(*gatherer, bucketStart + 2000, gatherer->personName(newPid), 15.0);
+        this->addArrival(*expectedGatherer, bucketStart + 1,
+                         expectedGatherer->personName(expectedNewPid), 10.0);
+        this->addArrival(*expectedGatherer, bucketStart + 2000,
+                         expectedGatherer->personName(expectedNewPid), 15.0);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -1455,30 +1314,13 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
         function_t::E_IndividualMetric, function_t::E_IndividualMetricMean,
         function_t::E_IndividualMetricMin, function_t::E_IndividualMetricMax,
         function_t::E_IndividualMetricSum};
-    TBoolVec useNull{true, false};
-    TStrVec byFields{"", "by"};
-    TStrVec partitionFields{"", "partition"};
 
-    CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
+    std::string fieldName{"value"};
+    std::string overFieldName;
 
-    int detectorIndex{0};
-    for (const auto& countFunction : countFunctions) {
-        for (bool usingNull : useNull) {
-            for (const auto& byField : byFields) {
-                for (const auto& partitionField : partitionFields) {
-                    CSearchKey key(++detectorIndex, countFunction, usingNull,
-                                   model_t::E_XF_None, "value", byField, "", partitionField);
-
-                    CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
-                        config.factory(key);
-
-                    LOG_DEBUG(<< "expected key = " << key);
-                    LOG_DEBUG(<< "actual key   = " << factory->searchKey());
-                    BOOST_TEST_REQUIRE(key == factory->searchKey());
-                }
-            }
-        }
-    }
+    generateAndCompareKey(countFunctions, fieldName, overFieldName,
+                          [](CSearchKey expectedKey, CSearchKey actualKey){
+                            BOOST_TEST_REQUIRE(expectedKey == actualKey);});
 }
 
 BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
@@ -1492,7 +1334,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     factory.fieldNames("", "", "P", "V", TStrVec(1, "I"));
 
     CModelFactory::TDataGathererPtr gathererNoGap(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", gathererNoGap, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererNoGap));
     CModelFactory::TModelPtr modelNoGapPtr(factory.makeModel(gathererNoGap));
     BOOST_TEST_REQUIRE(modelNoGapPtr);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, modelNoGapPtr->category());
@@ -1507,20 +1349,20 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         SAnnotatedProbability annotatedProbability;
 
         core_t::TTime time{startTime};
-        processBucket(time, bucketLength, bucket1, influencerValues1, *gathererNoGap,
-                      m_ResourceMonitor, modelNoGap, annotatedProbability);
+        processBucket(time, bucketLength, bucket1, influencerValues1,
+                      *gathererNoGap, modelNoGap, annotatedProbability);
 
         time += bucketLength;
-        processBucket(time, bucketLength, bucket2, influencerValues1, *gathererNoGap,
-                      m_ResourceMonitor, modelNoGap, annotatedProbability);
+        processBucket(time, bucketLength, bucket2, influencerValues1,
+                      *gathererNoGap, modelNoGap, annotatedProbability);
 
         time += bucketLength;
-        processBucket(time, bucketLength, bucket3, influencerValues1, *gathererNoGap,
-                      m_ResourceMonitor, modelNoGap, annotatedProbability);
+        processBucket(time, bucketLength, bucket3, influencerValues1,
+                      *gathererNoGap, modelNoGap, annotatedProbability);
     }
 
     CModelFactory::TDataGathererPtr gathererWithGap(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", gathererWithGap, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererWithGap));
     CModelFactory::TModelPtr modelWithGapPtr(factory.makeModel(gathererWithGap));
     BOOST_TEST_REQUIRE(modelWithGapPtr);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, modelWithGapPtr->category());
@@ -1536,20 +1378,20 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         SAnnotatedProbability annotatedProbability;
 
         core_t::TTime time{startTime};
-        processBucket(time, bucketLength, bucket1, influencerValues1, *gathererWithGap,
-                      m_ResourceMonitor, modelWithGap, annotatedProbability);
+        processBucket(time, bucketLength, bucket1, influencerValues1,
+                      *gathererWithGap, modelWithGap, annotatedProbability);
 
         time += gap;
         modelWithGap.skipSampling(time);
         LOG_DEBUG(<< "Calling sample over skipped interval should do nothing except print some ERRORs");
         modelWithGap.sample(startTime + bucketLength, time, m_ResourceMonitor);
 
-        processBucket(time, bucketLength, bucket2, influencerValues1, *gathererWithGap,
-                      m_ResourceMonitor, modelWithGap, annotatedProbability);
+        processBucket(time, bucketLength, bucket2, influencerValues1,
+                      *gathererWithGap, modelWithGap, annotatedProbability);
 
         time += bucketLength;
-        processBucket(time, bucketLength, bucket3, influencerValues1, *gathererWithGap,
-                      m_ResourceMonitor, modelWithGap, annotatedProbability);
+        processBucket(time, bucketLength, bucket3, influencerValues1,
+                      *gathererWithGap, modelWithGap, annotatedProbability);
     }
 
     BOOST_REQUIRE_EQUAL(
@@ -1586,20 +1428,20 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |(1, 42.0)|(1, 1.0)|(1, 1.0)|X|X|(1, 42.0)|
     // p2: |(1, 42.)|(0, 0.0)|(0, 0.0)|X|X|(0, 0.0)|
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 100, "p1", 42.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 100, "p2", 42.0,
-               TOptionalStr("i2"), TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 100, "p1", 42.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 100, "p2", 42.0, TOptionalStr("i2"),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap.sample(100, 200, m_ResourceMonitor);
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 200, "p1", 1.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 200, "p1", 1.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap.sample(200, 300, m_ResourceMonitor);
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 300, "p1", 1.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 300, "p1", 1.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap.sample(300, 400, m_ResourceMonitor);
     modelSkipGap.skipSampling(600);
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 600, "p1", 42.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 600, "p1", 42.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap.sample(600, 700, m_ResourceMonitor);
 
     CModelFactory::TDataGathererPtr gathererExNull(factory.makeDataGatherer(startTime));
@@ -1610,35 +1452,35 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |(1, 42.0), ("", 42.0), (null, 42.0)|(1, 1.0)|(1, 1.0)|(null, 100.0)|(null, 100.0)|(1, 42.0)|
     // p2: |(1, 42.0), ("", 42.0)|(0, 0.0)|(0, 0.0)|(null, 100.0)|(null, 100.0)|(0, 0.0)|
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p1", 42.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p1", 42.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr(""));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p1", 42.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("null"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p2", 42.0,
-               TOptionalStr("i2"), TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p2", 42.0,
-               TOptionalStr("i2"), TOptionalStr(), TOptionalStr(""));
+    this->addArrival(*gathererExNull, 100, "p1", 42.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 100, "p1", 42.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr(""));
+    this->addArrival(*gathererExNull, 100, "p1", 42.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 100, "p2", 42.0, TOptionalStr("i2"),
+                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 100, "p2", 42.0, TOptionalStr("i2"),
+                     TOptionalStr(), TOptionalStr(""));
     modelExNullGap.sample(100, 200, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 200, "p1", 1.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 200, "p1", 1.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
     modelExNullGap.sample(200, 300, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 300, "p1", 1.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 300, "p1", 1.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
     modelExNullGap.sample(300, 400, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 400, "p1", 100.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("null"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 400, "p2", 100.0,
-               TOptionalStr("i2"), TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 400, "p1", 100.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 400, "p2", 100.0, TOptionalStr("i2"),
+                     TOptionalStr(), TOptionalStr("null"));
     modelExNullGap.sample(400, 500, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 500, "p1", 100.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("null"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 500, "p2", 100.0,
-               TOptionalStr("i2"), TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 500, "p1", 100.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 500, "p2", 100.0, TOptionalStr("i2"),
+                     TOptionalStr(), TOptionalStr("null"));
     modelExNullGap.sample(500, 600, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 600, "p1", 42.0,
-               TOptionalStr("i1"), TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 600, "p1", 42.0, TOptionalStr("i1"),
+                     TOptionalStr(), TOptionalStr("1"));
     modelExNullGap.sample(600, 700, m_ResourceMonitor);
 
     BOOST_REQUIRE_EQUAL(
@@ -1664,8 +1506,8 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     factory.fieldNames("", "", "P", "V", TStrVec());
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
     BOOST_TEST_REQUIRE(!gatherer->isPopulation());
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", gatherer, m_ResourceMonitor));
-    BOOST_REQUIRE_EQUAL(std::size_t(1), addPerson("q", gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
+    BOOST_REQUIRE_EQUAL(std::size_t(1), this->addPerson("q", gatherer));
     CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
     BOOST_TEST_REQUIRE(model_);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
@@ -1687,88 +1529,88 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     SAnnotatedProbability annotatedProbability2;
 
     core_t::TTime time{startTime};
-    processBucket(time, bucketLength, bucket1, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket1, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket2, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket2, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket3, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket3, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket4, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket4, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket5, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket5, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket6, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket6, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket7, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket7, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket8, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket8, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket9, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket9, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket10, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket10, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket11, *gatherer, m_ResourceMonitor,
-                  model, annotatedProbability, annotatedProbability2);
+    processBucket(time, bucketLength, bucket11, *gatherer, model,
+                  annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);
@@ -1785,16 +1627,16 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     factory.fieldNames("", "", "P", "V", TStrVec(1, "I"));
 
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
     CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
     BOOST_TEST_REQUIRE(model_);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
     CMetricModel& model = static_cast<CMetricModel&>(*model_.get());
     CCountingModel countingModel(params, gatherer, interimBucketCorrector);
 
-    std::size_t pid1 = addPerson("p1", gatherer, m_ResourceMonitor);
-    std::size_t pid2 = addPerson("p2", gatherer, m_ResourceMonitor);
-    std::size_t pid3 = addPerson("p3", gatherer, m_ResourceMonitor);
+    std::size_t pid1 = this->addPerson("p1", gatherer);
+    std::size_t pid2 = this->addPerson("p2", gatherer);
+    std::size_t pid3 = this->addPerson("p3", gatherer);
 
     core_t::TTime now = startTime;
     core_t::TTime endTime(now + 2 * 24 * bucketLength);
@@ -1803,26 +1645,26 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p1", 1.0, TOptionalStr("i1"));
+            this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[1] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p2", 1.0, TOptionalStr("i2"));
+            this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[2] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p3", 1.0, TOptionalStr("i3"));
+            this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
         }
         countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model.sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p1", 1.0, TOptionalStr("i1"));
+        this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
     }
     for (std::size_t i = 0; i < 1; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p2", 1.0, TOptionalStr("i2"));
+        this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p3", 1.0, TOptionalStr("i3"));
+        this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -1886,9 +1728,9 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
     CMetricModel& model = static_cast<CMetricModel&>(*modelPtr.get());
     CCountingModel countingModel(params, gatherer, interimBucketCorrector);
 
-    std::size_t pid1 = addPerson("p1", gatherer, m_ResourceMonitor);
-    std::size_t pid2 = addPerson("p2", gatherer, m_ResourceMonitor);
-    std::size_t pid3 = addPerson("p3", gatherer, m_ResourceMonitor);
+    std::size_t pid1 = this->addPerson("p1", gatherer);
+    std::size_t pid2 = this->addPerson("p2", gatherer);
+    std::size_t pid3 = this->addPerson("p3", gatherer);
 
     core_t::TTime now = startTime;
     core_t::TTime endTime(now + 2 * 24 * bucketLength);
@@ -1897,26 +1739,26 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(80.0, 100.0, std::size_t(1), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p1", 1.0, TOptionalStr("i1"));
+            this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 10.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p2", 1.0, TOptionalStr("i2"));
+            this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] - 9.5); ++i) {
-            addArrival(*gatherer, m_ResourceMonitor, now, "p3", 1.0, TOptionalStr("i3"));
+            this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
         }
         countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model.sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 9; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p1", 1.0, TOptionalStr("i1"));
+        this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
     }
     for (std::size_t i = 0; i < 10; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p2", 1.0, TOptionalStr("i2"));
+        this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
     }
     for (std::size_t i = 0; i < 8; ++i) {
-        addArrival(*gatherer, m_ResourceMonitor, now, "p3", 1.0, TOptionalStr("i3"));
+        this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -1987,8 +1829,8 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatePersist, CTestFixture) {
     params.s_DecayRate = 0.001;
     params.s_MultivariateByFields = true;
     this->makeModel(params, {model_t::E_IndividualMeanByPerson}, startTime);
-    addPerson("p1", m_Gatherer, m_ResourceMonitor);
-    addPerson("p2", m_Gatherer, m_ResourceMonitor);
+    this->addPerson("p1", m_Gatherer);
+    this->addPerson("p2", m_Gatherer);
 
     core_t::TTime time{startTime};
     core_t::TTime bucket{time + bucketLength};
@@ -1997,8 +1839,8 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatePersist, CTestFixture) {
             m_Model->sample(bucket - bucketLength, bucket, m_ResourceMonitor);
             bucket += bucketLength;
         }
-        addArrival(*m_Gatherer, m_ResourceMonitor, time, "p1", samples[i][0]);
-        addArrival(*m_Gatherer, m_ResourceMonitor, time, "p2", samples[i][0]);
+        this->addArrival(*m_Gatherer, time, "p1", samples[i][0]);
+        this->addArrival(*m_Gatherer, time, "p2", samples[i][0]);
 
         if ((i + 1) % 1000 == 0) {
             // Test persistence. (We check for idempotency.)
@@ -2078,16 +1920,13 @@ BOOST_FIXTURE_TEST_CASE(testSummaryCountZeroRecordsAreIgnored, CTestFixture) {
             double value = values[0];
             rng.generateUniformSamples(0.0, 1.0, 1, values);
             if (values[0] < 0.05) {
-                addArrival(*gathererWithZeros, m_ResourceMonitor, now, "p1",
-                           value, TOptionalStr("i1"), TOptionalStr(),
-                           TOptionalStr(summaryCountZero));
+                this->addArrival(*gathererWithZeros, now, "p1", value, TOptionalStr("i1"),
+                                 TOptionalStr(), TOptionalStr(summaryCountZero));
             } else {
-                addArrival(*gathererWithZeros, m_ResourceMonitor, now, "p1",
-                           value, TOptionalStr("i1"), TOptionalStr(),
-                           TOptionalStr(summaryCountOne));
-                addArrival(*gathererNoZeros, m_ResourceMonitor, now, "p1",
-                           value, TOptionalStr("i1"), TOptionalStr(),
-                           TOptionalStr(summaryCountOne));
+                this->addArrival(*gathererWithZeros, now, "p1", value, TOptionalStr("i1"),
+                                 TOptionalStr(), TOptionalStr(summaryCountOne));
+                this->addArrival(*gathererNoZeros, now, "p1", value, TOptionalStr("i1"),
+                                 TOptionalStr(), TOptionalStr(summaryCountOne));
             }
         }
         modelWithZeros.sample(now, now + bucketLength, m_ResourceMonitor);
@@ -2148,9 +1987,8 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                                         t < core::constants::WEEK + 4 * 3600
                                     ? 1.0
                                     : 0.0);
-            addArrival(*gatherer, m_ResourceMonitor, t + bucketLength / 2, "p1", value[0]);
-            addArrival(*referenceGatherer, m_ResourceMonitor,
-                       t + bucketLength / 2, "p1", value[0]);
+            this->addArrival(*gatherer, t + bucketLength / 2, "p1", value[0]);
+            this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1", value[0]);
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
             meanPredictionError.add(std::fabs(
@@ -2208,10 +2046,9 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                            (t < 5 * core::constants::WEEK ? 1.0 : 2.0);
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
-            addArrival(*gatherer, m_ResourceMonitor, t + bucketLength / 2, "p1",
-                       value + noise[0]);
-            addArrival(*referenceGatherer, m_ResourceMonitor,
-                       t + bucketLength / 2, "p1", value + noise[0]);
+            this->addArrival(*gatherer, t + bucketLength / 2, "p1", value + noise[0]);
+            this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1",
+                             value + noise[0]);
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
             meanPredictionError.add(std::fabs(
@@ -2274,10 +2111,9 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                                 static_cast<double>(core::constants::WEEK)));
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
-            addArrival(*gatherer, m_ResourceMonitor, t + bucketLength / 2, "p1",
-                       value + noise[0]);
-            addArrival(*referenceGatherer, m_ResourceMonitor,
-                       t + bucketLength / 2, "p1", value + noise[0]);
+            this->addArrival(*gatherer, t + bucketLength / 2, "p1", value + noise[0]);
+            this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1",
+                             value + noise[0]);
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
             meanPredictionError.add(std::fabs(
@@ -2312,7 +2148,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMedian, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualLowMedianByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -2330,8 +2166,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMedian, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p", values[j]);
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
+                             "p", values[j]);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -2366,7 +2202,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMedian, CTestFixture) {
     SModelParams params(bucketLength);
     makeModel(params, {model_t::E_IndividualHighMeanByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", m_Gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -2384,8 +2220,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMedian, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(j), "p", values[j]);
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
+                             "p", values[j]);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -2447,8 +2283,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Add a bucket to both models
     for (std::size_t i = 0; i < 60; i++) {
-        addArrival(*gathererNoSkip, m_ResourceMonitor, startTime + i, "p1", 1.0);
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime + i, "p1", 1.0);
+        this->addArrival(*gathererNoSkip, startTime + i, "p1", 1.0);
+        this->addArrival(*gathererWithSkip, startTime + i, "p1", 1.0);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2458,8 +2294,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Add a bucket to both models
     for (std::size_t i = 0; i < 60; i++) {
-        addArrival(*gathererNoSkip, m_ResourceMonitor, startTime + i, "p1", 1.0);
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime + i, "p1", 1.0);
+        this->addArrival(*gathererNoSkip, startTime + i, "p1", 1.0);
+        this->addArrival(*gathererWithSkip, startTime + i, "p1", 1.0);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2469,7 +2305,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // this sample will be skipped by the detection rule
     for (std::size_t i = 0; i < 60; i++) {
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime + i, "p1", 110.0);
+        this->addArrival(*gathererWithSkip, startTime + i, "p1", 110.0);
     }
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
 
@@ -2480,8 +2316,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     modelNoSkip->skipSampling(startTime);
 
     for (std::size_t i = 0; i < 60; i++) {
-        addArrival(*gathererNoSkip, m_ResourceMonitor, startTime + i, "p1", 2.0);
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime + i, "p1", 2.0);
+        this->addArrival(*gathererNoSkip, startTime + i, "p1", 2.0);
+        this->addArrival(*gathererWithSkip, startTime + i, "p1", 2.0);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -62,19 +62,6 @@ const CModelTestFixtureBase::TSizeDoublePr1Vec NO_CORRELATES;
 
 class CTestFixture : public CModelTestFixtureBase {
 public:
-    CEventData makeEventData(core_t::TTime time,
-                             std::size_t pid,
-                             double value,
-                             const TOptionalStr& influence = TOptionalStr()) {
-        CEventData result;
-        result.time(time);
-        result.person(pid);
-        result.addAttribute(std::size_t(0));
-        result.addValue({value});
-        result.addInfluence(influence);
-        return result;
-    }
-
     TDouble1Vec featureData(const CMetricModel& model,
                             model_t::EFeature feature,
                             std::size_t pid,
@@ -997,8 +984,8 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
 
         core_t::TTime time{startTime};
         for (std::size_t i = 0u; i < values.size(); ++i) {
-            processBucket(time, bucketLength, values[i], influencers[i],
-                          *gatherer, model, annotatedProbability);
+            this->processBucket(time, bucketLength, values[i], influencers[i],
+                                *gatherer, model, annotatedProbability);
             BOOST_REQUIRE_EQUAL(influences[i].size(),
                                 annotatedProbability.s_Influences.size());
             if (influences[i].size() > 0) {
@@ -1215,7 +1202,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
                      k < n; ++k, time += dt) {
                     std::size_t pid = this->addPerson(people[i], gatherer);
                     events.push_back(
-                        makeEventData(time, pid, samples[static_cast<size_t>(k)]));
+                        makeEventData(time, pid, {samples[static_cast<size_t>(k)]}));
                 }
             }
         }
@@ -1236,7 +1223,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
                                std::end(expectedPeople), events[i].personId())) {
             expectedEvents.push_back(makeEventData(events[i].time(),
                                                    mapping[*events[i].personId()],
-                                                   events[i].values()[0][0]));
+                                                   {events[i].values()[0][0]}));
         }
     }
 
@@ -1349,16 +1336,16 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         SAnnotatedProbability annotatedProbability;
 
         core_t::TTime time{startTime};
-        processBucket(time, bucketLength, bucket1, influencerValues1,
-                      *gathererNoGap, modelNoGap, annotatedProbability);
+        this->processBucket(time, bucketLength, bucket1, influencerValues1,
+                            *gathererNoGap, modelNoGap, annotatedProbability);
 
         time += bucketLength;
-        processBucket(time, bucketLength, bucket2, influencerValues1,
-                      *gathererNoGap, modelNoGap, annotatedProbability);
+        this->processBucket(time, bucketLength, bucket2, influencerValues1,
+                            *gathererNoGap, modelNoGap, annotatedProbability);
 
         time += bucketLength;
-        processBucket(time, bucketLength, bucket3, influencerValues1,
-                      *gathererNoGap, modelNoGap, annotatedProbability);
+        this->processBucket(time, bucketLength, bucket3, influencerValues1,
+                            *gathererNoGap, modelNoGap, annotatedProbability);
     }
 
     CModelFactory::TDataGathererPtr gathererWithGap(factory.makeDataGatherer(startTime));
@@ -1378,20 +1365,20 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         SAnnotatedProbability annotatedProbability;
 
         core_t::TTime time{startTime};
-        processBucket(time, bucketLength, bucket1, influencerValues1,
-                      *gathererWithGap, modelWithGap, annotatedProbability);
+        this->processBucket(time, bucketLength, bucket1, influencerValues1,
+                            *gathererWithGap, modelWithGap, annotatedProbability);
 
         time += gap;
         modelWithGap.skipSampling(time);
         LOG_DEBUG(<< "Calling sample over skipped interval should do nothing except print some ERRORs");
         modelWithGap.sample(startTime + bucketLength, time, m_ResourceMonitor);
 
-        processBucket(time, bucketLength, bucket2, influencerValues1,
-                      *gathererWithGap, modelWithGap, annotatedProbability);
+        this->processBucket(time, bucketLength, bucket2, influencerValues1,
+                            *gathererWithGap, modelWithGap, annotatedProbability);
 
         time += bucketLength;
-        processBucket(time, bucketLength, bucket3, influencerValues1,
-                      *gathererWithGap, modelWithGap, annotatedProbability);
+        this->processBucket(time, bucketLength, bucket3, influencerValues1,
+                            *gathererWithGap, modelWithGap, annotatedProbability);
     }
 
     BOOST_REQUIRE_EQUAL(
@@ -1529,88 +1516,88 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     SAnnotatedProbability annotatedProbability2;
 
     core_t::TTime time{startTime};
-    processBucket(time, bucketLength, bucket1, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket1, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket2, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket2, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket3, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket3, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket4, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket4, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket5, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket5, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket6, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket6, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket7, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket7, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket8, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket8, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket9, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket9, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket10, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket10, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    processBucket(time, bucketLength, bucket11, *gatherer, model,
-                  annotatedProbability, annotatedProbability2);
+    this->processBucket(time, bucketLength, bucket11, *gatherer, model,
+                        annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.5);

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -55,8 +55,6 @@ using TMinAccumulator = maths::CBasicStatistics::COrderStatisticsStack<double, 1
 using TMaxAccumulator =
     maths::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>>;
 
-const std::string EMPTY_STRING;
-
 const std::size_t numberAttributes{5u};
 const std::size_t numberPeople{10u};
 }
@@ -788,8 +786,9 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
     std::string overFieldName{"over"};
 
     generateAndCompareKey(countFunctions, fieldName, overFieldName,
-                          [](CSearchKey expectedKey, CSearchKey actualKey){
-                            BOOST_TEST_REQUIRE(expectedKey == actualKey);});
+                          [](CSearchKey expectedKey, CSearchKey actualKey) {
+                              BOOST_TEST_REQUIRE(expectedKey == actualKey);
+                          });
 }
 
 BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -57,203 +57,111 @@ using TMaxAccumulator =
 
 const std::string EMPTY_STRING;
 
-struct SAnomaly {
-    SAnomaly() : s_Bucket(0u), s_Person(), s_Attributes() {}
-    SAnomaly(std::size_t bucket, const std::string& person, const TDoubleStrPrVec& attributes)
-        : s_Bucket(bucket), s_Person(person), s_Attributes(attributes) {}
-
-    std::size_t s_Bucket;
-    std::string s_Person;
-    TDoubleStrPrVec s_Attributes;
-
-    bool operator<(const SAnomaly& other) const {
-        return s_Bucket < other.s_Bucket;
-    }
-
-    std::string print() const {
-        std::ostringstream result;
-        result << "[" << s_Bucket << ", " + s_Person << ",";
-        for (std::size_t i = 0u; i < s_Attributes.size(); ++i) {
-            if (s_Attributes[i].first < 0.01) {
-                result << " " << s_Attributes[i].second;
-            }
-        }
-        result << "]";
-        return result.str();
-    }
-};
-
-struct SMessage {
-    SMessage(core_t::TTime time,
-             const std::string& person,
-             const std::string& attribute,
-             const TDouble1Vec& value)
-        : s_Time(time), s_Person(person), s_Attribute(attribute), s_Value(value) {}
-
-    bool operator<(const SMessage& other) const {
-        return maths::COrderings::lexicographical_compare(
-            s_Time, s_Person, s_Attribute, other.s_Time, other.s_Person, other.s_Attribute);
-    }
-
-    core_t::TTime s_Time;
-    std::string s_Person;
-    std::string s_Attribute;
-    TDouble1Vec s_Value;
-};
-
-using TMessageVec = std::vector<SMessage>;
-
 const std::size_t numberAttributes{5u};
 const std::size_t numberPeople{10u};
-
-double roundToNearestPersisted(double value) {
-    std::string valueAsString{core::CStringUtils::typeToStringPrecise(
-        value, core::CIEEE754::E_DoublePrecision)};
-    double result{0.0};
-    core::CStringUtils::stringToType(valueAsString, result);
-    return result;
 }
 
-void generateTestMessages(std::size_t dimension,
-                          core_t::TTime startTime,
-                          core_t::TTime bucketLength,
-                          TMessageVec& messages) {
-    // The test case is as follows:
-    //
-    //      attribute    |    0    |    1    |    2    |    3    |    4
-    // ------------------+---------+---------+---------+---------+--------
-    //        rate       |   10    |    2    |   15    |    2    |    1
-    // ------------------+---------+---------+---------+---------+--------
-    //        mean       |    5    |   10    |    7    |    3    |   15
-    // ------------------+---------+---------+---------+---------+--------
-    //     variance      |    1    |   0.5   |    2    |   0.1   |    4
-    // ------------------+---------+---------+---------+---------+--------
-    //  metric anomaly   | (12,2), |    -    | (30,5), | (12,2), | (60,2)
-    //  (bucket, people) | (15,3), |         | (44,9)  | (80,1)  |
-    //                   | (40,6)  |         |         |         |
-    //
-    // There are 10 people, 4 attributes and 100 buckets.
+class CTestFixture : public CModelTestFixtureBase {
+public:
+    void generateTestMessages(std::size_t dimension,
+                              core_t::TTime startTime,
+                              core_t::TTime bucketLength,
+                              TMessageVec& messages) {
+        // The test case is as follows:
+        //
+        //      attribute    |    0    |    1    |    2    |    3    |    4
+        // ------------------+---------+---------+---------+---------+--------
+        //        rate       |   10    |    2    |   15    |    2    |    1
+        // ------------------+---------+---------+---------+---------+--------
+        //        mean       |    5    |   10    |    7    |    3    |   15
+        // ------------------+---------+---------+---------+---------+--------
+        //     variance      |    1    |   0.5   |    2    |   0.1   |    4
+        // ------------------+---------+---------+---------+---------+--------
+        //  metric anomaly   | (12,2), |    -    | (30,5), | (12,2), | (60,2)
+        //  (bucket, people) | (15,3), |         | (44,9)  | (80,1)  |
+        //                   | (40,6)  |         |         |         |
+        //
+        // There are 10 people, 4 attributes and 100 buckets.
 
-    const std::size_t numberBuckets{100u};
+        const std::size_t numberBuckets{100u};
 
-    TStrVec people;
-    for (std::size_t i = 0u; i < numberPeople; ++i) {
-        people.push_back("p" + core::CStringUtils::typeToString(i));
-    }
-    LOG_DEBUG(<< "people = " << core::CContainerPrinter::print(people));
+        TStrVec people;
+        for (std::size_t i = 0u; i < numberPeople; ++i) {
+            people.push_back("p" + core::CStringUtils::typeToString(i));
+        }
+        LOG_DEBUG(<< "people = " << core::CContainerPrinter::print(people));
 
-    TStrVec attributes;
-    for (std::size_t i = 0u; i < numberAttributes; ++i) {
-        attributes.push_back("c" + core::CStringUtils::typeToString(i));
-    }
-    LOG_DEBUG(<< "attributes = " << core::CContainerPrinter::print(attributes));
+        TStrVec attributes;
+        for (std::size_t i = 0u; i < numberAttributes; ++i) {
+            attributes.push_back("c" + core::CStringUtils::typeToString(i));
+        }
+        LOG_DEBUG(<< "attributes = " << core::CContainerPrinter::print(attributes));
 
-    const TDoubleVec attributeRates{10.0, 2.0, 15.0, 2.0, 1.0};
-    const TDoubleVec means{5.0, 10.0, 7.0, 3.0, 15.0};
-    const TDoubleVec variances{1.0, 0.5, 2.0, 0.1, 4.0};
+        const TDoubleVec attributeRates{10.0, 2.0, 15.0, 2.0, 1.0};
+        const TDoubleVec means{5.0, 10.0, 7.0, 3.0, 15.0};
+        const TDoubleVec variances{1.0, 0.5, 2.0, 0.1, 4.0};
 
-    TSizeSizePrVecVec anomalies{{{40u, 6u}, {15u, 3u}, {12u, 2u}},
-                                {},
-                                {{44u, 9u}, {30u, 5u}},
-                                {{80u, 1u}, {12u, 2u}},
-                                {{60u, 2u}}};
+        TSizeSizePrVecVec anomalies{{{40u, 6u}, {15u, 3u}, {12u, 2u}},
+                                    {},
+                                    {{44u, 9u}, {30u, 5u}},
+                                    {{80u, 1u}, {12u, 2u}},
+                                    {{60u, 2u}}};
 
-    test::CRandomNumbers rng;
+        test::CRandomNumbers rng;
 
-    for (std::size_t i = 0u; i < numberBuckets; ++i, startTime += bucketLength) {
-        for (std::size_t j = 0u; j < numberAttributes; ++j) {
-            TUIntVec samples;
-            rng.generatePoissonSamples(attributeRates[j], numberPeople, samples);
+        for (std::size_t i = 0u; i < numberBuckets; ++i, startTime += bucketLength) {
+            for (std::size_t j = 0u; j < numberAttributes; ++j) {
+                TUIntVec samples;
+                rng.generatePoissonSamples(attributeRates[j], numberPeople, samples);
 
-            for (std::size_t k = 0u; k < numberPeople; ++k) {
-                bool anomaly = !anomalies[j].empty() && anomalies[j].back().first == i &&
-                               anomalies[j].back().second == k;
-                if (anomaly) {
-                    samples[k] += 4;
-                    anomalies[j].pop_back();
-                }
-
-                if (samples[k] == 0) {
-                    continue;
-                }
-
-                TDoubleVec values;
-                rng.generateNormalSamples(means[j], variances[j],
-                                          dimension * samples[k], values);
-
-                for (std::size_t l = 0u; l < values.size(); l += dimension) {
-                    TDouble1Vec value(dimension);
-                    for (std::size_t d = 0u; d < dimension; ++d) {
-                        double vd = values[l + d];
-                        if (anomaly && (l % (2 * dimension)) == 0) {
-                            vd += 6.0 * std::sqrt(variances[j]);
-                        }
-                        value[d] = roundToNearestPersisted(vd);
+                for (std::size_t k = 0u; k < numberPeople; ++k) {
+                    bool anomaly = !anomalies[j].empty() &&
+                                   anomalies[j].back().first == i &&
+                                   anomalies[j].back().second == k;
+                    if (anomaly) {
+                        samples[k] += 4;
+                        anomalies[j].pop_back();
                     }
-                    core_t::TTime dt = (static_cast<core_t::TTime>(l) * bucketLength) /
-                                       static_cast<core_t::TTime>(values.size());
-                    messages.push_back(SMessage(startTime + dt, people[k],
-                                                attributes[j], value));
+
+                    if (samples[k] == 0) {
+                        continue;
+                    }
+
+                    TDoubleVec values;
+                    rng.generateNormalSamples(means[j], variances[j],
+                                              dimension * samples[k], values);
+
+                    for (std::size_t l = 0u; l < values.size(); l += dimension) {
+                        TDouble1Vec value(dimension);
+                        for (std::size_t d = 0u; d < dimension; ++d) {
+                            double vd = values[l + d];
+                            if (anomaly && (l % (2 * dimension)) == 0) {
+                                vd += 6.0 * std::sqrt(variances[j]);
+                            }
+                            value[d] = this->roundToNearestPersisted(vd);
+                        }
+                        core_t::TTime dt = (static_cast<core_t::TTime>(l) * bucketLength) /
+                                           static_cast<core_t::TTime>(values.size());
+                        messages.push_back(SMessage(startTime + dt, people[k],
+                                                    attributes[j], value));
+                    }
                 }
             }
         }
+
+        LOG_DEBUG(<< "# messages = " << messages.size());
+        std::sort(messages.begin(), messages.end());
     }
 
-    LOG_DEBUG(<< "# messages = " << messages.size());
-    std::sort(messages.begin(), messages.end());
-}
-
-std::string valueAsString(const TDouble1Vec& value) {
-    std::string result{core::CStringUtils::typeToStringPrecise(
-        value[0], core::CIEEE754::E_DoublePrecision)};
-    for (std::size_t i = 1u; i < value.size(); ++i) {
-        result += CAnomalyDetectorModelConfig::DEFAULT_MULTIVARIATE_COMPONENT_DELIMITER +
-                  core::CStringUtils::typeToStringPrecise(
-                      value[i], core::CIEEE754::E_DoublePrecision);
+private:
+    double roundToNearestPersisted(double value) {
+        std::string valueAsString{core::CStringUtils::typeToStringPrecise(
+            value, core::CIEEE754::E_DoublePrecision)};
+        double result{0.0};
+        core::CStringUtils::stringToType(valueAsString, result);
+        return result;
     }
-    return result;
-}
-
-CEventData addArrival(const SMessage& message,
-                      const CModelFactory::TDataGathererPtr& gatherer,
-                      CResourceMonitor& resourceMonitor) {
-    std::string value{valueAsString(message.s_Value)};
-    CDataGatherer::TStrCPtrVec fields{&message.s_Person, &message.s_Attribute, &value};
-    CEventData result;
-    result.time(message.s_Time);
-    gatherer->addArrival(fields, result, resourceMonitor);
-    return result;
-}
-
-void processBucket(core_t::TTime time,
-                   core_t::TTime bucketLength,
-                   const TDoubleStrPrVec& bucket,
-                   CDataGatherer& gatherer,
-                   CResourceMonitor& resourceMonitor,
-                   CMetricPopulationModel& model,
-                   SAnnotatedProbability& probability) {
-    const std::string person{"p"};
-    const std::string attribute{"a"};
-    for (auto& pr : bucket) {
-        const std::string valueAsString{core::CStringUtils::typeToStringPrecise(
-            pr.first, core::CIEEE754::E_DoublePrecision)};
-
-        CDataGatherer::TStrCPtrVec fieldValues{&person, &attribute, &pr.second, &valueAsString};
-
-        CEventData eventData;
-        eventData.time(time);
-
-        gatherer.addArrival(fieldValues, eventData, resourceMonitor);
-    }
-    model.sample(time, time + bucketLength, resourceMonitor);
-    CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
-    model.computeProbability(0 /*pid*/, time, time + bucketLength,
-                             partitioningFields, 1, probability);
-    LOG_DEBUG(<< "influences = " << core::CContainerPrinter::print(probability.s_Influences));
-}
-}
-
-class CTestFixture : public CModelTestFixtureBase {};
+};
 
 BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
     // Check that the correct data is read retrieved by the
@@ -391,7 +299,7 @@ BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
             startTime += bucketLength;
         }
 
-        CEventData eventData = addArrival(message, gatherer, m_ResourceMonitor);
+        CEventData eventData = this->addArrival(message, gatherer);
         std::size_t pid = *eventData.personId();
         std::size_t cid = *eventData.attributeId();
         ++expectedBucketPersonCounts[message.s_Person];
@@ -532,7 +440,7 @@ BOOST_FIXTURE_TEST_CASE(testMinMaxAndMean, CTestFixture) {
             startTime += bucketLength;
         }
 
-        CEventData eventData = addArrival(message, gatherer, m_ResourceMonitor);
+        CEventData eventData = this->addArrival(message, gatherer);
         std::size_t pid = *eventData.personId();
         std::size_t cid = *eventData.attributeId();
         nonNegative &= message.s_Value[0] < 0.0;
@@ -595,53 +503,43 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     SAnnotatedProbability annotatedProbability;
 
     core_t::TTime time = startTime;
-    processBucket(time, bucketLength, b1, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b1, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b2, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b2, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b3, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b3, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b4, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b4, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b5, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b5, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b6, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b6, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b7, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b7, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b8, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b8, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.8);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b9, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b9, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability < 0.85);
 
     time += bucketLength;
-    processBucket(time, bucketLength, b10, *gatherer, m_ResourceMonitor, model,
-                  annotatedProbability);
+    processBucket(time, bucketLength, b10, *gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability < 0.1);
     BOOST_REQUIRE_EQUAL(std::size_t(1), annotatedProbability.s_Influences.size());
     BOOST_REQUIRE_EQUAL(std::string("I"),
@@ -656,11 +554,6 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbability, CTestFixture) {
 
     // Test that we correctly pick out synthetic the anomalies,
     // their people and attributes.
-
-    using TAnomalyVec = std::vector<SAnomaly>;
-    using TDoubleAnomalyPr = std::pair<double, SAnomaly>;
-    using TAnomalyAccumulator =
-        maths::CBasicStatistics::COrderStatisticsHeap<TDoubleAnomalyPr, maths::COrderings::SFirstLess>;
 
     core_t::TTime startTime{1367280000};
     const core_t::TTime bucketLength{3600};
@@ -685,58 +578,14 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbability, CTestFixture) {
         CMetricPopulationModel* model =
             dynamic_cast<CMetricPopulationModel*>(modelHolder.get());
 
-        TAnomalyAccumulator anomalies(7);
-
-        std::size_t bucket{0u};
-        for (const auto& message : messages) {
-            if (message.s_Time >= startTime + bucketLength) {
-                model->sample(startTime, startTime + bucketLength, m_ResourceMonitor);
-
-                LOG_DEBUG(<< "Testing bucket " << bucket << " = [" << startTime
-                          << "," << startTime + bucketLength << ")");
-
-                CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
-                SAnnotatedProbability annotatedProbability;
-                for (std::size_t pid = 0u; pid < numberPeople; ++pid) {
-                    model->computeProbability(pid, startTime, startTime + bucketLength,
-                                              partitioningFields, 2, annotatedProbability);
-
-                    if ((startTime / bucketLength) % 10 == 0) {
-                        LOG_DEBUG(<< "person = " << model->personName(pid) << ", probability = "
-                                  << annotatedProbability.s_Probability);
-                    }
-                    std::string person = model->personName(pid);
-                    TDoubleStrPrVec attributes;
-                    for (const auto& probability : annotatedProbability.s_AttributeProbabilities) {
-                        attributes.emplace_back(probability.s_Probability,
-                                                *probability.s_Attribute);
-                    }
-                    anomalies.add({annotatedProbability.s_Probability,
-                                   SAnomaly(bucket, person, attributes)});
-                }
-
-                startTime += bucketLength;
-                ++bucket;
-            }
-
-            addArrival(message, gatherer, m_ResourceMonitor);
-        }
-
-        anomalies.sort();
-        LOG_DEBUG(<< "Anomalies = " << anomalies.print());
-
-        TAnomalyVec orderedAnomalies;
-        for (std::size_t j = 0u; j < anomalies.count(); ++j) {
-            orderedAnomalies.push_back(anomalies[j].second);
-        }
-        std::sort(orderedAnomalies.begin(), orderedAnomalies.end());
-
-        LOG_DEBUG(<< "orderedAnomalies = "
-                  << core::CContainerPrinter::print(orderedAnomalies));
-
         TStrVec expectedAnomalies{
             "[12, p2, c0 c3]", "[15, p3, c0]", "[30, p5, c2]", "[40, p6, c0]",
             "[44, p9, c2]",    "[60, p2, c4]", "[80, p1, c3]"};
+
+        TAnomalyVec orderedAnomalies;
+
+        this->generateOrderedAnomalies(7u, startTime, bucketLength, messages,
+                                       gatherer, *model, orderedAnomalies);
 
         BOOST_REQUIRE_EQUAL(expectedAnomalies.size(), orderedAnomalies.size());
         for (std::size_t j = 0u; j < orderedAnomalies.size(); ++j) {
@@ -878,7 +727,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     size_t maxDimensionBeforePrune(model->dataGatherer().maxDimension());
@@ -892,7 +741,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(expectedMessage, expectedGatherer, m_ResourceMonitor);
+        this->addArrival(expectedMessage, expectedGatherer);
     }
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
 
@@ -909,8 +758,8 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
                             {bucketStart + 2100, "p5", "c6", TDouble1Vec(1, 15.0)}};
 
     for (auto& newMessage : newMessages) {
-        addArrival(newMessage, gatherer, m_ResourceMonitor);
-        addArrival(newMessage, expectedGatherer, m_ResourceMonitor);
+        this->addArrival(newMessage, gatherer);
+        this->addArrival(newMessage, expectedGatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -934,33 +783,13 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
         function_t::E_PopulationMetric, function_t::E_PopulationMetricMean,
         function_t::E_PopulationMetricMin, function_t::E_PopulationMetricMax,
         function_t::E_PopulationMetricSum};
-    TBoolVec useNull{true, false};
-    TStrVec byFields{"", "by"};
-    TStrVec partitionFields{"", "partition"};
 
-    {
-        CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
+    std::string fieldName{"value"};
+    std::string overFieldName{"over"};
 
-        int detectorIndex{0};
-        for (const auto& countFunction : countFunctions) {
-            for (bool usingNull : useNull) {
-                for (const auto& byField : byFields) {
-                    for (const auto& partitionField : partitionFields) {
-                        CSearchKey key(++detectorIndex, countFunction,
-                                       usingNull, model_t::E_XF_None, "value",
-                                       byField, "over", partitionField);
-
-                        CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
-                            config.factory(key);
-
-                        LOG_DEBUG(<< "expected key = " << key);
-                        LOG_DEBUG(<< "actual key   = " << factory->searchKey());
-                        BOOST_TEST_REQUIRE(key == factory->searchKey());
-                    }
-                }
-            }
-        }
-    }
+    generateAndCompareKey(countFunctions, fieldName, overFieldName,
+                          [](CSearchKey expectedKey, CSearchKey actualKey){
+                            BOOST_TEST_REQUIRE(expectedKey == actualKey);});
 }
 
 BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
@@ -1024,7 +853,7 @@ BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
             populationModel->sample(time, time + bucketLength, m_ResourceMonitor);
             time += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     {
@@ -1136,7 +965,7 @@ BOOST_FIXTURE_TEST_CASE(testSampleRateWeight, CTestFixture) {
             populationModel->sample(time, time + bucketLength, m_ResourceMonitor);
             time += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     // The heavy hitters generate one value per attribute per bucket.
@@ -1274,7 +1103,7 @@ BOOST_FIXTURE_TEST_CASE(testPeriodicity, CTestFixture) {
             time += bucketLength;
         }
 
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     double totalw{0.0};
@@ -1325,7 +1154,7 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
             origModel->sample(startTime, startTime + bucketLength, m_ResourceMonitor);
             startTime += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     std::string origXml;
@@ -1416,7 +1245,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     std::vector<CModelFactory::TDataGathererPtr> gatherers{gathererNoSkip, gathererWithSkip};
     for (auto& gatherer : gatherers) {
         for (auto& message : messages) {
-            addArrival(message, gatherer, m_ResourceMonitor);
+            this->addArrival(message, gatherer);
         }
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -1432,15 +1261,13 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     messages.emplace_back(startTime + 10, "p2", "c2", TDouble1Vec{1, 21.0});
     for (auto& gatherer : gatherers) {
         for (auto& message : messages) {
-            addArrival(message, gatherer, m_ResourceMonitor);
+            this->addArrival(message, gatherer);
         }
     }
 
     // This should be filtered out
-    addArrival(SMessage(startTime + 10, "p1", "c3", TDouble1Vec(1, 21.0)),
-               gathererWithSkip, m_ResourceMonitor);
-    addArrival(SMessage(startTime + 10, "p2", "c3", TDouble1Vec(1, 21.0)),
-               gathererWithSkip, m_ResourceMonitor);
+    this->addArrival(SMessage(startTime + 10, "p1", "c3", TDouble1Vec(1, 21.0)), gathererWithSkip);
+    this->addArrival(SMessage(startTime + 10, "p2", "c3", TDouble1Vec(1, 21.0)), gathererWithSkip);
 
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);

--- a/lib/model/unittest/CModelTestFixtureBase.cc
+++ b/lib/model/unittest/CModelTestFixtureBase.cc
@@ -1,0 +1,311 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CModelTestFixtureBase.h"
+
+#include <model/CDataGatherer.h>
+#include <model/CEventData.h>
+#include <model/CModelFactory.h>
+
+#include <string>
+
+namespace {
+const std::string EMPTY_STRING;
+}
+
+std::size_t CModelTestFixtureBase::addPerson(const std::string& p,
+                                             const ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                                             std::size_t numInfluencers,
+                                             TOptionalStr value) {
+    std::string i("i");
+
+    ml::model::CDataGatherer::TStrCPtrVec person{&p};
+    if (numInfluencers == 0) {
+        person.resize(gatherer->fieldsOfInterest().size(), nullptr);
+    }
+    for (std::size_t j = 0; j < numInfluencers; ++j) {
+        person.push_back(&i);
+    }
+    if (value) {
+        person.push_back(&(value.get()));
+    }
+    ml::model::CEventData result;
+    gatherer->processFields(person, result, m_ResourceMonitor);
+    return *result.personId();
+}
+
+void CModelTestFixtureBase::addArrival(ml::model::CDataGatherer& gatherer,
+                                       ml::core_t::TTime time,
+                                       const std::string& person,
+                                       const TOptionalStr& inf1,
+                                       const TOptionalStr& inf2,
+                                       const TOptionalStr& value) {
+    ml::model::CDataGatherer::TStrCPtrVec fieldValues{&person};
+    if (inf1) {
+        fieldValues.push_back(&(inf1.get()));
+    }
+    if (inf2) {
+        fieldValues.push_back(&(inf2.get()));
+    }
+
+    if (value) {
+        fieldValues.push_back(&(value.get()));
+    }
+
+    ml::model::CEventData eventData;
+    eventData.time(time);
+
+    gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+}
+
+std::string CModelTestFixtureBase::valueAsString(const TDouble1Vec& value) {
+    std::string result{ml::core::CStringUtils::typeToStringPrecise(
+        value[0], ml::core::CIEEE754::E_DoublePrecision)};
+    for (std::size_t i = 1u; i < value.size(); ++i) {
+        result += ml::model::CAnomalyDetectorModelConfig::DEFAULT_MULTIVARIATE_COMPONENT_DELIMITER +
+                  ml::core::CStringUtils::typeToStringPrecise(
+                      value[i], ml::core::CIEEE754::E_DoublePrecision);
+    }
+    return result;
+}
+
+ml::model::CEventData
+CModelTestFixtureBase::addArrival(const SMessage& message,
+                                  ml::model::CModelFactory::TDataGathererPtr& gatherer) {
+    ml::model::CDataGatherer::TStrCPtrVec fields{&message.s_Person, &message.s_Attribute};
+    if (message.s_Value.empty() == false) {
+        std::string value{valueAsString(message.s_Value)};
+        fields.push_back(&value);
+    }
+    ml::model::CEventData result;
+    result.time(message.s_Time);
+    gatherer->addArrival(fields, result, m_ResourceMonitor);
+
+    return result;
+}
+
+void CModelTestFixtureBase::addArrival(ml::model::CDataGatherer& gatherer,
+                                       ml::core_t::TTime time,
+                                       const std::string& person,
+                                       double value,
+                                       const TOptionalStr& inf1,
+                                       const TOptionalStr& inf2,
+                                       const TOptionalStr& count) {
+    ml::model::CDataGatherer::TStrCPtrVec fieldValues;
+    fieldValues.push_back(&person);
+    if (inf1) {
+        fieldValues.push_back(&(inf1.get()));
+    }
+    if (inf2) {
+        fieldValues.push_back(&(inf2.get()));
+    }
+    if (count) {
+        fieldValues.push_back(&(count.get()));
+    }
+    std::string valueAsString(ml::core::CStringUtils::typeToStringPrecise(
+        value, ml::core::CIEEE754::E_DoublePrecision));
+    fieldValues.push_back(&valueAsString);
+
+    ml::model::CEventData eventData;
+    eventData.time(time);
+
+    gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+}
+
+void CModelTestFixtureBase::addArrival(ml::model::CDataGatherer& gatherer,
+                                       ml::core_t::TTime time,
+                                       const std::string& person,
+                                       double lat,
+                                       double lng,
+                                       const TOptionalStr& inf1,
+                                       const TOptionalStr& inf2) {
+    ml::model::CDataGatherer::TStrCPtrVec fieldValues;
+    fieldValues.push_back(&person);
+    if (inf1) {
+        fieldValues.push_back(&(inf1.get()));
+    }
+    if (inf2) {
+        fieldValues.push_back(&(inf2.get()));
+    }
+    std::string valueAsString;
+    valueAsString += ml::core::CStringUtils::typeToStringPrecise(
+        lat, ml::core::CIEEE754::E_DoublePrecision);
+    valueAsString += ml::model::CAnomalyDetectorModelConfig::DEFAULT_MULTIVARIATE_COMPONENT_DELIMITER;
+    valueAsString += ml::core::CStringUtils::typeToStringPrecise(
+        lng, ml::core::CIEEE754::E_DoublePrecision);
+    fieldValues.push_back(&valueAsString);
+
+    ml::model::CEventData eventData;
+    eventData.time(time);
+
+    gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+}
+
+void CModelTestFixtureBase::processBucket(ml::core_t::TTime time,
+                                          ml::core_t::TTime bucketLength,
+                                          const TDoubleVec& bucket,
+                                          const TStrVec& influencerValues,
+                                          ml::model::CDataGatherer& gatherer,
+                                          ml::model::CAnomalyDetectorModel& model,
+                                          ml::model::SAnnotatedProbability& probability) {
+    for (std::size_t i = 0u; i < bucket.size(); ++i) {
+        this->addArrival(gatherer, time, "p", bucket[i],
+                         TOptionalStr(influencerValues[i]));
+    }
+    model.sample(time, time + bucketLength, m_ResourceMonitor);
+    ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+    model.computeProbability(0 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability);
+    LOG_DEBUG(<< "influences = "
+              << ml::core::CContainerPrinter::print(probability.s_Influences));
+}
+
+void CModelTestFixtureBase::processBucket(ml::core_t::TTime time,
+                                          ml::core_t::TTime bucketLength,
+                                          const TDoubleVec& bucket,
+                                          ml::model::CDataGatherer& gatherer,
+                                          ml::model::CAnomalyDetectorModel& model,
+                                          ml::model::SAnnotatedProbability& probability,
+                                          ml::model::SAnnotatedProbability& probability2) {
+    const std::string person("p");
+    const std::string person2("q");
+    for (std::size_t i = 0u; i < bucket.size(); ++i) {
+        ml::model::CDataGatherer::TStrCPtrVec fieldValues;
+        if (i % 2 == 0) {
+            fieldValues.push_back(&person);
+        } else {
+            fieldValues.push_back(&person2);
+        }
+
+        std::string valueAsString(ml::core::CStringUtils::typeToStringPrecise(
+            bucket[i], ml::core::CIEEE754::E_DoublePrecision));
+        fieldValues.push_back(&valueAsString);
+
+        ml::model::CEventData eventData;
+        eventData.time(time);
+
+        gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+    }
+    model.sample(time, time + bucketLength, m_ResourceMonitor);
+    ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+    model.computeProbability(0 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability);
+    model.computeProbability(1 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability2);
+}
+
+void CModelTestFixtureBase::processBucket(ml::core_t::TTime time,
+                                          ml::core_t::TTime bucketLength,
+                                          const TDoubleStrPrVec& bucket,
+                                          ml::model::CDataGatherer& gatherer,
+                                          ml::model::CAnomalyDetectorModel& model,
+                                          ml::model::SAnnotatedProbability& probability) {
+    const std::string person{"p"};
+    const std::string attribute{"a"};
+    for (auto& pr : bucket) {
+        const std::string valueAsString{ml::core::CStringUtils::typeToStringPrecise(
+            pr.first, ml::core::CIEEE754::E_DoublePrecision)};
+
+        ml::model::CDataGatherer::TStrCPtrVec fieldValues{
+            &person, &attribute, &pr.second, &valueAsString};
+
+        ml::model::CEventData eventData;
+        eventData.time(time);
+
+        gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+    }
+    model.sample(time, time + bucketLength, m_ResourceMonitor);
+    ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+    model.computeProbability(0 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability);
+    LOG_DEBUG(<< "influences = "
+              << ml::core::CContainerPrinter::print(probability.s_Influences));
+}
+
+void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
+                                                     ml::core_t::TTime startTime,
+                                                     ml::core_t::TTime bucketLength,
+                                                     const TMessageVec& messages,
+                                                     ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                                                     ml::model::CAnomalyDetectorModel& model,
+                                                     TAnomalyVec& orderedAnomalies) {
+
+    TAnomalyAccumulator anomalies(numAnomalies);
+
+    for (std::size_t i = 0u, bucket = 0u; i < messages.size(); ++i) {
+        if (messages[i].s_Time >= startTime + bucketLength) {
+            LOG_DEBUG(<< "Updating and testing bucket = [" << startTime << ","
+                      << startTime + bucketLength << ")");
+
+            model.sample(startTime, startTime + bucketLength, m_ResourceMonitor);
+
+            ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+            ml::model::SAnnotatedProbability annotatedProbability;
+            for (std::size_t pid = 0u; pid < gatherer->numberActivePeople(); ++pid) {
+                model.computeProbability(pid, startTime, startTime + bucketLength,
+                                         partitioningFields, 2, annotatedProbability);
+
+                std::string person = model.personName(pid);
+                TDoubleStrPrVec attributes;
+                for (const auto& probability : annotatedProbability.s_AttributeProbabilities) {
+                    attributes.emplace_back(probability.s_Probability,
+                                            *probability.s_Attribute);
+                }
+                LOG_DEBUG(<< "Adding anomaly " << pid);
+                anomalies.add({annotatedProbability.s_Probability,
+                               {bucket, person, attributes}});
+            }
+
+            startTime += bucketLength;
+            ++bucket;
+        }
+
+        this->addArrival(messages[i], gatherer);
+    }
+
+    anomalies.sort();
+    LOG_DEBUG(<< "Anomalies = " << anomalies.print());
+
+    for (std::size_t i = 0u; i < anomalies.count(); ++i) {
+        orderedAnomalies.push_back(anomalies[i].second);
+    }
+
+    std::sort(orderedAnomalies.begin(), orderedAnomalies.end());
+
+    LOG_DEBUG(<< "orderedAnomalies = "
+              << ml::core::CContainerPrinter::print(orderedAnomalies));
+}
+
+
+void CModelTestFixtureBase::generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
+                           const std::string& fieldName,
+                           const std::string& overFieldName,
+                           TKeyCompareFunc keyCompare) {
+    TBoolVec useNull{true, false};
+    TStrVec byFields{"", "by"};
+    TStrVec partitionFields{"", "partition"};
+
+    ml::model::CAnomalyDetectorModelConfig config = ml::model::CAnomalyDetectorModelConfig::defaultConfig();
+
+    int detectorIndex{0};
+    for (const auto& countFunction : countFunctions) {
+        for (bool usingNull : useNull) {
+            for (const auto& byField : byFields) {
+                for (const auto& partitionField : partitionFields) {
+                    ml::model::CSearchKey key(++detectorIndex, countFunction, usingNull,
+                                              ml::model_t::E_XF_None, fieldName, byField, overFieldName, partitionField);
+
+                    ml::model::CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
+                        config.factory(key);
+
+                    LOG_DEBUG(<< "expected key = " << key);
+                    LOG_DEBUG(<< "actual key   = " << factory->searchKey());
+                    keyCompare(key, factory->searchKey());
+                }
+            }
+        }
+    }
+}

--- a/lib/model/unittest/CModelTestFixtureBase.cc
+++ b/lib/model/unittest/CModelTestFixtureBase.cc
@@ -74,8 +74,9 @@ ml::model::CEventData
 CModelTestFixtureBase::addArrival(const SMessage& message,
                                   ml::model::CModelFactory::TDataGathererPtr& gatherer) {
     ml::model::CDataGatherer::TStrCPtrVec fields{&message.s_Person, &message.s_Attribute};
+    std::string value;
     if (message.s_Value.empty() == false) {
-        std::string value{valueAsString(message.s_Value)};
+        value = {valueAsString(message.s_Value)};
         fields.push_back(&value);
     }
     ml::model::CEventData result;

--- a/lib/model/unittest/CModelTestFixtureBase.cc
+++ b/lib/model/unittest/CModelTestFixtureBase.cc
@@ -12,9 +12,7 @@
 
 #include <string>
 
-namespace {
-const std::string EMPTY_STRING;
-}
+const std::string CModelTestFixtureBase::EMPTY_STRING;
 
 std::size_t CModelTestFixtureBase::addPerson(const std::string& p,
                                              const ml::model::CModelFactory::TDataGathererPtr& gatherer,
@@ -279,16 +277,16 @@ void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
               << ml::core::CContainerPrinter::print(orderedAnomalies));
 }
 
-
 void CModelTestFixtureBase::generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
-                           const std::string& fieldName,
-                           const std::string& overFieldName,
-                           TKeyCompareFunc keyCompare) {
+                                                  const std::string& fieldName,
+                                                  const std::string& overFieldName,
+                                                  TKeyCompareFunc keyCompare) {
     TBoolVec useNull{true, false};
     TStrVec byFields{"", "by"};
     TStrVec partitionFields{"", "partition"};
 
-    ml::model::CAnomalyDetectorModelConfig config = ml::model::CAnomalyDetectorModelConfig::defaultConfig();
+    ml::model::CAnomalyDetectorModelConfig config =
+        ml::model::CAnomalyDetectorModelConfig::defaultConfig();
 
     int detectorIndex{0};
     for (const auto& countFunction : countFunctions) {
@@ -296,7 +294,8 @@ void CModelTestFixtureBase::generateAndCompareKey(const ml::model::function_t::T
             for (const auto& byField : byFields) {
                 for (const auto& partitionField : partitionFields) {
                     ml::model::CSearchKey key(++detectorIndex, countFunction, usingNull,
-                                              ml::model_t::E_XF_None, fieldName, byField, overFieldName, partitionField);
+                                              ml::model_t::E_XF_None, fieldName,
+                                              byField, overFieldName, partitionField);
 
                     ml::model::CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
                         config.factory(key);

--- a/lib/model/unittest/CModelTestFixtureBase.cc
+++ b/lib/model/unittest/CModelTestFixtureBase.cc
@@ -278,11 +278,27 @@ void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
               << ml::core::CContainerPrinter::print(orderedAnomalies));
 }
 
+ml::model::CEventData CModelTestFixtureBase::makeEventData(ml::core_t::TTime time,
+                                                           std::size_t pid,
+                                                           TDouble1Vec value,
+                                                           const TOptionalStr& influence,
+                                                           const TOptionalStr& stringValue) {
+    ml::model::CEventData result;
+    result.time(time);
+    result.person(pid);
+    result.addAttribute(std::size_t(0));
+    result.addValue(value);
+    result.addInfluence(influence);
+    if (stringValue) {
+        result.stringValue(stringValue.get());
+    }
+    return result;
+}
+
 void CModelTestFixtureBase::generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
                                                   const std::string& fieldName,
                                                   const std::string& overFieldName,
                                                   TKeyCompareFunc keyCompare) {
-    TBoolVec useNull{true, false};
     TStrVec byFields{"", "by"};
     TStrVec partitionFields{"", "partition"};
 
@@ -291,7 +307,7 @@ void CModelTestFixtureBase::generateAndCompareKey(const ml::model::function_t::T
 
     int detectorIndex{0};
     for (const auto& countFunction : countFunctions) {
-        for (bool usingNull : useNull) {
+        for (bool usingNull : {true, false}) {
             for (const auto& byField : byFields) {
                 for (const auto& partitionField : partitionFields) {
                     ml::model::CSearchKey key(++detectorIndex, countFunction, usingNull,

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -13,69 +13,204 @@
 #include <maths/CModel.h>
 #include <maths/CMultivariatePrior.h>
 
+#include <model/CAnnotatedProbability.h>
+#include <model/CAnomalyDetectorModelConfig.h>
+#include <model/CDataGatherer.h>
+#include <model/CEventData.h>
+#include <model/CIndividualModel.h>
+#include <model/CModelFactory.h>
 #include <model/CResourceMonitor.h>
 
 #include <boost/optional.hpp>
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <utility>
 #include <vector>
 
-using TBoolVec = std::vector<bool>;
-
-using TDouble1Vec = ml::core::CSmallVector<double, 1>;
-using TDouble2Vec = ml::core::CSmallVector<double, 2>;
-using TDouble4Vec = ml::core::CSmallVector<double, 4>;
-using TDouble4Vec1Vec = ml::core::CSmallVector<TDouble4Vec, 1>;
-using TDoubleDoublePr = std::pair<double, double>;
-using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
-using TDoubleSizePr = std::pair<double, std::size_t>;
-using TDoubleStrPr = std::pair<double, std::string>;
-using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
-using TDoubleVec = std::vector<double>;
-using TDoubleVecVec = std::vector<TDoubleVec>;
-
-using TMathsModelPtr = std::shared_ptr<ml::maths::CModel>;
-using TMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
-using TMultivariatePriorPtr = std::shared_ptr<ml::maths::CMultivariatePrior>;
-
-using TOptionalDouble = boost::optional<double>;
-using TOptionalDoubleVec = std::vector<TOptionalDouble>;
-using TOptionalStr = boost::optional<std::string>;
-using TOptionalUInt64 = boost::optional<uint64_t>;
-
-using TPriorPtr = std::shared_ptr<ml::maths::CPrior>;
-
-using TSizeDoublePr = std::pair<std::size_t, double>;
-using TSizeDoublePr1Vec = ml::core::CSmallVector<TSizeDoublePr, 1>;
-using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-using TSizeSizePrVec = std::vector<TSizeSizePr>;
-using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
-using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
-using TSizeVec = std::vector<std::size_t>;
-using TSizeVecVec = std::vector<TSizeVec>;
-using TSizeVecVecVec = std::vector<TSizeVecVec>;
-using TStrSizePr = std::pair<std::string, std::size_t>;
-using TStrSizePrVec = std::vector<TStrSizePr>;
-using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
-using TStrSizePrVecVecVec = std::vector<TStrSizePrVecVec>;
-using TStrUInt64Map = std::map<std::string, uint64_t>;
-
-using TStrVec = std::vector<std::string>;
-using TStrVecVec = std::vector<TStrVec>;
-
-using TTimeDoublePr = std::pair<ml::core_t::TTime, double>;
-using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
-using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
-using TTimeStrVecPr = std::pair<ml::core_t::TTime, TStrVec>;
-using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
-using TTimeVec = std::vector<ml::core_t::TTime>;
-
-using TUInt64Vec = std::vector<uint64_t>;
-using TUIntVec = std::vector<unsigned int>;
-
 class CModelTestFixtureBase {
+public:
+    using TBoolVec = std::vector<bool>;
+
+    using TDouble1Vec = ml::core::CSmallVector<double, 1>;
+    using TDouble2Vec = ml::core::CSmallVector<double, 2>;
+    using TDouble4Vec = ml::core::CSmallVector<double, 4>;
+    using TDouble4Vec1Vec = ml::core::CSmallVector<TDouble4Vec, 1>;
+    using TDoubleDoublePr = std::pair<double, double>;
+    using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+    using TDoubleSizePr = std::pair<double, std::size_t>;
+    using TDoubleStrPr = std::pair<double, std::string>;
+    using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
+    using TDoubleVec = std::vector<double>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+
+    using TMathsModelPtr = std::shared_ptr<ml::maths::CModel>;
+    using TMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMultivariatePriorPtr = std::shared_ptr<ml::maths::CMultivariatePrior>;
+
+    using TOptionalDouble = boost::optional<double>;
+    using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+    using TOptionalStr = boost::optional<std::string>;
+    using TOptionalUInt64 = boost::optional<uint64_t>;
+
+    using TPriorPtr = std::shared_ptr<ml::maths::CPrior>;
+
+    using TSizeDoublePr = std::pair<std::size_t, double>;
+    using TSizeDoublePr1Vec = ml::core::CSmallVector<TSizeDoublePr, 1>;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+    using TSizeSizePrVec = std::vector<TSizeSizePr>;
+    using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
+    using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TSizeVecVecVec = std::vector<TSizeVecVec>;
+    using TStrSizePr = std::pair<std::string, std::size_t>;
+    using TStrSizePrVec = std::vector<TStrSizePr>;
+    using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
+    using TStrSizePrVecVecVec = std::vector<TStrSizePrVecVec>;
+    using TStrUInt64Map = std::map<std::string, uint64_t>;
+
+    using TStrVec = std::vector<std::string>;
+    using TStrVecVec = std::vector<TStrVec>;
+
+    using TTimeDoublePr = std::pair<ml::core_t::TTime, double>;
+    using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
+    using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
+    using TTimeStrVecPr = std::pair<ml::core_t::TTime, TStrVec>;
+    using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
+    using TTimeVec = std::vector<ml::core_t::TTime>;
+
+    using TUInt64Vec = std::vector<uint64_t>;
+    using TUIntVec = std::vector<unsigned int>;
+
+protected:
+    struct SAnomaly {
+        SAnomaly() : s_Bucket(0u), s_Person(), s_Attributes() {}
+        SAnomaly(std::size_t bucket, const std::string& person, const TDoubleStrPrVec& attributes)
+            : s_Bucket(bucket), s_Person(person), s_Attributes(attributes) {}
+
+        std::size_t s_Bucket;
+        std::string s_Person;
+        TDoubleStrPrVec s_Attributes;
+
+        bool operator<(const SAnomaly& other) const {
+            return s_Bucket < other.s_Bucket;
+        }
+
+        std::string print() const {
+            std::ostringstream result;
+            result << "[" << s_Bucket << ", " + s_Person << ",";
+            for (std::size_t i = 0u; i < s_Attributes.size(); ++i) {
+                if (s_Attributes[i].first < 0.01) {
+                    result << " " << s_Attributes[i].second;
+                }
+            }
+            result << "]";
+            return result.str();
+        }
+    };
+
+    using TAnomalyVec = std::vector<SAnomaly>;
+    using TDoubleAnomalyPr = std::pair<double, SAnomaly>;
+    using TAnomalyAccumulator =
+        ml::maths::CBasicStatistics::COrderStatisticsHeap<TDoubleAnomalyPr, ml::maths::COrderings::SFirstLess>;
+
+    struct SMessage {
+        SMessage(ml::core_t::TTime time,
+                 const std::string& person,
+                 const std::string& attribute,
+                 const TDouble1Vec& value)
+            : s_Time(time), s_Person(person), s_Attribute(attribute), s_Value(value) {}
+
+        SMessage(ml::core_t::TTime time, const std::string& person, const std::string& attribute)
+            : s_Time(time), s_Person(person), s_Attribute(attribute) {}
+
+        bool operator<(const SMessage& other) const {
+            return ml::maths::COrderings::lexicographical_compare(
+                s_Time, s_Person, s_Attribute, other.s_Time, other.s_Person,
+                other.s_Attribute);
+        }
+
+        ml::core_t::TTime s_Time;
+        std::string s_Person;
+        std::string s_Attribute;
+        TDouble1Vec s_Value{};
+    };
+    using TMessageVec = std::vector<SMessage>;
+
+protected:
+    std::size_t addPerson(const std::string& p,
+                          const ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                          std::size_t numInfluencers = 0,
+                          TOptionalStr value = TOptionalStr());
+
+    void addArrival(ml::model::CDataGatherer& gatherer,
+                    ml::core_t::TTime time,
+                    const std::string& person,
+                    const TOptionalStr& inf1 = TOptionalStr(),
+                    const TOptionalStr& inf2 = TOptionalStr(),
+                    const TOptionalStr& value = TOptionalStr());
+
+    std::string valueAsString(const TDouble1Vec& value);
+
+    ml::model::CEventData addArrival(const SMessage& message,
+                                     ml::model::CModelFactory::TDataGathererPtr& gatherer);
+
+    void addArrival(ml::model::CDataGatherer& gatherer,
+                    ml::core_t::TTime time,
+                    const std::string& person,
+                    double value,
+                    const TOptionalStr& inf1 = TOptionalStr(),
+                    const TOptionalStr& inf2 = TOptionalStr(),
+                    const TOptionalStr& count = TOptionalStr());
+
+    void addArrival(ml::model::CDataGatherer& gatherer,
+                    ml::core_t::TTime time,
+                    const std::string& person,
+                    double lat,
+                    double lng,
+                    const TOptionalStr& inf1 = TOptionalStr(),
+                    const TOptionalStr& inf2 = TOptionalStr());
+
+    void processBucket(ml::core_t::TTime time,
+                       ml::core_t::TTime bucketLength,
+                       const TDoubleVec& bucket,
+                       const TStrVec& influencerValues,
+                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CAnomalyDetectorModel& model,
+                       ml::model::SAnnotatedProbability& probability);
+
+    void processBucket(ml::core_t::TTime time,
+                       ml::core_t::TTime bucketLength,
+                       const TDoubleVec& bucket,
+                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CAnomalyDetectorModel& model,
+                       ml::model::SAnnotatedProbability& probability,
+                       ml::model::SAnnotatedProbability& probability2);
+
+    void processBucket(ml::core_t::TTime time,
+                       ml::core_t::TTime bucketLength,
+                       const TDoubleStrPrVec& bucket,
+                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CAnomalyDetectorModel& model,
+                       ml::model::SAnnotatedProbability& probability);
+
+    void generateOrderedAnomalies(std::size_t numAnomalies,
+                                  ml::core_t::TTime startTime,
+                                  ml::core_t::TTime bucketLength,
+                                  const TMessageVec& messages,
+                                  ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                                  ml::model::CAnomalyDetectorModel& model,
+                                  TAnomalyVec& orderedAnomalies);
+
+    using TKeyCompareFunc = std::function<void(ml::model::CSearchKey expectedKey, ml::model::CSearchKey actualKey)>;
+
+    void generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
+                               const std::string& fieldName,
+                               const std::string& overFieldName,
+                               TKeyCompareFunc keyCompare);
+
 protected:
     ml::model::CResourceMonitor m_ResourceMonitor;
 };

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -206,13 +206,19 @@ protected:
                                   ml::model::CAnomalyDetectorModel& model,
                                   TAnomalyVec& orderedAnomalies);
 
+    ml::model::CEventData makeEventData(ml::core_t::TTime time,
+                                        std::size_t pid,
+                                        TDouble1Vec value = TDoubleVec(1, 0.0),
+                                        const TOptionalStr& influence = TOptionalStr(),
+                                        const TOptionalStr& stringValue = TOptionalStr());
+
     using TKeyCompareFunc =
         std::function<void(ml::model::CSearchKey expectedKey, ml::model::CSearchKey actualKey)>;
 
-    void generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
-                               const std::string& fieldName,
-                               const std::string& overFieldName,
-                               TKeyCompareFunc keyCompare);
+    static void generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
+                                      const std::string& fieldName,
+                                      const std::string& overFieldName,
+                                      TKeyCompareFunc keyCompare);
 
 protected:
     ml::model::CResourceMonitor m_ResourceMonitor;

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -31,6 +31,8 @@
 
 class CModelTestFixtureBase {
 public:
+    static const std::string EMPTY_STRING;
+
     using TBoolVec = std::vector<bool>;
 
     using TDouble1Vec = ml::core::CSmallVector<double, 1>;
@@ -204,7 +206,8 @@ protected:
                                   ml::model::CAnomalyDetectorModel& model,
                                   TAnomalyVec& orderedAnomalies);
 
-    using TKeyCompareFunc = std::function<void(ml::model::CSearchKey expectedKey, ml::model::CSearchKey actualKey)>;
+    using TKeyCompareFunc =
+        std::function<void(ml::model::CSearchKey expectedKey, ml::model::CSearchKey actualKey)>;
 
     void generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
                                const std::string& fieldName,

--- a/lib/model/unittest/Makefile
+++ b/lib/model/unittest/Makefile
@@ -49,6 +49,7 @@ SRCS=\
 	CMetricPopulationModelTest.cc \
 	CModelDetailsViewTest.cc \
 	CModelMemoryTest.cc \
+	CModelTestFixtureBase.cc \
 	CModelToolsTest.cc \
 	CModelTypesTest.cc \
 	CProbabilityAndInfluenceCalculatorTest.cc \


### PR DESCRIPTION
Move existing model test helper functions to base class and share functionality where possible.

While this goes some way to reducing code duplication there may still be scope to
 * generalise the existing helper functions further to reduce their number
 * add further helper functions to encapsulate code duplicated in multiple suites 

Relates to #1477 