### PR TITLE
[ML] Provide factory setup for creating models

### DIFF
--- a/lib/model/unittest/CCountingModelTest.cc
+++ b/lib/model/unittest/CCountingModelTest.cc
@@ -77,7 +77,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         CModelFactory::TModelPtr modelNoGap;
         this->makeModelT<CCountingModelFactory>(
             params, features, startTime, model_t::E_Counting, gathererNoGap, modelNoGap);
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererNoGap));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gathererNoGap));
 
         // |2|2|0|0|1| -> 1.0 mean count
         this->addArrival(*gathererNoGap, 100, "p");
@@ -99,7 +99,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         this->makeModelT<CCountingModelFactory>(params, features, startTime,
                                                 model_t::E_Counting,
                                                 gathererWithGap, modelWithGap);
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererWithGap));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gathererWithGap));
 
         // |2|2|0|0|1|
         // |2|X|X|X|1| -> 1.5 mean count where X means skipped bucket
@@ -110,7 +110,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         this->addArrival(*gathererWithGap, 280, "p");
         modelWithGap->skipSampling(500);
         modelWithGap->prune(maxAgeBuckets);
-        BOOST_REQUIRE_EQUAL(std::size_t(1), gathererWithGap->numberActivePeople());
+        BOOST_REQUIRE_EQUAL(1, gathererWithGap->numberActivePeople());
         this->addArrival(*gathererWithGap, 500, "p");
         modelWithGap->sample(500, 600, m_ResourceMonitor);
 
@@ -141,7 +141,7 @@ BOOST_FIXTURE_TEST_CASE(testCheckScheduledEvents, CTestFixture) {
         this->makeModel(params, features, startTime);
         CCountingModel* modelNoGap = dynamic_cast<CCountingModel*>(m_Model.get());
         BOOST_TEST_REQUIRE(modelNoGap);
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
         SModelParams::TStrDetectionRulePrVec matchedEvents =
             modelNoGap->checkScheduledEvents(50);
@@ -186,7 +186,7 @@ BOOST_FIXTURE_TEST_CASE(testCheckScheduledEvents, CTestFixture) {
         this->makeModel(params, features, startTime);
         CCountingModel* modelNoGap = dynamic_cast<CCountingModel*>(m_Model.get());
         BOOST_TEST_REQUIRE(modelNoGap);
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
         // There are no events at this time
         modelNoGap->sampleBucketStatistics(0, 100, m_ResourceMonitor);
@@ -224,8 +224,8 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
     CCountingModel* model = dynamic_cast<CCountingModel*>(m_Model.get());
     BOOST_TEST_REQUIRE(model);
 
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p1", m_Gatherer));
-    BOOST_REQUIRE_EQUAL(std::size_t(1), this->addPerson("p2", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p1", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(1, this->addPerson("p2", m_Gatherer));
 
     test::CRandomNumbers rng;
 

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -193,8 +193,7 @@ public:
 
         for (std::size_t i = 0u; i < numberPeople; ++i) {
             BOOST_REQUIRE_EQUAL(
-                std::size_t(i),
-                this->addPerson("p" + core::CStringUtils::typeToString(i + 1), m_Gatherer));
+                i, this->addPerson("p" + core::CStringUtils::typeToString(i + 1), m_Gatherer));
         }
     }
 
@@ -409,7 +408,7 @@ BOOST_FIXTURE_TEST_CASE(testRare, CTestFixture) {
     }
 
     // We expect "p1 = p2 > p3 = p4 >> p5".
-    BOOST_REQUIRE_EQUAL(std::size_t(5), probabilities.size());
+    BOOST_REQUIRE_EQUAL(5, probabilities.size());
     BOOST_REQUIRE_EQUAL(probabilities[0], probabilities[1]);
     BOOST_TEST_REQUIRE(probabilities[1] > probabilities[2]);
     BOOST_REQUIRE_EQUAL(probabilities[2], probabilities[3]);
@@ -566,7 +565,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowNonZeroCount, CTestFixtu
     }
 
     LOG_DEBUG(<< "probabilities = " << core::CContainerPrinter::print(probabilities));
-    BOOST_REQUIRE_EQUAL(std::size_t(11), probabilities.size());
+    BOOST_REQUIRE_EQUAL(11, probabilities.size());
     BOOST_TEST_REQUIRE(probabilities[lowNonZeroCountBucket] < 0.06);
     BOOST_TEST_REQUIRE(probabilities[highNonZeroCountBucket] > 0.9);
 }
