### PR TITLE
[6.8][ML] Improve bounds checks in state restore code

### DIFF
--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -970,7 +970,12 @@ private:
                         LOG_ERROR(<< "Restoration error at " << traverser.name());
                         return false;
                     }
-                    *(i++) = value;
+                    if (i == container.end()) {
+                        LOG_ERROR(<< "Too many values for size " << N
+                                  << " array during restoration");
+                    } else {
+                        *(i++) = value;
+                    }
                 }
             } while (traverser.next());
             return true;

--- a/include/maths/CBasicStatisticsPersist.h
+++ b/include/maths/CBasicStatisticsPersist.h
@@ -124,7 +124,7 @@ bool CBasicStatistics::SSampleCentralMoments<T, ORDER>::fromDelimited(const std:
 
     std::size_t lastDelimPos{delimPos};
     std::size_t index{0};
-    while (lastDelimPos != std::string::npos) {
+    while (lastDelimPos != std::string::npos && index < ORDER) {
         delimPos = str.find(INTERNAL_DELIMITER, lastDelimPos + 1);
         if (delimPos == std::string::npos) {
             token.assign(str, lastDelimPos + 1, str.length() - lastDelimPos);
@@ -255,7 +255,12 @@ bool CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::fromDelimited(
     }
     m_Statistics[--m_UnusedCount] = statistic;
 
-    while (delimPos != value.size()) {
+    while (delimPos < value.size()) {
+        if (m_UnusedCount == 0) {
+            LOG_ERROR(<< "Too many statistics in '" << value
+                      << "' - expected at most " << m_Statistics.size());
+            return false;
+        }
         std::size_t nextDelimPos{
             std::min(value.find(INTERNAL_DELIMITER, delimPos + 1), value.size())};
         token.assign(value, delimPos + 1, nextDelimPos - delimPos - 1);


### PR DESCRIPTION
Fixes a few more places where array or vector bounds were not
checked during state restoration.

Backport of #1798