### PR TITLE
[ML] Use Eigen BLAS library when building PyTorch for Linux

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -283,6 +283,10 @@ export BUILD_TEST=OFF
 export BUILD_CAFFE2=OFF
 export USE_NUMPY=OFF
 export USE_DISTRIBUTED=OFF
+export USE_MKLDNN=OFF
+export BLAS=Eigen
+export PYTORCH_BUILD_VERSION=1.7.1
+export PYTORCH_BUILD_NUMBER=1
 /usr/local/bin/python3.7 setup.py install
 ```
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -131,6 +131,10 @@ RUN \
   export BUILD_CAFFE2=OFF && \
   export USE_NUMPY=OFF && \
   export USE_DISTRIBUTED=OFF && \
+  export USE_MKLDNN=OFF && \
+  export BLAS=Eigen && \
+  export PYTORCH_BUILD_VERSION=1.7.1 && \
+  export PYTORCH_BUILD_NUMBER=1 && \
   cd ${build_dir}/pytorch && \
   /usr/local/bin/python3.7 setup.py install && \
   mkdir /usr/local/gcc93/include/pytorch && \


### PR DESCRIPTION
Following https://github.com/elastic/ml-cpp/pull/1678#issuecomment-766327160 it is preferable to not have a dependency on libMKL for now at least. There are a number of alternative libraries that could be used in place of libMKL we have opted to use the header-only Eigen library. 

This uses the version of Eigen included in [PyTorch](https://github.com/pytorch/pytorch/tree/master/third_party) not the version in this repo.

Also sets the PyTorch library version number.

I've built and tested the docker image. 