### PR TITLE
[ML] Remove computed statistics instrumentation

### DIFF
--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -198,15 +198,6 @@ public:
     //! \return Structure contains hyperparameters.
     SHyperparameters& hyperparameters() override { return m_Hyperparameters; }
 
-    std::size_t& statisticsComputed() override { return m_StatsComputed; }
-    std::size_t& statisticsNotComputed() override { return m_StatsNotComputed; }
-    virtual void rowsSkipped(std::uint32_t numberRows) override {
-        m_RowsAccumulator.add(numberRows);
-    }
-    virtual std::uint32_t rowsSkipped() override {
-        return maths::CBasicStatistics::mean(m_RowsAccumulator);
-    }
-
 protected:
     counter_t::ECounterTypes memoryCounterType() override;
 
@@ -230,10 +221,6 @@ private:
     std::string m_LossType;
     TLossVec m_LossValues;
     SHyperparameters m_Hyperparameters;
-
-    std::size_t m_StatsComputed = 0;
-    std::size_t m_StatsNotComputed = 0;
-    TRowsAccumulator m_RowsAccumulator;
 };
 }
 }

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -16,7 +16,6 @@
 #include <maths/CBoostedTreeHyperparameters.h>
 #include <maths/CBoostedTreeUtils.h>
 #include <maths/CChecksum.h>
-#include <maths/CDataFrameAnalysisInstrumentationInterface.h>
 #include <maths/CLinearAlgebraEigen.h>
 #include <maths/CLinearAlgebraShims.h>
 #include <maths/CMathsFuncs.h>
@@ -62,7 +61,6 @@ public:
     using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage, Eigen::Aligned16>;
     using TMemoryMappedDoubleVector = CMemoryMappedDenseVector<double, Eigen::Aligned16>;
     using TMemoryMappedDoubleMatrix = CMemoryMappedDenseMatrix<double, Eigen::Aligned16>;
-    using TAnalysisInstrumentationPtr = CDataFrameTrainBoostedTreeInstrumentationInterface*;
 
     //! \brief Accumulates aggregate derivatives.
     class MATHS_EXPORT CDerivatives {
@@ -648,8 +646,7 @@ public:
                     const TRegularization& regularization,
                     const TSizeVec& featureBag,
                     const CBoostedTreeNode& split,
-                    CWorkspace& workspace,
-                    TAnalysisInstrumentationPtr instrumentation = nullptr);
+                    CWorkspace& workspace);
 
     //! Order two leaves by decreasing gain in splitting them.
     bool operator<(const CBoostedTreeLeafNodeStatistics& rhs) const;

--- a/include/maths/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/CDataFrameAnalysisInstrumentationInterface.h
@@ -139,11 +139,6 @@ public:
     virtual void lossValues(std::size_t fold, TDoubleVec&& lossValues) = 0;
     //! \return Structure contains hyperparameters.
     virtual SHyperparameters& hyperparameters() = 0;
-
-    virtual std::size_t& statisticsComputed() = 0;
-    virtual std::size_t& statisticsNotComputed() = 0;
-    virtual void rowsSkipped(std::uint32_t numberRows) = 0;
-    virtual std::uint32_t rowsSkipped() = 0;
 };
 
 //! \brief Dummies out all instrumentation for outlier detection.
@@ -174,16 +169,8 @@ public:
     void lossValues(std::size_t /* fold */, TDoubleVec&& /* lossValues */) override {}
     SHyperparameters& hyperparameters() override { return m_Hyperparameters; }
 
-    std::size_t& statisticsComputed() override { return m_StubStatsComputed; }
-    std::size_t& statisticsNotComputed() override {
-        return m_StubStatsComputed;
-    }
-    virtual void rowsSkipped(std::uint32_t /*numberRows*/) override {}
-    virtual std::uint32_t rowsSkipped() override { return 0ul; }
-
 private:
     SHyperparameters m_Hyperparameters;
-    std::size_t m_StubStatsComputed = 0;
 };
 }
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -295,16 +295,6 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
     m_Instrumentation->updateProgress(1.0);
     m_Instrumentation->updateMemoryUsage(
         static_cast<std::int64_t>(this->memoryUsage()) - lastMemoryUsage);
-
-    if (m_Instrumentation != nullptr) {
-        // TODO remove once performance measurements are finished
-        LOG_INFO(<< "Statistics computed: " << m_Instrumentation->statisticsComputed()
-                 << "\tnot computed: " << m_Instrumentation->statisticsNotComputed() << "\t saved: "
-                 << (static_cast<double>(m_Instrumentation->statisticsNotComputed()) /
-                     (m_Instrumentation->statisticsNotComputed() +
-                      m_Instrumentation->statisticsComputed()))
-                 << "\t avg. rows skipped: " << m_Instrumentation->rowsSkipped());
-    }
 }
 
 void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainState) const {
@@ -908,7 +898,7 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         std::tie(leftChild, rightChild) =
             leaf->split(leftChildId, rightChildId, m_NumberThreads,
                         smallestCandidateGain, frame, *m_Encoder, m_Regularization,
-                        featureBag, tree[leaf->id()], workspace, m_Instrumentation);
+                        featureBag, tree[leaf->id()], workspace);
 
         // Need gain to be computed to compare here
         if (leftChild != nullptr && rightChild != nullptr && less(rightChild, leftChild)) {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -895,10 +895,9 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 
         TLeafNodeStatisticsPtr leftChild;
         TLeafNodeStatisticsPtr rightChild;
-        std::tie(leftChild, rightChild) =
-            leaf->split(leftChildId, rightChildId, m_NumberThreads,
-                        smallestCandidateGain, frame, *m_Encoder, m_Regularization,
-                        featureBag, tree[leaf->id()], workspace);
+        std::tie(leftChild, rightChild) = leaf->split(
+            leftChildId, rightChildId, m_NumberThreads, smallestCandidateGain, frame,
+            *m_Encoder, m_Regularization, featureBag, tree[leaf->id()], workspace);
 
         // Need gain to be computed to compare here
         if (leftChild != nullptr && rightChild != nullptr && less(rightChild, leftChild)) {

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -149,13 +149,13 @@ CBoostedTreeLeafNodeStatistics::split(std::size_t leftChildId,
             if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
                 rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
                     rightChildId, std::move(*this), regularization, featureBag, workspace);
-            } 
+            }
         } else {
             if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
                 rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
                     rightChildId, *this, numberThreads, frame, encoder, regularization,
                     featureBag, false /*is left child*/, split, workspace);
-            } 
+            }
         }
         return {std::move(leftChild), std::move(rightChild)};
     }
@@ -173,7 +173,7 @@ CBoostedTreeLeafNodeStatistics::split(std::size_t leftChildId,
             leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
                 leftChildId, *this, numberThreads, frame, encoder, regularization,
                 featureBag, true /*is left child*/, split, workspace);
-        } 
+        }
     }
     return {std::move(leftChild), std::move(rightChild)};
 }


### PR DESCRIPTION
Since we finished benchmarking  #1313, the instrumentation of computed and avoided statistics has become unnecessary. Since this instrumentation is not "for free" I am removing the code from the codebase.
