### PR TITLE
[6.8][ML] Fix bug persisting and restoring time series model decay rate controller (part 2)

### DIFF
--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -112,7 +112,6 @@ double aggregateFeatureProbabilities(const TDouble4Vec& probabilities, double co
 
 const std::string VERSION_6_3_TAG("6.3");
 const std::string VERSION_6_5_TAG("6.5");
-const std::string VERSION_6_8_14_TAG("6.8.14");
 
 // Models
 // Version >= 6.3
@@ -1250,9 +1249,7 @@ std::size_t CUnivariateTimeSeriesModel::memoryUsage() const {
 
 bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParams& params,
                                                         core::CStateRestoreTraverser& traverser) {
-    bool stateMissingControllerChecks{false};
-    if (traverser.name() == VERSION_6_3_TAG || traverser.name() == VERSION_6_8_14_TAG) {
-        stateMissingControllerChecks = (traverser.name() == VERSION_6_3_TAG);
+    if (traverser.name() == VERSION_6_3_TAG) {
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_BUILT_IN(ID_6_3_TAG, m_Id)
@@ -1300,7 +1297,6 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
         }
     } else {
         // There is no version string this is historic state.
-        stateMissingControllerChecks = true;
         do {
             const std::string& name{traverser.name()};
             RESTORE_BUILT_IN(ID_OLD_TAG, m_Id)
@@ -1329,11 +1325,11 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
         } while (traverser.next());
     }
 
-    if (m_Controllers != nullptr && stateMissingControllerChecks) {
+    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
         (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
                                                 CDecayRateController::E_PredictionErrorIncrease);
     }
-    if (m_Controllers != nullptr && stateMissingControllerChecks) {
+    if (m_Controllers != nullptr && (*m_Controllers)[E_ResidualControl].checks() == 0) {
         (*m_Controllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);
@@ -1346,7 +1342,7 @@ void CUnivariateTimeSeriesModel::acceptPersistInserter(core::CStatePersistInsert
 
     // Note that we don't persist this->params() or the correlations
     // because that state is reinitialized.
-    inserter.insertValue(VERSION_6_8_14_TAG, "");
+    inserter.insertValue(VERSION_6_3_TAG, "");
     inserter.insertValue(ID_6_3_TAG, m_Id);
     inserter.insertValue(IS_NON_NEGATIVE_6_3_TAG, static_cast<int>(m_IsNonNegative));
     inserter.insertValue(IS_FORECASTABLE_6_3_TAG, static_cast<int>(m_IsForecastable));
@@ -2690,9 +2686,7 @@ std::size_t CMultivariateTimeSeriesModel::memoryUsage() const {
 
 bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParams& params,
                                                           core::CStateRestoreTraverser& traverser) {
-    bool stateMissingControllerChecks{false};
-    if (traverser.name() == VERSION_6_3_TAG || traverser.name() == VERSION_6_8_14_TAG) {
-        stateMissingControllerChecks = (traverser.name() == VERSION_6_3_TAG);
+    if (traverser.name() == VERSION_6_3_TAG) {
         while (traverser.next()) {
             const std::string& name{traverser.name()};
             RESTORE_BOOL(IS_NON_NEGATIVE_6_3_TAG, m_IsNonNegative)
@@ -2729,7 +2723,6 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
                 /**/)
         }
     } else {
-        stateMissingControllerChecks = true;
         do {
             const std::string& name{traverser.name()};
             RESTORE_BOOL(IS_NON_NEGATIVE_OLD_TAG, m_IsNonNegative)
@@ -2759,11 +2752,11 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
         } while (traverser.next());
     }
 
-    if (m_Controllers != nullptr && stateMissingControllerChecks) {
+    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
         (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
                                                 CDecayRateController::E_PredictionErrorIncrease);
     }
-    if (m_Controllers != nullptr && stateMissingControllerChecks) {
+    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
         (*m_Controllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);
@@ -2775,7 +2768,7 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
 void CMultivariateTimeSeriesModel::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     // Note that we don't persist this->params() because that state
     // is reinitialized.
-    inserter.insertValue(VERSION_6_8_14_TAG, "");
+    inserter.insertValue(VERSION_6_3_TAG, "");
     inserter.insertValue(IS_NON_NEGATIVE_6_3_TAG, static_cast<int>(m_IsNonNegative));
     if (m_Controllers) {
         core::CPersistUtils::persist(CONTROLLER_6_3_TAG, *m_Controllers, inserter);

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -2756,7 +2756,7 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
         (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
                                                 CDecayRateController::E_PredictionErrorIncrease);
     }
-    if (m_Controllers != nullptr && (*m_Controllers)[E_TrendControl].checks() == 0) {
+    if (m_Controllers != nullptr && (*m_Controllers)[E_ResidualControl].checks() == 0) {
         (*m_Controllers)[E_ResidualControl].checks(
             CDecayRateController::E_PredictionBias | CDecayRateController::E_PredictionErrorIncrease |
             maths::CDecayRateController::E_PredictionErrorDecrease);


### PR DESCRIPTION
Unfortunately, using the state tag to determine if the state is incomplete is not forward compatible. This breaks upgrading state from the 6.8 branch to 7.x branches. I could introduce a new item (which would be ignored) to carry this information, but since this parameter is currently not user configurable I can simply check its value to determine if it is missing. This fixes fallout from #1674 so marking as a non-issue since it logically belongs with that change.