### PR TITLE
[7.x][ML] Gain upper bound estimation for classification and regression 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,6 +38,8 @@
   {ml-pull}1520[#1520], {es-pull}63542[#63542], issue: {es-issue}62823[#62823].)
 * Fix an edge case which could cause typical and model plot bounds to blow up to around
   max double. (See {ml-pull}1551[#1551].)
+* Estimate upper bound of potential gains before splitting a decision tree node to avoid 
+  unnecessary computation. (See {ml-pull}1537[#1537].)
 
 == {es} version 7.10.0
 

--- a/include/maths/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/CDataFrameAnalysisInstrumentationInterface.h
@@ -139,6 +139,11 @@ public:
     virtual void lossValues(std::size_t fold, TDoubleVec&& lossValues) = 0;
     //! \return Structure contains hyperparameters.
     virtual SHyperparameters& hyperparameters() = 0;
+
+    virtual std::size_t& statisticsComputed() = 0;
+    virtual std::size_t& statisticsNotComputed() = 0;
+    virtual void rowsSkipped(std::uint32_t numberRows) = 0;
+    virtual std::uint32_t rowsSkipped() = 0;
 };
 
 //! \brief Dummies out all instrumentation for outlier detection.
@@ -169,8 +174,16 @@ public:
     void lossValues(std::size_t /* fold */, TDoubleVec&& /* lossValues */) override {}
     SHyperparameters& hyperparameters() override { return m_Hyperparameters; }
 
+    std::size_t& statisticsComputed() override { return m_StubStatsComputed; }
+    std::size_t& statisticsNotComputed() override {
+        return m_StubStatsComputed;
+    }
+    virtual void rowsSkipped(std::uint32_t /*numberRows*/) override{};
+    virtual std::uint32_t rowsSkipped() override { return 0ul; };
+
 private:
     SHyperparameters m_Hyperparameters;
+    std::size_t m_StubStatsComputed = 0;
 };
 }
 }

--- a/include/test/CRandomNumbers.h
+++ b/include/test/CRandomNumbers.h
@@ -156,6 +156,8 @@ public:
     //! Throw away \p n random numbers.
     void discard(std::size_t n);
 
+    void seed(std::size_t seed);
+
 private:
     //! The random number generator.
     TGenerator m_Generator;

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -295,6 +295,16 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
     m_Instrumentation->updateProgress(1.0);
     m_Instrumentation->updateMemoryUsage(
         static_cast<std::int64_t>(this->memoryUsage()) - lastMemoryUsage);
+
+    if (m_Instrumentation != nullptr) {
+        // TODO remove once performance measurements are finished
+        LOG_INFO(<< "Statistics computed: " << m_Instrumentation->statisticsComputed()
+                 << "\tnot computed: " << m_Instrumentation->statisticsNotComputed() << "\t saved: "
+                 << (static_cast<double>(m_Instrumentation->statisticsNotComputed()) /
+                     (m_Instrumentation->statisticsNotComputed() +
+                      m_Instrumentation->statisticsComputed()))
+                 << "\t avg. rows skipped: " << m_Instrumentation->rowsSkipped());
+    }
 }
 
 void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainState) const {
@@ -797,7 +807,7 @@ CBoostedTreeImpl::TNodeVec
 CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
                             const core::CPackedBitVector& trainingRowMask,
                             const TImmutableRadixSetVec& candidateSplits,
-                            const std::size_t maximumTreeSize,
+                            const std::size_t maximumNumberInternalNodes,
                             TWorkspace& workspace) const {
 
     LOG_TRACE(<< "Training one tree...");
@@ -808,7 +818,9 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
     workspace.reinitialize(m_NumberThreads, candidateSplits, m_Loss->numberParameters());
 
     TNodeVec tree(1);
-    tree.reserve(2 * maximumTreeSize + 1);
+    // Since number of leaves in a perfect binary tree is (numberInternalNodes+1)
+    // the total number of nodes in a tree is (2*numberInternalNodes+1)
+    tree.reserve(2 * maximumNumberInternalNodes + 1);
 
     // Sampling transforms the probabilities. We use a placeholder outside
     // the loop adding nodes so we only allocate the vector once.
@@ -816,8 +828,8 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
     TSizeVec featureBag;
     this->featureBag(featureSampleProbabilities, featureBag);
 
-    TLeafNodeStatisticsPtrQueue leaves(maximumTreeSize / 2 + 3);
-    leaves.push_back(std::make_shared<CBoostedTreeLeafNodeStatistics>(
+    TLeafNodeStatisticsPtrQueue splittableLeaves(maximumNumberInternalNodes / 2 + 3);
+    splittableLeaves.push_back(std::make_shared<CBoostedTreeLeafNodeStatistics>(
         0 /*root*/, m_ExtraColumns, m_Loss->numberParameters(), m_NumberThreads,
         frame, *m_Encoder, m_Regularization, candidateSplits, featureBag,
         0 /*depth*/, trainingRowMask, workspace));
@@ -832,7 +844,8 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         memory.s_Current += delta;
         memory.s_Max = std::max(memory.s_Max, memory.s_Current);
     }};
-    CScopeRecordMemoryUsage scopeMemoryUsage{leaves, std::move(localRecordMemoryUsage)};
+    CScopeRecordMemoryUsage scopeMemoryUsage{splittableLeaves,
+                                             std::move(localRecordMemoryUsage)};
     scopeMemoryUsage.add(workspace);
 
     // For each iteration we:
@@ -844,14 +857,14 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
     COrderings::SLess less;
 
-    for (std::size_t i = 0; i < maximumTreeSize; ++i) {
+    for (std::size_t i = 0; i < maximumNumberInternalNodes; ++i) {
 
-        if (leaves.empty()) {
+        if (splittableLeaves.empty()) {
             break;
         }
 
-        auto leaf = leaves.back();
-        leaves.pop_back();
+        auto leaf = splittableLeaves.back();
+        splittableLeaves.pop_back();
 
         scopeMemoryUsage.remove(leaf);
 
@@ -870,6 +883,7 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
         bool assignMissingToLeft{leaf->assignMissingToLeft()};
 
+        // add the left and right children to the tree
         std::size_t leftChildId, rightChildId;
         std::tie(leftChildId, rightChildId) =
             tree[leaf->id()].split(splitFeature, splitValue, assignMissingToLeft,
@@ -878,32 +892,48 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         featureSampleProbabilities = m_FeatureSampleProbabilities;
         this->featureBag(featureSampleProbabilities, featureBag);
 
+        std::size_t numberSplittableLeaves{splittableLeaves.size()};
+        std::size_t currentNumberInternalNodes{(tree.size() - 1) / 2};
+        auto smallestCurrentCandidateGainIndex =
+            static_cast<std::ptrdiff_t>(numberSplittableLeaves) -
+            static_cast<std::ptrdiff_t>(maximumNumberInternalNodes - currentNumberInternalNodes);
+        double smallestCandidateGain{
+            smallestCurrentCandidateGainIndex >= 0
+                ? splittableLeaves[static_cast<std::size_t>(smallestCurrentCandidateGainIndex)]
+                      ->gain()
+                : 0.0};
+
         TLeafNodeStatisticsPtr leftChild;
         TLeafNodeStatisticsPtr rightChild;
-        std::tie(leftChild, rightChild) = leaf->split(
-            leftChildId, rightChildId, m_NumberThreads, frame, *m_Encoder,
-            m_Regularization, featureBag, tree[leaf->id()], workspace);
+        std::tie(leftChild, rightChild) =
+            leaf->split(leftChildId, rightChildId, m_NumberThreads,
+                        smallestCandidateGain, frame, *m_Encoder, m_Regularization,
+                        featureBag, tree[leaf->id()], workspace, m_Instrumentation);
 
-        if (less(rightChild, leftChild)) {
+        // Need gain to be computed to compare here
+        if (leftChild != nullptr && rightChild != nullptr && less(rightChild, leftChild)) {
             std::swap(leftChild, rightChild);
         }
 
-        std::size_t n{leaves.size()};
-        if (leftChild->gain() >= MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
+        if (leftChild != nullptr &&
+            leftChild->gain() >= MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
             scopeMemoryUsage.add(leftChild);
-            leaves.push_back(std::move(leftChild));
+            splittableLeaves.push_back(std::move(leftChild));
         }
-        if (rightChild->gain() >= MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
+        if (rightChild != nullptr &&
+            rightChild->gain() >= MINIMUM_RELATIVE_GAIN_PER_SPLIT * totalGain) {
             scopeMemoryUsage.add(rightChild);
-            leaves.push_back(std::move(rightChild));
+            splittableLeaves.push_back(std::move(rightChild));
         }
-        std::inplace_merge(leaves.begin(), leaves.begin() + n, leaves.end(), less);
+        std::inplace_merge(splittableLeaves.begin(),
+                           splittableLeaves.begin() + numberSplittableLeaves,
+                           splittableLeaves.end(), less);
 
         // Drop any leaves which can't possibly be split.
-        while (leaves.size() + i + 1 > maximumTreeSize) {
-            scopeMemoryUsage.remove(leaves.front());
-            workspace.minimumGain(leaves.front()->gain());
-            leaves.pop_front();
+        while (splittableLeaves.size() + i + 1 > maximumNumberInternalNodes) {
+            scopeMemoryUsage.remove(splittableLeaves.front());
+            workspace.minimumGain(splittableLeaves.front()->gain());
+            splittableLeaves.pop_front();
         }
     }
 

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -24,6 +24,27 @@ using TRowItr = core::CDataFrame::TRowItr;
 namespace {
 const std::size_t ASSIGN_MISSING_TO_LEFT{0};
 const std::size_t ASSIGN_MISSING_TO_RIGHT{1};
+
+void incrementStatsComputed(CBoostedTreeLeafNodeStatistics::TAnalysisInstrumentationPtr instrumentation) {
+    if (instrumentation != nullptr) {
+        instrumentation->statisticsComputed() += 1;
+    }
+}
+
+void incrementStatsNotComputed(CBoostedTreeLeafNodeStatistics::TAnalysisInstrumentationPtr instrumentation,
+                               std::uint32_t rowsInChild) {
+    if (instrumentation != nullptr) {
+        instrumentation->statisticsNotComputed() += 1;
+        instrumentation->rowsSkipped(rowsInChild);
+    }
+}
+
+struct SChildredGainStats {
+    double s_MinLossLeft = -INF;
+    double s_MinLossRight = -INF;
+    double s_GLeft = -INF;
+    double s_GRight = -INF;
+};
 }
 
 CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
@@ -125,29 +146,66 @@ CBoostedTreeLeafNodeStatistics::TPtrPtrPr
 CBoostedTreeLeafNodeStatistics::split(std::size_t leftChildId,
                                       std::size_t rightChildId,
                                       std::size_t numberThreads,
+                                      double gainThreshold,
                                       const core::CDataFrame& frame,
                                       const CDataFrameCategoryEncoder& encoder,
                                       const TRegularization& regularization,
                                       const TSizeVec& featureBag,
                                       const CBoostedTreeNode& split,
-                                      CWorkspace& workspace) {
-
+                                      CWorkspace& workspace,
+                                      TAnalysisInstrumentationPtr instrumentation) {
+    TPtr leftChild;
+    TPtr rightChild;
     if (this->leftChildHasFewerRows()) {
-        auto leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-            leftChildId, *this, numberThreads, frame, encoder, regularization,
-            featureBag, true /*is left child*/, split, workspace);
-        auto rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-            rightChildId, std::move(*this), regularization, featureBag, workspace);
-
+        if (this->m_BestSplit.s_LeftChildMaxGain > gainThreshold) {
+            leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+                leftChildId, *this, numberThreads, frame, encoder, regularization,
+                featureBag, true /*is left child*/, split, workspace);
+            incrementStatsComputed(instrumentation);
+            if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
+                rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+                    rightChildId, std::move(*this), regularization, featureBag, workspace);
+                incrementStatsComputed(instrumentation);
+            } else {
+                incrementStatsNotComputed(instrumentation, this->m_BestSplit.s_RightChildRowCount);
+            }
+        } else {
+            incrementStatsNotComputed(instrumentation, this->m_BestSplit.s_LeftChildRowCount);
+            if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
+                rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+                    rightChildId, *this, numberThreads, frame, encoder, regularization,
+                    featureBag, false /*is left child*/, split, workspace);
+                incrementStatsComputed(instrumentation);
+            } else {
+                incrementStatsNotComputed(instrumentation, this->m_BestSplit.s_RightChildRowCount);
+            }
+        }
         return {std::move(leftChild), std::move(rightChild)};
     }
 
-    auto rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-        rightChildId, *this, numberThreads, frame, encoder, regularization,
-        featureBag, false /*is left child*/, split, workspace);
-    auto leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-        leftChildId, std::move(*this), regularization, featureBag, workspace);
-
+    if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
+        rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+            rightChildId, *this, numberThreads, frame, encoder, regularization,
+            featureBag, false /*is left child*/, split, workspace);
+        incrementStatsComputed(instrumentation);
+        if (this->m_BestSplit.s_LeftChildMaxGain > gainThreshold) {
+            leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+                leftChildId, std::move(*this), regularization, featureBag, workspace);
+            incrementStatsComputed(instrumentation);
+        } else {
+            incrementStatsNotComputed(instrumentation, this->m_BestSplit.s_LeftChildRowCount);
+        }
+    } else {
+        incrementStatsNotComputed(instrumentation, this->m_BestSplit.s_RightChildRowCount);
+        if (this->m_BestSplit.s_LeftChildMaxGain > gainThreshold) {
+            leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
+                leftChildId, *this, numberThreads, frame, encoder, regularization,
+                featureBag, true /*is left child*/, split, workspace);
+            incrementStatsComputed(instrumentation);
+        } else {
+            incrementStatsNotComputed(instrumentation, this->m_BestSplit.s_LeftChildRowCount);
+        }
+    }
     return {std::move(leftChild), std::move(rightChild)};
 }
 
