### PR TITLE
[ML] Implement the boosted tree leaf node statistics for incremental training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ nbactions.xml
 #vscode files
 .vscode
 .clangd
+.cache
 
 # gradle stuff
 .gradle/

--- a/include/core/CImmutableRadixSet.h
+++ b/include/core/CImmutableRadixSet.h
@@ -62,8 +62,8 @@ public:
 
     //! \name Iterators
     //@{
-    TCItr begin() const { m_Values.begin(); }
-    TCItr end() const { m_Values.end(); }
+    TCItr begin() const { return m_Values.begin(); }
+    TCItr end() const { return m_Values.end(); }
     //@}
 
     //! \name Lookup

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -134,6 +134,9 @@ public:
     //! Get the feature index of the split.
     std::size_t splitFeature() const { return m_SplitFeature; }
 
+    //! Get the feature value at which to split .
+    double splitValue() const { return m_SplitValue; }
+
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -667,6 +667,9 @@ public:
     //! Get the row mask for this leaf node.
     core::CPackedBitVector& rowMask();
 
+    //! Get the size of this object.
+    virtual std::size_t staticSize() const = 0;
+
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 

--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -503,6 +503,7 @@ public:
         using TPackedBitVectorVecVec = std::vector<TPackedBitVectorVec>;
         using TSplitsDerivativesVec = std::vector<CSplitsDerivatives>;
         using TSplitsDerivativesVecVec = std::vector<TSplitsDerivativesVec>;
+        using TNodeVec = std::vector<CBoostedTreeNode>;
 
     public:
         explicit CWorkspace(std::size_t numberMasks)
@@ -510,6 +511,9 @@ public:
         CWorkspace(CWorkspace&&) = default;
         CWorkspace& operator=(const CWorkspace& other) = delete;
         CWorkspace& operator=(CWorkspace&&) = default;
+
+        //! Define the tree to retrain.
+        void retraining(const TNodeVec& tree) { m_TreeToRetrain = &tree; }
 
         //! Re-initialize the masks and derivatives.
         void reinitialize(std::size_t numberThreads,
@@ -532,6 +536,9 @@ public:
                 }
             }
         }
+
+        //! Get the tree being retrained if there is one.
+        const TNodeVec* retraining() const { return m_TreeToRetrain; }
 
         //! Get the minimum leaf gain which will generate a split.
         double minimumGain() const { return m_MinimumGain; }
@@ -591,6 +598,7 @@ public:
         }
 
     private:
+        const TNodeVec* m_TreeToRetrain{nullptr};
         std::size_t m_NumberMasks{0};
         std::size_t m_NumberThreads{0};
         double m_MinimumGain{0.0};
@@ -621,9 +629,6 @@ public:
                             const TSizeVec& nodeFeatureBag,
                             const CBoostedTreeNode& split,
                             CWorkspace& workspace) = 0;
-
-    //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
 
     //! Order two leaves by decreasing gain in splitting them.
     bool operator<(const CBoostedTreeLeafNodeStatistics& rhs) const;
@@ -661,6 +666,16 @@ public:
 
     //! Get the row mask for this leaf node.
     core::CPackedBitVector& rowMask();
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const;
+
+    //! Estimate the maximum leaf statistics' memory usage training on a data frame
+    //! with \p numberCols columns using \p numberSplitsPerFeature for a loss function
+    //! with \p numberLossParameters parameters.
+    static std::size_t estimateMemoryUsage(std::size_t numberCols,
+                                           std::size_t numberSplitsPerFeature,
+                                           std::size_t numberLossParameters);
 
     //! Get the best split info as a string.
     std::string print() const;
@@ -710,18 +725,91 @@ protected:
         double s_RightChildMaxGain{boosted_tree_detail::INF};
     };
 
