### PR TITLE
[ML] Warn and error level log throttling

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@
   unnecessary computation. (See {ml-pull}1537[#1537].)
 * Improvements to time series modeling particularly in relation to adaption to change.
   (See {ml-pull})1614[#1614].)
+* Warn and error log throttling. (See {ml-pull}1615[#1615].)
 
 === Bug Fixes
 

--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -6,6 +6,7 @@
 #ifndef INCLUDED_ml_core_CLogger_h
 #define INCLUDED_ml_core_CLogger_h
 
+#include <core/CLoggerThrottler.h>
 #include <core/CNamedPipeFactory.h>
 #include <core/CNonCopyable.h>
 #include <core/ImportExport.h>
@@ -160,6 +161,9 @@ public:
     //! CLogger is a singleton, so we can not just create new instances
     void reset();
 
+    //! Get the object which performs log throttling.
+    CLoggerThrottler& throttler();
+
 private:
     //! Constructor for a singleton is private.
     CLogger();
@@ -193,6 +197,9 @@ private:
 
     //! The default handler for fatal errors.
     TFatalErrorHandler m_FatalErrorHandler;
+
+    //! The log throttler.
+    CLoggerThrottler m_Throttler;
 };
 
 CORE_EXPORT std::ostream& operator<<(std::ostream& strm, CLogger::ELevel level);

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -7,7 +7,6 @@
 #ifndef INCLUDED_ml_core_CLoggerThrottler_h
 #define INCLUDED_ml_core_CLoggerThrottler_h
 
-#include <core/CoreTypes.h>
 #include <core/ImportExport.h>
 
 #include <boost/unordered_map.hpp>
@@ -43,7 +42,9 @@ public:
     static CLoggerThrottler& instance();
 
     //! Set the minimum interval between repeated log messages.
-    void minimumLogInterval(std::int64_t minimumLogInterval);
+    //!
+    //! \note This expects the interval in milliseconds.
+    void minimumLogIntervalMs(std::int64_t minimumLogIntervalMs);
 
     //! Should we skip logging of \p line in \p file?
     //!
@@ -68,7 +69,7 @@ private:
 
 private:
     static CLoggerThrottler ms_Instance;
-    std::int64_t m_MinimumLogInterval;
+    std::int64_t m_MinimumLogIntervalMs;
     std::mutex m_Mutex;
     TConstCharPtrIntPrInt64SizePrUMap m_LastLogTimesAndCounts;
 };

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -62,9 +62,6 @@ private:
         boost::unordered_map<TConstCharPtrIntPr, TInt64SizePr>;
 
 private:
-    TInt64SizePr& lookup(const TConstCharPtrIntPr& key);
-
-private:
     std::int64_t m_MinimumLogIntervalMs;
     std::mutex m_Mutex;
     TConstCharPtrIntPrInt64SizePrUMap m_LastLogTimesAndCounts;

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -33,7 +33,7 @@ namespace core {
 //! little contention. Furthermore, the overhead of locking and unlocking the mutex
 //! should be neglible compared to the work done if the log line were actually
 //! emitted. So this should actually give a significant performance improvement
-//! if an log line is spamming.
+//! if a log line is spamming.
 class CORE_EXPORT CLoggerThrottler {
 public:
     CLoggerThrottler(const CLoggerThrottler&) = delete;
@@ -46,6 +46,14 @@ public:
     void minimumLogInterval(std::int64_t minimumLogInterval);
 
     //! Should we skip logging of \p line in \p file?
+    //!
+    //! \param[in] file The file containing the log line.
+    //! \param[in] line The log line.
+    //! \return A pair comprising the count of log lines since the log line was
+    //! last output (skip returned false) and whether to output the line or not.
+    //! \note This is expected to be used in conjuction with __FILE__ and __LINE__
+    //! macros although any unique identifiers which are a string literal and an
+    //! integer are permitted.
     std::pair<std::size_t, bool> skip(const char* file, int line);
 
 private:

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -53,11 +53,11 @@ public:
     //! \note This is expected to be used in conjuction with __FILE__ and __LINE__
     //! macros although any unique identifiers which are a string literal and an
     //! integer are permitted.
-    //! \warning We make no attempt to deduplicate errors for which __FILE__
-    //! resolves to a different string literal; this might conceivably happen
-    //! for log lines in a header. This is not expected to be important (it might
-    //! result in slightly more logging) and it is possible to work around this
-    //! by explicitly wrapping the logging, for example:
+    //! \warning We make no attempt to deduplicate logging from the same line for
+    //! which __FILE__ resolves to a different string literal; this might conceivably
+    //! happen for logging in a header. This is not expected to be important (it
+    //! might result in slightly more logging) and it is possible to work around
+    //! this by explicitly wrapping the logging, for example:
     //! \code
     //! if (core::CLogger::instance().throttler().skip("my unique string", 0) == false) {
     //!     LOG_ERROR(<< ...)

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -14,6 +14,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 
 namespace ml {
 namespace core {

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -18,7 +18,7 @@
 namespace ml {
 namespace core {
 
-//! \brief Implements per log line throttling. 
+//! \brief Implements per log line throttling.
 //!
 //! DESCRIPTION:\n
 //! This implements global throttling for a program per line log line. By default
@@ -45,10 +45,11 @@ public:
     void minimumLogInterval(std::int64_t minimumLogInterval);
 
     //! Should we skip logging of \p line in \p file?
-    bool skip(const char* file, int line);
+    std::pair<std::size_t, bool> skip(const char* file, int line);
 
 private:
-    using TCharIntInt64UMap = boost::unordered_map<std::pair<const char*, int>, std::int64_t>; 
+    using TCharIntPrInt64SizePrUMap =
+        boost::unordered_map<std::pair<const char*, int>, std::pair<std::int64_t, std::size_t>>;
 
 private:
     CLoggerThrottler();
@@ -57,9 +58,8 @@ private:
     static CLoggerThrottler ms_Instance;
     std::int64_t m_MinimumLogInterval;
     std::mutex m_Mutex;
-    TCharIntInt64UMap m_LastLogTimes;
+    TCharIntPrInt64SizePrUMap m_LastLogTimesAndCounts;
 };
-
 }
 }
 

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -53,6 +53,16 @@ public:
     //! \note This is expected to be used in conjuction with __FILE__ and __LINE__
     //! macros although any unique identifiers which are a string literal and an
     //! integer are permitted.
+    //! \warning We make no attempt to deduplicate errors for which __FILE__
+    //! resolves to a different string literal; this might conceivably happen
+    //! for log lines in a header. This is not expected to be important (it might
+    //! result in slightly more logging) and it is possible to work around this
+    //! by explicitly wrapping the logging, for example:
+    //! \code
+    //! if (core::CLogger::instance().throttler().skip("my unique string", 0) == false) {
+    //!     LOG_ERROR(<< ...)
+    //! }
+    //! \endcode
     std::pair<std::size_t, bool> skip(const char* file, int line);
 
 private:

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -35,11 +35,9 @@ namespace core {
 //! if a log line is spamming.
 class CORE_EXPORT CLoggerThrottler {
 public:
+    CLoggerThrottler();
     CLoggerThrottler(const CLoggerThrottler&) = delete;
     CLoggerThrottler& operator=(const CLoggerThrottler&) = delete;
-
-    //! Get the unique log throttler.
-    static CLoggerThrottler& instance();
 
     //! Set the minimum interval between repeated log messages.
     //!
@@ -64,11 +62,9 @@ private:
         boost::unordered_map<TConstCharPtrIntPr, TInt64SizePr>;
 
 private:
-    CLoggerThrottler();
     TInt64SizePr& lookup(const TConstCharPtrIntPr& key);
 
 private:
-    static CLoggerThrottler ms_Instance;
     std::int64_t m_MinimumLogIntervalMs;
     std::mutex m_Mutex;
     TConstCharPtrIntPrInt64SizePrUMap m_LastLogTimesAndCounts;

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_core_CLoggerThrottler_h
+#define INCLUDED_ml_core_CLoggerThrottler_h
+
+#include <core/CoreTypes.h>
+#include <core/ImportExport.h>
+
+#include <boost/unordered_map.hpp>
+
+#include <atomic>
+#include <cstdint>
+
+namespace ml {
+namespace core {
+
+//! \brief Implements per log line throttling. 
+//!
+//! DESCRIPTION:\n
+//! This implements global throttling for a program per line log line. By default
+//! the same log line will only be emitted once per hour.
+//!
+//! IMPLEMENTATION:\n
+//! This is thread safe but uses a very simple strategy: all accesses to a single
+//! hash map are sychronised. We assume that log throttling is only applied to
+//! messages which normally occur infrequently; for example, this is only currently
+//! applied to WARN and ERROR level logging (see LogMacros.h). So there will be
+//! little contention. Furthermore, the overhead of locking and unlocking the mutex
+//! should be neglible compared to the work done if the log line were actually
+//! emitted. So this should actually give a significant performance improvement
+//! if an log line is spamming.
+class CORE_EXPORT CLoggerThrottler {
+public:
+    CLoggerThrottler(const CLoggerThrottler&) = delete;
+    CLoggerThrottler& operator=(const CLoggerThrottler&) = delete;
+
+    //! Get the unique log throttler.
+    static CLoggerThrottler& instance();
+
+    //! Set the minimum interval between repeated log messages.
+    void minimumLogInterval(std::int64_t minimumLogInterval);
+
+    //! Should we skip logging of \p line in \p file?
+    bool skip(const char* file, int line);
+
+private:
+    using TCharIntInt64UMap = boost::unordered_map<std::pair<const char*, int>, std::int64_t>; 
+
+private:
+    CLoggerThrottler();
+
+private:
+    static CLoggerThrottler ms_Instance;
+    std::int64_t m_MinimumLogInterval;
+    std::mutex m_Mutex;
+    TCharIntInt64UMap m_LastLogTimes;
+};
+
+}
+}
+
+#endif // INCLUDED_ml_core_CLoggerThrottler_h

--- a/include/core/CLoggerThrottler.h
+++ b/include/core/CLoggerThrottler.h
@@ -57,17 +57,20 @@ public:
     std::pair<std::size_t, bool> skip(const char* file, int line);
 
 private:
-    using TCharIntPrInt64SizePrUMap =
-        boost::unordered_map<std::pair<const char*, int>, std::pair<std::int64_t, std::size_t>>;
+    using TConstCharPtrIntPr = std::pair<const char*, int>;
+    using TInt64SizePr = std::pair<std::int64_t, std::size_t>;
+    using TConstCharPtrIntPrInt64SizePrUMap =
+        boost::unordered_map<TConstCharPtrIntPr, TInt64SizePr>;
 
 private:
     CLoggerThrottler();
+    TInt64SizePr& lookup(const TConstCharPtrIntPr& key);
 
 private:
     static CLoggerThrottler ms_Instance;
     std::int64_t m_MinimumLogInterval;
     std::mutex m_Mutex;
-    TCharIntPrInt64SizePrUMap m_LastLogTimesAndCounts;
+    TConstCharPtrIntPrInt64SizePrUMap m_LastLogTimesAndCounts;
 };
 }
 }

--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -14,7 +14,9 @@
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
 
+#include <cstddef>
 #include <sstream>
+#include <tuple>
 
 // Location info
 #ifdef LOG_LOCATION_INFO
@@ -75,30 +77,42 @@
 #ifdef LOG_WARN
 #undef LOG_WARN
 #endif
-#define LOG_WARN(message)                                                                       \
-    if (ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) == false) {             \
-        BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Warn) \
-        LOG_LOCATION_INFO                                                                       \
-        message;                                                                                \
+#define LOG_WARN(message)                                                      \
+    {                                                                          \
+        std::size_t countOfWarnMessages;                                       \
+        bool skipWarnMessage;                                                  \
+        std::tie(countOfWarnMessages, skipWarnMessage) =                       \
+            ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);   \
+        if (skipWarnMessage == false) {                                        \
+            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),       \
+                                 ml::core::CLogger::E_Warn)                    \
+            LOG_LOCATION_INFO                                                  \
+            message << " [" << countOfWarnMessages << "]";                     \
+        }                                                                      \
     }
 #ifdef LOG_ERROR
 #undef LOG_ERROR
 #endif
-#define LOG_ERROR(message)                                                                       \
-    if (ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) == false) {              \
-        BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Error) \
-        LOG_LOCATION_INFO                                                                        \
-        message;                                                                                 \
+#define LOG_ERROR(message)                                                     \
+    {                                                                          \
+        std::size_t countOfErrorMessages;                                      \
+        bool skipErrorMessage;                                                 \
+        std::tie(countOfErrorMessages, skipErrorMessage) =                     \
+            ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);   \
+        if (skipErrorMessage == false) {                                       \
+            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),       \
+                                 ml::core::CLogger::E_Error)                   \
+            LOG_LOCATION_INFO                                                  \
+            message << " [" << countOfErrorMessages << "]";                    \
+        }                                                                      \
     }
 #ifdef LOG_FATAL
 #undef LOG_FATAL
 #endif