@@ -610,7 +609,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighNonZeroCount, CTestFixt
     }
 
     LOG_DEBUG(<< "probabilities = " << core::CContainerPrinter::print(probabilities));
-    BOOST_REQUIRE_EQUAL(std::size_t(11), probabilities.size());
+    BOOST_REQUIRE_EQUAL(11, probabilities.size());
     BOOST_TEST_REQUIRE(probabilities[lowNonZeroCountBucket] < 0.06);
     BOOST_TEST_REQUIRE(probabilities[highNonZeroCountBucket] > 0.9);
 }
@@ -1216,7 +1215,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1272,7 +1271,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1320,7 +1319,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         // We expect equal influence since the influencers share the count.
         // Also the count would be fairly normal if either influencer were
         // removed so their influence is high.
-        BOOST_REQUIRE_EQUAL(std::size_t(2), lastInfluencersResult.size());
+        BOOST_REQUIRE_EQUAL(2, lastInfluencersResult.size());
         BOOST_REQUIRE_CLOSE_ABSOLUTE(lastInfluencersResult[0].second,
                                      lastInfluencersResult[1].second, 0.05);
         BOOST_TEST_REQUIRE(lastInfluencersResult[0].second > 0.75);
@@ -1335,7 +1334,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1383,7 +1382,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         // We expect equal influence since the influencers share the count.
         // However, the bucket is still significantly anomalous omitting
         // the records from either influencer so their influence is smaller.
-        BOOST_REQUIRE_EQUAL(std::size_t(2), lastInfluencersResult.size());
+        BOOST_REQUIRE_EQUAL(2, lastInfluencersResult.size());
         BOOST_REQUIRE_CLOSE_ABSOLUTE(lastInfluencersResult[0].second,
                                      lastInfluencersResult[1].second, 0.05);
         BOOST_TEST_REQUIRE(lastInfluencersResult[0].second > 0.5);
@@ -1399,7 +1398,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1449,7 +1448,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         }
         // The influence should be dominated by the first influencer, and the
         // _extra influencers should be dropped by the cutoff threshold
-        BOOST_REQUIRE_EQUAL(std::size_t(1), lastInfluencersResult.size());
+        BOOST_REQUIRE_EQUAL(1, lastInfluencersResult.size());
         BOOST_TEST_REQUIRE(lastInfluencersResult[0].second > 0.99);
     }
     {
@@ -1462,7 +1461,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", "", "", influenceFieldNames);
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 2));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 2));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1515,7 +1514,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         }
         // The influence should be dominated by the first influencer for both fields,
         // and the _extra influencers should be dropped by the cutoff threshold
-        BOOST_REQUIRE_EQUAL(std::size_t(2), lastInfluencersResult.size());
+        BOOST_REQUIRE_EQUAL(2, lastInfluencersResult.size());
         BOOST_REQUIRE_EQUAL(std::string("IF1"), *lastInfluencersResult[0].first.first);
         BOOST_REQUIRE_EQUAL(std::string("inf"), *lastInfluencersResult[0].first.second);
         BOOST_REQUIRE_EQUAL(std::string("IF2"), *lastInfluencersResult[1].first.first);
@@ -1535,7 +1534,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
         factory.fieldNames("", "", byFieldName, "", {byFieldName});
         factory.features({model_t::E_IndividualCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer, 1));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1595,8 +1594,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            this->addPerson("p", gatherer, 1, TOptionalStr("v")));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1663,8 +1661,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            this->addPerson("p", gatherer, 1, TOptionalStr("v")));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1726,7 +1723,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         // The influence should be shared by the two influencers, and as the anomaly
         // is about twice the regular count, each influencer contributes a lot to
         // the anomaly
