### PR TITLE
[ML] Incremental train (part 1)

### DIFF
--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -223,6 +223,11 @@ public:
     //! Train on the examples in the data frame supplied to the constructor.
     void train() override;
 
+    //! Incrementally train the current model.
+    //!
+    //! \warning Train must have been previously called or a model loaded.
+    bool trainIncremental() override;
+
     //! Write the predictions to the data frame supplied to the constructor.
     //!
     //! \warning This can only be called after train.

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -127,9 +127,14 @@ public:
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
 
-    //! Estimate the maximum booking memory that training the boosted tree on a
-    //! data frame with \p numberRows row and \p numberColumns columns will use.
-    std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
+    //! Estimate the maximum booking memory that training a boosted tree on a data
+    //! frame with \p numberRows row and \p numberColumns columns will use.
+    std::size_t estimateMemoryUsageTrain(std::size_t numberRows, std::size_t numberColumns) const;
+    //! Estimate the maximum booking memory that incrementally training a boosted
+    //! tree on a data frame with \p numberRows row and \p numberColumns columns
+    //! will use.
+    std::size_t estimateMemoryUsageTrainIncremental(std::size_t numberRows,
+                                                    std::size_t numberColumns) const;
     //! Get the number of columns training the model will add to the data frame.
     std::size_t numberExtraColumnsForTrain() const;
     //! Build a boosted tree object for a given data frame.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -93,7 +93,8 @@ public:
     //!
     //! \warning Assumes that train has been called or a trained model has been
     //! reloaded.
-    bool trainIncrementally(core::CDataFrame& frame, const TTrainingStateCallback& recordTrainStateCallback);
+    bool trainIncremental(core::CDataFrame& frame,
+                          const TTrainingStateCallback& recordTrainStateCallback);
 
     //! Write the predictions of the best trained model to \p frame.
     //!
@@ -137,9 +138,15 @@ public:
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
-    //! Estimate the maximum booking memory that training the boosted tree on a data
+    //! Estimate the maximum booking memory that training a boosted tree on a data
     //! frame with \p numberRows row and \p numberColumns columns will use.
-    std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
+    std::size_t estimateMemoryUsageTrain(std::size_t numberRows, std::size_t numberColumns) const;
+
+    //! Estimate the maximum booking memory that incrementally training a boosted
+    //! tree on a data frame with \p numberRows row and \p numberColumns columns
+    //! will use.
+    std::size_t estimateMemoryUsageTrainIncremental(std::size_t numberRows,
+                                                    std::size_t numberColumns) const;
 
     //! Correct from worst case memory usage to a more realistic estimate.
     static std::size_t correctedMemoryUsage(double memoryUsageBytes);

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -186,6 +186,7 @@ private:
     using TOptionalDoubleVec = std::vector<TOptionalDouble>;
     using TOptionalDoubleVecVec = std::vector<TOptionalDoubleVec>;
     using TOptionalSize = boost::optional<std::size_t>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TImmutableRadixSetVec = std::vector<core::CImmutableRadixSet<double>>;
     using TNodeVecVecDoubleDoubleVecTuple = std::tuple<TNodeVecVec, double, TDoubleVec>;
@@ -193,9 +194,17 @@ private:
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
     using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
+    using TLeafNodeStatisticsPtr = CBoostedTreeLeafNodeStatistics::TPtr;
     using TWorkspace = CBoostedTreeLeafNodeStatistics::CWorkspace;
     using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameters>;
-    using TDoubleVecVec = std::vector<TDoubleVec>;
+    // clang-format off
+    using TMakeRootLeafNodeStatistics =
+        std::function<TLeafNodeStatisticsPtr (const TImmutableRadixSetVec&,
+                                              const TSizeVec&,
+                                              const TSizeVec&,
+                                              const core::CPackedBitVector&,
+                                              TWorkspace&)>;
+    // clang-format on
 
     //! Tag progress through initialization.
     enum EInitializationStage {
@@ -261,7 +270,8 @@ private:
     TNodeVec trainTree(core::CDataFrame& frame,
                        const core::CPackedBitVector& trainingRowMask,
                        const TImmutableRadixSetVec& candidateSplits,
-                       const std::size_t maximumTreeSize,
+                       std::size_t maximumNumberInternalNodes,
+                       const TMakeRootLeafNodeStatistics& makeRootLeafNodeStatistics,
                        TWorkspace& workspace) const;
 
     //! Compute the minimum mean test loss per fold for any round.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -89,6 +89,12 @@ public:
     //! Train the model on the values in \p frame.
     void train(core::CDataFrame& frame, const TTrainingStateCallback& recordTrainStateCallback);
 
+    //! Incrementally train the current model on the values in \p frame.
+    //!
+    //! \warning Assumes that train has been called or a trained model has been
+    //! reloaded.
+    bool trainIncrementally(core::CDataFrame& frame, const TTrainingStateCallback& recordTrainStateCallback);
+
     //! Write the predictions of the best trained model to \p frame.
     //!
     //! \warning Must be called only if a trained model is available.

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -172,7 +172,7 @@ public:
         }
 
     private:
-        std::size_t m_Count = 0;
+        std::size_t m_Count{0};
         TMemoryMappedDoubleVector m_Gradient;
         TMemoryMappedDoubleMatrix m_Curvature;
     };
@@ -184,28 +184,13 @@ public:
 
     public:
         explicit CSplitsDerivatives(std::size_t numberLossParameters = 0)
-            : m_NumberLossParameters{numberLossParameters},
-              m_PositiveDerivativesSum{TDerivatives2x1::Zero()},
-              m_NegativeDerivativesSum{TDerivatives2x1::Zero()},
-              m_PositiveDerivativesMax{-boosted_tree_detail::INF},
-              m_PositiveDerivativesMin{boosted_tree_detail::INF},
-              m_NegativeDerivativesMin{boosted_tree_detail::INF, boosted_tree_detail::INF} {}
+            : m_NumberLossParameters{numberLossParameters} {}
         CSplitsDerivatives(const TImmutableRadixSetVec& candidateSplits, std::size_t numberLossParameters)
-            : m_NumberLossParameters{numberLossParameters},
-              m_PositiveDerivativesSum{TDerivatives2x1::Zero()},
-              m_NegativeDerivativesSum{TDerivatives2x1::Zero()},
-              m_PositiveDerivativesMax{-boosted_tree_detail::INF},
-              m_PositiveDerivativesMin{boosted_tree_detail::INF},
-              m_NegativeDerivativesMin{boosted_tree_detail::INF, boosted_tree_detail::INF} {
+            : m_NumberLossParameters{numberLossParameters} {
             this->map(candidateSplits);
         }
         CSplitsDerivatives(const CSplitsDerivatives& other)
-            : m_NumberLossParameters{other.m_NumberLossParameters},
-              m_PositiveDerivativesSum{TDerivatives2x1::Zero()},
-              m_NegativeDerivativesSum{TDerivatives2x1::Zero()},
-              m_PositiveDerivativesMax{-boosted_tree_detail::INF},
-              m_PositiveDerivativesMin{boosted_tree_detail::INF},
-              m_NegativeDerivativesMin{boosted_tree_detail::INF, boosted_tree_detail::INF} {
+            : m_NumberLossParameters{other.m_NumberLossParameters} {
             this->map(other.m_Derivatives);
             this->add(other);
         }
@@ -374,10 +359,12 @@ public:
             return seed;
         }
 
+        //! Get the number of parameters in the loss function.
         std::size_t numberLossParameters() const {
             return m_NumberLossParameters;
         }
 
+        //! Update the positive derivative statistics.
         void addPositiveDerivatives(const TMemoryMappedFloatVector& derivatives) {
             m_PositiveDerivativesSum += derivatives;
             m_PositiveDerivativesMin = std::min(
@@ -386,31 +373,38 @@ public:
                 m_PositiveDerivativesMax, static_cast<double>(derivatives(0)));
         }
 
+        //! Update the negative derivative statistics.
         void addNegativeDerivatives(const TMemoryMappedFloatVector& derivatives) {
             m_NegativeDerivativesSum += derivatives;
             m_NegativeDerivativesMin = m_NegativeDerivativesMin.cwiseMin(derivatives);
         }
 
+        //! Get the sum of positive loss gradients.
         double positiveDerivativesGSum() const {
             return m_PositiveDerivativesSum(0);
         }
 
+        //! Get the sum of negative loss gradients.
         double negativeDerivativesGSum() const {
             return m_NegativeDerivativesSum(0);
         }
 
+        //! Get the largest positive gradient.
         double positiveDerivativesGMax() const {
             return m_PositiveDerivativesMax;
         }
 
+        //! Get the smallest loss curvature.
         double positiveDerivativesHMin() const {
             return m_PositiveDerivativesMin;
         }
 
+        //! Get the smallest negative loss gradient.
         double negativeDerivativesGMin() const {
             return m_NegativeDerivativesMin(0);
         }
 
+        //! Get the smallest loss curvature.
         double negativeDerivativesHMin() const {
             return m_NegativeDerivativesMin(1);
         }
@@ -484,15 +478,15 @@ public:
         }
 
     private:
-        std::size_t m_NumberLossParameters = 0;
+        std::size_t m_NumberLossParameters{0};
         TDerivativesVecVec m_Derivatives;
         TDerivativesVec m_MissingDerivatives;
         TAlignedDoubleVec m_Storage;
-        TDerivatives2x1 m_PositiveDerivativesSum;
-        TDerivatives2x1 m_NegativeDerivativesSum;
-        double m_PositiveDerivativesMax;
-        double m_PositiveDerivativesMin;
-        TDerivatives2x1 m_NegativeDerivativesMin;
+        TDerivatives2x1 m_PositiveDerivativesSum{TDerivatives2x1::Zero()};
+        TDerivatives2x1 m_NegativeDerivativesSum{TDerivatives2x1::Zero()};
+        double m_PositiveDerivativesMax{-boosted_tree_detail::INF};
+        double m_PositiveDerivativesMin{boosted_tree_detail::INF};
+        TDerivatives2x1 m_NegativeDerivativesMin{boosted_tree_detail::INF, boosted_tree_detail::INF};
     };
 
     //! \brief The derivatives and row masks objects to use for computations.
@@ -596,11 +590,11 @@ public:
         }
 
     private:
-        std::size_t m_NumberMasks = 0;
-        std::size_t m_NumberThreads = 0;
-        double m_MinimumGain = 0.0;
-        bool m_ReducedMasks = false;
-        bool m_ReducedDerivatives = false;
+        std::size_t m_NumberMasks{0};
+        std::size_t m_NumberThreads{0};
+        double m_MinimumGain{0.0};
+        bool m_ReducedMasks{false};
+        bool m_ReducedDerivatives{false};
         TPackedBitVectorVecVec m_Masks;
         TSplitsDerivativesVecVec m_Derivatives;
     };
@@ -704,15 +698,15 @@ protected:
             return result.str();
         }
 
