### PR TITLE
[ML] Remove mkl dependency and improve docker cleanup

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -266,7 +266,7 @@ sudo make altinstall
 PyTorch requires that certain Python modules are installed. Install these modules with `pip` using the same Python version you will build PyTorch with. If you followed the instructions above and built Python from source use `python3.7`:
 
 ```
-sudo /usr/local/bin/python3.7 -m pip install install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses
+sudo /usr/local/bin/python3.7 -m pip install install numpy ninja pyyaml setuptools cffi typing_extensions future six requests dataclasses
 ```
 
 Then obtain the PyTorch code:

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -160,7 +160,7 @@ Install using all the default options.  When the installer completes a Finder wi
 PyTorch requires that certain Python modules are installed.  To install them:
 
 ```
-sudo /Library/Frameworks/Python.framework/Versions/3.7/bin/pip3.7 install install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses
+sudo /Library/Frameworks/Python.framework/Versions/3.7/bin/pip3.7 install install numpy ninja pyyaml setuptools cffi typing_extensions future six requests dataclasses
 ```
 
 Then obtain the PyTorch code:
@@ -179,6 +179,9 @@ export BUILD_TEST=OFF
 export BUILD_CAFFE2=OFF
 export USE_NUMPY=OFF
 export USE_DISTRIBUTED=OFF
+export USE_MKLDNN=OFF
+export PYTORCH_BUILD_VERSION=1.7.1
+export PYTORCH_BUILD_NUMBER=1
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 setup.py install
 ```
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -102,7 +102,7 @@ RUN \
 
 # Install Python dependencies 
 RUN \
-  /usr/local/bin/pip3.7 install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses  
+  /usr/local/bin/pip3.7 install numpy ninja pyyaml setuptools cffi typing_extensions future six requests dataclasses  
 
 # Install CMake
 # v3.5 minimum is required
@@ -117,16 +117,14 @@ RUN \
 # Add cmake to PATH
 ENV PATH=${PATH}:/usr/local/cmake/bin
 
-# Clone PyTorch
+# Clone PyTorch and build LibTorch
+# If the PyTorch branch is changed also update PYTORCH_BUILD_VERSION
 RUN \
   cd ${build_dir} && \
   git -c advice.detachedHead=false clone --depth=1 --branch=v1.7.1 https://github.com/pytorch/pytorch.git && \
   cd pytorch && \
   git submodule sync && \
-  git submodule update --init --recursive 
-
-# Build LibTorch
-RUN \
+  git submodule update --init --recursive && \
   export BUILD_TEST=OFF && \
   export BUILD_CAFFE2=OFF && \
   export USE_NUMPY=OFF && \
@@ -140,8 +138,5 @@ RUN \
   mkdir /usr/local/gcc93/include/pytorch && \
   cp -r torch/include/* /usr/local/gcc93/include/pytorch/ && \
   cp torch/lib/libtorch_cpu.so /usr/local/gcc93/lib && \
-  cp torch/lib/libc10.so /usr/local/gcc93/lib 
-
-# Clean up
-RUN \
+  cp torch/lib/libc10.so /usr/local/gcc93/lib && \
   rm -rf ${build_dir}/*


### PR DESCRIPTION
Linux uses the Eigen BLAS library and macOS the Accelerate framework so MKL is not required.

This also fixes an intermittent problem building the Linux build image where the pytorch repo was not cleaned leaving a 23GB image. This fix takes the image size down to 5.4GB. 2GB of that is in `/usr/local/lib/python3.7` which could also be removed.