### PR TITLE
[7.x][ML] Fixing move constructor/assignment for CForecastRunner::SForecast

### DIFF
--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -174,10 +174,10 @@ public:
 
 private:
     struct API_EXPORT SForecast {
-        SForecast() {}
+        SForecast() = default;
 
-        SForecast(SForecast&& other) noexcept;
-        SForecast& operator=(SForecast&& other) noexcept;
+        SForecast(SForecast&& other) = default;
+        SForecast& operator=(SForecast&& other) = default;
 
         SForecast(const SForecast& that) = delete;
         SForecast& operator=(const SForecast&) = delete;

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -51,37 +51,6 @@ const std::string CForecastRunner::INFO_DEFAULT_DURATION("Forecast duration not 
 const std::string CForecastRunner::INFO_DEFAULT_EXPIRY("Forecast expires_in not specified, setting to 14 days");
 const std::string CForecastRunner::INFO_NO_MODELS_CAN_CURRENTLY_BE_FORECAST("Insufficient history to forecast for all models");
 
-CForecastRunner::SForecast::SForecast(SForecast&& other) noexcept
-    : s_ForecastId(std::move(other.s_ForecastId)),
-      s_ForecastAlias(std::move(other.s_ForecastAlias)),
-      s_ForecastSeries(std::move(other.s_ForecastSeries)),
-      s_CreateTime(other.s_CreateTime), s_StartTime(other.s_StartTime),
-      s_Duration(other.s_Duration), s_ExpiryTime(other.s_ExpiryTime),
-      s_BoundsPercentile(other.s_BoundsPercentile),
-      s_NumberOfModels(other.s_NumberOfModels),
-      s_NumberOfForecastableModels(other.s_NumberOfForecastableModels),
-      s_MemoryUsage(other.s_MemoryUsage), s_Messages(other.s_Messages),
-      s_TemporaryFolder(std::move(other.s_TemporaryFolder)) {
-}
-
-CForecastRunner::SForecast& CForecastRunner::SForecast::operator=(SForecast&& other) noexcept {
-    s_ForecastId = std::move(other.s_ForecastId);
-    s_ForecastAlias = std::move(other.s_ForecastAlias);
-    s_ForecastSeries = std::move(other.s_ForecastSeries);
-    s_CreateTime = other.s_CreateTime;
-    s_StartTime = other.s_StartTime;
-    s_Duration = other.s_Duration;
-    s_ExpiryTime = other.s_ExpiryTime;
-    s_BoundsPercentile = other.s_BoundsPercentile;
-    s_NumberOfModels = other.s_NumberOfModels;
-    s_NumberOfForecastableModels = other.s_NumberOfForecastableModels;
-    s_MemoryUsage = other.s_MemoryUsage;
-    s_Messages = other.s_Messages;
-    s_TemporaryFolder = std::move(other.s_TemporaryFolder);
-
-    return *this;
-}
-
 CForecastRunner::CForecastRunner(const std::string& jobId,
                                  core::CJsonOutputStreamWrapper& strmOut,
                                  model::CResourceMonitor& resourceMonitor)


### PR DESCRIPTION
The hand-crafted move constructor and move assignment operator
for CForecastRunner::SForecast were unnecessarily copying some
members instead of moving them.  The defaults will do the
correct thing and also avoid the need for future maintenance
when adding extra members.  (The hand-crafted versions were
created when we were using an old compiler that had a bug
related to default move assignment.)

Backport of #1561