### PR TITLE
[ML] Replace BOOST_REQUIRE with BOOST_TEST_REQUIRE

### DIFF
--- a/lib/maths/unittest/CBasicStatisticsTest.cc
+++ b/lib/maths/unittest/CBasicStatisticsTest.cc
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(testVarianceAtPercentile) {
     }
 
     LOG_DEBUG(<< "bias = " << maths::CBasicStatistics::mean(bias));
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(bias) < 0.1);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(bias) < 0.1);
 }
 
 BOOST_AUTO_TEST_CASE(testCentralMoments) {

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -407,10 +407,10 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
             leftChildId, rightChildId, numberThreads, 0.0, *frame, encoder, regularization,
             treeFeatureBag, nodeFeatureBag, tree[rootSplit->id()], workspace);
         if (leftChild != nullptr) {
-            BOOST_REQUIRE(rootSplit->leftChildMaxGain() >= leftChild->gain());
+            BOOST_TEST_REQUIRE(rootSplit->leftChildMaxGain() >= leftChild->gain());
         }
         if (rightChild != nullptr) {
-            BOOST_REQUIRE(rootSplit->rightChildMaxGain() >= rightChild->gain());
+            BOOST_TEST_REQUIRE(rootSplit->rightChildMaxGain() >= rightChild->gain());
         }
         BOOST_REQUIRE(rightChild != nullptr || leftChild != nullptr);
     }

--- a/lib/maths/unittest/CSignalTest.cc
+++ b/lib/maths/unittest/CSignalTest.cc
@@ -594,7 +594,7 @@ BOOST_AUTO_TEST_CASE(testFitSingleSeasonalComponent) {
                 expected(i), maths::CBasicStatistics::mean(actuals[0][i]), 4.0 * sigma);
             meanError(std::fabs(expected(i) - maths::CBasicStatistics::mean(actuals[0][i])) / sigma);
         }
-        BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 1.5);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 1.5);
     }
 }
 
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(testFitMultipleSeasonalComponents) {
                           sigma);
             }
         }
-        BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 2.5);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 2.5);
         overallMeanError += meanError;
 
         // We can only really guaranty individual component values up to additive
@@ -687,7 +687,7 @@ BOOST_AUTO_TEST_CASE(testFitMultipleSeasonalComponents) {
     }
 
     LOG_DEBUG(<< "Overall mean error = " << maths::CBasicStatistics::mean(overallMeanError));
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(overallMeanError) < 1.25);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(overallMeanError) < 1.25);
 }
 
 BOOST_AUTO_TEST_CASE(testFitTradingDaySeasonalComponents) {
@@ -810,7 +810,7 @@ BOOST_AUTO_TEST_CASE(testFitSingleSeasonalComponentRobust) {
 
     LOG_DEBUG(<< "Overall improvement = "
               << maths::CBasicStatistics::mean(overallImprovement));
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(overallImprovement) > 1.75);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(overallImprovement) > 1.75);
 }
 
 BOOST_AUTO_TEST_CASE(testFitMultipleSeasonalComponentsRobust) {
@@ -894,7 +894,7 @@ BOOST_AUTO_TEST_CASE(testFitMultipleSeasonalComponentsRobust) {
 
     LOG_DEBUG(<< "Overall improvement = "
               << maths::CBasicStatistics::mean(overallImprovement));
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(overallImprovement) > 4.0);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(overallImprovement) > 4.0);
 }
 
 BOOST_AUTO_TEST_CASE(testSingleComponentSeasonalDecomposition) {
@@ -935,7 +935,7 @@ BOOST_AUTO_TEST_CASE(testSingleComponentSeasonalDecomposition) {
 
         // We can detect additional components but must detect the real
         // component first.
-        BOOST_REQUIRE(decomposition.size() >= 1);
+        BOOST_TEST_REQUIRE(decomposition.size() >= 1);
 
         decomposition.resize(1);
 
@@ -999,7 +999,7 @@ BOOST_AUTO_TEST_CASE(testMultipleSeasonalDecomposition) {
 
         // We can detect additional components but must detect the two real
         // components first.
-        BOOST_REQUIRE(decomposition.size() >= 2);
+        BOOST_TEST_REQUIRE(decomposition.size() >= 2);
 
         decomposition.resize(2);
         std::sort(period.begin(), period.end());
@@ -1011,7 +1011,7 @@ BOOST_AUTO_TEST_CASE(testMultipleSeasonalDecomposition) {
     }
 
     LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.01);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.01);
 }
 
 BOOST_AUTO_TEST_CASE(testMultipleDiurnalSeasonalDecomposition) {
@@ -1303,8 +1303,8 @@ BOOST_AUTO_TEST_CASE(testSmoothResample) {
             }
 
             BOOST_REQUIRE_CLOSE(totalCount, totalResampledCount, 0.1 /*%*/);
-            BOOST_REQUIRE(std::fabs(maths::CBasicStatistics::mean(errorMoments)) < 0.05);
-            BOOST_REQUIRE(maths::CBasicStatistics::variance(errorMoments) < 1.2);
+            BOOST_TEST_REQUIRE(std::fabs(maths::CBasicStatistics::mean(errorMoments)) < 0.05);
+            BOOST_TEST_REQUIRE(maths::CBasicStatistics::variance(errorMoments) < 1.2);
 
             averageVariance.add(maths::CBasicStatistics::variance(errorMoments));
         }

