### PR TITLE
[ML] Avoid overfit when reinitialising the residual model with new seasonal components

### DIFF
--- a/include/maths/CSignal.h
+++ b/include/maths/CSignal.h
@@ -426,6 +426,7 @@ public:
     //! of \p component at granularity \p size. This is done by convolving with
     //! a function of width "component size" / "size" so \p component is not
     //! actually resized.
+    //! \warning \p size should be greater than zero.
     static TMeanAccumulatorVec smoothResample(std::size_t size, TMeanAccumulatorVec component);
 
     //! Restrict to the windows defined by \p period.

--- a/include/maths/CSignal.h
+++ b/include/maths/CSignal.h
@@ -418,6 +418,16 @@ public:
     static std::size_t selectComponentSize(const TFloatMeanAccumulatorVec& values,
                                            std::size_t period);
 
+    //! Apply a smooth resampling of \p component at \p size granularity.
+    //!
+    //! \param[in] size The granularity at which to resample.
+    //! \param[in] component The component to resample.
+    //! \return A resampling of \p component whose values are smoothed averages
+    //! of \p component at granularity \p size. This is done by convolving with
+    //! a function of width "component size" / "size" so \p component is not
+    //! actually resized.
+    static TMeanAccumulatorVec smoothResample(std::size_t size, TMeanAccumulatorVec component);
+
     //! Restrict to the windows defined by \p period.
     //!
     //! \param[in] period Defines the window to restrict to if any.

--- a/include/maths/CTimeSeriesSegmentation.h
+++ b/include/maths/CTimeSeriesSegmentation.h
@@ -29,7 +29,9 @@ public:
     using TTimeVec = std::vector<core_t::TTime>;
     using TFloatMeanAccumulator = CBasicStatistics::SSampleMean<CFloatStorage>::TAccumulator;
     using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;
-    using TFloatMeanAccumulatorVecDoubleVecPr = std::pair<TFloatMeanAccumulatorVec, TDoubleVec>;
+    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
+    using TMeanAccumulatorVecVec = std::vector<TMeanAccumulatorVec>;
     using TSeasonalComponent = CSignal::SSeasonalComponentSummary;
     using TSeasonalComponentVec = std::vector<TSeasonalComponent>;
     using TConstantScale = std::function<double(const TSizeVec&, const TDoubleVec&)>;
@@ -176,7 +178,7 @@ public:
                                                const TSizeVec& segmentation,
                                                const TConstantScale& computeConstantScale,
                                                double outlierFraction,
-                                               TDoubleVecVec& models,
+                                               TMeanAccumulatorVecVec& models,
                                                TDoubleVec& scales);
 
     //! Compute the weighted mean scale for the piecewise linear \p scales on
@@ -234,7 +236,6 @@ public:
 private:
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
-    using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TMeanVarAccumulatorSizePr = std::pair<TMeanVarAccumulator, std::size_t>;
     using TRegression = CLeastSquaresOnlineRegression<1, double>;
@@ -296,7 +297,7 @@ private:
                                                  const TSizeVec& segmentation,
                                                  double outlierFraction,
                                                  TFloatMeanAccumulatorVec& reweighted,
-                                                 TDoubleVecVec& model,
+                                                 TMeanAccumulatorVecVec& model,
                                                  TDoubleVec& scales);
 
     //! Implements top-down recursive segmentation of [\p begin, \p end) to minimise
@@ -341,12 +342,11 @@ private:
 
     //! Fit a seasonal model of period \p period to the values [\p begin, \p end).
     template<typename ITR>
-    static void fitSeasonalModel(ITR begin,
-                                 ITR end,
-                                 const TSeasonalComponent& period,
-                                 const TPredictor& predictor,
-                                 const TScale& scale,
-                                 TDoubleVec& result);
+    static TMeanAccumulatorVec fitSeasonalModel(ITR begin,
+                                                ITR end,
+                                                const TSeasonalComponent& period,
+                                                const TPredictor& predictor,
+                                                const TScale& scale);
 };
 }
 }

--- a/include/maths/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/CTimeSeriesTestForSeasonality.h
@@ -264,6 +264,10 @@ public:
         m_MinimumModelSize = value;
         return *this;
     }
