### PR TITLE
[ML] Fix hyperparameter scaling

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@
 === Bug Fixes
 
 * Fix potential cause for log errors from CXMeansOnline1d. (See {ml-pull}1586[#1586].)
+* Fix scaling of some hyperparameter for Bayesian optimization. (See {ml-pull}1612[#1612].)
 
 == {es} version 7.10.1
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1235,9 +1235,12 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     // Downsampling acts as a regularisation and also increases the variance
     // of each of the base learners so we scale the other regularisation terms
     // and the weight shrinkage to compensate.
-    double scale{std::min(1.0, 2.0 * m_DownsampleFactor /
-                                   (CTools::stableExp(minBoundary(0)) +
-                                    CTools::stableExp(maxBoundary(0))))};
+    double scale{1.0};
+    if (minBoundary.size() > 0) {
+        scale = std::min(scale, 2.0 * m_DownsampleFactor /
+                                    (CTools::stableExp(minBoundary(0)) +
+                                     CTools::stableExp(maxBoundary(0))));
+    }
 
     // Read parameters for last round.
     int i{0};

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1231,7 +1231,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     TVector minBoundary;
     TVector maxBoundary;
     std::tie(minBoundary, maxBoundary) = bopt.boundingBox();
-    
+
     // Downsampling acts as a regularisation and also increases the variance
     // of each of the base learners so we scale the other regularisation terms
     // and the weight shrinkage to compensate.

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE(testNonLinear) {
     test::CRandomNumbers rng;
     double noiseVariance{100.0};
     std::size_t trainRows{500};
-    std::size_t testRows{100};
+    std::size_t testRows{200};
     std::size_t cols{6};
     std::size_t capacity{500};
 


### PR DESCRIPTION
Since downsampling affects the scaling of some hyperparameter, sometimes the scaled hyperparamters were outside of the defined bounding boxes. This fix restores the boundary constraint. It allows us to better describe the error surface.