### PR TITLE
[ML] Fix bug persisting and restoring time series model decay rate controller

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -48,6 +48,12 @@
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
 
+=== Bug Fixes
+
+* Fix missing state in persist and restore for anomaly detection. This caused suboptimal
+  modelling after a job was closed and reopened or failed over to a different node.
+  (See {ml-pull}1668[#1668].)
+
 == {es} version 7.11.0
 
 === Enhancements

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -48,12 +48,6 @@
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
 
-=== Bug Fixes
-
-* Fix missing state in persist and restore for anomaly detection. This caused suboptimal
-  modelling after a job was closed and reopened or failed over to a different node.
-  (See {ml-pull}1668[#1668].)
-
 == {es} version 7.11.0
 
 === Enhancements
@@ -79,6 +73,9 @@
 
 * Fix potential cause for log errors from CXMeansOnline1d. (See {ml-pull}1586[#1586].)
 * Fix scaling of some hyperparameter for Bayesian optimization. (See {ml-pull}1612[#1612].)
+* Fix missing state in persist and restore for anomaly detection. This caused suboptimal
+  modelling after a job was closed and reopened or failed over to a different node.
+  (See {ml-pull}1668[#1668].)
 
 == {es} version 7.10.1
 

--- a/include/maths/CDecayRateController.h
+++ b/include/maths/CDecayRateController.h
@@ -14,7 +14,8 @@
 #include <maths/CPRNG.h>
 #include <maths/ImportExport.h>
 
-#include <stdint.h>
+#include <array>
+#include <cstdint>
 
 namespace ml {
 namespace core {
@@ -60,6 +61,12 @@ public:
     CDecayRateController();
     CDecayRateController(int checks, std::size_t dimension);
 
+    //! Get the checks which this controller is performing.
+    int checks() const;
+
+    //! Set the checks which this controller is performing.
+    void checks(int checks);
+
     //! Reset the errors.
     void reset();
 
@@ -90,21 +97,28 @@ public:
     std::size_t memoryUsage() const;
 
     //! Get a checksum of this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
 private:
-    //! Get the count of residuals added so far.
-    double count() const;
+    using TDouble3Ary = std::array<double, 3>;
 
-    //! Get the change to apply to the decay rate multiplier.
-    double change(const double (&stats)[3], core_t::TTime bucketLength) const;
+private:
+    double count() const;
+    double change(const TDouble3Ary& stats, core_t::TTime bucketLength) const;
+    bool notControlling() const;
+    bool increaseDecayRateErrorIncreasing(const TDouble3Ary& stats) const;
+    bool increaseDecayRateErrorDecreasing(const TDouble3Ary& stats) const;
+    bool increaseDecayRateBiased(const TDouble3Ary& stats) const;
+    bool decreaseDecayRateErrorNotIncreasing(const TDouble3Ary& stats) const;
+    bool decreaseDecayRateErrorNotDecreasing(const TDouble3Ary& stats) const;
+    bool decreaseDecayRateNotBiased(const TDouble3Ary& stats) const;
 
 private:
     //! The checks we perform to detect error conditions.
-    int m_Checks;
+    int m_Checks = 0;
 
     //! The current target multiplier.
-    double m_Target;
+    double m_Target = 1.0;
 
     //! The cumulative multiplier applied to the decay rate.
     TMeanAccumulator m_Multiplier;

--- a/include/maths/CPRNG.h
+++ b/include/maths/CPRNG.h
@@ -93,6 +93,9 @@ public:
         //! Restore from a string.
         bool fromString(const std::string& state);
 
+        //! Get a checksum for this object.
+        std::uint64_t checksum(std::uint64_t seed) const;
+
     private:
         static const result_type A;
         static const result_type B;
@@ -183,6 +186,9 @@ public:
         std::string toString() const;
         //! Restore from a string.
         bool fromString(const std::string& state);
+
+        //! Get a checksum for this object.
+        std::uint64_t checksum(std::uint64_t seed) const;
 
     private:
         static const result_type JUMP[2];
@@ -275,6 +281,9 @@ public:
         std::string toString() const;
         //! Restore from a string.
         bool fromString(std::string state);
+
+        //! Get a checksum for this object.
+        std::uint64_t checksum(std::uint64_t seed) const;
 
     private:
         static const result_type A;

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -284,7 +284,7 @@ private:
 
     //! These control the trend and residual model decay rates (see
     //! CDecayRateController for more details).
-    TDecayRateController2AryPtr m_Controllers;
+    TDecayRateController2AryPtr m_DecayRateControllers;
 
     //! The time series trend decomposition.
     //!
@@ -723,7 +723,7 @@ private:
 
     //! These control the trend and residual model decay rates (see
     //! CDecayRateController for more details).
-    TDecayRateController2AryPtr m_Controllers;
+    TDecayRateController2AryPtr m_DecayRateControllers;
 
     //! The time series trend decomposition.
     TDecompositionPtr10Vec m_TrendModel;

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -284,7 +284,7 @@ private:
 
     //! These control the trend and residual model decay rates (see
     //! CDecayRateController for more details).
-    TDecayRateController2AryPtr m_DecayRateControllers;
+    TDecayRateController2AryPtr m_Controllers;
 
     //! The time series trend decomposition.
     //!
@@ -723,7 +723,7 @@ private:
 
     //! These control the trend and residual model decay rates (see
     //! CDecayRateController for more details).
-    TDecayRateController2AryPtr m_DecayRateControllers;
+    TDecayRateController2AryPtr m_Controllers;
 
     //! The time series trend decomposition.
     TDecompositionPtr10Vec m_TrendModel;

--- a/lib/maths/CDecayRateController.cc
+++ b/lib/maths/CDecayRateController.cc
@@ -31,6 +31,7 @@ const std::string RECENT_ABS_ERROR_TAG{"d"};
 const std::string HISTORICAL_ABS_ERROR_TAG{"e"};
 const std::string RNG_TAG{"f"};
 const std::string MULTIPLIER_TAG{"g"};
+const std::string CHECKS_TAG{"h"};
 
 //! The factor by which we'll increase the decay rate per bucket.
 const double INCREASE_RATE{1.2};
@@ -92,14 +93,22 @@ double adjustedMaximumMultiplier(core_t::TTime bucketLength_) {
 }
 }
 
-CDecayRateController::CDecayRateController() : m_Checks(0), m_Target(1.0) {
+CDecayRateController::CDecayRateController() {
     m_Multiplier.add(m_Target);
 }
 
 CDecayRateController::CDecayRateController(int checks, std::size_t dimension)
-    : m_Checks(checks), m_Target(1.0), m_PredictionMean(dimension), m_Bias(dimension),
+    : m_Checks{checks}, m_PredictionMean(dimension), m_Bias(dimension),
       m_RecentAbsError(dimension), m_HistoricalAbsError(dimension) {
     m_Multiplier.add(m_Target);
+}
+
+int CDecayRateController::checks() const {
+    return m_Checks;
+}
+
+void CDecayRateController::checks(int checks) {
+    m_Checks = checks;
 }
 
 void CDecayRateController::reset() {
@@ -116,6 +125,7 @@ bool CDecayRateController::acceptRestoreTraverser(core::CStateRestoreTraverser& 
     m_Multiplier = TMeanAccumulator();
     do {
         const std::string& name = traverser.name();
+        RESTORE_BUILT_IN(CHECKS_TAG, m_Checks)
         RESTORE_BUILT_IN(TARGET_TAG, m_Target)
         RESTORE(MULTIPLIER_TAG, m_Multiplier.fromDelimited(traverser.value()))
         RESTORE(RNG_TAG, m_Rng.fromString(traverser.value()))
@@ -135,6 +145,7 @@ bool CDecayRateController::acceptRestoreTraverser(core::CStateRestoreTraverser& 
 }
 
 void CDecayRateController::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    inserter.insertValue(CHECKS_TAG, m_Checks);
     inserter.insertValue(TARGET_TAG, m_Target);
     inserter.insertValue(MULTIPLIER_TAG, m_Multiplier.toDelimited());
     inserter.insertValue(RNG_TAG, m_Rng.toString());
@@ -201,9 +212,9 @@ double CDecayRateController::multiplier(const TDouble1Vec& prediction,
     }
 
     if (count > 0.0) {
-        double factors[]{std::exp(-FAST_DECAY_RATE * decayRate),
-                         std::exp(-FAST_DECAY_RATE * decayRate),
-                         std::exp(-SLOW_DECAY_RATE * decayRate)};
+        TDouble3Ary factors{std::exp(-FAST_DECAY_RATE * decayRate),
+                            std::exp(-FAST_DECAY_RATE * decayRate),
+                            std::exp(-SLOW_DECAY_RATE * decayRate)};
         for (auto& component : m_PredictionMean) {
             component.age(factors[2]);
         }
@@ -222,7 +233,7 @@ double CDecayRateController::multiplier(const TDouble1Vec& prediction,
         // Compute the change to apply to the target decay rate.
         TMaxAccumulator change;
         for (std::size_t d = 0u; d < dimension; ++d) {
-            double stats[3];
+            TDouble3Ary stats;
             for (std::size_t i = 0u; i < 3; ++i) {
                 stats[i] = std::fabs(CBasicStatistics::mean((*stats_[i])[d]));
             }
@@ -272,7 +283,11 @@ std::size_t CDecayRateController::memoryUsage() const {
     return mem;
 }
 
-uint64_t CDecayRateController::checksum(uint64_t seed) const {
+std::uint64_t CDecayRateController::checksum(std::uint64_t seed) const {
+    seed = CChecksum::calculate(seed, m_Checks);
+    seed = CChecksum::calculate(seed, m_Target);
+    seed = CChecksum::calculate(seed, m_Multiplier);
+    seed = CChecksum::calculate(seed, m_Rng);
     seed = CChecksum::calculate(seed, m_PredictionMean);
     seed = CChecksum::calculate(seed, m_Bias);
     seed = CChecksum::calculate(seed, m_RecentAbsError);
@@ -283,20 +298,55 @@ double CDecayRateController::count() const {
     return CBasicStatistics::count(m_HistoricalAbsError[0]);
 }
 
-double CDecayRateController::change(const double (&stats)[3], core_t::TTime bucketLength) const {
-    if (((m_Checks & E_PredictionErrorIncrease) && stats[1] > ERROR_INCREASING * stats[2]) ||
-        ((m_Checks & E_PredictionErrorDecrease) && stats[2] > ERROR_DECREASING * stats[1]) ||
-        ((m_Checks & E_PredictionBias) && stats[0] > BIASED * stats[1])) {
+double CDecayRateController::change(const TDouble3Ary& stats, core_t::TTime bucketLength) const {
+    if (this->notControlling()) {
+        return 1.0;
+    }
+    if (this->increaseDecayRateErrorIncreasing(stats) ||
+        this->increaseDecayRateErrorDecreasing(stats) ||
+        this->increaseDecayRateBiased(stats)) {
         return adjustMultiplier(INCREASE_RATE, bucketLength);
     }
-    if ((!(m_Checks & E_PredictionErrorIncrease) ||
-         stats[1] < ERROR_NOT_INCREASING * stats[2]) &&
-        (!(m_Checks & E_PredictionErrorDecrease) ||
-         stats[2] < ERROR_NOT_DECREASING * stats[1]) &&
-        (!(m_Checks & E_PredictionBias) || stats[0] < NOT_BIASED * stats[1])) {
+    if (this->decreaseDecayRateErrorNotIncreasing(stats) &&
+        this->decreaseDecayRateErrorNotDecreasing(stats) &&
+        this->decreaseDecayRateNotBiased(stats)) {
         return adjustMultiplier(DECREASE_RATE, bucketLength);
     }
     return 1.0;
+}
+
+bool CDecayRateController::notControlling() const {
+    return (m_Checks & E_PredictionErrorIncrease) == false &&
+           (m_Checks & E_PredictionErrorDecrease) == false &&
+           (m_Checks & E_PredictionBias) == false;
+}
+
+bool CDecayRateController::increaseDecayRateErrorIncreasing(const TDouble3Ary& stats) const {
+    return (m_Checks & E_PredictionErrorIncrease) &&
+           stats[1] > ERROR_INCREASING * stats[2];
+}
+
+bool CDecayRateController::increaseDecayRateErrorDecreasing(const TDouble3Ary& stats) const {
+    return (m_Checks & E_PredictionErrorDecrease) &&
+           stats[2] > ERROR_DECREASING * stats[1];
+}
+
+bool CDecayRateController::increaseDecayRateBiased(const TDouble3Ary& stats) const {
+    return (m_Checks & E_PredictionBias) && stats[0] > BIASED * stats[1];
+}
+
+bool CDecayRateController::decreaseDecayRateErrorNotIncreasing(const TDouble3Ary& stats) const {
+    return (m_Checks & E_PredictionErrorIncrease) == false ||
+           stats[1] < ERROR_NOT_INCREASING * stats[2];
+}
+
+bool CDecayRateController::decreaseDecayRateErrorNotDecreasing(const TDouble3Ary& stats) const {
+    return (m_Checks & E_PredictionErrorDecrease) == false ||
+           stats[2] < ERROR_NOT_DECREASING * stats[1];
+}
+
+bool CDecayRateController::decreaseDecayRateNotBiased(const TDouble3Ary& stats) const {
+    return (m_Checks & E_PredictionBias) == false || stats[0] < NOT_BIASED * stats[1];
 }
 }
 }

--- a/lib/maths/CDecayRateController.cc
+++ b/lib/maths/CDecayRateController.cc
@@ -146,7 +146,7 @@ bool CDecayRateController::acceptRestoreTraverser(core::CStateRestoreTraverser& 
 
 void CDecayRateController::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     inserter.insertValue(CHECKS_TAG, m_Checks);
-    inserter.insertValue(TARGET_TAG, m_Target);
+    inserter.insertValue(TARGET_TAG, m_Target, core::CIEEE754::E_DoublePrecision);
     inserter.insertValue(MULTIPLIER_TAG, m_Multiplier.toDelimited());
     inserter.insertValue(RNG_TAG, m_Rng.toString());
     core::CPersistUtils::persist(PREDICTION_MEAN_TAG, m_PredictionMean, inserter);

--- a/lib/maths/CPRNG.cc
+++ b/lib/maths/CPRNG.cc
@@ -9,6 +9,8 @@
 #include <core/CPersistUtils.h>
 #include <core/CStringUtils.h>
 
+#include <maths/CChecksum.h>
+
 #include <algorithm>
 
 namespace ml {
@@ -69,6 +71,10 @@ std::string CPRNG::CSplitMix64::toString() const {
 
 bool CPRNG::CSplitMix64::fromString(const std::string& state) {
     return core::CStringUtils::stringToType(state, m_X);
+}
+
+std::uint64_t CPRNG::CSplitMix64::checksum(std::uint64_t seed) const {
+    return CChecksum::calculate(seed, m_X);
 }
 
 const CPRNG::CSplitMix64::result_type CPRNG::CSplitMix64::A(0x9E3779B97F4A7C15);
@@ -134,6 +140,10 @@ std::string CPRNG::CXorOShiro128Plus::toString() const {
 
 bool CPRNG::CXorOShiro128Plus::fromString(const std::string& state) {
     return core::CPersistUtils::fromString(state, &m_X[0], &m_X[2]);
+}
+
+std::uint64_t CPRNG::CXorOShiro128Plus::checksum(std::uint64_t seed) const {
+    return CChecksum::calculate(seed, m_X);
 }
 
 const CPRNG::CXorOShiro128Plus::result_type CPRNG::CXorOShiro128Plus::JUMP[] = {
@@ -211,6 +221,10 @@ bool CPRNG::CXorShift1024Mult::fromString(std::string state) {
     }
     state.resize(delimPos);
     return core::CPersistUtils::fromString(state, &m_X[0], &m_X[16]);
+}
+
+std::uint64_t CPRNG::CXorShift1024Mult::checksum(std::uint64_t seed) const {
+    return CChecksum::calculate(seed, m_X);
 }
 
 const CPRNG::CXorShift1024Mult::result_type CPRNG::CXorShift1024Mult::A(1181783497276652981);

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -99,6 +99,7 @@ double aggregateFeatureProbabilities(const TDouble4Vec& probabilities, double co
 const std::string VERSION_6_3_TAG("6.3");
 const std::string VERSION_6_5_TAG("6.5");
 const std::string VERSION_7_3_TAG("7.3");
+const std::string VERSION_7_11_TAG("7.11");
 
 // Models
 // Version >= 6.3
@@ -1291,7 +1292,9 @@ std::size_t CUnivariateTimeSeriesModel::memoryUsage() const {
 
 bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParams& params,
                                                         core::CStateRestoreTraverser& traverser) {
-    if (traverser.name() == VERSION_6_3_TAG) {
+    bool stateMissingControllerChecks{false};
+    if (traverser.name() == VERSION_6_3_TAG || traverser.name() == VERSION_7_11_TAG) {
+        stateMissingControllerChecks = (traverser.name() == VERSION_6_3_TAG);
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_BUILT_IN(ID_6_3_TAG, m_Id)
@@ -1329,6 +1332,7 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
         }
     } else {
         // There is no version string this is historic state.
+        stateMissingControllerChecks = true;
         do {
             const std::string& name{traverser.name()};
             RESTORE_BUILT_IN(ID_OLD_TAG, m_Id)
@@ -1357,11 +1361,11 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
         } while (traverser.next());
     }
 
-    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
+    if (m_Controllers != nullptr && stateMissingControllerChecks) {
         (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
                                                 CDecayRateController::E_PredictionErrorIncrease);
     }
-    if (m_Controllers != nullptr && (*m_Controllers)[E_ResidualControl].checks() == 0) {
+    if (m_Controllers != nullptr && stateMissingControllerChecks) {
         (*m_Controllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);
@@ -1389,7 +1393,7 @@ void CUnivariateTimeSeriesModel::acceptPersistInserter(core::CStatePersistInsert
 
     // Note that we don't persist this->params() or the correlations
     // because that state is reinitialized.
-    inserter.insertValue(VERSION_6_3_TAG, "");
+    inserter.insertValue(VERSION_7_11_TAG, "");
     inserter.insertValue(ID_6_3_TAG, m_Id);
     inserter.insertValue(IS_NON_NEGATIVE_6_3_TAG, static_cast<int>(m_IsNonNegative));
     inserter.insertValue(IS_FORECASTABLE_6_3_TAG, static_cast<int>(m_IsForecastable));
@@ -2702,7 +2706,9 @@ std::size_t CMultivariateTimeSeriesModel::memoryUsage() const {
 
 bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParams& params,
                                                           core::CStateRestoreTraverser& traverser) {
-    if (traverser.name() == VERSION_6_3_TAG) {
+    bool stateMissingControllerChecks{false};
+    if (traverser.name() == VERSION_6_3_TAG || traverser.name() == VERSION_7_11_TAG) {
+        stateMissingControllerChecks = (traverser.name() == VERSION_6_3_TAG);
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_BOOL(IS_NON_NEGATIVE_6_3_TAG, m_IsNonNegative)
@@ -2738,6 +2744,7 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
                 /**/)
         }
     } else {
+        stateMissingControllerChecks = true;
         do {
             const std::string& name{traverser.name()};
             RESTORE_BOOL(IS_NON_NEGATIVE_OLD_TAG, m_IsNonNegative)
@@ -2766,11 +2773,11 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
         } while (traverser.next());
     }
 
-    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
+    if (m_Controllers != nullptr && stateMissingControllerChecks) {
         (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
                                                 CDecayRateController::E_PredictionErrorIncrease);
     }
-    if (m_Controllers != nullptr && (*m_Controllers)[E_ResidualControl].checks() == 0) {
+    if (m_Controllers != nullptr && stateMissingControllerChecks) {
         (*m_Controllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);
@@ -2782,7 +2789,7 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
 void CMultivariateTimeSeriesModel::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     // Note that we don't persist this->params() because that state
     // is reinitialized.
-    inserter.insertValue(VERSION_6_3_TAG, "");
+    inserter.insertValue(VERSION_7_11_TAG, "");
     inserter.insertValue(IS_NON_NEGATIVE_6_3_TAG, static_cast<int>(m_IsNonNegative));
     if (m_Controllers) {
         core::CPersistUtils::persist(CONTROLLER_6_3_TAG, *m_Controllers, inserter);

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1357,10 +1357,14 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
         } while (traverser.next());
     }
 
-    if (m_DecayRateControllers != nullptr) {
+    if (m_DecayRateControllers != nullptr &&
+        (*m_DecayRateControllers)[E_TrendControl].checks() == 0) {
         (*m_DecayRateControllers)[E_TrendControl].checks(
             CDecayRateController::E_PredictionBias |
             CDecayRateController::E_PredictionErrorIncrease);
+    }
+    if (m_DecayRateControllers != nullptr &&
+        (*m_DecayRateControllers)[E_ResidualControl].checks() == 0) {
         (*m_DecayRateControllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);
@@ -2767,10 +2771,14 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
         } while (traverser.next());
     }
 
-    if (m_DecayRateControllers != nullptr) {
+    if (m_DecayRateControllers != nullptr &&
+        (*m_DecayRateControllers)[E_TrendControl].checks() == 0) {
         (*m_DecayRateControllers)[E_TrendControl].checks(
             CDecayRateController::E_PredictionBias |
             CDecayRateController::E_PredictionErrorIncrease);
+    }
+    if (m_DecayRateControllers != nullptr &&
+        (*m_DecayRateControllers)[E_ResidualControl].checks() == 0) {
         (*m_DecayRateControllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -613,7 +613,7 @@ CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(
                                     : nullptr),
       m_Correlations(nullptr) {
     if (controllers) {
-        m_DecayRateControllers = std::make_unique<TDecayRateController2Ary>(*controllers);
+        m_Controllers = std::make_unique<TDecayRateController2Ary>(*controllers);
     }
 }
 
@@ -1260,7 +1260,7 @@ void CUnivariateTimeSeriesModel::seasonalWeight(double confidence,
 
 std::uint64_t CUnivariateTimeSeriesModel::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_IsNonNegative);
-    seed = CChecksum::calculate(seed, m_DecayRateControllers);
+    seed = CChecksum::calculate(seed, m_Controllers);
     seed = CChecksum::calculate(seed, m_TrendModel);
     seed = CChecksum::calculate(seed, m_ResidualModel);
     seed = CChecksum::calculate(seed, m_MultibucketFeature);
@@ -1271,7 +1271,7 @@ std::uint64_t CUnivariateTimeSeriesModel::checksum(std::uint64_t seed) const {
 
 void CUnivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CUnivariateTimeSeriesModel");
-    core::CMemoryDebug::dynamicSize("m_DecayRateControllers", m_DecayRateControllers, mem);
+    core::CMemoryDebug::dynamicSize("m_Controllers", m_Controllers, mem);
     core::CMemoryDebug::dynamicSize("m_TrendModel", m_TrendModel, mem);
     core::CMemoryDebug::dynamicSize("m_ResidualModel", m_ResidualModel, mem);
     core::CMemoryDebug::dynamicSize("m_MultibucketFeature", m_MultibucketFeature, mem);
@@ -1281,7 +1281,7 @@ void CUnivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMem
 }
 
 std::size_t CUnivariateTimeSeriesModel::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_DecayRateControllers) +
+    return core::CMemory::dynamicSize(m_Controllers) +
            core::CMemory::dynamicSize(m_TrendModel) +
            core::CMemory::dynamicSize(m_ResidualModel) +
            core::CMemory::dynamicSize(m_MultibucketFeature) +
@@ -1299,8 +1299,8 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
             RESTORE_BOOL(IS_FORECASTABLE_6_3_TAG, m_IsForecastable)
             RESTORE_SETUP_TEARDOWN(
                 CONTROLLER_6_3_TAG,
-                m_DecayRateControllers = std::make_unique<TDecayRateController2Ary>(),
-                core::CPersistUtils::restore(CONTROLLER_6_3_TAG, *m_DecayRateControllers, traverser),
+                m_Controllers = std::make_unique<TDecayRateController2Ary>(),
+                core::CPersistUtils::restore(CONTROLLER_6_3_TAG, *m_Controllers, traverser),
                 /**/)
             RESTORE(TREND_MODEL_6_3_TAG,
                     traverser.traverseSubLevel(std::bind<bool>(
@@ -1336,8 +1336,8 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
             RESTORE_BOOL(IS_FORECASTABLE_OLD_TAG, m_IsForecastable)
             RESTORE_SETUP_TEARDOWN(
                 CONTROLLER_OLD_TAG,
-                m_DecayRateControllers = std::make_unique<TDecayRateController2Ary>(),
-                core::CPersistUtils::restore(CONTROLLER_OLD_TAG, *m_DecayRateControllers, traverser),
+                m_Controllers = std::make_unique<TDecayRateController2Ary>(),
+                core::CPersistUtils::restore(CONTROLLER_OLD_TAG, *m_Controllers, traverser),
                 /**/)
             RESTORE(TREND_OLD_TAG, traverser.traverseSubLevel(std::bind<bool>(
                                        CTimeSeriesDecompositionStateSerialiser(),
@@ -1357,15 +1357,12 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
         } while (traverser.next());
     }
 
-    if (m_DecayRateControllers != nullptr &&
-        (*m_DecayRateControllers)[E_TrendControl].checks() == 0) {
-        (*m_DecayRateControllers)[E_TrendControl].checks(
-            CDecayRateController::E_PredictionBias |
-            CDecayRateController::E_PredictionErrorIncrease);
+    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
+        (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
+                                                CDecayRateController::E_PredictionErrorIncrease);
     }
-    if (m_DecayRateControllers != nullptr &&
-        (*m_DecayRateControllers)[E_ResidualControl].checks() == 0) {
-        (*m_DecayRateControllers)[E_ResidualControl].checks(
+    if (m_Controllers != nullptr && (*m_Controllers)[E_ResidualControl].checks() == 0) {
+        (*m_Controllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);
     }
@@ -1396,8 +1393,8 @@ void CUnivariateTimeSeriesModel::acceptPersistInserter(core::CStatePersistInsert
     inserter.insertValue(ID_6_3_TAG, m_Id);
     inserter.insertValue(IS_NON_NEGATIVE_6_3_TAG, static_cast<int>(m_IsNonNegative));
     inserter.insertValue(IS_FORECASTABLE_6_3_TAG, static_cast<int>(m_IsForecastable));
-    if (m_DecayRateControllers != nullptr) {
-        core::CPersistUtils::persist(CONTROLLER_6_3_TAG, *m_DecayRateControllers, inserter);
+    if (m_Controllers != nullptr) {
+        core::CPersistUtils::persist(CONTROLLER_6_3_TAG, *m_Controllers, inserter);
     }
     if (m_TrendModel != nullptr) {
         inserter.insertLevel(
@@ -1467,9 +1464,8 @@ CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(const CUnivariateTimeSeri
                          ? std::make_unique<CTimeSeriesAnomalyModel>(*other.m_AnomalyModel)
                          : nullptr),
       m_Correlations(nullptr) {
-    if (!isForForecast && other.m_DecayRateControllers != nullptr) {
-        m_DecayRateControllers =
-            std::make_unique<TDecayRateController2Ary>(*other.m_DecayRateControllers);
+    if (!isForForecast && other.m_Controllers != nullptr) {
+        m_Controllers = std::make_unique<TDecayRateController2Ary>(*other.m_Controllers);
     }
 }
 
@@ -1529,7 +1525,7 @@ double CUnivariateTimeSeriesModel::updateDecayRates(const CModelAddSamplesParams
                                                     const TDouble1Vec& samples) {
     double multiplier{1.0};
 
-    if (m_DecayRateControllers == nullptr) {
+    if (m_Controllers == nullptr) {
         return multiplier;
     }
 
@@ -1540,7 +1536,7 @@ double CUnivariateTimeSeriesModel::updateDecayRates(const CModelAddSamplesParams
         this->appendPredictionErrors(params.propagationInterval(), sample, errors);
     }
     {
-        CDecayRateController& controller{(*m_DecayRateControllers)[E_TrendControl]};
+        CDecayRateController& controller{(*m_Controllers)[E_TrendControl]};
         TDouble1Vec trendMean{m_TrendModel->meanValue(time)};
         multiplier = controller.multiplier(
             trendMean, errors[E_TrendControl], this->params().bucketLength(),
@@ -1551,7 +1547,7 @@ double CUnivariateTimeSeriesModel::updateDecayRates(const CModelAddSamplesParams
         }
     }
     {
-        CDecayRateController& controller{(*m_DecayRateControllers)[E_ResidualControl]};
+        CDecayRateController& controller{(*m_Controllers)[E_ResidualControl]};
         TDouble1Vec residualMean{m_ResidualModel->marginalLikelihoodMean()};
         multiplier = controller.multiplier(
             residualMean, errors[E_ResidualControl], this->params().bucketLength(),
@@ -1584,12 +1580,12 @@ void CUnivariateTimeSeriesModel::appendPredictionErrors(double interval,
 
 void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAccumulatorVec residuals) {
 
-    if (m_DecayRateControllers != nullptr) {
+    if (m_Controllers != nullptr) {
         m_ResidualModel->decayRate(m_ResidualModel->decayRate() /
-                                   (*m_DecayRateControllers)[E_ResidualControl].multiplier());
+                                   (*m_Controllers)[E_ResidualControl].multiplier());
         m_TrendModel->decayRate(m_TrendModel->decayRate() /
-                                (*m_DecayRateControllers)[E_TrendControl].multiplier());
-        for (auto& controller : *m_DecayRateControllers) {
+                                (*m_Controllers)[E_TrendControl].multiplier());
+        for (auto& controller : *m_Controllers) {
             controller.reset();
         }
     }
@@ -2131,7 +2127,7 @@ CMultivariateTimeSeriesModel::CMultivariateTimeSeriesModel(
                                           params.decayRate())
                                     : nullptr) {
     if (controllers) {
-        m_DecayRateControllers = std::make_unique<TDecayRateController2Ary>(*controllers);
+        m_Controllers = std::make_unique<TDecayRateController2Ary>(*controllers);
     }
     for (std::size_t d = 0u; d < this->dimension(); ++d) {
         m_TrendModel.emplace_back(trend.clone());
@@ -2150,9 +2146,8 @@ CMultivariateTimeSeriesModel::CMultivariateTimeSeriesModel(const CMultivariateTi
       m_AnomalyModel(other.m_AnomalyModel != nullptr
                          ? std::make_unique<CTimeSeriesAnomalyModel>(*other.m_AnomalyModel)
                          : nullptr) {
-    if (other.m_DecayRateControllers) {
-        m_DecayRateControllers =
-            std::make_unique<TDecayRateController2Ary>(*other.m_DecayRateControllers);
+    if (other.m_Controllers) {
+        m_Controllers = std::make_unique<TDecayRateController2Ary>(*other.m_Controllers);
     }
     m_TrendModel.reserve(other.m_TrendModel.size());
     for (const auto& trend : other.m_TrendModel) {
@@ -2677,7 +2672,7 @@ void CMultivariateTimeSeriesModel::seasonalWeight(double confidence,
 
 std::uint64_t CMultivariateTimeSeriesModel::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_IsNonNegative);
-    seed = CChecksum::calculate(seed, m_DecayRateControllers);
+    seed = CChecksum::calculate(seed, m_Controllers);
     seed = CChecksum::calculate(seed, m_TrendModel);
     seed = CChecksum::calculate(seed, m_ResidualModel);
     seed = CChecksum::calculate(seed, m_MultibucketFeature);
@@ -2687,7 +2682,7 @@ std::uint64_t CMultivariateTimeSeriesModel::checksum(std::uint64_t seed) const {
 
 void CMultivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CUnivariateTimeSeriesModel");
-    core::CMemoryDebug::dynamicSize("m_DecayRateControllers", m_DecayRateControllers, mem);
+    core::CMemoryDebug::dynamicSize("m_Controllers", m_Controllers, mem);
     core::CMemoryDebug::dynamicSize("m_TrendModel", m_TrendModel, mem);
     core::CMemoryDebug::dynamicSize("m_ResidualModel", m_ResidualModel, mem);
     core::CMemoryDebug::dynamicSize("m_MultibucketFeature", m_MultibucketFeature, mem);
@@ -2697,7 +2692,7 @@ void CMultivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TM
 }
 
 std::size_t CMultivariateTimeSeriesModel::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_DecayRateControllers) +
+    return core::CMemory::dynamicSize(m_Controllers) +
            core::CMemory::dynamicSize(m_TrendModel) +
            core::CMemory::dynamicSize(m_ResidualModel) +
            core::CMemory::dynamicSize(m_MultibucketFeature) +
@@ -2713,8 +2708,8 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
             RESTORE_BOOL(IS_NON_NEGATIVE_6_3_TAG, m_IsNonNegative)
             RESTORE_SETUP_TEARDOWN(
                 CONTROLLER_6_3_TAG,
-                m_DecayRateControllers = std::make_unique<TDecayRateController2Ary>(),
-                core::CPersistUtils::restore(CONTROLLER_6_3_TAG, *m_DecayRateControllers, traverser),
+                m_Controllers = std::make_unique<TDecayRateController2Ary>(),
+                core::CPersistUtils::restore(CONTROLLER_6_3_TAG, *m_Controllers, traverser),
                 /**/)
             RESTORE_SETUP_TEARDOWN(
                 TREND_MODEL_6_3_TAG, m_TrendModel.push_back(TDecompositionPtr()),
@@ -2748,8 +2743,8 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
             RESTORE_BOOL(IS_NON_NEGATIVE_OLD_TAG, m_IsNonNegative)
             RESTORE_SETUP_TEARDOWN(
                 CONTROLLER_OLD_TAG,
-                m_DecayRateControllers = std::make_unique<TDecayRateController2Ary>(),
-                core::CPersistUtils::restore(CONTROLLER_6_3_TAG, *m_DecayRateControllers, traverser),
+                m_Controllers = std::make_unique<TDecayRateController2Ary>(),
+                core::CPersistUtils::restore(CONTROLLER_6_3_TAG, *m_Controllers, traverser),
                 /**/)
             RESTORE_SETUP_TEARDOWN(
                 TREND_OLD_TAG, m_TrendModel.push_back(TDecompositionPtr()),
@@ -2771,15 +2766,12 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
         } while (traverser.next());
     }
 
-    if (m_DecayRateControllers != nullptr &&
-        (*m_DecayRateControllers)[E_TrendControl].checks() == 0) {
-        (*m_DecayRateControllers)[E_TrendControl].checks(
-            CDecayRateController::E_PredictionBias |
-            CDecayRateController::E_PredictionErrorIncrease);
+    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
+        (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
+                                                CDecayRateController::E_PredictionErrorIncrease);
     }
-    if (m_DecayRateControllers != nullptr &&
-        (*m_DecayRateControllers)[E_ResidualControl].checks() == 0) {
-        (*m_DecayRateControllers)[E_ResidualControl].checks(
+    if (m_Controllers != nullptr && (*m_Controllers)[E_ResidualControl].checks() == 0) {
+        (*m_Controllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);
     }
@@ -2792,8 +2784,8 @@ void CMultivariateTimeSeriesModel::acceptPersistInserter(core::CStatePersistInse
     // is reinitialized.
     inserter.insertValue(VERSION_6_3_TAG, "");
     inserter.insertValue(IS_NON_NEGATIVE_6_3_TAG, static_cast<int>(m_IsNonNegative));
-    if (m_DecayRateControllers) {
-        core::CPersistUtils::persist(CONTROLLER_6_3_TAG, *m_DecayRateControllers, inserter);
+    if (m_Controllers) {
+        core::CPersistUtils::persist(CONTROLLER_6_3_TAG, *m_Controllers, inserter);
     }
     for (const auto& trend : m_TrendModel) {
         inserter.insertLevel(TREND_MODEL_6_3_TAG,
@@ -2913,7 +2905,7 @@ CMultivariateTimeSeriesModel::updateTrend(const CModelAddSamplesParams& params,
 void CMultivariateTimeSeriesModel::updateDecayRates(const CModelAddSamplesParams& params,
                                                     core_t::TTime time,
                                                     const TDouble10Vec1Vec& samples) {
-    if (m_DecayRateControllers != nullptr) {
+    if (m_Controllers != nullptr) {
         TDouble1VecVec errors[2];
         errors[0].reserve(samples.size());
         errors[1].reserve(samples.size());
@@ -2921,7 +2913,7 @@ void CMultivariateTimeSeriesModel::updateDecayRates(const CModelAddSamplesParams
             this->appendPredictionErrors(params.propagationInterval(), sample, errors);
         }
         {
-            CDecayRateController& controller{(*m_DecayRateControllers)[E_TrendControl]};
+            CDecayRateController& controller{(*m_Controllers)[E_TrendControl]};
             TDouble1Vec trendMean(this->dimension());
             for (std::size_t d = 0u; d < trendMean.size(); ++d) {
                 trendMean[d] = m_TrendModel[d]->meanValue(time);
@@ -2937,7 +2929,7 @@ void CMultivariateTimeSeriesModel::updateDecayRates(const CModelAddSamplesParams
             }
         }
         {
-            CDecayRateController& controller{(*m_DecayRateControllers)[E_ResidualControl]};
+            CDecayRateController& controller{(*m_Controllers)[E_ResidualControl]};
             TDouble1Vec residualMean(m_ResidualModel->marginalLikelihoodMean());
             double multiplier{controller.multiplier(
                 residualMean, errors[E_ResidualControl], this->params().bucketLength(),
@@ -2966,14 +2958,14 @@ void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMean
     using TDoubleVec = std::vector<double>;
     using TDouble10VecVec = std::vector<TDouble10Vec>;
 
-    if (m_DecayRateControllers != nullptr) {
+    if (m_Controllers != nullptr) {
         m_ResidualModel->decayRate(m_ResidualModel->decayRate() /
-                                   (*m_DecayRateControllers)[E_ResidualControl].multiplier());
+                                   (*m_Controllers)[E_ResidualControl].multiplier());
         for (auto& trend : m_TrendModel) {
             trend->decayRate(trend->decayRate() /
-                             (*m_DecayRateControllers)[E_TrendControl].multiplier());
+                             (*m_Controllers)[E_TrendControl].multiplier());
         }
-        for (auto& controller : *m_DecayRateControllers) {
+        for (auto& controller : *m_Controllers) {
             controller.reset();
         }
     }

--- a/lib/maths/unittest/CDecayRateControllerTest.cc
+++ b/lib/maths/unittest/CDecayRateControllerTest.cc
@@ -16,16 +16,18 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <vector>
+
 BOOST_AUTO_TEST_SUITE(CDecayRateControllerTest)
 
 using namespace ml;
 using namespace handy_typedefs;
+using TDoubleVec = std::vector<double>;
 
 BOOST_AUTO_TEST_CASE(testLowCov) {
-    // Supply small but biased errors so we increase the decay
-    // rate to its maximum then gradually reduce the error to
-    // less than the coefficient of variation cutoff to control
-    // and make sure the decay rate reverts to typical.
+    // Supply small but biased errors so we increase the decay rate to its maximum
+    // then gradually reduce the error to less than the coefficient of variation
+    // cutoff to control and make sure the decay rate reverts to typical.
 
     maths::CDecayRateController controller(maths::CDecayRateController::E_PredictionBias, 1);
 
@@ -46,9 +48,8 @@ BOOST_AUTO_TEST_CASE(testLowCov) {
 }
 
 BOOST_AUTO_TEST_CASE(testOrderedErrors) {
-    // Test that if we add a number of ordered samples, such
-    // that overall they don't have bias, the decay rate is
-    // not increased.
+    // Test that if we add a number of ordered samples, such that overall they don't
+    // have bias, the decay rate is not increased.
 
     using TDouble1VecVec = std::vector<TDouble1Vec>;
 
@@ -68,8 +69,6 @@ BOOST_AUTO_TEST_CASE(testOrderedErrors) {
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {
-    using TDoubleVec = std::vector<double>;
-
     test::CRandomNumbers rng;
 
     TDoubleVec values;
@@ -106,6 +105,49 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         LOG_DEBUG(<< "orig checksum = " << origController.checksum()
                   << ", new checksum = " << restoredController.checksum());
         BOOST_REQUIRE_EQUAL(origController.checksum(), restoredController.checksum());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testBehaviourAfterPersistAndRestore) {
+    // Test that we get the same decisions after persisting and restoring.
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec values;
+    rng.generateUniformSamples(1000.0, 1010.0, 1000, values);
+
+    TDoubleVec errors;
+    rng.generateUniformSamples(-2.0, 6.0, 1000, errors);
+
+    maths::CDecayRateController origController{
+        maths::CDecayRateController::E_PredictionBias, 1};
+    maths::CDecayRateController restoredController;
+    for (std::size_t i = 0; i < 500; ++i) {
+        origController.multiplier({values[i]}, {{errors[i]}}, 3600, 1.0, 0.0005);
+    }
+
+    std::string origXml;
+    {
+        core::CRapidXmlStatePersistInserter inserter("root");
+        origController.acceptPersistInserter(inserter);
+        inserter.toXml(origXml);
+    }
+
+    // Restore the XML into a new controller.
+    {
+        core::CRapidXmlParser parser;
+        BOOST_TEST_REQUIRE(parser.parseStringIgnoreCdata(origXml));
+        core::CRapidXmlStateRestoreTraverser traverser(parser);
+        BOOST_REQUIRE_EQUAL(true, traverser.traverseSubLevel(std::bind(
+                                      &maths::CDecayRateController::acceptRestoreTraverser,
+                                      &restoredController, std::placeholders::_1)));
+    }
+
+    for (std::size_t i = 500; i < values.size(); ++i) {
+        BOOST_REQUIRE_CLOSE(
+            origController.multiplier({values[i]}, {{errors[i]}}, 3600, 1.0, 0.0005),
+            restoredController.multiplier({values[i]}, {{errors[i]}}, 3600, 1.0, 0.0005),
+            0.001);
     }
 }
 


### PR DESCRIPTION
We were failing to persist and restore the checks we perform when controlling decay rate for time series models. The upshot is that we would disable decay rate control after a round of persist and restore. This could happen on failover or if the job is closed and restarted.

The checksum for the class was also incomplete which should have picked this up in the unit testing. I have however also added a test that the behaviour is preserved after persist and restore. 