### PR TITLE
[7.x][ML] Fix error logging for foreground persistence (#1555)

### DIFF
--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -427,7 +427,7 @@ void CAnomalyJob::processPersistControlMessage(const std::string& controlMessage
                          &snapshotTimestamp](core::CDataAdder& persister) {
                             return this->doPersistStateInForeground(
                                 persister, snapshotDescription, snapshotId, snapshotTimestamp);
-                        })) {
+                        }) == false) {
                     LOG_ERROR(<< "Failed to persist state with parameters \""
                               << controlMessageArgs << "\"");
                 }


### PR DESCRIPTION
Ensure an error is logged when persistence fails

Backports #1555 