-        BOOST_REQUIRE_EQUAL(std::size_t(2), lastInfluencersResult.size());
+        BOOST_REQUIRE_EQUAL(2, lastInfluencersResult.size());
         BOOST_REQUIRE_CLOSE_ABSOLUTE(lastInfluencersResult[0].second,
                                      lastInfluencersResult[1].second, 0.05);
         BOOST_TEST_REQUIRE(lastInfluencersResult[0].second > 0.6);
@@ -1741,8 +1738,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            this->addPerson("p", gatherer, 1, TOptionalStr("v")));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 1, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1802,7 +1798,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         }
         // The influence should be dominated by the first influencer, and the
         // _extra influencer should be dropped by the cutoff threshold
-        BOOST_REQUIRE_EQUAL(std::size_t(1), lastInfluencersResult.size());
+        BOOST_REQUIRE_EQUAL(1, lastInfluencersResult.size());
         BOOST_TEST_REQUIRE(lastInfluencersResult[0].second > 0.8);
     }
     {
@@ -1815,8 +1811,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         factory.fieldNames("", "", "", "foo", influenceFieldNames);
         factory.features({model_t::E_IndividualUniqueCountByBucketAndPerson});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            this->addPerson("p", gatherer, 2, TOptionalStr("v")));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer, 2, TOptionalStr("v")));
         CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
         CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
         BOOST_TEST_REQUIRE(model);
@@ -1883,7 +1878,7 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
         }
         // The influence should be dominated by the first influencer for both fields, and the
         // _extra influencers should be dropped by the cutoff threshold
-        BOOST_REQUIRE_EQUAL(std::size_t(2), lastInfluencersResult.size());
+        BOOST_REQUIRE_EQUAL(2, lastInfluencersResult.size());
         BOOST_REQUIRE_EQUAL(std::string("IF1"), *lastInfluencersResult[0].first.first);
         BOOST_REQUIRE_EQUAL(std::string("inf"), *lastInfluencersResult[0].first.second);
         BOOST_REQUIRE_EQUAL(std::string("IF2"), *lastInfluencersResult[1].first.first);
@@ -1905,11 +1900,11 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
     factory.fieldNames("", "", "", "", influenceFieldNames);
     factory.features(function_t::features(function_t::E_IndividualRare));
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p1", gatherer, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(1), this->addPerson("p2", gatherer, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(2), this->addPerson("p3", gatherer, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(3), this->addPerson("p4", gatherer, 1));
-    BOOST_REQUIRE_EQUAL(std::size_t(4), this->addPerson("p5", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p1", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(1, this->addPerson("p2", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(2, this->addPerson("p3", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(3, this->addPerson("p4", gatherer, 1));
+    BOOST_REQUIRE_EQUAL(4, this->addPerson("p5", gatherer, 1));
     CModelFactory::TModelPtr modelHolder(factory.makeModel(gatherer));
     CEventRateModel* model = dynamic_cast<CEventRateModel*>(modelHolder.get());
     BOOST_TEST_REQUIRE(model);
@@ -1949,7 +1944,7 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
     }
 
     // We expect "p1 = p2 = p3 = p4 >> p5".
-    BOOST_REQUIRE_EQUAL(std::size_t(5), probabilities.size());
+    BOOST_REQUIRE_EQUAL(5, probabilities.size());
     BOOST_REQUIRE_EQUAL(probabilities[0], probabilities[1]);
     BOOST_REQUIRE_EQUAL(probabilities[1], probabilities[2]);
     BOOST_REQUIRE_EQUAL(probabilities[2], probabilities[3]);
@@ -1957,7 +1952,7 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
 
     // Expect the influence for this anomaly to be "INF1":"inf2"
     LOG_DEBUG(<< core::CContainerPrinter::print(lastInfluencersResult));
-    BOOST_REQUIRE_EQUAL(std::size_t(1), lastInfluencersResult.size());
+    BOOST_REQUIRE_EQUAL(1, lastInfluencersResult.size());
     BOOST_TEST_REQUIRE(lastInfluencersResult[0].second > 0.75);
     BOOST_REQUIRE_EQUAL(std::string("IF1"), *lastInfluencersResult[0].first.first);
     BOOST_REQUIRE_EQUAL(std::string("inf2"), *lastInfluencersResult[0].first.second);
@@ -2003,8 +1998,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     CEventRateModel* modelNoGap = dynamic_cast<CEventRateModel*>(modelNoGap_.get());
     for (std::size_t i = 0u; i < 2; ++i) {
         BOOST_REQUIRE_EQUAL(
-            std::size_t(i),
-            this->addPerson("p" + core::CStringUtils::typeToString(i + 1), gathererNoGap));
+            i, this->addPerson("p" + core::CStringUtils::typeToString(i + 1), gathererNoGap));
     }
 
     // p1: |1|1|1|
