### PR TITLE
[ML] Amalgamate addArrival methods

### DIFF
--- a/lib/model/unittest/CCountingModelTest.cc
+++ b/lib/model/unittest/CCountingModelTest.cc
@@ -80,13 +80,13 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         BOOST_REQUIRE_EQUAL(0, this->addPerson("p", gathererNoGap));
 
         // |2|2|0|0|1| -> 1.0 mean count
-        this->addArrival(*gathererNoGap, 100, "p");
-        this->addArrival(*gathererNoGap, 110, "p");
+        this->addArrival(SMessage(100, "p", TOptionalStr()), gathererNoGap);
+        this->addArrival(SMessage(110, "p", TOptionalStr()), gathererNoGap);
         modelNoGap->sample(100, 200, m_ResourceMonitor);
-        this->addArrival(*gathererNoGap, 250, "p");
-        this->addArrival(*gathererNoGap, 280, "p");
+        this->addArrival(SMessage(250, "p", TOptionalStr()), gathererNoGap);
+        this->addArrival(SMessage(280, "p", TOptionalStr()), gathererNoGap);
         modelNoGap->sample(200, 500, m_ResourceMonitor);
-        this->addArrival(*gathererNoGap, 500, "p");
+        this->addArrival(SMessage(500, "p", TOptionalStr()), gathererNoGap);
         modelNoGap->sample(500, 600, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(1.0, *modelNoGap->baselineBucketCount(0));
@@ -103,15 +103,15 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
         // |2|2|0|0|1|
         // |2|X|X|X|1| -> 1.5 mean count where X means skipped bucket
-        this->addArrival(*gathererWithGap, 100, "p");
-        this->addArrival(*gathererWithGap, 110, "p");
+        this->addArrival(SMessage(100, "p", TOptionalStr()), gathererWithGap);
+        this->addArrival(SMessage(110, "p", TOptionalStr()), gathererWithGap);
         modelWithGap->sample(100, 200, m_ResourceMonitor);
-        this->addArrival(*gathererWithGap, 250, "p");
-        this->addArrival(*gathererWithGap, 280, "p");
+        this->addArrival(SMessage(250, "p", TOptionalStr()), gathererWithGap);
+        this->addArrival(SMessage(280, "p", TOptionalStr()), gathererWithGap);
         modelWithGap->skipSampling(500);
         modelWithGap->prune(maxAgeBuckets);
         BOOST_REQUIRE_EQUAL(1, gathererWithGap->numberActivePeople());
-        this->addArrival(*gathererWithGap, 500, "p");
+        this->addArrival(SMessage(500, "p", TOptionalStr()), gathererWithGap);
         modelWithGap->sample(500, 600, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(1.5, *modelWithGap->baselineBucketCount(0));
@@ -237,8 +237,9 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
         std::sort(offsets.begin(), offsets.end());
         for (auto offset : offsets) {
             rng.generateUniformSamples(0.0, 1.0, 1, uniform01);
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(offset),
-                             uniform01[0] < 0.5 ? "p1" : "p2");
+            this->addArrival(SMessage(time + static_cast<core_t::TTime>(offset),
+                                      uniform01[0] < 0.5 ? "p1" : "p2", TOptionalStr()),
+                             m_Gatherer);
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
@@ -248,8 +249,9 @@ BOOST_FIXTURE_TEST_CASE(testInterimBucketCorrector, CTestFixture) {
 
     for (std::size_t i = 0u; i < offsets.size(); ++i) {
         rng.generateUniformSamples(0.0, 1.0, 1, uniform01);
-        this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(offsets[i]),
-                         uniform01[0] < 0.5 ? "p1" : "p2");
+        this->addArrival(SMessage(time + static_cast<core_t::TTime>(offsets[i]),
+                                  uniform01[0] < 0.5 ? "p1" : "p2", TOptionalStr()),
+                         m_Gatherer);
         model->sampleBucketStatistics(time, time + bucketLength, m_ResourceMonitor);
         BOOST_REQUIRE_EQUAL(static_cast<double>(i + 1) / 10.0,
                             m_InterimBucketCorrector->completeness());

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -233,7 +233,7 @@ BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
 
         double count{0.0};
         for (/**/; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            this->addArrival(*m_Gatherer, eventTimes[i], "p1");
+            this->addArrival(SMessage(eventTimes[i], "p1", TOptionalDouble()), m_Gatherer);
             count += 1.0;
         }
 
@@ -328,7 +328,7 @@ BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
 
         double count{0.0};
         for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-            this->addArrival(*m_Gatherer, eventTimes[i], "p1");
+            this->addArrival(SMessage(eventTimes[i], "p1", TOptionalDouble()), m_Gatherer);
             count += 1.0;
         }
 
@@ -378,23 +378,23 @@ BOOST_FIXTURE_TEST_CASE(testRare, CTestFixture) {
 
     core_t::TTime time{startTime};
     for (/**/; time < startTime + 10 * bucketLength; time += bucketLength) {
-        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p1");
-        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p2");
+        this->addArrival(SMessage(time + bucketLength / 2, "p1", TOptionalDouble()), m_Gatherer);
+        this->addArrival(SMessage(time + bucketLength / 2, "p2", TOptionalDouble()), m_Gatherer);
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
     for (/**/; time < startTime + 50 * bucketLength; time += bucketLength) {
-        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p1");
-        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p2");
-        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p3");
-        this->addArrival(*m_Gatherer, time + bucketLength / 2, "p4");
+        this->addArrival(SMessage(time + bucketLength / 2, "p1", TOptionalDouble()), m_Gatherer);
+        this->addArrival(SMessage(time + bucketLength / 2, "p2", TOptionalDouble()), m_Gatherer);
+        this->addArrival(SMessage(time + bucketLength / 2, "p3", TOptionalDouble()), m_Gatherer);
+        this->addArrival(SMessage(time + bucketLength / 2, "p4", TOptionalDouble()), m_Gatherer);
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
 
-    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p1");
-    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p2");
-    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p3");
-    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p4");
-    this->addArrival(*m_Gatherer, time + bucketLength / 2, "p5");
+    this->addArrival(SMessage(time + bucketLength / 2, "p1", TOptionalDouble()), m_Gatherer);
+    this->addArrival(SMessage(time + bucketLength / 2, "p2", TOptionalDouble()), m_Gatherer);
+    this->addArrival(SMessage(time + bucketLength / 2, "p3", TOptionalDouble()), m_Gatherer);
+    this->addArrival(SMessage(time + bucketLength / 2, "p4", TOptionalDouble()), m_Gatherer);
+    this->addArrival(SMessage(time + bucketLength / 2, "p5", TOptionalDouble()), m_Gatherer);
     model->sample(time, time + bucketLength, m_ResourceMonitor);
 
     TDoubleVec probabilities;
@@ -490,7 +490,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculation, CTestFixture) {
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                this->addArrival(*m_Gatherer, eventTimes[i], "p1");
+                this->addArrival(SMessage(eventTimes[i], "p1", TOptionalDouble()), m_Gatherer);
                 count += 1.0;
             }
 
@@ -547,7 +547,9 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowNonZeroCount, CTestFixtu
         LOG_DEBUG(<< "Writing " << count << " values");
 
         for (std::size_t i = 0u; i < count; ++i) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(i), "p1");
+            this->addArrival(SMessage(time + static_cast<core_t::TTime>(i),
+                                      "p1", TOptionalDouble()),
+                             m_Gatherer);
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -591,7 +593,9 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighNonZeroCount, CTestFixt
         LOG_DEBUG(<< "Writing " << count << " values");
 
         for (std::size_t i = 0u; i < count; ++i) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(i), "p1");
+            this->addArrival(SMessage(time + static_cast<core_t::TTime>(i),
+                                      "p1", TOptionalDouble()),
+                             m_Gatherer);
         }
         model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -664,8 +668,9 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
                     n += anomalies[anomaly][j];
                 }
                 for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                    this->addArrival(*m_Gatherer,
-                                     time + static_cast<core_t::TTime>(j), person);
+                    this->addArrival(SMessage(time + static_cast<core_t::TTime>(j),
+                                              person, TOptionalDouble()),
+                                     m_Gatherer);
                 }
             }
             if (i == anomalyBuckets[anomaly]) {
@@ -761,8 +766,9 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedNoTrend, CTestFixture) {
                 }
                 n = std::max(n, 0.0);
                 for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                    this->addArrival(*m_Gatherer,
-                                     time + static_cast<core_t::TTime>(j), person);
+                    this->addArrival(SMessage(time + static_cast<core_t::TTime>(j),
+                                              person, TOptionalDouble()),
+                                     m_Gatherer);
                 }
             }
             if (i == anomalyBuckets[anomaly]) {
@@ -873,7 +879,9 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
             }
             n = std::max(n / 3.0, 0.0);
             for (std::size_t k = 0u; k < static_cast<std::size_t>(n); ++k) {
-                this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j), person);
+                this->addArrival(SMessage(time + static_cast<core_t::TTime>(j),
+                                          person, TOptionalDouble()),
+                                 m_Gatherer);
             }
         }
         if (i == anomalyBuckets[anomaly]) {
@@ -1005,8 +1013,10 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        this->addArrival(*gatherer, event.time(),
-                         gatherer->personName(event.personId().get()));
+        this->addArrival(SMessage(event.time(),
+                                  gatherer->personName(event.personId().get()),
+                                  TOptionalDouble()),
+                         gatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     size_t maxDimensionBeforePrune(model->dataGatherer().maxDimension());
@@ -1020,8 +1030,10 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        this->addArrival(*expectedGatherer, event.time(),
-                         expectedGatherer->personName(event.personId().get()));
+        this->addArrival(SMessage(event.time(),
+                                  expectedGatherer->personName(event.personId().get()),
+                                  TOptionalDouble()),
+                         expectedGatherer);
     }
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
 
@@ -1038,12 +1050,18 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
         BOOST_TEST_REQUIRE(newPid < 6);
         std::size_t expectedNewPid = this->addPerson(person, expectedGatherer);
 
-        this->addArrival(*gatherer, bucketStart + 1, gatherer->personName(newPid));
-        this->addArrival(*gatherer, bucketStart + 2000, gatherer->personName(newPid));
-        this->addArrival(*expectedGatherer, bucketStart + 1,
-                         expectedGatherer->personName(expectedNewPid));
-        this->addArrival(*expectedGatherer, bucketStart + 2000,
-                         expectedGatherer->personName(expectedNewPid));
+        this->addArrival(SMessage(bucketStart + 1, gatherer->personName(newPid),
+                                  TOptionalDouble()),
+                         gatherer);
+        this->addArrival(SMessage(bucketStart + 2000,
+                                  gatherer->personName(newPid), TOptionalDouble()),
+                         gatherer);
+        this->addArrival(SMessage(bucketStart + 1, expectedGatherer->personName(expectedNewPid),
+                                  TOptionalDouble()),
+                         expectedGatherer);
+        this->addArrival(SMessage(bucketStart + 2000, expectedGatherer->personName(expectedNewPid),
+                                  TOptionalDouble()),
+                         expectedGatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -1238,7 +1256,8 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
 
             double count = 0.0;
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                this->addArrival(*gatherer, eventTimes[i], "p", TOptionalStr("inf1"));
+                this->addArrival(
+                    SMessage(eventTimes[i], "p", {}, {}, TOptionalStr("inf1")), gatherer);
                 count += 1.0;
             }
 
@@ -1297,7 +1316,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                 std::stringstream ss;
                 ss << "inf" << (i % 2);
                 const std::string inf(ss.str());
-                this->addArrival(*gatherer, eventTimes[i], "p", inf);
+                this->addArrival(SMessage(eventTimes[i], "p", {}, {}, inf), gatherer);
                 count += 1.0;
             }
 
