### PR TITLE
[7.x][ML] Initialize detectors parser with filters map (#1562)

### DIFF
--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -41,7 +41,8 @@ public:
         public:
             CDetectorConfig() {}
 
-            void parse(const rapidjson::Value& json);
+            void parse(const rapidjson::Value& detectorConfig,
+                       const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters);
 
             std::string function() const { return m_Function; }
             std::string fieldName() const { return m_FieldName; }
@@ -90,7 +91,12 @@ public:
         using TDetectorConfigVec = std::vector<CDetectorConfig>;
 
     public:
+        //! Default constructor
         CAnalysisConfig() {}
+
+        //! Constructor taking a map of detector rule filters keyed by filter_id.
+        explicit CAnalysisConfig(const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters)
+            : m_RuleFilters(ruleFilters) {}
 
         void parse(const rapidjson::Value& json);
 
@@ -120,7 +126,7 @@ public:
         static core_t::TTime bucketSpanSeconds(const std::string& bucketSpanString);
 
     private:
-        std::size_t m_BucketSpan{300}; // 5m
+        core_t::TTime m_BucketSpan{DEFAULT_BUCKET_SPAN};
         std::string m_SummaryCountFieldName{};
         std::string m_CategorizationFieldName{};
         TStrVec m_CategorizationFilters{};
@@ -129,6 +135,9 @@ public:
         TDetectorConfigVec m_Detectors{};
         TStrVec m_Influencers{};
         std::string m_Latency{};
+
+        //! The filters per id used by categorical rule conditions.
+        CDetectionRulesJsonParser::TStrPatternSetUMap m_RuleFilters{};
     };
 
     class API_EXPORT CDataDescription {
@@ -218,6 +227,8 @@ public:
 public:
     //! Default constructor
     CAnomalyJobConfig() {}
+    explicit CAnomalyJobConfig(const CDetectionRulesJsonParser::TStrPatternSetUMap& rulesFilter)
+        : m_AnalysisConfig(rulesFilter) {}
 
     bool parse(const std::string& json);
 

--- a/include/api/CAnomalyJobConfigReader.h
+++ b/include/api/CAnomalyJobConfigReader.h
@@ -142,7 +142,7 @@ public:
 
     private:
         CParameter(const std::string& name, SArrayElementTag);
-        void handleFatal() const;
+        [[noreturn]] void handleFatal() const;
 
     private:
         std::string m_Name;

--- a/include/api/CDetectionRulesJsonParser.h
+++ b/include/api/CDetectionRulesJsonParser.h
@@ -31,7 +31,7 @@ public:
 
 public:
     //! Default constructor
-    CDetectionRulesJsonParser(TStrPatternSetUMap& filtersByIdMap);
+    CDetectionRulesJsonParser(const TStrPatternSetUMap& filtersByIdMap);
 
     //! Parses a string expected to contain a JSON array with
     //! detection rules and adds the rule objects into the given vector.
@@ -62,7 +62,7 @@ private:
 
 private:
     //! The filters per id used by categorical rule conditions.
-    TStrPatternSetUMap& m_FiltersByIdMap;
+    const TStrPatternSetUMap& m_FiltersByIdMap;
 };
 }
 }

--- a/lib/api/CAnomalyJobConfigReader.cc
+++ b/lib/api/CAnomalyJobConfigReader.cc
@@ -73,7 +73,6 @@ bool CAnomalyJobConfigReader::CParameter::fallback(bool value) const {
     }
     if (m_Value->IsBool() == false) {
         this->handleFatal();
-        return value;
     }
     return m_Value->GetBool();
 }
@@ -84,7 +83,6 @@ std::size_t CAnomalyJobConfigReader::CParameter::fallback(std::size_t value) con
     }
     if (m_Value->IsUint64() == false) {
         this->handleFatal();
-        return value;
     }
     return m_Value->GetUint64();
 }
@@ -95,7 +93,6 @@ std::ptrdiff_t CAnomalyJobConfigReader::CParameter::fallback(std::ptrdiff_t valu
     }
     if (m_Value->IsInt64() == false) {
         this->handleFatal();
-        return value;
     }
     return m_Value->GetInt64();
 }
@@ -109,7 +106,6 @@ double CAnomalyJobConfigReader::CParameter::fallback(double value) const {
     }
     if (m_Value->IsDouble() == false) {
         this->handleFatal();
-        return value;
     }
     return m_Value->GetDouble();
 }
@@ -120,7 +116,6 @@ std::string CAnomalyJobConfigReader::CParameter::fallback(const std::string& val
     }
     if (m_Value->IsString() == false) {
         this->handleFatal();
-        return value;
     }
     return m_Value->GetString();
 }

--- a/lib/api/CDetectionRulesJsonParser.cc
+++ b/lib/api/CDetectionRulesJsonParser.cc
@@ -36,7 +36,7 @@ const std::string TYPICAL("typical");
 const std::string VALUE("value");
 }
 
-CDetectionRulesJsonParser::CDetectionRulesJsonParser(TStrPatternSetUMap& filtersByIdMap)
+CDetectionRulesJsonParser::CDetectionRulesJsonParser(const TStrPatternSetUMap& filtersByIdMap)
     : m_FiltersByIdMap(filtersByIdMap) {
 }
 


### PR DESCRIPTION
Detector rules may possibly refer to rule filters that are defined
separately, outside of the anomaly job configuration. As an interim
solution pass the rule filters parsed from the old-style field config to
the new-style JSON parser.

Relates to #1253
Backports #1562 