-        double s_Gain = -boosted_tree_detail::INF;
-        double s_Curvature = 0.0;
-        std::size_t s_Feature = std::numeric_limits<std::size_t>::max();
-        double s_SplitAt = boosted_tree_detail::INF;
-        std::uint32_t s_MinimumChildRowCount = 0;
-        bool s_LeftChildHasFewerRows = true;
-        bool s_AssignMissingToLeft = true;
-        double s_LeftChildMaxGain = boosted_tree_detail::INF;
-        double s_RightChildMaxGain = boosted_tree_detail::INF;
+        double s_Gain{-boosted_tree_detail::INF};
+        double s_Curvature{0.0};
+        std::size_t s_Feature{std::numeric_limits<std::size_t>::max()};
+        double s_SplitAt{boosted_tree_detail::INF};
+        std::uint32_t s_MinimumChildRowCount{0};
+        bool s_LeftChildHasFewerRows{true};
+        bool s_AssignMissingToLeft{true};
+        double s_LeftChildMaxGain{boosted_tree_detail::INF};
+        double s_RightChildMaxGain{boosted_tree_detail::INF};
     };
 
 protected:

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -522,7 +522,7 @@ public:
                           std::size_t numberLossParameters) {
             m_MinimumGain = 0.0;
             m_Masks.resize(m_NumberMasks);
-            m_Derivatives.reserve(m_NumberMasks);
+            m_Derivatives.resize(m_NumberMasks);
             for (std::size_t i = 0; i < m_NumberMasks; ++i) {
                 m_Masks[i].resize(numberThreads);
                 m_Derivatives[i].reserve(numberThreads);
@@ -571,9 +571,9 @@ public:
         //! Get the reduction of the per thread masks.
         const core::CPackedBitVector& reducedMask(std::size_t index, std::size_t size) {
             if (m_ReducedMasks == false) {
-                m_Masks[index][0].extend(false, size - m_Masks[0].size());
+                m_Masks[index][0].extend(false, size - m_Masks[index][0].size());
                 for (std::size_t i = 1; i < m_NumberThreads; ++i) {
-                    m_Masks[index][i].extend(false, size - m_Masks[i].size());
+                    m_Masks[index][i].extend(false, size - m_Masks[index][i].size());
                     m_Masks[index][0] |= m_Masks[index][i];
                 }
                 m_ReducedMasks = true;

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -619,6 +619,9 @@ public:
                             const CBoostedTreeNode& split,
                             CWorkspace& workspace) = 0;
 
+    //! Get the memory used by this object.
+    virtual std::size_t memoryUsage() const;
+
     //! Order two leaves by decreasing gain in splitting them.
     bool operator<(const CBoostedTreeLeafNodeStatistics& rhs) const;
 
@@ -656,11 +659,8 @@ public:
     //! Get the row mask for this leaf node.
     core::CPackedBitVector& rowMask();
 
-    //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
-
     //! Get the best split info as a string.
-    std::string print() const { return m_BestSplit.print(); }
+    std::string print() const;
 
 protected:
     using TSizeVecCRef = std::reference_wrapper<const TSizeVec>;

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -486,7 +486,8 @@ public:
         TDerivatives2x1 m_NegativeDerivativesSum{TDerivatives2x1::Zero()};
         double m_PositiveDerivativesMax{-boosted_tree_detail::INF};
         double m_PositiveDerivativesMin{boosted_tree_detail::INF};
-        TDerivatives2x1 m_NegativeDerivativesMin{boosted_tree_detail::INF, boosted_tree_detail::INF};
+        TDerivatives2x1 m_NegativeDerivativesMin{boosted_tree_detail::INF,
+                                                 boosted_tree_detail::INF};
     };
 
     //! \brief The derivatives and row masks objects to use for computations.

--- a/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
+++ b/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CBoostedTreeLeafNodeStatisticsIncremental_h
+#define INCLUDED_ml_maths_CBoostedTreeLeafNodeStatisticsIncremental_h
+
+#include <core/CMemory.h>
+#include <core/CPackedBitVector.h>
+
+#include <maths/CBoostedTreeHyperparameters.h>
+#include <maths/CBoostedTreeLeafNodeStatistics.h>
+#include <maths/CBoostedTreeUtils.h>
+#include <maths/CChecksum.h>
+#include <maths/CLinearAlgebraEigen.h>
+#include <maths/CLinearAlgebraShims.h>
+#include <maths/CMathsFuncs.h>
+#include <maths/COrderings.h>
+#include <maths/ImportExport.h>
+#include <maths/MathsTypes.h>
+
+#include <boost/operators.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+namespace ml {
+namespace core {
+class CDataFrame;
+}
+namespace maths {
+class CBoostedTreeNode;
+class CDataFrameCategoryEncoder;
+class CEncodedDataFrameRowRef;
+
+//! \brief Maintains a collection of statistics about a leaf of the regression
+//! tree as it is built.
+//!
+//! DESCRIPTION:\N
+//! The regression tree is grown top down by greedily selecting the split with
+//! the maximum gain (in the loss). This finds and scores the maximum gain split
+//! of a single leaf of the tree.
+//!
+//! This version is used for training incrementally.
+class MATHS_EXPORT CBoostedTreeLeafNodeStatisticsIncremental final
+    : public CBoostedTreeLeafNodeStatistics {
+public:
+    CBoostedTreeLeafNodeStatisticsIncremental(const CBoostedTreeLeafNodeStatisticsIncremental&) = delete;
+    CBoostedTreeLeafNodeStatisticsIncremental&
+    operator=(const CBoostedTreeLeafNodeStatisticsIncremental&) = delete;
+
+    // Move construction/assignment not possible due to const reference member.
+
+    //! Apply the split defined by \p split.
+    //!
+    //! \return Shared pointers to the left and right child node statistics.
+    TPtrPtrPr split(std::size_t leftChildId,
+                    std::size_t rightChildId,
+                    std::size_t numberThreads,
+                    double gainThreshold,
+                    const core::CDataFrame& frame,
+                    const CDataFrameCategoryEncoder& encoder,
+                    const TRegularization& regularization,
+                    const TSizeVec& treeFeatureBag,
+                    const TSizeVec& nodeFeatureBag,
+                    const CBoostedTreeNode& split,
+                    CWorkspace& workspace) override;
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const override;
+
+    //! Estimate the maximum leaf statistics' memory usage training on a data frame
+    //! with \p numberCols columns using \p numberSplitsPerFeature for a loss function
+    //! with \p numberLossParameters parameters.
+    static std::size_t estimateMemoryUsage(std::size_t numberCols,
+                                           std::size_t numberSplitsPerFeature,
+                                           std::size_t numberLossParameters);
+
+private:
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CBoostedTreeLeafNodeStatisticsIncremental_h

--- a/include/maths/CBoostedTreeLeafNodeStatisticsScratch.h
+++ b/include/maths/CBoostedTreeLeafNodeStatisticsScratch.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_CBoostedTreeLeafNodeStatisticsScratch_h
+#define INCLUDED_ml_maths_CBoostedTreeLeafNodeStatisticsScratch_h
+
+#include <core/CMemory.h>
+#include <core/CPackedBitVector.h>
+
+#include <maths/CBoostedTreeHyperparameters.h>
+#include <maths/CBoostedTreeLeafNodeStatistics.h>
+#include <maths/CBoostedTreeUtils.h>
+#include <maths/CChecksum.h>
+#include <maths/CLinearAlgebraEigen.h>
+#include <maths/CLinearAlgebraShims.h>
+#include <maths/CMathsFuncs.h>
+#include <maths/COrderings.h>
+#include <maths/ImportExport.h>
+#include <maths/MathsTypes.h>
+
+#include <boost/operators.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+namespace ml {
+namespace core {
+class CDataFrame;
+}
+namespace maths {
+class CBoostedTreeNode;
+class CDataFrameCategoryEncoder;
+class CEncodedDataFrameRowRef;
+
+//! \brief Maintains a collection of statistics about a leaf of the regression
+//! tree as it is built.
+//!
+//! DESCRIPTION:\N
+//! The regression tree is grown top down by greedily selecting the split with
+//! the maximum gain (in the loss). This finds and scores the maximum gain split
+//! of a single leaf of the tree.
+//!
+//! This version is used for training from scratch.
+class MATHS_EXPORT CBoostedTreeLeafNodeStatisticsScratch final
+    : public CBoostedTreeLeafNodeStatistics {
+public:
+    CBoostedTreeLeafNodeStatisticsScratch(std::size_t id,
+                                          const TSizeVec& extraColumns,
+                                          std::size_t numberLossParameters,
+                                          std::size_t numberThreads,
+                                          const core::CDataFrame& frame,
+                                          const CDataFrameCategoryEncoder& encoder,
+                                          const TRegularization& regularization,
+                                          const TImmutableRadixSetVec& candidateSplits,
+                                          const TSizeVec& treeFeatureBag,
+                                          const TSizeVec& nodeFeatureBag,
+                                          std::size_t depth,
+                                          const core::CPackedBitVector& rowMask,
+                                          CWorkspace& workspace);
+
+    //! Only called by split but is public so it's accessible to std::make_shared.
+    CBoostedTreeLeafNodeStatisticsScratch(std::size_t id,
+                                          const CBoostedTreeLeafNodeStatisticsScratch& parent,
+                                          std::size_t numberThreads,
+                                          const core::CDataFrame& frame,
+                                          const CDataFrameCategoryEncoder& encoder,
+                                          const TRegularization& regularization,
+                                          const TSizeVec& treeFeatureBag,
+                                          const TSizeVec& nodeFeatureBag,
+                                          bool isLeftChild,
+                                          const CBoostedTreeNode& split,
+                                          CWorkspace& workspace);
+
+    //! Only called by split but is public so it's accessible to std::make_shared.
+    CBoostedTreeLeafNodeStatisticsScratch(std::size_t id,
+                                          CBoostedTreeLeafNodeStatisticsScratch&& parent,
+                                          const TRegularization& regularization,
+                                          const TSizeVec& nodeFeatureBag,
+                                          CWorkspace& workspace);
+
+    CBoostedTreeLeafNodeStatisticsScratch(const CBoostedTreeLeafNodeStatisticsScratch&) = delete;
+    CBoostedTreeLeafNodeStatisticsScratch&
+    operator=(const CBoostedTreeLeafNodeStatisticsScratch&) = delete;
+
+    // Move construction/assignment not possible due to const reference member.
+
+    //! Apply the split defined by \p split.
+    //!
+    //! \return Shared pointers to the left and right child node statistics.
+    TPtrPtrPr split(std::size_t leftChildId,
+                    std::size_t rightChildId,
+                    std::size_t numberThreads,
+                    double gainThreshold,
+                    const core::CDataFrame& frame,
+                    const CDataFrameCategoryEncoder& encoder,
+                    const TRegularization& regularization,
+                    const TSizeVec& treeFeatureBag,
+                    const TSizeVec& nodeFeatureBag,
+                    const CBoostedTreeNode& split,
+                    CWorkspace& workspace) override;
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const override;
+
+    //! Estimate the maximum leaf statistics' memory usage training on a data frame
+    //! with \p numberCols columns using \p numberSplitsPerFeature for a loss function
+    //! with \p numberLossParameters parameters.
+    static std::size_t estimateMemoryUsage(std::size_t numberCols,
+                                           std::size_t numberSplitsPerFeature,
+                                           std::size_t numberLossParameters);
+
+private:
+    void computeAggregateLossDerivatives(std::size_t numberThreads,
+                                         const core::CDataFrame& frame,
+                                         const CDataFrameCategoryEncoder& encoder,
+                                         const TSizeVec& featureBag,
+                                         const core::CPackedBitVector& rowMask,
+                                         CWorkspace& workspace) const;
+    void computeRowMaskAndAggregateLossDerivatives(std::size_t numberThreads,
+                                                   const core::CDataFrame& frame,
+                                                   const CDataFrameCategoryEncoder& encoder,
+                                                   bool isLeftChild,
+                                                   const CBoostedTreeNode& split,
+                                                   const TSizeVec& featureBag,
+                                                   const core::CPackedBitVector& parentRowMask,
+                                                   CWorkspace& workspace) const;
+    void addRowDerivatives(const TSizeVec& featureBag,
+                           const CEncodedDataFrameRowRef& row,
+                           CSplitsDerivatives& splitsDerivatives) const;
+
+    SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,
+                                                const TSizeVec& featureBag) const;
+
+    double childMaxGain(double gChild, double minLossChild, double lambda) const;
+
+private:
+    CSplitsDerivatives m_Derivatives;
+};
+}
+}
+
+#endif // INCLUDED_ml_maths_CBoostedTreeLeafNodeStatisticsScratch_h

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -51,6 +51,11 @@ public:
     //! Train on the examples in the data frame supplied to the constructor.
     virtual void train() = 0;
 
+    //! Incrementally train the current model.
+    //!
+    //! \warning Train must have been previously called or a model loaded.
+    virtual bool trainIncremental() = 0;
+
     //! Write the predictions to the data frame supplied to the constructor.
     //!
     //! \warning This can only be called after train.

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -358,7 +358,7 @@ std::size_t CDataFrameTrainBoostedTreeRunner::estimateBookkeepingMemoryUsage(
     std::size_t totalNumberRows,
     std::size_t /*partitionNumberRows*/,
     std::size_t numberColumns) const {
-    // TODO Incremental training.
+    // TODO https://github.com/elastic/ml-cpp/issues/1790.
     return m_BoostedTreeFactory->estimateMemoryUsageTrain(
         static_cast<std::size_t>(static_cast<double>(totalNumberRows) * m_TrainingPercent + 0.5),
         numberColumns);

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -358,7 +358,8 @@ std::size_t CDataFrameTrainBoostedTreeRunner::estimateBookkeepingMemoryUsage(
     std::size_t totalNumberRows,
     std::size_t /*partitionNumberRows*/,
     std::size_t numberColumns) const {
-    return m_BoostedTreeFactory->estimateMemoryUsage(
+    // TODO Incremental training.
+    return m_BoostedTreeFactory->estimateMemoryUsageTrain(
         static_cast<std::size_t>(static_cast<double>(totalNumberRows) * m_TrainingPercent + 0.5),
         numberColumns);
 }

--- a/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
+++ b/lib/api/unittest/CBoostedTreeInferenceModelBuilderTest.cc
@@ -124,8 +124,6 @@ BOOST_AUTO_TEST_CASE(testIntegrationRegression) {
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target_col"),
         outputWriterFactory};
 
-    TDataFrameUPtr frame{
-        core::makeMainStorageDataFrame(cols + 2, numberExamples).first};
     for (std::size_t i = 0; i < numberExamples; ++i) {
         for (std::size_t j = 0; j < cols; ++j) {
             fieldValues[j] = core::CStringUtils::typeToStringPrecise(

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -155,6 +155,10 @@ void CBoostedTree::train() {
     m_Impl->train(this->frame(), this->trainingStateRecorder());
 }
 
+bool CBoostedTree::trainIncrementally() {
+    return m_Impl->trainIncrementally(this->frame(), this->trainingStateRecorder());
+}
+
 void CBoostedTree::predict() const {
     m_Impl->predict(this->frame());
 }

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -155,8 +155,8 @@ void CBoostedTree::train() {
     m_Impl->train(this->frame(), this->trainingStateRecorder());
 }
 
-bool CBoostedTree::trainIncrementally() {
-    return m_Impl->trainIncrementally(this->frame(), this->trainingStateRecorder());
+bool CBoostedTree::trainIncremental() {
+    return m_Impl->trainIncremental(this->frame(), this->trainingStateRecorder());
 }
 
 void CBoostedTree::predict() const {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1419,15 +1419,21 @@ CBoostedTreeFactory& CBoostedTreeFactory::earlyStoppingEnabled(bool enable) {
     return *this;
 }
 
-std::size_t CBoostedTreeFactory::estimateMemoryUsage(std::size_t numberRows,
-                                                     std::size_t numberColumns) const {
+std::size_t CBoostedTreeFactory::estimateMemoryUsageTrain(std::size_t numberRows,
+                                                          std::size_t numberColumns) const {
     std::size_t maximumNumberTrees{this->mainLoopMaximumNumberTrees(
         m_TreeImpl->m_EtaOverride != boost::none ? *m_TreeImpl->m_EtaOverride
                                                  : computeEta(numberColumns))};
     std::swap(maximumNumberTrees, m_TreeImpl->m_MaximumNumberTrees);
-    std::size_t result{m_TreeImpl->estimateMemoryUsage(numberRows, numberColumns)};
+    std::size_t result{m_TreeImpl->estimateMemoryUsageTrain(numberRows, numberColumns)};
     std::swap(maximumNumberTrees, m_TreeImpl->m_MaximumNumberTrees);
     return result;
+}
+
+std::size_t
+CBoostedTreeFactory::estimateMemoryUsageTrainIncremental(std::size_t numberRows,
+                                                         std::size_t numberColumns) const {
+    return m_TreeImpl->estimateMemoryUsageTrainIncremental(numberRows, numberColumns);
 }
 
 std::size_t CBoostedTreeFactory::numberExtraColumnsForTrain() const {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -291,6 +291,17 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
         static_cast<std::int64_t>(this->memoryUsage()) - lastMemoryUsage);
 }
 
+bool CBoostedTreeImpl::trainIncrementally(core::CDataFrame& /*frame*/,
+                                          const TTrainingStateCallback& /*recordTrainStateCallback*/) {
+
+    if (m_BestForest.empty()) {
+        LOG_ERROR(<< "No model available to incrementally train.");
+        return false;
+    }
+
+    // TODO.
+}
+
 void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainState) const {
     recordTrainState([this](core::CStatePersistInserter& inserter) {
         this->acceptPersistInserter(inserter);
@@ -1883,7 +1894,6 @@ void CBoostedTreeImpl::checkTrainInvariants(const core::CDataFrame& frame) const
     if (m_DependentVariable >= frame.numberColumns()) {
         HANDLE_FATAL(<< "Internal error: dependent variable '" << m_DependentVariable
                      << "' was incorrectly initialized. Please report this problem.");
-        return;
     }
     if (m_Loss == nullptr) {
         HANDLE_FATAL(<< "Internal error: must supply a loss function for training. "

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -301,7 +301,7 @@ bool CBoostedTreeImpl::trainIncremental(core::CDataFrame& /*frame*/,
         return false;
     }
 
-    // TODO Placeholder.
+    // TODO https://github.com/elastic/ml-cpp/issues/1721.
 
     return true;
 }
@@ -395,7 +395,7 @@ std::size_t
 CBoostedTreeImpl::estimateMemoryUsageTrainIncremental(std::size_t /*numberRows*/,
                                                       std::size_t /*numberColumns*/) const {
 
-    // TODO Placeholder.
+    // TODO https://github.com/elastic/ml-cpp/issues/1790.
     return 0;
 }
 

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -12,6 +12,10 @@
 
 namespace ml {
 namespace maths {
+std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
+    return core::CMemory::dynamicSize(m_RowMask);
+}
+
 bool CBoostedTreeLeafNodeStatistics::operator<(const CBoostedTreeLeafNodeStatistics& rhs) const {
     return COrderings::lexicographical_compare(m_BestSplit, m_Id, rhs.m_BestSplit, rhs.m_Id);
 }
@@ -60,8 +64,8 @@ core::CPackedBitVector& CBoostedTreeLeafNodeStatistics::rowMask() {
     return m_RowMask;
 }
 
-std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_RowMask);
+std::string CBoostedTreeLeafNodeStatistics::print() const {
+    return m_BestSplit.print();
 }
 
 CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(std::size_t id,

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -6,180 +6,12 @@
 
 #include <maths/CBoostedTreeLeafNodeStatistics.h>
 
-#include <core/CDataFrame.h>
-#include <core/CImmutableRadixSet.h>
-#include <core/CLogger.h>
+#include <core/CMemory.h>
 
-#include <maths/CBoostedTree.h>
-#include <maths/CDataFrameCategoryEncoder.h>
-#include <maths/CTools.h>
-
-#include <limits>
+#include <maths/COrderings.h>
 
 namespace ml {
 namespace maths {
-using namespace boosted_tree_detail;
-using TRowItr = core::CDataFrame::TRowItr;
-
-namespace {
-const std::size_t ASSIGN_MISSING_TO_LEFT{0};
-const std::size_t ASSIGN_MISSING_TO_RIGHT{1};
-
-struct SChildredGainStats {
-    double s_MinLossLeft = -INF;
-    double s_MinLossRight = -INF;
-    double s_GLeft = -INF;
-    double s_GRight = -INF;
-};
-}
-
-CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
-    std::size_t id,
-    const TSizeVec& extraColumns,
-    std::size_t numberLossParameters,
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder,
-    const TRegularization& regularization,
-    const TImmutableRadixSetVec& candidateSplits,
-    const TSizeVec& treeFeatureBag,
-    const TSizeVec& nodeFeatureBag,
-    std::size_t depth,
-    const core::CPackedBitVector& rowMask,
-    CWorkspace& workspace)
-    : m_Id{id}, m_Depth{depth}, m_ExtraColumns{extraColumns},
-      m_NumberLossParameters{numberLossParameters}, m_CandidateSplits{candidateSplits} {
-
-    this->computeAggregateLossDerivatives(numberThreads, frame, encoder,
-                                          treeFeatureBag, rowMask, workspace);
-
-    // Lazily copy the mask and derivatives to avoid unnecessary allocations.
-
-    m_Derivatives.swap(workspace.reducedDerivatives());
-    m_BestSplit = this->computeBestSplitStatistics(regularization, nodeFeatureBag);
-    workspace.reducedDerivatives().swap(m_Derivatives);
-
-    if (this->gain() > workspace.minimumGain()) {
-        m_RowMask = rowMask;
-        CSplitsDerivatives tmp{workspace.derivatives()[0]};
-        m_Derivatives = std::move(tmp);
-    }
-}
-
-CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
-    std::size_t id,
-    const CBoostedTreeLeafNodeStatistics& parent,
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder,
-    const TRegularization& regularization,
-    const TSizeVec& treeFeatureBag,
-    const TSizeVec& nodeFeatureBag,
-    bool isLeftChild,
-    const CBoostedTreeNode& split,
-    CWorkspace& workspace)
-    : m_Id{id}, m_Depth{parent.m_Depth + 1}, m_ExtraColumns{parent.m_ExtraColumns},
-      m_NumberLossParameters{parent.m_NumberLossParameters}, m_CandidateSplits{
-                                                                 parent.m_CandidateSplits} {
-
-    // The number of threads we'll use breaks down as follows:
-    //   - We need a minimum number of rows per thread to ensure reasonable
-    //     load balancing.
-    //   - We need a minimum amount of work per thread to make the overheads
-    //     of distributing worthwhile.
-    std::size_t features{treeFeatureBag.size()};
-    std::size_t rows{parent.minimumChildRowCount()};
-    std::size_t rowsPerThreadConstraint{rows / 64};
-    std::size_t workPerThreadConstraint{(features * rows) / (8 * 128)};
-    std::size_t maximumNumberThreads{std::max(
-        std::min(rowsPerThreadConstraint, workPerThreadConstraint), std::size_t{1})};
-    numberThreads = std::min(numberThreads, maximumNumberThreads);
-
-    this->computeRowMaskAndAggregateLossDerivatives(numberThreads, frame, encoder,
-                                                    isLeftChild, split, treeFeatureBag,
-                                                    parent.m_RowMask, workspace);
-
-    // Lazily copy the mask and derivatives to avoid unnecessary allocations.
-
-    m_Derivatives.swap(workspace.reducedDerivatives());
-    m_BestSplit = this->computeBestSplitStatistics(regularization, nodeFeatureBag);
-    workspace.reducedDerivatives().swap(m_Derivatives);
-
-    if (this->gain() >= workspace.minimumGain()) {
-        CSplitsDerivatives tmp{workspace.reducedDerivatives()};
-        m_RowMask = workspace.reducedMask(parent.m_RowMask.size());
-        m_Derivatives = std::move(tmp);
-    }
-}
-
-CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
-    std::size_t id,
-    CBoostedTreeLeafNodeStatistics&& parent,
-    const TRegularization& regularization,
-    const TSizeVec& nodeFeatureBag,
-    CWorkspace& workspace)
-    : m_Id{id}, m_Depth{parent.m_Depth + 1}, m_ExtraColumns{parent.m_ExtraColumns},
-      m_NumberLossParameters{parent.m_NumberLossParameters},
-      m_CandidateSplits{parent.m_CandidateSplits}, m_Derivatives{std::move(
-                                                       parent.m_Derivatives)} {
-
-    // Lazily compute the row mask to avoid unnecessary work.
-
-    m_Derivatives.subtract(workspace.reducedDerivatives());
-    m_BestSplit = this->computeBestSplitStatistics(regularization, nodeFeatureBag);
-    if (this->gain() >= workspace.minimumGain()) {
-        m_RowMask = std::move(parent.m_RowMask);
-        m_RowMask ^= workspace.reducedMask(m_RowMask.size());
-    }
-}
-
-CBoostedTreeLeafNodeStatistics::TPtrPtrPr
-CBoostedTreeLeafNodeStatistics::split(std::size_t leftChildId,
-                                      std::size_t rightChildId,
-                                      std::size_t numberThreads,
-                                      double gainThreshold,
-                                      const core::CDataFrame& frame,
-                                      const CDataFrameCategoryEncoder& encoder,
-                                      const TRegularization& regularization,
-                                      const TSizeVec& treeFeatureBag,
-                                      const TSizeVec& nodeFeatureBag,
-                                      const CBoostedTreeNode& split,
-                                      CWorkspace& workspace) {
-    TPtr leftChild;
-    TPtr rightChild;
-    if (this->leftChildHasFewerRows()) {
-        if (this->m_BestSplit.s_LeftChildMaxGain > gainThreshold) {
-            leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-                leftChildId, *this, numberThreads, frame, encoder, regularization,
-                treeFeatureBag, nodeFeatureBag, true /*is left child*/, split, workspace);
-            if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
-                rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-                    rightChildId, std::move(*this), regularization, nodeFeatureBag, workspace);
-            }
-        } else if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
-            rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-                rightChildId, *this, numberThreads, frame, encoder, regularization,
-                treeFeatureBag, nodeFeatureBag, false /*is left child*/, split, workspace);
-        }
-        return {std::move(leftChild), std::move(rightChild)};
-    }
-
-    if (this->m_BestSplit.s_RightChildMaxGain > gainThreshold) {
-        rightChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-            rightChildId, *this, numberThreads, frame, encoder, regularization,
-            treeFeatureBag, nodeFeatureBag, false /*is left child*/, split, workspace);
-        if (this->m_BestSplit.s_LeftChildMaxGain > gainThreshold) {
-            leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-                leftChildId, std::move(*this), regularization, nodeFeatureBag, workspace);
-        }
-    } else if (this->m_BestSplit.s_LeftChildMaxGain > gainThreshold) {
-        leftChild = std::make_shared<CBoostedTreeLeafNodeStatistics>(
-            leftChildId, *this, numberThreads, frame, encoder, regularization,
-            treeFeatureBag, nodeFeatureBag, true /*is left child*/, split, workspace);
-    }
-    return {std::move(leftChild), std::move(rightChild)};
-}
-
 bool CBoostedTreeLeafNodeStatistics::operator<(const CBoostedTreeLeafNodeStatistics& rhs) const {
     return COrderings::lexicographical_compare(m_BestSplit, m_Id, rhs.m_BestSplit, rhs.m_Id);
 }
@@ -220,367 +52,48 @@ std::size_t CBoostedTreeLeafNodeStatistics::id() const {
     return m_Id;
 }
 
+const core::CPackedBitVector& CBoostedTreeLeafNodeStatistics::rowMask() const {
+    return m_RowMask;
+}
+
 core::CPackedBitVector& CBoostedTreeLeafNodeStatistics::rowMask() {
     return m_RowMask;
 }
 
 std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_RowMask) + core::CMemory::dynamicSize(m_Derivatives);
+    return core::CMemory::dynamicSize(m_RowMask);
 }
 
-std::size_t
-CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(std::size_t numberFeatures,
-                                                    std::size_t numberSplitsPerFeature,
-                                                    std::size_t numberLossParameters) {
-    // See CBoostedTreeImpl::estimateMemoryUsage for a discussion of the cost
-    // of the row mask.
-    std::size_t splitsDerivativesSize{CSplitsDerivatives::estimateMemoryUsage(
-        numberFeatures, numberSplitsPerFeature, numberLossParameters)};
-    return sizeof(CBoostedTreeLeafNodeStatistics) + splitsDerivativesSize;
+CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(std::size_t id,
+                                                               std::size_t depth,
+                                                               TSizeVecCRef extraColumns,
+                                                               std::size_t numberLossParameters,
+                                                               const TImmutableRadixSetVec& candidateSplits)
+    : m_Id{id}, m_Depth{depth}, m_ExtraColumns{extraColumns},
+      m_NumberLossParameters{numberLossParameters}, m_CandidateSplits{candidateSplits} {
 }
 
-void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivatives(
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder,
-    const TSizeVec& featureBag,
-    const core::CPackedBitVector& rowMask,
-    CWorkspace& workspace) const {
-
-    workspace.newLeaf(numberThreads);
-
-    core::CDataFrame::TRowFuncVec aggregators;
-    aggregators.reserve(numberThreads);
-
-    for (std::size_t i = 0; i < numberThreads; ++i) {
-        auto& splitsDerivatives = workspace.derivatives()[i];
-        splitsDerivatives.zero();
-        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                this->addRowDerivatives(featureBag, encoder.encode(*row), splitsDerivatives);
-            }
-        });
-    }
-
-    frame.readRows(0, frame.numberRows(), aggregators, &rowMask);
+CBoostedTreeLeafNodeStatistics::SSplitStatistics&
+CBoostedTreeLeafNodeStatistics::bestSplitStatistics() {
+    return m_BestSplit;
 }
 
-void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
-    std::size_t numberThreads,
-    const core::CDataFrame& frame,
-    const CDataFrameCategoryEncoder& encoder,
-    bool isLeftChild,
-    const CBoostedTreeNode& split,
-    const TSizeVec& featureBag,
-    const core::CPackedBitVector& parentRowMask,
-    CWorkspace& workspace) const {
-
-    workspace.newLeaf(numberThreads);
-
-    core::CDataFrame::TRowFuncVec aggregators;
-    aggregators.reserve(numberThreads);
-
-    for (std::size_t i = 0; i < numberThreads; ++i) {
-        auto& mask = workspace.masks()[i];
-        auto& splitsDerivatives = workspace.derivatives()[i];
-        mask.clear();
-        splitsDerivatives.zero();
-        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                auto encodedRow = encoder.encode(*row);
-                if (split.assignToLeft(encodedRow) == isLeftChild) {
-                    std::size_t index{row->index()};
-                    mask.extend(false, index - mask.size());
-                    mask.extend(true);
-                    this->addRowDerivatives(featureBag, encodedRow, splitsDerivatives);
-                }
-            }
-        });
-    }
-
-    frame.readRows(0, frame.numberRows(), aggregators, &parentRowMask);
+std::size_t CBoostedTreeLeafNodeStatistics::depth() const {
+    return m_Depth;
 }
 
