### PR TITLE
[7.x][ML] Parse field clauses using CAnomalyJobConfig (#1619)

### DIFF
--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -178,20 +178,12 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    std::string anomalyJobConfigJson;
-    bool couldReadConfigFile;
-    std::tie(anomalyJobConfigJson, couldReadConfigFile) =
-        ml::core::CStringUtils::readFileToString(configFile);
-    if (couldReadConfigFile == false) {
-        LOG_FATAL(<< "Failed to read config file '" << configFile << "'");
-        return EXIT_FAILURE;
-    }
-    // For now we need to reference the rule filters parsed by the old-style
-    // field config.
+    // For now we need to reference the rule filters and scheduled events parsed
+    // by the old-style field config as they are not present in the JSON job config.
     ml::api::CAnomalyJobConfig jobConfig{fieldConfig.ruleFilters(),
                                          fieldConfig.scheduledEvents()};
-    if (jobConfig.parse(anomalyJobConfigJson) == false) {
-        LOG_FATAL(<< "Failed to parse anomaly job config: '" << anomalyJobConfigJson << "'");
+    if (jobConfig.initFromFile(configFile) == false) {
+        LOG_FATAL(<< "JSON config could not be interpreted");
         return EXIT_FAILURE;
     }
 

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -367,8 +367,8 @@ private:
                  core_t::TTime firstTime,
                  const model::CAnomalyDetector::TModelFactoryCPtr& modelFactory);
 
-    //! Populate detector keys from the field config.
-    void populateDetectorKeys(const CFieldConfig& fieldConfig, TKeyVec& keys);
+    //! Populate detector keys from the anomaly job config.
+    void populateDetectorKeys(const CAnomalyJobConfig& jobConfig, TKeyVec& keys);
 
     //! Extract the field called \p fieldName from \p dataRowFields.
     const std::string* fieldValue(const std::string& fieldName, const TStrStrUMap& dataRowFields);

--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -12,16 +12,20 @@
 #include <api/ImportExport.h>
 
 #include <model/CLimits.h>
+#include <model/FunctionTypes.h>
 
 #include <rapidjson/document.h>
 
 #include <string>
 #include <vector>
 
+class CTestAnomalyJob;
+
 namespace ml {
 namespace model {
 class CAnomalyDetectorModelConfig;
 }
+
 namespace api {
 
 //! \brief A parser to convert JSON configuration of an anomaly job JSON into an object
@@ -45,34 +49,129 @@ public:
             static const std::string EXCLUDE_FREQUENT;
             static const std::string CUSTOM_RULES;
             static const std::string USE_NULL;
+            static const std::string ALL_TOKEN;
+            static const std::string BY_TOKEN;
+            static const std::string NONE_TOKEN;
+            static const std::string OVER_TOKEN;
+
+            //! Strings that define the type of analysis to run
+            static const std::string FUNCTION_COUNT;
+            static const std::string FUNCTION_COUNT_ABBREV;
+            static const std::string FUNCTION_LOW_COUNT;
+            static const std::string FUNCTION_LOW_COUNT_ABBREV;
+            static const std::string FUNCTION_HIGH_COUNT;
+            static const std::string FUNCTION_HIGH_COUNT_ABBREV;
+            static const std::string FUNCTION_DISTINCT_COUNT;
+            static const std::string FUNCTION_DISTINCT_COUNT_ABBREV;
+            static const std::string FUNCTION_LOW_DISTINCT_COUNT;
+            static const std::string FUNCTION_LOW_DISTINCT_COUNT_ABBREV;
+            static const std::string FUNCTION_HIGH_DISTINCT_COUNT;
+            static const std::string FUNCTION_HIGH_DISTINCT_COUNT_ABBREV;
+            static const std::string FUNCTION_NON_ZERO_COUNT;
+            static const std::string FUNCTION_NON_ZERO_COUNT_ABBREV;
+            static const std::string FUNCTION_RARE_NON_ZERO_COUNT;
+            static const std::string FUNCTION_RARE_NON_ZERO_COUNT_ABBREV;
+            static const std::string FUNCTION_RARE;
+            static const std::string FUNCTION_RARE_COUNT;
+            static const std::string FUNCTION_FREQ_RARE;
+            static const std::string FUNCTION_FREQ_RARE_ABBREV;
+            static const std::string FUNCTION_FREQ_RARE_COUNT;
+            static const std::string FUNCTION_FREQ_RARE_COUNT_ABBREV;
+            static const std::string FUNCTION_LOW_NON_ZERO_COUNT;
+            static const std::string FUNCTION_LOW_NON_ZERO_COUNT_ABBREV;
+            static const std::string FUNCTION_HIGH_NON_ZERO_COUNT;
+            static const std::string FUNCTION_HIGH_NON_ZERO_COUNT_ABBREV;
+            static const std::string FUNCTION_INFO_CONTENT;
+            static const std::string FUNCTION_LOW_INFO_CONTENT;
+            static const std::string FUNCTION_HIGH_INFO_CONTENT;
+            static const std::string FUNCTION_METRIC;
+            static const std::string FUNCTION_AVERAGE;
+            static const std::string FUNCTION_MEAN;
+            static const std::string FUNCTION_LOW_MEAN;
+            static const std::string FUNCTION_HIGH_MEAN;
+            static const std::string FUNCTION_LOW_AVERAGE;
+            static const std::string FUNCTION_HIGH_AVERAGE;
+            static const std::string FUNCTION_MEDIAN;
+            static const std::string FUNCTION_LOW_MEDIAN;
+            static const std::string FUNCTION_HIGH_MEDIAN;
+            static const std::string FUNCTION_MIN;
+            static const std::string FUNCTION_MAX;
+            static const std::string FUNCTION_VARIANCE;
+            static const std::string FUNCTION_LOW_VARIANCE;
+            static const std::string FUNCTION_HIGH_VARIANCE;
+            static const std::string FUNCTION_SUM;
+            static const std::string FUNCTION_LOW_SUM;
+            static const std::string FUNCTION_HIGH_SUM;
+            static const std::string FUNCTION_NON_NULL_SUM;
+            static const std::string FUNCTION_NON_NULL_SUM_ABBREV;
+            static const std::string FUNCTION_LOW_NON_NULL_SUM;
+            static const std::string FUNCTION_LOW_NON_NULL_SUM_ABBREV;
+            static const std::string FUNCTION_HIGH_NON_NULL_SUM;
+            static const std::string FUNCTION_HIGH_NON_NULL_SUM_ABBREV;
+            static const std::string FUNCTION_TIME_OF_DAY;
+            static const std::string FUNCTION_TIME_OF_WEEK;
+            static const std::string FUNCTION_LAT_LONG;
+            static const std::string FUNCTION_MAX_VELOCITY;
+            static const std::string FUNCTION_MIN_VELOCITY;
+            static const std::string FUNCTION_MEAN_VELOCITY;
+            static const std::string FUNCTION_SUM_VELOCITY;
 
         public:
             CDetectorConfig() {}
 
+            // Convenience ctor intended for use by the unit tests only
+            CDetectorConfig(const std::string& functionName,
+                            const std::string& fieldName,
+                            const std::string& byFieldName,
+                            const std::string& overFieldName,
+                            const std::string& partitionFieldName)
+                : m_FunctionName(functionName),
+                  m_FieldName(fieldName), m_ByFieldName{byFieldName},
+                  m_OverFieldName{overFieldName}, m_PartitionFieldName{partitionFieldName} {
+                this->determineFunction(false);
+                this->decipherExcludeFrequentSetting();
+            }
+
             void parse(const rapidjson::Value& detectorConfig,
                        const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters,
+                       bool haveSummaryCountField,
                        CDetectionRulesJsonParser::TDetectionRuleVec& detectionRules);
 
-            std::string function() const { return m_Function; }
+            int detectorIndex() const { return m_DetectorIndex; }
+            std::string functionName() const { return m_FunctionName; }
+            model::function_t::EFunction function() const { return m_Function; }
             std::string fieldName() const { return m_FieldName; }
             std::string byFieldName() const { return m_ByFieldName; }
             std::string overFieldName() const { return m_OverFieldName; }
             std::string partitionFieldName() const {
                 return m_PartitionFieldName;
             }
-            std::string excludeFrequent() const { return m_ExcludeFrequent; }
+
+            model_t::EExcludeFrequent excludeFrequent() const;
+
             std::string detectorDescription() const {
                 return m_DetectorDescription;
             }
             bool useNull() const { return m_UseNull; }
+            bool isPopulation() const {
+                return m_OverFieldName.empty() == false;
+            }
 
         private:
-            std::string m_Function{};
+            bool determineFunction(bool haveSummaryCountField);
+
+            bool decipherExcludeFrequentSetting();
+
+        private:
+            std::string m_FunctionName{};
+            model::function_t::EFunction m_Function;
             std::string m_FieldName{};
             std::string m_ByFieldName{};
             std::string m_OverFieldName{};
             std::string m_PartitionFieldName{};
             std::string m_ExcludeFrequent{};
+            bool m_ByHasExcludeFrequent{false};
+            bool m_OverHasExcludeFrequent{false};
             std::string m_DetectorDescription{};
             int m_DetectorIndex{};
             bool m_UseNull{false};
@@ -114,9 +213,10 @@ public:
         //! Default constructor
         CAnalysisConfig() {}
 
-        //! Constructor taking a map of detector rule filters keyed by filter_id.
-        explicit CAnalysisConfig(const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters,
-                                 const TStrDetectionRulePrVec& scheduledEvents)
+        //! Constructor taking a map of detector rule filters keyed by filter_id &
+        //! a vector of scheduled events data
+        CAnalysisConfig(const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters,
+                        const TStrDetectionRulePrVec& scheduledEvents)
             : m_RuleFilters(ruleFilters), m_ScheduledEvents(scheduledEvents) {}
 
         void parse(const rapidjson::Value& json);
@@ -169,6 +269,20 @@ public:
                                              core_t::TTime defaultDuration);
 
     private:
+        // Convenience method intended for use by the unit tests only
+        void addDetector(const std::string& functionName,
+                         const std::string& fieldName,
+                         const std::string& byFieldName,
+                         const std::string& overFieldName,
+                         const std::string& partitionFieldName,
+                         const TStrVec& influencers,
+                         const std::string& summaryCountFieldName) {
+            m_Influencers = influencers;
+            m_SummaryCountFieldName = summaryCountFieldName;
+            m_Detectors.emplace_back(functionName, fieldName, byFieldName,
+                                     overFieldName, partitionFieldName);
+        }
+
         bool processFilter(const std::string& key, const std::string& value);
 
         //! Process and store a scheduled event
@@ -201,6 +315,8 @@ public:
         //! The scheduled events (events apply to all detectors).
         //! Events consist of a description and a detection rule
         TStrDetectionRulePrVec m_ScheduledEvents{};
+
+        friend class ::CTestAnomalyJob;
     };
 
     class API_EXPORT CDataDescription {
@@ -293,6 +409,8 @@ public:
     explicit CAnomalyJobConfig(const CDetectionRulesJsonParser::TStrPatternSetUMap& rulesFilter,
                                const TStrDetectionRulePrVec& scheduledEvents)
         : m_AnalysisConfig(rulesFilter, scheduledEvents) {}
+
+    bool initFromFile(const std::string& configFile);
 
     bool parse(const std::string& json);
 

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -192,7 +192,7 @@ bool CAnomalyJob::handleRecord(const TStrStrUMap& dataRowFields, TOptionalTime t
     this->outputBucketResultsUntil(*time);
 
     if (m_DetectorKeys.empty()) {
-        this->populateDetectorKeys(m_FieldConfig, m_DetectorKeys);
+        this->populateDetectorKeys(m_JobConfig, m_DetectorKeys);
     }
 
     for (std::size_t i = 0u; i < m_DetectorKeys.size(); ++i) {
@@ -1594,18 +1594,18 @@ CAnomalyJob::makeDetector(const model::CAnomalyDetectorModelConfig& modelConfig,
                                                            firstTime, modelFactory);
 }
 
-void CAnomalyJob::populateDetectorKeys(const CFieldConfig& fieldConfig, TKeyVec& keys) {
+void CAnomalyJob::populateDetectorKeys(const CAnomalyJobConfig& jobConfig, TKeyVec& keys) {
     keys.clear();
 
     // Add a key for the simple count detector.
     keys.push_back(model::CSearchKey::simpleCountKey());
 
-    for (const auto& fieldOptions : fieldConfig.fieldOptions()) {
-        keys.emplace_back(fieldOptions.configKey(), fieldOptions.function(),
+    for (const auto& fieldOptions : jobConfig.analysisConfig().detectorsConfig()) {
+        keys.emplace_back(fieldOptions.detectorIndex(), fieldOptions.function(),
                           fieldOptions.useNull(), fieldOptions.excludeFrequent(),
                           fieldOptions.fieldName(), fieldOptions.byFieldName(),
                           fieldOptions.overFieldName(), fieldOptions.partitionFieldName(),
-                          fieldConfig.influencerFieldNames());
+                          jobConfig.analysisConfig().influencers());
     }
 }
 

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -14,6 +14,7 @@
 
 #include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CLimits.h>
+#include <model/FunctionTypes.h>
 
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
@@ -80,6 +81,115 @@ const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::EXCLUDE_F
     "exclude_frequent"};
 const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::USE_NULL{"use_null"};
 const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::CUSTOM_RULES{"custom_rules"};
+
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::ALL_TOKEN("all");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::BY_TOKEN("by");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::NONE_TOKEN("none");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::OVER_TOKEN("over");
+
+// Event rate functions
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_COUNT("count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_COUNT_ABBREV("c");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_COUNT("low_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_COUNT_ABBREV("low_c");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_COUNT("high_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_COUNT_ABBREV("high_c");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_DISTINCT_COUNT("distinct_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_DISTINCT_COUNT_ABBREV("dc");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_DISTINCT_COUNT("low_distinct_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_DISTINCT_COUNT_ABBREV("low_dc");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_DISTINCT_COUNT("high_distinct_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_DISTINCT_COUNT_ABBREV("high_dc");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_NON_ZERO_COUNT("non_zero_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_NON_ZERO_COUNT_ABBREV("nzc");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_RARE_NON_ZERO_COUNT("rare_non_zero_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_RARE_NON_ZERO_COUNT_ABBREV("rnzc");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_RARE("rare");
+// No abbreviation for "rare" as "r" is a little too obscure
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_RARE_COUNT("rare_count");
+// No abbreviation for "rare_count" as "rc" is sometimes used as an abbreviation
+// for "return code"
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_FREQ_RARE("freq_rare");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_FREQ_RARE_ABBREV("fr");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_FREQ_RARE_COUNT("freq_rare_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_FREQ_RARE_COUNT_ABBREV("frc");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_NON_ZERO_COUNT("low_non_zero_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_NON_ZERO_COUNT_ABBREV("low_nzc");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_NON_ZERO_COUNT("high_non_zero_count");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_NON_ZERO_COUNT_ABBREV("high_nzc");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_INFO_CONTENT("info_content");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_INFO_CONTENT("low_info_content");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_INFO_CONTENT("high_info_content");
+
+// Metric functions
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_METRIC("metric");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_AVERAGE("avg");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_MEAN("mean");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_MEAN("low_mean");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_MEAN("high_mean");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_AVERAGE("low_avg");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_AVERAGE("high_avg");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_MEDIAN("median");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_MEDIAN("low_median");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_MEDIAN("high_median");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_MIN("min");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_MAX("max");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_VARIANCE("varp");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_VARIANCE("low_varp");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_VARIANCE("high_varp");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_SUM("sum");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_SUM("low_sum");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_SUM("high_sum");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_NON_NULL_SUM("non_null_sum");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_NON_NULL_SUM_ABBREV("nns");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_NON_NULL_SUM("low_non_null_sum");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LOW_NON_NULL_SUM_ABBREV("low_nns");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_NON_NULL_SUM("high_non_null_sum");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_HIGH_NON_NULL_SUM_ABBREV("high_nns");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_TIME_OF_DAY("time_of_day");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_TIME_OF_WEEK("time_of_week");
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_LAT_LONG("lat_long");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_MAX_VELOCITY("max_velocity");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_MIN_VELOCITY("min_velocity");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_MEAN_VELOCITY("mean_velocity");
+const std::string
+    CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION_SUM_VELOCITY("sum_velocity");
 
 const std::string CAnomalyJobConfig::CModelPlotConfig::ANNOTATIONS_ENABLED{"annotations_enabled"};
 const std::string CAnomalyJobConfig::CModelPlotConfig::ENABLED{"enabled"};
@@ -207,6 +317,24 @@ const CAnomalyJobConfigReader DATA_DESCRIPTION_READER{[] {
 }()};
 }
 
+bool CAnomalyJobConfig::initFromFile(const std::string& configFile) {
+    std::string anomalyJobConfigJson;
+    bool couldReadConfigFile;
+    std::tie(anomalyJobConfigJson, couldReadConfigFile) =
+        ml::core::CStringUtils::readFileToString(configFile);
+    if (couldReadConfigFile == false) {
+        LOG_ERROR(<< "Failed to read config file '" << configFile << "'");
+        return false;
+    }
+
+    if (this->parse(anomalyJobConfigJson) == false) {
+        LOG_ERROR(<< "Failed to parse anomaly job config: '" << anomalyJobConfigJson << "'");
+        return false;
+    }
+
+    return true;
+}
+
 bool CAnomalyJobConfig::parse(const std::string& json) {
     LOG_DEBUG(<< "Parsing anomaly job config");
 
@@ -324,6 +452,7 @@ void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisC
         m_Detectors.resize(detectorsConfig->Size());
         for (std::size_t i = 0; i < detectorsConfig->Size(); ++i) {
             m_Detectors[i].parse((*detectorsConfig)[static_cast<int>(i)], m_RuleFilters,
+                                 (m_SummaryCountFieldName.empty() == false),
                                  m_DetectorRules[static_cast<int>(i)]);
         }
     }
@@ -453,17 +582,17 @@ bool CAnomalyJobConfig::CAnalysisConfig::parseRules(CDetectionRulesJsonParser::T
 
 ml::model::CAnomalyDetectorModelConfig
 CAnomalyJobConfig::CAnalysisConfig::makeModelConfig() const {
-    ml::model_t::ESummaryMode summaryMode{
-        m_SummaryCountFieldName.empty() ? ml::model_t::E_None : ml::model_t::E_Manual};
+    model_t::ESummaryMode summaryMode{
+        m_SummaryCountFieldName.empty() ? model_t::E_None : model_t::E_Manual};
 
-    ml::model::CAnomalyDetectorModelConfig modelConfig{ml::model::CAnomalyDetectorModelConfig::defaultConfig(
+    model::CAnomalyDetectorModelConfig modelConfig{model::CAnomalyDetectorModelConfig::defaultConfig(
         m_BucketSpan, summaryMode, m_SummaryCountFieldName, m_Latency, m_MultivariateByFields)};
 
     modelConfig.detectionRules(
-        ml::model::CAnomalyDetectorModelConfig::TIntDetectionRuleVecUMapCRef(m_DetectorRules));
+        model::CAnomalyDetectorModelConfig::TIntDetectionRuleVecUMapCRef(m_DetectorRules));
 
     modelConfig.scheduledEvents(
-        ml::model::CAnomalyDetectorModelConfig::TStrDetectionRulePrVecCRef(m_ScheduledEvents));
+        model::CAnomalyDetectorModelConfig::TStrDetectionRulePrVecCRef(m_ScheduledEvents));
 
     return modelConfig;
 }
@@ -489,11 +618,12 @@ CAnomalyJobConfig::CAnalysisConfig::durationSeconds(const std::string& durationS
 void CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::parse(
     const rapidjson::Value& detectorConfig,
     const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters,
+    bool haveSummaryCountField,
     CDetectionRulesJsonParser::TDetectionRuleVec& detectionRules) {
 
     auto parameters = DETECTOR_CONFIG_READER.read(detectorConfig);
 
-    m_Function = parameters[FUNCTION].as<std::string>();
+    m_FunctionName = parameters[FUNCTION].as<std::string>();
     m_FieldName = parameters[FIELD_NAME].fallback(EMPTY_STRING);
     m_ByFieldName = parameters[BY_FIELD_NAME].fallback(EMPTY_STRING);
     m_OverFieldName = parameters[OVER_FIELD_NAME].fallback(EMPTY_STRING);
@@ -520,6 +650,293 @@ void CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::parse(
     }
 
     m_UseNull = parameters[USE_NULL].fallback(false);
+
+    if (this->determineFunction(haveSummaryCountField) == false) {
+        throw CAnomalyJobConfigReader::CParseError("Error determining function");
+    }
+    if (this->decipherExcludeFrequentSetting() == false) {
+        throw CAnomalyJobConfigReader::CParseError("Error deciphering exclude frequent setting");
+    }
+}
+
+bool CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::determineFunction(bool haveSummaryCountField) {
+
+    bool isPopulation{m_OverFieldName.empty() == false};
+    bool hasByField{m_ByFieldName.empty() == false};
+
+    // Some functions must take a field, some mustn't and for the rest it's
+    // optional.  Validate this based on the contents of these flags after
+    // determining the function.  Similarly for by fields.
+    // TODO: Check how much validation is required here (if any) if parsing JSON job config.
+    bool fieldRequired{false};
+    bool fieldInvalid{false};
+    bool byFieldRequired{false};
+    bool byFieldInvalid{false};
+
+    if (m_FunctionName.empty()) {
+        LOG_ERROR(<< "No function specified");
+        return false;
+    }
+
+    if (m_FunctionName == FUNCTION_COUNT || m_FunctionName == FUNCTION_COUNT_ABBREV) {
+        m_Function = isPopulation ? model::function_t::E_PopulationCount
+                                  : model::function_t::E_IndividualRareCount;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_DISTINCT_COUNT ||
+               m_FunctionName == FUNCTION_DISTINCT_COUNT_ABBREV) {
+        m_Function = isPopulation ? model::function_t::E_PopulationDistinctCount
+                                  : model::function_t::E_IndividualDistinctCount;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_DISTINCT_COUNT ||
+               m_FunctionName == FUNCTION_LOW_DISTINCT_COUNT_ABBREV) {
+        m_Function = isPopulation ? model::function_t::E_PopulationLowDistinctCount
+                                  : model::function_t::E_IndividualLowDistinctCount;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_DISTINCT_COUNT ||
+               m_FunctionName == FUNCTION_HIGH_DISTINCT_COUNT_ABBREV) {
+        m_Function = isPopulation ? model::function_t::E_PopulationHighDistinctCount
+                                  : model::function_t::E_IndividualHighDistinctCount;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_NON_ZERO_COUNT ||
+               m_FunctionName == FUNCTION_NON_ZERO_COUNT_ABBREV) {
+        m_Function = model::function_t::E_IndividualNonZeroCount;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_RARE_NON_ZERO_COUNT ||
+               m_FunctionName == FUNCTION_RARE_NON_ZERO_COUNT_ABBREV) {
+        m_Function = model::function_t::E_IndividualRareNonZeroCount;
+        fieldInvalid = true;
+        byFieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_RARE) {
+        m_Function = isPopulation ? model::function_t::E_PopulationRare
+                                  : model::function_t::E_IndividualRare;
+        fieldInvalid = true;
+        byFieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_RARE_COUNT) {
+        m_Function = model::function_t::E_PopulationRareCount;
+        fieldInvalid = true;
+        byFieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_COUNT || m_FunctionName == FUNCTION_LOW_COUNT_ABBREV) {
+        m_Function = isPopulation ? model::function_t::E_PopulationLowCounts
+                                  : model::function_t::E_IndividualLowCounts;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_COUNT ||
+               m_FunctionName == FUNCTION_HIGH_COUNT_ABBREV) {
+        m_Function = isPopulation ? model::function_t::E_PopulationHighCounts
+                                  : model::function_t::E_IndividualHighCounts;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_LOW_NON_ZERO_COUNT ||
+               m_FunctionName == FUNCTION_LOW_NON_ZERO_COUNT_ABBREV) {
+        m_Function = model::function_t::E_IndividualLowNonZeroCount;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_NON_ZERO_COUNT ||
+               m_FunctionName == FUNCTION_HIGH_NON_ZERO_COUNT_ABBREV) {
+        m_Function = model::function_t::E_IndividualHighNonZeroCount;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_FREQ_RARE || m_FunctionName == FUNCTION_FREQ_RARE_ABBREV) {
+        m_Function = model::function_t::E_PopulationFreqRare;
+        fieldInvalid = true;
+        byFieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_FREQ_RARE_COUNT ||
+               m_FunctionName == FUNCTION_FREQ_RARE_COUNT_ABBREV) {
+        m_Function = model::function_t::E_PopulationFreqRareCount;
+        fieldInvalid = true;
+        byFieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_INFO_CONTENT) {
+        m_Function = isPopulation ? model::function_t::E_PopulationInfoContent
+                                  : model::function_t::E_IndividualInfoContent;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_INFO_CONTENT) {
+        m_Function = isPopulation ? model::function_t::E_PopulationLowInfoContent
+                                  : model::function_t::E_IndividualLowInfoContent;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_INFO_CONTENT) {
+        m_Function = isPopulation ? model::function_t::E_PopulationHighInfoContent
+                                  : model::function_t::E_IndividualHighInfoContent;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_METRIC) {
+        if (haveSummaryCountField) {
+            LOG_ERROR(<< "Function " << m_FunctionName
+                      << "() cannot be used with a summary count field");
+            return false;
+        }
+
+        m_Function = isPopulation ? model::function_t::E_PopulationMetric
+                                  : model::function_t::E_IndividualMetric;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_AVERAGE || m_FunctionName == FUNCTION_MEAN) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricMean
+                                  : model::function_t::E_IndividualMetricMean;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_AVERAGE || m_FunctionName == FUNCTION_LOW_MEAN) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricLowMean
+                                  : model::function_t::E_IndividualMetricLowMean;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_AVERAGE || m_FunctionName == FUNCTION_HIGH_MEAN) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricHighMean
+                                  : model::function_t::E_IndividualMetricHighMean;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_MEDIAN) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricMedian
+                                  : model::function_t::E_IndividualMetricMedian;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_MEDIAN) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricLowMedian
+                                  : model::function_t::E_IndividualMetricLowMedian;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_MEDIAN) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricHighMedian
+                                  : model::function_t::E_IndividualMetricHighMedian;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_MIN) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricMin
+                                  : model::function_t::E_IndividualMetricMin;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_MAX) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricMax
+                                  : model::function_t::E_IndividualMetricMax;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_VARIANCE) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricVariance
+                                  : model::function_t::E_IndividualMetricVariance;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_VARIANCE) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricLowVariance
+                                  : model::function_t::E_IndividualMetricLowVariance;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_VARIANCE) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricHighVariance
+                                  : model::function_t::E_IndividualMetricHighVariance;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_SUM) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricSum
+                                  : model::function_t::E_IndividualMetricSum;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_SUM) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricLowSum
+                                  : model::function_t::E_IndividualMetricLowSum;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_SUM) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMetricHighSum
+                                  : model::function_t::E_IndividualMetricHighSum;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_NON_NULL_SUM ||
+               m_FunctionName == FUNCTION_NON_NULL_SUM_ABBREV) {
+        m_Function = model::function_t::E_IndividualMetricNonNullSum;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_LOW_NON_NULL_SUM ||
+               m_FunctionName == FUNCTION_LOW_NON_NULL_SUM_ABBREV) {
+        m_Function = model::function_t::E_IndividualMetricLowNonNullSum;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_HIGH_NON_NULL_SUM ||
+               m_FunctionName == FUNCTION_HIGH_NON_NULL_SUM_ABBREV) {
+        m_Function = model::function_t::E_IndividualMetricHighNonNullSum;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_TIME_OF_DAY) {
+        m_Function = isPopulation ? model::function_t::E_PopulationTimeOfDay
+                                  : model::function_t::E_IndividualTimeOfDay;
+        fieldRequired = false;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_TIME_OF_WEEK) {
+        m_Function = isPopulation ? model::function_t::E_PopulationTimeOfWeek
+                                  : model::function_t::E_IndividualTimeOfWeek;
+        fieldRequired = false;
+        fieldInvalid = true;
+    } else if (m_FunctionName == FUNCTION_LAT_LONG) {
+        m_Function = isPopulation ? model::function_t::E_PopulationLatLong
+                                  : model::function_t::E_IndividualLatLong;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_MAX_VELOCITY) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMaxVelocity
+                                  : model::function_t::E_IndividualMaxVelocity;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_MIN_VELOCITY) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMinVelocity
+                                  : model::function_t::E_IndividualMinVelocity;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_MEAN_VELOCITY) {
+        m_Function = isPopulation ? model::function_t::E_PopulationMeanVelocity
+                                  : model::function_t::E_IndividualMeanVelocity;
+        fieldRequired = true;
+    } else if (m_FunctionName == FUNCTION_SUM_VELOCITY) {
+        m_Function = isPopulation ? model::function_t::E_PopulationSumVelocity
+                                  : model::function_t::E_IndividualSumVelocity;
+        fieldRequired = true;
+    } else {
+        LOG_ERROR(<< "Invalid function " << m_FunctionName << " specified");
+        return false;
+    }
+
+    // Validate
+    if (model::function_t::isPopulation(m_Function) && isPopulation == false) {
+        LOG_ERROR(<< "Function " << m_FunctionName << " requires an 'over' field");
+        return false;
+    }
+
+    if (isPopulation && model::function_t::isPopulation(m_Function) == false) {
+        LOG_ERROR(<< "Function " << m_FunctionName << " cannot be used with an 'over' field");
+        return false;
+    }
+
+    if (byFieldRequired && hasByField == false) {
+        LOG_ERROR(<< "Function " << m_FunctionName << " requires a 'by' field");
+        return false;
+    }
+
+    if (byFieldInvalid && hasByField) {
+        LOG_ERROR(<< "Function " << m_FunctionName << " cannot be used with a 'by' field");
+        return false;
+    }
+
+    if (fieldRequired && m_FieldName.empty()) {
+        LOG_ERROR(<< "Function " << m_FunctionName << " requires a field");
+        return false;
+    }
+
+    if (fieldInvalid && m_FieldName.empty() == false) {
+        LOG_ERROR(<< "Function " << m_FunctionName << " does not work on a field");
+        return false;
+    }
+
+    return true;
+}
+
+model_t::EExcludeFrequent
+CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::excludeFrequent() const {
+    if (m_OverHasExcludeFrequent) {
+        if (m_ByHasExcludeFrequent) {
+            return model_t::E_XF_Both;
+        } else {
+            return model_t::E_XF_Over;
+        }
+    } else {
+        if (m_ByHasExcludeFrequent) {
+            return model_t::E_XF_By;
+        }
+    }
+    return model_t::E_XF_None;
+}
+
+bool CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::decipherExcludeFrequentSetting() {
+
+    bool hasByField{m_ByFieldName.empty() == false};
+    bool isPopulation{m_OverFieldName.empty() == false};
+
+    if (m_ExcludeFrequent.empty() == false) {
+        if (m_ExcludeFrequent == ALL_TOKEN) {
+            m_ByHasExcludeFrequent = hasByField;
+            m_OverHasExcludeFrequent = isPopulation;
+        } else if (m_ExcludeFrequent == BY_TOKEN) {
+            m_ByHasExcludeFrequent = hasByField;
+        } else if (m_ExcludeFrequent == OVER_TOKEN) {
+            m_OverHasExcludeFrequent = isPopulation;
+        } else {
+            if (m_ExcludeFrequent != NONE_TOKEN) {
+                LOG_ERROR(<< "Unexpected exclude_frequent value = " << m_ExcludeFrequent);
+                return false;
+            }
+        }
+    }
+    return true;
 }
 }
 }

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -8,6 +8,8 @@
 
 #include <api/CAnomalyJobConfig.h>
 
