### PR TITLE
[ML] Changes to allow native compilation on ARM Macs

### DIFF
--- a/3rd_party/3rd_party.sh
+++ b/3rd_party/3rd_party.sh
@@ -37,7 +37,12 @@ case `uname` in
     Darwin)
         BOOST_LOCATION=/usr/local/lib
         BOOST_COMPILER=clang
-        BOOST_EXTENSION=mt-x64-1_71.dylib
+        if [ `uname -m` = x86_64 ] ; then
+            BOOST_ARCH=x64
+        else
+            BOOST_ARCH=a64
+        fi
+        BOOST_EXTENSION=mt-${BOOST_ARCH}-1_71.dylib
         BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread'
         XML_LOCATION=
         GCC_RT_LOCATION=

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -1,5 +1,7 @@
 # Machine Learning Build Machine Setup for macOS
 
+These same instructions should work for native compilation on both x86_64 and aarch64 architectures.
+
 To ensure everything is consistent for redistributable builds we build all redistributable components from source.
 
 NOTE: if you upgrade macOS then Xcode may need to be re-installed. Please ensure your Xcode is still valid after upgrades.
@@ -27,11 +29,12 @@ Note, that bash doesn't read `~/.bashrc` for login shells (which is what you get
 Some tools may be built via a GNU "configure" script. There are some environment variables that affect the behaviour of this. Therefore, when building ANY tool on macOS, set the following environment variables:
 
 ```
+export SSEFLAGS=`[ $(uname -m) = x86_64 ] && echo -msse4.2`
 export CPP='clang -E'
 export CC=clang
-export CFLAGS='-O3 -msse4.2'
+export CFLAGS="-O3 $SSEFLAGS"
 export CXX='clang++ -std=c++17 -stdlib=libc++'
-export CXXFLAGS='-O3 -msse4.2'
+export CXXFLAGS="-O3 $SSEFLAGS"
 export CXXCPP='clang++ -std=c++17 -E'
 export LDFLAGS=-Wl,-headerpad_max_install_names
 unset CPATH
@@ -50,7 +53,7 @@ For C++17 Xcode 10 is required, and this requires macOS High Sierra or above. Th
 
 - If you are using High Sierra, you must install Xcode 10.1.x
 - If you are using Mojave, you must install Xcode 11.3.x
-- If you are using Catalina, you must install Xcode 11.6.x or above
+- If you are using Catalina or Big Sur, you must install Xcode 12.3.x or above
 
 Xcode is distributed as a `.xip` file; simply double click the `.xip` file to expand it, then drag `Xcode.app` to your `/Applications` directory.
 (Older versions of Xcode can be downloaded from [here](https://developer.apple.com/download/more/), provided you are signed in with your Apple ID.)
@@ -93,11 +96,39 @@ to:
     (3ul)(17ul)(29ul)(37ul)(53ul)(67ul)(79ul) \
 ```
 
+Then edit `tools/build/src/tools/darwin.jam` and change:
+
+```
+        case arm :
+        {
+            if $(instruction-set) {
+                options = -arch$(_)$(instruction-set) ;
+            } else {
+                options = -arch arm ;
+            }
+        }
+```
+
+to:
+
+```
+        case arm :
+        {
+            if $(instruction-set) {
+                options = -arch$(_)$(instruction-set) ;
+            } else if $(address-model) = 64 {
+                options = -arch arm64 ;
+            } else {
+                options = -arch arm ;
+            }
+        }
+```
+
 To complete the build, type:
 
 ```
-./b2 -j8 --layout=versioned --disable-icu cxxflags="-std=c++17 -stdlib=libc++ -msse4.2" linkflags="-std=c++17 -stdlib=libc++ -Wl,-headerpad_max_install_names" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC
-sudo ./b2 install --layout=versioned --disable-icu cxxflags="-std=c++17 -stdlib=libc++ -msse4.2" linkflags="-std=c++17 -stdlib=libc++ -Wl,-headerpad_max_install_names" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC
+./b2 -j8 --layout=versioned --disable-icu cxxflags="-std=c++17 -stdlib=libc++ $SSEFLAGS" linkflags="-std=c++17 -stdlib=libc++ -Wl,-headerpad_max_install_names" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC
+sudo ./b2 install --layout=versioned --disable-icu cxxflags="-std=c++17 -stdlib=libc++ $SSEFLAGS" linkflags="-std=c++17 -stdlib=libc++ -Wl,-headerpad_max_install_names" optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC
 ```
 
 to install the Boost headers and libraries.

--- a/build.gradle
+++ b/build.gradle
@@ -37,28 +37,28 @@ if (cppCrossCompile != '' && cppCrossCompile != 'macosx' && cppCrossCompile != '
   throw new GradleException("CPP_CROSS_COMPILE property must be empty, 'macosx' or 'aarch64'")
 }
 
+String osArch = System.properties['os.arch']
+// Some versions of Java report hardware architectures that
+// don't match other tools - these need to be normalized
+if (osArch == 'amd64') {
+  osArch = 'x86_64'
+} else if (osArch == 'arm64') {
+  osArch = 'aarch64'
+}
 String artifactClassifier;
 if (isWindows) {
   artifactClassifier = 'windows-x86_64'
 } else if (isMacOsX || cppCrossCompile == 'macosx') {
-  artifactClassifier = 'darwin-x86_64'
+  artifactClassifier = 'darwin-' + osArch
 } else if (cppCrossCompile != '') {
   artifactClassifier = 'linux-' + cppCrossCompile
 } else {
-  String osArch = System.properties['os.arch']
-  // Some versions of Java report hardware architectures that
-  // don't match other tools - these need to be normalized
-  if (osArch == 'amd64') {
-    osArch = 'x86_64'
-  } else if (osArch == 'i386') {
-    osArch = 'x86'
-  }
   artifactClassifier = 'linux-' + osArch
 }
 
 // Always do the C++ build using bash (Git bash on Windows)
 project.ext.bash = isWindows ? "C:\\Program Files\\Git\\bin\\bash" : "/bin/bash"