-void CBoostedTreeLeafNodeStatistics::addRowDerivatives(const TSizeVec& featureBag,
-                                                       const CEncodedDataFrameRowRef& row,
-                                                       CSplitsDerivatives& splitsDerivatives) const {
-
-    auto derivatives = readLossDerivatives(row.unencodedRow(), m_ExtraColumns,
-                                           m_NumberLossParameters);
-
-    if (derivatives.size() == 2) {
-        if (derivatives(0) >= 0.0) {
-            splitsDerivatives.addPositiveDerivatives(derivatives);
-        } else {
-            splitsDerivatives.addNegativeDerivatives(derivatives);
-        }
-    }
-
-    for (auto feature : featureBag) {
-        double featureValue{row[feature]};
-        if (CDataFrameUtils::isMissing(featureValue)) {
-            splitsDerivatives.addMissingDerivatives(feature, derivatives);
-        } else {
-            std::ptrdiff_t split{m_CandidateSplits[feature].upperBound(featureValue)};
-            splitsDerivatives.addDerivatives(feature, split, derivatives);
-        }
-    }
+CBoostedTreeLeafNodeStatistics::TSizeVecCRef
+CBoostedTreeLeafNodeStatistics::extraColumns() const {
+    return m_ExtraColumns;
 }
 
-CBoostedTreeLeafNodeStatistics::SSplitStatistics
-CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization& regularization,
-                                                           const TSizeVec& featureBag) const {
-
-    // We have three possible regularization terms we'll use:
-    //   1. Tree size: gamma * "node count"
-    //   2. Sum square weights: lambda * sum{"leaf weight" ^ 2)}
-    //   3. Tree depth: alpha * sum{exp(("depth" / "target depth" - 1.0) / "tolerance")}
-
-    SSplitStatistics result;
-
-    // We seek to find the value at the minimum of the quadratic expansion of the
-    // regularized loss function. For a given leaf this expansion is
-    //
-    //   L(w) = 1/2 w^t H(\lambda) w + g^t w
-    //
-    // where H(\lambda) = \sum_i H_i + \lambda I, g = \sum_i g_i and w is the leaf's
-    // weight. Here, g_i and H_i denote an example's loss gradient and Hessian and i
-    // ranges over the examples in the leaf. Writing this as the sum of a quadratic
-    // form and constant, i.e. x(w)^t H(\lambda) x(w) + constant, and noting that H
-    // is positive definite, we see that we'll minimise loss by choosing w such that
-    // x is zero, i.e. w^* = arg\min_w(L(w)) satisfies x(w) = 0. This gives
-    //
-    //   L(w^*) = -1/2 g^t H(\lambda)^{-1} g
-
-    using TDoubleVector = CDenseVector<double>;
-    using TDoubleMatrix = CDenseMatrix<double>;
-    using TMinimumLoss = std::function<double(const TDoubleVector&, const TDoubleMatrix&)>;
-
-    int d{static_cast<int>(m_NumberLossParameters)};
-
-    TMinimumLoss minimumLoss;
-
-    double lambda{regularization.leafWeightPenaltyMultiplier()};
-    Eigen::MatrixXd hessian{d, d};
-    Eigen::MatrixXd hessian_{d, d};
-    Eigen::VectorXd hessianInvg{d};
-    if (m_NumberLossParameters == 1) {
-        // There is a significant overhead for using a matrix decomposition when g and h
-        // are scalar so we have special case handling.
-        minimumLoss = [&](const TDoubleVector& g, const TDoubleMatrix& h) -> double {
-            return CTools::pow2(g(0)) / (h(0, 0) + lambda);
-        };
-    } else {
-        minimumLoss = [&](const TDoubleVector& g, const TDoubleMatrix& h) -> double {
-            hessian_ = hessian =
-                (h + lambda * TDoubleMatrix::Identity(d, d)).selfadjointView<Eigen::Lower>();
-            // Since the Hessian is positive semidefinite, the trace is larger than the
-            // largest eigenvalue. Therefore, H_eps = H + eps * trace(H) * I will have
-            // condition number at least eps. As long as eps >> double epsilon we should
-            // be able to invert it accurately.
-            double eps{std::max(1e-5 * hessian.trace(), 1e-10)};
-            for (std::size_t i = 0; i < 2; ++i) {
-                Eigen::LLT<Eigen::Ref<Eigen::MatrixXd>> llt{hessian};
-                hessianInvg = llt.solve(g);
-                if ((hessian_ * hessianInvg - g).norm() < 1e-2 * g.norm()) {
-                    return g.transpose() * hessianInvg;
-                } else {
-                    hessian_.diagonal().array() += eps;
-                    hessian = hessian_;
-                }
-            }
-            return -INF / 2.0; // We couldn't invert the Hessian: discard this split.
-        };
-    }
-
-    TDoubleVector g{d};
-    TDoubleMatrix h{d, d};
-    TDoubleVector gl[]{TDoubleVector{d}, TDoubleVector{d}};
-    TDoubleVector gr[]{TDoubleVector{d}, TDoubleVector{d}};
-    TDoubleMatrix hl[]{TDoubleMatrix{d, d}, TDoubleMatrix{d, d}};
-    TDoubleMatrix hr[]{TDoubleMatrix{d, d}, TDoubleMatrix{d, d}};
-
-    double gain[2];
-    double minLossLeft[2]{0.0, 0.0};
-    double minLossRight[2]{0.0, 0.0};
-    SChildredGainStats childrenGainStatsGlobal;
-    SChildredGainStats childrenGainStatsPerFeature;
-
-    for (auto feature : featureBag) {
-        std::size_t c{m_Derivatives.missingCount(feature)};
-        g = m_Derivatives.missingGradient(feature);
-        h = m_Derivatives.missingCurvature(feature);
-        for (const auto& derivatives : m_Derivatives.derivatives(feature)) {
-            c += derivatives.count();
-            g += derivatives.gradient();
-            h += derivatives.curvature();
-        }
-        std::size_t cl[]{m_Derivatives.missingCount(feature), 0};
-        gl[ASSIGN_MISSING_TO_LEFT] = m_Derivatives.missingGradient(feature);
-        gl[ASSIGN_MISSING_TO_RIGHT] = TDoubleVector::Zero(g.rows());
-        gr[ASSIGN_MISSING_TO_LEFT] = g - m_Derivatives.missingGradient(feature);
-        gr[ASSIGN_MISSING_TO_RIGHT] = g;
-        hl[ASSIGN_MISSING_TO_LEFT] = m_Derivatives.missingCurvature(feature);
-        hl[ASSIGN_MISSING_TO_RIGHT] = TDoubleMatrix::Zero(h.rows(), h.cols());
-        hr[ASSIGN_MISSING_TO_LEFT] = h - m_Derivatives.missingCurvature(feature);
-        hr[ASSIGN_MISSING_TO_RIGHT] = h;
-
-        double maximumGain{-INF};
-        double splitAt{-INF};
-        std::size_t leftChildRowCount{0};
-        bool assignMissingToLeft{true};
-        std::size_t size{m_Derivatives.derivatives(feature).size()};
-
-        for (std::size_t split = 0; split + 1 < size; ++split) {
-
-            std::size_t count{m_Derivatives.count(feature, split)};
-            if (count == 0) {
-                continue;
-            }
-
-            const TMemoryMappedDoubleVector& gradient{m_Derivatives.gradient(feature, split)};
-            const TMemoryMappedDoubleMatrix& curvature{m_Derivatives.curvature(feature, split)};
-
-            cl[ASSIGN_MISSING_TO_LEFT] += count;
-            cl[ASSIGN_MISSING_TO_RIGHT] += count;
-            gl[ASSIGN_MISSING_TO_LEFT] += gradient;
-            gl[ASSIGN_MISSING_TO_RIGHT] += gradient;
-            gr[ASSIGN_MISSING_TO_LEFT] -= gradient;
-            gr[ASSIGN_MISSING_TO_RIGHT] -= gradient;
-            hl[ASSIGN_MISSING_TO_LEFT] += curvature;
-            hl[ASSIGN_MISSING_TO_RIGHT] += curvature;
-            hr[ASSIGN_MISSING_TO_LEFT] -= curvature;
-            hr[ASSIGN_MISSING_TO_RIGHT] -= curvature;
-
-            if (cl[ASSIGN_MISSING_TO_LEFT] == 0 || cl[ASSIGN_MISSING_TO_LEFT] == c) {
-                gain[ASSIGN_MISSING_TO_LEFT] = -INF;
-            } else {
-                minLossLeft[ASSIGN_MISSING_TO_LEFT] = minimumLoss(
-                    gl[ASSIGN_MISSING_TO_LEFT], hl[ASSIGN_MISSING_TO_LEFT]);
-                minLossRight[ASSIGN_MISSING_TO_LEFT] = minimumLoss(
-                    gr[ASSIGN_MISSING_TO_LEFT], hr[ASSIGN_MISSING_TO_LEFT]);
-                gain[ASSIGN_MISSING_TO_LEFT] = minLossLeft[ASSIGN_MISSING_TO_LEFT] +
-                                               minLossRight[ASSIGN_MISSING_TO_LEFT];
-            }
-
-            if (cl[ASSIGN_MISSING_TO_RIGHT] == 0 || cl[ASSIGN_MISSING_TO_RIGHT] == c) {
-                gain[ASSIGN_MISSING_TO_RIGHT] = -INF;
-            } else {
-                minLossLeft[ASSIGN_MISSING_TO_RIGHT] = minimumLoss(
-                    gl[ASSIGN_MISSING_TO_RIGHT], hl[ASSIGN_MISSING_TO_RIGHT]);
-                minLossRight[ASSIGN_MISSING_TO_RIGHT] = minimumLoss(
-                    gr[ASSIGN_MISSING_TO_RIGHT], hr[ASSIGN_MISSING_TO_RIGHT]);
-                gain[ASSIGN_MISSING_TO_RIGHT] = minLossLeft[ASSIGN_MISSING_TO_RIGHT] +
-                                                minLossRight[ASSIGN_MISSING_TO_RIGHT];
-            }
-
-            if (gain[ASSIGN_MISSING_TO_LEFT] > maximumGain) {
-                maximumGain = gain[ASSIGN_MISSING_TO_LEFT];
-                splitAt = m_CandidateSplits[feature][split];
-                leftChildRowCount = cl[ASSIGN_MISSING_TO_LEFT];
-                assignMissingToLeft = true;
-                // if gain > -INF then minLossLeft and minLossRight were initialized
-                childrenGainStatsPerFeature = {minLossLeft[ASSIGN_MISSING_TO_LEFT],
-                                               minLossRight[ASSIGN_MISSING_TO_LEFT],
-                                               gl[ASSIGN_MISSING_TO_LEFT](0),
-                                               gr[ASSIGN_MISSING_TO_LEFT](0)};
-            }
-            if (gain[ASSIGN_MISSING_TO_RIGHT] > maximumGain) {
-                maximumGain = gain[ASSIGN_MISSING_TO_RIGHT];
-                splitAt = m_CandidateSplits[feature][split];
-                leftChildRowCount = cl[ASSIGN_MISSING_TO_RIGHT];
-                assignMissingToLeft = false;
-                // if gain > -INF then minLossLeft and minLossRight were initialized
-                childrenGainStatsPerFeature = {minLossLeft[ASSIGN_MISSING_TO_RIGHT],
-                                               minLossRight[ASSIGN_MISSING_TO_RIGHT],
-                                               gl[ASSIGN_MISSING_TO_RIGHT](0),
-                                               gr[ASSIGN_MISSING_TO_RIGHT](0)};
-            }
-        }
-
-        double penaltyForDepth{regularization.penaltyForDepth(m_Depth)};
-        double penaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 1)};
-
-        // The gain is the difference between the quadratic minimum for loss with
-        // no split and the loss with the minimum loss split we found.
-        double totalGain{0.5 * (maximumGain - minimumLoss(g, h)) -
-                         regularization.treeSizePenaltyMultiplier() -
-                         regularization.depthPenaltyMultiplier() *
-                             (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
-        SSplitStatistics candidate{totalGain,
-                                   h.trace() / static_cast<double>(m_NumberLossParameters),
-                                   feature,
-                                   splitAt,
-                                   std::min(leftChildRowCount, c - leftChildRowCount),
-                                   2 * leftChildRowCount < c,
-                                   assignMissingToLeft};
-        LOG_TRACE(<< "candidate split: " << candidate.print());
-
-        if (candidate > result) {
-            result = candidate;
-            childrenGainStatsGlobal = childrenGainStatsPerFeature;
-        }
-    }
-    if (m_Derivatives.numberLossParameters() > 2) {
-        // short-circuit the bound computation for the multi-class case
-        result.s_LeftChildMaxGain = INF;
-        result.s_RightChildMaxGain = INF;
-    } else if (result.s_Gain > 0) {
-        double childPenaltyForDepth{regularization.penaltyForDepth(m_Depth + 1)};
-        double childPenaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 2)};
-        double childPenalty{regularization.treeSizePenaltyMultiplier() +
-                            regularization.depthPenaltyMultiplier() *
-                                (2.0 * childPenaltyForDepthPlusOne - childPenaltyForDepth)};
-        result.s_LeftChildMaxGain =
-            0.5 * this->childMaxGain(childrenGainStatsGlobal.s_GLeft,
-                                     childrenGainStatsGlobal.s_MinLossLeft, lambda) -
-            childPenalty;
-
-        result.s_RightChildMaxGain =
-            0.5 * this->childMaxGain(childrenGainStatsGlobal.s_GRight,
-                                     childrenGainStatsGlobal.s_MinLossRight, lambda) -
-            childPenalty;
-    }
-
-    LOG_TRACE(<< "best split: " << result.print());
-
-    return result;
+std::size_t CBoostedTreeLeafNodeStatistics::numberLossParameters() const {
+    return m_NumberLossParameters;
 }
 
