### PR TITLE
[ML] Add ability to evaluate a simple PyTorch model

### DIFF
--- a/bin/pytorch_inference/CCommandParser.h
+++ b/bin/pytorch_inference/CCommandParser.h
@@ -45,18 +45,21 @@ class CCommandParser {
 public:
     static const std::string REQUEST_ID;
     static const std::string TOKENS;
+    static const std::string INPUTS;
     static const std::string VAR_ARG_PREFIX;
     static const std::string UNKNOWN_ID;
 
     using TUint64Vec = std::vector<std::uint64_t>;
     using TUint64VecVec = std::vector<TUint64Vec>;
+    using TDoubleVec = std::vector<double>;
 
     struct SRequest {
         std::string s_RequestId;
         TUint64Vec s_Tokens;
         TUint64VecVec s_SecondaryArguments;
+        TDoubleVec s_Inputs;
 
-        void clear();
+        bool hasTokens();
     };
 
     using TRequestHandlerFunc = std::function<bool(SRequest&)>;
@@ -78,6 +81,7 @@ private:
     bool validateJson(const rapidjson::Document& doc,
                       const TErrorHandlerFunc& errorHandler) const;
     bool checkArrayContainsUInts(const rapidjson::Value& arr) const;
+    bool checkArrayContainsDoubles(const rapidjson::Value& arr) const;
     void jsonToRequest(const rapidjson::Document& doc);
 
 private:

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -83,7 +83,7 @@ def write_request(request, destination):
     json.dump(request, destination)
 
 
-def compare_results(expected, actual):
+def compare_results(expected, actual, tolerance):
     try:
         if expected['request_id'] != actual['request_id']:
             print("request_ids do not match [{}], [{}]".format(expected['request_id'], actual['request_id']), flush=True)
@@ -103,7 +103,7 @@ def compare_results(expected, actual):
 
             are_close = True
             for j in range(len(expected_row)):
-                are_close = are_close and math.isclose(expected_row[j], actual_row[j], rel_tol=1e-04)
+                are_close = are_close and math.isclose(expected_row[j], actual_row[j], abs_tol=tolerance)
 
             if are_close == False:
                 print("row [{}] values are not close {}, {}".format(i, expected_row, actual_row), flush=True)
@@ -159,9 +159,13 @@ def main():
                     return
 
                 expected = test_evaluation[doc_count]['expected_output']
+                 
+                tolerance = 1e-04
+                if 'how_close' in test_evaluation[doc_count]:
+                    tolerance = test_evaluation[doc_count]['how_close']                    
 
                 # compare to expected
-                if compare_results(expected, result) == False:
+                if compare_results(expected, result, tolerance) == False:
                     print()
                     print('ERROR: inference result [{}] does not match expected results'.format(doc_count))
                     print()

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -169,6 +169,12 @@ def main():
 
                 doc_count = doc_count +1
 
+            if doc_count != len(test_evaluation): 
+                print()
+                print('ERROR: The number of inference results [{}] does not match expected count [{}]'.format(doc_count, len(test_evaluation)))
+                print()
+                results_match = False
+
             if results_match:
                 print()
                 print('SUCCESS: inference results match expected', flush=True)

--- a/bin/pytorch_inference/examples/simplest/test_run.json
+++ b/bin/pytorch_inference/examples/simplest/test_run.json
@@ -1,18 +1,20 @@
 [
 	{
 		"description": "Approximate sin(x) for x = pi",
+		"how_close": 0.2,
 		"input": {
 			"request_id": "one", 
 			"inputs": [3.1416, 9.8696, 31.0063]
 		},
-		"expected_output": {"request_id": "one", "inference": [[-1.8438e-01]]}
+		"expected_output": {"request_id": "one", "inference": [[0.0]]}
 	},
 	{
 		"description": "Approximate sin(x) for x= pi/2",
+		"how_close": 0.2,
 		"input": {
 			"request_id": "two", 
 			"inputs": [1.5708, 2.4674,  3.8758]
 		},
-		"expected_output": {"request_id": "two", "inference": [[9.6963e-01]]}
+		"expected_output": {"request_id": "two", "inference": [[1.0]]}
 	}
 ]

--- a/bin/pytorch_inference/examples/simplest/test_run.json
+++ b/bin/pytorch_inference/examples/simplest/test_run.json
@@ -1,0 +1,18 @@
+[
+	{
+		"description": "Approximate sin(x) for x = pi",
+		"input": {
+			"request_id": "one", 
+			"inputs": [3.1416, 9.8696, 31.0063]
+		},
+		"expected_output": {"request_id": "one", "inference": [[-1.8438e-01]]}
+	},
+	{
+		"description": "Approximate sin(x) for x= pi/2",
+		"input": {
+			"request_id": "two", 
+			"inputs": [1.5708, 2.4674,  3.8758]
+		},
+		"expected_output": {"request_id": "two", "inference": [[9.6963e-01]]}
+	}
+]


### PR DESCRIPTION
The main motivation for this change is to enable round trip testing of the Java and C++ processes with a small TorchScript model where downloading a large BERT model in the integration tests is not practical. Additionally this represents another use-case which is beneficial for evolving the design. 

PyTorch tensors have a type, BERT uses uint 64 whereas this model expects float 32, to distinguish between the 2 a new field has been added to the input JSON. The JSON document is used only for internal communications between Java and C++ and can be changed freely provided both sides are upgraded together, for this reason I have gone for a practical rather than elegant structure. 

`test_run.json` describes the input and output

The app knows little about the model is it evaluating, some introspection is possible but not much. In future a more complex command document may be required to express has the inputs and outputs should be processed.  

cc @dimitris-athanasiou 