@@ -2025,8 +2019,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     CEventRateModel* modelWithGap = dynamic_cast<CEventRateModel*>(modelWithGap_.get());
     for (std::size_t i = 0u; i < 2; ++i) {
         BOOST_REQUIRE_EQUAL(
-            std::size_t(i),
-            this->addPerson("p" + core::CStringUtils::typeToString(i + 1), gathererWithGap));
+            i, this->addPerson("p" + core::CStringUtils::typeToString(i + 1), gathererWithGap));
     }
 
     // p1: |1|1|0|0|0|0|0|0|0|0|1|1|
@@ -2046,7 +2039,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
     // Check prune does not remove people because last seen times are updated by adding gap duration
     modelWithGap->prune(maxAgeBuckets);
-    BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActivePeople());
+    BOOST_REQUIRE_EQUAL(2, gathererWithGap->numberActivePeople());
 
     this->addArrival(*gathererWithGap, 1000, "p1");
     modelWithGap->sample(1000, 1100, m_ResourceMonitor);
@@ -2075,11 +2068,11 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     modelWithGap->sample(1200, 1500, m_ResourceMonitor);
     modelWithGap->prune(maxAgeBuckets);
     // Age at this point will be 500 and since it's equal to maxAge it should still be here
-    BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActivePeople());
+    BOOST_REQUIRE_EQUAL(2, gathererWithGap->numberActivePeople());
     modelWithGap->sample(1500, 1600, m_ResourceMonitor);
     modelWithGap->prune(maxAgeBuckets);
     // Age at this point will be 600 so it should get pruned
-    BOOST_REQUIRE_EQUAL(std::size_t(1), gathererWithGap->numberActivePeople());
+    BOOST_REQUIRE_EQUAL(1, gathererWithGap->numberActivePeople());
 }
 
 BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
