### PR TITLE
[ML] Fixing the debug build

### DIFF
--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -18,6 +18,19 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
+#ifdef Windows
+// rapidjson::Writer<rapidjson::StringBuffer> gets instantiated in the core
+// library, and on Windows it gets exported too, because
+// CRapidJsonConcurrentLineWriter inherits from it and is also exported.
+// To avoid breaching the one-definition rule we must reuse this exported
+// instantiation, as deduplication of template instantiations doesn't work
+// across DLLs.  To make this even more confusing, this is only strictly
+// necessary when building without optimisation, because with optimisation
+// enabled the instantiation in this library gets inlined to the extent that
+// there are no clashing symbols.
+template class CORE_EXPORT rapidjson::Writer<rapidjson::StringBuffer>;
+#endif
+
 namespace ml {
 namespace api {
 


### PR DESCRIPTION
When building without optimisation RapidJson's templates
cause problems on Windows when used in different libraries.
This change works around the problem by telling the api
library to use the definition from the core library.  (We
don't notice this when optimisation is used because the
problematic classes end up being inlined away.)