### PR TITLE
[7.x][ML] Init AD job config with scheduled events (#1607)

### DIFF
--- a/lib/api/CConfigUpdater.cc
+++ b/lib/api/CConfigUpdater.cc
@@ -66,7 +66,8 @@ bool CConfigUpdater::update(const std::string& config) {
                 return false;
             }
         } else if (stanzaName == SCHEDULED_EVENTS) {
-            if (m_FieldConfig.updateScheduledEvents(subTree) == false) {
+            // TODO: Move to JSON format for config updates.
+            if (m_JobConfig.analysisConfig().updateScheduledEvents(subTree) == false) {
                 LOG_ERROR(<< "Failed to update scheduled events");
                 return false;
             }

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -387,7 +387,8 @@ BOOST_AUTO_TEST_CASE(testParse) {
 
         // Expect parsing to succeed if the filter referenced by the custom rule can be found in the filter map.
         ml::api::CDetectionRulesJsonParser::TStrPatternSetUMap filterMap{{"safe_ips", {}}};
-        ml::api::CAnomalyJobConfig jobConfig(filterMap);
+        ml::api::CAnomalyJobConfig::TStrDetectionRulePrVec scheduledEvents{};
+        ml::api::CAnomalyJobConfig jobConfig(filterMap, scheduledEvents);
         BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfigWithCustomRuleFilter),
                               "Cannot parse JSON job config!");
     }

--- a/lib/api/unittest/CConfigUpdaterTest.cc
+++ b/lib/api/unittest/CConfigUpdaterTest.cc
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(testUpdateGivenScheduledEvents) {
 
         BOOST_TEST_REQUIRE(configUpdater.update(configUpdate.str()));
 
-        const auto& events = fieldConfig.scheduledEvents();
+        const auto& events = jobConfig.analysisConfig().scheduledEvents();
         BOOST_REQUIRE_EQUAL(std::size_t(2), events.size());
         BOOST_REQUIRE_EQUAL(std::string("new_event_1"), events[0].first);
         BOOST_REQUIRE_EQUAL(std::string("SKIP_RESULT AND SKIP_MODEL_UPDATE IF TIME >= 3.000000 AND TIME < 4.000000"),
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(testUpdateGivenScheduledEvents) {
 
         BOOST_TEST_REQUIRE(configUpdater.update(configUpdate.str()));
 
-        const auto& events = fieldConfig.scheduledEvents();
+        const auto& events = jobConfig.analysisConfig().scheduledEvents();
         BOOST_TEST_REQUIRE(events.empty());
     }
 }


### PR DESCRIPTION
* Scheduled events configuration exists outside of the job config.
As an interim step pass the scheduled events parsed from
the old-style field config to the new-style JSON parser.

* Ensure that updates to scheduled event rules are correctly handled.

* Tidy the code to create the anomaly detector model config.

Relates to #1253
Backports #1607 