### PR TITLE
[7.x][ML] Early stopping for hyperparameter optimization procedure

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -36,6 +36,8 @@
   if the time series has non-diurnal seasonality. (See {ml-pull}1634[#1634].)
 * Compute importance of hyperparameters optimized in the fine parameter tuning step.
   (See {ml-pull}1627[#1627].)
+* Early stopping for the fine parameter tuning step  of classification and regression
+  model training. (See {ml-pull}1676[#1676].)
 * Correct upgrade for pre-6.3 state for lat_long anomaly anomaly detectors. (See
   {ml-pull}1681[#1681].)
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -54,6 +54,7 @@ public:
     static const std::string NUM_TOP_FEATURE_IMPORTANCE_VALUES;
     static const std::string TRAINING_PERCENT_FIELD_NAME;
     static const std::string FEATURE_PROCESSORS;
+    static const std::string EARLY_STOPPING_ALLOWED;
 
     // Output
     static const std::string IS_TRAINING_FIELD_NAME;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -115,6 +115,8 @@ public:
     CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
     //! Set the number of training examples we need per feature we'll include.
     CBoostedTreeFactory& numberTopShapValues(std::size_t numberTopShapValues);
+    //! Stop hyperparameter optimization early if the the process is not promising.
+    CBoostedTreeFactory& stopHyperparameterOptimizationEarly(bool stopEarly);
 
     //! Set pointer to the analysis instrumentation.
     CBoostedTreeFactory&

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -178,6 +178,7 @@ private:
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
     using TWorkspace = CBoostedTreeLeafNodeStatistics::CWorkspace;
     using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameters>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
 
     //! Tag progress through initialization.
     enum EInitializationStage {
@@ -330,8 +331,11 @@ private:
     //! Record hyperparameters for instrumentation.
     void recordHyperparameters();
 
-    //! Populate the list of tunable hyperparameters
+    //! Populate the list of tunable hyperparameters.
     void initializeTunableHyperparameters();
+
+    //! Use Sobol sampler for for random hyperparamers.
+    void initializeHyperparameterSamples();
 
 private:
     mutable CPRNG::CXorOShiro128Plus m_Rng;
@@ -383,6 +387,8 @@ private:
     mutable TMeanAccumulator m_ForestSizeAccumulator;
     mutable TMeanAccumulator m_MeanLossAccumulator;
     THyperparametersVec m_TunableHyperparameters;
+    TDoubleVecVec m_HyperparameterSamples;
+    bool m_StopHyperparameterOptimizationEarly = true;
 
 private:
     friend class CBoostedTreeFactory;

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -85,6 +85,7 @@ public:
     predictionPersisterSupplier(TPersisterSupplier* persisterSupplier);
     CDataFrameAnalysisSpecificationFactory&
     predictionRestoreSearcherSupplier(TRestoreSearcherSupplier* restoreSearcherSupplier);
+    CDataFrameAnalysisSpecificationFactory& earlyStoppingAllowed(bool earlyStoppingAllowed);
 
     // Regression
     CDataFrameAnalysisSpecificationFactory& regressionLossFunction(TLossFunctionType lossFunction);
@@ -145,6 +146,7 @@ private:
     std::size_t m_NumberClasses = 2;
     std::size_t m_NumberTopClasses = 0;
     std::string m_PredictionFieldType;
+    bool m_EarlyStoppingAllowed = true;
 };
 }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -65,6 +65,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(FEATURE_PROCESSORS,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(EARLY_STOPPING_ALLOWED,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -82,6 +84,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         m_DependentVariableFieldName + "_prediction");
 
     m_TrainingPercent = parameters[TRAINING_PERCENT_FIELD_NAME].fallback(100.0) / 100.0;
+
+    bool earlyStoppingAllowed = parameters[EARLY_STOPPING_ALLOWED].fallback(true);
+
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
     double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
@@ -144,7 +149,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     (*m_BoostedTreeFactory)
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
-        .trainingStateCallback(this->statePersister());
+        .trainingStateCallback(this->statePersister())
+        .stopHyperparameterOptimizationEarly(earlyStoppingAllowed);
 
     if (downsampleRowsPerFeature > 0) {
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(
@@ -389,6 +395,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME{"fea
 const std::string CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME{"importance"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS{"feature_processors"};
+const std::string CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ALLOWED{"early_stopping_allowed"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -617,8 +617,8 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceNoImportance, SFixture) {
             double c1{readShapValue(result, "c1")};
             double prediction{
                 result["row_results"]["results"]["ml"]["target_prediction"].GetDouble()};
-            // c1 explains 94% of the prediction value, i.e. the difference from the prediction is less than 6%.
-            BOOST_REQUIRE_CLOSE(c1, prediction, 6.0);
+            // c1 explains 92% of the prediction value, i.e. the difference from the prediction is less than 8%.
+            BOOST_REQUIRE_CLOSE(c1, prediction, 8.0);
             for (const auto& feature : {"c2", "c3", "c4"}) {
                 double c = readShapValue(result, feature);
                 BOOST_REQUIRE_SMALL(c, 3.0);

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1900000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1910000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -597,6 +597,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
                     .predictionPersisterSupplier(persisterSupplier)
                     .predictionRestoreSearcherSupplier(restorerSupplier)
                     .regressionLossFunction(lossFunction)
+                    .earlyStoppingAllowed(false)
                     .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(),
                                     dependentVariable);
             };
@@ -681,7 +682,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 4500000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1900000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 1910000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -1011,6 +1012,7 @@ BOOST_AUTO_TEST_CASE(testProgressFromRestart) {
             .memoryLimit(18000000)
             .predictionPersisterSupplier(persisterSupplier)
             .predictionRestoreSearcherSupplier(restorerSupplier)
+            .earlyStoppingAllowed(false)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target");
     };
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1302,6 +1302,11 @@ CBoostedTreeFactory& CBoostedTreeFactory::trainingStateCallback(TTrainingStateCa
     return *this;
 }
 
+CBoostedTreeFactory& CBoostedTreeFactory::stopHyperparameterOptimizationEarly(bool stopEarly) {
+    m_TreeImpl->m_StopHyperparameterOptimizationEarly = stopEarly;
+    return *this;
+}
+
 std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
                                                      std::size_t numberColumns) const {
     std::size_t maximumNumberTrees{this->mainLoopMaximumNumberTrees(

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -247,7 +247,6 @@ auto predictAndComputeEvaluationMetrics(const F& generateFunction,
 
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   1, lossFunction->clone())
-                                  .stopHyperparameterOptimizationEarly(false)
                                   .buildFor(*frame, cols - 1);
 
             regression->train();
@@ -362,7 +361,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
                     8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
             }
             // Good R^2...
-            BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.94);
+            BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.93);
 
             meanModelRSquared.add(modelRSquared[i][0]);
         }
@@ -435,7 +434,7 @@ BOOST_AUTO_TEST_CASE(testLinear) {
             meanModelRSquared.add(modelRSquared[i][0]);
         }
         LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.98);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
     }
 }
 
@@ -759,7 +758,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.08);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.1);
     BOOST_TEST_REQUIRE(modelRSquared > 0.98);
 }
 
@@ -1422,7 +1421,6 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
         std::thread worker{[&]() {
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   threads, std::make_unique<maths::boosted_tree::CMse>())
-                                  .stopHyperparameterOptimizationEarly(false)
                                   .analysisInstrumentation(instrumentation)
                                   .buildFor(*frame, cols - 1);
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1067,13 +1067,13 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.67);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 0.68);
         meanLogRelativeError.add(maths::CBasicStatistics::mean(logRelativeError));
     }
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.5);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.51);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
@@ -1156,7 +1156,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     LOG_DEBUG(<< "recalls    = " << core::CContainerPrinter::print(recalls));
 
     BOOST_TEST_REQUIRE(std::fabs(precisions[0] - precisions[1]) < 0.1);
