### PR TITLE
[7.x][ML] A couple of improvements to setting RPATH

### DIFF
--- a/3rd_party/3rd_party.sh
+++ b/3rd_party/3rd_party.sh
@@ -210,7 +210,7 @@ case `uname` in
             for FILE in `find . -type f | egrep -v '^core|-debug$|libMl'`
             do
                 # Replace RPATH for 3rd party libraries that already have one
-                patchelf --print-rpath $FILE | grep lib >/dev/null 2>&1 && patchelf --set-rpath '$ORIGIN/.' $FILE
+                patchelf --print-rpath $FILE | grep lib >/dev/null 2>&1 && patchelf --force-rpath --set-rpath '$ORIGIN' $FILE
                 if [ $? -eq 0 ] ; then
                     echo "Set RPATH in $FILE"
                 else

--- a/mk/linux.mk
+++ b/mk/linux.mk
@@ -78,7 +78,7 @@ EIGENINCLUDES=-isystem $(CPP_SRC_HOME)/3rd_party/eigen
 EIGENCPPFLAGS=-DEIGEN_MPL2_ONLY -DEIGEN_MAX_ALIGN_BYTES=32
 XMLINCLUDES=`/usr/local/gcc75/bin/xml2-config --cflags`
 XMLLIBS=`/usr/local/gcc75/bin/xml2-config --libs`
-DYNAMICLIBLDFLAGS=$(PLATPICFLAGS) -shared -Wl,--as-needed -L$(CPP_PLATFORM_HOME)/$(DYNAMIC_LIB_DIR) $(COVERAGE) -Wl,-z,relro -Wl,-z,now -Wl,-rpath,'$$ORIGIN/.'
+DYNAMICLIBLDFLAGS=$(PLATPICFLAGS) -shared -Wl,--as-needed -L$(CPP_PLATFORM_HOME)/$(DYNAMIC_LIB_DIR) $(COVERAGE) -Wl,-z,relro -Wl,-z,now -Wl,-rpath,'$$ORIGIN'
 JAVANATIVEINCLUDES=-I$(JAVA_HOME)/include
 JAVANATIVELDFLAGS=-L$(JAVA_HOME)/jre/lib/server
 JAVANATIVELIBS=-ljvm

--- a/mk/linux_crosscompile_linux.mk
+++ b/mk/linux_crosscompile_linux.mk
@@ -79,7 +79,7 @@ EIGENINCLUDES=-isystem $(CPP_SRC_HOME)/3rd_party/eigen
 EIGENCPPFLAGS=-DEIGEN_MPL2_ONLY -DEIGEN_MAX_ALIGN_BYTES=32
 XMLINCLUDES=-I$(SYSROOT)/usr/local/gcc75/include/libxml2
 XMLLIBS=-L$(SYSROOT)/usr/local/gcc75/lib -lxml2 -lz -lm -ldl
-DYNAMICLIBLDFLAGS=$(PLATPICFLAGS) -shared -Wl,--as-needed -L$(CPP_PLATFORM_HOME)/$(DYNAMIC_LIB_DIR) $(COVERAGE) -Wl,-z,relro -Wl,-z,now -Wl,-rpath,'$$ORIGIN/.'
+DYNAMICLIBLDFLAGS=$(PLATPICFLAGS) -shared -Wl,--as-needed -L$(CPP_PLATFORM_HOME)/$(DYNAMIC_LIB_DIR) $(COVERAGE) -Wl,-z,relro -Wl,-z,now -Wl,-rpath,'$$ORIGIN'
 ZLIBLIBS=-lz
 EXELDFLAGS=-pie $(PLATPIEFLAGS) -L$(CPP_PLATFORM_HOME)/$(DYNAMIC_LIB_DIR) $(COVERAGE) -Wl,-z,relro -Wl,-z,now -Wl,-rpath,'$$ORIGIN/../lib'
 UTLDFLAGS=$(EXELDFLAGS) -Wl,-rpath,$(CPP_PLATFORM_HOME)/$(DYNAMIC_LIB_DIR)


### PR DESCRIPTION
1. When setting RPATH using patchelf, use the --force-rpath
   option, because otherwise it sets RUNPATH instead. This
   only makes a difference when LD_LIBRARY_PATH is set, so
   won't affect our expected production scenario where
   LD_LIBRARY_PATH is _not_ set. But preferring RPATH may
   avoid confusion in dev environments.
2. Use $ORIGIN instead of $ORIGIN/. when setting RPATH on
   the link line. The /. gets appended automatically, so
   we are actually using $ORIGIN/./. at the moment, which
   works fine but looks messy.

Backport of #1812