### PR TITLE
[ML] Check invariants after state restoration

### DIFF
--- a/include/core/RestoreMacros.h
+++ b/include/core/RestoreMacros.h
@@ -10,6 +10,21 @@
 namespace ml {
 namespace core {
 
+#define VIOLATES_INVARIANT(lhs, op, rhs)                                       \
+    do {                                                                       \
+        if (lhs op rhs) {                                                      \
+            LOG_ABORT(<< "Invariance check failed: " #lhs " " #op " " #rhs "." \
+                      << " [" << lhs << " " << #op << " " << rhs << "]");      \
+        }                                                                      \
+    } while (0)
+
+#define VIOLATES_INVARIANT_NO_EVALUATION(lhs, op, rhs)                           \
+    do {                                                                         \
+        if (lhs op rhs) {                                                        \
+            LOG_ABORT(<< "Invariance check failed: " #lhs " " #op " " #rhs "."); \
+        }                                                                        \
+    } while (0)
+
 #define RESTORE(tag, restore)                                                          \
     if (name == tag) {                                                                 \
         if ((restore) == false) {                                                      \

--- a/include/maths/CAdaptiveBucketing.h
+++ b/include/maths/CAdaptiveBucketing.h
@@ -167,6 +167,10 @@ protected:
     //! Get the accept persist function bound to this object.
     TPersistFunc getAcceptPersistInserter() const;
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
     //! Restore by traversing a state document
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 

--- a/include/maths/CBayesianOptimisation.h
+++ b/include/maths/CBayesianOptimisation.h
@@ -166,6 +166,10 @@ private:
     TVector transformTo01(const TVector& x) const;
     TVector scaledKernelParameters() const;
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
 private:
     CPRNG::CXorOShiro128Plus m_Rng;
     std::size_t m_Restarts;

--- a/include/maths/CBjkstUniqueValues.h
+++ b/include/maths/CBjkstUniqueValues.h
@@ -91,6 +91,10 @@ private:
     //! Create by traversing a state document.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
 public:
     //! Convert to a node tree.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/maths/CCalendarComponentAdaptiveBucketing.h
+++ b/include/maths/CCalendarComponentAdaptiveBucketing.h
@@ -109,6 +109,10 @@ private:
     //! Restore by traversing a state document
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
     //! Compute the values corresponding to the change in end
     //! points from \p endpoints. The values are assigned based
     //! on their intersection with each bucket in the previous

--- a/include/maths/CCalendarCyclicTest.h
+++ b/include/maths/CCalendarCyclicTest.h
@@ -104,6 +104,10 @@ private:
     //! Extract from the compressed representation.
     TErrorStatsVec inflate() const;
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants(const TErrorStatsVec& errors) const;
+
 private:
     //! The rate at which the error counts are aged.
     double m_DecayRate;

--- a/include/maths/CDecayRateController.h
+++ b/include/maths/CDecayRateController.h
@@ -113,6 +113,10 @@ private:
     bool decreaseDecayRateErrorNotDecreasing(const TDouble3Ary& stats) const;
     bool decreaseDecayRateNotBiased(const TDouble3Ary& stats) const;
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
 private:
     //! The checks we perform to detect error conditions.
     int m_Checks = 0;

--- a/include/maths/CDecompositionComponent.h
+++ b/include/maths/CDecompositionComponent.h
@@ -105,6 +105,11 @@ protected:
         std::size_t memoryUsage() const;
 
     private:
+        //! Check the state invariants after restoration
+        //! Abort on failure.
+        void checkRestoredInvariants() const;
+
+    private:
         //! The splines' types.
         TTypeArray m_Types;
         //! The splines' knots.

--- a/include/maths/CExpandingWindow.h
+++ b/include/maths/CExpandingWindow.h
@@ -169,6 +169,10 @@ private:
     //! Implements inflate.
     void doInflate(bool commit);
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
 private:
     //! True if the bucket values are stored in deflated format.
     bool m_Deflate;

--- a/include/maths/CMultimodalPrior.h
+++ b/include/maths/CMultimodalPrior.h
@@ -329,6 +329,10 @@ private:
     bool acceptRestoreTraverser(const SDistributionRestoreParams& params,
                                 core::CStateRestoreTraverser& traverser);
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
     //! We should only use this prior when it has multiple modes.
     virtual bool participatesInModelSelection() const;
 

--- a/include/maths/CMultinomialConjugate.h
+++ b/include/maths/CMultinomialConjugate.h
@@ -349,6 +349,10 @@ private:
     //! Read parameters from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
     //! Shrinks vectors so that we don't use more memory than we need.
     //! Typically vector implements a doubling policy when growing the
     //! buffer, which means that the buffers can end up twice as large

--- a/include/maths/CNaiveBayes.h
+++ b/include/maths/CNaiveBayes.h
@@ -135,6 +135,11 @@ public:
     virtual std::string print() const;
 
 private:
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
+private:
     using TPriorPtr = std::unique_ptr<CPrior>;
 
 private:

--- a/include/maths/CQDigest.h
+++ b/include/maths/CQDigest.h
@@ -224,6 +224,10 @@ private:
         bool operator()(const CNode* lhs, const CNode* rhs) const;
     };
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
     //! Represents a node of the q-digest with convenience
     //! operations for compression.
     class MATHS_EXPORT CNode {

--- a/include/maths/CSeasonalComponentAdaptiveBucketing.h
+++ b/include/maths/CSeasonalComponentAdaptiveBucketing.h
@@ -172,6 +172,10 @@ private:
     using TBucketVec = std::vector<SBucket>;
 
 private:
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
     //! Restore by traversing a state document
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -275,6 +275,10 @@ private:
                            TMultivariatePriorCPtrSizePr1Vec& correlationDistributionModels,
                            TModelCPtr1Vec& correlatedTimeSeriesModels) const;
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
 private:
     //! A unique identifier for this model.
     std::size_t m_Id;
@@ -722,6 +726,10 @@ private:
 
     //! Get the model dimension.
     std::size_t dimension() const;
+
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkInvariants() const;
 
 private:
     //! True if the data are non-negative.

--- a/include/maths/CTimeSeriesModel.h
+++ b/include/maths/CTimeSeriesModel.h
@@ -729,7 +729,7 @@ private:
 
     //! Check the state invariants after restoration
     //! Abort on failure.
-    void checkInvariants() const;
+    void checkRestoredInvariants() const;
 
 private:
     //! True if the data are non-negative.

--- a/include/maths/CTrendComponent.h
+++ b/include/maths/CTrendComponent.h
@@ -258,6 +258,10 @@ private:
     //! Get the weight to assign to the prediction verses the long term mean.
     double weightOfPrediction(core_t::TTime time) const;
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
 private:
     //! The default rate at which information is aged out of the trend models.
     double m_DefaultDecayRate;

--- a/lib/maths/CAdaptiveBucketing.cc
+++ b/lib/maths/CAdaptiveBucketing.cc
@@ -178,7 +178,27 @@ bool CAdaptiveBucketing::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
     if (m_LargeErrorCounts.empty()) {
         m_LargeErrorCounts.resize(m_Centres.size(), 0.0);
     }
+
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CAdaptiveBucketing::checkRestoredInvariants() const {
+
+    // Fail if the invariant "m_Endpoints.size() == m_Centres.size() + 1 or both empty"
+    // does not hold true.
+    if ((m_Endpoints.size() != m_Centres.size() + 1) &&
+        (m_Endpoints.empty() == false || m_Centres.empty() == false)) {
+        LOG_ABORT(<< "Invariance check failed: m_Endpoints.size() != m_Centres.size() + 1."
+                  << " [" << m_Endpoints.size() << " != " << m_Centres.size() + 1 << "]"
+                  << " && "
+                  << "(m_Endpoints.empty() == false || m_Centres.empty() == false)"
+                  << " [" << std::boolalpha << m_Endpoints.empty() << " || "
+                  << m_Centres.empty() << "]");
+    }
+
+    VIOLATES_INVARIANT(m_Centres.size(), !=, m_LargeErrorCounts.size());
 }
 
 void CAdaptiveBucketing::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CBayesianOptimisation.cc
+++ b/lib/maths/CBayesianOptimisation.cc
@@ -715,11 +715,19 @@ bool CBayesianOptimisation::acceptRestoreTraverser(core::CStateRestoreTraverser&
             return false;
         }
 
+        this->checkRestoredInvariants();
+
         return true;
     }
     LOG_ERROR(<< "Input error: unsupported state serialization version. Currently supported version: "
               << VERSION_7_5_TAG);
     return false;
+}
+
+void CBayesianOptimisation::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT(m_FunctionMeanValues.size(), !=, m_ErrorVariances.size());
+    VIOLATES_INVARIANT(m_MinBoundary.size(), !=, m_MaxBoundary.size());
+    VIOLATES_INVARIANT(m_KernelParameters.size(), !=, m_MinBoundary.size() + 1);
 }
 
 std::size_t CBayesianOptimisation::memoryUsage() const {

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -331,7 +331,17 @@ bool CBjkstUniqueValues::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
         }
     } while (traverser.next());
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CBjkstUniqueValues::checkRestoredInvariants() const {
+    const SSketch& sketch = boost::get<SSketch>(m_Sketch);
+    VIOLATES_INVARIANT(sketch.s_G.size(), !=, sketch.s_H.size());
+    VIOLATES_INVARIANT(sketch.s_H.size(), !=, sketch.s_Z.size());
+    VIOLATES_INVARIANT(sketch.s_Z.size(), !=, sketch.s_B.size());
+    VIOLATES_INVARIANT(sketch.s_B.size(), !=, m_NumberHashes);
 }
 
 void CBjkstUniqueValues::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -337,11 +337,13 @@ bool CBjkstUniqueValues::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
 }
 
 void CBjkstUniqueValues::checkRestoredInvariants() const {
-    const SSketch& sketch = boost::get<SSketch>(m_Sketch);
-    VIOLATES_INVARIANT(sketch.s_G.size(), !=, sketch.s_H.size());
-    VIOLATES_INVARIANT(sketch.s_H.size(), !=, sketch.s_Z.size());
-    VIOLATES_INVARIANT(sketch.s_Z.size(), !=, sketch.s_B.size());
-    VIOLATES_INVARIANT(sketch.s_B.size(), !=, m_NumberHashes);
+    const SSketch* sketch = boost::get<SSketch>(&m_Sketch);
+    if (sketch != nullptr) {
+        VIOLATES_INVARIANT(sketch->s_G.size(), !=, sketch->s_H.size());
+        VIOLATES_INVARIANT(sketch->s_H.size(), !=, sketch->s_Z.size());
+        VIOLATES_INVARIANT(sketch->s_Z.size(), !=, sketch->s_B.size());
+        VIOLATES_INVARIANT(sketch->s_B.size(), !=, m_NumberHashes);
+    }
 }
 
 void CBjkstUniqueValues::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/CCalendarComponentAdaptiveBucketing.cc
