### PR TITLE
[7.10][ML] Include peak memory usage in model snapshots (#1572)

### DIFF
--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -62,6 +62,7 @@ int main(int argc, char** argv) {
         ml::counter_t::E_TSADNumberNewPeopleRecycled,
         ml::counter_t::E_TSADNumberApiRecordsHandled,
         ml::counter_t::E_TSADMemoryUsage,
+        ml::counter_t::E_TSADPeakMemoryUsage,
         ml::counter_t::E_TSADNumberMemoryUsageChecks,
         ml::counter_t::E_TSADNumberMemoryUsageEstimates,
         ml::counter_t::E_TSADNumberRecordsNoTimeField,

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 7.10.1
+
+=== Bug Fixes
+
+* Fix a bug where the peak_model_bytes value of the model_size_stats object  was not
+  restored from the anomaly detector job snapshots.
+
 == {es} version 7.10.0
 
 === Enhancements


### PR DESCRIPTION
Ensure that the static counter tracking the peak memory usage for a job
is included in the limited set to be persisted/restored from model state
snapshots.

Relates to elastic/elasticsearch#64154
Backports #1572