### PR TITLE
[ML] Fix scale initialization

### DIFF
--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -181,42 +181,70 @@ void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {
     // less than p_1, this translates to using log parameter values.
 
     CBayesianOptimisation::TDoubleDoublePrVec boundingBox;
-    if (m_TreeImpl->m_DownsampleFactorOverride == boost::none) {
-        boundingBox.emplace_back(
-            m_LogDownsampleFactorSearchInterval(MIN_REGULARIZER_INDEX),
-            m_LogDownsampleFactorSearchInterval(MAX_REGULARIZER_INDEX));
-    }
-    if (m_TreeImpl->m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
-        boundingBox.emplace_back(
-            m_LogDepthPenaltyMultiplierSearchInterval(MIN_REGULARIZER_INDEX),
-            m_LogDepthPenaltyMultiplierSearchInterval(MAX_REGULARIZER_INDEX));
-    }
-    if (m_TreeImpl->m_RegularizationOverride.leafWeightPenaltyMultiplier() == boost::none) {
-        boundingBox.emplace_back(
-            m_LogLeafWeightPenaltyMultiplierSearchInterval(MIN_REGULARIZER_INDEX),
-            m_LogLeafWeightPenaltyMultiplierSearchInterval(MAX_REGULARIZER_INDEX));
-    }
-    if (m_TreeImpl->m_RegularizationOverride.treeSizePenaltyMultiplier() == boost::none) {
-        boundingBox.emplace_back(
-            m_LogTreeSizePenaltyMultiplierSearchInterval(MIN_REGULARIZER_INDEX),
-            m_LogTreeSizePenaltyMultiplierSearchInterval(MAX_REGULARIZER_INDEX));
-    }
-    if (m_TreeImpl->m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
-        boundingBox.emplace_back(m_SoftDepthLimitSearchInterval(MIN_REGULARIZER_INDEX),
-                                 m_SoftDepthLimitSearchInterval(MAX_REGULARIZER_INDEX));
-    }
-    if (m_TreeImpl->m_RegularizationOverride.softTreeDepthTolerance() == boost::none) {
-        boundingBox.emplace_back(MIN_SOFT_DEPTH_LIMIT_TOLERANCE, MAX_SOFT_DEPTH_LIMIT_TOLERANCE);
-    }
-    if (m_TreeImpl->m_EtaOverride == boost::none) {
-        double rate{m_TreeImpl->m_EtaGrowthRatePerTree - 1.0};
-        boundingBox.emplace_back(m_LogEtaSearchInterval(MIN_REGULARIZER_INDEX),
-                                 m_LogEtaSearchInterval(MAX_REGULARIZER_INDEX));
-        boundingBox.emplace_back(1.0 + MIN_ETA_GROWTH_RATE_SCALE * rate,
-                                 1.0 + MAX_ETA_GROWTH_RATE_SCALE * rate);
-    }
-    if (m_TreeImpl->m_FeatureBagFractionOverride == boost::none) {
-        boundingBox.emplace_back(MIN_FEATURE_BAG_FRACTION, MAX_FEATURE_BAG_FRACTION);
+    for (int i = 0; i < static_cast<int>(NUMBER_HYPERPARAMETERS); ++i) {
+        switch (i) {
+        case E_DownsampleFactor:
+            if (m_TreeImpl->m_DownsampleFactorOverride == boost::none) {
+                boundingBox.emplace_back(
+                    m_LogDownsampleFactorSearchInterval(MIN_REGULARIZER_INDEX),
+                    m_LogDownsampleFactorSearchInterval(MAX_REGULARIZER_INDEX));
+            }
+            break;
+        case E_Alpha:
+            if (m_TreeImpl->m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
+                boundingBox.emplace_back(
+                    m_LogDepthPenaltyMultiplierSearchInterval(MIN_REGULARIZER_INDEX),
+                    m_LogDepthPenaltyMultiplierSearchInterval(MAX_REGULARIZER_INDEX));
+            }
+            break;
+        case E_Lambda:
+            if (m_TreeImpl->m_RegularizationOverride.leafWeightPenaltyMultiplier() ==
+                boost::none) {
+                boundingBox.emplace_back(
+                    m_LogLeafWeightPenaltyMultiplierSearchInterval(MIN_REGULARIZER_INDEX),
+                    m_LogLeafWeightPenaltyMultiplierSearchInterval(MAX_REGULARIZER_INDEX));
+            }
+            break;
+        case E_Gamma:
+            if (m_TreeImpl->m_RegularizationOverride.treeSizePenaltyMultiplier() ==
+                boost::none) {
+                boundingBox.emplace_back(
+                    m_LogTreeSizePenaltyMultiplierSearchInterval(MIN_REGULARIZER_INDEX),
+                    m_LogTreeSizePenaltyMultiplierSearchInterval(MAX_REGULARIZER_INDEX));
+            }
+            break;
+        case E_SoftTreeDepthLimit:
+            if (m_TreeImpl->m_RegularizationOverride.softTreeDepthLimit() == boost::none) {
+                boundingBox.emplace_back(
+                    m_SoftDepthLimitSearchInterval(MIN_REGULARIZER_INDEX),
+                    m_SoftDepthLimitSearchInterval(MAX_REGULARIZER_INDEX));
+            }
+            break;
+        case E_SoftTreeDepthTolerance:
+            if (m_TreeImpl->m_RegularizationOverride.softTreeDepthTolerance() == boost::none) {
+                boundingBox.emplace_back(MIN_SOFT_DEPTH_LIMIT_TOLERANCE,
+                                         MAX_SOFT_DEPTH_LIMIT_TOLERANCE);
+            }
+            break;
+        case E_Eta:
+            if (m_TreeImpl->m_EtaOverride == boost::none) {
+                boundingBox.emplace_back(m_LogEtaSearchInterval(MIN_REGULARIZER_INDEX),
+                                         m_LogEtaSearchInterval(MAX_REGULARIZER_INDEX));
+            }
+            break;
+        case E_EtaGrowthRatePerTree:
+            if (m_TreeImpl->m_EtaOverride == boost::none) {
+                double rate{m_TreeImpl->m_EtaGrowthRatePerTree - 1.0};
+                boundingBox.emplace_back(1.0 + MIN_ETA_GROWTH_RATE_SCALE * rate,
+                                         1.0 + MAX_ETA_GROWTH_RATE_SCALE * rate);
+            }
+            break;
+        case E_FeatureBagFraction:
+            if (m_TreeImpl->m_FeatureBagFractionOverride == boost::none) {
+                boundingBox.emplace_back(MIN_FEATURE_BAG_FRACTION, MAX_FEATURE_BAG_FRACTION);
+            }
+            break;
+        }
     }
     LOG_TRACE(<< "hyperparameter search bounding box = "
               << core::CContainerPrinter::print(boundingBox));


### PR DESCRIPTION
This PR completes the assignment of hyperparameters using enumeration, which was started in  #1627. Using enums instead of fixed order allows preventing bugs if new hyperparameters will be added.