### PR TITLE
[ML] Leniency parsing background_persist_interval

### DIFF
--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -573,16 +573,17 @@ bool CAnomalyJobConfig::parse(const std::string& json) {
             m_ModelConfig.parse(*modelPlotConfig);
         }
 
-        // We choose to ignore any errors here parsing the time duration string as
-        // we assume that it has already been validated by ES. In the event that any
-        // error _does_ occur an error is logged and a default value used.
-        const std::string& bucketPersistIntervalString{
-            parameters[BACKGROUND_PERSIST_INTERVAL].fallback(EMPTY_STRING)};
-
         const core_t::TTime defaultBackgroundPersistInterval{
             DEFAULT_BASE_PERSIST_INTERVAL + this->intervalStagger()};
-        m_BackgroundPersistInterval = CAnomalyJobConfig::CAnalysisConfig::durationSeconds(
-            bucketPersistIntervalString, defaultBackgroundPersistInterval);
+
+        const std::string& backgroundPersistIntervalString{
+            parameters[BACKGROUND_PERSIST_INTERVAL].fallback(EMPTY_STRING)};
+        if (backgroundPersistIntervalString.empty() == false) {
+            m_BackgroundPersistInterval = CAnomalyJobConfig::CAnalysisConfig::durationSeconds(
+                backgroundPersistIntervalString, defaultBackgroundPersistInterval);
+        } else {
+            m_BackgroundPersistInterval = defaultBackgroundPersistInterval;
+        }
 
         m_MaxQuantilePersistInterval = BASE_MAX_QUANTILE_INTERVAL + this->intervalStagger();
 


### PR DESCRIPTION
Be more lenient when parsing the background_persist_interval field as it is: 
1. optional and 
2. not present in the job config in the majority of cases