@@ -157,6 +215,14 @@ bool CBoostedTreeLeafNodeStatistics::operator<(const CBoostedTreeLeafNodeStatist
 
 double CBoostedTreeLeafNodeStatistics::gain() const {
     return m_BestSplit.s_Gain;
+}
+
+double CBoostedTreeLeafNodeStatistics::leftChildMaxGain() const {
+    return m_BestSplit.s_LeftChildMaxGain;
+}
+
+double CBoostedTreeLeafNodeStatistics::rightChildMaxGain() const {
+    return m_BestSplit.s_RightChildMaxGain;
 }
 
 double CBoostedTreeLeafNodeStatistics::curvature() const {
@@ -267,6 +333,15 @@ void CBoostedTreeLeafNodeStatistics::addRowDerivatives(const CEncodedDataFrameRo
 
     auto derivatives = readLossDerivatives(row.unencodedRow(), m_ExtraColumns,
                                            m_NumberLossParameters);
+
+    if (derivatives.size() == 2) {
+        if (derivatives(0) >= 0.0) {
+            splitsDerivatives.addPositiveDerivatives(derivatives);
+        } else {
+            splitsDerivatives.addNegativeDerivatives(derivatives);
+        }
+    }
+
     std::size_t numberFeatures{m_CandidateSplits.size()};
     for (std::size_t feature = 0; feature < numberFeatures; ++feature) {
         double featureValue{row[feature]};
@@ -352,6 +427,12 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
     TDoubleMatrix hl[]{TDoubleMatrix{d, d}, TDoubleMatrix{d, d}};
     TDoubleMatrix hr[]{TDoubleMatrix{d, d}, TDoubleMatrix{d, d}};
 
+    double gain[2];
+    double minLossLeft[2]{0.0, 0.0};
+    double minLossRight[2]{0.0, 0.0};
+    SChildredGainStats childrenGainStatsGlobal;
+    SChildredGainStats childrenGainStatsPerFeature;
+
     for (auto feature : featureBag) {
         std::size_t c{m_Derivatives.missingCount(feature)};
         g = m_Derivatives.missingGradient(feature);
@@ -398,30 +479,49 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
             hr[ASSIGN_MISSING_TO_LEFT] -= curvature;
             hr[ASSIGN_MISSING_TO_RIGHT] -= curvature;
 
-            double gain[2];
-            gain[ASSIGN_MISSING_TO_LEFT] =
-                cl[ASSIGN_MISSING_TO_LEFT] == 0 || cl[ASSIGN_MISSING_TO_LEFT] == c
-                    ? -INF
-                    : minimumLoss(gl[ASSIGN_MISSING_TO_LEFT], hl[ASSIGN_MISSING_TO_LEFT]) +
-                          minimumLoss(gr[ASSIGN_MISSING_TO_LEFT], hr[ASSIGN_MISSING_TO_LEFT]);
-            gain[ASSIGN_MISSING_TO_RIGHT] =
-                cl[ASSIGN_MISSING_TO_RIGHT] == 0 || cl[ASSIGN_MISSING_TO_RIGHT] == c
-                    ? -INF
-                    : minimumLoss(gl[ASSIGN_MISSING_TO_RIGHT], hl[ASSIGN_MISSING_TO_RIGHT]) +
-                          minimumLoss(gr[ASSIGN_MISSING_TO_RIGHT],
-                                      hr[ASSIGN_MISSING_TO_RIGHT]);
+            if (cl[ASSIGN_MISSING_TO_LEFT] == 0 || cl[ASSIGN_MISSING_TO_LEFT] == c) {
+                gain[ASSIGN_MISSING_TO_LEFT] = -INF;
+            } else {
+                minLossLeft[ASSIGN_MISSING_TO_LEFT] = minimumLoss(
+                    gl[ASSIGN_MISSING_TO_LEFT], hl[ASSIGN_MISSING_TO_LEFT]);
+                minLossRight[ASSIGN_MISSING_TO_LEFT] = minimumLoss(
+                    gr[ASSIGN_MISSING_TO_LEFT], hr[ASSIGN_MISSING_TO_LEFT]);
+                gain[ASSIGN_MISSING_TO_LEFT] = minLossLeft[ASSIGN_MISSING_TO_LEFT] +
+                                               minLossRight[ASSIGN_MISSING_TO_LEFT];
+            }
+
+            if (cl[ASSIGN_MISSING_TO_RIGHT] == 0 || cl[ASSIGN_MISSING_TO_RIGHT] == c) {
+                gain[ASSIGN_MISSING_TO_RIGHT] = -INF;
+            } else {
+                minLossLeft[ASSIGN_MISSING_TO_RIGHT] = minimumLoss(
+                    gl[ASSIGN_MISSING_TO_RIGHT], hl[ASSIGN_MISSING_TO_RIGHT]);
+                minLossRight[ASSIGN_MISSING_TO_RIGHT] = minimumLoss(
+                    gr[ASSIGN_MISSING_TO_RIGHT], hr[ASSIGN_MISSING_TO_RIGHT]);
+                gain[ASSIGN_MISSING_TO_RIGHT] = minLossLeft[ASSIGN_MISSING_TO_RIGHT] +
+                                                minLossRight[ASSIGN_MISSING_TO_RIGHT];
+            }
 
             if (gain[ASSIGN_MISSING_TO_LEFT] > maximumGain) {
                 maximumGain = gain[ASSIGN_MISSING_TO_LEFT];
                 splitAt = m_CandidateSplits[feature][split];
                 leftChildRowCount = cl[ASSIGN_MISSING_TO_LEFT];
                 assignMissingToLeft = true;
+                // if gain > -INF then minLossLeft and minLossRight were initialized
+                childrenGainStatsPerFeature = {minLossLeft[ASSIGN_MISSING_TO_LEFT],
+                                               minLossRight[ASSIGN_MISSING_TO_LEFT],
+                                               gl[ASSIGN_MISSING_TO_LEFT](0),
+                                               gr[ASSIGN_MISSING_TO_LEFT](0)};
             }
             if (gain[ASSIGN_MISSING_TO_RIGHT] > maximumGain) {
                 maximumGain = gain[ASSIGN_MISSING_TO_RIGHT];
                 splitAt = m_CandidateSplits[feature][split];
                 leftChildRowCount = cl[ASSIGN_MISSING_TO_RIGHT];
                 assignMissingToLeft = false;
+                // if gain > -INF then minLossLeft and minLossRight were initialized
+                childrenGainStatsPerFeature = {minLossLeft[ASSIGN_MISSING_TO_RIGHT],
+                                               minLossRight[ASSIGN_MISSING_TO_RIGHT],
+                                               gl[ASSIGN_MISSING_TO_RIGHT](0),
+                                               gr[ASSIGN_MISSING_TO_RIGHT](0)};
             }
         }
 
@@ -434,24 +534,82 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
                     regularization.treeSizePenaltyMultiplier() -
                     regularization.depthPenaltyMultiplier() *
                         (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
-
         SSplitStatistics candidate{gain,
                                    h.trace() / static_cast<double>(m_NumberLossParameters),
                                    feature,
                                    splitAt,
                                    std::min(leftChildRowCount, c - leftChildRowCount),
                                    2 * leftChildRowCount < c,
-                                   assignMissingToLeft};
+                                   assignMissingToLeft,
+                                   leftChildRowCount,
+                                   c - leftChildRowCount};
         LOG_TRACE(<< "candidate split: " << candidate.print());
 
         if (candidate > result) {
             result = candidate;
+            childrenGainStatsGlobal = childrenGainStatsPerFeature;
         }
+    }
+    if (m_Derivatives.numberLossParameters() > 2) {
+        // short-circuit the bound computation for the multi-class case
+        result.s_LeftChildMaxGain = INF;
+        result.s_RightChildMaxGain = INF;
+    } else if (result.s_Gain > 0) {
+        double childPenaltyForDepth{regularization.penaltyForDepth(m_Depth + 1)};
+        double childPenaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 2)};
+        double childPenalty{regularization.treeSizePenaltyMultiplier() +
+                            regularization.depthPenaltyMultiplier() *
+                                (2.0 * childPenaltyForDepthPlusOne - childPenaltyForDepth)};
+        result.s_LeftChildMaxGain =
+            0.5 * this->childMaxGain(childrenGainStatsGlobal.s_GLeft,
+                                     childrenGainStatsGlobal.s_MinLossLeft, lambda) -
+            childPenalty;
+
+        result.s_RightChildMaxGain =
+            0.5 * this->childMaxGain(childrenGainStatsGlobal.s_GRight,
+                                     childrenGainStatsGlobal.s_MinLossRight, lambda) -
+            childPenalty;
     }
 
     LOG_TRACE(<< "best split: " << result.print());
 
     return result;
+}
+
+double CBoostedTreeLeafNodeStatistics::childMaxGain(double gChild,
+                                                    double minLossChild,
+                                                    double lambda) const {
+
+    // This computes the maximum possible gain we can expect splitting a child node given
+    // we know the sum of the positive (g^+) and negative gradients (g^-) at its parent,
+    // the minimum curvature on the positive and negative gradient set (hmin^+ and hmin^-)
+    // and largest and smallest gradient (gmax and gmin, respectively). The highest possible
+    // gain consistent with these constraints can be shown to be:
+    // (g^+)^2 / (hmin^+ * g^+ / gmax + lambda) + (g^-)^2 / (hmin^- * g^- / gmin + lambda)
+    // Since gchild = gchild^+ + gchild^-, we can improve estimates on g^+ and g^- for the child as:
+    // g^+ = max(min(gchild - g^-, g^+), 0),
+    // g^- = max(min(gchild - g^+, g^-), 0).
+    double positiveDerivativesGSum =
+        std::max(std::min(gChild - m_Derivatives.negativeDerivativesGSum(),
+                          m_Derivatives.positiveDerivativesGSum()),
+                 0.0);
+    double negativeDerivativesGSum =
+        std::min(std::max(gChild - m_Derivatives.positiveDerivativesGSum(),
+                          m_Derivatives.negativeDerivativesGSum()),
+                 0.0);
+    double lookAheadGain{((positiveDerivativesGSum != 0.0)
+                              ? CTools::pow2(positiveDerivativesGSum) /
+                                    (m_Derivatives.positiveDerivativesHMin() * positiveDerivativesGSum /
+                                         m_Derivatives.positiveDerivativesGMax() +
+                                     lambda + 1e-10)
+                              : 0.0) +
+                         ((negativeDerivativesGSum != 0.0)
+                              ? CTools::pow2(negativeDerivativesGSum) /
+                                    (m_Derivatives.negativeDerivativesHMin() * negativeDerivativesGSum /
+                                         m_Derivatives.negativeDerivativesGMin() +
+                                     lambda + 1e-10)
+                              : 0.0)};
+    return lookAheadGain - minLossChild;
 }
 }
 }

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -530,11 +530,11 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
 
         // The gain is the difference between the quadratic minimum for loss with
         // no split and the loss with the minimum loss split we found.
