### PR TITLE
[ML] Improve test to decide whether to drop seasonal components

### DIFF
--- a/include/maths/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/CTimeSeriesTestForSeasonality.h
@@ -373,8 +373,13 @@ private:
         //! Check if this is better than \p other.
         bool isBetter(const SHypothesisStats& other) const;
 
-        //! Check if we should evict an existing component from the model.
+        //! Check whether to evict an existing component from the model.
         bool evict(const CTimeSeriesTestForSeasonality& params, std::size_t modelledIndex) const;
+
+        //! Check if it is permitted to evict an existing component from the model
+        //! given the test window parameters.
+        bool isEvictionPermitted(const CTimeSeriesTestForSeasonality& params,
+                                 std::size_t modelledIndex) const;
 
         //! The weight of this hypothesis for compouting decomposition properties.
         double weight() const;
@@ -460,6 +465,8 @@ private:
         bool isAlternative() const;
         //! The similarity of the components after applying this hypothesis.
         double componentsSimilarity() const;
+        //! Check if we are allowed to evict all components of this model.
+        std::size_t isEvictionPermitted() const;
         //! The p-value of this model vs H0.
         double pValue(const SModel& H0,
                       double minimumRelativeTruncatedVariance = 0.0,
@@ -595,7 +602,7 @@ private:
     double m_LowAutocorrelation = 0.3;
     double m_MediumAutocorrelation = 0.5;
     double m_HighAutocorrelation = 0.7;
-    double m_PValueToEvict = 0.5;
+    double m_PValueToEvict = 0.4;
     double m_SignificantPValue = 5e-3;
     double m_VerySignificantPValue = 1e-6;
     double m_AcceptedFalsePostiveRate = 1e-4;

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -1981,9 +1981,9 @@ bool CTimeSeriesTestForSeasonality::SHypothesisStats::isBetter(const SHypothesis
 
 bool CTimeSeriesTestForSeasonality::SHypothesisStats::evict(const CTimeSeriesTestForSeasonality& params,
                                                             std::size_t modelledIndex) const {
-    return this->isEvictionPermitted(params, modelledIndex) &&
-           s_ExplainedVariancePValue > params.m_PValueToEvict &&
-           s_AmplitudePValue > params.m_PValueToEvict;
+    return s_ExplainedVariancePValue > params.m_PValueToEvict &&
+           s_AmplitudePValue > params.m_PValueToEvict &&
+           this->isEvictionPermitted(params, modelledIndex);
 }
 
 bool CTimeSeriesTestForSeasonality::SHypothesisStats::isEvictionPermitted(

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -2023,13 +2023,11 @@ BOOST_FIXTURE_TEST_CASE(testRemoveSeasonal, CTestFixture) {
     test::CRandomNumbers rng;
 
     auto trend = [](core_t::TTime time) {
-        return 20.0 +
-               10.0 * std::sin(boost::math::double_constants::two_pi *
-                               static_cast<double>(time) / static_cast<double>(DAY)) -
-               10.0 * (time > 4 * WEEK
-                           ? std::sin(boost::math::double_constants::two_pi *
-                                      static_cast<double>(time) / static_cast<double>(DAY))
-                           : 0.0);
+        return 20.0 + 10.0 * (time <= 4 * WEEK
+                                  ? std::sin(boost::math::double_constants::two_pi *
+                                             static_cast<double>(time) /
+                                             static_cast<double>(DAY))
+                                  : 0.0);
     };
 
     maths::CTimeSeriesDecomposition decomposition(0.012, FIVE_MINS);


### PR DESCRIPTION
Our regression test suite showed up some places where we are now over eager to drop all seasonal components. This turns out to be because we weren't properly considering whether the time window we test is suitable for making this decision. This rolls out the checks we were already performing per component to decide if we can drop seasonality modelling altogether. I've also included some consideration of the fraction of values in the window we've observed: we require more evidence to drop seasonality modelling if we're observing a fraction of the window.

This affects results, but it only impacts the decision to keep modelling specific seasonal components so the impact is small. Since this improves unreleased code I've marked it as a non-issue.