### PR TITLE
[7.x][ML] Move model test helper functions to base class (#1523)

### DIFF
--- a/lib/model/unittest/CCountingModelTest.cc
+++ b/lib/model/unittest/CCountingModelTest.cc
@@ -29,53 +29,28 @@ BOOST_AUTO_TEST_SUITE(CCountingModelTest)
 using namespace ml;
 using namespace model;
 
-namespace {
-std::size_t addPerson(const std::string& p,
-                      const CModelFactory::TDataGathererPtr& gatherer,
-                      CResourceMonitor& resourceMonitor) {
-    CDataGatherer::TStrCPtrVec person;
-    person.push_back(&p);
-    CEventData result;
-    gatherer->processFields(person, result, resourceMonitor);
-    return *result.personId();
-}
+class CTestFixture : public CModelTestFixtureBase {
+protected:
+    SModelParams::TStrDetectionRulePr
+    makeScheduledEvent(const std::string& description, double start, double end) {
+        CRuleCondition conditionGte;
+        conditionGte.appliesTo(CRuleCondition::E_Time);
+        conditionGte.op(CRuleCondition::E_GTE);
+        conditionGte.value(start);
+        CRuleCondition conditionLt;
+        conditionLt.appliesTo(CRuleCondition::E_Time);
+        conditionLt.op(CRuleCondition::E_LT);
+        conditionLt.value(end);
 
-void addArrival(CDataGatherer& gatherer,
-                CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
-                const std::string& person) {
-    CDataGatherer::TStrCPtrVec fieldValues;
-    fieldValues.push_back(&person);
+        CDetectionRule rule;
+        rule.action(CDetectionRule::E_SkipModelUpdate);
+        rule.addCondition(conditionGte);
+        rule.addCondition(conditionLt);
 
-    CEventData eventData;
-    eventData.time(time);
-    gatherer.addArrival(fieldValues, eventData, resourceMonitor);
-}
-
-SModelParams::TStrDetectionRulePr
-makeScheduledEvent(const std::string& description, double start, double end) {
-    CRuleCondition conditionGte;
-    conditionGte.appliesTo(CRuleCondition::E_Time);
-    conditionGte.op(CRuleCondition::E_GTE);
-    conditionGte.value(start);
-    CRuleCondition conditionLt;
-    conditionLt.appliesTo(CRuleCondition::E_Time);
-    conditionLt.op(CRuleCondition::E_LT);
-    conditionLt.value(end);
-
-    CDetectionRule rule;
-    rule.action(CDetectionRule::E_SkipModelUpdate);
-    rule.addCondition(conditionGte);
-    rule.addCondition(conditionLt);
-
-    SModelParams::TStrDetectionRulePr event = std::make_pair(description, rule);
-    return event;
-}
-
-const std::string EMPTY_STRING;
-}
-
-class CTestFixture : public CModelTestFixtureBase {};
+        SModelParams::TStrDetectionRulePr event = std::make_pair(description, rule);
+        return event;
+    }
+};
 
 BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     core_t::TTime startTime{100};
@@ -94,20 +69,20 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         CModelFactory::SGathererInitializationData gathererNoGapInitData(startTime);
         CModelFactory::TDataGathererPtr gathererNoGap(
             factory.makeDataGatherer(gathererNoGapInitData));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p", gathererNoGap, m_ResourceMonitor));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererNoGap));
         CModelFactory::SModelInitializationData modelNoGapInitData(gathererNoGap);
         CAnomalyDetectorModel::TModelPtr modelHolderNoGap(factory.makeModel(modelNoGapInitData));
         CCountingModel* modelNoGap =
             dynamic_cast<CCountingModel*>(modelHolderNoGap.get());
 
         // |2|2|0|0|1| -> 1.0 mean count
-        addArrival(*gathererNoGap, m_ResourceMonitor, 100, "p");
-        addArrival(*gathererNoGap, m_ResourceMonitor, 110, "p");
+        this->addArrival(*gathererNoGap, 100, "p");
+        this->addArrival(*gathererNoGap, 110, "p");
         modelNoGap->sample(100, 200, m_ResourceMonitor);
-        addArrival(*gathererNoGap, m_ResourceMonitor, 250, "p");
-        addArrival(*gathererNoGap, m_ResourceMonitor, 280, "p");
+        this->addArrival(*gathererNoGap, 250, "p");
+        this->addArrival(*gathererNoGap, 280, "p");
         modelNoGap->sample(200, 500, m_ResourceMonitor);
-        addArrival(*gathererNoGap, m_ResourceMonitor, 500, "p");
+        this->addArrival(*gathererNoGap, 500, "p");
         modelNoGap->sample(500, 600, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(1.0, *modelNoGap->baselineBucketCount(0));
@@ -118,8 +93,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         CModelFactory::SGathererInitializationData gathererWithGapInitData(startTime);
         CModelFactory::TDataGathererPtr gathererWithGap(
             factory.makeDataGatherer(gathererWithGapInitData));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPerson("p", gathererWithGap, m_ResourceMonitor));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererWithGap));
         CModelFactory::SModelInitializationData modelWithGapInitData(gathererWithGap);
         CAnomalyDetectorModel::TModelPtr modelHolderWithGap(
             factory.makeModel(modelWithGapInitData));
@@ -128,15 +102,15 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
         // |2|2|0|0|1|
         // |2|X|X|X|1| -> 1.5 mean count where X means skipped bucket
-        addArrival(*gathererWithGap, m_ResourceMonitor, 100, "p");
-        addArrival(*gathererWithGap, m_ResourceMonitor, 110, "p");
+        this->addArrival(*gathererWithGap, 100, "p");
+        this->addArrival(*gathererWithGap, 110, "p");
         modelWithGap->sample(100, 200, m_ResourceMonitor);
-        addArrival(*gathererWithGap, m_ResourceMonitor, 250, "p");
-        addArrival(*gathererWithGap, m_ResourceMonitor, 280, "p");
+        this->addArrival(*gathererWithGap, 250, "p");
+        this->addArrival(*gathererWithGap, 280, "p");
         modelWithGap->skipSampling(500);
         modelWithGap->prune(maxAgeBuckets);
         BOOST_REQUIRE_EQUAL(std::size_t(1), gathererWithGap->numberActivePeople());
-        addArrival(*gathererWithGap, m_ResourceMonitor, 500, "p");
+        this->addArrival(*gathererWithGap, 500, "p");
         modelWithGap->sample(500, 600, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(1.5, *modelWithGap->baselineBucketCount(0));
@@ -166,7 +140,7 @@ BOOST_FIXTURE_TEST_CASE(testCheckScheduledEvents, CTestFixture) {
         CModelFactory::SGathererInitializationData gathererNoGapInitData(startTime);
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererNoGapInitData));
         CModelFactory::SModelInitializationData modelNoGapInitData(gatherer);
-        addArrival(*gatherer, m_ResourceMonitor, 200, "p");
+        this->addArrival(*gatherer, 200, "p");
 
         CAnomalyDetectorModel::TModelPtr modelHolderNoGap(factory.makeModel(modelNoGapInitData));
         CCountingModel* modelNoGap =
@@ -215,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(testCheckScheduledEvents, CTestFixture) {
         CModelFactory::SGathererInitializationData gathererNoGapInitData(startTime);
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererNoGapInitData));
         CModelFactory::SModelInitializationData modelNoGapInitData(gatherer);
-        addArrival(*gatherer, m_ResourceMonitor, 100, "p");
+        this->addArrival(*gatherer, 100, "p");
 
         CAnomalyDetectorModel::TModelPtr modelHolderNoGap(factory.makeModel(modelNoGapInitData));
         CCountingModel* modelNoGap =
@@ -259,8 +233,8 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
 
     CModelFactory::SGathererInitializationData gathererInitData(time);
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), addPerson("p1", gatherer, m_ResourceMonitor));
-    BOOST_REQUIRE_EQUAL(std::size_t(1), addPerson("p2", gatherer, m_ResourceMonitor));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p1", gatherer));
+    BOOST_REQUIRE_EQUAL(std::size_t(1), this->addPerson("p2", gatherer));
     CModelFactory::SModelInitializationData modelInitData(gatherer);
     CAnomalyDetectorModel::TModelPtr modelHolder(factory.makeModel(modelInitData));
     CCountingModel* model{dynamic_cast<CCountingModel*>(modelHolder.get())};
