### PR TITLE
[7.11][ML] Work around erroneous reference requirement for std::vector::assign

### DIFF
--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -71,8 +71,8 @@ public:
         using iterator_category = std::input_iterator_tag;
         using value_type = std::size_t;
         using difference_type = std::ptrdiff_t;
-        using pointer = void;
-        using reference = void;
+        using pointer = std::size_t*;
+        using reference = std::size_t&;
 
     public:
         COneBitIndexConstIterator() = default;


### PR DESCRIPTION
Backport #1578.