### PR TITLE
[7.x][ML] Hyperparameter importance

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,8 @@
 
 * Fix edge case which could cause spurious anomalies early in the learning process
   if the time series has non-diurnal seasonality. (See {ml-pull}1634[#1634].)
+* Compute importance of hyperparameters optimized in the fine parameter tuning step.
+  (See {ml-pull}1627[#1627].)
 
 == {es} version 7.11.0
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -42,6 +42,7 @@ public:
     static const std::string LAMBDA;
     static const std::string GAMMA;
     static const std::string ETA;
+    static const std::string ETA_GROWTH_RATE_PER_TREE;
     static const std::string SOFT_TREE_DEPTH_LIMIT;
     static const std::string SOFT_TREE_DEPTH_TOLERANCE;
     static const std::string MAX_TREES;

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -7,12 +7,14 @@
 #define INCLUDED_ml_api_CInferenceModelMetadata_h
 
 #include <maths/CBasicStatistics.h>
+#include <maths/CBoostedTree.h>
 #include <maths/CLinearAlgebraEigen.h>
 
 #include <api/CInferenceModelDefinition.h>
 #include <api/ImportExport.h>
 
 #include <string>
+#include <tuple>
 
 namespace ml {
 namespace api {
@@ -21,16 +23,22 @@ namespace api {
 //! (such as totol feature importance) into JSON format.
 class API_EXPORT CInferenceModelMetadata {
 public:
+    static const std::string JSON_ABSOLUTE_IMPORTANCE_TAG;
     static const std::string JSON_BASELINE_TAG;
-    static const std::string JSON_FEATURE_IMPORTANCE_BASELINE_TAG;
     static const std::string JSON_CLASS_NAME_TAG;
     static const std::string JSON_CLASSES_TAG;
+    static const std::string JSON_FEATURE_IMPORTANCE_BASELINE_TAG;
     static const std::string JSON_FEATURE_NAME_TAG;
+    static const std::string JSON_HYPERPARAMETERS_TAG;
+    static const std::string JSON_HYPERPARAMETER_NAME_TAG;
+    static const std::string JSON_HYPERPARAMETER_VALUE_TAG;
+    static const std::string JSON_HYPERPARAMETER_SUPPLIED_TAG;
     static const std::string JSON_IMPORTANCE_TAG;
     static const std::string JSON_MAX_TAG;
     static const std::string JSON_MEAN_MAGNITUDE_TAG;
     static const std::string JSON_MIN_TAG;
     static const std::string JSON_MODEL_METADATA_TAG;
+    static const std::string JSON_RELATIVE_IMPORTANCE_TAG;
     static const std::string JSON_TOTAL_FEATURE_IMPORTANCE_TAG;
 
 public:
@@ -53,17 +61,36 @@ public:
     //! Set the feature importance baseline (the individual feature importances are additive corrections
     //! to the baseline value).
     void featureImportanceBaseline(TVector&& baseline);
+    void hyperparameterImportance(const maths::CBoostedTree::THyperparameterImportanceVec& hyperparameterImportance);
 
 private:
+    struct SHyperparameterImportance {
+        SHyperparameterImportance(std::string hyperparameterName,
+                                  double value,
+                                  double absoluteImportance,
+                                  double relativeImportance,
+                                  bool supplied)
+            : s_HyperparameterName(hyperparameterName), s_Value(value),
+              s_AbsoluteImportance(absoluteImportance),
+              s_RelativeImportance(relativeImportance), s_Supplied(supplied){};
+        std::string s_HyperparameterName;
+        double s_Value;
+        double s_AbsoluteImportance;
+        double s_RelativeImportance;
+        bool s_Supplied;
+    };
+
     using TMeanAccumulator =
         std::vector<maths::CBasicStatistics::SSampleMean<double>::TAccumulator>;
     using TMinMaxAccumulator = std::vector<maths::CBasicStatistics::CMinMax<double>>;
     using TSizeMeanAccumulatorUMap = std::unordered_map<std::size_t, TMeanAccumulator>;
     using TSizeMinMaxAccumulatorUMap = std::unordered_map<std::size_t, TMinMaxAccumulator>;
     using TOptionalVector = boost::optional<TVector>;
+    using THyperparametersVec = std::vector<SHyperparameterImportance>;
 
 private:
     void writeTotalFeatureImportance(TRapidJsonWriter& writer) const;
+    void writeHyperparameterImportance(TRapidJsonWriter& writer) const;
     void writeFeatureImportanceBaseline(TRapidJsonWriter& writer) const;
 
 private:
@@ -76,6 +103,7 @@ private:
         [](const std::string& value, TRapidJsonWriter& writer) {
             writer.String(value);
         };
+    THyperparametersVec m_HyperparameterImportance;
 };
 }
 }

--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -93,6 +93,31 @@ public:
     static std::size_t estimateMemoryUsage(std::size_t numberParameters,
                                            std::size_t numberRounds);
 
+    //! Evaluate the Guassian process at the point \p input.
+    double evaluate(const TVector& input) const;
+
+    //! Compute the marginalized value of the Gaussian process in the dimension
+    //! \p dimension for the values \p input.
+    double evaluate1D(double input, int dimension) const;
+
+    //! Get the constant factor of the ANOVA decomposition of the Gaussian process.
+    double anovaConstantFactor() const;
+
+    //! Get the total variance of the hyperparameters in the Gaussian process
+    //! using ANOVA decomposition.
+    double anovaTotalVariance() const;
+
+    //! Get the main effect of the parameter \p dimension in the Gaussian process
+    //! using ANOVA decomposition.
+    double anovaMainEffect(int dimension) const;
+
+    //! Get the vector of main effects as an absolute value and as a fraction
+    //! of the total variance.
+    TDoubleDoublePrVec anovaMainEffects() const;
+
+    //! Set kernel \p parameters explicitly.
+    void kernelParameters(const TVector& parameters);
+
     //! \name Test Interface
     //@{
     //! Get minus the data likelihood and its gradient as a function of the kernel
@@ -132,6 +157,14 @@ private:
     TMatrix kernel(const TVector& a, double v) const;
     TVectorDoublePr kernelCovariates(const TVector& a, const TVector& x, double vx) const;
     double kernel(const TVector& a, const TVector& x, const TVector& y) const;
+    double evaluate(const TVector& Kinvf, const TVector& input) const;
+    double evaluate1D(const TVector& Kinvf, double input, int dimension) const;
+    double anovaConstantFactor(const TVector& Kinvf) const;
+    double anovaTotalVariance(const TVector& Kinvf) const;
+    double anovaMainEffect(const TVector& Kinvf, int dimension) const;
+    TVector kinvf() const;
+    TVector transformTo01(const TVector& x) const;
+    TVector scaledKernelParameters() const;
 
 private:
     CPRNG::CXorOShiro128Plus m_Rng;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -13,6 +13,7 @@
 #include <core/CStateRestoreTraverser.h>
 
 #include <maths/CBoostedTreeHyperparameters.h>
+#include <maths/CBoostedTreeUtils.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CDataFramePredictiveModel.h>
 #include <maths/CLinearAlgebraEigen.h>
@@ -201,6 +202,8 @@ public:
     using TDataFramePtr = core::CDataFrame*;
     using TNodeVec = std::vector<CBoostedTreeNode>;
     using TNodeVecVec = std::vector<TNodeVec>;
+    using THyperparameterImportanceVec =
+        std::vector<boosted_tree_detail::SHyperparameterImportance>;
 
     class MATHS_EXPORT CVisitor : public CDataFrameCategoryEncoder::CVisitor,
                                   public CBoostedTreeNode::CVisitor {
@@ -229,6 +232,9 @@ public:
     //!
     //! \warning Will return a nullptr if a trained model isn't available.
     CTreeShapFeatureImportance* shap() const override;
+
+    //! Get the vector of hyperparameter importances.
+    THyperparameterImportanceVec hyperparameterImportance() const;
 
     //! Get the column containing the dependent variable.
     std::size_t columnHoldingDependentVariable() const override;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -28,7 +28,6 @@
 #include <maths/ImportExport.h>
 
 #include <boost/optional.hpp>
-#include <boost/range/irange.hpp>
 
 #include <limits>
 #include <memory>
@@ -66,8 +65,9 @@ public:
     using TOptionalDouble = boost::optional<double>;
     using TRegularization = CBoostedTreeRegularization<double>;
     using TSizeVec = std::vector<std::size_t>;
-    using TSizeRange = boost::integer_range<std::size_t>;
     using TAnalysisInstrumentationPtr = CDataFrameTrainBoostedTreeInstrumentationInterface*;
+    using THyperparameterImportanceVec =
+        std::vector<boosted_tree_detail::SHyperparameterImportance>;
 
 public:
     static const double MINIMUM_RELATIVE_GAIN_PER_SPLIT;
@@ -94,6 +94,9 @@ public:
     //!
     //! \warning Will return a nullptr if a trained model isn't available.
     CTreeShapFeatureImportance* shap();
+
+    //! Get the vector of hyperparameter importances.
+    THyperparameterImportanceVec hyperparameterImportance() const;
 
     //! Get the model produced by training if it has been run.
     const TNodeVecVec& trainedModel() const;
@@ -174,6 +177,7 @@ private:
     using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
     using TWorkspace = CBoostedTreeLeafNodeStatistics::CWorkspace;
+    using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameters>;
 
     //! Tag progress through initialization.
     enum EInitializationStage {
@@ -326,6 +330,9 @@ private:
     //! Record hyperparameters for instrumentation.
     void recordHyperparameters();
 
+    //! Populate the list of tunable hyperparameters
+    void initializeTunableHyperparameters();
+
 private:
     mutable CPRNG::CXorOShiro128Plus m_Rng;
     EInitializationStage m_InitializationStage = E_NotInitialized;
@@ -374,6 +381,7 @@ private:
     TAnalysisInstrumentationPtr m_Instrumentation;
     mutable TMeanAccumulator m_ForestSizeAccumulator;
     mutable TMeanAccumulator m_MeanLossAccumulator;
+    THyperparametersVec m_TunableHyperparameters;
 
 private:
     friend class CBoostedTreeFactory;

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -31,6 +31,36 @@ using TAlignedMemoryMappedFloatVector =
 
 enum EExtraColumn { E_Prediction = 0, E_Gradient, E_Curvature, E_Weight };
 
+enum EHyperparameters {
+    E_DownsampleFactor = 0,
+    E_Alpha,
+    E_Lambda,
+    E_Gamma,
+    E_SoftTreeDepthLimit,
+    E_SoftTreeDepthTolerance,
+    E_Eta,
+    E_EtaGrowthRatePerTree,
+    E_FeatureBagFraction
+};
+
+constexpr std::size_t NUMBER_HYPERPARAMETERS = E_FeatureBagFraction + 1; // This must be last hyperparameter
+
+struct SHyperparameterImportance {
+    SHyperparameterImportance(EHyperparameters hyperparameter,
+                              double value,
+                              double absoluteImportance,
+                              double relativeImportance,
+                              bool supplied)
+        : s_Hyperparameter(hyperparameter), s_Value(value),
+          s_AbsoluteImportance(absoluteImportance),
+          s_RelativeImportance(relativeImportance), s_Supplied(supplied) {}
+    EHyperparameters s_Hyperparameter;
+    double s_Value;
+    double s_AbsoluteImportance;
+    double s_RelativeImportance;
+    bool s_Supplied;
+};
+
 //! Get the size of upper triangle of the loss Hessain.
 inline std::size_t lossHessianUpperTriangleSize(std::size_t numberLossParameters) {
     return numberLossParameters * (numberLossParameters + 1) / 2;

--- a/include/maths/CSampling.h
+++ b/include/maths/CSampling.h
@@ -660,6 +660,10 @@ public:
     //! and \p rate on the \p n quantile intervals.
     static void gammaSampleQuantiles(double shape, double rate, std::size_t n, TDoubleVec& result);
 
+    //! Generate \p samples of Sobol sequence \p n elements on
+    //! the hypercube [0, 1] in \p dim dimensions.
+    static void sobolSequenceSample(std::size_t dim, std::size_t n, TDoubleVecVec& samples);
+
 private:
     //! \brief A uniform generator on the interval [0, n).
     template<typename RNG>

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -301,6 +301,8 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
     if (featureImportance) {
         m_InferenceModelMetadata.featureImportanceBaseline(featureImportance->baseline());
     }
+    m_InferenceModelMetadata.hyperparameterImportance(
+        this->boostedTree().hyperparameterImportance());
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -159,6 +159,8 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
     if (featureImportance) {
         m_InferenceModelMetadata.featureImportanceBaseline(featureImportance->baseline());
     }
+    m_InferenceModelMetadata.hyperparameterImportance(
+        this->boostedTree().hyperparameterImportance());
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -367,6 +367,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::ALPHA{"alpha"};
 const std::string CDataFrameTrainBoostedTreeRunner::LAMBDA{"lambda"};
 const std::string CDataFrameTrainBoostedTreeRunner::GAMMA{"gamma"};
 const std::string CDataFrameTrainBoostedTreeRunner::ETA{"eta"};
+const std::string CDataFrameTrainBoostedTreeRunner::ETA_GROWTH_RATE_PER_TREE{"eta_growth_rate_per_tree"};
 const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT{"soft_tree_depth_limit"};
 const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE{"soft_tree_depth_tolerance"};
 const std::string CDataFrameTrainBoostedTreeRunner::MAX_TREES{"max_trees"};

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -5,6 +5,10 @@
  */
 #include <api/CInferenceModelMetadata.h>
 
+#include <api/CDataFrameTrainBoostedTreeRunner.h>
+
+#include <maths/CBoostedTreeUtils.h>
+
 #include <cmath>
 
 namespace ml {
@@ -13,6 +17,7 @@ namespace api {
 void CInferenceModelMetadata::write(TRapidJsonWriter& writer) const {
     this->writeTotalFeatureImportance(writer);
     this->writeFeatureImportanceBaseline(writer);
+    this->writeHyperparameterImportance(writer);
 }
 
 void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writer) const {
@@ -136,6 +141,29 @@ void CInferenceModelMetadata::writeFeatureImportanceBaseline(TRapidJsonWriter& w
     }
 }
 
+void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& writer) const {
+    // TODO use struct instead of a tuple
+    writer.Key(JSON_HYPERPARAMETERS_TAG);
+    writer.StartArray();
+    for (const auto& item : m_HyperparameterImportance) {
+        writer.StartObject();
+        writer.Key(JSON_HYPERPARAMETER_NAME_TAG);
+        writer.String(item.s_HyperparameterName);
+        writer.Key(JSON_HYPERPARAMETER_VALUE_TAG);
+        writer.Double(item.s_Value);
+        if (item.s_Supplied == false) {
+            writer.Key(JSON_ABSOLUTE_IMPORTANCE_TAG);
+            writer.Double(item.s_AbsoluteImportance);
+            writer.Key(JSON_RELATIVE_IMPORTANCE_TAG);
+            writer.Double(item.s_RelativeImportance);
+        }
+        writer.Key(JSON_HYPERPARAMETER_SUPPLIED_TAG);
+        writer.Bool(item.s_Supplied);
+        writer.EndObject();
+    }
+    writer.EndArray();
+}
+
 const std::string& CInferenceModelMetadata::typeString() const {
     return JSON_MODEL_METADATA_TAG;
 }
@@ -171,17 +199,68 @@ void CInferenceModelMetadata::featureImportanceBaseline(TVector&& baseline) {
     m_ShapBaseline = baseline;
 }
 
+void CInferenceModelMetadata::hyperparameterImportance(
+    const maths::CBoostedTree::THyperparameterImportanceVec& hyperparameterImportance) {
+    m_HyperparameterImportance.clear();
+    m_HyperparameterImportance.reserve(hyperparameterImportance.size());
+    for (const auto& item : hyperparameterImportance) {
+        std::string hyperparameterName;
+        switch (item.s_Hyperparameter) {
+        case maths::boosted_tree_detail::E_Alpha:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::ALPHA;
+            break;
+        case maths::boosted_tree_detail::E_DownsampleFactor:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_FACTOR;
+            break;
+        case maths::boosted_tree_detail::E_Eta:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_FACTOR;
+            break;
+        case maths::boosted_tree_detail::E_EtaGrowthRatePerTree:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::ETA_GROWTH_RATE_PER_TREE;
+            break;
+        case maths::boosted_tree_detail::E_FeatureBagFraction:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION;
+            break;
+        case maths::boosted_tree_detail::E_Gamma:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::GAMMA;
+            break;
+        case maths::boosted_tree_detail::E_Lambda:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::LAMBDA;
+            break;
+        case maths::boosted_tree_detail::E_SoftTreeDepthLimit:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT;
+            break;
+        case maths::boosted_tree_detail::E_SoftTreeDepthTolerance:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE;
+            break;
+        }
+        m_HyperparameterImportance.emplace_back(
+            hyperparameterName, item.s_Value, item.s_AbsoluteImportance,
+            item.s_RelativeImportance, item.s_Supplied);
+    }
+    std::sort(m_HyperparameterImportance.begin(),
+              m_HyperparameterImportance.end(), [](const auto& a, const auto& b) {
+                  return a.s_AbsoluteImportance > b.s_AbsoluteImportance;
+              });
+}
+
 // clang-format off
+const std::string CInferenceModelMetadata::JSON_ABSOLUTE_IMPORTANCE_TAG{"absolute_importance"};
 const std::string CInferenceModelMetadata::JSON_BASELINE_TAG{"baseline"};
-const std::string CInferenceModelMetadata::JSON_FEATURE_IMPORTANCE_BASELINE_TAG{"feature_importance_baseline"};
 const std::string CInferenceModelMetadata::JSON_CLASS_NAME_TAG{"class_name"};
 const std::string CInferenceModelMetadata::JSON_CLASSES_TAG{"classes"};
+const std::string CInferenceModelMetadata::JSON_FEATURE_IMPORTANCE_BASELINE_TAG{"feature_importance_baseline"};
 const std::string CInferenceModelMetadata::JSON_FEATURE_NAME_TAG{"feature_name"};
+const std::string CInferenceModelMetadata::JSON_HYPERPARAMETERS_TAG{"hyperparameters"};
+const std::string CInferenceModelMetadata::JSON_HYPERPARAMETER_NAME_TAG{"name"};
+const std::string CInferenceModelMetadata::JSON_HYPERPARAMETER_VALUE_TAG{"value"};
+const std::string CInferenceModelMetadata::JSON_HYPERPARAMETER_SUPPLIED_TAG{"supplied"};
 const std::string CInferenceModelMetadata::JSON_IMPORTANCE_TAG{"importance"};
 const std::string CInferenceModelMetadata::JSON_MAX_TAG{"max"};
 const std::string CInferenceModelMetadata::JSON_MEAN_MAGNITUDE_TAG{"mean_magnitude"};
 const std::string CInferenceModelMetadata::JSON_MIN_TAG{"min"};
 const std::string CInferenceModelMetadata::JSON_MODEL_METADATA_TAG{"model_metadata"};
+const std::string CInferenceModelMetadata::JSON_RELATIVE_IMPORTANCE_TAG{"relative_importance"};
 const std::string CInferenceModelMetadata::JSON_TOTAL_FEATURE_IMPORTANCE_TAG{"total_feature_importance"};
 // clang-format on
 }

--- a/lib/api/unittest/CInferenceModelMetadataTest.cc
+++ b/lib/api/unittest/CInferenceModelMetadataTest.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+#include <boost/test/tools/interface.hpp>
+#include <core/CJsonOutputStreamWrapper.h>
+
+#include <maths/CBoostedTreeLoss.h>
+
+#include <api/CDataFrameAnalyzer.h>
+
+#include <test/CDataFrameAnalysisSpecificationFactory.h>
+#include <test/CDataFrameAnalyzerTrainingFactory.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/schema.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <fstream>
+#include <string>
+
+BOOST_AUTO_TEST_SUITE(CInferenceModelMetadataTest)
+
+using namespace ml;
+
+namespace {
+using TDoubleVec = std::vector<double>;
+using TStrVec = std::vector<std::string>;
+using TLossFunctionType = maths::boosted_tree::ELossType;
+}
+
+BOOST_AUTO_TEST_CASE(testJsonSchema) {
+    // Test the results the analyzer produces match running the regression directly.
+
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    TDoubleVec expectedPredictions;
+
+    TStrVec fieldNames{"f1", "f2", "f3", "f4", "target", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    api::CDataFrameAnalyzer analyzer{
+        test::CDataFrameAnalysisSpecificationFactory{}
+            .predictionLambda(0.5)
+            .predictionEta(.5)
+            .predictionGamma(0.5)
+            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
+        outputWriterFactory};
+    test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
+        TLossFunctionType::E_MseRegression, fieldNames, fieldValues, analyzer,
+        expectedPredictions);
+
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    rapidjson::Document results;
+    rapidjson::ParseResult ok(results.Parse(output.str()));
+    LOG_DEBUG(<< output.str());
+    BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+
+    std::ifstream modelMetaDataSchemaFileStream("testfiles/model_meta_data/model_meta_data.schema.json");
+    BOOST_REQUIRE_MESSAGE(modelMetaDataSchemaFileStream.is_open(), "Cannot open test file!");
+    std::string modelMetaDataSchemaJson(
+        (std::istreambuf_iterator<char>(modelMetaDataSchemaFileStream)),
+        std::istreambuf_iterator<char>());
+    rapidjson::Document modelMetaDataSchemaDocument;
+    BOOST_REQUIRE_MESSAGE(
+        modelMetaDataSchemaDocument.Parse(modelMetaDataSchemaJson).HasParseError() == false,
+        "Cannot parse JSON schema!");
+    rapidjson::SchemaDocument modelMetaDataSchema(modelMetaDataSchemaDocument);
+    rapidjson::SchemaValidator modelMetaDataValidator(modelMetaDataSchema);
+
+    bool hasModelMetadata{false};
+    for (const auto& result : results.GetArray()) {
+        if (result.HasMember("model_metadata")) {
+            hasModelMetadata = true;
+            BOOST_TEST_REQUIRE(result["model_metadata"].IsObject() = true);
+            if (result["model_metadata"].Accept(modelMetaDataValidator) == false) {
+                rapidjson::StringBuffer sb;
+                modelMetaDataValidator.GetInvalidSchemaPointer().StringifyUriFragment(sb);
+                LOG_ERROR(<< "Invalid schema: " << sb.GetString());
+                LOG_ERROR(<< "Invalid keyword: "
+                          << modelMetaDataValidator.GetInvalidSchemaKeyword());
+                sb.Clear();
+                modelMetaDataValidator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
+                LOG_ERROR(<< "Invalid document: " << sb.GetString());
+                BOOST_FAIL("Schema validation failed");
+            }
+        }
+    }
+
+    BOOST_TEST_REQUIRE(hasModelMetadata);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -41,6 +41,7 @@ SRCS=\
 	CFieldDataCategorizerTest.cc \
 	CForecastRunnerTest.cc \
 	CGlobalCategoryIdTest.cc \
+	CInferenceModelMetadataTest.cc \
 	CIoManagerTest.cc \
 	CJsonOutputWriterTest.cc \
 	CLengthEncodedInputParserTest.cc \

--- a/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
+++ b/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
@@ -1,0 +1,97 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/elastic/ml-json-schemas-private/master/schemas/model_meta_data/model_meta_data.schema.json",
+    "description": "Optional model meta information",
+    "title": "model_meta_data",
+    "type": "object",
+    "properties": {
+        "total_feature_importance": {
+            "description": "Average feature importance for all features used by the model",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "field_name": {
+                        "type": "string"
+                    },
+                    "importance": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "field_name",
+                    "importance"
+                ],
+                "additionalProperties": false
+            },
+            "additionalItems": false
+        },
+        "hyperparameters": {
+            "description": "List of hyperparameters together their absolute and relative importances from Bayesian optimization.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "oneOf": [
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The best hyperparameter value or the value supplied by the user.",
+                                "type": "number"
+                            },
+                            "supplied": {
+                                "description": "Wether or not the value was supplied by the user.",
+                                "type": "boolean",
+                                "enum": [
+                                    false
+                                ]
+                            },
+                            "absolute_importance": {
+                                "type": "number"
+                            },
+                            "relative_importance": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "value",
+                            "supplied",
+                            "absolute_importance",
+                            "relative_importance"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The best hyperparameter value or the value supplied by the user.",
+                                "type": "number"
+                            },
+                            "supplied": {
+                                "description": "Wether or not the value was supplied by the user.",
+                                "type": "boolean",
+                                "enum": [
+                                    true
+                                ]
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "value",
+                            "supplied"
+                        ],
+                        "additionalProperties": false
+                    }
+                ]
+            },
+            "additionalItems": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -163,6 +163,10 @@ CTreeShapFeatureImportance* CBoostedTree::shap() const {
     return m_Impl->shap();
 }
 
+CBoostedTree::THyperparameterImportanceVec CBoostedTree::hyperparameterImportance() const {
+    return m_Impl->hyperparameterImportance();
+}
+
 std::size_t CBoostedTree::columnHoldingDependentVariable() const {
     return m_Impl->columnHoldingDependentVariable();
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -16,6 +16,7 @@
 #include <maths/CBayesianOptimisation.h>
 #include <maths/CBoostedTreeImpl.h>
 #include <maths/CBoostedTreeLoss.h>
+#include <maths/CBoostedTreeUtils.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CLeastSquaresOnlineRegression.h>
 #include <maths/CLeastSquaresOnlineRegressionDetail.h>
@@ -220,6 +221,7 @@ void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {
     LOG_TRACE(<< "hyperparameter search bounding box = "
               << core::CContainerPrinter::print(boundingBox));
 
+    m_TreeImpl->initializeTunableHyperparameters();
     m_TreeImpl->m_BayesianOptimization = std::make_unique<CBayesianOptimisation>(
         std::move(boundingBox),
         m_BayesianOptimisationRestarts.value_or(CBayesianOptimisation::RESTARTS));

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -339,6 +339,8 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
     std::size_t foldRoundLossMemoryUsage{m_NumberFolds * m_NumberRounds *
                                          sizeof(TOptionalDouble)};
     std::size_t hyperparametersMemoryUsage{numberColumns * sizeof(double)};
+    std::size_t tunableHyperparametersMemoryUsage{m_TunableHyperparameters.size() *
+                                                  sizeof(int)};
     // The leaves' row masks memory is accounted for here because it's proportional
     // to the log2(number of nodes). The compressed bit vector representation uses
     // roughly log2(E[run length]) / E[run length] bytes per bit. As we grow the
@@ -371,8 +373,9 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
         this->numberHyperparametersToTune(), m_NumberRounds)};
     std::size_t worstCaseMemoryUsage{
         sizeof(*this) + forestMemoryUsage + foldRoundLossMemoryUsage +
-        hyperparametersMemoryUsage + leafNodeStatisticsMemoryUsage +
-        dataTypeMemoryUsage + featureSampleProbabilities + missingFeatureMaskMemoryUsage +
+        hyperparametersMemoryUsage + tunableHyperparametersMemoryUsage +
+        leafNodeStatisticsMemoryUsage + dataTypeMemoryUsage +
+        featureSampleProbabilities + missingFeatureMaskMemoryUsage +
         trainTestMaskMemoryUsage + bayesianOptimisationMemoryUsage};
 
     return CBoostedTreeImpl::correctedMemoryUsage(static_cast<double>(worstCaseMemoryUsage));
@@ -1265,8 +1268,8 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     double meanLoss{CBasicStatistics::mean(lossMoments)};
     double lossVariance{CBasicStatistics::variance(lossMoments)};
 
-    LOG_TRACE(<< "round = " << m_CurrentRound << " loss = " << meanLoss
-              << ": regularization = " << m_Regularization.print()
+    LOG_TRACE(<< "round = " << m_CurrentRound << " loss = " << meanLoss << " variance = "
+              << lossVariance << ": regularization = " << m_Regularization.print()
               << ", downsample factor = " << m_DownsampleFactor << ", eta = " << m_Eta
               << ", eta growth rate per tree = " << m_EtaGrowthRatePerTree
               << ", feature bag fraction = " << m_FeatureBagFraction);
@@ -1283,6 +1286,16 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     }
 
     // Write parameters for next round.
+    if (m_DownsampleFactorOverride == boost::none) {
+        auto i = std::distance(m_TunableHyperparameters.begin(),
+                               std::find(m_TunableHyperparameters.begin(),
+                                         m_TunableHyperparameters.end(), E_DownsampleFactor));
+        if (static_cast<std::size_t>(i) < m_TunableHyperparameters.size()) {
+            scale = std::min(1.0, 2.0 * parameters(i) /
+                                      (CTools::stableExp(minBoundary(0)) +
+                                       CTools::stableExp(maxBoundary(0))));
+        }
+    }
     i = 0;
     if (m_DownsampleFactorOverride == boost::none) {
         m_DownsampleFactor = CTools::stableExp(parameters(i++));
@@ -1388,6 +1401,59 @@ void CBoostedTreeImpl::recordHyperparameters() {
             m_Regularization.softTreeDepthTolerance(),
             m_Regularization.treeSizePenaltyMultiplier(),
             m_Regularization.leafWeightPenaltyMultiplier()};
+}
+
+void CBoostedTreeImpl::initializeTunableHyperparameters() {
+    m_TunableHyperparameters.clear();
+    for (int i = 0; i < static_cast<int>(NUMBER_HYPERPARAMETERS); ++i) {
+        switch (i) {
+        case E_DownsampleFactor:
+            if (m_DownsampleFactorOverride == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_DownsampleFactor);
+            }
+            break;
+        case E_Alpha:
+            if (m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_Alpha);
+            }
+            break;
+        case E_Lambda:
+            if (m_RegularizationOverride.leafWeightPenaltyMultiplier() == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_Lambda);
+            }
+            break;
+        case E_Gamma:
+            if (m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_Gamma);
+            }
+            break;
+        case E_SoftTreeDepthLimit:
+            if (m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_SoftTreeDepthLimit);
+            }
+            break;
+        case E_SoftTreeDepthTolerance:
+            if (m_RegularizationOverride.softTreeDepthTolerance() == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_SoftTreeDepthTolerance);
+            }
+            break;
+        case E_Eta:
+            if (m_EtaOverride == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_Eta);
+            }
+            break;
+        case E_EtaGrowthRatePerTree:
+            if (m_EtaOverride == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_EtaGrowthRatePerTree);
+            }
+            break;
+        case E_FeatureBagFraction:
+            if (m_FeatureBagFractionOverride == boost::none) {
+                m_TunableHyperparameters.emplace_back(E_FeatureBagFraction);
+            }
+            break;
+        }
+    }
 }
 
 void CBoostedTreeImpl::startProgressMonitoringFineTuneHyperparameters() {
@@ -1540,6 +1606,7 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
                                  m_StopCrossValidationEarly, inserter);
     core::CPersistUtils::persist(TESTING_ROW_MASKS_TAG, m_TestingRowMasks, inserter);
     core::CPersistUtils::persist(TRAINING_ROW_MASKS_TAG, m_TrainingRowMasks, inserter);
