### PR TITLE
[ML] Early stopping for hyperparameter optimization procedure

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,9 +47,11 @@
   if the time series has non-diurnal seasonality. (See {ml-pull}1634[#1634].)
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
-* Early stopping for the fine parameter tuning step. (See {ml-pull}1676[#1676].)
+* Early stopping for the fine parameter tuning step  of classification and regression
+  model training. (See {ml-pull}1676[#1676].)
 * Correct upgrade for pre-6.3 state for lat_long anomaly anomaly detectors. (See
   {ml-pull}1681[#1681].)
+
 == {es} version 7.11.0
 
 === Enhancements

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@
   if the time series has non-diurnal seasonality. (See {ml-pull}1634[#1634].)
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
+* Early stopping for the fine parameter tuning step. (See {ml-pull}1676[#1676].)
 
 == {es} version 7.11.0
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -54,6 +54,7 @@ public:
     static const std::string NUM_TOP_FEATURE_IMPORTANCE_VALUES;
     static const std::string TRAINING_PERCENT_FIELD_NAME;
     static const std::string FEATURE_PROCESSORS;
+    static const std::string EARLY_STOPPING_ALLOWED;
 
     // Output
     static const std::string IS_TRAINING_FIELD_NAME;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -120,6 +120,8 @@ public:
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
 
+    CBoostedTreeFactory& earlyStoppingAllowed(bool earlyStopping = true);
+
     //! Estimate the maximum booking memory that training the boosted tree on a
     //! data frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -113,14 +113,14 @@ public:
     CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
     //! Set the number of training examples we need per feature we'll include.
     CBoostedTreeFactory& numberTopShapValues(std::size_t numberTopShapValues);
+    //! Stop hyperparameter optimization early if the the process is not promising.
+    CBoostedTreeFactory& stopHyperparameterOptimizationEarly(bool stopEarly);
 
     //! Set pointer to the analysis instrumentation.
     CBoostedTreeFactory&
     analysisInstrumentation(CDataFrameTrainBoostedTreeInstrumentationInterface& instrumentation);
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
-
-    CBoostedTreeFactory& earlyStoppingAllowed(bool earlyStopping = true);
 
     //! Estimate the maximum booking memory that training the boosted tree on a
     //! data frame with \p numberRows row and \p numberColumns columns will use.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -387,6 +387,7 @@ private:
     mutable TMeanAccumulator m_MeanLossAccumulator;
     THyperparametersVec m_TunableHyperparameters;
     TDoubleVecVec m_HyperparameterSamples;
+    bool m_EarlyStoppingAllowed = true;
 
 private:
     friend class CBoostedTreeFactory;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -178,6 +178,7 @@ private:
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
     using TWorkspace = CBoostedTreeLeafNodeStatistics::CWorkspace;
     using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameters>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
 
     //! Tag progress through initialization.
     enum EInitializationStage {
@@ -330,8 +331,11 @@ private:
     //! Record hyperparameters for instrumentation.
     void recordHyperparameters();
 
-    //! Populate the list of tunable hyperparameters
+    //! Populate the list of tunable hyperparameters.
     void initializeTunableHyperparameters();
+
+    //! Use Sobol sampler for for random hyperparamers.
+    void initializeHyperparameterSamples();
 
 private:
     mutable CPRNG::CXorOShiro128Plus m_Rng;
@@ -382,6 +386,7 @@ private:
     mutable TMeanAccumulator m_ForestSizeAccumulator;
     mutable TMeanAccumulator m_MeanLossAccumulator;
     THyperparametersVec m_TunableHyperparameters;
+    TDoubleVecVec m_HyperparameterSamples;
 
 private:
     friend class CBoostedTreeFactory;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -387,7 +387,7 @@ private:
     mutable TMeanAccumulator m_MeanLossAccumulator;
     THyperparametersVec m_TunableHyperparameters;
     TDoubleVecVec m_HyperparameterSamples;
-    bool m_EarlyStoppingAllowed = true;
+    bool m_StopHyperparameterOptimizationEarly = true;
 
 private:
     friend class CBoostedTreeFactory;

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -85,6 +85,7 @@ public:
     predictionPersisterSupplier(TPersisterSupplier* persisterSupplier);
     CDataFrameAnalysisSpecificationFactory&
     predictionRestoreSearcherSupplier(TRestoreSearcherSupplier* restoreSearcherSupplier);
+    CDataFrameAnalysisSpecificationFactory& earlyStoppingAllowed(bool earlyStoppingAllowed);
 
     // Regression
     CDataFrameAnalysisSpecificationFactory& regressionLossFunction(TLossFunctionType lossFunction);
@@ -145,6 +146,7 @@ private:
     std::size_t m_NumberClasses = 2;
     std::size_t m_NumberTopClasses = 0;
     std::string m_PredictionFieldType;
+    bool m_EarlyStoppingAllowed = true;
 };
 }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -146,7 +146,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
-        .earlyStoppingAllowed(earlyStoppingAllowed);
+        .stopHyperparameterOptimizationEarly(earlyStoppingAllowed);
 
     if (downsampleRowsPerFeature > 0) {
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -65,6 +65,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(FEATURE_PROCESSORS,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(EARLY_STOPPING_ALLOWED,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -82,6 +84,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         m_DependentVariableFieldName + "_prediction");
 
     m_TrainingPercent = parameters[TRAINING_PERCENT_FIELD_NAME].fallback(100.0) / 100.0;
+
+    bool earlyStoppingAllowed = parameters[EARLY_STOPPING_ALLOWED].fallback(true);
+
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
     double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
@@ -140,7 +145,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     (*m_BoostedTreeFactory)
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
-        .trainingStateCallback(this->statePersister());
+        .trainingStateCallback(this->statePersister())
+        .earlyStoppingAllowed(earlyStoppingAllowed);
 
     if (downsampleRowsPerFeature > 0) {
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(
@@ -382,6 +388,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME{"fea
 const std::string CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME{"importance"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS{"feature_processors"};
+const std::string CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ALLOWED{"early_stopping_allowed"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -617,8 +617,8 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoImportance, SFixture) {
             double c1{readShapValue(result, "c1")};
             double prediction{
                 result["row_results"]["results"]["ml"]["target_prediction"].GetDouble()};
-            // c1 explains 94% of the prediction value, i.e. the difference from the prediction is less than 6%.
-            BOOST_REQUIRE_CLOSE(c1, prediction, 6.0);
+            // c1 explains 92% of the prediction value, i.e. the difference from the prediction is less than 8%.
+            BOOST_REQUIRE_CLOSE(c1, prediction, 8.0);
             for (const auto& feature : {"c2", "c3", "c4"}) {
                 double c = readShapValue(result, feature);
                 BOOST_REQUIRE_SMALL(c, 3.0);

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1900000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1910000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -682,7 +682,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1900000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1910000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -1011,6 +1011,7 @@ BOOST_AUTO_TEST_CASE(testProgressFromRestart) {
             .memoryLimit(18000000)
             .predictionPersisterSupplier(persisterSupplier)
             .predictionRestoreSearcherSupplier(restorerSupplier)
+            .earlyStoppingAllowed(false)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target");
     };
 

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -597,6 +597,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
                     .predictionPersisterSupplier(persisterSupplier)
                     .predictionRestoreSearcherSupplier(restorerSupplier)
                     .regressionLossFunction(lossFunction)
+                    .earlyStoppingAllowed(false)
                     .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(),
                                     dependentVariable);
             };

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1285,8 +1285,8 @@ CBoostedTreeFactory& CBoostedTreeFactory::trainingStateCallback(TTrainingStateCa
     return *this;
 }
 
-CBoostedTreeFactory& CBoostedTreeFactory::earlyStoppingAllowed(bool earlyStoppingAllowed) {
-    m_TreeImpl->m_EarlyStoppingAllowed = earlyStoppingAllowed;
+CBoostedTreeFactory& CBoostedTreeFactory::stopHyperparameterOptimizationEarly(bool stopEarly) {
+    m_TreeImpl->m_StopHyperparameterOptimizationEarly = stopEarly;
     return *this;
 }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1285,6 +1285,11 @@ CBoostedTreeFactory& CBoostedTreeFactory::trainingStateCallback(TTrainingStateCa
     return *this;
 }
 
+CBoostedTreeFactory& CBoostedTreeFactory::earlyStoppingAllowed(bool earlyStoppingAllowed) {
+    m_TreeImpl->m_EarlyStoppingAllowed = earlyStoppingAllowed;
+    return *this;
+}
+
 std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
                                                      std::size_t numberColumns) const {
     std::size_t maximumNumberTrees{this->mainLoopMaximumNumberTrees(

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1297,7 +1297,8 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
                   m_HyperparameterSamples[m_CurrentRound].end(), parameters.data());
         parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
     } else {
-        if (m_EarlyStoppingAllowed && m_BayesianOptimization->anovaTotalVariance() < 1e-9) {
+        if (m_StopHyperparameterOptimizationEarly &&
+            m_BayesianOptimization->anovaTotalVariance() < 1e-9) {
             return false;
         }
         std::tie(parameters, std::ignore) = bopt.maximumExpectedImprovement();
@@ -1635,7 +1636,7 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persist(TESTING_ROW_MASKS_TAG, m_TestingRowMasks, inserter);
     core::CPersistUtils::persist(TRAINING_ROW_MASKS_TAG, m_TrainingRowMasks, inserter);
     core::CPersistUtils::persist(STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG,
-                                 m_EarlyStoppingAllowed, inserter);
+                                 m_StopHyperparameterOptimizationEarly, inserter);
     // m_TunableHyperparameters is not persisted explicitly, it is restored from overriden hyperparameters
     // m_HyperparameterSamples is not persisted explicitly, it is re-generated
 }
@@ -1657,7 +1658,7 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
     int initializationStage{static_cast<int>(E_FullyInitialized)};
 
     if (traverser.name() != VERSION_7_11_TAG) {
-        m_EarlyStoppingAllowed = false;
+        m_StopHyperparameterOptimizationEarly = false;
     }
 
     do {
@@ -1758,7 +1759,7 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
                 core::CPersistUtils::restore(TRAINING_ROW_MASKS_TAG, m_TrainingRowMasks, traverser))
         RESTORE(STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG,
                 core::CPersistUtils::restore(STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG,
-                                             m_EarlyStoppingAllowed, traverser))
+                                             m_StopHyperparameterOptimizationEarly, traverser))
         // m_TunableHyperparameters is not restored explicitly, it is restored from overriden hyperparameters
         // m_HyperparameterSamples is not restored explicitly, it is re-generated
     } while (traverser.next());

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -343,6 +343,11 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
     std::size_t hyperparametersMemoryUsage{numberColumns * sizeof(double)};
     std::size_t tunableHyperparametersMemoryUsage{m_TunableHyperparameters.size() *
                                                   sizeof(int)};
+    std::size_t hyperparameterSamplesMemoryUsage{
+        m_HyperparameterSamples.empty()
+            ? 0
+            : m_HyperparameterSamples.size() *
+                  m_HyperparameterSamples[0].size() * sizeof(double)};
     // The leaves' row masks memory is accounted for here because it's proportional
     // to the log2(number of nodes). The compressed bit vector representation uses
     // roughly log2(E[run length]) / E[run length] bytes per bit. As we grow the
@@ -376,8 +381,8 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsage(std::size_t numberRows,
     std::size_t worstCaseMemoryUsage{
         sizeof(*this) + forestMemoryUsage + foldRoundLossMemoryUsage +
         hyperparametersMemoryUsage + tunableHyperparametersMemoryUsage +
-        leafNodeStatisticsMemoryUsage + dataTypeMemoryUsage +
-        featureSampleProbabilities + missingFeatureMaskMemoryUsage +
+        hyperparameterSamplesMemoryUsage + leafNodeStatisticsMemoryUsage +
+        dataTypeMemoryUsage + featureSampleProbabilities + missingFeatureMaskMemoryUsage +
         trainTestMaskMemoryUsage + bayesianOptimisationMemoryUsage};
 
     return CBoostedTreeImpl::correctedMemoryUsage(static_cast<double>(worstCaseMemoryUsage));

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1295,9 +1295,6 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     if (3 * m_CurrentRound < m_NumberRounds) {
         std::move(m_HyperparameterSamples[m_CurrentRound].begin(),
                   m_HyperparameterSamples[m_CurrentRound].end(), parameters.data());
-        // std::generate_n(parameters.data(), parameters.size(), [&]() {
-        //     return CSampling::uniformSample(m_Rng, 0.0, 1.0);
-        // });
         parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
     } else {
         if (m_EarlyStoppingAllowed && m_BayesianOptimization->anovaTotalVariance() < 1e-9) {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1287,11 +1287,15 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     bopt.add(parameters, meanLoss, lossVariance);
     if (3 * m_CurrentRound < m_NumberRounds) {
         std::generate_n(parameters.data(), parameters.size(), [&]() {
+            // TODO [bopt-early-stopping] should be better a Sobol sampling
             return CSampling::uniformSample(m_Rng, 0.0, 1.0);
         });
 
         parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
     } else {
+        if (m_BayesianOptimization->anovaTotalVariance() < 1e-9) {
+            return false;
+        }
         std::tie(parameters, std::ignore) = bopt.maximumExpectedImprovement();
     }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1295,9 +1295,12 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     if (3 * m_CurrentRound < m_NumberRounds) {
         std::move(m_HyperparameterSamples[m_CurrentRound].begin(),
                   m_HyperparameterSamples[m_CurrentRound].end(), parameters.data());
+        // std::generate_n(parameters.data(), parameters.size(), [&]() {
+        //     return CSampling::uniformSample(m_Rng, 0.0, 1.0);
+        // });
         parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
     } else {
-        if (m_BayesianOptimization->anovaTotalVariance() < 1e-9) {
+        if (m_EarlyStoppingAllowed && m_BayesianOptimization->anovaTotalVariance() < 1e-9) {
             return false;
         }
         std::tie(parameters, std::ignore) = bopt.maximumExpectedImprovement();

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1073,7 +1073,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.51);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1421,7 +1421,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
         std::thread worker{[&]() {
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   threads, std::make_unique<maths::boosted_tree::CMse>())
-                                  .earlyStoppingAllowed(false)
+                                  .stopHyperparameterOptimizationEarly(false)
                                   .analysisInstrumentation(instrumentation)
                                   .buildFor(*frame, cols - 1);
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1067,7 +1067,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.67);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.68);
         meanLogRelativeError.add(maths::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1156,7 +1156,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     LOG_DEBUG(<< "recalls    = " << core::CContainerPrinter::print(recalls));
 
     BOOST_TEST_REQUIRE(std::fabs(precisions[0] - precisions[1]) < 0.1);
-    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.1);
+    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.11);
 }
 
 BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
@@ -1421,7 +1421,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
         std::thread worker{[&]() {
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   threads, std::make_unique<maths::boosted_tree::CMse>())
-                                  .EarlyStoppingAllowed(false)
+                                  .earlyStoppingAllowed(false)
                                   .analysisInstrumentation(instrumentation)
                                   .buildFor(*frame, cols - 1);
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1421,6 +1421,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
         std::thread worker{[&]() {
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   threads, std::make_unique<maths::boosted_tree::CMse>())
+                                  .EarlyStoppingAllowed(false)
                                   .analysisInstrumentation(instrumentation)
                                   .buildFor(*frame, cols - 1);
 

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -182,6 +182,12 @@ CDataFrameAnalysisSpecificationFactory::predictionRestoreSearcherSupplier(
 }
 
 CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::earlyStoppingAllowed(bool earlyStoppingAllowed) {
+    m_EarlyStoppingAllowed = earlyStoppingAllowed;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::numberClasses(std::size_t number) {
     m_NumberClasses = number;
     return *this;
@@ -338,6 +344,10 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
     if (m_CustomProcessors.IsNull() == false) {
         writer.Key(api::CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS);
         writer.write(m_CustomProcessors);
+    }
+    if (m_EarlyStoppingAllowed == false) {
+        writer.Key(api::CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ALLOWED);
+        writer.Bool(m_EarlyStoppingAllowed);
     }
 
     if (analysis == regression()) {


### PR DESCRIPTION
This PR implements early stopping of fine parameter tuning if the search process if the loss surfaces appear to be flat (very low total variation of the loss surface of hyperparameters). 
It also replaces uniform sampling of the hyperparameter in the first step of exploration by Sobol sampling which has a higher discrepancy.

I introduced the new configuration parameter `early_stopping_allowed` similar to the `disk_usage_allowed`. In the internal routines and for persist/restore, I call this flag `stopHyperparameterOptimizationEarly` similar to `stopCrossValidationEarly` that is already used.

Closes  #1669 