-#define LOG_FATAL(message)                                                                       \
-    if (ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) == false) {              \
-        BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Fatal) \
-        LOG_LOCATION_INFO                                                                        \
-        message;                                                                                 \
-    }
+#define LOG_FATAL(message)                                                                   \
+    BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Fatal) \
+    LOG_LOCATION_INFO                                                                        \
+    message
 #ifdef HANDLE_FATAL
 #undef HANDLE_FATAL
 #endif

--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <sstream>
+#include <string>
 #include <tuple>
 
 // Location info
@@ -75,34 +76,38 @@
 #ifdef LOG_WARN
 #undef LOG_WARN
 #endif
-#define LOG_WARN(message)                                                       \
-    {                                                                           \
-        std::size_t countOfWarnMessages;                                        \
-        bool skipWarnMessage;                                                   \
-        std::tie(countOfWarnMessages, skipWarnMessage) =                        \
-            ml::core::CLogger::instance().throttler().skip(__FILE__, __LINE__); \
-        if (skipWarnMessage == false) {                                         \
-            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
-                                 ml::core::CLogger::E_Warn)                     \
-            LOG_LOCATION_INFO                                                   \
-            message << " | repeated [" << countOfWarnMessages << "]";           \
-        }                                                                       \
+#define LOG_WARN(message)                                                                 \
+    {                                                                                     \
+        std::size_t countOfWarnMessages;                                                  \
+        bool skipWarnMessage;                                                             \
+        std::tie(countOfWarnMessages, skipWarnMessage) =                                  \
+            ml::core::CLogger::instance().throttler().skip(__FILE__, __LINE__);           \
+        if (skipWarnMessage == false) {                                                   \
+            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),                  \
+                                 ml::core::CLogger::E_Warn)                               \
+            LOG_LOCATION_INFO                                                             \
+            message << (countOfWarnMessages > 1                                           \
+                            ? " | repeated [" + std::to_string(countOfWarnMessages) + "]" \
+                            : "");                                                        \
+        }                                                                                 \
     }
 #ifdef LOG_ERROR
 #undef LOG_ERROR
 #endif
