### PR TITLE
[ML] Fix invalid writes and increase robustness

### DIFF
--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -372,9 +372,6 @@ public:
         //! Sample the prediction residuals.
         void handle(const SDetectedTrend& message) override;
 
-        //! Test to see whether any seasonal components are present.
-        void test(const SAddValue& message);
-
         //! Shift the start of the tests' expanding windows by \p shift at \p time.
         void shiftTime(core_t::TTime time, core_t::TTime shift);
 
@@ -401,6 +398,9 @@ public:
     private:
         //! Handle \p symbol.
         void apply(std::size_t symbol, const SMessage& message);
+
+        //! Test to see whether any seasonal components are present.
+        void test(const SAddValue& message);
 
         //! Check if we should run the periodicity test on \p window.
         bool shouldTest(ETest test, core_t::TTime time) const;
@@ -785,7 +785,10 @@ public:
             void refreshForNewComponents();
 
             //! Remove all components masked by \p removeComponentsMask.
-            void remove(const TBoolVec& removeComponentsMask);
+            bool remove(const TBoolVec& removeComponentsMask);
+
+            //! Remove any components with invalid values
+            bool removeComponentsWithBadValues(core_t::TTime);
 
             //! Remove low value components
             bool prune(core_t::TTime time, core_t::TTime bucketLength);
@@ -801,9 +804,6 @@ public:
 
             //! Get the memory used by this object.
             std::size_t memoryUsage() const;
-
-            //! Remove any components with invalid values
-            bool removeComponentsWithBadValues(core_t::TTime);
 
         private:
             //! The components.

--- a/include/maths/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/CTimeSeriesTestForSeasonality.h
@@ -227,6 +227,9 @@ public:
     //! Fit and remove any seasonality we're modelling and can't test.
     void fitAndRemoveUntestableModelledComponents();
 
+    //! Check invariants which are relied on to hold.
+    bool checkInvariants() const;
+
     //! Run the test and return the new components found if any.
     CSeasonalDecomposition decompose() const;
 

--- a/lib/maths/CExpandingWindow.cc
+++ b/lib/maths/CExpandingWindow.cc
@@ -146,15 +146,16 @@ void CExpandingWindow::initialize(core_t::TTime time) {
 }
 
 void CExpandingWindow::shiftTime(core_t::TTime time, core_t::TTime shift) {
-    std::size_t index((std::max(time, m_StartTime) - m_StartTime) / m_BucketLengths[m_BucketLengthIndex]);
+    std::size_t index((std::max(time, m_StartTime) - m_StartTime) /
+                      m_BucketLengths[m_BucketLengthIndex]);
     if (index < m_BucketValues.size()) {
         if (m_Deflate == false) {
             std::fill(m_BucketValues.begin() + index, m_BucketValues.end(),
-                    TFloatMeanAccumulator{});
+                      TFloatMeanAccumulator{});
         } else {
             CScopeInflate inflate(*this, true);
             std::fill(m_BucketValues.begin() + index, m_BucketValues.end(),
-                    TFloatMeanAccumulator{});
+                      TFloatMeanAccumulator{});
         }
     }
     m_StartTime += shift;