+    // m_TunableHyperparameters is not persisted explicitly, it is restored from overriden hyperparameters
 }
 
 bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
@@ -1653,8 +1720,9 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
                 core::CPersistUtils::restore(TESTING_ROW_MASKS_TAG, m_TestingRowMasks, traverser))
         RESTORE(TRAINING_ROW_MASKS_TAG,
                 core::CPersistUtils::restore(TRAINING_ROW_MASKS_TAG, m_TrainingRowMasks, traverser))
+        // m_TunableHyperparameters is not restored explicitly, it is restored from overriden hyperparameters
     } while (traverser.next());
-
+    this->initializeTunableHyperparameters();
     m_InitializationStage = static_cast<EInitializationStage>(initializationStage);
 
     return true;
@@ -1693,6 +1761,60 @@ const CBoostedTreeHyperparameters& CBoostedTreeImpl::bestHyperparameters() const
 
 CTreeShapFeatureImportance* CBoostedTreeImpl::shap() {
     return m_TreeShap.get();
+}
+
+CBoostedTreeImpl::THyperparameterImportanceVec
+CBoostedTreeImpl::hyperparameterImportance() const {
+    THyperparameterImportanceVec hyperparameterImportances;
+    hyperparameterImportances.reserve(m_TunableHyperparameters.size());
+    CBayesianOptimisation::TDoubleDoublePrVec anovaMainEffects{
+        m_BayesianOptimization->anovaMainEffects()};
+    for (std::size_t i = 0; i < static_cast<std::size_t>(NUMBER_HYPERPARAMETERS); ++i) {
+        double absoluteImportance{0.0};
+        double relativeImportance{0.0};
+        bool supplied{true};
+        auto tunableIndex = std::distance(m_TunableHyperparameters.begin(),
+                                          std::find(m_TunableHyperparameters.begin(),
+                                                    m_TunableHyperparameters.end(), i));
+        if (static_cast<std::size_t>(tunableIndex) < m_TunableHyperparameters.size()) {
+            supplied = false;
+            std::tie(absoluteImportance, relativeImportance) = anovaMainEffects[tunableIndex];
+        }
+        double hyperparameterValue;
+        switch (i) {
+        case E_Alpha:
+            hyperparameterValue = m_Regularization.depthPenaltyMultiplier();
+            break;
+        case E_DownsampleFactor:
+            hyperparameterValue = m_DownsampleFactor;
+            break;
+        case E_Eta:
+            hyperparameterValue = m_Eta;
+            break;
+        case E_EtaGrowthRatePerTree:
+            hyperparameterValue = m_EtaGrowthRatePerTree;
+            break;
+        case E_FeatureBagFraction:
+            hyperparameterValue = m_FeatureBagFraction;
+            break;
+        case E_Gamma:
+            hyperparameterValue = m_Regularization.treeSizePenaltyMultiplier();
+            break;
+        case E_Lambda:
+            hyperparameterValue = m_Regularization.leafWeightPenaltyMultiplier();
+            break;
+        case E_SoftTreeDepthLimit:
+            hyperparameterValue = m_Regularization.softTreeDepthLimit();
+            break;
+        case E_SoftTreeDepthTolerance:
+            hyperparameterValue = m_Regularization.softTreeDepthTolerance();
+            break;
+        }
+        hyperparameterImportances.emplace_back(static_cast<EHyperparameters>(i),
+                                               hyperparameterValue, absoluteImportance,
+                                               relativeImportance, supplied);
+    }
+    return hyperparameterImportances;
 }
 
 const CBoostedTreeImpl::TDoubleVec& CBoostedTreeImpl::featureSampleProbabilities() const {

--- a/lib/maths/CSampling.cc
+++ b/lib/maths/CSampling.cc
@@ -23,7 +23,10 @@
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/chi_squared_distribution.hpp>
 #include <boost/random/normal_distribution.hpp>
+#include <boost/random/sobol.hpp>
+#include <boost/random/uniform_01.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -817,6 +820,30 @@ void CSampling::gammaSampleQuantiles(double shape, double rate, std::size_t n, T
         LOG_ERROR(<< "Failed to sample normal quantiles: " << e.what()
                   << ", shape = " << shape << ", rate = " << rate);
         result.clear();
+    }
+}
+
+void CSampling::sobolSequenceSample(std::size_t dim, std::size_t n, TDoubleVecVec& samples) {
+    samples.clear();
+    if (n == 0 || dim == 0) {
+        return;
+    }
+
+    try {
+        using TSobolGenerator =
+            boost::variate_generator<boost::random::sobol&, boost::uniform_01<double>>;
+        boost::random::sobol engine(dim);
+        TSobolGenerator gen(engine, boost::uniform_01<double>());
+        samples.resize(n, TDoubleVec(dim));
+        for (std::size_t i = 0u; i < n; ++i) {
+            for (std::size_t j = 0u; j < dim; ++j) {
+                samples[i][j] = gen();
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG_ERROR(<< "Failed to sample Sobol sequence: " << e.what()
+                  << ", dim = " << dim << ", n = " << n);
+        samples.clear();
     }
 }
 

--- a/lib/maths/unittest/CSamplingTest.cc
+++ b/lib/maths/unittest/CSamplingTest.cc
@@ -389,4 +389,36 @@ BOOST_AUTO_TEST_CASE(testVectorDissimilaritySampler) {
     BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentageSeparationIncrease) > 50.0);
 }
 
