### PR TITLE
[7.10][ML] Correcting model state min_version

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@
 * Avoid potential "Failed to compute quantile" and "No values added to quantile sketch" log errors
   training regression and classification models if there are features with mostly missing values.
   (See {ml-pull}1500[#1500].)
+* Correct the anomaly detection job model state `min_version`. (See {ml-pull}1546[#1546].)
 
 == {es} version 7.9.2
 

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -85,7 +85,12 @@ const std::string INTERIM_BUCKET_CORRECTOR_TAG("k");
 
 //! The minimum version required to read the state corresponding to a model snapshot.
 //! This should be updated every time there is a breaking change to the model state.
-const std::string MODEL_SNAPSHOT_MIN_VERSION("6.4.0");
+//! Newer versions are able to read the model state of older versions, but older
+//! versions cannot read the model state of newer versions following a breaking
+//! change.  This constant tells the node assignment code not to load new model states
+//! on old nodes in a mixed version cluster.  (The last breaking change was in 7.9 in
+//! lib/core/CPackedBitVector.cc in https://github.com/elastic/ml-cpp/pull/1340.)
+const std::string MODEL_SNAPSHOT_MIN_VERSION("7.9.0");
 
 //! Persist state as JSON with meaningful tag names.
 class CReadableJsonStatePersistInserter : public core::CJsonStatePersistInserter {


### PR DESCRIPTION
The model state min_version should indicate the minimum
node version required to restore the model state.  This
has not been updated since 6.4.0, meaning we have not had
the intended protection against model states being used on
nodes that are too old.  This change updates the
min_version to the correct version at present, which is
7.9.0 for latest state.

Backport of #1546