+    CTimeSeriesTestForSeasonality& maximumModelSize(std::size_t value) {
+        m_MaximumModelSize = value;
+        return *this;
+    }
     CTimeSeriesTestForSeasonality& maximumNumberOfComponents(std::ptrdiff_t value) {
         m_MaximumNumberComponents = value;
         return *this;
@@ -272,7 +276,6 @@ public:
 
 private:
     using TDoubleVec = std::vector<double>;
-    using TDoubleVecVec = std::vector<TDoubleVec>;
     using TSizeSizePr = std::pair<std::size_t, std::size_t>;
     using TSizeVec = std::vector<std::size_t>;
     using TOptionalSize = boost::optional<std::size_t>;
@@ -534,7 +537,7 @@ private:
                        const TSeasonalComponentVec& periods,
                        const TSizeVec& scaleSegments,
                        TFloatMeanAccumulatorVec& values,
-                       TDoubleVecVec& components,
+                       TMeanAccumulatorVecVec& components,
                        TDoubleVec& scales) const;
     TVarianceStats residualVarianceStats(const TFloatMeanAccumulatorVec& values) const;
     TMeanVarAccumulator
@@ -595,6 +598,7 @@ private:
     double m_AcceptedFalsePostiveRate = 1e-4;
     std::ptrdiff_t m_MaximumNumberComponents = 10;
     std::size_t m_MinimumModelSize = 24;
+    std::size_t m_MaximumModelSize = std::numeric_limits<std::size_t>::max();
     TOptionalSize m_StartOfWeekOverride;
     TOptionalTime m_StartOfWeekTimeOverride;
     core_t::TTime m_MinimumPeriod = 0;
@@ -623,7 +627,7 @@ private:
     mutable TSizeVec m_ModelTrendSegments;
     mutable TMaxAccumulator m_Outliers;
     mutable TSizeVec m_WindowIndices;
-    mutable TDoubleVecVec m_ScaledComponent;
+    mutable TMeanAccumulatorVecVec m_ScaledComponent;
     mutable TDoubleVec m_ComponentScales;
 };
 }

--- a/lib/maths/CSignal.cc
+++ b/lib/maths/CSignal.cc
@@ -917,6 +917,13 @@ CSignal::smoothResample(std::size_t size, TMeanAccumulatorVec component) {
         return component;
     }
 
+    // Pass size of zero is really an error. We'll handle this as best we can
+    // and log an error.
+    if (size == 0) {
+        LOG_ERROR(<< "Smooth resample passed component size of zero! Using one.");
+        size = 1;
+    }
+
     // Smooth by convolving with a triangle function.
 
     int n{static_cast<int>(component.size())};

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1984,6 +1984,7 @@ CTimeSeriesDecompositionDetail::CComponents::makeTestForSeasonality(const TFilte
             m_BucketLength, std::move(values), window.withinBucketVariance());
         test.minimumPeriod(minimumPeriod)
             .minimumModelSize(2 * m_SeasonalComponentSize / 3)
