### PR TITLE
[ML] Allow a user to override weights for assigning labels to classes

### DIFF
--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace ml {
@@ -74,9 +75,18 @@ public:
         T as() const {
             if (m_Value == nullptr) {
                 HANDLE_FATAL(<< "Input error: expected value for '" << m_Name
-                             << "'. Please report this problem.");
+                             << "'. Please report this problem.")
             }
             return this->fallback(T{});
+        }
+        //! Get a name value pair parameter.
+        std::pair<std::string, double> as(const std::string& name,
+                                          const std::string& value) const {
+            if (m_Value == nullptr) {
+                HANDLE_FATAL(<< "Input error: expected value for '" << m_Name
+                             << "'. Please report this problem.")
+            }
+            return this->fallback(name, value, std::make_pair("", 0.0));
         }
         //! Get the JSON object.
         const rapidjson::Value* jsonObject() { return m_Value; }
@@ -90,6 +100,16 @@ public:
         double fallback(double value) const;
         //! Get a string parameter.
         std::string fallback(const std::string& value) const;
+        //! Get a (name, value) pair parameter.
+        std::pair<std::string, double>
+        fallback(const std::string& name,
+                 const std::string& value,
+                 const std::pair<std::string, double>& fallback) const;
+        //! Get an array of (name, value) pair objects.
+        std::vector<std::pair<std::string, double>>
+        fallback(const std::string& name,
+                 const std::string& value,
+                 const std::vector<std::pair<std::string, double>>& fallback) const;
         //! Get an enum point parameter.
         template<typename ENUM>
         ENUM fallback(ENUM value) const {
@@ -110,13 +130,13 @@ public:
         }
         //! Get an array of objects of type T.
         template<typename T>
