### PR TITLE
[ML] Make too many array values on restore fatal

### DIFF
--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -980,9 +980,9 @@ private:
                     if (i == container.end()) {
                         LOG_ERROR(<< "Too many values for size " << N
                                   << " array during restoration");
-                    } else {
-                        *(i++) = std::move(value);
+                        return false;
                     }
+                    *(i++) = std::move(value);
                 }
             } while (traverser.next());
             return true;


### PR DESCRIPTION
This implements what was discussed in
https://github.com/elastic/ml-cpp/pull/1798#discussion_r592515203

By making this change only on the master branch we will have a
long time to see if there are any unexpected side effects, where
we were accidentally relying on the bug.