### PR TITLE
[7.x][ML] Initialise CLimits from JSON config (#1597)

### DIFF
--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -176,12 +176,6 @@ int main(int argc, char** argv) {
     // hence is done before reducing CPU priority.
     ml::core::CProcessPriority::reduceCpuPriority();
 
-    ml::model::CLimits limits{isPersistInForeground};
-    if (!limitConfigFile.empty() && limits.init(limitConfigFile) == false) {
-        LOG_FATAL(<< "ML limit config file '" << limitConfigFile << "' could not be loaded");
-        return EXIT_FAILURE;
-    }
-
     ml::api::CFieldConfig fieldConfig;
 
     if (fieldConfig.initFromCmdLine(fieldConfigFile, clauseTokens) == false) {
@@ -204,6 +198,12 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "Failed to parse anomaly job config: '" << anomalyJobConfigJson << "'");
         return EXIT_FAILURE;
     }
+
+    const ml::api::CAnomalyJobConfig::CAnalysisLimits& analysisLimits =
+        jobConfig.analysisLimits();
+    ml::model::CLimits limits{isPersistInForeground};
+    limits.init(analysisLimits.categorizationExamplesLimit(),
+                analysisLimits.modelMemoryLimitMb());
 
     bool doingCategorization{fieldConfig.fieldNameSuperset().count(
                                  ml::api::CFieldDataCategorizer::MLCATEGORY_NAME) > 0};

--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -203,9 +203,9 @@ public:
 
         //! Size of the memory limit for the resource monitor
         //! as a whole number of MB.
-        std::size_t modelMemoryLimit() const { return m_ModelMemoryLimit; }
+        std::size_t modelMemoryLimitMb() const { return m_ModelMemoryLimitMb; }
 
-        long categorizationExamplesLimit() const {
+        std::size_t categorizationExamplesLimit() const {
             return m_CategorizationExamplesLimit;
         }
 
@@ -213,7 +213,7 @@ public:
 
     private:
         std::size_t m_CategorizationExamplesLimit{model::CLimits::DEFAULT_RESULTS_MAX_EXAMPLES};
-        std::size_t m_ModelMemoryLimit{};
+        std::size_t m_ModelMemoryLimitMb{model::CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB};
     };
 
 public:

--- a/include/model/CLimits.h
+++ b/include/model/CLimits.h
@@ -69,6 +69,11 @@ public:
     //! in the config file will be reset to their default values.
     bool init(const std::string& configFile);
 
+    //! Initialise with given values for the maximum number of
+    //! (categorisation) examples and the model memory limit (in MB).
+    //! All other settings take their default values.
+    void init(std::size_t maxExamples, std::size_t modelMemoryLimitMB);
+
     //! Access to settings
     size_t anomalyMaxTimeBuckets() const;
     size_t maxExamples() const;

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -253,24 +253,24 @@ void CAnomalyJobConfig::CAnalysisLimits::parse(const rapidjson::Value& analysisL
         model::CLimits::DEFAULT_RESULTS_MAX_EXAMPLES);
 
     const std::string memoryLimitStr{parameters[MODEL_MEMORY_LIMIT].as<std::string>()};
-    m_ModelMemoryLimit = CAnomalyJobConfig::CAnalysisLimits::modelMemoryLimitMb(memoryLimitStr);
+    m_ModelMemoryLimitMb = CAnomalyJobConfig::CAnalysisLimits::modelMemoryLimitMb(memoryLimitStr);
 }
 
 std::size_t CAnomalyJobConfig::CAnalysisLimits::modelMemoryLimitMb(const std::string& memoryLimitStr) {
-    std::size_t memoryLimitMb{0};
-
     // We choose to ignore any errors here parsing the model memory limit string
     // as we assume that it has already been validated by ES. In the event that any
     // error _does_ occur an error is logged and a default value used.
-    std::tie(memoryLimitMb, std::ignore) = core::CStringUtils::memorySizeStringToBytes(
+    std::size_t memoryLimitBytes{0};
+    std::tie(memoryLimitBytes, std::ignore) = core::CStringUtils::memorySizeStringToBytes(
         memoryLimitStr, DEFAULT_MEMORY_LIMIT_BYTES);
 
-    memoryLimitMb /= core::constants::BYTES_IN_MEGABYTE;
+    std::size_t memoryLimitMb = memoryLimitBytes / core::constants::BYTES_IN_MEGABYTE;
 
     if (memoryLimitMb == 0) {
         LOG_ERROR(<< "Invalid limit value " << memoryLimitStr << ". Limit must have a minimum value of 1mb."
-                  << " Using default memory limit value " << DEFAULT_MEMORY_LIMIT_BYTES);
-        memoryLimitMb = DEFAULT_MEMORY_LIMIT_BYTES;
+                  << " Using default memory limit value "
+                  << DEFAULT_MEMORY_LIMIT_BYTES / core::constants::BYTES_IN_MEGABYTE);
+        memoryLimitMb = DEFAULT_MEMORY_LIMIT_BYTES / core::constants::BYTES_IN_MEGABYTE;
     }
 
     return memoryLimitMb;

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
 
         // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
-        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimit());
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
 
         using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
         const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
 
         // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
