### PR TITLE
[7.x][ML] Improve bounds checks in state restore code

### DIFF
--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -977,7 +977,12 @@ private:
                         LOG_ERROR(<< "Restoration error at " << traverser.name());
                         return false;
                     }
-                    *(i++) = std::move(value);
+                    if (i == container.end()) {
+                        LOG_ERROR(<< "Too many values for size " << N
+                                  << " array during restoration");
+                    } else {
+                        *(i++) = std::move(value);
+                    }
                 }
             } while (traverser.next());
             return true;

--- a/include/maths/CBasicStatisticsPersist.h
+++ b/include/maths/CBasicStatisticsPersist.h
@@ -124,7 +124,7 @@ bool CBasicStatistics::SSampleCentralMoments<T, ORDER>::fromDelimited(const std:
 
     std::size_t lastDelimPos{delimPos};
     std::size_t index{0};
-    while (lastDelimPos != std::string::npos) {
+    while (lastDelimPos != std::string::npos && index < ORDER) {
         delimPos = str.find(INTERNAL_DELIMITER, lastDelimPos + 1);
         if (delimPos == std::string::npos) {
             token.assign(str, lastDelimPos + 1, str.length() - lastDelimPos);
@@ -265,7 +265,12 @@ bool CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::fromDelimited(
     }
     m_Statistics[--m_UnusedCount] = statistic;
 
-    while (delimPos != value.size()) {
+    while (delimPos < value.size()) {
+        if (m_UnusedCount == 0) {
+            LOG_ERROR(<< "Too many statistics in '" << value
+                      << "' - expected at most " << m_Statistics.size());
+            return false;
+        }
         std::size_t nextDelimPos{
             std::min(value.find(INTERNAL_DELIMITER, delimPos + 1), value.size())};
         token.assign(value, delimPos + 1, nextDelimPos - delimPos - 1);

--- a/lib/core/CProgramCounters.cc
+++ b/lib/core/CProgramCounters.cc
@@ -72,7 +72,7 @@ CProgramCounters::TCounter& CProgramCounters::counter(std::size_t index) {
         // can only happen when restoring state that contains one or more counters that are unknown to this version of the application.
         // As this doesn't indicate a problem with the analytics in the running application we simply log a warning.
         // A dummy counter is returned in which to store the unknown counter.
-        LOG_WARN(<< "Bad index " << index);
+        LOG_WARN(<< "Bad counter index " << index);
         return ms_Instance.m_DummyCounter;
     }
     return ms_Instance.m_Counters[index];
@@ -147,13 +147,12 @@ void CProgramCounters::staticsAcceptPersistInserter(CStatePersistInserter& inser
 }
 
 bool CProgramCounters::staticsAcceptRestoreTraverser(CStateRestoreTraverser& traverser) {
-    std::uint64_t value = 0;
-    int key = 0;
+    std::uint64_t value{0};
+    int key{-1};
     do {
         const std::string& name = traverser.name();
         if (name == KEY_TAG) {
-            value = 0;
-            if (CStringUtils::stringToType(traverser.value(), key) == false) {
+            if (CStringUtils::stringToType(traverser.value(), key) == false || key < 0) {
                 LOG_ERROR(<< "Invalid key value in " << traverser.value());
                 return false;
             }
@@ -171,9 +170,13 @@ bool CProgramCounters::staticsAcceptRestoreTraverser(CStateRestoreTraverser& tra
                     value = 0;
                 }
             }
-            counter(key) = value;
-            key = 0;
-            value = 0;
+            if (key < 0) {
+                LOG_ERROR(<< "Found counter value without corresponding key "
+                          << traverser.value());
+            } else {
+                counter(key) = value;
+                key = -1;
+            }
         }
     } while (traverser.next());
 

--- a/lib/core/unittest/CProgramCountersTest.cc
+++ b/lib/core/unittest/CProgramCountersTest.cc
@@ -285,7 +285,7 @@ BOOST_FIXTURE_TEST_CASE(testUnknownCounter, ml::test::CProgramCounterClearingFix
     std::ifstream log(logFile);
     BOOST_TEST_REQUIRE(log.is_open());
     ml::core::CRegex regex;
-    BOOST_TEST_REQUIRE(regex.init(".*Bad index.*"));
+    BOOST_TEST_REQUIRE(regex.init(".*Bad counter index.*"));
     std::string line;
     while (std::getline(log, line)) {
         LOG_INFO(<< "Got '" << line << "'");

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -291,14 +291,15 @@ std::string CDataFrameUtils::SDataType::toDelimited() const {
 
 bool CDataFrameUtils::SDataType::fromDelimited(const std::string& delimited) {
     TDoubleVec state(3);
-    int pos{0}, i{0};
-    for (auto delimiter = delimited.find(INTERNAL_DELIMITER); delimiter != std::string::npos;
+    std::size_t pos{0}, i{0};
+    for (auto delimiter = delimited.find(INTERNAL_DELIMITER);
+         delimiter != std::string::npos && i < state.size();
          delimiter = delimited.find(INTERNAL_DELIMITER, pos)) {
         if (core::CStringUtils::stringToType(delimited.substr(pos, delimiter - pos),
                                              state[i++]) == false) {
             return false;
         }
-        pos = static_cast<int>(delimiter + 1);
+        pos = delimiter + 1;
     }
     std::tie(s_IsInteger, s_Min, s_Max) =
         std::make_tuple(state[0] == 1.0, state[1], state[2]);


### PR DESCRIPTION
Fixes a few more places where array or vector bounds were not
checked during state restoration.

Backport of #1798