-#define LOG_ERROR(message)                                                      \
-    {                                                                           \
-        std::size_t countOfErrorMessages;                                       \
-        bool skipErrorMessage;                                                  \
-        std::tie(countOfErrorMessages, skipErrorMessage) =                      \
-            ml::core::CLogger::instance().throttler().skip(__FILE__, __LINE__); \
-        if (skipErrorMessage == false) {                                        \
-            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
-                                 ml::core::CLogger::E_Error)                    \
-            LOG_LOCATION_INFO                                                   \
-            message << " | repeated [" << countOfErrorMessages << "]";          \
-        }                                                                       \
+#define LOG_ERROR(message)                                                                 \
+    {                                                                                      \
+        std::size_t countOfErrorMessages;                                                  \
+        bool skipErrorMessage;                                                             \
+        std::tie(countOfErrorMessages, skipErrorMessage) =                                 \
+            ml::core::CLogger::instance().throttler().skip(__FILE__, __LINE__);            \
+        if (skipErrorMessage == false) {                                                   \
+            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),                   \
+                                 ml::core::CLogger::E_Error)                               \
+            LOG_LOCATION_INFO                                                              \
+            message << (countOfErrorMessages > 1                                           \
+                            ? " | repeated [" + std::to_string(countOfErrorMessages) + "]" \
+                            : "");                                                         \
+        }                                                                                  \
     }
 #ifdef LOG_FATAL
 #undef LOG_FATAL

--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -7,6 +7,8 @@
 // The lack of include guards is deliberate in this file, to allow per-file
 // redefinition of logging macros
 
+#include <core/CLoggerThrottler.h>
+
 #include <boost/current_function.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/sources/severity_logger.hpp>
@@ -73,25 +75,30 @@
 #ifdef LOG_WARN
 #undef LOG_WARN
 #endif
-#define LOG_WARN(message)                                                                   \
-    BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Warn) \
-    LOG_LOCATION_INFO                                                                       \
-    message
+#define LOG_WARN(message)                                                                       \
+    if (ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) == false) {             \
+        BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Warn) \
+        LOG_LOCATION_INFO                                                                       \
+        message;                                                                                \
+    }
 #ifdef LOG_ERROR
 #undef LOG_ERROR
 #endif
-#define LOG_ERROR(message)                                                                   \
-    BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Error) \
-    LOG_LOCATION_INFO                                                                        \
-    message
+#define LOG_ERROR(message)                                                                       \
+    if (ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) == false) {              \
+        BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Error) \
+        LOG_LOCATION_INFO                                                                        \
+        message;                                                                                 \
+    }
 #ifdef LOG_FATAL
 #undef LOG_FATAL
 #endif
-#define LOG_FATAL(message)                                                                   \
-    BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Fatal) \
-    LOG_LOCATION_INFO                                                                        \
-    message
-
+#define LOG_FATAL(message)                                                                       \
+    if (ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) == false) {              \
+        BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(), ml::core::CLogger::E_Fatal) \
+        LOG_LOCATION_INFO                                                                        \
+        message;                                                                                 \
+    }
 #ifdef HANDLE_FATAL
 #undef HANDLE_FATAL
 #endif

--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -101,7 +101,7 @@
             BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
                                  ml::core::CLogger::E_Error)                    \
             LOG_LOCATION_INFO                                                   \
-            message << " [" << countOfErrorMessages << "]";                     \
+            message << " | repeated [" << countOfErrorMessages << "]";                     \
         }                                                                       \
     }
 #ifdef LOG_FATAL

--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -7,8 +7,6 @@
 // The lack of include guards is deliberate in this file, to allow per-file
 // redefinition of logging macros
 
-#include <core/CLoggerThrottler.h>
-
 #include <boost/current_function.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/sources/severity_logger.hpp>
@@ -77,34 +75,34 @@
 #ifdef LOG_WARN
 #undef LOG_WARN
 #endif
