### PR TITLE
[ML] Add argument for config file to autodetect

### DIFF
--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -64,7 +64,7 @@ bool CCmdLineParser::parse(int argc,
             ("help", "Display this information and exit")
             ("version", "Display version information and exit")
             ("config", boost::program_options::value<std::string>(),
-             "The configuration file")
+             "The job configuration file")
             ("limitconfig", boost::program_options::value<std::string>(),
                         "Optional limit config file")
             ("modelconfig", boost::program_options::value<std::string>(),

--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -22,6 +22,7 @@ const std::string CCmdLineParser::DESCRIPTION = "Usage: autodetect [options] [<f
 
 bool CCmdLineParser::parse(int argc,
                            const char* const* argv,
+                           std::string& configFile,
                            std::string& limitConfigFile,
                            std::string& modelConfigFile,
                            std::string& fieldConfigFile,
@@ -62,6 +63,8 @@ bool CCmdLineParser::parse(int argc,
         desc.add_options()
             ("help", "Display this information and exit")
             ("version", "Display version information and exit")
+            ("config", boost::program_options::value<std::string>(),
+             "The configuration file")
             ("limitconfig", boost::program_options::value<std::string>(),
                         "Optional limit config file")
             ("modelconfig", boost::program_options::value<std::string>(),
@@ -153,6 +156,9 @@ bool CCmdLineParser::parse(int argc,
                       << model::CAnomalyScore::CURRENT_FORMAT_VERSION << std::endl
                       << ver::CBuildInfo::fullInfo() << std::endl;
             return false;
+        }
+        if (vm.count("config") > 0) {
+            configFile = vm["config"].as<std::string>();
         }
         if (vm.count("limitconfig") > 0) {
             limitConfigFile = vm["limitconfig"].as<std::string>();

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -34,6 +34,7 @@ public:
     //! later on by the api::CFieldConfig class.
     static bool parse(int argc,
                       const char* const* argv,
+                      std::string& config,
                       std::string& limitConfigFile,
                       std::string& modelConfigFile,
                       std::string& fieldConfigFile,

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -82,6 +82,7 @@ int main(int argc, char** argv) {
     using TStrVec = ml::autodetect::CCmdLineParser::TStrVec;
 
     // Read command line options
+    std::string configFile;
     std::string limitConfigFile;
     std::string modelConfigFile;
     std::string fieldConfigFile;
@@ -118,7 +119,7 @@ int main(int argc, char** argv) {
     bool stopCategorizationOnWarnStatus{false};
     TStrVec clauseTokens;
     if (ml::autodetect::CCmdLineParser::parse(
-            argc, argv, limitConfigFile, modelConfigFile, fieldConfigFile,
+            argc, argv, configFile, limitConfigFile, modelConfigFile, fieldConfigFile,
             modelPlotConfigFile, jobId, logProperties, logPipe, bucketSpan, latency,
             summaryCountFieldName, delimiter, lengthEncodedInput, timeField,
             timeFormat, quantilesStateFile, deleteStateFiles, persistInterval,


### PR DESCRIPTION
Add an argument to autodetect to enable specifying a config file.

Eventually this will be used to read an autodetect job config in JSON
format but in this initial step it is unused. 

Relates to #1253