### PR TITLE
[ML] Recalculate memory usage before upgrading model state

### DIFF
--- a/include/model/CResourceMonitor.h
+++ b/include/model/CResourceMonitor.h
@@ -102,6 +102,9 @@ public:
     //! Recalculate the memory usage regardless of whether there is a memory limit
     void forceRefresh(CMonitoredResource& resource);
 
+    //! Recalculate the memory usage for all monitored resources
+    void forceRefreshAll();
+
     //! Set the internal memory limit, as specified in a limits config file
     void memoryLimit(std::size_t limitMBs);
 

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -122,6 +122,14 @@ void CResourceMonitor::forceRefresh(CMonitoredResource& resource) {
     this->updateAllowAllocations();
 }
 
+void CResourceMonitor::forceRefreshAll() {
+    for (auto& resource : m_Resources) {
+        this->memUsage(resource.first);
+    }
+
+    this->updateAllowAllocations();
+}
+
 void CResourceMonitor::updateAllowAllocations() {
     std::size_t total{this->totalMemory()};
     core::CProgramCounters::counter(counter_t::E_TSADMemoryUsage) = total;

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -265,6 +265,23 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusOk, m_ReportedModelSizeStats.s_MemoryStatus);
     }
     {
+        // As above but refreshing all resources in one call
+        CResourceMonitor mon;
+        mon.registerComponent(categorizer);
+        mon.registerComponent(detector1);
+        mon.registerComponent(detector2);
+
+        mon.memoryUsageReporter(std::bind(&CTestFixture::reportCallback, this,
+                                          std::placeholders::_1));
+        m_ReportedModelSizeStats.s_Usage = 0;
+        BOOST_REQUIRE_EQUAL(std::size_t(0), m_ReportedModelSizeStats.s_Usage);
+
+        mon.forceRefreshAll();
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        BOOST_REQUIRE_EQUAL(mem, m_ReportedModelSizeStats.s_Usage);
+        BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusOk, m_ReportedModelSizeStats.s_MemoryStatus);
+    }
+    {
         // Test the report callback for allocation failures
         CResourceMonitor mon;
         mon.registerComponent(categorizer);


### PR DESCRIPTION
When a persist control message with arguments is received
by the anomaly detector it doesn't go through the standard
chain of persistence calls, as it unconditionally rewrites
the state (even if no data has been seen) and includes only
the anomaly detector state rather than the categorizer state
too.  Because of this the memory usage was not being
recalculated prior to persisting the state as would normally
happen.  This PR rectifies that omission.

Fixes one of the problems detailed in
https://github.com/elastic/elasticsearch/pull/64665#pullrequestreview-524548875