-#define LOG_WARN(message)                                                      \
-    {                                                                          \
-        std::size_t countOfWarnMessages;                                       \
-        bool skipWarnMessage;                                                  \
-        std::tie(countOfWarnMessages, skipWarnMessage) =                       \
-            ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);   \
-        if (skipWarnMessage == false) {                                        \
-            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),       \
-                                 ml::core::CLogger::E_Warn)                    \
-            LOG_LOCATION_INFO                                                  \
-            message << " [" << countOfWarnMessages << "]";                     \
-        }                                                                      \
+#define LOG_WARN(message)                                                       \
+    {                                                                           \
+        std::size_t countOfWarnMessages;                                        \
+        bool skipWarnMessage;                                                   \
+        std::tie(countOfWarnMessages, skipWarnMessage) =                        \
+            ml::core::CLogger::instance().throttler().skip(__FILE__, __LINE__); \
+        if (skipWarnMessage == false) {                                         \
+            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
+                                 ml::core::CLogger::E_Warn)                     \
+            LOG_LOCATION_INFO                                                   \
+            message << " [" << countOfWarnMessages << "]";                      \
+        }                                                                       \
     }
 #ifdef LOG_ERROR
 #undef LOG_ERROR
 #endif
-#define LOG_ERROR(message)                                                     \
-    {                                                                          \
-        std::size_t countOfErrorMessages;                                      \
-        bool skipErrorMessage;                                                 \
-        std::tie(countOfErrorMessages, skipErrorMessage) =                     \
-            ml::core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);   \
-        if (skipErrorMessage == false) {                                       \
-            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),       \
-                                 ml::core::CLogger::E_Error)                   \
-            LOG_LOCATION_INFO                                                  \
-            message << " [" << countOfErrorMessages << "]";                    \
-        }                                                                      \
+#define LOG_ERROR(message)                                                      \
+    {                                                                           \
+        std::size_t countOfErrorMessages;                                       \
+        bool skipErrorMessage;                                                  \
+        std::tie(countOfErrorMessages, skipErrorMessage) =                      \
+            ml::core::CLogger::instance().throttler().skip(__FILE__, __LINE__); \
+        if (skipErrorMessage == false) {                                        \
+            BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
+                                 ml::core::CLogger::E_Error)                    \
+            LOG_LOCATION_INFO                                                   \
+            message << " [" << countOfErrorMessages << "]";                     \
+        }                                                                       \
     }
 #ifdef LOG_FATAL
 #undef LOG_FATAL

--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -85,7 +85,7 @@
             BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
                                  ml::core::CLogger::E_Warn)                     \
             LOG_LOCATION_INFO                                                   \
-            message << " [" << countOfWarnMessages << "]";                      \
+            message << " | repeated [" << countOfWarnMessages << "]";                      \
         }                                                                       \
     }
 #ifdef LOG_ERROR

--- a/include/core/LogMacros.h
+++ b/include/core/LogMacros.h
@@ -85,7 +85,7 @@
             BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
                                  ml::core::CLogger::E_Warn)                     \
             LOG_LOCATION_INFO                                                   \
-            message << " | repeated [" << countOfWarnMessages << "]";                      \
+            message << " | repeated [" << countOfWarnMessages << "]";           \
         }                                                                       \
     }
 #ifdef LOG_ERROR
@@ -101,7 +101,7 @@
             BOOST_LOG_STREAM_SEV(ml::core::CLogger::instance().logger(),        \
                                  ml::core::CLogger::E_Error)                    \
             LOG_LOCATION_INFO                                                   \
-            message << " | repeated [" << countOfErrorMessages << "]";                     \
+            message << " | repeated [" << countOfErrorMessages << "]";          \
         }                                                                       \
     }
 #ifdef LOG_FATAL

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -177,6 +177,10 @@ void CLogger::reset() {
     m_Reconfigured.store(false);
 }
 
