### PR TITLE
[ML] Addressing a QA regression due to 1451 and 1580 

### DIFF
--- a/include/maths/CExpandingWindow.h
+++ b/include/maths/CExpandingWindow.h
@@ -59,7 +59,7 @@ public:
     using TPredictor = std::function<double(core_t::TTime)>;
 
 public:
-    CExpandingWindow(core_t::TTime bucketLength,
+    CExpandingWindow(core_t::TTime sampleInterval,
                      TTimeCRng bucketLengths,
                      std::size_t size,
                      double decayRate = 0.0,
@@ -81,8 +81,8 @@ public:
     std::size_t size() const;
 
     //! Get the mean time offset of the data points added with respect to the start
-    //! of the *data* bucket.
-    core_t::TTime dataPointsTimeOffsetInBucket() const;
+    //! of the sample interval.
+    core_t::TTime sampleAverageOffset() const;
 
     //! Get the time of the first window value.
     core_t::TTime beginValuesTime() const;
@@ -179,8 +179,8 @@ private:
     //! The number of buckets.
     std::size_t m_Size;
 
-    //! The data bucket length.
-    core_t::TTime m_DataBucketLength;
+    //! The average length of time between samples.
+    core_t::TTime m_SampleInterval;
 
     //! The set of possible expanded window bucket lengths.
     TTimeCRng m_BucketLengths;

--- a/include/maths/CSeasonalComponentAdaptiveBucketing.h
+++ b/include/maths/CSeasonalComponentAdaptiveBucketing.h
@@ -95,8 +95,8 @@ public:
     //! at \p time fixed.
     void shiftSlope(core_t::TTime time, double shift);
 
-    //! Linearly scale the regressions by \p scale.
-    void linearScale(double scale);
+    //! Linearly scale the regressions by \p scale at \p time.
+    void linearScale(core_t::TTime time, double scale);
 
     //! Add the function value at \p time.
     //!

--- a/include/maths/CSignal.h
+++ b/include/maths/CSignal.h
@@ -50,7 +50,8 @@ public:
     using TMomentTransformFunc = std::function<double(const TFloatMeanAccumulator&)>;
     using TMomentWeightFunc = std::function<double(const TFloatMeanAccumulator&)>;
     using TIndexWeightFunc = std::function<double(std::size_t)>;
-    using TPredictor = std::function<double(std::size_t)>;
+    using TIndexPredictor = std::function<double(std::size_t)>;
+    using TPredictor = std::function<double(core_t::TTime)>;
 
     //! \brief A description of a seasonal component.
     struct SSeasonalComponentSummary {
@@ -361,7 +362,7 @@ public:
     //! \param[in] fraction The fraction of values treated as outliers.
     //! \param[in,out] values The values to reweight.
     //! \return True if this reweighted any \p values.
-    static bool reweightOutliers(const TPredictor& predictor,
+    static bool reweightOutliers(const TIndexPredictor& predictor,
                                  double fraction,
                                  TFloatMeanAccumulatorVec& values);
 
@@ -472,6 +473,21 @@ public:
             return CBasicStatistics::count(value) > 0.0;
         });
     }
+
+    //! Get a predictor for the average of predictions \p sampleInterval apart
+    //! for buckets starting at \p bucketsStartTime and length \p bucketLength.
+    //!
+    //! \param[in] predictor The predictor from which to compute the average.
+    //! \param[in] bucketsStartTime The start time of the buckets.
+    //! \param[in] bucketLength The bucket length.
+    //! \param[in] bucketAverageSampleTime The average of the sample offsets in
+    //! a time bucket.
+    //! \param[in] sampleInterval The average time between samples.
+    static TPredictor bucketPredictor(const TPredictor& predictor,
+                                      core_t::TTime bucketsStartTime,
+                                      core_t::TTime bucketLength,
+                                      core_t::TTime bucketAverageSampleTime,
+                                      core_t::TTime sampleInterval);
 
 private:
     static void removeComponents(const TSeasonalComponentVec& periods,

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -279,6 +279,12 @@ public:
         //! The length of time in which we expect to detect a change.
         core_t::TTime maximumIntervalToDetectChange() const;
 
+        //! The start of the sliding window of buckets given the time is now \p time.
+        core_t::TTime bucketsStartTime(core_t::TTime time, core_t::TTime bucketsLength) const;
+
+        //! The start of the values given the buckets start at \p bucketStartTime.
+        core_t::TTime valuesStartTime(core_t::TTime bucketsStartTime) const;
+
         //! The start time of the window bucket containing \p time.
         core_t::TTime startOfWindowBucket(core_t::TTime time) const;
 

--- a/include/maths/CTimeSeriesTestForChange.h
+++ b/include/maths/CTimeSeriesTestForChange.h
@@ -235,7 +235,7 @@ private:
     using TMaxAccumulator =
         CBasicStatistics::COrderStatisticsHeap<double, std::greater<double>>;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
-    using TBucketPredictor = std::function<double(std::size_t)>;
+    using TBucketIndexPredictor = std::function<double(std::size_t)>;
     using TTransform = std::function<double(const TFloatMeanAccumulator&)>;
 
     struct SChangePoint {
@@ -258,8 +258,8 @@ private:
     SChangePoint levelShift(double varianceH0, double truncatedVarianceH0, double parametersH0) const;
     SChangePoint scale(double varianceH0, double truncatedVarianceH0, double parametersH0) const;
     SChangePoint timeShift(double varianceH0, double truncatedVarianceH0, double parametersH0) const;
-    TBucketPredictor bucketPredictor() const;
-    TPredictor bucketTimePredictor() const;
+    TBucketIndexPredictor bucketIndexPredictor() const;
+    TPredictor bucketPredictor() const;
     TMeanVarAccumulator truncatedMoments(double outlierFraction,
                                          const TFloatMeanAccumulatorVec& residuals,
                                          const TTransform& transform = mean) const;
@@ -279,7 +279,7 @@ private:
                   double parametersH1,
                   double n) const;
     double aic(const SChangePoint& change) const;
-    static TFloatMeanAccumulatorVec removePredictions(const TBucketPredictor& predictor,
+    static TFloatMeanAccumulatorVec removePredictions(const TBucketIndexPredictor& predictor,
                                                       TFloatMeanAccumulatorVec values);
     static std::size_t buckets(core_t::TTime bucketLength, core_t::TTime interval);
     static double mean(const TFloatMeanAccumulator& value) {

--- a/include/maths/CTrendComponent.h
+++ b/include/maths/CTrendComponent.h
@@ -108,7 +108,7 @@ public:
     void dontShiftLevel(core_t::TTime time, double value);
 
     //! Apply a linear scale by \p scale.
-    void linearScale(double scale);
+    void linearScale(core_t::TTime time, double scale);
 
     //! Adds a value \f$(t, f(t))\f$ to this component.
     //!

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -141,7 +141,7 @@ void CSeasonalComponent::shiftSlope(core_t::TTime time, double shift) {
 }
 
 void CSeasonalComponent::linearScale(core_t::TTime time, double scale) {
-    m_Bucketing.linearScale(scale);
+    m_Bucketing.linearScale(time, scale);
     this->interpolate(time, false);
 }
 

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -289,10 +289,9 @@ void CTrendComponent::dontShiftLevel(core_t::TTime time, double value) {
     }
 }
 
-void CTrendComponent::linearScale(double scale) {
-    for (auto& model : m_TrendModels) {
-        model.s_Regression.linearScale(scale);
-    }
+void CTrendComponent::linearScale(core_t::TTime time, double scale) {
+    double shift{(scale - 1.0) * CBasicStatistics::mean(this->value(time, 0.0))};
+    this->shiftLevel(shift);
 }
 
 void CTrendComponent::add(core_t::TTime time, double value, double weight) {

--- a/lib/maths/unittest/CExpandingWindowTest.cc
+++ b/lib/maths/unittest/CExpandingWindowTest.cc
@@ -152,11 +152,9 @@ BOOST_AUTO_TEST_CASE(testBasicUsage) {
     LOG_DEBUG(<< "Testing overflow");
 
     window.add(static_cast<core_t::TTime>(size * 3600 + 1), 0.1);
-    BOOST_REQUIRE_EQUAL(static_cast<core_t::TTime>(size * 3600) +
-                            window.dataPointsTimeOffsetInBucket(),
+    BOOST_REQUIRE_EQUAL(static_cast<core_t::TTime>(size * 3600) + window.sampleAverageOffset(),
                         window.beginValuesTime());
-    BOOST_REQUIRE_EQUAL(static_cast<core_t::TTime>(size * 3900) +
-                            window.dataPointsTimeOffsetInBucket(),
+    BOOST_REQUIRE_EQUAL(static_cast<core_t::TTime>(size * 3900) + window.sampleAverageOffset(),
                         window.endValuesTime());
 
     TFloatMeanAccumulatorVec expected(size);

--- a/lib/maths/unittest/CTimeSeriesTestForSeasonalityTest.cc
+++ b/lib/maths/unittest/CTimeSeriesTestForSeasonalityTest.cc
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticNoSeasonality) {
                 }
 
                 maths::CTimeSeriesTestForSeasonality seasonality{
-                    startTime, startTime, bucketLength, values};
+                    startTime, startTime, bucketLength, bucketLength, values};
 
                 auto result = seasonality.decompose();
                 bool isSeasonal{result.seasonal().size() > 0};
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticDiurnal) {
                 }
 
                 maths::CTimeSeriesTestForSeasonality seasonality{
-                    startTime, startTime, bucketLength, values};
+                    startTime, startTime, bucketLength, bucketLength, values};
 
                 auto result = seasonality.decompose();
 
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(testRealSpikeyDaily) {
 
             if (time > lastTest[j] + windows[j]) {
                 maths::CTimeSeriesTestForSeasonality seasonality{
-                    lastTest[j], lastTest[j], HOUR, values[j]};
+                    lastTest[j], lastTest[j], HOUR, HOUR, values[j]};
                 auto result = seasonality.decompose();
                 BOOST_REQUIRE_EQUAL("[86400]", result.print());
                 values[j].assign(windows[j] / HOUR, TFloatMeanAccumulator{});
@@ -286,7 +286,8 @@ BOOST_AUTO_TEST_CASE(testRealTradingDays) {
         values[((time - lastTest) % window) / HOUR].add(value);
 
         if (time > lastTest + window) {
-            maths::CTimeSeriesTestForSeasonality seasonality{lastTest, lastTest, HOUR, values};
+            maths::CTimeSeriesTestForSeasonality seasonality{lastTest, lastTest, HOUR,
+                                                             HALF_HOUR, values};
             auto result = seasonality.decompose();
             LOG_DEBUG(<< result.print());
             BOOST_REQUIRE(result.print() == "[86400/(172800,604800), 604800/(0,172800), 604800/(172800,604800)]" ||
@@ -326,7 +327,8 @@ BOOST_AUTO_TEST_CASE(testRealTradingDaysPlusOutliers) {
         values[((time - lastTest) % window) / HOUR].add(value);
 
         if (time > lastTest + window) {
-            maths::CTimeSeriesTestForSeasonality seasonality{lastTest, lastTest, HOUR, values};
+            maths::CTimeSeriesTestForSeasonality seasonality{lastTest, lastTest, HOUR,
+                                                             FIVE_MINS, values};
             auto result = seasonality.decompose();
             LOG_DEBUG(<< result.print());
             BOOST_REQUIRE(result.print() == "[86400/(0,172800), 86400/(172800,604800), 604800/(0,172800), 604800/(172800,604800)]" ||
@@ -367,7 +369,8 @@ BOOST_AUTO_TEST_CASE(testRealSwitchingNoSeasonality) {
         values[((time - lastTest) % window) / HOUR].add(value);
 
         if (time > lastTest + window) {
-            maths::CTimeSeriesTestForSeasonality seasonality{lastTest, lastTest, HOUR, values};
+            maths::CTimeSeriesTestForSeasonality seasonality{lastTest, lastTest, HOUR,
+                                                             HALF_HOUR, values};
             auto result = seasonality.decompose();
             BOOST_REQUIRE(result.print() == "[]");
             values.assign(window / HOUR, TFloatMeanAccumulator{});
@@ -433,7 +436,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticNonDiurnal) {
                 }
 
                 maths::CTimeSeriesTestForSeasonality seasonality{
-                    startTime, startTime, bucketLength, values};
+                    startTime, startTime, bucketLength, FIVE_MINS, values};
                 auto result = seasonality.decompose();
 
                 double found[]{0.0, 0.0, 0.0, 0.0};
@@ -513,7 +516,8 @@ BOOST_AUTO_TEST_CASE(testSyntheticSparseDaily) {
             }
 
             if (day > 3) {
-                maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HALF_HOUR, values};
+                maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HALF_HOUR,
+                                                                 HALF_HOUR, values};
                 auto result = seasonality.decompose();
                 BOOST_REQUIRE(result.print() == (test == 0 ? "[86400]" : "[]"));
             }
@@ -565,7 +569,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticSparseWeekly) {
             }
 
             if (week >= 3) {
-                maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HOUR, values};
+                maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HOUR, HOUR, values};
                 auto result = seasonality.decompose();
                 LOG_DEBUG(<< result.print());
                 if (test == 0) {
@@ -628,7 +632,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticWithOutliers) {
                 }
 
                 maths::CTimeSeriesTestForSeasonality seasonality{
-                    startTime, startTime, bucketLength, values};
+                    startTime, startTime, bucketLength, bucketLength, values};
                 auto result = seasonality.decompose();
                 LOG_DEBUG(<< result.print());
                 BOOST_REQUIRE(result.print() == "[" + std::to_string(period) + "]");
@@ -670,7 +674,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticWithOutliers) {
             }
 
             maths::CTimeSeriesTestForSeasonality seasonality{
-                startTime, startTime, bucketLength, std::move(values)};
+                startTime, startTime, bucketLength, bucketLength, std::move(values)};
             auto result = seasonality.decompose();
             LOG_DEBUG(<< result.print());
             BOOST_REQUIRE(result.print() == "[86400/(0,172800), 86400/(172800,604800)]");
@@ -743,7 +747,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticMixtureOfSeasonalities) {
                 }
 
                 maths::CTimeSeriesTestForSeasonality seasonality{
-                    startTime, startTime, bucketLength, values};
+                    startTime, startTime, bucketLength, FIVE_MINS, values};
                 auto result = seasonality.decompose();
 
                 std::size_t found[]{0, 0};
@@ -825,8 +829,8 @@ BOOST_AUTO_TEST_CASE(testSyntheticDiurnalWithLinearScaling) {
                 values[bucket].add(trend(startTime + time) + noise[bucket]);
             }
 
-            maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime,
-                                                             HALF_HOUR, values};
+            maths::CTimeSeriesTestForSeasonality seasonality{
+                startTime, startTime, HALF_HOUR, HALF_HOUR, values};
             auto result = seasonality.decompose();
 
             if (result.print() != "[86400]") {
@@ -897,7 +901,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticNonDiurnalWithLinearTrend) {
                 }
 
                 maths::CTimeSeriesTestForSeasonality seasonality{
-                    startTime, startTime, bucketLength, values};
+                    startTime, startTime, bucketLength, FIVE_MINS, values};
                 auto result = seasonality.decompose();
 
                 double found[]{0.0, 0.0, 0.0, 0.0};
