### PR TITLE
[ML] Rename the early stopping configuration parameter

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -54,7 +54,7 @@ public:
     static const std::string NUM_TOP_FEATURE_IMPORTANCE_VALUES;
     static const std::string TRAINING_PERCENT_FIELD_NAME;
     static const std::string FEATURE_PROCESSORS;
-    static const std::string EARLY_STOPPING_ALLOWED;
+    static const std::string EARLY_STOPPING_ENABLED;
 
     // Output
     static const std::string IS_TRAINING_FIELD_NAME;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -261,7 +261,7 @@ private:
     //! Stubs out persistence.
     static void noopRecordTrainingState(CBoostedTree::TPersistFunc);
 
-    //! Stop hyperparameter optimization early if the the process is not promising.
+    //! Stop hyperparameter optimization early if the process is not promising.
     void stopHyperparameterOptimizationEarly(bool stopEarly);
 
 private:

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -115,8 +115,8 @@ public:
     CBoostedTreeFactory& rowsPerFeature(std::size_t rowsPerFeature);
     //! Set the number of training examples we need per feature we'll include.
     CBoostedTreeFactory& numberTopShapValues(std::size_t numberTopShapValues);
-    //! Stop hyperparameter optimization early if the the process is not promising.
-    CBoostedTreeFactory& stopHyperparameterOptimizationEarly(bool stopEarly);
+    //! Set the flag to enable or disable early stopping.
+    CBoostedTreeFactory& earlyStoppingEnabled(bool earlyStoppingEnabled);
 
     //! Set pointer to the analysis instrumentation.
     CBoostedTreeFactory&
@@ -260,6 +260,9 @@ private:
 
     //! Stubs out persistence.
     static void noopRecordTrainingState(CBoostedTree::TPersistFunc);
+
+    //! Stop hyperparameter optimization early if the the process is not promising.
+    void stopHyperparameterOptimizationEarly(bool stopEarly);
 
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -85,7 +85,7 @@ public:
     predictionPersisterSupplier(TPersisterSupplier* persisterSupplier);
     CDataFrameAnalysisSpecificationFactory&
     predictionRestoreSearcherSupplier(TRestoreSearcherSupplier* restoreSearcherSupplier);
-    CDataFrameAnalysisSpecificationFactory& earlyStoppingAllowed(bool earlyStoppingAllowed);
+    CDataFrameAnalysisSpecificationFactory& earlyStoppingEnabled(bool earlyStoppingEnabled);
 
     // Regression
     CDataFrameAnalysisSpecificationFactory& regressionLossFunction(TLossFunctionType lossFunction);
@@ -146,7 +146,7 @@ private:
     std::size_t m_NumberClasses = 2;
     std::size_t m_NumberTopClasses = 0;
     std::string m_PredictionFieldType;
-    bool m_EarlyStoppingAllowed = true;
+    bool m_EarlyStoppingEnabled = true;
 };
 }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -65,7 +65,7 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(FEATURE_PROCESSORS,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
-        theReader.addParameter(EARLY_STOPPING_ALLOWED,
+        theReader.addParameter(EARLY_STOPPING_ENABLED,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
@@ -85,7 +85,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
 
     m_TrainingPercent = parameters[TRAINING_PERCENT_FIELD_NAME].fallback(100.0) / 100.0;
 
-    bool earlyStoppingAllowed = parameters[EARLY_STOPPING_ALLOWED].fallback(true);
+    bool earlyStoppingEnabled = parameters[EARLY_STOPPING_ENABLED].fallback(true);
 
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
@@ -150,7 +150,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
-        .stopHyperparameterOptimizationEarly(earlyStoppingAllowed);
+        .earlyStoppingEnabled(earlyStoppingEnabled);
 
     if (downsampleRowsPerFeature > 0) {
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(
@@ -395,7 +395,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_NAME_FIELD_NAME{"fea
 const std::string CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME{"importance"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS{"feature_processors"};
-const std::string CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ALLOWED{"early_stopping_allowed"};
+const std::string CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ENABLED{"early_stopping_enabled"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -597,7 +597,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
                     .predictionPersisterSupplier(persisterSupplier)
                     .predictionRestoreSearcherSupplier(restorerSupplier)
                     .regressionLossFunction(lossFunction)
-                    .earlyStoppingAllowed(false)
+                    .earlyStoppingEnabled(false)
                     .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(),
                                     dependentVariable);
             };
@@ -1012,7 +1012,7 @@ BOOST_AUTO_TEST_CASE(testProgressFromRestart) {
             .memoryLimit(18000000)
             .predictionPersisterSupplier(persisterSupplier)
             .predictionRestoreSearcherSupplier(restorerSupplier)
-            .earlyStoppingAllowed(false)
+            .earlyStoppingEnabled(false)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target");
     };
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1302,9 +1302,13 @@ CBoostedTreeFactory& CBoostedTreeFactory::trainingStateCallback(TTrainingStateCa
     return *this;
 }
 
-CBoostedTreeFactory& CBoostedTreeFactory::stopHyperparameterOptimizationEarly(bool stopEarly) {
-    m_TreeImpl->m_StopHyperparameterOptimizationEarly = stopEarly;
+CBoostedTreeFactory& CBoostedTreeFactory::earlyStoppingEnabled(bool earlyStoppingEnabled) {
+    this->stopHyperparameterOptimizationEarly(earlyStoppingEnabled);
     return *this;
+}
+
+void CBoostedTreeFactory::stopHyperparameterOptimizationEarly(bool stopEarly) {
+    m_TreeImpl->m_StopHyperparameterOptimizationEarly = stopEarly;
 }
 
 std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1422,7 +1422,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
             auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                                   threads, std::make_unique<maths::boosted_tree::CMse>())
                                   .analysisInstrumentation(instrumentation)
-                                  .stopHyperparameterOptimizationEarly(false)
+                                  .earlyStoppingEnabled(false)
                                   .buildFor(*frame, cols - 1);
 
             regression->train();

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -182,8 +182,8 @@ CDataFrameAnalysisSpecificationFactory::predictionRestoreSearcherSupplier(
 }
 
 CDataFrameAnalysisSpecificationFactory&
-CDataFrameAnalysisSpecificationFactory::earlyStoppingAllowed(bool earlyStoppingAllowed) {
-    m_EarlyStoppingAllowed = earlyStoppingAllowed;
+CDataFrameAnalysisSpecificationFactory::earlyStoppingEnabled(bool earlyStoppingEnabled) {
+    m_EarlyStoppingEnabled = earlyStoppingEnabled;
     return *this;
 }
 
@@ -345,9 +345,9 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
         writer.Key(api::CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS);
         writer.write(m_CustomProcessors);
     }
-    if (m_EarlyStoppingAllowed == false) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ALLOWED);
-        writer.Bool(m_EarlyStoppingAllowed);
+    if (m_EarlyStoppingEnabled == false) {
+        writer.Key(api::CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ENABLED);
+        writer.Bool(m_EarlyStoppingEnabled);
     }
 
     if (analysis == regression()) {


### PR DESCRIPTION
We agreed that the parameter should be renamed to `early_stopping_enabled` for consistency. 

Within `CBoostedTreeImpl` I would still keep the differentiated set of flags to enable/disable early stopping in different stages. All this flags will be initialized in `CBoostedTreeFactory` using the value from `early_stopping_enabled` configuration from the API.

Relates #1676.