### PR TITLE
[ML] Assorted time series modelling stability fixes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -52,7 +52,7 @@
 
 * Fix a source of instability in time series modeling for anomaly detection. This has
   been observed to cause spurious anomalies for a partition which no longer receives
-  any data.
+  any data. (See {ml-pull}1675[#1675].)
 
 == {es} version 7.11.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -48,6 +48,12 @@
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
 
+=== Bug Fixes
+
+* Fix a source of instability in time series modeling for anomaly detection. This has
+  been observed to cause spurious anomalies for a partition which no longer receives
+  any data.
+
 == {es} version 7.11.0
 
 === Enhancements

--- a/include/maths/CCalendarComponent.h
+++ b/include/maths/CCalendarComponent.h
@@ -93,6 +93,9 @@ public:
     //! less influence it has on the component.
     void add(core_t::TTime time, double value, double weight = 1.0);
 
+    //! Check whether to reinterpolate the component predictions.
+    bool shouldInterpolate(core_t::TTime time) const;
+
     //! Update the interpolation of the bucket values.
     //!
     //! \param[in] time The time at which to interpolate.
@@ -152,6 +155,9 @@ private:
 private:
     //! The mean and variance in collection of buckets covering the period.
     CCalendarComponentAdaptiveBucketing m_Bucketing;
+
+    //! The last interpolation time.
+    core_t::TTime m_LastInterpolationTime;
 };
 
 //! Create a free function which will be found by Koenig lookup.

--- a/include/maths/CCalendarFeature.h
+++ b/include/maths/CCalendarFeature.h
@@ -14,10 +14,9 @@
 #include <boost/operators.hpp>
 
 #include <array>
+#include <cstdint>
 #include <iosfwd>
 #include <string>
-
-#include <stdint.h>
 
 namespace ml {
 namespace maths {
@@ -33,24 +32,24 @@ public:
     //! See core::CMemory.
     static bool dynamicSizeAlwaysZero() { return true; }
 
-    static const uint16_t DAYS_SINCE_START_OF_MONTH = 1;
-    static const uint16_t DAYS_BEFORE_END_OF_MONTH = 2;
-    static const uint16_t DAY_OF_WEEK_AND_WEEKS_SINCE_START_OF_MONTH = 3;
-    static const uint16_t DAY_OF_WEEK_AND_WEEKS_BEFORE_END_OF_MONTH = 4;
-    static const uint16_t BEGIN_FEATURES = 1;
-    static const uint16_t END_FEATURES = 5;
+    static const std::uint16_t DAYS_SINCE_START_OF_MONTH = 1;
+    static const std::uint16_t DAYS_BEFORE_END_OF_MONTH = 2;
+    static const std::uint16_t DAY_OF_WEEK_AND_WEEKS_SINCE_START_OF_MONTH = 3;
+    static const std::uint16_t DAY_OF_WEEK_AND_WEEKS_BEFORE_END_OF_MONTH = 4;
+    static const std::uint16_t BEGIN_FEATURES = 1;
+    static const std::uint16_t END_FEATURES = 5;
 
     using TCalendarFeature4Ary = std::array<CCalendarFeature, 4>;
 
 public:
     CCalendarFeature();
-    CCalendarFeature(uint16_t feature, core_t::TTime time);
+    CCalendarFeature(std::uint16_t feature, core_t::TTime time);
 
     //! Get all the features for \p time.
     static TCalendarFeature4Ary features(core_t::TTime time);
 
     //! Initialize with day of week, month and the month and year.
-    void initialize(uint16_t feature, int dayOfWeek, int dayOfMonth, int month, int year);
+    void initialize(std::uint16_t feature, int dayOfWeek, int dayOfMonth, int month, int year);
 
     //! Initialize from \p value.
     bool fromDelimited(const std::string& value);
@@ -77,21 +76,24 @@ public:
     //! Get this feature's window.
     core_t::TTime window() const;
 
+    //! The approximate feature repeat.
+    core_t::TTime repeat() const;
+
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Get a debug description of the feature.
     std::string print() const;
 
 private:
     //! An invalid feature value.
-    static const uint16_t INVALID;
+    static const std::uint16_t INVALID;
 
 private:
     //! The feature.
-    uint16_t m_Feature;
+    std::uint16_t m_Feature;
     //! The feature value.
-    uint16_t m_Value;
+    std::uint16_t m_Value;
 };
 
 MATHS_EXPORT

--- a/include/maths/CCalendarFeature.h
+++ b/include/maths/CCalendarFeature.h
@@ -42,7 +42,7 @@ public:
     using TCalendarFeature4Ary = std::array<CCalendarFeature, 4>;
 
 public:
-    CCalendarFeature();
+    CCalendarFeature() = default;
     CCalendarFeature(std::uint16_t feature, core_t::TTime time);
 
     //! Get all the features for \p time.
@@ -76,9 +76,6 @@ public:
     //! Get this feature's window.
     core_t::TTime window() const;
 
-    //! The approximate feature repeat.
-    core_t::TTime repeat() const;
-
     //! Get a checksum for this object.
     std::uint64_t checksum(std::uint64_t seed = 0) const;
 
@@ -91,9 +88,9 @@ private:
 
 private:
     //! The feature.
-    std::uint16_t m_Feature;
+    std::uint16_t m_Feature = INVALID;
     //! The feature value.
-    std::uint16_t m_Value;
+    std::uint16_t m_Value = INVALID;
 };
 
 MATHS_EXPORT

--- a/include/maths/CSeasonalComponent.h
+++ b/include/maths/CSeasonalComponent.h
@@ -114,7 +114,13 @@ public:
     //! \param[in] value The value at \p time.
     //! \param[in] weight The weight of \p value. The smaller this is the
     //! less influence it has on the component.
-    void add(core_t::TTime time, double value, double weight = 1.0);
+    //! \param[in] gradientLearnRate Must be in the range [0,1] with lower
+    //! values reducing the rate at which we adapt bucket regression model
+    //! gradients.
+    void add(core_t::TTime time, double value, double weight = 1.0, double gradientLearnRate = 1.0);
+
+    //! Check whether to reinterpolate the component predictions.
+    bool shouldInterpolate(core_t::TTime time) const;
 
     //! Update the interpolation of the bucket values.
     //!
@@ -137,6 +143,9 @@ public:
 
     //! Get the time provider.
     const CSeasonalTime& time() const;
+
+    //! Get the bucket models.
+    const CSeasonalComponentAdaptiveBucketing& bucketing() const;
 
     //! Interpolate the component at \p time.
     //!
@@ -186,7 +195,7 @@ public:
     bool slopeAccurate(core_t::TTime time) const;
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Debug the memory used by this component.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
@@ -213,6 +222,9 @@ private:
 
     //! Regression models for a collection of buckets covering the period.
     CSeasonalComponentAdaptiveBucketing m_Bucketing;
+
+    //! The last interpolation time.
+    core_t::TTime m_LastInterpolationTime;
 
     //! Befriend a helper class used by the unit tests
     friend class CTimeSeriesDecompositionTest::CNanInjector;

--- a/include/maths/CSeasonalComponentAdaptiveBucketing.h
+++ b/include/maths/CSeasonalComponentAdaptiveBucketing.h
@@ -16,10 +16,9 @@
 #include <maths/ImportExport.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <vector>
-
-#include <stdint.h>
 
 namespace CTimeSeriesDecompositionTest {
 class CNanInjector;
@@ -103,9 +102,16 @@ public:
     //! \param[in] time The time of \p value.
     //! \param[in] value The value of the function at \p time.
     //! \param[in] prediction The prediction for \p value.
-    //! \param[in] weight The weight of function point. The smaller
-    //! this is the less influence it has on the bucket.
-    void add(core_t::TTime time, double value, double prediction, double weight = 1.0);
+    //! \param[in] weight The weight of function point. The smaller this is
+    //! the less influence it has on the bucket.
+    //! \param[in] gradientLearnRate Must be in the range [0,1] with lower
+    //! values reduce the rate at which we adapt bucket regression model
+    //! gradients.
+    void add(core_t::TTime time,
+             double value,
+             double prediction,
+             double weight = 1.0,
+             double gradientLearnRate = 1.0);
 
     //! Age the bucket values to account for \p time elapsed time.
     //!

--- a/include/maths/CSeasonalTime.h
+++ b/include/maths/CSeasonalTime.h
@@ -61,6 +61,9 @@ public:
     //! between \p start and \p end.
     double regressionInterval(core_t::TTime start, core_t::TTime end) const;
 
+    //! Get the start time of the period containing \p time.
+    core_t::TTime startOfPeriod(core_t::TTime time) const;
+
     //! Get the start of the repeat containing \p time.
     core_t::TTime startOfWindowRepeat(core_t::TTime time) const;
 

--- a/include/maths/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/CTimeSeriesDecompositionDetail.h
@@ -760,10 +760,10 @@ public:
             void appendPredictions(core_t::TTime time, TDoubleVec& predictions) const;
 
             //! Check if we need to interpolate any of the components.
-            bool shouldInterpolate(core_t::TTime time, core_t::TTime last) const;
+            bool shouldInterpolate(core_t::TTime time) const;
 
             //! Interpolate the components at \p time.
-            void interpolate(core_t::TTime time, core_t::TTime last, bool refine);
+            void interpolate(core_t::TTime time, bool refine);
 
             //! Check if any of the components has been initialized.
             bool initialized() const;
@@ -857,10 +857,10 @@ public:
             void appendPredictions(core_t::TTime time, TDoubleVec& predictions) const;
 
             //! Check if we need to interpolate any of the components.
-            bool shouldInterpolate(core_t::TTime time, core_t::TTime last) const;
+            bool shouldInterpolate(core_t::TTime time) const;
 
             //! Interpolate the components at \p time.
-            void interpolate(core_t::TTime time, core_t::TTime last, bool refine);
+            void interpolate(core_t::TTime time, bool refine);
 
             //! Check if any of the components has been initialized.
             bool initialized() const;
@@ -925,7 +925,7 @@ public:
         bool shouldUseTrendForPrediction();
 
         //! Check if we should interpolate.
-        bool shouldInterpolate(core_t::TTime time, core_t::TTime last);
+        bool shouldInterpolate(core_t::TTime time);
 
         //! Maybe re-interpolate the components.
         void interpolate(const SMessage& message);

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -30,25 +30,6 @@ class CTimeSeriesMultibucketFeature;
 struct SDistributionRestoreParams;
 struct SModelRestoreParams;
 
-namespace winsorisation {
-//! The minimum Winsorisation weight.
-constexpr double MINIMUM_WEIGHT{0.01};
-
-//! Computes a Winsorisation weight for \p value based on its
-//! one tail p-value.
-MATHS_EXPORT
-double weight(const CPrior& prior, double derate, double scale, double value);
-
-//! Computes a Winsorisation weight for \p value based on its
-//! marginal for \p dimension one tail p-value.
-MATHS_EXPORT
-double weight(const CMultivariatePrior& prior,
-              std::size_t dimension,
-              double derate,
-              double scale,
-              const core::CSmallVector<double, 10>& value);
-}
-
 //! \brief A CModel implementation for modeling a univariate time series.
 class MATHS_EXPORT CUnivariateTimeSeriesModel : public CModel {
 public:

--- a/lib/maths/CCalendarComponent.cc
+++ b/lib/maths/CCalendarComponent.cc
@@ -18,10 +18,8 @@
 #include <maths/CSampling.h>
 #include <maths/CSeasonalTime.h>
 
-#include <boost/math/distributions/chi_squared.hpp>
-#include <boost/math/distributions/normal.hpp>
-
 #include <ios>
+#include <limits>
 #include <vector>
 
 namespace ml {
@@ -30,6 +28,7 @@ namespace {
 using TDoubleDoublePr = maths_t::TDoubleDoublePr;
 const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
 const core::TPersistenceTag BUCKETING_TAG{"b", "bucketing"};
+const core::TPersistenceTag LAST_INTERPOLATION_TAG{"c", "last_interpolation_time"};
 const std::string EMPTY_STRING;
 }
 
@@ -42,7 +41,8 @@ CCalendarComponent::CCalendarComponent(const CCalendarFeature& feature,
                                        CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{maxSize, boundaryCondition,
                               valueInterpolationType, varianceInterpolationType},
-      m_Bucketing{feature, decayRate, minimumBucketLength} {
+      m_Bucketing{feature, decayRate, minimumBucketLength},
+      m_LastInterpolationTime{std::numeric_limits<core_t::TTime>::min()} {
 }
 
 CCalendarComponent::CCalendarComponent(double decayRate,
@@ -51,7 +51,8 @@ CCalendarComponent::CCalendarComponent(double decayRate,
                                        CSplineTypes::EType valueInterpolationType,
                                        CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{0, CSplineTypes::E_Periodic,
-                              valueInterpolationType, varianceInterpolationType} {
+                              valueInterpolationType, varianceInterpolationType},
+      m_LastInterpolationTime{std::numeric_limits<core_t::TTime>::min()} {
     traverser.traverseSubLevel(std::bind(&CCalendarComponent::acceptRestoreTraverser,
                                          this, decayRate, minimumBucketLength,
                                          std::placeholders::_1));
@@ -60,6 +61,7 @@ CCalendarComponent::CCalendarComponent(double decayRate,
 void CCalendarComponent::swap(CCalendarComponent& other) {
     this->CDecompositionComponent::swap(other);
     m_Bucketing.swap(other.m_Bucketing);
+    std::swap(m_LastInterpolationTime, other.m_LastInterpolationTime);
 }
 
 bool CCalendarComponent::acceptRestoreTraverser(double decayRate,
@@ -75,6 +77,7 @@ bool CCalendarComponent::acceptRestoreTraverser(double decayRate,
                                CCalendarComponentAdaptiveBucketing bucketing(
                                    decayRate, minimumBucketLength, traverser),
                                true, m_Bucketing.swap(bucketing))
+        RESTORE_BUILT_IN(LAST_INTERPOLATION_TAG, m_LastInterpolationTime)
     } while (traverser.next());
 
     return true;
@@ -88,6 +91,7 @@ void CCalendarComponent::acceptPersistInserter(core::CStatePersistInserter& inse
     inserter.insertLevel(BUCKETING_TAG,
                          std::bind(&CCalendarComponentAdaptiveBucketing::acceptPersistInserter,
                                    &m_Bucketing, std::placeholders::_1));
+    inserter.insertValue(LAST_INTERPOLATION_TAG, m_LastInterpolationTime);
 }
 
 bool CCalendarComponent::initialized() const {
@@ -119,6 +123,11 @@ void CCalendarComponent::add(core_t::TTime time, double value, double weight) {
     m_Bucketing.add(time, value, weight);
 }
 
+bool CCalendarComponent::shouldInterpolate(core_t::TTime time) const {
+    return CIntegerTools::floor(time, this->feature().repeat()) !=
+           CIntegerTools::floor(m_LastInterpolationTime, this->feature().repeat());
+}
+
 void CCalendarComponent::interpolate(core_t::TTime time, bool refine) {
     if (refine) {
         m_Bucketing.refine(time);
@@ -129,6 +138,7 @@ void CCalendarComponent::interpolate(core_t::TTime time, bool refine) {
     if (m_Bucketing.knots(time, this->boundaryCondition(), knots, values, variances)) {
         this->CDecompositionComponent::interpolate(knots, values, variances);
     }
+    m_LastInterpolationTime = time;
 }
 
 double CCalendarComponent::decayRate() const {
@@ -167,9 +177,10 @@ double CCalendarComponent::meanVariance() const {
     return this->CDecompositionComponent::meanVariance();
 }
 
-uint64_t CCalendarComponent::checksum(uint64_t seed) const {
+std::uint64_t CCalendarComponent::checksum(std::uint64_t seed) const {
     seed = this->CDecompositionComponent::checksum(seed);
-    return CChecksum::calculate(seed, m_Bucketing);
+    seed = CChecksum::calculate(seed, m_Bucketing);
+    return CChecksum::calculate(seed, m_LastInterpolationTime);
 }
 
 void CCalendarComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {

--- a/lib/maths/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/CCalendarComponentAdaptiveBucketing.cc
@@ -130,7 +130,7 @@ void CCalendarComponentAdaptiveBucketing::propagateForwardsByTime(double time) {
 }
 
 double CCalendarComponentAdaptiveBucketing::count(core_t::TTime time) const {
-    const TFloatMeanVarAccumulator* value = this->value(time);
+    const TFloatMeanVarAccumulator* value{this->value(time)};
     return value ? static_cast<double>(CBasicStatistics::count(*value)) : 0.0;
 }
 

--- a/lib/maths/CCalendarFeature.cc
+++ b/lib/maths/CCalendarFeature.cc
@@ -57,7 +57,7 @@ std::string print_(int count, bool suffix) {
 CCalendarFeature::CCalendarFeature() : m_Feature(INVALID), m_Value(INVALID) {
 }
 
-CCalendarFeature::CCalendarFeature(uint16_t feature, core_t::TTime time)
+CCalendarFeature::CCalendarFeature(std::uint16_t feature, core_t::TTime time)
     : m_Feature(INVALID), m_Value(INVALID) {
     int dayOfWeek{};
     int dayOfMonth{};
@@ -86,7 +86,8 @@ CCalendarFeature::TCalendarFeature4Ary CCalendarFeature::features(core_t::TTime 
                                                month, year, secondsSinceMidnight)) {
         dayOfMonth -= 1;
         auto i = result.begin();
-        for (uint16_t feature = BEGIN_FEATURES; feature < END_FEATURES; ++feature, ++i) {
+        for (std::uint16_t feature = BEGIN_FEATURES; feature < END_FEATURES;
+             ++feature, ++i) {
             i->initialize(feature, dayOfWeek, dayOfMonth, month, year);
         }
     } else {
@@ -95,23 +96,23 @@ CCalendarFeature::TCalendarFeature4Ary CCalendarFeature::features(core_t::TTime 
     return result;
 }
 
-void CCalendarFeature::initialize(uint16_t feature, int dayOfWeek, int dayOfMonth, int month, int year) {
+void CCalendarFeature::initialize(std::uint16_t feature, int dayOfWeek, int dayOfMonth, int month, int year) {
     switch (feature) {
     case DAYS_SINCE_START_OF_MONTH:
         m_Feature = feature;
-        m_Value = static_cast<uint16_t>(dayOfMonth);
+        m_Value = static_cast<std::uint16_t>(dayOfMonth);
         break;
     case DAYS_BEFORE_END_OF_MONTH:
         m_Feature = feature;
-        m_Value = static_cast<uint16_t>(lastDayInMonth(year, month) - dayOfMonth);
+        m_Value = static_cast<std::uint16_t>(lastDayInMonth(year, month) - dayOfMonth);
         break;
     case DAY_OF_WEEK_AND_WEEKS_SINCE_START_OF_MONTH:
         m_Feature = feature;
-        m_Value = static_cast<uint16_t>(8 * (dayOfMonth / 7) + dayOfWeek);
+        m_Value = static_cast<std::uint16_t>(8 * (dayOfMonth / 7) + dayOfWeek);
         break;
     case DAY_OF_WEEK_AND_WEEKS_BEFORE_END_OF_MONTH:
         m_Feature = feature;
-        m_Value = static_cast<uint16_t>(
+        m_Value = static_cast<std::uint16_t>(
             8 * ((lastDayInMonth(year, month) - dayOfMonth) / 7) + dayOfWeek);
         break;
     default:
@@ -123,8 +124,8 @@ void CCalendarFeature::initialize(uint16_t feature, int dayOfWeek, int dayOfMont
 bool CCalendarFeature::fromDelimited(const std::string& value) {
     int state[2]{0, 0};
     if (core::CPersistUtils::fromString(value, std::begin(state), std::end(state))) {
-        m_Feature = static_cast<uint16_t>(state[0]);
-        m_Value = static_cast<uint16_t>(state[1]);
+        m_Feature = static_cast<std::uint16_t>(state[0]);
+        m_Value = static_cast<std::uint16_t>(state[1]);
         return true;
     }
     return false;
@@ -197,7 +198,11 @@ core_t::TTime CCalendarFeature::window() const {
     return core::constants::DAY;
 }
 
-uint64_t CCalendarFeature::checksum(uint64_t seed) const {
+core_t::TTime CCalendarFeature::repeat() const {
+    return 30 * core::constants::DAY;
+}
+
+std::uint64_t CCalendarFeature::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_Feature);
     return CChecksum::calculate(seed, m_Value);
 }
@@ -222,7 +227,7 @@ std::string CCalendarFeature::print() const {
     return "-";
 }
 
-const uint16_t CCalendarFeature::INVALID(boost::numeric::bounds<uint16_t>::highest());
+const std::uint16_t CCalendarFeature::INVALID(std::numeric_limits<std::uint16_t>::max());
 
 std::ostream& operator<<(std::ostream& strm, const CCalendarFeature& feature) {
     return strm << feature.print();

--- a/lib/maths/CCalendarFeature.cc
+++ b/lib/maths/CCalendarFeature.cc
@@ -14,8 +14,7 @@
 #include <maths/CChecksum.h>
 #include <maths/CIntegerTools.h>
 
-#include <boost/numeric/conversion/bounds.hpp>
-
+#include <limits>
 #include <ostream>
 
 namespace ml {

--- a/lib/maths/CCalendarFeature.cc
+++ b/lib/maths/CCalendarFeature.cc
@@ -54,9 +54,6 @@ std::string print_(int count, bool suffix) {
 }
 }
 
-CCalendarFeature::CCalendarFeature() : m_Feature(INVALID), m_Value(INVALID) {
-}
-
 CCalendarFeature::CCalendarFeature(std::uint16_t feature, core_t::TTime time)
     : m_Feature(INVALID), m_Value(INVALID) {
     int dayOfWeek{};
@@ -132,9 +129,9 @@ bool CCalendarFeature::fromDelimited(const std::string& value) {
 }
 
 std::string CCalendarFeature::toDelimited() const {
-    int state[2] = {static_cast<int>(m_Feature), static_cast<int>(m_Value)};
-    const int* begin = std::begin(state);
-    const int* end = std::end(state);
+    int state[2]{static_cast<int>(m_Feature), static_cast<int>(m_Value)};
+    const int* begin{std::begin(state)};
+    const int* end{std::end(state)};
     return core::CPersistUtils::toString(begin, end);
 }
 
@@ -190,16 +187,12 @@ core_t::TTime CCalendarFeature::offset(core_t::TTime time) const {
 }
 
 bool CCalendarFeature::inWindow(core_t::TTime time) const {
-    core_t::TTime offset = this->offset(time);
+    core_t::TTime offset{this->offset(time)};
     return offset >= 0 && offset < this->window();
 }
 
 core_t::TTime CCalendarFeature::window() const {
     return core::constants::DAY;
-}
-
-core_t::TTime CCalendarFeature::repeat() const {
-    return 30 * core::constants::DAY;
 }
 
 std::uint64_t CCalendarFeature::checksum(std::uint64_t seed) const {

--- a/lib/maths/CSeasonalComponent.cc
+++ b/lib/maths/CSeasonalComponent.cc
@@ -19,10 +19,8 @@
 #include <maths/CSampling.h>
 #include <maths/CSeasonalTime.h>
 
-#include <boost/math/distributions/chi_squared.hpp>
-#include <boost/math/distributions/normal.hpp>
-
 #include <cmath>
+#include <limits>
 #include <vector>
 
 namespace ml {
@@ -34,6 +32,7 @@ using TDoubleDoublePr = maths_t::TDoubleDoublePr;
 const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
 const core::TPersistenceTag RNG_TAG{"b", "rng"};
 const core::TPersistenceTag BUCKETING_TAG{"c", "bucketing"};
+const core::TPersistenceTag LAST_INTERPOLATION_TAG{"d", "last_interpolation_time"};
 const std::string EMPTY_STRING;
 }
 
@@ -46,7 +45,8 @@ CSeasonalComponent::CSeasonalComponent(const CSeasonalTime& time,
                                        CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{maxSize, boundaryCondition,
                               valueInterpolationType, varianceInterpolationType},
-      m_Bucketing{time, decayRate, minimumBucketLength} {
+      m_Bucketing{time, decayRate, minimumBucketLength},
+      m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
 }
 
 CSeasonalComponent::CSeasonalComponent(double decayRate,
@@ -55,7 +55,8 @@ CSeasonalComponent::CSeasonalComponent(double decayRate,
                                        CSplineTypes::EType valueInterpolationType,
                                        CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{0, CSplineTypes::E_Periodic,
-                              valueInterpolationType, varianceInterpolationType} {
+                              valueInterpolationType, varianceInterpolationType},
+      m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
     traverser.traverseSubLevel(std::bind(&CSeasonalComponent::acceptRestoreTraverser,
                                          this, decayRate, minimumBucketLength,
                                          std::placeholders::_1));
@@ -65,6 +66,7 @@ void CSeasonalComponent::swap(CSeasonalComponent& other) {
     this->CDecompositionComponent::swap(other);
     std::swap(m_Rng, other.m_Rng);
     m_Bucketing.swap(other.m_Bucketing);
+    std::swap(m_LastInterpolationTime, other.m_LastInterpolationTime);
 }
 
 bool CSeasonalComponent::acceptRestoreTraverser(double decayRate,
@@ -81,6 +83,7 @@ bool CSeasonalComponent::acceptRestoreTraverser(double decayRate,
                                CSeasonalComponentAdaptiveBucketing bucketing(
                                    decayRate, minimumBucketLength, traverser),
                                true, m_Bucketing.swap(bucketing))
+        RESTORE_BUILT_IN(LAST_INTERPOLATION_TAG, m_LastInterpolationTime)
     } while (traverser.next());
 
     return true;
@@ -95,6 +98,7 @@ void CSeasonalComponent::acceptPersistInserter(core::CStatePersistInserter& inse
     inserter.insertLevel(BUCKETING_TAG,
                          std::bind(&CSeasonalComponentAdaptiveBucketing::acceptPersistInserter,
                                    &m_Bucketing, std::placeholders::_1));
+    inserter.insertValue(LAST_INTERPOLATION_TAG, m_LastInterpolationTime);
 }
 
 bool CSeasonalComponent::initialized() const {
@@ -106,7 +110,7 @@ bool CSeasonalComponent::initialize(core_t::TTime startTime,
                                     const TFloatMeanAccumulatorVec& values) {
     this->clear();
 
-    if (!m_Bucketing.initialize(this->maxSize())) {
+    if (m_Bucketing.initialize(this->maxSize()) == false) {
         LOG_ERROR(<< "Bad input size: " << this->maxSize());
         return false;
     }
@@ -141,25 +145,42 @@ void CSeasonalComponent::shiftSlope(core_t::TTime time, double shift) {
 }
 
 void CSeasonalComponent::linearScale(core_t::TTime time, double scale) {
+    const auto& time_ = m_Bucketing.time();
+    core_t::TTime startOfWindow{time_.startOfWindow(time) +
+                                (time_.inWindow(time) ? 0 : time_.windowRepeat())};
+    time = time <= startOfWindow ? startOfWindow : time_.startOfPeriod(time);
     m_Bucketing.linearScale(time, scale);
     this->interpolate(time, false);
 }
 
-void CSeasonalComponent::add(core_t::TTime time, double value, double weight) {
+void CSeasonalComponent::add(core_t::TTime time, double value, double weight, double gradientLearnRate) {
     double predicted{CBasicStatistics::mean(this->value(this->jitter(time), 0.0))};
-    m_Bucketing.add(time, value, predicted, weight);
+    m_Bucketing.add(time, value, predicted, weight, gradientLearnRate);
+}
+
+bool CSeasonalComponent::shouldInterpolate(core_t::TTime time) const {
+    const auto& time_ = m_Bucketing.time();
+    return time_.startOfPeriod(time) > time_.startOfPeriod(m_LastInterpolationTime);
 }
 
 void CSeasonalComponent::interpolate(core_t::TTime time, bool refine) {
     if (refine) {
         m_Bucketing.refine(time);
     }
+
+    const auto& time_ = m_Bucketing.time();
+    core_t::TTime startOfWindow{time_.startOfWindow(time) +
+                                (time_.inWindow(time) ? 0 : time_.windowRepeat())};
+
     TDoubleVec knots;
     TDoubleVec values;
     TDoubleVec variances;
-    if (m_Bucketing.knots(time, this->boundaryCondition(), knots, values, variances)) {
+    if (m_Bucketing.knots(time <= startOfWindow ? startOfWindow : time_.startOfPeriod(time),
+                          this->boundaryCondition(), knots, values, variances)) {
         this->CDecompositionComponent::interpolate(knots, values, variances);
     }
+    m_LastInterpolationTime = time_.startOfPeriod(time);
+    LOG_TRACE(<< "last interpolation time = " << m_LastInterpolationTime);
 }
 
 double CSeasonalComponent::decayRate() const {
@@ -176,6 +197,10 @@ void CSeasonalComponent::propagateForwardsByTime(double time, double meanRevertF
 
 const CSeasonalTime& CSeasonalComponent::time() const {
     return m_Bucketing.time();
+}
+
+const CSeasonalComponentAdaptiveBucketing& CSeasonalComponent::bucketing() const {
+    return m_Bucketing;
 }
 
 TDoubleDoublePr CSeasonalComponent::value(core_t::TTime time, double confidence) const {
@@ -253,7 +278,7 @@ double CSeasonalComponent::meanVariance() const {
 bool CSeasonalComponent::covariances(core_t::TTime time, TMatrix& result) const {
     result = TMatrix(0.0);
 
-    if (!this->initialized()) {
+    if (this->initialized() == false) {
         return false;
     }
 
@@ -277,9 +302,10 @@ bool CSeasonalComponent::slopeAccurate(core_t::TTime time) const {
     return m_Bucketing.slopeAccurate(time);
 }
 
-uint64_t CSeasonalComponent::checksum(uint64_t seed) const {
+std::uint64_t CSeasonalComponent::checksum(std::uint64_t seed) const {
     seed = this->CDecompositionComponent::checksum(seed);
-    return CChecksum::calculate(seed, m_Bucketing);
+    seed = CChecksum::calculate(seed, m_Bucketing);
+    return CChecksum::calculate(seed, m_LastInterpolationTime);
 }
 
 void CSeasonalComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -179,28 +179,36 @@ void CSeasonalComponentAdaptiveBucketing::shiftLevel(double shift) {
 
 void CSeasonalComponentAdaptiveBucketing::shiftSlope(core_t::TTime time, double shift) {
     if (std::fabs(shift) > 0.0) {
-        for (auto& bucket : m_Buckets) {
-            bucket.s_Regression.shiftGradient(shift);
-            bucket.s_Regression.shiftOrdinate(-shift * m_Time->regression(time));
+        for (std::size_t i = 0; i < m_Buckets.size(); ++i) {
+            m_Buckets[i].s_Regression.shiftGradient(shift);
+            m_Buckets[i].s_Regression.shiftOrdinate(-shift * m_Time->regression(time));
         }
     }
 }
 
 void CSeasonalComponentAdaptiveBucketing::linearScale(core_t::TTime time, double scale) {
-    for (auto& bucket : m_Buckets) {
-        double gradientBefore{gradient(bucket.s_Regression)};
-        bucket.s_Regression.linearScale(scale);
-        double gradientAfter{gradient(bucket.s_Regression)};
-        bucket.s_Regression.shiftGradient(gradientBefore - gradientAfter);
-        bucket.s_Regression.shiftOrdinate(-(gradientBefore - gradientAfter) *
-                                          m_Time->regression(time));
+    const auto& centres = this->centres();
+    for (std::size_t i = 0; i < m_Buckets.size(); ++i) {
+        if (scale <= 1.0) {
+            m_Buckets[i].s_Regression.linearScale(scale);
+        } else {
+            double gradientBefore{gradient(m_Buckets[i].s_Regression)};
+            m_Buckets[i].s_Regression.linearScale(scale);
+            double gradientAfter{gradient(m_Buckets[i].s_Regression)};
+
+            core_t::TTime bucketTime{time + static_cast<core_t::TTime>(centres[i] + 0.5)};
+            m_Buckets[i].s_Regression.shiftGradient(gradientBefore - gradientAfter);
+            m_Buckets[i].s_Regression.shiftOrdinate(
+                (gradientAfter - gradientBefore) * m_Time->regression(bucketTime));
+        }
     }
 }
 
 void CSeasonalComponentAdaptiveBucketing::add(core_t::TTime time,
                                               double value,
                                               double prediction,
-                                              double weight) {
+                                              double weight,
+                                              double gradientLearnRate) {
     std::size_t bucket{0};
     if (this->initialized() == false || this->bucket(time, bucket) == false) {
         return;
@@ -213,26 +221,36 @@ void CSeasonalComponentAdaptiveBucketing::add(core_t::TTime time,
     double t{m_Time->regression(time)};
     TRegression& regression{bucket_.s_Regression};
 
-    TDoubleMeanVarAccumulator moments = CBasicStatistics::momentsAccumulator(
-        regression.count(), prediction, static_cast<double>(bucket_.s_Variance));
+    TDoubleMeanVarAccumulator moments{CBasicStatistics::momentsAccumulator(
+        regression.count(), prediction, static_cast<double>(bucket_.s_Variance))};
     moments.add(value, weight * weight);
 
-    regression.add(t, value, weight);
-    bucket_.s_Variance = CBasicStatistics::maximumLikelihoodVariance(moments);
+    if (m_Time->regressionInterval(bucket_.s_FirstUpdate, bucket_.s_LastUpdate) <
+        SUFFICIENT_INTERVAL_TO_ESTIMATE_SLOPE) {
+        regression.add(t, value, weight);
+        double gradientAfter{gradient(regression)};
+        regression.shiftGradient(-gradientAfter);
+        regression.shiftOrdinate(gradientAfter * t);
+    } else if (gradientLearnRate < 1.0) {
+        double gradientBefore{gradient(regression)};
+        regression.add(t, value, weight);
+        double gradientAfter{gradient(regression)};
+        if (std::fabs(gradientAfter) > std::fabs(gradientBefore)) {
+            regression.shiftGradient((1.0 - gradientLearnRate) *
+                                     (gradientBefore - gradientAfter));
+            regression.shiftOrdinate((1.0 - gradientLearnRate) *
+                                     (gradientAfter - gradientBefore) * t);
+        }
+    } else {
+        regression.add(t, value, weight);
+    }
 
     if (std::fabs(value - prediction) >
         LARGE_ERROR_STANDARD_DEVIATIONS * std::sqrt(bucket_.s_Variance)) {
         this->addLargeError(bucket, time);
     }
 
-    if (m_Time->regressionInterval(bucket_.s_FirstUpdate, bucket_.s_LastUpdate) <
-        SUFFICIENT_INTERVAL_TO_ESTIMATE_SLOPE) {
-        double delta{regression.predict(t)};
-        regression.shiftGradient(-gradient(regression));
-        delta -= regression.predict(t);
-        regression.shiftOrdinate(delta);
-    }
-
+    bucket_.s_Variance = CBasicStatistics::maximumLikelihoodVariance(moments);
     bucket_.s_FirstUpdate = bucket_.s_FirstUpdate == UNSET_TIME
                                 ? time
                                 : std::min(bucket_.s_FirstUpdate, time);
@@ -249,7 +267,7 @@ void CSeasonalComponentAdaptiveBucketing::propagateForwardsByTime(double time, d
     if (time < 0.0) {
         LOG_ERROR(<< "Can't propagate bucketing backwards in time");
     } else if (this->initialized()) {
-        double factor{std::exp(-this->decayRate() * m_Time->fractionInWindow() * time)};
+        double factor{std::exp(-this->decayRate() * time)};
         this->age(factor);
         for (auto& bucket : m_Buckets) {
             bucket.s_Regression.age(factor, meanRevertFactor);

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -179,9 +179,9 @@ void CSeasonalComponentAdaptiveBucketing::shiftLevel(double shift) {
 
 void CSeasonalComponentAdaptiveBucketing::shiftSlope(core_t::TTime time, double shift) {
     if (std::fabs(shift) > 0.0) {
-        for (std::size_t i = 0; i < m_Buckets.size(); ++i) {
-            m_Buckets[i].s_Regression.shiftGradient(shift);
-            m_Buckets[i].s_Regression.shiftOrdinate(-shift * m_Time->regression(time));
+        for (auto& bucket : m_Buckets) {
+            bucket.s_Regression.shiftGradient(shift);
+            bucket.s_Regression.shiftOrdinate(-shift * m_Time->regression(time));
         }
     }
 }

--- a/lib/maths/CSeasonalTime.cc
+++ b/lib/maths/CSeasonalTime.cc
@@ -61,6 +61,11 @@ double CSeasonalTime::regressionInterval(core_t::TTime start, core_t::TTime end)
            static_cast<double>(this->regressionTimeScale());
 }
 
+core_t::TTime CSeasonalTime::startOfPeriod(core_t::TTime time) const {
+    core_t::TTime startOfWindow{this->startOfWindow(time)};
+    return startOfWindow + CIntegerTools::floor(time - startOfWindow, m_Period);
+}
+
 core_t::TTime CSeasonalTime::startOfWindowRepeat(core_t::TTime time) const {
     return this->startOfWindowRepeat(this->windowRepeatStart(), time);
 }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -2975,9 +2975,8 @@ bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::shouldInterpolate(c
 void CTimeSeriesDecompositionDetail::CComponents::CCalendar::interpolate(core_t::TTime time,
                                                                          bool refine) {
     for (auto& component : m_Components) {
-        CCalendarFeature feature = component.feature();
         if (component.shouldInterpolate(time)) {
-            component.interpolate(time - feature.offset(time), refine);
+            component.interpolate(time, refine);
         }
     }
 }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -1773,7 +1773,7 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SAddValue& messag
             CSeasonalComponent* component{seasonalComponents[i - 1]};
             CComponentErrors* error_{seasonalErrors[i - 1]};
             double varianceIncrease{variance == 0.0 ? 1.0 : variances[i] / variance / expectedVarianceIncrease};
-            component->add(time, values[i], weight);
+            component->add(time, values[i], weight, 0.5);
             error_->add(referenceError, error, predictions[i - 1], varianceIncrease, weight);
         }
         for (std::size_t i = m + 1; i <= m + n; ++i) {
@@ -1885,12 +1885,12 @@ void CTimeSeriesDecompositionDetail::CComponents::handle(const SDetectedChangePo
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::interpolateForForecast(core_t::TTime time) {
-    if (this->shouldInterpolate(time, time - m_BucketLength)) {
+    if (this->shouldInterpolate(time)) {
         if (m_Seasonal != nullptr) {
-            m_Seasonal->interpolate(time, time - m_BucketLength, false);
+            m_Seasonal->interpolate(time, false);
         }
         if (m_Calendar != nullptr) {
-            m_Calendar->interpolate(time, time - m_BucketLength, true);
+            m_Calendar->interpolate(time, true);
         }
     }
 }
@@ -2224,24 +2224,21 @@ bool CTimeSeriesDecompositionDetail::CComponents::shouldUseTrendForPrediction() 
     return m_UsingTrendForPrediction;
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::shouldInterpolate(core_t::TTime time,
-                                                                    core_t::TTime last) {
+bool CTimeSeriesDecompositionDetail::CComponents::shouldInterpolate(core_t::TTime time) {
     return m_Machine.state() == SC_NEW_COMPONENTS ||
-           (m_Seasonal && m_Seasonal->shouldInterpolate(time, last)) ||
-           (m_Calendar && m_Calendar->shouldInterpolate(time, last));
+           (m_Seasonal && m_Seasonal->shouldInterpolate(time)) ||
+           (m_Calendar && m_Calendar->shouldInterpolate(time));
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::interpolate(const SMessage& message) {
     core_t::TTime time{message.s_Time};
-    core_t::TTime lastTime{message.s_LastTime};
-
     std::size_t state{m_Machine.state()};
 
     switch (state) {
     case SC_NORMAL:
     case SC_NEW_COMPONENTS:
         this->canonicalize(time);
-        if (this->shouldInterpolate(time, lastTime)) {
+        if (this->shouldInterpolate(time)) {
             LOG_TRACE(<< "Interpolating values at " << time);
 
             // As well as interpolating we also remove components that contain
@@ -2252,13 +2249,13 @@ void CTimeSeriesDecompositionDetail::CComponents::interpolate(const SMessage& me
                 if (m_Seasonal->removeComponentsWithBadValues(time)) {
                     m_ComponentChangeCallback({});
                 }
-                m_Seasonal->interpolate(time, lastTime, true);
+                m_Seasonal->interpolate(time, true);
             }
             if (m_Calendar != nullptr) {
                 if (m_Calendar->removeComponentsWithBadValues(time)) {
                     m_ComponentChangeCallback({});
                 }
-                m_Calendar->interpolate(time, lastTime, true);
+                m_Calendar->interpolate(time, true);
             }
 
             this->apply(SC_INTERPOLATED, message);
@@ -2284,6 +2281,15 @@ void CTimeSeriesDecompositionDetail::CComponents::shiftOrigin(core_t::TTime time
 
 void CTimeSeriesDecompositionDetail::CComponents::canonicalize(core_t::TTime time) {
 
+    // There is redundancy in the specification of the additive decomposition. For
+    // any collection of models {m_i} then for any set of |{m_i}| constants {c_j}
+    // satisfying sum_j c_j = 0 all models of the form m_i' = s_i + c_{j(i)} for
+    // any permutation j(.) give the same predictions. Here we choose a canonical
+    // form which minimises the values of the components to avoid issues with
+    // cancellation errors.
+
+    using TMinMaxAccumulator = CBasicStatistics::CMinMax<double>;
+
     this->shiftOrigin(time);
 
     if (m_Seasonal != nullptr && m_Seasonal->prune(time, m_BucketLength)) {
@@ -2294,17 +2300,54 @@ void CTimeSeriesDecompositionDetail::CComponents::canonicalize(core_t::TTime tim
     }
 
     if (m_Seasonal != nullptr) {
-        TSeasonalComponentVec& seasonal{m_Seasonal->components()};
-        double slope{0.0};
-        for (auto& component : seasonal) {
+        // Compute the sum level and slope for each separate window if the
+        // components are time windowed.
+        TTimeTimePrDoubleFMap levels;
+        TTimeTimePrDoubleFMap slopes;
+        TTimeTimePrDoubleFMap numberLevels;
+        TTimeTimePrDoubleFMap numberSlopes;
+        for (auto& component : m_Seasonal->components()) {
+            auto window = component.time().windowed() ? component.time().window()
+                                                      : TTimeTimePr{0, 0};
+            levels[window] += component.meanValue();
+            numberLevels[window] += 1.0;
             if (component.slopeAccurate(time)) {
-                double slope_{component.slope()};
-                slope += slope_;
-                component.shiftSlope(time, -slope_);
+                slopes[window] += component.slope();
+                numberSlopes[window] += 1.0;
             }
         }
-        if (slope != 0.0) {
-            m_Trend.shiftSlope(time, slope);
+
+        TMinMaxAccumulator commonLevel;
+        for (const auto& level : levels) {
+            commonLevel.add(level.second);
+        }
+        if (commonLevel.signMargin() != 0.0) {
+            for (auto& component : m_Seasonal->components()) {
+                auto window = component.time().windowed() ? component.time().window()
+                                                          : TTimeTimePr{0, 0};
+                component.shiftLevel((levels[window] - commonLevel.signMargin()) /
+                                         numberLevels[window] -
+                                     component.meanValue());
+            }
+            m_Trend.shiftLevel(commonLevel.signMargin());
+        }
+
+        TMinMaxAccumulator commonSlope;
+        for (const auto& slope : slopes) {
+            commonSlope.add(slope.second);
+        }
+        if (commonSlope.signMargin() != 0.0) {
+            for (auto& component : m_Seasonal->components()) {
+                if (component.slopeAccurate(time)) {
+                    auto window = component.time().windowed()
+                                      ? component.time().window()
+                                      : TTimeTimePr{0, 0};
+                    component.shiftSlope(time, (slopes[window] - commonSlope.signMargin()) /
+                                                       numberSlopes[window] -
+                                                   component.slope());
+                }
+            }
+            m_Trend.shiftSlope(time, commonSlope.signMargin());
         }
     }
 }
@@ -2358,7 +2401,12 @@ double CTimeSeriesDecompositionDetail::CComponents::CGainController::gain() cons
         TRegression::TArray params;
         m_MeanSumAmplitudesTrend.parameters(params);
         if (params[1] > 0.01 * CBasicStatistics::mean(m_MeanSumAmplitudes)) {
-            return 1.0;
+            // Anything less than one is sufficient to ensure that the basic update
+            // dynamics are stable (poles of the Z-transform inside the unit circle).
+            // There are however other factors at play which are hard to quantify
+            // such as the sample weight and the fact that there's a lag detecting
+            // instability. This gives us a margin for error.
+            return 0.8;
         }
     }
     return 3.0;
@@ -2623,14 +2671,9 @@ void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::appendPredictions(
     }
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::shouldInterpolate(
-    core_t::TTime time,
-    core_t::TTime last) const {
+bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::shouldInterpolate(core_t::TTime time) const {
     for (const auto& component : m_Components) {
-        core_t::TTime period{component.time().period()};
-        core_t::TTime a{CIntegerTools::floor(last, period)};
-        core_t::TTime b{CIntegerTools::floor(time, period)};
-        if (b > a) {
+        if (component.shouldInterpolate(time)) {
             return true;
         }
     }
@@ -2638,14 +2681,10 @@ bool CTimeSeriesDecompositionDetail::CComponents::CSeasonal::shouldInterpolate(
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::interpolate(core_t::TTime time,
-                                                                         core_t::TTime lastTime,
                                                                          bool refine) {
     for (auto& component : m_Components) {
-        core_t::TTime period{component.time().period()};
-        core_t::TTime a{CIntegerTools::floor(lastTime, period)};
-        core_t::TTime b{CIntegerTools::floor(time, period)};
-        if (b > a || component.initialized() == false) {
-            component.interpolate(b, refine);
+        if (component.shouldInterpolate(time)) {
+            component.interpolate(time, refine);
         }
     }
 }
@@ -2670,7 +2709,7 @@ void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::add(
     const TFloatMeanAccumulatorVec& values) {
     m_Components.emplace_back(seasonalTime, size, decayRate, bucketLength, boundaryCondition);
     m_Components.back().initialize(startTime, endTime, values);
-    m_Components.back().interpolate(CIntegerTools::floor(endTime, seasonalTime.period()));
+    m_Components.back().interpolate(endTime);
     m_PredictionErrors.emplace_back();
 }
 
@@ -2924,12 +2963,9 @@ void CTimeSeriesDecompositionDetail::CComponents::CCalendar::appendPredictions(
     }
 }
 
-bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::shouldInterpolate(
-    core_t::TTime time,
-    core_t::TTime last) const {
+bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::shouldInterpolate(core_t::TTime time) const {
     for (const auto& component : m_Components) {
-        CCalendarFeature feature = component.feature();
-        if (feature.inWindow(time) == false && feature.inWindow(last)) {
+        if (component.shouldInterpolate(time)) {
             return true;
         }
     }
@@ -2937,11 +2973,10 @@ bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::shouldInterpolate(
 }
 
 void CTimeSeriesDecompositionDetail::CComponents::CCalendar::interpolate(core_t::TTime time,
-                                                                         core_t::TTime lastTime,
                                                                          bool refine) {
     for (auto& component : m_Components) {
         CCalendarFeature feature = component.feature();
-        if (feature.inWindow(time) == false && feature.inWindow(lastTime)) {
+        if (component.shouldInterpolate(time)) {
             component.interpolate(time - feature.offset(time), refine);
         }
     }

--- a/lib/maths/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/CTimeSeriesDecompositionDetail.cc
@@ -2595,7 +2595,7 @@ void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::propagateForwards(c
     for (std::size_t i = 0; i < m_Components.size(); ++i) {
         core_t::TTime period{m_Components[i].time().period()};
         stepwisePropagateForwards(start, end, period, [&](double time) {
-            m_Components[i].propagateForwardsByTime(time / 8.0, 0.25);
+            m_Components[i].propagateForwardsByTime(time / 6.0, 0.25);
             m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
         });
     }
@@ -2902,7 +2902,7 @@ void CTimeSeriesDecompositionDetail::CComponents::CCalendar::propagateForwards(c
                                                                                core_t::TTime end) {
     for (std::size_t i = 0; i < m_Components.size(); ++i) {
         stepwisePropagateForwards(start, end, MONTH, [&](double time) {
-            m_Components[i].propagateForwardsByTime(time / 8.0);
+            m_Components[i].propagateForwardsByTime(time / 6.0);
             m_PredictionErrors[i].age(std::exp(-m_Components[i].decayRate() * time));
         });
     }

--- a/lib/maths/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/CTimeSeriesTestForSeasonality.cc
@@ -111,6 +111,7 @@ CNewSeasonalComponentSummary::seasonalTime() const {
     auto interval = [this](std::size_t i) {
         return m_BucketLength * static_cast<core_t::TTime>(i);
     };
+
     if ((m_PeriodDescriptor & E_Diurnal) != 0) {
         core_t::TTime period{[this] {
             if (m_PeriodDescriptor == E_Day) {
@@ -147,11 +148,13 @@ CNewSeasonalComponentSummary::seasonalTime() const {
                                         core::constants::WEEK};
             return std::make_unique<CDiurnalTime>(startOfWeek, windowStart, windowEnd, period);
         }
-        return std::make_unique<CDiurnalTime>(0, 0, core::constants::WEEK, period);
+        return std::make_unique<CGeneralPeriodTime>(period);
     }
+
     if (m_PeriodDescriptor == E_Year) {
         return std::make_unique<CGeneralPeriodTime>(core::constants::YEAR);
     }
+
     return std::make_unique<CGeneralPeriodTime>(interval(m_Period.s_Period));
 }
 

--- a/lib/maths/unittest/CDecayRateControllerTest.cc
+++ b/lib/maths/unittest/CDecayRateControllerTest.cc
@@ -69,6 +69,8 @@ BOOST_AUTO_TEST_CASE(testOrderedErrors) {
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {
+    // Test persist and restore preserves checksums.
+
     test::CRandomNumbers rng;
 
     TDoubleVec values;

--- a/lib/maths/unittest/CForecastTest.cc
+++ b/lib/maths/unittest/CForecastTest.cc
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(testComplexVaryingLongTermTrend) {
     test.bucketLength(bucketLength)
         .daysToLearn(98)
         .noiseVariance(4.0)
-        .maximumPercentageOutOfBounds(17.0)
+        .maximumPercentageOutOfBounds(23.0)
         .maximumError(0.05)
         .run(trend);
 }

--- a/lib/maths/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/unittest/CSeasonalComponentTest.cc
@@ -11,6 +11,8 @@
 #include <core/Constants.h>
 
 #include <maths/CIntegerTools.h>
+#include <maths/CLeastSquaresOnlineRegression.h>
+#include <maths/CLeastSquaresOnlineRegressionDetail.h>
 #include <maths/COrderings.h>
 #include <maths/CSeasonalComponent.h>
 #include <maths/CSeasonalTime.h>
@@ -42,40 +44,27 @@ public:
     using maths::CSeasonalComponent::initialize;
 
 public:
-    CTestSeasonalComponent(
-        core_t::TTime startTime,
-        core_t::TTime period,
-        std::size_t space,
-        double decayRate = 0.0,
-        double minimumBucketLength = 0.0,
-        maths::CSplineTypes::EBoundaryCondition boundaryCondition = maths::CSplineTypes::E_Periodic,
-        maths::CSplineTypes::EType valueInterpolationType = maths::CSplineTypes::E_Cubic,
-        maths::CSplineTypes::EType varianceInterpolationType = maths::CSplineTypes::E_Linear)
-        : maths::CSeasonalComponent(maths::CDiurnalTime(0, 0, core::constants::WEEK, period),
-                                    space,
-                                    decayRate,
-                                    minimumBucketLength,
-                                    boundaryCondition,
-                                    valueInterpolationType,
-                                    varianceInterpolationType),
-          m_StartTime(startTime) {}
+    CTestSeasonalComponent(core_t::TTime period,
+                           std::size_t space,
+                           double decayRate = 0.0,
+                           double minimumBucketLength = 0.0)
+        : maths::CSeasonalComponent(maths::CGeneralPeriodTime{period}, space, decayRate, minimumBucketLength) {
+        this->initialize();
+    }
+    CTestSeasonalComponent(const maths::CSeasonalTime& time,
+                           std::size_t space,
+                           double decayRate = 0.0,
+                           double minimumBucketLength = 0.0)
+        : maths::CSeasonalComponent(time, space, decayRate, minimumBucketLength) {
+        this->initialize();
+    }
 
     void addPoint(core_t::TTime time, double value, double weight = 1.0) {
-        core_t::TTime period = this->time().period();
-        if (time > m_StartTime + period) {
-            this->updateStartOfCurrentPeriodAndInterpolate(time);
+        if (this->shouldInterpolate(time)) {
+            this->interpolate(time);
         }
         this->maths::CSeasonalComponent::add(time, value, weight);
     }
-
-    void updateStartOfCurrentPeriodAndInterpolate(core_t::TTime time) {
-        core_t::TTime period = this->time().period();
-        this->interpolate(maths::CIntegerTools::floor(time, period));
-        m_StartTime = maths::CIntegerTools::floor(time, period);
-    }
-
-private:
-    core_t::TTime m_StartTime;
 };
 
 void generateSeasonalValues(test::CRandomNumbers& rng,
@@ -115,7 +104,114 @@ double mean(const TDoubleDoublePr& x) {
 }
 }
 
-BOOST_AUTO_TEST_CASE(testNoPeriodicity) {
+BOOST_AUTO_TEST_CASE(testSwap) {
+
+    // Test swap preserves object checksums.
+
+    TTimeDoublePrVec function;
+    for (std::size_t i = 0; i < 25; ++i) {
+        function.emplace_back((i * core::constants::DAY) / 24,
+                              0.1 * static_cast<double>(i));
+    }
+
+    test::CRandomNumbers rng;
+
+    std::size_t n{100};
+
+    TTimeDoublePrVec samples;
+    generateSeasonalValues(rng, function, 0, 3 * core::constants::DAY, n, samples);
+
+    CTestSeasonalComponent seasonal1(core::constants::DAY, 24);
+    CTestSeasonalComponent seasonal2(core::constants::DAY, 24);
+    for (std::size_t i = 0; i < n; ++i) {
+        seasonal1.addPoint(samples[i].first, samples[i].second);
+        seasonal2.addPoint(samples[i].first,
+                           0.01 * static_cast<double>(samples[i].first) +
+                               samples[i].second);
+    }
+    seasonal1.interpolate(3 * core::constants::DAY);
+    seasonal2.interpolate(3 * core::constants::DAY);
+
+    std::uint64_t checksum1{seasonal1.checksum()};
+    std::uint64_t checksum2{seasonal2.checksum()};
+
+    seasonal1.swap(seasonal2);
+
+    BOOST_REQUIRE_EQUAL(checksum1, seasonal2.checksum());
+    BOOST_REQUIRE_EQUAL(checksum2, seasonal1.checksum());
+}
+
+BOOST_AUTO_TEST_CASE(testShouldInterpolate) {
+    // Test should interpolate is true at the times we expect.
+
+    // Vanilla...
+    for (core_t::TTime period : {core::constants::DAY, core::constants::WEEK}) {
+        LOG_DEBUG(<< "period = " << period);
+
+        maths::CGeneralPeriodTime time{period};
+        maths::CSeasonalComponent component{time, 36};
+        BOOST_REQUIRE(component.shouldInterpolate(0));
+        component.interpolate(0);
+
+        for (core_t::TTime startTime = 0; startTime < 2 * period; startTime += period) {
+            core_t::TTime t{startTime};
+            for (/**/; t < startTime + period; t += core::constants::HOUR) {
+                if (component.shouldInterpolate(t))
+                    LOG_DEBUG(<< t);
+                BOOST_REQUIRE_EQUAL(false, component.shouldInterpolate(t));
+            }
+            BOOST_REQUIRE(component.shouldInterpolate(t));
+            component.interpolate(t);
+        }
+        // Gap...
+        BOOST_REQUIRE(component.shouldInterpolate(5 * core::constants::WEEK));
+    }
+
+    // Time windowed...
+    for (core_t::TTime startOfWeek : {0, 10800}) {
+        LOG_DEBUG(<< "start of week = " << startOfWeek);
+        for (core_t::TTime period : {core::constants::DAY, core::constants::WEEK}) {
+            LOG_DEBUG(<< "period = " << period);
+
+            maths::CDiurnalTime weekendTime{startOfWeek, 0, core::constants::WEEKEND, period};
+            maths::CSeasonalComponent weekendComponent{weekendTime, 36};
+            BOOST_REQUIRE(weekendComponent.shouldInterpolate(0));
+            weekendComponent.interpolate(startOfWeek);
+            for (core_t::TTime startTime = 0; startTime < 2 * period; startTime += period) {
+                core_t::TTime time{startTime + startOfWeek};
+                for (/**/; time < startTime + startOfWeek + period;
+                     time += core::constants::HOUR) {
+                    BOOST_REQUIRE_EQUAL(false, weekendComponent.shouldInterpolate(time));
+                }
+                BOOST_REQUIRE(weekendComponent.shouldInterpolate(time));
+                weekendComponent.interpolate(time);
+            }
+            // Gap...
+            BOOST_REQUIRE(weekendComponent.shouldInterpolate(5 * core::constants::WEEK));
+
+            maths::CDiurnalTime weekdayTime{startOfWeek, core::constants::WEEKEND,
+                                            core::constants::WEEK, period};
+            maths::CSeasonalComponent weekdayComponent{weekdayTime, 36};
+            BOOST_REQUIRE(weekdayComponent.shouldInterpolate(0));
+            weekdayComponent.interpolate(startOfWeek + core::constants::WEEKEND);
+            for (core_t::TTime startTime = 0; startTime < 2 * period; startTime += period) {
+                core_t::TTime time{startTime + startOfWeek + core::constants::WEEKEND};
+                for (/**/; time < startTime + startOfWeek + core::constants::WEEKEND + period;
+                     time += core::constants::HOUR) {
+                    BOOST_REQUIRE_EQUAL(false, weekdayComponent.shouldInterpolate(time));
+                }
+                BOOST_REQUIRE(weekdayComponent.shouldInterpolate(time));
+                weekdayComponent.interpolate(time);
+            }
+            // Gap...
+            BOOST_REQUIRE(weekdayComponent.shouldInterpolate(5 * core::constants::WEEK));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testConstant) {
+    // Test that the seasonal component tends to the correct constant.
+
     const core_t::TTime startTime = 1354492800;
 
     TTimeDoublePrVec function;
@@ -125,8 +221,6 @@ BOOST_AUTO_TEST_CASE(testNoPeriodicity) {
 
     test::CRandomNumbers rng;
 
-    // Test that the seasonal component tends to flat if the
-    // values have no seasonal component.
     std::size_t n = 5000u;
 
     TTimeDoublePrVec samples;
@@ -137,12 +231,7 @@ BOOST_AUTO_TEST_CASE(testNoPeriodicity) {
     rng.generateGammaSamples(10.0, 1.2, n, residuals);
     double residualMean = maths::CBasicStatistics::mean(residuals);
 
-    CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24);
-    seasonal.initialize();
-
-    //std::ofstream file;
-    //file.open("results.m");
-    //file << "hold on;\n";
+    CTestSeasonalComponent seasonal(core::constants::DAY, 24);
 
     double totalError1 = 0.0;
     double totalError2 = 0.0;
@@ -155,15 +244,9 @@ BOOST_AUTO_TEST_CASE(testNoPeriodicity) {
 
             time += core::constants::DAY;
 
-            //std::ostringstream t;
-            //std::ostringstream ft;
-            //t << "t = [";
-            //ft << "ft = [";
             double error1 = 0.0;
             double error2 = 0.0;
             for (std::size_t j = 0u; j < function.size(); ++j) {
-                //t << time + function[j].first << " ";
-                //ft << function[j].second << " ";
                 TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
                 double f = function[j].second + residualMean;
 
@@ -171,8 +254,6 @@ BOOST_AUTO_TEST_CASE(testNoPeriodicity) {
                 error1 += std::fabs(e);
                 error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
             }
-            //t << "];\n";
-            //ft << "];\n";
 
             if (d > 1) {
                 LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
@@ -189,12 +270,6 @@ BOOST_AUTO_TEST_CASE(testNoPeriodicity) {
             BOOST_TEST_REQUIRE(error2 < 0.35);
             totalError1 += error1;
             totalError2 += error2;
-
-            //file << seasonal.print() << "\n";
-            //file << t.str();
-            //file << ft.str();
-            //file << "plot(t, ft, 'r');\n";
-            //file << "input(\"Hit any key for next period\");\n\n";
         }
     }
 
@@ -206,12 +281,12 @@ BOOST_AUTO_TEST_CASE(testNoPeriodicity) {
     BOOST_TEST_REQUIRE(totalError2 < 0.15);
 }
 
-BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
+BOOST_AUTO_TEST_CASE(testStablePeriodic) {
     const core_t::TTime startTime = 1354492800;
 
     test::CRandomNumbers rng;
 
-    // Test smooth.
+    // Test smooth...
     {
         LOG_DEBUG(<< "*** sin(2 * pi * t / 24 hrs) ***");
 
@@ -233,12 +308,7 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
         rng.generateGammaSamples(10.0, 1.2, n, residuals);
         double residualMean = maths::CBasicStatistics::mean(residuals);
 
-        CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24, 0.01);
-        seasonal.initialize();
-
-        //std::ofstream file;
-        //file.open("results.m");
-        //file << "hold on;\n";
+        CTestSeasonalComponent seasonal(core::constants::DAY, 24, 0.01);
 
         double totalError1 = 0.0;
         double totalError2 = 0.0;
@@ -251,23 +321,15 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
 
                 time += core::constants::DAY;
 
-                //std::ostringstream t;
-                //std::ostringstream ft;
-                //t << "t = [";
-                //ft << "ft = [";
                 double error1 = 0.0;
                 double error2 = 0.0;
                 for (std::size_t j = 0u; j < function.size(); ++j) {
-                    //t << time + function[j].first << " ";
-                    //ft << function[j].second << " ";
                     TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
                     double f = residualMean + function[j].second;
                     double e = mean(interval) - f;
                     error1 += std::fabs(e);
                     error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
                 }
-                //t << "];\n";
-                //ft << "];\n";
 
                 if (d > 1) {
                     LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
@@ -286,12 +348,6 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
                 totalError1 += error1;
                 totalError2 += error2;
 
-                //file << seasonal.print() << "\n";
-                //file << t.str();
-                //file << ft.str();
-                //file << "plot(t, ft, 'r');\n";
-                //file << "input(\"Hit any key for next period\");\n\n";
-
                 seasonal.propagateForwardsByTime(1.0);
             }
         }
@@ -304,11 +360,11 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
         BOOST_TEST_REQUIRE(totalError2 < 0.01);
     }
 
-    // Test high slope.
+    // Test non-smooth...
     {
         LOG_DEBUG(<< "*** piecewise linear ***");
 
-        TTimeDoublePr knotPoints[] = {
+        TTimeDoublePrVec function{
             TTimeDoublePr(0, 1.0),       TTimeDoublePr(1800, 1.0),
             TTimeDoublePr(3600, 2.0),    TTimeDoublePr(5400, 3.0),
             TTimeDoublePr(7200, 5.0),    TTimeDoublePr(9000, 5.0),
@@ -335,8 +391,6 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
             TTimeDoublePr(82800, 1.0),   TTimeDoublePr(84600, 1.0),
             TTimeDoublePr(86400, 1.0)};
 
-        TTimeDoublePrVec function(std::begin(knotPoints), std::end(knotPoints));
-
         std::size_t n = 6000u;
 
         TTimeDoublePrVec samples;
@@ -347,12 +401,7 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
         rng.generateGammaSamples(10.0, 1.2, n, residuals);
         double residualMean = maths::CBasicStatistics::mean(residuals);
 
-        CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24, 0.01);
-        seasonal.initialize();
-
-        //std::ofstream file;
-        //file.open("results.m");
-        //file << "hold on;\n";
+        CTestSeasonalComponent seasonal(core::constants::DAY, 24, 0.01);
 
         double totalError1 = 0.0;
         double totalError2 = 0.0;
@@ -364,16 +413,9 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
                 LOG_TRACE(<< "Processing day = " << ++d);
 
                 time += core::constants::DAY;
-
-                //std::ostringstream t;
-                //std::ostringstream ft;
-                //t << "t = [";
-                //ft << "ft = [";
                 double error1 = 0.0;
                 double error2 = 0.0;
                 for (std::size_t j = 0u; j < function.size(); ++j) {
-                    //t << time + function[j].first << " ";
-                    //ft << function[j].second << " ";
                     TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
                     double f = residualMean + function[j].second;
 
@@ -381,8 +423,6 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
                     error1 += std::fabs(e);
                     error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
                 }
-                //t << "];\n";
-                //ft << "];\n";
 
                 if (d > 1) {
                     LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
@@ -401,12 +441,6 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
                 totalError1 += error1;
                 totalError2 += error2;
 
-                //file << seasonal.print() << "\n";
-                //file << t.str();
-                //file << ft.str();
-                //file << "plot(t, ft, 'r');\n";
-                //file << "input(\"Hit any key for next period\");\n\n";
-
                 seasonal.propagateForwardsByTime(1.0);
             }
         }
@@ -421,12 +455,11 @@ BOOST_AUTO_TEST_CASE(testConstantPeriodic) {
 }
 
 BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
-    // Test a signal with periodicity which changes slowly
-    // over time.
+    // Test a signal with periodicity which changes slowly over time.
 
     core_t::TTime startTime = 0;
 
-    TTimeDoublePr knotPoints[] = {
+    TTimeDoublePrVec function{
         TTimeDoublePr(0, 1.0),       TTimeDoublePr(1800, 1.0),
         TTimeDoublePr(3600, 2.0),    TTimeDoublePr(5400, 3.0),
         TTimeDoublePr(7200, 5.0),    TTimeDoublePr(9000, 5.0),
@@ -453,12 +486,9 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
         TTimeDoublePr(82800, 1.0),   TTimeDoublePr(84600, 1.0),
         TTimeDoublePr(86400, 1.0)};
 
-    TTimeDoublePrVec function(std::begin(knotPoints), std::end(knotPoints));
-
     test::CRandomNumbers rng;
 
-    CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24, 0.048);
-    seasonal.initialize();
+    CTestSeasonalComponent seasonal(core::constants::DAY, 24, 0.048);
 
     core_t::TTime time = startTime;
 
@@ -484,18 +514,12 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
 
         time += core::constants::DAY;
 
-        seasonal.updateStartOfCurrentPeriodAndInterpolate(time);
+        seasonal.interpolate(time);
 
         if (seasonal.initialized()) {
-            //std::ostringstream t;
-            //std::ostringstream ft;
-            //t << "t = [";
-            //ft << "ft = [";
             double error1 = 0.0;
             double error2 = 0.0;
             for (std::size_t j = 0u; j < function.size(); ++j) {
-                //t << time + function[j].first << " ";
-                //ft << function[j].second << " ";
                 TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
                 double f = residualMean + scale * function[j].second;
 
@@ -503,8 +527,6 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
                 error1 += std::fabs(e);
                 error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
             }
-            //t << "];\n";
-            //ft << "];\n";
 
             if (d > 1) {
                 LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
@@ -523,12 +545,6 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
             totalError1 += error1;
             totalError2 += error2;
             numberErrors += 1.0;
-
-            //file << seasonal.print() << "\n";
-            //file << t.str();
-            //file << ft.str();
-            //file << "plot(t, ft, 'r');\n";
-            //file << "input(\"Hit any key for next period\");\n\n";
         }
 
         seasonal.propagateForwardsByTime(1.0);
@@ -536,8 +552,80 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
 
     LOG_DEBUG(<< "mean error 1 = " << totalError1 / numberErrors);
     LOG_DEBUG(<< "mean error 2 = " << totalError2 / numberErrors);
-    BOOST_TEST_REQUIRE(totalError1 / numberErrors < 18.0);
+    BOOST_TEST_REQUIRE(totalError1 / numberErrors < 19.0);
     BOOST_TEST_REQUIRE(totalError2 / numberErrors < 14.0);
+}
+
+BOOST_AUTO_TEST_CASE(testWindowed) {
+    // Test time windowed components.
+
+    auto trend = [](core_t::TTime time) {
+        return 0.0001 * static_cast<double>(time);
+    };
+    auto seasonality = [](core_t::TTime time) {
+        return 50.0 * std::sin(boost::math::double_constants::two_pi *
+                               static_cast<double>(time) /
+                               static_cast<double>(core::constants::DAY));
+    };
+
+    core_t::TTime bucketLength{core::constants::HOUR / 2};
+
+    maths::CDiurnalTime weekendTime{0, 0, core::constants::WEEKEND, core::constants::DAY};
+    maths::CDiurnalTime weekdayTime{0, core::constants::WEEKEND,
+                                    core::constants::WEEK, core::constants::DAY};
+    CTestSeasonalComponent weekendComponent{weekendTime, 36, 0.048,
+                                            static_cast<double>(bucketLength)};
+    CTestSeasonalComponent weekdayComponent{weekdayTime, 36, 0.048,
+                                            static_cast<double>(bucketLength)};
+
+    core_t::TTime time{0};
+    for (/**/; time < 4 * core::constants::WEEK; time += bucketLength) {
+        if (weekendTime.inWindow(time)) {
+            weekendComponent.addPoint(time, trend(time) + 0.3 * seasonality(time));
+            weekendComponent.propagateForwardsByTime(1.0 / 24.0);
+        }
+        if (weekdayTime.inWindow(time)) {
+            weekdayComponent.addPoint(time, trend(time) + seasonality(time));
+            weekdayComponent.propagateForwardsByTime(1.0 / 24.0);
+        }
+    }
+    for (/**/; time < 6 * core::constants::WEEK; time += bucketLength) {
+        if (weekendTime.inWindow(time)) {
+            if (weekendComponent.shouldInterpolate(time)) {
+                weekendComponent.interpolate(time);
+                double error{0.0};
+                for (core_t::TTime t = 0; t < core::constants::DAY; t += bucketLength) {
+                    double rt{weekendComponent.time().regression(time + t)};
+                    error += std::fabs(
+                        maths::CBasicStatistics::mean(weekendComponent.value(time + t, 0.0)) -
+                        weekendComponent.bucketing().regression(time + t)->predict(rt));
+                }
+                error /= 48.0;
+                LOG_DEBUG(<< "error = " << error);
+                BOOST_TEST_REQUIRE(error < 2.5);
+            }
+            weekendComponent.add(time, trend(time) + 0.3 * seasonality(time));
+            weekendComponent.propagateForwardsByTime(1.0 / 24.0);
+        }
+
+        if (weekdayTime.inWindow(time)) {
+            if (weekdayComponent.shouldInterpolate(time)) {
+                weekdayComponent.interpolate(time);
+                double error{0.0};
+                for (core_t::TTime t = 0; t < core::constants::DAY; t += bucketLength) {
+                    double rt{weekdayComponent.time().regression(time + t)};
+                    error += std::fabs(
+                        maths::CBasicStatistics::mean(weekdayComponent.value(time + t, 0.0)) -
+                        weekdayComponent.bucketing().regression(time + t)->predict(rt));
+                }
+                error /= 48.0;
+                LOG_DEBUG(<< "error = " << error);
+                BOOST_TEST_REQUIRE(error < 2.5);
+            }
+            weekdayComponent.add(time, trend(time) + seasonality(time));
+            weekdayComponent.propagateForwardsByTime(1.0 / 24.0);
+        }
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testVeryLowVariation) {
@@ -564,12 +652,7 @@ BOOST_AUTO_TEST_CASE(testVeryLowVariation) {
 
     double deviation = std::sqrt(1e-3);
 
-    CTestSeasonalComponent seasonal(startTime, core::constants::DAY, 24);
-    seasonal.initialize(startTime);
-
-    //std::ofstream file;
-    //file.open("results.m");
-    //file << "hold on;\n";
+    CTestSeasonalComponent seasonal(core::constants::DAY, 24);
 
     double totalError1 = 0.0;
     double totalError2 = 0.0;
@@ -582,15 +665,9 @@ BOOST_AUTO_TEST_CASE(testVeryLowVariation) {
 
             time += core::constants::DAY;
 
-            //std::ostringstream t;
-            //std::ostringstream ft;
-            //t << "t = [";
-            //ft << "ft = [";
             double error1 = 0.0;
             double error2 = 0.0;
             for (std::size_t j = 0u; j < function.size(); ++j) {
-                //t << time + function[j].first << " ";
-                //ft << function[j].second << " ";
                 TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
                 double f = residualMean + function[j].second;
 
@@ -598,8 +675,6 @@ BOOST_AUTO_TEST_CASE(testVeryLowVariation) {
                 error1 += std::fabs(e);
                 error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
             }
-            //t << "];\n";
-            //ft << "];\n";
 
             if (d > 1) {
                 LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
@@ -616,12 +691,6 @@ BOOST_AUTO_TEST_CASE(testVeryLowVariation) {
             BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, error2, 0.1 * deviation);
             totalError1 += error1;
             totalError2 += error2;
-
-            //file << seasonal.print() << "\n";
-            //file << t.str();
-            //file << ft.str();
-            //file << "plot(t, ft, 'r');\n";
-            //file << "input(\"Hit any key for next period\");\n\n";
         }
     }
 
@@ -652,8 +721,7 @@ BOOST_AUTO_TEST_CASE(testVariance) {
         }
     }
 
-    CTestSeasonalComponent seasonal(0, core::constants::DAY, 24);
-    seasonal.initialize(0);
+    CTestSeasonalComponent seasonal(core::constants::DAY, 24);
 
     for (std::size_t i = 0u; i < function.size(); ++i) {
         seasonal.addPoint(function[i].first, function[i].second);
@@ -669,14 +737,14 @@ BOOST_AUTO_TEST_CASE(testVariance) {
         LOG_TRACE(<< "v_ = " << v_ << ", v = " << core::CContainerPrinter::print(vv)
                   << ", relative error = " << std::fabs(v - v_) / v_);
 
-        BOOST_REQUIRE_CLOSE_ABSOLUTE(v_, v, 0.4 * v_);
+        BOOST_REQUIRE_CLOSE_ABSOLUTE(v_, v, 0.5 * v_);
         BOOST_TEST_REQUIRE(v_ > vv.first);
         BOOST_TEST_REQUIRE(v_ < vv.second);
         error.add(std::fabs(v - v_) / v_);
     }
 
     LOG_DEBUG(<< "mean relative error = " << maths::CBasicStatistics::mean(error));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.11);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.12);
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {
@@ -706,8 +774,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     TDoubleVec residuals;
     rng.generateGammaSamples(10.0, 1.2, n, residuals);
 
-    CTestSeasonalComponent origSeasonal(startTime, core::constants::DAY, 24, decayRate);
-    origSeasonal.initialize(startTime);
+    CTestSeasonalComponent origSeasonal(core::constants::DAY, 24, decayRate);
 
     for (std::size_t i = 0u; i < n; ++i) {
         origSeasonal.addPoint(samples[i].first, samples[i].second + residuals[i]);

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -306,9 +306,9 @@ BOOST_FIXTURE_TEST_CASE(testDistortedPeriodicProblemCase, CTestFixture) {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                BOOST_TEST_REQUIRE(sumResidual < 0.24 * sumValue);
+                BOOST_TEST_REQUIRE(sumResidual < 0.26 * sumValue);
                 BOOST_TEST_REQUIRE(maxResidual < 0.54 * maxValue);
-                BOOST_TEST_REQUIRE(percentileError < 0.16 * sumValue);
+                BOOST_TEST_REQUIRE(percentileError < 0.18 * sumValue);
 
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -325,9 +325,9 @@ BOOST_FIXTURE_TEST_CASE(testDistortedPeriodicProblemCase, CTestFixture) {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.15 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.16 * totalSumValue);
     BOOST_TEST_REQUIRE(totalMaxResidual < 0.23 * totalMaxValue);
-    BOOST_TEST_REQUIRE(totalPercentileError < 0.09 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalPercentileError < 0.10 * totalSumValue);
 }
 
 BOOST_FIXTURE_TEST_CASE(testMinimizeLongComponents, CTestFixture) {
@@ -428,7 +428,7 @@ BOOST_FIXTURE_TEST_CASE(testMinimizeLongComponents, CTestFixture) {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     BOOST_TEST_REQUIRE(totalSumResidual < 0.04 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.14 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.11 * totalMaxValue);
     BOOST_TEST_REQUIRE(totalPercentileError < 0.01 * totalSumValue);
 
     meanSlope /= refinements;
@@ -660,8 +660,8 @@ BOOST_FIXTURE_TEST_CASE(testSinglePeriodicity, CTestFixture) {
 
             if (time >= 1 * WEEK) {
                 BOOST_TEST_REQUIRE(sumResidual < 0.025 * sumValue);
-                BOOST_TEST_REQUIRE(maxResidual < 0.035 * maxValue);
-                BOOST_TEST_REQUIRE(percentileError < 0.01 * sumValue);
+                BOOST_TEST_REQUIRE(maxResidual < 0.045 * maxValue);
+                BOOST_TEST_REQUIRE(percentileError < 0.02 * sumValue);
 
                 totalSumResidual += sumResidual;
                 totalMaxResidual += maxResidual;
@@ -849,7 +849,7 @@ BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError));
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.4);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.5);
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentileError) < 0.1);
         BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, maths::CBasicStatistics::mean(meanScale), 0.02);
     }
@@ -1043,7 +1043,7 @@ BOOST_FIXTURE_TEST_CASE(testSpikeyDataProblemCase, CTestFixture) {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     BOOST_TEST_REQUIRE(totalSumResidual < 0.17 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.25 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.27 * totalMaxValue);
     BOOST_TEST_REQUIRE(totalPercentileError < 0.12 * totalSumValue);
 
     double pMinScaled = 1.0;
@@ -1156,9 +1156,9 @@ BOOST_FIXTURE_TEST_CASE(testVeryLargeValuesProblemCase, CTestFixture) {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.35 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.73 * totalMaxValue);
-    BOOST_TEST_REQUIRE(totalPercentileError < 0.23 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.34 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.74 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalPercentileError < 0.24 * totalSumValue);
 
     TMeanAccumulator scale;
     double variance = decomposition.meanVariance();
@@ -1257,8 +1257,8 @@ BOOST_FIXTURE_TEST_CASE(testMixedSmoothAndSpikeyDataProblemCase, CTestFixture) {
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
     BOOST_TEST_REQUIRE(totalSumResidual < 0.20 * totalSumValue);
-    BOOST_TEST_REQUIRE(totalMaxResidual < 0.48 * totalMaxValue);
-    BOOST_TEST_REQUIRE(totalPercentileError < 0.08 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalMaxResidual < 0.40 * totalMaxValue);
+    BOOST_TEST_REQUIRE(totalPercentileError < 0.09 * totalSumValue);
 }
 
 BOOST_FIXTURE_TEST_CASE(testDiurnalPeriodicityWithMissingValues, CTestFixture) {
@@ -1653,8 +1653,8 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
         LOG_DEBUG(<< "total 'sum residual' / 'sum value' = " << totalSumResidual / totalSumValue);
         LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
 
-        BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.15);
-        BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.12);
+        BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.17);
+        BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.14);
     }
 
     LOG_DEBUG(<< "Two daily");
@@ -1728,7 +1728,7 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
         LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
 
         BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.09);
-        BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.21);
+        BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.20);
     }
 }
 
@@ -1889,7 +1889,7 @@ BOOST_FIXTURE_TEST_CASE(testCalendar, CTestFixture) {
         debug.addValue(time, trend(time) + noise[0]);
 
         if (time - DAY == *std::lower_bound(months.begin(), months.end(), time - DAY)) {
-            LOG_TRACE(<< "time = " << time);
+            LOG_DEBUG(<< "time = " << time);
 
             std::size_t largeErrorCount = 0;
 
@@ -1909,11 +1909,11 @@ BOOST_FIXTURE_TEST_CASE(testCalendar, CTestFixture) {
                 debug.addPrediction(time_, prediction, actual - prediction);
             }
 
-            LOG_TRACE(<< "large error count = " << largeErrorCount);
-            if (++count <= 4) {
+            LOG_DEBUG(<< "large error count = " << largeErrorCount);
+            if (++count <= 5) {
                 BOOST_TEST_REQUIRE(largeErrorCount > 15);
             }
-            if (count >= 5) {
+            if (count >= 6) {
                 BOOST_TEST_REQUIRE(largeErrorCount <= 1);
             }
         }
@@ -2008,7 +2008,7 @@ BOOST_FIXTURE_TEST_CASE(testComponentLifecycle, CTestFixture) {
         debug.addPrediction(time, prediction, trend(time) + noise[0] - prediction);
     }
 
-    double bounds[]{0.01, 0.013, 0.17, 0.03};
+    double bounds[]{0.01, 0.013, 0.17, 0.02};
     for (std::size_t i = 0; i < 4; ++i) {
         double error{maths::CBasicStatistics::mean(errors[i])};
         LOG_DEBUG(<< "error = " << error);

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -851,8 +851,8 @@ BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {
         LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(error));
         LOG_DEBUG(<< "mean 70% error = " << maths::CBasicStatistics::mean(percentileError));
         LOG_DEBUG(<< "mean scale = " << maths::CBasicStatistics::mean(meanScale));
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.5);
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentileError) < 0.1);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(error) < 0.55);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(percentileError) < 0.15);
         BOOST_REQUIRE_CLOSE_ABSOLUTE(1.0, maths::CBasicStatistics::mean(meanScale), 0.02);
     }
     LOG_DEBUG(<< "Smoothly Varying Variance");

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -1806,30 +1806,25 @@ BOOST_AUTO_TEST_CASE(testUpgradeFrom6p2) {
         maths::SModelRestoreParams restoreParams{params, decompositionParams, distributionParams};
         maths::CUnivariateTimeSeriesModel restoredModel{restoreParams, traverser};
 
+        TMeanAccumulator meanError;
         TStrVec expectedInterval;
-        TStrVec interval;
-        for (core_t::TTime time = 600000, i = 0;
-             i < static_cast<core_t::TTime>(expectedIntervals.size());
-             time += halfHour, ++i) {
+        core_t::TTime time{600000};
+        for (std::size_t i = 0; i < expectedIntervals.size(); ++i, time += halfHour) {
             expectedInterval.clear();
-            interval.clear();
-
             core::CStringUtils::tokenise(",", expectedIntervals[i], expectedInterval, empty);
-            std::string interval_{core::CContainerPrinter::print(restoredModel.confidenceInterval(
-                time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(1)))};
-            core::CStringUtils::replace("[", "", interval_);
-            core::CStringUtils::replace("]", "", interval_);
-            core::CStringUtils::replace(" ", "", interval_);
-            interval_ += ",";
-            core::CStringUtils::tokenise(",", interval_, interval, empty);
+
+            auto interval = restoredModel.confidenceInterval(
+                time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
 
             BOOST_REQUIRE_EQUAL(expectedInterval.size(), interval.size());
-            for (std::size_t j = 0u; j < expectedInterval.size(); ++j) {
+            for (std::size_t j = 0; j < expectedInterval.size(); ++j) {
                 BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                    boost::lexical_cast<double>(expectedInterval[j]),
-                    boost::lexical_cast<double>(interval[j]), 0.0001);
+                    boost::lexical_cast<double>(expectedInterval[j]), interval[j][0], 1.0);
+                meanError.add(std::fabs(boost::lexical_cast<double>(expectedInterval[j]) -
+                                        interval[j][0]));
             }
         }
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.005);
         BOOST_TEST_REQUIRE(restoredModel.decayRateControllers() != nullptr);
         BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[0].checks() != 0);
         BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[1].checks() != 0);
@@ -1860,30 +1855,24 @@ BOOST_AUTO_TEST_CASE(testUpgradeFrom6p2) {
         maths::SModelRestoreParams restoreParams{params, decompositionParams, distributionParams};
         maths::CMultivariateTimeSeriesModel restoredModel{restoreParams, traverser};
 
+        TMeanAccumulator meanError;
+        core_t::TTime time{600000};
         TStrVec expectedInterval;
-        TStrVec interval;
-        for (core_t::TTime time = 600000, i = 0;
-             i < static_cast<core_t::TTime>(expectedIntervals.size());
-             time += halfHour, ++i) {
+        for (std::size_t i = 0; i < expectedIntervals.size(); ++i, time += halfHour) {
             expectedInterval.clear();
-            interval.clear();
-
             core::CStringUtils::tokenise(",", expectedIntervals[i], expectedInterval, empty);
-            std::string interval_{core::CContainerPrinter::print(restoredModel.confidenceInterval(
-                time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(3)))};
-            core::CStringUtils::replace("[", "", interval_);
-            core::CStringUtils::replace("]", "", interval_);
-            core::CStringUtils::replace(" ", "", interval_);
-            interval_ += ",";
-            core::CStringUtils::tokenise(",", interval_, interval, empty);
 
-            BOOST_REQUIRE_EQUAL(expectedInterval.size(), interval.size());
-            for (std::size_t j = 0u; j < expectedInterval.size(); ++j) {
-                BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                    boost::lexical_cast<double>(expectedInterval[j]),
-                    boost::lexical_cast<double>(interval[j]), 0.0001);
+            auto interval = restoredModel.confidenceInterval(
+                time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(3));
+
+            for (std::size_t j = 0; j < expectedInterval.size(); ++j) {
+                BOOST_REQUIRE_CLOSE_ABSOLUTE(boost::lexical_cast<double>(expectedInterval[j]),
+                                             interval[j / 3][j % 3], 1.0);
+                meanError.add(std::fabs(boost::lexical_cast<double>(expectedInterval[j]) -
+                                        interval[j / 3][j % 3]));
             }
         }
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.01);
         BOOST_TEST_REQUIRE(restoredModel.decayRateControllers() != nullptr);
         BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[0].checks() != 0);
         BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[1].checks() != 0);
@@ -2357,7 +2346,7 @@ BOOST_AUTO_TEST_CASE(testLinearScaling) {
         auto x = model.confidenceInterval(
             time, 90.0, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
         BOOST_TEST_REQUIRE(std::fabs(sample - x[1][0]) < 3.6 * std::sqrt(noiseVariance));
-        BOOST_TEST_REQUIRE(std::fabs(x[2][0] - x[0][0]) < 4.0 * std::sqrt(noiseVariance));
+        BOOST_TEST_REQUIRE(std::fabs(x[2][0] - x[0][0]) < 4.5 * std::sqrt(noiseVariance));
         time += bucketLength;
     }
 }

--- a/lib/maths/unittest/CTimeSeriesTestForSeasonalityTest.cc
+++ b/lib/maths/unittest/CTimeSeriesTestForSeasonalityTest.cc
@@ -1212,7 +1212,7 @@ BOOST_AUTO_TEST_CASE(testNewComponentInitialValues) {
                 BOOST_REQUIRE_EQUAL(false, time->windowed());
                 BOOST_REQUIRE_EQUAL(0, time->windowRepeatStart());
                 BOOST_REQUIRE_EQUAL(0, time->windowStart());
-                BOOST_REQUIRE_EQUAL(WEEK, time->windowEnd());
+                BOOST_REQUIRE_EQUAL(DAY, time->windowEnd());
                 BOOST_REQUIRE_EQUAL(DAY, time->period());
             }
             break;

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2689,7 +2689,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         // control.
 
         params.s_ControlDecayRate = true;
-        params.s_DecayRate = 0.001;
+        params.s_DecayRate = 0.0005;
         auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
         CEventRateModelFactory factory(params, interimBucketCorrector);
         factory.features(features);
@@ -2698,7 +2698,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         this->addPerson("p1", gatherer);
 
         params.s_ControlDecayRate = false;
-        params.s_DecayRate = 0.001;
+        params.s_DecayRate = 0.0005;
         CEventRateModelFactory referenceFactory(params, interimBucketCorrector);
         referenceFactory.features(features);
         CModelFactory::TDataGathererPtr referenceGatherer{
@@ -2745,7 +2745,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanPredictionError) <
-                           0.82 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                           0.75 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2059,7 +2059,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         // control.
 
         params.s_ControlDecayRate = true;
-        params.s_DecayRate = 0.001;
+        params.s_DecayRate = 0.0005;
         auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
         CMetricModelFactory factory(params, interimBucketCorrector);
         factory.features(features);
@@ -2067,7 +2067,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         CModelFactory::TModelPtr model(factory.makeModel(gatherer));
 
         params.s_ControlDecayRate = false;
-        params.s_DecayRate = 0.001;
+        params.s_DecayRate = 0.0005;
         CMetricModelFactory referenceFactory(params, interimBucketCorrector);
         referenceFactory.features(features);
         CModelFactory::TDataGathererPtr referenceGatherer(
@@ -2111,7 +2111,7 @@ BOOST_FIXTURE_TEST_CASE(testDecayRateControl, CTestFixture) {
         LOG_DEBUG(<< "reference = "
                   << maths::CBasicStatistics::mean(meanReferencePredictionError));
         BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanPredictionError) <
-                           0.8 * maths::CBasicStatistics::mean(meanReferencePredictionError));
+                           0.75 * maths::CBasicStatistics::mean(meanReferencePredictionError));
     }
 }
 


### PR DESCRIPTION
This addresses various sources of instability in the time series modelling for anomaly detection:
1. Our update dynamics were stable (just). However, we do other things which aren't considered in this analysis, such as apply different weights to different updates. I added a small margin.
2. There was an error in the times at which we asked for model predictions when component models were restricted to time windows, i.e. weekdays and weekends.
3. We could use stale predictions when there were long gaps in the data.
4. Changing the seasonal derivative too fast can create transient instability after data changes.

I've also added some more unit testing. Particular, in the area of when we refresh predictions and an explicit testing long term stability.