### PR TITLE
[ML] Make coefficient of variation formula more robust

### DIFF
--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -9,6 +9,7 @@
 #include <core/CProgramCounters.h>
 #include <core/Constants.h>
 
+#include <maths/CMathsFuncs.h>
 #include <maths/CTools.h>
 
 #include <model/CMonitoredResource.h>
@@ -345,11 +346,8 @@ bool CResourceMonitor::isMemoryStable(core_t::TTime bucketLength) const {
               << ", coefficient of variation = " << (std::sqrt(variance) / mean));
     // Instead of literally testing the coefficient of variation it's more
     // robust against zeroes and NaNs to rearrange it as follows
-    if (variance > maths::CTools::pow2(ESTABLISHED_MEMORY_CV_THRESHOLD * mean)) {
-        return false;
-    }
-
-    return true;
+    return maths::CMathsFuncs::isNan(variance) == false &&
+           variance <= maths::CTools::pow2(ESTABLISHED_MEMORY_CV_THRESHOLD * mean);
 }
 
 void CResourceMonitor::sendMemoryUsageReport(core_t::TTime bucketStartTime,

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -553,24 +553,28 @@ BOOST_FIXTURE_TEST_CASE(testPeakUsage, CTestFixture) {
         std::bind(&CTestFixture::reportCallback, this, std::placeholders::_1));
     std::size_t baseTotalMemory = monitor.totalMemory();
 
+    monitor.updateMoments(monitor.totalMemory(), 0, 1);
     monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory, m_ReportedModelSizeStats.s_PeakUsage);
 
     monitor.addExtraMemory(100);
 
+    monitor.updateMoments(monitor.totalMemory(), 0, 1);
     monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 100, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 100, m_ReportedModelSizeStats.s_PeakUsage);
 
     monitor.addExtraMemory(-50);
 
+    monitor.updateMoments(monitor.totalMemory(), 0, 1);
     monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 50, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 100, m_ReportedModelSizeStats.s_PeakUsage);
 
     monitor.addExtraMemory(100);
 
+    monitor.updateMoments(monitor.totalMemory(), 0, 1);
     monitor.sendMemoryUsageReport(0, 1);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 150, m_ReportedModelSizeStats.s_Usage);
     BOOST_REQUIRE_EQUAL(baseTotalMemory + 150, m_ReportedModelSizeStats.s_PeakUsage);
@@ -581,42 +585,72 @@ BOOST_FIXTURE_TEST_CASE(testUpdateMoments, CTestFixture) {
     static const core_t::TTime FIRST_TIME{358556400};
     static const core_t::TTime BUCKET_LENGTH{3600};
 
-    CLimits limits;
-    CResourceMonitor& monitor = limits.resourceMonitor();
-    core_t::TTime time{FIRST_TIME};
-    std::size_t totalMemory{1000000};
+    // First a realistic case
+    {
+        CLimits limits;
+        CResourceMonitor& monitor = limits.resourceMonitor();
+        core_t::TTime time{FIRST_TIME};
+        std::size_t totalMemory{1000000};
 
-    // For the first 19 buckets memory is not stable due to the bucket count alone
-    for (std::size_t count = 0; count < 19; ++count) {
-        monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
-        BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
-        BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
-        BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
-        time += BUCKET_LENGTH;
-        totalMemory += 200000;
+        // For the first 19 buckets memory is not stable due to the bucket count alone
+        for (std::size_t count = 0; count < 19; ++count) {
+            monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
+            BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
+            time += BUCKET_LENGTH;
+            totalMemory += 200000;
+        }
+
+        // At bucket 20 the coefficient of variation comes into play - initially it's
+        // too high, as we added 200000 bytes to the memory usage in every one of the
+        // first 19 buckets
+        for (std::size_t count = 20; count < 45; ++count) {
+            monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
+            BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
+            time += BUCKET_LENGTH;
+        }
+
+        // After several buckets of flat memory use memory should be reported as
+        // stable, and should continue to be reported as stable even when there
+        // are small fluctuations
+        for (std::size_t count = 46; count < 100; ++count) {
+            monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
+            BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(true, monitor.isMemoryStable(BUCKET_LENGTH));
+            time += BUCKET_LENGTH;
+            totalMemory += (count % 5 - 2) * 1000;
+        }
     }
+    // Unexpected edge cases - mean and variance both always zero
+    {
+        CLimits limits;
+        CResourceMonitor& monitor = limits.resourceMonitor();
+        core_t::TTime time{FIRST_TIME};
 
-    // At bucket 20 the coefficient of variation comes into play - initially it's
-    // too high, as we added 200000 bytes to the memory usage in every one of the
-    // first 19 buckets
-    for (std::size_t count = 20; count < 45; ++count) {
-        monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
-        BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
-        BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+        // Asking about stability before adding any measurements is wrong but
+        // should not cause a crash
         BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
-        time += BUCKET_LENGTH;
-    }
 
-    // After several buckets of flat memory use memory should be reported as
-    // stable, and should continue to be reported as stable even when there
-    // are small fluctuations
-    for (std::size_t count = 46; count < 100; ++count) {
-        monitor.updateMoments(totalMemory, time, BUCKET_LENGTH);
+        // For the first 19 buckets memory is not stable due to the bucket count alone
+        for (std::size_t count = 0; count < 19; ++count) {
+            monitor.updateMoments(0, time, BUCKET_LENGTH);
+            BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
+            BOOST_REQUIRE_EQUAL(false, monitor.isMemoryStable(BUCKET_LENGTH));
+            time += BUCKET_LENGTH;
+        }
+
+        // At bucket 20 the coefficient of variation comes into play, and by its
+        // textbook definition it's 0/0.  However, the rearrangement of the
+        // formula should avoid NaNs.
+        monitor.updateMoments(0, time, BUCKET_LENGTH);
         BOOST_REQUIRE_EQUAL(FIRST_TIME, monitor.m_FirstMomentsUpdateTime);
         BOOST_REQUIRE_EQUAL(time, monitor.m_LastMomentsUpdateTime);
         BOOST_REQUIRE_EQUAL(true, monitor.isMemoryStable(BUCKET_LENGTH));
-        time += BUCKET_LENGTH;
-        totalMemory += (count % 5 - 2) * 1000;
     }
 }
 


### PR DESCRIPTION
The previous formula was vulnerable to dividing by zero
in unlikely edge cases.  This change rearranges the formula
to avoid that, and also adds a test to prove no crashes
occur in edge cases.

Relates #1623