@@ -1011,8 +1015,8 @@ BOOST_AUTO_TEST_CASE(testSyntheticDiurnalWithPiecewiseLinearTrend) {
                 values[bucket].add(trend(startTime + time) + noise[bucket]);
             }
 
-            maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime,
-                                                             HALF_HOUR, values};
+            maths::CTimeSeriesTestForSeasonality seasonality{
+                startTime, startTime, HALF_HOUR, HALF_HOUR, values};
             auto result = seasonality.decompose();
 
             if (result.print() != "[86400]") {
@@ -1064,7 +1068,7 @@ BOOST_AUTO_TEST_CASE(testModelledSeasonalityWithNoChange) {
                 values[time / HOUR].add(5.0 * generator(time) + noise[time / FIVE_MINS]);
             }
 
-            maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HOUR, values};
+            maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HOUR, FIVE_MINS, values};
             for (const auto& time : modelledComponents[index[0]]) {
                 seasonality.addModelledSeasonality(time, 24);
             }
@@ -1121,7 +1125,7 @@ BOOST_AUTO_TEST_CASE(testModelledSeasonalityWithChange) {
                 values[time / HOUR].add(10.0 * generator(time) + noise[time / FIVE_MINS]);
             }
 
-            maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HOUR, values};
+            maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HOUR, FIVE_MINS, values};
             for (const auto& time : modelledComponents[index[0]]) {
                 seasonality.addModelledSeasonality(time, 24);
             }
