### PR TITLE
[7.x][ML] Ensure program counters cache always cleared (#1774)

### DIFF
--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -165,18 +165,22 @@ public:
     bool restoreState(core::CDataSearcher& restoreSearcher,
                       core_t::TTime& completeToTime) override;
 
-    //! Persist current state
+    //! Persist state in the foreground. As this blocks the current thread of execution
+    //! it should only be called in special circumstances, e.g. at job close, where it won't impact job analysis.
     bool persistStateInForeground(core::CDataAdder& persister,
                                   const std::string& descriptionPrefix) override;
 
-    //! Persist the current model state regardless of whether
+    //! Persist the current model state in the foreground regardless of whether
     //! any results have been output.
     bool doPersistStateInForeground(core::CDataAdder& persister,
                                     const std::string& description,
                                     const std::string& snapshotId,
                                     core_t::TTime snapshotTimestamp);
 
-    //! Persist state of the residual models only
+    //! Persist state of the residual models only.
+    //! This method is not intended to be called in production code
+    //! as it only persists a very small subset of model state with longer,
+    //! human readable tags.
     bool persistModelsState(core::CDataAdder& persister,
                             core_t::TTime timestamp,
                             const std::string& outputFormat);
@@ -275,7 +279,10 @@ private:
     bool periodicPersistStateInBackground() override;
     bool periodicPersistStateInForeground() override;
 
-    //! Persist state of the residual models only
+    //! Persist state of the residual models only.
+    //! This method is not intended to be called in production code.
+    //! \p outputFormat specifies the format of the output document and may
+    //! either be JSON or XML.
     bool persistModelsState(const TKeyCRefAnomalyDetectorPtrPrVec& detectors,
                             core::CDataAdder& persister,
                             core_t::TTime timestamp,

--- a/include/core/CProgramCounters.h
+++ b/include/core/CProgramCounters.h
@@ -179,6 +179,14 @@ struct SCounterDefinition {
 //! A singleton class: there should only be one collection of global counters
 //!
 class CORE_EXPORT CProgramCounters {
+public:
+    //! \brief
+    //! The cache of program counters is cleared upon destruction of an instance of this class.
+    class CORE_EXPORT CCacheManager {
+    public:
+        ~CCacheManager();
+    };
+
 private:
     //! \brief
     //! An atomic counter object
@@ -257,6 +265,9 @@ public:
 
     //! Copy the collection of live counters to a cache
     static void cacheCounters();
+
+    //! Clear the collection of cached counters
+    static void clearCachedCounters();
 
     //! \name Persistence
     //@{

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -425,7 +425,7 @@ bool CFieldDataCategorizer::persistStateInForeground(core::CDataAdder& persister
         return false;
     }
 
-    LOG_DEBUG(<< "Persist categorizer state");
+    LOG_DEBUG(<< "Persist categorizer state in foreground");
 
     TStrVec partitionFieldValues;
     TPersistFuncVec dataCategorizerPersistFuncs;
@@ -469,6 +469,13 @@ bool CFieldDataCategorizer::doPersistState(const TStrVec& partitionFieldValues,
                                            const TPersistFuncVec& dataCategorizerPersistFuncs,
                                            std::size_t categorizerAllocationFailures,
                                            core::CDataAdder& persister) {
+
+    // TODO: if the standalone categorize program is ever progressed, a mechanism needs
+    // to be added that does the following:
+    // 1. Caches program counters in the foreground before starting background persistence
+    // 2. Calls core::CProgramCounters::staticsAcceptPersistInserter once and only once per persist
+    // 3. Clears the program counter cache after persistence is complete
+
     // The two input vectors should have the same size _unless_ we are not
     // doing per-partition categorization, in which case partition field values
     // should be empty and there should be exactly one categorizer
@@ -537,7 +544,7 @@ bool CFieldDataCategorizer::doPersistState(const TStrVec& partitionFieldValues,
 }
 
 bool CFieldDataCategorizer::periodicPersistStateInBackground() {
-    LOG_DEBUG(<< "Periodic persist categorizer state");
+    LOG_DEBUG(<< "Periodic persist categorizer state in background");
 
     // Make sure that the model size stats are up to date
     for (auto& dataCategorizerEntry : m_DataCategorizers) {
@@ -598,7 +605,7 @@ bool CFieldDataCategorizer::periodicPersistStateInBackground() {
 }
 
 bool CFieldDataCategorizer::periodicPersistStateInForeground() {
-    LOG_DEBUG(<< "Periodic persist categorizer state");
+    LOG_DEBUG(<< "Periodic persist categorizer state in foreground");
 
     if (m_PersistenceManager == nullptr) {
         return false;

--- a/lib/api/unittest/CPersistenceManagerTest.cc
+++ b/lib/api/unittest/CPersistenceManagerTest.cc
@@ -81,7 +81,7 @@ protected:
             foregroundStream = new std::ostringstream()};
         ml::api::CSingleStreamDataAdder foregroundDataAdder{foregroundStreamPtr};
 
-        // The 30000 second persist interval is set large enough that the timer will
+        // The 30000 second persist interval is set large enough that the timer
         // will not trigger during the test - we bypass the timer in this test
         // and kick off the background persistence chain explicitly
         ml::api::CPersistenceManager persistenceManager{

--- a/lib/core/CProgramCounters.cc
+++ b/lib/core/CProgramCounters.cc
@@ -53,6 +53,10 @@ void addStringInt(TGenericLineWriter& writer,
 }
 }
 
+CProgramCounters::CCacheManager::~CCacheManager() {
+    CProgramCounters::clearCachedCounters();
+}
+
 CProgramCounters& CProgramCounters::instance() {
     return ms_Instance;
 }
@@ -88,6 +92,15 @@ void CProgramCounters::cacheCounters() {
     }
     ms_Instance.m_Cache.assign(ms_Instance.m_Counters.begin(),
                                ms_Instance.m_Counters.end());
+    LOG_TRACE(<< "Cached " << ms_Instance.m_Cache.size() << " counters.");
+}
+
+void CProgramCounters::clearCachedCounters() {
+    if (ms_Instance.m_Cache.empty() == false) {
+        LOG_TRACE(<< "Clearing cache of " << ms_Instance.m_Cache.size() << " counters.");
+        // clear the cache
+        TUInt64Vec().swap(ms_Instance.m_Cache);
+    }
 }
 
 void CProgramCounters::staticsAcceptPersistInserter(CStatePersistInserter& inserter) {
@@ -125,10 +138,11 @@ void CProgramCounters::staticsAcceptPersistInserter(CStatePersistInserter& inser
 
         staticsAcceptPersistInserter(ms_Instance.m_Counters);
     } else {
+        LOG_TRACE(<< "Persisting " << ms_Instance.m_Cache.size() << " cached counters.");
         staticsAcceptPersistInserter(ms_Instance.m_Cache);
 
         // clear the cache
-        TUInt64Vec().swap(ms_Instance.m_Cache);
+        clearCachedCounters();
     }
 }
 


### PR DESCRIPTION
The collection of static program counters is cached prior to
persistence. This provides the background persistence thread access to a
consistent set of counters as they are being written.

As it is desired to only persist the program counters the once for each
model state snapshot, their persistence, and the clearing of the cache,
is coupled to the persistence of the simple count detector, which is
assumed to always exist.

However there is a scenario where persistence operates on an empty
collection of detectors. This occurs when no data has been seen but time
has advanced (see #393 for more details). In this situation the program
counter cache is populated but not cleared. A subsequent persistence
operation will lead to a warning that the counter cache is being
overwritten.

To avoid the warning message, we take the approach of ensuring
that the program counter cache is always cleared at the end of the
persistence operation, regardless of its success or not.

Backports #1774 