### PR TITLE
[ML] Provide the ability to override eta growth rate hyperparameter

### DIFF
--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -100,6 +100,8 @@ public:
     CBoostedTreeFactory& maxTreeDepthTolerance(double maxTreeDepthTolerance);
     //! Set the amount we'll shrink the weights on each each iteration.
     CBoostedTreeFactory& eta(double eta);
+    //! Set the amount we'll grow eta on each each iteration.
+    CBoostedTreeFactory& etaGrowthRatePerTree(double etaGrowthRatePerTree);
     //! Set the maximum number of trees in the ensemble.
     CBoostedTreeFactory& maximumNumberTrees(std::size_t maximumNumberTrees);
     //! Set the fraction of features we'll use in the bag to build a tree.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -347,6 +347,7 @@ private:
     TRegularizationOverride m_RegularizationOverride;
     TOptionalDouble m_DownsampleFactorOverride;
     TOptionalDouble m_EtaOverride;
+    TOptionalDouble m_EtaGrowthRatePerTreeOverride;
     TOptionalSize m_NumberFoldsOverride;
     TOptionalSize m_MaximumNumberTreesOverride;
     TOptionalDouble m_FeatureBagFractionOverride;

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -100,6 +100,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double lambda{parameters[LAMBDA].fallback(-1.0)};
     double gamma{parameters[GAMMA].fallback(-1.0)};
     double eta{parameters[ETA].fallback(-1.0)};
+    double etaGrowthRatePerTree{parameters[ETA_GROWTH_RATE_PER_TREE].fallback(-1.0)};
     double softTreeDepthLimit{parameters[SOFT_TREE_DEPTH_LIMIT].fallback(-1.0)};
     double softTreeDepthTolerance{parameters[SOFT_TREE_DEPTH_TOLERANCE].fallback(-1.0)};
     double featureBagFraction{parameters[FEATURE_BAG_FRACTION].fallback(-1.0)};
