### PR TITLE
[ML] Line search feature bag fraction for classification and regression model training

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,6 +39,13 @@
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3. (See
   {ml-pull}1170[#1170].)
 
+== {es} version 7.13.0
+
+=== Enhancements
+
+* Speed up training of regression and classification model training for data sets
+  with many features. (See {ml-pull}1746[#1746].)
+
 == {es} version 7.12.0
 
 === Enhancements

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -269,7 +269,7 @@ private:
     //! Stubs out persistence.
     static void noopRecordTrainingState(CBoostedTree::TPersistFunc);
 
-    //! Stop hyperparameter optimization early if the process is not promising.
+    //! Stubs out test loss adjustment.
     static double noopAdjustTestLoss(double, double, double testLoss);
 
 private:

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -147,7 +147,7 @@ private:
     using TOptionalVector = boost::optional<TVector>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TBoostedTreeImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
-    using TApplyRegularizer = std::function<bool(CBoostedTreeImpl&, double)>;
+    using TApplyParameter = std::function<bool(CBoostedTreeImpl&, double)>;
 
 private:
     CBoostedTreeFactory(std::size_t numberThreads, TLossFunctionUPtr loss);
@@ -208,7 +208,7 @@ private:
     //! \return The interval to search during the main hyperparameter optimisation
     //! loop or null if this couldn't be found.
     TOptionalVector testLossLineSearch(core::CDataFrame& frame,
-                                       const TApplyRegularizer& applyRegularizerStep,
+                                       const TApplyParameter& applyParameterStep,
                                        double intervalLeftEnd,
                                        double intervalRightEnd,
                                        double returnedIntervalLeftEndOffset,

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -285,12 +285,12 @@ private:
     std::size_t m_NumberThreads;
     TBoostedTreeImplUPtr m_TreeImpl;
     TVector m_LogDownsampleFactorSearchInterval;
+    TVector m_LogFeatureBagFractionInterval;
     TVector m_LogDepthPenaltyMultiplierSearchInterval;
     TVector m_LogTreeSizePenaltyMultiplierSearchInterval;
     TVector m_LogLeafWeightPenaltyMultiplierSearchInterval;
     TVector m_SoftDepthLimitSearchInterval;
     TVector m_LogEtaSearchInterval;
-    TVector m_LogFeatureBagFractionInterval;
     TTrainingStateCallback m_RecordTrainingState = noopRecordTrainingState;
 };
 }

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -192,8 +192,9 @@ private:
         E_TreeSizePenaltyMultiplierInitialized = 3,
         E_LeafWeightPenaltyMultiplierInitialized = 4,
         E_DownsampleFactorInitialized = 5,
-        E_EtaInitialized = 6,
-        E_FullyInitialized = 7
+        E_FeatureBagFractionInitialized = 6,
+        E_EtaInitialized = 7,
+        E_FullyInitialized = 8
     };
 
 private:

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -150,8 +150,8 @@ CBoostedTreeFactory::restoreFor(core::CDataFrame& frame, std::size_t dependentVa
     case CBoostedTreeImpl::E_DepthPenaltyMultiplierInitialized:
     case CBoostedTreeImpl::E_TreeSizePenaltyMultiplierInitialized:
     case CBoostedTreeImpl::E_LeafWeightPenaltyMultiplierInitialized:
-    case CBoostedTreeImpl::E_FeatureBagFractionInitialized:
     case CBoostedTreeImpl::E_DownsampleFactorInitialized:
+    case CBoostedTreeImpl::E_FeatureBagFractionInitialized:
     case CBoostedTreeImpl::E_EtaInitialized:
         return this->buildFor(frame, dependentVariable);
     }
@@ -864,7 +864,7 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
 void CBoostedTreeFactory::initializeUnsetFeatureBagFraction(core::CDataFrame& frame) {
 
     if (m_TreeImpl->m_FeatureBagFractionOverride == boost::none) {
-        if (skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_FeatureBagFractionInitialized, [&] {
+        if (this->skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_FeatureBagFractionInitialized, [&] {
                 double searchIntervalSize{FEATURE_BAG_FRACTION_LINE_SEARCH_RANGE};
                 double logMaxFeatureBagFraction{CTools::stableLog(std::min(
                     2.0 * m_TreeImpl->m_FeatureBagFraction, MAX_FEATURE_BAG_FRACTION))};
@@ -1552,6 +1552,7 @@ const std::string INITIALIZATION_CHECKPOINT_TAG{"initialization_checkpoint"};
 const std::string LOG_DEPTH_PENALTY_MULTIPLIER_SEARCH_INTERVAL_TAG{"log_depth_penalty_multiplier_search_interval"};
 const std::string LOG_DOWNSAMPLE_FACTOR_SEARCH_INTERVAL_TAG{"log_downsample_factor_search_interval"};
 const std::string LOG_ETA_SEARCH_INTERVAL_TAG{"log_eta_search_interval"};
+const std::string LOG_FEATURE_BAG_FRACTION_INTERVAL_TAG{"log_feature_bag_fraction_interval"};
 const std::string LOG_LEAF_WEIGHT_PENALTY_MULTIPLIER_SEARCH_INTERVAL_TAG{"log_leaf_weight_penalty_multiplier_search_interval"};
 const std::string LOG_TREE_SIZE_PENALTY_MULTIPLIER_SEARCH_INTERVAL_TAG{"log_tree_size_penalty_multiplier_search_interval"};
 const std::string SOFT_DEPTH_LIMIT_SEARCH_INTERVAL_TAG{"soft_depth_limit_search_interval"};
@@ -1577,6 +1578,8 @@ void CBoostedTreeFactory::acceptPersistInserter(core::CStatePersistInserter& ins
                                      m_LogDownsampleFactorSearchInterval, inserter);
         core::CPersistUtils::persist(LOG_ETA_SEARCH_INTERVAL_TAG,
                                      m_LogEtaSearchInterval, inserter);
+        core::CPersistUtils::persist(LOG_FEATURE_BAG_FRACTION_INTERVAL_TAG,
+                                     m_LogFeatureBagFractionInterval, inserter);
         core::CPersistUtils::persist(
             LOG_LEAF_WEIGHT_PENALTY_MULTIPLIER_SEARCH_INTERVAL_TAG,
             m_LogLeafWeightPenaltyMultiplierSearchInterval, inserter);
@@ -1628,6 +1631,10 @@ bool CBoostedTreeFactory::acceptRestoreTraverser(core::CStateRestoreTraverser& t
                         RESTORE(LOG_ETA_SEARCH_INTERVAL_TAG,
                                 core::CPersistUtils::restore(LOG_ETA_SEARCH_INTERVAL_TAG,
                                                              m_LogEtaSearchInterval, traverser))
+                        RESTORE(LOG_FEATURE_BAG_FRACTION_INTERVAL_TAG,
+                                core::CPersistUtils::restore(
+                                    LOG_FEATURE_BAG_FRACTION_INTERVAL_TAG,
+                                    m_LogFeatureBagFractionInterval, traverser))
                         RESTORE(LOG_LEAF_WEIGHT_PENALTY_MULTIPLIER_SEARCH_INTERVAL_TAG,
                                 core::CPersistUtils::restore(
                                     LOG_LEAF_WEIGHT_PENALTY_MULTIPLIER_SEARCH_INTERVAL_TAG,

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -767,7 +767,7 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
                                               CTools::stableLog(searchIntervalSize)};
                 double meanLogDownSampleFactor{
                     (logMinDownsampleFactor + logMaxDownsampleFactor) / 2.0};
-                LOG_TRACE(<< "mean log down sample factor = " << meanLogDownSampleFactor);
+                LOG_TRACE(<< "mean log downsample factor = " << meanLogDownSampleFactor);
 
                 double previousDownsampleFactor{m_TreeImpl->m_DownsampleFactor};
                 double previousDepthPenaltyMultiplier{
@@ -778,7 +778,7 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
                     m_TreeImpl->m_Regularization.leafWeightPenaltyMultiplier()};
 
                 // We need to scale the regularisation terms to account for the difference
-                // in the down sample factor compared to the value used in the line search.
+                // in the downsample factor compared to the value used in the line search.
                 auto scaleRegularizers = [&](CBoostedTreeImpl& tree, double downsampleFactor) {
                     double scale{previousDownsampleFactor / downsampleFactor};
                     if (tree.m_RegularizationOverride.depthPenaltyMultiplier() == boost::none) {
@@ -810,7 +810,7 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
 
                 // If there is very little relative difference in the loss prefer smaller
                 // downsample factors because they train faster. We add a penalty which is
-                // eps * lmin * (x - xmin) / (xmax - xmin) for x the down sample factor,
+                // eps * lmin * (x - xmin) / (xmax - xmin) for x the downsample factor,
                 // [xmin, xmax] the search interval and lmin the minimum test loss. This
                 // means we'll never use a parameter whose loss is more than 1 + eps times
                 // larger than the minimum.
@@ -835,12 +835,12 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
                         .value_or(fallback);
 
                 // Truncate the log(factor) to be less than or equal to log(1.0) and the
-                // down sampled set contains at least ten examples on average.
+                // downsampled set contains at least ten examples on average.
                 m_LogDownsampleFactorSearchInterval =
                     min(max(m_LogDownsampleFactorSearchInterval,
                             TVector{CTools::stableLog(10.0 / numberTrainingRows)}),
                         TVector{0.0});
-                LOG_TRACE(<< "log down sample factor search interval = ["
+                LOG_TRACE(<< "log downsample factor search interval = ["
                           << m_LogDownsampleFactorSearchInterval.toDelimited() << "]");
 
                 m_TreeImpl->m_DownsampleFactor = CTools::stableExp(

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1099,7 +1099,7 @@ std::size_t CBoostedTreeImpl::featureBagSize(double fraction) const {
 
 void CBoostedTreeImpl::treeFeatureBag(TDoubleVec& probabilities, TSizeVec& treeFeatureBag) const {
 
-    std::size_t size{this->featureBagSize(1.5 * m_FeatureBagFraction)};
+    std::size_t size{this->featureBagSize(1.25 * m_FeatureBagFraction)};
 
     this->candidateRegressorFeatures(probabilities, treeFeatureBag);
     if (size >= treeFeatureBag.size()) {
@@ -1313,13 +1313,14 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     for (std::size_t i = 0; i < m_TunableHyperparameters.size(); ++i) {
         switch (m_TunableHyperparameters[i]) {
         case E_Alpha:
-            parameters(i) = CTools::stableLog(m_Regularization.depthPenaltyMultiplier());
+            parameters(i) =
+                CTools::stableLog(m_Regularization.depthPenaltyMultiplier() / scale);
             break;
         case E_DownsampleFactor:
             parameters(i) = CTools::stableLog(m_DownsampleFactor);
             break;
         case E_Eta:
-            parameters(i) = CTools::stableLog(m_Eta) / scale;
+            parameters(i) = CTools::stableLog(m_Eta);
             break;
         case E_EtaGrowthRatePerTree:
             parameters(i) = m_EtaGrowthRatePerTree;
@@ -1380,13 +1381,14 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     for (std::size_t i = 0; i < m_TunableHyperparameters.size(); ++i) {
         switch (m_TunableHyperparameters[i]) {
         case E_Alpha:
-            m_Regularization.depthPenaltyMultiplier(CTools::stableExp(parameters(i)));
+            m_Regularization.depthPenaltyMultiplier(
+                scale * CTools::stableExp(parameters(i)));
             break;
         case E_DownsampleFactor:
             m_DownsampleFactor = CTools::stableExp(parameters(i));
             break;
         case E_Eta:
-            m_Eta = CTools::stableExp(scale * parameters(i));
+            m_Eta = CTools::stableExp(parameters(i));
             break;
         case E_EtaGrowthRatePerTree:
             m_EtaGrowthRatePerTree = parameters(i);

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1294,9 +1294,10 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
     TVector maxBoundary;
     std::tie(minBoundary, maxBoundary) = bopt.boundingBox();
 
-    // Downsampling acts as a regularisation and also increases the variance
-    // of each of the base learners so we scale the other regularisation terms
-    // and the weight shrinkage to compensate.
+    // Downsampling directly affects the loss terms: it multiplies the sums over
+    // gradients and Hessians in expectation by the downsample factor. To preserve
+    // the same effect for regularisers we need to scale these terms by the same
+    // multiplier.
     double scale{1.0};
     if (m_DownsampleFactorOverride == boost::none) {
         auto i = std::distance(m_TunableHyperparameters.begin(),

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -626,7 +626,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
             0.0, modelBias[i],
             4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.97);
+        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.96);
 
         meanModelRSquared.add(modelRSquared[i]);
     }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -882,7 +882,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.16);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.98);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.97);
 }
 
 BOOST_AUTO_TEST_CASE(testFeatureBags) {


### PR DESCRIPTION
Following on from #1733, we can get further speedups by line searching for the best feature bag fraction for data sets where we only need a fraction of the features per tree. For example, training time on Higgs 1M drops from 2585s to 1742s and we actually get a small improvement in accuracy because our hyperparameter search region is better initialised.

This makes three changes:
1. Adds a line search for the best initial feature bag fraction to use.
2. Adds a small linear penalty at most 1% minimum loss to encourage larger down sample factors and smaller feature bag fractions.
3. Handles better the case we have many features and relatively few training examples.

Some of the variable naming in `CBoostedTreeFactory` is also now misleading. I've split this change out into a non-functional commit. The functional commit is [f9eacc2](https://github.com/elastic/ml-cpp/commit/f9eacc23559e5b921fb421b1f7a61cc6dd2668d1).