@@ -1360,7 +1379,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                 std::stringstream ss;
                 ss << "inf" << (i % 2);
                 const std::string inf(ss.str());
-                this->addArrival(*gatherer, eventTimes[i], "p", inf);
+                this->addArrival(SMessage(eventTimes[i], "p", {}, {}, inf), gatherer);
                 count += 1.0;
             }
 
@@ -1427,7 +1446,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                     ss << "_extra";
                 }
                 const std::string inf(ss.str());
-                this->addArrival(*gatherer, eventTimes[i], "p", inf);
+                this->addArrival(SMessage(eventTimes[i], "p", {}, {}, inf), gatherer);
                 count += 1.0;
             }
 
@@ -1492,7 +1511,7 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
                 const std::string inf1(ss.str());
                 ss << "_another";
                 const std::string inf2(ss.str());
-                this->addArrival(*gatherer, eventTimes[i], "p", inf1, inf2);
+                this->addArrival(SMessage(eventTimes[i], "p", {}, {}, inf1, inf2), gatherer);
 
                 count += 1.0;
             }
@@ -1556,7 +1575,8 @@ BOOST_FIXTURE_TEST_CASE(testCountProbabilityCalculationWithInfluence, CTestFixtu
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                this->addArrival(*gatherer, eventTimes[i], "p", TOptionalStr("p"));
+                this->addArrival(
+                    SMessage(eventTimes[i], "p", {}, {}, TOptionalStr("p")), gatherer);
                 count += 1.0;
             }
 
@@ -1617,8 +1637,9 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                this->addArrival(*gatherer, eventTimes[i], "p",
-                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
+                this->addArrival(SMessage(eventTimes[i], "p", {}, {}, TOptionalStr("inf1"),
+                                          TOptionalStr(uniqueValue)),
+                                 gatherer);
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1627,8 +1648,10 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                 for (std::size_t k = 0; k < 20; k++) {
                     std::stringstream ss;
                     ss << uniqueValue << "_" << k;
-                    this->addArrival(*gatherer, eventTimes[i - 1], "p",
-                                     TOptionalStr("inf1"), TOptionalStr(ss.str()));
+                    this->addArrival(SMessage(eventTimes[i - 1], "p", {}, {},
+                                              TOptionalStr("inf1"),
+                                              TOptionalStr(ss.str())),
+                                     gatherer);
                 }
             }
 
@@ -1684,8 +1707,9 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                this->addArrival(*gatherer, eventTimes[i], "p",
-                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
+                this->addArrival(SMessage(eventTimes[i], "p", {}, {}, TOptionalStr("inf1"),
+                                          TOptionalStr(uniqueValue)),
+                                 gatherer);
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1696,11 +1720,15 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                     ss << uniqueValue << "_" << k;
                     CEventData d = makeEventData(eventTimes[i - 1], 0, {}, ss.str());
                     if (k % 2 == 0) {
-                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
-                                         TOptionalStr("inf1"), TOptionalStr(ss.str()));
+                        this->addArrival(SMessage(eventTimes[i - 1], "p", {},
+                                                  {}, TOptionalStr("inf1"),
+                                                  TOptionalStr(ss.str())),
+                                         gatherer);
                     } else {
-                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
-                                         TOptionalStr("inf2"), TOptionalStr(ss.str()));
+                        this->addArrival(SMessage(eventTimes[i - 1], "p", {},
+                                                  {}, TOptionalStr("inf2"),
+                                                  TOptionalStr(ss.str())),
+                                         gatherer);
                     }
                 }
             }
@@ -1761,8 +1789,9 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                this->addArrival(*gatherer, eventTimes[i], "p",
-                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
+                this->addArrival(SMessage(eventTimes[i], "p", {}, {}, TOptionalStr("inf1"),
+                                          TOptionalStr(uniqueValue)),
+                                 gatherer);
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1772,11 +1801,15 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                     std::stringstream ss;
                     ss << uniqueValue << "_" << k;
                     if (k == 1) {
-                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
-                                         TOptionalStr("inf2"), TOptionalStr(ss.str()));
+                        this->addArrival(SMessage(eventTimes[i - 1], "p", {},
+                                                  {}, TOptionalStr("inf2"),
+                                                  TOptionalStr(ss.str())),
+                                         gatherer);
                     } else {
-                        this->addArrival(*gatherer, eventTimes[i - 1], "p",
-                                         TOptionalStr("inf1"), TOptionalStr(ss.str()));
+                        this->addArrival(SMessage(eventTimes[i - 1], "p", {},
+                                                  {}, TOptionalStr("inf1"),
+                                                  TOptionalStr(ss.str())),
+                                         gatherer);
                     }
                 }
             }
