### PR TITLE
[ML] Work around erroneous reference requirement for std::vector::assign

### DIFF
--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -71,8 +71,8 @@ public:
         using iterator_category = std::input_iterator_tag;
         using value_type = std::size_t;
         using difference_type = std::ptrdiff_t;
-        using pointer = void;
-        using reference = void;
+        using pointer = std::size_t*;
+        using reference = std::size_t&;
 
     public:
         COneBitIndexConstIterator() = default;


### PR DESCRIPTION
It seems that some versions of libc++ require that an iterator has a non void reference type to be used with `std::vector::assign`. This is an annoying unnecessary extra type requirement, since the code doesn't actually need operator* to return a reference, but never mind. Defining them - as we had implicitly before via `std::iterator` - should be harmless. Follows on from #1570.