### PR TITLE
[ML] Some command line improvements

### DIFF
--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -52,7 +52,7 @@ bool CCmdLineParser::parse(int argc,
         desc.add_options()
             ("help", "Display this information and exit")
             ("version", "Display version information and exit")
-            ("config", boost::program_options::value<std::string>()->required(),
+            ("config", boost::program_options::value<std::string>(),
                     "The job configuration file")
             ("filtersconfig", boost::program_options::value<std::string>(),
                     "The filters configuration file")
@@ -114,9 +114,12 @@ bool CCmdLineParser::parse(int argc,
                       << ver::CBuildInfo::fullInfo() << std::endl;
             return false;
         }
-        if (vm.count("config") > 0) {
-            configFile = vm["config"].as<std::string>();
+        if (vm.count("config") == 0) {
+            std::cerr << "Error processing command line: the option '--config' is required but missing";
+            return false;
         }
+
+        configFile = vm["config"].as<std::string>();
         if (vm.count("filtersconfig") > 0) {
             filtersConfigFile = vm["filtersconfig"].as<std::string>();
         }

--- a/devbin/state_search_splitter/Main.cc
+++ b/devbin/state_search_splitter/Main.cc
@@ -25,6 +25,8 @@
 namespace {
 const std::string ID_PREFIX{"\"_id\":\""};
 const std::string SOURCE_PREFIX{"\"_source\":"};
+const std::string ID_PREFIX_PRETTY{"\"_id\" : \""};
+const std::string SOURCE_PREFIX_PRETTY{"\"_source\" : "};
 }
 
 void skipPreamble(std::istream& input) {
@@ -41,32 +43,37 @@ void skipPreamble(std::istream& input) {
 
 void saveSource(const std::string& doc) {
 
-    std::size_t idPos{doc.find(ID_PREFIX)};
+    bool isPretty{doc.find(ID_PREFIX_PRETTY) != std::string::npos};
+
+    const std::string& idPrefix{isPretty ? ID_PREFIX_PRETTY : ID_PREFIX};
+    const std::string& sourcePrefix{isPretty ? SOURCE_PREFIX_PRETTY : SOURCE_PREFIX};
+
+    std::size_t idPos{doc.find(idPrefix)};
     if (idPos == std::string::npos) {
         LOG_ERROR(<< "_id start not found");
         return;
     }
-    std::size_t idEnd{doc.find('"', idPos + ID_PREFIX.length())};
+    std::size_t idEnd{doc.find('"', idPos + idPrefix.length())};
     if (idEnd == std::string::npos) {
         LOG_ERROR(<< "_id end not found");
         return;
     }
-    std::size_t sourcePos{doc.find(SOURCE_PREFIX)};
+    std::size_t sourcePos{doc.find(sourcePrefix)};
     if (sourcePos == std::string::npos) {
         LOG_ERROR(<< "_source start not found");
         return;
     }
     std::size_t sourceEnd{doc.length() - 1};
-    std::string docId{doc.substr(idPos + ID_PREFIX.length(),
-                                 idEnd - idPos - ID_PREFIX.length())};
+    std::string docId{doc.substr(idPos + idPrefix.length(),
+                                 idEnd - idPos - idPrefix.length())};
     std::ofstream singleSourceFile{docId + ".json"};
     if (singleSourceFile.is_open() == false) {
         LOG_ERROR(<< "Could not open output file " << docId << ".json");
         return;
     }
     LOG_INFO(<< "Saving _source of document with _id " << docId);
-    singleSourceFile << doc.substr(sourcePos + SOURCE_PREFIX.length(),
-                                   sourceEnd - sourcePos - SOURCE_PREFIX.length())
+    singleSourceFile << doc.substr(sourcePos + sourcePrefix.length(),
+                                   sourceEnd - sourcePos - sourcePrefix.length())
                      << std::endl;
 }
 


### PR DESCRIPTION
The autodetect executable needs to check for missing config after handling help and version requests. This also handles pretty printed search results in the state_search_splitter executable.