### PR TITLE
[7.x][ML] Check invariants after restoration (#1737)

### DIFF
--- a/lib/model/CDetectorEqualizer.cc
+++ b/lib/model/CDetectorEqualizer.cc
@@ -45,8 +45,7 @@ bool CDetectorEqualizer::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
                                /**/)
         if (name == SKETCH_TAG) {
             if (!detector) {
-                LOG_ERROR(<< "Expected the detector label first");
-                return false;
+                LOG_ABORT(<< "Expected the detector label first");
             }
             m_Sketches.emplace_back(
                 *detector, maths::CQuantileSketch(SKETCH_INTERPOLATION, SKETCH_SIZE));

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -228,10 +228,9 @@ bool restoreAttributePeopleData(core::CStateRestoreTraverser& traverser, TSizeUS
                 data.resize(lastCid + 1);
             }
         } else if (name == PERSON_TAG) {
-            if (!seenCid) {
-                LOG_ERROR(<< "Incorrect format - person ID before attribute ID in "
+            if (seenCid == false) {
+                LOG_ABORT(<< "Incorrect format - person ID before attribute ID in "
                           << traverser.value());
-                return false;
             }
             std::size_t pid = 0;
             if (core::CStringUtils::stringToType(traverser.value(), pid) == false) {

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -416,6 +416,8 @@ bool CIndividualModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser& tr
         }
     }
 
+    VIOLATES_INVARIANT(m_FirstBucketTimes.size(), !=, m_LastBucketTimes.size());
+
     return true;
 }
 

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -323,6 +323,9 @@ bool CPopulationModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser& tr
         }
     } while (traverser.next());
 
+    VIOLATES_INVARIANT(m_AttributeFirstBucketTimes.size(), !=,
+                       m_AttributeLastBucketTimes.size());
+
     return true;
 }
 


### PR DESCRIPTION
Add checking of invariants after restoration of several classes in the
model library.

Also change a number of conditions where an error was emitted during the
restoration process to be hard stops with LOG_ABORT.

Relates #1717
Backports #1737 