### PR TITLE
[ML] Build libtorch for Linux aarch64

### DIFF
--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -36,10 +36,10 @@ def path_to_app():
     if os_platform == 'Darwin':
         sub_path = 'darwin-x86_64/controller.app/Contents/MacOS/'
     elif os_platform == 'Linux':
-		if platform.machine() == 'aarch64':
-			sub_path = 'linux-aarch64/bin/'
-		else:
-			sub_path = 'linux-x86_64/bin/'
+        if platform.machine() == 'aarch64':
+            sub_path = 'linux-aarch64/bin/'
+        else:
+            sub_path = 'linux-x86_64/bin/'
     elif os_platform == 'Windows':
         sub_path = 'windows-x86_64/bin/'
     else:

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -36,8 +36,10 @@ def path_to_app():
     if os_platform == 'Darwin':
         sub_path = 'darwin-x86_64/controller.app/Contents/MacOS/'
     elif os_platform == 'Linux':
-        # TODO handle the different path for arm architecture
-        sub_path = 'linux-x86_64/bin/'
+		if platform.machine() == 'aarch64':
+			sub_path = 'linux-aarch64/bin/'
+		else:
+			sub_path = 'linux-x86_64/bin/'
     elif os_platform == 'Windows':
         sub_path = 'windows-x86_64/bin/'
     else:

--- a/dev-tools/docker/build_linux_aarch64_native_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_native_build_image.sh
@@ -23,7 +23,7 @@ fi
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-aarch64-native-build
-VERSION=2
+VERSION=3
 
 set -e
 

--- a/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
@@ -19,7 +19,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-aarch64-linux-gnu/usr && \
   cd /usr/local/sysroot-aarch64-linux-gnu/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-aarch64-linux-gnu-2.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-aarch64-linux-gnu-3.tar.bz2 | tar jxf - && \
   cd .. && \
   ln -s usr/lib lib && \
   ln -s usr/lib64 lib64

--- a/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:2
+FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:3
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -82,3 +82,54 @@ RUN \
   cd .. && \
   rm -rf patchelf-0.10
 
