### PR TITLE
[7.x][ML] Include assignment_memory_basis in model_size_stats

### DIFF
--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -77,7 +77,8 @@ int main(int argc, char** argv) {
         ml::counter_t::E_TSADNumberExcludedFrequentInvocations,
         ml::counter_t::E_TSADNumberSamplesOutsideLatencyWindow,
         ml::counter_t::E_TSADNumberMemoryLimitModelCreationFailures,
-        ml::counter_t::E_TSADNumberPrunedItems};
+        ml::counter_t::E_TSADNumberPrunedItems,
+        ml::counter_t::E_TSADAssignmentMemoryBasis};
 
     ml::core::CProgramCounters::registerProgramCounterTypes(counters);
 

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -19,6 +19,7 @@
 #include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
 #include <core/CProcessPriority.h>
+#include <core/CProgramCounters.h>
 #include <core/CoreTypes.h>
 
 #include <ver/CBuildInfo.h>
@@ -48,6 +49,16 @@
 #include <string>
 
 int main(int argc, char** argv) {
+
+    // Register the set of counters in which this program is interested
+    const ml::counter_t::TCounterTypeSet counters{
+        ml::counter_t::E_TSADMemoryUsage, ml::counter_t::E_TSADPeakMemoryUsage,
+        ml::counter_t::E_TSADNumberRecordsNoTimeField,
+        ml::counter_t::E_TSADNumberTimeFieldConversionErrors,
+        ml::counter_t::E_TSADAssignmentMemoryBasis};
+
+    ml::core::CProgramCounters::registerProgramCounterTypes(counters);
+
     // Read command line options
     std::string limitConfigFile;
     std::string jobId;

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -45,6 +45,9 @@
 * Improvements to time series modeling particularly in relation to adaption to change.
   (See {ml-pull})1614[#1614].)
 * Warn and error log throttling. (See {ml-pull}1615[#1615].)
+* Soften the effect of fluctuations in anomaly detection job memory usage on node
+  assignment and add `assignment_memory_basis` to `model_size_stats`.
+  (See {ml-pull}1623[#1623], {es-pull}65561[#65561], issue: {es-issue}63163[#63163].)
 
 === Bug Fixes
 

--- a/include/core/CProgramCounters.h
+++ b/include/core/CProgramCounters.h
@@ -99,6 +99,9 @@ enum ECounterTypes {
     //! The number of times partial memory estimates have been carried out
     E_TSADNumberMemoryUsageEstimates = 18,
 
+    //! Which option is being used to get model memory for node assignment?
+    E_TSADAssignmentMemoryBasis = 29,
+
     // Data Frame Outlier Detection
 
     //! The estimated peak memory usage for outlier detection in bytes
@@ -133,10 +136,10 @@ enum ECounterTypes {
     // Add any new values here
 
     //! This MUST be last, increment the value for every new enum added
-    E_LastEnumCounter = 29
+    E_LastEnumCounter = 30
 };
 
-static constexpr size_t NUM_COUNTERS = static_cast<size_t>(E_LastEnumCounter);
+static constexpr std::size_t NUM_COUNTERS = static_cast<std::size_t>(E_LastEnumCounter);
 
 using TCounterTypeSet = std::set<ECounterTypes>;
 }
@@ -248,7 +251,7 @@ public:
 
     //! Provide access to the relevant counter from the collection
     static TCounter& counter(counter_t::ECounterTypes counterType);
-    static TCounter& counter(size_t index);
+    static TCounter& counter(std::size_t index);
 
     //! Copy the collection of live counters to a cache
     static void cacheCounters();
@@ -327,6 +330,8 @@ private:
           "The number of model creation failures from being over memory limit"},
          {counter_t::E_TSADNumberPrunedItems, "E_TSADNumberPrunedItems",
           "The number of old people or attributes pruned from the models"},
+         {counter_t::E_TSADAssignmentMemoryBasis, "E_TSADAssignmentMemoryBasis",
+          "Which option is being used to get model memory for node assignment?"},
          {counter_t::E_DFOEstimatedPeakMemoryUsage, "E_DFOEstimatedPeakMemoryUsage",
           "The upfront estimate of the peak memory outlier detection would use"},
          {counter_t::E_DFOPeakMemoryUsage, "E_DFOPeakMemoryUsage", "The peak memory outlier detection used"},

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -793,6 +793,22 @@ enum EMemoryStatus {
 MODEL_EXPORT
 std::string print(EMemoryStatus memoryStatus);
 
+//! Where to get the job memory from for use in node assignment decisions.
+//! Prior to 7.11 this decision was made in Java code, indicated by the
+//! "unknown" value of this enum.  From 7.11 onwards the CResourceMonitor
+//! class makes the decision, and uses this enum to report that to the Java
+//! code.
+enum EAssignmentMemoryBasis {
+    E_AssignmentBasisUnknown = 0,           //!< Decision made in Java code
+    E_AssignmentBasisModelMemoryLimit = 1,  //!< Use model memory limit
+    E_AssignmentBasisCurrentModelBytes = 2, //!< Use current actual model size
+    E_AssignmentBasisPeakModelBytes = 3 //!< Use highest ever actual model size
+};
+
+//! Get a string description of \p assignmentMemoryBasis.
+MODEL_EXPORT
+std::string print(EAssignmentMemoryBasis assignmentMemoryBasis);
+
 //! An enumeration of the TokenListDataCategorizer status -
 //! Start in the OK state. Moves into the "warn" state if too
 //! few categories are being seen frequently.

--- a/lib/api/CModelSizeStatsJsonWriter.cc
+++ b/lib/api/CModelSizeStatsJsonWriter.cc
@@ -26,6 +26,7 @@ const std::string TOTAL_OVER_FIELD_COUNT{"total_over_field_count"};
 const std::string TOTAL_PARTITION_FIELD_COUNT{"total_partition_field_count"};
 const std::string BUCKET_ALLOCATION_FAILURES_COUNT{"bucket_allocation_failures_count"};
 const std::string MEMORY_STATUS{"memory_status"};
+const std::string ASSIGNMENT_MEMORY_BASIS{"assignment_memory_basis"};
 const std::string CATEGORIZED_DOC_COUNT{"categorized_doc_count"};
 const std::string TOTAL_CATEGORY_COUNT{"total_category_count"};
 const std::string FREQUENT_CATEGORY_COUNT{"frequent_category_count"};
@@ -72,6 +73,11 @@ void CModelSizeStatsJsonWriter::write(const std::string& jobId,
 
     writer.Key(MEMORY_STATUS);
     writer.String(model_t::print(results.s_MemoryStatus));
+
+    if (results.s_AssignmentMemoryBasis != model_t::E_AssignmentBasisUnknown) {
+        writer.Key(ASSIGNMENT_MEMORY_BASIS);
+        writer.String(model_t::print(results.s_AssignmentMemoryBasis));
+    }
 
     CModelSizeStatsJsonWriter::writeCommonFields(
         jobId, results.s_OverallCategorizerStats, results.s_BucketStartTime, writer);

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -241,7 +241,7 @@ void testBucketWriteHelper(bool isInterim) {
         const rapidjson::Value& bucket = bucketWrapper["bucket"];
         BOOST_TEST_REQUIRE(bucket.IsObject());
         BOOST_TEST_REQUIRE(bucket.HasMember("job_id"));
-        BOOST_REQUIRE_EQUAL(std::string("job"), std::string(bucket["job_id"].GetString()));
+        BOOST_REQUIRE_EQUAL("job", bucket["job_id"].GetString());
 
         // 3 detectors each have 2 records (simple count detector isn't added)
         // except the population detector which has a single record and clauses
@@ -260,9 +260,8 @@ void testBucketWriteHelper(bool isInterim) {
         BOOST_TEST_REQUIRE(bucketInfluencer.HasMember("anomaly_score"));
         BOOST_REQUIRE_CLOSE_ABSOLUTE(
             70.0, bucketInfluencer["anomaly_score"].GetDouble(), 0.00001);
-        BOOST_REQUIRE_EQUAL(
-            std::string("bucket_time"),
-            std::string(bucketInfluencer["influencer_field_name"].GetString()));
+        BOOST_REQUIRE_EQUAL("bucket_time",
+                            bucketInfluencer["influencer_field_name"].GetString());
 
         BOOST_REQUIRE_EQUAL(79, bucket["event_count"].GetInt());
         BOOST_TEST_REQUIRE(bucket.HasMember("anomaly_score"));
@@ -293,8 +292,7 @@ void testBucketWriteHelper(bool isInterim) {
         {
             const rapidjson::Value& record = records[rapidjson::SizeType(0)];
             BOOST_TEST_REQUIRE(record.HasMember("job_id"));
-            BOOST_REQUIRE_EQUAL(std::string("job"),
-                                std::string(record["job_id"].GetString()));
+            BOOST_REQUIRE_EQUAL("job", record["job_id"].GetString());
             BOOST_TEST_REQUIRE(record.HasMember("detector_index"));
             BOOST_REQUIRE_EQUAL(1, record["detector_index"].GetInt());
             BOOST_TEST_REQUIRE(record.HasMember("timestamp"));
@@ -302,22 +300,18 @@ void testBucketWriteHelper(bool isInterim) {
             BOOST_TEST_REQUIRE(record.HasMember("probability"));
             BOOST_REQUIRE_EQUAL(0.0, record["probability"].GetDouble());
             BOOST_TEST_REQUIRE(record.HasMember("by_field_name"));
-            BOOST_REQUIRE_EQUAL(std::string("airline"),
-                                std::string(record["by_field_name"].GetString()));
+            BOOST_REQUIRE_EQUAL("airline", record["by_field_name"].GetString());
             BOOST_TEST_REQUIRE(!record.HasMember("by_field_value"));
             BOOST_TEST_REQUIRE(!record.HasMember("correlated_by_field_value"));
             BOOST_TEST_REQUIRE(record.HasMember("function"));
-            BOOST_REQUIRE_EQUAL(std::string("mean"),
-                                std::string(record["function"].GetString()));
+            BOOST_REQUIRE_EQUAL("mean", record["function"].GetString());
             BOOST_TEST_REQUIRE(record.HasMember("function_description"));
-            BOOST_REQUIRE_EQUAL(std::string("mean(responsetime)"),
-                                std::string(record["function_description"].GetString()));
+            BOOST_REQUIRE_EQUAL("mean(responsetime)",
+                                record["function_description"].GetString());
             BOOST_TEST_REQUIRE(record.HasMember("over_field_name"));
-            BOOST_REQUIRE_EQUAL(std::string("pfn"),
-                                std::string(record["over_field_name"].GetString()));
+            BOOST_REQUIRE_EQUAL("pfn", record["over_field_name"].GetString());
             BOOST_TEST_REQUIRE(record.HasMember("over_field_value"));
-            BOOST_REQUIRE_EQUAL(std::string("pfv"),
-                                std::string(record["over_field_value"].GetString()));
+            BOOST_REQUIRE_EQUAL("pfv", record["over_field_value"].GetString());
             BOOST_TEST_REQUIRE(record.HasMember("bucket_span"));
             BOOST_REQUIRE_EQUAL(100, record["bucket_span"].GetInt());
             // It's hard to predict what these will be, so just assert their
@@ -340,30 +334,22 @@ void testBucketWriteHelper(bool isInterim) {
                 BOOST_TEST_REQUIRE(cause.HasMember("probability"));
                 BOOST_REQUIRE_EQUAL(0.0, cause["probability"].GetDouble());
                 BOOST_TEST_REQUIRE(cause.HasMember("field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("responsetime"),
-                                    std::string(cause["field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("responsetime", cause["field_name"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("by_field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("airline"),
-                                    std::string(cause["by_field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("airline", cause["by_field_name"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("by_field_value"));
-                BOOST_REQUIRE_EQUAL(std::string("GAL"),
-                                    std::string(cause["by_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("GAL", cause["by_field_value"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("correlated_by_field_value"));
-                BOOST_REQUIRE_EQUAL(
-                    std::string("BAW"),
-                    std::string(cause["correlated_by_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("BAW", cause["correlated_by_field_value"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("partition_field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("tfn"),
-                                    std::string(cause["partition_field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("tfn", cause["partition_field_name"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("partition_field_value"));
-                BOOST_REQUIRE_EQUAL(std::string(""),
-                                    std::string(cause["partition_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("", cause["partition_field_value"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("function"));
-                BOOST_REQUIRE_EQUAL(std::string("mean"),
-                                    std::string(cause["function"].GetString()));
+                BOOST_REQUIRE_EQUAL("mean", cause["function"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("function_description"));
-                BOOST_REQUIRE_EQUAL(std::string("mean(responsetime)"),
-                                    std::string(cause["function_description"].GetString()));
+                BOOST_REQUIRE_EQUAL("mean(responsetime)",
+                                    cause["function_description"].GetString());
                 BOOST_TEST_REQUIRE(cause.HasMember("typical"));
                 BOOST_TEST_REQUIRE(cause["typical"].IsArray());
                 BOOST_REQUIRE_EQUAL(rapidjson::SizeType(1), cause["typical"].Size());
@@ -383,8 +369,7 @@ void testBucketWriteHelper(bool isInterim) {
             for (rapidjson::SizeType k = 1; k < 3; k++) {
                 const rapidjson::Value& record = records[k];
                 BOOST_TEST_REQUIRE(record.HasMember("job_id"));
-                BOOST_REQUIRE_EQUAL(std::string("job"),
-                                    std::string(record["job_id"].GetString()));
+                BOOST_REQUIRE_EQUAL("job", record["job_id"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("detector_index"));
                 BOOST_REQUIRE_EQUAL(2, record["detector_index"].GetInt());
                 BOOST_TEST_REQUIRE(record.HasMember("timestamp"));
@@ -392,15 +377,11 @@ void testBucketWriteHelper(bool isInterim) {
                 BOOST_TEST_REQUIRE(record.HasMember("probability"));
                 BOOST_REQUIRE_EQUAL(0.0, record["probability"].GetDouble());
                 BOOST_TEST_REQUIRE(record.HasMember("by_field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("airline"),
-                                    std::string(record["by_field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("airline", record["by_field_name"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("by_field_value"));
-                BOOST_REQUIRE_EQUAL(std::string("GAL"),
-                                    std::string(record["by_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("GAL", record["by_field_value"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("correlated_by_field_value"));
-                BOOST_REQUIRE_EQUAL(
-                    std::string("BAW"),
-                    std::string(record["correlated_by_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("BAW", record["correlated_by_field_value"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("typical"));
                 BOOST_TEST_REQUIRE(record["typical"].IsArray());
                 BOOST_REQUIRE_EQUAL(rapidjson::SizeType(1), record["typical"].Size());
@@ -412,20 +393,16 @@ void testBucketWriteHelper(bool isInterim) {
                 BOOST_REQUIRE_EQUAL(
                     10090.0, record["actual"][rapidjson::SizeType(0)].GetDouble());
                 BOOST_TEST_REQUIRE(record.HasMember("field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("responsetime"),
-                                    std::string(record["field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("responsetime", record["field_name"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("function"));
-                BOOST_REQUIRE_EQUAL(std::string("mean"),
-                                    std::string(record["function"].GetString()));
+                BOOST_REQUIRE_EQUAL("mean", record["function"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("function_description"));
-                BOOST_REQUIRE_EQUAL(std::string("mean(responsetime)"),
-                                    std::string(record["function_description"].GetString()));
+                BOOST_REQUIRE_EQUAL("mean(responsetime)",
+                                    record["function_description"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("partition_field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("tfn"),
-                                    std::string(record["partition_field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("tfn", record["partition_field_name"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("partition_field_value"));
-                BOOST_REQUIRE_EQUAL(std::string(""),
-                                    std::string(record["partition_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("", record["partition_field_value"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("bucket_span"));
                 BOOST_REQUIRE_EQUAL(100, record["bucket_span"].GetInt());
                 // It's hard to predict what these will be, so just assert their
@@ -446,8 +423,7 @@ void testBucketWriteHelper(bool isInterim) {
             for (rapidjson::SizeType k = 3; k < 5; k++) {
                 const rapidjson::Value& record = records[k];
                 BOOST_TEST_REQUIRE(record.HasMember("job_id"));
-                BOOST_REQUIRE_EQUAL(std::string("job"),
-                                    std::string(record["job_id"].GetString()));
+                BOOST_REQUIRE_EQUAL("job", record["job_id"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("detector_index"));
                 BOOST_REQUIRE_EQUAL(4, record["detector_index"].GetInt());
                 BOOST_TEST_REQUIRE(record.HasMember("timestamp"));
@@ -455,15 +431,11 @@ void testBucketWriteHelper(bool isInterim) {
                 BOOST_TEST_REQUIRE(record.HasMember("probability"));
                 BOOST_REQUIRE_EQUAL(0.0, record["probability"].GetDouble());
                 BOOST_TEST_REQUIRE(record.HasMember("by_field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("airline"),
-                                    std::string(record["by_field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("airline", record["by_field_name"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("by_field_value"));
-                BOOST_REQUIRE_EQUAL(std::string("GAL"),
-                                    std::string(record["by_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("GAL", record["by_field_value"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("correlated_by_field_value"));
-                BOOST_REQUIRE_EQUAL(
-                    std::string("BAW"),
-                    std::string(record["correlated_by_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("BAW", record["correlated_by_field_value"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("typical"));
                 BOOST_TEST_REQUIRE(record["typical"].IsArray());
                 BOOST_REQUIRE_EQUAL(rapidjson::SizeType(1), record["typical"].Size());
@@ -476,17 +448,14 @@ void testBucketWriteHelper(bool isInterim) {
                     10090.0, record["actual"][rapidjson::SizeType(0)].GetDouble());
                 BOOST_TEST_REQUIRE(record.HasMember("function"));
                 // This would be count in the real case with properly generated input data
-                BOOST_REQUIRE_EQUAL(std::string("mean"),
-                                    std::string(record["function"].GetString()));
+                BOOST_REQUIRE_EQUAL("mean", record["function"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("function_description"));
-                BOOST_REQUIRE_EQUAL(std::string("mean(responsetime)"),
-                                    std::string(record["function_description"].GetString()));
+                BOOST_REQUIRE_EQUAL("mean(responsetime)",
+                                    record["function_description"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("partition_field_name"));
-                BOOST_REQUIRE_EQUAL(std::string("tfn"),
-                                    std::string(record["partition_field_name"].GetString()));
+                BOOST_REQUIRE_EQUAL("tfn", record["partition_field_name"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("partition_field_value"));
-                BOOST_REQUIRE_EQUAL(std::string(""),
-                                    std::string(record["partition_field_value"].GetString()));
+                BOOST_REQUIRE_EQUAL("", record["partition_field_value"].GetString());
                 BOOST_TEST_REQUIRE(record.HasMember("bucket_span"));
                 BOOST_REQUIRE_EQUAL(100, record["bucket_span"].GetInt());
                 // It's hard to predict what these will be, so just assert their
@@ -1040,11 +1009,11 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
         BOOST_TEST_REQUIRE(record.HasMember("geo_results"));
         auto geoResultsObject = record["geo_results"].GetObject();
         BOOST_TEST_REQUIRE(geoResultsObject.HasMember("actual_point"));
-        BOOST_REQUIRE_EQUAL(std::string("40.000000000000,-40.000000000000"),
-                            (geoResultsObject["actual_point"].GetString()));
+        BOOST_REQUIRE_EQUAL("40.000000000000,-40.000000000000",
+                            geoResultsObject["actual_point"].GetString());
         BOOST_TEST_REQUIRE(geoResultsObject.HasMember("typical_point"));
-        BOOST_REQUIRE_EQUAL(std::string("90.000000000000,-90.000000000000"),
-                            (geoResultsObject["typical_point"].GetString()));
+        BOOST_REQUIRE_EQUAL("90.000000000000,-90.000000000000",
+                            geoResultsObject["typical_point"].GetString());
     }
 
     {
@@ -1164,7 +1133,7 @@ BOOST_AUTO_TEST_CASE(testWriteNonAnomalousBucket) {
 
     const rapidjson::Value& bucket = bucketWrapper["bucket"];
     BOOST_TEST_REQUIRE(bucket.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"), std::string(bucket["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", bucket["job_id"].GetString());
     BOOST_REQUIRE_EQUAL(1000, bucket["timestamp"].GetInt());
     BOOST_TEST_REQUIRE(bucket.HasMember("bucket_influencers") == false);
     BOOST_REQUIRE_EQUAL(0, bucket["event_count"].GetInt());
@@ -1203,7 +1172,7 @@ BOOST_AUTO_TEST_CASE(testFlush) {
     const rapidjson::Value& flush = flushWrapper["flush"];
     BOOST_TEST_REQUIRE(flush.IsObject());
     BOOST_TEST_REQUIRE(flush.HasMember("id"));
-    BOOST_REQUIRE_EQUAL(testId, std::string(flush["id"].GetString()));
+    BOOST_REQUIRE_EQUAL(testId, flush["id"].GetString());
     BOOST_TEST_REQUIRE(flush.HasMember("last_finalized_bucket_end"));
     BOOST_REQUIRE_EQUAL(lastFinalizedBucketEnd * 1000,
                         static_cast<ml::core_t::TTime>(
@@ -1247,16 +1216,16 @@ BOOST_AUTO_TEST_CASE(testWriteCategoryDefinition) {
 
     const rapidjson::Value& category = categoryWrapper["category_definition"];
     BOOST_TEST_REQUIRE(category.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"), std::string(category["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", category["job_id"].GetString());
     BOOST_TEST_REQUIRE(category.HasMember("partition_field_name") == false);
     BOOST_TEST_REQUIRE(category.HasMember("partition_field_value") == false);
     BOOST_TEST_REQUIRE(category.IsObject());
     BOOST_TEST_REQUIRE(category.HasMember("category_id"));
     BOOST_REQUIRE_EQUAL(categoryId.globalId(), category["category_id"].GetInt());
     BOOST_TEST_REQUIRE(category.HasMember("terms"));
-    BOOST_REQUIRE_EQUAL(terms, std::string(category["terms"].GetString()));
+    BOOST_REQUIRE_EQUAL(terms, category["terms"].GetString());
     BOOST_TEST_REQUIRE(category.HasMember("regex"));
-    BOOST_REQUIRE_EQUAL(regex, std::string(category["regex"].GetString()));
+    BOOST_REQUIRE_EQUAL(regex, category["regex"].GetString());
     BOOST_TEST_REQUIRE(category.HasMember("max_matching_length"));
     BOOST_REQUIRE_EQUAL(maxMatchingLength,
                         static_cast<std::size_t>(category["max_matching_length"].GetInt()));
@@ -1307,20 +1276,18 @@ BOOST_AUTO_TEST_CASE(testWritePerPartitionCategoryDefinition) {
 
     const rapidjson::Value& category = categoryWrapper["category_definition"];
     BOOST_TEST_REQUIRE(category.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"), std::string(category["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", category["job_id"].GetString());
     BOOST_TEST_REQUIRE(category.HasMember("partition_field_name"));
-    BOOST_REQUIRE_EQUAL("event.dataset",
-                        std::string(category["partition_field_name"].GetString()));
+    BOOST_REQUIRE_EQUAL("event.dataset", category["partition_field_name"].GetString());
     BOOST_TEST_REQUIRE(category.HasMember("partition_field_value"));
-    BOOST_REQUIRE_EQUAL("elasticsearch",
-                        std::string(category["partition_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL("elasticsearch", category["partition_field_value"].GetString());
     BOOST_TEST_REQUIRE(category.IsObject());
     BOOST_TEST_REQUIRE(category.HasMember("category_id"));
     BOOST_REQUIRE_EQUAL(categoryId.globalId(), category["category_id"].GetInt());
     BOOST_TEST_REQUIRE(category.HasMember("terms"));
-    BOOST_REQUIRE_EQUAL(terms, std::string(category["terms"].GetString()));
+    BOOST_REQUIRE_EQUAL(terms, category["terms"].GetString());
     BOOST_TEST_REQUIRE(category.HasMember("regex"));
-    BOOST_REQUIRE_EQUAL(regex, std::string(category["regex"].GetString()));
+    BOOST_REQUIRE_EQUAL(regex, category["regex"].GetString());
     BOOST_TEST_REQUIRE(category.HasMember("max_matching_length"));
     BOOST_REQUIRE_EQUAL(maxMatchingLength,
                         static_cast<std::size_t>(category["max_matching_length"].GetInt()));
@@ -1390,16 +1357,14 @@ BOOST_AUTO_TEST_CASE(testWriteInfluencers) {
 
     const rapidjson::Value& influencer = influencers[rapidjson::SizeType(0)];
     BOOST_TEST_REQUIRE(influencer.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"), std::string(influencer["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", influencer["job_id"].GetString());
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.5, influencer["probability"].GetDouble(), 0.001);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(
         10.0, influencer["initial_influencer_score"].GetDouble(), 0.001);
     BOOST_TEST_REQUIRE(influencer.HasMember("influencer_score"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(10.0, influencer["influencer_score"].GetDouble(), 0.001);
-    BOOST_REQUIRE_EQUAL(std::string("user"),
-                        std::string(influencer["influencer_field_name"].GetString()));
-    BOOST_REQUIRE_EQUAL(std::string("daisy"),
-                        std::string(influencer["influencer_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL("user", influencer["influencer_field_name"].GetString());
+    BOOST_REQUIRE_EQUAL("daisy", influencer["influencer_field_value"].GetString());
     BOOST_REQUIRE_EQUAL(42000, influencer["timestamp"].GetInt());
     BOOST_TEST_REQUIRE(influencer["is_interim"].GetBool());
     BOOST_TEST_REQUIRE(influencer.HasMember("bucket_span"));
@@ -1410,10 +1375,8 @@ BOOST_AUTO_TEST_CASE(testWriteInfluencers) {
         100.0, influencer2["initial_influencer_score"].GetDouble(), 0.001);
     BOOST_TEST_REQUIRE(influencer2.HasMember("influencer_score"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(100.0, influencer2["influencer_score"].GetDouble(), 0.001);
-    BOOST_REQUIRE_EQUAL(std::string("user"),
-                        std::string(influencer2["influencer_field_name"].GetString()));
-    BOOST_REQUIRE_EQUAL(std::string("jim"),
-                        std::string(influencer2["influencer_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL("user", influencer2["influencer_field_name"].GetString());
+    BOOST_REQUIRE_EQUAL("jim", influencer2["influencer_field_value"].GetString());
     BOOST_REQUIRE_EQUAL(42000, influencer2["timestamp"].GetInt());
     BOOST_TEST_REQUIRE(influencer2["is_interim"].GetBool());
     BOOST_TEST_REQUIRE(influencer2.HasMember("bucket_span"));
@@ -1507,10 +1470,8 @@ BOOST_AUTO_TEST_CASE(testWriteInfluencersWithLimit) {
         100.0, influencer["initial_influencer_score"].GetDouble(), 0.001);
     BOOST_TEST_REQUIRE(influencer.HasMember("influencer_score"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(100.0, influencer["influencer_score"].GetDouble(), 0.001);
-    BOOST_REQUIRE_EQUAL(std::string("user"),
-                        std::string(influencer["influencer_field_name"].GetString()));
-    BOOST_REQUIRE_EQUAL(std::string("jim"),
-                        std::string(influencer["influencer_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL("user", influencer["influencer_field_name"].GetString());
+    BOOST_REQUIRE_EQUAL("jim", influencer["influencer_field_value"].GetString());
     BOOST_TEST_REQUIRE(influencer.HasMember("bucket_span"));
 
     const rapidjson::Value& influencer2 = influencers[rapidjson::SizeType(1)];
@@ -1519,10 +1480,8 @@ BOOST_AUTO_TEST_CASE(testWriteInfluencersWithLimit) {
         12.0, influencer2["initial_influencer_score"].GetDouble(), 0.001);
     BOOST_TEST_REQUIRE(influencer2.HasMember("influencer_score"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(12.0, influencer2["influencer_score"].GetDouble(), 0.001);
-    BOOST_REQUIRE_EQUAL(std::string("computer"),
-                        std::string(influencer2["influencer_field_name"].GetString()));
-    BOOST_REQUIRE_EQUAL(std::string("laptop"),
-                        std::string(influencer2["influencer_field_value"].GetString()));
+    BOOST_REQUIRE_EQUAL("computer", influencer2["influencer_field_name"].GetString());
+    BOOST_REQUIRE_EQUAL("laptop", influencer2["influencer_field_value"].GetString());
     BOOST_TEST_REQUIRE(influencer2.HasMember("bucket_span"));
 
     // bucket influencers
@@ -1537,8 +1496,7 @@ BOOST_AUTO_TEST_CASE(testWriteInfluencersWithLimit) {
     BOOST_REQUIRE_CLOSE_ABSOLUTE(100.0, binf["initial_anomaly_score"].GetDouble(), 0.001);
     BOOST_TEST_REQUIRE(binf.HasMember("anomaly_score"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(100.0, binf["anomaly_score"].GetDouble(), 0.001);
-    BOOST_REQUIRE_EQUAL(std::string("computer"),
-                        std::string(binf["influencer_field_name"].GetString()));
+    BOOST_REQUIRE_EQUAL("computer", binf["influencer_field_name"].GetString());
     BOOST_REQUIRE_CLOSE_ABSOLUTE(10.0, binf["raw_anomaly_score"].GetDouble(), 0.001);
 
     const rapidjson::Value& binf2 = bucketInfluencers[rapidjson::SizeType(1)];
@@ -1546,8 +1504,7 @@ BOOST_AUTO_TEST_CASE(testWriteInfluencersWithLimit) {
     BOOST_REQUIRE_CLOSE_ABSOLUTE(10.0, binf2["initial_anomaly_score"].GetDouble(), 0.001);
     BOOST_TEST_REQUIRE(binf2.HasMember("anomaly_score"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(10.0, binf2["anomaly_score"].GetDouble(), 0.001);
-    BOOST_REQUIRE_EQUAL(std::string("user"),
-                        std::string(binf2["influencer_field_name"].GetString()));
+    BOOST_REQUIRE_EQUAL("user", binf2["influencer_field_name"].GetString());
     BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, binf2["raw_anomaly_score"].GetDouble(), 0.001);
 
     const rapidjson::Value& binf3 = bucketInfluencers[rapidjson::SizeType(2)];
@@ -1555,8 +1512,7 @@ BOOST_AUTO_TEST_CASE(testWriteInfluencersWithLimit) {
     BOOST_REQUIRE_CLOSE_ABSOLUTE(10.0, binf3["initial_anomaly_score"].GetDouble(), 0.001);
     BOOST_TEST_REQUIRE(binf3.HasMember("anomaly_score"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(10.0, binf3["anomaly_score"].GetDouble(), 0.001);
-    BOOST_REQUIRE_EQUAL(std::string("bucket_time"),
-                        std::string(binf3["influencer_field_name"].GetString()));
+    BOOST_REQUIRE_EQUAL("bucket_time", binf3["influencer_field_name"].GetString());
     BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, binf3["raw_anomaly_score"].GetDouble(), 0.001);
 }
 
@@ -1663,41 +1619,32 @@ BOOST_AUTO_TEST_CASE(testWriteWithInfluences) {
     {
         const rapidjson::Value& influence = influences[rapidjson::SizeType(0)];
         BOOST_TEST_REQUIRE(influence.HasMember("influencer_field_name"));
-        BOOST_REQUIRE_EQUAL(std::string("host"),
-                            std::string(influence["influencer_field_name"].GetString()));
+        BOOST_REQUIRE_EQUAL("host", influence["influencer_field_name"].GetString());
         BOOST_TEST_REQUIRE(influence.HasMember("influencer_field_values"));
         const rapidjson::Value& influencerFieldValues = influence["influencer_field_values"];
         BOOST_TEST_REQUIRE(influencerFieldValues.IsArray());
         BOOST_REQUIRE_EQUAL(rapidjson::SizeType(2), influencerFieldValues.Size());
 
         // Check influencers are ordered
+        BOOST_REQUIRE_EQUAL("web-server",
+                            influencerFieldValues[rapidjson::SizeType(0)].GetString());
         BOOST_REQUIRE_EQUAL(
-            std::string("web-server"),
-            std::string(influencerFieldValues[rapidjson::SizeType(0)].GetString()));
-        BOOST_REQUIRE_EQUAL(
-            std::string("localhost"),
-            std::string(influencerFieldValues[rapidjson::SizeType(1)].GetString()));
+            "localhost", influencerFieldValues[rapidjson::SizeType(1)].GetString());
     }
     {
         const rapidjson::Value& influence = influences[rapidjson::SizeType(1)];
         BOOST_TEST_REQUIRE(influence.HasMember("influencer_field_name"));
-        BOOST_REQUIRE_EQUAL(std::string("user"),
-                            std::string(influence["influencer_field_name"].GetString()));
+        BOOST_REQUIRE_EQUAL("user", influence["influencer_field_name"].GetString());
         BOOST_TEST_REQUIRE(influence.HasMember("influencer_field_values"));
         const rapidjson::Value& influencerFieldValues = influence["influencer_field_values"];
         BOOST_TEST_REQUIRE(influencerFieldValues.IsArray());
         BOOST_REQUIRE_EQUAL(rapidjson::SizeType(3), influencerFieldValues.Size());
 
         // Check influencers are ordered
+        BOOST_REQUIRE_EQUAL("cat", influencerFieldValues[rapidjson::SizeType(0)].GetString());
         BOOST_REQUIRE_EQUAL(
-            std::string("cat"),
-            std::string(influencerFieldValues[rapidjson::SizeType(0)].GetString()));
-        BOOST_REQUIRE_EQUAL(
-            std::string("dave"),
-            std::string(influencerFieldValues[rapidjson::SizeType(1)].GetString()));
-        BOOST_REQUIRE_EQUAL(
-            std::string("jo"),
-            std::string(influencerFieldValues[rapidjson::SizeType(2)].GetString()));
+            "dave", influencerFieldValues[rapidjson::SizeType(1)].GetString());
+        BOOST_REQUIRE_EQUAL("jo", influencerFieldValues[rapidjson::SizeType(2)].GetString());
     }
 }
 
@@ -1728,8 +1675,7 @@ BOOST_AUTO_TEST_CASE(testPersistNormalizer) {
     BOOST_TEST_REQUIRE(quantileWrapper.HasMember("quantiles"));
     const rapidjson::Value& quantileState = quantileWrapper["quantiles"];
     BOOST_TEST_REQUIRE(quantileState.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"),
-                        std::string(quantileState["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", quantileState["job_id"].GetString());
     BOOST_TEST_REQUIRE(quantileState.HasMember("quantile_state"));
     BOOST_TEST_REQUIRE(quantileState.HasMember("timestamp"));
 }
@@ -1750,6 +1696,7 @@ BOOST_AUTO_TEST_CASE(testReportMemoryUsage) {
         resourceUsage.s_OverFields = 7;
         resourceUsage.s_AllocationFailures = 8;
         resourceUsage.s_MemoryStatus = ml::model_t::E_MemoryStatusHardLimit;
+        resourceUsage.s_AssignmentMemoryBasis = ml::model_t::E_AssignmentBasisCurrentModelBytes;
         resourceUsage.s_BucketStartTime = 9;
         resourceUsage.s_BytesExceeded = 10;
         resourceUsage.s_BytesMemoryLimit = 11;
@@ -1776,7 +1723,7 @@ BOOST_AUTO_TEST_CASE(testReportMemoryUsage) {
     const rapidjson::Value& sizeStats = resourceWrapper["model_size_stats"];
 
     BOOST_TEST_REQUIRE(sizeStats.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string{"job"}, sizeStats["job_id"].GetString());
+    BOOST_REQUIRE_EQUAL("job", sizeStats["job_id"].GetString());
     BOOST_TEST_REQUIRE(sizeStats.HasMember("model_bytes"));
     BOOST_REQUIRE_EQUAL(2, sizeStats["model_bytes"].GetInt());
     BOOST_TEST_REQUIRE(sizeStats.HasMember("peak_model_bytes"));
@@ -1792,7 +1739,10 @@ BOOST_AUTO_TEST_CASE(testReportMemoryUsage) {
     BOOST_TEST_REQUIRE(sizeStats.HasMember("timestamp"));
     BOOST_REQUIRE_EQUAL(9000, sizeStats["timestamp"].GetInt());
     BOOST_TEST_REQUIRE(sizeStats.HasMember("memory_status"));
-    BOOST_REQUIRE_EQUAL(std::string{"hard_limit"}, sizeStats["memory_status"].GetString());
+    BOOST_REQUIRE_EQUAL("hard_limit", sizeStats["memory_status"].GetString());
+    BOOST_TEST_REQUIRE(sizeStats.HasMember("assignment_memory_basis"));
+    BOOST_REQUIRE_EQUAL("current_model_bytes",
+                        sizeStats["assignment_memory_basis"].GetString());
     BOOST_TEST_REQUIRE(sizeStats.HasMember("log_time"));
     std::int64_t nowMs{ml::core::CTimeUtils::nowMs()};
     BOOST_TEST_REQUIRE(nowMs >= sizeStats["log_time"].GetInt64());
@@ -1813,7 +1763,7 @@ BOOST_AUTO_TEST_CASE(testReportMemoryUsage) {
     BOOST_TEST_REQUIRE(sizeStats.HasMember("failed_category_count"));
     BOOST_REQUIRE_EQUAL(17, sizeStats["failed_category_count"].GetInt());
     BOOST_TEST_REQUIRE(sizeStats.HasMember("categorization_status"));
-    BOOST_REQUIRE_EQUAL(std::string{"warn"}, sizeStats["categorization_status"].GetString());
+    BOOST_REQUIRE_EQUAL("warn", sizeStats["categorization_status"].GetString());
 }
 
 BOOST_AUTO_TEST_CASE(testWriteCategorizerStats) {
@@ -1845,13 +1795,11 @@ BOOST_AUTO_TEST_CASE(testWriteCategorizerStats) {
     const rapidjson::Value& categorizerStats = resourceWrapper["categorizer_stats"];
 
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string{"job"}, categorizerStats["job_id"].GetString());
+    BOOST_REQUIRE_EQUAL("job", categorizerStats["job_id"].GetString());
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("partition_field_name"));
-    BOOST_REQUIRE_EQUAL(std::string{"foo"},
-                        categorizerStats["partition_field_name"].GetString());
+    BOOST_REQUIRE_EQUAL("foo", categorizerStats["partition_field_name"].GetString());
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("partition_field_value"));
-    BOOST_REQUIRE_EQUAL(std::string{"bar"},
-                        categorizerStats["partition_field_value"].GetString());
+    BOOST_REQUIRE_EQUAL("bar", categorizerStats["partition_field_value"].GetString());
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("categorized_doc_count"));
     BOOST_REQUIRE_EQUAL(1, categorizerStats["categorized_doc_count"].GetInt());
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("total_category_count"));
@@ -1865,8 +1813,7 @@ BOOST_AUTO_TEST_CASE(testWriteCategorizerStats) {
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("failed_category_count"));
     BOOST_REQUIRE_EQUAL(6, categorizerStats["failed_category_count"].GetInt());
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("categorization_status"));
-    BOOST_REQUIRE_EQUAL(std::string{"ok"},
-                        categorizerStats["categorization_status"].GetString());
+    BOOST_REQUIRE_EQUAL("ok", categorizerStats["categorization_status"].GetString());
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("categorization_status"));
     BOOST_REQUIRE_EQUAL("ok", categorizerStats["categorization_status"].GetString());
     BOOST_TEST_REQUIRE(categorizerStats.HasMember("timestamp"));
@@ -1939,10 +1886,8 @@ BOOST_AUTO_TEST_CASE(testWriteScheduledEvent) {
     const rapidjson::Value& events = bucketWithEvents["scheduled_events"];
     BOOST_TEST_REQUIRE(events.IsArray());
     BOOST_REQUIRE_EQUAL(rapidjson::SizeType(2), events.Size());
-    BOOST_REQUIRE_EQUAL(std::string("event-foo"),
-                        std::string(events[rapidjson::SizeType(0)].GetString()));
-    BOOST_REQUIRE_EQUAL(std::string("event-bar"),
-                        std::string(events[rapidjson::SizeType(1)].GetString()));
+    BOOST_REQUIRE_EQUAL("event-foo", events[rapidjson::SizeType(0)].GetString());
+    BOOST_REQUIRE_EQUAL("event-bar", events[rapidjson::SizeType(1)].GetString());
 }
 
 BOOST_AUTO_TEST_CASE(testThroughputWithScopedAllocator) {

--- a/lib/api/unittest/CModelSnapshotJsonWriterTest.cc
+++ b/lib/api/unittest/CModelSnapshotJsonWriterTest.cc
@@ -15,7 +15,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <cstdint>
 #include <string>
 
 BOOST_AUTO_TEST_SUITE(CModelSnapshotJsonWriterTest)
@@ -29,24 +28,25 @@ BOOST_AUTO_TEST_CASE(testWrite) {
     // The output writer won't close the JSON structures until is is destroyed
     {
         model::CResourceMonitor::SModelSizeStats modelSizeStats{
-            10000,                     // bytes used
-            20000,                     // bytes used (adjusted)
-            30000,                     // peak bytes used
-            60000,                     // peak bytes used (adjusted)
-            3,                         // # by fields
-            1,                         // # partition fields
-            150,                       // # over fields
-            4,                         // # allocation failures
-            model_t::E_MemoryStatusOk, // memory status
-            core_t::TTime(1521046309), // bucket start time
-            0,                         // model bytes exceeded
-            50000,                     // model bytes memory limit
-            {1000,                     // categorized messages
-             100,                      // total categories
-             7,                        // frequent categories
-             13,                       // rare categories
-             2,                        // dead categories
-             8,                        // failed categories
+            10000,                             // bytes used
+            20000,                             // bytes used (adjusted)
+            30000,                             // peak bytes used
+            60000,                             // peak bytes used (adjusted)
+            3,                                 // # by fields
+            1,                                 // # partition fields
+            150,                               // # over fields
+            4,                                 // # allocation failures
+            model_t::E_MemoryStatusOk,         // memory status
+            model_t::E_AssignmentBasisUnknown, // assignment memory basis
+            core_t::TTime(1521046309),         // bucket start time
+            0,                                 // model bytes exceeded
+            50000,                             // model bytes memory limit
+            {1000,                             // categorized messages
+             100,                              // total categories
+             7,                                // frequent categories
+             13,                               // rare categories
+             2,                                // dead categories
+             8,                                // failed categories
              model_t::E_CategorizationStatusWarn}};
 
         CModelSnapshotJsonWriter::SModelSnapshotReport report{
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(testWrite) {
             core_t::TTime(1521046309),
             "the snapshot description",
             "test_snapshot_id",
-            size_t(15), // # docs
+            15, // # docs
             modelSizeStats,
             "some normalizer state",
             core_t::TTime(1521046409), // last record time
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(testWrite) {
     arrayDoc.Parse<rapidjson::kParseDefaultFlags>(sstream.str().c_str());
 
     BOOST_TEST_REQUIRE(arrayDoc.IsArray());
-    BOOST_REQUIRE_EQUAL(rapidjson::SizeType(1), arrayDoc.Size());
+    BOOST_REQUIRE_EQUAL(1, arrayDoc.Size());
 
     const rapidjson::Value& object = arrayDoc[rapidjson::SizeType(0)];
     BOOST_TEST_REQUIRE(object.IsObject());
@@ -78,91 +78,71 @@ BOOST_AUTO_TEST_CASE(testWrite) {
     BOOST_TEST_REQUIRE(object.HasMember("model_snapshot"));
     const rapidjson::Value& snapshot = object["model_snapshot"];
     BOOST_TEST_REQUIRE(snapshot.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"), std::string(snapshot["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", snapshot["job_id"].GetString());
     BOOST_TEST_REQUIRE(snapshot.HasMember("min_version"));
-    BOOST_REQUIRE_EQUAL(std::string("6.3.0"),
-                        std::string(snapshot["min_version"].GetString()));
+    BOOST_REQUIRE_EQUAL("6.3.0", snapshot["min_version"].GetString());
     BOOST_TEST_REQUIRE(snapshot.HasMember("snapshot_id"));
-    BOOST_REQUIRE_EQUAL(std::string("test_snapshot_id"),
-                        std::string(snapshot["snapshot_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("test_snapshot_id", snapshot["snapshot_id"].GetString());
     BOOST_TEST_REQUIRE(snapshot.HasMember("snapshot_doc_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(15), snapshot["snapshot_doc_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(15, snapshot["snapshot_doc_count"].GetUint64());
     BOOST_TEST_REQUIRE(snapshot.HasMember("timestamp"));
-    BOOST_REQUIRE_EQUAL(std::int64_t(1521046309000), snapshot["timestamp"].GetInt64());
+    BOOST_REQUIRE_EQUAL(1521046309000, snapshot["timestamp"].GetInt64());
     BOOST_TEST_REQUIRE(snapshot.HasMember("description"));
-    BOOST_REQUIRE_EQUAL(std::string("the snapshot description"),
-                        std::string(snapshot["description"].GetString()));
+    BOOST_REQUIRE_EQUAL("the snapshot description", snapshot["description"].GetString());
     BOOST_TEST_REQUIRE(snapshot.HasMember("latest_record_time_stamp"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(1521046409000),
-                        snapshot["latest_record_time_stamp"].GetUint64());
+    BOOST_REQUIRE_EQUAL(1521046409000, snapshot["latest_record_time_stamp"].GetInt64());
     BOOST_TEST_REQUIRE(snapshot.HasMember("latest_result_time_stamp"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(1521040000000),
-                        snapshot["latest_result_time_stamp"].GetUint64());
+    BOOST_REQUIRE_EQUAL(1521040000000, snapshot["latest_result_time_stamp"].GetInt64());
 
     BOOST_TEST_REQUIRE(snapshot.HasMember("model_size_stats"));
     const rapidjson::Value& modelSizeStats = snapshot["model_size_stats"];
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"),
-                        std::string(modelSizeStats["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", modelSizeStats["job_id"].GetString());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("model_bytes"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(20000), modelSizeStats["model_bytes"].GetUint64());
+    BOOST_REQUIRE_EQUAL(20000, modelSizeStats["model_bytes"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("peak_model_bytes"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(60000),
-                        modelSizeStats["peak_model_bytes"].GetUint64());
+    BOOST_REQUIRE_EQUAL(60000, modelSizeStats["peak_model_bytes"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("total_by_field_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(3),
-                        modelSizeStats["total_by_field_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(3, modelSizeStats["total_by_field_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("total_partition_field_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
-                        modelSizeStats["total_partition_field_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(1, modelSizeStats["total_partition_field_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("total_over_field_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(150),
-                        modelSizeStats["total_over_field_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(150, modelSizeStats["total_over_field_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("bucket_allocation_failures_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(4),
-                        modelSizeStats["bucket_allocation_failures_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(4, modelSizeStats["bucket_allocation_failures_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("memory_status"));
-    BOOST_REQUIRE_EQUAL(std::string("ok"),
-                        std::string(modelSizeStats["memory_status"].GetString()));
+    BOOST_REQUIRE_EQUAL("ok", modelSizeStats["memory_status"].GetString());
+    BOOST_REQUIRE_EQUAL(false, modelSizeStats.HasMember("assignment_memory_basis"));
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("model_bytes_exceeded"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(0),
-                        modelSizeStats["model_bytes_exceeded"].GetUint64());
+    BOOST_REQUIRE_EQUAL(0, modelSizeStats["model_bytes_exceeded"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("model_bytes_memory_limit"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(50000),
-                        modelSizeStats["model_bytes_memory_limit"].GetUint64());
+    BOOST_REQUIRE_EQUAL(50000, modelSizeStats["model_bytes_memory_limit"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("categorized_doc_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(1000),
-                        modelSizeStats["categorized_doc_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(1000, modelSizeStats["categorized_doc_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("total_category_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(100),
-                        modelSizeStats["total_category_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(100, modelSizeStats["total_category_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("frequent_category_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(7),
-                        modelSizeStats["frequent_category_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(7, modelSizeStats["frequent_category_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("rare_category_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(13),
-                        modelSizeStats["rare_category_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(13, modelSizeStats["rare_category_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("dead_category_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(2), modelSizeStats["dead_category_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(2, modelSizeStats["dead_category_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("failed_category_count"));
-    BOOST_REQUIRE_EQUAL(std::uint64_t(8),
-                        modelSizeStats["failed_category_count"].GetUint64());
+    BOOST_REQUIRE_EQUAL(8, modelSizeStats["failed_category_count"].GetUint64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("memory_status"));
-    BOOST_REQUIRE_EQUAL(std::string("warn"),
-                        std::string(modelSizeStats["categorization_status"].GetString()));
+    BOOST_REQUIRE_EQUAL("warn", modelSizeStats["categorization_status"].GetString());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("timestamp"));
-    BOOST_REQUIRE_EQUAL(std::int64_t(1521046309000), modelSizeStats["timestamp"].GetInt64());
+    BOOST_REQUIRE_EQUAL(1521046309000, modelSizeStats["timestamp"].GetInt64());
     BOOST_TEST_REQUIRE(modelSizeStats.HasMember("log_time"));
 
     BOOST_TEST_REQUIRE(snapshot.HasMember("quantiles"));
     const rapidjson::Value& quantiles = snapshot["quantiles"];
     BOOST_TEST_REQUIRE(quantiles.HasMember("job_id"));
-    BOOST_REQUIRE_EQUAL(std::string("job"), std::string(quantiles["job_id"].GetString()));
+    BOOST_REQUIRE_EQUAL("job", quantiles["job_id"].GetString());
     BOOST_TEST_REQUIRE(quantiles.HasMember("quantile_state"));
-    BOOST_REQUIRE_EQUAL(std::string("some normalizer state"),
-                        std::string(quantiles["quantile_state"].GetString()));
+    BOOST_REQUIRE_EQUAL("some normalizer state", quantiles["quantile_state"].GetString());
     BOOST_TEST_REQUIRE(quantiles.HasMember("timestamp"));
-    BOOST_REQUIRE_EQUAL(std::int64_t(1521040000000), quantiles["timestamp"].GetInt64());
+    BOOST_REQUIRE_EQUAL(1521040000000, quantiles["timestamp"].GetInt64());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/CProgramCounters.cc
+++ b/lib/core/CProgramCounters.cc
@@ -37,7 +37,7 @@ const std::string VALUE_TAG("b");
 void addStringInt(TGenericLineWriter& writer,
                   const std::string& name,
                   const std::string& description,
-                  uint64_t counter) {
+                  std::uint64_t counter) {
     writer.StartObject();
 
     writer.String(NAME_TYPE);
@@ -58,11 +58,11 @@ CProgramCounters& CProgramCounters::instance() {
 }
 
 CProgramCounters::TCounter& CProgramCounters::counter(counter_t::ECounterTypes counterType) {
-    size_t counterPos = static_cast<size_t>(counterType);
+    std::size_t counterPos = static_cast<std::size_t>(counterType);
     return counter(counterPos);
 }
 
-CProgramCounters::TCounter& CProgramCounters::counter(size_t index) {
+CProgramCounters::TCounter& CProgramCounters::counter(std::size_t index) {
     if (index >= ms_Instance.m_Counters.size()) {
         // If the enum values in ECounterTypes have been maintained in a contiguous block then logically this
         // can only happen when restoring state that contains one or more counters that are unknown to this version of the application.
@@ -101,7 +101,7 @@ void CProgramCounters::staticsAcceptPersistInserter(CStatePersistInserter& inser
         if (ms_Instance.m_ProgramCounterTypes.size() > 0) {
             for (const auto& counterType : ms_Instance.m_ProgramCounterTypes) {
                 const auto& counter = container[counterType];
-                if (counter != uint64_t{0}) {
+                if (counter != 0) {
                     inserter.insertValue(KEY_TAG, counterType);
                     inserter.insertValue(VALUE_TAG, counter);
                 }
@@ -133,7 +133,7 @@ void CProgramCounters::staticsAcceptPersistInserter(CStatePersistInserter& inser
 }
 
 bool CProgramCounters::staticsAcceptRestoreTraverser(CStateRestoreTraverser& traverser) {
-    uint64_t value = 0;
+    std::uint64_t value = 0;
     int key = 0;
     do {
         const std::string& name = traverser.name();

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -13,29 +13,29 @@
 #include <model/CStringStore.h>
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
+
+namespace {
+const std::size_t BUCKETS_FOR_ESTABLISHED_MEMORY_SIZE{20};
+const double ESTABLISHED_MEMORY_CV_THRESHOLD{0.1};
+}
 
 namespace ml {
 namespace model {
 
 // Only prune once per hour
-const core_t::TTime CResourceMonitor::MINIMUM_PRUNE_FREQUENCY(60 * 60);
-const std::size_t CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB(4096);
-const double CResourceMonitor::DEFAULT_BYTE_LIMIT_MARGIN(0.7);
-const core_t::TTime
-    CResourceMonitor::MAXIMUM_BYTE_LIMIT_MARGIN_PERIOD(2 * core::constants::HOUR);
+const core_t::TTime CResourceMonitor::MINIMUM_PRUNE_FREQUENCY{60 * 60};
+const std::size_t CResourceMonitor::DEFAULT_MEMORY_LIMIT_MB{4096};
+const double CResourceMonitor::DEFAULT_BYTE_LIMIT_MARGIN{0.7};
+const core_t::TTime CResourceMonitor::MAXIMUM_BYTE_LIMIT_MARGIN_PERIOD{2 * core::constants::HOUR};
 
 CResourceMonitor::CResourceMonitor(bool persistenceInForeground, double byteLimitMargin)
-    : m_AllowAllocations(true), m_ByteLimitMargin{byteLimitMargin},
-      m_ByteLimitHigh(0), m_ByteLimitLow(0), m_MonitoredResourceCurrentMemory(0),
-      m_ExtraMemory(0), m_PreviousTotal(this->totalMemory()),
-      m_LastAllocationFailureReport(0), m_MemoryStatus(model_t::E_MemoryStatusOk),
-      m_HasPruningStarted(false), m_PruneThreshold(0), m_LastPruneTime(0),
-      m_PruneWindow(std::numeric_limits<std::size_t>::max()),
-      m_PruneWindowMaximum(std::numeric_limits<std::size_t>::max()),
-      m_PruneWindowMinimum(std::numeric_limits<std::size_t>::max()),
-      m_NoLimit(false), m_CurrentBytesExceeded(0),
-      m_PersistenceInForeground(persistenceInForeground) {
+    : m_ByteLimitMargin{byteLimitMargin}, m_PreviousTotal{this->totalMemory()},
+      m_PruneWindow{std::numeric_limits<std::size_t>::max()},
+      m_PruneWindowMaximum{std::numeric_limits<std::size_t>::max()},
+      m_PruneWindowMinimum{std::numeric_limits<std::size_t>::max()},
+      m_PersistenceInForeground{persistenceInForeground} {
     this->updateMemoryLimitsAndPruneThreshold(DEFAULT_MEMORY_LIMIT_MB);
 }
 
@@ -45,7 +45,7 @@ void CResourceMonitor::memoryUsageReporter(const TMemoryUsageReporterFunc& repor
 
 void CResourceMonitor::registerComponent(CMonitoredResource& resource) {
     LOG_TRACE(<< "Registering component: " << &resource);
-    m_Resources.emplace(&resource, std::size_t(0));
+    m_Resources.emplace(&resource, 0);
 }
 
 void CResourceMonitor::unRegisterComponent(CMonitoredResource& resource) {
@@ -254,20 +254,60 @@ void CResourceMonitor::memUsage(CMonitoredResource* resource) {
     m_MonitoredResourceCurrentMemory += (modelCurrentUsage - modelPreviousUsage);
 }
 
-void CResourceMonitor::sendMemoryUsageReportIfSignificantlyChanged(core_t::TTime bucketStartTime) {
-    if (this->needToSendReport()) {
-        this->sendMemoryUsageReport(bucketStartTime);
+void CResourceMonitor::sendMemoryUsageReportIfSignificantlyChanged(core_t::TTime bucketStartTime,
+                                                                   core_t::TTime bucketLength) {
+    std::uint64_t assignmentMemoryBasis{
+        core::CProgramCounters::counter(counter_t::E_TSADAssignmentMemoryBasis)};
+    if (this->needToSendReport(static_cast<model_t::EAssignmentMemoryBasis>(assignmentMemoryBasis),
+                               bucketStartTime, bucketLength)) {
+        this->sendMemoryUsageReport(bucketStartTime, bucketLength);
     }
 }
 
-bool CResourceMonitor::needToSendReport() {
-    // Has the usage changed by more than 1% ?
+void CResourceMonitor::updateMoments(std::size_t totalMemory,
+                                     core_t::TTime bucketStartTime,
+                                     core_t::TTime bucketLength) {
+    if (m_FirstMomentsUpdateTime <= 0) {
+        m_FirstMomentsUpdateTime = bucketStartTime;
+    } else {
+        if (bucketLength > 0 && bucketStartTime >= m_LastMomentsUpdateTime + bucketLength) {
+            // The idea is to age this so that observations from more than 20
+            // buckets ago have little effect.  This means the end results will
+            // be close to what the old Java calculation did - it literally
+            // searched the last 20 buckets.  Aging at e^-0.1 seems reasonable
+            // to reduce the variance at the required rate.
+            double factor{std::exp(
+                -static_cast<double>((bucketStartTime - m_LastMomentsUpdateTime) / bucketLength) /
+                static_cast<double>(BUCKETS_FOR_ESTABLISHED_MEMORY_SIZE / 2))};
+            m_ModelBytesMoments.age(factor);
+        }
+    }
+    m_ModelBytesMoments.add(static_cast<double>(totalMemory));
+    m_LastMomentsUpdateTime = bucketStartTime;
+}
+
+bool CResourceMonitor::needToSendReport(model_t::EAssignmentMemoryBasis currentAssignmentMemoryBasis,
+                                        core_t::TTime bucketStartTime,
+                                        core_t::TTime bucketLength) {
     std::size_t total{this->totalMemory()};
+
+    // Update the moments that are used to determine whether memory is stable
+    this->updateMoments(total, bucketStartTime, bucketLength);
+
+    // Has the usage changed by more than 1% ?
     if ((std::max(total, m_PreviousTotal) - std::min(total, m_PreviousTotal)) >
         m_PreviousTotal / 100) {
         return true;
     }
 
+    // Is the assignment memory basis changing?
+    if ((currentAssignmentMemoryBasis == model_t::E_AssignmentBasisUnknown ||
+         currentAssignmentMemoryBasis == model_t::E_AssignmentBasisModelMemoryLimit) &&
+        this->isMemoryStable(bucketLength)) {
+        return true;
+    }
+
+    // Have we had new allocation failures
     if (!m_AllocationFailures.empty()) {
         core_t::TTime latestAllocationError{(--m_AllocationFailures.end())->first};
         if (latestAllocationError > m_LastAllocationFailureReport) {
@@ -277,8 +317,38 @@ bool CResourceMonitor::needToSendReport() {
     return false;
 }
 
-void CResourceMonitor::sendMemoryUsageReport(core_t::TTime bucketStartTime) {
+bool CResourceMonitor::isMemoryStable(core_t::TTime bucketLength) const {
+
+    // Must have been monitoring for 20 buckets
+    std::size_t bucketCount{
+        static_cast<std::size_t>((m_LastMomentsUpdateTime - m_FirstMomentsUpdateTime) / bucketLength) +
+        1};
+    if (bucketCount < BUCKETS_FOR_ESTABLISHED_MEMORY_SIZE) {
+        return false;
+    }
+
+    // Coefficient of variation must be less than 0.1
+    double mean{maths::CBasicStatistics::mean(m_ModelBytesMoments)};
+    double variance{maths::CBasicStatistics::variance(m_ModelBytesMoments)};
+    double cv{(variance > 0.0) ? std::sqrt(variance) / mean : 0.0};
+    LOG_TRACE(<< "Model memory stability at " << m_LastMomentsUpdateTime
+              << ": bucket count = " << bucketCount << ", sample count = "
+              << maths::CBasicStatistics::count(m_ModelBytesMoments) << ", mean = " << mean
+              << ", variance = " << variance << ", coefficient of variation = " << cv);
+    if (cv > ESTABLISHED_MEMORY_CV_THRESHOLD) {
+        return false;
+    }
+
+    return true;
+}
+
+void CResourceMonitor::sendMemoryUsageReport(core_t::TTime bucketStartTime,
+                                             core_t::TTime bucketLength) {
     std::size_t total{this->totalMemory()};
+    if (this->isMemoryStable(bucketLength)) {
+        core::CProgramCounters::counter(counter_t::E_TSADAssignmentMemoryBasis) =
+            static_cast<std::uint64_t>(model_t::E_AssignmentBasisCurrentModelBytes);
+    }
     core::CProgramCounters::counter(counter_t::E_TSADPeakMemoryUsage) = std::max(
         static_cast<std::size_t>(core::CProgramCounters::counter(counter_t::E_TSADPeakMemoryUsage)),
         total);
@@ -302,6 +372,10 @@ CResourceMonitor::createMemoryUsageReport(core_t::TTime bucketStartTime) {
     res.s_BytesMemoryLimit = this->persistenceMemoryIncreaseFactor() * m_ByteLimitHigh;
     res.s_BytesExceeded = m_CurrentBytesExceeded;
     res.s_MemoryStatus = m_MemoryStatus;
+    std::uint64_t assignmentMemoryBasis{
+        core::CProgramCounters::counter(counter_t::E_TSADAssignmentMemoryBasis)};
+    res.s_AssignmentMemoryBasis =
+        static_cast<model_t::EAssignmentMemoryBasis>(assignmentMemoryBasis);
     res.s_BucketStartTime = bucketStartTime;
     for (const auto& resource : m_Resources) {
         resource.first->updateModelSizeStats(res);

--- a/lib/model/ModelTypes.cc
+++ b/lib/model/ModelTypes.cc
@@ -2044,6 +2044,20 @@ std::string print(EMemoryStatus memoryStatus) {
     return "-";
 }
 
+std::string print(EAssignmentMemoryBasis assignmentMemoryBasis) {
+    switch (assignmentMemoryBasis) {
+    case E_AssignmentBasisUnknown:
+        return "unknown";
+    case E_AssignmentBasisModelMemoryLimit:
+        return "model_memory_limit";
+    case E_AssignmentBasisCurrentModelBytes:
+        return "current_model_bytes";
+    case E_AssignmentBasisPeakModelBytes:
+        return "peak_model_bytes";
+    }
+    return "-";
+}
+
 std::string print(ECategorizationStatus categorizationStatus) {
     switch (categorizationStatus) {
     case E_CategorizationStatusOk:

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -57,7 +57,8 @@ public:
             for (; bucketStart + bucketLength <= time; bucketStart += bucketLength) {
                 detector.buildResults(bucketStart, bucketStart + bucketLength, results);
                 monitor.pruneIfRequired(bucketStart);
-                numBuckets++;
+                monitor.updateMoments(monitor.totalMemory(), bucketStart, bucketLength);
+                ++numBuckets;
                 newBucket = true;
             }
 
@@ -87,9 +88,9 @@ protected:
 };
 
 BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
-    const std::string EMPTY_STRING;
-    const core_t::TTime FIRST_TIME(358556400);
-    const core_t::TTime BUCKET_LENGTH(3600);
+    static const std::string EMPTY_STRING;
+    static const core_t::TTime FIRST_TIME{358556400};
+    static const core_t::TTime BUCKET_LENGTH{3600};
 
     CAnomalyDetectorModelConfig modelConfig =
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
@@ -182,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         mon.refresh(categorizer);
         mon.refresh(detector1);
         mon.refresh(detector2);
-        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0, 1);
         BOOST_REQUIRE_EQUAL(mem, mon.totalMemory());
         BOOST_REQUIRE_EQUAL(mem, mon.m_PreviousTotal);
 
@@ -260,7 +261,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         mon.refresh(categorizer);
         mon.refresh(detector1);
         mon.refresh(detector2);
-        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0, 1);
         BOOST_REQUIRE_EQUAL(mem, m_ReportedModelSizeStats.s_Usage);
         BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusOk, m_ReportedModelSizeStats.s_MemoryStatus);
     }
@@ -277,7 +278,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         BOOST_REQUIRE_EQUAL(std::size_t(0), m_ReportedModelSizeStats.s_Usage);
 
         mon.forceRefreshAll();
-        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0, 1);
         BOOST_REQUIRE_EQUAL(mem, m_ReportedModelSizeStats.s_Usage);
         BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusOk, m_ReportedModelSizeStats.s_MemoryStatus);
     }
@@ -300,7 +301,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         mon.refresh(categorizer);
         mon.refresh(detector1);
         mon.refresh(detector2);
-        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0, 1);
         BOOST_REQUIRE_EQUAL(std::size_t(0), m_ReportedModelSizeStats.s_AllocationFailures);
         BOOST_REQUIRE_EQUAL(mem, m_ReportedModelSizeStats.s_Usage);
         BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusSoftLimit,
@@ -317,7 +318,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         mon.refresh(categorizer);
         mon.refresh(detector1);
         mon.refresh(detector2);
-        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0, 1);
         BOOST_REQUIRE_EQUAL(std::size_t(12345), m_ReportedModelSizeStats.s_AllocationFailures);
         BOOST_REQUIRE_EQUAL(std::size_t(54321), m_ReportedModelSizeStats.s_ByFields);
         BOOST_REQUIRE_EQUAL(std::size_t(23456), m_ReportedModelSizeStats.s_OverFields);
@@ -335,7 +336,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         mon.refresh(categorizer);
         mon.refresh(detector1);
         mon.refresh(detector2);
-        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0, 1);
         BOOST_REQUIRE_EQUAL(std::size_t(3), m_ReportedModelSizeStats.s_AllocationFailures);
         BOOST_REQUIRE_EQUAL(mem, m_ReportedModelSizeStats.s_Usage);
         BOOST_REQUIRE_EQUAL(core_t::TTime(14402000), mon.m_LastAllocationFailureReport);
@@ -353,7 +354,7 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         mon.refresh(categorizer);
         mon.refresh(detector1);
         mon.refresh(detector2);
-        mon.sendMemoryUsageReportIfSignificantlyChanged(0);
+        mon.sendMemoryUsageReportIfSignificantlyChanged(0, 1);
         BOOST_REQUIRE_EQUAL(std::size_t(12345), m_ReportedModelSizeStats.s_AllocationFailures);
         BOOST_REQUIRE_EQUAL(std::size_t(54321), m_ReportedModelSizeStats.s_ByFields);
         BOOST_REQUIRE_EQUAL(std::size_t(23456), m_ReportedModelSizeStats.s_OverFields);
@@ -365,52 +366,60 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
         CResourceMonitor mon;
         mon.memoryUsageReporter(std::bind(&CTestFixture::reportCallback, this,
                                           std::placeholders::_1));
-        BOOST_TEST_REQUIRE(!mon.needToSendReport());
+        BOOST_TEST_REQUIRE(!mon.needToSendReport(
+            model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
 
         std::size_t origTotalMemory = mon.totalMemory();
 
         // Go up to 10 bytes, triggering a need
         mon.m_MonitoredResourceCurrentMemory = 10;
-        BOOST_TEST_REQUIRE(mon.needToSendReport());
-        mon.sendMemoryUsageReport(0);
+        BOOST_TEST_REQUIRE(
+            mon.needToSendReport(model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
+        mon.sendMemoryUsageReport(0, 1);
         BOOST_REQUIRE_EQUAL(origTotalMemory + 10, m_ReportedModelSizeStats.s_Usage);
 
         // Nothing new added, so no report
-        BOOST_TEST_REQUIRE(!mon.needToSendReport());
+        BOOST_TEST_REQUIRE(!mon.needToSendReport(
+            model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
 
         // 10% increase should trigger a need
         mon.m_MonitoredResourceCurrentMemory += 1 + (origTotalMemory + 9) / 10;
-        BOOST_TEST_REQUIRE(mon.needToSendReport());
-        mon.sendMemoryUsageReport(0);
+        BOOST_TEST_REQUIRE(
+            mon.needToSendReport(model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
+        mon.sendMemoryUsageReport(0, 1);
         BOOST_REQUIRE_EQUAL(origTotalMemory + 11 + (origTotalMemory + 9) / 10,
                             m_ReportedModelSizeStats.s_Usage);
 
         // Huge increase should trigger a need
         mon.m_MonitoredResourceCurrentMemory = 1000;
-        BOOST_TEST_REQUIRE(mon.needToSendReport());
-        mon.sendMemoryUsageReport(0);
+        BOOST_TEST_REQUIRE(
+            mon.needToSendReport(model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
+        mon.sendMemoryUsageReport(0, 1);
         BOOST_REQUIRE_EQUAL(origTotalMemory + 1000, m_ReportedModelSizeStats.s_Usage);
 
         // 0.1% increase should not trigger a need
         mon.m_MonitoredResourceCurrentMemory += 1 + (origTotalMemory + 999) / 1000;
-        BOOST_TEST_REQUIRE(!mon.needToSendReport());
+        BOOST_TEST_REQUIRE(!mon.needToSendReport(
+            model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
 
         // A decrease should trigger a need
         mon.m_MonitoredResourceCurrentMemory = 900;
-        BOOST_TEST_REQUIRE(mon.needToSendReport());
-        mon.sendMemoryUsageReport(0);
+        BOOST_TEST_REQUIRE(
+            mon.needToSendReport(model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
+        mon.sendMemoryUsageReport(0, 1);
         BOOST_REQUIRE_EQUAL(origTotalMemory + 900, m_ReportedModelSizeStats.s_Usage);
 
         // A tiny decrease should not trigger a need
         mon.m_MonitoredResourceCurrentMemory = 899;
-        BOOST_TEST_REQUIRE(!mon.needToSendReport());
+        BOOST_TEST_REQUIRE(!mon.needToSendReport(
+            model_t::E_AssignmentBasisCurrentModelBytes, 0, 1));
     }
 }
 
 BOOST_FIXTURE_TEST_CASE(testPruning, CTestFixture) {
-    const std::string EMPTY_STRING;
-    const core_t::TTime FIRST_TIME(358556400);
-    const core_t::TTime BUCKET_LENGTH(3600);
+    static const std::string EMPTY_STRING;
+    static const core_t::TTime FIRST_TIME{358556400};
+    static const core_t::TTime BUCKET_LENGTH{3600};
 
     CAnomalyDetectorModelConfig modelConfig =
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
@@ -434,6 +443,8 @@ BOOST_FIXTURE_TEST_CASE(testPruning, CTestFixture) {
     BOOST_REQUIRE_EQUAL(false, monitor.pruneIfRequired(bucket));
     BOOST_REQUIRE_EQUAL(false, monitor.m_HasPruningStarted);
     BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusOk, monitor.m_MemoryStatus);
+    // Memory should not be stable, as we've only seen 2 buckets
+    BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
 
     LOG_DEBUG(<< "Saturating the pruner");
     // Add enough data to saturate the pruner
@@ -443,6 +454,9 @@ BOOST_FIXTURE_TEST_CASE(testPruning, CTestFixture) {
     BOOST_REQUIRE_EQUAL(true, monitor.m_HasPruningStarted);
     BOOST_TEST_REQUIRE(monitor.m_PruneWindow < std::size_t(1000));
     BOOST_REQUIRE_EQUAL(model_t::E_MemoryStatusSoftLimit, monitor.m_MemoryStatus);
+    // Memory should be stable now, after 1100 more buckets,
+    // and with the pruner running
+    BOOST_REQUIRE_EQUAL(true, monitor.isMemoryStable(BUCKET_LENGTH));
     BOOST_REQUIRE_EQUAL(true, monitor.m_AllowAllocations);
 
     LOG_DEBUG(<< "Allowing pruner to relax");
@@ -484,9 +498,9 @@ BOOST_FIXTURE_TEST_CASE(testPruning, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testExtraMemory, CTestFixture) {
-    const std::string EMPTY_STRING;
-    const core_t::TTime FIRST_TIME(358556400);
-    const core_t::TTime BUCKET_LENGTH(3600);
+    static const std::string EMPTY_STRING;
+    static const core_t::TTime FIRST_TIME{358556400};
+    static const core_t::TTime BUCKET_LENGTH{3600};
 
     CAnomalyDetectorModelConfig modelConfig =
         CAnomalyDetectorModelConfig::defaultConfig(BUCKET_LENGTH);
@@ -519,7 +533,7 @@ BOOST_FIXTURE_TEST_CASE(testExtraMemory, CTestFixture) {
     // Push over the limit by adding 1MB
     monitor.addExtraMemory(1024 * 1024);
     BOOST_TEST_REQUIRE(monitor.areAllocationsAllowed() == false);
-    BOOST_REQUIRE_EQUAL(std::size_t(0), monitor.allocationLimit());
+    BOOST_REQUIRE_EQUAL(0, monitor.allocationLimit());
 
     monitor.clearExtraMemory();
     BOOST_TEST_REQUIRE(monitor.areAllocationsAllowed());
@@ -536,27 +550,71 @@ BOOST_FIXTURE_TEST_CASE(testPeakUsage, CTestFixture) {
         std::bind(&CTestFixture::reportCallback, this, std::placeholders::_1));
     std::size_t baseTotalMemory = monitor.totalMemory();
 
-    monitor.sendMemoryUsageReport(0);
+    monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory, m_ReportedModelSizeStats.s_PeakUsage);
 
     monitor.addExtraMemory(100);
 
-    monitor.sendMemoryUsageReport(0);
+    monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 100, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 100, m_ReportedModelSizeStats.s_PeakUsage);
 
     monitor.addExtraMemory(-50);
 
-    monitor.sendMemoryUsageReport(0);
+    monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 50, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 100, m_ReportedModelSizeStats.s_PeakUsage);
 
     monitor.addExtraMemory(100);
 
-    monitor.sendMemoryUsageReport(0);
+    monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 150, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 150, m_ReportedModelSizeStats.s_PeakUsage);
+}
+
+BOOST_FIXTURE_TEST_CASE(testUpdateMoments, CTestFixture) {
+
+    static const core_t::TTime FIRST_TIME{358556400};
+    static const core_t::TTime BUCKET_LENGTH{3600};
+
+    CLimits limits;
+    CResourceMonitor& monitor = limits.resourceMonitor();
+    core_t::TTime time{FIRST_TIME};
+    std::size_t totalMemory{1000000};
+
+    // For the first 19 buckets memory is not stable due to the bucket count alone
+    for (std::size_t count = 0; count < 19; ++count) {
+        monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
+        BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
+        BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+        BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
+        time += BUCKET_LENGTH;
+        totalMemory += 200000;
+    }
+
+    // At bucket 20 the coefficient of variation comes into play - initially it's
+    // too high, as we added 200000 bytes to the memory usage in every one of the
+    // first 19 buckets
+    for (std::size_t count = 20; count < 45; ++count) {
+        monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
+        BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
+        BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+        BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
+        time += BUCKET_LENGTH;
+    }
+
+    // After several buckets of flat memory use memory should be reported as
+    // stable, and should continue to be reported as stable even when there
+    // are small fluctuations
+    for (std::size_t count = 46; count < 100; ++count) {
+        monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
+        BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
+        BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+        BOOST_REQUIRE_EQUAL(true, monitor.isMemoryStable(BUCKET_LENGTH));
+        time += BUCKET_LENGTH;
+        totalMemory += (count % 5 - 2) * 1000;
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change is the companion to elastic/elasticsearch#65561.
It calculates the new model_size_stats field,
assignment_memory_basis, to indicate whether an actual model
size or the model memory limit should be used when assigning
jobs to nodes.  The switch only goes one way: once we have
switched from model memory limit to an actual model size we
never revert to using the limit.  This is a change compared
to 7.10, because with autoscaling flipping backwards and
forwards between model memory limit and actual model memory
could (in bad edge cases) cause the cluster to repeatedly
scale up and down.

Backport of #1623