+#include <model/FunctionTypes.h>
+
 #include <boost/test/unit_test.hpp>
 
 #include <rapidjson/stringbuffer.h>
@@ -88,7 +90,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
             "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
-            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
             "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
@@ -113,12 +115,14 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
         BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
         BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
-        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationCount,
+                            detectorsConfig[0].function());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].byFieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_Both, detectorsConfig[0].excludeFrequent());
         BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
         BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
 
@@ -135,7 +139,442 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
         BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
     }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"by_field_name\":\"customer_id\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
 
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_IndividualRareCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_By, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_Over, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"whatever\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(validAnomalyJobConfig));
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"by\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_By, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"over\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_Over, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"by\",\"by_field_name\":\"customer_id\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_IndividualRareCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_By, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"none\",\"by_field_name\":\"customer_id\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_IndividualRareCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_None, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"over\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_Over, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
+    {
+        const std::string validAnomalyJobConfig{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"none\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfig),
+                              "Cannot parse JSON job config!");
+
+        BOOST_REQUIRE_EQUAL("anomaly_detector", jobConfig.jobType());
+        BOOST_REQUIRE_EQUAL("flight_event_rate", jobConfig.jobId());
+
+        const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
+
+        const TDataDescription& dataDescription = jobConfig.dataDescription();
+
+        BOOST_REQUIRE_EQUAL("timestamp", dataDescription.timeField());
+
+        const TDetectorConfigVec& detectorsConfig = analysisConfig.detectorsConfig();
+        BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationCount,
+                            detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].byFieldName());
+        BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
+        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_None, detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
+        BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
+
+        const TStrVec& influencers = analysisConfig.influencers();
+        BOOST_REQUIRE_EQUAL(0, influencers.size());
+
+        const TAnalysisLimits& analysisLimits = jobConfig.analysisLimits();
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.categorizationExamplesLimit());
+
+        // Expect the model memory limit to be rounded down to the nearest whole number of megabytes
+        BOOST_REQUIRE_EQUAL(4, analysisLimits.modelMemoryLimitMb());
+
+        const TModelPlotConfig& modelPlotConfig = jobConfig.modelPlotConfig();
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.enabled());
+        BOOST_REQUIRE_EQUAL(true, modelPlotConfig.annotationsEnabled());
+    }
     {
         const std::string validAnomalyJobConfigWithMultipleInfluencers{
             "{\"job_id\":\"logs_max_bytes_by_geo\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603290557883,\"description\":\"\","
@@ -171,12 +610,14 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
         BOOST_REQUIRE_EQUAL("max(bytes) by \"geo.src\" partitionfield=\"host.keyword\"",
                             detectorsConfig[0].detectorDescription());
-        BOOST_REQUIRE_EQUAL("max", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("max", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_IndividualMetricMax,
+                            detectorsConfig[0].function());
         BOOST_REQUIRE_EQUAL("bytes", detectorsConfig[0].fieldName());
         BOOST_REQUIRE_EQUAL("geo.src", detectorsConfig[0].byFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
         BOOST_REQUIRE_EQUAL("host.keyword", detectorsConfig[0].partitionFieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_None, detectorsConfig[0].excludeFrequent());
         BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
         BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
 
@@ -232,23 +673,27 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_REQUIRE_EQUAL(2, detectorsConfig.size());
         BOOST_REQUIRE_EQUAL("distinct_count(\"category.keyword\") by customer_id over \"category.keyword\"",
                             detectorsConfig[0].detectorDescription());
-        BOOST_REQUIRE_EQUAL("distinct_count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("distinct_count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationDistinctCount,
+                            detectorsConfig[0].function());
         BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].fieldName());
         BOOST_REQUIRE_EQUAL("customer_id", detectorsConfig[0].byFieldName());
         BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[0].overFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_None, detectorsConfig[0].excludeFrequent());
         BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
         BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
 
         BOOST_REQUIRE_EQUAL("count over \"category.keyword\"",
                             detectorsConfig[1].detectorDescription());
-        BOOST_REQUIRE_EQUAL("count", detectorsConfig[1].function());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[1].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_PopulationCount,
+                            detectorsConfig[1].function());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[1].fieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[1].byFieldName());
         BOOST_REQUIRE_EQUAL("category.keyword", detectorsConfig[1].overFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[1].partitionFieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[1].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_None, detectorsConfig[1].excludeFrequent());
         BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(1).size());
         BOOST_REQUIRE_EQUAL(false, detectorsConfig[1].useNull());
 
