### PR TITLE
[ML] Handle edge case where missing values mean we can't test the existing seasonality

### DIFF
--- a/include/maths/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/CTimeSeriesTestForSeasonality.h
@@ -376,6 +376,8 @@ private:
         //! Get a readable description.
         std::string print() const;
 
+        //! Set to true if the hypothesis can tested.
+        bool s_IsTestable = false;
         //! If true then this should be modelled.
         bool s_Model = false;
         //! True if we're going to discard this model.
@@ -444,6 +446,8 @@ private:
 
         //! Does this include seasonality?
         bool seasonal() const { return s_Hypotheses.size() > 0; }
+        //! True if every seasonal component could be tested.
+        bool isTestable() const;
         //! Should this behave as a null hypothesis?
         bool isNull() const;
         //! Should this behave as an alternative hypothesis?


### PR DESCRIPTION
We were running into an issue where [this](https://github.com/elastic/ml-cpp/compare/long-bucket-modelling-improvements...tveasey:untestable-edge-case?expand=1#diff-7b9b36a6bec1003216b0e96287772112bc8515fd2968580f7ceb55a4dfc357c2L986) check means that we can't compute test statistics for one of the components of the seasonality we're already modelling. In this case we choose not to change seasonality.