### PR TITLE
[ML] Upgrading to PyTorch 1.8.0 on Windows

### DIFF
--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2016-2.zip"
+$Archive="usr-x86_64-windows-2016-3.zip"
 $Destination="C:\"
 if (!(Test-Path "$Destination\usr\local\bin\torch_cpu.dll")) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore


### PR DESCRIPTION
Upgrades PyTorch from version 1.7.1 to version 1.8.0 on Windows.

The build instructions are also adjusted to remove functions that
call an external compiler to build custom extensions. Although
these would never have worked in our programs due to system call
filtering, it's best if they aren't present at all as they could
alarm heuristic virus scanners.

(A similar upgrade will be done for Linux in the near future.)