### PR TITLE
[ML] Remove redundant autodetect options

### DIFF
--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -37,7 +37,7 @@ public:
                       std::string& config,
                       std::string& filtersConfig,
                       std::string& eventsConfig,
-                      std::string& modelPlotConfigFile,
+                      std::string& modelConfigFile,
                       std::string& logProperties,
                       std::string& logPipe,
                       char& delimiter,
@@ -57,9 +57,7 @@ public:
                       bool& isPersistFileNamedPipe,
                       bool& isPersistInForeground,
                       std::size_t& maxAnomalyRecords,
-                      bool& memoryUsage,
-                      bool& stopCategorizationOnWarnStatus,
-                      TStrVec& unknownTokens);
+                      bool& memoryUsage);
 
 private:
     static const std::string DESCRIPTION;

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -42,7 +42,6 @@ public:
                       std::string& logPipe,
                       char& delimiter,
                       bool& lengthEncodedInput,
-                      std::string& timeField,
                       std::string& timeFormat,
                       std::string& quantilesState,
                       bool& deleteStateFiles,
@@ -60,7 +59,7 @@ public:
                       std::size_t& maxAnomalyRecords,
                       bool& memoryUsage,
                       bool& stopCategorizationOnWarnStatus,
-                      TStrVec& clauseTokens);
+                      TStrVec& unknownTokens);
 
 private:
     static const std::string DESCRIPTION;

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -109,7 +109,6 @@ int main(int argc, char** argv) {
     bool isPersistInForeground{false};
     std::size_t maxAnomalyRecords{100};
     bool memoryUsage{false};
-    TStrVec unknownTokens;
     if (ml::autodetect::CCmdLineParser::parse(
             argc, argv, configFile, filtersConfigFile, eventsConfigFile,
             modelConfigFile, logProperties, logPipe, delimiter, lengthEncodedInput,

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -109,16 +109,15 @@ int main(int argc, char** argv) {
     bool isPersistInForeground{false};
     std::size_t maxAnomalyRecords{100};
     bool memoryUsage{false};
-    bool stopCategorizationOnWarnStatus{false};
     TStrVec unknownTokens;
     if (ml::autodetect::CCmdLineParser::parse(
             argc, argv, configFile, filtersConfigFile, eventsConfigFile,
             modelConfigFile, logProperties, logPipe, delimiter, lengthEncodedInput,
             timeFormat, quantilesStateFile, deleteStateFiles, bucketPersistInterval,
-            namedPipeConnectTimeout, inputFileName, isInputFileNamedPipe, outputFileName,
-            isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe, persistFileName,
-            isPersistFileNamedPipe, isPersistInForeground, maxAnomalyRecords,
-            memoryUsage, stopCategorizationOnWarnStatus, unknownTokens) == false) {
+            namedPipeConnectTimeout, inputFileName, isInputFileNamedPipe,
+            outputFileName, isOutputFileNamedPipe, restoreFileName,
+            isRestoreFileNamedPipe, persistFileName, isPersistFileNamedPipe,
+            isPersistInForeground, maxAnomalyRecords, memoryUsage) == false) {
         return EXIT_FAILURE;
     }
 
@@ -150,12 +149,6 @@ int main(int argc, char** argv) {
     // must be done from the program, and NOT a shared library, as each program
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
-
-    if (unknownTokens.size()) {
-        LOG_ERROR(<< "Unkown command line options: "
-                  << ml::core::CContainerPrinter::print(unknownTokens));
-        return EXIT_FAILURE;
-    }
 
     // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -92,7 +92,6 @@ int main(int argc, char** argv) {
     std::string logPipe;
     char delimiter{'\t'};
     bool lengthEncodedInput{false};
-    std::string timeField{ml::api::CAnomalyJob::DEFAULT_TIME_FIELD_NAME};
     std::string timeFormat;
     std::string quantilesStateFile;
     bool deleteStateFiles{false};
@@ -111,15 +110,15 @@ int main(int argc, char** argv) {
     std::size_t maxAnomalyRecords{100};
     bool memoryUsage{false};
     bool stopCategorizationOnWarnStatus{false};
-    TStrVec clauseTokens;
+    TStrVec unknownTokens;
     if (ml::autodetect::CCmdLineParser::parse(
-            argc, argv, configFile, filtersConfigFile, eventsConfigFile, modelConfigFile,
-            logProperties, logPipe, delimiter, lengthEncodedInput, timeField,
+            argc, argv, configFile, filtersConfigFile, eventsConfigFile,
+            modelConfigFile, logProperties, logPipe, delimiter, lengthEncodedInput,
             timeFormat, quantilesStateFile, deleteStateFiles, bucketPersistInterval,
             namedPipeConnectTimeout, inputFileName, isInputFileNamedPipe, outputFileName,
             isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe, persistFileName,
             isPersistFileNamedPipe, isPersistInForeground, maxAnomalyRecords,
-            memoryUsage, stopCategorizationOnWarnStatus, clauseTokens) == false) {
+            memoryUsage, stopCategorizationOnWarnStatus, unknownTokens) == false) {
         return EXIT_FAILURE;
     }
 
@@ -151,6 +150,12 @@ int main(int argc, char** argv) {
     // must be done from the program, and NOT a shared library, as each program
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
+
+    if (unknownTokens.size()) {
+        LOG_ERROR(<< "Unkown command line options: "
+                  << ml::core::CContainerPrinter::print(unknownTokens));
+        return EXIT_FAILURE;
+    }
 
     // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();

--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -219,12 +219,6 @@ public:
         CAnalysisConfig(const std::string& categorizationFieldName)
             : m_CategorizationFieldName{categorizationFieldName} {}
 
-        //! Constructor taking a map of detector rule filters keyed by filter_id &
-        //! a vector of scheduled events data
-        CAnalysisConfig(const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters,
-                        const TStrDetectionRulePrVec& scheduledEvents)
-            : m_RuleFilters(ruleFilters), m_ScheduledEvents(scheduledEvents) {}
-
         void init(const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters,
                   const TStrDetectionRulePrVec& scheduledEvents) {
             m_RuleFilters = ruleFilters;
@@ -487,12 +481,6 @@ public:
 
     explicit CAnomalyJobConfig(const std::string& categorizationFieldName)
         : m_AnalysisConfig(categorizationFieldName) {}
-
-    // This one is only needed for historical reasons. Once The Java side sends the
-    // scheduled events and filters config as JSON this can go.
-    CAnomalyJobConfig(const CDetectionRulesJsonParser::TStrPatternSetUMap& ruleFilters,
-                      const TStrDetectionRulePrVec& scheduledEvents)
-        : m_AnalysisConfig(ruleFilters, scheduledEvents) {}
 
     bool readFile(const std::string& fileName, std::string& fileContents);
 

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -1040,9 +1040,18 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_TEST_REQUIRE(!jobConfigEmptyFilterMap.isInitialized());
 
         // Expect parsing to succeed if the filter referenced by the custom rule can be found in the filter map.
-        ml::api::CDetectionRulesJsonParser::TStrPatternSetUMap filterMap{{"safe_ips", {}}};
-        ml::api::CAnomalyJobConfig::TStrDetectionRulePrVec scheduledEvents{};
-        ml::api::CAnomalyJobConfig jobConfig(filterMap, scheduledEvents);
+        const std::string filterConfigJson{"{\"filters\":[{\"filter_id\":\"safe_ips\",\"items\":[]}]}"};
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(jobConfig.parseFilterConfig(filterConfigJson));
+
+        const std::string validScheduledEventsConfigJson{"{\"events\":["
+                                                         "]}"};
+
+        BOOST_TEST_REQUIRE(jobConfig.parseEventConfig(validScheduledEventsConfigJson));
+
+        jobConfig.analysisConfig().init(jobConfig.ruleFilters(),
+                                        jobConfig.scheduledEvents());
+
         BOOST_REQUIRE_MESSAGE(jobConfig.parse(validAnomalyJobConfigWithCustomRuleFilter),
                               "Cannot parse JSON job config!");
         BOOST_TEST_REQUIRE(jobConfig.isInitialized());


### PR DESCRIPTION
Remove the now redundant `autodetect` command line options and
exit with error message on seeing unknown command line arguments