-project.ext.make = (isMacOsX || isWindows) ? "gnumake" : (isLinux ? "make" : "gmake")
+project.ext.make = (isMacOsX || isWindows) ? "gnumake" : "make"
 project.ext.numCpus = Runtime.runtime.availableProcessors()
 project.ext.makeEnvironment = [ 'CPP_CROSS_COMPILE': cppCrossCompile,
                                 'VERSION_QUALIFIER': versionQualifier,

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -74,7 +74,7 @@ private:
                                   bool supplied)
             : s_HyperparameterName(hyperparameterName), s_Value(value),
               s_AbsoluteImportance(absoluteImportance),
-              s_RelativeImportance(relativeImportance), s_Supplied(supplied){};
+              s_RelativeImportance(relativeImportance), s_Supplied(supplied) {}
         std::string s_HyperparameterName;
         double s_Value;
         double s_AbsoluteImportance;

--- a/lib/core/CUname.cc
+++ b/lib/core/CUname.cc
@@ -76,28 +76,18 @@ std::string CUname::mlPlatform() {
     // downloads.  For *nix platforms this is more-or-less `uname -s`-`uname -m`
     // converted to lower case.  However, for consistency between different
     // operating systems on the same architecture "amd64"/"i86pc" are replaced
-    // with "x86_64" and "i386"/"i686" with "x86".
+    // with "x86_64", "i386"/"i686" with "x86" and "arm64" with "aarch64".
     //
     // Assuming the current platform is supported this name will be one of:
+    // - darwin-aarch64
     // - darwin-x86_64
+    // - linux-aarch64
     // - linux-x86_64
     //
     // For an unsupported platform it will be something different, but hopefully
     // still recognisable.
 
     std::string os(CStringUtils::toLower(name.sysname));
-#ifdef _CS_GNU_LIBC_VERSION
-    if (os == "linux") {
-        char buffer[128] = {'\0'};
-        // This isn't great because it's assuming that any C runtime library
-        // that doesn't identify itself as glibc is musl, but it's hard to do
-        // better as musl goes out of its way to be hard to detect
-        if (::confstr(_CS_GNU_LIBC_VERSION, buffer, sizeof(buffer)) == 0 ||
-            ::strstr(buffer, "glibc") == 0) {
-            os += "-musl";
-        }
-    }
-#endif
 
     const std::string& machine = CStringUtils::toLower(name.machine);
     if (machine.length() == 4 && machine[0] == 'i' && machine[2] == '8' &&
@@ -107,6 +97,10 @@ std::string CUname::mlPlatform() {
 
     if (machine == "amd64" || machine == "i86pc") {
         return os + "-x86_64";
+    }
+
+    if (machine == "arm64") {
+        return os + "-aarch64";
     }
 
     return os + '-' + machine;

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1067,7 +1067,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.65);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.67);
         meanLogRelativeError.add(maths::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/unittest/CLinearAlgebraTest.cc
+++ b/lib/maths/unittest/CLinearAlgebraTest.cc
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(testVectorNx1) {
             maths::CVectorNx1<double, 4> sy = s * y;
             LOG_DEBUG(<< "Sy = " << sy);
             for (std::size_t i = 0u; i < 4; ++i) {
-                BOOST_REQUIRE_EQUAL(expected(i), sy(i));
+                BOOST_REQUIRE_CLOSE_ABSOLUTE(expected(i), sy(i), 1e-14);
             }
         }
     }

--- a/set_env.sh
+++ b/set_env.sh
@@ -24,7 +24,7 @@ case `uname` in
 
     Darwin)
         SIMPLE_PLATFORM=macos
-        BUNDLE_PLATFORM=darwin-x86_64
+        BUNDLE_PLATFORM=darwin-`uname -m | sed 's/arm64/aarch64/'`
         ;;
 
     Linux)
@@ -91,10 +91,6 @@ case $SIMPLE_PLATFORM in
         PATH=/usr/local/gcc93/bin:/usr/bin:/bin:/usr/local/gcc93/sbin:/usr/sbin:/sbin:/usr/local/bin
         ;;
 
-    linux-musl)
-        PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
-        ;;
-
     macos)
         PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
         ;;
@@ -118,10 +114,6 @@ case $SIMPLE_PLATFORM in
 
     linux)
         export LD_LIBRARY_PATH=/usr/local/gcc93/lib64:/usr/local/gcc93/lib:/usr/lib:/lib
-        ;;
-
-    linux-musl)
-        export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib:/lib
         ;;
 
     windows)


### PR DESCRIPTION
This allows native compilation on a Mac containing the
Apple M1 CPU.

PR builds will currently NOT test this platform, nor even
check compilation for it.  Release manager will not build
it either.  Still, it is a step in the right direction to
be able to compile locally for it.

Cross compilation for this platform is still NOT possible.
This can be investigated in a followup PR.  (Supporting
this actually requires considerable changes to the cross
compilation framework, as it currently contains a quite
deeply embedded assumption that macOS is x86_64 only.)

The last dregs of Linux MUSL port code are also removed.
(Most support for MUSL was removed previously, but a few
bits were missed.)