--- a/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/unittest/CTimeSeriesDecompositionTest.cc
@@ -2046,7 +2046,7 @@ BOOST_FIXTURE_TEST_CASE(testStability, CTestFixture) {
         debug.addPrediction(time, prediction, trend(time) - prediction);
 
         if (time > 20 * WEEK) {
-            BOOST_REQUIRE(std::fabs(trend(time) - prediction) < 5.0);
+            BOOST_TEST_REQUIRE(std::fabs(trend(time) - prediction) < 5.0);
         }
     }
 }

--- a/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
+++ b/lib/maths/unittest/CTimeSeriesSegmentationTest.cc
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(testMeanScalePiecewiseLinearScaledSeasonal) {
             values = TSegmentation::constantScalePiecewiseLinearScaledSeasonal(
                 std::move(values), periods[i], segmentation, meanScale, 0.05,
                 scaledModels, modelScales);
-            BOOST_REQUIRE(values.size() > 0);
+            BOOST_TEST_REQUIRE(values.size() > 0);
 
             maths::CSignal::fitSeasonalComponents(periods[i], values, components);
 
@@ -623,14 +623,14 @@ BOOST_AUTO_TEST_CASE(testPiecewiseTimeShifted) {
             error += std::abs(static_cast<int>(estimatedSegmentation[j]) -
                               static_cast<int>(segmentation[j]));
         }
-        BOOST_REQUIRE(error < 10);
+        BOOST_TEST_REQUIRE(error < 10);
         BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(shifts),
                             core::CContainerPrinter::print(estimatedShifts));
         meanError.add(static_cast<double>(error));
     }
 
     LOG_DEBUG(<< "mean error = " << maths::CBasicStatistics::mean(meanError));
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 2.7);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 2.7);
 }
 
 BOOST_AUTO_TEST_CASE(testMeanScale) {

--- a/lib/maths/unittest/CTimeSeriesTestForChangeTest.cc
+++ b/lib/maths/unittest/CTimeSeriesTestForChangeTest.cc
@@ -101,9 +101,9 @@ void testChange(const TGeneratorVec& trends,
 
     truePositives /= static_cast<double>(numberTests);
 
-    BOOST_REQUIRE(truePositives >= 0.98);
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.04);
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanTimeError) < 5000);
+    BOOST_TEST_REQUIRE(truePositives >= 0.98);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.04);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanTimeError) < 5000);
 }
 }
 
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(testNoChange) {
 
     trueNegatives /= static_cast<double>(numberTests);
 
-    BOOST_REQUIRE(trueNegatives >= 0.99);
+    BOOST_TEST_REQUIRE(trueNegatives >= 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testLevelShift) {
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(testWithReversion) {
 
         LOG_TRACE(<< (change == nullptr ? "null" : change->print()));
         if (change != nullptr) {
-            BOOST_REQUIRE(change->largeEnough(3.0 * std::sqrt(noiseVariance)) == false);
+            BOOST_TEST_REQUIRE(change->largeEnough(3.0 * std::sqrt(noiseVariance)) == false);
         }
     }
 }

--- a/lib/maths/unittest/CTimeSeriesTestForSeasonalityTest.cc
+++ b/lib/maths/unittest/CTimeSeriesTestForSeasonalityTest.cc
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticNoSeasonality) {
     }
 
     LOG_DEBUG(<< "True negative rate = " << TN / (FP + TN));
