### PR TITLE
[ML] Increase tolerance for read/write lock test

### DIFF
--- a/lib/core/unittest/CReadWriteLockTest.cc
+++ b/lib/core/unittest/CReadWriteLockTest.cc
@@ -241,9 +241,10 @@ BOOST_AUTO_TEST_CASE(testReadLock) {
 
     LOG_INFO(<< "Reader concurrency test took " << duration << " seconds");
 
-    // Allow the test to run slightly over 1 second, as there is processing
-    // other than the sleeping.
-    BOOST_TEST_REQUIRE(duration <= 2);
+    // Allow the test to run up to 3 seconds, as there is processing
+    // other than the sleeping, and also sleeps are not very accurate
+    // under Jenkins on Apple M1.
+    BOOST_TEST_REQUIRE(duration <= 3);
     BOOST_TEST_REQUIRE(duration >= 1);
 
     BOOST_REQUIRE_EQUAL(testVariable, reader1.lastRead());


### PR DESCRIPTION
In #1759 the tolerance on the read/write lock test
had to be increased again due to a problem with sleep
calls sleeping for longer than specified when running
under Jenkins on macOS on ARM.  The change was in the
2nd commit on #1759.

This change makes the same increase on the master
branch, to keep the branches in sync.