### PR TITLE
[ML] Addressing a QA regression due to 1451 and 1580

### DIFF
--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -934,7 +934,7 @@ core_t::TTime CTimeSeriesDecompositionDetail::CChangePointTest::windowBucketLeng
 std::size_t CTimeSeriesDecompositionDetail::CChangePointTest::windowSize() const {
     return std::max(static_cast<std::size_t>((4 * core::constants::DAY) /
                                              this->windowBucketLength()),
-                    std::size_t{18});
+                    std::size_t{32});
 }
 
 //////// CSeasonalityTest ////////

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -298,8 +298,9 @@ void CTimeSeriesTestForSeasonality::fitAndRemoveUntestableModelledComponents() {
 
     TSeasonalComponentVec untestable;
     untestable.reserve(m_ModelledPeriods.size());
+    std::size_t minimumPeriod{buckets(m_BucketLength, m_MinimumPeriod)};
     for (const auto& period : m_ModelledPeriods) {
-        if (period.period() > 1 && periodTooShortToTest(m_MinimumPeriod, period)) {
+        if (period.period() > 1 && periodTooShortToTest(minimumPeriod, period)) {
             untestable.push_back(period);
         }
     }


### PR DESCRIPTION
There was a bug in `fitAndRemoveUntestableModelledComponents` which should check the component length against the minimum component length in *window buckets* not time units. For very long bucket lengths we also need more values in the sliding window to test for changes. This is unreleased code so a non-issue.