@@ -1180,8 +1184,8 @@ BOOST_AUTO_TEST_CASE(testNewComponentInitialValues) {
             values[time / HALF_HOUR].add(10.0 * generator(startTime + time));
         }
 
-        maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime,
-                                                         HALF_HOUR, values};
+        maths::CTimeSeriesTestForSeasonality seasonality{
+            startTime, startTime, HALF_HOUR, HALF_HOUR, values};
         auto result = seasonality.decompose();
 
         // Expect agreement with generator.
@@ -1258,7 +1262,8 @@ BOOST_AUTO_TEST_CASE(testNewComponentInitialValuesWithPiecewiseLinearScaling) {
                                     0.1 * noise[time / HOUR]);
         }
 
-        maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime, HOUR, values};
+        maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime,
+                                                         HOUR, HOUR, values};
         auto result = seasonality.decompose();
         BOOST_REQUIRE_EQUAL(1, result.seasonal().size());
         const auto& seasonal = result.seasonal()[0].initialValues();
@@ -1301,7 +1306,8 @@ BOOST_AUTO_TEST_CASE(testNewTrendSummary) {
             values[time / HOUR].add(generator(startTime + time));
         }
 
-        maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime, HOUR, values};
+        maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime,
+                                                         HOUR, HOUR, values};
         auto result = seasonality.decompose();
 
         BOOST_REQUIRE(result.trend() != nullptr);