+    class CLookAheadBound {};
+    class CNoLookAheadBound {};
+
+protected:
+    static constexpr std::size_t MASK_INDEX{0};
+
 protected:
     CBoostedTreeLeafNodeStatistics(std::size_t id,
                                    std::size_t depth,
                                    TSizeVecCRef extraColumns,
                                    std::size_t numberLossParameters,
-                                   const TImmutableRadixSetVec& candidateSplits);
+                                   const TImmutableRadixSetVec& candidateSplits,
+                                   CSplitsDerivatives derivatives = CSplitsDerivatives{});
 
+    static std::size_t
+    maximumNumberThreadsToAggregateDerivatives(const CBoostedTreeLeafNodeStatistics& parent,
+                                               const TSizeVec& treeFeatureBag);
+    void computeAggregateLossDerivatives(CLookAheadBound,
+                                         std::size_t numberThreads,
+                                         const core::CDataFrame& frame,
+                                         const CDataFrameCategoryEncoder& encoder,
+                                         const TSizeVec& featureBag,
+                                         const core::CPackedBitVector& rowMask,
+                                         CWorkspace& workspace) const;
+    void computeAggregateLossDerivatives(CNoLookAheadBound,
+                                         std::size_t numberThreads,
+                                         const core::CDataFrame& frame,
+                                         const CDataFrameCategoryEncoder& encoder,
+                                         const TSizeVec& featureBag,
+                                         const core::CPackedBitVector& rowMask,
+                                         CWorkspace& workspace) const;
+    void computeRowMaskAndAggregateLossDerivatives(CLookAheadBound,
+                                                   std::size_t numberThreads,
+                                                   const core::CDataFrame& frame,
+                                                   const CDataFrameCategoryEncoder& encoder,
+                                                   bool isLeftChild,
+                                                   const CBoostedTreeNode& split,
+                                                   const TSizeVec& featureBag,
+                                                   const core::CPackedBitVector& parentRowMask,
+                                                   CWorkspace& workspace) const;
+    void computeRowMaskAndAggregateLossDerivatives(CNoLookAheadBound,
+                                                   std::size_t numberThreads,
+                                                   const core::CDataFrame& frame,
+                                                   const CDataFrameCategoryEncoder& encoder,
+                                                   bool isLeftChild,
+                                                   const CBoostedTreeNode& split,
+                                                   const TSizeVec& featureBag,
+                                                   const core::CPackedBitVector& parentRowMask,
+                                                   CWorkspace& workspace) const;
     SSplitStatistics& bestSplitStatistics();
+    CSplitsDerivatives& derivatives();
+    const CSplitsDerivatives& derivatives() const;
     std::size_t depth() const;
     TSizeVecCRef extraColumns() const;
     std::size_t numberLossParameters() const;
     const TImmutableRadixSetVec& candidateSplits() const;
+
+private:
+    template<typename BOUND>
+    void computeAggregateLossDerivativesWith(BOUND bound,
+                                             std::size_t numberThreads,
+                                             const core::CDataFrame& frame,
+                                             const CDataFrameCategoryEncoder& encoder,
+                                             const TSizeVec& featureBag,
+                                             const core::CPackedBitVector& rowMask,
+                                             CWorkspace& workspace) const;
+    template<typename BOUND>
+    void
+    computeRowMaskAndAggregateLossDerivativesWith(BOUND bound,
+                                                  std::size_t numberThreads,
+                                                  const core::CDataFrame& frame,
+                                                  const CDataFrameCategoryEncoder& encoder,
+                                                  bool isLeftChild,
+                                                  const CBoostedTreeNode& split,
+                                                  const TSizeVec& featureBag,
+                                                  const core::CPackedBitVector& parentRowMask,
+                                                  CWorkspace& workspace) const;
+    void addRowDerivatives(CLookAheadBound,
+                           const TSizeVec& featureBag,
+                           const CEncodedDataFrameRowRef& row,
+                           CSplitsDerivatives& splitsDerivatives) const;
+    void addRowDerivatives(CNoLookAheadBound,
+                           const TSizeVec& featureBag,
+                           const CEncodedDataFrameRowRef& row,
+                           CSplitsDerivatives& splitsDerivatives) const;
 
 private:
     std::size_t m_Id;
