### PR TITLE
[7.x][ML] Parse filters and events from JSON config files (#1640)

### DIFF
--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -23,6 +23,8 @@ const std::string CCmdLineParser::DESCRIPTION = "Usage: autodetect [options] [<f
 bool CCmdLineParser::parse(int argc,
                            const char* const* argv,
                            std::string& configFile,
+                           std::string& filtersConfigFile,
+                           std::string& eventsConfigFile,
                            std::string& limitConfigFile,
                            std::string& modelConfigFile,
                            std::string& fieldConfigFile,
@@ -60,6 +62,10 @@ bool CCmdLineParser::parse(int argc,
             ("version", "Display version information and exit")
             ("config", boost::program_options::value<std::string>(),
                     "The job configuration file")
+            ("filtersconfig", boost::program_options::value<std::string>(),
+             "The filters configuration file")
+            ("eventsconfig", boost::program_options::value<std::string>(),
+             "The scheduled events configuration file")
             ("limitconfig", boost::program_options::value<std::string>(),
                     "Optional limit config file")
             ("modelconfig", boost::program_options::value<std::string>(),
@@ -154,6 +160,12 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("config") > 0) {
             configFile = vm["config"].as<std::string>();
+        }
+        if (vm.count("filtersconfig") > 0) {
+            filtersConfigFile = vm["filtersconfig"].as<std::string>();
+        }
+        if (vm.count("eventsconfig") > 0) {
+            eventsConfigFile = vm["eventsconfig"].as<std::string>();
         }
         if (vm.count("limitconfig") > 0) {
             limitConfigFile = vm["limitconfig"].as<std::string>();

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -35,6 +35,8 @@ public:
     static bool parse(int argc,
                       const char* const* argv,
                       std::string& config,
+                      std::string& filtersConfig,
+                      std::string& eventsConfig,
                       std::string& limitConfigFile,
                       std::string& modelConfigFile,
                       std::string& fieldConfigFile,

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -86,6 +86,8 @@ int main(int argc, char** argv) {
 
     // Read command line options
     std::string configFile;
+    std::string filtersConfigFile;
+    std::string eventsConfigFile;
     std::string limitConfigFile;
     std::string modelConfigFile;
     std::string fieldConfigFile;
@@ -117,9 +119,10 @@ int main(int argc, char** argv) {
     bool stopCategorizationOnWarnStatus{false};
     TStrVec clauseTokens;
     if (ml::autodetect::CCmdLineParser::parse(
-            argc, argv, configFile, limitConfigFile, modelConfigFile, fieldConfigFile,
-            modelPlotConfigFile, logProperties, logPipe, delimiter, lengthEncodedInput,
-            timeField, timeFormat, quantilesStateFile, deleteStateFiles, persistInterval,
+            argc, argv, configFile, filtersConfigFile, eventsConfigFile,
+            limitConfigFile, modelConfigFile, fieldConfigFile, modelPlotConfigFile,
+            logProperties, logPipe, delimiter, lengthEncodedInput, timeField,
+            timeFormat, quantilesStateFile, deleteStateFiles, persistInterval,
             bucketPersistInterval, maxQuantileInterval, namedPipeConnectTimeout,
             inputFileName, isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe,
             restoreFileName, isRestoreFileNamedPipe, persistFileName,
@@ -172,6 +175,15 @@ int main(int argc, char** argv) {
     // hence is done before reducing CPU priority.
     ml::core::CProcessPriority::reduceCpuPriority();
 
+    // TODO enable the currently disabled code block once the Java code supplying the
+    // filters and events config files is committed.
+#if 0
+    ml::api::CAnomalyJobConfig jobConfig;
+    if (jobConfig.initFromFiles(configFile, filtersConfigFile, eventsConfigFile) == false) {
+        LOG_FATAL(<< "JSON config could not be interpreted");
+        return EXIT_FAILURE;
+    }
+#else
     ml::api::CFieldConfig fieldConfig;
 
     if (fieldConfig.initFromCmdLine(fieldConfigFile, clauseTokens) == false) {
@@ -187,6 +199,7 @@ int main(int argc, char** argv) {
         LOG_FATAL(<< "JSON config could not be interpreted");
         return EXIT_FAILURE;
     }
+#endif
 
     const ml::api::CAnomalyJobConfig::CAnalysisLimits& analysisLimits =
         jobConfig.analysisLimits();

--- a/include/core/CPatternSet.h
+++ b/include/core/CPatternSet.h
@@ -48,6 +48,8 @@ public:
     //! Initialise the set from JSON that is an array of strings.
     bool initFromJson(const std::string& json);
 
+    bool initFromPatternList(const std::vector<std::string>& patterns);
+
     //! Check if the set contains the given key.
     bool contains(const std::string& key) const;
 


### PR DESCRIPTION
Parse JSON config files supplied on the autodetect command line to
extract rule filters and scheduled events configuration.

The new functionality is currently disabled in autodetect until the Java
code to supply the new JSON configuration files has been committed.

It is imperative that these C++ changes be committed ahead of the
corresponding Java changes as the new command line options must be
recognised.

Relates #1253 
Backports #1640