@@ -1401,7 +1407,7 @@ BOOST_AUTO_TEST_CASE(testNewTrendSummaryPiecewiseLinearTrend) {
         }
 
         maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime,
-                                                         2 * HOUR, values};
+                                                         2 * HOUR, 2 * HOUR, values};
         auto result = seasonality.decompose();
 
         // Since we remove step continuities just check agreement on the last
@@ -1443,7 +1449,7 @@ BOOST_AUTO_TEST_CASE(testWithSuppliedPredictor) {
         values[time / HOUR].add(daily(startTime + time) + weekly(startTime + time));
     }
 
-    maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime, HOUR, values};
+    maths::CTimeSeriesTestForSeasonality seasonality{startTime, startTime, HOUR, HOUR, values};
     seasonality.addModelledSeasonality(maths::CDiurnalTime{0, 0, WEEK, DAY}, 24);
     seasonality.modelledSeasonalityPredictor([](core_t::TTime time, const TBoolVec&) {
         return std::sin(boost::math::double_constants::pi *


### PR DESCRIPTION
Some more refinements following on from #1451 and #1580 aimed at fixing a specific QA regression.

This does the following:
1. Rolls out the refinement to the bucket predictor (for already modelled components) from change detection to the test for seasonal components. The previous approach introduced spurious errors for very long bucket lengths (which we use when testing for long, i.e. monthly, yearly, etc, seasonal components). These could cause us to detect spurious seasonality at multiples of the modelled components.
2. Precondition before testing for seasonal components by explicitly removing any modelled seasonality which is too short to test given the window bucket length. The intent is similar to 1 and works around any error in the seasonal model.
3. Don't adjust the gradient when applying scaling events. The window we use to test for change is generally not long enough to reliably estimate changes in gradient and changing it can cause instability and transient anomalies after a change is applied, particularly if the scale factor is large.

Note I've also tried to standardise terminology across different classes where there were discrepancies. The code isn't released so marking as a non-issue.