-    BOOST_REQUIRE(TN / (FP + TN) > 0.99);
+    BOOST_TEST_REQUIRE(TN / (FP + TN) > 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testSyntheticDiurnal) {
@@ -209,8 +209,8 @@ BOOST_AUTO_TEST_CASE(testSyntheticDiurnal) {
 
     LOG_DEBUG(<< "recall = " << TP / (TP + FN));
     LOG_DEBUG(<< "accuracy = " << TP / (TP + FP));
-    BOOST_REQUIRE(TP / (TP + FN) > 0.99);
-    BOOST_REQUIRE(TP / (TP + FP) > 0.99);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.99);
+    BOOST_TEST_REQUIRE(TP / (TP + FP) > 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testRealSpikeyDaily) {
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(testRealSpikeyDaily) {
     BOOST_REQUIRE(test::CTimeSeriesTestData::parse(
         "testfiles/spikey_data.csv", timeseries, startTime, endTime,
         test::CTimeSeriesTestData::CSV_UNIX_REGEX));
-    BOOST_REQUIRE(timeseries.size() > 0);
+    BOOST_TEST_REQUIRE(timeseries.size() > 0);
 
     LOG_DEBUG(<< "timeseries = "
               << core::CContainerPrinter::print(timeseries.begin(), timeseries.begin() + 10)
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(testRealTradingDays) {
         "testfiles/thirty_minute_samples.csv", timeseries, startTime, endTime,
         test::CTimeSeriesTestData::CSV_ISO8601_REGEX,
         test::CTimeSeriesTestData::CSV_ISO8601_DATE_FORMAT));
-    BOOST_REQUIRE(timeseries.size() > 0);
+    BOOST_TEST_REQUIRE(timeseries.size() > 0);
 
     LOG_DEBUG(<< "timeseries = "
               << core::CContainerPrinter::print(timeseries.begin(), timeseries.begin() + 10)
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(testRealTradingDaysPlusOutliers) {
     BOOST_REQUIRE(test::CTimeSeriesTestData::parse(
         "testfiles/diurnal.csv", timeseries, startTime, endTime,
         test::CTimeSeriesTestData::CSV_UNIX_REGEX));
-    BOOST_REQUIRE(timeseries.size() > 0);
+    BOOST_TEST_REQUIRE(timeseries.size() > 0);
 
     LOG_DEBUG(<< "timeseries = "
               << core::CContainerPrinter::print(timeseries.begin(), timeseries.begin() + 10)
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(testRealSwitchingNoSeasonality) {
         "testfiles/no_periods.csv", timeseries, startTime, endTime,
         test::CTimeSeriesTestData::CSV_ISO8601_REGEX,
         test::CTimeSeriesTestData::CSV_ISO8601_DATE_FORMAT));
-    BOOST_REQUIRE(timeseries.size() > 0);
+    BOOST_TEST_REQUIRE(timeseries.size() > 0);
 
     LOG_DEBUG(<< "timeseries = "
               << core::CContainerPrinter::print(timeseries.begin(), timeseries.begin() + 10)
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(testRealSwitchingNoSeasonality) {
             maths::CTimeSeriesTestForSeasonality seasonality{lastTest, lastTest, HOUR,
                                                              HALF_HOUR, values};
             auto result = seasonality.decompose();
-            BOOST_REQUIRE(result.print() == "[]");
+            BOOST_TEST_REQUIRE(result.print() == "[]");
             values.assign(window / HOUR, TFloatMeanAccumulator{});
             lastTest = time;
         }
@@ -477,12 +477,12 @@ BOOST_AUTO_TEST_CASE(testSyntheticNonDiurnal) {
     LOG_DEBUG(<< "accuracy @ 0% error = " << TP[0] / (TP[0] + FP));
     LOG_DEBUG(<< "accuracy @ 1% error = " << TP[1] / (TP[1] + FP));
     LOG_DEBUG(<< "accuracy @ 5% error = " << TP[2] / (TP[2] + FP));
-    BOOST_REQUIRE(TP[0] / (TP[0] + FN[0]) > 0.98);
-    BOOST_REQUIRE(TP[1] / (TP[1] + FN[1]) > 0.99);
-    BOOST_REQUIRE(TP[2] / (TP[2] + FN[2]) > 0.99);
-    BOOST_REQUIRE(TP[0] / (TP[0] + FP) > 0.96);
-    BOOST_REQUIRE(TP[1] / (TP[1] + FP) > 0.96);
-    BOOST_REQUIRE(TP[2] / (TP[2] + FP) > 0.96);
+    BOOST_TEST_REQUIRE(TP[0] / (TP[0] + FN[0]) > 0.98);
+    BOOST_TEST_REQUIRE(TP[1] / (TP[1] + FN[1]) > 0.99);
+    BOOST_TEST_REQUIRE(TP[2] / (TP[2] + FN[2]) > 0.99);
+    BOOST_TEST_REQUIRE(TP[0] / (TP[0] + FP) > 0.96);
+    BOOST_TEST_REQUIRE(TP[1] / (TP[1] + FP) > 0.96);
+    BOOST_TEST_REQUIRE(TP[2] / (TP[2] + FP) > 0.96);
 }
 
 BOOST_AUTO_TEST_CASE(testSyntheticSparseDaily) {
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticSparseDaily) {
                 maths::CTimeSeriesTestForSeasonality seasonality{0, 0, HALF_HOUR,
                                                                  HALF_HOUR, values};
                 auto result = seasonality.decompose();
-                BOOST_REQUIRE(result.print() == (test == 0 ? "[86400]" : "[]"));
+                BOOST_TEST_REQUIRE(result.print() == (test == 0 ? "[86400]" : "[]"));
             }
         }
     }
@@ -573,9 +573,9 @@ BOOST_AUTO_TEST_CASE(testSyntheticSparseWeekly) {
                 auto result = seasonality.decompose();
                 LOG_DEBUG(<< result.print());
                 if (test == 0) {
-                    BOOST_REQUIRE(result.print() == "[86400/(0,172800), 604800/(0,172800), 604800/(172800,604800)]");
+                    BOOST_TEST_REQUIRE(result.print() == "[86400/(0,172800), 604800/(0,172800), 604800/(172800,604800)]");
                 } else {
-                    BOOST_REQUIRE(result.print() == "[]");
+                    BOOST_TEST_REQUIRE(result.print() == "[]");
                 }
             }
         }
@@ -635,7 +635,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticWithOutliers) {
                     startTime, startTime, bucketLength, bucketLength, values};
                 auto result = seasonality.decompose();
                 LOG_DEBUG(<< result.print());
-                BOOST_REQUIRE(result.print() == "[" + std::to_string(period) + "]");
+                BOOST_TEST_REQUIRE(result.print() == "[" + std::to_string(period) + "]");
             }
         }
     }
