### PR TITLE
[7.x][ML] Fix hyperparameter scaling

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -46,6 +46,7 @@
 === Bug Fixes
 
 * Fix potential cause for log errors from CXMeansOnline1d. (See {ml-pull}1586[#1586].)
+* Fix scaling of some hyperparameter for Bayesian optimization. (See {ml-pull}1612[#1612].)
 
 == {es} version 7.10.1
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1228,6 +1228,20 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
 
     TVector parameters{this->numberHyperparametersToTune()};
 
+    TVector minBoundary;
+    TVector maxBoundary;
+    std::tie(minBoundary, maxBoundary) = bopt.boundingBox();
+
+    // Downsampling acts as a regularisation and also increases the variance
+    // of each of the base learners so we scale the other regularisation terms
+    // and the weight shrinkage to compensate.
+    double scale{1.0};
+    if (minBoundary.size() > 0) {
+        scale = std::min(scale, 2.0 * m_DownsampleFactor /
+                                    (CTools::stableExp(minBoundary(0)) +
+                                     CTools::stableExp(maxBoundary(0))));
+    }
+
     // Read parameters for last round.
     int i{0};
     if (m_DownsampleFactorOverride == boost::none) {
@@ -1237,10 +1251,12 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         parameters(i++) = CTools::stableLog(m_Regularization.depthPenaltyMultiplier());
     }
     if (m_RegularizationOverride.leafWeightPenaltyMultiplier() == boost::none) {
-        parameters(i++) = CTools::stableLog(m_Regularization.leafWeightPenaltyMultiplier());
+        parameters(i++) =
+            CTools::stableLog(m_Regularization.leafWeightPenaltyMultiplier() / scale);
     }
     if (m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
-        parameters(i++) = CTools::stableLog(m_Regularization.treeSizePenaltyMultiplier());
+        parameters(i++) =
+            CTools::stableLog(m_Regularization.treeSizePenaltyMultiplier() / scale);
     }
     if (m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
         parameters(i++) = m_Regularization.softTreeDepthLimit();
@@ -1249,7 +1265,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         parameters(i++) = m_Regularization.softTreeDepthTolerance();
     }
     if (m_EtaOverride == boost::none) {
-        parameters(i++) = CTools::stableLog(m_Eta);
+        parameters(i++) = CTools::stableLog(m_Eta) / scale;
         parameters(i++) = m_EtaGrowthRatePerTree;
     }
     if (m_FeatureBagFractionOverride == boost::none) {
@@ -1270,29 +1286,19 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         std::generate_n(parameters.data(), parameters.size(), [&]() {
             return CSampling::uniformSample(m_Rng, 0.0, 1.0);
         });
-        TVector minBoundary;
-        TVector maxBoundary;
-        std::tie(minBoundary, maxBoundary) = bopt.boundingBox();
+
         parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
     } else {
         std::tie(parameters, std::ignore) = bopt.maximumExpectedImprovement();
     }
 
-    // Downsampling acts as a regularisation and also increases the variance
-    // of each of the base learners so we scale the other regularisation terms
-    // and the weight shrinkage to compensate.
-    double scale{1.0};
-
     // Write parameters for next round.
     i = 0;
     if (m_DownsampleFactorOverride == boost::none) {
         m_DownsampleFactor = CTools::stableExp(parameters(i++));
-        TVector minBoundary;
-        TVector maxBoundary;
-        std::tie(minBoundary, maxBoundary) = bopt.boundingBox();
-        scale = std::min(scale, 2.0 * m_DownsampleFactor /
-                                    (CTools::stableExp(minBoundary(0)) +
-                                     CTools::stableExp(maxBoundary(0))));
+        scale = std::min(1.0, 2.0 * m_DownsampleFactor /
+                                  (CTools::stableExp(minBoundary(0)) +
+                                   CTools::stableExp(maxBoundary(0))));
     }
     if (m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
         m_Regularization.depthPenaltyMultiplier(CTools::stableExp(parameters(i++)));

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE(testNonLinear) {
     test::CRandomNumbers rng;
     double noiseVariance{100.0};
     std::size_t trainRows{500};
-    std::size_t testRows{100};
+    std::size_t testRows{200};
     std::size_t cols{6};
     std::size_t capacity{500};
 


### PR DESCRIPTION
Since downsampling affects the scaling of some hyperparameter, sometimes the scaled hyperparamters were outside of the defined bounding boxes. This fix restores the boundary constraint. It allows us to better describe the error surface.

Backport of #1612