@@ -275,9 +249,8 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
         std::sort(offsets.begin(), offsets.end());
         for (auto offset : offsets) {
             rng.generateUniformSamples(0.0, 1.0, 1, uniform01);
-            addArrival(*gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(offset),
-                       uniform01[0] < 0.5 ? "p1" : "p2");
+            this->addArrival(*gatherer, time + static_cast<core_t::TTime>(offset),
+                             uniform01[0] < 0.5 ? "p1" : "p2");
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
@@ -287,9 +260,8 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
 
     for (std::size_t i = 0u; i < offsets.size(); ++i) {
         rng.generateUniformSamples(0.0, 1.0, 1, uniform01);
-        addArrival(*gatherer, m_ResourceMonitor,
-                   time + static_cast<core_t::TTime>(offsets[i]),
-                   uniform01[0] < 0.5 ? "p1" : "p2");
+        this->addArrival(*gatherer, time + static_cast<core_t::TTime>(offsets[i]),
+                         uniform01[0] < 0.5 ? "p1" : "p2");
         model->sampleBucketStatistics(time, time + bucketLength, m_ResourceMonitor);
         BOOST_REQUIRE_EQUAL(static_cast<double>(i + 1) / 10.0,
                             interimBucketCorrector->completeness());

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(TStrVec::iterator)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(CModelTestFixtureBase::TStrVec::iterator)
 
 BOOST_AUTO_TEST_SUITE(CEventRateModelTest)
 
@@ -52,210 +52,136 @@ using namespace ml;
 using namespace model;
 
 namespace {
-
 const std::string EMPTY_STRING;
-
-TUInt64Vec rawEventCounts(std::size_t copies = 1) {
-    uint64_t counts[] = {54, 67, 39, 58, 46, 50, 42,
-                         48, 53, 51, 50, 57, 53, 49};
-    TUInt64Vec result;
-    for (std::size_t i = 0u; i < copies; ++i) {
-        result.insert(result.end(), std::begin(counts), std::end(counts));
-    }
-    return result;
-}
-
-void generateEvents(const core_t::TTime& startTime,
-                    const core_t::TTime& bucketLength,
-                    const TUInt64Vec& eventCountsPerBucket,
-                    TTimeVec& eventArrivalTimes) {
-    // Generate an ordered collection of event arrival times.
-    test::CRandomNumbers rng;
-    double bucketStartTime = static_cast<double>(startTime);
-    for (auto count : eventCountsPerBucket) {
-        double bucketEndTime = bucketStartTime + static_cast<double>(bucketLength);
-
-        TDoubleVec bucketEventTimes;
-        rng.generateUniformSamples(bucketStartTime, bucketEndTime - 1.0,
-                                   static_cast<std::size_t>(count), bucketEventTimes);
-
-        std::sort(bucketEventTimes.begin(), bucketEventTimes.end());
-
-        for (auto time_ : bucketEventTimes) {
-            core_t::TTime time = static_cast<core_t::TTime>(time_);
-            time = std::min(static_cast<core_t::TTime>(bucketEndTime - 1.0),
-                            std::max(static_cast<core_t::TTime>(bucketStartTime), time));
-            eventArrivalTimes.push_back(time);
-        }
-
-        bucketStartTime = bucketEndTime;
-    }
-}
-
-void generateSporadicEvents(const core_t::TTime& startTime,
-                            const core_t::TTime& bucketLength,
-                            const TUInt64Vec& nonZeroEventCountsPerBucket,
-                            TTimeVec& eventArrivalTimes) {
-    // Generate an ordered collection of event arrival times.
-    test::CRandomNumbers rng;
-    double bucketStartTime = static_cast<double>(startTime);
-    for (auto count : nonZeroEventCountsPerBucket) {
-        double bucketEndTime = bucketStartTime + static_cast<double>(bucketLength);
-
-        TDoubleVec bucketEventTimes;
-        rng.generateUniformSamples(bucketStartTime, bucketEndTime - 1.0,
-                                   static_cast<std::size_t>(count), bucketEventTimes);
-
-        std::sort(bucketEventTimes.begin(), bucketEventTimes.end());
-
-        for (auto time_ : bucketEventTimes) {
-            core_t::TTime time = static_cast<core_t::TTime>(time_);
-            time = std::min(static_cast<core_t::TTime>(bucketEndTime - 1.0),
-                            std::max(static_cast<core_t::TTime>(bucketStartTime), time));
-            eventArrivalTimes.push_back(time);
-        }
-
-        TDoubleVec gap;
-        rng.generateUniformSamples(0.0, 10.0, 1u, gap);
-        bucketStartTime += static_cast<double>(bucketLength) * std::ceil(gap[0]);
-    }
-}
-
-std::size_t addPerson(const std::string& p,
-                      const CModelFactory::TDataGathererPtr& gatherer,
-                      CResourceMonitor& resourceMonitor) {
-    CDataGatherer::TStrCPtrVec person{&p};
-    CEventData result;
-    gatherer->processFields(person, result, resourceMonitor);
-    return *result.personId();
-}
-
-std::size_t addPersonWithInfluence(const std::string& p,
-                                   const CModelFactory::TDataGathererPtr& gatherer,
-                                   CResourceMonitor& resourceMonitor,
-                                   std::size_t numInfluencers,
-                                   TOptionalStr value = TOptionalStr()) {
-    std::string i("i");
-    CDataGatherer::TStrCPtrVec person{&p};
-    for (std::size_t j = 0; j < numInfluencers; ++j) {
-        person.push_back(&i);
-    }
-    if (value) {
-        person.push_back(&(value.get()));
-    }
-    CEventData result;
-    gatherer->processFields(person, result, resourceMonitor);
-    return *result.personId();
-}
-
-void addArrival(CDataGatherer& gatherer,
-                CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
-                const std::string& person,
-                const TOptionalStr& inf1 = TOptionalStr(),
-                const TOptionalStr& inf2 = TOptionalStr(),
-                const TOptionalStr& value = TOptionalStr()) {
-    CDataGatherer::TStrCPtrVec fieldValues{&person};
-    if (inf1) {
-        fieldValues.push_back(&(inf1.get()));
-    }
-    if (inf2) {
-        fieldValues.push_back(&(inf2.get()));
-    }
-
-    if (value) {
-        fieldValues.push_back(&(value.get()));
-    }
-
-    CEventData eventData;
-    eventData.time(time);
-
-    gatherer.addArrival(fieldValues, eventData, resourceMonitor);
-}
-
-CEventData makeEventData(core_t::TTime time, std::size_t pid) {
-    CEventData eventData;
-    eventData.time(time);
-    eventData.person(pid);
-    eventData.addAttribute(std::size_t(0));
-    eventData.addValue(TDoubleVec(1, 0.0));
-    return eventData;
-}
-
-CEventData makeEventData(core_t::TTime time, std::size_t pid, const std::string value) {
-    CEventData eventData;
-    eventData.time(time);
-    eventData.person(pid);
-    eventData.addAttribute(std::size_t(0));
-    eventData.addValue(TDoubleVec(1, 0.0));
-    eventData.stringValue(value);
-    return eventData;
-}
-
-void handleEvent(const CDataGatherer::TStrCPtrVec& fields,
-                 core_t::TTime time,
-                 CModelFactory::TDataGathererPtr& gatherer,
-                 CResourceMonitor& resourceMonitor) {
-    CEventData eventResult;
-    eventResult.time(time);
-    gatherer->addArrival(fields, eventResult, resourceMonitor);
-}
-
-void testModelWithValueField(model_t::EFeature feature,
-                             TSizeVecVecVec& fields,
-                             TStrVec& strings,
-                             CResourceMonitor& resourceMonitor) {
-    LOG_DEBUG(<< "  *** testing feature " << model_t::print(feature));
-
-    const core_t::TTime startTime{1346968800};
-    const core_t::TTime bucketLength{3600};
-    SModelParams params(bucketLength);
-    auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
-    CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
-    factory.features({feature});
-    factory.fieldNames("", "", "P", "V", TStrVec());
-    CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-    CModelFactory::TModelPtr model(factory.makeModel(gatherer));
-    BOOST_TEST_REQUIRE(model);
-
-    std::size_t anomalousBucket{20u};
-    std::size_t numberBuckets{30u};
-
-    const core_t::TTime endTime = startTime + (numberBuckets * bucketLength);
-
-    std::size_t i{0u};
-    for (core_t::TTime bucketStartTime = startTime; bucketStartTime < endTime;
-         bucketStartTime += bucketLength, i++) {
-        core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
-
-        for (std::size_t j = 0; j < fields[i].size(); ++j) {
-            CDataGatherer::TStrCPtrVec f{&strings[fields[i][j][0]],
-                                         &strings[fields[i][j][1]],
-                                         &strings[fields[i][j][2]]};
-            handleEvent(f, bucketStartTime + j, gatherer, resourceMonitor);
-        }
-
-        model->sample(bucketStartTime, bucketEndTime, resourceMonitor);
-
-        SAnnotatedProbability annotatedProbability;
-        CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
-        model->computeProbability(0 /*pid*/, bucketStartTime, bucketEndTime,
-                                  partitioningFields, 1, annotatedProbability);
-        LOG_DEBUG(<< "probability = " << annotatedProbability.s_Probability);
-        if (i == anomalousBucket) {
-            BOOST_TEST_REQUIRE(annotatedProbability.s_Probability < 0.001);
-        } else {
-            BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.6);
-        }
-    }
-}
-
-const TSizeDoublePr1Vec NO_CORRELATES;
-
+const CModelTestFixtureBase::TSizeDoublePr1Vec NO_CORRELATES;
 } // unnamed::
 
 class CTestFixture : public CModelTestFixtureBase {
 public:
+    TUInt64Vec rawEventCounts(std::size_t copies = 1) {
+        uint64_t counts[] = {54, 67, 39, 58, 46, 50, 42,
+                             48, 53, 51, 50, 57, 53, 49};
+        TUInt64Vec result;
+        for (std::size_t i = 0u; i < copies; ++i) {
+            result.insert(result.end(), std::begin(counts), std::end(counts));
+        }
+        return result;
+    }
+
+    void generateEvents(const core_t::TTime& startTime,
+                        const core_t::TTime& bucketLength,
+                        const TUInt64Vec& eventCountsPerBucket,
+                        TTimeVec& eventArrivalTimes) {
+        // Generate an ordered collection of event arrival times.
+        test::CRandomNumbers rng;
+        double bucketStartTime = static_cast<double>(startTime);
+        for (auto count : eventCountsPerBucket) {
+            double bucketEndTime = bucketStartTime + static_cast<double>(bucketLength);
+
+            TDoubleVec bucketEventTimes;
+            rng.generateUniformSamples(bucketStartTime, bucketEndTime - 1.0,
+                                       static_cast<std::size_t>(count), bucketEventTimes);
+
+            std::sort(bucketEventTimes.begin(), bucketEventTimes.end());
+
+            for (auto time_ : bucketEventTimes) {
+                core_t::TTime time = static_cast<core_t::TTime>(time_);
+                time = std::min(static_cast<core_t::TTime>(bucketEndTime - 1.0),
+                                std::max(static_cast<core_t::TTime>(bucketStartTime), time));
+                eventArrivalTimes.push_back(time);
+            }
+
+            bucketStartTime = bucketEndTime;
+        }
+    }
+
+    void generateSporadicEvents(const core_t::TTime& startTime,
+                                const core_t::TTime& bucketLength,
+                                const TUInt64Vec& nonZeroEventCountsPerBucket,
+                                TTimeVec& eventArrivalTimes) {
+        // Generate an ordered collection of event arrival times.
+        test::CRandomNumbers rng;
+        double bucketStartTime = static_cast<double>(startTime);
+        for (auto count : nonZeroEventCountsPerBucket) {
+            double bucketEndTime = bucketStartTime + static_cast<double>(bucketLength);
+
+            TDoubleVec bucketEventTimes;
+            rng.generateUniformSamples(bucketStartTime, bucketEndTime - 1.0,
+                                       static_cast<std::size_t>(count), bucketEventTimes);
+
+            std::sort(bucketEventTimes.begin(), bucketEventTimes.end());
+
+            for (auto time_ : bucketEventTimes) {
+                core_t::TTime time = static_cast<core_t::TTime>(time_);
+                time = std::min(static_cast<core_t::TTime>(bucketEndTime - 1.0),
+                                std::max(static_cast<core_t::TTime>(bucketStartTime), time));
+                eventArrivalTimes.push_back(time);
+            }
+
+            TDoubleVec gap;
+            rng.generateUniformSamples(0.0, 10.0, 1u, gap);
+            bucketStartTime += static_cast<double>(bucketLength) * std::ceil(gap[0]);
+        }
+    }
+
+    void handleEvent(const CDataGatherer::TStrCPtrVec& fields,
+                     core_t::TTime time,
+                     CModelFactory::TDataGathererPtr& gatherer,
+                     CResourceMonitor& resourceMonitor) {
+        CEventData eventResult;
+        eventResult.time(time);
+        gatherer->addArrival(fields, eventResult, resourceMonitor);
+    }
+
+    void testModelWithValueField(model_t::EFeature feature,
+                                 TSizeVecVecVec& fields,
+                                 TStrVec& strings,
+                                 CResourceMonitor& resourceMonitor) {
+        LOG_DEBUG(<< "  *** testing feature " << model_t::print(feature));
+
+        const core_t::TTime startTime{1346968800};
+        const core_t::TTime bucketLength{3600};
+        SModelParams params(bucketLength);
+        auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
+        CEventRatePopulationModelFactory factory(params, interimBucketCorrector);
+        factory.features({feature});
+        factory.fieldNames("", "", "P", "V", TStrVec());
+        CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
+        CModelFactory::TModelPtr model(factory.makeModel(gatherer));
+        BOOST_TEST_REQUIRE(model);
+
+        std::size_t anomalousBucket{20u};
+        std::size_t numberBuckets{30u};
+
+        const core_t::TTime endTime = startTime + (numberBuckets * bucketLength);
+
+        std::size_t i{0u};
+        for (core_t::TTime bucketStartTime = startTime;
+             bucketStartTime < endTime; bucketStartTime += bucketLength, i++) {
+            core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
+
+            for (std::size_t j = 0; j < fields[i].size(); ++j) {
+                CDataGatherer::TStrCPtrVec f{&strings[fields[i][j][0]],
+                                             &strings[fields[i][j][1]],
+                                             &strings[fields[i][j][2]]};
+                handleEvent(f, bucketStartTime + j, gatherer, resourceMonitor);
+            }
+
+            model->sample(bucketStartTime, bucketEndTime, resourceMonitor);
+
+            SAnnotatedProbability annotatedProbability;
+            CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+            model->computeProbability(0 /*pid*/, bucketStartTime, bucketEndTime,
+                                      partitioningFields, 1, annotatedProbability);
+            LOG_DEBUG(<< "probability = " << annotatedProbability.s_Probability);
+            if (i == anomalousBucket) {
+                BOOST_TEST_REQUIRE(annotatedProbability.s_Probability < 0.001);
+            } else {
+                BOOST_TEST_REQUIRE(annotatedProbability.s_Probability > 0.6);
+            }
+        }
+    }
+
     void makeModel(const SModelParams& params,
                    const model_t::TFeatureVec& features,
                    core_t::TTime startTime,
@@ -289,9 +215,9 @@ public:
         BOOST_REQUIRE_EQUAL(model_t::E_EventRateOnline, model->category());
         BOOST_REQUIRE_EQUAL(params.s_BucketLength, model->bucketLength());
         for (std::size_t i = 0u; i < numberPeople; ++i) {
-            BOOST_REQUIRE_EQUAL(std::size_t(i),
-                                addPerson("p" + core::CStringUtils::typeToString(i + 1),
-                                          gatherer, m_ResourceMonitor));
+            BOOST_REQUIRE_EQUAL(
+                std::size_t(i),
+                this->addPerson("p" + core::CStringUtils::typeToString(i + 1), gatherer));
         }
     }
 
@@ -340,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
 
         double count{0.0};
         for (/**/; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
+            this->addArrival(*m_Gatherer, eventTimes[i], "p1");
             count += 1.0;
         }
 
@@ -435,7 +361,7 @@ BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
 
         double count{0.0};
         for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
+            this->addArrival(*m_Gatherer, eventTimes[i], "p1");
             count += 1.0;
         }
 
@@ -485,23 +411,23 @@ BOOST_FIXTURE_TEST_CASE(testRare, CTestFixture) {
 
     core_t::TTime time{startTime};
     for (/**/; time < startTime + 10 * bucketLength; time += bucketLength) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
-        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
+        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p1");
+        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p2");
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
     for (/**/; time < startTime + 50 * bucketLength; time += bucketLength) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
-        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
-        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3");
-        addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4");
+        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p1");
+        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p2");
+        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p3");
+        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p4");
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
 
-    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1");
-    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2");
-    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3");
-    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4");
-    addArrival(*m_Gatherer, m_ResourceMonitor, time + bucketLength / 2, "p5");
+    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p1");
+    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p2");
+    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p3");
+    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p4");
+    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p5");
     model->sample(time, time + bucketLength, m_ResourceMonitor);
 
     TDoubleVec probabilities;
@@ -597,7 +523,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculation, CTestFixture) {
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                addArrival(*m_Gatherer, m_ResourceMonitor, eventTimes[i], "p1");
+                this->addArrival(*m_Gatherer, eventTimes[i], "p1");
                 count += 1.0;
             }
 
@@ -654,8 +580,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowNonZeroCount, CTestFixtu
         LOG_DEBUG(<< "Writing " << count << " values");
 
         for (std::size_t i = 0u; i < count; ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(i), "p1");
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(i), "p1");
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -699,8 +624,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighNonZeroCount, CTestFixt
         LOG_DEBUG(<< "Writing " << count << " values");
 
         for (std::size_t i = 0u; i < count; ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor,
-                       time + static_cast<core_t::TTime>(i), "p1");
+            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(i), "p1");
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -773,8 +697,8 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
                     n += anomalies[anomaly][j];
                 }
                 for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                    addArrival(*m_Gatherer, m_ResourceMonitor,
-                               time + static_cast<core_t::TTime>(j), person);
+                    this->addArrival(*m_Gatherer,
+                                     time + static_cast<core_t::TTime>(j), person);
                 }
             }
             if (i == anomalyBuckets[anomaly]) {
@@ -870,8 +794,8 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
                 }
                 n = std::max(n, 0.0);
                 for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                    addArrival(*m_Gatherer, m_ResourceMonitor,
-                               time + static_cast<core_t::TTime>(j), person);
+                    this->addArrival(*m_Gatherer,
+                                     time + static_cast<core_t::TTime>(j), person);
                 }
             }
             if (i == anomalyBuckets[anomaly]) {
@@ -982,8 +906,7 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
             }
             n = std::max(n / 3.0, 0.0);
             for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                addArrival(*m_Gatherer, m_ResourceMonitor,
-                           time + static_cast<core_t::TTime>(j), person);
+                this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j), person);
             }
         }
         if (i == anomalyBuckets[anomaly]) {
@@ -1079,7 +1002,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
         generateEvents(startTime, bucketLength, eventCounts[i], eventTimes);
         if (eventTimes.size() > 0) {
             std::sort(eventTimes.begin(), eventTimes.end());
-            std::size_t pid = addPerson(people[i], gatherer, m_ResourceMonitor);
+            std::size_t pid = this->addPerson(people[i], gatherer);
             for (auto time : eventTimes) {
                 events.push_back(makeEventData(time, pid));
             }
@@ -1093,7 +1016,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
     expectedEvents.reserve(events.size());
     TSizeSizeMap mapping;
     for (auto person : expectedPeople) {
-        mapping[person] = addPerson(people[person], expectedGatherer, m_ResourceMonitor);
+        mapping[person] = this->addPerson(people[person], expectedGatherer);
     }
     for (const auto& event : events) {
         if (std::binary_search(expectedPeople.begin(), expectedPeople.end(),
@@ -1103,7 +1026,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
         }
     }
     for (auto person : expectedPeople) {
-        addPerson(people[person], expectedGatherer, m_ResourceMonitor);
+        this->addPerson(people[person], expectedGatherer);
     }
 
     core_t::TTime bucketStart = startTime;
@@ -1112,8 +1035,8 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(*gatherer, m_ResourceMonitor, event.time(),
-                   gatherer->personName(event.personId().get()));
+        this->addArrival(*gatherer, event.time(),
+                         gatherer->personName(event.personId().get()));
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     size_t maxDimensionBeforePrune(model->dataGatherer().maxDimension());
@@ -1127,8 +1050,8 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(*expectedGatherer, m_ResourceMonitor, event.time(),
-                   expectedGatherer->personName(event.personId().get()));
+        this->addArrival(*expectedGatherer, event.time(),
+                         expectedGatherer->personName(event.personId().get()));
     }
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
 
@@ -1141,18 +1064,16 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
     bucketStart = gatherer->currentBucketStartTime() + bucketLength;
     TStrVec newPeople{"p7", "p8", "p9"};
     for (const auto& person : newPeople) {
-        std::size_t newPid = addPerson(person, gatherer, m_ResourceMonitor);
+        std::size_t newPid = this->addPerson(person, gatherer);
         BOOST_TEST_REQUIRE(newPid < 6);
-        std::size_t expectedNewPid = addPerson(person, expectedGatherer, m_ResourceMonitor);
+        std::size_t expectedNewPid = this->addPerson(person, expectedGatherer);
 
-        addArrival(*gatherer, m_ResourceMonitor, bucketStart + 1,
-                   gatherer->personName(newPid));
-        addArrival(*gatherer, m_ResourceMonitor, bucketStart + 2000,
-                   gatherer->personName(newPid));
-        addArrival(*expectedGatherer, m_ResourceMonitor, bucketStart + 1,
-                   expectedGatherer->personName(expectedNewPid));
-        addArrival(*expectedGatherer, m_ResourceMonitor, bucketStart + 2000,
-                   expectedGatherer->personName(expectedNewPid));
+        this->addArrival(*gatherer, bucketStart + 1, gatherer->personName(newPid));
+        this->addArrival(*gatherer, bucketStart + 2000, gatherer->personName(newPid));
+        this->addArrival(*expectedGatherer, bucketStart + 1,
+                         expectedGatherer->personName(expectedNewPid));
+        this->addArrival(*expectedGatherer, bucketStart + 2000,
+                         expectedGatherer->personName(expectedNewPid));
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -1178,30 +1099,14 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
                                             function_t::E_IndividualRare,
                                             function_t::E_IndividualLowCounts,
                                             function_t::E_IndividualHighCounts};
-    TBoolVec useNull{true, false};
-    TStrVec byFields{"", "by"};
-    TStrVec partitionFields{"", "partition"};
 
-    CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
+    std::string fieldName;
+    std::string overFieldName;
 
-    int detectorIndex{0};
-    for (const auto& countFunction : countFunctions) {
-        for (bool usingNull : useNull) {
-            for (const auto& byField : byFields) {
-                for (const auto& partitionField : partitionFields) {
-                    CSearchKey key(++detectorIndex, countFunction, usingNull,
-                                   model_t::E_XF_None, "", byField, "", partitionField);
-
-                    CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
-                        config.factory(key);
-
-                    LOG_DEBUG(<< "expected key = " << key);
-                    LOG_DEBUG(<< "actual key   = " << factory->searchKey());
-                    BOOST_TEST_REQUIRE(key == factory->searchKey());
-                }
-            }
-        }
-    }
+    generateAndCompareKey(countFunctions, fieldName, overFieldName,
+                          [](CSearchKey expectedKey, CSearchKey actualKey) {
+                              BOOST_TEST_REQUIRE(expectedKey == actualKey);
+                          });
 }
 
 BOOST_FIXTURE_TEST_CASE(testModelsWithValueFields, CTestFixture) {
@@ -1340,8 +1245,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1364,8 +1268,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
 
             double count = 0.0;
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
-                           TOptionalStr("inf1"));
+                this->addArrival(*gatherer, eventTimes[i], "p", TOptionalStr("inf1"));
                 count += 1.0;
             }
 