@@ -677,7 +677,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticWithOutliers) {
                 startTime, startTime, bucketLength, bucketLength, std::move(values)};
             auto result = seasonality.decompose();
             LOG_DEBUG(<< result.print());
-            BOOST_REQUIRE(result.print() == "[86400/(0,172800), 86400/(172800,604800)]");
+            BOOST_TEST_REQUIRE(result.print() == "[86400/(0,172800), 86400/(172800,604800)]");
         }
     }
 }
@@ -769,8 +769,8 @@ BOOST_AUTO_TEST_CASE(testSyntheticMixtureOfSeasonalities) {
 
     LOG_DEBUG(<< "recall = " << TP / (TP + FN));
     LOG_DEBUG(<< "accuracy = " << TP / (TP + FP));
-    BOOST_REQUIRE(TP / (TP + FN) > 0.99);
-    BOOST_REQUIRE(TP / (TP + FP) > 0.99);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.99);
+    BOOST_TEST_REQUIRE(TP / (TP + FP) > 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testSyntheticDiurnalWithLinearScaling) {
@@ -842,7 +842,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticDiurnalWithLinearScaling) {
     }
 
     LOG_DEBUG(<< "Recall = " << TP / (TP + FN));
-    BOOST_REQUIRE(TP / (TP + FN) > 0.99);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testSyntheticNonDiurnalWithLinearTrend) {
@@ -942,12 +942,12 @@ BOOST_AUTO_TEST_CASE(testSyntheticNonDiurnalWithLinearTrend) {
     LOG_DEBUG(<< "accuracy @ 0% error = " << TP[0] / (TP[0] + FP));
     LOG_DEBUG(<< "accuracy @ 1% error = " << TP[1] / (TP[1] + FP));
     LOG_DEBUG(<< "accuracy @ 5% error = " << TP[2] / (TP[2] + FP));
-    BOOST_REQUIRE(TP[0] / (TP[0] + FN[0]) > 0.98);
-    BOOST_REQUIRE(TP[1] / (TP[1] + FN[1]) > 0.99);
-    BOOST_REQUIRE(TP[2] / (TP[2] + FN[2]) > 0.99);
-    BOOST_REQUIRE(TP[0] / (TP[0] + FP) > 0.94);
-    BOOST_REQUIRE(TP[1] / (TP[1] + FP) > 0.94);
-    BOOST_REQUIRE(TP[2] / (TP[2] + FP) > 0.94);
+    BOOST_TEST_REQUIRE(TP[0] / (TP[0] + FN[0]) > 0.98);
+    BOOST_TEST_REQUIRE(TP[1] / (TP[1] + FN[1]) > 0.99);
+    BOOST_TEST_REQUIRE(TP[2] / (TP[2] + FN[2]) > 0.99);
+    BOOST_TEST_REQUIRE(TP[0] / (TP[0] + FP) > 0.94);
+    BOOST_TEST_REQUIRE(TP[1] / (TP[1] + FP) > 0.94);
+    BOOST_TEST_REQUIRE(TP[2] / (TP[2] + FP) > 0.94);
 }
 
 BOOST_AUTO_TEST_CASE(testSyntheticDiurnalWithPiecewiseLinearTrend) {
@@ -1028,7 +1028,7 @@ BOOST_AUTO_TEST_CASE(testSyntheticDiurnalWithPiecewiseLinearTrend) {
     }
 
     LOG_DEBUG(<< "Recall = " << TP / (TP + FN));
-    BOOST_REQUIRE(TP / (TP + FN) > 0.92);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.92);
 }
 
 BOOST_AUTO_TEST_CASE(testModelledSeasonalityWithNoChange) {
@@ -1150,8 +1150,8 @@ BOOST_AUTO_TEST_CASE(testModelledSeasonalityWithChange) {
 
     LOG_DEBUG(<< "recall = " << TP / (TP + FN));
     LOG_DEBUG(<< "accuracy = " << TP / (TP + FP));
-    BOOST_REQUIRE(TP / (TP + FN) > 0.92);
-    BOOST_REQUIRE(TP / (TP + FP) > 0.85);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.92);
+    BOOST_TEST_REQUIRE(TP / (TP + FP) > 0.85);
 }
 
 BOOST_AUTO_TEST_CASE(testNewComponentInitialValues) {
@@ -1424,7 +1424,7 @@ BOOST_AUTO_TEST_CASE(testNewTrendSummaryPiecewiseLinearTrend) {
         }
     }
 
-    BOOST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.03);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanError) < 0.03);
 }
 
 BOOST_AUTO_TEST_CASE(testWithSuppliedPredictor) {


### PR DESCRIPTION
BOOST_TEST_REQUIRE is better than BOOST_REQUIRE for assertions
that contain a single comparison operator and where both the
left hand side and right hand side of it are printable.  The
advantage is that on failure it prints the values that failed
the test.