@@ -729,6 +817,7 @@ private:
     TSizeVecCRef m_ExtraColumns;
     std::size_t m_NumberLossParameters;
     const TImmutableRadixSetVec& m_CandidateSplits;
+    CSplitsDerivatives m_Derivatives;
     core::CPackedBitVector m_RowMask;
     SSplitStatistics m_BestSplit;
 };

--- a/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
+++ b/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
@@ -51,6 +51,40 @@ class CEncodedDataFrameRowRef;
 class MATHS_EXPORT CBoostedTreeLeafNodeStatisticsIncremental final
     : public CBoostedTreeLeafNodeStatistics {
 public:
+    CBoostedTreeLeafNodeStatisticsIncremental(std::size_t id,
+                                              const TSizeVec& extraColumns,
+                                              std::size_t numberLossParameters,
+                                              std::size_t numberThreads,
+                                              const core::CDataFrame& frame,
+                                              const CDataFrameCategoryEncoder& encoder,
+                                              const TRegularization& regularization,
+                                              const TImmutableRadixSetVec& candidateSplits,
+                                              const TSizeVec& treeFeatureBag,
+                                              const TSizeVec& nodeFeatureBag,
+                                              std::size_t depth,
+                                              const core::CPackedBitVector& rowMask,
+                                              CWorkspace& workspace);
+
+    //! Only called by split but is public so it's accessible to std::make_shared.
+    CBoostedTreeLeafNodeStatisticsIncremental(std::size_t id,
+                                              const CBoostedTreeLeafNodeStatisticsIncremental& parent,
+                                              std::size_t numberThreads,
+                                              const core::CDataFrame& frame,
+                                              const CDataFrameCategoryEncoder& encoder,
+                                              const TRegularization& regularization,
+                                              const TSizeVec& treeFeatureBag,
+                                              const TSizeVec& nodeFeatureBag,
+                                              bool isLeftChild,
+                                              const CBoostedTreeNode& split,
+                                              CWorkspace& workspace);
+
+    //! Only called by split but is public so it's accessible to std::make_shared.
+    CBoostedTreeLeafNodeStatisticsIncremental(std::size_t id,
+                                              CBoostedTreeLeafNodeStatisticsIncremental&& parent,
+                                              const TRegularization& regularization,
+                                              const TSizeVec& nodeFeatureBag,
+                                              CWorkspace& workspace);
+
     CBoostedTreeLeafNodeStatisticsIncremental(const CBoostedTreeLeafNodeStatisticsIncremental&) = delete;
     CBoostedTreeLeafNodeStatisticsIncremental&
     operator=(const CBoostedTreeLeafNodeStatisticsIncremental&) = delete;
@@ -72,17 +106,9 @@ public:
                     const CBoostedTreeNode& split,
                     CWorkspace& workspace) override;
 
-    //! Get the memory used by this object.
-    std::size_t memoryUsage() const override;
-
-    //! Estimate the maximum leaf statistics' memory usage training on a data frame
-    //! with \p numberCols columns using \p numberSplitsPerFeature for a loss function
-    //! with \p numberLossParameters parameters.
-    static std::size_t estimateMemoryUsage(std::size_t numberCols,
-                                           std::size_t numberSplitsPerFeature,
-                                           std::size_t numberLossParameters);
-
 private:
+    SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,
+                                                const TSizeVec& featureBag) const;
 };
 }
 }

--- a/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
+++ b/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
@@ -106,9 +106,26 @@ public:
                     const CBoostedTreeNode& split,
                     CWorkspace& workspace) override;
 
+    //! Get the size of this object.
+    std::size_t staticSize() const override;
+
+private:
+    //! \brief Describes a split in the tree being incrementally retrained.
+    struct SPreviousSplit {
+        std::size_t s_Feature;
+        double s_SplitAt;
+    };
+    using TOptionalPreviousSplit = boost::optional<SPreviousSplit>;
+
 private:
     SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,
                                                 const TSizeVec& featureBag) const;
+    double penaltyForTreeChange(const TRegularization& regularization,
+                                std::size_t feature,
+                                std::size_t split) const;
+
+private:
+    TOptionalPreviousSplit m_PreviousSplit;
 };
 }
 }

