### PR TITLE
[7.11][ML] Fixes to get CI working on CentOS on AArch64

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -71,15 +71,39 @@ if [ -z "$ES_BUILD_JAVA" ]; then
     exit 1
 fi
 
-# On aarch64 adoptopenjdk is used in place of openjdk,
-# and the CDS archive can cause problems with Gradle
+# On aarch64:
+# - openjdk is built with a 64KB page size
+# - adoptopenjdk is built with a 4KB page size
+# It's necessary to use use the one that matches the page size of the
+# distribution that it's running on, which is:
+# - 4KB for Ubuntu, Debian and SLES
+# - 64KB for RHEL and CentOS
+# We still disable the CDS archive as an extra measure to avoid warnings related
+# to mismatched page sizes that can cause problems with Java (both for Gradle
+# and the tests themselves).  This should cease to be necessary in Java 17 and
+# above.
 if [ `uname -m` = aarch64 ] ; then
-    export ES_BUILD_JAVA=adopt$ES_BUILD_JAVA
+    case `getconf PAGE_SIZE` in
+        4096)
+            export ES_BUILD_JAVA=adopt$ES_BUILD_JAVA
+            ;;
+
+        65536)
+            export ES_BUILD_JAVA=$(echo $ES_BUILD_JAVA | sed 's/^adopt//')
+            ;;
+
+        *)
+            echo "Unexpected page size:" `getconf PAGE_SIZE 2>&1`
+            exit 2
+            ;;
+    esac
     export GRADLE_OPTS=-Xshare:off
+    export EXTRA_TEST_OPTS="-Dtests.jvm.argline=-Xshare:off"
 fi
 
 echo "Setting JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA"
 export JAVA_HOME="$HOME/.java/$ES_BUILD_JAVA"
+export RUNTIME_JAVA_HOME="$JAVA_HOME"
 
 # For the ES build we need to:
 # 1. Convince it that this is not part of a PR build, becuase it will get
@@ -94,5 +118,5 @@ export GIT_COMMIT="$(git rev-parse HEAD)"
 export GIT_PREVIOUS_COMMIT="$GIT_COMMIT"
 
 IVY_REPO_URL="file://$2"
-./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest
-./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:yamlRestTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}"
+./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest $EXTRA_TEST_OPTS
+./gradlew -Dbuild.ml_cpp.repo="$IVY_REPO_URL" :x-pack:plugin:yamlRestTest --tests "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=ml/*}" $EXTRA_TEST_OPTS

--- a/set_env.sh
+++ b/set_env.sh
@@ -9,9 +9,11 @@
 
 umask 0002
 
-# Modify some limits (soft limits only, hence -S)
-ulimit -S -c unlimited
-ulimit -S -n 1024
+# Modify some limits if not running in Docker (soft limits only, hence -S)
+if [ ! -f /.dockerenv ]; then
+    ulimit -S -c unlimited
+    ulimit -S -n 1024
+fi
 
 # Set $CPP_SRC_HOME to be an absolute path to this script's location, as
 # different builds will come from different repositories and go to different


### PR DESCRIPTION
Setting shell limits has been observed to fail in
Docker running on CentOS 8.3. It's also not
necessary - those ulimit commands were really
intended for tests running on static workers
where we could log in afterwards to look at core
dumps.

Additionally, there are complexities with the Java
build used to run the subset of Elasticsearch tests.
We need to use a Java that was built on a
distribution with the same page size as the test
machine.

Backport of #1777