+# Build Python 3.7
+# —-enable-optimizations for a stable/release build
+RUN \
+  cd ${build_dir} && \
+  wget --quiet -O - https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz | tar xzf - && \
+  cd Python-3.7.9/ && \  
+  ./configure --enable-optimizations && \ 
+  make altinstall && \
+  cd .. && rm -rf Python-3.7.9
+
+# Install Python dependencies 
+RUN \
+  /usr/local/bin/pip3.7 install numpy ninja pyyaml setuptools cffi typing_extensions future six requests dataclasses  
+
+# Install CMake
+# v3.5 minimum is required
+RUN \
+  cd ${build_dir} && \
+  wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-aarch64.sh && \
+  chmod +x cmake-3.19.3-Linux-aarch64.sh && \
+  mkdir /usr/local/cmake && \
+  ./cmake-3.19.3-Linux-aarch64.sh --skip-license --prefix=/usr/local/cmake && \
+  rm -f cmake-3.19.3-Linux-aarch64.sh
+
+# Add cmake to PATH
+ENV PATH=${PATH}:/usr/local/cmake/bin
+
+# Clone PyTorch and build LibTorch
+# If the PyTorch branch is changed also update PYTORCH_BUILD_VERSION
+RUN \
+  cd ${build_dir} && \
+  git -c advice.detachedHead=false clone --depth=1 --branch=v1.7.1 https://github.com/pytorch/pytorch.git && \
+  cd pytorch && \
+  git submodule sync && \
+  git submodule update --init --recursive && \
+  export BUILD_TEST=OFF && \
+  export USE_FBGEMM=OFF  && \
+  export USE_NUMPY=OFF && \
+  export USE_DISTRIBUTED=OFF && \
+  export USE_MKLDNN=OFF && \
+  export BLAS=Eigen && \
+  export PYTORCH_BUILD_VERSION=1.7.1 && \
+  export PYTORCH_BUILD_NUMBER=1 && \
+  cd ${build_dir}/pytorch && \
+  /usr/local/bin/python3.7 setup.py install && \
+  mkdir /usr/local/gcc93/include/pytorch && \
+  cp -r torch/include/* /usr/local/gcc93/include/pytorch/ && \
+  cp torch/lib/libtorch_cpu.so /usr/local/gcc93/lib && \
+  cp torch/lib/libc10.so /usr/local/gcc93/lib && \
+  rm -rf ${build_dir}/*
+

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-FROM centos:7
+FROM centos:7 AS builder
 
 # This is basically automating the setup instructions in build-setup/linux.md
 
@@ -139,3 +139,9 @@ RUN \
   cp torch/lib/libc10.so /usr/local/gcc93/lib && \
   cd .. && rm -rf ${build_dir}/*
 
+FROM centos:7
+COPY --from=builder /usr/local/gcc93 /usr/local/gcc93
+COPY --from=builder /usr/include /usr/include
+RUN \
+  rm /var/lib/rpm/__db.* && \
+  yum install -y bzip2 git make unzip which zip zlib-devel

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Make sure OS packages are up to date and required packages are installed
 RUN \
   rm /var/lib/rpm/__db.* && \
-  yum install -y bzip2 gcc gcc-c++ git make texinfo unzip wget which zip zlib-devel
+  yum install -y bzip2 gcc gcc-c++ git libffi-devel make openssl-devel texinfo unzip wget which zip zlib-devel
 
 # For compiling with hardening and optimisation
 ENV CFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2 -march=armv8-a+crc+crypto"
@@ -21,8 +21,11 @@ ENV CXXFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2 -march=armv8-a+crc+cr
 ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now"
 ENV LDFLAGS_FOR_TARGET "-Wl,-z,relro -Wl,-z,now"
 
+ARG build_dir=/usr/src
+
 # Build gcc 9.3
 RUN \
+  cd ${build_dir} && \
   wget --quiet -O - http://ftpmirror.gnu.org/gcc/gcc-9.3.0/gcc-9.3.0.tar.gz | tar zxf - && \
   cd gcc-9.3.0 && \
   contrib/download_prerequisites && \
@@ -43,6 +46,7 @@ ENV CXX "g++ -std=gnu++17"
 
 # Build binutils
 RUN \
+  cd ${build_dir} && \
   wget --quiet -O - http://ftpmirror.gnu.org/binutils/binutils-2.34.tar.bz2 | tar jxf - && \
   cd binutils-2.34 && \
   ./configure --prefix=/usr/local/gcc93 --enable-vtable-verify --with-system-zlib --disable-libstdcxx --with-gcc-major-version-only && \
@@ -53,6 +57,7 @@ RUN \
 
 # Build libxml2
 RUN \
+  cd ${build_dir} && \
   wget --quiet -O - ftp://anonymous@ftp.xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz | tar zxf - && \
   cd libxml2-2.9.7 && \
   ./configure --prefix=/usr/local/gcc93 --without-python --without-readline && \
@@ -63,6 +68,7 @@ RUN \
 
 # Build Boost
 RUN \
+  cd ${build_dir} && \
   wget --quiet -O - http://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 | tar jxf - && \
   cd boost_1_71_0 && \
   ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=mpi --without-libraries=python --without-icu && \
@@ -74,6 +80,7 @@ RUN \
 
 # Build patchelf
 RUN \
+  cd ${build_dir} && \
   wget --quiet -O - http://nixos.org/releases/patchelf/patchelf-0.10/patchelf-0.10.tar.gz | tar zxf - && \
   cd patchelf-0.10 && \
   ./configure --prefix=/usr/local/gcc93 && \
@@ -83,7 +90,7 @@ RUN \
   rm -rf patchelf-0.10
 
 # Build Python 3.7
-# —-enable-optimizations for a stable/release build
+# --enable-optimizations for a stable/release build
 RUN \
   cd ${build_dir} && \
   wget --quiet -O - https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz | tar xzf - && \
@@ -94,7 +101,7 @@ RUN \
 
 # Install Python dependencies 
 RUN \
-  /usr/local/bin/pip3.7 install numpy ninja pyyaml setuptools cffi typing_extensions future six requests dataclasses  
+  /usr/local/bin/pip3.7 install numpy pyyaml setuptools cffi typing_extensions future six requests dataclasses  
 
 # Install CMake
 # v3.5 minimum is required
@@ -125,11 +132,10 @@ RUN \
   export BLAS=Eigen && \
   export PYTORCH_BUILD_VERSION=1.7.1 && \
   export PYTORCH_BUILD_NUMBER=1 && \
-  cd ${build_dir}/pytorch && \
   /usr/local/bin/python3.7 setup.py install && \
   mkdir /usr/local/gcc93/include/pytorch && \
   cp -r torch/include/* /usr/local/gcc93/include/pytorch/ && \
   cp torch/lib/libtorch_cpu.so /usr/local/gcc93/lib && \
   cp torch/lib/libc10.so /usr/local/gcc93/lib && \
-  rm -rf ${build_dir}/*
+  cd .. && rm -rf ${build_dir}/*
 

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -144,4 +144,4 @@ COPY --from=builder /usr/local/gcc93 /usr/local/gcc93
 COPY --from=builder /usr/include /usr/include
 RUN \
   rm /var/lib/rpm/__db.* && \
-  yum install -y bzip2 git make unzip which zip zlib-devel
+  yum install -y bzip2 gcc git make unzip which zip zlib-devel

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -145,4 +145,4 @@ COPY --from=builder /usr/local/gcc93 /usr/local/gcc93
 COPY --from=builder /usr/include /usr/include
 RUN \
   rm /var/lib/rpm/__db.* && \
-  yum install -y bzip2 git make unzip which zip zlib-devel
+  yum install -y bzip2 gcc git make unzip which zip zlib-devel

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-FROM centos:7
+FROM centos:7 AS builder
 
 # This is basically automating the setup instructions in build-setup/linux.md
 
@@ -139,3 +139,10 @@ RUN \
   cp torch/lib/libtorch_cpu.so /usr/local/gcc93/lib && \
   cp torch/lib/libc10.so /usr/local/gcc93/lib && \
   cd .. && rm -rf ${build_dir}/*
+
+FROM centos:7
+COPY --from=builder /usr/local/gcc93 /usr/local/gcc93
+COPY --from=builder /usr/include /usr/include
+RUN \
+  rm /var/lib/rpm/__db.* && \
+  yum install -y bzip2 git make unzip which zip zlib-devel

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -133,10 +133,9 @@ RUN \
   export BLAS=Eigen && \
   export PYTORCH_BUILD_VERSION=1.7.1 && \
   export PYTORCH_BUILD_NUMBER=1 && \
-  cd ${build_dir}/pytorch && \
   /usr/local/bin/python3.7 setup.py install && \
   mkdir /usr/local/gcc93/include/pytorch && \
   cp -r torch/include/* /usr/local/gcc93/include/pytorch/ && \
   cp torch/lib/libtorch_cpu.so /usr/local/gcc93/lib && \
   cp torch/lib/libc10.so /usr/local/gcc93/lib && \
-  rm -rf ${build_dir}/*
+  cd .. && rm -rf ${build_dir}/*


### PR DESCRIPTION
The main difference between the x86 and aarch builds is that FBGEMM requires [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2) instructions. FBGEMM cannot be compiled on aarch64, Caffe2 is used instead. 

x86 builds set `BUILD_CAFFE2=OFF` but it is required here and left unset.  

I've built and run the smoketest `evaluate.py` script on native linux aarch64. 

## Multi-stage DockerFile
The process of building the libraries ml uses creates a lot of files that are not required in the final build image. The simple solution is to use a multi-stage build where the final image copies all the required dependencies built in the intermediate image. Primarily it is the contents of `/usr/local/gcc93` and `/usr/include` that must be copied and also some programs (make, git, etc) must then be installed in the final image.

There is one unexpected requirement: `/lib64/crti.o` and `/lib64/crtn.o` are needed to link the ml libs and these files are installed with `gcc` so `gcc` must be installed again even though we have just copied the contents of  `/usr/local/gcc93`. This may not be the optimal solution but it is the one I've tested. 