-    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.1);
+    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.11);
 }
 
 BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
@@ -1421,6 +1421,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
         std::thread worker{[&]() {
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   threads, std::make_unique<maths::boosted_tree::CMse>())
+                                  .stopHyperparameterOptimizationEarly(false)
                                   .analysisInstrumentation(instrumentation)
                                   .buildFor(*frame, cols - 1);
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -247,6 +247,7 @@ auto predictAndComputeEvaluationMetrics(const F& generateFunction,
 
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   1, lossFunction->clone())
+                                  .stopHyperparameterOptimizationEarly(false)
                                   .buildFor(*frame, cols - 1);
 
             regression->train();

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1422,6 +1422,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   threads, std::make_unique<maths::boosted_tree::CMse>())
                                   .analysisInstrumentation(instrumentation)
+                                  .stopHyperparameterOptimizationEarly(false)
                                   .buildFor(*frame, cols - 1);
 
             regression->train();

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -182,6 +182,12 @@ CDataFrameAnalysisSpecificationFactory::predictionRestoreSearcherSupplier(
 }
 
 CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::earlyStoppingAllowed(bool earlyStoppingAllowed) {
+    m_EarlyStoppingAllowed = earlyStoppingAllowed;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::numberClasses(std::size_t number) {
     m_NumberClasses = number;
     return *this;
@@ -338,6 +344,10 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
     if (m_CustomProcessors.IsNull() == false) {
         writer.Key(api::CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS);
         writer.write(m_CustomProcessors);
+    }
+    if (m_EarlyStoppingAllowed == false) {
+        writer.Key(api::CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ALLOWED);
+        writer.Bool(m_EarlyStoppingAllowed);
     }
 
     if (analysis == regression()) {


### PR DESCRIPTION
This PR implements early stopping of fine parameter tuning if the search process if the loss surfaces appear to be flat (very low total variation of the loss surface of hyperparameters).
It also replaces uniform sampling of the hyperparameter in the first step of exploration by Sobol sampling which has a higher discrepancy.

I introduced the new configuration parameter early_stopping_allowed similar to the disk_usage_allowed. In the internal routines and for persist/restore, I call this flag stopHyperparameterOptimizationEarly similar to stopCrossValidationEarly that is already used.

Backport for  #1676.