### PR TITLE
[ML] Add pytorch_inference to Makefile and controller

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -16,6 +16,7 @@ COMPONENTS= \
             controller \
             data_frame_analyzer \
             normalize \
+            pytorch_inference \
 
 include $(CPP_SRC_HOME)/mk/toplevel.mk
 

--- a/bin/controller/Main.cc
+++ b/bin/controller/Main.cc
@@ -25,6 +25,7 @@
 //! 2) ./categorize
 //! 3) ./data_frame_analyzer
 //! 4) ./normalize
+//! 5) ./pytorch_inference
 //!
 //! The assumption here is that the working directory of this
 //! process will be the directory containing these other
@@ -156,7 +157,8 @@ int main(int argc, char** argv) {
     }
 
     ml::controller::CCommandProcessor::TStrVec permittedProcessPaths{
-        "./autodetect", "./categorize", "./data_frame_analyzer", "./normalize"};
+        "./autodetect", "./categorize", "./data_frame_analyzer", "./normalize",
+        "./pytorch_inference"};
 
     ml::controller::CCommandProcessor processor{permittedProcessPaths, *outputStream};
     processor.processCommands(*commandStream);

--- a/bin/pytorch_inference/.gitignore
+++ b/bin/pytorch_inference/.gitignore
@@ -1,0 +1,3 @@
+input_file
+output_file
+restore_file


### PR DESCRIPTION
Now we have built libraries for all the different platforms
pytorch_inference can be added to the Makefile without
breaking CI.

If CI fails for this PR it will smoke out any mistakes in
Docker images or dependency bundles.

Also adding to controller as that's a one-liner.

Closes #1702