+BOOST_AUTO_TEST_CASE(testSobolSequenceSampling) {
+    {
+        // 1-dimensional sequence
+        std::size_t dim{1};
+        std::size_t n{10};
+        TDoubleVecVec expected{{0.5},   {0.75},  {0.25},   {0.375},  {0.875},
+                               {0.625}, {0.125}, {0.1875}, {0.6875}, {0.9375}};
+        TDoubleVecVec actual;
+        maths::CSampling::sobolSequenceSample(dim, n, actual);
+        for (std::size_t i = 0u; i < n; ++i) {
+            BOOST_REQUIRE_EQUAL_COLLECTIONS(expected[i].begin(), expected[i].end(),
+                                            actual[i].begin(), actual[i].end());
+        }
+    }
+
+    {
+        // 2-dimensional sequence
+        std::size_t dim{2};
+        std::size_t n{10};
+        TDoubleVecVec expected{
+            {0.5, 0.5},       {0.75, 0.25},    {0.25, 0.75},   {0.375, 0.375},
+            {0.875, 0.875},   {0.625, 0.125},  {0.125, 0.625}, {0.1875, 0.3125},
+            {0.6875, 0.8125}, {0.9375, 0.0625}};
+        TDoubleVecVec actual;
+        maths::CSampling::sobolSequenceSample(dim, n, actual);
+        for (std::size_t i = 0u; i < n; ++i) {
+            BOOST_REQUIRE_EQUAL_COLLECTIONS(expected[i].begin(), expected[i].end(),
+                                            actual[i].begin(), actual[i].end());
+        }
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR implements hyperparameter importance calculation using ANOVA decomposition of the Gaussian process model used in the Bayesian optimization routine. The results is recorded in the model metadata structure. For convenience, I record the anova variance as an absolute value as well as a fraction of the total variation. This "relative importance" simplifies the comparison between different parameters.

Additionally, I record the best value for the individual hyperparameter s.t. it can be used in a follow-up job configuration and doesn't have to be looked up separately.

Example output:
```json
"hyperparameter_importance": [
        {
            "name": "downsample_factor",
            "value": 0.35355339059327386,
            "absolute_importance": 0.123,
            "relative_importance": 0.9123
        },
        {
            "name": "alpha",
            "value": 0.010766199582740555,
            "absolute_importance": 0.0123,
            "relative_importance": 0.0321
        }
    ]
```
In order to verify the analytical formulas, I implemented Sobol sequence random number generation, which leads to lower variance for Monte-Carlo estimations.

Backport of #1627 