### PR TITLE
[ML] Time series time shift segmentation

### DIFF
--- a/include/maths/CTimeSeriesSegmentation.h
+++ b/include/maths/CTimeSeriesSegmentation.h
@@ -13,7 +13,7 @@
 #include <maths/Constants.h>
 #include <maths/MathsTypes.h>
 
-#include <utility>
+#include <limits>
 #include <vector>
 
 namespace ml {
@@ -26,6 +26,7 @@ public:
     using TDoubleVecVec = std::vector<TDoubleVec>;
     using TDoubleVecDoubleVecPr = std::pair<TDoubleVec, TDoubleVec>;
     using TSizeVec = std::vector<std::size_t>;
+    using TTimeVec = std::vector<core_t::TTime>;
     using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
     using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
     using TFloatMeanAccumulatorVecDoubleVecPr = std::pair<TFloatMeanAccumulatorVec, TDoubleVec>;
@@ -33,24 +34,22 @@ public:
     using TSeasonalComponentVec = std::vector<TSeasonalComponent>;
     using TSeasonality = std::function<double(std::size_t)>;
     using TIndexWeight = std::function<double(std::size_t)>;
+    using TModel = std::function<double(core_t::TTime)>;
 
     //! Perform top-down recursive segmentation with linear models.
     //!
     //! The time series is segmented using piecewise linear models in a top down
-    //! fashion with each break point being chosen to maximize r-squared and model
-    //! selection happening for each candidate segmentation. Model selection
-    //! is achieved by thresholding the significance of the unexplained variance
-    //! ratio for segmented versus non-segmented models.
+    //! fashion with each break point being chosen to minimise the residual variance.
+    //! Model selection happens for each candidate segment. This is uses the p-value
+    //! of the variance the segment explains.
     //!
     //! \param[in] values The time series values to segment. These are assumed to
     //! be equally spaced in time order.
     //! \param[in] pValueToSegment The maximum p-value of the explained variance
     //! to accept a trend segment.
     //! \param[in] outlierFraction The proportion of values to treat as outliers.
-    //! Outliers are re-weighted when doing model fit and computing unexplained
-    //! variance for model selection. This must be in the range [0.0, 1.0).
-    //! \param[in] maxSegments The maximum number of segments to divide \p values
-    //! into.
+    //! This must be in the range (0.0, 1.0].
+    //! \param[in] maxSegments The maximum number of segments to divide \p values into.
     //! \return The sorted segmentation indices. This includes the start and end
     //! indices of \p values, i.e. 0 and values.size().
     static TSizeVec
@@ -61,11 +60,16 @@ public:
 
     //! Remove the predictions of a piecewise linear model.
     //!
+    //! \param[in] values The time series values.
     //! \param[in] segmentation The segmentation of \p values to use.
-    //! \return The values minus the model predictions.
+    //! \param[in] outlierFraction The proportion of values to treat as outliers.
+    //! This must be in the range (0.0, 1.0].
+    //! \param[out] shifts If not null filled in with the average shift of each segment.
+    //! \return \p values minus the model predictions.
     static TFloatMeanAccumulatorVec removePiecewiseLinear(TFloatMeanAccumulatorVec values,
                                                           const TSizeVec& segmentation,
-                                                          double outlierFraction);
+                                                          double outlierFraction,
+                                                          TDoubleVec* shifts = nullptr);
 
     //! Remove only the jump discontinuities in the segmented model.
     //!
@@ -73,21 +77,23 @@ public:
     //! in backwards pass such that values in each preceding segment are adjusted
     //! relative to each succeeding segment.
     //!
+    //! \param[in] values The time series values.
     //! \param[in] segmentation The segmentation of \p values to use.
-    //! \return The values minus discontinuities.
+    //! \param[in] outlierFraction The proportion of values to treat as outliers.
+    //! This must be in the range (0.0, 1.0].
+    //! \return \p values minus discontinuities at the trend knot points.
     static TFloatMeanAccumulatorVec
     removePiecewiseLinearDiscontinuities(TFloatMeanAccumulatorVec values,
                                          const TSizeVec& segmentation,
                                          double outlierFraction);
 
-    //! Perform top-down recursive segmentation of seasonal model into segments with
+    //! Perform top-down recursive segmentation of a seasonal model into segments with
     //! constant linear scale.
     //!
     //! The time series is segmented using piecewise constant linear scaled seasonal
-    //! model in a top down fashion with break points being chosen to maximize r-squared
-    //! and model selection happening for each candidate segmentation. Since each split
-    //! generates a nested model we check the significance using the explained variance
-    //! divided by segmented model's residual variance. A scaled seasonal model is
+    //! model in a top down fashion with break points being chosen to minimise residual
+    //! Model selection happens for each candidate segment. This is via the p-value
+    //! of the variance the segment explains. Formally, a scaled seasonal model is
     //! defined here as:
     //! <pre class="fragment">
     //!   \f$ \sum_i 1\{t_i \leq t < t_{i+1}\} s_i f_p(t) \f$
@@ -95,35 +101,53 @@ public:
     //! where \f$\{s_i\}\f$ are a collection of constant scales and \f$f_p(\cdot)\f$
     //! denotes a function with period \p period.
     //!
-    //! \param[in] values The time series values to segment.
-    //! \param[in] seasonality A model of the seasonality to segment which returns
-    //! its value for the i'th bucket of \p values.
-    //! \param[in] pValueToSegment The maximum p-value of the F-test to accept a
-    //! scaling segment.
-    //! \param[in] maxSegments The maximum number of segments to divide \p values
-    //! into.
+    //! \param[in] values The time series values to segment. These are assumed to be
+    //! equally spaced in time order.
+    //! \param[in] model A model of the seasonality to segment which returns its value
+    //! for the i'th bucket of \p values.
+    //! \param[in] pValueToSegment The maximum p-value of the explained variance
+    //! to accept a scaling segment.
+    //! \param[in] maxSegments The maximum number of segments to divide \p values into.
     //! \return The sorted segmentation indices. This includes the start and end
     //! indices of \p values, i.e. 0 and values.size().
     static TSizeVec piecewiseLinearScaledSeasonal(
         const TFloatMeanAccumulatorVec& values,
-        const TSeasonality& seasonality,
+        const TSeasonality& model,
         double pValueToSegment,
         std::size_t maxSegments = std::numeric_limits<std::size_t>::max());
 
-    //! Rescale the piecewise linear scaled seasonal component of \p values with
-    //! period \p period to its mean scale.
+    //! Remove the scaled predictions of \p model from \p values.
     //!
-    //! \param[in] values The time series values to segment.
-    //! \param[in] periods The seasonal components to model.
+    //! This fits a piecewise linear scaled \p model on \p segmentation to minimise the
+    //! residuals from \p values and returns \p values minus the scaled predictions.
+    //!
+    //! \param[in] model A model of the seasonality to remove which returns its value
+    //! for the i'th bucket of \p values.
     //! \param[in] segmentation The segmentation of \p values into intervals with
     //! constant scale.
