### PR TITLE
[ML] Fix edge case in start up behaviour for non-diurnal seasonality

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,6 +39,13 @@
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3. (See
   {ml-pull}1170[#1170].)
 
+== {es} version 7.12.0
+
+=== Enhancements
+
+* Fix edge case which could cause spurious anomalies early in the learning process
+  if the time series has non-diurnal seasonality. (See {ml-pull}1634[#1634].)
+
 == {es} version 7.11.0
 
 === Enhancements


### PR DESCRIPTION
Investigating changes associated with #1614 in our QA suite turned up an existing deficiency related to us requiring a minimum number of repeats to estimate the period of non-diurnal seasonal components accurately. In particular, we could accept a period which is slightly less than the true period of the seasonality present in the data because it explained the time series well enough. From an anomaly detection standpoint this is a bad idea and it is better to wait until we've seen more data and can estimate the correct periodicity. We'd eventually recover, but it could create transient false positives. For example,
before
![Screenshot 2020-12-16 at 18 09 57](https://user-images.githubusercontent.com/7591487/102484917-d3d53180-405e-11eb-86e5-be2e75db88e5.png)
after
![Screenshot 2020-12-17 at 11 55 12](https://user-images.githubusercontent.com/7591487/102484937-db94d600-405e-11eb-8ecc-cdf6735d6ae6.png)

This change adds a "look ahead" which checks for significantly stronger autocorrelation among slightly longer periods than those for which we can currently accurately estimate their period. If there is one it delays us modelling seasonality.

Whilst this affects results it will only affect non-diurnal seasonality and then only start up behaviour so the scope is limited.