-        BOOST_REQUIRE_EQUAL(5, analysisLimits.modelMemoryLimit());
+        BOOST_REQUIRE_EQUAL(5, analysisLimits.modelMemoryLimitMb());
 
         using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
         const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
         using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
         const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
         BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
-        BOOST_REQUIRE_EQUAL(17, analysisLimits.modelMemoryLimit());
+        BOOST_REQUIRE_EQUAL(17, analysisLimits.modelMemoryLimitMb());
 
         using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
         const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
         using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
         const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
         BOOST_REQUIRE_EQUAL(5, analysisLimits.categorizationExamplesLimit());
-        BOOST_REQUIRE_EQUAL(11, analysisLimits.modelMemoryLimit());
+        BOOST_REQUIRE_EQUAL(11, analysisLimits.modelMemoryLimitMb());
 
         using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
         const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
         using TAnalysisLimits = ml::api::CAnomalyJobConfig::CAnalysisLimits;
         const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
         BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
-        BOOST_REQUIRE_EQUAL(26, analysisLimits.modelMemoryLimit());
+        BOOST_REQUIRE_EQUAL(26, analysisLimits.modelMemoryLimitMb());
 
         using TModelPlotConfig = ml::api::CAnomalyJobConfig::CModelPlotConfig;
         const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();

--- a/lib/model/CLimits.cc
+++ b/lib/model/CLimits.cc
@@ -65,6 +65,13 @@ bool CLimits::init(const std::string& configFile) {
     return true;
 }
 
+void CLimits::init(std::size_t maxExamples, std::size_t modelMemoryLimitMB) {
+    m_MaxExamples = maxExamples;
+    m_MemoryLimitMB = modelMemoryLimitMB;
+
+    m_ResourceMonitor.memoryLimit(m_MemoryLimitMB);
+}
+
 size_t CLimits::anomalyMaxTimeBuckets() const {
     return m_AnomalyMaxTimeBuckets;
 }

--- a/lib/model/unittest/CLimitsTest.cc
+++ b/lib/model/unittest/CLimitsTest.cc
@@ -24,18 +24,38 @@ BOOST_AUTO_TEST_CASE(testTrivial) {
 }
 
 BOOST_AUTO_TEST_CASE(testValid) {
-    ml::model::CLimits config;
-    BOOST_TEST_REQUIRE(config.init("testfiles/mllimits.conf"));
+    {
+        ml::model::CLimits config;
+        BOOST_TEST_REQUIRE(config.init("testfiles/mllimits.conf"));
 
-    // This one isn't present in the config file so should be defaulted
-    BOOST_REQUIRE_EQUAL(ml::model::CLimits::DEFAULT_ANOMALY_MAX_TIME_BUCKETS,
-                        config.anomalyMaxTimeBuckets());
+        // This one isn't present in the config file so should be defaulted
+        BOOST_REQUIRE_EQUAL(ml::model::CLimits::DEFAULT_ANOMALY_MAX_TIME_BUCKETS,
+                            config.anomalyMaxTimeBuckets());
 
-    BOOST_REQUIRE_EQUAL(size_t(8), config.maxExamples());
+        BOOST_REQUIRE_EQUAL(8, config.maxExamples());
 
-    BOOST_REQUIRE_EQUAL(0.005, config.unusualProbabilityThreshold());
+        BOOST_REQUIRE_EQUAL(0.005, config.unusualProbabilityThreshold());
 
-    BOOST_REQUIRE_EQUAL(size_t(4567), config.memoryLimitMB());
+        BOOST_REQUIRE_EQUAL(4567, config.memoryLimitMB());
+    }
+    {
+        ml::model::CLimits config;
+
+        // initialise from given values
+        config.init(2, 4096);
+
+        // This one should always be defaulted when there is no config file
+        BOOST_REQUIRE_EQUAL(ml::model::CLimits::DEFAULT_ANOMALY_MAX_TIME_BUCKETS,
+                            config.anomalyMaxTimeBuckets());
+
+        // This also should be defaulted (as a percentage)
+        BOOST_REQUIRE_EQUAL(ml::model::CLimits::DEFAULT_RESULTS_UNUSUAL_PROBABILITY_THRESHOLD / 100,
+                            config.unusualProbabilityThreshold());
+
+        // These two should be as specified in the constructor.
+        BOOST_REQUIRE_EQUAL(2, config.maxExamples());
+        BOOST_REQUIRE_EQUAL(4096, config.memoryLimitMB());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testInvalid) {


### PR DESCRIPTION
Initialise the max categorisation examples and model memory limit
settings in CLimits with values extracted from the JSON anomaly job
config file.

Backports #1597 
Relates #1253 