@@ -1834,8 +1867,10 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
 
             double count{0.0};
             for (; i < eventTimes.size() && eventTimes[i] < bucketEndTime; ++i) {
-                this->addArrival(*gatherer, eventTimes[i], "p", TOptionalStr("inf1"),
-                                 TOptionalStr("inf1"), TOptionalStr(uniqueValue));
+                this->addArrival(
+                    SMessage(eventTimes[i], "p", {}, {}, TOptionalStr("inf1"),
+                             TOptionalStr("inf1"), TOptionalStr(uniqueValue)),
+                    gatherer);
                 count += 1.0;
             }
             if (i == eventTimes.size()) {
@@ -1855,9 +1890,10 @@ BOOST_FIXTURE_TEST_CASE(testDistinctCountProbabilityCalculationWithInfluence, CT
                     LOG_DEBUG(<< "Inf1 = " << inf1);
                     LOG_DEBUG(<< "Inf2 = " << inf2);
                     LOG_DEBUG(<< "Value = " << ss1.str());
-                    this->addArrival(*gatherer, eventTimes[i - 1], "p",
-                                     TOptionalStr(inf1), TOptionalStr(inf2),
-                                     TOptionalStr(ss1.str()));
+                    this->addArrival(SMessage(eventTimes[i - 1], "p", {}, {},
+                                              TOptionalStr(inf1), TOptionalStr(inf2),
+                                              TOptionalStr(ss1.str())),
+                                     gatherer);
                 }
             }
 
