### PR TITLE
[ML] Switch to using global memory constants

### DIFF
--- a/include/core/Constants.h
+++ b/include/core/Constants.h
@@ -42,19 +42,19 @@ constexpr core_t::TTime WEEK{604800};
 constexpr core_t::TTime YEAR{31536000};
 
 //! The number of bytes in a kilobyte
-const std::size_t BYTES_IN_KILOBYTE{1024ULL};
+constexpr std::size_t BYTES_IN_KILOBYTES{1024ULL};
 
 //! The number of bytes in a megabyte
-const std::size_t BYTES_IN_MEGABYTE{1024ULL * 1024};
+constexpr std::size_t BYTES_IN_MEGABYTES{1024ULL * 1024};
 
 //! The number of bytes in a gigabyte
-const std::size_t BYTES_IN_GIGABYTE{1024ULL * 1024 * 1024};
+constexpr std::size_t BYTES_IN_GIGABYTES{1024ULL * 1024 * 1024};
 
 //! The number of bytes in a terabyte
-const std::size_t BYTES_IN_TERABYTE{1024ULL * 1024 * 1024 * 1024};
+constexpr std::size_t BYTES_IN_TERABYTES{1024ULL * 1024 * 1024 * 1024};
 
 //! The number of bytes in a gigabyte
-const std::size_t BYTES_IN_PETABYTE{1024ULL * 1024 * 1024 * 1024 * 1024};
+constexpr std::size_t BYTES_IN_PETABYTES{1024ULL * 1024 * 1024 * 1024 * 1024};
 
 //! Log of min double.
 const double LOG_MIN_DOUBLE{std::log(std::numeric_limits<double>::min())};
@@ -72,9 +72,9 @@ constexpr double LOG_TWO{0.693147180559945};
 constexpr double LOG_TWO_PI{1.83787706640935};
 
 #ifdef Windows
-const char PATH_SEPARATOR = '\\';
+constexpr char PATH_SEPARATOR{'\\'};
 #else
-const char PATH_SEPARATOR = '/';
+constexpr char PATH_SEPARATOR{'/'};
 #endif
 }
 }

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -9,6 +9,7 @@
 
 #include <core/CDataFrame.h>
 #include <core/CSmallVector.h>
+#include <core/Constants.h>
 
 #include <maths/CBoostedTreeFactory.h>
 #include <maths/CBoostedTreeLoss.h>
@@ -162,8 +163,8 @@ public:
             treeFactory.featureBagFraction(featureBagFraction);
         }
 
-        const std::int64_t memoryLimit{1024 * 1024 * 1024}; // 1gb default value
-        ml::api::CDataFrameTrainBoostedTreeInstrumentation instrumentation("testJob", memoryLimit);
+        ml::api::CDataFrameTrainBoostedTreeInstrumentation instrumentation(
+            "testJob", core::constants::BYTES_IN_GIGABYTES);
         treeFactory.analysisInstrumentation(instrumentation);
 
         auto tree = treeFactory.buildFor(*frame, weights.size());

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -276,13 +276,13 @@ std::size_t CAnomalyJobConfig::CAnalysisLimits::modelMemoryLimitMb(const std::st
     std::tie(memoryLimitBytes, std::ignore) = core::CStringUtils::memorySizeStringToBytes(
         memoryLimitStr, DEFAULT_MEMORY_LIMIT_BYTES);
 
-    std::size_t memoryLimitMb = memoryLimitBytes / core::constants::BYTES_IN_MEGABYTE;
+    std::size_t memoryLimitMb{memoryLimitBytes / core::constants::BYTES_IN_MEGABYTES};
 
     if (memoryLimitMb == 0) {
         LOG_ERROR(<< "Invalid limit value " << memoryLimitStr << ". Limit must have a minimum value of 1mb."
                   << " Using default memory limit value "
-                  << DEFAULT_MEMORY_LIMIT_BYTES / core::constants::BYTES_IN_MEGABYTE);
-        memoryLimitMb = DEFAULT_MEMORY_LIMIT_BYTES / core::constants::BYTES_IN_MEGABYTE;
+                  << DEFAULT_MEMORY_LIMIT_BYTES / core::constants::BYTES_IN_MEGABYTES);
+        memoryLimitMb = DEFAULT_MEMORY_LIMIT_BYTES / core::constants::BYTES_IN_MEGABYTES;
     }
 
     return memoryLimitMb;

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -6,6 +6,7 @@
 #include <api/CDataFrameAnalysisInstrumentation.h>
 
 #include <core/CTimeUtils.h>
