### PR TITLE
[ML] Upgrading to PyTorch 1.8.0 on macOS

### DIFF
--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -183,14 +183,15 @@ external processes.
 Build as follows:
 
 ```
+# TODO: add BLAS=vecLib when we upgrade to 1.9
 export BUILD_TEST=OFF
 export BUILD_CAFFE2=OFF
 export USE_NUMPY=OFF
 export USE_DISTRIBUTED=OFF
 export USE_MKLDNN=OFF
-# TODO: add BLAS=vecLib when we upgrade to 1.9
-[ $(uname -m) != x86_64 ] && export USE_QNNPACK=OFF
-[ $(uname -m) != x86_64 ] && export USE_PYTORCH_QNNPACK=OFF
+export USE_QNNPACK=OFF
+export USE_PYTORCH_QNNPACK=OFF
+[ $(uname -m) = x86_64 ] && export USE_XNNPACK=OFF
 # TODO: recheck if this is still necessary next time we upgrade
 [ $(uname -m) != x86_64 ] && export CMAKE_OSX_ARCHITECTURES=`uname -m`
 export PYTORCH_BUILD_VERSION=1.8.0

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -155,7 +155,7 @@ Download the graphical installer for Python 3.7.9 from <https://www.python.org/f
 
 Install using all the default options.  When the installer completes a Finder window pops up.  Double click the `Install Certificates.command` file in this folder to install the SSL certificates Python needs.
 
-### PyTorch 1.7.1
+### PyTorch 1.8.0
 
 PyTorch requires that certain Python modules are installed.  To install them:
 
@@ -166,21 +166,32 @@ sudo /Library/Frameworks/Python.framework/Versions/3.7/bin/pip3.7 install instal
 Then obtain the PyTorch code:
 
 ```
-git clone --depth=1 --branch=v1.7.1 https://github.com/pytorch/pytorch.git
+git clone --depth=1 --branch=v1.8.0 https://github.com/pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
 ```
 
+Edit `torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp` and replace all
+occurrences of `system(` with `strlen(`. This file is used to compile
+fused CPU kernels, which we do not expect to be doing and never want to
+do for security reasons. Replacing the calls to `system()` ensures that
+a heuristic virus scanner looking for potentially dangerous function
+calls in our shipped product will not encounter these functions that run
+external processes.
+
 Build as follows:
 
 ```
+export CMAKE_OSX_ARCHITECTURES=`uname -m`
 export BUILD_TEST=OFF
 export BUILD_CAFFE2=OFF
 export USE_NUMPY=OFF
 export USE_DISTRIBUTED=OFF
 export USE_MKLDNN=OFF
-export PYTORCH_BUILD_VERSION=1.7.1
+[ $(uname -m) != x86_64 ] && export USE_QNNPACK=OFF
+[ $(uname -m) != x86_64 ] && export USE_PYTORCH_QNNPACK=OFF
+export PYTORCH_BUILD_VERSION=1.8.0
 export PYTORCH_BUILD_NUMBER=1
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 setup.py install
 ```

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -183,14 +183,16 @@ external processes.
 Build as follows:
 
 ```
-export CMAKE_OSX_ARCHITECTURES=`uname -m`
 export BUILD_TEST=OFF
 export BUILD_CAFFE2=OFF
 export USE_NUMPY=OFF
 export USE_DISTRIBUTED=OFF
 export USE_MKLDNN=OFF
+# TODO: add BLAS=vecLib when we upgrade to 1.9
 [ $(uname -m) != x86_64 ] && export USE_QNNPACK=OFF
 [ $(uname -m) != x86_64 ] && export USE_PYTORCH_QNNPACK=OFF
+# TODO: recheck if this is still necessary next time we upgrade
+[ $(uname -m) != x86_64 ] && export CMAKE_OSX_ARCHITECTURES=`uname -m`
 export PYTORCH_BUILD_VERSION=1.8.0
 export PYTORCH_BUILD_NUMBER=1
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 setup.py install
@@ -199,7 +201,7 @@ export PYTORCH_BUILD_NUMBER=1
 Once built copy headers and libraries to system directories:
 
 ```
-sudo mkdir /usr/local/include/pytorch
+sudo mkdir -p /usr/local/include/pytorch
 sudo cp -r torch/include/* /usr/local/include/pytorch/
 sudo cp torch/lib/libtorch_cpu.dylib /usr/local/lib/
 sudo cp torch/lib/libc10.dylib /usr/local/lib/

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -17,7 +17,7 @@
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-macosx-build
-VERSION=10
+VERSION=11
 
 set -e
 

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-macosx-build:10
+FROM docker.elastic.co/ml-dev/ml-macosx-build:11
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/macosx_image/Dockerfile
+++ b/dev-tools/docker/macosx_image/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
   cd /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.14-2.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.14-3.tar.bz2 | tar jxf - && \
   wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/xcode-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf - && \
   wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/sdk-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf -
 

--- a/dev-tools/download_macos_deps.sh
+++ b/dev-tools/download_macos_deps.sh
@@ -20,7 +20,7 @@ DEST=/usr
 case `uname -m` in
 
     arm64)
-        ARCHIVE=local-arm64-apple-macosx11.1-2.tar.bz2
+        ARCHIVE=local-arm64-apple-macosx11.1-3.tar.bz2
         ;;
 
     *)


### PR DESCRIPTION
Upgrades PyTorch from version 1.7.1 to version 1.8.0 on macOS.

It is now possible to build a version that works on Apple Silicon.

The build instructions are also adjusted to remove functions that
call an external compiler to build custom extensions. Although
these would never have worked in our programs due to system call
filtering, it's best if they aren't present at all as they could
alarm heuristic virus scanners.

(Similar upgrades will be done for Windows and Linux in the near
future.)