-        std::vector<T> fallback(const std::vector<T>& value) const {
+        std::vector<T> fallback(const std::vector<T>& fallback) const {
             if (m_Value == nullptr) {
-                return value;
+                return fallback;
             }
             if (m_Value->IsArray() == false) {
                 this->handleFatal();
-                return value;
+                return fallback;
             }
             std::vector<T> result;
             result.reserve(m_Value->Size());

--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -44,6 +44,9 @@ public:
     static const std::string CLASSES_FIELD_NAME;
     static const std::string CLASS_NAME_FIELD_NAME;
     static const TStrVec CLASS_ASSIGNMENT_OBJECTIVE_VALUES;
+    static const std::string CLASSIFICATION_WEIGHTS;
+    static const std::string CLASSIFICATION_WEIGHTS_CLASS;
+    static const std::string CLASSIFICATION_WEIGHTS_WEIGHT;
 
 public:
     static const CDataFrameAnalysisConfigReader& parameterReader();

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -276,8 +276,11 @@ public:
     //! A list of the names of the best individual hyperparameters in the state document.
     static TStrVec bestHyperparameterNames();
 
-    //! \return Class containing best hyperparameters.
+    //! \return The best hyperparameters.
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
+
+    //! \return The classification weights vector.
+    TDoubleVec classificationWeights() const;
     //@}
 
 private:

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -36,6 +36,7 @@ class CBoostedTreeImpl;
 //! Factory for CBoostedTree objects.
 class MATHS_EXPORT CBoostedTreeFactory final {
 public:
+    using TStrDoublePrVec = std::vector<std::pair<std::string, double>>;
     using TVector = CVectorNx1<double, 3>;
     using TBoostedTreeUPtr = std::unique_ptr<CBoostedTree>;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
@@ -73,6 +74,8 @@ public:
     //! Set the objective to use when choosing the class assignments.
     CBoostedTreeFactory&
     classAssignmentObjective(CBoostedTree::EClassAssignmentObjective objective);
+    //! Set the class weights used for assigning labels to classes from the predicted probabilities.
+    CBoostedTreeFactory& classificationWeights(TStrDoublePrVec weights);
     //! Set the minimum fraction with a category value to one-hot encode.
     CBoostedTreeFactory& minimumFrequencyToOneHotEncode(double frequency);
     //! Set the number of folds to use for estimating the generalisation error.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -114,7 +114,7 @@ public:
 
     //! Get the weights to apply to each class's predicted probability when
     //! assigning classes.
-    TVector classificationWeights() const;
+    const TVector& classificationWeights() const;
 
     //! Get the number of columns training the model will add to the data frame.
     static std::size_t numberExtraColumnsForTrain(std::size_t numberLossParameters) {

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -49,7 +49,11 @@ class CTreeShapFeatureImportance;
 class MATHS_EXPORT CBoostedTreeImpl final {
 public:
     using TDoubleVec = std::vector<double>;
+    using TSizeVec = std::vector<std::size_t>;
     using TStrVec = std::vector<std::string>;
+    using TOptionalDouble = boost::optional<double>;
+    using TStrDoublePrVec = std::vector<std::pair<std::string, double>>;
+    using TOptionalStrDoublePrVec = boost::optional<TStrDoublePrVec>;
     using TVector = CDenseVector<double>;
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
@@ -62,9 +66,7 @@ public:
     using TLossFunction = boosted_tree::CLoss;
     using TLossFunctionUPtr = CBoostedTree::TLossFunctionUPtr;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
-    using TOptionalDouble = boost::optional<double>;
     using TRegularization = CBoostedTreeRegularization<double>;
-    using TSizeVec = std::vector<std::size_t>;
     using TAnalysisInstrumentationPtr = CDataFrameTrainBoostedTreeInstrumentationInterface*;
     using THyperparameterImportanceVec =
         std::vector<boosted_tree_detail::SHyperparameterImportance>;
@@ -355,6 +357,7 @@ private:
     TOptionalSize m_NumberFoldsOverride;
     TOptionalSize m_MaximumNumberTreesOverride;
     TOptionalDouble m_FeatureBagFractionOverride;
+    TOptionalStrDoublePrVec m_ClassificationWeightsOverride;
     TRegularization m_Regularization;
     TVector m_ClassificationWeights;
     double m_DownsampleFactor = 0.5;

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -39,8 +39,9 @@ public:
 
     //! The objective for the classification decision (given predicted class probabilities).
     enum EClassAssignmentObjective {
-        E_Accuracy,     //!< Maximize prediction accuracy.
-        E_MinimumRecall //!< Maximize the minimum per class recall.
+        E_Accuracy,      //!< Maximize prediction accuracy.
+        E_MinimumRecall, //!< Maximize the minimum per class recall.
+        E_Custom         //!< User defined class weights.
     };
 
 public:

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -32,6 +32,7 @@ namespace test {
 class TEST_EXPORT CDataFrameAnalysisSpecificationFactory {
 public:
     using TStrVec = std::vector<std::string>;
+    using TStrDoublePrVec = std::vector<std::pair<std::string, double>>;
     using TDataAdderUPtr = std::unique_ptr<core::CDataAdder>;
     using TPersisterSupplier = std::function<TDataAdderUPtr()>;
     using TDataSearcherUPtr = std::unique_ptr<core::CDataSearcher>;
@@ -96,6 +97,8 @@ public:
     CDataFrameAnalysisSpecificationFactory& numberClasses(std::size_t number);
     CDataFrameAnalysisSpecificationFactory& numberTopClasses(std::size_t number);
     CDataFrameAnalysisSpecificationFactory& predictionFieldType(const std::string& type);
+    CDataFrameAnalysisSpecificationFactory&
+    classificationWeights(const TStrDoublePrVec& weights);
 
     std::string outlierParams() const;
     TSpecificationUPtr outlierSpec() const;
@@ -147,6 +150,7 @@ private:
     std::size_t m_NumberTopClasses = 0;
     std::string m_PredictionFieldType;
     bool m_EarlyStoppingEnabled = true;
+    TStrDoublePrVec m_ClassificationWeights;
 };
 }
 }

--- a/lib/api/CDataFrameAnalysisConfigReader.cc
+++ b/lib/api/CDataFrameAnalysisConfigReader.cc
@@ -90,62 +90,107 @@ CDataFrameAnalysisConfigReader::CParameter::CParameter(const std::string& name,
     : m_Name{name}, m_Value{&value}, m_PermittedValues{&permittedValues} {
 }
 
-bool CDataFrameAnalysisConfigReader::CParameter::fallback(bool value) const {
+bool CDataFrameAnalysisConfigReader::CParameter::fallback(bool fallback) const {
     if (m_Value == nullptr) {
-        return value;
+        return fallback;
     }
     if (m_Value->IsBool() == false) {
         this->handleFatal();
-        return value;
+        return fallback;
     }
     return m_Value->GetBool();
 }
 
-std::size_t CDataFrameAnalysisConfigReader::CParameter::fallback(std::size_t value) const {
+std::size_t CDataFrameAnalysisConfigReader::CParameter::fallback(std::size_t fallback) const {
     if (m_Value == nullptr) {
-        return value;
+        return fallback;
     }
     if (m_Value->IsUint64() == false) {
         this->handleFatal();
-        return value;
+        return fallback;
     }
     return m_Value->GetUint64();
 }
 
-std::ptrdiff_t CDataFrameAnalysisConfigReader::CParameter::fallback(std::ptrdiff_t value) const {
+std::ptrdiff_t CDataFrameAnalysisConfigReader::CParameter::fallback(std::ptrdiff_t fallback) const {
     if (m_Value == nullptr) {
-        return value;
+        return fallback;
     }
     if (m_Value->IsInt64() == false) {
         this->handleFatal();
-        return value;
+        return fallback;
     }
     return m_Value->GetInt64();
 }
 
-double CDataFrameAnalysisConfigReader::CParameter::fallback(double value) const {
+double CDataFrameAnalysisConfigReader::CParameter::fallback(double fallback) const {
     if (m_Value == nullptr) {
-        return value;
+        return fallback;
     }
     if (m_Value->IsInt64()) {
         return static_cast<double>(m_Value->GetInt64());
     }
     if (m_Value->IsDouble() == false) {
         this->handleFatal();
-        return value;
+        return fallback;
     }
     return m_Value->GetDouble();
 }
 
-std::string CDataFrameAnalysisConfigReader::CParameter::fallback(const std::string& value) const {
+std::string CDataFrameAnalysisConfigReader::CParameter::fallback(const std::string& fallback) const {
     if (m_Value == nullptr) {
-        return value;
+        return fallback;
     }
     if (m_Value->IsString() == false) {
         this->handleFatal();
-        return value;
+        return fallback;
     }
     return m_Value->GetString();
+}
+
+std::pair<std::string, double> CDataFrameAnalysisConfigReader::CParameter::fallback(
+    const std::string& name,
+    const std::string& value,
+    const std::pair<std::string, double>& fallback) const {
+    if (m_Value == nullptr) {
+        return fallback;
+    }
+    if (m_Value->IsObject() == false) {
+        this->handleFatal();
+        return fallback;
+    }
+    auto name_ = m_Value->FindMember(name);
+    auto value_ = m_Value->FindMember(value);
+    if (name_ == m_Value->MemberEnd() || value_ == m_Value->MemberEnd()) {
+        this->handleFatal();
+        return fallback;
+    }
+    if (name_->value.IsString() == false || value_->value.IsDouble() == false) {
+        this->handleFatal();
+        return fallback;
+    }
+    return {name_->value.GetString(), value_->value.GetDouble()};
+}
+
+std::vector<std::pair<std::string, double>> CDataFrameAnalysisConfigReader::CParameter::fallback(
+    const std::string& name,
+    const std::string& value,
+    const std::vector<std::pair<std::string, double>>& fallback) const {
+    if (m_Value == nullptr) {
+        return fallback;
+    }
+    if (m_Value->IsArray() == false) {
+        this->handleFatal();
+        return fallback;
+    }
+    std::vector<std::pair<std::string, double>> result;
+    result.reserve(m_Value->Size());
+    CParameter element{m_Name, SArrayElementTag{}};
+    for (std::size_t i = 0; i < m_Value->Size(); ++i) {
+        element.m_Value = &(*m_Value)[static_cast<int>(i)];
+        result.push_back(element.as(name, value));
+    }
+    return result;
 }
 
 CDataFrameAnalysisConfigReader::CParameter::CParameter(const std::string& name, SArrayElementTag)

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -66,10 +66,14 @@ CDataFrameTrainBoostedTreeClassifierRunner::parameterReader() {
                                 {typeBool, int{E_PredictionFieldTypeBool}}});
         int accuracy{maths::CDataFramePredictiveModel::E_Accuracy};
         int recall{maths::CDataFramePredictiveModel::E_MinimumRecall};
+        int custom{maths::CDataFramePredictiveModel::E_Custom};
         theReader.addParameter(
             CLASS_ASSIGNMENT_OBJECTIVE, CDataFrameAnalysisConfigReader::E_OptionalParameter,
             {{CLASS_ASSIGNMENT_OBJECTIVE_VALUES[accuracy], accuracy},
-             {CLASS_ASSIGNMENT_OBJECTIVE_VALUES[recall], int{recall}}});
+             {CLASS_ASSIGNMENT_OBJECTIVE_VALUES[recall], recall},
+             {CLASS_ASSIGNMENT_OBJECTIVE_VALUES[custom], custom}});
+        theReader.addParameter(CLASSIFICATION_WEIGHTS,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -81,11 +85,19 @@ CDataFrameTrainBoostedTreeClassifierRunner::CDataFrameTrainBoostedTreeClassifier
     : CDataFrameTrainBoostedTreeRunner{
           spec, parameters, loss(parameters[NUM_CLASSES].as<std::size_t>())} {
 
+    std::size_t numberClasses{parameters[NUM_CLASSES].as<std::size_t>()};
+    auto classAssignmentObjective = parameters[CLASS_ASSIGNMENT_OBJECTIVE].fallback(
+        maths::CBoostedTree::E_MinimumRecall);
     m_NumTopClasses = parameters[NUM_TOP_CLASSES].fallback(std::ptrdiff_t{0});
     m_PredictionFieldType =
         parameters[PREDICTION_FIELD_TYPE].fallback(E_PredictionFieldTypeString);
-    this->boostedTreeFactory().classAssignmentObjective(
-        parameters[CLASS_ASSIGNMENT_OBJECTIVE].fallback(maths::CBoostedTree::E_MinimumRecall));
+    this->boostedTreeFactory().classAssignmentObjective(classAssignmentObjective);
+    auto classificationWeights = parameters[CLASSIFICATION_WEIGHTS].fallback(
+        CLASSIFICATION_WEIGHTS_CLASS, CLASSIFICATION_WEIGHTS_WEIGHT,
+        std::vector<std::pair<std::string, double>>{});
+    if (classificationWeights.size() > 0) {
+        this->boostedTreeFactory().classificationWeights(classificationWeights);
+    }
 
     const TStrVec& categoricalFieldNames{spec.categoricalFieldNames()};
     if (std::find(categoricalFieldNames.begin(), categoricalFieldNames.end(),
@@ -95,6 +107,18 @@ CDataFrameTrainBoostedTreeClassifierRunner::CDataFrameTrainBoostedTreeClassifier
     if (PREDICTION_FIELD_NAME_BLACKLIST.count(this->predictionFieldName()) > 0) {
         HANDLE_FATAL(<< "Input error: " << PREDICTION_FIELD_NAME << " must not be equal to any of "
                      << core::CContainerPrinter::print(PREDICTION_FIELD_NAME_BLACKLIST) << ".")
+    }
+    if (classificationWeights.size() > 0 &&
+        classAssignmentObjective != maths::CBoostedTree::E_Custom) {
+        HANDLE_FATAL(<< "Input error: expected "
+                     << CLASS_ASSIGNMENT_OBJECTIVE_VALUES[maths::CDataFramePredictiveModel::E_Custom]
+                     << " for " << CLASS_ASSIGNMENT_OBJECTIVE << " if supplying "
+                     << CLASSIFICATION_WEIGHTS << " but got '"
+                     << CLASS_ASSIGNMENT_OBJECTIVE_VALUES[classAssignmentObjective] << "'.")
+    }
+    if (classificationWeights.size() > 0 && classificationWeights.size() != numberClasses) {
+        HANDLE_FATAL(<< "Input error: expected " << numberClasses << " " << CLASSIFICATION_WEIGHTS
+                     << " but got " << classificationWeights.size() << ".")
     }
 }
 
@@ -166,12 +190,13 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     }
 
     if (featureImportance != nullptr) {
-        std::size_t numberClasses{classValues.size()};
+        int numberClasses{static_cast<int>(classValues.size())};
         m_InferenceModelMetadata.columnNames(featureImportance->columnNames());
         m_InferenceModelMetadata.classValues(classValues);
         m_InferenceModelMetadata.predictionFieldTypeResolverWriter(
-            [this](const std::string& categoryValue, core::CRapidJsonConcurrentLineWriter& writer) {
-                this->writePredictedCategoryValue(categoryValue, writer);
+            [this](const std::string& categoryValue,
+                   core::CRapidJsonConcurrentLineWriter& writer_) {
+                this->writePredictedCategoryValue(categoryValue, writer_);
             });
         featureImportance->shap(
             row, [&](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
@@ -188,7 +213,7 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
                             // output feature importance for individual classes in binary case
                             writer.Key(CLASSES_FIELD_NAME);
                             writer.StartArray();
-                            for (std::size_t j = 0; j < numberClasses; ++j) {
+                            for (int j = 0; j < numberClasses; ++j) {
                                 writer.StartObject();
                                 writer.Key(CLASS_NAME_FIELD_NAME);
                                 writePredictedCategoryValue(classValues[j], writer);
@@ -205,8 +230,7 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
                             // output feature importance for individual classes in multiclass case
                             writer.Key(CLASSES_FIELD_NAME);
                             writer.StartArray();
-                            for (std::size_t j = 0;
-                                 j < shap[i].size() && j < numberClasses; ++j) {
+                            for (int j = 0; j < shap[i].size() && j < numberClasses; ++j) {
                                 writer.StartObject();
                                 writer.Key(CLASS_NAME_FIELD_NAME);
                                 writePredictedCategoryValue(classValues[j], writer);
@@ -315,7 +339,11 @@ const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"n
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE{"prediction_field_type"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE{"class_assignment_objective"};
 const CDataFrameTrainBoostedTreeClassifierRunner::TStrVec
-CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE_VALUES{"maximize_accuracy", "maximize_minimum_recall"};
+CDataFrameTrainBoostedTreeClassifierRunner::CLASS_ASSIGNMENT_OBJECTIVE_VALUES{
+    "maximize_accuracy", "maximize_minimum_recall", "custom"};
+const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASSIFICATION_WEIGHTS{"classification_weights"};
+const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASSIFICATION_WEIGHTS_CLASS{"class"};
+const std::string CDataFrameTrainBoostedTreeClassifierRunner::CLASSIFICATION_WEIGHTS_WEIGHT{"weight"};
 // clang-format on
 
 const std::string& CDataFrameTrainBoostedTreeClassifierRunnerFactory::name() const {

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -298,9 +298,8 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
     std::size_t dependentVariableColumn(dependentVariablePos -
                                         frame.columnNames().begin());
 
-    // Create restore searcher and restore in a scope
-    // so that the restore searcher gets destructed
-    // and performs any cleanup necessary.
+    // Create restore searcher and restore in a scope so that the restore searcher
+    // gets destructed and performs any cleanup necessary.
     {
         auto restoreSearcher{this->spec().restoreSearcher()};
         bool treeRestored{false};

--- a/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisSpecificationTest.cc
@@ -15,6 +15,7 @@
 #include <api/CDataFrameTrainBoostedTreeClassifierRunner.h>
 #include <api/CDataFrameTrainBoostedTreeRegressionRunner.h>
 
+#include <test/CDataFrameAnalysisSpecificationFactory.h>
 #include <test/CTestTmpDir.h>
 
 #include "CDataFrameMockAnalysisRunner.h"
@@ -366,6 +367,20 @@ BOOST_AUTO_TEST_CASE(testCreate) {
             api::CDataFrameAnalysisSpecificationJsonWriter::jsonString(
                 "testJob", 10000, 5, 100000000, 1, "42", {}, true,
                 test::CTestTmpDir::tmpDir(), "", "regression", parameters)};
+        LOG_DEBUG(<< core::CContainerPrinter::print(errors));
+        BOOST_TEST_REQUIRE(errors.size() > 0);
+    }
+
+    LOG_DEBUG(<< "Invalid number of class weights");
+    {
+        errors.clear();
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        auto spec = specFactory.rows(5)
+                        .predictionCategoricalFieldNames({"f1", "target"})
+                        .numberClasses(2)
+                        .classificationWeights({{"a", 0.1}, {"b", 0.4}, {"c", 0.5}})
+                        .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(),
+                                        "target");
         LOG_DEBUG(<< core::CContainerPrinter::print(errors));
         BOOST_TEST_REQUIRE(errors.size() > 0);
     }

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -235,5 +235,14 @@ void CBoostedTree::accept(CBoostedTree::CVisitor& visitor) const {
 const CBoostedTreeHyperparameters& CBoostedTree::bestHyperparameters() const {
     return m_Impl->bestHyperparameters();
 }
+
+CBoostedTree::TDoubleVec CBoostedTree::classificationWeights() const {
+    const auto& weights = m_Impl->classificationWeights();
+    TDoubleVec result(weights.size());
+    for (int i = 0; i < weights.size(); ++i) {
+        result[i] = weights(i);
+    }
+    return result;
+}
 }
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1128,6 +1128,11 @@ CBoostedTreeFactory::classAssignmentObjective(CBoostedTree::EClassAssignmentObje
     return *this;
 }
 
+CBoostedTreeFactory& CBoostedTreeFactory::classificationWeights(TStrDoublePrVec weights) {
+    m_TreeImpl->m_ClassificationWeightsOverride = std::move(weights);
+    return *this;
+}
+
 CBoostedTreeFactory& CBoostedTreeFactory::minimumFrequencyToOneHotEncode(double frequency) {
     if (frequency >= 1.0) {
         LOG_WARN(<< "Frequency to one-hot encode must be less than one");

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1702,7 +1702,7 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
                 core::CPersistUtils::restore(BEST_HYPERPARAMETERS_TAG,
                                              m_BestHyperparameters, traverser))
         RESTORE_SETUP_TEARDOWN(
-            FEATURE_BAG_FRACTION_OVERRIDE_TAG,
+            CLASSIFICATION_WEIGHTS_OVERRIDE_TAG,
             m_ClassificationWeightsOverride = TStrDoublePrVec{},
             core::CPersistUtils::restore(CLASSIFICATION_WEIGHTS_OVERRIDE_TAG,
                                          *m_ClassificationWeightsOverride, traverser),

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1921,7 +1921,7 @@ const CBoostedTreeImpl::TSizeVec& CBoostedTreeImpl::extraColumns() const {
     return m_ExtraColumns;
 }
 
-CBoostedTreeImpl::TVector CBoostedTreeImpl::classificationWeights() const {
+const CBoostedTreeImpl::TVector& CBoostedTreeImpl::classificationWeights() const {
     return m_ClassificationWeights;
 }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CLogger.h>
@@ -1091,7 +1092,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     TDoubleVecVec x;
     TDoubleVec means{0.0, 3.0};
     TDoubleVec variances{6.0, 6.0};
-    for (std::size_t i = 0; i < 4; ++i) {
+    for (std::size_t i = 0; i < std::size(classes); ++i) {
         TDoubleVecVec xi;
         double mean{means[classes[i]]};
         double variance{variances[classes[i]]};
@@ -1102,7 +1103,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
 
     auto frame = core::makeMainStorageDataFrame(cols).first;
     frame->categoricalColumns(TBoolVec{false, false, true});
-    for (std::size_t i = 0, index = 0; i < 4; ++i) {
+    for (std::size_t i = 0, index = 0; i < std::size(classes); ++i) {
         for (std::size_t j = 0; j < classesRowCounts[i]; ++j, ++index) {
             frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 for (std::size_t k = 0; k < cols - 1; ++k, ++column) {
@@ -1115,13 +1116,12 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     }
     frame->finishWritingRows();
 
-    auto classification =
-        maths::CBoostedTreeFactory::constructFromParameters(
-            1, std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>())
-            .buildFor(*frame, cols - 1);
+    auto classifier = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>())
+                          .buildFor(*frame, cols - 1);
 
-    classification->train();
-    classification->predict();
+    classifier->train();
+    classifier->predict();
 
     TDoubleVec precisions;
     TDoubleVec recalls;
@@ -1132,7 +1132,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
         TDoubleVec falseNegatives(2, 0.0);
         frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                auto scores = classification->readAndAdjustPrediction(*row);
+                auto scores = classifier->readAndAdjustPrediction(*row);
                 std::size_t prediction(scores[1] < scores[0] ? 0 : 1);
                 if (row->index() >= trainRows &&
                     row->index() < trainRows + classesRowCounts[2]) {
@@ -1157,6 +1157,57 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
 
     BOOST_TEST_REQUIRE(std::fabs(precisions[0] - precisions[1]) < 0.1);
     BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.11);
+}
+
+BOOST_AUTO_TEST_CASE(testClassificationWeightsOverride) {
+
+    // Test that the overrides are reflected in the classification weights used.
+
+    using TStrVec = std::vector<std::string>;
+
+    test::CRandomNumbers rng;
+
+    std::size_t classes[]{1, 0};
+    std::size_t classesRowCounts[]{50, 50};
+    std::size_t cols{3};
+
+    TDoubleVecVec x;
+    TDoubleVec means{0.0, 3.0};
+    TDoubleVec variances{6.0, 6.0};
+    for (std::size_t i = 0; i < std::size(classes); ++i) {
+        TDoubleVecVec xi;
+        double mean{means[classes[i]]};
+        double variance{variances[classes[i]]};
+        rng.generateMultivariateNormalSamples(
+            {mean, mean}, {{variance, 0.0}, {0.0, variance}}, classesRowCounts[i], xi);
+        x.insert(x.end(), xi.begin(), xi.end());
+    }
+
+    auto frame = core::makeMainStorageDataFrame(cols).first;
+    frame->categoricalColumns(TBoolVec{false, false, true});
+
+    std::string classValues[]{"foo", "bar"};
+    TStrVec row(cols);
+    for (std::size_t i = 0, index = 0; i < std::size(classes); ++i) {
+        for (std::size_t j = 0; j < classesRowCounts[i]; ++j, ++index) {
+            row[0] = std::to_string(x[index][0]);
+            row[1] = std::to_string(x[index][1]);
+            row[2] = classValues[i];
+            frame->parseAndWriteRow({row, 0, cols});
+        }
+    }
+    frame->finishWritingRows();
+
+    auto classifier = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>())
+                          .classAssignmentObjective(maths::CBoostedTree::E_Custom)
+                          .classificationWeights({{"foo", 0.8}, {"bar", 0.2}})
+                          .buildFor(*frame, cols - 1);
+
+    classifier->train();
+
+    BOOST_TEST_REQUIRE("[0.8, 0.2]", core::CContainerPrinter::print(
+                                         classifier->classificationWeights()));
 }
 
 BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -206,6 +206,12 @@ CDataFrameAnalysisSpecificationFactory::predictionFieldType(const std::string& t
 }
 
 CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::classificationWeights(const TStrDoublePrVec& weights) {
+    m_ClassificationWeights = weights;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::regressionLossFunction(TLossFunctionType lossFunction) {
     m_RegressionLossFunction = lossFunction;
     return *this;
@@ -272,97 +278,116 @@ std::string
 CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& analysis,
                                                          const std::string& dependentVariable) const {
 
+    using TRunner = api::CDataFrameTrainBoostedTreeRunner;
+    using TClassificationRunner = api::CDataFrameTrainBoostedTreeClassifierRunner;
+    using TRegressionRunner = api::CDataFrameTrainBoostedTreeRegressionRunner;
+
     rapidjson::StringBuffer parameters;
     TRapidJsonLineWriter writer;
     writer.Reset(parameters);
 
     writer.StartObject();
-    writer.Key(api::CDataFrameTrainBoostedTreeRunner::DEPENDENT_VARIABLE_NAME);
+    writer.Key(TRunner::DEPENDENT_VARIABLE_NAME);
     writer.String(dependentVariable);
     if (m_Alpha >= 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::ALPHA);
+        writer.Key(TRunner::ALPHA);
         writer.Double(m_Alpha);
     }
     if (m_Lambda >= 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::LAMBDA);
+        writer.Key(TRunner::LAMBDA);
         writer.Double(m_Lambda);
     }
     if (m_Gamma >= 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::GAMMA);
+        writer.Key(TRunner::GAMMA);
         writer.Double(m_Gamma);
     }
     if (m_SoftTreeDepthLimit >= 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT);
+        writer.Key(TRunner::SOFT_TREE_DEPTH_LIMIT);
         writer.Double(m_SoftTreeDepthLimit);
     }
     if (m_SoftTreeDepthTolerance >= 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE);
+        writer.Key(TRunner::SOFT_TREE_DEPTH_TOLERANCE);
         writer.Double(m_SoftTreeDepthTolerance);
     }
     if (m_Eta > 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::ETA);
+        writer.Key(TRunner::ETA);
         writer.Double(m_Eta);
     }
     if (m_DownsampleFactor > 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_FACTOR);
+        writer.Key(TRunner::DOWNSAMPLE_FACTOR);
         writer.Double(m_DownsampleFactor);
     }
     if (m_MaximumNumberTrees > 0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::MAX_TREES);
+        writer.Key(TRunner::MAX_TREES);
         writer.Uint64(m_MaximumNumberTrees);
     }
     if (m_FeatureBagFraction > 0.0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION);
+        writer.Key(TRunner::FEATURE_BAG_FRACTION);
         writer.Double(m_FeatureBagFraction);
     }
     if (m_NumberRoundsPerHyperparameter > 0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER);
+        writer.Key(TRunner::MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER);
         writer.Uint64(m_NumberRoundsPerHyperparameter);
     }
     if (m_BayesianOptimisationRestarts > 0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::BAYESIAN_OPTIMISATION_RESTARTS);
+        writer.Key(TRunner::BAYESIAN_OPTIMISATION_RESTARTS);
         writer.Uint64(m_BayesianOptimisationRestarts);
     }
     if (m_NumberTopShapValues > 0) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::NUM_TOP_FEATURE_IMPORTANCE_VALUES);
+        writer.Key(TRunner::NUM_TOP_FEATURE_IMPORTANCE_VALUES);
         writer.Uint64(m_NumberTopShapValues);
     }
     if (m_PredictionFieldName.empty() == false) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::PREDICTION_FIELD_NAME);
+        writer.Key(TRunner::PREDICTION_FIELD_NAME);
         writer.String(m_PredictionFieldName);
     }
-    if (m_PredictionFieldType.empty() == false) {
-        writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE);
-        writer.String(m_PredictionFieldType);
-    }
-    if (analysis == classification()) {
-        writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES);
-        writer.Uint64(m_NumberClasses);
-        writer.Key(api::CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES);
-        writer.Uint64(m_NumberTopClasses);
-    }
     if (m_CustomProcessors.IsNull() == false) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS);
+        writer.Key(TRunner::FEATURE_PROCESSORS);
         writer.write(m_CustomProcessors);
     }
     if (m_EarlyStoppingEnabled == false) {
-        writer.Key(api::CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ENABLED);
+        writer.Key(TRunner::EARLY_STOPPING_ENABLED);
         writer.Bool(m_EarlyStoppingEnabled);
     }
 
+    if (analysis == classification()) {
+        writer.Key(TClassificationRunner::NUM_CLASSES);
+        writer.Uint64(m_NumberClasses);
+        writer.Key(TClassificationRunner::NUM_TOP_CLASSES);
+        writer.Uint64(m_NumberTopClasses);
+        if (m_PredictionFieldType.empty() == false) {
+            writer.Key(TClassificationRunner::PREDICTION_FIELD_TYPE);
+            writer.String(m_PredictionFieldType);
+        }
+        if (m_ClassificationWeights.size() > 0) {
+            writer.Key(TClassificationRunner::CLASS_ASSIGNMENT_OBJECTIVE);
+            writer.String(
+                TClassificationRunner::CLASS_ASSIGNMENT_OBJECTIVE_VALUES[maths::CDataFramePredictiveModel::E_Custom]);
+            writer.Key(TClassificationRunner::CLASSIFICATION_WEIGHTS);
+            writer.StartArray();
+            for (const auto& weight : m_ClassificationWeights) {
+                writer.StartObject();
+                writer.Key(TClassificationRunner::CLASSIFICATION_WEIGHTS_CLASS);
+                writer.String(weight.first);
+                writer.Key(TClassificationRunner::CLASSIFICATION_WEIGHTS_WEIGHT);
+                writer.Double(weight.second);
+                writer.EndObject();
+            }
+            writer.EndArray();
+        }
+    }
     if (analysis == regression()) {
-
         if (m_RegressionLossFunction) {
-            writer.Key(api::CDataFrameTrainBoostedTreeRegressionRunner::LOSS_FUNCTION);
+            writer.Key(TRegressionRunner::LOSS_FUNCTION);
             switch (m_RegressionLossFunction.get()) {
             case TLossFunctionType::E_MsleRegression:
-                writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::MSLE);
+                writer.String(TRegressionRunner::MSLE);
                 break;
             case TLossFunctionType::E_MseRegression:
-                writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::MSE);
+                writer.String(TRegressionRunner::MSE);
                 break;
             case TLossFunctionType::E_HuberRegression:
-                writer.String(api::CDataFrameTrainBoostedTreeRegressionRunner::PSEUDO_HUBER);
+                writer.String(TRegressionRunner::PSEUDO_HUBER);
                 break;
             case TLossFunctionType::E_BinaryClassification:
             case TLossFunctionType::E_MulticlassClassification:
@@ -371,7 +396,7 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
             }
         }
         if (m_RegressionLossFunctionParameter) {
-            writer.Key(api::CDataFrameTrainBoostedTreeRegressionRunner::LOSS_FUNCTION_PARAMETER);
+            writer.Key(TRegressionRunner::LOSS_FUNCTION_PARAMETER);
             writer.Double(m_RegressionLossFunctionParameter.get());
         }
     }

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -359,7 +359,7 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
             writer.Key(TClassificationRunner::PREDICTION_FIELD_TYPE);
             writer.String(m_PredictionFieldType);
         }
-        if (m_ClassificationWeights.size() > 0) {
+        if (m_ClassificationWeights.empty() == false) {
             writer.Key(TClassificationRunner::CLASS_ASSIGNMENT_OBJECTIVE);
             writer.String(
                 TClassificationRunner::CLASS_ASSIGNMENT_OBJECTIVE_VALUES[maths::CDataFramePredictiveModel::E_Custom]);

--- a/lib/test/CDataFrameAnalyzerTrainingFactory.cc
+++ b/lib/test/CDataFrameAnalyzerTrainingFactory.cc
@@ -94,7 +94,7 @@ CDataFrameAnalyzerTrainingFactory::setupBinaryClassificationData(const TStrVec& 
             row[j] = regressors[i + j];
         }
 
-        for (std::size_t j = 0; j < row.size() - 1; ++j) {
+        for (std::size_t j = 0; j < row.size(); ++j) {
             fieldValues[j] = core::CStringUtils::typeToStringPrecise(
                 row[j], core::CIEEE754::E_DoublePrecision);
         }


### PR DESCRIPTION
We plan to allow users to also set weights for class assignment via choosing a point on the ROC curve. In this case, the config should allow overriding class weights to reflect the user's error preferences if retraining. This introduces a new value in the parameters section of the JSON object of the form
```
"classification_weights": [{"class":"<string>", "weight": <double>}]
```
and a new class assignment objective `custom`.

Closes #1719. I've marked this as a non-issue because it isn't really user facing and we should only document when the Java side of the changes to support overriding the decision threshold is implemented.