-        double gain{0.5 * (maximumGain - minimumLoss(g, h)) -
-                    regularization.treeSizePenaltyMultiplier() -
-                    regularization.depthPenaltyMultiplier() *
-                        (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
-        SSplitStatistics candidate{gain,
+        double splitGain{0.5 * (maximumGain - minimumLoss(g, h)) -
+                         regularization.treeSizePenaltyMultiplier() -
+                         regularization.depthPenaltyMultiplier() *
+                             (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
+        SSplitStatistics candidate{splitGain,
                                    h.trace() / static_cast<double>(m_NumberLossParameters),
                                    feature,
                                    splitAt,

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -331,11 +331,12 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
         frame->resizeColumns(numberThreads, cols + extraColumns.size());
         TDoubleVec features;
         features.reserve(rows);
-        double min, max;
+
         while (true) {
             rng.generateUniformSamples(0.0, 1.0, rows, features);
-            std::tie(min, max) = std::minmax_element(features.begin(), features.end());
-            if (min < 0.25 && max > 0.75) {
+            const auto min = std::min_element(features.begin(), features.end());
+            const auto max = std::max_element(features.begin(), features.end());
+            if (*min < 0.25 && *max > 0.75) {
                 break;
             }
         }

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -4,20 +4,25 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <maths/CBoostedTreeLeafNodeStatistics.h>
-
 #include <core/CLogger.h>
 
+#include <maths/CBoostedTree.h>
+#include <maths/CBoostedTreeLeafNodeStatistics.h>
 #include <maths/CBoostedTreeUtils.h>
+#include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CLinearAlgebraEigen.h>
+#include <maths/CQuantileSketch.h>
 
 #include <test/CRandomNumbers.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
+
 BOOST_AUTO_TEST_SUITE(CBoostedTreeLeafNodeStatisticsTest)
 
 using namespace ml;
+using TBoolVec = std::vector<bool>;
 using TDoubleVec = std::vector<double>;
 using TDoubleVecVec = std::vector<TDoubleVec>;
 using TSizeVec = std::vector<std::size_t>;
@@ -305,6 +310,105 @@ BOOST_AUTO_TEST_CASE(testPerSplitDerivatives) {
 
     testPerSplitDerivativesFor(1 /*loss function parameter*/);
     testPerSplitDerivativesFor(3 /*loss function parameters*/);
+}
+
+BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
+    using TRegularization = maths::CBoostedTreeRegularization<double>;
+    using TLeafNodeStatisticsPtr = maths::CBoostedTreeLeafNodeStatistics::TPtr;
+    using TNodeVec = maths::CBoostedTree::TNodeVec;
+    // create dataset and encoding
+    std::size_t cols{2};
+    TSizeVec extraColumns{2, 3, 4, 5};
+    std::size_t rows{50};
+    std::size_t numberThreads{1};
+
+    for (std::size_t seed = 0; seed < 1000; ++seed) {
+        maths::CQuantileSketch sketch(maths::CQuantileSketch::E_Linear, rows);
+        test::CRandomNumbers rng;
+        rng.seed(seed);
+        auto frame = core::makeMainStorageDataFrame(cols, rows).first;
+        frame->categoricalColumns(TBoolVec{false, false});
+        frame->resizeColumns(numberThreads, cols + extraColumns.size());
+        TDoubleVec features;
+        features.reserve(rows);
+        while (true) {
+            rng.generateUniformSamples(0.0, 1.0, rows, features);
+            const auto[min, max] =
+                std::minmax_element(features.begin(), features.end());
+            if (*min < 0.25 && *max > 0.75) {
+                break;
+            }
+        }
+
+        TDoubleVec targets;
+        targets.reserve(features.size());
+        rng.generateUniformSamples(-10.0, 10.0, features.size(), targets);
+        TDoubleVec predictions(rows, 0.0);
+        TDoubleVec curvature(rows, 2.0);
+        TDoubleVec weights(rows, 1.0);
+
+        for (std::size_t i = 0; i < rows; ++i) {
+            frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+                *(column) = features[i];
+                *(++column) = targets[i];
+                *(++column) = predictions[i];
+                *(++column) = targets[i] - predictions[i];
+                *(++column) = curvature[i];
+                *(++column) = weights[i];
+
+            });
+            sketch.add(features[i]);
+        }
+        frame->finishWritingRows();
+
+        maths::CDataFrameCategoryEncoder encoder{{numberThreads, *frame, 0}};
+
+        TDoubleVec splitValues(3);
+        sketch.quantile(25.0, splitValues[0]);
+        sketch.quantile(50.0, splitValues[1]);
+        sketch.quantile(75.0, splitValues[2]);
+        TImmutableRadixSetVec featureSplits;
+        featureSplits.push_back(TImmutableRadixSet(splitValues));
+
+        maths::CBoostedTreeLeafNodeStatistics::CWorkspace workspace;
+        workspace.reinitialize(numberThreads, featureSplits, 1);
+
+        core::CPackedBitVector trainingRowMask(rows, true);
+
+        TSizeVec featureBag{0};
+
+        TRegularization regularization;
+        regularization.softTreeDepthLimit(1.0).softTreeDepthTolerance(1.0);
+
+        TNodeVec tree(1);
+
+        auto rootSplit = std::make_shared<maths::CBoostedTreeLeafNodeStatistics>(
+            0 /*root*/, extraColumns, 1, numberThreads, *frame, encoder, regularization,
+            featureSplits, featureBag, 0 /*depth*/, trainingRowMask, workspace);
+
+        std::size_t splitFeature;
+        double splitValue;
+        std::tie(splitFeature, splitValue) = rootSplit->bestSplit();
+        bool assignMissingToLeft{rootSplit->assignMissingToLeft()};
+
+        std::size_t leftChildId, rightChildId;
+        std::tie(leftChildId, rightChildId) = tree[rootSplit->id()].split(
+            splitFeature, splitValue, assignMissingToLeft, rootSplit->gain(),
+            rootSplit->curvature(), tree);
+
+        TLeafNodeStatisticsPtr leftChild;
+        TLeafNodeStatisticsPtr rightChild;
+        std::tie(leftChild, rightChild) = rootSplit->split(
+            leftChildId, rightChildId, numberThreads, 0.0, *frame, encoder,
+            regularization, featureBag, tree[rootSplit->id()], workspace);
+        if (leftChild != nullptr) {
+            BOOST_REQUIRE(rootSplit->leftChildMaxGain() >= leftChild->gain());
+        }
+        if (rightChild != nullptr) {
+            BOOST_REQUIRE(rootSplit->rightChildMaxGain() >= rightChild->gain());
+        }
+        BOOST_REQUIRE(rightChild != nullptr || leftChild != nullptr);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -331,11 +331,11 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
         frame->resizeColumns(numberThreads, cols + extraColumns.size());
         TDoubleVec features;
         features.reserve(rows);
+        double min, max;
         while (true) {
             rng.generateUniformSamples(0.0, 1.0, rows, features);
-            const auto[min, max] =
-                std::minmax_element(features.begin(), features.end());
-            if (*min < 0.25 && *max > 0.75) {
+            std::tie(min, max) = std::minmax_element(features.begin(), features.end());
+            if (min < 0.25 && max > 0.75) {
                 break;
             }
         }

--- a/lib/test/CRandomNumbers.cc
+++ b/lib/test/CRandomNumbers.cc
@@ -200,6 +200,10 @@ void CRandomNumbers::discard(std::size_t n) {
     m_Generator.discard(n);
 }
 
+void CRandomNumbers::seed(std::size_t seed) {
+    m_Generator.seed(seed);
+}
+
 CRandomNumbers::CUniform0nGenerator::CUniform0nGenerator(const TGenerator& generator)
     : m_Generator(new TGenerator(generator)) {
 }

--- a/mk/windows.mk
+++ b/mk/windows.mk
@@ -45,7 +45,7 @@ CFLAGS=-nologo $(OPTCFLAGS) -W4 $(CRT_OPT) -EHsc -Zi -Gw -FS -Zc:inline -diagnos
 CXXFLAGS=-TP $(CFLAGS) -Zc:rvalueCast -Zc:strictStrings -wd4127 -we4150 -wd4201 -wd4231 -wd4251 -wd4355 -wd4512 -wd4702 -bigobj
 ANALYZEFLAGS=-nologo -analyze:only -analyze:stacksize100000 $(CRT_OPT)
 
-CPPFLAGS=-X -I$(CPP_SRC_HOME)/3rd_party/include -I$(LOCAL_DRIVE):/usr/local/include $(VCINCLUDES) $(WINSDKINCLUDES) -D$(OS) -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -DWIN32_LEAN_AND_MEAN -DNTDDI_VERSION=0x06010000 -D_WIN32_WINNT=0x0601 -DBUILDING_$(basename $(notdir $(TARGET))) $(OPTCPPFLAGS)
+CPPFLAGS=-X -I$(CPP_SRC_HOME)/3rd_party/include -I$(LOCAL_DRIVE):/usr/local/include $(VCINCLUDES) $(WINSDKINCLUDES) -D$(OS) -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -DWIN32_LEAN_AND_MEAN -DNTDDI_VERSION=0x06010000 -D_WIN32_WINNT=0x0601 -D_ENABLE_EXTENDED_ALIGNED_STORAGE -DBUILDING_$(basename $(notdir $(TARGET))) $(OPTCPPFLAGS)
 # -MD defines _DLL and _MT - for dependency determination we must define these
 # otherwise the Boost headers will throw errors during preprocessing
 ifeq ($(CRT_OPT),-MD)


### PR DESCRIPTION
In this PR we start computing an upper bound on the potential gain from splitting a node. If the upper bound of the gain is lower than the currently smallest gain among all candidates, we ignore the node and this way prevent computations that are especially expensive on the large datasets.

Since we avoid computation of the splits that we wouldn't be added to the tree anyway, this PR does not change the qualitative results.

At the moment, we can only compute the upper bound for regression and binary classification. For multiclass classification we proceed as before.

Note: this PR contains additional instrumentation to assess the performance improvement. I will remove this instrumentation in a follow-up PR after tests.

Backport of #1537