--- a/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
+++ b/include/maths/CBoostedTreeLeafNodeStatisticsIncremental.h
@@ -83,6 +83,7 @@ public:
                                               CBoostedTreeLeafNodeStatisticsIncremental&& parent,
                                               const TRegularization& regularization,
                                               const TSizeVec& nodeFeatureBag,
+                                              bool isLeftChild,
                                               CWorkspace& workspace);
 
     CBoostedTreeLeafNodeStatisticsIncremental(const CBoostedTreeLeafNodeStatisticsIncremental&) = delete;
@@ -110,8 +111,12 @@ public:
     std::size_t staticSize() const override;
 
 private:
-    //! \brief Describes a split in the tree being incrementally retrained.
+    //! \brief Describes a split of the tree being incrementally retrained.
     struct SPreviousSplit {
+        SPreviousSplit(std::size_t nodeIndex, std::size_t feature, double splitAt)
+            : s_NodeIndex{nodeIndex}, s_Feature{feature}, s_SplitAt{splitAt} {}
+
+        std::size_t s_NodeIndex;
         std::size_t s_Feature;
         double s_SplitAt;
     };
@@ -123,6 +128,11 @@ private:
     double penaltyForTreeChange(const TRegularization& regularization,
                                 std::size_t feature,
                                 std::size_t split) const;
+    TOptionalPreviousSplit rootPreviousSplit(const CWorkspace& workspace) const;
+    TOptionalPreviousSplit leftChildPreviousSplit(std::size_t feature,
+                                                  const CWorkspace& workspace) const;
+    TOptionalPreviousSplit rightChildPreviousSplit(std::size_t feature,
+                                                   const CWorkspace& workspace) const;
 
 private:
     TOptionalPreviousSplit m_PreviousSplit;

--- a/include/maths/CBoostedTreeLeafNodeStatisticsScratch.h
+++ b/include/maths/CBoostedTreeLeafNodeStatisticsScratch.h
@@ -106,6 +106,9 @@ public:
                     const CBoostedTreeNode& split,
                     CWorkspace& workspace) override;
 
+    //! Get the size of this object.
+    std::size_t staticSize() const override;
+
 private:
     SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,
                                                 const TSizeVec& featureBag) const;

--- a/include/maths/CBoostedTreeLeafNodeStatisticsScratch.h
+++ b/include/maths/CBoostedTreeLeafNodeStatisticsScratch.h
@@ -106,42 +106,11 @@ public:
                     const CBoostedTreeNode& split,
                     CWorkspace& workspace) override;
 
-    //! Get the memory used by this object.
-    std::size_t memoryUsage() const override;
-
-    //! Estimate the maximum leaf statistics' memory usage training on a data frame
-    //! with \p numberCols columns using \p numberSplitsPerFeature for a loss function
-    //! with \p numberLossParameters parameters.
-    static std::size_t estimateMemoryUsage(std::size_t numberCols,
-                                           std::size_t numberSplitsPerFeature,
-                                           std::size_t numberLossParameters);
-
 private:
-    void computeAggregateLossDerivatives(std::size_t numberThreads,
-                                         const core::CDataFrame& frame,
-                                         const CDataFrameCategoryEncoder& encoder,
-                                         const TSizeVec& featureBag,
-                                         const core::CPackedBitVector& rowMask,
-                                         CWorkspace& workspace) const;
-    void computeRowMaskAndAggregateLossDerivatives(std::size_t numberThreads,
-                                                   const core::CDataFrame& frame,
-                                                   const CDataFrameCategoryEncoder& encoder,
-                                                   bool isLeftChild,
-                                                   const CBoostedTreeNode& split,
-                                                   const TSizeVec& featureBag,
-                                                   const core::CPackedBitVector& parentRowMask,
-                                                   CWorkspace& workspace) const;
-    void addRowDerivatives(const TSizeVec& featureBag,
-                           const CEncodedDataFrameRowRef& row,
-                           CSplitsDerivatives& splitsDerivatives) const;
-
     SSplitStatistics computeBestSplitStatistics(const TRegularization& regularization,
                                                 const TSizeVec& featureBag) const;
 
