### PR TITLE
[ML] Address spurious anomalies after reinitialising time series decomposition

### DIFF
--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1883,10 +1883,14 @@ CTimeSeriesDecompositionDetail::CComponents::makeTestForSeasonality(const TFilte
         values = window.valuesMinusPrediction(std::move(values), [&](core_t::TTime time) {
             return preconditioner(time, testableMask);
         });
-        CTimeSeriesTestForSeasonality test{
-            valuesStartTime,    windowBucketStartTime,
-            windowBucketLength, m_BucketLength,
-            std::move(values),  window.withinBucketVariance()};
+        // Inject noise at 1% of the value to avoid overfitting very stable data.
+        CPRNG::CXorOShiro128Plus rng;
+        for (auto& value : values) {
+            CBasicStatistics::moment<0>(value) *= CSampling::uniformSample(rng, 0.995, 1.005);
+        }
+        CTimeSeriesTestForSeasonality test(
+            valuesStartTime, windowBucketStartTime, windowBucketLength,
+            m_BucketLength, std::move(values), window.withinBucketVariance());
         test.minimumPeriod(minimumPeriod)
             .minimumModelSize(2 * m_SeasonalComponentSize / 3)
             .modelledSeasonalityPredictor(predictor);

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE(testComplexConstantLongTermTrend) {
     test.bucketLength(bucketLength)
         .daysToLearn(63)
         .noiseVariance(4.0)
-        .maximumPercentageOutOfBounds(7.0)
+        .maximumPercentageOutOfBounds(7.5)
         .maximumError(0.02)
         .run(trend);
 }

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -902,7 +902,7 @@ BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.3);
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentileError) < 0.04);
-        BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, maths::CBasicStatistics::mean(meanScale), 0.01);
+        BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, maths::CBasicStatistics::mean(meanScale), 0.02);
     }
     LOG_DEBUG(<< "Long Term Trend");
     {
@@ -1056,7 +1056,7 @@ BOOST_FIXTURE_TEST_CASE(testSpikeyDataProblemCase, CTestFixture) {
         double lb, ub;
         maths_t::ETail tail;
         model.probabilityOfLessLikelySamples(
-            maths_t::E_TwoSided, {decomposition.detrend(time, value, 70.0)},
+            maths_t::E_TwoSided, {decomposition.detrend(time, value, 0.0)},
             {maths_t::seasonalVarianceScaleWeight(std::max(
                 decomposition.varianceScaleWeight(time, variance, 70.0).second, 0.25))},
             lb, ub, tail);
@@ -1064,7 +1064,7 @@ BOOST_FIXTURE_TEST_CASE(testSpikeyDataProblemCase, CTestFixture) {
         pMinScaled = std::min(pMinScaled, pScaled);
 
         model.probabilityOfLessLikelySamples(
-            maths_t::E_TwoSided, {decomposition.detrend(time, value, 70.0)},
+            maths_t::E_TwoSided, {decomposition.detrend(time, value, 0.0)},
             maths_t::CUnitWeights::SINGLE_UNIT, lb, ub, tail);
         double pUnscaled = (lb + ub) / 2.0;
         pMinUnscaled = std::min(pMinUnscaled, pUnscaled);
@@ -1072,7 +1072,7 @@ BOOST_FIXTURE_TEST_CASE(testSpikeyDataProblemCase, CTestFixture) {
 
     LOG_DEBUG(<< "pMinScaled = " << pMinScaled);
     LOG_DEBUG(<< "pMinUnscaled = " << pMinUnscaled);
-    BOOST_TEST_REQUIRE(pMinScaled > 10.0 * pMinUnscaled);
+    BOOST_TEST_REQUIRE(pMinScaled > 1e6 * pMinUnscaled);
 }
 
 BOOST_FIXTURE_TEST_CASE(testVeryLargeValuesProblemCase, CTestFixture) {

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2404,7 +2404,7 @@ BOOST_AUTO_TEST_CASE(testDaylightSaving) {
         BOOST_REQUIRE_EQUAL(hour, model.trendModel().timeShift());
         auto x = model.confidenceInterval(
             time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
-        BOOST_TEST_REQUIRE(std::fabs(sample - x[1][0]) < 3.8 * std::sqrt(noiseVariance));
+        BOOST_TEST_REQUIRE(std::fabs(sample - x[1][0]) < 4.0 * std::sqrt(noiseVariance));
         BOOST_TEST_REQUIRE(std::fabs(x[2][0] - x[0][0]) < 3.5 * std::sqrt(noiseVariance));
         time += bucketLength;
     }
@@ -2426,7 +2426,7 @@ BOOST_AUTO_TEST_CASE(testDaylightSaving) {
         BOOST_REQUIRE_EQUAL(core_t::TTime(0), model.trendModel().timeShift());
         auto x = model.confidenceInterval(
             time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
-        BOOST_TEST_REQUIRE(std::fabs(sample - x[1][0]) < 3.3 * std::sqrt(noiseVariance));
+        BOOST_TEST_REQUIRE(std::fabs(sample - x[1][0]) < 3.5 * std::sqrt(noiseVariance));
         BOOST_TEST_REQUIRE(std::fabs(x[2][0] - x[0][0]) < 3.5 * std::sqrt(noiseVariance));
         time += bucketLength;
     }

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -823,8 +823,8 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
     const TDoubleVec means{20.0, 25.0, 50.0, 100.0};
     const TDoubleVecVec covariances{{20.0, 10.0, 0.0, 0.0},
                                     {10.0, 30.0, 0.0, 0.0},
-                                    {0.0, 0.0, 50.0, -40.0},
-                                    {0.0, 0.0, -40.0, 50.0}};
+                                    {0.0, 0.0, 40.0, -30.0},
+                                    {0.0, 0.0, -30.0, 40.0}};
     const TDoubleVecVec trends{
         {0.0, 0.0, 0.0,  1.0, 1.0, 2.0, 4.0, 10.0, 11.0, 10.0, 8.0, 8.0,
          7.0, 9.0, 12.0, 4.0, 3.0, 1.0, 1.0, 0.0,  0.0,  0.0,  0.0, 0.0},
@@ -2745,7 +2745,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanPredictionError) <
-                           0.8 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                           0.82 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 


### PR DESCRIPTION
QA regressions associated #1451 and #1580 have shown we've increased false positives after changing the seasonal components included in the decomposition. This change injects a small amount of noise into the window values we test for seasonal components. This has two advantages:
1. If the signal if very stable we don't want to model seasonality if it's relative amplitude is too small
2. It avoids underestimating the variance when reinitialising the residual model which is the cause of the false positives