@@ -2198,7 +2191,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     core_t::TTime now{startTime};
     TDoubleVec samples(3, 0.0);
     while (now < endTime) {
-        rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
+        rng.generateUniformSamples(50.0, 70.0, 3, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
             this->addArrival(*m_Gatherer, now, "p1");
         }
@@ -2323,7 +2316,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
     test::CRandomNumbers rng;
     TDoubleVec samples(1, 0.0);
     while (now < endTime) {
-        rng.generateUniformSamples(80.0, 100.0, std::size_t(1), samples);
+        rng.generateUniformSamples(80.0, 100.0, 1, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
             this->addArrival(*m_Gatherer, now, "p1");
         }
@@ -2467,7 +2460,7 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbabilityGivenDetectionRule, CTestFixture) 
     core_t::TTime now = startTime;
     TDoubleVec samples(1, 0.0);
     while (now < endTime) {
-        rng.generateUniformSamples(50.0, 70.0, std::size_t(1), samples);
+        rng.generateUniformSamples(50.0, 70.0, 1, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
             this->addArrival(*m_Gatherer, now, "p1");
         }

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -34,7 +34,6 @@
 
 #include "CModelTestFixtureBase.h"
 
-#include <boost/lexical_cast.hpp>
 #include <boost/optional/optional_io.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/tuple/tuple.hpp>
@@ -45,6 +44,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -85,12 +85,12 @@ public:
 
         TStrVec attributes;
         for (std::size_t i = 0u; i < numberAttributes; ++i) {
-            attributes.push_back("c" + boost::lexical_cast<std::string>(i));
+            attributes.push_back("c" + std::to_string(i));
         }
 
         TStrVec people;
         for (std::size_t i = 0u; i < numberPeople; ++i) {
-            people.push_back("p" + boost::lexical_cast<std::string>(i));
+            people.push_back("p" + std::to_string(i));
         }
 
         TSizeVecVec attributePeople{
@@ -270,14 +270,14 @@ BOOST_FIXTURE_TEST_CASE(testFeatures, CTestFixture) {
         TDouble2VecWeightsAryVec& weights() { return m_Weights; }
 
     private:
-        using TDoubleSizeUMap = boost::unordered_map<double, std::size_t>;
+        using TDoubleSizeUMap = std::unordered_map<double, std::size_t>;
 
     private:
         TDoubleSizeUMap m_Uniques;
         TDouble2VecVec m_Values;
         TDouble2VecWeightsAryVec m_Weights;
     };
-    using TSizeUniqueValuesUMap = boost::unordered_map<std::size_t, CUniqueValues>;
+    using TSizeUniqueValuesUMap = std::unordered_map<std::size_t, CUniqueValues>;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;
@@ -298,7 +298,7 @@ BOOST_FIXTURE_TEST_CASE(testFeatures, CTestFixture) {
 
     model::CModelFactory::TFeatureMathsModelPtrPrVec models{
         m_Factory->defaultFeatureModels(features, bucketLength, 1.0, false)};
-    BOOST_REQUIRE_EQUAL(std::size_t(1), models.size());
+    BOOST_REQUIRE_EQUAL(1, models.size());
     BOOST_REQUIRE_EQUAL(model_t::E_PopulationCountByBucketPersonAndAttribute,
                         models[0].first);
 
@@ -972,8 +972,8 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
     // Check prune does not remove people because last seen times are updated by adding gap duration
     modelWithGap->prune(maxAgeBuckets);
-    BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActivePeople());
-    BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActiveAttributes());
+    BOOST_REQUIRE_EQUAL(2, gathererWithGap->numberActivePeople());
+    BOOST_REQUIRE_EQUAL(2, gathererWithGap->numberActiveAttributes());
 
     this->addArrival(SMessage(1000, "p1", "a1"), gathererWithGap);
     modelWithGap->sample(1000, 1100, m_ResourceMonitor);
@@ -1004,12 +1004,12 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     modelWithGap->sample(1200, 1500, m_ResourceMonitor);
     modelWithGap->prune(maxAgeBuckets);
     // Age at this point will be 500 and since it's equal to maxAge it should still be here
-    BOOST_REQUIRE_EQUAL(std::size_t(2), gathererWithGap->numberActiveAttributes());
+    BOOST_REQUIRE_EQUAL(2, gathererWithGap->numberActiveAttributes());
     modelWithGap->sample(1500, 1600, m_ResourceMonitor);
     modelWithGap->prune(maxAgeBuckets);
     // Age at this point will be 600 so it should get pruned
-    BOOST_REQUIRE_EQUAL(std::size_t(1), gathererWithGap->numberActivePeople());
-    BOOST_REQUIRE_EQUAL(std::size_t(1), gathererWithGap->numberActiveAttributes());
+    BOOST_REQUIRE_EQUAL(1, gathererWithGap->numberActivePeople());
+    BOOST_REQUIRE_EQUAL(1, gathererWithGap->numberActiveAttributes());
 }
 
 BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
@@ -1030,7 +1030,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     core_t::TTime endTime = now + 2 * 24 * bucketLength;
     TDoubleVec samples(3, 0.0);
     while (now < endTime) {
-        rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
+        rng.generateUniformSamples(50.0, 70.0, 3, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
             this->addArrival(SMessage(now, "p1", "a1"), m_Gatherer);
         }

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -107,7 +107,7 @@ BOOST_FIXTURE_TEST_CASE(testSample, CTestFixture) {
 
             this->makeModel(params, features, startTime, sampleCount);
             CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-            BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+            BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
             // Bucket values.
             uint64_t expectedCount{0};
@@ -200,14 +200,11 @@ BOOST_FIXTURE_TEST_CASE(testSample, CTestFixture) {
                             core_t::TTime sampleTime{static_cast<core_t::TTime>(
                                 expectedSampleTimes[k] + 0.5)};
                             expectedMeanSamples_.emplace_back(
-                                sampleTime, TDouble2Vec{expectedMeanSamples[k]},
-                                std::size_t(0));
+                                sampleTime, TDouble2Vec{expectedMeanSamples[k]}, 0);
                             expectedMinSamples_.emplace_back(
-                                sampleTime, TDouble2Vec{expectedMinSamples[k]},
-                                std::size_t(0));
+                                sampleTime, TDouble2Vec{expectedMinSamples[k]}, 0);
                             expectedMaxSamples_.emplace_back(
-                                sampleTime, TDouble2Vec{expectedMaxSamples[k]},
-                                std::size_t(0));
+                                sampleTime, TDouble2Vec{expectedMaxSamples[k]}, 0);
                         }
                         expectedMeanModel->addSamples(params_, expectedMeanSamples_);
                         expectedMinModel->addSamples(params_, expectedMinSamples_);
