### PR TITLE
[ML] Make sure we remove seasonality modelling when data flatlines

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -53,6 +53,10 @@
 * Fix a source of instability in time series modeling for anomaly detection. This has
   been observed to cause spurious anomalies for a partition which no longer receives
   any data. (See {ml-pull}1646[#1646].)
+* Ensure that we stop modeling seasonality for data which flatlines. This is important
+  for count and sum detectors which treat empty buckets as zero. We could see spurious
+  anomalies in realtime detection after a partition no longer received data any data
+  as a result. (See {ml-pull}1654[#1654].)
 
 == {es} version 7.11.0
 

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -160,7 +160,7 @@ void CSeasonalComponent::interpolate(core_t::TTime time, bool refine) {
     }
 
     const auto& time_ = m_Bucketing.time();
-    time = time_.startOfWindow(time) + (time_.inWindow(time) ? 0 : +time_.windowRepeat());
+    time = time_.startOfWindow(time) + (time_.inWindow(time) ? 0 : time_.windowRepeat());
 
     TDoubleVec knots;
     TDoubleVec values;

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1977,11 +1977,6 @@ CTimeSeriesDecompositionDetail::CComponents::makeTestForSeasonality(const TFilte
         values = window.valuesMinusPrediction(std::move(values), [&](core_t::TTime time) {
             return preconditioner(time, testableMask);
         });
-        // Inject noise at 1% of the value to avoid overfitting very stable data.
-        CPRNG::CXorOShiro128Plus rng;
-        for (auto& value : values) {
-            CBasicStatistics::moment<0>(value) *= CSampling::uniformSample(rng, 0.995, 1.005);
-        }
         CTimeSeriesTestForSeasonality test(
             valuesStartTime, windowBucketStartTime, windowBucketLength,
             m_BucketLength, std::move(values), window.withinBucketVariance());

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(testComplexVaryingLongTermTrend) {
     test.bucketLength(bucketLength)
         .daysToLearn(98)
         .noiseVariance(4.0)
-        .maximumPercentageOutOfBounds(23.0)
+        .maximumPercentageOutOfBounds(24.0)
         .maximumError(0.05)
         .run(trend);
 }


### PR DESCRIPTION
While fixing #1646, I noticed we weren't reliably removing seasonal components from our time series model when the data flatlined. This happens for example, when a count anomaly detector stops receiving new data.

The behaviour was due to a bug in how we computed statistics related to the components we already modelled. Specifically, we would discard the correct statistics because `SHypothesisStats::isBetter` didn't consider whether or not the type was default initialised. In such cases, discarding seasonality leads to smaller, more accurate and more stable models.

I took the opportunity to remove the previous approach of perturbing the values to deal with low variation data, because this doesn't work when the values are zero, and otherwise should no longer be needed.