### PR TITLE
[ML] Fix incorrect forecast bounds

### DIFF
--- a/include/api/CForecastRunner.h
+++ b/include/api/CForecastRunner.h
@@ -101,10 +101,6 @@ public:
     //! minimum time between stat updates to prevent to many updates in a short time
     static const std::uint64_t MINIMUM_TIME_ELAPSED_FOR_STATS_UPDATE = 3000ul; // 3s
 
-    //! default bounds percentile
-    //! (not defined inline because we need its address)
-    static const double DEFAULT_BOUNDS_PERCENTILE;
-
 private:
     static const std::string ERROR_FORECAST_REQUEST_FAILED_TO_PARSE;
     static const std::string ERROR_NO_FORECAST_ID;
@@ -210,7 +206,7 @@ private:
         core_t::TTime s_ExpiryTime{0};
 
         //! Forecast bounds
-        double s_BoundsPercentile{DEFAULT_BOUNDS_PERCENTILE};
+        double s_BoundsPercentile{maths::CModel::DEFAULT_FORECAST_CONFIDENCE_INTERVAL};
 
         //! total number of models
         std::size_t s_NumberOfModels{0};

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -305,6 +305,10 @@ public:
     //! Combine the results \p lhs and \p rhs.
     static EUpdateResult combine(EUpdateResult lhs, EUpdateResult rhs);
 
+    //! default confidence interval for forecasting
+    //! (not defined inline because we need its address)
+    static const double DEFAULT_FORECAST_CONFIDENCE_INTERVAL;
+
 public:
     explicit CModel(const CModelParams& params);
     virtual ~CModel() = default;

--- a/lib/api/CForecastRunner.cc
+++ b/lib/api/CForecastRunner.cc
@@ -28,7 +28,6 @@ const std::string EMPTY_STRING;
 
 const std::size_t CForecastRunner::DEFAULT_MAX_FORECAST_MODEL_MEMORY{20971520}; // 20MB
 const std::size_t CForecastRunner::DEFAULT_MIN_FORECAST_AVAILABLE_DISK_SPACE{4294967296ull}; // 4GB
-const double CForecastRunner::DEFAULT_BOUNDS_PERCENTILE{0.95};
 
 const std::string CForecastRunner::ERROR_FORECAST_REQUEST_FAILED_TO_PARSE("Failed to parse forecast request: ");
 const std::string CForecastRunner::ERROR_NO_FORECAST_ID("forecast ID must be specified and non empty");
@@ -401,8 +400,8 @@ bool CForecastRunner::parseAndValidateForecastRequest(const std::string& control
         expiresIn = properties.get<core_t::TTime>("expires_in", -1l);
 
         // note: this is not exposed on the Java side
-        forecastJob.s_BoundsPercentile =
-            properties.get<double>("boundspercentile", DEFAULT_BOUNDS_PERCENTILE);
+        forecastJob.s_BoundsPercentile = properties.get<double>(
+            "boundspercentile", maths::CModel::DEFAULT_FORECAST_CONFIDENCE_INTERVAL);
     } catch (const std::exception& e) {
         LOG_ERROR(<< ERROR_FORECAST_REQUEST_FAILED_TO_PARSE << e.what());
         return false;

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -248,6 +248,8 @@ SModelProbabilityResult::SFeatureProbability::SFeatureProbability(EFeatureProbab
 
 //////// CModel ////////
 
+const double CModel::DEFAULT_FORECAST_CONFIDENCE_INTERVAL{95.0};
+
 CModel::EUpdateResult CModel::combine(EUpdateResult lhs, EUpdateResult rhs) {
     switch (lhs) {
     case E_Success:

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -381,7 +381,8 @@ BOOST_AUTO_TEST_CASE(testNonNegative) {
     std::string m;
     TModelPtr forecastModel(model.cloneForForecast());
     forecastModel->forecast(
-        0, start, start, end, 95.0, MINIMUM_VALUE, MAXIMUM_VALUE,
+        0, start, start, end, maths::CModel::DEFAULT_FORECAST_CONFIDENCE_INTERVAL,
+        MINIMUM_VALUE, MAXIMUM_VALUE,
         std::bind(&mockSink, std::placeholders::_1, std::ref(prediction)), m);
 
     std::size_t outOfBounds{0};


### PR DESCRIPTION
Due to a mistake in #1559 the forecast bounds were
reduced from 95% to 0.95%.

This change reinstates the correct bounds, and also
moves the definition of the constant to the maths
library, where it can be used in a unit test that
will fail if it is ever inadvertently changed again.

Fixes #1606