### PR TITLE
[ML] Make sure we don't try and test significance when there is insufficient data

### DIFF
--- a/lib/maths/CTimeSeriesTestForChange.cc
+++ b/lib/maths/CTimeSeriesTestForChange.cc
@@ -41,7 +41,9 @@ using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 constexpr double EPS{0.1};
 
 double rightTailFTest(double v0, double v1, double df0, double df1) {
-    if (df1 <= 0.0) {
+    // If there is insufficient data for either hypothesis treat we are conservative
+    // and say the alternative hypothesis is not provable.
+    if (df0 <= 0.0 || df1 <= 0.0) {
         return 1.0;
     }
     double F{v0 == v1 ? 1.0 : (v0 / df0) / (v1 / df1)};

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -40,7 +40,9 @@ namespace ml {
 namespace maths {
 namespace {
 double rightTailFTest(double v0, double v1, double df0, double df1) {
-    if (df1 <= 0.0) {
+    // If there is insufficient data for either hypothesis treat we are conservative
+    // and say the alternative hypothesis is not provable.
+    if (df0 <= 0.0 || df1 <= 0.0) {
         return 1.0;
     }
     double F{v0 == v1 ? 1.0 : v0 / v1};


### PR DESCRIPTION
We aren't guaranteed that H0 always has more degrees of freedom H1 in all cases where we were testing explained variance. This could therefore sometimes trigger log errors. In the cases this happens it is appropriate to treat the p-value of the alternative as 1, i.e. unproven.

Showed up running #1550 through the QA. Marking as a non issue since it fixes an issue in unreleased code.