@@ -297,12 +742,14 @@ BOOST_AUTO_TEST_CASE(testParse) {
 
         BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
         BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].detectorDescription());
-        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_IndividualRareCount,
+                            detectorsConfig[0].function());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].byFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_None, detectorsConfig[0].excludeFrequent());
         BOOST_REQUIRE_EQUAL(1, analysisConfig.detectionRules().at(0).size());
         BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
 
@@ -345,12 +792,14 @@ BOOST_AUTO_TEST_CASE(testParse) {
 
         BOOST_REQUIRE_EQUAL(1, detectorsConfig.size());
         BOOST_REQUIRE_EQUAL("count by mlcategory", detectorsConfig[0].detectorDescription());
-        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].function());
+        BOOST_REQUIRE_EQUAL("count", detectorsConfig[0].functionName());
+        BOOST_REQUIRE_EQUAL(ml::model::function_t::E_IndividualRareCount,
+                            detectorsConfig[0].function());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].fieldName());
         BOOST_REQUIRE_EQUAL("mlcategory", detectorsConfig[0].byFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].overFieldName());
         BOOST_REQUIRE_EQUAL("", detectorsConfig[0].partitionFieldName());
-        BOOST_REQUIRE_EQUAL("", detectorsConfig[0].excludeFrequent());
+        BOOST_REQUIRE_EQUAL(ml::model_t::E_XF_None, detectorsConfig[0].excludeFrequent());
         BOOST_REQUIRE_EQUAL(0, analysisConfig.detectionRules().at(0).size());
         BOOST_REQUIRE_EQUAL(false, detectorsConfig[0].useNull());
 

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -97,17 +97,10 @@ BOOST_AUTO_TEST_CASE(testAccuracy) {
         // Without limits, this data set should make the models around
         // 1230000 bytes
         // Run the data once to find out what the current platform uses
-        ml::api::CAnomalyJobConfig jobConfig;
-        api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clause;
-        clause.push_back("value");
-        clause.push_back("by");
-        clause.push_back("colour");
-        clause.push_back("over");
-        clause.push_back("species");
-        clause.push_back("partitionfield=greenhouse");
+        ml::api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "colour", "species", "greenhouse");
 