+#include <core/Constants.h>
 
 #include <maths/CBoostedTree.h>
 
@@ -33,6 +34,7 @@ using TStrVec = std::vector<std::string>;
 const double MEMORY_LIMIT_INCREMENT{2.0}; // request 100% more memory
 const std::size_t MAXIMUM_FRACTIONAL_PROGRESS{std::size_t{1}
                                               << ((sizeof(std::size_t) - 2) * 8)};
+const std::int64_t BYTES_IN_KB{static_cast<std::int64_t>(core::constants::BYTES_IN_KILOBYTES)};
 
 // clang-format off
 const std::string CLASSIFICATION_STATS_TAG{"classification_stats"};
@@ -73,16 +75,16 @@ const std::string PHASE{"phase"};
 const std::string PROGRESS_PERCENT{"progress_percent"};
 // clang-format on
 
-std::string bytesToString(double value) {
+std::string bytesToString(std::int64_t value) {
     std::ostringstream stream;
     stream << std::fixed;
     stream << std::setprecision(0);
-    value = std::ceil(value / 1024);
-    if (value < 1024) {
+    value = (value + BYTES_IN_KB - 1) / BYTES_IN_KB;
+    if (value < BYTES_IN_KB) {
         stream << value;
         stream << " kb";
     } else {
-        value = std::ceil(value / 1024);
+        value = (value + BYTES_IN_KB - 1) / BYTES_IN_KB;
         stream << value;
         stream << " mb";
     }
@@ -90,8 +92,8 @@ std::string bytesToString(double value) {
     return stream.str();
 }
 
-std::string bytesToString(std::int64_t bytes) {
-    return bytesToString(static_cast<double>(bytes));
+std::string bytesToString(double bytes) {
+    return bytesToString(static_cast<std::int64_t>(bytes));
 }
 }
 

--- a/lib/api/CInferenceModelDefinition.cc
+++ b/lib/api/CInferenceModelDefinition.cc
@@ -8,6 +8,7 @@
 #include <core/CBase64Filter.h>
 #include <core/CPersistUtils.h>
 #include <core/CStringUtils.h>
+#include <core/Constants.h>
 
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
@@ -84,7 +85,7 @@ const std::string JSON_WEIGHTED_SUM_TAG{"weighted_sum"};
 const std::string JSON_WEIGHTS_TAG{"weights"};
 // clang-format on
 
-const std::size_t MAX_DOCUMENT_SIZE(16 * 1024 * 1024); // 16MB
+const std::size_t MAX_DOCUMENT_SIZE(16 * core::constants::BYTES_IN_MEGABYTES);
 
 auto toRapidjsonValue(std::size_t value) {
     return rapidjson::Value{static_cast<std::uint64_t>(value)};
@@ -431,9 +432,10 @@ void CInferenceModelDefinition::addToDocumentCompressed(TRapidJsonWriter& writer
     std::streamsize remained{compressedStream.tellg()};
     compressedStream.seekg(0, compressedStream.beg);
     std::size_t docNum{0};
+    std::string buffer;
     while (remained > 0) {
         std::size_t bytesToProcess{std::min(MAX_DOCUMENT_SIZE, static_cast<size_t>(remained))};
-        std::string buffer;
+        buffer.clear();
         std::copy_n(std::istreambuf_iterator<char>(compressedStream.seekg(processed)),
                     bytesToProcess, std::back_inserter(buffer));
         remained -= bytesToProcess;

--- a/lib/api/CSingleStreamDataAdder.cc
+++ b/lib/api/CSingleStreamDataAdder.cc
@@ -6,20 +6,21 @@
 #include <api/CSingleStreamDataAdder.h>
 
 #include <core/CLogger.h>
+#include <core/Constants.h>
 
 #include <ostream>
 
 namespace ml {
 namespace api {
 
-const size_t CSingleStreamDataAdder::MAX_DOCUMENT_SIZE(16 * 1024 * 1024); // 16MB
+const std::size_t CSingleStreamDataAdder::MAX_DOCUMENT_SIZE(16 * core::constants::BYTES_IN_MEGABYTES);
 
 CSingleStreamDataAdder::CSingleStreamDataAdder(const TOStreamP& stream)
     : m_Stream(stream) {
 }
 
 CSingleStreamDataAdder::TOStreamP CSingleStreamDataAdder::addStreamed(const std::string& id) {
-    if (m_Stream != nullptr && !m_Stream->bad()) {
+    if (m_Stream != nullptr && m_Stream->bad() == false) {
         // Start with metadata, leaving the index for the receiving code to set
         (*m_Stream) << "{\"index\":{\"_id\":\"" << id << "\"}}\n";
     }
@@ -33,7 +34,7 @@ bool CSingleStreamDataAdder::streamComplete(TOStreamP& stream, bool force) {
         return false;
     }
 
-    if (stream != nullptr && !stream->bad()) {
+    if (stream != nullptr && stream->bad() == false) {
         // Each Elasticsearch document must be followed by a newline
         stream->put('\n');
 
@@ -46,7 +47,7 @@ bool CSingleStreamDataAdder::streamComplete(TOStreamP& stream, bool force) {
         }
     }
 
-    return stream != nullptr && !stream->bad();
+    return stream != nullptr && stream->bad() == false;
 }
 
 std::size_t CSingleStreamDataAdder::maxDocumentSize() const {

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -418,13 +418,15 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             LOG_DEBUG(<< "# partition = " << used.s_PartitionFields);
             LOG_DEBUG(<< "Memory status = " << used.s_MemoryStatus);
             LOG_DEBUG(<< "Memory usage bytes = " << used.s_Usage);
-            LOG_DEBUG(<< "Memory limit bytes = " << memoryLimit * 1024 * 1024);
+            LOG_DEBUG(<< "Memory limit bytes = "
+                      << memoryLimit * core::constants::BYTES_IN_MEGABYTES);
             BOOST_TEST_REQUIRE(used.s_ByFields > testParam.s_ExpectedByFields);
             BOOST_TEST_REQUIRE(used.s_ByFields < 800);
             BOOST_REQUIRE_EQUAL(std::size_t(2), used.s_PartitionFields);
             BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                memoryLimit * 1024 * 1024 / 2, used.s_Usage,
-                memoryLimit * 1024 * 1024 / testParam.s_ExpectedByMemoryUsageRelativeErrorDivisor);
+                memoryLimit * core::constants::BYTES_IN_MEGABYTES / 2, used.s_Usage,
+                memoryLimit * core::constants::BYTES_IN_MEGABYTES /
+                    testParam.s_ExpectedByMemoryUsageRelativeErrorDivisor);
         }
 
         LOG_DEBUG(<< "**** Test partition with bucketLength = " << testParam.s_BucketLength
@@ -477,8 +479,9 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             BOOST_TEST_REQUIRE(static_cast<double>(used.s_ByFields) >
                                0.96 * static_cast<double>(used.s_PartitionFields));
             BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                memoryLimit * 1024 * 1024 / 2, used.s_Usage,
-                memoryLimit * 1024 * 1024 / testParam.s_ExpectedPartitionUsageRelativeErrorDivisor);
+                memoryLimit * core::constants::BYTES_IN_MEGABYTES / 2, used.s_Usage,
+                memoryLimit * core::constants::BYTES_IN_MEGABYTES /
+                    testParam.s_ExpectedPartitionUsageRelativeErrorDivisor);
         }
 
         LOG_DEBUG(<< "**** Test over with bucketLength = " << testParam.s_BucketLength
@@ -527,8 +530,9 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             BOOST_TEST_REQUIRE(used.s_OverFields > testParam.s_ExpectedOverFields);
             BOOST_TEST_REQUIRE(used.s_OverFields < 7000);
             BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                memoryLimit * 1024 * 1024 / 2, used.s_Usage,
-                memoryLimit * 1024 * 1024 / testParam.s_ExpectedOverUsageRelativeErrorDivisor);
+                memoryLimit * core::constants::BYTES_IN_MEGABYTES / 2, used.s_Usage,
+                memoryLimit * core::constants::BYTES_IN_MEGABYTES /
+                    testParam.s_ExpectedOverUsageRelativeErrorDivisor);
         }
     }
 }

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -101,16 +101,15 @@ void addOutlierTestData(TStrVec fieldNames,
 
 BOOST_AUTO_TEST_CASE(testMemoryState) {
     std::string jobId{"testJob"};
-    std::int64_t memoryLimit{1024 * 1024 * 1024}; //1gb default value
+    std::size_t memoryLimit{core::constants::BYTES_IN_GIGABYTES};
     std::int64_t memoryUsage{500000};
     std::int64_t timeBefore{std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count()};
     std::stringstream outputStream;
     {
-        core::CJsonOutputStreamWrapper streamWrapper(outputStream);
-        api::CDataFrameTrainBoostedTreeInstrumentation instrumentation{
-            jobId, static_cast<std::size_t>(memoryLimit)};
+        core::CJsonOutputStreamWrapper streamWrapper{outputStream};
+        api::CDataFrameTrainBoostedTreeInstrumentation instrumentation{jobId, memoryLimit};
         api::CDataFrameTrainBoostedTreeInstrumentation::CScopeSetOutputStream setStream{
             instrumentation, streamWrapper};
         instrumentation.updateMemoryUsage(memoryUsage);

--- a/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisRunnerTest.cc
@@ -181,7 +181,7 @@ void testEstimateMemoryUsage(std::int64_t numberRows,
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor0Rows) {
-    testEstimateMemoryUsage(0, "0", "0", 1);
+    testEstimateMemoryUsage(0, "0mb", "0mb", 1);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsageFor1Row) {

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -14,6 +14,7 @@
 #include <core/CPackedBitVector.h>
 #include <core/CStringUtils.h>
 #include <core/Concurrency.h>
+#include <core/Constants.h>
 
 #include <algorithm>
 #include <future>
@@ -716,7 +717,8 @@ CDataFrame::CDataFrameRowSliceWriter::finishWritingRows() {
 }
 
 std::size_t dataFrameDefaultSliceCapacity(std::size_t numberColumns) {
-    std::size_t oneMbChunkSize{1024 * 1024 / sizeof(CFloatStorage) / numberColumns};
+    std::size_t oneMbChunkSize{constants::BYTES_IN_MEGABYTES /
+                               sizeof(CFloatStorage) / numberColumns};
     return std::max(oneMbChunkSize, std::size_t{128});
 }
 

--- a/lib/core/CStringUtils.cc
+++ b/lib/core/CStringUtils.cc
@@ -501,15 +501,15 @@ CStringUtils::memorySizeStringToBytes(const std::string& memorySizeStr, std::siz
     if (multiplierStr[0] == BYTES) {
         // no-op
     } else if (multiplierStr[0] == KILOBYTES) {
-        size *= constants::BYTES_IN_KILOBYTE;
+        size *= constants::BYTES_IN_KILOBYTES;
     } else if (multiplierStr[0] == MEGABYTES) {
-        size *= constants::BYTES_IN_MEGABYTE;
+        size *= constants::BYTES_IN_MEGABYTES;
     } else if (multiplierStr[0] == GIGABYTES) {
-        size *= constants::BYTES_IN_GIGABYTE;
+        size *= constants::BYTES_IN_GIGABYTES;
     } else if (multiplierStr[0] == TERABYTES) {
-        size *= constants::BYTES_IN_TERABYTE;
+        size *= constants::BYTES_IN_TERABYTES;
     } else if (multiplierStr[0] == PETABYTES) {
-        size *= constants::BYTES_IN_PETABYTE;
+        size *= constants::BYTES_IN_PETABYTES;
     }
 
     return {size, true};

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -13,6 +13,7 @@
 #include <core/CPersistUtils.h>
 #include <core/CProgramCounters.h>
 #include <core/CStopWatch.h>
+#include <core/Constants.h>
 
 #include <maths/CBasicStatisticsPersist.h>
 #include <maths/CBayesianOptimisation.h>
@@ -51,7 +52,7 @@ namespace {
 const double MINIMUM_SPLIT_REFRESH_INTERVAL{3.0};
 const std::string HYPERPARAMETER_OPTIMIZATION_ROUND{"hyperparameter_optimization_round_"};
 const std::string TRAIN_FINAL_FOREST{"train_final_forest"};
-const int BYTES_IN_MB{1024 * 1024};
+const double BYTES_IN_MB{static_cast<double>(core::constants::BYTES_IN_MEGABYTES)};
 
 //! \brief Record the memory used by a supplied object using the RAII idiom.
 class CScopeRecordMemoryUsage {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -59,7 +59,7 @@ using TLossFunctionUPtr = maths::CBoostedTreeFactory::TLossFunctionUPtr;
 namespace {
 
 const double LARGE_POSITIVE_CONSTANT{300.0};
-const int BYTES_IN_MB{1024 * 1024};
+const double BYTES_IN_MB{static_cast<double>(core::constants::BYTES_IN_MEGABYTES)};
 
 class CTestInstrumentation : public maths::CDataFrameTrainBoostedTreeInstrumentationStub {
 public:

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -90,8 +90,8 @@ void CResourceMonitor::updateMemoryLimitsAndPruneThreshold(std::size_t limitMBs)
         // more models?", and it causes problems if these calculations overflow.
         m_ByteLimitHigh = std::numeric_limits<std::size_t>::max() / 2 + 1;
     } else {
-        m_ByteLimitHigh = static_cast<std::size_t>(
-            (limitMBs * 1024 * 1024) / this->persistenceMemoryIncreaseFactor());
+        m_ByteLimitHigh = (limitMBs * core::constants::BYTES_IN_MEGABYTES) /
+                          this->persistenceMemoryIncreaseFactor();
     }
     m_ByteLimitLow = (m_ByteLimitHigh * 49) / 50;
     m_PruneThreshold = (m_ByteLimitHigh * 3) / 5;

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -5,6 +5,7 @@
  */
 
 #include <core/CWordDictionary.h>
+#include <core/Constants.h>
 
 #include <model/CAnomalyDetector.h>
 #include <model/CAnomalyDetectorModelConfig.h>
@@ -127,7 +128,8 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         LOG_DEBUG(<< "Resource limit is: " << mon.m_ByteLimitHigh);
         if (sizeof(std::size_t) == 8) {
             // 64-bit platform
-            BOOST_REQUIRE_EQUAL(std::size_t(4096ull * 1024 * 1024 / 2), mon.m_ByteLimitHigh);
+            BOOST_REQUIRE_EQUAL(std::size_t(4 * core::constants::BYTES_IN_GIGABYTES / 2),
+                                mon.m_ByteLimitHigh);
         } else {
             // Unexpected platform
             BOOST_TEST_REQUIRE(false);
@@ -143,7 +145,8 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         LOG_DEBUG(<< "Resource limit is: " << mon.m_ByteLimitHigh);
         if (sizeof(std::size_t) == 8) {
             // 64-bit platform
-            BOOST_REQUIRE_EQUAL(std::size_t(4096ull * 1024 * 1024), mon.m_ByteLimitHigh);
+            BOOST_REQUIRE_EQUAL(std::size_t(4 * core::constants::BYTES_IN_GIGABYTES),
+                                mon.m_ByteLimitHigh);
         } else {
             // Unexpected platform
             BOOST_TEST_REQUIRE(false);
@@ -517,7 +520,7 @@ BOOST_FIXTURE_TEST_CASE(testExtraMemory, CTestFixture) {
     BOOST_REQUIRE_EQUAL(allocationLimit, monitor.allocationLimit());
 
     // Push over the limit by adding 1MB
-    monitor.addExtraMemory(1024 * 1024);
+    monitor.addExtraMemory(core::constants::BYTES_IN_MEGABYTES);
     BOOST_TEST_REQUIRE(monitor.areAllocationsAllowed() == false);
     BOOST_REQUIRE_EQUAL(std::size_t(0), monitor.allocationLimit());
 


### PR DESCRIPTION
We have global constants for memory in KB, MB, etc, but we were not reliably using them. This is a small tidy up to migrate to using them consistently. Since this is a refactor I don't think it needs documentation and I'm marking as a non-issue.