@@ -1914,19 +1950,28 @@ BOOST_FIXTURE_TEST_CASE(testRareWithInfluence, CTestFixture) {
     core_t::TTime time{startTime};
 
     for (/**/; time < startTime + 50 * bucketLength; time += bucketLength) {
-        this->addArrival(*gatherer, time + bucketLength / 2, "p1", TOptionalStr("inf1"));
-        this->addArrival(*gatherer, time + bucketLength / 2, "p2", TOptionalStr("inf1"));
-        this->addArrival(*gatherer, time + bucketLength / 2, "p3", TOptionalStr("inf1"));
-        this->addArrival(*gatherer, time + bucketLength / 2, "p4", TOptionalStr("inf1"));
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p1", {}, {}, TOptionalStr("inf1")), gatherer);
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p2", {}, {}, TOptionalStr("inf1")), gatherer);
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p3", {}, {}, TOptionalStr("inf1")), gatherer);
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p4", {}, {}, TOptionalStr("inf1")), gatherer);
         model->sample(time, time + bucketLength, m_ResourceMonitor);
     }
 
     {
-        this->addArrival(*gatherer, time + bucketLength / 2, "p1", TOptionalStr("inf1"));
-        this->addArrival(*gatherer, time + bucketLength / 2, "p2", TOptionalStr("inf1"));
-        this->addArrival(*gatherer, time + bucketLength / 2, "p3", TOptionalStr("inf1"));
-        this->addArrival(*gatherer, time + bucketLength / 2, "p4", TOptionalStr("inf1"));
-        this->addArrival(*gatherer, time + bucketLength / 2, "p5", TOptionalStr("inf2"));
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p1", {}, {}, TOptionalStr("inf1")), gatherer);
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p2", {}, {}, TOptionalStr("inf1")), gatherer);
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p3", {}, {}, TOptionalStr("inf1")), gatherer);
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p4", {}, {}, TOptionalStr("inf1")), gatherer);
+        this->addArrival(
+            SMessage(time + bucketLength / 2, "p5", {}, {}, TOptionalStr("inf2")), gatherer);
     }
     model->sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -2003,12 +2048,12 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
     // p1: |1|1|1|
     // p2: |1|0|0|
-    this->addArrival(*gathererNoGap, 100, "p1");
-    this->addArrival(*gathererNoGap, 100, "p2");
+    this->addArrival(SMessage(100, "p1", TOptionalDouble()), gathererNoGap);
+    this->addArrival(SMessage(100, "p2", TOptionalDouble()), gathererNoGap);
     modelNoGap->sample(100, 200, m_ResourceMonitor);
-    this->addArrival(*gathererNoGap, 200, "p1");
+    this->addArrival(SMessage(200, "p1", TOptionalDouble()), gathererNoGap);
     modelNoGap->sample(200, 300, m_ResourceMonitor);
-    this->addArrival(*gathererNoGap, 300, "p1");
+    this->addArrival(SMessage(300, "p1", TOptionalDouble()), gathererNoGap);
     modelNoGap->sample(300, 400, m_ResourceMonitor);
 
     CModelFactory::TDataGathererPtr gathererWithGap;
@@ -2028,11 +2073,11 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     // p2: |1|X|X|X|X|X|X|X|X|X|0|0| -> equal to |1|0|0|
     // where X means skipped bucket
 
-    this->addArrival(*gathererWithGap, 100, "p1");
-    this->addArrival(*gathererWithGap, 100, "p2");
+    this->addArrival(SMessage(100, "p1", TOptionalDouble()), gathererWithGap);
+    this->addArrival(SMessage(100, "p2", TOptionalDouble()), gathererWithGap);
     modelWithGap->sample(100, 200, m_ResourceMonitor);
-    this->addArrival(*gathererWithGap, 200, "p1");
-    this->addArrival(*gathererWithGap, 200, "p2");
+    this->addArrival(SMessage(200, "p1", TOptionalDouble()), gathererWithGap);
+    this->addArrival(SMessage(200, "p2", TOptionalDouble()), gathererWithGap);
     modelWithGap->skipSampling(1000);
     LOG_DEBUG(<< "Calling sample over skipped interval should do nothing except print some ERRORs");
     modelWithGap->sample(200, 1000, m_ResourceMonitor);
@@ -2041,9 +2086,9 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
     modelWithGap->prune(maxAgeBuckets);
     BOOST_REQUIRE_EQUAL(2, gathererWithGap->numberActivePeople());
 
-    this->addArrival(*gathererWithGap, 1000, "p1");
+    this->addArrival(SMessage(1000, "p1", TOptionalDouble()), gathererWithGap);
     modelWithGap->sample(1000, 1100, m_ResourceMonitor);
-    this->addArrival(*gathererWithGap, 1100, "p1");
+    this->addArrival(SMessage(1100, "p1", TOptionalDouble()), gathererWithGap);
     modelWithGap->sample(1100, 1200, m_ResourceMonitor);
 
     // Check priors are the same
@@ -2096,22 +2141,28 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |1|1|1|X|X|1|
     // p2: |1|1|0|X|X|0|
-    this->addArrival(*gathererSkipGap, 100, "p1", TOptionalStr(),
-                     TOptionalStr(), TOptionalStr("1"));
-    this->addArrival(*gathererSkipGap, 100, "p2", TOptionalStr(),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(100, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererSkipGap);
+    this->addArrival(SMessage(100, "p2", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap->sample(100, 200, m_ResourceMonitor);
-    this->addArrival(*gathererSkipGap, 200, "p1", TOptionalStr(),
-                     TOptionalStr(), TOptionalStr("1"));
-    this->addArrival(*gathererSkipGap, 200, "p2", TOptionalStr(),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(200, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererSkipGap);
+    this->addArrival(SMessage(200, "p2", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap->sample(200, 300, m_ResourceMonitor);
-    this->addArrival(*gathererSkipGap, 300, "p1", TOptionalStr(),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(300, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap->sample(300, 400, m_ResourceMonitor);
     modelSkipGap->skipSampling(600);
-    this->addArrival(*gathererSkipGap, 600, "p1", TOptionalStr(),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(600, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap->sample(600, 700, m_ResourceMonitor);
 
     CModelFactory::TDataGathererPtr gathererExNull;
@@ -2124,37 +2175,50 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |1,"",null|1|1|null|null|1|
     // p2: |1,""|1|0|null|null|0|
-    this->addArrival(*gathererExNull, 100, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("1"));
-    this->addArrival(*gathererExNull, 100, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr(""));
-    this->addArrival(*gathererExNull, 100, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("null"));
-    this->addArrival(*gathererExNull, 100, "p2", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("1"));
-    this->addArrival(*gathererExNull, 100, "p2", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr(""));
+    this->addArrival(SMessage(100, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("null")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p2", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p2", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("")),
+                     gathererExNull);
     modelExNullGap->sample(100, 200, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 200, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("1"));
-    this->addArrival(*gathererExNull, 200, "p2", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("1"));
+    this->addArrival(SMessage(200, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererExNull);
+    this->addArrival(SMessage(200, "p2", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererExNull);
     modelExNullGap->sample(200, 300, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 300, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("1"));
+    this->addArrival(SMessage(300, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererExNull);
     modelExNullGap->sample(300, 400, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 400, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("null"));
-    this->addArrival(*gathererExNull, 400, "p2", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("null"));
+    this->addArrival(SMessage(400, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("null")),
+                     gathererExNull);
+    this->addArrival(SMessage(400, "p2", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("null")),
+                     gathererExNull);
     modelExNullGap->sample(400, 500, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 500, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("null"));
-    this->addArrival(*gathererExNull, 500, "p2", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("null"));
+    this->addArrival(SMessage(500, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("null")),
+                     gathererExNull);
+    this->addArrival(SMessage(500, "p2", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("null")),
+                     gathererExNull);
     modelExNullGap->sample(500, 600, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 600, "p1", TOptionalStr(), TOptionalStr(),
-                     TOptionalStr("1"));
+    this->addArrival(SMessage(600, "p1", {}, {}, TOptionalStr(), TOptionalStr(),
+                              TOptionalStr("1")),
+                     gathererExNull);
     modelExNullGap->sample(600, 700, m_ResourceMonitor);
 
     // Check priors are the same
@@ -2193,26 +2257,26 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, 3, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            this->addArrival(*m_Gatherer, now, "p1");
+            this->addArrival(SMessage(now, "p1", TOptionalDouble()), m_Gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[1] + 0.5); ++i) {
-            this->addArrival(*m_Gatherer, now, "p2");
+            this->addArrival(SMessage(now, "p2", TOptionalDouble()), m_Gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[2] + 0.5); ++i) {
-            this->addArrival(*m_Gatherer, now, "p3");
+            this->addArrival(SMessage(now, "p3", TOptionalDouble()), m_Gatherer);
         }
         countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        this->addArrival(*m_Gatherer, now, "p1");
+        this->addArrival(SMessage(now, "p1", TOptionalDouble()), m_Gatherer);
     }
     for (std::size_t i = 0; i < 1; ++i) {
-        this->addArrival(*m_Gatherer, now, "p2");
+        this->addArrival(SMessage(now, "p2", TOptionalDouble()), m_Gatherer);
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        this->addArrival(*m_Gatherer, now, "p3");
+        this->addArrival(SMessage(now, "p3", TOptionalDouble()), m_Gatherer);
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -2259,13 +2323,13 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     BOOST_TEST_REQUIRE(p3Baseline[0] < 62.0);
 
     for (std::size_t i = 0; i < 25; ++i) {
-        this->addArrival(*m_Gatherer, now, "p1");
+        this->addArrival(SMessage(now, "p1", TOptionalDouble()), m_Gatherer);
     }
     for (std::size_t i = 0; i < 59; ++i) {
-        this->addArrival(*m_Gatherer, now, "p2");
+        this->addArrival(SMessage(now, "p2", TOptionalDouble()), m_Gatherer);
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        this->addArrival(*m_Gatherer, now, "p3");
+        this->addArrival(SMessage(now, "p3", TOptionalDouble()), m_Gatherer);
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -2318,25 +2382,25 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(80.0, 100.0, 1, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            this->addArrival(*m_Gatherer, now, "p1");
+            this->addArrival(SMessage(now, "p1", TOptionalDouble()), m_Gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 10.5); ++i) {
-            this->addArrival(*m_Gatherer, now, "p2");
+            this->addArrival(SMessage(now, "p2", TOptionalDouble()), m_Gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] - 9.5); ++i) {
-            this->addArrival(*m_Gatherer, now, "p3");
+            this->addArrival(SMessage(now, "p3", TOptionalDouble()), m_Gatherer);
         }
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 9; ++i) {
-        this->addArrival(*m_Gatherer, now, "p1");
+        this->addArrival(SMessage(now, "p1", TOptionalDouble()), m_Gatherer);
     }
     for (std::size_t i = 0; i < 10; ++i) {
-        this->addArrival(*m_Gatherer, now, "p2");
+        this->addArrival(SMessage(now, "p2", TOptionalDouble()), m_Gatherer);
     }
     for (std::size_t i = 0; i < 8; ++i) {
-        this->addArrival(*m_Gatherer, now, "p3");
+        this->addArrival(SMessage(now, "p3", TOptionalDouble()), m_Gatherer);
     }
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
@@ -2421,13 +2485,16 @@ BOOST_FIXTURE_TEST_CASE(testSummaryCountZeroRecordsAreIgnored, CTestFixture) {
         rng.generateUniformSamples(0.0, 1.0, 1, zeroCountProbability);
         for (std::size_t i = 0; i < samples[0]; ++i) {
             if (zeroCountProbability[0] < 0.2) {
-                this->addArrival(*gathererWithZeros, now, "p1", TOptionalStr(),
-                                 TOptionalStr(), TOptionalStr(summaryCountZero));
+                this->addArrival(SMessage(now, "p1", {}, {}, TOptionalStr(),
+                                          TOptionalStr(), TOptionalStr(summaryCountZero)),
+                                 gathererWithZeros);
             } else {
-                this->addArrival(*gathererWithZeros, now, "p1", TOptionalStr(),
-                                 TOptionalStr(), TOptionalStr(summaryCountOne));
-                this->addArrival(*gathererNoZeros, now, "p1", TOptionalStr(),
-                                 TOptionalStr(), TOptionalStr(summaryCountOne));
+                this->addArrival(SMessage(now, "p1", {}, {}, TOptionalStr(),
+                                          TOptionalStr(), TOptionalStr(summaryCountOne)),
+                                 gathererWithZeros);
+                this->addArrival(SMessage(now, "p1", {}, {}, TOptionalStr(),
+                                          TOptionalStr(), TOptionalStr(summaryCountOne)),
+                                 gathererNoZeros);
             }
         }
         modelWithZeros.sample(now, now + bucketLength, m_ResourceMonitor);
@@ -2462,13 +2529,13 @@ BOOST_FIXTURE_TEST_CASE(testComputeProbabilityGivenDetectionRule, CTestFixture) 
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, 1, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            this->addArrival(*m_Gatherer, now, "p1");
+            this->addArrival(SMessage(now, "p1", TOptionalDouble()), m_Gatherer);
         }
         model->sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        this->addArrival(*m_Gatherer, now, "p1");
+        this->addArrival(SMessage(now, "p1", TOptionalDouble()), m_Gatherer);
     }
     model->sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
 
@@ -2533,8 +2600,10 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                                    ? 1.0
                                    : 0.0);
             for (std::size_t i = 0u; i < static_cast<std::size_t>(rate[0]); ++i) {
-                this->addArrival(*gatherer, t + bucketLength / 2, "p1");
-                this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1");
+                this->addArrival(
+                    SMessage(t + bucketLength / 2, "p1", TOptionalDouble()), gatherer);
+                this->addArrival(SMessage(t + bucketLength / 2, "p1", TOptionalDouble()),
+                                 referenceGatherer);
             }
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
@@ -2595,8 +2664,10 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
             for (std::size_t i = 0u; i < static_cast<std::size_t>(rate + noise[0]); ++i) {
-                this->addArrival(*gatherer, t + bucketLength / 2, "p1");
-                this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1");
+                this->addArrival(
+                    SMessage(t + bucketLength / 2, "p1", TOptionalDouble()), gatherer);
+                this->addArrival(SMessage(t + bucketLength / 2, "p1", TOptionalDouble()),
+                                 referenceGatherer);
             }
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
@@ -2662,8 +2733,10 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
             for (std::size_t i = 0u; i < static_cast<std::size_t>(rate + noise[0]); ++i) {
-                this->addArrival(*gatherer, t + bucketLength / 2, "p1");
-                this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1");
+                this->addArrival(
+                    SMessage(t + bucketLength / 2, "p1", TOptionalDouble()), gatherer);
+                this->addArrival(SMessage(t + bucketLength / 2, "p1", TOptionalDouble()),
+                                 referenceGatherer);
             }
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
@@ -2731,8 +2804,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Add a bucket to both models
     for (int i = 0; i < 66; ++i) {
-        this->addArrival(*gathererNoSkip, startTime, "p1");
-        this->addArrival(*gathererWithSkip, startTime, "p1");
+        this->addArrival(SMessage(startTime, "p1", TOptionalDouble()), gathererNoSkip);
+        this->addArrival(SMessage(startTime, "p1", TOptionalDouble()), gathererWithSkip);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2742,8 +2815,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Add a bucket to both models
     for (int i = 0; i < 55; ++i) {
-        this->addArrival(*gathererNoSkip, startTime, "p1");
-        this->addArrival(*gathererWithSkip, startTime, "p1");
+        this->addArrival(SMessage(startTime, "p1", TOptionalDouble()), gathererNoSkip);
+        this->addArrival(SMessage(startTime, "p1", TOptionalDouble()), gathererWithSkip);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2753,7 +2826,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // this sample will be skipped by the detection rule
     for (int i = 0; i < 110; ++i) {
-        this->addArrival(*gathererWithSkip, startTime, "p1");
+        this->addArrival(SMessage(startTime, "p1", TOptionalDouble()), gathererWithSkip);
     }
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
 
@@ -2764,8 +2837,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     modelNoSkip->skipSampling(startTime);
 
     for (int i = 0; i < 55; ++i) {
-        this->addArrival(*gathererNoSkip, startTime, "p1");
-        this->addArrival(*gathererWithSkip, startTime, "p1");
+        this->addArrival(SMessage(startTime, "p1", TOptionalDouble()), gathererNoSkip);
+        this->addArrival(SMessage(startTime, "p1", TOptionalDouble()), gathererWithSkip);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -142,7 +142,7 @@ BOOST_FIXTURE_TEST_CASE(testSample, CTestFixture) {
                     LOG_DEBUG(<< "Adding " << data[j].second << " at "
                               << data[j].first);
 
-                    this->addArrival(*m_Gatherer, data[j].first, "p", data[j].second);
+                    this->addArrival(SMessage(data[j].first, "p", data[j].second), m_Gatherer);
 
                     ++expectedCount;
                     expectedMean.add(data[j].second);
@@ -375,8 +375,10 @@ BOOST_FIXTURE_TEST_CASE(testMultivariateSample, CTestFixture) {
                 LOG_DEBUG(<< "Adding " << data[j].second[0] << ","
                           << data[j].second[1] << " at " << data[j].first);
 
-                this->addArrival(*m_Gatherer, data[j].first, "p",
-                                 data[j].second[0], data[j].second[1]);
+                this->addArrival(
+                    SMessage(data[j].first, "p", {},
+                             TDoubleDoublePr(data[j].second[0], data[j].second[1])),
+                    m_Gatherer);
 
                 ++expectedCount;
                 expectedLatLong.add(TVector2(data[j].second));
@@ -531,8 +533,9 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMetric, CTestFixture) {
                   << ", offset = " << (i == anomalousBucket ? anomaly : 0.0));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j), "p",
-                             values[j] + (i == anomalousBucket ? anomaly : 0.0));
+            this->addArrival(SMessage(time + static_cast<core_t::TTime>(j), "p",
+                                      values[j] + (i == anomalousBucket ? anomaly : 0.0)),
+                             m_Gatherer);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -589,8 +592,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
-                             "p", values[j]);
+            this->addArrival(
+                SMessage(time + static_cast<core_t::TTime>(j), "p", values[j]), m_Gatherer);
         }
 
         model.sample(time, time + bucketLength, m_ResourceMonitor);
@@ -658,8 +661,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMean, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
-                             "p", values[j]);
+            this->addArrival(
+                SMessage(time + static_cast<core_t::TTime>(j), "p", values[j]), m_Gatherer);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -714,8 +717,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMean, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
-                             "p", values[j]);
+            this->addArrival(
+                SMessage(time + static_cast<core_t::TTime>(j), "p", values[j]), m_Gatherer);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -768,8 +771,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowSum, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
-                             "p", values[j]);
+            this->addArrival(
+                SMessage(time + static_cast<core_t::TTime>(j), "p", values[j]), m_Gatherer);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -821,8 +824,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighSum, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
-                             "p", values[j]);
+            this->addArrival(
+                SMessage(time + static_cast<core_t::TTime>(j), "p", values[j]), m_Gatherer);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -887,8 +890,9 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
             maths::CBasicStatistics::SMin<TDoubleStrPr>::TAccumulator min;
             maths::CBasicStatistics::SMax<TDoubleStrPr>::TAccumulator max;
             for (std::size_t j = 0u; j < samples.size(); ++j) {
-                this->addArrival(*gatherer, time, "p", samples[j],
-                                 TOptionalStr(influencerValues[j]));
+                this->addArrival(SMessage(time, "p", samples[j], {},
+                                          TOptionalStr(influencerValues[j])),
+                                 gatherer);
                 min.add(TDoubleStrPr(samples[j], influencerValues[j]));
                 max.add(TDoubleStrPr(samples[j], influencerValues[j]));
             }
@@ -949,7 +953,7 @@ BOOST_FIXTURE_TEST_CASE(testInfluence, CTestFixture) {
         core_t::TTime time{startTime};
         for (std::size_t i = 0u; i < values.size(); ++i) {
             this->processBucket(time, bucketLength, values[i], influencers[i],
-                                *gatherer, model, annotatedProbability);
+                                gatherer, model, annotatedProbability);
             BOOST_REQUIRE_EQUAL(influences[i].size(),
                                 annotatedProbability.s_Influences.size());
             if (influences[i].size() > 0) {
@@ -1199,9 +1203,10 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
             model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
             bucketStart += bucketLength;
         }
-        this->addArrival(*gatherer, events[i].time(),
-                         gatherer->personName(events[i].personId().get()),
-                         events[i].values()[0][0]);
+        this->addArrival(SMessage(events[i].time(),
+                                  gatherer->personName(events[i].personId().get()),
+                                  events[i].values()[0][0]),
+                         gatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     size_t maxDimensionBeforePrune(model->dataGatherer().maxDimension());
@@ -1217,9 +1222,10 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
         }
 
         this->addArrival(
-            *expectedGatherer, expectedEvents[i].time(),
-            expectedGatherer->personName(expectedEvents[i].personId().get()),
-            expectedEvents[i].values()[0][0]);
+            SMessage(expectedEvents[i].time(),
+                     expectedGatherer->personName(expectedEvents[i].personId().get()),
+                     expectedEvents[i].values()[0][0]),
+            expectedGatherer);
     }
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
 
@@ -1237,12 +1243,15 @@ BOOST_FIXTURE_TEST_CASE(testPrune, CTestFixture) {
 
         std::size_t expectedNewPid = this->addPerson(newPerson, expectedGatherer);
 
-        this->addArrival(*gatherer, bucketStart + 1, gatherer->personName(newPid), 10.0);
-        this->addArrival(*gatherer, bucketStart + 2000, gatherer->personName(newPid), 15.0);
-        this->addArrival(*expectedGatherer, bucketStart + 1,
-                         expectedGatherer->personName(expectedNewPid), 10.0);
-        this->addArrival(*expectedGatherer, bucketStart + 2000,
-                         expectedGatherer->personName(expectedNewPid), 15.0);
+        this->addArrival(SMessage(bucketStart + 1, gatherer->personName(newPid), 10.0), gatherer);
+        this->addArrival(SMessage(bucketStart + 2000, gatherer->personName(newPid), 15.0),
+                         gatherer);
+        this->addArrival(SMessage(bucketStart + 1,
+                                  expectedGatherer->personName(expectedNewPid), 10.0),
+                         expectedGatherer);
+        this->addArrival(SMessage(bucketStart + 2000,
+                                  expectedGatherer->personName(expectedNewPid), 15.0),
+                         expectedGatherer);
     }
     model->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
     expectedModel->sample(bucketStart, bucketStart + bucketLength, m_ResourceMonitor);
@@ -1303,15 +1312,15 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
         core_t::TTime time{startTime};
         this->processBucket(time, bucketLength, bucket1, influencerValues1,
-                            *gathererNoGap, modelNoGap, annotatedProbability);
+                            gathererNoGap, modelNoGap, annotatedProbability);
 
         time += bucketLength;
         this->processBucket(time, bucketLength, bucket2, influencerValues1,
-                            *gathererNoGap, modelNoGap, annotatedProbability);
+                            gathererNoGap, modelNoGap, annotatedProbability);
 
         time += bucketLength;
         this->processBucket(time, bucketLength, bucket3, influencerValues1,
-                            *gathererNoGap, modelNoGap, annotatedProbability);
+                            gathererNoGap, modelNoGap, annotatedProbability);
     }
 
     CModelFactory::TDataGathererPtr gathererWithGap(factory.makeDataGatherer(startTime));
@@ -1332,7 +1341,7 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
 
         core_t::TTime time{startTime};
         this->processBucket(time, bucketLength, bucket1, influencerValues1,
-                            *gathererWithGap, modelWithGap, annotatedProbability);
+                            gathererWithGap, modelWithGap, annotatedProbability);
 
         time += gap;
         modelWithGap.skipSampling(time);
