### PR TITLE
[7.x][ML] Parse anomaly job JSON config file (#1552)

### DIFF
--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -27,7 +27,6 @@ bool CCmdLineParser::parse(int argc,
                            std::string& modelConfigFile,
                            std::string& fieldConfigFile,
                            std::string& modelPlotConfigFile,
-                           std::string& jobId,
                            std::string& logProperties,
                            std::string& logPipe,
                            core_t::TTime& bucketSpan,
@@ -171,9 +170,6 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("modelplotconfig") > 0) {
             modelPlotConfigFile = vm["modelplotconfig"].as<std::string>();
-        }
-        if (vm.count("jobid") > 0) {
-            jobId = vm["jobid"].as<std::string>();
         }
         if (vm.count("logProperties") > 0) {
             logProperties = vm["logProperties"].as<std::string>();

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -39,7 +39,6 @@ public:
                       std::string& modelConfigFile,
                       std::string& fieldConfigFile,
                       std::string& modelPlotConfigFile,
-                      std::string& jobId,
                       std::string& logProperties,
                       std::string& logPipe,
                       core_t::TTime& bucketSpan,

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -21,6 +21,7 @@
 #include <core/CNonInstantiatable.h>
 #include <core/CProcessPriority.h>
 #include <core/CProgramCounters.h>
+#include <core/CStringUtils.h>
 #include <core/Concurrency.h>
 
 #include <ver/CBuildInfo.h>
@@ -46,17 +47,6 @@
 #include <string>
 
 namespace {
-std::pair<std::string, bool> readFileToString(const std::string& fileName) {
-    std::ifstream fileStream{fileName};
-    if (fileStream.is_open() == false) {
-        LOG_FATAL(<< "Environment error: failed to open file '" << fileName << "'.");
-        return {std::string{}, false};
-    }
-    return {std::string{std::istreambuf_iterator<char>{fileStream},
-                        std::istreambuf_iterator<char>{}},
-            true};
-}
-
 class CCleanUpOnExit : private ml::core::CNonInstantiatable {
 public:
     using TTemporaryDirectoryPtr = std::shared_ptr<ml::core::CTemporaryDirectory>;
@@ -169,7 +159,8 @@ int main(int argc, char** argv) {
 
     std::string analysisSpecificationJson;
     bool couldReadConfigFile;
-    std::tie(analysisSpecificationJson, couldReadConfigFile) = readFileToString(configFile);
+    std::tie(analysisSpecificationJson, couldReadConfigFile) =
+        ml::core::CStringUtils::readFileToString(configFile);
     if (couldReadConfigFile == false) {
         LOG_FATAL(<< "Failed to read config file '" << configFile << "'");
         return EXIT_FAILURE;

--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#ifndef INCLUDED_ml_api_CAnomalyJobConfig_h
+#define INCLUDED_ml_api_CAnomalyJobConfig_h
+
+#include <core/CLogger.h>
+
+#include <api/CDetectionRulesJsonParser.h>
+#include <api/ImportExport.h>
+
+#include <model/CLimits.h>
+
+#include <rapidjson/document.h>
+
+#include <string>
+#include <vector>
+
+namespace ml {
+namespace api {
+
+//! \brief A parser to convert JSON configuration of an anomaly job JSON into an object
+class API_EXPORT CAnomalyJobConfig {
+public:
+    class API_EXPORT CAnalysisConfig {
+    public:
+        class API_EXPORT CDetectorConfig {
+        public:
+            static const std::string FUNCTION;
+            static const std::string FIELD_NAME;
+            static const std::string BY_FIELD_NAME;
+            static const std::string OVER_FIELD_NAME;
+            static const std::string PARTITION_FIELD_NAME;
+            static const std::string DETECTOR_DESCRIPTION;
+            static const std::string EXCLUDE_FREQUENT;
+            static const std::string CUSTOM_RULES;
+            static const std::string USE_NULL;
+
+        public:
+            CDetectorConfig() {}
+
+            void parse(const rapidjson::Value& json);
+
+            std::string function() const { return m_Function; }
+            std::string fieldName() const { return m_FieldName; }
+            std::string byFieldName() const { return m_ByFieldName; }
+            std::string overFieldName() const { return m_OverFieldName; }
+            std::string partitionFieldName() const {
+                return m_PartitionFieldName;
+            }
+            std::string excludeFrequent() const { return m_ExcludeFrequent; }
+            std::string detectorDescription() const {
+                return m_DetectorDescription;
+            }
+            CDetectionRulesJsonParser::TDetectionRuleVec customRules() const {
+                return m_CustomRules;
+            }
+            bool useNull() const { return m_UseNull; }
+
+        private:
+            std::string m_Function{};
+            std::string m_FieldName{};
+            std::string m_ByFieldName{};
+            std::string m_OverFieldName{};
+            std::string m_PartitionFieldName{};
+            std::string m_ExcludeFrequent{};
+            std::string m_DetectorDescription{};
+            CDetectionRulesJsonParser::TDetectionRuleVec m_CustomRules{};
+            bool m_UseNull{false};
+        };
+
+    public:
+        static const std::string BUCKET_SPAN;
+        static const std::string SUMMARY_COUNT_FIELD_NAME;
+        static const std::string CATEGORIZATION_FIELD_NAME;
+        static const std::string CATEGORIZATION_FILTERS;
+        static const std::string DETECTORS;
+        static const std::string INFLUENCERS;
+        static const std::string LATENCY;
+        static const std::string PER_PARTITION_CATEGORIZATION;
+        static const std::string ENABLED;
+        static const std::string STOP_ON_WARN;
+
+        static const core_t::TTime DEFAULT_BUCKET_SPAN;
+
+    public:
+        using TStrVec = std::vector<std::string>;
+        using TDetectorConfigVec = std::vector<CDetectorConfig>;
+
+    public:
+        CAnalysisConfig() {}
+
+        void parse(const rapidjson::Value& json);
+
+        core_t::TTime bucketSpan() const { return m_BucketSpan; }
+
+        std::string summaryCountFieldName() const {
+            return m_SummaryCountFieldName;
+        }
+        std::string categorizationFieldName() const {
+            return m_CategorizationFieldName;
+        }
+        const TStrVec& categorizationFilters() const {
+            return m_CategorizationFilters;
+        }
+        bool perPartitionCategorizationEnabled() const {
+            return m_PerPartitionCategorizationEnabled;
+        }
+        bool perPartitionCategorizationStopOnWarn() const {
+            return m_PerPartitionCategorizationStopOnWarn;
+        }
+        const TDetectorConfigVec& detectorsConfig() const {
+            return m_Detectors;
+        }
+        const TStrVec& influencers() const { return m_Influencers; }
+        std::string latency() const { return m_Latency; }
+
+        static core_t::TTime bucketSpanSeconds(const std::string& bucketSpanString);
+
+    private:
+        std::size_t m_BucketSpan{300}; // 5m
+        std::string m_SummaryCountFieldName{};
+        std::string m_CategorizationFieldName{};
+        TStrVec m_CategorizationFilters{};
+        bool m_PerPartitionCategorizationEnabled{false};
+        bool m_PerPartitionCategorizationStopOnWarn{false};
+        TDetectorConfigVec m_Detectors{};
+        TStrVec m_Influencers{};
+        std::string m_Latency{};
+    };
+
+    class API_EXPORT CDataDescription {
+    public:
+        static const std::string TIME_FIELD;
+
+        //  The time format present in the job config is in Java format and
+        // should be ignored in the C++ code. In any case, in production, the
+        // time field is always specified in seconds since epoch.
+        static const std::string TIME_FORMAT;
+
+    public:
+        //! Default constructor
+        CDataDescription() {}
+
+        void parse(const rapidjson::Value& json);
+
+        std::string timeField() const { return m_TimeField; }
+
+    private:
+        std::string m_TimeField;  // e.g. timestamp
+        std::string m_TimeFormat; // e.g. epoch_ms
+    };
+
+    class API_EXPORT CModelPlotConfig {
+    public:
+        static const std::string ANNOTATIONS_ENABLED;
+        static const std::string ENABLED;
+        static const std::string TERMS;
+
+    public:
+        //! Default constructor
+        CModelPlotConfig() {}
+
+        void parse(const rapidjson::Value& modelPlotConfig);
+
+        bool annotationsEnabled() const { return m_AnnotationsEnabled; }
+        bool enabled() const { return m_Enabled; }
+
+        // The terms string is a comma separated list of partition or
+        // by field values, but with no form of escaping.
+        // TODO improve this to be a more robust format
+        std::string terms() const { return m_Terms; }
+
+    private:
+        bool m_AnnotationsEnabled{false};
+        bool m_Enabled{false};
+        std::string m_Terms;
+    };
+
+    class API_EXPORT CAnalysisLimits {
+    public:
+        static const std::string MODEL_MEMORY_LIMIT;
+        static const std::string CATEGORIZATION_EXAMPLES_LIMIT;
+
+        static const std::size_t DEFAULT_MEMORY_LIMIT_BYTES;
+
+    public:
+        //! Default constructor
+        CAnalysisLimits() {}
+
+        void parse(const rapidjson::Value& analysLimits);
+
+        //! Size of the memory limit for the resource monitor
+        //! as a whole number of MB.
+        std::size_t modelMemoryLimit() const { return m_ModelMemoryLimit; }
+
+        long categorizationExamplesLimit() const {
+            return m_CategorizationExamplesLimit;
+        }
+
+        static std::size_t modelMemoryLimitMb(const std::string& memoryLimitStr);
+
+    private:
+        std::size_t m_CategorizationExamplesLimit{model::CLimits::DEFAULT_RESULTS_MAX_EXAMPLES};
+        std::size_t m_ModelMemoryLimit{};
+    };
+
+public:
+    static const std::string JOB_ID;
+    static const std::string JOB_TYPE;
+    static const std::string ANALYSIS_CONFIG;
+    static const std::string DATA_DESCRIPTION;
+    static const std::string MODEL_PLOT_CONFIG;
+    static const std::string ANALYSIS_LIMITS;
+
+public:
+    //! Default constructor
+    CAnomalyJobConfig() {}
+
+    bool parse(const std::string& json);
+
+    std::string jobId() const { return m_JobId; }
+    std::string jobType() const { return m_JobType; }
+    const CAnalysisConfig& analysisConfig() const { return m_AnalysisConfig; }
+    const CDataDescription& dataDescription() const {
+        return m_DataDescription;
+    }
+    const CModelPlotConfig& modelPlotConfig() const { return m_ModelConfig; }
+    const CAnalysisLimits& analysisLimits() const { return m_AnalysisLimits; }
+
+private:
+    std::string m_JobId;
+    std::string m_JobType;
+    CAnalysisConfig m_AnalysisConfig;
+    CDataDescription m_DataDescription;
+    CModelPlotConfig m_ModelConfig;
+    CAnalysisLimits m_AnalysisLimits;
+};
+}
+}
+#endif // INCLUDED_ml_api_CAnomalyJobConfig_h

--- a/include/api/CAnomalyJobConfigReader.h
+++ b/include/api/CAnomalyJobConfigReader.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_api_CAnomalyJobConfigReader_h
+#define INCLUDED_ml_api_CAnomalyJobConfigReader_h
+
+#include <core/CLogger.h>
+
+#include <api/ImportExport.h>
+
+#include <rapidjson/document.h>
+
+#include <map>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace ml {
+namespace api {
+class CAnomalyJobParameters;
+
+//! \brief Reads and validates parameters for an anomaly detection job.
+//!
+//! DESCRIPTION:\n
+//! This wraps up extracting parameter values from a JSON configuration object.
+//! It supports predefining a set of expected parameters.
+//!
+//! The read method extracts all the parameters the JSON contains and returns
+//! a collection to get them by name.
+//!
+//! Expected usage is:
+//! \code
+//! static const CAnomalyJobConfigReader reader{[] {
+//!     CAnomalyJobConfigReader theReader;
+//!     theReader.addParameter("foo", CAnomalyJobConfigReader::E_OptionalParameter);
+//!     theReader.addParameter("bar", CAnomalyJobConfigReader::E_RequiredParameter);
+//! }()};
+//!
+//! auto parameters = reader.read(json);
+//! bool foo{parameters["foo"].fallback(true)};
+//! double bar{parameters["bar"].as<double>()};
+//! \endcode
+//!
+//! IMPLEMENTATION:\n
+//! Parsing errors such as incorrect JSON format, unexpected value type, missing a
+//! required value result in a CParseError exception being thrown.
+//! However the parser is lenient in the sense that unexpected parameters re not seen
+//! as an error.
+//! It is the calling code's responsibility to ask for the right type for a parameter.
+//! If a parameter is known to exist, i.e. it is required, then it can be accessed
+//! from the read value by calling as<T>(), for type T, otherwise use the fallback
+//! method and provide the default value for the case it is missing.
+
+class API_EXPORT CAnomalyJobConfigReader {
+public:
+    class CParseError : public std::runtime_error {
+    public:
+        explicit CParseError(const std::string& what)
+            : std::runtime_error{what} {}
+        virtual ~CParseError() throw() = default;
+    };
+
+public:
+    using TStrIntMap = std::map<std::string, int>;
+
+    enum ERequirement { E_OptionalParameter, E_RequiredParameter };
+
+    //! \brief A single parameter which has been read.
+    class API_EXPORT CParameter {
+    public:
+        explicit CParameter(const std::string& name) : m_Name{name} {}
+        CParameter(const std::string& name,
+                   const rapidjson::Value& value,
+                   const TStrIntMap& permittedValues);
+
+        //! Get the name of the parameter.
+        const std::string& name() const { return m_Name; }
+        //! Get the parameter of type T.
+        template<typename T>
+        T as() const {
+            if (m_Value == nullptr) {
+                throw CParseError("Input error: expected a value for '" +
+                                  m_Name + "'. Please report this problem.");
+            }
+            return this->fallback(T{});
+        }
+        //! Get the JSON object.
+        const rapidjson::Value* jsonObject() { return m_Value; }
+        //! Get a boolean parameter.
+        bool fallback(bool value) const;
+        //! Get an unsigned integer parameter.
+        std::size_t fallback(std::size_t value) const;
+        //! Get a signed integer parameter.
+        std::ptrdiff_t fallback(std::ptrdiff_t value) const;
+        //! Get a floating point parameter.
+        double fallback(double value) const;
+        //! Get a string parameter.
+        std::string fallback(const std::string& value) const;
+        //! Get an enum point parameter.
+        template<typename ENUM>
+        ENUM fallback(ENUM value) const {
+            static_assert(std::is_enum<ENUM>::value, "ENUM must be an enumeration");
+            if (m_Value == nullptr) {
+                return value;
+            }
+            if (m_Value->IsString() == false) {
+                this->handleFatal();
+                return value;
+            }
+            auto pos = m_PermittedValues->find(std::string{m_Value->GetString()});
+            if (pos == m_PermittedValues->end()) {
+                this->handleFatal();
+                return value;
+            }
+            return static_cast<ENUM>(pos->second);
+        }
+        //! Get an array of objects of type T.
+        template<typename T>
+        std::vector<T> fallback(const std::vector<T>& value) const {
+            if (m_Value == nullptr) {
+                return value;
+            }
+            if (m_Value->IsArray() == false) {
+                this->handleFatal();
+                return value;
+            }
+            std::vector<T> result;
+            result.reserve(m_Value->Size());
+            CParameter element{m_Name, SArrayElementTag{}};
+            for (std::size_t i = 0; i < m_Value->Size(); ++i) {
+                element.m_Value = &(*m_Value)[static_cast<int>(i)];
+                result.push_back(element.as<T>());
+            }
+            return result;
+        }
+
+    private:
+        struct SArrayElementTag {};
+
+    private:
+        CParameter(const std::string& name, SArrayElementTag);
+        void handleFatal() const;
+
+    private:
+        std::string m_Name;
+        const rapidjson::Value* m_Value = nullptr;
+        const TStrIntMap* m_PermittedValues = nullptr;
+        bool m_ArrayElement = false;
+    };
+
+public:
+    //! Register a parameter.
+    //!
+    //! \param[in] name The parameter name.
+    //! \param[in] requirement Is the parameter required or optional.
+    //! \param[in] permittedValues The permitted values for an enumeration.
+    void addParameter(const std::string& name,
+                      ERequirement requirement,
+                      TStrIntMap permittedValues = TStrIntMap{});
+
+    //! Extract the parameters from a JSON object.
+    CAnomalyJobParameters read(const rapidjson::Value& json) const;
+
+private:
+    //! Reads a parameter from the JSON configuration object.
+    class API_EXPORT CParameterReader {
+    public:
+        CParameterReader(const std::string& name, ERequirement requirement, TStrIntMap permittedValues);
+
+        const std::string& name() const { return m_Name; }
+        bool required() const { return m_Requirement == E_RequiredParameter; }
+        CParameter readFrom(const rapidjson::Value& json) const {
+            return {m_Name, json[m_Name], m_PermittedValues};
+        }
+
+    private:
+        std::string m_Name;
+        ERequirement m_Requirement;
+        TStrIntMap m_PermittedValues;
+    };
+
+private:
+    std::vector<CParameterReader> m_ParameterReaders;
+};
+
+//! \brief A collection of all the data frame analysis parameters which have been read.
+class API_EXPORT CAnomalyJobParameters {
+public:
+    using TParameter = CAnomalyJobConfigReader::CParameter;
+
+public:
+    //! Add \p parameter.
+    void add(const CAnomalyJobConfigReader::CParameter& parameter) {
+        m_ParameterValues.push_back(parameter);
+    }
+
+    //! Get the parameter called \p name.
+    TParameter operator[](const std::string& name) const {
+        for (const auto& value : m_ParameterValues) {
+            if (name == value.name()) {
+                return value;
+            }
+        }
+        return TParameter{name};
+    }
+
+private:
+    std::vector<TParameter> m_ParameterValues;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CAnomalyJobConfigReader_h

--- a/include/api/CAnomalyJobConfigReader.h
+++ b/include/api/CAnomalyJobConfigReader.h
@@ -60,7 +60,7 @@ public:
     public:
         explicit CParseError(const std::string& what)
             : std::runtime_error{what} {}
-        virtual ~CParseError() throw() = default;
+        virtual ~CParseError() noexcept = default;
     };
 
 public:

--- a/include/api/CDetectionRulesJsonParser.h
+++ b/include/api/CDetectionRulesJsonParser.h
@@ -37,6 +37,11 @@ public:
     //! detection rules and adds the rule objects into the given vector.
     bool parseRules(const std::string& json, TDetectionRuleVec& rules);
 
+    //! Parses a JSON value object expected to represent a JSON array of
+    //! detection rules. Adds rule objects to the given vector. Any error messages
+    //! are passed back in the error string.
+    bool parseRules(const rapidjson::Value& value, TDetectionRuleVec& rules, std::string& errorString);
+
 private:
     bool parseRuleScope(const rapidjson::Value& ruleObject, model::CDetectionRule& rule);
     bool parseRuleConditions(const rapidjson::Value& ruleObject, model::CDetectionRule& rule);

--- a/include/core/CStringUtils.h
+++ b/include/core/CStringUtils.h
@@ -33,6 +33,8 @@ public:
     static const std::string WHITESPACE_CHARS;
 
 public:
+    using TSizeBoolPr = std::pair<std::size_t, bool>;
+    using TStrBoolPr = std::pair<std::string, bool>;
     using TStrVec = std::vector<std::string>;
     using TStrVecItr = TStrVec::iterator;
     using TStrVecCItr = TStrVec::const_iterator;
@@ -83,6 +85,12 @@ public:
     static bool stringToTypeSilent(const std::string& str, T& ret) {
         return CStringUtils::_stringToType(true, str, ret);
     }
+
+    //! Convert a string representation of a memory size (in ES format e.g. "4gb") to a whole number
+    //! of bytes. Returns a default value if any error occurs, however the assumption is that the input string
+    //! has already been validated by ES.
+    static TSizeBoolPr memorySizeStringToBytes(const std::string& memorySizeStr,
+                                               std::size_t defaultValue);
 
     //! Joins the strings in the container with the \p delimiter.
     //! CONTAINER must be a container of std::string.
@@ -177,6 +185,10 @@ public:
     //! TODO - remove when we switch to a character conversion library
     //! (e.g. ICU)
     static const std::locale& locale();
+
+    //! Read the contents of a file into a string.
+    //! Returns a pair containing the file contents and a boolean indicating success or failure.
+    static TStrBoolPr readFileToString(const std::string& fileName);
 
 private:
     //! Internal calls for public templated methods

--- a/include/core/CTimeUtils.h
+++ b/include/core/CTimeUtils.h
@@ -35,6 +35,8 @@ public:
     //! customer site
     static const core_t::TTime MAX_CLOCK_DISCREPANCY;
 
+    using TTimeBoolPr = std::pair<core_t::TTime, bool>;
+
 public:
     //! Current time in seconds since the epoch
     static core_t::TTime now();
@@ -73,6 +75,12 @@ public:
 
     //! Formats the given duration as human-readable string.
     static std::string durationToString(core_t::TTime duration);
+
+    //! Convert a string representation of a time duration (in ES format e.g. "1000ms") to a whole number
+    //! of seconds. Returns a default value if any error occurs, however the assumption is that the input string
+    //! has already been validated by ES.
+    static TTimeBoolPr timeDurationStringToSeconds(const std::string& timeDurationString,
+                                                   core_t::TTime defaultValue);
 
 private:
     //! Factor out common code from the three string conversion methods

--- a/include/core/Constants.h
+++ b/include/core/Constants.h
@@ -37,6 +37,21 @@ const core_t::TTime WEEK{604800};
 //! A (364 day) year in seconds.
 const core_t::TTime YEAR{31449600};
 
+//! The number of bytes in a kilobyte
+const std::size_t BYTES_IN_KILOBYTE{1024ULL};
+
+//! The number of bytes in a megabyte
+const std::size_t BYTES_IN_MEGABYTE{1024ULL * 1024};
+
+//! The number of bytes in a gigabyte
+const std::size_t BYTES_IN_GIGABYTE{1024ULL * 1024 * 1024};
+
+//! The number of bytes in a terabyte
+const std::size_t BYTES_IN_TERABYTE{1024ULL * 1024 * 1024 * 1024};
+
+//! The number of bytes in a gigabyte
+const std::size_t BYTES_IN_PETABYTE{1024ULL * 1024 * 1024 * 1024 * 1024};
+
 //! Log of min double.
 const double LOG_MIN_DOUBLE{std::log(std::numeric_limits<double>::min())};
 

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -1,0 +1,356 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include <api/CAnomalyJobConfig.h>
+
+#include <core/CLogger.h>
+#include <core/CStringUtils.h>
+#include <core/CTimeUtils.h>
+#include <core/Constants.h>
+
+#include <api/CAnomalyJobConfigReader.h>
+
+#include <model/CLimits.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+namespace ml {
+namespace api {
+
+const std::string CAnomalyJobConfig::JOB_ID{"job_id"};
+const std::string CAnomalyJobConfig::JOB_TYPE{"job_type"};
+const std::string CAnomalyJobConfig::ANALYSIS_CONFIG{"analysis_config"};
+const std::string CAnomalyJobConfig::ANALYSIS_LIMITS{"analysis_limits"};
+const std::string CAnomalyJobConfig::DATA_DESCRIPTION{"data_description"};
+const std::string CAnomalyJobConfig::MODEL_PLOT_CONFIG{"model_plot_config"};
+
+const std::string CAnomalyJobConfig::CAnalysisConfig::BUCKET_SPAN{"bucket_span"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::SUMMARY_COUNT_FIELD_NAME{
+    "summary_count_field_name"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CATEGORIZATION_FIELD_NAME{
+    "categorization_field_name"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CATEGORIZATION_FILTERS{"categorization_filters"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::DETECTORS{"detectors"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::INFLUENCERS{"influencers"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::PER_PARTITION_CATEGORIZATION{
+    "per_partition_categorization"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::ENABLED{"enabled"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::STOP_ON_WARN{"stop_on_warn"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::LATENCY{"latency"};
+
+const core_t::TTime CAnomalyJobConfig::CAnalysisConfig::DEFAULT_BUCKET_SPAN{300};
+
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION{"function"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FIELD_NAME{"field_name"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::BY_FIELD_NAME{"by_field_name"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::OVER_FIELD_NAME{
+    "over_field_name"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::PARTITION_FIELD_NAME{
+    "partition_field_name"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::DETECTOR_DESCRIPTION{
+    "detector_description"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::EXCLUDE_FREQUENT{
+    "exclude_frequent"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::USE_NULL{"use_null"};
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::CUSTOM_RULES{"custom_rules"};
+
+const std::string CAnomalyJobConfig::CModelPlotConfig::ANNOTATIONS_ENABLED{"annotations_enabled"};
+const std::string CAnomalyJobConfig::CModelPlotConfig::ENABLED{"enabled"};
+const std::string CAnomalyJobConfig::CModelPlotConfig::TERMS{"terms"};
+
+const std::string CAnomalyJobConfig::CAnalysisLimits::CATEGORIZATION_EXAMPLES_LIMIT{
+    "categorization_examples_limit"};
+const std::string CAnomalyJobConfig::CAnalysisLimits::MODEL_MEMORY_LIMIT{"model_memory_limit"};
+
+const std::size_t CAnomalyJobConfig::CAnalysisLimits::DEFAULT_MEMORY_LIMIT_BYTES{
+    1024ULL * 1024 * 1024};
+
+const std::string CAnomalyJobConfig::CDataDescription::TIME_FIELD{"time_field"};
+const std::string CAnomalyJobConfig::CDataDescription::TIME_FORMAT{"time_format"};
+
+namespace {
+const std::string EMPTY_STRING;
+
+std::string toString(const rapidjson::Value& value) {
+    rapidjson::StringBuffer strbuf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
+    value.Accept(writer);
+    return strbuf.GetString();
+};
+
+const CAnomalyJobConfigReader CONFIG_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::JOB_ID,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::JOB_TYPE,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::ANALYSIS_CONFIG,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::ANALYSIS_LIMITS,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::MODEL_PLOT_CONFIG,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::DATA_DESCRIPTION,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    return theReader;
+}()};
+
+const CAnomalyJobConfigReader ANALYSIS_CONFIG_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::BUCKET_SPAN,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::SUMMARY_COUNT_FIELD_NAME,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CATEGORIZATION_FIELD_NAME,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CATEGORIZATION_FILTERS,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::PER_PARTITION_CATEGORIZATION,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::DETECTORS,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::INFLUENCERS,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::LATENCY,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    return theReader;
+}()};
+
+const CAnomalyJobConfigReader DETECTOR_CONFIG_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FIELD_NAME,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::BY_FIELD_NAME,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::OVER_FIELD_NAME,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::PARTITION_FIELD_NAME,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::DETECTOR_DESCRIPTION,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::EXCLUDE_FREQUENT,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::USE_NULL,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::CUSTOM_RULES,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    return theReader;
+}()};
+
+const CAnomalyJobConfigReader PPC_CONFIG_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::ENABLED,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::STOP_ON_WARN,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    return theReader;
+}()};
+
+const CAnomalyJobConfigReader MODEL_PLOT_CONFIG_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::CModelPlotConfig::ANNOTATIONS_ENABLED,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CModelPlotConfig::ENABLED,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CModelPlotConfig::TERMS,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    return theReader;
+}()};
+
+const CAnomalyJobConfigReader ANALYSIS_LIMITS_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisLimits::CATEGORIZATION_EXAMPLES_LIMIT,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisLimits::MODEL_MEMORY_LIMIT,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    return theReader;
+}()};
+
+const CAnomalyJobConfigReader DATA_DESCRIPTION_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::CDataDescription::TIME_FIELD,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::CDataDescription::TIME_FORMAT,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    return theReader;
+}()};
+}
+
+bool CAnomalyJobConfig::parse(const std::string& json) {
+    LOG_DEBUG(<< "Parsing anomaly job config");
+
+    rapidjson::Document doc;
+    if (doc.Parse<0>(json).HasParseError()) {
+        LOG_ERROR(<< "An error occurred while parsing anomaly job config from JSON: "
+                  << doc.GetParseError());
+        return false;
+    }
+
+    try {
+        auto parameters = CONFIG_READER.read(doc);
+
+        m_JobId = parameters[JOB_ID].as<std::string>();
+        m_JobType = parameters[JOB_TYPE].as<std::string>();
+
+        auto analysisConfig = parameters[ANALYSIS_CONFIG].jsonObject();
+        if (analysisConfig != nullptr) {
+            m_AnalysisConfig.parse(*analysisConfig);
+        }
+
+        auto analysisLimits = parameters[ANALYSIS_LIMITS].jsonObject();
+        if (analysisLimits != nullptr) {
+            m_AnalysisLimits.parse(*analysisLimits);
+        }
+
+        auto description = parameters[DATA_DESCRIPTION].jsonObject();
+        if (description != nullptr) {
+            m_DataDescription.parse(*description);
+        }
+
+        auto modelPlotConfig = parameters[MODEL_PLOT_CONFIG].jsonObject();
+        if (modelPlotConfig != nullptr) {
+            m_ModelConfig.parse(*modelPlotConfig);
+        }
+    } catch (CAnomalyJobConfigReader::CParseError& e) {
+        LOG_ERROR(<< "Error parsing anomaly job config: " << e.what());
+        return false;
+    }
+
+    return true;
+}
+
+void CAnomalyJobConfig::CModelPlotConfig::parse(const rapidjson::Value& modelPlotConfig) {
+    auto parameters = MODEL_PLOT_CONFIG_READER.read(modelPlotConfig);
+
+    m_AnnotationsEnabled = parameters[ANNOTATIONS_ENABLED].fallback(false);
+    m_Enabled = parameters[ENABLED].fallback(false);
+    m_Terms = parameters[TERMS].fallback(EMPTY_STRING);
+}
+
+void CAnomalyJobConfig::CAnalysisLimits::parse(const rapidjson::Value& analysisLimits) {
+    auto parameters = ANALYSIS_LIMITS_READER.read(analysisLimits);
+
+    m_CategorizationExamplesLimit = parameters[CATEGORIZATION_EXAMPLES_LIMIT].fallback(
+        model::CLimits::DEFAULT_RESULTS_MAX_EXAMPLES);
+
+    const std::string memoryLimitStr{parameters[MODEL_MEMORY_LIMIT].as<std::string>()};
+    m_ModelMemoryLimit = CAnomalyJobConfig::CAnalysisLimits::modelMemoryLimitMb(memoryLimitStr);
+}
+
+std::size_t CAnomalyJobConfig::CAnalysisLimits::modelMemoryLimitMb(const std::string& memoryLimitStr) {
+    std::size_t memoryLimitMb{0};
+
+    // We choose to ignore any errors here parsing the model memory limit string
+    // as we assume that it has already been validated by ES. In the event that any
+    // error _does_ occur an error is logged and a default value used.
+    std::tie(memoryLimitMb, std::ignore) = core::CStringUtils::memorySizeStringToBytes(
+        memoryLimitStr, DEFAULT_MEMORY_LIMIT_BYTES);
+
+    memoryLimitMb /= core::constants::BYTES_IN_MEGABYTE;
+
+    if (memoryLimitMb == 0) {
+        LOG_ERROR(<< "Invalid limit value " << memoryLimitStr << ". Limit must have a minimum value of 1mb."
+                  << " Using default memory limit value " << DEFAULT_MEMORY_LIMIT_BYTES);
+        memoryLimitMb = DEFAULT_MEMORY_LIMIT_BYTES;
+    }
+
+    return memoryLimitMb;
+}
+
+void CAnomalyJobConfig::CDataDescription::parse(const rapidjson::Value& analysisLimits) {
+    auto parameters = DATA_DESCRIPTION_READER.read(analysisLimits);
+
+    m_TimeField = parameters[TIME_FIELD].as<std::string>();
+    m_TimeFormat = parameters[TIME_FORMAT].fallback(EMPTY_STRING); // Ignore
+}
+
+void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisConfig) {
+    auto parameters = ANALYSIS_CONFIG_READER.read(analysisConfig);
+    // We choose to ignore any errors here parsing the time duration string as
+    // we assume that it has already been validated by ES. In the event that any
+    // error _does_ occur an error is logged and a default value used.
+    const std::string bucketSpanString{parameters[BUCKET_SPAN].as<std::string>()};
+    m_BucketSpan = CAnomalyJobConfig::CAnalysisConfig::bucketSpanSeconds(bucketSpanString);
+
+    m_SummaryCountFieldName = parameters[SUMMARY_COUNT_FIELD_NAME].fallback(EMPTY_STRING);
+    m_CategorizationFieldName = parameters[CATEGORIZATION_FIELD_NAME].fallback(EMPTY_STRING);
+    m_CategorizationFilters = parameters[CATEGORIZATION_FILTERS].fallback(TStrVec{});
+
+    auto ppc = parameters[PER_PARTITION_CATEGORIZATION].jsonObject();
+    if (ppc != nullptr) {
+        auto ppcParameters = PPC_CONFIG_READER.read(*ppc);
+        m_PerPartitionCategorizationEnabled = ppcParameters[ENABLED].fallback(false);
+        m_PerPartitionCategorizationStopOnWarn = ppcParameters[STOP_ON_WARN].fallback(false);
+    }
+
+    auto detectorsConfig = parameters[DETECTORS].jsonObject();
+
+    // The Job config has already been validated by Java before being passed to
+    // the C++ backend. So we can safely assume that the detector config is a
+    // non-null array - hence this check isn't strictly necessary.
+    if (detectorsConfig != nullptr && detectorsConfig->IsArray()) {
+        m_Detectors.resize(detectorsConfig->Size());
+        for (std::size_t i = 0; i < detectorsConfig->Size(); ++i) {
+            m_Detectors[i].parse((*detectorsConfig)[static_cast<int>(i)]);
+        }
+    }
+
+    m_Influencers = parameters[INFLUENCERS].fallback(TStrVec{});
+    m_Latency = parameters[LATENCY].fallback(EMPTY_STRING);
+}
+
+core_t::TTime CAnomalyJobConfig::CAnalysisConfig::bucketSpanSeconds(const std::string& bucketSpanString) {
+    core_t::TTime bucketSpanSeconds{0};
+    std::tie(bucketSpanSeconds, std::ignore) =
+        core::CTimeUtils::timeDurationStringToSeconds(bucketSpanString, DEFAULT_BUCKET_SPAN);
+
+    if (bucketSpanSeconds == 0) {
+        LOG_ERROR(<< "Invalid bucket span value " << bucketSpanString
+                  << ". Duration must have a minimum value of 1s. "
+                     "Using default bucket span value "
+                  << DEFAULT_BUCKET_SPAN);
+        bucketSpanSeconds = DEFAULT_BUCKET_SPAN;
+    }
+
+    return bucketSpanSeconds;
+}
+
+void CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::parse(const rapidjson::Value& detectorConfig) {
+    auto parameters = DETECTOR_CONFIG_READER.read(detectorConfig);
+
+    m_Function = parameters[FUNCTION].as<std::string>();
+    m_FieldName = parameters[FIELD_NAME].fallback(EMPTY_STRING);
+    m_ByFieldName = parameters[BY_FIELD_NAME].fallback(EMPTY_STRING);
+    m_OverFieldName = parameters[OVER_FIELD_NAME].fallback(EMPTY_STRING);
+    m_ByFieldName = parameters[BY_FIELD_NAME].fallback(EMPTY_STRING);
+    m_PartitionFieldName = parameters[PARTITION_FIELD_NAME].fallback(EMPTY_STRING);
+    m_ExcludeFrequent = parameters[EXCLUDE_FREQUENT].fallback(EMPTY_STRING);
+    m_DetectorDescription = parameters[DETECTOR_DESCRIPTION].fallback(EMPTY_STRING);
+
+    auto customRules = parameters[CUSTOM_RULES].jsonObject();
+    if (customRules != nullptr) {
+        std::string errorString;
+        using TStrPatternSetUMap = CDetectionRulesJsonParser::TStrPatternSetUMap;
+        // TODO How to populate the filters by Id map passed to the detection rules JSON parser?
+        // Pass an empty map as a placeholder
+        TStrPatternSetUMap emptyMap{};
+        CDetectionRulesJsonParser rulesParser(emptyMap);
+        if (rulesParser.parseRules(*customRules, m_CustomRules, errorString) == false) {
+            // TODO Re-enable this error handling when the CDetectionRulesJsonParser instance
+            // has been constructed with a valid filter map.
+            //            LOG_ERROR(<< errorString << toString(*customRules));
+            //            throw CAnomalyJobConfigReader::CParseError(
+            //                "Error parsing custom rules: " + toString(*customRules));
+        }
+    }
+
+    m_UseNull = parameters[USE_NULL].fallback(false);
+}
+}
+}

--- a/lib/api/CAnomalyJobConfigReader.cc
+++ b/lib/api/CAnomalyJobConfigReader.cc
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CAnomalyJobConfigReader.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#ifdef Windows
+// rapidjson::Writer<rapidjson::StringBuffer> gets instantiated in the core
+// library, and on Windows it gets exported too, because
+// CRapidJsonConcurrentLineWriter inherits from it and is also exported.
+// To avoid breaching the one-definition rule we must reuse this exported
+// instantiation, as deduplication of template instantiations doesn't work
+// across DLLs.  To make this even more confusing, this is only strictly
+// necessary when building without optimisation, because with optimisation
+// enabled the instantiation in this library gets inlined to the extent that
+// there are no clashing symbols.
+template class CORE_EXPORT rapidjson::Writer<rapidjson::StringBuffer>;
+#endif
+
+namespace ml {
+namespace api {
+namespace {
+std::string toString(const rapidjson::Value& value) {
+    rapidjson::StringBuffer valueAsString;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(valueAsString);
+    value.Accept(writer);
+    return valueAsString.GetString();
+}
+}
+
+void CAnomalyJobConfigReader::addParameter(const std::string& name,
+                                           ERequirement requirement,
+                                           TStrIntMap permittedValues) {
+    m_ParameterReaders.emplace_back(name, requirement, std::move(permittedValues));
+}
+
+CAnomalyJobParameters CAnomalyJobConfigReader::read(const rapidjson::Value& json) const {
+    if (json.IsObject() == false) {
+        throw CParseError("Input error: expected JSON object but input was '" +
+                          toString(json) + "'. Please report this problem.");
+    }
+
+    CAnomalyJobParameters result;
+    for (const auto& reader : m_ParameterReaders) {
+        if (json.HasMember(reader.name())) {
+            result.add(reader.readFrom(json));
+        } else if (reader.required()) {
+            throw CParseError("Input error: missing required parameter '" +
+                              reader.name() + "'. Please report this problem.");
+        } else {
+            result.add(CParameter{reader.name()});
+        }
+    }
+
+    return result;
+}
+
+CAnomalyJobConfigReader::CParameter::CParameter(const std::string& name,
+                                                const rapidjson::Value& value,
+                                                const TStrIntMap& permittedValues)
+    : m_Name{name}, m_Value{&value}, m_PermittedValues{&permittedValues} {
+}
+
+bool CAnomalyJobConfigReader::CParameter::fallback(bool value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsBool() == false) {
+        this->handleFatal();
+        return value;
+    }
+    return m_Value->GetBool();
+}
+
+std::size_t CAnomalyJobConfigReader::CParameter::fallback(std::size_t value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsUint64() == false) {
+        this->handleFatal();
+        return value;
+    }
+    return m_Value->GetUint64();
+}
+
+std::ptrdiff_t CAnomalyJobConfigReader::CParameter::fallback(std::ptrdiff_t value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsInt64() == false) {
+        this->handleFatal();
+        return value;
+    }
+    return m_Value->GetInt64();
+}
+
+double CAnomalyJobConfigReader::CParameter::fallback(double value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsInt64()) {
+        return static_cast<double>(m_Value->GetInt64());
+    }
+    if (m_Value->IsDouble() == false) {
+        this->handleFatal();
+        return value;
+    }
+    return m_Value->GetDouble();
+}
+
+std::string CAnomalyJobConfigReader::CParameter::fallback(const std::string& value) const {
+    if (m_Value == nullptr) {
+        return value;
+    }
+    if (m_Value->IsString() == false) {
+        this->handleFatal();
+        return value;
+    }
+    return m_Value->GetString();
+}
+
+CAnomalyJobConfigReader::CParameter::CParameter(const std::string& name, SArrayElementTag)
+    : m_Name{name}, m_ArrayElement{true} {
+}
+
+void CAnomalyJobConfigReader::CParameter::handleFatal() const {
+    throw CParseError("Input error: bad value '" + toString(*m_Value) + "' for " +
+                      (m_ArrayElement ? "element of '" : "'") + m_Name + "'.");
+}
+
+CAnomalyJobConfigReader::CParameterReader::CParameterReader(const std::string& name,
+                                                            ERequirement requirement,
+                                                            TStrIntMap permittedValues)
+    : m_Name{name}, m_Requirement{requirement}, m_PermittedValues{std::move(permittedValues)} {
+}
+}
+}

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -20,6 +20,8 @@ all: build
 
 SRCS= \
 CAnomalyJob.cc \
+CAnomalyJobConfig.cc \
+CAnomalyJobConfigReader.cc \
 CBenchMarker.cc \
 CBoostedTreeInferenceModelBuilder.cc \
 CCategoryIdMapper.cc \

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -1,0 +1,403 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CLogger.h>
+
+#include <api/CAnomalyJobConfig.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <rapidjson/stringbuffer.h>
+
+BOOST_AUTO_TEST_SUITE(CAnomalyJobConfigTest)
+
+BOOST_AUTO_TEST_CASE(testParse) {
+    {
+        const std::string inValidModelMemoryLimitBytes{
+            "[{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"1048076b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}]"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(inValidModelMemoryLimitBytes));
+    }
+    {
+        const std::string inValidModelMemoryLimitKiloBytes{
+            "[{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"1004kb\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}]"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(inValidModelMemoryLimitKiloBytes));
+    }
+    {
+        const std::string inValidAnomalyJobConfig{
+            "[{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"11mb\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}]"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(inValidAnomalyJobConfig));
+    }
+    {
+        const std::string inValidBucketSpanType{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":1800,\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"11mb\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(inValidBucketSpanType));
+    }
+    {
+        const std::string missingRequiredJobId{
+            "{\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"11mb\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(missingRequiredJobId));
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        using TAnalysisConfig = ml::api::CAnomalyJobConfig::CAnalysisConfig;
+        using TDataDescription = ml::api::CAnomalyJobConfig::CDataDescription;
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        using TDetectorConfigVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TDetectorConfigVec;
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, detectorsConfig[0].customRules().size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        using TStrVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TStrVec;
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimit());
+
+        using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+
+    {
+        const std::string validAnomalyJobConfigWithMultipleInfluencers{
+            "{\"job_id\":\"logs_max_bytes_by_geo\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603290557883,\"description\":\"\","
+            "\"analysis_config\":{\"bucket_span\":\"900ms\",\"detectors\":[{\"detector_description\":\"max(bytes) by \\\"geo.src\\\" partitionfield=\\\"host.keyword\\\"\","
+            "\"function\":\"max\",\"field_name\":\"bytes\",\"by_field_name\":\"geo.src\",\"partition_field_name\":\"host.keyword\",\"detector_index\":0}],"
+            "\"influencers\":[\"geo.src\",\"host.keyword\"]},\"analysis_limits\":{\"model_memory_limit\":\"5140KB\",\"categorization_examples_limit\":4},"
+            "\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,\"daily_model_snapshot_retention_after_days\":1,"
+            "\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfigWithMultipleInfluencers),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("logs_max_bytes_by_geo", jobConfig.jobId());
+
+        using TAnalysisConfig = ml::api::CAnomalyJobConfig::CAnalysisConfig;
+        using TDataDescription = ml::api::CAnomalyJobConfig::CDataDescription;
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        // When the configured bucket span equates to less than 1s expect the default value
+        // to be used.
+        BOOST_REQUIRE_EQUAL(ml::api::CAnomalyJobConfig::CAnalysisConfig::DEFAULT_BUCKET_SPAN,
+                            analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        using TDetectorConfigVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TDetectorConfigVec;
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("max(bytes) by \"geo.src\" partitionfield=\"host.keyword\"",
+                            detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("max", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("bytes", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("geo.src", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("host.keyword", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, detectorsConfig[0].customRules().size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        using TStrVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TStrVec;
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(2, influencers.size());
+        BOOST_REQUIRE_EQUAL("geo.src", influencers[0]);
+        BOOST_REQUIRE_EQUAL("host.keyword", influencers[1]);
+
+        using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(5, analysisLimits.modelMemoryLimit());
+
+        using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfigWithMultipleDetectors{
+            "{\"job_id\":\"ecommerce_population\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603290153486,"
+            "\"description\":\"ecommerce population job based on category and split by user\","
+            "\"analysis_config\":{\"bucket_span\":\"800000micros\","
+            "\"detectors\":["
+            "{\"detector_description\":\"distinct_count(\\\"category.keyword\\\") by customer_id over \\\"category.keyword\\\"\",\"function\":\"distinct_count\",\"field_name\":\"category.keyword\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0},"
+            "{\"detector_description\":\"count over \\\"category.keyword\\\"\",\"function\":\"count\",\"over_field_name\":\"category.keyword\",\"detector_index\":1}],"
+            "\"influencers\":[\"category.keyword\",\"customer_id\"]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"17mb\",\"categorization_examples_limit\":4},"
+            "\"data_description\":{\"time_field\":\"order_date\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfigWithMultipleDetectors),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("ecommerce_population", jobConfig.jobId());
+
+        using TAnalysisConfig = ml::api::CAnomalyJobConfig::CAnalysisConfig;
+        using TDataDescription = ml::api::CAnomalyJobConfig::CDataDescription;
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        // When the configured bucket span equates to less than 1s expect the default value
+        // to be used.
+        BOOST_REQUIRE_EQUAL(ml::api::CAnomalyJobConfig::CAnalysisConfig::DEFAULT_BUCKET_SPAN,
+                            analysisConfig.bucketSpan());
+        BOOST_REQUIRE_EQUAL("", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("order_date", dataDescription.timeField());
+
+        using TDetectorConfigVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TDetectorConfigVec;
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+
+        BOOST_REQUIRE_EQUAL(2, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("distinct_count(\"category.keyword\") by customer_id over \"category.keyword\"",
+                            detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("distinct_count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, detectorsConfig[0].customRules().size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        BOOST_REQUIRE_EQUAL("count over \"category.keyword\"",
+                            detectorsConfig[1].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[1].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[1].fieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[1].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[1].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[1].partitionFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[1].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, detectorsConfig[1].customRules().size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[1].useNull());
+
+        using TStrVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TStrVec;
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(2, influencers.size());
+        BOOST_REQUIRE_EQUAL("category.keyword", influencers[0]);
+        BOOST_REQUIRE_EQUAL("customer_id", influencers[1]);
+
+        using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+        BOOST_REQUIRE_EQUAL(17, analysisLimits.modelMemoryLimit());
+
+        using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfigWithCustomRule{
+            "{\"job_id\":\"count_with_range\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603901206253,\"description\":\"\","
+            "\"analysis_config\":{\"bucket_span\":\"700000000nanos\",\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"custom_rules\":[{\"actions\":[\"skip_result\"],\"conditions\":[{\"applies_to\":\"actual\",\"operator\":\"gt\",\"value\":30.0},{\"applies_to\":\"actual\",\"operator\":\"lt\",\"value\":50.0}]}],\"detector_index\":0}],"
+            "\"influencers\":[]},\"analysis_limits\":{\"model_memory_limit\":\"11mb\",\"categorization_examples_limit\":5},"
+            "\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_snapshot_retention_days\":10,\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfigWithCustomRule),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("count_with_range", jobConfig.jobId());
+
+        using TAnalysisConfig = ml::api::CAnomalyJobConfig::CAnalysisConfig;
+        using TDataDescription = ml::api::CAnomalyJobConfig::CDataDescription;
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        // When the configured bucket span equates to less than 1s expect the default value
+        // to be used.
+        BOOST_REQUIRE_EQUAL(ml::api::CAnomalyJobConfig::CAnalysisConfig::DEFAULT_BUCKET_SPAN,
+                            analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        using TDetectorConfigVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TDetectorConfigVec;
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig[0].customRules().size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        using TStrVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TStrVec;
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(5, analysisLimits.categorizationExamplesLimit());
+        BOOST_REQUIRE_EQUAL(11, analysisLimits.modelMemoryLimit());
+
+        using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(false, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(false, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validCategorizationJobConfig{
+            "{\"job_id\":\"unusual_message_counts\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1604311804567,\"custom_settings\":{\"created_by\":\"categorization-wizard\"},\"description\":\"Unusual message counts\","
+            "\"analysis_config\":{\"bucket_span\":\"15m\",\"categorization_field_name\":\"message\",\"categorization_filters\":[\"foo.*\",\"bar.*\"],\"per_partition_categorization\":{\"enabled\":false},\"detectors\":[{\"detector_description\":\"count by mlcategory\",\"function\":\"count\",\"by_field_name\":\"mlcategory\",\"detector_index\":0}],\"influencers\":[\"mlcategory\"]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"26mb\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},\"model_plot_config\":{\"enabled\":false,\"annotations_enabled\":false},"
+            "\"model_snapshot_retention_days\":10,\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validCategorizationJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("unusual_message_counts", jobConfig.jobId());
+
+        using TAnalysisConfig = ml::api::CAnomalyJobConfig::CAnalysisConfig;
+        using TDataDescription = ml::api::CAnomalyJobConfig::CDataDescription;
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(900, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        using TDetectorConfigVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TDetectorConfigVec;
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count by mlcategory", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("mlcategory", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, detectorsConfig[0].customRules().size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        using TStrVec = ml::api::CAnomalyJobConfig::CAnalysisConfig::TStrVec;
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(1, influencers.size());
+        BOOST_REQUIRE_EQUAL("mlcategory", influencers[0]);
+
+        BOOST_REQUIRE_EQUAL("message", analysisConfig.categorizationFieldName());
+        const TStrVec& categorizationFilters = analysisConfig.categorizationFilters();
+        BOOST_REQUIRE_EQUAL(2, categorizationFilters.size());
+        BOOST_REQUIRE_EQUAL("foo.*", categorizationFilters[0]);
+        BOOST_REQUIRE_EQUAL("bar.*", categorizationFilters[1]);
+
+        using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+        BOOST_REQUIRE_EQUAL(26, analysisLimits.modelMemoryLimit());
+
+        using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(false, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(false, modelPlotConfig.annotationsEnabled());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -21,6 +21,7 @@ all: build
 
 SRCS=\
 	Main.cc \
+	CAnomalyJobConfigTest.cc \
 	CAnomalyJobLimitTest.cc \
 	CAnomalyJobTest.cc \
 	CBoostedTreeInferenceModelBuilderTest.cc \

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -6,9 +6,11 @@
 #include <core/CTimeUtils.h>
 
 #include <core/CLogger.h>
+#include <core/CRegex.h>
 #include <core/CScopedFastLock.h>
 #include <core/CStrFTime.h>
 #include <core/CStrPTime.h>
+#include <core/CStringUtils.h>
 #include <core/CTimezone.h>
 #include <core/Constants.h>
 #include <core/CoreTypes.h>
@@ -17,6 +19,25 @@
 
 #include <errno.h>
 #include <string.h>
+
+namespace {
+
+// Constants for parsing & converting time duration strings in standard ES format
+const std::string TIME_DURATION_FORMAT{"([\\d]+)(d|h|m|s|ms|micros|nanos)"};
+const std::string DAY{"d"};
+const std::string HOUR{"h"};
+const std::string MINUTE{"m"};
+const std::string SECOND{"s"};
+const std::string MILLI_SECOND{"ms"};
+const std::string MICRO_SECOND{"micros"};
+const std::string NANO_SECOND{"nanos"};
+const ml::core_t::TTime SECONDS_IN_DAY{24 * 60 * 60};
+const ml::core_t::TTime SECONDS_IN_HOUR{60 * 60};
+const ml::core_t::TTime SECONDS_IN_MINUTE{60};
+const ml::core_t::TTime MILLI_SECONDS_IN_SECOND{1000};
+const ml::core_t::TTime MICRO_SECONDS_IN_SECOND{1000 * 1000};
+const ml::core_t::TTime NANO_SECONDS_IN_SECOND{1000 * 1000 * 1000};
+}
 
 namespace ml {
 namespace core {
@@ -170,6 +191,64 @@ std::string CTimeUtils::durationToString(core_t::TTime duration) {
         res += std::to_string(duration) + "s";
     }
     return res;
+}
+
+CTimeUtils::TTimeBoolPr
+CTimeUtils::timeDurationStringToSeconds(const std::string& timeDurationString,
+                                        core_t::TTime defaultValue) {
+    if (timeDurationString.empty()) {
+        LOG_ERROR(<< "Unable to parse empty time duration string");
+        return {defaultValue, false};
+    }
+
+    CRegex regex;
+
+    if (regex.init(TIME_DURATION_FORMAT) == false) {
+        LOG_ERROR(<< "Unable to init regex " << TIME_DURATION_FORMAT);
+        return {defaultValue, false};
+    }
+
+    CRegex::TStrVec tokens;
+    const std::string lowerDurationString{CStringUtils::toLower(timeDurationString)};
+    if (regex.tokenise(lowerDurationString, tokens) == false) {
+        LOG_ERROR(<< "Unable to parse a time duration from " << timeDurationString);
+        return {defaultValue, false};
+    }
+
+    if (tokens.size() != 2) {
+        LOG_INFO(<< "Got wrong number of tokens:: " << tokens.size());
+        return {defaultValue, false};
+    }
+
+    const std::string& spanStr = tokens[0];
+    const std::string& multiplierStr = tokens[1];
+
+    core_t::TTime span{0};
+    if (CStringUtils::stringToType(spanStr, span) == false) {
+        LOG_ERROR(<< "Could not convert " << spanStr << " to type long.");
+        return {defaultValue, false};
+    }
+
+    // The assumption here is that the bucket span string has already been validated
+    // in the sense that it is convertible to a whole number of seconds with a minimum
+    // value of 1s.
+    if (multiplierStr == DAY) {
+        span *= SECONDS_IN_DAY;
+    } else if (multiplierStr == HOUR) {
+        span *= SECONDS_IN_HOUR;
+    } else if (multiplierStr == MINUTE) {
+        span *= SECONDS_IN_MINUTE;
+    } else if (multiplierStr == SECOND) {
+        // no-op
+    } else if (multiplierStr == MILLI_SECOND) {
+        span /= MILLI_SECONDS_IN_SECOND;
+    } else if (multiplierStr == MICRO_SECOND) {
+        span /= MICRO_SECONDS_IN_SECOND;
+    } else if (multiplierStr == NANO_SECOND) {
+        span /= NANO_SECONDS_IN_SECOND;
+    }
+
+    return {span, true};
 }
 
 // Initialise statics for the inner class CDateWordCache

--- a/lib/core/unittest/CStringUtilsTest.cc
+++ b/lib/core/unittest/CStringUtilsTest.cc
@@ -969,4 +969,151 @@ BOOST_AUTO_TEST_CASE(testRoundtripMaxDouble) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testMemorySizeStringToBytes) {
+    bool parsedOk{false};
+    std::size_t memorySizeBytes{0};
+    const std::size_t defaultValue{1};
+
+    {
+        // All valid and specifying a whole number of bytes
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("4194304b", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(4194304, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("4194304B", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(4194304, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("5120kb", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(5242880, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("5120k", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(5242880, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("5120KB", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(5242880, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("5120K", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(5242880, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("6mb", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(6291456, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("6MB", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(6291456, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("6m", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(6291456, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("6M", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(6291456, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("7gb", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(7516192768, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("7Gb", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(7516192768, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("7G", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(7516192768, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("7g", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(7516192768, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("8Tb", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(8796093022208ULL, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("8TB", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(8796093022208ULL, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("8T", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(8796093022208ULL, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("8t", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(8796093022208ULL, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("9pb", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(10133099161583616ULL, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("9PB", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(10133099161583616ULL, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("9P", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(10133099161583616ULL, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("9p", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(10133099161583616ULL, memorySizeBytes);
+    }
+    {
+        // All invalid formats. Expect a default value of 1 byte to be returned.
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("5140KiB", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("6.5mb", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("0.9gb", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("1terabyte", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, memorySizeBytes);
+
+        std::tie(memorySizeBytes, parsedOk) =
+            ml::core::CStringUtils::memorySizeStringToBytes("2pbs", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, memorySizeBytes);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/unittest/CTimeUtilsTest.cc
+++ b/lib/core/unittest/CTimeUtilsTest.cc
@@ -509,4 +509,155 @@ BOOST_AUTO_TEST_CASE(testDurationToString) {
                                             365 * d + 5 * h + 48 * m + 46 * s));
 }
 
+BOOST_AUTO_TEST_CASE(testTimeDurationStringToSeconds) {
+    bool parsedOk{false};
+    ml::core_t::TTime durationSeconds{0};
+    const ml::core_t::TTime defaultValue{1};
+
+    {
+        // All valid and specifying a whole number of seconds
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("14d", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(1209600, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("14D", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(1209600, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("24h", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(86400, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("24H", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(86400, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("15m", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(900, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("15M", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(900, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("30s", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(30, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("30S", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(30, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("2000ms", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(2, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("2000MS", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(2, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("3000000micros", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(3, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("3000000MICROS", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(3, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("3000000MiCrOs", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(3, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("4000000000nanos", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(4, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("4000000000NANOS", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(4, durationSeconds);
+    }
+
+    {
+        // Valid and equating to a fractional number of seconds. We expect the returned value to be rounded
+        // down to the nearest whole number of seconds
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("2500ms", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(2, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("3800000micros", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(3, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("4900000000nanos", defaultValue);
+        BOOST_TEST_REQUIRE(parsedOk);
+        BOOST_REQUIRE_EQUAL(4, durationSeconds);
+    }
+
+    {
+        // All invalid formats
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("2w", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("14days", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("24hrs", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("15minutes", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("30seconds", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("2.5s", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) =
+            ml::core::CTimeUtils::timeDurationStringToSeconds("2000millis", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) = ml::core::CTimeUtils::timeDurationStringToSeconds(
+            "3000000Microseconds", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+
+        std::tie(durationSeconds, parsedOk) = ml::core::CTimeUtils::timeDurationStringToSeconds(
+            "4000000000nanoseconds", defaultValue);
+        BOOST_TEST_REQUIRE(!parsedOk);
+        BOOST_REQUIRE_EQUAL(1, durationSeconds);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add a parser for the recently added anomaly job configuration file, which
is in JSON format.

As an initial step to the configuration file replacing a number of
command line arguments, modify autodetect to use the jobId extracted by
the parser.

Relates to #1253
Backports #1552