-        BOOST_TEST_REQUIRE(fieldConfig.initFromClause(clause));
+        api::CFieldConfig fieldConfig;
 
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(3600);
@@ -142,17 +135,10 @@ BOOST_AUTO_TEST_CASE(testAccuracy) {
     }
     {
         // Now run the data with limiting
-        ml::api::CAnomalyJobConfig jobConfig;
-        api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clause;
-        clause.push_back("value");
-        clause.push_back("by");
-        clause.push_back("colour");
-        clause.push_back("over");
-        clause.push_back("species");
-        clause.push_back("partitionfield=greenhouse");
+        ml::api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "colour", "species", "greenhouse");
 
-        BOOST_TEST_REQUIRE(fieldConfig.initFromClause(clause));
+        api::CFieldConfig fieldConfig;
 
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(3600);
@@ -204,17 +190,9 @@ BOOST_AUTO_TEST_CASE(testLimit) {
         // Run the data without any resource limits and check that
         // all the expected fields are in the results set
         model::CLimits limits;
-        ml::api::CAnomalyJobConfig jobConfig;
+        api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "colour", "species", "greenhouse");
         api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clause;
-        clause.push_back("value");
-        clause.push_back("by");
-        clause.push_back("colour");
-        clause.push_back("over");
-        clause.push_back("species");
-        clause.push_back("partitionfield=greenhouse");
-
-        BOOST_TEST_REQUIRE(fieldConfig.initFromClause(clause));
 
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(3600);
@@ -251,17 +229,10 @@ BOOST_AUTO_TEST_CASE(testLimit) {
         // Run the data with some resource limits after the first 4 records and
         // check that we get only anomalies from the first 2 partitions
         model::CLimits limits;
-        ml::api::CAnomalyJobConfig jobConfig;
-        api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clause;
-        clause.push_back("value");
-        clause.push_back("by");
-        clause.push_back("colour");
-        clause.push_back("over");
-        clause.push_back("species");
-        clause.push_back("partitionfield=greenhouse");
+        ml::api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "colour", "species", "greenhouse");
 
