### PR TITLE
[ML] Remove references to the .ml-state index from C++ code

### DIFF
--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -70,9 +70,6 @@ class CFieldConfig;
 //!
 class API_EXPORT CAnomalyJob : public CDataProcessor {
 public:
-    //! Elasticsearch index for state
-    static const std::string ML_STATE_INDEX;
-
     //! Discriminant for Elasticsearch IDs
     static const std::string STATE_TYPE;
 

--- a/include/api/CFieldDataCategorizer.h
+++ b/include/api/CFieldDataCategorizer.h
@@ -71,8 +71,6 @@ class CPersistenceManager;
 //!
 class API_EXPORT CFieldDataCategorizer : public CDataProcessor {
 public:
-    //! The index where state is stored
-    static const std::string ML_STATE_INDEX;
     //! The name of the field where the category is going to be written
     static const std::string MLCATEGORY_NAME;
 

--- a/include/api/CSingleStreamDataAdder.h
+++ b/include/api/CSingleStreamDataAdder.h
@@ -45,21 +45,20 @@ public:
     //! be detected by this method, so the stream will go into the
     //! "bad" state if an error occurs during upload.  The caller
     //! must check for this.
-    //! \param index Index to add to metadata document
     //! \param id ID to add to metadata document
-    virtual TOStreamP addStreamed(const std::string& index, const std::string& id);
+    TOStreamP addStreamed(const std::string& id) override;
 
     //! Clients that get a stream using addStreamed() must call this
     //! method one they've finished sending data to the stream.
     //! \param stream The completed data stream
     //! \param force If true the stream is flushed
-    virtual bool streamComplete(TOStreamP& stream, bool force);
+    bool streamComplete(TOStreamP& stream, bool force) override;
 
-    virtual std::size_t maxDocumentSize() const;
+    std::size_t maxDocumentSize() const override;
 
 private:
     //! Recommended maximum Elasticsearch document size
-    static const size_t MAX_DOCUMENT_SIZE;
+    static const std::size_t MAX_DOCUMENT_SIZE;
 
 private:
     //! The stream we're writing to.

--- a/include/api/ElasticsearchStateIndex.h
+++ b/include/api/ElasticsearchStateIndex.h
@@ -12,11 +12,6 @@
 
 namespace ml {
 namespace api {
-//! Elasticsearch index for state
-extern API_EXPORT const std::string ML_STATE_INDEX;
-extern API_EXPORT const std::string MODEL_STATE_TYPE;
-extern API_EXPORT const std::string STATE_ID_SUFFIX;
-
 API_EXPORT std::string getStateId(const std::string& jobId, const std::string& analysisName);
 }
 }

--- a/include/core/CDataAdder.h
+++ b/include/core/CDataAdder.h
@@ -30,8 +30,7 @@ namespace core {
 //!
 //! IMPLEMENTATION DECISIONS:\n
 //! There's an assumption that persisted state will be saved to a
-//! data store that can retrieve based on 2 values: index and ID.
-//! Elasticsearch supports this.
+//! data store that can retrieve based on a single ID.
 //!
 class CORE_EXPORT CDataAdder : private CNonCopyable {
 public:
@@ -48,7 +47,7 @@ public:
     //! returns it is not possible to detect all error conditions
     //! immediately.  If the stream goes bad whilst being written to then
     //! this also indicates failure.
-    virtual TOStreamP addStreamed(const std::string& index, const std::string& id) = 0;
+    virtual TOStreamP addStreamed(const std::string& id) = 0;
 
     //! Clients that get a stream using addStreamed() must call this
     //! method one they've finished sending data to the stream.
@@ -69,7 +68,7 @@ public:
     //! document number.  The ID is of the form baseId#currentDocNum if
     //! baseId is not empty, and simply currentDocNum converted to a string
     //! if baseId is empty.
-    static std::string makeCurrentDocId(const std::string& baseId, size_t currentDocNum);
+    static std::string makeCurrentDocId(const std::string& baseId, std::size_t currentDocNum);
 };
 }
 }

--- a/include/core/CDataSearcher.h
+++ b/include/core/CDataSearcher.h
@@ -12,7 +12,6 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
-#include <vector>
 
 namespace ml {
 namespace core {
@@ -32,9 +31,6 @@ namespace core {
 //!
 class CORE_EXPORT CDataSearcher : private CNonCopyable {
 public:
-    using TStrVec = std::vector<std::string>;
-    using TStrVecCItr = TStrVec::const_iterator;
-
     using TIStreamP = std::shared_ptr<std::istream>;
 
 public:
@@ -42,23 +38,13 @@ public:
     static const std::string EMPTY_STRING;
 
 public:
-    CDataSearcher();
     virtual ~CDataSearcher();
 
     //! Do a search that results in an input stream.
     //! A return value of NULL indicates a technical problem with the
     //! creation of the stream.  Other errors may be indicated by the
     //! returned stream going into the "bad" state.
-    virtual TIStreamP search(size_t currentDocNum, size_t limit) = 0;
-
-    //! Set the search for all documents in the index
-    virtual void setStateRestoreSearch(const std::string& index);
-
-    //! Set the search for all documents in the index with the ID
-    virtual void setStateRestoreSearch(const std::string& index, const std::string& id);
-
-protected:
-    TStrVec m_SearchTerms;
+    virtual TIStreamP search(std::size_t currentDocNum, std::size_t limit) = 0;
 };
 }
 }

--- a/include/core/CStateCompressor.h
+++ b/include/core/CStateCompressor.h
@@ -69,15 +69,15 @@ public:
         //! Interface method: flush the output and close the stream
         void close();
 
-        //! Set the search ID to use
-        void index(const std::string& index, const std::string& id);
+        //! Set the base ID to use in searches
+        void baseId(const std::string& baseId);
 
         //! True if all of the chunked writes were successful.
         //! If one or any of the writes failed the result is false
         bool allWritesSuccessful();
 
         //! How many compressed documents have been generated?
-        size_t numCompressedDocs() const;
+        std::size_t numCompressedDocs() const;
 
     private:
         //! Handle the details of writing a stream of bytes to the internal
@@ -103,9 +103,6 @@ public:
         //! The largest document size permitted by the downstream CDataAdder
         std::size_t m_MaxDocSize;
 
-        //! The search index to use - set by the upstream CDataAdder
-        std::string m_Index;
-
         //! The base ID
         std::string m_BaseId;
 
@@ -125,17 +122,17 @@ public:
     //! As this class compresses incoming stream data, it is responsible for
     //! dealing with the underlying storage layer, so only 1 stream will ever
     //! be given out to clients.
-    virtual TOStreamP addStreamed(const std::string& index, const std::string& id);
+    TOStreamP addStreamed(const std::string& id) override;
 
     //! Clients that get a stream using addStreamed() must call this
     //! method one they've finished sending data to the stream.
     //! They should set force to true.
     //! Returns true if all of the chunked uploads were
     //! successful
-    virtual bool streamComplete(TOStreamP& strm, bool force);
+    bool streamComplete(TOStreamP& strm, bool force) override;
 
     //! How many compressed documents have been generated?
-    size_t numCompressedDocs() const;
+    std::size_t numCompressedDocs() const;
 
 private:
     //! The chunking part of the iostreams filter chain

--- a/include/core/CStateDecompressor.h
+++ b/include/core/CStateDecompressor.h
@@ -145,7 +145,7 @@ public:
         std::streamsize m_BufferOffset;
 
         //! Level of nested objects, used to unwind later on.
-        size_t m_NestedLevel;
+        std::size_t m_NestedLevel;
     };
 
 public:
@@ -154,17 +154,9 @@ public:
 
     //! CDataSearcher interface method - transparently read compressed
     //! data and return it in an uncompressed stream
-    virtual TIStreamP search(size_t currentDocNum, size_t limit);
-
-    virtual void setStateRestoreSearch(const std::string& index);
-
-    //! CDataSearcher interface method - specify the search strings to use
-    virtual void setStateRestoreSearch(const std::string& index, const std::string& id);
+    TIStreamP search(std::size_t currentDocNum, std::size_t limit) override;
 
 private:
-    //! Reference to the downstream data store
-    CDataSearcher& m_Searcher;
-
     //! The dechunker object
     CDechunkFilter m_FilterSource;
 

--- a/include/test/CMultiFileDataAdder.h
+++ b/include/test/CMultiFileDataAdder.h
@@ -20,10 +20,9 @@ namespace test {
 //!
 //! DESCRIPTION:\n
 //! Output file paths are a concatenation of the baseFilename
-//! passed to the constructor, the "index" argument to the
-//! persistence method, the "id" argument to the persistence
-//! method and the file extension passed to the constructor (default
-//! '.json').
+//! passed to the constructor, a hardcoded "_index" directory,
+//! the "id" argument to the persistence method and the file
+//! extension passed to the constructor (default '.json').
 //!
 //! IMPLEMENTATION DECISIONS:\n
 //! Only stream-based methods are presented here, as persistence
@@ -43,17 +42,16 @@ public:
     CMultiFileDataAdder(std::string baseFilename, std::string fileExtension = JSON_FILE_EXT);
 
     //! Add streamed data
-    //! \param index Sub-directory name
     //! \param id File name (without extension)
-    virtual TOStreamP addStreamed(const std::string& index, const std::string& id);
+    TOStreamP addStreamed(const std::string& id) override;
 
     //! Clients that get a stream using addStreamed() must call this
     //! method one they've finished sending data to the stream.
-    virtual bool streamComplete(TOStreamP& strm, bool force);
+    bool streamComplete(TOStreamP& strm, bool force) override;
 
 private:
     //! Make a file name of the form base/_index/id.extension
-    std::string makeFilename(const std::string& index, const std::string& id) const;
+    std::string makeFilename(const std::string& id) const;
 
 private:
     //! Name of the file to serialise models to

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -119,7 +119,6 @@ private:
 }
 
 // Statics
-const std::string CAnomalyJob::ML_STATE_INDEX(".ml-state");
 const std::string CAnomalyJob::STATE_TYPE("model_state");
 const std::string CAnomalyJob::DEFAULT_TIME_FIELD_NAME("time");
 const std::string CAnomalyJob::EMPTY_STRING;
@@ -792,7 +791,6 @@ bool CAnomalyJob::restoreState(core::CDataSearcher& restoreSearcher,
     try {
         // Restore from Elasticsearch compressed data
         core::CStateDecompressor decompressor(restoreSearcher);
-        decompressor.setStateRestoreSearch(ML_STATE_INDEX);
 
         core::CDataSearcher::TIStreamP strm(decompressor.search(1, 1));
         if (strm == nullptr) {
@@ -1194,8 +1192,8 @@ bool CAnomalyJob::persistModelsState(const TKeyCRefAnomalyDetectorPtrPrVec& dete
                                      const std::string& outputFormat) {
     try {
         const std::string snapShotId{core::CStringUtils::typeToString(timestamp)};
-        core::CDataAdder::TOStreamP strm = persister.addStreamed(
-            ML_STATE_INDEX, m_JobId + '_' + STATE_TYPE + '_' + snapShotId);
+        core::CDataAdder::TOStreamP strm =
+            persister.addStreamed(m_JobId + '_' + STATE_TYPE + '_' + snapShotId);
         if (strm != nullptr) {
             {
                 // The JSON inserter must be destroyed before the stream is complete
@@ -1250,8 +1248,8 @@ bool CAnomalyJob::persistCopiedState(const std::string& description,
     try {
         core::CStateCompressor compressor(persister);
 
-        core::CDataAdder::TOStreamP strm = compressor.addStreamed(
-            ML_STATE_INDEX, m_JobId + '_' + STATE_TYPE + '_' + snapshotId);
+        core::CDataAdder::TOStreamP strm =
+            compressor.addStreamed(m_JobId + '_' + STATE_TYPE + '_' + snapshotId);
         if (strm != nullptr) {
             // IMPORTANT - this method can run in a background thread while the
             // analytics carries on processing new buckets in the main thread.

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -174,7 +174,7 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
         if (persister != nullptr) {
             core::CStateCompressor compressor(*persister);
             auto persistStream = compressor.addStreamed(
-                ML_STATE_INDEX, getStateId(m_Spec.jobId(), m_Spec.analysisName()));
+                getStateId(m_Spec.jobId(), m_Spec.analysisName()));
             {
                 core::CJsonStatePersistInserter inserter{*persistStream};
                 persistFunction(inserter);

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -311,8 +311,6 @@ bool CDataFrameTrainBoostedTreeRunner::restoreBoostedTree(core::CDataFrame& fram
     // Restore from compressed JSON.
     try {
         core::CStateDecompressor decompressor(*restoreSearcher);
-        decompressor.setStateRestoreSearch(
-            ML_STATE_INDEX, getStateId(this->spec().jobId(), this->spec().analysisName()));
         core::CDataSearcher::TIStreamP inputStream{decompressor.search(1, 1)}; // search arguments are ignored
         if (inputStream == nullptr) {
             LOG_ERROR(<< "Unable to connect to data store");

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -41,7 +41,6 @@ const std::string EMPTY_STRING;
 } // unnamed
 
 // Initialise statics
-const std::string CFieldDataCategorizer::ML_STATE_INDEX{".ml-state"};
 const std::string CFieldDataCategorizer::MLCATEGORY_NAME{"mlcategory"};
 const double CFieldDataCategorizer::SIMILARITY_THRESHOLD{0.7};
 const std::string CFieldDataCategorizer::STATE_TYPE{"categorizer_state"};
@@ -280,7 +279,6 @@ bool CFieldDataCategorizer::restoreState(core::CDataSearcher& restoreSearcher,
     try {
         // Restore from Elasticsearch compressed data
         core::CStateDecompressor decompressor(restoreSearcher);
-        decompressor.setStateRestoreSearch(ML_STATE_INDEX);
 
         core::CDataSearcher::TIStreamP strm(decompressor.search(1, 1));
         if (strm == nullptr) {
@@ -484,8 +482,7 @@ bool CFieldDataCategorizer::doPersistState(const TStrVec& partitionFieldValues,
     try {
         core::CStateCompressor compressor{persister};
 
-        core::CDataAdder::TOStreamP strm{
-            compressor.addStreamed(ML_STATE_INDEX, m_JobId + '_' + STATE_TYPE)};
+        core::CDataAdder::TOStreamP strm{compressor.addStreamed(m_JobId + '_' + STATE_TYPE)};
 
         if (strm == nullptr) {
             LOG_ERROR(<< "Failed to create persistence stream");

--- a/lib/api/CSingleStreamDataAdder.cc
+++ b/lib/api/CSingleStreamDataAdder.cc
@@ -18,8 +18,7 @@ CSingleStreamDataAdder::CSingleStreamDataAdder(const TOStreamP& stream)
     : m_Stream(stream) {
 }
 
-CSingleStreamDataAdder::TOStreamP
-CSingleStreamDataAdder::addStreamed(const std::string& /*index*/, const std::string& id) {
+CSingleStreamDataAdder::TOStreamP CSingleStreamDataAdder::addStreamed(const std::string& id) {
     if (m_Stream != nullptr && !m_Stream->bad()) {
         // Start with metadata, leaving the index for the receiving code to set
         (*m_Stream) << "{\"index\":{\"_id\":\"" << id << "\"}}\n";

--- a/lib/api/ElasticsearchStateIndex.cc
+++ b/lib/api/ElasticsearchStateIndex.cc
@@ -9,9 +9,9 @@
 namespace ml {
 namespace api {
 
-const std::string ML_STATE_INDEX{".ml-state"};
-const std::string MODEL_STATE_TYPE{"model_state"};
+namespace {
 const std::string STATE_ID_SUFFIX{"_state"};
+}
 
 std::string getStateId(const std::string& jobId, const std::string& analysisName) {
     return jobId + '_' + analysisName + STATE_ID_SUFFIX;

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -62,7 +62,7 @@ public:
     CTestDataSearcher(const std::string& data)
         : m_Stream(new std::istringstream(data)) {}
 
-    virtual TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) {
+    TIStreamP search(std::size_t /*currentDocNum*/, std::size_t /*limit*/) override {
         std::istringstream* intermediateStateStream{
             static_cast<std::istringstream*>(m_Stream.get())};
         // Discard first line, which contains the state id.
@@ -101,8 +101,6 @@ rapidjson::Document treeToJsonDocument(const maths::CBoostedTree& tree) {
 auto restoreTree(std::string persistedState, TDataFrameUPtr& frame, std::size_t dependentVariable) {
     CTestDataSearcher dataSearcher(persistedState);
     auto decompressor = std::make_unique<core::CStateDecompressor>(dataSearcher);
-    decompressor->setStateRestoreSearch(api::ML_STATE_INDEX,
-                                        api::getStateId("testJob", "regression"));
     auto stream = decompressor->search(1, 1);
     return maths::CBoostedTreeFactory::constructFromString(*stream).restoreFor(
         *frame, dependentVariable);

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -125,7 +125,7 @@ class CTestDataAdder : public core::CDataAdder {
 public:
     CTestDataAdder() : m_Stream(new std::ostringstream) {}
 
-    TOStreamP addStreamed(const std::string& /*index*/, const std::string& /*id*/) override {
+    TOStreamP addStreamed(const std::string& /*id*/) override {
         return m_Stream;
     }
 

--- a/lib/api/unittest/CMockDataAdder.cc
+++ b/lib/api/unittest/CMockDataAdder.cc
@@ -6,45 +6,33 @@
 #include "CMockDataAdder.h"
 
 #include <core/CLogger.h>
-#include <core/CStringUtils.h>
-
-#include "CMockSearcher.h"
 
 CMockDataAdder::CMockDataAdder() {
 }
 
-CMockDataAdder::TOStreamP CMockDataAdder::addStreamed(const std::string& index,
-                                                      const std::string& /*id*/) {
-    LOG_TRACE(<< "Add Streamed for index " << index);
-    if (m_Streams.find(index) == m_Streams.end()) {
-        m_Streams[index] = TOStreamP(new std::ostringstream);
+CMockDataAdder::TOStreamP CMockDataAdder::addStreamed(const std::string& /*id*/) {
+    if (m_Stream == nullptr) {
+        m_Stream.reset(new std::ostringstream{});
     }
-    return m_Streams[index];
+    return m_Stream;
 }
 
 bool CMockDataAdder::streamComplete(TOStreamP& strm, bool /*force*/) {
-    LOG_TRACE(<< "Stream complete");
-    bool found = false;
-    for (TStrOStreamPMapItr i = m_Streams.begin(); i != m_Streams.end(); ++i) {
-        if (i->second == strm) {
-            LOG_TRACE(<< "Found stream for " << i->first);
-            std::ostringstream* ss = dynamic_cast<std::ostringstream*>(i->second.get());
-            if (ss != nullptr) {
-                const std::string& result = ss->str();
-                LOG_TRACE(<< "Adding data: " << result);
-                m_Events[i->first].push_back('[' + result + ']');
-                found = true;
-            }
-        }
+    if (strm == nullptr || m_Stream != strm) {
+        return false;
     }
-    return found;
+    const std::string& result = dynamic_cast<std::ostringstream&>(*m_Stream).str();
+    LOG_TRACE(<< "Stream complete - adding data: " << result);
+    m_Events.push_back('[' + result + ']');
+    m_Stream.reset();
+    return true;
 }
 
-const CMockDataAdder::TStrStrVecMap& CMockDataAdder::events() const {
+const CMockDataAdder::TStrVec& CMockDataAdder::events() const {
     return m_Events;
 }
 
 void CMockDataAdder::clear() {
     m_Events.clear();
-    m_Streams.clear();
+    m_Stream.reset();
 }

--- a/lib/api/unittest/CMockDataAdder.h
+++ b/lib/api/unittest/CMockDataAdder.h
@@ -24,11 +24,6 @@
 class CMockDataAdder : public ml::core::CDataAdder {
 public:
     using TStrVec = std::vector<std::string>;
-    using TStrStrVecMap = std::map<std::string, TStrVec>;
-    using TStrStrVecMapCItr = TStrStrVecMap::const_iterator;
-    using TStrOStreamPMap = std::map<std::string, TOStreamP>;
-    using TStrOStreamPMapCItr = TStrOStreamPMap::const_iterator;
-    using TStrOStreamPMapItr = TStrOStreamPMap::iterator;
 
 public:
     CMockDataAdder();
@@ -38,26 +33,26 @@ public:
     //! returns it is not possible to detect all error conditions
     //! immediately.  If the stream goes bad whilst being written to then
     //! this also indicates failure.
-    virtual TOStreamP addStreamed(const std::string& index, const std::string& id);
+    TOStreamP addStreamed(const std::string& id) override;
 
     //! Clients that get a stream using addStreamed() must call this
     //! method one they've finished sending data to the stream.
     //! They should set force to true when the very last stream is
     //! complete, in case the persister needs to close off some
     //! sort of cached data structure.
-    virtual bool streamComplete(TOStreamP& strm, bool force);
+    bool streamComplete(TOStreamP& strm, bool force) override;
 
     //! Access persisted events
-    const TStrStrVecMap& events() const;
+    const TStrVec& events() const;
 
     //! Wipe the contents of the data store
     void clear();
 
 private:
     //! Persisted events
-    TStrStrVecMap m_Events;
+    TStrVec m_Events;
 
-    TStrOStreamPMap m_Streams;
+    TOStreamP m_Stream;
 };
 
 #endif // INCLUDED_CMockDataAdder_h

--- a/lib/api/unittest/CMockSearcher.cc
+++ b/lib/api/unittest/CMockSearcher.cc
@@ -10,29 +10,18 @@
 #include "CMockDataAdder.h"
 
 CMockSearcher::CMockSearcher(const CMockDataAdder& mockDataAdder)
-    : m_MockDataAdder(mockDataAdder) {
+    : m_MockDataAdder{mockDataAdder} {
 }
 
-CMockSearcher::TIStreamP CMockSearcher::search(size_t currentDocNum, size_t /*limit*/) {
+CMockSearcher::TIStreamP CMockSearcher::search(std::size_t currentDocNum, std::size_t /*limit*/) {
     if (currentDocNum == 0) {
         LOG_ERROR(<< "Current doc number cannot be 0 - data store requires 1-based numbers");
-        return TIStreamP();
+        return TIStreamP{};
     }
 
-    TIStreamP stream;
-    const CMockDataAdder::TStrStrVecMap events = m_MockDataAdder.events();
-
-    CMockDataAdder::TStrStrVecMapCItr iter = events.find(m_SearchTerms[0]);
-    if (iter == events.end()) {
-        LOG_TRACE(<< "Can't find search " << m_SearchTerms[0]);
-        stream.reset(new std::stringstream("{}"));
-    } else {
-        LOG_TRACE(<< "Got search data for " << m_SearchTerms[0]);
-        if (currentDocNum > iter->second.size()) {
-            stream.reset(new std::stringstream("[ ]"));
-        } else {
-            stream.reset(new std::stringstream(iter->second[currentDocNum - 1]));
-        }
+    const CMockDataAdder::TStrVec& events = m_MockDataAdder.events();
+    if (currentDocNum > events.size()) {
+        return TIStreamP{new std::istringstream("[ ]")};
     }
-    return stream;
+    return TIStreamP{new std::istringstream(events[currentDocNum - 1])};
 }

--- a/lib/api/unittest/CMockSearcher.h
+++ b/lib/api/unittest/CMockSearcher.h
@@ -30,7 +30,7 @@ public:
     //! A return value of NULL indicates a technical problem with the
     //! creation of the stream.  Other errors may be indicated by the
     //! returned stream going into the "bad" state.
-    virtual TIStreamP search(size_t currentDocNum, size_t limit);
+    TIStreamP search(std::size_t currentDocNum, std::size_t limit) override;
 
 private:
     const CMockDataAdder& m_MockDataAdder;

--- a/lib/api/unittest/CMultiFileDataAdderTest.cc
+++ b/lib/api/unittest/CMultiFileDataAdderTest.cc
@@ -60,7 +60,7 @@ void detectorPersistHelper(const std::string& configFileName,
     static const std::string JOB_ID("job");
 
     // Open the input and output files
-    std::ifstream inputStrm(inputFilename.c_str());
+    std::ifstream inputStrm(inputFilename);
     BOOST_TEST_REQUIRE(inputStrm.is_open());
 
     std::ofstream outputStrm(ml::core::COsFileFuncs::NULL_FILENAME);
@@ -113,14 +113,12 @@ void detectorPersistHelper(const std::string& configFileName,
     TStrVec origFileContents(numOrigDocs);
     for (size_t index = 0; index < numOrigDocs; ++index) {
         std::string expectedOrigFilename(baseOrigOutputFilename);
-        expectedOrigFilename += "/_";
-        expectedOrigFilename += CTestAnomalyJob::ML_STATE_INDEX;
-        expectedOrigFilename += '/';
+        expectedOrigFilename += "/_index/";
         expectedOrigFilename +=
             ml::core::CDataAdder::makeCurrentDocId(origBaseDocId, 1 + index);
         expectedOrigFilename += ml::test::CMultiFileDataAdder::JSON_FILE_EXT;
         LOG_DEBUG(<< "Trying to open file: " << expectedOrigFilename);
-        std::ifstream origFile(expectedOrigFilename.c_str());
+        std::ifstream origFile(expectedOrigFilename);
         BOOST_TEST_REQUIRE(origFile.is_open());
         std::string json((std::istreambuf_iterator<char>(origFile)),
                          std::istreambuf_iterator<char>());
@@ -166,13 +164,11 @@ void detectorPersistHelper(const std::string& configFileName,
 
     for (size_t index = 0; index < numRestoredDocs; ++index) {
         std::string expectedRestoredFilename(baseRestoredOutputFilename);
-        expectedRestoredFilename += "/_";
-        expectedRestoredFilename += CTestAnomalyJob::ML_STATE_INDEX;
-        expectedRestoredFilename += '/';
+        expectedRestoredFilename += "/_index/";
         expectedRestoredFilename +=
             ml::core::CDataAdder::makeCurrentDocId(restoredBaseDocId, 1 + index);
         expectedRestoredFilename += ml::test::CMultiFileDataAdder::JSON_FILE_EXT;
-        std::ifstream restoredFile(expectedRestoredFilename.c_str());
+        std::ifstream restoredFile(expectedRestoredFilename);
         BOOST_TEST_REQUIRE(restoredFile.is_open());
         std::string json((std::istreambuf_iterator<char>(restoredFile)),
                          std::istreambuf_iterator<char>());
@@ -196,7 +192,7 @@ BOOST_AUTO_TEST_CASE(testSimpleWrite) {
     std::string baseOutputFilename(ml::test::CTestTmpDir::tmpDir() + "/filepersister");
 
     std::string expectedFilename(baseOutputFilename);
-    expectedFilename += "/_hello/1";
+    expectedFilename += "/_index/1";
     expectedFilename += EXTENSION;
 
     {
@@ -205,14 +201,14 @@ BOOST_AUTO_TEST_CASE(testSimpleWrite) {
         BOOST_REQUIRE_NO_THROW(boost::filesystem::remove_all(workDir));
 
         ml::test::CMultiFileDataAdder persister(baseOutputFilename, EXTENSION);
-        ml::core::CDataAdder::TOStreamP strm = persister.addStreamed("hello", "1");
+        ml::core::CDataAdder::TOStreamP strm = persister.addStreamed("1");
         BOOST_TEST_REQUIRE(strm);
         (*strm) << EVENT;
         BOOST_TEST_REQUIRE(persister.streamComplete(strm, true));
     }
 
     {
-        std::ifstream persistedFile(expectedFilename.c_str());
+        std::ifstream persistedFile(expectedFilename);
 
         BOOST_TEST_REQUIRE(persistedFile.is_open());
         std::string line;
@@ -223,19 +219,19 @@ BOOST_AUTO_TEST_CASE(testSimpleWrite) {
     BOOST_REQUIRE_EQUAL(0, ::remove(expectedFilename.c_str()));
 
     expectedFilename = baseOutputFilename;
-    expectedFilename += "/_stash/1";
+    expectedFilename += "/_index/2";
     expectedFilename += EXTENSION;
 
     {
         ml::test::CMultiFileDataAdder persister(baseOutputFilename, EXTENSION);
-        ml::core::CDataAdder::TOStreamP strm = persister.addStreamed("stash", "1");
+        ml::core::CDataAdder::TOStreamP strm = persister.addStreamed("2");
         BOOST_TEST_REQUIRE(strm);
         (*strm) << SUMMARY_EVENT;
         BOOST_TEST_REQUIRE(persister.streamComplete(strm, true));
     }
 
     {
-        std::ifstream persistedFile(expectedFilename.c_str());
+        std::ifstream persistedFile(expectedFilename);
 
         BOOST_TEST_REQUIRE(persistedFile.is_open());
         std::string line;

--- a/lib/core/CDataSearcher.cc
+++ b/lib/core/CDataSearcher.cc
@@ -10,20 +10,7 @@ namespace core {
 
 const std::string CDataSearcher::EMPTY_STRING;
 
-CDataSearcher::CDataSearcher() : m_SearchTerms(2) {
-}
-
 CDataSearcher::~CDataSearcher() {
-}
-
-void CDataSearcher::setStateRestoreSearch(const std::string& index) {
-    m_SearchTerms[0] = index;
-    m_SearchTerms[1].clear();
-}
-
-void CDataSearcher::setStateRestoreSearch(const std::string& index, const std::string& id) {
-    m_SearchTerms[0] = index;
-    m_SearchTerms[1] = id;
 }
 }
 }

--- a/lib/core/CStateCompressor.cc
+++ b/lib/core/CStateCompressor.cc
@@ -20,11 +20,8 @@ CStateCompressor::CStateCompressor(CDataAdder& compressedAdder)
     LOG_TRACE(<< "New compressor");
 }
 
-CDataAdder::TOStreamP CStateCompressor::addStreamed(const std::string& index,
-                                                    const std::string& baseId) {
-    LOG_TRACE(<< "StateCompressor asking for index " << index);
-
-    m_FilterSink.index(index, baseId);
+CDataAdder::TOStreamP CStateCompressor::addStreamed(const std::string& baseId) {
+    m_FilterSink.baseId(baseId);
     return m_OutStream;
 }
 
@@ -34,7 +31,7 @@ bool CStateCompressor::streamComplete(CDataAdder::TOStreamP& /*strm*/, bool /*fo
     return m_FilterSink.allWritesSuccessful();
 }
 
-size_t CStateCompressor::numCompressedDocs() const {
+std::size_t CStateCompressor::numCompressedDocs() const {
     return m_FilterSink.numCompressedDocs();
 }
 
@@ -51,9 +48,9 @@ std::streamsize CStateCompressor::CChunkFilter::write(const char* s, std::stream
     while (n > 0) {
         if (!m_OStream) {
             const std::string& currentDocId = m_Adder.makeCurrentDocId(m_BaseId, m_CurrentDocNum);
-            LOG_TRACE(<< "Add streamed: " << m_Index << ", " << currentDocId);
+            LOG_TRACE(<< "Add streamed: " << currentDocId);
 
-            m_OStream = m_Adder.addStreamed(m_Index, currentDocId);
+            m_OStream = m_Adder.addStreamed(currentDocId);
             if (!m_OStream) {
                 LOG_ERROR(<< "Failed to connect to store");
                 return 0;
@@ -111,9 +108,7 @@ void CStateCompressor::CChunkFilter::closeStream(bool isFinal) {
     }
 }
 
-void CStateCompressor::CChunkFilter::index(const std::string& index,
-                                           const std::string& baseId) {
-    m_Index = index;
+void CStateCompressor::CChunkFilter::baseId(const std::string& baseId) {
     m_BaseId = baseId;
 }
 
@@ -134,7 +129,7 @@ bool CStateCompressor::CChunkFilter::allWritesSuccessful() {
     return m_WritesSuccessful;
 }
 
-size_t CStateCompressor::CChunkFilter::numCompressedDocs() const {
+std::size_t CStateCompressor::CChunkFilter::numCompressedDocs() const {
     return m_CurrentDocNum - 1;
 }
 

--- a/lib/core/CStateDecompressor.cc
+++ b/lib/core/CStateDecompressor.cc
@@ -19,32 +19,24 @@
 namespace ml {
 namespace core {
 
-const std::string CStateDecompressor::EMPTY_DATA("H4sIAAAAAAAA/4uOBQApu0wNAgAAAA==");
+const std::string CStateDecompressor::EMPTY_DATA{"H4sIAAAAAAAA/4uOBQApu0wNAgAAAA=="};
 
 CStateDecompressor::CStateDecompressor(CDataSearcher& compressedSearcher)
-    : m_Searcher(compressedSearcher), m_FilterSource(compressedSearcher) {
-    m_InFilter.reset(new TFilteredInput);
+    : m_FilterSource{compressedSearcher} {
+    m_InFilter.reset(new TFilteredInput{});
     m_InFilter->push(boost::iostreams::gzip_decompressor());
-    m_InFilter->push(CBase64Decoder());
+    m_InFilter->push(CBase64Decoder{});
     m_InFilter->push(boost::ref(m_FilterSource));
 }
 
-CDataSearcher::TIStreamP CStateDecompressor::search(size_t /*currentDocNum*/, size_t /*limit*/) {
+CDataSearcher::TIStreamP CStateDecompressor::search(std::size_t /*currentDocNum*/,
+                                                    std::size_t /*limit*/) {
     return m_InFilter;
 }
 
-void CStateDecompressor::setStateRestoreSearch(const std::string& index) {
-    m_Searcher.setStateRestoreSearch(index);
-}
-
-void CStateDecompressor::setStateRestoreSearch(const std::string& index,
-                                               const std::string& id) {
-    m_Searcher.setStateRestoreSearch(index, id);
-}
-
 CStateDecompressor::CDechunkFilter::CDechunkFilter(CDataSearcher& searcher)
-    : m_Initialised(false), m_SentData(false), m_Searcher(searcher),
-      m_CurrentDocNum(1), m_EndOfStream(false), m_BufferOffset(0), m_NestedLevel(1) {
+    : m_Initialised{false}, m_SentData{false}, m_Searcher{searcher},
+      m_CurrentDocNum{1}, m_EndOfStream{false}, m_BufferOffset{0}, m_NestedLevel{1} {
 }
 
 std::streamsize CStateDecompressor::CDechunkFilter::read(char* s, std::streamsize n) {

--- a/lib/test/CMultiFileDataAdder.cc
+++ b/lib/test/CMultiFileDataAdder.cc
@@ -17,18 +17,17 @@
 namespace ml {
 namespace test {
 
-const std::string CMultiFileDataAdder::JSON_FILE_EXT = ".json";
+const std::string CMultiFileDataAdder::JSON_FILE_EXT{".json"};
 
 CMultiFileDataAdder::CMultiFileDataAdder(std::string baseFilename, std::string fileExtension) {
-    m_BaseFilename.swap(baseFilename);
-    m_FileExtension.swap(fileExtension);
+    m_BaseFilename = std::move(baseFilename);
+    m_FileExtension = std::move(fileExtension);
 }
 
-CMultiFileDataAdder::TOStreamP
-CMultiFileDataAdder::addStreamed(const std::string& index, const std::string& id) {
-    const std::string& filename = this->makeFilename(index, id);
+CMultiFileDataAdder::TOStreamP CMultiFileDataAdder::addStreamed(const std::string& id) {
+    const std::string& filename{this->makeFilename(id)};
 
-    TOStreamP strm(std::make_shared<std::ofstream>(filename.c_str()));
+    TOStreamP strm{std::make_shared<std::ofstream>(filename)};
     if (!strm->good()) {
         LOG_ERROR(<< "Failed to create new output stream for file " << filename);
         strm.reset();
@@ -38,7 +37,7 @@ CMultiFileDataAdder::addStreamed(const std::string& index, const std::string& id
 }
 
 bool CMultiFileDataAdder::streamComplete(TOStreamP& strm, bool /*force*/) {
-    std::ofstream* ofs(dynamic_cast<std::ofstream*>(strm.get()));
+    std::ofstream* ofs{dynamic_cast<std::ofstream*>(strm.get())};
     if (ofs == nullptr) {
         return false;
     }
@@ -48,20 +47,16 @@ bool CMultiFileDataAdder::streamComplete(TOStreamP& strm, bool /*force*/) {
     return !ofs->bad();
 }
 
-std::string CMultiFileDataAdder::makeFilename(const std::string& index,
-                                              const std::string& id) const {
+std::string CMultiFileDataAdder::makeFilename(const std::string& id) const {
     // NB: The logic in here must mirror that of CMultiFileSearcher::search()
 
-    std::string filename(m_BaseFilename);
-    if (!index.empty()) {
-        filename += "/_";
-        filename += index;
-    }
+    std::string filename{m_BaseFilename};
+    filename += "/_index";
 
     try {
         // Prior existence of the directory is not considered an error by
         // boost::filesystem, and this is what we want
-        boost::filesystem::path directoryPath(filename);
+        boost::filesystem::path directoryPath{filename};
         boost::filesystem::create_directories(directoryPath);
     } catch (std::exception& e) {
         LOG_ERROR(<< "Failed to create directory " << filename << " - " << e.what());

--- a/lib/test/CMultiFileSearcher.cc
+++ b/lib/test/CMultiFileSearcher.cc
@@ -10,48 +10,37 @@
 
 #include <fstream>
 #include <memory>
-#include <utility>
 
 namespace ml {
 namespace test {
 
-const std::string CMultiFileSearcher::JSON_FILE_EXT(".json");
+const std::string CMultiFileSearcher::JSON_FILE_EXT{".json"};
 
 CMultiFileSearcher::CMultiFileSearcher(std::string baseFilename,
                                        std::string baseDocId,
                                        std::string fileExtension)
-    : m_BaseFilename(std::move(baseFilename)), m_BaseDocId(std::move(baseDocId)),
-      m_FileExtension(std::move(fileExtension)) {
+    : m_BaseFilename{std::move(baseFilename)}, m_BaseDocId{std::move(baseDocId)},
+      m_FileExtension{std::move(fileExtension)} {
 }
 
-CMultiFileSearcher::TIStreamP CMultiFileSearcher::search(size_t currentDocNum, size_t limit) {
+CMultiFileSearcher::TIStreamP CMultiFileSearcher::search(std::size_t currentDocNum,
+                                                         std::size_t limit) {
     if (limit != 1) {
         LOG_ERROR(<< "File searcher can only operate with a limit of 1");
-        return TIStreamP();
+        return TIStreamP{};
     }
 
     // NB: The logic in here must mirror that of CMultiFileDataAdder::makeFilename()
 
-    std::string filename(m_BaseFilename);
-    if (!m_SearchTerms[0].empty()) {
-        filename += '/';
-        if (m_SearchTerms[0].front() == '.') {
-            filename += '_';
-        }
-        filename += m_SearchTerms[0];
-    }
-    if (!m_SearchTerms[1].empty()) {
-        filename += '/';
-        filename += m_SearchTerms[1];
-    }
-    filename += '/';
+    std::string filename{m_BaseFilename};
+    filename += "/_index/";
     filename += core::CDataAdder::makeCurrentDocId(m_BaseDocId, currentDocNum);
     filename += m_FileExtension;
 
     // Failure to open the file is not necessarily an error - the calling method
     // will decide.  Therefore, return a pointer to the stream even if it's not
     // in the "good" state.
-    return std::make_shared<std::ifstream>(filename.c_str());
+    return std::make_shared<std::ifstream>(filename);
 }
 }
 }


### PR DESCRIPTION
The ML C++ code contains several references to the .ml-state
index.  These date back to the days when the C++ code decided
which index to store state in.  Now this decision is made in
the Java code, and the index used isn't even .ml-state any
more, so it was highly confusing to have this name embedded
in the C++ code.  This PR also changes a few interfaces to
make clearer that the C++ isn't choosing the index to store
state in.