-double CBoostedTreeLeafNodeStatistics::childMaxGain(double gChild,
-                                                    double minLossChild,
-                                                    double lambda) const {
-
-    // This computes the maximum possible gain we can expect splitting a child node given
-    // we know the sum of the positive (g^+) and negative gradients (g^-) at its parent,
-    // the minimum curvature on the positive and negative gradient set (hmin^+ and hmin^-)
-    // and largest and smallest gradient (gmax and gmin, respectively). The highest possible
-    // gain consistent with these constraints can be shown to be:
-    // (g^+)^2 / (hmin^+ * g^+ / gmax + lambda) + (g^-)^2 / (hmin^- * g^- / gmin + lambda)
-    // Since gchild = gchild^+ + gchild^-, we can improve estimates on g^+ and g^- for the child as:
-    // g^+ = max(min(gchild - g^-, g^+), 0),
-    // g^- = max(min(gchild - g^+, g^-), 0).
-    double positiveDerivativesGSum =
-        std::max(std::min(gChild - m_Derivatives.negativeDerivativesGSum(),
-                          m_Derivatives.positiveDerivativesGSum()),
-                 0.0);
-    double negativeDerivativesGSum =
-        std::min(std::max(gChild - m_Derivatives.positiveDerivativesGSum(),
-                          m_Derivatives.negativeDerivativesGSum()),
-                 0.0);
-    double lookAheadGain{((positiveDerivativesGSum != 0.0)
-                              ? CTools::pow2(positiveDerivativesGSum) /
-                                    (m_Derivatives.positiveDerivativesHMin() * positiveDerivativesGSum /
-                                         m_Derivatives.positiveDerivativesGMax() +
-                                     lambda + 1e-10)
-                              : 0.0) +
-                         ((negativeDerivativesGSum != 0.0)
-                              ? CTools::pow2(negativeDerivativesGSum) /
-                                    (m_Derivatives.negativeDerivativesHMin() * negativeDerivativesGSum /
-                                         m_Derivatives.negativeDerivativesGMin() +
-                                     lambda + 1e-10)
-                              : 0.0)};
-    return lookAheadGain - minLossChild;
+const CBoostedTreeLeafNodeStatistics::TImmutableRadixSetVec&
+CBoostedTreeLeafNodeStatistics::candidateSplits() const {
+    return m_CandidateSplits;
 }
 }
 }