-    //! \param[in] indexWeight A function used to weight indices of \p segmentation
-    //! when computing the mean scale over \p values.
     //! \param[in] outlierFraction The proportion of values to treat as outliers.
-    //! Outliers are re-weighted when doing model fit. This must be in the range
-    //! [0.0, 1.0).
-    //! \param[out] models Set to the fitted models for each period in \p periods.
-    //! \param[out] scales Set to the scales for each segment of \p segmentation.
+    //! This must be in the range (0.0, 1.0].
+    //! \param[out] scales If not null filled in with the average scale of each segment.
+    //! \return The values minus the scaled model predictions.
+    static TFloatMeanAccumulatorVec
+    removePiecewiseLinearScaledSeasonal(TFloatMeanAccumulatorVec values,
+                                        const TSeasonality& model,
+                                        const TSizeVec& segmentation,
+                                        double outlierFraction,
+                                        TDoubleVec* scales = nullptr);
+
+    //! Rescale \p values on \p segmentation to minimise residual variance for seasonal
+    //! components with periods \p periods.
+    //!
+    //! \param[in] values The values to scale.
+    //! \param[in] periods The seasonal components present in \p values.
+    //! \param[in] segmentation The segmentation of \p values into intervals with
+    //! constant scale.
+    //! \param[in] indexWeight A function used to weight indices of \p segmentation.
+    //! \param[in] outlierFraction The proportion of values to treat as outliers.
+    //! This must be in the range (0.0, 1.0].
+    //! \param[out] models The component models.
+    //! \param[out] scales The scales to apply to \p models in each segment.
     //! \return The values with the mean scaled seasonal component.
     static TFloatMeanAccumulatorVec
     meanScalePiecewiseLinearScaledSeasonal(const TFloatMeanAccumulatorVec& values,
@@ -144,7 +168,7 @@ public:
                             const TDoubleVec& scales,
                             const TIndexWeight& indexWeight);
 
-    //! Compute the scale at \p index for the piecewise linear \p scales on
+    //! Compute the scale to use at \p index for the piecewise linear \p scales on
     //! \p segmentation.
     //!
     //! \param[in] index The index at which to compute the scale.
@@ -153,11 +177,42 @@ public:
     //! \return The scale at \p index.
     static double scaleAt(std::size_t index, const TSizeVec& segmentation, const TDoubleVec& scales);
 
+    //! Perform top-down recursive segmentation of a seasonal model into segments with
+    //! constant time shift.
+    //!
+    //! \param[in] bucketLength The time bucket length of \p values.
+    //! \param[in] candidateShifts The time shifts we'll consider applying.
+    //! \param[in] model A model of the seasonality to segment which returns its value
+    //! for the i'th bucket of \p values.
+    //! \param[in] pValueToSegment The maximum p-value of the explained variance
+    //! to accept a scaling segment.
+    //! \param[in] maxSegments The maximum number of segments to divide \p values into.
+    //! \param[out] shifts If not null filled in with the shift for each segment.
+    static TSizeVec
+    piecewiseTimeShifted(const TFloatMeanAccumulatorVec& values,
+                         core_t::TTime bucketLength,
+                         const TTimeVec& candidateShifts,
+                         const TModel& model,
+                         double pValueToSegment,
+                         std::size_t maxSegments = std::numeric_limits<std::size_t>::max(),
+                         TTimeVec* shifts = nullptr);
+
+    //! Compute the time shift to use at \p index for the piecewise constant \p shifts
+    //! on \p segmentation.
+    //!
+    //! \param[in] index The index at which to compute the shift.
+    //! \param[in] segmentation The segmentation into intervals with constant time shifts.
+    //! \param[in] shifts The piecewise constant time shift to apply.
+    //! \return The shift at \p index.
+    static core_t::TTime
+    shiftAt(std::size_t index, const TSizeVec& segmentation, const TTimeVec& shifts);
+
 private:
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using TMeanVarAccumulatorSizePr = std::pair<TMeanVarAccumulator, std::size_t>;
     using TRegression = CLeastSquaresOnlineRegression<1, double>;
     using TPredictor = std::function<double(double)>;
     using TScale = std::function<double(std::size_t)>;
@@ -168,7 +223,8 @@ private:
                                    TSizeVec& segmentation,
                                    TDoubleDoublePrVec& depthAndPValue);
 
-    //! Implements top-down recursive segmentation with linear models.
+    //! Implements top-down recursive segmentation of [\p begin, \p end) to minimise
+    //! square residuals for a linear model.
     template<typename ITR>
     static void fitTopDownPiecewiseLinear(ITR begin,
                                           ITR end,
@@ -186,8 +242,8 @@ private:
                                          double outlierFraction,
                                          TFloatMeanAccumulatorVec& values);
 
-    //! Implements top-down recursive segmentation of a seasonal model with
-    //! piecewise constant linear scales.
+    //! Implements top-down recursive segmentation of [\p begin, \p end) to minimise
+    //! square residuals for linear scales of \p model.
     template<typename ITR>
     static void fitTopDownPiecewiseLinearScaledSeasonal(ITR begin,
                                                         ITR end,
@@ -199,6 +255,15 @@ private:
                                                         TSizeVec& segmentation,
                                                         TDoubleDoublePrVec& depthAndPValue);
 
+    //! Fit \p model with piecewise constant linear scaling to \p values for the
+    //! segmentation \p segmentation.
+    static void fitPiecewiseLinearScaledSeasonal(const TFloatMeanAccumulatorVec& values,
+                                                 const TSeasonality& model,
+                                                 const TSizeVec& segmentation,
+                                                 double outlierFraction,
+                                                 TFloatMeanAccumulatorVec& reweighted,
+                                                 TDoubleVec& scales);
+
     //! Fit a seasonal model with piecewise constant linear scaling to \p values
     //! for the segmentation \p segmentation.
     static void fitPiecewiseLinearScaledSeasonal(const TFloatMeanAccumulatorVec& values,
@@ -208,6 +273,19 @@ private:
                                                  TFloatMeanAccumulatorVec& reweighted,
                                                  TDoubleVecVec& model,
                                                  TDoubleVec& scales);
+
+    //! Implements top-down recursive segmentation of [\p begin, \p end) to minimise
+    //! square residuals for time shifts of a base model \p predictions.
+    template<typename ITR>
+    static void fitTopDownPiecewiseTimeShifted(ITR begin,
+                                               ITR end,
+                                               std::size_t depth,
+                                               std::size_t offset,
+                                               const TDoubleVecVec& predictions,
+                                               std::size_t maxDepth,
+                                               double pValueToSegment,
+                                               TSizeVec& segmentation,
+                                               TDoubleDoublePrVec& depthAndPValue);
 
     //! Compute the residual moments of a least squares linear model fit to
     //! [\p begin, \p end).
