### PR TITLE
[ML] Disable early stopping for the feature importance API tests

### DIFF
--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -195,6 +195,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             specFactory.rows(s_Rows)
                 .memoryLimit(26000000)
+                .earlyStoppingEnabled(false)
                 .predictionCategoricalFieldNames({"c1"})
                 .predictionAlpha(s_Alpha)
                 .predictionLambda(s_Lambda)
@@ -247,6 +248,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             specFactory.rows(s_Rows)
                 .memoryLimit(26000000)
+                .earlyStoppingEnabled(false)
                 .predictionCategoricalFieldNames({"target"})
                 .predictionAlpha(s_Alpha)
                 .predictionLambda(s_Lambda)
@@ -296,6 +298,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             specFactory.rows(s_Rows)
                 .memoryLimit(26000000)
+                .earlyStoppingEnabled(false)
                 .predictionCategoricalFieldNames({"target"})
                 .predictionAlpha(s_Alpha)
                 .predictionLambda(s_Lambda)
@@ -346,6 +349,7 @@ struct SFixture {
         api::CDataFrameAnalyzer analyzer{
             specFactory.rows(s_Rows)
                 .memoryLimit(26000000)
+                .earlyStoppingEnabled(false)
                 .predictionAlpha(s_Alpha)
                 .predictionLambda(s_Lambda)
                 .predictionGamma(s_Gamma)


### PR DESCRIPTION
Running feature importance tests with early stopping activate resulted in [flacky tests in the CI](#1693). I disable early stopping to be able to test the complete functionality.

Fixes #1693.