+            .maximumModelSize(2 * m_SeasonalComponentSize)
             .modelledSeasonalityPredictor(predictor);
         std::ptrdiff_t maximumNumberComponents{MAXIMUM_COMPONENTS};
         for (const auto& component : this->seasonal()) {
@@ -2083,13 +2084,8 @@ void CTimeSeriesDecompositionDetail::CComponents::addSeasonalComponents(const CS
                                      : CSplineTypes::E_Periodic;
         double bucketLength{static_cast<double>(m_BucketLength)};
 
-        std::size_t size{CTools::truncate(component.size(), // desired
-                                          2 * m_SeasonalComponentSize / 3,
-                                          2 * m_SeasonalComponentSize)};
-        LOG_TRACE(<< "size = " << size << ", target = " << component.size());
-
         // Add the new seasonal component.
-        m_Seasonal->add(*time, size, m_DecayRate, bucketLength,
+        m_Seasonal->add(*time, component.size(), m_DecayRate, bucketLength,
                         boundaryCondition, startTime, endTime, initialValues);
         m_ModelAnnotationCallback(component.annotationText());
     }

--- a/lib/maths/unittest/CSignalTest.cc
+++ b/lib/maths/unittest/CSignalTest.cc
@@ -1269,6 +1269,11 @@ BOOST_AUTO_TEST_CASE(testSmoothResample) {
     BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(values),
                         core::CContainerPrinter::print(resampled));
 
+    auto resampled0 = maths::CSignal::smoothResample(0, values);
+    auto resampled1 = maths::CSignal::smoothResample(1, values);
+    BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(resampled1),
+                        core::CContainerPrinter::print(resampled0));
+
     TMeanVarAccumulator averageVariance;
 
     for (std::size_t test = 0; test < 50; ++test) {

--- a/lib/maths/unittest/CSignalTest.cc
+++ b/lib/maths/unittest/CSignalTest.cc
@@ -1247,6 +1247,68 @@ BOOST_AUTO_TEST_CASE(testSelectComponentSize) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testSmoothResample) {
+
+    // Test that smoothing:
+    //   1. Doesn't introduce a bias.
+    //   2. Doesn't change the total count.
+    //   3. Produces the correct residual error variance.
+    //   4. Properly handles missing values.
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec u01;
+    maths::CSignal::TMeanAccumulatorVec values(144);
+    TDoubleVec noise;
+    rng.generateNormalSamples(0.0, 1.0, values.size(), noise);
+    for (core_t::TTime time = 0; time < 86400; time += 600) {
+        values[time / 600].add(10.0 * smoothDaily(time) + noise[time / 600]);
+    }
+
+    auto resampled = maths::CSignal::smoothResample(values.size(), values);
+    BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(values),
+                        core::CContainerPrinter::print(resampled));
+
+    TMeanVarAccumulator averageVariance;
+
+    for (std::size_t test = 0; test < 50; ++test) {
+
+        values.assign(values.size(), maths::CSignal::TFloatMeanAccumulator{});
+        rng.generateUniformSamples(0.0, 1.0, values.size(), u01);
+        double fractionMissing{static_cast<double>(test) / 100.0};
+        for (core_t::TTime time = 0; time < 86400; time += 600) {
+            if (u01[time / 600] > fractionMissing) {
+                values[time / 600].add(10.0 * smoothDaily(time) + noise[time / 600]);
+            }
+        }
+
+        for (std::size_t reduction = 2; reduction <= 6; ++reduction) {
+            resampled = maths::CSignal::smoothResample(values.size() / reduction, values);
+
+            BOOST_REQUIRE_EQUAL(values.size(), resampled.size());
+
+            TMeanVarAccumulator errorMoments;
+            double totalCount{0.0};
+            double totalResampledCount{0.0};
+            for (std::size_t i = 0; i < values.size(); ++i) {
+                errorMoments.add(maths::CBasicStatistics::mean(values[i]) -
+                                 maths::CBasicStatistics::mean(resampled[i]));
+                totalCount += maths::CBasicStatistics::count(values[i]);
+                totalResampledCount += maths::CBasicStatistics::count(resampled[i]);
+            }
+
+            BOOST_REQUIRE_CLOSE(totalCount, totalResampledCount, 0.1 /*%*/);
+            BOOST_REQUIRE(std::fabs(maths::CBasicStatistics::mean(errorMoments)) < 0.05);
+            BOOST_REQUIRE(maths::CBasicStatistics::variance(errorMoments) < 1.2);
+
+            averageVariance.add(maths::CBasicStatistics::variance(errorMoments));
+        }
+    }
+
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(averageVariance) > 0.4);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(averageVariance) < 1.1);
+}
+
 BOOST_AUTO_TEST_CASE(testBucketPredictor) {
 
     TPredictorVec predictors{smoothDaily, spikeyDaily};

--- a/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
+++ b/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
@@ -485,8 +485,6 @@ BOOST_AUTO_TEST_CASE(testMeanScalePiecewiseLinearScaledSeasonal) {
 
     // Test that mean scaling a component produces the expected values.
 
-    using TDoubleVecVec = std::vector<TDoubleVec>;
-
     auto predictor = [](const maths::CSignal::TSeasonalComponentVec& periods,
                         const maths::CSignal::TMeanAccumulatorVecVec& components,
                         std::size_t j) {
@@ -524,7 +522,7 @@ BOOST_AUTO_TEST_CASE(testMeanScalePiecewiseLinearScaledSeasonal) {
     for (const auto& seasonal : {smoothDaily, weekends}) {
 
         TMeanVarAccumulator overallErrorMoments;
-        TDoubleVecVec scaledModels;
+        TSegmentation::TMeanAccumulatorVecVec scaledModels;
         TDoubleVec modelScales;
 
         for (std::size_t test = 0; test < 10; ++test) {


### PR DESCRIPTION
We're running into issues where we estimate the residual distribution after removing seasonality using a larger more accurate model than we eventually choose. This means we can underestimate its variance and generate false transient positives. This change migrates to matching the model predictions to the model size we select so that our residual distribution is correctly initialised. The code isn't released so this is a non-issue.