-    double childMaxGain(double gChild, double minLossChild, double lambda) const;
-
-private:
-    CSplitsDerivatives m_Derivatives;
+    double childMaxGain(double childGain, double minLossChild, double lambda) const;
 };
 }
 }

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -63,6 +63,10 @@ struct SHyperparameterImportance {
     bool s_Supplied;
 };
 
+//! Get the index of the root node in a canonical tree node vector.
+MATHS_EXPORT
+std::size_t rootIndex();
+
 //! Get the root node of \p tree.
 MATHS_EXPORT
 const CBoostedTreeNode& root(const std::vector<CBoostedTreeNode>& tree);

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -435,7 +435,7 @@ void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) {
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
                 [&] { this->initializeHyperparametersSetup(frame); });
 
-    if (m_TreeImpl->m_RegularizationOverride.countNotSet() > 0) {
+    if (m_TreeImpl->m_RegularizationOverride.countNotSetForTrain() > 0) {
         this->initializeUnsetRegularizationHyperparameters(frame);
     }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1484,7 +1484,7 @@ void CBoostedTreeImpl::restoreBestHyperparameters() {
 }
 
 std::size_t CBoostedTreeImpl::numberHyperparametersToTune() const {
-    return m_RegularizationOverride.countNotSet() +
+    return m_RegularizationOverride.countNotSetForTrain() +
            (m_DownsampleFactorOverride != boost::none ? 0 : 1) +
            (m_EtaOverride != boost::none
                 ? 0

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -8,13 +8,15 @@
 
 #include <core/CMemory.h>
 
+#include <maths/CBoostedTree.h>
+#include <maths/CDataFrameCategoryEncoder.h>
+#include <maths/CDataFrameUtils.h>
 #include <maths/COrderings.h>
 
 namespace ml {
 namespace maths {
-std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_RowMask);
-}
+using namespace boosted_tree_detail;
+using TRowItr = core::CDataFrame::TRowItr;
 
 bool CBoostedTreeLeafNodeStatistics::operator<(const CBoostedTreeLeafNodeStatistics& rhs) const {
     return COrderings::lexicographical_compare(m_BestSplit, m_Id, rhs.m_BestSplit, rhs.m_Id);
@@ -64,6 +66,21 @@ core::CPackedBitVector& CBoostedTreeLeafNodeStatistics::rowMask() {
     return m_RowMask;
 }
 
+std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
+    return core::CMemory::dynamicSize(m_RowMask) + core::CMemory::dynamicSize(m_Derivatives);
+}
+
+std::size_t
+CBoostedTreeLeafNodeStatistics::estimateMemoryUsage(std::size_t numberFeatures,
+                                                    std::size_t numberSplitsPerFeature,
+                                                    std::size_t numberLossParameters) {
+    // See CBoostedTreeImpl::estimateMemoryUsage for a discussion of the cost
+    // of the row mask which is accounted for there.
+    std::size_t splitsDerivativesSize{CSplitsDerivatives::estimateMemoryUsage(
+        numberFeatures, numberSplitsPerFeature, numberLossParameters)};
+    return sizeof(CBoostedTreeLeafNodeStatistics) + splitsDerivativesSize;
+}
+
 std::string CBoostedTreeLeafNodeStatistics::print() const {
     return m_BestSplit.print();
 }
@@ -72,14 +89,208 @@ CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(std::size_t id,
                                                                std::size_t depth,
                                                                TSizeVecCRef extraColumns,
                                                                std::size_t numberLossParameters,
-                                                               const TImmutableRadixSetVec& candidateSplits)
-    : m_Id{id}, m_Depth{depth}, m_ExtraColumns{extraColumns},
-      m_NumberLossParameters{numberLossParameters}, m_CandidateSplits{candidateSplits} {
+                                                               const TImmutableRadixSetVec& candidateSplits,
+                                                               CSplitsDerivatives derivatives)
+    : m_Id{id}, m_Depth{depth}, m_ExtraColumns{extraColumns}, m_NumberLossParameters{numberLossParameters},
+      m_CandidateSplits{candidateSplits}, m_Derivatives{std::move(derivatives)} {
+}
+
+std::size_t CBoostedTreeLeafNodeStatistics::maximumNumberThreadsToAggregateDerivatives(
+    const CBoostedTreeLeafNodeStatistics& parent,
+    const TSizeVec& treeFeatureBag) {
+    // The number of threads we'll use breaks down as follows:
+    //   - We need a minimum number of rows per thread to ensure reasonable
+    //     load balancing.
+    //   - We need a minimum amount of work per thread to make the overheads
+    //     of distributing worthwhile.
+    std::size_t features{treeFeatureBag.size()};
+    std::size_t rows{parent.minimumChildRowCount()};
+    std::size_t rowsPerThreadConstraint{rows / 64};
+    std::size_t workPerThreadConstraint{(features * rows) / (8 * 128)};
+    return std::max(std::min(rowsPerThreadConstraint, workPerThreadConstraint),
+                    std::size_t{1});
+}
+
+void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivatives(
+    CLookAheadBound bound,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& rowMask,
+    CWorkspace& workspace) const {
+    this->computeAggregateLossDerivativesWith(bound, numberThreads, frame, encoder,
+                                              featureBag, rowMask, workspace);
+}
+
+void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivatives(
+    CNoLookAheadBound bound,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& rowMask,
+    CWorkspace& workspace) const {
+    this->computeAggregateLossDerivativesWith(bound, numberThreads, frame, encoder,
+                                              featureBag, rowMask, workspace);
+}
+
+void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
+    CLookAheadBound bound,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    bool isLeftChild,
+    const CBoostedTreeNode& split,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& parentRowMask,
+    CWorkspace& workspace) const {
+    this->computeRowMaskAndAggregateLossDerivativesWith(
+        bound, numberThreads, frame, encoder, isLeftChild, split, featureBag,
+        parentRowMask, workspace);
+}
+
+void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
+    CNoLookAheadBound bound,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    bool isLeftChild,
+    const CBoostedTreeNode& split,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& parentRowMask,
+    CWorkspace& workspace) const {
+    this->computeRowMaskAndAggregateLossDerivativesWith(
+        bound, numberThreads, frame, encoder, isLeftChild, split, featureBag,
+        parentRowMask, workspace);
+}
+
+template<typename BOUND>
+void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivativesWith(
+    BOUND bound,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& rowMask,
+    CWorkspace& workspace) const {
+
+    workspace.newLeaf(numberThreads);
+
+    core::CDataFrame::TRowFuncVec aggregators;
+    aggregators.reserve(numberThreads);
+
+    for (std::size_t i = 0; i < numberThreads; ++i) {
+        auto& splitsDerivatives = workspace.derivatives(MASK_INDEX)[i];
+        splitsDerivatives.zero();
+        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                this->addRowDerivatives(bound, featureBag, encoder.encode(*row),
+                                        splitsDerivatives);
+            }
+        });
+    }
+
+    frame.readRows(0, frame.numberRows(), aggregators, &rowMask);
+}
+
+template<typename BOUND>
+void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivativesWith(
+    BOUND bound,
+    std::size_t numberThreads,
+    const core::CDataFrame& frame,
+    const CDataFrameCategoryEncoder& encoder,
+    bool isLeftChild,
+    const CBoostedTreeNode& split,
+    const TSizeVec& featureBag,
+    const core::CPackedBitVector& parentRowMask,
+    CWorkspace& workspace) const {
+
+    workspace.newLeaf(numberThreads);
+
+    core::CDataFrame::TRowFuncVec aggregators;
+    aggregators.reserve(numberThreads);
+
+    for (std::size_t i = 0; i < numberThreads; ++i) {
+        auto& mask = workspace.masks(MASK_INDEX)[i];
+        auto& splitsDerivatives = workspace.derivatives(MASK_INDEX)[i];
+        mask.clear();
+        splitsDerivatives.zero();
+        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                auto encodedRow = encoder.encode(*row);
+                if (split.assignToLeft(encodedRow) == isLeftChild) {
+                    std::size_t index{row->index()};
+                    mask.extend(false, index - mask.size());
+                    mask.extend(true);
+                    this->addRowDerivatives(bound, featureBag, encodedRow, splitsDerivatives);
+                }
+            }
+        });
+    }
+
+    frame.readRows(0, frame.numberRows(), aggregators, &parentRowMask);
+}
+
+void CBoostedTreeLeafNodeStatistics::addRowDerivatives(CLookAheadBound,
+                                                       const TSizeVec& featureBag,
+                                                       const CEncodedDataFrameRowRef& row,
+                                                       CSplitsDerivatives& splitsDerivatives) const {
+
+    auto derivatives = readLossDerivatives(row.unencodedRow(), m_ExtraColumns,
+                                           m_NumberLossParameters);
+
+    if (derivatives.size() == 2) {
+        if (derivatives(0) >= 0.0) {
+            splitsDerivatives.addPositiveDerivatives(derivatives);
+        } else {
+            splitsDerivatives.addNegativeDerivatives(derivatives);
+        }
+    }
+
+    for (auto feature : featureBag) {
+        double featureValue{row[feature]};
+        if (CDataFrameUtils::isMissing(featureValue)) {
+            splitsDerivatives.addMissingDerivatives(feature, derivatives);
+        } else {
+            std::ptrdiff_t split{m_CandidateSplits[feature].upperBound(featureValue)};
+            splitsDerivatives.addDerivatives(feature, split, derivatives);
+        }
+    }
+}
+
+void CBoostedTreeLeafNodeStatistics::addRowDerivatives(CNoLookAheadBound,
+                                                       const TSizeVec& featureBag,
+                                                       const CEncodedDataFrameRowRef& row,
+                                                       CSplitsDerivatives& splitsDerivatives) const {
+
+    auto derivatives = readLossDerivatives(row.unencodedRow(), m_ExtraColumns,
+                                           m_NumberLossParameters);
+
+    for (auto feature : featureBag) {
+        double featureValue{row[feature]};
+        if (CDataFrameUtils::isMissing(featureValue)) {
+            splitsDerivatives.addMissingDerivatives(feature, derivatives);
+        } else {
+            std::ptrdiff_t split{m_CandidateSplits[feature].upperBound(featureValue)};
+            splitsDerivatives.addDerivatives(feature, split, derivatives);
+        }
+    }
 }
 
 CBoostedTreeLeafNodeStatistics::SSplitStatistics&
 CBoostedTreeLeafNodeStatistics::bestSplitStatistics() {
     return m_BestSplit;
+}
+
+CBoostedTreeLeafNodeStatistics::CSplitsDerivatives&
+CBoostedTreeLeafNodeStatistics::derivatives() {
+    return m_Derivatives;
+}
+
+const CBoostedTreeLeafNodeStatistics::CSplitsDerivatives&
+CBoostedTreeLeafNodeStatistics::derivatives() const {
+    return m_Derivatives;
 }
 
 std::size_t CBoostedTreeLeafNodeStatistics::depth() const {

--- a/lib/maths/CBoostedTreeLeafNodeStatisticsIncremental.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatisticsIncremental.cc
@@ -261,7 +261,7 @@ CBoostedTreeLeafNodeStatisticsIncremental::computeBestSplitStatistics(
 
     double gain[2];
 
-    const auto derivatives = this->derivatives();
+    const auto& derivatives = this->derivatives();
 
     for (auto feature : featureBag) {
         std::size_t c{derivatives.missingCount(feature)};

--- a/lib/maths/CBoostedTreeLeafNodeStatisticsIncremental.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatisticsIncremental.cc
@@ -401,7 +401,7 @@ CBoostedTreeLeafNodeStatisticsIncremental::penaltyForTreeChange(const TRegulariz
 
     double splitAt{candidateSplits[split]};
     return 0.5 * regularization.treeTopologyChangePenalty() *
-           std::fabs(splitAt - CTools::truncate(m_PreviousSplit->s_SplitAt, a, b) / (b - a);
+           std::fabs(splitAt - CTools::truncate(m_PreviousSplit->s_SplitAt, a, b)) / (b - a);
 }
 
 CBoostedTreeLeafNodeStatisticsIncremental::TOptionalPreviousSplit

--- a/lib/maths/CBoostedTreeLeafNodeStatisticsIncremental.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatisticsIncremental.cc
@@ -400,8 +400,9 @@ CBoostedTreeLeafNodeStatisticsIncremental::penaltyForTreeChange(const TRegulariz
     }
 
     double splitAt{candidateSplits[split]};
+    double previousSplitAt{CTools::truncate(m_PreviousSplit->s_SplitAt, a, b)};
     return 0.5 * regularization.treeTopologyChangePenalty() *
-           std::fabs(splitAt - CTools::truncate(m_PreviousSplit->s_SplitAt, a, b)) / (b - a);
+           std::fabs(splitAt - previousSplitAt) / (b - a);
 }
 
 CBoostedTreeLeafNodeStatisticsIncremental::TOptionalPreviousSplit

--- a/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
@@ -175,6 +175,10 @@ CBoostedTreeLeafNodeStatisticsScratch::split(std::size_t leftChildId,
     return {std::move(leftChild), std::move(rightChild)};
 }
 
+std::size_t CBoostedTreeLeafNodeStatisticsScratch::staticSize() const {
+    return sizeof(*this);
+}
+
 CBoostedTreeLeafNodeStatisticsScratch::SSplitStatistics
 CBoostedTreeLeafNodeStatisticsScratch::computeBestSplitStatistics(const TRegularization& regularization,
                                                                   const TSizeVec& featureBag) const {

--- a/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatisticsScratch.cc
@@ -258,7 +258,7 @@ CBoostedTreeLeafNodeStatisticsScratch::computeBestSplitStatistics(const TRegular
     SChildredGainStats bestSplitChildrenGainStats;
     SChildredGainStats featureChildrenGainStats;
 
-    const auto derivatives = this->derivatives();
+    const auto& derivatives = this->derivatives();
 
     for (auto feature : featureBag) {
         std::size_t c{derivatives.missingCount(feature)};

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -15,12 +15,16 @@ namespace maths {
 namespace boosted_tree_detail {
 using namespace boosted_tree;
 
+std::size_t rootIndex() {
+    return 0;
+}
+
 const CBoostedTreeNode& root(const std::vector<CBoostedTreeNode>& tree) {
-    return tree[0];
+    return tree[rootIndex()];
 }
 
 CBoostedTreeNode& root(std::vector<CBoostedTreeNode>& tree) {
-    return tree[0];
+    return tree[rootIndex()];
 }
 
 void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {

--- a/lib/maths/Makefile
+++ b/lib/maths/Makefile
@@ -28,6 +28,7 @@ CBoostedTreeFactory.cc \
 CBoostedTreeHyperparameters.cc \
 CBoostedTreeImpl.cc \
 CBoostedTreeLeafNodeStatistics.cc \
+CBoostedTreeLeafNodeStatisticsIncremental.cc \
 CBoostedTreeLeafNodeStatisticsScratch.cc \
 CBoostedTreeLoss.cc \
 CBoostedTreeUtils.cc \


### PR DESCRIPTION
This is a first pass implementing leaf node statistics for incremental training. This introduces an extra term in the gain calculation penalising changing the topology of the tree being retrained. It also migrates common functionality back to `CBoostedTreeLeafNodeStatistics`. Note that I have not tried to compute look ahead bounds for incremental training (because this is complicated by the split dependent penalty). Therefore, I optionally disable the extra statistics we compute to support this. I decided not to unit test this yet because I think it will be more valuable in the context of end-to-end testing, but it represents a nice self contained piece of work, so I'm breaking this out into a PR.