--- a/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
@@ -116,9 +116,7 @@ CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
     const TRegularization& regularization,
     const TSizeVec& nodeFeatureBag,
     CWorkspace& workspace)
-    : CBoostedTreeLeafNodeStatistics{id,
-                                     parent.depth() + 1,
-                                     parent.extraColumns(),
+    : CBoostedTreeLeafNodeStatistics{id, parent.depth() + 1, parent.extraColumns(),
                                      parent.numberLossParameters(),
                                      parent.candidateSplits()},
       m_Derivatives{std::move(parent.m_Derivatives)} {
@@ -468,13 +466,14 @@ CBoostedTreeLeafNodeStatisticsScratch::computeBestSplitStatistics(const TRegular
                          regularization.treeSizePenaltyMultiplier() -
                          regularization.depthPenaltyMultiplier() *
                              (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
-        SSplitStatistics candidate{totalGain,
-                                   h.trace() / static_cast<double>(this->numberLossParameters()),
-                                   feature,
-                                   splitAt,
-                                   std::min(leftChildRowCount, c - leftChildRowCount),
-                                   2 * leftChildRowCount < c,
-                                   assignMissingToLeft};
+        SSplitStatistics candidate{
+            totalGain,
+            h.trace() / static_cast<double>(this->numberLossParameters()),
+            feature,
+            splitAt,
+            std::min(leftChildRowCount, c - leftChildRowCount),
+            2 * leftChildRowCount < c,
+            assignMissingToLeft};
         LOG_TRACE(<< "candidate split: " << candidate.print());
 
         if (candidate > result) {
@@ -488,7 +487,8 @@ CBoostedTreeLeafNodeStatisticsScratch::computeBestSplitStatistics(const TRegular
         result.s_RightChildMaxGain = INF;
     } else if (result.s_Gain > 0) {
         double childPenaltyForDepth{regularization.penaltyForDepth(this->depth() + 1)};
-        double childPenaltyForDepthPlusOne{regularization.penaltyForDepth(this->depth() + 2)};
+        double childPenaltyForDepthPlusOne{
+            regularization.penaltyForDepth(this->depth() + 2)};
         double childPenalty{regularization.treeSizePenaltyMultiplier() +
                             regularization.depthPenaltyMultiplier() *
                                 (2.0 * childPenaltyForDepthPlusOne - childPenaltyForDepth)};

--- a/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
@@ -1,0 +1,551 @@
+#include <maths/CBoostedTreeLeafNodeStatisticsScratch.h>
+
+#include <core/CDataFrame.h>
+#include <core/CImmutableRadixSet.h>
+#include <core/CLogger.h>
+#include <core/CMemory.h>
+
+#include <maths/CBoostedTree.h>
+#include <maths/CDataFrameCategoryEncoder.h>
+#include <maths/CTools.h>
+
+#include <limits>
+
+namespace ml {
+namespace maths {
+using namespace boosted_tree_detail;
+
+namespace {
+using TRowItr = core::CDataFrame::TRowItr;
+
+struct SChildredGainStats {
+    double s_MinLossLeft = -INF;
+    double s_MinLossRight = -INF;
+    double s_GLeft = -INF;
+    double s_GRight = -INF;
+};
+
+const std::size_t ASSIGN_MISSING_TO_LEFT{0};
+const std::size_t ASSIGN_MISSING_TO_RIGHT{1};
+}
+
+CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
+    std::size_t id,
+    const TSizeVec& extraColumns,
+    std::size_t numberLossParameters,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TRegularization& regularization,
+    const TImmutableRadixSetVec& candidateSplits,
+    const TSizeVec& treeFeatureBag,
+    const TSizeVec& nodeFeatureBag,
+    std::size_t depth,
+    const core::CPackedBitVector& rowMask,
+    CWorkspace& workspace)
+    : CBoostedTreeLeafNodeStatistics{id, depth, extraColumns,
+                                     numberLossParameters, candidateSplits} {
+
+    this->computeAggregateLossDerivatives(numberThreads, frame, encoder,
+                                          treeFeatureBag, rowMask, workspace);
+
+    // Lazily copy the mask and derivatives to avoid unnecessary allocations.
+
+    m_Derivatives.swap(workspace.reducedDerivatives());
+    this->bestSplitStatistics() =
+        this->computeBestSplitStatistics(regularization, nodeFeatureBag);
+    workspace.reducedDerivatives().swap(m_Derivatives);
+
+    if (this->gain() > workspace.minimumGain()) {
+        this->rowMask() = rowMask;
+        CSplitsDerivatives tmp{workspace.derivatives()[0]};
+        m_Derivatives = std::move(tmp);
+    }
+}
+
+CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
+    std::size_t id,
+    const CBoostedTreeLeafNodeStatisticsScratch& parent,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TRegularization& regularization,
+    const TSizeVec& treeFeatureBag,
+    const TSizeVec& nodeFeatureBag,
+    bool isLeftChild,
+    const CBoostedTreeNode& split,
+    CWorkspace& workspace)
+    : CBoostedTreeLeafNodeStatistics{id, parent.depth() + 1, parent.extraColumns(),
+                                     parent.numberLossParameters(),
+                                     parent.candidateSplits()} {
+
+    // The number of threads we'll use breaks down as follows:
+    //   - We need a minimum number of rows per thread to ensure reasonable
+    //     load balancing.
+    //   - We need a minimum amount of work per thread to make the overheads
+    //     of distributing worthwhile.
+    std::size_t features{treeFeatureBag.size()};
+    std::size_t rows{parent.minimumChildRowCount()};
+    std::size_t rowsPerThreadConstraint{rows / 64};
+    std::size_t workPerThreadConstraint{(features * rows) / (8 * 128)};
+    std::size_t maximumNumberThreads{std::max(
+        std::min(rowsPerThreadConstraint, workPerThreadConstraint), std::size_t{1})};
+    numberThreads = std::min(numberThreads, maximumNumberThreads);
+
+    this->computeRowMaskAndAggregateLossDerivatives(numberThreads, frame, encoder,
+                                                    isLeftChild, split, treeFeatureBag,
+                                                    parent.rowMask(), workspace);
+
+    // Lazily copy the mask and derivatives to avoid unnecessary allocations.
+
+    m_Derivatives.swap(workspace.reducedDerivatives());
+    this->bestSplitStatistics() =
+        this->computeBestSplitStatistics(regularization, nodeFeatureBag);
+    workspace.reducedDerivatives().swap(m_Derivatives);
+
+    if (this->gain() >= workspace.minimumGain()) {
+        CSplitsDerivatives tmp{workspace.reducedDerivatives()};
+        this->rowMask() = workspace.reducedMask(parent.rowMask().size());
+        m_Derivatives = std::move(tmp);
+    }
+}
+
+CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
+    std::size_t id,
+    CBoostedTreeLeafNodeStatisticsScratch&& parent,
+    const TRegularization& regularization,
+    const TSizeVec& nodeFeatureBag,
+    CWorkspace& workspace)
+    : CBoostedTreeLeafNodeStatistics{id,
+                                     parent.depth() + 1,
+                                     parent.extraColumns(),
+                                     parent.numberLossParameters(),
+                                     parent.candidateSplits()},
+      m_Derivatives{std::move(parent.m_Derivatives)} {
+
+    // Lazily compute the row mask to avoid unnecessary work.
+
+    m_Derivatives.subtract(workspace.reducedDerivatives());
+    this->bestSplitStatistics() =
+        this->computeBestSplitStatistics(regularization, nodeFeatureBag);
+    if (this->gain() >= workspace.minimumGain()) {
+        this->rowMask() = std::move(parent.rowMask());
+        this->rowMask() ^= workspace.reducedMask(this->rowMask().size());
+    }
+}
+
+CBoostedTreeLeafNodeStatisticsScratch::TPtrPtrPr
+CBoostedTreeLeafNodeStatisticsScratch::split(std::size_t leftChildId,
+                                             std::size_t rightChildId,
+                                             std::size_t numberThreads,
+                                             double gainThreshold,
+                                             const core::CDataFrame& frame,
+                                             const CDataFrameCategoryEncoder& encoder,
+                                             const TRegularization& regularization,
+                                             const TSizeVec& treeFeatureBag,
+                                             const TSizeVec& nodeFeatureBag,
+                                             const CBoostedTreeNode& split,
+                                             CWorkspace& workspace) {
+    TPtr leftChild;
+    TPtr rightChild;
+    if (this->leftChildHasFewerRows()) {
+        if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
+            leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+                leftChildId, *this, numberThreads, frame, encoder, regularization,
+                treeFeatureBag, nodeFeatureBag, true /*is left child*/, split, workspace);
+            if (this->bestSplitStatistics().s_RightChildMaxGain > gainThreshold) {
+                rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+                    rightChildId, std::move(*this), regularization, nodeFeatureBag, workspace);
+            }
+        } else if (this->bestSplitStatistics().s_RightChildMaxGain > gainThreshold) {
+            rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+                rightChildId, *this, numberThreads, frame, encoder, regularization,
+                treeFeatureBag, nodeFeatureBag, false /*is left child*/, split, workspace);
+        }
+        return {std::move(leftChild), std::move(rightChild)};
+    }
+
+    if (this->bestSplitStatistics().s_RightChildMaxGain > gainThreshold) {
+        rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+            rightChildId, *this, numberThreads, frame, encoder, regularization,
+            treeFeatureBag, nodeFeatureBag, false /*is left child*/, split, workspace);
+        if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
+            leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+                leftChildId, std::move(*this), regularization, nodeFeatureBag, workspace);
+        }
+    } else if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
+        leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+            leftChildId, *this, numberThreads, frame, encoder, regularization,
+            treeFeatureBag, nodeFeatureBag, true /*is left child*/, split, workspace);
+    }
+    return {std::move(leftChild), std::move(rightChild)};
+}
+
+std::size_t CBoostedTreeLeafNodeStatisticsScratch::memoryUsage() const {
+    return this->CBoostedTreeLeafNodeStatistics::memoryUsage() +
+           core::CMemory::dynamicSize(m_Derivatives);
+}
+
+std::size_t
+CBoostedTreeLeafNodeStatisticsScratch::estimateMemoryUsage(std::size_t numberFeatures,
+                                                           std::size_t numberSplitsPerFeature,
+                                                           std::size_t numberLossParameters) {
+    // See CBoostedTreeImpl::estimateMemoryUsage for a discussion of the cost
+    // of the row mask which is accounted for there.
+    std::size_t splitsDerivativesSize{CSplitsDerivatives::estimateMemoryUsage(
+        numberFeatures, numberSplitsPerFeature, numberLossParameters)};
+    return sizeof(CBoostedTreeLeafNodeStatistics) + splitsDerivativesSize;
+}
+
+void CBoostedTreeLeafNodeStatisticsScratch::computeAggregateLossDerivatives(
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& rowMask,
+    CWorkspace& workspace) const {
+
+    workspace.newLeaf(numberThreads);
+
+    core::CDataFrame::TRowFuncVec aggregators;
+    aggregators.reserve(numberThreads);
+
+    for (std::size_t i = 0; i < numberThreads; ++i) {
+        auto& splitsDerivatives = workspace.derivatives()[i];
+        splitsDerivatives.zero();
+        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                this->addRowDerivatives(featureBag, encoder.encode(*row), splitsDerivatives);
+            }
+        });
+    }
+
+    frame.readRows(0, frame.numberRows(), aggregators, &rowMask);
+}
+
+void CBoostedTreeLeafNodeStatisticsScratch::computeRowMaskAndAggregateLossDerivatives(
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    bool isLeftChild,
+    const CBoostedTreeNode& split,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& parentRowMask,
+    CWorkspace& workspace) const {
+
+    workspace.newLeaf(numberThreads);
+
+    core::CDataFrame::TRowFuncVec aggregators;
+    aggregators.reserve(numberThreads);
+
+    for (std::size_t i = 0; i < numberThreads; ++i) {
+        auto& mask = workspace.masks()[i];
+        auto& splitsDerivatives = workspace.derivatives()[i];
+        mask.clear();
+        splitsDerivatives.zero();
+        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                auto encodedRow = encoder.encode(*row);
+                if (split.assignToLeft(encodedRow) == isLeftChild) {
+                    std::size_t index{row->index()};
+                    mask.extend(false, index - mask.size());
+                    mask.extend(true);
+                    this->addRowDerivatives(featureBag, encodedRow, splitsDerivatives);
+                }
+            }
+        });
+    }
+
+    frame.readRows(0, frame.numberRows(), aggregators, &parentRowMask);
+}
+
+void CBoostedTreeLeafNodeStatisticsScratch::addRowDerivatives(
+    const TSizeVec& featureBag,
+    const CEncodedDataFrameRowRef& row,
+    CSplitsDerivatives& splitsDerivatives) const {
+
+    auto derivatives = readLossDerivatives(row.unencodedRow(), this->extraColumns(),
+                                           this->numberLossParameters());
+
+    if (derivatives.size() == 2) {
+        if (derivatives(0) >= 0.0) {
+            splitsDerivatives.addPositiveDerivatives(derivatives);
+        } else {
+            splitsDerivatives.addNegativeDerivatives(derivatives);
+        }
+    }
+
+    const auto& candidateSplits = this->candidateSplits();
+
+    for (auto feature : featureBag) {
+        double featureValue{row[feature]};
+        if (CDataFrameUtils::isMissing(featureValue)) {
+            splitsDerivatives.addMissingDerivatives(feature, derivatives);
+        } else {
+            std::ptrdiff_t split{candidateSplits[feature].upperBound(featureValue)};
+            splitsDerivatives.addDerivatives(feature, split, derivatives);
+        }
+    }
+}
+
+CBoostedTreeLeafNodeStatisticsScratch::SSplitStatistics
+CBoostedTreeLeafNodeStatisticsScratch::computeBestSplitStatistics(const TRegularization& regularization,
+                                                                  const TSizeVec& featureBag) const {
+
+    // We have three possible regularization terms we'll use:
+    //   1. Tree size: gamma * "node count"
+    //   2. Sum square weights: lambda * sum{"leaf weight" ^ 2)}
+    //   3. Tree depth: alpha * sum{exp(("depth" / "target depth" - 1.0) / "tolerance")}
+
+    SSplitStatistics result;
+
+    // We seek to find the value at the minimum of the quadratic expansion of the
+    // regularized loss function. For a given leaf this expansion is
+    //
+    //   L(w) = 1/2 w^t H(\lambda) w + g^t w
+    //
+    // where H(\lambda) = \sum_i H_i + \lambda I, g = \sum_i g_i and w is the leaf's
+    // weight. Here, g_i and H_i denote an example's loss gradient and Hessian and i
+    // ranges over the examples in the leaf. Writing this as the sum of a quadratic
+    // form and constant, i.e. x(w)^t H(\lambda) x(w) + constant, and noting that H
+    // is positive definite, we see that we'll minimise loss by choosing w such that
+    // x is zero, i.e. w^* = arg\min_w(L(w)) satisfies x(w) = 0. This gives
+    //
+    //   L(w^*) = -1/2 g^t H(\lambda)^{-1} g
+
+    using TDoubleVector = CDenseVector<double>;
+    using TDoubleMatrix = CDenseMatrix<double>;
+    using TMinimumLoss = std::function<double(const TDoubleVector&, const TDoubleMatrix&)>;
+
+    int d{static_cast<int>(this->numberLossParameters())};
+
+    TMinimumLoss minimumLoss;
+
+    double lambda{regularization.leafWeightPenaltyMultiplier()};
+    Eigen::MatrixXd hessian{d, d};
+    Eigen::MatrixXd hessian_{d, d};
+    Eigen::VectorXd hessianInvg{d};
+    if (this->numberLossParameters() == 1) {
+        // There is a significant overhead for using a matrix decomposition when g and h
+        // are scalar so we have special case handling.
+        minimumLoss = [&](const TDoubleVector& g, const TDoubleMatrix& h) -> double {
+            return CTools::pow2(g(0)) / (h(0, 0) + lambda);
+        };
+    } else {
+        minimumLoss = [&](const TDoubleVector& g, const TDoubleMatrix& h) -> double {
+            hessian_ = hessian =
+                (h + lambda * TDoubleMatrix::Identity(d, d)).selfadjointView<Eigen::Lower>();
+            // Since the Hessian is positive semidefinite, the trace is larger than the
+            // largest eigenvalue. Therefore, H_eps = H + eps * trace(H) * I will have
+            // condition number at least eps. As long as eps >> double epsilon we should
+            // be able to invert it accurately.
+            double eps{std::max(1e-5 * hessian.trace(), 1e-10)};
+            for (std::size_t i = 0; i < 2; ++i) {
+                Eigen::LLT<Eigen::Ref<Eigen::MatrixXd>> llt{hessian};
+                hessianInvg = llt.solve(g);
+                if ((hessian_ * hessianInvg - g).norm() < 1e-2 * g.norm()) {
+                    return g.transpose() * hessianInvg;
+                } else {
+                    hessian_.diagonal().array() += eps;
+                    hessian = hessian_;
+                }
+            }
+            return -INF / 2.0; // We couldn't invert the Hessian: discard this split.
+        };
+    }
+
+    TDoubleVector g{d};
+    TDoubleMatrix h{d, d};
+    TDoubleVector gl[]{TDoubleVector{d}, TDoubleVector{d}};
+    TDoubleVector gr[]{TDoubleVector{d}, TDoubleVector{d}};
+    TDoubleMatrix hl[]{TDoubleMatrix{d, d}, TDoubleMatrix{d, d}};
+    TDoubleMatrix hr[]{TDoubleMatrix{d, d}, TDoubleMatrix{d, d}};
+
+    double gain[2];
+    double minLossLeft[2]{0.0, 0.0};
+    double minLossRight[2]{0.0, 0.0};
+    SChildredGainStats childrenGainStatsGlobal;
+    SChildredGainStats childrenGainStatsPerFeature;
+
+    for (auto feature : featureBag) {
+        std::size_t c{m_Derivatives.missingCount(feature)};
+        g = m_Derivatives.missingGradient(feature);
+        h = m_Derivatives.missingCurvature(feature);
+        for (const auto& derivatives : m_Derivatives.derivatives(feature)) {
+            c += derivatives.count();
+            g += derivatives.gradient();
+            h += derivatives.curvature();
+        }
+        std::size_t cl[]{m_Derivatives.missingCount(feature), 0};
+        gl[ASSIGN_MISSING_TO_LEFT] = m_Derivatives.missingGradient(feature);
+        gl[ASSIGN_MISSING_TO_RIGHT] = TDoubleVector::Zero(g.rows());
+        gr[ASSIGN_MISSING_TO_LEFT] = g - m_Derivatives.missingGradient(feature);
+        gr[ASSIGN_MISSING_TO_RIGHT] = g;
+        hl[ASSIGN_MISSING_TO_LEFT] = m_Derivatives.missingCurvature(feature);
+        hl[ASSIGN_MISSING_TO_RIGHT] = TDoubleMatrix::Zero(h.rows(), h.cols());
+        hr[ASSIGN_MISSING_TO_LEFT] = h - m_Derivatives.missingCurvature(feature);
+        hr[ASSIGN_MISSING_TO_RIGHT] = h;
+
+        double maximumGain{-INF};
+        double splitAt{-INF};
+        std::size_t leftChildRowCount{0};
+        bool assignMissingToLeft{true};
+        std::size_t size{m_Derivatives.derivatives(feature).size()};
+
+        for (std::size_t split = 0; split + 1 < size; ++split) {
+
+            std::size_t count{m_Derivatives.count(feature, split)};
+            if (count == 0) {
+                continue;
+            }
+
+            const TMemoryMappedDoubleVector& gradient{m_Derivatives.gradient(feature, split)};
+            const TMemoryMappedDoubleMatrix& curvature{m_Derivatives.curvature(feature, split)};
+
+            cl[ASSIGN_MISSING_TO_LEFT] += count;
+            cl[ASSIGN_MISSING_TO_RIGHT] += count;
+            gl[ASSIGN_MISSING_TO_LEFT] += gradient;
+            gl[ASSIGN_MISSING_TO_RIGHT] += gradient;
+            gr[ASSIGN_MISSING_TO_LEFT] -= gradient;
+            gr[ASSIGN_MISSING_TO_RIGHT] -= gradient;
+            hl[ASSIGN_MISSING_TO_LEFT] += curvature;
+            hl[ASSIGN_MISSING_TO_RIGHT] += curvature;
+            hr[ASSIGN_MISSING_TO_LEFT] -= curvature;
+            hr[ASSIGN_MISSING_TO_RIGHT] -= curvature;
+
+            if (cl[ASSIGN_MISSING_TO_LEFT] == 0 || cl[ASSIGN_MISSING_TO_LEFT] == c) {
+                gain[ASSIGN_MISSING_TO_LEFT] = -INF;
+            } else {
+                minLossLeft[ASSIGN_MISSING_TO_LEFT] = minimumLoss(
+                    gl[ASSIGN_MISSING_TO_LEFT], hl[ASSIGN_MISSING_TO_LEFT]);
+                minLossRight[ASSIGN_MISSING_TO_LEFT] = minimumLoss(
+                    gr[ASSIGN_MISSING_TO_LEFT], hr[ASSIGN_MISSING_TO_LEFT]);
+                gain[ASSIGN_MISSING_TO_LEFT] = minLossLeft[ASSIGN_MISSING_TO_LEFT] +
+                                               minLossRight[ASSIGN_MISSING_TO_LEFT];
+            }
+
+            if (cl[ASSIGN_MISSING_TO_RIGHT] == 0 || cl[ASSIGN_MISSING_TO_RIGHT] == c) {
+                gain[ASSIGN_MISSING_TO_RIGHT] = -INF;
+            } else {
+                minLossLeft[ASSIGN_MISSING_TO_RIGHT] = minimumLoss(
+                    gl[ASSIGN_MISSING_TO_RIGHT], hl[ASSIGN_MISSING_TO_RIGHT]);
+                minLossRight[ASSIGN_MISSING_TO_RIGHT] = minimumLoss(
+                    gr[ASSIGN_MISSING_TO_RIGHT], hr[ASSIGN_MISSING_TO_RIGHT]);
+                gain[ASSIGN_MISSING_TO_RIGHT] = minLossLeft[ASSIGN_MISSING_TO_RIGHT] +
+                                                minLossRight[ASSIGN_MISSING_TO_RIGHT];
+            }
+
+            if (gain[ASSIGN_MISSING_TO_LEFT] > maximumGain) {
+                maximumGain = gain[ASSIGN_MISSING_TO_LEFT];
+                splitAt = this->candidateSplits()[feature][split];
+                leftChildRowCount = cl[ASSIGN_MISSING_TO_LEFT];
+                assignMissingToLeft = true;
+                // If gain > -INF then minLossLeft and minLossRight were initialized.
+                childrenGainStatsPerFeature = {minLossLeft[ASSIGN_MISSING_TO_LEFT],
+                                               minLossRight[ASSIGN_MISSING_TO_LEFT],
+                                               gl[ASSIGN_MISSING_TO_LEFT](0),
+                                               gr[ASSIGN_MISSING_TO_LEFT](0)};
+            }
+            if (gain[ASSIGN_MISSING_TO_RIGHT] > maximumGain) {
+                maximumGain = gain[ASSIGN_MISSING_TO_RIGHT];
+                splitAt = this->candidateSplits()[feature][split];
+                leftChildRowCount = cl[ASSIGN_MISSING_TO_RIGHT];
+                assignMissingToLeft = false;
+                // If gain > -INF then minLossLeft and minLossRight were initialized.
+                childrenGainStatsPerFeature = {minLossLeft[ASSIGN_MISSING_TO_RIGHT],
+                                               minLossRight[ASSIGN_MISSING_TO_RIGHT],
+                                               gl[ASSIGN_MISSING_TO_RIGHT](0),
+                                               gr[ASSIGN_MISSING_TO_RIGHT](0)};
+            }
+        }
+
+        double penaltyForDepth{regularization.penaltyForDepth(this->depth())};
+        double penaltyForDepthPlusOne{regularization.penaltyForDepth(this->depth() + 1)};
+
+        // The gain is the difference between the quadratic minimum for loss with
+        // no split and the loss with the minimum loss split we found.
+        double totalGain{0.5 * (maximumGain - minimumLoss(g, h)) -
+                         regularization.treeSizePenaltyMultiplier() -
+                         regularization.depthPenaltyMultiplier() *
+                             (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
+        SSplitStatistics candidate{totalGain,
+                                   h.trace() / static_cast<double>(this->numberLossParameters()),
+                                   feature,
+                                   splitAt,
+                                   std::min(leftChildRowCount, c - leftChildRowCount),
+                                   2 * leftChildRowCount < c,
+                                   assignMissingToLeft};
+        LOG_TRACE(<< "candidate split: " << candidate.print());
+
+        if (candidate > result) {
+            result = candidate;
+            childrenGainStatsGlobal = childrenGainStatsPerFeature;
+        }
+    }
+    if (m_Derivatives.numberLossParameters() > 2) {
+        // Short-circuit the bound computation for the multi-class case.
+        result.s_LeftChildMaxGain = INF;
+        result.s_RightChildMaxGain = INF;
+    } else if (result.s_Gain > 0) {
+        double childPenaltyForDepth{regularization.penaltyForDepth(this->depth() + 1)};
+        double childPenaltyForDepthPlusOne{regularization.penaltyForDepth(this->depth() + 2)};
+        double childPenalty{regularization.treeSizePenaltyMultiplier() +
+                            regularization.depthPenaltyMultiplier() *
+                                (2.0 * childPenaltyForDepthPlusOne - childPenaltyForDepth)};
+        result.s_LeftChildMaxGain =
+            0.5 * this->childMaxGain(childrenGainStatsGlobal.s_GLeft,
+                                     childrenGainStatsGlobal.s_MinLossLeft, lambda) -
+            childPenalty;
+
+        result.s_RightChildMaxGain =
+            0.5 * this->childMaxGain(childrenGainStatsGlobal.s_GRight,
+                                     childrenGainStatsGlobal.s_MinLossRight, lambda) -
+            childPenalty;
+    }
+
+    LOG_TRACE(<< "best split: " << result.print());
+
+    return result;
+}
+
+double CBoostedTreeLeafNodeStatisticsScratch::childMaxGain(double gChild,
+                                                           double minLossChild,
+                                                           double lambda) const {
+
+    // This computes the maximum possible gain we can expect splitting a child node given
+    // we know the sum of the positive (g^+) and negative gradients (g^-) at its parent,
+    // the minimum curvature on the positive and negative gradient set (hmin^+ and hmin^-)
+    // and largest and smallest gradient (gmax and gmin, respectively). The highest possible
+    // gain consistent with these constraints can be shown to be:
+    //
+    //   (g^+)^2 / (hmin^+ * g^+ / gmax + lambda) + (g^-)^2 / (hmin^- * g^- / gmin + lambda)
+    //
+    // Since gchild = gchild^+ + gchild^-, we can improve estimates on g^+ and g^- for the
+    // child as:
+    //   g^+ = max(min(gchild - g^-, g^+), 0),
+    //   g^- = max(min(gchild - g^+, g^-), 0).
+
+    double positiveDerivativesGSum =
+        std::max(std::min(gChild - m_Derivatives.negativeDerivativesGSum(),
+                          m_Derivatives.positiveDerivativesGSum()),
+                 0.0);
+    double negativeDerivativesGSum =
+        std::min(std::max(gChild - m_Derivatives.positiveDerivativesGSum(),
+                          m_Derivatives.negativeDerivativesGSum()),
+                 0.0);
+    double lookAheadGain{((positiveDerivativesGSum != 0.0)
+                              ? CTools::pow2(positiveDerivativesGSum) /
+                                    (m_Derivatives.positiveDerivativesHMin() * positiveDerivativesGSum /
+                                         m_Derivatives.positiveDerivativesGMax() +
+                                     lambda + 1e-10)
+                              : 0.0) +
+                         ((negativeDerivativesGSum != 0.0)
+                              ? CTools::pow2(negativeDerivativesGSum) /
+                                    (m_Derivatives.negativeDerivativesHMin() * negativeDerivativesGSum /
+                                         m_Derivatives.negativeDerivativesGMin() +
+                                     lambda + 1e-10)
+                              : 0.0)};
+    return lookAheadGain - minLossChild;
+}
+}
+}

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -28,6 +28,7 @@ CBoostedTreeFactory.cc \
 CBoostedTreeHyperparameters.cc \
 CBoostedTreeImpl.cc \
 CBoostedTreeLeafNodeStatistics.cc \
