### PR TITLE
[7.x][ML] Avoid misleading error message

### DIFF
--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -306,8 +306,10 @@ bool CLogger::reconfigureLogToNamedPipe(const std::string& pipeName,
 
     m_PipeFile = CNamedPipeFactory::openPipeFileWrite(pipeName, isCancelled);
     if (m_PipeFile == nullptr) {
-        LOG_ERROR(<< "Cannot log to named pipe " << pipeName
-                  << " as it could not be opened for writing");
+        if (isCancelled.load() == false) {
+            LOG_ERROR(<< "Cannot log to named pipe " << pipeName
+                      << " as it could not be opened for writing");
+        }
         return false;
     }
 


### PR DESCRIPTION
When the logging named pipe is not connected because process
startup gets cancelled, the named pipe classes intentionally
do not log errors, as this would be confusing for people
reading the logs.  However, the logger class was still logging
an error message that implied a problem with the file system
rather than cancellation of startup.

This change stops that error message from being logged, using
the same mechanism that is used in the named pipe classes.

Backport of #1591