@@ -1398,8 +1301,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1425,7 +1327,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                 std::stringstream ss;
                 ss << "inf" << (i % 2);
                 const std::string inf(ss.str());
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p", inf);
+                this->addArrival(*gatherer, eventTimes[i], "p", inf);
                 count += 1.0;
             }
 
@@ -1462,8 +1364,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1489,7 +1390,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                 std::stringstream ss;
                 ss << "inf" << (i % 2);
                 const std::string inf(ss.str());
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p", inf);
+                this->addArrival(*gatherer, eventTimes[i], "p", inf);
                 count += 1.0;
             }
 
@@ -1527,8 +1428,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1557,7 +1457,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                     ss << "_extra";
                 }
                 const std::string inf(ss.str());
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p", inf);
+                this->addArrival(*gatherer, eventTimes[i], "p", inf);
                 count += 1.0;
             }
 
@@ -1591,8 +1491,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 2));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 2));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1623,7 +1522,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                 const std::string inf1(ss.str());
                 ss << "_another";
                 const std::string inf2(ss.str());
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p", inf1, inf2);
+                this->addArrival(*gatherer, eventTimes[i], "p", inf1, inf2);
 
                 count += 1.0;
             }
@@ -1665,8 +1564,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", byFieldName, "", {byFieldName});
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor, 1));
+        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1688,8 +1586,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
-                           TOptionalStr("p"));
+                this->addArrival(*gatherer, eventTimes[i], "p", TOptionalStr("p"));
                 count += 1.0;
             }
 
@@ -1728,8 +1625,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
-                                                   1, TOptionalStr("v")));
+                            this->addPerson("p", gatherer, 1, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1752,8 +1648,8 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
-                           TOptionalStr("inf1"), TOptionalStr(uniqueValue));
+                this->addArrival(*gatherer, eventTimes[i], "p",
+                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1762,8 +1658,8 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                 for (std::size_t k = 0; k < 20; k++) {
                     std::stringstream ss;
                     ss << uniqueValue << "_" << k;
-                    addArrival(*gatherer, m_ResourceMonitor, eventTimes[i - 1],
-                               "p", TOptionalStr("inf1"), TOptionalStr(ss.str()));
+                    this->addArrival(*gatherer, eventTimes[i - 1], "p",
+                                     TOptionalStr("inf1"), TOptionalStr(ss.str()));
                 }
             }
 
@@ -1797,8 +1693,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
-                                                   1, TOptionalStr("v")));
+                            this->addPerson("p", gatherer, 1, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1821,8 +1716,8 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
-                           TOptionalStr("inf1"), TOptionalStr(uniqueValue));
+                this->addArrival(*gatherer, eventTimes[i], "p",
+                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1831,13 +1726,13 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                 for (std::size_t k = 1; k < 20; k++) {
                     std::stringstream ss;
                     ss << uniqueValue << "_" << k;
-                    CEventData d = makeEventData(eventTimes[i - 1], 0, ss.str());
+                    CEventData d = makeEventData(eventTimes[i - 1], 0, {}, ss.str());
                     if (k % 2 == 0) {
-                        addArrival(*gatherer, m_ResourceMonitor, eventTimes[i - 1], "p",
-                                   TOptionalStr("inf1"), TOptionalStr(ss.str()));
+                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
+                                         TOptionalStr("inf1"), TOptionalStr(ss.str()));
                     } else {
-                        addArrival(*gatherer, m_ResourceMonitor, eventTimes[i - 1], "p",
-                                   TOptionalStr("inf2"), TOptionalStr(ss.str()));
+                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
+                                         TOptionalStr("inf2"), TOptionalStr(ss.str()));
                     }
                 }
             }
@@ -1876,8 +1771,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
-                                                   1, TOptionalStr("v")));
+                            this->addPerson("p", gatherer, 1, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1900,8 +1794,8 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
-                           TOptionalStr("inf1"), TOptionalStr(uniqueValue));
+                this->addArrival(*gatherer, eventTimes[i], "p",
+                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1911,11 +1805,11 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                     std::stringstream ss;
                     ss << uniqueValue << "_" << k;
                     if (k == 1) {
-                        addArrival(*gatherer, m_ResourceMonitor, eventTimes[i - 1], "p",
-                                   TOptionalStr("inf2"), TOptionalStr(ss.str()));
+                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
+                                         TOptionalStr("inf2"), TOptionalStr(ss.str()));
                     } else {
-                        addArrival(*gatherer, m_ResourceMonitor, eventTimes[i - 1], "p",
-                                   TOptionalStr("inf1"), TOptionalStr(ss.str()));
+                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
+                                         TOptionalStr("inf1"), TOptionalStr(ss.str()));
                     }
                 }
             }
@@ -1951,8 +1845,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
         BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            addPersonWithInfluence("p", gatherer, m_ResourceMonitor,
-                                                   2, TOptionalStr("v")));
+                            this->addPerson("p", gatherer, 2, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1975,9 +1868,8 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, eventTimes[i], "p",
-                           TOptionalStr("inf1"), TOptionalStr("inf1"),
-                           TOptionalStr(uniqueValue));
+                this->addArrival(*gatherer, eventTimes[i], "p", TOptionalStr("inf1"),
+                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1997,9 +1889,9 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                     LOG_DEBUG(<< "Inf1 = " << inf1);
                     LOG_DEBUG(<< "Inf2 = " << inf2);
                     LOG_DEBUG(<< "Value = " << ss1.str());
-                    addArrival(*gatherer, m_ResourceMonitor, eventTimes[i - 1],
-                               "p", TOptionalStr(inf1), TOptionalStr(inf2),
-                               TOptionalStr(ss1.str()));
+                    this->addArrival(*gatherer, eventTimes[i - 1], "p",
+                                     TOptionalStr(inf1), TOptionalStr(inf2),
+                                     TOptionalStr(ss1.str()));
                 }
             }
 