+CBoostedTreeLeafNodeStatisticsScratch.cc \
 CBoostedTreeLoss.cc \
 CBoostedTreeUtils.cc \
 CCalendarCyclicTest.cc \

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -8,6 +8,7 @@
 
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeLeafNodeStatistics.h>
+#include <maths/CBoostedTreeLeafNodeStatisticsScratch.h>
 #include <maths/CBoostedTreeUtils.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CLinearAlgebraEigen.h>
@@ -386,7 +387,7 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
 
         TNodeVec tree(1);
 
-        auto rootSplit = std::make_shared<maths::CBoostedTreeLeafNodeStatistics>(
+        auto rootSplit = std::make_shared<maths::CBoostedTreeLeafNodeStatisticsScratch>(
             0 /*root*/, extraColumns, 1, numberThreads, *frame, encoder,
             regularization, featureSplits, treeFeatureBag, nodeFeatureBag,
             0 /*depth*/, trainingRowMask, workspace);

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
         TImmutableRadixSetVec featureSplits;
         featureSplits.push_back(TImmutableRadixSet(splitValues));
 
-        maths::CBoostedTreeLeafNodeStatistics::CWorkspace workspace;
+        maths::CBoostedTreeLeafNodeStatistics::CWorkspace workspace{1};
         workspace.reinitialize(numberThreads, featureSplits, 1);
 
         core::CPackedBitVector trainingRowMask(rows, true);

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1582,7 +1582,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {
 
         std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
                                          1, std::make_unique<maths::boosted_tree::CMse>())
-                                         .estimateMemoryUsage(rows, cols));
+                                         .estimateMemoryUsageTrain(rows, cols));
 
         CTestInstrumentation instrumentation;
         auto regression = maths::CBoostedTreeFactory::constructFromParameters(
@@ -1643,14 +1643,14 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrainWithTestRows) {
         }
         frame->finishWritingRows();
 
