### PR TITLE
[ML] Trap potential cause of log errors from CXMeansOnline1d

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -54,6 +54,10 @@
 * Estimate upper bound of potential gains before splitting a decision tree node to avoid 
   unnecessary computation. (See {ml-pull}1537[#1537].)
 
+=== Bug Fixes
+
+* Fix potential cause for log errors from CXMeansOnline1d. (See {ml-pull}1586[#1586].)
+
 == {es} version 7.10.1
 
 === Bug Fixes

--- a/lib/maths/CNaturalBreaksClassifier.cc
+++ b/lib/maths/CNaturalBreaksClassifier.cc
@@ -194,7 +194,8 @@ bool CNaturalBreaksClassifier::split(std::size_t n, std::size_t p, TClassifierVe
         TTupleVec category(1);
         for (std::size_t i = 0u; i < m_Categories.size(); ++i) {
             category[0] = m_Categories[i];
-            result.emplace_back(m_Space, m_DecayRate, m_MinimumCategoryCount, category);
+            result.push_back(CNaturalBreaksClassifier(
+                m_Space, m_DecayRate, m_MinimumCategoryCount, category));
         }
         return true;
     } else if (n == 1) {
@@ -221,7 +222,8 @@ bool CNaturalBreaksClassifier::split(std::size_t n, std::size_t p, TClassifierVe
         for (/**/; j < split[i]; ++j) {
             categories.push_back(m_Categories[j]);
         }
-        result.emplace_back(m_Space, m_DecayRate, m_MinimumCategoryCount, categories);
+        result.push_back(CNaturalBreaksClassifier(
+            m_Space, m_DecayRate, m_MinimumCategoryCount, categories));
     }
 
     return true;
@@ -247,7 +249,8 @@ bool CNaturalBreaksClassifier::split(const TSizeVec& split, TClassifierVec& resu
         for (/**/; j < split[i]; ++j) {
             categories.push_back(m_Categories[j]);
         }
-        result.emplace_back(m_Space, m_DecayRate, m_MinimumCategoryCount, categories);
+        result.push_back(CNaturalBreaksClassifier(
+            m_Space, m_DecayRate, m_MinimumCategoryCount, categories));
     }
 
     return true;

--- a/lib/maths/CNaturalBreaksClassifier.cc
+++ b/lib/maths/CNaturalBreaksClassifier.cc
@@ -194,8 +194,7 @@ bool CNaturalBreaksClassifier::split(std::size_t n, std::size_t p, TClassifierVe
         TTupleVec category(1);
         for (std::size_t i = 0u; i < m_Categories.size(); ++i) {
             category[0] = m_Categories[i];
-            result.emplace_back(
-                m_Space, m_DecayRate, m_MinimumCategoryCount, category);
+            result.emplace_back(m_Space, m_DecayRate, m_MinimumCategoryCount, category);
         }
         return true;
     } else if (n == 1) {
@@ -222,8 +221,7 @@ bool CNaturalBreaksClassifier::split(std::size_t n, std::size_t p, TClassifierVe
         for (/**/; j < split[i]; ++j) {
             categories.push_back(m_Categories[j]);
         }
-        result.emplace_back(
-            m_Space, m_DecayRate, m_MinimumCategoryCount, categories);
+        result.emplace_back(m_Space, m_DecayRate, m_MinimumCategoryCount, categories);
     }
 
     return true;
@@ -249,8 +247,7 @@ bool CNaturalBreaksClassifier::split(const TSizeVec& split, TClassifierVec& resu
         for (/**/; j < split[i]; ++j) {
             categories.push_back(m_Categories[j]);
         }
-        result.emplace_back(
-            m_Space, m_DecayRate, m_MinimumCategoryCount, categories);
+        result.emplace_back(m_Space, m_DecayRate, m_MinimumCategoryCount, categories);
     }
 
     return true;

--- a/lib/maths/CXMeansOnline1d.cc
+++ b/lib/maths/CXMeansOnline1d.cc
@@ -418,6 +418,10 @@ void BICGain(maths_t::EDataType dataType,
 //! \param[in,out] category The category to Winsorise.
 void winsorise(const TDoubleDoublePr& interval, TTuple& category) {
 
+    if (CBasicStatistics::maximumLikelihoodVariance(category) < 0.0) {
+        CBasicStatisticcs::moment<1>(category) = 0.0;
+    }
+
     double a = interval.first;
     double b = interval.second;
     double m = CBasicStatistics::mean(category);
@@ -432,7 +436,7 @@ void winsorise(const TDoubleDoublePr& interval, TTuple& category) {
     }
 
     try {
-        boost::math::normal_distribution<> normal(m, sigma);
+        boost::math::normal normal(m, sigma);
         double pa = xa > t ? 0.0 : CTools::safeCdf(normal, a);
         double pb = xb > t ? 0.0 : CTools::safeCdfComplement(normal, b);
 
@@ -456,8 +460,8 @@ void winsorise(const TDoubleDoublePr& interval, TTuple& category) {
 
         double n = CBasicStatistics::count(category);
 
-        category.s_Moments[0] = wm;
-        category.s_Moments[1] = std::max((n - 1.0) / n * wv, 0.0);
+        CBasicStatistics::moment<0>(category) = wm;
+        CBasicStatistics::moment<1>(category) = std::max((n - 1.0) / n * wv, 0.0);
     } catch (const std::exception& e) {
         LOG_ERROR(<< "Bad category = " << category << ": " << e.what());
     }

--- a/lib/maths/CXMeansOnline1d.cc
+++ b/lib/maths/CXMeansOnline1d.cc
@@ -419,7 +419,7 @@ void BICGain(maths_t::EDataType dataType,
 void winsorise(const TDoubleDoublePr& interval, TTuple& category) {
 
     if (CBasicStatistics::maximumLikelihoodVariance(category) < 0.0) {
-        CBasicStatisticcs::moment<1>(category) = 0.0;
+        CBasicStatistics::moment<1>(category) = 0.0;
     }
 
     double a = interval.first;


### PR DESCRIPTION
We are getting log errors like
```
[CXMeansOnline1d.cc@462] Bad category = (0.0017123, 2.27255e+10, 0): Error in function boost::math::normal_distribution<double>::normal_distribution...
```
from a long running QA job.

Whilst this has proven difficult to reproduce the underlying cause seems to be that numerical errors have resulted in a variance being around `-eps`. Since we take the `sqrt` of this in the offending code it generates a NaN which triggers this and other log errors. The code which does this should be defensive.

The only mechanism I can see causing this is if the weight used for update is somehow negative. This also shouldn't be possible and it is a large task to trace back how this might be occurring. I simply now also trap this case and discard the sample.

This can affect results, but it is an edge case and we've only seen these errors in one job, so I would assume that nearly all the time this change will have no impact.