@@ -225,6 +303,12 @@ private:
     template<typename ITR>
     static TMeanVarAccumulator
     residualMoments(ITR begin, ITR end, double startTime, const TRegression& model);
+
+    //! Compute the moments of the values in [\p begin, \p end) after subtracting
+    //! \p predictions minimising variance over the outer index.
+    template<typename ITR>
+    static TMeanVarAccumulatorSizePr
+    residualMoments(ITR begin, ITR end, std::size_t offset, const TDoubleVecVec& predictions);
 
     //! Fit a linear model to the values in [\p begin, \p end).
     template<typename ITR>

--- a/include/maths/CTimeSeriesSegmentation.h
+++ b/include/maths/CTimeSeriesSegmentation.h
@@ -188,6 +188,8 @@ public:
     //! to accept a scaling segment.
     //! \param[in] maxSegments The maximum number of segments to divide \p values into.
     //! \param[out] shifts If not null filled in with the shift for each segment.
+    //! \return The sorted segmentation indices. This includes the start and end
+    //! indices of \p values, i.e. 0 and values.size().
     static TSizeVec
     piecewiseTimeShifted(const TFloatMeanAccumulatorVec& values,
                          core_t::TTime bucketLength,

--- a/lib/maths/CTimeSeriesSegmentation.cc
+++ b/lib/maths/CTimeSeriesSegmentation.cc
@@ -593,7 +593,7 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinearScaledSeasonal(
 
         // The following loop is the interesting part. We compute (up to constants)
         //
-        //   min_i{ min_{sl, sr}{ sum_{j<i}{(x_ij - sl p_j)^2} + sum_{j>=i}{(x_j - sr p_j)^2} } }
+        //   min_i{ min_{sl, sr}{ sum_{j<i}{(x_j - sl p_j)^2} + sum_{j>=i}{(x_j - sr p_j)^2} } }
         //
         // We use the fact that we can maintain sufficient statistics to which
         // we can both add and remove values to compute this in O(|S||T|) for

--- a/lib/maths/CTimeSeriesSegmentation.cc
+++ b/lib/maths/CTimeSeriesSegmentation.cc
@@ -19,7 +19,7 @@
 #include <maths/CTools.h>
 
 #include <algorithm>
-#include <iterator>
+#include <limits>
 #include <numeric>
 
 namespace ml {
@@ -51,7 +51,9 @@ CTimeSeriesSegmentation::piecewiseLinear(const TFloatMeanAccumulatorVec& values,
 CTimeSeriesSegmentation::TFloatMeanAccumulatorVec
 CTimeSeriesSegmentation::removePiecewiseLinear(TFloatMeanAccumulatorVec values,
                                                const TSizeVec& segmentation,
-                                               double outlierFraction) {
+                                               double outlierFraction,
+                                               TDoubleVec* shifts) {
+
     TFloatMeanAccumulatorVec reweighted{values};
     auto predict = fitPiecewiseLinear(segmentation, outlierFraction, reweighted);
     for (std::size_t i = 0; i < values.size(); ++i) {
@@ -59,6 +61,19 @@ CTimeSeriesSegmentation::removePiecewiseLinear(TFloatMeanAccumulatorVec values,
             CBasicStatistics::moment<0>(values[i]) -= predict(static_cast<double>(i));
         }
     }
+
+    if (shifts != nullptr) {
+        shifts->clear();
+        shifts->reserve(segmentation.size() - 2);
+        for (std::size_t i = 1; i < segmentation.size(); ++i) {
+            TMeanAccumulator shift;
+            for (std::size_t j = segmentation[i - 1]; j < segmentation[i]; ++j) {
+                shift.add(predict(static_cast<double>(j)));
+            }
+            shifts->push_back(CBasicStatistics::mean(shift));
+        }
+    }
+
     return values;
 }
 
@@ -66,7 +81,8 @@ CTimeSeriesSegmentation::TFloatMeanAccumulatorVec
 CTimeSeriesSegmentation::removePiecewiseLinearDiscontinuities(TFloatMeanAccumulatorVec values,
                                                               const TSizeVec& segmentation,
                                                               double outlierFraction) {
-    TFloatMeanAccumulatorVec reweighted(values);
+
+    TFloatMeanAccumulatorVec reweighted{values};
     auto predict = fitPiecewiseLinear(segmentation, outlierFraction, reweighted);
     TDoubleVec steps;
     steps.reserve(segmentation.size() - 1);
@@ -76,6 +92,7 @@ CTimeSeriesSegmentation::removePiecewiseLinearDiscontinuities(TFloatMeanAccumula
     }
     steps.push_back(0.0);
     LOG_TRACE(<< "steps = " << core::CContainerPrinter::print(steps));
+
     std::partial_sum(steps.rbegin(), steps.rend(), steps.rbegin());
     for (std::size_t i = segmentation.size() - 1; i > 0; --i) {
         LOG_TRACE(<< "Shifting [" << segmentation[i - 1] << ","
@@ -84,6 +101,7 @@ CTimeSeriesSegmentation::removePiecewiseLinearDiscontinuities(TFloatMeanAccumula
             CBasicStatistics::moment<0>(values[j]) -= steps[i - 1];
         }
     }
+
     return values;
 }
 
@@ -108,6 +126,26 @@ CTimeSeriesSegmentation::piecewiseLinearScaledSeasonal(const TFloatMeanAccumulat
     selectSegmentation(maxSegments, segmentation, depthAndPValue);
 
     return segmentation;
+}
+
+CTimeSeriesSegmentation::TFloatMeanAccumulatorVec
+CTimeSeriesSegmentation::removePiecewiseLinearScaledSeasonal(TFloatMeanAccumulatorVec values,
+                                                             const TSeasonality& model,
+                                                             const TSizeVec& segmentation,
+                                                             double outlierFraction,
+                                                             TDoubleVec* scales_) {
+    TFloatMeanAccumulatorVec reweighted{values};
+    TDoubleVec scales;
+    fitPiecewiseLinearScaledSeasonal(values, model, segmentation,
+                                     outlierFraction, reweighted, scales);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        CBasicStatistics::moment<0>(values[i]) -= scaleAt(i, segmentation, scales) *
+                                                  model(i);
+    }
+    if (scales_ != nullptr) {
+        *scales_ = std::move(scales);
+    }
+    return values;
 }
 
 CTimeSeriesSegmentation::TFloatMeanAccumulatorVec
@@ -151,7 +189,7 @@ CTimeSeriesSegmentation::meanScalePiecewiseLinearScaledSeasonal(
                             CBasicStatistics::count(scaledValues[i]));
             }
         }
-        return CBasicStatistics::variance(moments);
+        return CBasicStatistics::maximumLikelihoodVariance(moments);
     }())};
 
     double amplitude{[&] {
@@ -219,6 +257,63 @@ double CTimeSeriesSegmentation::scaleAt(std::size_t index,
                   segmentation.begin() - 1];
 }
 
+CTimeSeriesSegmentation::TSizeVec
+CTimeSeriesSegmentation::piecewiseTimeShifted(const TFloatMeanAccumulatorVec& values,
+                                              core_t::TTime bucketLength,
+                                              const TTimeVec& candidateShifts,
+                                              const TModel& model,
+                                              double pValueToSegment,
+                                              std::size_t maxSegments,
+                                              TTimeVec* shifts) {
+
+    std::size_t maxDepth{static_cast<std::size_t>(
+        std::ceil(std::log2(static_cast<double>(maxSegments))))};
+    LOG_TRACE(<< "max depth = " << maxDepth);
+
+    TDoubleVecVec predictions(candidateShifts.size() + 1, TDoubleVec(values.size()));
+    for (std::size_t j = 0; j < values.size(); ++j) {
+        predictions[0][j] = model(bucketLength * static_cast<core_t::TTime>(j));
+    }
+    for (std::size_t i = 0; i < candidateShifts.size(); ++i) {
+        for (std::size_t j = 0; j < values.size(); ++j) {
+            predictions[i + 1][j] = model(
+                bucketLength * static_cast<core_t::TTime>(j) + candidateShifts[i]);
+        }
+    }
+
+    TFloatMeanAccumulatorVec reweighted;
+    TSizeVec segmentation{0, values.size()};
+    TDoubleDoublePrVec depthAndPValue;
+    fitTopDownPiecewiseTimeShifted(values.cbegin(), values.cend(),
+                                   0, // depth
+                                   0, // offset of first value in range
+                                   predictions, maxDepth, pValueToSegment,
+                                   segmentation, depthAndPValue);
+
+    selectSegmentation(maxSegments, segmentation, depthAndPValue);
+
+    if (shifts != nullptr) {
+        shifts->clear();
+        shifts->reserve(segmentation.size() - 1);
+        for (std::size_t i = 1; i < segmentation.size(); ++i) {
+            std::size_t shift;
+            std::tie(std::ignore, shift) = residualMoments(
+                values.begin() + segmentation[i - 1],
+                values.begin() + segmentation[i], segmentation[i - 1], predictions);
+            shifts->push_back(shift == 0 ? 0 : candidateShifts[shift - 1]);
+        }
+    }
+
+    return segmentation;
+}
+
+core_t::TTime CTimeSeriesSegmentation::shiftAt(std::size_t index,
+                                               const TSizeVec& segmentation,
+                                               const TTimeVec& shifts) {
+    return shifts[std::upper_bound(segmentation.begin(), segmentation.end(), index) -
+                  segmentation.begin() - 1];
+}
+
 void CTimeSeriesSegmentation::selectSegmentation(std::size_t maxSegments,
                                                  TSizeVec& segmentation,
                                                  TDoubleDoublePrVec& depthAndPValue) {
@@ -250,13 +345,13 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
                                                         double outlierFraction,
                                                         TSizeVec& segmentation,
                                                         TDoubleDoublePrVec& depthAndPValue,
-                                                        TFloatMeanAccumulatorVec& values) {
+                                                        TFloatMeanAccumulatorVec& reweighted) {
 
     // We want to find the partition of [begin, end) into linear models which
-    // efficiently predicts the values. To this end we maximize R^2 whilst
-    // maintaining a parsimonious model. We achieve the later objective by
-    // doing model selection for each candidate segment using the significance
-    // of the variance ratio.
+    // efficiently predicts the values. To this end we minimize residual variance
+    // whilst maintaining a parsimonious model. We achieve the later objective by
+    // doing model selection for each candidate segment using a significance test
+    // of the explained variance.
 
     auto range = std::distance(begin, end);
     int step{3};
@@ -267,15 +362,15 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
     LOG_TRACE(<< "Considering splitting [" << offset << "," << offset + range << ")");
 
     double startTime{static_cast<double>(offset)};
-    values.assign(begin, end);
+    reweighted.assign(begin, end);
     TMeanVarAccumulator moments{[&] {
-        TRegression model{fitLinearModel(values.cbegin(), values.cend(), startTime)};
+        TRegression model{fitLinearModel(reweighted.cbegin(), reweighted.cend(), startTime)};
         auto predict = [&](std::size_t i) {
             double time{startTime + static_cast<double>(i)};
             return model.predict(time);
         };
-        CSignal::reweightOutliers(predict, outlierFraction, values);
-        return centredResidualMoments(values.begin(), values.end(), startTime);
+        CSignal::reweightOutliers(predict, outlierFraction, reweighted);
+        return centredResidualMoments(reweighted.cbegin(), reweighted.cend(), startTime);
     }()};
 
     if (CBasicStatistics::variance(moments) > 0.0) {
@@ -285,7 +380,8 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
         auto variance = [](const TMeanVarAccumulator& l, const TMeanVarAccumulator& r) {
             double nl{CBasicStatistics::count(l)};
             double nr{CBasicStatistics::count(r)};
-            return (nl * CBasicStatistics::variance(l) + nr * CBasicStatistics::variance(r)) /
+            return (nl * CBasicStatistics::maximumLikelihoodVariance(l) +
+                    nr * CBasicStatistics::maximumLikelihoodVariance(r)) /
                    (nl + nr);
         };
 
@@ -295,29 +391,29 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
         // are removed based on an initial best split.
 
         TMinAccumulator minResidualVariance;
-        values.assign(begin, end);
+        reweighted.assign(begin, end);
 
         for (auto reweights : {0, 1}) {
             LOG_TRACE(<< "  reweights = " << reweights);
 
-            ITR i = values.cbegin();
+            ITR i = reweighted.cbegin();
             minResidualVariance = TMinAccumulator{};
             double splitTime{startTime};
             TRegression leftModel;
-            TRegression rightModel{fitLinearModel(i, values.cend(), splitTime)};
+            TRegression rightModel{fitLinearModel(i, reweighted.cend(), splitTime)};
 
-            auto varianceAfterStep = [&](int s) {
-                TRegression deltaModel{fitLinearModel(i, i + s, splitTime)};
-                return variance(residualMoments(values.cbegin(), i + s, startTime,
-                                                leftModel + deltaModel),
-                                residualMoments(i + s, values.cend(), splitTime + s,
+            auto varianceAfterStep = [&](int j) {
+                TRegression deltaModel{fitLinearModel(i, i + j, splitTime)};
+                return variance(residualMoments(reweighted.cbegin(), i + j,
+                                                startTime, leftModel + deltaModel),
+                                residualMoments(i + j, reweighted.cend(), splitTime + j,
                                                 rightModel - deltaModel));
             };
 
-            for (/**/; i + step < values.cend(); i += step, splitTime += step) {
+            for (/**/; i + step < reweighted.cend(); i += step, splitTime += step) {
                 if (minResidualVariance.add({varianceAfterStep(step), i + step})) {
-                    for (int s = 1; s < step; ++s) {
-                        minResidualVariance.add({varianceAfterStep(s), i + s});
+                    for (int j = 1; j < step; ++j) {
+                        minResidualVariance.add({varianceAfterStep(j), i + j});
                     }
                 }
                 TRegression deltaModel{fitLinearModel(i, i + step, splitTime)};
@@ -333,28 +429,28 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
                 break;
             } else {
                 ITR split{minResidualVariance[0].second};
-                splitTime = static_cast<double>(std::distance(values.cbegin(), split));
-                leftModel = fitLinearModel(values.cbegin(), split, startTime);
-                rightModel = fitLinearModel(split, values.cend(), splitTime);
+                splitTime = static_cast<double>(std::distance(reweighted.cbegin(), split));
+                leftModel = fitLinearModel(reweighted.cbegin(), split, startTime);
+                rightModel = fitLinearModel(split, reweighted.cend(), splitTime);
                 auto predict = [&](std::size_t j) {
                     double time{startTime + static_cast<double>(j)};
                     return (time < splitTime ? leftModel : rightModel).predict(time);
                 };
-                values.assign(begin, end);
-                CSignal::reweightOutliers(predict, outlierFraction, values);
+                reweighted.assign(begin, end);
+                CSignal::reweightOutliers(predict, outlierFraction, reweighted);
             }
         }
 
         ITR split{minResidualVariance[0].second};
-        std::size_t splitOffset(std::distance(values.cbegin(), split));
+        std::size_t splitOffset(std::distance(reweighted.cbegin(), split));
         double splitTime{static_cast<double>(splitOffset)};
         LOG_TRACE(<< "  candidate = " << offset + splitOffset
                   << ", variance = " << minResidualVariance[0].first);
 
         TMeanVarAccumulator leftMoments{
-            centredResidualMoments(values.cbegin(), split, startTime)};
+            centredResidualMoments(reweighted.cbegin(), split, startTime)};
         TMeanVarAccumulator rightMoments{
-            centredResidualMoments(split, values.cend(), splitTime)};
+            centredResidualMoments(split, reweighted.cend(), splitTime)};
         TMeanAccumulator meanAbs{std::accumulate(
             begin, end, TMeanAccumulator{}, [](auto partialMean, const auto& value) {
                 partialMean.add(std::fabs(CBasicStatistics::mean(value)),
@@ -371,16 +467,16 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
         double F{(df[1] * std::max(v[0] - v[1], 0.0)) / (df[0] * v[1])};
         double pValue{CTools::oneMinusPowOneMinusX(
             CStatisticalTests::rightTailFTest(F, df[0], df[1]),
-            static_cast<double>(values.size() / step))};
+            static_cast<double>(reweighted.size() / step))};
         LOG_TRACE(<< "  p-value = " << pValue);
 
         if (pValue < pValueToSegment) {
             fitTopDownPiecewiseLinear(begin, begin + splitOffset, depth + 1, offset,
                                       maxDepth, pValueToSegment, outlierFraction,
-                                      segmentation, depthAndPValue, values);
+                                      segmentation, depthAndPValue, reweighted);
             fitTopDownPiecewiseLinear(begin + splitOffset, end, depth + 1, offset + splitOffset,
                                       maxDepth, pValueToSegment, outlierFraction,
-                                      segmentation, depthAndPValue, values);
+                                      segmentation, depthAndPValue, reweighted);
             segmentation.push_back(offset + splitOffset);
             depthAndPValue.emplace_back(static_cast<double>(depth), pValue);
         }
@@ -440,15 +536,13 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinearScaledSeasonal(
     TDoubleDoublePrVec& depthAndPValue) {
 
     // We want to find the partition of [begin, end) into scaled seasonal
-    // models which efficiently predicts the values. To this end we maximize
-    // R^2 whilst maintaining a parsimonious model. We achieve the later
-    // objective by doing model selection for each candidate segment using
-    // the significance of the explained variance divided by the split model
-    // residual variance.
+    // models which efficiently predicts the values. To this end we minimize
+    // residual variance whilst maintaining a parsimonious model. We achieve
+    // the later objective by doing model selection for each candidate segment
+    // using a significance test of the explained variance.
 
     using TDoubleItrPr = std::pair<double, ITR>;
-    using TMinAccumulator =
-        CBasicStatistics::COrderStatisticsStack<TDoubleItrPr, 1, COrderings::SFirstLess>;
+    using TMinAccumulator = typename CBasicStatistics::SMin<TDoubleItrPr>::TAccumulator;
     using TMeanAccumulatorAry = std::array<TMeanAccumulator, 3>;
 
     std::size_t range{static_cast<std::size_t>(std::distance(begin, end))};
@@ -496,6 +590,14 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinearScaledSeasonal(
         TMeanAccumulatorAry leftStatistics{statistics(begin, i)};
         TMeanAccumulatorAry rightStatistics{statistics(i, end)};
         minResidualVariance.add({variance(leftStatistics, rightStatistics), i});
+
+        // The following loop is the interesting part. We compute (up to constants)
+        //
+        //   min_j{ min_s{ sum_{i<j}{(x_i - s p_i)^2} } + min_s{ sum_{i>=j}{(x_i - s p_i)^2} } }
+        //
+        // We use the fact that we can maintain sufficient statistics to which
+        // we can both add and remove values to compute this in O(|S||T|) for
+        // S candidate splits and T sufficient statistics.
 
         for (ITR end_ = std::prev(end, 2); i != end_; ++i) {
             TMeanAccumulatorAry deltaStatistics{statistics(i, std::next(i))};
@@ -549,6 +651,60 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinearScaledSeasonal(
 
 void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
     const TFloatMeanAccumulatorVec& values,
+    const TSeasonality& model,
+    const TSizeVec& segmentation,
+    double outlierFraction,
+    TFloatMeanAccumulatorVec& reweighted,
+    TDoubleVec& scales) {
+
+    scales.assign(segmentation.size() - 1, 1.0);
+
+    auto scale = [&](std::size_t i) { return scaleAt(i, segmentation, scales); };
+
+    auto scaledModel = [&](std::size_t i) { return scale(i) * model(i); };
+
+    auto computeScales = [&] {
+        for (std::size_t j = 1; j < segmentation.size(); ++j) {
+            TMeanAccumulator projection;
+            TMeanAccumulator Z;
+            for (std::size_t i = segmentation[j - 1]; i < segmentation[j]; ++i) {
+                double x{CBasicStatistics::mean(reweighted[i])};
+                double w{CBasicStatistics::count(reweighted[i])};
+                double p{model(i)};
+                if (w > 0.0) {
+                    projection.add(x * p, w);
+                    Z.add(p * p, w);
+                }
+            }
+            scales[j - 1] = CBasicStatistics::mean(Z) == 0.0
+                                ? 1.0
+                                : CBasicStatistics::mean(projection) /
+                                      CBasicStatistics::mean(Z);
+        }
+    };
+
+    LOG_TRACE(<< "segmentation = " << core::CContainerPrinter::print(segmentation));
+
+    // First pass to re-weight any large outliers.
+    reweighted = values;
+    computeScales();
+    CSignal::reweightOutliers(scaledModel, outlierFraction, reweighted);
+
+    // Fit the model adjusting for scales.
+    computeScales();
+    LOG_TRACE(<< "scales = " << core::CContainerPrinter::print(scales));
+
+    // Re-weight outliers based on the new model.
+    reweighted = values;
+    if (CSignal::reweightOutliers(scaledModel, outlierFraction, reweighted)) {
+        // If any re-weighting happened fine tune.
+        computeScales();
+        LOG_TRACE(<< "scales = " << core::CContainerPrinter::print(scales));
+    }
+}
+
+void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
+    const TFloatMeanAccumulatorVec& values,
     const TSeasonalComponentVec& periods,
     const TSizeVec& segmentation,
     double outlierFraction,
@@ -559,7 +715,7 @@ void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
     models.assign(periods.size(), {});
     scales.assign(segmentation.size() - 1, 1.0);
 
-    auto seasonality = [&](std::size_t i) {
+    auto model = [&](std::size_t i) {
         double result{0.0};
         for (std::size_t j = 0; j < periods.size(); ++j) {
             if (periods[j].contains(i)) {
@@ -571,9 +727,7 @@ void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
 
     auto scale = [&](std::size_t i) { return scaleAt(i, segmentation, scales); };
 
-    auto scaledSeasonality = [&](std::size_t i) {
-        return scale(i) * seasonality(i);
-    };
+    auto scaledModel = [&](std::size_t i) { return scale(i) * model(i); };
 
     auto computeScale = [&](std::size_t begin, std::size_t end) {
         TMeanAccumulator projection;
@@ -581,14 +735,14 @@ void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
         for (std::size_t i = begin; i < end; ++i) {
             double x{CBasicStatistics::mean(reweighted[i])};
             double w{CBasicStatistics::count(reweighted[i])};
-            double p{seasonality(i)};
+            double p{model(i)};
             if (w > 0.0) {
                 projection.add(x * p, w);
                 Z.add(p * p, w);
             }
         }
         return CBasicStatistics::mean(Z) == 0.0
-                   ? 0.0
+                   ? 1.0
                    : CBasicStatistics::mean(projection) / CBasicStatistics::mean(Z);
     };
 
@@ -601,7 +755,7 @@ void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
             for (std::size_t j = 0; j < periods.size(); ++j) {
                 models[j].assign(periods[j].period(), 0.0);
                 fitSeasonalModel(reweighted.begin(), reweighted.end(),
-                                 periods[j], seasonality, scale_, models[j]);
+                                 periods[j], model, scale_, models[j]);
             }
         }
     };
@@ -620,7 +774,7 @@ void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
     // First pass to re-weight any large outliers.
     reweighted = values;
     fitSeasonalModels([](std::size_t) { return 1.0; });
-    CSignal::reweightOutliers(scaledSeasonality, outlierFraction, reweighted);
+    CSignal::reweightOutliers(scaledModel, outlierFraction, reweighted);
 
     // Fit the model adjusting for scales.
     fitScaledSeasonalModels(scale);
@@ -629,11 +783,137 @@ void CTimeSeriesSegmentation::fitPiecewiseLinearScaledSeasonal(
 
     // Re-weight outliers based on the new model.
     reweighted = values;
-    if (CSignal::reweightOutliers(scaledSeasonality, outlierFraction, reweighted)) {
+    if (CSignal::reweightOutliers(scaledModel, outlierFraction, reweighted)) {
         // If any re-weighting happened fine tune.
         fitScaledSeasonalModels(scale);
         LOG_TRACE(<< "model = " << core::CContainerPrinter::print(models));
         LOG_TRACE(<< "scales = " << core::CContainerPrinter::print(scales));
+    }
+}
+
+template<typename ITR>
+void CTimeSeriesSegmentation::fitTopDownPiecewiseTimeShifted(ITR begin,
+                                                             ITR end,
+                                                             std::size_t depth,
+                                                             std::size_t offset,
+                                                             const TDoubleVecVec& predictions,
+                                                             std::size_t maxDepth,
+                                                             double pValueToSegment,
+                                                             TSizeVec& segmentation,
+                                                             TDoubleDoublePrVec& depthAndPValue) {
+
+    using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
+
+    // We want to find the partition of [begin, end) into shifted seasonal
+    // models which efficiently predicts the values. To this end we maximise
+    // residual variance whilst maintaining a parsimonious model. We achieve
+    // the later objective by doing model selection for each candidate segment
+    // using a significance test of the explained variance.
+
+    std::size_t range{static_cast<std::size_t>(std::distance(begin, end))};
+    if (range < 10 || depth > maxDepth) {
+        return;
+    }
+
+    LOG_TRACE(<< "Considering splitting [" << offset << "," << offset + range << ")");
+
+    TMeanVarAccumulator totalMoments;
+    std::tie(totalMoments, std::ignore) = residualMoments(begin, end, offset, predictions);
+    double totalVariance{CBasicStatistics::maximumLikelihoodVariance(totalMoments)};
+    LOG_TRACE(<< "total moments = " << totalMoments);
+
+    if (totalVariance > 0.0) {
+        double bestSplitVariance{std::numeric_limits<double>::max()};
+        std::size_t bestSplit{range};
+
+        TMeanVarAccumulatorVec leftMoments(predictions.size());
+        for (std::size_t j = 0; j < 4; ++j) {
+            const auto& value = *(begin + j);
+            for (std::size_t i = 0; i < predictions.size(); ++i) {
+                double prediction{predictions[i][offset + j]};
+                leftMoments[i].add(CBasicStatistics::mean(value) - prediction,
+                                   CBasicStatistics::count(value));
+            }
+        }
+        TMeanVarAccumulatorVec rightMoments(predictions.size());
+        for (std::size_t j = 4; j < range; ++j) {
+            const auto& value = *(begin + j);
+            for (std::size_t i = 0; i < predictions.size(); ++i) {
+                double prediction{predictions[i][offset + j]};
+                rightMoments[i].add(CBasicStatistics::mean(value) - prediction,
+                                    CBasicStatistics::count(value));
+            }
+        }
+
+        // The following loop is the interesting part. We compute
+        //
+        //   min_j{ min_s{ sum_{i < j}{(x_i - p_i(s))^2} } + min_s{ sum_{i >= j}{(x_i - p_i(s))^2} } }
+        //
+        // We use the fact that we can remove values from the central moments
+        // accumulator to compute this in O(|S||T|^2) for S candidate splits
+        // and T candidate shifts.
+
+        for (std::size_t split = 5; split + 5 < range; ++split) {
+            const auto& valueLeftOfSplit = *(begin + split - 1);
+            for (std::size_t i = 0; i < predictions.size(); ++i) {
+                double prediction{predictions[i][offset + split - 1]};
+                TMeanVarAccumulator delta;
+                delta.add(CBasicStatistics::mean(valueLeftOfSplit) - prediction,
+                          CBasicStatistics::count(valueLeftOfSplit));
+                leftMoments[i].add(CBasicStatistics::mean(valueLeftOfSplit) - prediction,
+                                   CBasicStatistics::count(valueLeftOfSplit));
+                rightMoments[i] -= delta;
+            }
+
+            double variance{std::numeric_limits<double>::max()};
+            for (std::size_t i = 0; i < leftMoments.size(); ++i) {
+                for (std::size_t j = 0; j < rightMoments.size(); ++j) {
+                    double shiftsVariance{CBasicStatistics::maximumLikelihoodVariance(
+                        leftMoments[i] + rightMoments[j])};
+                    if (shiftsVariance < variance) {
+                        variance = shiftsVariance;
+                    }
+                }
+            }
+            LOG_TRACE(<< "  split = " << split << ", variance = " << variance);
+
+            if (variance < bestSplitVariance) {
+                std::tie(bestSplitVariance, bestSplit) = std::make_pair(variance, split);
+            }
+        }
+
+        auto split = begin + bestSplit;
+        std::size_t splitOffset{offset + bestSplit};
+
+        TMeanAccumulator meanAbs{std::accumulate(
+            begin, end, TMeanAccumulator{}, [](auto partialMean, const auto& value) {
+                partialMean.add(std::fabs(CBasicStatistics::mean(value)),
+                                CBasicStatistics::count(value));
+                return partialMean;
+            })};
+        LOG_TRACE(<< "  total variance = " << totalVariance << ", best split = " << bestSplit
+                  << ", best split variance = " << bestSplitVariance
+                  << ", mean abs = " << meanAbs);
+
+        double v[]{totalVariance, bestSplitVariance + MINIMUM_COEFFICIENT_OF_VARIATION *
+                                                          CBasicStatistics::mean(meanAbs)};
+        double df[]{3.0 - 2.0, static_cast<double>(range - 3)};
+        double F{df[1] * std::max(v[0] - v[1], 0.0) / (df[0] * v[1])};
+        double pValue{CTools::oneMinusPowOneMinusX(
+            CStatisticalTests::rightTailFTest(F, df[0], df[1]),
+            static_cast<double>(range - 10))};
+        LOG_TRACE(<< "  p-value = " << pValue);
+
+        if (pValue < pValueToSegment) {
+            fitTopDownPiecewiseTimeShifted(begin, split, depth + 1, offset,
+                                           predictions, maxDepth, pValueToSegment,
+                                           segmentation, depthAndPValue);
+            fitTopDownPiecewiseTimeShifted(split, end, depth + 1, splitOffset,
+                                           predictions, maxDepth, pValueToSegment,
+                                           segmentation, depthAndPValue);
+            segmentation.push_back(splitOffset);
+            depthAndPValue.emplace_back(static_cast<double>(depth), pValue);
+        }
     }
 }
 
@@ -668,19 +948,19 @@ CTimeSeriesSegmentation::centredResidualMoments(ITR begin,
     }
 
     TMeanAccumulator projection;
-    TMeanAccumulator norm2;
+    TMeanAccumulator Z;
     for (ITR i = begin; i != end; ++i) {
         double x{CBasicStatistics::mean(*i)};
         double w{CBasicStatistics::count(*i)};
         double p{model(offset + std::distance(begin, i))};
         if (w > 0.0) {
             projection.add(x * p, w);
-            norm2.add(p * p, w);
+            Z.add(p * p, w);
         }
     }
-    double scale{CBasicStatistics::mean(projection) == CBasicStatistics::mean(norm2)
+    double scale{CBasicStatistics::mean(Z) == 0.0
                      ? 1.0
-                     : CBasicStatistics::mean(projection) / CBasicStatistics::mean(norm2)};
+                     : CBasicStatistics::mean(projection) / CBasicStatistics::mean(Z)};
     LOG_TRACE(<< "  scale = " << scale);
 
     TMeanVarAccumulator moments;
@@ -712,6 +992,36 @@ CTimeSeriesSegmentation::residualMoments(ITR begin, ITR end, double startTime, c
         }
     }
     return moments;
+}
+
+template<typename ITR>
+CTimeSeriesSegmentation::TMeanVarAccumulatorSizePr
+CTimeSeriesSegmentation::residualMoments(ITR begin,
+                                         ITR end,
+                                         std::size_t offset,
+                                         const TDoubleVecVec& predictions) {
+
+    std::size_t range{static_cast<std::size_t>(std::distance(begin, end))};
+
+    TMeanVarAccumulator bestMoments;
+    std::size_t bestShift{predictions.size()};
+    double bestVariance{std::numeric_limits<double>::max()};
+
+    for (std::size_t i = 0; i < predictions.size(); ++i) {
+        TMeanVarAccumulator shiftMoments;
+        for (std::size_t j = 0; j < range; ++j) {
+            const auto& value = *(begin + j);
+            shiftMoments.add(CBasicStatistics::mean(value) - predictions[i][offset + j],
+                             CBasicStatistics::count(value));
+        }
+        if (CBasicStatistics::maximumLikelihoodVariance(shiftMoments) < bestVariance) {
+            bestMoments = shiftMoments;
+            bestShift = i;
+            bestVariance = CBasicStatistics::maximumLikelihoodVariance(shiftMoments);
+        }
+    }
+
+    return std::make_pair(bestMoments, bestShift);
 }
 
 template<typename ITR>

--- a/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
+++ b/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
@@ -87,6 +87,8 @@ std::size_t distance(const TSizeVec& lhs, const TSizeVec& rhs) {
 
 BOOST_AUTO_TEST_CASE(testPiecewiseLinear) {
 
+    // Test we identify trend knot points.
+
     core_t::TTime halfHour{core::constants::HOUR / 2};
     core_t::TTime week{core::constants::WEEK};
     core_t::TTime range{5 * week};
@@ -217,6 +219,8 @@ BOOST_AUTO_TEST_CASE(testPiecewiseLinear) {
 
 BOOST_AUTO_TEST_CASE(testPiecewiseLinearScaledSeasonal) {
 
+    // Test we identify scale change points.
+
     core_t::TTime halfHour{core::constants::HOUR / 2};
     core_t::TTime week{core::constants::WEEK};
     core_t::TTime range{5 * week};
@@ -333,7 +337,82 @@ BOOST_AUTO_TEST_CASE(testPiecewiseLinearScaledSeasonal) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testRemovePiecewiseLinearScaledSeasonal) {
+
+    // Test we get the residual distribution we expect after removing a piecewise
+    // linear scaled seasonal component.
+
+    core_t::TTime halfHour{core::constants::HOUR / 2};
+    core_t::TTime week{core::constants::WEEK};
+    core_t::TTime range{5 * week};
+
+    test::CRandomNumbers rng;
+
+    std::string descriptions[]{"smooth", "weekends", "spikey"};
+    maths::CSignal::TSeasonalComponentVec periods[]{
+        {maths::CSignal::seasonalComponentSummary(48)},
+        {maths::CSignal::SSeasonalComponentSummary{48, 0, 336, {0, 240}},
+         maths::CSignal::SSeasonalComponentSummary{336, 0, 336, {0, 240}},
+         maths::CSignal::SSeasonalComponentSummary{48, 0, 336, {240, 336}},
+         maths::CSignal::SSeasonalComponentSummary{336, 0, 336, {240, 336}}},
+        {maths::CSignal::seasonalComponentSummary(48)}};
+
+    TFloatMeanAccumulatorVec values(range / halfHour);
+    TDoubleVec noise;
+
+    LOG_DEBUG(<< "Basic");
+    std::size_t i{0};
+    for (auto seasonal : {smoothDaily, weekends, spikeyDaily}) {
+        LOG_DEBUG(<< descriptions[i]);
+        CDebugGenerator debug{"results." + descriptions[i] + ".py"};
+
+        values.assign(range / halfHour, TFloatMeanAccumulator{});
+        TMeanVarAccumulator noiseMoments;
+        for (core_t::TTime time = 0; time < range; time += halfHour) {
+            rng.generateNormalSamples(0.0, 3.0, 1, noise);
+            noiseMoments.add(noise[0]);
+            if (time < 3 * week / 2) {
+                values[time / halfHour].add(100.0 * seasonal(time) + noise[0]);
+            } else if (time < 2 * week) {
+                values[time / halfHour].add(50.0 * seasonal(time) + noise[0]);
+            } else {
+                values[time / halfHour].add(300.0 * seasonal(time) + noise[0]);
+            }
+            debug.addValue(maths::CBasicStatistics::mean(values[time / halfHour]));
+        }
+        TSizeVec segmentation{0, static_cast<std::size_t>(3 * week / halfHour / 2),
+                              static_cast<std::size_t>(2 * week / halfHour),
+                              values.size()};
+
+        TDoubleVec scales;
+        TFloatMeanAccumulatorVec residuals{TSegmentation::removePiecewiseLinearScaledSeasonal(
+            values, [&](std::size_t j) { return seasonal(halfHour * j); },
+            segmentation, 0.1, &scales)};
+
+        TMeanVarAccumulator residualMoments;
+        for (const auto& residual : residuals) {
+            residualMoments.add(maths::CBasicStatistics::mean(residual));
+            debug.addResidual(maths::CBasicStatistics::mean(residual));
+        }
+        LOG_DEBUG(<< "noise moments    = " << noiseMoments);
+        LOG_DEBUG(<< "residual moments = " << residualMoments);
+
+        // Not biased.
+        BOOST_TEST_REQUIRE(
+            std::fabs(maths::CBasicStatistics::mean(residualMoments) -
+                      maths::CBasicStatistics::mean(noiseMoments)) <
+            3.0 * std::sqrt(maths::CBasicStatistics::variance(noiseMoments) /
+                            maths::CBasicStatistics::count(noiseMoments)));
+
+        // We've explained nearly all the variance.
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::variance(residualMoments) <
+                           1.1 * maths::CBasicStatistics::variance(noiseMoments));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testRemovePiecewiseLinearDiscontinuities) {
+
+    // Test we correctly remove step discontinuities.
 
     std::size_t length{300};
 
@@ -491,6 +570,68 @@ BOOST_AUTO_TEST_CASE(testMeanScalePiecewiseLinearScaledSeasonal) {
                             15.0); // 15%
         ++i;
     }
+}
+
+BOOST_AUTO_TEST_CASE(testPiecewiseTimeShifted) {
+
+    // Test that we identify time shift points.
+
+    core_t::TTime hour{core::constants::HOUR};
+
+    TSegmentation::TModel models[]{
+        [](core_t::TTime time) { return 10.0 * smoothDaily(86400 + time); },
+        [](core_t::TTime time) { return 10.0 * spikeyDaily(86400 + time); }};
+
+    test::CRandomNumbers rng;
+
+    TSizeVec shift;
+    core_t::TTime shifts[3]{0};
+    TFloatMeanAccumulatorVec values;
+    TDoubleVec noise;
+
+    TSizeVec segmentation{0, 80, 200, 240};
+
+    TSizeVec estimatedSegmentation;
+    TSegmentation::TTimeVec estimatedShifts;
+    TMeanVarAccumulator meanError;
+
+    for (std::size_t i = 0; i < 10; ++i) {
+        rng.generateUniformSamples(-5 * hour, -hour, 1, shift);
+        shifts[1] = hour * (static_cast<core_t::TTime>(shift[0]) / hour);
+        rng.generateUniformSamples(hour, 5 * hour, 1, shift);
+        shifts[2] = hour * (static_cast<core_t::TTime>(shift[0]) / hour);
+        LOG_DEBUG(<< "shifts = " << core::CContainerPrinter::print(shifts));
+
+        values.assign(240, TFloatMeanAccumulator{});
+        rng.generateNormalSamples(0.0, 1.0, 240, noise);
+
+        core_t::TTime time{0};
+        for (std::size_t j = 0; j < values.size(); ++j, time += hour / 2) {
+            core_t::TTime shiftedTime{
+                time + (j < 80 ? shifts[0] : (j < 200 ? shifts[1] : shifts[2]))};
+            values[j].add(models[i % 2](shiftedTime) + noise[j]);
+        }
+
+        estimatedSegmentation = TSegmentation::piecewiseTimeShifted(
+            values, hour / 2,
+            {-4 * hour, -3 * hour, -2 * hour, -1 * hour, 1 * hour, 2 * hour,
+             3 * hour, 4 * hour},
+            models[i % 2], 0.001, 3, &estimatedShifts);
+
+        BOOST_REQUIRE_EQUAL(segmentation.size(), estimatedSegmentation.size());
+        int error{0};
+        for (std::size_t j = 0; j < 4; ++j) {
+            error += std::abs(static_cast<int>(estimatedSegmentation[j]) -
+                              static_cast<int>(segmentation[j]));
+        }
+        BOOST_REQUIRE(error < 10);
+        BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(shifts),
+                            core::CContainerPrinter::print(estimatedShifts));
+        meanError.add(static_cast<double>(error));
+    }
+
+    LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
+    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 2.2);
 }
 
 BOOST_AUTO_TEST_CASE(testMeanScale) {

--- a/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
+++ b/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseTimeShifted) {
     }
 
     LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 2.2);
+    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 2.7);
 }
 
 BOOST_AUTO_TEST_CASE(testMeanScale) {


### PR DESCRIPTION
This implements segmentation of a window of times series values allowing for piecewise constant time shifts of the seasonality. This is needed to extend change detection to handle a wider range of possible time shifts. I also took the opportunity to finish up testing time series segmentation and make some improvements to documentation and variable naming.

This isn't used yet; I plan to wire it in the next change. This is marked as a non-issue because it will not be documented separately.