### PR TITLE
[7.x][ML] Disabling ill behaved invariant check (#1730)

### DIFF
--- a/lib/maths/CQDigest.cc
+++ b/lib/maths/CQDigest.cc
@@ -80,9 +80,13 @@ bool CQDigest::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
 
 void CQDigest::checkRestoredInvariants() const {
     VIOLATES_INVARIANT_NO_EVALUATION(m_Root, ==, nullptr);
-    if (this->checkInvariants() == false) {
-        LOG_ABORT(<< "Invariance check failed for Q Digest");
-    }
+
+    // This check on invariants is proving unreliable as it
+    // fails on occasion, see ml-cpp#1728 for details.
+    // Disabling the check pending investigation.
+    //    if (this->checkInvariants() == false) {
+    //        LOG_ABORT(<< "Invariance check failed for Q Digest");
+    //    }
 }
 
 void CQDigest::add(uint32_t value, uint64_t n) {


### PR DESCRIPTION
A recently enabled check on invariants after state restoration is
failing on occasion. Disable the test until a full investigation can be
carried out.

Backports #1730 
Relates #1717
Closes #1728