### PR TITLE
[ML] Parse JSON format config updates

### DIFF
--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -39,6 +39,8 @@ public:
     public:
         class API_EXPORT CDetectorConfig {
         public:
+            static const std::string DETECTOR_RULES;
+
             static const std::string FUNCTION;
             static const std::string FIELD_NAME;
             static const std::string BY_FIELD_NAME;
@@ -287,6 +289,10 @@ public:
 
         bool parseRules(int detectorIndex, const std::string& rules);
 
+        bool parseRules(int detectorIndex, const rapidjson::Value& rules);
+
+        bool parseRulesUpdate(const rapidjson::Value& rulesUpdateConfig);
+
     private:
         // Convenience method intended for use by the unit tests only
         void addDetector(const std::string& functionName,
@@ -302,13 +308,8 @@ public:
                                      overFieldName, partitionFieldName);
         }
 
-        bool processFilter(const std::string& key, const std::string& value);
-
-        //! Process and store a scheduled event
-        bool processScheduledEvent(const boost::property_tree::ptree& propTree,
-                                   const std::string& key,
-                                   const std::string& value,
-                                   TIntSet& handledScheduledEvents);
+        bool parseRules(CDetectionRulesJsonParser::TDetectionRuleVec& detectionRules,
+                        const rapidjson::Value& rules);
 
         bool parseRules(CDetectionRulesJsonParser::TDetectionRuleVec& detectionRules,
                         const std::string& rules);
@@ -523,6 +524,7 @@ public:
         return m_DataDescription;
     }
     const CModelPlotConfig& modelPlotConfig() const { return m_ModelConfig; }