@@ -1340,11 +1349,11 @@ BOOST_FIXTURE_TEST_CASE(testSkipSampling, CTestFixture) {
         modelWithGap.sample(startTime + bucketLength, time, m_ResourceMonitor);
 
         this->processBucket(time, bucketLength, bucket2, influencerValues1,
-                            *gathererWithGap, modelWithGap, annotatedProbability);
+                            gathererWithGap, modelWithGap, annotatedProbability);
 
         time += bucketLength;
         this->processBucket(time, bucketLength, bucket3, influencerValues1,
-                            *gathererWithGap, modelWithGap, annotatedProbability);
+                            gathererWithGap, modelWithGap, annotatedProbability);
     }
 
     BOOST_REQUIRE_EQUAL(
@@ -1381,20 +1390,25 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |(1, 42.0)|(1, 1.0)|(1, 1.0)|X|X|(1, 42.0)|
     // p2: |(1, 42.)|(0, 0.0)|(0, 0.0)|X|X|(0, 0.0)|
-    this->addArrival(*gathererSkipGap, 100, "p1", 42.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
-    this->addArrival(*gathererSkipGap, 100, "p2", 42.0, TOptionalStr("i2"),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(100, "p1", 42.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererSkipGap);
+    this->addArrival(SMessage(100, "p2", 42.0, {}, TOptionalStr("i2"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap.sample(100, 200, m_ResourceMonitor);
-    this->addArrival(*gathererSkipGap, 200, "p1", 1.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(200, "p1", 1.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap.sample(200, 300, m_ResourceMonitor);
-    this->addArrival(*gathererSkipGap, 300, "p1", 1.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(300, "p1", 1.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap.sample(300, 400, m_ResourceMonitor);
     modelSkipGap.skipSampling(600);
-    this->addArrival(*gathererSkipGap, 600, "p1", 42.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(600, "p1", 42.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererSkipGap);
     modelSkipGap.sample(600, 700, m_ResourceMonitor);
 
     CModelFactory::TDataGathererPtr gathererExNull(factory.makeDataGatherer(startTime));
@@ -1405,35 +1419,47 @@ BOOST_FIXTURE_TEST_CASE(testExplicitNulls, CTestFixture) {
 
     // p1: |(1, 42.0), ("", 42.0), (null, 42.0)|(1, 1.0)|(1, 1.0)|(null, 100.0)|(null, 100.0)|(1, 42.0)|
     // p2: |(1, 42.0), ("", 42.0)|(0, 0.0)|(0, 0.0)|(null, 100.0)|(null, 100.0)|(0, 0.0)|
-    this->addArrival(*gathererExNull, 100, "p1", 42.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
-    this->addArrival(*gathererExNull, 100, "p1", 42.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr(""));
-    this->addArrival(*gathererExNull, 100, "p1", 42.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("null"));
-    this->addArrival(*gathererExNull, 100, "p2", 42.0, TOptionalStr("i2"),
-                     TOptionalStr(), TOptionalStr("1"));
-    this->addArrival(*gathererExNull, 100, "p2", 42.0, TOptionalStr("i2"),
-                     TOptionalStr(), TOptionalStr(""));
+    this->addArrival(SMessage(100, "p1", 42.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p1", 42.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p1", 42.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("null")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p2", 42.0, {}, TOptionalStr("i2"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererExNull);
+    this->addArrival(SMessage(100, "p2", 42.0, {}, TOptionalStr("i2"),
+                              TOptionalStr(), TOptionalStr("")),
+                     gathererExNull);
     modelExNullGap.sample(100, 200, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 200, "p1", 1.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(200, "p1", 1.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererExNull);
     modelExNullGap.sample(200, 300, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 300, "p1", 1.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(300, "p1", 1.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererExNull);
     modelExNullGap.sample(300, 400, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 400, "p1", 100.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("null"));
-    this->addArrival(*gathererExNull, 400, "p2", 100.0, TOptionalStr("i2"),
-                     TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(SMessage(400, "p1", 100.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("null")),
+                     gathererExNull);
+    this->addArrival(SMessage(400, "p2", 100.0, {}, TOptionalStr("i2"),
+                              TOptionalStr(), TOptionalStr("null")),
+                     gathererExNull);
     modelExNullGap.sample(400, 500, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 500, "p1", 100.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("null"));
-    this->addArrival(*gathererExNull, 500, "p2", 100.0, TOptionalStr("i2"),
-                     TOptionalStr(), TOptionalStr("null"));
+    this->addArrival(SMessage(500, "p1", 100.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("null")),
+                     gathererExNull);
+    this->addArrival(SMessage(500, "p2", 100.0, {}, TOptionalStr("i2"),
+                              TOptionalStr(), TOptionalStr("null")),
+                     gathererExNull);
     modelExNullGap.sample(500, 600, m_ResourceMonitor);
-    this->addArrival(*gathererExNull, 600, "p1", 42.0, TOptionalStr("i1"),
-                     TOptionalStr(), TOptionalStr("1"));
+    this->addArrival(SMessage(600, "p1", 42.0, {}, TOptionalStr("i1"),
+                              TOptionalStr(), TOptionalStr("1")),
+                     gathererExNull);
     modelExNullGap.sample(600, 700, m_ResourceMonitor);
 
     BOOST_REQUIRE_EQUAL(
@@ -1482,7 +1508,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     SAnnotatedProbability annotatedProbability2;
 
     core_t::TTime time{startTime};
-    this->processBucket(time, bucketLength, bucket1, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket1, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1490,7 +1516,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket2, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket2, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1498,7 +1524,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket3, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket3, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1506,7 +1532,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket4, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket4, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1514,7 +1540,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket5, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket5, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1522,7 +1548,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket6, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket6, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1530,7 +1556,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket7, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket7, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1538,7 +1564,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.8);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket8, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket8, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1546,7 +1572,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket9, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket9, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1554,7 +1580,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket10, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket10, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1562,7 +1588,7 @@ BOOST_FIXTURE_TEST_CASE(testVarp, CTestFixture) {
     BOOST_TEST_REQUIRE(annotatedProbability2.s_Probability > 0.5);
 
     time += bucketLength;
-    this->processBucket(time, bucketLength, bucket11, *gatherer, model,
+    this->processBucket(time, bucketLength, bucket11, gatherer, model,
                         annotatedProbability, annotatedProbability2);
     LOG_DEBUG(<< "P1 " << annotatedProbability.s_Probability << ", P2 "
               << annotatedProbability2.s_Probability);
@@ -1598,26 +1624,26 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrections, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(50.0, 70.0, 3, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
+            this->addArrival(SMessage(now, "p1", 1.0, {}, TOptionalStr("i1")), gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[1] + 0.5); ++i) {
-            this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
+            this->addArrival(SMessage(now, "p2", 1.0, {}, TOptionalStr("i2")), gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[2] + 0.5); ++i) {
-            this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
+            this->addArrival(SMessage(now, "p3", 1.0, {}, TOptionalStr("i3")), gatherer);
         }
         countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model.sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 35; ++i) {
-        this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
+        this->addArrival(SMessage(now, "p1", 1.0, {}, TOptionalStr("i1")), gatherer);
     }
     for (std::size_t i = 0; i < 1; ++i) {
-        this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
+        this->addArrival(SMessage(now, "p2", 1.0, {}, TOptionalStr("i2")), gatherer);
     }
     for (std::size_t i = 0; i < 100; ++i) {
-        this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
+        this->addArrival(SMessage(now, "p3", 1.0, {}, TOptionalStr("i3")), gatherer);
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -1692,26 +1718,26 @@ BOOST_FIXTURE_TEST_CASE(testInterimCorrectionsWithCorrelations, CTestFixture) {
     while (now < endTime) {
         rng.generateUniformSamples(80.0, 100.0, 1, samples);
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 0.5); ++i) {
-            this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
+            this->addArrival(SMessage(now, "p1", 1.0, {}, TOptionalStr("i1")), gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] + 10.5); ++i) {
-            this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
+            this->addArrival(SMessage(now, "p2", 1.0, {}, TOptionalStr("i2")), gatherer);
         }
         for (std::size_t i = 0; i < static_cast<std::size_t>(samples[0] - 9.5); ++i) {
-            this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
+            this->addArrival(SMessage(now, "p3", 1.0, {}, TOptionalStr("i3")), gatherer);
         }
         countingModel.sample(now, now + bucketLength, m_ResourceMonitor);
         model.sample(now, now + bucketLength, m_ResourceMonitor);
         now += bucketLength;
     }
     for (std::size_t i = 0; i < 9; ++i) {
-        this->addArrival(*gatherer, now, "p1", 1.0, TOptionalStr("i1"));
+        this->addArrival(SMessage(now, "p1", 1.0, {}, TOptionalStr("i1")), gatherer);
     }
     for (std::size_t i = 0; i < 10; ++i) {
-        this->addArrival(*gatherer, now, "p2", 1.0, TOptionalStr("i2"));
+        this->addArrival(SMessage(now, "p2", 1.0, {}, TOptionalStr("i2")), gatherer);
     }
     for (std::size_t i = 0; i < 8; ++i) {
-        this->addArrival(*gatherer, now, "p3", 1.0, TOptionalStr("i3"));
+        this->addArrival(SMessage(now, "p3", 1.0, {}, TOptionalStr("i3")), gatherer);
     }
     countingModel.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
     model.sampleBucketStatistics(now, now + bucketLength, m_ResourceMonitor);
@@ -1792,8 +1818,8 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatePersist, CTestFixture) {
             m_Model->sample(bucket - bucketLength, bucket, m_ResourceMonitor);
             bucket += bucketLength;
         }
-        this->addArrival(*m_Gatherer, time, "p1", samples[i][0]);
-        this->addArrival(*m_Gatherer, time, "p2", samples[i][0]);
+        this->addArrival(SMessage(time, "p1", samples[i][0]), m_Gatherer);
+        this->addArrival(SMessage(time, "p2", samples[i][0]), m_Gatherer);
 
         if ((i + 1) % 1000 == 0) {
             // Test persistence. (We check for idempotency.)
@@ -1873,13 +1899,16 @@ BOOST_FIXTURE_TEST_CASE(testSummaryCountZeroRecordsAreIgnored, CTestFixture) {
             double value = values[0];
             rng.generateUniformSamples(0.0, 1.0, 1, values);
             if (values[0] < 0.05) {
-                this->addArrival(*gathererWithZeros, now, "p1", value, TOptionalStr("i1"),
-                                 TOptionalStr(), TOptionalStr(summaryCountZero));
+                this->addArrival(SMessage(now, "p1", value, {}, TOptionalStr("i1"),
+                                          TOptionalStr(), TOptionalStr(summaryCountZero)),
+                                 gathererWithZeros);
             } else {
-                this->addArrival(*gathererWithZeros, now, "p1", value, TOptionalStr("i1"),
-                                 TOptionalStr(), TOptionalStr(summaryCountOne));
-                this->addArrival(*gathererNoZeros, now, "p1", value, TOptionalStr("i1"),
-                                 TOptionalStr(), TOptionalStr(summaryCountOne));
+                this->addArrival(SMessage(now, "p1", value, {}, TOptionalStr("i1"),
+                                          TOptionalStr(), TOptionalStr(summaryCountOne)),
+                                 gathererWithZeros);
+                this->addArrival(SMessage(now, "p1", value, {}, TOptionalStr("i1"),
+                                          TOptionalStr(), TOptionalStr(summaryCountOne)),
+                                 gathererNoZeros);
             }
         }
         modelWithZeros.sample(now, now + bucketLength, m_ResourceMonitor);
@@ -1940,8 +1969,8 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                                         t < core::constants::WEEK + 4 * 3600
                                     ? 1.0
                                     : 0.0);
-            this->addArrival(*gatherer, t + bucketLength / 2, "p1", value[0]);
-            this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1", value[0]);
+            this->addArrival(SMessage(t + bucketLength / 2, "p1", value[0]), gatherer);
+            this->addArrival(SMessage(t + bucketLength / 2, "p1", value[0]), referenceGatherer);
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
             meanPredictionError.add(std::fabs(
@@ -1999,9 +2028,9 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                            (t < 5 * core::constants::WEEK ? 1.0 : 2.0);
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
-            this->addArrival(*gatherer, t + bucketLength / 2, "p1", value + noise[0]);
-            this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1",
-                             value + noise[0]);
+            this->addArrival(SMessage(t + bucketLength / 2, "p1", value + noise[0]), gatherer);
+            this->addArrival(SMessage(t + bucketLength / 2, "p1", value + noise[0]),
+                             referenceGatherer);
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
             meanPredictionError.add(std::fabs(
@@ -2064,9 +2093,9 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
                                 static_cast<double>(core::constants::WEEK)));
             TDoubleVec noise;
             rng.generateUniformSamples(0.0, 3.0, 1, noise);
-            this->addArrival(*gatherer, t + bucketLength / 2, "p1", value + noise[0]);
-            this->addArrival(*referenceGatherer, t + bucketLength / 2, "p1",
-                             value + noise[0]);
+            this->addArrival(SMessage(t + bucketLength / 2, "p1", value + noise[0]), gatherer);
+            this->addArrival(SMessage(t + bucketLength / 2, "p1", value + noise[0]),
+                             referenceGatherer);
             model->sample(t, t + bucketLength, m_ResourceMonitor);
             referenceModel->sample(t, t + bucketLength, m_ResourceMonitor);
             meanPredictionError.add(std::fabs(
@@ -2119,8 +2148,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForLowMedian, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
-                             "p", values[j]);
+            this->addArrival(
+                SMessage(time + static_cast<core_t::TTime>(j), "p", values[j]), m_Gatherer);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -2173,8 +2202,8 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMedian, CTestFixture) {
         LOG_DEBUG(<< "values = " << core::CContainerPrinter::print(values));
 
         for (std::size_t j = 0u; j < values.size(); ++j) {
-            this->addArrival(*m_Gatherer, time + static_cast<core_t::TTime>(j),
-                             "p", values[j]);
+            this->addArrival(
+                SMessage(time + static_cast<core_t::TTime>(j), "p", values[j]), m_Gatherer);
         }
         model.sample(time, time + bucketLength, m_ResourceMonitor);
 
@@ -2236,8 +2265,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Add a bucket to both models
     for (std::size_t i = 0; i < 60; i++) {
-        this->addArrival(*gathererNoSkip, startTime + i, "p1", 1.0);
-        this->addArrival(*gathererWithSkip, startTime + i, "p1", 1.0);
+        this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererNoSkip);
+        this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererWithSkip);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2247,8 +2276,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Add a bucket to both models
     for (std::size_t i = 0; i < 60; i++) {
-        this->addArrival(*gathererNoSkip, startTime + i, "p1", 1.0);
-        this->addArrival(*gathererWithSkip, startTime + i, "p1", 1.0);
+        this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererNoSkip);
+        this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererWithSkip);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
@@ -2258,7 +2287,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // this sample will be skipped by the detection rule
     for (std::size_t i = 0; i < 60; i++) {
-        this->addArrival(*gathererWithSkip, startTime + i, "p1", 110.0);
+        this->addArrival(SMessage(startTime + i, "p1", 110.0), gathererWithSkip);
     }
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
 
@@ -2269,8 +2298,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     modelNoSkip->skipSampling(startTime);
 
     for (std::size_t i = 0; i < 60; i++) {
-        this->addArrival(*gathererNoSkip, startTime + i, "p1", 2.0);
-        this->addArrival(*gathererWithSkip, startTime + i, "p1", 2.0);
+        this->addArrival(SMessage(startTime + i, "p1", 2.0), gathererNoSkip);
+        this->addArrival(SMessage(startTime + i, "p1", 2.0), gathererWithSkip);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -37,10 +37,12 @@ public:
     using TBoolVec = std::vector<bool>;
 
     using TDouble1Vec = ml::core::CSmallVector<double, 1>;
+    using TOptionalDouble1Vec = boost::optional<TDouble1Vec>;
     using TDouble2Vec = ml::core::CSmallVector<double, 2>;
     using TDouble4Vec = ml::core::CSmallVector<double, 4>;
     using TDouble4Vec1Vec = ml::core::CSmallVector<TDouble4Vec, 1>;
     using TDoubleDoublePr = std::pair<double, double>;
+    using TOptionalDoubleDoublePr = boost::optional<TDoubleDoublePr>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
     using TDoubleSizePr = std::pair<double, std::size_t>;
     using TDoubleStrPr = std::pair<double, std::string>;
@@ -123,12 +125,20 @@ protected:
     struct SMessage {
         SMessage(ml::core_t::TTime time,
                  const std::string& person,
-                 const std::string& attribute,
-                 const TDouble1Vec& value)
-            : s_Time(time), s_Person(person), s_Attribute(attribute), s_Value(value) {}
+                 const TOptionalStr& attribute = {},
+                 const TOptionalDouble1Vec& dbl1Vec = {})
+            : s_Time(time), s_Person(person), s_Attribute(attribute),
+              s_Dbl1Vec(dbl1Vec) {}
 
-        SMessage(ml::core_t::TTime time, const std::string& person, const std::string& attribute)
-            : s_Time(time), s_Person(person), s_Attribute(attribute) {}
+        SMessage(ml::core_t::TTime time,
+                 const std::string& person,
+                 TOptionalDouble dbl = {},
+                 const TOptionalDoubleDoublePr& dblPr = {},
+                 const TOptionalStr& inf1 = {},
+                 const TOptionalStr& inf2 = {},
+                 const TOptionalStr& value = {})
+            : s_Time(time), s_Person(person), s_Dbl(dbl), s_DblPr(dblPr),
+              s_Inf1(inf1), s_Inf2(inf2), s_Value(value) {}
 
         bool operator<(const SMessage& other) const {
             return ml::maths::COrderings::lexicographical_compare(
@@ -136,10 +146,15 @@ protected:
                 other.s_Attribute);
         }
 
-        ml::core_t::TTime s_Time;
-        std::string s_Person;
-        std::string s_Attribute;
-        TDouble1Vec s_Value{};
+        ml::core_t::TTime s_Time{};
+        std::string s_Person{};
+        TOptionalStr s_Attribute{};
+        TOptionalDouble1Vec s_Dbl1Vec{};
+        TOptionalDouble s_Dbl{};
+        TOptionalDoubleDoublePr s_DblPr{};
+        TOptionalStr s_Inf1{};
+        TOptionalStr s_Inf2{};
+        TOptionalStr s_Value{};
     };
     using TMessageVec = std::vector<SMessage>;
 
@@ -149,46 +164,23 @@ protected:
                           std::size_t numInfluencers = 0,
                           TOptionalStr value = TOptionalStr());
 
-    void addArrival(ml::model::CDataGatherer& gatherer,
-                    ml::core_t::TTime time,
-                    const std::string& person,
-                    const TOptionalStr& inf1 = TOptionalStr(),
-                    const TOptionalStr& inf2 = TOptionalStr(),
-                    const TOptionalStr& value = TOptionalStr());
-
     std::string valueAsString(const TDouble1Vec& value);
 
     ml::model::CEventData addArrival(const SMessage& message,
                                      ml::model::CModelFactory::TDataGathererPtr& gatherer);
 
-    void addArrival(ml::model::CDataGatherer& gatherer,
-                    ml::core_t::TTime time,
-                    const std::string& person,
-                    double value,
-                    const TOptionalStr& inf1 = TOptionalStr(),
-                    const TOptionalStr& inf2 = TOptionalStr(),
-                    const TOptionalStr& count = TOptionalStr());
-
-    void addArrival(ml::model::CDataGatherer& gatherer,
-                    ml::core_t::TTime time,
-                    const std::string& person,
-                    double lat,
-                    double lng,
-                    const TOptionalStr& inf1 = TOptionalStr(),
-                    const TOptionalStr& inf2 = TOptionalStr());
-
     void processBucket(ml::core_t::TTime time,
                        ml::core_t::TTime bucketLength,
                        const TDoubleVec& bucket,
                        const TStrVec& influencerValues,
-                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CModelFactory::TDataGathererPtr& gatherer,
                        ml::model::CAnomalyDetectorModel& model,
                        ml::model::SAnnotatedProbability& probability);
 
     void processBucket(ml::core_t::TTime time,
                        ml::core_t::TTime bucketLength,
                        const TDoubleVec& bucket,
-                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CModelFactory::TDataGathererPtr& gatherer,
                        ml::model::CAnomalyDetectorModel& model,
                        ml::model::SAnnotatedProbability& probability,
                        ml::model::SAnnotatedProbability& probability2);
@@ -196,7 +188,7 @@ protected:
     void processBucket(ml::core_t::TTime time,
                        ml::core_t::TTime bucketLength,
                        const TDoubleStrPrVec& bucket,
-                       ml::model::CDataGatherer& gatherer,
+                       ml::model::CModelFactory::TDataGathererPtr& gatherer,
                        ml::model::CAnomalyDetectorModel& model,
                        ml::model::SAnnotatedProbability& probability);
 


### PR DESCRIPTION
Provide a common interface to addArrival by extending the existing SMessage structure.

This reduces the amount of code duplicated between multiple addArrival methods at the expense of some added verbosity when specifying default arguments.

Relates to #1477 