### PR TITLE
[7.x][ML] Prefer smaller models with similar performance 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 7.11.0
+
+=== Enhancements
+
+* During regression and classification training prefer smaller models if performance is
+  similar (See {ml-pull}1516[#1516].)
+
 == {es} version 7.10.0
 
 === Enhancements

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -54,7 +54,8 @@ public:
     using TVector = CDenseVector<double>;
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
-    using TMeanVarAccumulatorSizePr = std::pair<TMeanVarAccumulator, std::size_t>;
+    using TMeanVarAccumulatorSizeDoubleTuple =
+        std::tuple<TMeanVarAccumulator, std::size_t, double>;
     using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
     using TBayesinOptimizationUPtr = std::unique_ptr<maths::CBayesianOptimisation>;
     using TNodeVec = CBoostedTree::TNodeVec;
@@ -211,7 +212,7 @@ private:
     void initializeTreeShap(const core::CDataFrame& frame);
 
     //! Train the forest and compute loss moments on each fold.
-    TMeanVarAccumulatorSizePr crossValidateForest(core::CDataFrame& frame);
+    TMeanVarAccumulatorSizeDoubleTuple crossValidateForest(core::CDataFrame& frame);
 
     //! Initialize the predictions and loss function derivatives for the masked
     //! rows in \p frame.
@@ -289,7 +290,8 @@ private:
 
     //! Capture the current hyperparameter values.
     void captureBestHyperparameters(const TMeanVarAccumulator& lossMoments,
-                                    std::size_t maximumNumberTrees);
+                                    std::size_t maximumNumberTrees,
+                                    double numberNodes);
 
     //! Set the hyperparamaters from the best recorded.
     void restoreBestHyperparameters();
@@ -370,6 +372,8 @@ private:
     std::size_t m_NumberTopShapValues = 0;
     TTreeShapFeatureImportanceUPtr m_TreeShap;
     TAnalysisInstrumentationPtr m_Instrumentation;
+    mutable TMeanAccumulator m_ForestSizeAccumulator;
+    mutable TMeanAccumulator m_MeanLossAccumulator;
 
 private:
     friend class CBoostedTreeFactory;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
                     8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
             }
             // Good R^2...
-            BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.95);
+            BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.94);
 
             meanModelRSquared.add(modelRSquared[i][0]);
         }


### PR DESCRIPTION
For regression and classification, during hyperparameter optimization we prefer smaller models if the loss functions are otherwise comparable.

To this end, we add 0.01 * "forest number nodes" * E[GP] / "average forest number nodes" as an additional penalty.

Backport of #1516.