+    CModelPlotConfig& modelPlotConfig() { return m_ModelConfig; }
     const CAnalysisLimits& analysisLimits() const { return m_AnalysisLimits; }
     bool isInitialized() const { return m_IsInitialized; }
     core_t::TTime persistInterval() const {

--- a/include/api/CConfigUpdater.h
+++ b/include/api/CConfigUpdater.h
@@ -24,13 +24,13 @@ namespace api {
 //! update, a control message is being sent with the requested
 //! configuration changes. This class is responsible for parsing
 //! text with the requested configuration changes and apply them.
-//! The changes are expected in an ini type of syntax.
+//! The changes are expected in an JSON formatted syntax.
 //!
 //! IMPLEMENTATION DECISIONS:\n
 //! As long as the parsing of the configuration changes is
 //! done successfully, the updater tries to apply as many
 //! changes as possible even if it fails on a particular
-//! change (e.g. unknown stanza name).
+//! change.
 //!
 class API_EXPORT CConfigUpdater {
 public:
@@ -40,14 +40,6 @@ public:
     //! Update from given config changes
     //! \param config the requested changes in an ini syntax
     bool update(const std::string& config);
-
-private:
-    static const std::string MODEL_DEBUG_CONFIG;
-    static const std::string DETECTOR_RULES;
-    static const std::string DETECTOR_INDEX;
-    static const std::string RULES_JSON;
-    static const std::string FILTERS;
-    static const std::string SCHEDULED_EVENTS;
 
 private:
     CAnomalyJobConfig& m_JobConfig;

--- a/include/api/CConfigUpdater.h
+++ b/include/api/CConfigUpdater.h
@@ -24,7 +24,7 @@ namespace api {
 //! update, a control message is being sent with the requested
 //! configuration changes. This class is responsible for parsing
 //! text with the requested configuration changes and apply them.
-//! The changes are expected in an JSON formatted syntax.
+//! The changes are expected in a JSON document.
 //!
 //! IMPLEMENTATION DECISIONS:\n
 //! As long as the parsing of the configuration changes is

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -379,6 +379,9 @@ public:
     //! Get the central confidence interval for the model debug plot.
     double modelPlotBoundsPercentile() const;
 
+    //! Is model plot enabled?
+    bool modelPlotEnabled() const;
+
     //! Are annotations enabled for each of the models?
     bool modelPlotAnnotationsEnabled() const;
 
@@ -450,6 +453,9 @@ private:
 
     //! A cache of customized factories requested from this config.
     mutable TSearchKeyFactoryCPtrMap m_FactoryCache;
+
+    //! Is model plot enabled?
+    bool m_ModelPlotEnabled{false};
 
     //! Are annotations enabled for each of the models?
     bool m_ModelPlotAnnotationsEnabled{false};

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -75,6 +75,8 @@ const std::string CAnomalyJobConfig::CAnalysisConfig::SCHEDULED_EVENT_PREFIX("sc
 const std::string CAnomalyJobConfig::CAnalysisConfig::DESCRIPTION_SUFFIX(".description");
 const std::string CAnomalyJobConfig::CAnalysisConfig::RULES_SUFFIX(".rules");
 
+const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::DETECTOR_RULES{"detector_rules"};
+
 const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FUNCTION{"function"};
 const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::FIELD_NAME{"field_name"};
 const std::string CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::BY_FIELD_NAME{"by_field_name"};
@@ -316,6 +318,15 @@ const CAnomalyJobConfigReader DETECTOR_CONFIG_READER{[] {
     return theReader;
 }()};
 
+const CAnomalyJobConfigReader CUSTOM_RULES_UPDATE_CONFIG_READER{[] {
+    CAnomalyJobConfigReader theReader;
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::DETECTOR_INDEX,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::CUSTOM_RULES,
+                           CAnomalyJobConfigReader::E_RequiredParameter);
+    return theReader;
+}()};
+
 const CAnomalyJobConfigReader PPC_CONFIG_READER{[] {
     CAnomalyJobConfigReader theReader;
     theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::ENABLED,
@@ -431,6 +442,8 @@ bool CAnomalyJobConfig::parseEventConfig(const std::string& json) {
         return false;
     }
 
+    m_ScheduledEvents.clear();
+
     if (doc.ObjectEmpty()) {
         return true;
     }
@@ -443,6 +456,7 @@ bool CAnomalyJobConfig::parseEventConfig(const std::string& json) {
 
         const rapidjson::Value& value = doc[EVENTS];
 
+        m_Events.clear();
         m_Events.resize(value.Size());
         for (unsigned int i = 0; i < value.Size(); ++i) {
             if (value[i].IsObject() == false) {
@@ -488,9 +502,10 @@ void CAnomalyJobConfig::CEventConfig::parse(const rapidjson::Value& filterConfig
     scheduledEvents.emplace_back(m_Description, m_DetectionRules[0]);
 }
 
-bool CAnomalyJobConfig::parseFilterConfig(const std::string& json) {
+bool CAnomalyJobConfig::parseFilterConfig(const std::string& jsonString) {
+
     rapidjson::Document doc;
-    if (doc.Parse<0>(json).HasParseError()) {
+    if (doc.Parse<0>(jsonString).HasParseError()) {
         LOG_ERROR(<< "An error occurred while parsing filter config from JSON: "
                   << doc.GetParseError());
         return false;
@@ -502,7 +517,8 @@ bool CAnomalyJobConfig::parseFilterConfig(const std::string& json) {
 
     try {
         if (doc.HasMember(FILTERS) == false || doc[FILTERS].IsArray() == false) {
-            LOG_ERROR(<< "Missing expected array field '" << FILTERS << "'. JSON: " << json);
+            LOG_ERROR(<< "Missing expected array field '" << FILTERS
+                      << "'. JSON: " << jsonString);
             return false;
         }
 
@@ -514,7 +530,6 @@ bool CAnomalyJobConfig::parseFilterConfig(const std::string& json) {
                           << toString(value[i]));
                 return false;
             }
-
             m_Filters[i].parse(value[i], m_RuleFilters);
         }
     } catch (CAnomalyJobConfigReader::CParseError& e) {
@@ -717,114 +732,47 @@ void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisC
     m_MultivariateByFields = parameters[MULTIVARIATE_BY_FIELDS].fallback(false);
 }
 
-// TODO: Process updates as JSON
-bool CAnomalyJobConfig::CAnalysisConfig::updateFilters(const boost::property_tree::ptree& propTree) {
-    for (const auto& filterEntry : propTree) {
-        const std::string& key = filterEntry.first;
-        const std::string& value = filterEntry.second.data();
-        if (this->processFilter(key, value) == false) {
-            return false;
+bool CAnomalyJobConfig::CAnalysisConfig::parseRulesUpdate(const rapidjson::Value& rulesUpdateConfig) {
+    try {
+        auto parameters = CUSTOM_RULES_UPDATE_CONFIG_READER.read(rulesUpdateConfig);
+        int detectorIndex = parameters[CDetectorConfig::DETECTOR_INDEX].as<int>();
+        auto customRules = parameters[CDetectorConfig::CUSTOM_RULES].jsonObject();
+        if (customRules != nullptr) {
+            m_DetectorRules[detectorIndex].clear();
+            if (this->parseRules(detectorIndex, *customRules) == false) {
+                LOG_ERROR(<< "Failed to update detector rules for detector: " << detectorIndex);
+                return false;
+            }
         }
-    }
-    return true;
-}
-
-// TODO: Process updates as JSON
-bool CAnomalyJobConfig::CAnalysisConfig::processFilter(const std::string& key,
-                                                       const std::string& value) {
-    // expected format is filter.<filterId>=[json, array]
-    std::size_t sepPos{key.find(SUFFIX_SEPARATOR)};
-    if (sepPos == std::string::npos) {
-        LOG_ERROR(<< "Unrecognised filter key: " + key);
+    } catch (CAnomalyJobConfigReader::CParseError& e) {
+        LOG_ERROR(<< "Error parsing events config: " << e.what());
         return false;
     }
-    std::string filterId = key.substr(sepPos + 1);
-    core::CPatternSet& filter = m_RuleFilters[filterId];
-    return filter.initFromJson(value);
-}
-
-// TODO: Process updates as JSON
-bool CAnomalyJobConfig::CAnalysisConfig::updateScheduledEvents(const boost::property_tree::ptree& propTree) {
-    m_ScheduledEvents.clear();
-
-    bool isClear = propTree.get(CLEAR, false);
-    if (isClear) {
-        return true;
-    }
-
-    TIntSet handledScheduledEvents;
-
-    for (const auto& scheduledEventEntry : propTree) {
-        const std::string& key = scheduledEventEntry.first;
-        const std::string& value = scheduledEventEntry.second.data();
-        if (this->processScheduledEvent(propTree, key, value, handledScheduledEvents) == false) {
-            return false;
-        }
-    }
-    return true;
-}
-
-// TODO: Process updates as JSON
-bool CAnomalyJobConfig::CAnalysisConfig::processScheduledEvent(
-    const boost::property_tree::ptree& propTree,
-    const std::string& key,
-    const std::string& value,
-    TIntSet& handledScheduledEvents) {
-    // Here we pull out the "1" in "scheduledevent.1.description"
-    // description may contain a '.'
-    std::size_t sepPos{key.find(SUFFIX_SEPARATOR, SCHEDULED_EVENT_PREFIX.length() + 1)};
-    if (sepPos == std::string::npos || sepPos == key.length() - 1) {
-        LOG_ERROR(<< "Unrecognised configuration option " << key << " = " << value);
-        return false;
-    }
-
-    std::string indexString{key, SCHEDULED_EVENT_PREFIX.length(),
-                            sepPos - SCHEDULED_EVENT_PREFIX.length()};
-    int indexKey;
-    if (core::CStringUtils::stringToType(indexString, indexKey) == false) {
-        LOG_ERROR(<< "Cannot convert config key to integer: " << indexString);
-        return false;
-    }
-
-    // Check if we've already seen this key
-    if (handledScheduledEvents.insert(indexKey).second == false) {
-        // Not an error
-        return true;
-    }
-
-    std::string description{propTree.get(
-        boost::property_tree::ptree::path_type{
-            SCHEDULED_EVENT_PREFIX + indexString + DESCRIPTION_SUFFIX, '\t'},
-        EMPTY_STRING)};
-
-    std::string rules{propTree.get(
-        boost::property_tree::ptree::path_type{
-            SCHEDULED_EVENT_PREFIX + indexString + RULES_SUFFIX, '\t'},
-        EMPTY_STRING)};
-
-    CDetectionRulesJsonParser::TDetectionRuleVec detectionRules;
-    if (this->parseRules(detectionRules, rules) == false) {
-        // parseRules() will have logged the error
-        return false;
-    }
-
-    if (detectionRules.size() != 1) {
-        LOG_ERROR(<< "Scheduled events must have exactly 1 rule");
-        return false;
-    }
-
-    m_ScheduledEvents.emplace_back(description, detectionRules[0]);
 
     return true;
 }
 
-// TODO: Process updates as JSON
+bool CAnomalyJobConfig::CAnalysisConfig::parseRules(int detectorIndex,
+                                                    const rapidjson::Value& rules) {
+    return parseRules(m_DetectorRules[detectorIndex], rules);
+}
+
+bool CAnomalyJobConfig::CAnalysisConfig::parseRules(CDetectionRulesJsonParser::TDetectionRuleVec& detectionRules,
+                                                    const rapidjson::Value& rules) {
+    CDetectionRulesJsonParser rulesParser{m_RuleFilters};
+    std::string errorString;
+    if (rulesParser.parseRules(rules, detectionRules, errorString) == false) {
+        LOG_ERROR(<< "Error parsing detector rules: " << errorString);
+        return false;
+    }
+    return true;
+}
+
 bool CAnomalyJobConfig::CAnalysisConfig::parseRules(int detectorIndex,
                                                     const std::string& rules) {
     return parseRules(m_DetectorRules[detectorIndex], rules);
 }
 
-// TODO: Process updates as JSON
 bool CAnomalyJobConfig::CAnalysisConfig::parseRules(CDetectionRulesJsonParser::TDetectionRuleVec& detectionRules,
                                                     const std::string& rules) {
     if (rules.empty()) {
@@ -921,7 +869,6 @@ bool CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::determineFunction(bool
     // Some functions must take a field, some mustn't and for the rest it's
     // optional.  Validate this based on the contents of these flags after
     // determining the function.  Similarly for by fields.
-    // TODO: Check how much validation is required here (if any) if parsing JSON job config.
     bool fieldRequired{false};
     bool fieldInvalid{false};
     bool byFieldRequired{false};

--- a/lib/api/CConfigUpdater.cc
+++ b/lib/api/CConfigUpdater.cc
@@ -23,7 +23,7 @@ bool CConfigUpdater::update(const std::string& json) {
     rapidjson::Document doc;
     if (doc.Parse<0>(json.c_str()).HasParseError()) {
         LOG_ERROR(<< "An error occurred while parsing pattern set from JSON: "
-                         << rapidjson::GetParseError_En(doc.GetParseError()));
+                  << rapidjson::GetParseError_En(doc.GetParseError()));
         return false;
     }
 

--- a/lib/api/CConfigUpdater.cc
+++ b/lib/api/CConfigUpdater.cc
@@ -22,8 +22,8 @@ CConfigUpdater::CConfigUpdater(CAnomalyJobConfig& jobConfig,
 bool CConfigUpdater::update(const std::string& json) {
     rapidjson::Document doc;
     if (doc.Parse<0>(json.c_str()).HasParseError()) {
-        LOG_ERROR(<< "An error occurred while parsing pattern set from JSON: " +
-                         std::string(rapidjson::GetParseError_En(doc.GetParseError())));
+        LOG_ERROR(<< "An error occurred while parsing pattern set from JSON: "
+                         << rapidjson::GetParseError_En(doc.GetParseError()));
         return false;
     }
 

--- a/lib/api/CConfigUpdater.cc
+++ b/lib/api/CConfigUpdater.cc
@@ -7,75 +7,68 @@
 
 #include <model/CLimits.h>
 
-#include <boost/property_tree/ini_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
+#include <rapidjson/document.h>
+#include <rapidjson/error/en.h>
+#include <rapidjson/stringbuffer.h>
 
 namespace ml {
 namespace api {
-
-const std::string CConfigUpdater::MODEL_DEBUG_CONFIG("modelPlotConfig");
-const std::string CConfigUpdater::DETECTOR_RULES("detectorRules");
-const std::string CConfigUpdater::DETECTOR_INDEX("detectorIndex");
-const std::string CConfigUpdater::RULES_JSON("rulesJson");
-const std::string CConfigUpdater::FILTERS("filters");
-const std::string CConfigUpdater::SCHEDULED_EVENTS("scheduledEvents");
 
 CConfigUpdater::CConfigUpdater(CAnomalyJobConfig& jobConfig,
                                model::CAnomalyDetectorModelConfig& modelConfig)
     : m_JobConfig(jobConfig), m_ModelConfig(modelConfig) {
 }
 
-bool CConfigUpdater::update(const std::string& config) {
-    boost::property_tree::ptree propTree;
-
-    try {
-        std::istringstream strm(config);
-        boost::property_tree::ini_parser::read_ini(strm, propTree);
-    } catch (boost::property_tree::ptree_error& e) {
-        LOG_ERROR(<< "Error parsing config from '" << config << "' : " << e.what());
+bool CConfigUpdater::update(const std::string& json) {
+    rapidjson::Document doc;
+    if (doc.Parse<0>(json.c_str()).HasParseError()) {
+        LOG_ERROR(<< "An error occurred while parsing pattern set from JSON: " +
+                         std::string(rapidjson::GetParseError_En(doc.GetParseError())));
         return false;
     }
 
-    for (boost::property_tree::ptree::const_iterator stanzaItr = propTree.begin();
-         stanzaItr != propTree.end(); ++stanzaItr) {
-        const std::string& stanzaName = stanzaItr->first;
-        const boost::property_tree::ptree& subTree = stanzaItr->second;
-
-        if (stanzaName == MODEL_DEBUG_CONFIG) {
-            if (m_ModelConfig.configureModelPlot(subTree) == false) {
-                LOG_ERROR(<< "Could not parse modelPlotConfig");
-                return false;
-            }
-        } else if (stanzaName == DETECTOR_RULES) {
-            std::string detectorIndexString = subTree.get(DETECTOR_INDEX, std::string());
-            int detectorIndex;
-            if (core::CStringUtils::stringToType(detectorIndexString, detectorIndex) == false) {
-                LOG_ERROR(<< "Invalid detector index: " << detectorIndexString);
-                return false;
-            }
-            std::string rulesJson = subTree.get(RULES_JSON, std::string());
-            if (m_JobConfig.analysisConfig().parseRules(detectorIndex, rulesJson) == false) {
-                LOG_ERROR(<< "Failed to update detector rules for detector: " << detectorIndex);
-                return false;
-            }
-        } else if (stanzaName == FILTERS) {
-            // TODO: Move to JSON format for config updates.
-            if (m_JobConfig.analysisConfig().updateFilters(subTree) == false) {
-                LOG_ERROR(<< "Failed to update filters");
-                return false;
-            }
-        } else if (stanzaName == SCHEDULED_EVENTS) {
-            // TODO: Move to JSON format for config updates.
-            if (m_JobConfig.analysisConfig().updateScheduledEvents(subTree) == false) {
-                LOG_ERROR(<< "Failed to update scheduled events");
-                return false;
-            }
-        } else {
-            LOG_WARN(<< "Ignoring unknown update config stanza: " << stanzaName);
-            return false;
-        }
+    if (doc.IsObject() == false) {
+        LOG_ERROR(<< "Input error: expected JSON object but input was '" << json
+                  << "'. Please report this problem.");
+        return false;
     }
 
+    if (doc.HasMember(CAnomalyJobConfig::MODEL_PLOT_CONFIG)) {
+        if (doc[CAnomalyJobConfig::MODEL_PLOT_CONFIG].IsObject() == false) {
+            LOG_ERROR(<< "Input error: expected "
+                      << CAnomalyJobConfig::MODEL_PLOT_CONFIG
+                      << " to be JSON object but input was '"
+                      << json
+                      << "'. Please report this problem.");
+            return false;
+        }
+        const rapidjson::Value& value = doc[CAnomalyJobConfig::MODEL_PLOT_CONFIG];
+
+        m_JobConfig.modelPlotConfig().parse(value);
+        const ml::api::CAnomalyJobConfig::CModelPlotConfig& modelPlotConfig =
+            m_JobConfig.modelPlotConfig();
+        m_ModelConfig.configureModelPlot(modelPlotConfig.enabled(),
+                                         modelPlotConfig.annotationsEnabled(),
+                                         modelPlotConfig.terms());
+    } else if (doc.HasMember(CAnomalyJobConfig::FILTERS)) {
+        if (m_JobConfig.parseFilterConfig(json) == false) {
+            LOG_ERROR(<< "Failed to parse filter config update: " << json);
+            return false;
+        }
+        m_JobConfig.initRuleFilters();
+    } else if (doc.HasMember(CAnomalyJobConfig::EVENTS)) {
+        if (m_JobConfig.parseEventConfig(json) == false) {
+            LOG_ERROR(<< "Failed to parse events config update: " << json);
+            return false;
+        }
+        m_JobConfig.initScheduledEvents();
+    } else if (doc.HasMember(CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::DETECTOR_RULES)) {
+        return m_JobConfig.analysisConfig().parseRulesUpdate(
+            doc[CAnomalyJobConfig::CAnalysisConfig::CDetectorConfig::DETECTOR_RULES]);
+    } else {
+        LOG_ERROR(<< "Unexpected JSON update message: " << json);
+        return false;
+    }
     return true;
 }
 }

--- a/lib/api/CConfigUpdater.cc
+++ b/lib/api/CConfigUpdater.cc
@@ -35,10 +35,8 @@ bool CConfigUpdater::update(const std::string& json) {
 
     if (doc.HasMember(CAnomalyJobConfig::MODEL_PLOT_CONFIG)) {
         if (doc[CAnomalyJobConfig::MODEL_PLOT_CONFIG].IsObject() == false) {
-            LOG_ERROR(<< "Input error: expected "
-                      << CAnomalyJobConfig::MODEL_PLOT_CONFIG
-                      << " to be JSON object but input was '"
-                      << json
+            LOG_ERROR(<< "Input error: expected " << CAnomalyJobConfig::MODEL_PLOT_CONFIG
+                      << " to be JSON object but input was '" << json
                       << "'. Please report this problem.");
             return false;
         }

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -375,7 +375,9 @@ bool CAnomalyDetectorModelConfig::init(const boost::property_tree::ptree& propTr
 void CAnomalyDetectorModelConfig::configureModelPlot(bool modelPlotEnabled,
                                                      bool annotationsEnabled,
                                                      const std::string& terms) {
-    if (modelPlotEnabled) {
+    m_ModelPlotEnabled = modelPlotEnabled;
+
+    if (m_ModelPlotEnabled) {
         m_ModelPlotBoundsPercentile = maths::CModel::DEFAULT_BOUNDS_PERCENTILE;
     }
 
@@ -390,6 +392,8 @@ void CAnomalyDetectorModelConfig::configureModelPlot(bool modelPlotEnabled,
     if (remainder.empty() == false) {
         tokens.push_back(remainder);
     }
+
+    m_ModelPlotTerms.clear();
     for (const auto& token : tokens) {
         m_ModelPlotTerms.insert(token);
     }
@@ -479,6 +483,10 @@ bool CAnomalyDetectorModelConfig::configureModelPlot(const boost::property_tree:
     }
 
     return true;
+}
+
+bool CAnomalyDetectorModelConfig::modelPlotEnabled() const {
+    return m_ModelPlotEnabled;
 }
 
 bool CAnomalyDetectorModelConfig::modelPlotAnnotationsEnabled() const {


### PR DESCRIPTION
Expect configuration update requests to be received in JSON formatted
strings. Remove support for old, ini file parsing.

Relates elastic/elasticsearch#67721, #1253 