-        BOOST_TEST_REQUIRE(fieldConfig.initFromClause(clause));
+        api::CFieldConfig fieldConfig;
 
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(3600);
@@ -380,10 +351,10 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             std::size_t memoryLimit{10 /*MB*/};
             model::CLimits limits;
             limits.resourceMonitor().memoryLimit(memoryLimit);
-            ml::api::CAnomalyJobConfig jobConfig;
+            ml::api::CAnomalyJobConfig jobConfig =
+                CTestAnomalyJob::makeSimpleJobConfig("mean", "foo", "bar", "", "");
+
             api::CFieldConfig fieldConfig;
-            api::CFieldConfig::TStrVec clauses{"mean(foo)", "by", "bar"};
-            fieldConfig.initFromClause(clauses);
             model::CAnomalyDetectorModelConfig modelConfig =
                 model::CAnomalyDetectorModelConfig::defaultConfig(testParam.s_BucketLength);
             CTestAnomalyJob job("job", limits, jobConfig, fieldConfig,
@@ -433,10 +404,10 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             std::size_t memoryLimit{10 /*MB*/};
             model::CLimits limits;
             limits.resourceMonitor().memoryLimit(memoryLimit);
-            ml::api::CAnomalyJobConfig jobConfig;
+            ml::api::CAnomalyJobConfig jobConfig =
+                CTestAnomalyJob::makeSimpleJobConfig("mean", "foo", "", "", "bar");
+
             api::CFieldConfig fieldConfig;
-            api::CFieldConfig::TStrVec clauses{"mean(foo)", "partitionfield=bar"};
-            fieldConfig.initFromClause(clauses);
             model::CAnomalyDetectorModelConfig modelConfig =
                 model::CAnomalyDetectorModelConfig::defaultConfig(testParam.s_BucketLength);
             CTestAnomalyJob job("job", limits, jobConfig, fieldConfig,
@@ -487,10 +458,10 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             std::size_t memoryLimit{5 /*MB*/};
             model::CLimits limits;
             limits.resourceMonitor().memoryLimit(memoryLimit);
-            ml::api::CAnomalyJobConfig jobConfig;
+            ml::api::CAnomalyJobConfig jobConfig =
+                CTestAnomalyJob::makeSimpleJobConfig("mean", "foo", "", "bar", "");
+
             api::CFieldConfig fieldConfig;
-            api::CFieldConfig::TStrVec clauses{"mean(foo)", "over", "bar"};
-            fieldConfig.initFromClause(clauses);
             model::CAnomalyDetectorModelConfig modelConfig =
                 model::CAnomalyDetectorModelConfig::defaultConfig(testParam.s_BucketLength);
             CTestAnomalyJob job("job", limits, jobConfig, fieldConfig,

--- a/lib/api/unittest/CAnomalyJobTest.cc
+++ b/lib/api/unittest/CAnomalyJobTest.cc
@@ -185,12 +185,11 @@ BOOST_AUTO_TEST_CASE(testBadTimes) {
     {
         // Test with no time field
         model::CLimits limits;
-        api::CAnomalyJobConfig jobConfig;
+        api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "", "", "greenhouse");
+
         api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("value");
-        clauses.push_back("partitionfield=greenhouse");
-        fieldConfig.initFromClause(clauses);
+
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
         std::stringstream outputStrm;
@@ -210,12 +209,11 @@ BOOST_AUTO_TEST_CASE(testBadTimes) {
     {
         // Test with bad time field
         model::CLimits limits;
-        api::CAnomalyJobConfig jobConfig;
+        api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "", "", "greenhouse");
+
         api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("value");
-        clauses.push_back("partitionfield=greenhouse");
-        fieldConfig.initFromClause(clauses);
+
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
         std::stringstream outputStrm;
@@ -235,12 +233,11 @@ BOOST_AUTO_TEST_CASE(testBadTimes) {
     {
         // Test with bad time field format
         model::CLimits limits;
-        api::CAnomalyJobConfig jobConfig;
+        api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "", "", "greenhouse");
+
         api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("value");
-        clauses.push_back("partitionfield=greenhouse");
-        fieldConfig.initFromClause(clauses);
+
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
         std::stringstream outputStrm;
@@ -264,12 +261,11 @@ BOOST_AUTO_TEST_CASE(testOutOfSequence) {
     {
         // Test out of sequence record
         model::CLimits limits;
-        api::CAnomalyJobConfig jobConfig;
+        api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "", "", "greenhouse");
+
         api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("value");
-        clauses.push_back("partitionfield=greenhouse");
-        fieldConfig.initFromClause(clauses);
+
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
         std::stringstream outputStrm;
@@ -302,12 +298,11 @@ BOOST_AUTO_TEST_CASE(testControlMessages) {
     {
         // Test control messages
         model::CLimits limits;
-        api::CAnomalyJobConfig jobConfig;
+        api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+            "metric", "value", "", "", "greenhouse");
+
         api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("value");
-        clauses.push_back("partitionfield=greenhouse");
-        fieldConfig.initFromClause(clauses);
+
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
         std::stringstream outputStrm;
@@ -336,12 +331,11 @@ BOOST_AUTO_TEST_CASE(testControlMessages) {
     {
         // Test reset bucket
         model::CLimits limits;
-        api::CAnomalyJobConfig jobConfig;
+        api::CAnomalyJobConfig jobConfig =
+            CTestAnomalyJob::makeSimpleJobConfig("count", "", "", "", "greenhouse");
+
         api::CFieldConfig fieldConfig;
-        api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("count");
-        clauses.push_back("partitionfield=greenhouse");
-        fieldConfig.initFromClause(clauses);
+
         model::CAnomalyDetectorModelConfig modelConfig =
             model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
 
@@ -454,11 +448,11 @@ BOOST_AUTO_TEST_CASE(testControlMessages) {
 
 BOOST_AUTO_TEST_CASE(testSkipTimeControlMessage) {
     model::CLimits limits;
-    api::CAnomalyJobConfig jobConfig;
+    api::CAnomalyJobConfig jobConfig =
+        CTestAnomalyJob::makeSimpleJobConfig("count", "", "", "", "");
+
     api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clauses;
-    clauses.push_back("count");
-    fieldConfig.initFromClause(clauses);
+
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
 
@@ -506,11 +500,11 @@ BOOST_AUTO_TEST_CASE(testSkipTimeControlMessage) {
 BOOST_AUTO_TEST_CASE(testIsPersistenceNeeded) {
 
     model::CLimits limits;
-    api::CAnomalyJobConfig jobConfig;
+    api::CAnomalyJobConfig jobConfig =
+        CTestAnomalyJob::makeSimpleJobConfig("count", "", "", "", "");
+
     api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clauses;
-    clauses.push_back("count");
-    fieldConfig.initFromClause(clauses);
+
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
 
@@ -613,13 +607,10 @@ BOOST_AUTO_TEST_CASE(testIsPersistenceNeeded) {
 BOOST_AUTO_TEST_CASE(testModelPlot) {
     core_t::TTime bucketSize = 10000;
     model::CLimits limits;
-    api::CAnomalyJobConfig jobConfig;
     api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clauses;
-    clauses.push_back("mean(value)");
-    clauses.push_back("by");
-    clauses.push_back("animal");
-    fieldConfig.initFromClause(clauses);
+
+    ml::api::CAnomalyJobConfig jobConfig =
+        CTestAnomalyJob::makeSimpleJobConfig("mean", "value", "animal", "", "");
 
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(bucketSize, model_t::E_None,
@@ -693,10 +684,10 @@ BOOST_AUTO_TEST_CASE(testInterimResultEdgeCases) {
 
     core_t::TTime bucketSize = 3600;
     model::CLimits limits;
-    api::CAnomalyJobConfig jobConfig;
+    api::CAnomalyJobConfig jobConfig =
+        CTestAnomalyJob::makeSimpleJobConfig("count", "", "error", "", "");
+
     api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clauses{"count", "by", "error"};
-    fieldConfig.initFromClause(clauses);
 
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(bucketSize);
@@ -755,12 +746,11 @@ BOOST_AUTO_TEST_CASE(testInterimResultEdgeCases) {
 
 BOOST_AUTO_TEST_CASE(testRestoreFailsWithEmptyStream) {
     model::CLimits limits;
-    api::CAnomalyJobConfig jobConfig;
+    api::CAnomalyJobConfig jobConfig =
+        CTestAnomalyJob::makeSimpleJobConfig("value", "", "", "", "greenhouse");
+
     api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clauses;
-    clauses.push_back("value");
-    clauses.push_back("partitionfield=greenhouse");
-    fieldConfig.initFromClause(clauses);
+
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SIZE);
     std::ostringstream outputStrm;

--- a/lib/api/unittest/CForecastRunnerTest.cc
+++ b/lib/api/unittest/CForecastRunnerTest.cc
@@ -75,7 +75,8 @@ BOOST_AUTO_TEST_CASE(testSummaryCount) {
         ml::core::CJsonOutputStreamWrapper streamWrapper(outputStrm);
         ml::model::CLimits limits;
         ml::api::CFieldConfig fieldConfig;
-        ml::api::CAnomalyJobConfig jobConfig;
+        ml::api::CAnomalyJobConfig jobConfig =
+            CTestAnomalyJob::makeSimpleJobConfig("count", "", "", "", "", {}, "count");
         ml::api::CFieldConfig::TStrVec clauses;
         clauses.push_back("count");
         clauses.push_back("summarycountfield=count");
@@ -190,14 +191,11 @@ BOOST_AUTO_TEST_CASE(testRare) {
     {
         ml::core::CJsonOutputStreamWrapper streamWrapper(outputStrm);
         ml::model::CLimits limits;
-        ml::api::CAnomalyJobConfig jobConfig;
-        ml::api::CFieldConfig fieldConfig;
-        ml::api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("rare");
-        clauses.push_back("by");
-        clauses.push_back("status");
+        ml::api::CAnomalyJobConfig jobConfig =
+            CTestAnomalyJob::makeSimpleJobConfig("rare", "", "status", "", "");
 
-        fieldConfig.initFromClause(clauses);
+        ml::api::CFieldConfig fieldConfig;
+
         ml::model::CAnomalyDetectorModelConfig modelConfig =
             ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
 
@@ -235,11 +233,11 @@ BOOST_AUTO_TEST_CASE(testInsufficientData) {
     {
         ml::core::CJsonOutputStreamWrapper streamWrapper(outputStrm);
         ml::model::CLimits limits;
-        ml::api::CAnomalyJobConfig jobConfig;
+        ml::api::CAnomalyJobConfig jobConfig =
+            CTestAnomalyJob::makeSimpleJobConfig("count", "", "", "", "");
+
         ml::api::CFieldConfig fieldConfig;
-        ml::api::CFieldConfig::TStrVec clauses;
-        clauses.push_back("count");
-        fieldConfig.initFromClause(clauses);
+
         ml::model::CAnomalyDetectorModelConfig modelConfig =
             ml::model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
 

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -125,15 +125,10 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
     core_t::TTime BUCKET_SPAN(10000);
     core_t::TTime time = 100000000;
 
-    api::CAnomalyJobConfig jobConfig;
     api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clause;
-    clause.push_back("max(notes)");
-    clause.push_back("by");
-    clause.push_back("composer");
-    clause.push_back("partitionfield=instrument");
 
-    BOOST_TEST_REQUIRE(fieldConfig.initFromClause(clause));
+    api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+        "max", "notes", "composer", "", "instrument");
 
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SPAN);
@@ -150,10 +145,8 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         model::CStringStore::influencers().clearEverythingTestOnly();
         model::CStringStore::names().clearEverythingTestOnly();
 
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::influencers().m_Strings.size());
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::names().m_Strings.size());
 
         LOG_TRACE(<< "Setting up job");
 
@@ -200,10 +193,8 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         model::CStringStore::influencers().clearEverythingTestOnly();
         model::CStringStore::names().clearEverythingTestOnly();
 
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::influencers().m_Strings.size());
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::names().m_Strings.size());
 
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
@@ -215,8 +206,7 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         adder.clear();
 
         // No influencers in this configuration
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
 
         // "", "count", "notes", "composer", "instrument", "Elgar", "Holst", "Delius", "flute", "tuba"
         BOOST_TEST_REQUIRE(this->nameExists("count"));
@@ -241,10 +231,8 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         model::CStringStore::influencers().clearEverythingTestOnly();
         model::CStringStore::names().clearEverythingTestOnly();
 
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::influencers().m_Strings.size());
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::names().m_Strings.size());
 
         std::ostringstream outputStrm;
         ml::core::CJsonOutputStreamWrapper wrappedOutputStream(outputStrm);
@@ -256,8 +244,7 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         adder.clear();
 
         // No influencers in this configuration
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
 
         // While the 3 composers from the second partition should have been culled in the prune,
         // their names still exist in the first partition, so will still be in the string store
@@ -318,15 +305,10 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
     core_t::TTime BUCKET_SPAN(10000);
     core_t::TTime time = 100000000;
 
-    api::CAnomalyJobConfig jobConfig;
     api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clause;
-    clause.push_back("dc(notes)");
-    clause.push_back("over");
-    clause.push_back("composer");
-    clause.push_back("partitionfield=instrument");
 
-    BOOST_TEST_REQUIRE(fieldConfig.initFromClause(clause));
+    api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+        "dc", "notes", "", "composer", "instrument");
 
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SPAN);
@@ -343,10 +325,8 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         model::CStringStore::influencers().clearEverythingTestOnly();
         model::CStringStore::names().clearEverythingTestOnly();
 
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::influencers().m_Strings.size());
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::names().m_Strings.size());
 
         LOG_TRACE(<< "Setting up job");
         std::ostringstream outputStrm;
@@ -511,14 +491,10 @@ BOOST_FIXTURE_TEST_CASE(testInfluencerStringPruning, CTestFixture) {
     core_t::TTime BUCKET_SPAN(10000);
     core_t::TTime time = 100000000;
 
-    api::CAnomalyJobConfig jobConfig;
-    api::CFieldConfig fieldConfig;
-    api::CFieldConfig::TStrVec clause;
-    clause.push_back("max(notes)");
-    clause.push_back("influencerfield=instrument");
-    clause.push_back("influencerfield=composer");
+    api::CAnomalyJobConfig jobConfig = CTestAnomalyJob::makeSimpleJobConfig(
+        "max", "notes", "", "", "", {"composer", "instrument"});
 
-    BOOST_TEST_REQUIRE(fieldConfig.initFromClause(clause));
+    api::CFieldConfig fieldConfig;
 
     model::CAnomalyDetectorModelConfig modelConfig =
         model::CAnomalyDetectorModelConfig::defaultConfig(BUCKET_SPAN);
@@ -534,10 +510,8 @@ BOOST_FIXTURE_TEST_CASE(testInfluencerStringPruning, CTestFixture) {
         model::CStringStore::influencers().clearEverythingTestOnly();
         model::CStringStore::names().clearEverythingTestOnly();
 
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::influencers().m_Strings.size());
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            model::CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, model::CStringStore::names().m_Strings.size());
 
         LOG_TRACE(<< "Setting up job");
         std::ostringstream outputStrm;

--- a/lib/api/unittest/CTestAnomalyJob.cc
+++ b/lib/api/unittest/CTestAnomalyJob.cc
@@ -5,6 +5,8 @@
  */
 #include "CTestAnomalyJob.h"
 
+#include <api/CAnomalyJobConfig.h>
+
 CTestAnomalyJob::CTestAnomalyJob(const std::string& jobId,
                                  ml::model::CLimits& limits,
                                  ml::api::CAnomalyJobConfig& jobConfig,
@@ -29,4 +31,19 @@ CTestAnomalyJob::CTestAnomalyJob(const std::string& jobId,
                            timeFieldName,
                            timeFieldFormat,
                            maxAnomalyRecords) {
+}
+
+ml::api::CAnomalyJobConfig
+CTestAnomalyJob::makeSimpleJobConfig(const std::string& functionName,
+                                     const std::string& fieldName,
+                                     const std::string& byFieldName,
+                                     const std::string& overFieldName,
+                                     const std::string& partitionFieldName,
+                                     const ml::api::CDataProcessor::TStrVec& influencers,
+                                     const std::string& summaryCountFieldName) {
+    ml::api::CAnomalyJobConfig jobConfig;
+    jobConfig.analysisConfig().addDetector(functionName, fieldName, byFieldName,
+                                           overFieldName, partitionFieldName,
+                                           influencers, summaryCountFieldName);
+    return jobConfig;
 }

--- a/lib/api/unittest/CTestAnomalyJob.h
+++ b/lib/api/unittest/CTestAnomalyJob.h
@@ -42,6 +42,15 @@ public:
     bool handleRecord(const TStrStrUMap& dataRowFields) {
         return this->handleRecord(dataRowFields, TOptionalTime{});
     }
+
+    static ml::api::CAnomalyJobConfig
+    makeSimpleJobConfig(const std::string& functionName,
+                        const std::string& fieldName,
+                        const std::string& byFieldName,
+                        const std::string& overFieldName,
+                        const std::string& partitionFieldName,
+                        const TStrVec& influencers = {},
+                        const std::string& summaryCountFieldName = "");
 };
 
 #endif // INCLUDED_CTestAnomalyJob_h


### PR DESCRIPTION
Replicate CFieldConfig code that parses clauses and
determines function types in CAnomalyJobConfig.

Relates to #1253
Backports #1619 