### PR TITLE
[ML] Fixes to get CI working on CentOS on AArch64

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -103,6 +103,7 @@ fi
 
 echo "Setting JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA"
 export JAVA_HOME="$HOME/.java/$ES_BUILD_JAVA"
+export RUNTIME_JAVA_HOME="$JAVA_HOME"
 
 # For the ES build we need to:
 # 1. Convince it that this is not part of a PR build, becuase it will get

--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -72,10 +72,12 @@ if [ -z "$ES_BUILD_JAVA" ]; then
 fi
 
 # On aarch64 adoptopenjdk is used in place of openjdk,
-# and the CDS archive can cause problems with Gradle
+# and the CDS archive can cause problems with Java
+# (both for Gradle and the tests themselves)
 if [ `uname -m` = aarch64 ] ; then
     export ES_BUILD_JAVA=adopt$ES_BUILD_JAVA
     export GRADLE_OPTS=-Xshare:off
+    export EXTRA_TEST_OPTS=-Xshare:off
 fi
 
 echo "Setting JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA"
@@ -94,5 +96,5 @@ export GIT_COMMIT="$(git rev-parse HEAD)"
 export GIT_PREVIOUS_COMMIT="$GIT_COMMIT"
 
 IVY_REPO_URL="file://$2"
-./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest
-./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:yamlRestTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}"
+./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest $EXTRA_TEST_OPTS
+./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:yamlRestTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}" $EXTRA_TEST_OPTS

--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -77,7 +77,7 @@ fi
 if [ `uname -m` = aarch64 ] ; then
     export ES_BUILD_JAVA=adopt$ES_BUILD_JAVA
     export GRADLE_OPTS=-Xshare:off
-    export EXTRA_TEST_OPTS=-Xshare:off
+    export EXTRA_TEST_OPTS="-Dtests.jvm.argline=-Xshare:off"
 fi
 
 echo "Setting JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA"

--- a/set_env.sh
+++ b/set_env.sh
@@ -9,9 +9,11 @@
 
 umask 0002
 
-# Modify some limits (soft limits only, hence -S)
-ulimit -S -c unlimited
-ulimit -S -n 1024
+# Modify some limits if not running in Docker (soft limits only, hence -S)
+if [ ! -f /.dockerenv ]; then
+    ulimit -S -c unlimited
+    ulimit -S -n 1024
+fi
 
 # Set $CPP_SRC_HOME to be an absolute path to this script's location, as
 # different builds will come from different repositories and go to different


### PR DESCRIPTION
This has been observed to fail in Docker running
on CentOS 8.3.  It's also not necessary - those
ulimit commands were really intended for tests
running on static workers where we could log in
afterwards to look at core dumps.

Additionally, there are complexities with the Java
build used to run the subset of Elasticsearch tests.
We need to use a Java that was built on a
distribution with the same page size as the test
machine.