@@ -174,7 +174,13 @@ bool CCalendarComponentAdaptiveBucketing::acceptRestoreTraverser(core::CStateRes
         RESTORE(VALUES_TAG, core::CPersistUtils::restore(VALUES_TAG, m_Values, traverser))
     } while (traverser.next());
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CCalendarComponentAdaptiveBucketing::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT(m_Values.size(), !=, this->centres().size());
 }
 
 void CCalendarComponentAdaptiveBucketing::refresh(const TFloatVec& oldEndpoints) {

--- a/lib/maths/CCalendarCyclicTest.cc
+++ b/lib/maths/CCalendarCyclicTest.cc
@@ -108,8 +108,15 @@ bool CCalendarCyclicTest::acceptRestoreTraverser(core::CStateRestoreTraverser& t
         } while (traverser.next());
         errors.resize(SIZE);
     }
+    this->checkRestoredInvariants(errors);
     this->deflate(errors);
     return true;
+}
+
+void CCalendarCyclicTest::checkRestoredInvariants(const TErrorStatsVec& errors) const {
+    VIOLATES_INVARIANT(m_CurrentBucketIndex, >=,
+                       static_cast<core_t::TTime>(errors.size()));
+    VIOLATES_INVARIANT(errors.size(), !=, SIZE);
 }
 
 void CCalendarCyclicTest::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CDecayRateController.cc