--- a/lib/maths/CExpandingWindow.cc
+++ b/lib/maths/CExpandingWindow.cc
@@ -146,14 +146,16 @@ void CExpandingWindow::initialize(core_t::TTime time) {
 }
 
 void CExpandingWindow::shiftTime(core_t::TTime time, core_t::TTime shift) {
-    std::size_t index((time - m_StartTime) / m_BucketLengths[m_BucketLengthIndex]);
-    if (m_Deflate == false) {
-        std::fill(m_BucketValues.begin() + index, m_BucketValues.end(),
-                  TFloatMeanAccumulator{});
-    } else {
-        CScopeInflate inflate(*this, true);
-        std::fill(m_BucketValues.begin() + index, m_BucketValues.end(),
-                  TFloatMeanAccumulator{});
+    std::size_t index((std::max(time, m_StartTime) - m_StartTime) / m_BucketLengths[m_BucketLengthIndex]);
+    if (index < m_BucketValues.size()) {
+        if (m_Deflate == false) {
+            std::fill(m_BucketValues.begin() + index, m_BucketValues.end(),
+                    TFloatMeanAccumulator{});
+        } else {
+            CScopeInflate inflate(*this, true);
+            std::fill(m_BucketValues.begin() + index, m_BucketValues.end(),
+                    TFloatMeanAccumulator{});
+        }
     }
     m_StartTime += shift;
 }

--- a/lib/maths/CSignal.cc
+++ b/lib/maths/CSignal.cc
@@ -334,7 +334,7 @@ CSignal::seasonalDecomposition(const TFloatMeanAccumulatorVec& values,
         valuesToTest.resize(n + 3 * pad);
         autocorrelations(valuesToTest, placeholder, correlations);
         valuesToTest.resize(n);
-        correlations.resize(3 * pad);
+        correlations.resize(std::max(3 * pad, periods.back()));
 
         // In order to handle with smooth varying functions whose autocorrelation
         // is high for small offsets we perform an average the serial correlations
@@ -538,7 +538,7 @@ CSignal::tradingDayDecomposition(const TFloatMeanAccumulatorVec& values,
     initialize({weekend, week}, components[WEEKDAY_DAILY]);
     LOG_TRACE(<< "components = " << core::CContainerPrinter::print(components));
 
-    TMeanAccumulator variances[4];
+    TMeanAccumulator variances[std::size(components)];
     for (std::size_t i = 0; i < std::size(components); ++i) {
         variances[i] = std::accumulate(
             components[i].begin(), components[i].end(), TMeanAccumulator{},

--- a/lib/maths/CTimeSeriesSegmentation.cc
+++ b/lib/maths/CTimeSeriesSegmentation.cc
@@ -191,7 +191,7 @@ CTimeSeriesSegmentation::constantScalePiecewiseLinearScaledSeasonal(
     }
     LOG_TRACE(<< "weights = " << core::CContainerPrinter::print(weights));
 
-    for (std::size_t i = 0; i < values.size(); ++i) {
+    for (std::size_t i = 0; i < scaledValues.size(); ++i) {
         if (std::any_of(periods.begin(), periods.end(),
                         [&](const auto& period) { return period.contains(i); })) {
             double weight{scaleAt(i, segmentation, weights)};
@@ -248,9 +248,9 @@ CTimeSeriesSegmentation::piecewiseTimeShifted(const TFloatMeanAccumulatorVec& va
         predictions[0][j] = model(bucketLength * static_cast<core_t::TTime>(j));
     }
     for (std::size_t i = 0; i < candidateShifts.size(); ++i) {
-        for (std::size_t j = 0; j < values.size(); ++j) {
-            predictions[i + 1][j] = model(
-                bucketLength * static_cast<core_t::TTime>(j) + candidateShifts[i]);
+        core_t::TTime time{candidateShifts[i]};
+        for (std::size_t j = 0; j < values.size(); ++j, time += bucketLength) {
+            predictions[i + 1][j] = model(time);
         }
     }
 

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -314,8 +314,19 @@ void CTimeSeriesTestForSeasonality::fitAndRemoveUntestableModelledComponents() {
 }
 
 bool CTimeSeriesTestForSeasonality::checkInvariants() const {
-    return m_ModelledPeriods.size() == m_ModelledPeriodsSizes.size() ||
-           m_ModelledPeriodsSizes.size() == m_ModelledPeriodsTestable.size();
+    if (m_ModelledPeriods.size() != m_ModelledPeriodsSizes.size()) {
+        LOG_ERROR(<< "# modelled periods ("
+                  << core::CContainerPrinter::print(m_ModelledPeriods) << ") != # modelled period sizes ("
+                  << core::CContainerPrinter::print(m_ModelledPeriodsSizes) << ")");
+        return false;
+    }
+    if (m_ModelledPeriodsSizes.size() != m_ModelledPeriodsTestable.size()) {
+        LOG_ERROR(<< "# modelled period sizes ("
+                  << core::CContainerPrinter::print(m_ModelledPeriodsSizes) << ") != # modelled period testable ("
+                  << core::CContainerPrinter::print(m_ModelledPeriodsTestable) << ")");
+        return false;
+    }
+    return true;
 }
 
 CSeasonalDecomposition CTimeSeriesTestForSeasonality::decompose() const {

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -1105,7 +1105,7 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
             m_Periods.push_back(hypotheses[i].s_Period);
             periodsHypotheses.push_back(i);
         } else if (hypotheses[i].s_DiscardingModel == false &&
-                   hypotheses[i].s_SimilarModelled < m_ModelledPeriodsTestable.size() && 
+                   hypotheses[i].s_SimilarModelled < m_ModelledPeriodsTestable.size() &&
                    m_ModelledPeriodsTestable[hypotheses[i].s_SimilarModelled]) {
             componentsExcludedMask[hypotheses[i].s_SimilarModelled] = true;
             m_Periods.push_back(hypotheses[i].s_Period);
@@ -1289,7 +1289,8 @@ CTimeSeriesTestForSeasonality::selectModelledHypotheses(bool alreadyModelled,
             for (auto& hypothesis : hypotheses) {
                 std::size_t similar{hypothesis.s_SimilarModelled};
                 if (similar < m_ModelledPeriods.size() && componentsToRemoveMask[similar] &&
-                    m_ModelledPeriods[similar].windowed() && retainingModelForWindow(similar) == false) {
+                    m_ModelledPeriods[similar].windowed() &&
+                    retainingModelForWindow(similar) == false) {
                     componentsToRemoveMask[similar] = false;
                     hypothesis.s_DiscardingModel = false;
                     ++excess;
@@ -1304,7 +1305,8 @@ CTimeSeriesTestForSeasonality::selectModelledHypotheses(bool alreadyModelled,
                 std::size_t similar{hypothesis.s_SimilarModelled};
                 if (similar < m_ModelledPeriodsTestable.size()) {
                     bool remove{componentsToRemoveMask[similar]};
-                    hypothesis.s_Model = m_ModelledPeriodsTestable[similar] && remove == false;
+                    hypothesis.s_Model = m_ModelledPeriodsTestable[similar] &&
+                                         remove == false;
                     componentsToRemoveMask[similar] = remove || hypothesis.s_Model;
                 }
             }

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -313,6 +313,11 @@ void CTimeSeriesTestForSeasonality::fitAndRemoveUntestableModelledComponents() {
     }
 }
 
+bool CTimeSeriesTestForSeasonality::checkInvariants() const {
+    return m_ModelledPeriods.size() == m_ModelledPeriodsSizes.size() ||
+           m_ModelledPeriodsSizes.size() == m_ModelledPeriodsTestable.size();
+}
+
 CSeasonalDecomposition CTimeSeriesTestForSeasonality::decompose() const {
 
     // The quality of anomaly detection is sensitive to bias variance tradeoff.
@@ -358,6 +363,11 @@ CSeasonalDecomposition CTimeSeriesTestForSeasonality::decompose() const {
     // easily be identified as a better choice after the fact. The final selection
     // is based on a number of criterion which are geared towards our modelling
     // techniques and are described in select.
+
+    if (this->checkInvariants() == false) {
+        LOG_ERROR(<< "Failed invariants. Not testing for seasonality.");
+        return {};
+    }
 
     LOG_TRACE(<< "decomposing " << m_Values.size()
               << " values, bucket length = " << m_BucketLength);
@@ -1095,6 +1105,7 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
             m_Periods.push_back(hypotheses[i].s_Period);
             periodsHypotheses.push_back(i);
         } else if (hypotheses[i].s_DiscardingModel == false &&
+                   hypotheses[i].s_SimilarModelled < m_ModelledPeriodsTestable.size() && 
                    m_ModelledPeriodsTestable[hypotheses[i].s_SimilarModelled]) {
             componentsExcludedMask[hypotheses[i].s_SimilarModelled] = true;
             m_Periods.push_back(hypotheses[i].s_Period);
@@ -1122,7 +1133,7 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
         for (auto scale : {scaleSegments.size() > 2, false}) {
 
             m_TemporaryValues = residuals;
-            m_WindowIndices.resize(m_TemporaryValues.size());
+            m_WindowIndices.resize(residuals.size());
             std::iota(m_WindowIndices.begin(), m_WindowIndices.end(), 0);
             this->removePredictions({m_Periods, i + 1, m_Periods.size()},
                                     {m_Components, i + 1, m_Components.size()},
@@ -1149,7 +1160,7 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
 
             hypotheses[j].s_ModelSize =
                 this->selectComponentSize(m_TemporaryValues, period[0]);
-            hypotheses[j].s_InitialValues.resize(values.size());
+            hypotheses[j].s_InitialValues.resize(residuals.size());
             component[0] = CSignal::smoothResample(hypotheses[j].s_ModelSize,
                                                    std::move(component[0]));
 
@@ -1160,15 +1171,16 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
                 }))};
 
             for (std::size_t k = 0; k < m_TemporaryValues.size(); ++k) {
-                if (CBasicStatistics::count(m_TemporaryValues[k]) > 0.0) {
-                    auto& value = CBasicStatistics::moment<0>(m_TemporaryValues[k]);
+                auto& moments = m_TemporaryValues[k];
+                if (CBasicStatistics::count(moments) > 0.0) {
+                    auto& value = CBasicStatistics::moment<0>(moments);
                     double prediction{(scale ? TSegmentation::scaleAt(k, scaleSegments, m_ComponentScales)
                                              : 1.0) *
                                       period[0].value(component[0], k)};
                     value = prediction + (value - prediction) / overlapping;
                     CBasicStatistics::moment<0>(residuals[m_WindowIndices[k]]) -= prediction;
                 }
-                hypotheses[j].s_InitialValues[m_WindowIndices[k]] = m_TemporaryValues[k];
+                hypotheses[j].s_InitialValues[m_WindowIndices[k]] = moments;
             }
             break;
         }
@@ -1258,26 +1270,28 @@ CTimeSeriesTestForSeasonality::selectModelledHypotheses(bool alreadyModelled,
     if (alreadyModelled && std::count(componentsToRemoveMask.begin(),
                                       componentsToRemoveMask.end(), true) > 0) {
 
-        // Ensure we still have one component per window.
-        if (*std::find_if(
-                boost::counting_iterator<std::size_t>(0),
-                boost::counting_iterator<std::size_t>(m_ModelledPeriods.size()), [&](auto i) {
-                    return m_ModelledPeriods[i].windowed() &&
-                           componentsToRemoveMask[i] == false;
-                }) != m_ModelledPeriods.size()) {
-            for (std::size_t i = 0; i < numberModelled; ++i) {
-                if (m_ModelledPeriods[i].windowed() && componentsToRemoveMask[i] &&
-                    // There is no other component for this window.
-                    *std::find_if(boost::counting_iterator<std::size_t>(0),
-                                  boost::counting_iterator<std::size_t>(
-                                      m_ModelledPeriods.size()),
-                                  [&](auto j) {
-                                      return m_ModelledPeriods[j].s_Window ==
-                                                 m_ModelledPeriods[i].s_Window &&
-                                             componentsToRemoveMask[j] == false;
-                                  }) == m_ModelledPeriods.size()) {
-                    componentsToRemoveMask[i] = false;
-                    hypotheses[i].s_DiscardingModel = false;
+        // Are we retaining any already modelled windowed components?
+        if (*std::find_if(boost::counting_iterator<std::size_t>(0),
+                          boost::counting_iterator<std::size_t>(numberModelled), [&](auto i) {
+                              return m_ModelledPeriods[i].windowed() &&
+                                     componentsToRemoveMask[i] == false;
+                          }) != numberModelled) {
+            auto retainingModelForWindow = [&](std::size_t i) {
+                return m_ModelledPeriods[i].windowed() &&
+                       *std::find_if(boost::counting_iterator<std::size_t>(0),
+                                     boost::counting_iterator<std::size_t>(numberModelled),
+                                     [&](auto j) {
+                                         return m_ModelledPeriods[j].s_Window ==
+                                                    m_ModelledPeriods[i].s_Window &&
+                                                componentsToRemoveMask[j] == false;
+                                     }) < numberModelled;
+            };
+            for (auto& hypothesis : hypotheses) {
+                std::size_t similar{hypothesis.s_SimilarModelled};
+                if (similar < m_ModelledPeriods.size() && componentsToRemoveMask[similar] &&
+                    m_ModelledPeriods[similar].windowed() && retainingModelForWindow(similar) == false) {
+                    componentsToRemoveMask[similar] = false;
+                    hypothesis.s_DiscardingModel = false;
                     ++excess;
                 }
             }
@@ -1288,9 +1302,11 @@ CTimeSeriesTestForSeasonality::selectModelledHypotheses(bool alreadyModelled,
                        componentsToRemoveMask.end(), true) > 0) {
             for (auto& hypothesis : hypotheses) {
                 std::size_t similar{hypothesis.s_SimilarModelled};
-                bool remove{componentsToRemoveMask[similar]};
-                hypothesis.s_Model = m_ModelledPeriodsTestable[similar] && remove == false;
-                componentsToRemoveMask[similar] = remove || hypothesis.s_Model;
+                if (similar < m_ModelledPeriodsTestable.size()) {
+                    bool remove{componentsToRemoveMask[similar]};
+                    hypothesis.s_Model = m_ModelledPeriodsTestable[similar] && remove == false;
+                    componentsToRemoveMask[similar] = remove || hypothesis.s_Model;
+                }
             }
         }
         LOG_TRACE(<< "components to remove = "


### PR DESCRIPTION
This primarily fixes two potential edge cases leading to invalid writes:
1. We weren't checking that the time supplied to `shiftTime` for the expanding window was after the start of the window. This led to unsigned integer underflow and bad arguments supplied to `std::fill`. This could very occasionally happen.
2. We were applying the wrongly indexing the seasonal hypothesis vector if some of them weren't testable. This could lead to an invalid write.

As part of tracking down these memory corruptions, I also audited potentially dangerous places in the code. These were safe, but relied on rather delicate invariants or inputs being correct. I've tightened up the logic to ensure that these assumptions are now checked.

This is unreleased code so marking as a non-issue.