@@ -118,6 +119,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     }
     if (eta != -1.0 && (eta <= 0.0 || eta > 1.0)) {
         HANDLE_FATAL(<< "Input error: '" << ETA << "' should be in the range (0, 1].")
+    }
+    if (etaGrowthRatePerTree != -1.0 && etaGrowthRatePerTree <= 0.0) {
+        HANDLE_FATAL(<< "Input error: '" << ETA_GROWTH_RATE_PER_TREE << "' should be positive.")
     }
     if (softTreeDepthLimit != -1.0 && softTreeDepthLimit < 0.0) {
         HANDLE_FATAL(<< "Input error: '" << SOFT_TREE_DEPTH_LIMIT << "' should be non-negative.")
@@ -160,6 +164,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     }
     if (eta > 0.0 && eta <= 1.0) {
         m_BoostedTreeFactory->eta(eta);
+    }
+    if (etaGrowthRatePerTree > 0.0) {
+        m_BoostedTreeFactory->etaGrowthRatePerTree(etaGrowthRatePerTree);
     }
     if (softTreeDepthLimit >= 0.0) {
         m_BoostedTreeFactory->softTreeDepthLimit(softTreeDepthLimit);

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1234,7 +1234,7 @@ CBoostedTreeFactory& CBoostedTreeFactory::eta(double eta) {
 
 CBoostedTreeFactory& CBoostedTreeFactory::etaGrowthRatePerTree(double etaGrowthRatePerTree) {
     if (etaGrowthRatePerTree < MIN_ETA) {
-        LOG_WARN(<< "Truncating supplied learning rate " << etaGrowthRatePerTree
+        LOG_WARN(<< "Truncating supplied learning rate growth rate " << etaGrowthRatePerTree
                  << " which must be no smaller than " << MIN_ETA);
         etaGrowthRatePerTree = std::max(etaGrowthRatePerTree, MIN_ETA);
     }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -233,7 +233,8 @@ void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {
             }
             break;
         case E_EtaGrowthRatePerTree:
-            if (m_TreeImpl->m_EtaOverride == boost::none) {
+            if (m_TreeImpl->m_EtaOverride == boost::none &&
+                m_TreeImpl->m_EtaGrowthRatePerTreeOverride == boost::none) {
                 double rate{m_TreeImpl->m_EtaGrowthRatePerTree - 1.0};
                 boundingBox.emplace_back(1.0 + MIN_ETA_GROWTH_RATE_SCALE * rate,
                                          1.0 + MAX_ETA_GROWTH_RATE_SCALE * rate);
@@ -441,6 +442,10 @@ void CBoostedTreeFactory::initializeHyperparametersSetup(core::CDataFrame& frame
         m_TreeImpl->m_Eta =
             computeEta(frame.numberColumns() - this->numberExtraColumnsForTrain());
         m_TreeImpl->m_EtaGrowthRatePerTree = 1.0 + m_TreeImpl->m_Eta / 2.0;
+    }
+
+    if (m_TreeImpl->m_EtaGrowthRatePerTreeOverride != boost::none) {
+        m_TreeImpl->m_EtaGrowthRatePerTree = *(m_TreeImpl->m_EtaGrowthRatePerTreeOverride);
     }
 
     if (m_TreeImpl->m_MaximumNumberTreesOverride != boost::none) {
@@ -839,7 +844,9 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
 
                 auto applyEta = [](CBoostedTreeImpl& tree, double eta) {
                     tree.m_Eta = CTools::stableExp(eta);
-                    tree.m_EtaGrowthRatePerTree = 1.0 + tree.m_Eta / 2.0;
+                    if (tree.m_EtaGrowthRatePerTreeOverride == boost::none) {
+                        tree.m_EtaGrowthRatePerTree = 1.0 + tree.m_Eta / 2.0;
+                    }
                     if (tree.m_MaximumNumberTreesOverride == boost::none) {
                         tree.m_MaximumNumberTrees = computeMaximumNumberTrees(tree.m_Eta);
                     }
@@ -1222,6 +1229,16 @@ CBoostedTreeFactory& CBoostedTreeFactory::eta(double eta) {
         eta = 1.0;
     }
     m_TreeImpl->m_EtaOverride = eta;
+    return *this;
+}
+
+CBoostedTreeFactory& CBoostedTreeFactory::etaGrowthRatePerTree(double etaGrowthRatePerTree) {
+    if (etaGrowthRatePerTree < MIN_ETA) {
+        LOG_WARN(<< "Truncating supplied learning rate " << etaGrowthRatePerTree
+                 << " which must be no smaller than " << MIN_ETA);
+        etaGrowthRatePerTree = std::max(etaGrowthRatePerTree, MIN_ETA);
+    }
+    m_TreeImpl->m_EtaGrowthRatePerTreeOverride = etaGrowthRatePerTree;
     return *this;
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1513,8 +1513,8 @@ const std::string DOWNSAMPLE_FACTOR_OVERRIDE_TAG{"downsample_factor_override"};
 const std::string DOWNSAMPLE_FACTOR_TAG{"downsample_factor"};
 const std::string ENCODER_TAG{"encoder"};
 const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
+const std::string ETA_GROWTH_RATE_PER_TREE_OVERRIDE_TAG{"eta_growth_rate_per_tree_override"};
 const std::string ETA_OVERRIDE_TAG{"eta_override"};
-const std::string ETA_GROWTH_PER_TREE_OVERRIDE_TAG{"eta_growth_per_tree"};
 const std::string ETA_TAG{"eta"};
 const std::string FEATURE_BAG_FRACTION_OVERRIDE_TAG{"feature_bag_fraction_override"};
 const std::string FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
@@ -1580,10 +1580,10 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persistIfNotNull(ENCODER_TAG, m_Encoder, inserter);
     core::CPersistUtils::persist(ETA_GROWTH_RATE_PER_TREE_TAG,
                                  m_EtaGrowthRatePerTree, inserter);
+    core::CPersistUtils::persist(ETA_GROWTH_RATE_PER_TREE_OVERRIDE_TAG,
+                                 m_EtaGrowthRatePerTreeOverride, inserter);
     core::CPersistUtils::persist(ETA_TAG, m_Eta, inserter);
     core::CPersistUtils::persist(ETA_OVERRIDE_TAG, m_EtaOverride, inserter);
-    core::CPersistUtils::persist(ETA_GROWTH_PER_TREE_OVERRIDE_TAG,
-                                 m_EtaGrowthRatePerTreeOverride, inserter);
     core::CPersistUtils::persist(FEATURE_BAG_FRACTION_TAG, m_FeatureBagFraction, inserter);
     core::CPersistUtils::persist(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
                                  m_FeatureBagFractionOverride, inserter);
@@ -1669,11 +1669,11 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
         RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
                 core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
                                              m_EtaGrowthRatePerTree, traverser))
+        RESTORE(ETA_GROWTH_RATE_PER_TREE_OVERRIDE_TAG,
+                core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_OVERRIDE_TAG,
+                                             m_EtaGrowthRatePerTreeOverride, traverser))
         RESTORE(ETA_OVERRIDE_TAG,
                 core::CPersistUtils::restore(ETA_OVERRIDE_TAG, m_EtaOverride, traverser))
-        RESTORE(ETA_GROWTH_PER_TREE_OVERRIDE_TAG,
-                core::CPersistUtils::restore(ETA_GROWTH_PER_TREE_OVERRIDE_TAG,
-                                             m_EtaGrowthRatePerTreeOverride, traverser))
         RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
         RESTORE(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
                 core::CPersistUtils::restore(FEATURE_BAG_FRACTION_OVERRIDE_TAG,

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1381,7 +1381,9 @@ void CBoostedTreeImpl::restoreBestHyperparameters() {
 std::size_t CBoostedTreeImpl::numberHyperparametersToTune() const {
     return m_RegularizationOverride.countNotSet() +
            (m_DownsampleFactorOverride != boost::none ? 0 : 1) +
-           (m_EtaOverride != boost::none ? 0 : 2) +
+           (m_EtaOverride != boost::none
+                ? 0
+                : (m_EtaGrowthRatePerTreeOverride != boost::none ? 1 : 2)) +
            (m_FeatureBagFractionOverride != boost::none ? 0 : 1);
 }
 
@@ -1455,7 +1457,7 @@ void CBoostedTreeImpl::initializeTunableHyperparameters() {
             }
             break;
         case E_EtaGrowthRatePerTree:
-            if (m_EtaOverride == boost::none) {
+            if (m_EtaOverride == boost::none && m_EtaGrowthRatePerTreeOverride == boost::none) {
                 m_TunableHyperparameters.emplace_back(E_EtaGrowthRatePerTree);
             }
             break;
@@ -1512,6 +1514,7 @@ const std::string DOWNSAMPLE_FACTOR_TAG{"downsample_factor"};
 const std::string ENCODER_TAG{"encoder"};
 const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
 const std::string ETA_OVERRIDE_TAG{"eta_override"};
+const std::string ETA_GROWTH_PER_TREE_OVERRIDE_TAG{"eta_growth_per_tree"};
 const std::string ETA_TAG{"eta"};
 const std::string FEATURE_BAG_FRACTION_OVERRIDE_TAG{"feature_bag_fraction_override"};
 const std::string FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
@@ -1579,6 +1582,8 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
                                  m_EtaGrowthRatePerTree, inserter);
     core::CPersistUtils::persist(ETA_TAG, m_Eta, inserter);
     core::CPersistUtils::persist(ETA_OVERRIDE_TAG, m_EtaOverride, inserter);
+    core::CPersistUtils::persist(ETA_GROWTH_PER_TREE_OVERRIDE_TAG,
+                                 m_EtaGrowthRatePerTreeOverride, inserter);
     core::CPersistUtils::persist(FEATURE_BAG_FRACTION_TAG, m_FeatureBagFraction, inserter);
     core::CPersistUtils::persist(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
                                  m_FeatureBagFractionOverride, inserter);
@@ -1666,6 +1671,9 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
                                              m_EtaGrowthRatePerTree, traverser))
         RESTORE(ETA_OVERRIDE_TAG,
                 core::CPersistUtils::restore(ETA_OVERRIDE_TAG, m_EtaOverride, traverser))
+        RESTORE(ETA_GROWTH_PER_TREE_OVERRIDE_TAG,
+                core::CPersistUtils::restore(ETA_GROWTH_PER_TREE_OVERRIDE_TAG,
+                                             m_EtaGrowthRatePerTreeOverride, traverser))
         RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
         RESTORE(FEATURE_BAG_FRACTION_OVERRIDE_TAG,
                 core::CPersistUtils::restore(FEATURE_BAG_FRACTION_OVERRIDE_TAG,

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1617,6 +1617,28 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
         BOOST_REQUIRE_EQUAL(0.4, regression->bestHyperparameters().featureBagFraction());
         BOOST_REQUIRE_EQUAL(0.6, regression->bestHyperparameters().downsampleFactor());
     }
+    {
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .analysisInstrumentation(instrumentation)
+                              .depthPenaltyMultiplier(1.0)
+                              .softTreeDepthLimit(3.0)
+                              .softTreeDepthTolerance(0.1)
+                              .featureBagFraction(0.4)
+                              .downsampleFactor(0.6)
+                              .etaGrowthRatePerTree(1.1)
+                              .buildFor(*frame, cols - 1);
+
+        regression->train();
+        BOOST_REQUIRE_EQUAL(
+            1.0, regression->bestHyperparameters().regularization().depthPenaltyMultiplier());
+        BOOST_REQUIRE_EQUAL(
+            3.0, regression->bestHyperparameters().regularization().softTreeDepthLimit());
+        BOOST_REQUIRE_EQUAL(
+            0.1, regression->bestHyperparameters().regularization().softTreeDepthTolerance());
+        BOOST_REQUIRE_EQUAL(0.4, regression->bestHyperparameters().featureBagFraction());
+        BOOST_REQUIRE_EQUAL(1.1, regression->bestHyperparameters().etaGrowthRatePerTree());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testPersistRestore) {


### PR DESCRIPTION
The eta growth rate was historically controlled by the choice for the eta parameter, but setting them independently might sometimes yield better results. This adds the ability to override it manually. This isn't user facing yet (in the Java) so marking as a non-issue and not documenting.