+++ b/lib/maths/CDecayRateController.cc
@@ -141,7 +141,15 @@ bool CDecayRateController::acceptRestoreTraverser(core::CStateRestoreTraverser& 
     if (CBasicStatistics::count(m_Multiplier) == 0.0) {
         m_Multiplier.add(m_Target);
     }
+    this->checkRestoredInvariants();
     return true;
+}
+
+void CDecayRateController::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT(m_PredictionMean.size(), !=, m_Bias.size());
+    VIOLATES_INVARIANT(m_Bias.size(), !=, m_RecentAbsError.size());
+    VIOLATES_INVARIANT(m_RecentAbsError.size(), !=, m_HistoricalAbsError.size());
+    VIOLATES_INVARIANT(m_PredictionMean.size(), <=, 0);
 }
 
 void CDecayRateController::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CDecompositionComponent.cc
+++ b/lib/maths/CDecompositionComponent.cc
@@ -245,7 +245,14 @@ bool CDecompositionComponent::CPackedSplines::acceptRestoreTraverser(
         this->interpolate(knots, values, variances, boundary);
     }
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CDecompositionComponent::CPackedSplines::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT(m_Knots.size(), !=, m_Values[0].size());
+    VIOLATES_INVARIANT(m_Values[0].size(), !=, m_Values[1].size());
 }
 
 void CDecompositionComponent::CPackedSplines::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CExpandingWindow.cc