+CLoggerThrottler& CLogger::throttler() {
+    return m_Throttler;
+}
+
 CLogger& CLogger::instance() {
     static CLogger instance;
     return instance;

--- a/lib/core/CLoggerThrottler.cc
+++ b/lib/core/CLoggerThrottler.cc
@@ -8,8 +8,8 @@
 
 #include <core/CTimeUtils.h>
 
-#include <limits>
 #include <iostream>
+#include <limits>
 
 namespace ml {
 namespace core {
@@ -22,22 +22,26 @@ void CLoggerThrottler::minimumLogInterval(std::int64_t minimumLogInterval) {
     m_MinimumLogInterval = minimumLogInterval;
 }
 
-bool CLoggerThrottler::skip(const char* file, int line) {
+std::pair<std::size_t, bool> CLoggerThrottler::skip(const char* file, int line) {
 
     auto key = std::make_pair(file, line);
+    auto value = std::make_pair(std::numeric_limits<std::int64_t>::min(), 0);
     auto now = CTimeUtils::nowMs();
 
     std::unique_lock<std::mutex> lock{m_Mutex};
-    auto lastTime = m_LastLogTimes.emplace(key, std::numeric_limits<std::int64_t>::min()).first;
+    auto lastTime = m_LastLogTimesAndCounts.emplace(key, value).first;
+    auto count = lastTime->second.second + 1;
 
-    if (now > lastTime->second + m_MinimumLogInterval) {
-        lastTime->second = now;
-        return false;
+    if (now > lastTime->second.first + m_MinimumLogInterval) {
+        lastTime->second = std::make_pair(now, 0);
+        return std::make_pair(count, false);
     }
-    return true;
+    ++lastTime->second.second;
+    return std::make_pair(count, true);
 }
 
-CLoggerThrottler::CLoggerThrottler() : m_MinimumLogInterval{3600 * 1000} {}
+CLoggerThrottler::CLoggerThrottler() : m_MinimumLogInterval{3600 * 1000} {
+}
 
 CLoggerThrottler CLoggerThrottler::ms_Instance;
 }

--- a/lib/core/CLoggerThrottler.cc
+++ b/lib/core/CLoggerThrottler.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CLoggerThrottler.h>
+
+#include <core/CTimeUtils.h>
+
+#include <limits>
+#include <iostream>
+
+namespace ml {
+namespace core {
+
+CLoggerThrottler& CLoggerThrottler::instance() {
+    return ms_Instance;
+}
+
+void CLoggerThrottler::minimumLogInterval(std::int64_t minimumLogInterval) {
+    m_MinimumLogInterval = minimumLogInterval;
+}
+
+bool CLoggerThrottler::skip(const char* file, int line) {
+
+    auto key = std::make_pair(file, line);
+    auto now = CTimeUtils::nowMs();
+
+    std::unique_lock<std::mutex> lock{m_Mutex};
+    auto lastTime = m_LastLogTimes.emplace(key, std::numeric_limits<std::int64_t>::min()).first;
+
+    if (now > lastTime->second + m_MinimumLogInterval) {
+        lastTime->second = now;
+        return false;
+    }
+    return true;
+}
+
+CLoggerThrottler::CLoggerThrottler() : m_MinimumLogInterval{3600 * 1000} {}
+
+CLoggerThrottler CLoggerThrottler::ms_Instance;
+}
+}

--- a/lib/core/CLoggerThrottler.cc
+++ b/lib/core/CLoggerThrottler.cc
@@ -8,7 +8,6 @@
 
 #include <core/CTimeUtils.h>
 
-#include <iostream>
 #include <limits>
 
 namespace ml {
@@ -18,8 +17,8 @@ CLoggerThrottler& CLoggerThrottler::instance() {
     return ms_Instance;
 }
 
-void CLoggerThrottler::minimumLogInterval(std::int64_t minimumLogInterval) {
-    m_MinimumLogInterval = minimumLogInterval;
+void CLoggerThrottler::minimumLogIntervalMs(std::int64_t minimumLogIntervalMs) {
+    m_MinimumLogIntervalMs = minimumLogIntervalMs;
 }
 
 std::pair<std::size_t, bool> CLoggerThrottler::skip(const char* file, int line) {
@@ -33,7 +32,7 @@ std::pair<std::size_t, bool> CLoggerThrottler::skip(const char* file, int line) 
     auto& value = this->lookup(key);
     std::size_t count{value.second + 1};
 
-    if (now > value.first + m_MinimumLogInterval) {
+    if (now >= value.first + m_MinimumLogIntervalMs) {
         value = std::make_pair(now, 0);
         return std::make_pair(count, false);
     }
@@ -41,7 +40,7 @@ std::pair<std::size_t, bool> CLoggerThrottler::skip(const char* file, int line) 
     return std::make_pair(count, true);
 }
 
-CLoggerThrottler::CLoggerThrottler() : m_MinimumLogInterval{3600 * 1000} {
+CLoggerThrottler::CLoggerThrottler() : m_MinimumLogIntervalMs{3600 * 1000} {
 }
 
 CLoggerThrottler::TInt64SizePr& CLoggerThrottler::lookup(const TConstCharPtrIntPr& key) {

--- a/lib/core/CLoggerThrottler.cc
+++ b/lib/core/CLoggerThrottler.cc
@@ -13,8 +13,7 @@
 namespace ml {
 namespace core {
 
-CLoggerThrottler& CLoggerThrottler::instance() {
-    return ms_Instance;
+CLoggerThrottler::CLoggerThrottler() : m_MinimumLogIntervalMs{3600 * 1000} {
 }
 
 void CLoggerThrottler::minimumLogIntervalMs(std::int64_t minimumLogIntervalMs) {
@@ -40,15 +39,10 @@ std::pair<std::size_t, bool> CLoggerThrottler::skip(const char* file, int line) 
     return std::make_pair(count, true);
 }
 
-CLoggerThrottler::CLoggerThrottler() : m_MinimumLogIntervalMs{3600 * 1000} {
-}
-
 CLoggerThrottler::TInt64SizePr& CLoggerThrottler::lookup(const TConstCharPtrIntPr& key) {
     auto value = std::make_pair(std::numeric_limits<std::int64_t>::min(), 0);
     std::unique_lock<std::mutex> lock{m_Mutex};
     return m_LastLogTimesAndCounts.emplace(key, value).first->second;
 }
-
-CLoggerThrottler CLoggerThrottler::ms_Instance;
 }
 }

--- a/lib/core/Makefile
+++ b/lib/core/Makefile
@@ -87,6 +87,7 @@ CJsonOutputStreamWrapper.cc \
 CJsonStatePersistInserter.cc \
 CJsonStateRestoreTraverser.cc \
 CLogger.cc \
+CLoggerThrottler.cc \
 CLoopProgress.cc \
 CMemory.cc \
 CMemoryUsage.cc \

--- a/lib/core/unittest/CLoggerTest.cc
+++ b/lib/core/unittest/CLoggerTest.cc
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(testNonAsciiJsonLogging, CTestFixture) {
         }
         rapidjson::Document doc;
         doc.Parse<rapidjson::kParseDefaultFlags>(line);
-        BOOST_TEST_REQUIRE(!doc.HasParseError());
+        BOOST_TEST_REQUIRE(doc.HasParseError() == false);
         BOOST_TEST_REQUIRE(doc.HasMember("message"));
         const rapidjson::Value& messageValue = doc["message"];
         std::string messageString(messageValue.GetString(), messageValue.GetStringLength());
@@ -236,11 +236,10 @@ BOOST_FIXTURE_TEST_CASE(testWarnAndErrorThrottling, CTestFixture) {
         }
         rapidjson::Document doc;
         doc.Parse<rapidjson::kParseDefaultFlags>(line);
-        BOOST_TEST_REQUIRE(!doc.HasParseError());
+        BOOST_TEST_REQUIRE(doc.HasParseError() == false);
         BOOST_TEST_REQUIRE(doc.HasMember("message"));
         const rapidjson::Value& messageValue = doc["message"];
         std::string messageString(messageValue.GetString(), messageValue.GetStringLength());
-        std::cout << messageString << std::endl;
 
         // we expect messages to be in order, so we only need to test the current one
         if (messageString.find(messages[foundMessages]) != std::string::npos) {

--- a/lib/core/unittest/CLoggerTest.cc
+++ b/lib/core/unittest/CLoggerTest.cc
@@ -207,7 +207,6 @@ BOOST_FIXTURE_TEST_CASE(testNonAsciiJsonLogging, CTestFixture) {
     logger.reset();
 
     reader.join();
-
     loggedExpectedMessages(loggedData.str(), messages);
 }
 

--- a/lib/core/unittest/CLoggerTest.cc
+++ b/lib/core/unittest/CLoggerTest.cc
@@ -32,6 +32,8 @@ const char* const TEST_PIPE_NAME = "\\\\.\\pipe\\testpipe";
 const char* const TEST_PIPE_NAME = "testfiles/testpipe";
 #endif
 
+using TStrVec = std::vector<std::string>;
+
 class CTestFixture {
 public:
     ~CTestFixture() {
@@ -56,6 +58,33 @@ std::function<void()> makeReader(std::ostringstream& loggedData) {
         }
         BOOST_FAIL("Failed to connect to logging pipe within a reasonable time");
     };
+}
+
+void loggedExpectedMessages(const std::string& logging, const TStrVec& messages) {
+    std::istringstream inputStream{logging};
+    std::string line;
+    std::size_t foundMessages{0};
+
+    // test that we found the messages we put in,
+    while (std::getline(inputStream, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        rapidjson::Document doc;
+        doc.Parse<rapidjson::kParseDefaultFlags>(line);
+        BOOST_TEST_REQUIRE(doc.HasParseError() == false);
+        BOOST_TEST_REQUIRE(doc.HasMember("message"));
+        const rapidjson::Value& messageValue = doc["message"];
+        std::string messageString(messageValue.GetString(), messageValue.GetStringLength());
+
+        // we expect messages to be in order, so we only need to test the current one
+        if (messageString.find(messages[foundMessages]) != std::string::npos) {
+            ++foundMessages;
+        } else if (foundMessages > 0) {
+            BOOST_FAIL(messageString + " did not contain " + messages[foundMessages]);
+        }
+    }
+    BOOST_REQUIRE_EQUAL(messages.size(), foundMessages);
 }
 }
 
@@ -83,14 +112,14 @@ BOOST_FIXTURE_TEST_CASE(testLogging, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testReconfiguration, CTestFixture) {
-    ml::core::CLogger& logger = ml::core::CLogger::instance();
+    ml::core::CLogger& logger{ml::core::CLogger::instance()};
 
     LOG_DEBUG(<< "Starting logger reconfiguration test");
 
     LOG_TRACE(<< "This shouldn't be seen because the hardcoded default log level is DEBUG");
-    BOOST_TEST_REQUIRE(!logger.hasBeenReconfigured());
+    BOOST_TEST_REQUIRE(logger.hasBeenReconfigured() == false);
 
-    BOOST_TEST_REQUIRE(!logger.reconfigureFromFile("nonexistantfile"));
+    BOOST_TEST_REQUIRE(logger.reconfigureFromFile("nonexistantfile") == false);
 
     BOOST_TEST_REQUIRE(logger.reconfigureLogJson());
     LOG_INFO(<< "This should be logged as JSON!");
@@ -104,7 +133,7 @@ BOOST_FIXTURE_TEST_CASE(testReconfiguration, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testSetLevel, CTestFixture) {
-    ml::core::CLogger& logger = ml::core::CLogger::instance();
+    ml::core::CLogger& logger{ml::core::CLogger::instance()};
 
     LOG_DEBUG(<< "Starting logger level test");
 
@@ -159,8 +188,8 @@ BOOST_FIXTURE_TEST_CASE(testSetLevel, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testNonAsciiJsonLogging, CTestFixture) {
-    std::vector<std::string> messages{"Non-iso8859-15: 编码", "Non-ascii: üaöä",
-                                      "Non-iso8859-15: 编码 test", "surrogate pair: 𐐷 test"};
+    TStrVec messages{"Non-iso8859-15: 编码", "Non-ascii: üaöä",
+                     "Non-iso8859-15: 编码 test", "surrogate pair: 𐐷 test"};
 
     std::ostringstream loggedData;
     std::thread reader(makeReader(loggedData));
@@ -178,38 +207,16 @@ BOOST_FIXTURE_TEST_CASE(testNonAsciiJsonLogging, CTestFixture) {
     logger.reset();
 
     reader.join();
-    std::istringstream inputStream(loggedData.str());
-    std::string line;
-    size_t foundMessages = 0;
 
-    // test that we found the messages we put in,
-    while (std::getline(inputStream, line)) {
-        if (line.empty()) {
-            continue;
-        }
-        rapidjson::Document doc;
-        doc.Parse<rapidjson::kParseDefaultFlags>(line);
-        BOOST_TEST_REQUIRE(doc.HasParseError() == false);
-        BOOST_TEST_REQUIRE(doc.HasMember("message"));
-        const rapidjson::Value& messageValue = doc["message"];
-        std::string messageString(messageValue.GetString(), messageValue.GetStringLength());
-
-        // we expect messages to be in order, so we only need to test the current one
-        if (messageString.find(messages[foundMessages]) != std::string::npos) {
-            ++foundMessages;
-        } else if (foundMessages > 0) {
-            BOOST_FAIL(messageString + " did not contain " + messages[foundMessages]);
-        }
-    }
-    BOOST_REQUIRE_EQUAL(messages.size(), foundMessages);
+    loggedExpectedMessages(loggedData.str(), messages);
 }
 
 BOOST_FIXTURE_TEST_CASE(testWarnAndErrorThrottling, CTestFixture) {
 
     std::ostringstream loggedData;
-    std::thread reader(makeReader(loggedData));
+    std::thread reader{makeReader(loggedData)};
 
-    std::string messages[]{"Warn should only be seen once", "Error should only be seen once"};
+    TStrVec messages{"Warn should only be seen once", "Error should only be seen once"};
 
     ml::core::CLogger& logger = ml::core::CLogger::instance();
     // logger might have been reconfigured in previous tests, so reset and reconfigure it
@@ -225,29 +232,7 @@ BOOST_FIXTURE_TEST_CASE(testWarnAndErrorThrottling, CTestFixture) {
     logger.reset();
 
     reader.join();
-    std::istringstream inputStream(loggedData.str());
-    std::string line;
-    size_t foundMessages = 0;
-
-    // test that we found the messages we put in,
-    while (std::getline(inputStream, line)) {
-        if (line.empty()) {
-            continue;
-        }
-        rapidjson::Document doc;
-        doc.Parse<rapidjson::kParseDefaultFlags>(line);
-        BOOST_TEST_REQUIRE(doc.HasParseError() == false);
-        BOOST_TEST_REQUIRE(doc.HasMember("message"));
-        const rapidjson::Value& messageValue = doc["message"];
-        std::string messageString(messageValue.GetString(), messageValue.GetStringLength());
-
-        // we expect messages to be in order, so we only need to test the current one
-        if (messageString.find(messages[foundMessages]) != std::string::npos) {
-            ++foundMessages;
-        } else if (foundMessages > 1) {
-            BOOST_FAIL(messageString + " did not contain " + messages[foundMessages]);
-        }
-    }
+    loggedExpectedMessages(loggedData.str(), messages);
 }
 
 // Disabled because it doesn't assert

--- a/lib/core/unittest/CLoggerThrottlerTest.cc
+++ b/lib/core/unittest/CLoggerThrottlerTest.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(testThreadSafety) {
 
     std::size_t logged1[]{0, 0, 0, 0};
     std::thread t1{[&] {
-        for (std::size_t i = 0; i < 100; ++i) {
+        for (std::size_t i = 0; i < 1000; ++i) {
             logged1[0] += throttler.skip("a", 290).second ? 0 : 1;
             logged1[1] += throttler.skip("a", 382).second ? 0 : 1;
             logged1[2] += throttler.skip("b", 21).second ? 0 : 1;
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(testThreadSafety) {
 
     std::size_t logged2[]{0, 0, 0, 0};
     std::thread t2{[&] {
-        for (std::size_t i = 0; i < 100; ++i) {
+        for (std::size_t i = 0; i < 1000; ++i) {
             logged2[0] += throttler.skip("a", 290).second ? 0 : 1;
             logged2[1] += throttler.skip("a", 382).second ? 0 : 1;
             logged2[2] += throttler.skip("b", 21).second ? 0 : 1;

--- a/lib/core/unittest/CLoggerThrottlerTest.cc
+++ b/lib/core/unittest/CLoggerThrottlerTest.cc
@@ -20,23 +20,25 @@ using namespace ml;
 
 BOOST_AUTO_TEST_CASE(testThreadSafety) {
 
+    core::CLoggerThrottler throttler;
+
     std::size_t logged1[]{0, 0, 0, 0};
     std::thread t1{[&] {
         for (std::size_t i = 0; i < 100; ++i) {
-            logged1[0] += core::CLoggerThrottler::instance().skip("a", 290).second ? 0 : 1;
-            logged1[1] += core::CLoggerThrottler::instance().skip("a", 382).second ? 0 : 1;
-            logged1[2] += core::CLoggerThrottler::instance().skip("b", 21).second ? 0 : 1;
-            logged1[3] += core::CLoggerThrottler::instance().skip("b", 12).second ? 0 : 1;
+            logged1[0] += throttler.skip("a", 290).second ? 0 : 1;
+            logged1[1] += throttler.skip("a", 382).second ? 0 : 1;
+            logged1[2] += throttler.skip("b", 21).second ? 0 : 1;
+            logged1[3] += throttler.skip("b", 12).second ? 0 : 1;
         }
     }};
 
     std::size_t logged2[]{0, 0, 0, 0};
     std::thread t2{[&] {
         for (std::size_t i = 0; i < 100; ++i) {
-            logged2[0] += core::CLoggerThrottler::instance().skip("a", 290).second ? 0 : 1;
-            logged2[1] += core::CLoggerThrottler::instance().skip("a", 382).second ? 0 : 1;
-            logged2[2] += core::CLoggerThrottler::instance().skip("b", 21).second ? 0 : 1;
-            logged2[3] += core::CLoggerThrottler::instance().skip("b", 12).second ? 0 : 1;
+            logged2[0] += throttler.skip("a", 290).second ? 0 : 1;
+            logged2[1] += throttler.skip("a", 382).second ? 0 : 1;
+            logged2[2] += throttler.skip("b", 21).second ? 0 : 1;
+            logged2[3] += throttler.skip("b", 12).second ? 0 : 1;
         }
     }};
 
@@ -50,7 +52,8 @@ BOOST_AUTO_TEST_CASE(testThreadSafety) {
 
 BOOST_AUTO_TEST_CASE(testThrottling) {
 
-    core::CLoggerThrottler::instance().minimumLogIntervalMs(1000); // 1s
+    core::CLoggerThrottler throttler;
+    throttler.minimumLogIntervalMs(1000); // 1s
 
     std::size_t logged[]{0, 0};
     std::size_t counts[]{0, 0};
@@ -61,10 +64,10 @@ BOOST_AUTO_TEST_CASE(testThrottling) {
         // Make sure we wait long enough at the end to see all the messages.
         std::this_thread::sleep_for(i == 99 ? std::chrono::milliseconds{1050}
                                             : std::chrono::milliseconds{50});
-        std::tie(count, skip) = core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);
+        std::tie(count, skip) = throttler.skip(__FILE__, __LINE__);
         logged[0] += skip ? 0 : 1;
         counts[0] += skip ? 0 : count;
-        std::tie(count, skip) = core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);
+        std::tie(count, skip) = throttler.skip(__FILE__, __LINE__);
         logged[1] += skip ? 0 : 1;
         counts[1] += skip ? 0 : count;
     }

--- a/lib/core/unittest/CLoggerThrottlerTest.cc
+++ b/lib/core/unittest/CLoggerThrottlerTest.cc
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(testThreadSafety) {
 
 BOOST_AUTO_TEST_CASE(testThrottling) {
 
-    core::CLoggerThrottler::instance().minimumLogInterval(1000); // 1s
+    core::CLoggerThrottler::instance().minimumLogIntervalMs(1000); // 1s
 
     std::size_t logged[]{0, 0};
     std::size_t counts[]{0, 0};

--- a/lib/core/unittest/CLoggerThrottlerTest.cc
+++ b/lib/core/unittest/CLoggerThrottlerTest.cc
@@ -12,6 +12,7 @@
 
 #include <chrono>
 #include <thread>
+#include <tuple>
 
 BOOST_AUTO_TEST_SUITE(CLoggerThrottlerTest)
 
@@ -22,20 +23,20 @@ BOOST_AUTO_TEST_CASE(testThreadSafety) {
     std::size_t logged1[]{0, 0, 0, 0};
     std::thread t1{[&] {
         for (std::size_t i = 0; i < 100; ++i) {
-            logged1[0] += core::CLoggerThrottler::instance().skip("a", 290) ? 0 : 1;
-            logged1[1] += core::CLoggerThrottler::instance().skip("a", 382) ? 0 : 1;
-            logged1[2] += core::CLoggerThrottler::instance().skip("b", 21) ? 0 : 1;
-            logged1[3] += core::CLoggerThrottler::instance().skip("b", 12) ? 0 : 1;
+            logged1[0] += core::CLoggerThrottler::instance().skip("a", 290).second ? 0 : 1;
+            logged1[1] += core::CLoggerThrottler::instance().skip("a", 382).second ? 0 : 1;
+            logged1[2] += core::CLoggerThrottler::instance().skip("b", 21).second ? 0 : 1;
+            logged1[3] += core::CLoggerThrottler::instance().skip("b", 12).second ? 0 : 1;
         }
     }};
 
     std::size_t logged2[]{0, 0, 0, 0};
     std::thread t2{[&] {
         for (std::size_t i = 0; i < 100; ++i) {
-            logged2[0] += core::CLoggerThrottler::instance().skip("a", 290) ? 0 : 1;
-            logged2[1] += core::CLoggerThrottler::instance().skip("a", 382) ? 0 : 1;
-            logged2[2] += core::CLoggerThrottler::instance().skip("b", 21) ? 0 : 1;
-            logged2[3] += core::CLoggerThrottler::instance().skip("b", 12) ? 0 : 1;
+            logged2[0] += core::CLoggerThrottler::instance().skip("a", 290).second ? 0 : 1;
+            logged2[1] += core::CLoggerThrottler::instance().skip("a", 382).second ? 0 : 1;
+            logged2[2] += core::CLoggerThrottler::instance().skip("b", 21).second ? 0 : 1;
+            logged2[3] += core::CLoggerThrottler::instance().skip("b", 12).second ? 0 : 1;
         }
     }};
 
@@ -52,18 +53,30 @@ BOOST_AUTO_TEST_CASE(testThrottling) {
     core::CLoggerThrottler::instance().minimumLogInterval(1000); // 1s
 
     std::size_t logged[]{0, 0};
+    std::size_t counts[]{0, 0};
+    bool skip;
+    std::size_t count;
 
     for (std::size_t i = 0; i < 100; ++i) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{50});
-        logged[0] += core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) ? 0 : 1;
-        logged[1] += core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) ? 0 : 1;
+        // Make sure we wait long enough at the end to see all the messages.
+        std::this_thread::sleep_for(i == 99 ? std::chrono::milliseconds{1050}
+                                            : std::chrono::milliseconds{50});
+        std::tie(count, skip) = core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);
+        logged[0] += skip ? 0 : 1;
+        counts[0] += skip ? 0 : count;
+        std::tie(count, skip) = core::CLoggerThrottler::instance().skip(__FILE__, __LINE__);
+        logged[1] += skip ? 0 : 1;
+        counts[1] += skip ? 0 : count;
     }
 
-    LOG_DEBUG(<< core::CContainerPrinter::print(logged));
     BOOST_REQUIRE(logged[0] >= 4);
     BOOST_REQUIRE(logged[0] >= 4);
-    BOOST_REQUIRE(logged[1] < 10); // Allow for long stalls running the tests.
+    // Allow for long stalls running the tests.
     BOOST_REQUIRE(logged[1] < 10);
+    BOOST_REQUIRE(logged[1] < 10);
+
+    BOOST_REQUIRE_EQUAL(100, counts[0]);
+    BOOST_REQUIRE_EQUAL(100, counts[1]);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/unittest/CLoggerThrottlerTest.cc
+++ b/lib/core/unittest/CLoggerThrottlerTest.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CContainerPrinter.h>
+#include <core/CLogger.h>
+#include <core/CLoggerThrottler.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <thread>
+
+BOOST_AUTO_TEST_SUITE(CLoggerThrottlerTest)
+
+using namespace ml;
+
+BOOST_AUTO_TEST_CASE(testThreadSafety) {
+
+    std::size_t logged1[]{0, 0, 0, 0};
+    std::thread t1{[&] {
+        for (std::size_t i = 0; i < 100; ++i) {
+            logged1[0] += core::CLoggerThrottler::instance().skip("a", 290) ? 0 : 1;
+            logged1[1] += core::CLoggerThrottler::instance().skip("a", 382) ? 0 : 1;
+            logged1[2] += core::CLoggerThrottler::instance().skip("b", 21) ? 0 : 1;
+            logged1[3] += core::CLoggerThrottler::instance().skip("b", 12) ? 0 : 1;
+        }
+    }};
+
+    std::size_t logged2[]{0, 0, 0, 0};
+    std::thread t2{[&] {
+        for (std::size_t i = 0; i < 100; ++i) {
+            logged2[0] += core::CLoggerThrottler::instance().skip("a", 290) ? 0 : 1;
+            logged2[1] += core::CLoggerThrottler::instance().skip("a", 382) ? 0 : 1;
+            logged2[2] += core::CLoggerThrottler::instance().skip("b", 21) ? 0 : 1;
+            logged2[3] += core::CLoggerThrottler::instance().skip("b", 12) ? 0 : 1;
+        }
+    }};
+
+    t1.join();
+    t2.join();
+
+    for (std::size_t i = 0; i < 4; ++i) {
+        BOOST_REQUIRE_EQUAL(1, logged1[i] + logged2[i]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testThrottling) {
+
+    core::CLoggerThrottler::instance().minimumLogInterval(1000); // 1s
+
+    std::size_t logged[]{0, 0};
+
+    for (std::size_t i = 0; i < 100; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds{50});
+        logged[0] += core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) ? 0 : 1;
+        logged[1] += core::CLoggerThrottler::instance().skip(__FILE__, __LINE__) ? 0 : 1;
+    }
+
+    LOG_DEBUG(<< core::CContainerPrinter::print(logged));
+    BOOST_REQUIRE(logged[0] >= 4);
+    BOOST_REQUIRE(logged[0] >= 4);
+    BOOST_REQUIRE(logged[1] < 10); // Allow for long stalls running the tests.
+    BOOST_REQUIRE(logged[1] < 10);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/unittest/Makefile
+++ b/lib/core/unittest/Makefile
@@ -50,6 +50,7 @@ CJsonOutputStreamWrapperTest.cc \
 CJsonStatePersistInserterTest.cc \
 CJsonStateRestoreTraverserTest.cc \
 CLoggerTest.cc \
+CLoggerThrottlerTest.cc \
 CLoopProgressTest.cc \
 CMemoryUsageJsonWriterTest.cc \
 CMemoryUsageTest.cc \


### PR DESCRIPTION
We have some C++ log message deduplication on the Java side, but it relies on the log messages repeating. If several different lines interleave their logging then all lines are logged. We've had situations where we get a lot of logging generated at ERROR level which can significantly slow down anomaly detection. They also spam the global Elasticsearch logs.

This proposes a simple mechanism to throttle logging at WARN and ERROR level on C++ side per process. In particular, it
1. Always outputs the first WARN or ERROR for a particular log line
2. Thereafter limits to outputting a duplicate line once per hour (wall clock)

This should be enough to allow us to check for presence of errors (useful for QA). Also, nearly always, only the first instance of an error is useful.

Since I only introduce this for WARN and ERROR logging I have not attempted to make the throttling mechanism particularly efficient: there is contention on a global hash map which caches the last log times. In normal operation this should have no overhead and if there is a spamming log line the overhead of writing all those messages should dwarf the cost. Finally, we don't have enough distinct log lines for the memory usage of this map to warrant tracking as part of memory estimation.