### PR TITLE
[ML] Correct a bug in upgrade from pre 6.3 state for the lat_long function

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@
   if the time series has non-diurnal seasonality. (See {ml-pull}1634[#1634].)
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
+* Correct upgrade for pre-6.3 state for lat_long anomaly anomaly detectors. (See
+  {ml-pull}1681[#1681].)
 
 == {es} version 7.11.0
 

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -214,6 +214,9 @@ public:
 
     //! Get the residual model.
     const CPrior& residualModel() const;
+
+    //! Get the decay rate controllers.
+    const TDecayRateController2Ary* decayRateControllers() const;
     //@}
 
 private:
@@ -681,6 +684,9 @@ public:
 
     //! Get the residual model.
     const CMultivariatePrior& residualModel() const;
+
+    //! Get the decay rate controllers.
+    const TDecayRateController2Ary* decayRateControllers() const;
     //@}
 
 private:

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1451,6 +1451,11 @@ const CPrior& CUnivariateTimeSeriesModel::residualModel() const {
     return *m_ResidualModel;
 }
 
+const CUnivariateTimeSeriesModel::TDecayRateController2Ary*
+CUnivariateTimeSeriesModel::decayRateControllers() const {
+    return m_Controllers.get();
+}
+
 CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(const CUnivariateTimeSeriesModel& other,
                                                        std::size_t id,
                                                        bool isForForecast)
@@ -2751,7 +2756,7 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
             RESTORE_SETUP_TEARDOWN(
                 CONTROLLER_OLD_TAG,
                 m_Controllers = std::make_unique<TDecayRateController2Ary>(),
-                core::CPersistUtils::restore(CONTROLLER_6_3_TAG, *m_Controllers, traverser),
+                core::CPersistUtils::restore(CONTROLLER_OLD_TAG, *m_Controllers, traverser),
                 /**/)
             RESTORE_SETUP_TEARDOWN(
                 TREND_OLD_TAG, m_TrendModel.push_back(TDecompositionPtr()),
@@ -2847,6 +2852,11 @@ CMultivariateTimeSeriesModel::trendModel() const {
 
 const CMultivariatePrior& CMultivariateTimeSeriesModel::residualModel() const {
     return *m_ResidualModel;
+}
+
+const CMultivariateTimeSeriesModel::TDecayRateController2Ary*
+CMultivariateTimeSeriesModel::decayRateControllers() const {
+    return m_Controllers.get();
 }
 
 CMultivariateTimeSeriesModel::EUpdateResult

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -1829,7 +1829,7 @@ BOOST_AUTO_TEST_CASE(testUpgradeFrom6p2) {
                     boost::lexical_cast<double>(expectedInterval[j]),
                     boost::lexical_cast<double>(interval[j]), 0.0001);
             }
-        }        
+        }
         BOOST_TEST_REQUIRE(restoredModel.decayRateControllers() != nullptr);
         BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[0].checks() != 0);
         BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[1].checks() != 0);

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -1762,7 +1762,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     // TODO LOG_DEBUG(<< "Correlates");
 }
 
-BOOST_AUTO_TEST_CASE(testUpgrade) {
+BOOST_AUTO_TEST_CASE(testUpgradeFrom6p2) {
     // Test upgrade is minimally disruptive. We test the upgraded model
     // predicted confidence intervals verses the values we obtain from
     // the previous model. Note the confidence interval depends on both
@@ -1829,7 +1829,12 @@ BOOST_AUTO_TEST_CASE(testUpgrade) {
                     boost::lexical_cast<double>(expectedInterval[j]),
                     boost::lexical_cast<double>(interval[j]), 0.0001);
             }
-        }
+        }        
+        BOOST_TEST_REQUIRE(restoredModel.decayRateControllers() != nullptr);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[0].checks() != 0);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[1].checks() != 0);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[0].dimension() == 1);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[1].dimension() == 1);
     }
 
     LOG_DEBUG(<< "Multivariate");
@@ -1879,6 +1884,11 @@ BOOST_AUTO_TEST_CASE(testUpgrade) {
                     boost::lexical_cast<double>(interval[j]), 0.0001);
             }
         }
+        BOOST_TEST_REQUIRE(restoredModel.decayRateControllers() != nullptr);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[0].checks() != 0);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[1].checks() != 0);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[0].dimension() == 3);
+        BOOST_TEST_REQUIRE((*restoredModel.decayRateControllers())[1].dimension() == 3);
     }
 }
 


### PR DESCRIPTION
Whilst investigating #1680 I noticed another issue in state upgrade. This one is much more limited in scope and only affects pre 6.3 lat_long models.