@@ -2042,16 +1934,11 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
     factory.fieldNames("", "", "", "", influenceFieldNames);
     factory.features(function_t::features(function_t::E_IndividualRare));
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0),
-                        addPersonWithInfluence("p1", gatherer, m_ResourceMonitor, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(1),
-                        addPersonWithInfluence("p2", gatherer, m_ResourceMonitor, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(2),
-                        addPersonWithInfluence("p3", gatherer, m_ResourceMonitor, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(3),
-                        addPersonWithInfluence("p4", gatherer, m_ResourceMonitor, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(4),
-                        addPersonWithInfluence("p5", gatherer, m_ResourceMonitor, 1));
+    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p1", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(std::size_t(1), this->addPerson("p2", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(std::size_t(2), this->addPerson("p3", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(std::size_t(3), this->addPerson("p4", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(std::size_t(4), this->addPerson("p5", gatherer, 1));
     CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
     CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
     BOOST_TEST_REQUIRE(model);
@@ -2061,28 +1948,19 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
     core_t::TTime time{startTime};
 
     for (/**/; time < startTime + 50 * bucketLength; time += bucketLength) {
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1",
-                   TOptionalStr("inf1"));
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2",
-                   TOptionalStr("inf1"));
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3",
-                   TOptionalStr("inf1"));
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4",
-                   TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p1", TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p2", TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p3", TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p4", TOptionalStr("inf1"));
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
 
     {
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p1",
-                   TOptionalStr("inf1"));
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p2",
-                   TOptionalStr("inf1"));
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p3",
-                   TOptionalStr("inf1"));
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p4",
-                   TOptionalStr("inf1"));
-        addArrival(*gatherer, m_ResourceMonitor, time + bucketLength / 2, "p5",
-                   TOptionalStr("inf2"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p1", TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p2", TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p3", TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p4", TOptionalStr("inf1"));
+        this->addArrival(*gatherer, time + bucketLength / 2, "p5", TOptionalStr("inf2"));
     }
     model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -2153,12 +2031,12 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
     // p1: |1|1|1|
     // p2: |1|0|0|
-    addArrival(*gathererNoGap, m_ResourceMonitor, 100, "p1");
-    addArrival(*gathererNoGap, m_ResourceMonitor, 100, "p2");
+    this->addArrival(*gathererNoGap, 100, "p1");
+    this->addArrival(*gathererNoGap, 100, "p2");
     modelNoGap->sample(100, 200, m_ResourceMonitor);
-    addArrival(*gathererNoGap, m_ResourceMonitor, 200, "p1");
+    this->addArrival(*gathererNoGap, 200, "p1");
     modelNoGap->sample(200, 300, m_ResourceMonitor);
-    addArrival(*gathererNoGap, m_ResourceMonitor, 300, "p1");
+    this->addArrival(*gathererNoGap, 300, "p1");
     modelNoGap->sample(300, 400, m_ResourceMonitor);
 
     CModelFactory::TDataGathererPtr gathererWithGap;
@@ -2172,11 +2050,11 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     // p2: |1|X|X|X|X|X|X|X|X|X|0|0| -> equal to |1|0|0|
     // where X means skipped bucket
 
-    addArrival(*gathererWithGap, m_ResourceMonitor, 100, "p1");
-    addArrival(*gathererWithGap, m_ResourceMonitor, 100, "p2");
+    this->addArrival(*gathererWithGap, 100, "p1");
+    this->addArrival(*gathererWithGap, 100, "p2");
     modelWithGap->sample(100, 200, m_ResourceMonitor);
-    addArrival(*gathererWithGap, m_ResourceMonitor, 200, "p1");
-    addArrival(*gathererWithGap, m_ResourceMonitor, 200, "p2");
+    this->addArrival(*gathererWithGap, 200, "p1");
+    this->addArrival(*gathererWithGap, 200, "p2");
     modelWithGap->skipSampling(1000);
     LOG_DEBUG(<< "Calling sample over skipped interval should do nothing except print some ERRORs");
     modelWithGap->sample(200, 1000, m_ResourceMonitor);
@@ -2185,9 +2063,9 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     modelWithGap->prune(maxAgeBuckets);
     BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActivePeople());
 
-    addArrival(*gathererWithGap, m_ResourceMonitor, 1000, "p1");
+    this->addArrival(*gathererWithGap, 1000, "p1");
     modelWithGap->sample(1000, 1100, m_ResourceMonitor);
-    addArrival(*gathererWithGap, m_ResourceMonitor, 1100, "p1");
+    this->addArrival(*gathererWithGap, 1100, "p1");
     modelWithGap->sample(1100, 1200, m_ResourceMonitor);
 
     // Check priors are the same
@@ -2239,22 +2117,22 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |1|1|1|X|X|1|
     // p2: |1|1|0|X|X|0|
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 100, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 100, "p2", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 100, "p1", TOptionalStr(),
+                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 100, "p2", TOptionalStr(),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap->sample(100, 200, m_ResourceMonitor);
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 200, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 200, "p2", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 200, "p1", TOptionalStr(),
+                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 200, "p2", TOptionalStr(),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap->sample(200, 300, m_ResourceMonitor);
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 300, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 300, "p1", TOptionalStr(),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap->sample(300, 400, m_ResourceMonitor);
     modelSkipGap->skipSampling(600);
-    addArrival(*gathererSkipGap, m_ResourceMonitor, 600, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererSkipGap, 600, "p1", TOptionalStr(),
+                     TOptionalStr(), TOptionalStr("1"));
     modelSkipGap->sample(600, 700, m_ResourceMonitor);
 
     CModelFactory::TDataGathererPtr gathererExNull;
@@ -2266,37 +2144,37 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |1,"",null|1|1|null|null|1|
     // p2: |1,""|1|0|null|null|0|
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr(""));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("null"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p2", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 100, "p2", TOptionalStr(),
-               TOptionalStr(), TOptionalStr(""));
+    this->addArrival(*gathererExNull, 100, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 100, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr(""));
+    this->addArrival(*gathererExNull, 100, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 100, "p2", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 100, "p2", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr(""));
     modelExNullGap->sample(100, 200, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 200, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 200, "p2", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 200, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 200, "p2", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("1"));
     modelExNullGap->sample(200, 300, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 300, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 300, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("1"));
     modelExNullGap->sample(300, 400, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 400, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("null"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 400, "p2", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 400, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 400, "p2", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("null"));
     modelExNullGap->sample(400, 500, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 500, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("null"));
-    addArrival(*gathererExNull, m_ResourceMonitor, 500, "p2", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 500, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("null"));
+    this->addArrival(*gathererExNull, 500, "p2", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("null"));
     modelExNullGap->sample(500, 600, m_ResourceMonitor);
-    addArrival(*gathererExNull, m_ResourceMonitor, 600, "p1", TOptionalStr(),
-               TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(*gathererExNull, 600, "p1", TOptionalStr(), TOptionalStr(),
+                     TOptionalStr("1"));
     modelExNullGap->sample(600, 700, m_ResourceMonitor);
 
     // Check priors are the same
@@ -2335,26 +2213,26 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
+            this->addArrival(*m_Gatherer, now, "p1");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[1] + 0.5); ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
+            this->addArrival(*m_Gatherer, now, "p2");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[2] + 0.5); ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
+            this->addArrival(*m_Gatherer, now, "p3");
         }
         countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
+        this->addArrival(*m_Gatherer, now, "p1");
     }
     for (std::size_t i = 0; i < 1; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
+        this->addArrival(*m_Gatherer, now, "p2");
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
+        this->addArrival(*m_Gatherer, now, "p3");
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -2401,13 +2279,13 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     BOOST_TEST_REQUIRE(p3Baseline[0] < 62.0);
 
     for (std::size_t i = 0; i < 25; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
+        this->addArrival(*m_Gatherer, now, "p1");
     }
     for (std::size_t i = 0; i < 59; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
+        this->addArrival(*m_Gatherer, now, "p2");
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
+        this->addArrival(*m_Gatherer, now, "p3");
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -2460,25 +2338,25 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(80.0, 100.0, std::size_t(1), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
+            this->addArrival(*m_Gatherer, now, "p1");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 10.5); ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
+            this->addArrival(*m_Gatherer, now, "p2");
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] - 9.5); ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
+            this->addArrival(*m_Gatherer, now, "p3");
         }
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 9; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
+        this->addArrival(*m_Gatherer, now, "p1");
     }
     for (std::size_t i = 0; i < 10; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p2");
+        this->addArrival(*m_Gatherer, now, "p2");
     }
     for (std::size_t i = 0; i < 8; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p3");
+        this->addArrival(*m_Gatherer, now, "p3");
     }
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
@@ -2560,13 +2438,13 @@ BOOST_FIXTURE_TEST_CASE(testSummaryCountZeroRecordsAreIgnored, CTestFixture) {
         rng.generateUniformSamples(0.0, 1.0, 1, zeroCountProbability);
         for (std::size_t i = 0; i < samples[0]; ++i) {
             if (zeroCountProbability[0] < 0.2) {
-                addArrival(*gathererWithZeros, m_ResourceMonitor, now, "p1",
-                           TOptionalStr(), TOptionalStr(), TOptionalStr(summaryCountZero));
+                this->addArrival(*gathererWithZeros, now, "p1", TOptionalStr(),
+                                 TOptionalStr(), TOptionalStr(summaryCountZero));
             } else {
-                addArrival(*gathererWithZeros, m_ResourceMonitor, now, "p1",
-                           TOptionalStr(), TOptionalStr(), TOptionalStr(summaryCountOne));
-                addArrival(*gathererNoZeros, m_ResourceMonitor, now, "p1",
-                           TOptionalStr(), TOptionalStr(), TOptionalStr(summaryCountOne));
+                this->addArrival(*gathererWithZeros, now, "p1", TOptionalStr(),
+                                 TOptionalStr(), TOptionalStr(summaryCountOne));
+                this->addArrival(*gathererNoZeros, now, "p1", TOptionalStr(),
+                                 TOptionalStr(), TOptionalStr(summaryCountOne));
             }
         }
         modelWithZeros.sample(now, now + bucketLength, m_ResourceMonitor);
@@ -2601,13 +2479,13 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbabilityGivenDetectionRule, CTestFixture) 
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, std::size_t(1), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
+            this->addArrival(*m_Gatherer, now, "p1");
         }
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        addArrival(*m_Gatherer, m_ResourceMonitor, now, "p1");
+        this->addArrival(*m_Gatherer, now, "p1");
     }
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
@@ -2645,7 +2523,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         factory.features(features);
         CModelFactory::TDataGathererPtr gatherer{factory.makeDataGatherer(startTime)};
         CModelFactory::TModelPtr model{factory.makeModel(gatherer)};
-        addPerson("p1", gatherer, m_ResourceMonitor);
+        this->addPerson("p1", gatherer);
 
         params.s_ControlDecayRate = false;
         params.s_DecayRate = 0.0001;
@@ -2654,7 +2532,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         CModelFactory::TDataGathererPtr referenceGatherer{
             referenceFactory.makeDataGatherer(startTime)};
         CModelFactory::TModelPtr referenceModel{referenceFactory.makeModel(referenceGatherer)};
-        addPerson("p1", referenceGatherer, m_ResourceMonitor);
+        this->addPerson("p1", referenceGatherer);
 
         TMeanAccumulator meanPredictionError;
         TMeanAccumulator meanReferencePredictionError;
@@ -2672,9 +2550,8 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                                    ? 1.0
                                    : 0.0);
             for (std::size_t i = 0u; i < static_cast<std::size_t>(rate[0]); ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, t + bucketLength / 2, "p1");
-                addArrival(*referenceGatherer, m_ResourceMonitor,
-                           t + bucketLength / 2, "p1");
+                this->addArrival(*gatherer, t + bucketLength / 2, "p1");
+                this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1");
             }
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
@@ -2708,7 +2585,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         factory.features(features);
         CModelFactory::TDataGathererPtr gatherer{factory.makeDataGatherer(startTime)};
         CModelFactory::TModelPtr model{factory.makeModel(gatherer)};
-        addPerson("p1", gatherer, m_ResourceMonitor);
+        this->addPerson("p1", gatherer);
 
         params.s_ControlDecayRate = false;
         params.s_DecayRate = 0.001;
@@ -2716,7 +2593,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         referenceFactory.features(features);
         CModelFactory::TDataGathererPtr referenceGatherer{factory.makeDataGatherer(startTime)};
         CModelFactory::TModelPtr referenceModel{factory.makeModel(gatherer)};
-        addPerson("p1", referenceGatherer, m_ResourceMonitor);
+        this->addPerson("p1", referenceGatherer);
 
         TMeanAccumulator meanPredictionError;
         TMeanAccumulator meanReferencePredictionError;
@@ -2735,9 +2612,8 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
             for (std::size_t i = 0u; i < static_cast<std::size_t>(rate + noise[0]); ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, t + bucketLength / 2, "p1");
-                addArrival(*referenceGatherer, m_ResourceMonitor,
-                           t + bucketLength / 2, "p1");
+                this->addArrival(*gatherer, t + bucketLength / 2, "p1");
+                this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1");
             }
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
@@ -2773,7 +2649,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         factory.features(features);
         CModelFactory::TDataGathererPtr gatherer{factory.makeDataGatherer(startTime)};
         CModelFactory::TModelPtr model{factory.makeModel(gatherer)};
-        addPerson("p1", gatherer, m_ResourceMonitor);
+        this->addPerson("p1", gatherer);
 
         params.s_ControlDecayRate = false;
         params.s_DecayRate = 0.001;
@@ -2782,7 +2658,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         CModelFactory::TDataGathererPtr referenceGatherer{
             referenceFactory.makeDataGatherer(startTime)};
         CModelFactory::TModelPtr referenceModel{referenceFactory.makeModel(gatherer)};