+++ b/lib/maths/CExpandingWindow.cc
@@ -62,8 +62,15 @@ bool CExpandingWindow::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
                 m_AverageWithinBucketVariance.fromDelimited(traverser.value()))
         RESTORE(MEAN_OFFSET_TAG, m_MeanOffset.fromDelimited(traverser.value()))
     } while (traverser.next());
+    this->checkRestoredInvariants();
     this->deflate(true);
     return true;
+}
+
+void CExpandingWindow::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT(m_BucketIndex, >=, m_BucketValues.size());
+    VIOLATES_INVARIANT(m_BucketLengthIndex, >=, m_BucketLengths.size());
+    VIOLATES_INVARIANT(m_Size, !=, m_BucketValues.size());
 }
 
 void CExpandingWindow::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CMultimodalPrior.cc
+++ b/lib/maths/CMultimodalPrior.cc
@@ -209,7 +209,13 @@ bool CMultimodalPrior::acceptRestoreTraverser(const SDistributionRestoreParams& 
         m_Clusterer->mergeFunc(CModeMergeCallback(*this));
     }
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CMultimodalPrior::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT_NO_EVALUATION(m_SeedPrior, ==, nullptr);
 }
 
 CMultimodalPrior::CMultimodalPrior(const CMultimodalPrior& other)

--- a/lib/maths/CMultinomialConjugate.cc
+++ b/lib/maths/CMultinomialConjugate.cc
@@ -313,9 +313,15 @@ bool CMultinomialConjugate::acceptRestoreTraverser(core::CStateRestoreTraverser&
                                this->numberSamples(numberSamples))
     } while (traverser.next());
 
+    this->checkRestoredInvariants();
+
     this->shrink();
 
     return true;
+}
+
+void CMultinomialConjugate::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT(m_Concentrations.size(), !=, m_Categories.size());
 }
 
 void CMultinomialConjugate::swap(CMultinomialConjugate& other) noexcept {

--- a/lib/maths/CNaiveBayes.cc
+++ b/lib/maths/CNaiveBayes.cc
@@ -61,7 +61,14 @@ bool CNaiveBayesFeatureDensityFromPrior::acceptRestoreTraverser(
                                CPriorStateSerialiser(), std::cref(params),
                                std::ref(m_Prior), std::placeholders::_1)));
     } while (traverser.next());
