### PR TITLE
[ML] Revert "Improve time series model stability"

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -48,12 +48,6 @@
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
 
-=== Bug Fixes
-
-* Fix a source of instability in time series modeling for anomaly detection. This has
-  been observed to cause spurious anomalies for a partition which no longer receives
-  any data. (See {ml-pull}1646[#1646].)
-
 == {es} version 7.11.0
 
 === Enhancements

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -106,7 +106,7 @@ bool CSeasonalComponent::initialize(core_t::TTime startTime,
                                     const TFloatMeanAccumulatorVec& values) {
     this->clear();
 
-    if (m_Bucketing.initialize(this->maxSize()) == false) {
+    if (!m_Bucketing.initialize(this->maxSize())) {
         LOG_ERROR(<< "Bad input size: " << this->maxSize());
         return false;
     }
@@ -137,14 +137,10 @@ void CSeasonalComponent::shiftLevel(double shift) {
 }
 
 void CSeasonalComponent::shiftSlope(core_t::TTime time, double shift) {
-    const auto& time_ = m_Bucketing.time();
-    time = time_.startOfWindow(time) + (time_.inWindow(time) ? 0 : time_.windowRepeat());
     m_Bucketing.shiftSlope(time, shift);
 }
 
 void CSeasonalComponent::linearScale(core_t::TTime time, double scale) {
-    const auto& time_ = m_Bucketing.time();
-    time = time_.startOfWindow(time) + (time_.inWindow(time) ? 0 : time_.windowRepeat());
     m_Bucketing.linearScale(time, scale);
     this->interpolate(time, false);
 }
@@ -158,10 +154,6 @@ void CSeasonalComponent::interpolate(core_t::TTime time, bool refine) {
     if (refine) {
         m_Bucketing.refine(time);
     }
-
-    const auto& time_ = m_Bucketing.time();
-    time = time_.startOfWindow(time) + (time_.inWindow(time) ? 0 : +time_.windowRepeat());
-
     TDoubleVec knots;
     TDoubleVec values;
     TDoubleVec variances;
@@ -261,7 +253,7 @@ double CSeasonalComponent::meanVariance() const {
 bool CSeasonalComponent::covariances(core_t::TTime time, TMatrix& result) const {
     result = TMatrix(0.0);
 
-    if (this->initialized() == false) {
+    if (!this->initialized()) {
         return false;
     }
 

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -179,30 +179,21 @@ void CSeasonalComponentAdaptiveBucketing::shiftLevel(double shift) {
 
 void CSeasonalComponentAdaptiveBucketing::shiftSlope(core_t::TTime time, double shift) {
     if (std::fabs(shift) > 0.0) {
-        const auto& centres = this->centres();
-        for (std::size_t i = 0; i < m_Buckets.size(); ++i) {
-            core_t::TTime bucketTime{time + static_cast<core_t::TTime>(centres[i] + 0.5)};
-            m_Buckets[i].s_Regression.shiftGradient(shift);
-            m_Buckets[i].s_Regression.shiftOrdinate(-shift * m_Time->regression(bucketTime));
+        for (auto& bucket : m_Buckets) {
+            bucket.s_Regression.shiftGradient(shift);
+            bucket.s_Regression.shiftOrdinate(-shift * m_Time->regression(time));
         }
     }
 }
 
 void CSeasonalComponentAdaptiveBucketing::linearScale(core_t::TTime time, double scale) {
-    const auto& centres = this->centres();
-    for (std::size_t i = 0; i < m_Buckets.size(); ++i) {
-        if (scale <= 1.0) {
-            m_Buckets[i].s_Regression.linearScale(scale);
-        } else {
-            double gradientBefore{gradient(m_Buckets[i].s_Regression)};
-            m_Buckets[i].s_Regression.linearScale(scale);
-            double gradientAfter{gradient(m_Buckets[i].s_Regression)};
-
-            core_t::TTime bucketTime{time + static_cast<core_t::TTime>(centres[i] + 0.5)};
-            m_Buckets[i].s_Regression.shiftGradient(gradientBefore - gradientAfter);
-            m_Buckets[i].s_Regression.shiftOrdinate(
-                -(gradientBefore - gradientAfter) * m_Time->regression(bucketTime));
-        }
+    for (auto& bucket : m_Buckets) {
+        double gradientBefore{gradient(bucket.s_Regression)};
+        bucket.s_Regression.linearScale(scale);
+        double gradientAfter{gradient(bucket.s_Regression)};
+        bucket.s_Regression.shiftGradient(gradientBefore - gradientAfter);
+        bucket.s_Regression.shiftOrdinate(-(gradientBefore - gradientAfter) *
+                                          m_Time->regression(time));
     }
 }
 
@@ -222,8 +213,8 @@ void CSeasonalComponentAdaptiveBucketing::add(core_t::TTime time,
     double t{m_Time->regression(time)};
     TRegression& regression{bucket_.s_Regression};
 
-    TDoubleMeanVarAccumulator moments{CBasicStatistics::momentsAccumulator(
-        regression.count(), prediction, static_cast<double>(bucket_.s_Variance))};
+    TDoubleMeanVarAccumulator moments = CBasicStatistics::momentsAccumulator(
+        regression.count(), prediction, static_cast<double>(bucket_.s_Variance));
     moments.add(value, weight * weight);
 
     regression.add(t, value, weight);

--- a/lib/maths/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentTest.cc
@@ -536,7 +536,7 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
 
     LOG_DEBUG(<< "mean error 1 = " << totalError1 / numberErrors);
     LOG_DEBUG(<< "mean error 2 = " << totalError2 / numberErrors);
-    BOOST_TEST_REQUIRE(totalError1 / numberErrors < 19.0);
+    BOOST_TEST_REQUIRE(totalError1 / numberErrors < 18.0);
     BOOST_TEST_REQUIRE(totalError2 / numberErrors < 14.0);
 }
 

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -849,7 +849,7 @@ BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError));
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.5);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.4);
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentileError) < 0.1);
         BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, maths::CBasicStatistics::mean(meanScale), 0.02);
     }

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2689,7 +2689,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         // control.
 
         params.s_ControlDecayRate = true;
-        params.s_DecayRate = 0.0005;
+        params.s_DecayRate = 0.001;
         auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
         CEventRateModelFactory factory(params, interimBucketCorrector);
         factory.features(features);
@@ -2698,7 +2698,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         this->addPerson("p1", gatherer);
 
         params.s_ControlDecayRate = false;
-        params.s_DecayRate = 0.0005;
+        params.s_DecayRate = 0.001;
         CEventRateModelFactory referenceFactory(params, interimBucketCorrector);
         referenceFactory.features(features);
         CModelFactory::TDataGathererPtr referenceGatherer{
@@ -2745,7 +2745,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanPredictionError) <
-                           0.75 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                           0.82 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2059,7 +2059,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         // control.
 
         params.s_ControlDecayRate = true;
-        params.s_DecayRate = 0.0005;
+        params.s_DecayRate = 0.001;
         auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
         CMetricModelFactory factory(params, interimBucketCorrector);
         factory.features(features);
@@ -2067,7 +2067,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         CModelFactory::TModelPtr model(factory.makeModel(gatherer));
 
         params.s_ControlDecayRate = false;
-        params.s_DecayRate = 0.0005;
+        params.s_DecayRate = 0.001;
         CMetricModelFactory referenceFactory(params, interimBucketCorrector);
         referenceFactory.features(features);
         CModelFactory::TDataGathererPtr referenceGatherer(
@@ -2111,7 +2111,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanPredictionError) <
-                           0.75 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                           0.8 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 


### PR DESCRIPTION
#1646 created some QA regressions. It also doesn't fully fix the underlying issues with time windowed components. I'm going to prepare a new PR which targets just this issue and introduces better unit testing and revert this in the mean time.