-        addPerson("p1", referenceGatherer, m_ResourceMonitor);
+        this->addPerson("p1", referenceGatherer);
 
         TMeanAccumulator meanPredictionError;
         TMeanAccumulator meanReferencePredictionError;
@@ -2803,9 +2679,8 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
             for (std::size_t i = 0u; i < static_cast<std::size_t>(rate + noise[0]); ++i) {
-                addArrival(*gatherer, m_ResourceMonitor, t + bucketLength / 2, "p1");
-                addArrival(*referenceGatherer, m_ResourceMonitor,
-                           t + bucketLength / 2, "p1");
+                this->addArrival(*gatherer, t + bucketLength / 2, "p1");
+                this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1");
             }
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
@@ -2854,7 +2729,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     CModelFactory::TDataGathererPtr gathererNoSkip{factory.makeDataGatherer(startTime)};
     CModelFactory::TModelPtr modelPtrNoSkip{factory.makeModel(gathererNoSkip)};
     CEventRateModel* modelNoSkip = dynamic_cast<CEventRateModel*>(modelPtrNoSkip.get());
-    addPerson("p1", gathererNoSkip, m_ResourceMonitor);
+    this->addPerson("p1", gathererNoSkip);
 
     // Model with the skip sampling rule
     SModelParams paramsWithRules(bucketLength);
@@ -2867,14 +2742,14 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     CModelFactory::TModelPtr modelPtrWithSkip{factoryWithSkip.makeModel(gathererWithSkip)};
     CEventRateModel* modelWithSkip =
         dynamic_cast<CEventRateModel*>(modelPtrWithSkip.get());
-    addPerson("p1", gathererWithSkip, m_ResourceMonitor);
+    this->addPerson("p1", gathererWithSkip);
 
     std::size_t endTime = startTime + bucketLength;
 
     // Add a bucket to both models
     for (int i = 0; i < 66; ++i) {
-        addArrival(*gathererNoSkip, m_ResourceMonitor, startTime, "p1");
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime, "p1");
+        this->addArrival(*gathererNoSkip, startTime, "p1");
+        this->addArrival(*gathererWithSkip, startTime, "p1");
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2884,8 +2759,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Add a bucket to both models
     for (int i = 0; i < 55; ++i) {
-        addArrival(*gathererNoSkip, m_ResourceMonitor, startTime, "p1");
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime, "p1");
+        this->addArrival(*gathererNoSkip, startTime, "p1");
+        this->addArrival(*gathererWithSkip, startTime, "p1");
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2895,7 +2770,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // this sample will be skipped by the detection rule
     for (int i = 0; i < 110; ++i) {
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime, "p1");
+        this->addArrival(*gathererWithSkip, startTime, "p1");
     }
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
 
