### PR TITLE
[ML] Migrate away from inheriting from std::iterator

### DIFF
--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -129,8 +129,14 @@ public:
 //! DESCRIPTION:\n
 //! This is a helper class used to read rows of a CDataFrame object which
 //! dereferences to CRowRef objects.
-class CORE_EXPORT CRowIterator final
-    : public std::iterator<std::forward_iterator_tag, CRowRef, std::ptrdiff_t, CRowPtr, CRowRef> {
+class CORE_EXPORT CRowIterator final {
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = CRowRef;
+    using difference_type = std::ptrdiff_t;
+    using pointer = CRowPtr;
+    using reference = CRowRef;
+
 public:
     CRowIterator() = default;
 

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -52,9 +52,9 @@ namespace core {
 //! \warning Since it allows a more efficient implementation and covers our use cases
 //! this only supports vectors up to length 2^30.
 // clang-format off
-class CORE_EXPORT CPackedBitVector : private boost::equality_comparable<CPackedBitVector,
-                                             boost::partially_ordered<CPackedBitVector,
-                                             boost::bitwise<CPackedBitVector>>> {
+class CORE_EXPORT CPackedBitVector final : private boost::equality_comparable<CPackedBitVector,
+                                                   boost::partially_ordered<CPackedBitVector,
+                                                   boost::bitwise<CPackedBitVector>>> {
     // clang-format on
 public:
     using TBoolVec = std::vector<bool>;
@@ -66,8 +66,14 @@ public:
     enum EOperation { E_AND, E_OR, E_XOR };
 
     //! \brief A forward iterator over the indices of the one bits in bit vector.
-    class CORE_EXPORT COneBitIndexConstIterator
-        : public std::iterator<std::input_iterator_tag, std::size_t, std::ptrdiff_t> {
+    class CORE_EXPORT COneBitIndexConstIterator final {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = void;
+        using reference = void;
+
     public:
         COneBitIndexConstIterator() = default;
         COneBitIndexConstIterator(bool first, TUInt8VecCItr runLengthsItr, TUInt8VecCItr endRunLengthsItr);
@@ -79,7 +85,7 @@ public:
             return m_Current == rhs.m_Current && m_RunLengthsItr == rhs.m_RunLengthsItr;
         }
         bool operator!=(const COneBitIndexConstIterator& rhs) const {
-            return !(*this == rhs);
+            return (*this == rhs) == false;
         }
 
         COneBitIndexConstIterator& operator++() {

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -52,9 +52,9 @@ namespace core {
 //! \warning Since it allows a more efficient implementation and covers our use cases
 //! this only supports vectors up to length 2^30.
 // clang-format off
-class CORE_EXPORT CPackedBitVector final : private boost::equality_comparable<CPackedBitVector,
-                                                   boost::partially_ordered<CPackedBitVector,
-                                                   boost::bitwise<CPackedBitVector>>> {
+class CORE_EXPORT CPackedBitVector : private boost::equality_comparable<CPackedBitVector,
+                                             boost::partially_ordered<CPackedBitVector,
+                                             boost::bitwise<CPackedBitVector>>> {
     // clang-format on
 public:
     using TBoolVec = std::vector<bool>;

--- a/include/maths/CLinearAlgebraEigen.h
+++ b/include/maths/CLinearAlgebraEigen.h
@@ -134,8 +134,15 @@ inline CSparseVectorCoordinate<SCALAR> vectorCoordinate(std::ptrdiff_t row, SCAL
 
 //! \brief Adapts Eigen::SparseVector::InnerIterator for use with STL.
 template<typename SCALAR, int FLAGS = Eigen::RowMajorBit>
-class CSparseVectorIndexIterator
-    : public std::iterator<std::input_iterator_tag, std::ptrdiff_t> {
+class CSparseVectorIndexIterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = std::ptrdiff_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = void;
+
+public:
     CSparseVectorIndexIterator(const CSparseVector<SCALAR, FLAGS>& vector, std::size_t index)
         : m_Vector(&vector), m_Base(vector, index) {}
 
@@ -144,7 +151,7 @@ class CSparseVectorIndexIterator
                m_Base.col() == rhs.m_Base.col();
     }
     bool operator!=(const CSparseVectorIndexIterator& rhs) const {
-        return !(*this == rhs);
+        return (*this == rhs) == false;
     }
 
     std::ptrdiff_t operator*() const {

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -50,18 +50,20 @@ using TUInt8UInt8Pr = std::pair<uint8_t, uint8_t>;
 //!   |(g(x) >> 8) % 256|    g(x) % 256   |    zeros(x)     |
 //! \endcode
 // clang-format off
-class EMPTY_BASE_OPT CHashIterator
-    : public std::iterator<std::random_access_iterator_tag, uint16_t>,
-      private boost::less_than_comparable<CHashIterator,
+class EMPTY_BASE_OPT CHashIterator final
+    : private boost::less_than_comparable<CHashIterator,
               boost::addable<CHashIterator, ptrdiff_t,
               boost::subtractable<CHashIterator, ptrdiff_t>>> {
     // clang-format on
 public:
-    //! The STL that comes with g++ requires a default constructor - this
-    //! will create an object that's suitable only to be assigned to, which
-    //! is hopefully all g++'s STL does with it!
-    CHashIterator() : m_Itr() {}
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = uint16_t;
+    using difference_type = ptrdiff_t;
+    using pointer = void;
+    using reference = void;
 
+public:
+    CHashIterator() = default;
     CHashIterator(TUInt8VecItr itr) : m_Itr(itr) {}
 
     TUInt8VecItr base() const { return m_Itr; }


### PR DESCRIPTION
C++17 deprecates inheriting from `std::iterator` for iterator trait typedefs. Our use of this generates a lot of deprecation warnings from our VS compiler. This change migrates the few instances we have to explicit typedefs.