@@ -356,7 +353,7 @@ BOOST_FIXTURE_TEST_CASE(testMultivariateSample, CTestFixture) {
         this->makeModel(params, {model_t::E_IndividualMeanLatLongByPerson},
                         startTime, sampleCount);
         CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
         // Bucket values.
         uint64_t expectedCount{0};
@@ -520,7 +517,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMetric, CTestFixture) {
 
     this->makeModel(params, features, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr> minProbabilities(2u);
     test::CRandomNumbers rng;
@@ -571,7 +568,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualMedianByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     maths::CBasicStatistics::COrderStatisticsHeap<TDoubleSizePr> minProbabilities(2u);
     test::CRandomNumbers rng;
@@ -625,7 +622,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
 
     // assert there is only 1 value in the last bucket and its the median
     BOOST_REQUIRE_EQUAL(fd->s_BucketValue->value()[0], mean * 3.0);
-    BOOST_REQUIRE_EQUAL(fd->s_BucketValue->value().size(), std::size_t(1));
+    BOOST_REQUIRE_EQUAL(fd->s_BucketValue->value().size(), 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMean, CTestFixture) {
@@ -643,7 +640,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMean, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualLowMeanByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -699,7 +696,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMean, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualHighMeanByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -753,7 +750,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowSum, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualLowSumByBucketAndPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -806,7 +803,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighSum, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualHighSumByBucketAndPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -875,7 +872,7 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
         factory.bucketLength(bucketLength);
         factory.fieldNames("", "", "P", "V", TStrVec{"I"});
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer));
         CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
         BOOST_TEST_REQUIRE(model_);
         BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
@@ -941,7 +938,7 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
         factory.fieldNames("", "", "P", "V", TStrVec(1, "I"));
         CModelFactory::SGathererInitializationData gathererInitData(startTime);
         CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(gathererInitData));
-        BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
+        BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer));
         CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
         BOOST_TEST_REQUIRE(model_);
         BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
@@ -1290,7 +1287,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     factory.fieldNames("", "", "P", "V", TStrVec(1, "I"));
 
     CModelFactory::TDataGathererPtr gathererNoGap(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererNoGap));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gathererNoGap));
     CModelFactory::TModelPtr modelNoGapPtr(factory.makeModel(gathererNoGap));
     BOOST_TEST_REQUIRE(modelNoGapPtr);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, modelNoGapPtr->category());