@@ -2906,8 +2781,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     modelNoSkip->skipSampling(startTime);
 
     for (int i = 0; i < 55; ++i) {
-        addArrival(*gathererNoSkip, m_ResourceMonitor, startTime, "p1");
-        addArrival(*gathererWithSkip, m_ResourceMonitor, startTime, "p1");
+        this->addArrival(*gathererNoSkip, startTime, "p1");
+        this->addArrival(*gathererWithSkip, startTime, "p1");
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -54,141 +54,94 @@ using namespace ml;
 using namespace model;
 
 namespace {
+const CModelTestFixtureBase::TSizeDoublePr1Vec NO_CORRELATES;
+}
 
-const std::string EMPTY_STRING;
+class CTestFixture : public CModelTestFixtureBase {
+public:
+    void generateTestMessages(core_t::TTime startTime,
+                              core_t::TTime bucketLength,
+                              TMessageVec& messages) {
+        // The test case is as follows:
+        //
+        //   attribute   |    0    |    1    |    2    |    3    |   4
+        // --------------+---------+---------+---------+---------+--------
+        //    people     |  [0-19] |  [0-2], |  [0,2], |   3,4   |   3
+        //               |         |  [5-19] |  [4,19] |         |
+        // --------------+---------+---------+---------+---------+--------
+        //    rate       |   10    |   0.02  |   15    |    2    |   1
+        // --------------+---------+---------+---------+---------+--------
+        //  rate anomaly |   1,11  |    -    |   4,5   |   n/a   |  n/a
+        //     people    |         |         |         |         |
+        //
+        // There are 100 buckets.
 
-struct SMessage {
-    SMessage(core_t::TTime time, const std::string& person, const std::string& attribute)
-        : s_Time(time), s_Person(person), s_Attribute(attribute) {}
+        using TStrVec = std::vector<std::string>;
+        using TSizeSizeSizeTr = boost::tuple<std::size_t, std::size_t, size_t>;
 
-    bool operator<(const SMessage& other) const {
-        return maths::COrderings::lexicographical_compare(
-            s_Time, s_Person, s_Attribute, other.s_Time, other.s_Person, other.s_Attribute);
-    }
+        const std::size_t numberBuckets = 100u;
+        const std::size_t numberAttributes = 5u;
+        const std::size_t numberPeople = 20u;
 
-    core_t::TTime s_Time;
-    std::string s_Person;
-    std::string s_Attribute;
-};
-
-struct SAnomaly {
-    SAnomaly() : s_Bucket(0u), s_Person(), s_Attributes() {}
-    SAnomaly(std::size_t bucket, const std::string& person, const TDoubleStrPrVec& attributes)
-        : s_Bucket(bucket), s_Person(person), s_Attributes(attributes) {}
-
-    std::size_t s_Bucket;
-    std::string s_Person;
-    TDoubleStrPrVec s_Attributes;
-
-    bool operator<(const SAnomaly& other) const {
-        return s_Bucket < other.s_Bucket;
-    }
-
-    std::string print() const {
-        std::ostringstream result;
-        result << "[" << s_Bucket << ", " + s_Person << ",";
-        for (std::size_t i = 0u; i < s_Attributes.size(); ++i) {
-            if (s_Attributes[i].first < 0.01) {
-                result << " " << s_Attributes[i].second;
-            }
+        TStrVec attributes;
+        for (std::size_t i = 0u; i < numberAttributes; ++i) {
+            attributes.push_back("c" + boost::lexical_cast<std::string>(i));
         }
-        result << "]";
-        return result.str();
-    }
-};
 
-using TMessageVec = std::vector<SMessage>;
+        TStrVec people;
+        for (std::size_t i = 0u; i < numberPeople; ++i) {
+            people.push_back("p" + boost::lexical_cast<std::string>(i));
+        }
 
-void generateTestMessages(core_t::TTime startTime, core_t::TTime bucketLength, TMessageVec& messages) {
-    // The test case is as follows:
-    //
-    //   attribute   |    0    |    1    |    2    |    3    |   4
-    // --------------+---------+---------+---------+---------+--------
-    //    people     |  [0-19] |  [0-2], |  [0,2], |   3,4   |   3
-    //               |         |  [5-19] |  [4,19] |         |
-    // --------------+---------+---------+---------+---------+--------
-    //    rate       |   10    |   0.02  |   15    |    2    |   1
-    // --------------+---------+---------+---------+---------+--------
-    //  rate anomaly |   1,11  |    -    |   4,5   |   n/a   |  n/a
-    //     people    |         |         |         |         |
-    //
-    // There are 100 buckets.
+        TSizeVecVec attributePeople{
+            {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+             10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+            {0, 1, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+            {0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+            {3, 4},
+            {3}};
 
-    using TStrVec = std::vector<std::string>;
-    using TSizeSizeSizeTr = boost::tuple<std::size_t, std::size_t, size_t>;
+        double attributeRates[] = {10.0, 0.02, 15.0, 2.0, 1.0};
 
-    const std::size_t numberBuckets = 100u;
-    const std::size_t numberAttributes = 5u;
-    const std::size_t numberPeople = 20u;
+        TSizeSizeSizeTr anomaliesAttributePerson[] = {
+            {10u, 0u, 1u}, {15u, 0u, 11u}, {30u, 2u, 4u},
+            {35u, 2u, 5u}, {50u, 0u, 11u}, {75u, 2u, 5u}};
 
-    TStrVec attributes;
-    for (std::size_t i = 0u; i < numberAttributes; ++i) {
-        attributes.push_back("c" + boost::lexical_cast<std::string>(i));
-    }
+        test::CRandomNumbers rng;
 
-    TStrVec people;
-    for (std::size_t i = 0u; i < numberPeople; ++i) {
-        people.push_back("p" + boost::lexical_cast<std::string>(i));
-    }
+        for (std::size_t i = 0u; i < numberBuckets; ++i, startTime += bucketLength) {
+            for (std::size_t j = 0u; j < numberAttributes; ++j) {
+                TUIntVec samples;
+                rng.generatePoissonSamples(attributeRates[j],
+                                           attributePeople[j].size(), samples);
 
-    TSizeVecVec attributePeople{
-        {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
-        {0, 1, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
-        {0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
-        {3, 4},
-        {3}};
+                for (std::size_t k = 0u; k < samples.size(); ++k) {
+                    unsigned int n = samples[k];
+                    if (std::binary_search(std::begin(anomaliesAttributePerson),
+                                           std::end(anomaliesAttributePerson),
+                                           TSizeSizeSizeTr(i, j, attributePeople[j][k]))) {
+                        n += static_cast<unsigned int>(2.5 * attributeRates[j]);
+                        LOG_DEBUG(<< i << " " << attributes[j]
+                                  << " generating anomaly " << n);
+                    }
 
-    double attributeRates[] = {10.0, 0.02, 15.0, 2.0, 1.0};
+                    TDoubleVec times;
+                    rng.generateUniformSamples(
+                        0.0, static_cast<double>(bucketLength - 1), n, times);
 
-    TSizeSizeSizeTr anomaliesAttributePerson[] = {
-        {10u, 0u, 1u}, {15u, 0u, 11u}, {30u, 2u, 4u},
-        {35u, 2u, 5u}, {50u, 0u, 11u}, {75u, 2u, 5u}};
-
-    test::CRandomNumbers rng;
-
-    for (std::size_t i = 0u; i < numberBuckets; ++i, startTime += bucketLength) {
-        for (std::size_t j = 0u; j < numberAttributes; ++j) {
-            TUIntVec samples;
-            rng.generatePoissonSamples(attributeRates[j], attributePeople[j].size(), samples);
-
-            for (std::size_t k = 0u; k < samples.size(); ++k) {
-                unsigned int n = samples[k];
-                if (std::binary_search(std::begin(anomaliesAttributePerson),
-                                       std::end(anomaliesAttributePerson),
-                                       TSizeSizeSizeTr(i, j, attributePeople[j][k]))) {
-                    n += static_cast<unsigned int>(2.5 * attributeRates[j]);
-                    LOG_DEBUG(<< i << " " << attributes[j] << " generating anomaly " << n);
-                }
-
-                TDoubleVec times;
-                rng.generateUniformSamples(
-                    0.0, static_cast<double>(bucketLength - 1), n, times);
-
-                for (std::size_t l = 0u; l < times.size(); ++l) {
-                    core_t::TTime time = startTime + static_cast<core_t::TTime>(times[l]);
-                    messages.emplace_back(time, people[attributePeople[j][k]],
-                                          attributes[j]);
+                    for (std::size_t l = 0u; l < times.size(); ++l) {
+                        core_t::TTime time = startTime +
+                                             static_cast<core_t::TTime>(times[l]);
+                        messages.emplace_back(time, people[attributePeople[j][k]],
+                                              attributes[j]);
+                    }
                 }
             }
         }
+
+        std::sort(messages.begin(), messages.end());
     }
-
-    std::sort(messages.begin(), messages.end());
-}
-
-void addArrival(const SMessage& message,
-                const CModelFactory::TDataGathererPtr& gatherer,
-                CResourceMonitor& resourceMonitor) {
-    CDataGatherer::TStrCPtrVec fields{&message.s_Person, &message.s_Attribute};
-    CEventData result;
-    result.time(message.s_Time);
-    gatherer->addArrival(fields, result, resourceMonitor);
-}
-
-const TSizeDoublePr1Vec NO_CORRELATES;
-}
-
-class CTestFixture : public CModelTestFixtureBase {};
+};
 
 BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
     // Check that the correct data is read retrieved by the
@@ -274,7 +227,7 @@ BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
             startTime += bucketLength;
         }
 
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
 
         std::size_t pid, cid;
         BOOST_TEST_REQUIRE(gatherer->personId(message.s_Person, pid));
@@ -446,7 +399,7 @@ BOOST_FIXTURE_TEST_CASE(testFeatures, CTestFixture) {
             expectedCounts.clear();
         }
 
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
 
         std::size_t pid, cid;
         BOOST_TEST_REQUIRE(gatherer->personId(message.s_Person, pid));
@@ -457,14 +410,8 @@ BOOST_FIXTURE_TEST_CASE(testFeatures, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testComputeProbability, CTestFixture) {
     // Check that we get the probabilities we expect.
-
-    using TAnomalyVec = std::vector<SAnomaly>;
-    using TDoubleAnomalyPr = std::pair<double, SAnomaly>;
-    using TAnomalyAccumulator =
-        maths::CBasicStatistics::COrderStatisticsHeap<TDoubleAnomalyPr, maths::COrderings::SFirstLess>;
-
-    core_t::TTime startTime = 1367280000;
-    const core_t::TTime bucketLength = 3600;
+    core_t::TTime startTime{1367280000};
+    const core_t::TTime bucketLength{3600};
 
     TMessageVec messages;
     generateTestMessages(startTime, bucketLength, messages);
@@ -482,54 +429,13 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbability, CTestFixture) {
     CEventRatePopulationModel* model =
         dynamic_cast<CEventRatePopulationModel*>(modelHolder.get());
 
-    TAnomalyAccumulator anomalies(6u);
-
-    for (std::size_t i = 0u, bucket = 0u; i < messages.size(); ++i) {
-        if (messages[i].s_Time >= startTime + bucketLength) {
-            LOG_DEBUG(<< "Updating and testing bucket = [" << startTime << ","
-                      << startTime + bucketLength << ")");
-
-            model->sample(startTime, startTime + bucketLength, m_ResourceMonitor);
-
-            SAnnotatedProbability annotatedProbability;
-            for (std::size_t pid = 0u; pid < gatherer->numberActivePeople(); ++pid) {
-                CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
-                model->computeProbability(pid, startTime, startTime + bucketLength,
-                                          partitioningFields, 2, annotatedProbability);
-
-                std::string person = model->personName(pid);
-                TDoubleStrPrVec attributes;
-                for (std::size_t j = 0u;
-                     j < annotatedProbability.s_AttributeProbabilities.size(); ++j) {
-                    attributes.emplace_back(
-                        annotatedProbability.s_AttributeProbabilities[j].s_Probability,
-                        *annotatedProbability.s_AttributeProbabilities[j].s_Attribute);
-                }
-                anomalies.add({annotatedProbability.s_Probability,
-                               SAnomaly(bucket, person, attributes)});
-            }
-
-            startTime += bucketLength;
-            ++bucket;
-        }
-
-        addArrival(messages[i], gatherer, m_ResourceMonitor);
-    }
-
-    anomalies.sort();
-    LOG_DEBUG(<< "Anomalies = " << anomalies.print());
-
-    TAnomalyVec orderedAnomalies;
-    for (std::size_t i = 0u; i < anomalies.count(); ++i) {
-        orderedAnomalies.push_back(anomalies[i].second);
-    }
-
-    std::sort(orderedAnomalies.begin(), orderedAnomalies.end());
-
-    LOG_DEBUG(<< "orderedAnomalies = " << core::CContainerPrinter::print(orderedAnomalies));
-
     TStrVec expectedAnomalies{"[10, p1, c0]", "[15, p11, c0]", "[30, p4, c2]",
                               "[35, p5, c2]", "[50, p11, c0]", "[75, p5, c2]"};
+
+    TAnomalyVec orderedAnomalies;
+
+    this->generateOrderedAnomalies(6u, startTime, bucketLength, messages,
+                                   gatherer, *model, orderedAnomalies);
 
     BOOST_REQUIRE_EQUAL(expectedAnomalies.size(), orderedAnomalies.size());
     for (std::size_t i = 0u; i < orderedAnomalies.size(); ++i) {
@@ -652,7 +558,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     size_t maxDimensionBeforePrune(model->dataGatherer().maxDimension());
@@ -666,7 +572,7 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        addArrival(expectedMessage, expectedGatherer, m_ResourceMonitor);
+        this->addArrival(expectedMessage, expectedGatherer);
     }
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
 
@@ -683,8 +589,8 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
                             {bucketStart + 2100, "p5", "c6"}};
 
     for (const auto& newMessage : newMessages) {
-        addArrival(newMessage, gatherer, m_ResourceMonitor);
-        addArrival(newMessage, expectedGatherer, m_ResourceMonitor);
+        this->addArrival(newMessage, gatherer);
+        this->addArrival(newMessage, expectedGatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -712,38 +618,17 @@ BOOST_FIXTURE_TEST_CASE(testKey, CTestFixture) {
                                             function_t::E_PopulationFreqRareCount,
                                             function_t::E_PopulationLowCounts,
                                             function_t::E_PopulationHighCounts};
-    TBoolVec useNull{true, false};
-    TStrVec byFields{"", "by"};
-    TStrVec partitionFields{"", "partition"};
 
-    {
-        CAnomalyDetectorModelConfig config = CAnomalyDetectorModelConfig::defaultConfig();
+    std::string fieldName;
+    std::string overFieldName{"over"};
 
-        int detectorIndex = 0;
-        for (const auto& countFunction : countFunctions) {
-            for (bool usingNull : useNull) {
-                for (const auto& byField : byFields) {
-                    for (const auto& partitionField : partitionFields) {
-                        CSearchKey key(++detectorIndex, countFunction,
-                                       usingNull, model_t::E_XF_None, "",
-                                       byField, "over", partitionField);
-
-                        CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
-                            config.factory(key);
-
-                        LOG_DEBUG(<< "expected key = " << key);
-                        LOG_DEBUG(<< "actual key   = " << factory->searchKey());
-                        BOOST_TEST_REQUIRE(key == factory->searchKey());
-                    }
-                }
-            }
-        }
-    }
+    generateAndCompareKey(countFunctions, fieldName, overFieldName,
+                          [](CSearchKey expectedKey, CSearchKey actualKey) {
+                              BOOST_TEST_REQUIRE(expectedKey == actualKey);
+                          });
 }
 
 BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
-    using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
-
     // Test we correctly compute frequencies for people and attributes.
 
     struct SDatum {
@@ -805,7 +690,7 @@ BOOST_FIXTURE_TEST_CASE(testFrequency, CTestFixture) {
             populationModel->sample(time, time + bucketLength, m_ResourceMonitor);
             time += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     {
@@ -916,7 +801,7 @@ BOOST_FIXTURE_TEST_CASE(testSampleRateWeight, CTestFixture) {
             populationModel->sample(time, time + bucketLength, m_ResourceMonitor);
             time += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     // The heavy hitters generate one value per attribute per bucket.
@@ -1058,7 +943,7 @@ BOOST_FIXTURE_TEST_CASE(testPeriodicity, CTestFixture) {
             time += bucketLength;
         }
 
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     double totalw{0.0};
@@ -1096,13 +981,13 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     CEventRatePopulationModel* modelNoGap =
         dynamic_cast<CEventRatePopulationModel*>(modelNoGapHolder.get());
 
-    addArrival(SMessage(100, "p1", "a1"), gathererNoGap, m_ResourceMonitor);
-    addArrival(SMessage(100, "p1", "a2"), gathererNoGap, m_ResourceMonitor);
-    addArrival(SMessage(100, "p2", "a1"), gathererNoGap, m_ResourceMonitor);
+    this->addArrival(SMessage(100, "p1", "a1"), gathererNoGap);
+    this->addArrival(SMessage(100, "p1", "a2"), gathererNoGap);
+    this->addArrival(SMessage(100, "p2", "a1"), gathererNoGap);
     modelNoGap->sample(100, 200, m_ResourceMonitor);
-    addArrival(SMessage(200, "p1", "a1"), gathererNoGap, m_ResourceMonitor);
+    this->addArrival(SMessage(200, "p1", "a1"), gathererNoGap);
     modelNoGap->sample(200, 300, m_ResourceMonitor);
-    addArrival(SMessage(300, "p1", "a1"), gathererNoGap, m_ResourceMonitor);
+    this->addArrival(SMessage(300, "p1", "a1"), gathererNoGap);
     modelNoGap->sample(300, 400, m_ResourceMonitor);
 
     CModelFactory::SGathererInitializationData gathererWithGapInitData(startTime);
@@ -1113,11 +998,11 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     CEventRatePopulationModel* modelWithGap =
         dynamic_cast<CEventRatePopulationModel*>(modelWithGapHolder.get());
 
-    addArrival(SMessage(100, "p1", "a1"), gathererWithGap, m_ResourceMonitor);
-    addArrival(SMessage(100, "p1", "a2"), gathererWithGap, m_ResourceMonitor);
-    addArrival(SMessage(100, "p2", "a1"), gathererWithGap, m_ResourceMonitor);
+    this->addArrival(SMessage(100, "p1", "a1"), gathererWithGap);
+    this->addArrival(SMessage(100, "p1", "a2"), gathererWithGap);
+    this->addArrival(SMessage(100, "p2", "a1"), gathererWithGap);
     modelWithGap->sample(100, 200, m_ResourceMonitor);
-    addArrival(SMessage(200, "p1", "a1"), gathererWithGap, m_ResourceMonitor);
+    this->addArrival(SMessage(200, "p1", "a1"), gathererWithGap);
     modelWithGap->skipSampling(1000);
     LOG_DEBUG(<< "Calling sample over skipped interval should do nothing except print some ERRORs");
     modelWithGap->sample(200, 1000, m_ResourceMonitor);
@@ -1127,9 +1012,9 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActivePeople());
     BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActiveAttributes());
 
-    addArrival(SMessage(1000, "p1", "a1"), gathererWithGap, m_ResourceMonitor);
+    this->addArrival(SMessage(1000, "p1", "a1"), gathererWithGap);
     modelWithGap->sample(1000, 1100, m_ResourceMonitor);
-    addArrival(SMessage(1100, "p1", "a1"), gathererWithGap, m_ResourceMonitor);
+    this->addArrival(SMessage(1100, "p1", "a1"), gathererWithGap);
     modelWithGap->sample(1100, 1200, m_ResourceMonitor);
 
     // Check priors are the same
@@ -1185,26 +1070,26 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            addArrival(SMessage(now, "p1", "a1"), gatherer, m_ResourceMonitor);
+            this->addArrival(SMessage(now, "p1", "a1"), gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[1] + 0.5); ++i) {
-            addArrival(SMessage(now, "p2", "a1"), gatherer, m_ResourceMonitor);
+            this->addArrival(SMessage(now, "p2", "a1"), gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[2] + 0.5); ++i) {
-            addArrival(SMessage(now, "p3", "a2"), gatherer, m_ResourceMonitor);
+            this->addArrival(SMessage(now, "p3", "a2"), gatherer);
         }
         countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        addArrival(SMessage(now, "p1", "a1"), gatherer, m_ResourceMonitor);
+        this->addArrival(SMessage(now, "p1", "a1"), gatherer);
     }
     for (std::size_t i = 0; i < 1; ++i) {
-        addArrival(SMessage(now, "p2", "a1"), gatherer, m_ResourceMonitor);
+        this->addArrival(SMessage(now, "p2", "a1"), gatherer);
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        addArrival(SMessage(now, "p3", "a2"), gatherer, m_ResourceMonitor);
+        this->addArrival(SMessage(now, "p3", "a2"), gatherer);
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -1278,7 +1163,7 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
             origModel->sample(startTime, startTime + bucketLength, m_ResourceMonitor);
             startTime += bucketLength;
         }
-        addArrival(message, gatherer, m_ResourceMonitor);
+        this->addArrival(message, gatherer);
     }
 
     std::string origXml;
@@ -1364,33 +1249,33 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     CAnomalyDetectorModel::TModelPtr modelWithSkip(
         factoryWithSkipRule.makeModel(modelWithSkipInitData));
 
-    addArrival(SMessage(100, "p1", "a1"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(100, "p1", "a1"), gathererWithSkip, m_ResourceMonitor);
-    addArrival(SMessage(100, "p1", "a2"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(100, "p1", "a2"), gathererWithSkip, m_ResourceMonitor);
-    addArrival(SMessage(100, "p2", "a1"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(100, "p2", "a1"), gathererWithSkip, m_ResourceMonitor);
+    this->addArrival(SMessage(100, "p1", "a1"), gathererNoSkip);
+    this->addArrival(SMessage(100, "p1", "a1"), gathererWithSkip);
+    this->addArrival(SMessage(100, "p1", "a2"), gathererNoSkip);
+    this->addArrival(SMessage(100, "p1", "a2"), gathererWithSkip);
+    this->addArrival(SMessage(100, "p2", "a1"), gathererNoSkip);
+    this->addArrival(SMessage(100, "p2", "a1"), gathererWithSkip);
     modelNoSkip->sample(100, 200, m_ResourceMonitor);
     modelWithSkip->sample(100, 200, m_ResourceMonitor);
 
     BOOST_REQUIRE_EQUAL(modelWithSkip->checksum(), modelNoSkip->checksum());
 
-    addArrival(SMessage(200, "p1", "a1"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p1", "a1"), gathererWithSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p1", "a2"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p1", "a2"), gathererWithSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p2", "a1"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p2", "a1"), gathererWithSkip, m_ResourceMonitor);
+    this->addArrival(SMessage(200, "p1", "a1"), gathererNoSkip);
+    this->addArrival(SMessage(200, "p1", "a1"), gathererWithSkip);
+    this->addArrival(SMessage(200, "p1", "a2"), gathererNoSkip);
+    this->addArrival(SMessage(200, "p1", "a2"), gathererWithSkip);
+    this->addArrival(SMessage(200, "p2", "a1"), gathererNoSkip);
+    this->addArrival(SMessage(200, "p2", "a1"), gathererWithSkip);
 
     // This should be filtered out
-    addArrival(SMessage(200, "p1", "a3"), gathererWithSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p2", "a3"), gathererWithSkip, m_ResourceMonitor);
+    this->addArrival(SMessage(200, "p1", "a3"), gathererWithSkip);
+    this->addArrival(SMessage(200, "p2", "a3"), gathererWithSkip);
 
     // Add another attribute that must not be skipped
-    addArrival(SMessage(200, "p1", "a4"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p1", "a4"), gathererWithSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p2", "a4"), gathererNoSkip, m_ResourceMonitor);
-    addArrival(SMessage(200, "p2", "a4"), gathererWithSkip, m_ResourceMonitor);
+    this->addArrival(SMessage(200, "p1", "a4"), gathererNoSkip);
+    this->addArrival(SMessage(200, "p1", "a4"), gathererWithSkip);
+    this->addArrival(SMessage(200, "p2", "a4"), gathererNoSkip);
+    this->addArrival(SMessage(200, "p2", "a4"), gathererWithSkip);
 
     modelNoSkip->sample(200, 300, m_ResourceMonitor);
     modelWithSkip->sample(200, 300, m_ResourceMonitor);

--- a/lib/model/unittest/CModelTestFixtureBase.cc
+++ b/lib/model/unittest/CModelTestFixtureBase.cc
@@ -1,0 +1,327 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "CModelTestFixtureBase.h"
+
+#include <model/CDataGatherer.h>
+#include <model/CEventData.h>
+#include <model/CModelFactory.h>
+
+#include <string>
+
+const std::string CModelTestFixtureBase::EMPTY_STRING;
+
+std::size_t CModelTestFixtureBase::addPerson(const std::string& p,
+                                             const ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                                             std::size_t numInfluencers,
+                                             TOptionalStr value) {
+    std::string i("i");
+
+    ml::model::CDataGatherer::TStrCPtrVec person{&p};
+    if (numInfluencers == 0) {
+        person.resize(gatherer->fieldsOfInterest().size(), nullptr);
+    }
+    for (std::size_t j = 0; j < numInfluencers; ++j) {
+        person.push_back(&i);
+    }
+    if (value) {
+        person.push_back(&(value.get()));
+    }
+    ml::model::CEventData result;
+    gatherer->processFields(person, result, m_ResourceMonitor);
+    return *result.personId();
+}
+
+void CModelTestFixtureBase::addArrival(ml::model::CDataGatherer& gatherer,
+                                       ml::core_t::TTime time,
+                                       const std::string& person,
+                                       const TOptionalStr& inf1,
+                                       const TOptionalStr& inf2,
+                                       const TOptionalStr& value) {
+    ml::model::CDataGatherer::TStrCPtrVec fieldValues{&person};
+    if (inf1) {
+        fieldValues.push_back(&(inf1.get()));
+    }
+    if (inf2) {
+        fieldValues.push_back(&(inf2.get()));
+    }
+
+    if (value) {
+        fieldValues.push_back(&(value.get()));
+    }
+
+    ml::model::CEventData eventData;
+    eventData.time(time);
+
+    gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+}
+
+std::string CModelTestFixtureBase::valueAsString(const TDouble1Vec& value) {
+    std::string result{ml::core::CStringUtils::typeToStringPrecise(
+        value[0], ml::core::CIEEE754::E_DoublePrecision)};
+    for (std::size_t i = 1u; i < value.size(); ++i) {
+        result += ml::model::CAnomalyDetectorModelConfig::DEFAULT_MULTIVARIATE_COMPONENT_DELIMITER +
+                  ml::core::CStringUtils::typeToStringPrecise(
+                      value[i], ml::core::CIEEE754::E_DoublePrecision);
+    }
+    return result;
+}
+
+ml::model::CEventData
+CModelTestFixtureBase::addArrival(const SMessage& message,
+                                  ml::model::CModelFactory::TDataGathererPtr& gatherer) {
+    ml::model::CDataGatherer::TStrCPtrVec fields{&message.s_Person, &message.s_Attribute};
+    std::string value;
+    if (message.s_Value.empty() == false) {
+        value = {valueAsString(message.s_Value)};
+        fields.push_back(&value);
+    }
+    ml::model::CEventData result;
+    result.time(message.s_Time);
+    gatherer->addArrival(fields, result, m_ResourceMonitor);
+
+    return result;
+}
+
+void CModelTestFixtureBase::addArrival(ml::model::CDataGatherer& gatherer,
+                                       ml::core_t::TTime time,
+                                       const std::string& person,
+                                       double value,
+                                       const TOptionalStr& inf1,
+                                       const TOptionalStr& inf2,
+                                       const TOptionalStr& count) {
+    ml::model::CDataGatherer::TStrCPtrVec fieldValues;
+    fieldValues.push_back(&person);
+    if (inf1) {
+        fieldValues.push_back(&(inf1.get()));
+    }
+    if (inf2) {
+        fieldValues.push_back(&(inf2.get()));
+    }
+    if (count) {
+        fieldValues.push_back(&(count.get()));
+    }
+    std::string valueAsString(ml::core::CStringUtils::typeToStringPrecise(
+        value, ml::core::CIEEE754::E_DoublePrecision));
+    fieldValues.push_back(&valueAsString);
+
+    ml::model::CEventData eventData;
+    eventData.time(time);
+
+    gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+}
+
+void CModelTestFixtureBase::addArrival(ml::model::CDataGatherer& gatherer,
+                                       ml::core_t::TTime time,
+                                       const std::string& person,
+                                       double lat,
+                                       double lng,
+                                       const TOptionalStr& inf1,
+                                       const TOptionalStr& inf2) {
+    ml::model::CDataGatherer::TStrCPtrVec fieldValues;
+    fieldValues.push_back(&person);
+    if (inf1) {
+        fieldValues.push_back(&(inf1.get()));
+    }
+    if (inf2) {
+        fieldValues.push_back(&(inf2.get()));
+    }
+    std::string valueAsString;
+    valueAsString += ml::core::CStringUtils::typeToStringPrecise(
+        lat, ml::core::CIEEE754::E_DoublePrecision);
+    valueAsString += ml::model::CAnomalyDetectorModelConfig::DEFAULT_MULTIVARIATE_COMPONENT_DELIMITER;
+    valueAsString += ml::core::CStringUtils::typeToStringPrecise(
+        lng, ml::core::CIEEE754::E_DoublePrecision);
+    fieldValues.push_back(&valueAsString);
+
+    ml::model::CEventData eventData;
+    eventData.time(time);
+
+    gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+}
+
+void CModelTestFixtureBase::processBucket(ml::core_t::TTime time,
+                                          ml::core_t::TTime bucketLength,
+                                          const TDoubleVec& bucket,
+                                          const TStrVec& influencerValues,
+                                          ml::model::CDataGatherer& gatherer,
+                                          ml::model::CAnomalyDetectorModel& model,
+                                          ml::model::SAnnotatedProbability& probability) {
+    for (std::size_t i = 0u; i < bucket.size(); ++i) {
+        this->addArrival(gatherer, time, "p", bucket[i],
+                         TOptionalStr(influencerValues[i]));
+    }
+    model.sample(time, time + bucketLength, m_ResourceMonitor);
+    ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+    model.computeProbability(0 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability);
+    LOG_DEBUG(<< "influences = "
+              << ml::core::CContainerPrinter::print(probability.s_Influences));
+}
+
+void CModelTestFixtureBase::processBucket(ml::core_t::TTime time,
+                                          ml::core_t::TTime bucketLength,
+                                          const TDoubleVec& bucket,
+                                          ml::model::CDataGatherer& gatherer,
+                                          ml::model::CAnomalyDetectorModel& model,
+                                          ml::model::SAnnotatedProbability& probability,
+                                          ml::model::SAnnotatedProbability& probability2) {
+    const std::string person("p");
+    const std::string person2("q");
+    for (std::size_t i = 0u; i < bucket.size(); ++i) {
+        ml::model::CDataGatherer::TStrCPtrVec fieldValues;
+        if (i % 2 == 0) {
+            fieldValues.push_back(&person);
+        } else {
+            fieldValues.push_back(&person2);
+        }
+
+        std::string valueAsString(ml::core::CStringUtils::typeToStringPrecise(
+            bucket[i], ml::core::CIEEE754::E_DoublePrecision));
+        fieldValues.push_back(&valueAsString);
+
+        ml::model::CEventData eventData;
+        eventData.time(time);
+
+        gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+    }
+    model.sample(time, time + bucketLength, m_ResourceMonitor);
+    ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+    model.computeProbability(0 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability);
+    model.computeProbability(1 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability2);
+}
+
+void CModelTestFixtureBase::processBucket(ml::core_t::TTime time,
+                                          ml::core_t::TTime bucketLength,
+                                          const TDoubleStrPrVec& bucket,
+                                          ml::model::CDataGatherer& gatherer,
+                                          ml::model::CAnomalyDetectorModel& model,
+                                          ml::model::SAnnotatedProbability& probability) {
+    const std::string person{"p"};
+    const std::string attribute{"a"};
+    for (auto& pr : bucket) {
+        const std::string valueAsString{ml::core::CStringUtils::typeToStringPrecise(
+            pr.first, ml::core::CIEEE754::E_DoublePrecision)};
+
+        ml::model::CDataGatherer::TStrCPtrVec fieldValues{
+            &person, &attribute, &pr.second, &valueAsString};
+
+        ml::model::CEventData eventData;
+        eventData.time(time);
+
+        gatherer.addArrival(fieldValues, eventData, m_ResourceMonitor);
+    }
+    model.sample(time, time + bucketLength, m_ResourceMonitor);
+    ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+    model.computeProbability(0 /*pid*/, time, time + bucketLength,
+                             partitioningFields, 1, probability);
+    LOG_DEBUG(<< "influences = "
+              << ml::core::CContainerPrinter::print(probability.s_Influences));
+}
+
+void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
+                                                     ml::core_t::TTime startTime,
+                                                     ml::core_t::TTime bucketLength,
+                                                     const TMessageVec& messages,
+                                                     ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                                                     ml::model::CAnomalyDetectorModel& model,
+                                                     TAnomalyVec& orderedAnomalies) {
+
+    TAnomalyAccumulator anomalies(numAnomalies);
+
+    for (std::size_t i = 0u, bucket = 0u; i < messages.size(); ++i) {
+        if (messages[i].s_Time >= startTime + bucketLength) {
+            LOG_DEBUG(<< "Updating and testing bucket = [" << startTime << ","
+                      << startTime + bucketLength << ")");
+
+            model.sample(startTime, startTime + bucketLength, m_ResourceMonitor);
+
+            ml::model::CPartitioningFields partitioningFields(EMPTY_STRING, EMPTY_STRING);
+            ml::model::SAnnotatedProbability annotatedProbability;
+            for (std::size_t pid = 0u; pid < gatherer->numberActivePeople(); ++pid) {
+                model.computeProbability(pid, startTime, startTime + bucketLength,
+                                         partitioningFields, 2, annotatedProbability);
+
+                std::string person = model.personName(pid);
+                TDoubleStrPrVec attributes;
+                for (const auto& probability : annotatedProbability.s_AttributeProbabilities) {
+                    attributes.emplace_back(probability.s_Probability,
+                                            *probability.s_Attribute);
+                }
+                LOG_DEBUG(<< "Adding anomaly " << pid);
+                anomalies.add({annotatedProbability.s_Probability,
+                               {bucket, person, attributes}});
+            }
+
+            startTime += bucketLength;
+            ++bucket;
+        }
+
+        this->addArrival(messages[i], gatherer);
+    }
+
+    anomalies.sort();
+    LOG_DEBUG(<< "Anomalies = " << anomalies.print());
+
+    for (std::size_t i = 0u; i < anomalies.count(); ++i) {
+        orderedAnomalies.push_back(anomalies[i].second);
+    }
+
+    std::sort(orderedAnomalies.begin(), orderedAnomalies.end());
+
+    LOG_DEBUG(<< "orderedAnomalies = "
+              << ml::core::CContainerPrinter::print(orderedAnomalies));
+}
+
+ml::model::CEventData CModelTestFixtureBase::makeEventData(ml::core_t::TTime time,
+                                                           std::size_t pid,
+                                                           TDouble1Vec value,
+                                                           const TOptionalStr& influence,
+                                                           const TOptionalStr& stringValue) {
+    ml::model::CEventData result;
+    result.time(time);
+    result.person(pid);
+    result.addAttribute(std::size_t(0));
+    result.addValue(value);
+    result.addInfluence(influence);
+    if (stringValue) {
+        result.stringValue(stringValue.get());
+    }
+    return result;
+}
+
+void CModelTestFixtureBase::generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
+                                                  const std::string& fieldName,
+                                                  const std::string& overFieldName,
+                                                  TKeyCompareFunc keyCompare) {
+    TStrVec byFields{"", "by"};
+    TStrVec partitionFields{"", "partition"};
+
+    ml::model::CAnomalyDetectorModelConfig config =
+        ml::model::CAnomalyDetectorModelConfig::defaultConfig();
+
+    int detectorIndex{0};
+    for (const auto& countFunction : countFunctions) {
+        for (bool usingNull : {true, false}) {
+            for (const auto& byField : byFields) {
+                for (const auto& partitionField : partitionFields) {
+                    ml::model::CSearchKey key(++detectorIndex, countFunction, usingNull,
+                                              ml::model_t::E_XF_None, fieldName,
+                                              byField, overFieldName, partitionField);
+
+                    ml::model::CAnomalyDetectorModelConfig::TModelFactoryCPtr factory =
+                        config.factory(key);
+
+                    LOG_DEBUG(<< "expected key = " << key);
+                    LOG_DEBUG(<< "actual key   = " << factory->searchKey());
+                    keyCompare(key, factory->searchKey());
+                }
+            }
+        }
+    }
+}

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -13,69 +13,213 @@
 #include <maths/CModel.h>
 #include <maths/CMultivariatePrior.h>
 
+#include <model/CAnnotatedProbability.h>
+#include <model/CAnomalyDetectorModelConfig.h>
+#include <model/CDataGatherer.h>
+#include <model/CEventData.h>
+#include <model/CIndividualModel.h>
+#include <model/CModelFactory.h>
 #include <model/CResourceMonitor.h>
 
 #include <boost/optional.hpp>
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <utility>
 #include <vector>
 
-using TBoolVec = std::vector<bool>;
-
-using TDouble1Vec = ml::core::CSmallVector<double, 1>;
-using TDouble2Vec = ml::core::CSmallVector<double, 2>;
-using TDouble4Vec = ml::core::CSmallVector<double, 4>;
-using TDouble4Vec1Vec = ml::core::CSmallVector<TDouble4Vec, 1>;
-using TDoubleDoublePr = std::pair<double, double>;
-using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
-using TDoubleSizePr = std::pair<double, std::size_t>;
-using TDoubleStrPr = std::pair<double, std::string>;
-using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
-using TDoubleVec = std::vector<double>;
-using TDoubleVecVec = std::vector<TDoubleVec>;
-
-using TMathsModelPtr = std::shared_ptr<ml::maths::CModel>;
-using TMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
-using TMultivariatePriorPtr = std::shared_ptr<ml::maths::CMultivariatePrior>;
-
-using TOptionalDouble = boost::optional<double>;
-using TOptionalDoubleVec = std::vector<TOptionalDouble>;
-using TOptionalStr = boost::optional<std::string>;
-using TOptionalUInt64 = boost::optional<uint64_t>;
-
-using TPriorPtr = std::shared_ptr<ml::maths::CPrior>;
-
-using TSizeDoublePr = std::pair<std::size_t, double>;
-using TSizeDoublePr1Vec = ml::core::CSmallVector<TSizeDoublePr, 1>;
-using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-using TSizeSizePrVec = std::vector<TSizeSizePr>;
-using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
-using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
-using TSizeVec = std::vector<std::size_t>;
-using TSizeVecVec = std::vector<TSizeVec>;
-using TSizeVecVecVec = std::vector<TSizeVecVec>;
-using TStrSizePr = std::pair<std::string, std::size_t>;
-using TStrSizePrVec = std::vector<TStrSizePr>;
-using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
-using TStrSizePrVecVecVec = std::vector<TStrSizePrVecVec>;
-using TStrUInt64Map = std::map<std::string, uint64_t>;
-
-using TStrVec = std::vector<std::string>;
-using TStrVecVec = std::vector<TStrVec>;
-
-using TTimeDoublePr = std::pair<ml::core_t::TTime, double>;
-using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
-using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
-using TTimeStrVecPr = std::pair<ml::core_t::TTime, TStrVec>;
-using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
-using TTimeVec = std::vector<ml::core_t::TTime>;
-
-using TUInt64Vec = std::vector<uint64_t>;
-using TUIntVec = std::vector<unsigned int>;
-
 class CModelTestFixtureBase {
+public:
+    static const std::string EMPTY_STRING;
+
+    using TBoolVec = std::vector<bool>;
+
+    using TDouble1Vec = ml::core::CSmallVector<double, 1>;
+    using TDouble2Vec = ml::core::CSmallVector<double, 2>;
+    using TDouble4Vec = ml::core::CSmallVector<double, 4>;
+    using TDouble4Vec1Vec = ml::core::CSmallVector<TDouble4Vec, 1>;
+    using TDoubleDoublePr = std::pair<double, double>;
+    using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+    using TDoubleSizePr = std::pair<double, std::size_t>;
+    using TDoubleStrPr = std::pair<double, std::string>;
+    using TDoubleStrPrVec = std::vector<TDoubleStrPr>;
+    using TDoubleVec = std::vector<double>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+
+    using TMathsModelPtr = std::shared_ptr<ml::maths::CModel>;
+    using TMeanAccumulator = ml::maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMultivariatePriorPtr = std::shared_ptr<ml::maths::CMultivariatePrior>;
+
+    using TOptionalDouble = boost::optional<double>;
+    using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+    using TOptionalStr = boost::optional<std::string>;
+    using TOptionalUInt64 = boost::optional<uint64_t>;
+
+    using TPriorPtr = std::shared_ptr<ml::maths::CPrior>;
+
+    using TSizeDoublePr = std::pair<std::size_t, double>;
+    using TSizeDoublePr1Vec = ml::core::CSmallVector<TSizeDoublePr, 1>;
+    using TSizeSizePr = std::pair<std::size_t, std::size_t>;
+    using TSizeSizePrVec = std::vector<TSizeSizePr>;
+    using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
+    using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+    using TSizeVec = std::vector<std::size_t>;
+    using TSizeVecVec = std::vector<TSizeVec>;
+    using TSizeVecVecVec = std::vector<TSizeVecVec>;
+    using TStrSizePr = std::pair<std::string, std::size_t>;
+    using TStrSizePrVec = std::vector<TStrSizePr>;
+    using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
+    using TStrSizePrVecVecVec = std::vector<TStrSizePrVecVec>;
+    using TStrUInt64Map = std::map<std::string, uint64_t>;
+
+    using TStrVec = std::vector<std::string>;
+    using TStrVecVec = std::vector<TStrVec>;
+
+    using TTimeDoublePr = std::pair<ml::core_t::TTime, double>;
+    using TTimeDoublePrVec = std::vector<TTimeDoublePr>;
+    using TOptionalTimeDoublePr = boost::optional<TTimeDoublePr>;
+    using TTimeStrVecPr = std::pair<ml::core_t::TTime, TStrVec>;
+    using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
+    using TTimeVec = std::vector<ml::core_t::TTime>;
+
+    using TUInt64Vec = std::vector<uint64_t>;
+    using TUIntVec = std::vector<unsigned int>;
+
+protected:
+    struct SAnomaly {
+        SAnomaly() : s_Bucket(0u), s_Person(), s_Attributes() {}
+        SAnomaly(std::size_t bucket, const std::string& person, const TDoubleStrPrVec& attributes)
+            : s_Bucket(bucket), s_Person(person), s_Attributes(attributes) {}
+
+        std::size_t s_Bucket;
+        std::string s_Person;
+        TDoubleStrPrVec s_Attributes;
+
+        bool operator<(const SAnomaly& other) const {
+            return s_Bucket < other.s_Bucket;
+        }
+
+        std::string print() const {
+            std::ostringstream result;
+            result << "[" << s_Bucket << ", " + s_Person << ",";
+            for (std::size_t i = 0u; i < s_Attributes.size(); ++i) {
+                if (s_Attributes[i].first < 0.01) {
+                    result << " " << s_Attributes[i].second;
+                }
+            }
+            result << "]";
+            return result.str();
+        }
+    };
+
+    using TAnomalyVec = std::vector<SAnomaly>;
+    using TDoubleAnomalyPr = std::pair<double, SAnomaly>;
+    using TAnomalyAccumulator =
+        ml::maths::CBasicStatistics::COrderStatisticsHeap<TDoubleAnomalyPr, ml::maths::COrderings::SFirstLess>;
+
+    struct SMessage {
+        SMessage(ml::core_t::TTime time,
+                 const std::string& person,
+                 const std::string& attribute,
+                 const TDouble1Vec& value)
+            : s_Time(time), s_Person(person), s_Attribute(attribute), s_Value(value) {}
+
+        SMessage(ml::core_t::TTime time, const std::string& person, const std::string& attribute)
+            : s_Time(time), s_Person(person), s_Attribute(attribute) {}
+
+        bool operator<(const SMessage& other) const {
+            return ml::maths::COrderings::lexicographical_compare(
+                s_Time, s_Person, s_Attribute, other.s_Time, other.s_Person,
+                other.s_Attribute);
+        }
+
+        ml::core_t::TTime s_Time;
+        std::string s_Person;
+        std::string s_Attribute;
+        TDouble1Vec s_Value{};
+    };
+    using TMessageVec = std::vector<SMessage>;
+
+protected:
+    std::size_t addPerson(const std::string& p,
+                          const ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                          std::size_t numInfluencers = 0,
+                          TOptionalStr value = TOptionalStr());
+
+    void addArrival(ml::model::CDataGatherer& gatherer,
+                    ml::core_t::TTime time,
+                    const std::string& person,
+                    const TOptionalStr& inf1 = TOptionalStr(),
+                    const TOptionalStr& inf2 = TOptionalStr(),
+                    const TOptionalStr& value = TOptionalStr());
+
+    std::string valueAsString(const TDouble1Vec& value);
+
+    ml::model::CEventData addArrival(const SMessage& message,
+                                     ml::model::CModelFactory::TDataGathererPtr& gatherer);
+
+    void addArrival(ml::model::CDataGatherer& gatherer,
+                    ml::core_t::TTime time,
+                    const std::string& person,
+                    double value,
+                    const TOptionalStr& inf1 = TOptionalStr(),
+                    const TOptionalStr& inf2 = TOptionalStr(),
+                    const TOptionalStr& count = TOptionalStr());
+
+    void addArrival(ml::model::CDataGatherer& gatherer,
+                    ml::core_t::TTime time,
+                    const std::string& person,
+                    double lat,
+                    double lng,
+                    const TOptionalStr& inf1 = TOptionalStr(),
+                    const TOptionalStr& inf2 = TOptionalStr());
+
+    void processBucket(ml::core_t::TTime time,
+                       ml::core_t::TTime bucketLength,
+                       const TDoubleVec& bucket,
+                       const TStrVec& influencerValues,
+                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CAnomalyDetectorModel& model,
+                       ml::model::SAnnotatedProbability& probability);
+
+    void processBucket(ml::core_t::TTime time,
+                       ml::core_t::TTime bucketLength,
+                       const TDoubleVec& bucket,
+                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CAnomalyDetectorModel& model,
+                       ml::model::SAnnotatedProbability& probability,
+                       ml::model::SAnnotatedProbability& probability2);
+
+    void processBucket(ml::core_t::TTime time,
+                       ml::core_t::TTime bucketLength,
+                       const TDoubleStrPrVec& bucket,
+                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CAnomalyDetectorModel& model,
+                       ml::model::SAnnotatedProbability& probability);
+
+    void generateOrderedAnomalies(std::size_t numAnomalies,
+                                  ml::core_t::TTime startTime,
+                                  ml::core_t::TTime bucketLength,
+                                  const TMessageVec& messages,
+                                  ml::model::CModelFactory::TDataGathererPtr& gatherer,
+                                  ml::model::CAnomalyDetectorModel& model,
+                                  TAnomalyVec& orderedAnomalies);
+
+    ml::model::CEventData makeEventData(ml::core_t::TTime time,
+                                        std::size_t pid,
+                                        TDouble1Vec value = TDoubleVec(1, 0.0),
+                                        const TOptionalStr& influence = TOptionalStr(),
+                                        const TOptionalStr& stringValue = TOptionalStr());
+
+    using TKeyCompareFunc =
+        std::function<void(ml::model::CSearchKey expectedKey, ml::model::CSearchKey actualKey)>;
+
+    static void generateAndCompareKey(const ml::model::function_t::TFunctionVec& countFunctions,
+                                      const std::string& fieldName,
+                                      const std::string& overFieldName,
+                                      TKeyCompareFunc keyCompare);
+
 protected:
     ml::model::CResourceMonitor m_ResourceMonitor;
 };

--- a/lib/model/unittest/Makefile
+++ b/lib/model/unittest/Makefile
@@ -49,6 +49,7 @@ SRCS=\
 	CMetricPopulationModelTest.cc \
 	CModelDetailsViewTest.cc \
 	CModelMemoryTest.cc \
+	CModelTestFixtureBase.cc \
 	CModelToolsTest.cc \
 	CModelTypesTest.cc \
 	CProbabilityAndInfluenceCalculatorTest.cc \


### PR DESCRIPTION
Move existing model test helper functions to base class and share functionality where possible.

Backports #1523