-        double percentTrainingRows = 1.0 - static_cast<double>(numTestRows) /
-                                               static_cast<double>(rows);
+        double percentTrainingRows{1.0 - static_cast<double>(numTestRows) /
+                                             static_cast<double>(rows)};
+        std::size_t trainRows{static_cast<std::size_t>(static_cast<double>(rows) *
+                                                       percentTrainingRows)};
 
-        std::int64_t estimatedMemory(
-            maths::CBoostedTreeFactory::constructFromParameters(
-                1, std::make_unique<maths::boosted_tree::CMse>())
-                .estimateMemoryUsage(static_cast<std::size_t>(static_cast<double>(rows) * percentTrainingRows),
-                                     cols));
+        std::int64_t estimatedMemory(maths::CBoostedTreeFactory::constructFromParameters(
+                                         1, std::make_unique<maths::boosted_tree::CMse>())
+                                         .estimateMemoryUsageTrain(trainRows, cols));
 
         CTestInstrumentation instrumentation;
         auto regression = maths::CBoostedTreeFactory::constructFromParameters(


### PR DESCRIPTION
This makes some mainly interface changes in anticipation of incremental training. The plan is to adjust the loss function to include penalties for modifying the tree topology and results. It should be possible to manage this in `CBoostedTreeLeafNodeStatistics` and reuse our existing training code. As such I've made this a hierarchy. The current implementation moves into `CBoostedTreeLeafNodeStatisticsScratch` and I'll have a new implementation `CBoostedTreeLeafNodeStatisticsIncremental` (placeholder). There will likely need to be further tweaks down the line particularly to the workspace object, but I'll make those in the context of working on the implementation `CBoostedTreeLeafNodeStatisticsIncremental`. This feels like a useful place to break up the change before I move into implementation details.

A step towards #1721.