### PR TITLE
[ML] Do nothing on macOS ARM workers on old branches

### DIFF
--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -51,6 +51,12 @@ fi
 VERSION=$(cat ../gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo)
 HARDWARE_ARCH=$(uname -m)
 
+# arm64 catches macOS on ARM but not Linux, as Linux reports aarch64
+if [ "$HARDWARE_ARCH" = arm64 ] ; then
+    echo "$VERSION is not built on $HARDWARE_ARCH"
+    exit 0
+fi
+
 # Jenkins sets BUILD_SNAPSHOT, but our Docker scripts require SNAPSHOT
 if [ "$BUILD_SNAPSHOT" = false ] ; then
     export SNAPSHOT=no


### PR DESCRIPTION
PR builds will now fan out to workers that include macOS ARM
workers. But for old branches we cannot build on this architecture,
so just make such builds a no-op.

The approach is similar to #1203, and because the 6.8 branch
already contains #1203 this change is only needed for 7.11 and
7.12.