+
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CNaiveBayesFeatureDensityFromPrior::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT_NO_EVALUATION(m_Prior, ==, nullptr);
 }
 
 void CNaiveBayesFeatureDensityFromPrior::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CQDigest.cc
+++ b/lib/maths/CQDigest.cc
@@ -73,7 +73,13 @@ bool CQDigest::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
         }
     } while (traverser.next());
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CQDigest::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT_NO_EVALUATION(m_Root, ==, nullptr);
 }
 
 void CQDigest::add(uint32_t value, uint64_t n) {
@@ -103,7 +109,7 @@ void CQDigest::add(uint32_t value, uint64_t n) {
         this->compress(compress);
     }
 
-    //this->checkInvariants();
+    this->checkInvariants();
 }
 
 void CQDigest::merge(const CQDigest& digest) {
@@ -123,7 +129,7 @@ void CQDigest::merge(const CQDigest& digest) {
     // Compress the whole tree.
     this->compress();
 
-    //this->checkInvariants();
+    this->checkInvariants();
 }
 
 void CQDigest::propagateForwardsByTime(double time) {

--- a/lib/maths/CQDigest.cc
+++ b/lib/maths/CQDigest.cc
@@ -80,7 +80,9 @@ bool CQDigest::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
 
 void CQDigest::checkRestoredInvariants() const {
     VIOLATES_INVARIANT_NO_EVALUATION(m_Root, ==, nullptr);
-    this->checkInvariants();
+    if (this->checkInvariants() == false) {
+        LOG_ABORT(<< "Invariance check failed for Q Digest");
+    }
 }
 
 void CQDigest::add(uint32_t value, uint64_t n) {

--- a/lib/maths/CQDigest.cc
+++ b/lib/maths/CQDigest.cc
@@ -80,6 +80,7 @@ bool CQDigest::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
 
 void CQDigest::checkRestoredInvariants() const {
     VIOLATES_INVARIANT_NO_EVALUATION(m_Root, ==, nullptr);
+    this->checkInvariants();
 }
 
 void CQDigest::add(uint32_t value, uint64_t n) {
@@ -108,8 +109,6 @@ void CQDigest::add(uint32_t value, uint64_t n) {
         TNodePtrVec compress(1u, &leaf);
         this->compress(compress);
     }
-
-    this->checkInvariants();
 }
 
 void CQDigest::merge(const CQDigest& digest) {
@@ -128,8 +127,6 @@ void CQDigest::merge(const CQDigest& digest) {
 
     // Compress the whole tree.
     this->compress();
-
-    this->checkInvariants();
 }
 
 void CQDigest::propagateForwardsByTime(double time) {

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -362,7 +362,14 @@ bool CSeasonalComponentAdaptiveBucketing::acceptRestoreTraverser(core::CStateRes
 
     m_Buckets.shrink_to_fit();
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CSeasonalComponentAdaptiveBucketing::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT_NO_EVALUATION(m_Time, ==, nullptr);
+    VIOLATES_INVARIANT(m_Buckets.size(), !=, this->centres().size());
 }
 
 void CSeasonalComponentAdaptiveBucketing::refresh(const TFloatVec& oldEndpoints) {

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -2785,7 +2785,7 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
         } while (traverser.next());
     }
 
-    this->checkInvariants();
+    this->checkRestoredInvariants();
 
     if (m_Controllers != nullptr && stateMissingControllerChecks) {
         (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
@@ -2800,7 +2800,7 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
     return true;
 }
 
-void CMultivariateTimeSeriesModel::checkInvariants() const {
+void CMultivariateTimeSeriesModel::checkRestoredInvariants() const {
     for (const auto& trendModel : m_TrendModel) {
         VIOLATES_INVARIANT_NO_EVALUATION(trendModel, ==, nullptr);
     }

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -1371,7 +1371,14 @@ bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestoreParam
             maths::CDecayRateController::E_PredictionErrorDecrease);
     }
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CUnivariateTimeSeriesModel::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT_NO_EVALUATION(m_TrendModel, ==, nullptr);
+    VIOLATES_INVARIANT_NO_EVALUATION(m_ResidualModel, ==, nullptr);
 }
 
 void CUnivariateTimeSeriesModel::persistModelsState(core::CStatePersistInserter& inserter) const {
@@ -2690,7 +2697,7 @@ std::uint64_t CMultivariateTimeSeriesModel::checksum(std::uint64_t seed) const {
 }
 
 void CMultivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
-    mem->setName("CUnivariateTimeSeriesModel");
+    mem->setName("CMultivariateTimeSeriesModel");
     core::CMemoryDebug::dynamicSize("m_Controllers", m_Controllers, mem);
     core::CMemoryDebug::dynamicSize("m_TrendModel", m_TrendModel, mem);
     core::CMemoryDebug::dynamicSize("m_ResidualModel", m_ResidualModel, mem);
@@ -2778,6 +2785,8 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
         } while (traverser.next());
     }
 
+    this->checkInvariants();
+
     if (m_Controllers != nullptr && stateMissingControllerChecks) {
         (*m_Controllers)[E_TrendControl].checks(CDecayRateController::E_PredictionBias |
                                                 CDecayRateController::E_PredictionErrorIncrease);
@@ -2789,6 +2798,18 @@ bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const SModelRestorePar
     }
 
     return true;
+}
+
+void CMultivariateTimeSeriesModel::checkInvariants() const {
+    for (const auto& trendModel : m_TrendModel) {
+        VIOLATES_INVARIANT_NO_EVALUATION(trendModel, ==, nullptr);
+    }
+    VIOLATES_INVARIANT_NO_EVALUATION(m_ResidualModel, ==, nullptr);
+    VIOLATES_INVARIANT(m_TrendModel.size(), !=, this->dimension());
+    VIOLATES_INVARIANT_NO_EVALUATION(m_Controllers, ==, nullptr);
+    VIOLATES_INVARIANT((*m_Controllers)[E_TrendControl].dimension(), !=, this->dimension());
+    VIOLATES_INVARIANT((*m_Controllers)[E_ResidualControl].dimension(), !=,
+                       this->dimension());
 }
 
 void CMultivariateTimeSeriesModel::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/CTrendComponent.cc
+++ b/lib/maths/CTrendComponent.cc
@@ -184,7 +184,14 @@ bool CTrendComponent::acceptRestoreTraverser(const SDistributionRestoreParams& p
                          m_MagnitudeOfLevelChangeModel =
                              CNormalMeanPrecConjugate(params, traverser))
     } while (traverser.next());
+
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CTrendComponent::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT(m_FirstUpdate, >, m_LastUpdate);
 }
 
 bool CTrendComponent::initialized() const {

--- a/lib/maths/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/unittest/CBayesianOptimisationTest.cc
@@ -468,7 +468,6 @@ BOOST_AUTO_TEST_CASE(testAnovaConstantFactor) {
 
 BOOST_AUTO_TEST_CASE(testAnovaTotalVariance) {
     using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
-    TMeanAccumulator meanAccumulator;
     std::size_t dim{2};
     std::size_t mcSamples{1000};
     TDoubleVecVec testSamples;
@@ -493,7 +492,6 @@ BOOST_AUTO_TEST_CASE(testAnovaTotalVariance) {
 
 BOOST_AUTO_TEST_CASE(testAnovaMainEffect) {
     using TMeanAccumulator = maths::CBasicStatistics::SSampleMean<double>::TAccumulator;
-    TMeanAccumulator meanAccumulator;
     std::size_t dim{2};
     std::size_t mcSamples{1000};
     TDoubleVecVec testSamples;


### PR DESCRIPTION
Abort early if expected object invariants do not hold true after state
restoration.

Provide new macros to check violation of invariants and to abort with a
clear, consistently formatted messages.

This commit follows an audit of the maths library only. More to follow.