@@ -1318,7 +1315,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     }
 
     CModelFactory::TDataGathererPtr gathererWithGap(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gathererWithGap));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gathererWithGap));
     CModelFactory::TModelPtr modelWithGapPtr(factory.makeModel(gathererWithGap));
     BOOST_TEST_REQUIRE(modelWithGapPtr);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, modelWithGapPtr->category());
@@ -1462,8 +1459,8 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     factory.fieldNames("", "", "P", "V", TStrVec());
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
     BOOST_TEST_REQUIRE(!gatherer->isPopulation());
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
-    BOOST_REQUIRE_EQUAL(std::size_t(1), this->addPerson("q", gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer));
+    BOOST_REQUIRE_EQUAL(1, this->addPerson("q", gatherer));
     CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
     BOOST_TEST_REQUIRE(model_);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
@@ -1583,7 +1580,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     factory.fieldNames("", "", "P", "V", TStrVec(1, "I"));
 
     CModelFactory::TDataGathererPtr gatherer(factory.makeDataGatherer(startTime));
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gatherer));
     CModelFactory::TModelPtr model_(factory.makeModel(gatherer));
     BOOST_TEST_REQUIRE(model_);
     BOOST_REQUIRE_EQUAL(model_t::E_MetricOnline, model_->category());
@@ -1599,7 +1596,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     test::CRandomNumbers rng;
     TDoubleVec samples(3, 0.0);
     while (now < endTime) {
-        rng.generateUniformSamples(50.0, 70.0, std::size_t(3), samples);
+        rng.generateUniformSamples(50.0, 70.0, 3, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
             this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
         }
@@ -1693,7 +1690,7 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
     test::CRandomNumbers rng;
     TDoubleVec samples(1, 0.0);
     while (now < endTime) {
-        rng.generateUniformSamples(80.0, 100.0, std::size_t(1), samples);
+        rng.generateUniformSamples(80.0, 100.0, 1, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
             this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
         }
@@ -2104,7 +2101,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMedian, CTestFixture) {
     SModelParams params(bucketLength);
     this->makeModel(params, {model_t::E_IndividualLowMedianByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;
@@ -2158,7 +2155,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMedian, CTestFixture) {
     SModelParams params(bucketLength);
     makeModel(params, {model_t::E_IndividualHighMeanByPerson}, startTime);
     CMetricModel& model = static_cast<CMetricModel&>(*m_Model);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), this->addPerson("p", m_Gatherer));
+    BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
     TOptionalDoubleVec probabilities;
     test::CRandomNumbers rng;

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -538,7 +538,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     time += bucketLength;
     processBucket(time, bucketLength, b10, *m_Gatherer, model, annotatedProbability);
     BOOST_TEST_REQUIRE(annotatedProbability.s_Probability < 0.1);
-    BOOST_REQUIRE_EQUAL(std::size_t(1), annotatedProbability.s_Influences.size());
+    BOOST_REQUIRE_EQUAL(1, annotatedProbability.s_Influences.size());
     BOOST_REQUIRE_EQUAL(std::string("I"),
                         *annotatedProbability.s_Influences[0].first.first);
     BOOST_REQUIRE_EQUAL(std::string("i2"),

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -256,7 +256,7 @@ protected:
 
 protected:
     using TInterimBucketCorrectorPtr = std::shared_ptr<ml::model::CInterimBucketCorrector>;
-    using TModelFactoryPtr = boost::shared_ptr<ml::model::CModelFactory>;
+    using TModelFactoryPtr = std::shared_ptr<ml::model::CModelFactory>;
 
 protected:
     ml::model::CResourceMonitor m_ResourceMonitor;


### PR DESCRIPTION
Move boilerplate code for creating models to a base class method.

This goes some way to reducing duplicated code and standardising how models are created.

Relates to #1477