### PR TITLE
[ML] Further increase tolerance for logger throttler test

### DIFF
--- a/lib/core/unittest/CLoggerThrottlerTest.cc
+++ b/lib/core/unittest/CLoggerThrottlerTest.cc
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(testThrottling) {
 
     BOOST_TEST_REQUIRE(logged[0] >= 4);
     // Allow for long stalls running the tests.
-    BOOST_TEST_REQUIRE(logged[1] <= 16);
+    BOOST_TEST_REQUIRE(logged[1] <= 18);
 
     BOOST_REQUIRE_EQUAL(100, counts[0]);
     BOOST_REQUIRE_EQUAL(100, counts[1]);


### PR DESCRIPTION
In the backport of #1745 the tolerance on the logger
throttler test had to be increased again due to a
problem with sleep calls sleeping for longer than
specified when running under Jenkins on macOS on ARM.
The change was in the 3rd commit on #1752.

This change makes the same increase on the master
branch, to keep the branches in sync.