### PR TITLE
[ML] Avoid applying scale change points when the scale can't be accurately estimated

### DIFF
--- a/include/maths/CTimeSeriesTestForChange.h
+++ b/include/maths/CTimeSeriesTestForChange.h
@@ -44,7 +44,7 @@ public:
 
     virtual TChangePointUPtr undoable() const = 0;
     virtual bool largeEnough(double threshold) const = 0;
-    bool longEnough(core_t::TTime time, core_t::TTime minimumDuration) const;
+    virtual bool longEnough(core_t::TTime time, core_t::TTime minimumDuration) const = 0;
     virtual bool apply(CTimeSeriesDecomposition&) const { return false; }
     virtual bool apply(CTrendComponent&) const { return false; }
     virtual bool apply(CSeasonalComponent&) const { return false; }
@@ -100,6 +100,7 @@ public:
 
     TChangePointUPtr undoable() const override;
     bool largeEnough(double threshold) const override;
+    bool longEnough(core_t::TTime time, core_t::TTime minimumDuration) const override;
     bool apply(CTrendComponent& component) const override;
     const std::string& type() const override;
     std::string print() const override;
@@ -124,11 +125,13 @@ public:
     CScale(core_t::TTime time,
            double scale,
            double magnitude,
+           double minimumDurationScale,
            TFloatMeanAccumulatorVec residuals,
            double significantPValue);
 
     TChangePointUPtr undoable() const override;
     bool largeEnough(double threshold) const override;
+    bool longEnough(core_t::TTime time, core_t::TTime minimumDuration) const override;
     bool apply(CTrendComponent& component) const override;
     bool apply(CSeasonalComponent& component) const override;
     bool apply(CCalendarComponent& component) const override;
@@ -140,6 +143,7 @@ public:
 private:
     double m_Scale = 1.0;
     double m_Magnitude = 0.0;
+    double m_MinimumDurationScale = 1.0;
 };
 
 //! \brief Represents a time shift of a time series.
@@ -157,6 +161,7 @@ public:
 
     TChangePointUPtr undoable() const override;
     bool largeEnough(double) const override { return m_Shift != 0; }
+    bool longEnough(core_t::TTime time, core_t::TTime minimumDuration) const override;
     bool apply(CTimeSeriesDecomposition& decomposition) const override;
     const std::string& type() const override;
     std::string print() const override;

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -902,7 +902,7 @@ core_t::TTime CTimeSeriesDecompositionDetail::CChangePointTest::minimumChangeLen
 
 core_t::TTime
 CTimeSeriesDecompositionDetail::CChangePointTest::maximumIntervalToDetectChange() const {
-    return 4 * this->minimumChangeLength() / 3;
+    return 5 * this->minimumChangeLength() / 3;
 }
 
 core_t::TTime

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2326,7 +2326,7 @@ BOOST_AUTO_TEST_CASE(testLinearScaling) {
         auto x = model.confidenceInterval(
             time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
         BOOST_TEST_REQUIRE(std::fabs(sample - x[1][0]) < 1.6 * std::sqrt(noiseVariance));
-        BOOST_TEST_REQUIRE(std::fabs(x[2][0] - x[0][0]) < 3.4 * std::sqrt(noiseVariance));
+        BOOST_TEST_REQUIRE(std::fabs(x[2][0] - x[0][0]) < 3.5 * std::sqrt(noiseVariance));
         time += bucketLength;
     }
 


### PR DESCRIPTION
Scaling has little impact on values close to zero. This means if the window we test for change points overlap a region where the time series is small we cannot estimate scale points well. In such cases it is appropriate to wait to observe more data before committing the change. For example, this can easily happen with say an unusual Friday if the data display typical elevated values during trading days:
before
<img width="1658" alt="Screenshot 2020-12-18 at 18 58 59" src="https://user-images.githubusercontent.com/7591487/102650920-82fb3100-4163-11eb-9511-99f65a8eb285.png">
after
<img width="1652" alt="Screenshot 2020-12-18 at 19 03 05" src="https://user-images.githubusercontent.com/7591487/102651034-b5a52980-4163-11eb-9a52-1cb0ba93faef.png">

This checks the *predicted* values before and after a candidate scale change point and waits longer to accept the change if the values after are relatively closer to zero.

Since this only affects the decision to apply a scale change point and then only sometimes delays making the choice the scope should be limited. This affects unreleased code and I plan to port this correction to the 7.11 branch, so marking as a non-issue.