### PR TITLE
[ML] Handle validation errors in PyTorch requests

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -165,7 +165,7 @@ void CCommandParser::jsonToRequest(const rapidjson::Document& doc) {
     TUint64Vec arg;
     while (doc.HasMember(varArgName)) {
         const rapidjson::Value& v = doc[varArgName];
-        for (const auto* itr = v.Begin(); itr != v.End(); ++itr) {
+        for (auto itr = v.Begin(); itr != v.End(); ++itr) {
             arg.push_back(itr->GetUint64());
         }
 

--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -14,6 +14,8 @@
 #include <rapidjson/writer.h>
 
 #include <istream>
+#include <sstream>
+#include <string>
 
 namespace rapidjson {
 
@@ -31,11 +33,13 @@ namespace torch {
 const std::string CCommandParser::REQUEST_ID{"request_id"};
 const std::string CCommandParser::TOKENS{"tokens"};
 const std::string CCommandParser::VAR_ARG_PREFIX{"arg_"};
+const std::string CCommandParser::UNKNOWN_ID;
 
 CCommandParser::CCommandParser(std::istream& strmIn) : m_StrmIn(strmIn) {
 }
 
-bool CCommandParser::ioLoop(const TRequestHandlerFunc& requestHandler) {
+bool CCommandParser::ioLoop(const TRequestHandlerFunc& requestHandler,
+                            const TErrorHandlerFunc& errorHandler) {
 
     rapidjson::IStreamWrapper isw{m_StrmIn};
 
@@ -49,14 +53,17 @@ bool CCommandParser::ioLoop(const TRequestHandlerFunc& requestHandler) {
                 break;
             }
 
-            LOG_ERROR(<< "Error parsing command from JSON: "
-                      << rapidjson::GetParseError_En(parseResult.Code())
-                      << ". At offset: " << parseResult.Offset());
+            std::ostringstream ss;
+            ss << "Error parsing command from JSON: "
+               << rapidjson::GetParseError_En(parseResult.Code())
+               << ". At offset: " << parseResult.Offset();
+
+            errorHandler(UNKNOWN_ID, ss.str());
 
             return false;
         }
 
-        if (validateJson(doc) == false) {
+        if (validateJson(doc, errorHandler) == false) {
             continue;
         }
 
@@ -71,31 +78,35 @@ bool CCommandParser::ioLoop(const TRequestHandlerFunc& requestHandler) {
     return true;
 }
 
-bool CCommandParser::validateJson(const rapidjson::Document& doc) const {
+bool CCommandParser::validateJson(const rapidjson::Document& doc,
+                                  const TErrorHandlerFunc& errorHandler) const {
     if (doc.HasMember(REQUEST_ID) == false) {
-        LOG_ERROR(<< "Invalid command: missing field [" << REQUEST_ID << "]");
+        errorHandler(UNKNOWN_ID, "Invalid command: missing field [" + REQUEST_ID + "]");
         return false;
     }
 
     if (doc[REQUEST_ID].IsString() == false) {
-        LOG_ERROR(<< "Invalid command: [" << REQUEST_ID << "] field is not a string");
+        errorHandler(UNKNOWN_ID, "Invalid command: [" + REQUEST_ID + "] field is not a string");
         return false;
     }
 
     if (doc.HasMember(TOKENS) == false) {
-        LOG_ERROR(<< "Invalid command: missing field [" << TOKENS << "]");
+        errorHandler(doc[REQUEST_ID].GetString(),
+                     "Invalid command: missing field [" + TOKENS + "]");
         return false;
     }
 
     const rapidjson::Value& tokens = doc[TOKENS];
     if (tokens.IsArray() == false) {
-        LOG_ERROR(<< "Invalid command: expected an array [" << TOKENS << "]");
+        errorHandler(doc[REQUEST_ID].GetString(),
+                     "Invalid command: expected an array [" + TOKENS + "]");
         return false;
     }
 
     if (checkArrayContainsUInts(tokens) == false) {
-        LOG_ERROR(<< "Invalid command: array [" << TOKENS
-                  << "] contains values that are not unsigned integers");
+        errorHandler(doc[REQUEST_ID].GetString(),
+                     "Invalid command: array [" + TOKENS +
+                         "] contains values that are not unsigned integers");
         return false;
     }
 
@@ -105,13 +116,15 @@ bool CCommandParser::validateJson(const rapidjson::Document& doc) const {
     while (doc.HasMember(varArgName)) {
         const rapidjson::Value& value = doc[varArgName];
         if (value.IsArray() == false) {
-            LOG_ERROR(<< "Invalid command: argument [" << varArgName << "] is not an array");
+            errorHandler(doc[REQUEST_ID].GetString(),
+                         "Invalid command: argument [" + varArgName + "] is not an array");
             return false;
         }
 
         if (checkArrayContainsUInts(value) == false) {
-            LOG_ERROR(<< "Invalid command: array [" << varArgName
-                      << "] contains values that are not unsigned integers");
+            errorHandler(doc[REQUEST_ID].GetString(),
+                         "Invalid command: array [" + varArgName +
+                             "] contains values that are not unsigned integers");
             return false;
         }
 
@@ -152,7 +165,7 @@ void CCommandParser::jsonToRequest(const rapidjson::Document& doc) {
     TUint64Vec arg;
     while (doc.HasMember(varArgName)) {
         const rapidjson::Value& v = doc[varArgName];
-        for (auto itr = v.Begin(); itr != v.End(); ++itr) {
+        for (const auto* itr = v.Begin(); itr != v.End(); ++itr) {
             arg.push_back(itr->GetUint64());
         }
 

--- a/bin/pytorch_inference/CCommandParser.h
+++ b/bin/pytorch_inference/CCommandParser.h
@@ -46,6 +46,7 @@ public:
     static const std::string REQUEST_ID;
     static const std::string TOKENS;
     static const std::string VAR_ARG_PREFIX;
+    static const std::string UNKNOWN_ID;
 
     using TUint64Vec = std::vector<std::uint64_t>;
     using TUint64VecVec = std::vector<TUint64Vec>;
@@ -59,18 +60,23 @@ public:
     };
 
     using TRequestHandlerFunc = std::function<bool(SRequest&)>;
+    using TErrorHandlerFunc =
+        std::function<void(const std::string& requestId, const std::string& message)>;
 
 public:
-    CCommandParser(std::istream& strmIn);
+    explicit CCommandParser(std::istream& strmIn);
 
     //! Pass input to the processor until it's consumed as much as it can.
-    bool ioLoop(const TRequestHandlerFunc& requestHandler);
+    //! Parsed requests are passed to the requestHandler, errors such
+    //! as a failed validation are passed to errorHandler
+    bool ioLoop(const TRequestHandlerFunc& requestHandler, const TErrorHandlerFunc& errorHandler);
 
     CCommandParser(const CCommandParser&) = delete;
     CCommandParser& operator=(const CCommandParser&) = delete;
 
 private:
-    bool validateJson(const rapidjson::Document& doc) const;
+    bool validateJson(const rapidjson::Document& doc,
+                      const TErrorHandlerFunc& errorHandler) const;
     bool checkArrayContainsUInts(const rapidjson::Value& arr) const;
     void jsonToRequest(const rapidjson::Document& doc);
 

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -202,9 +202,13 @@ int main(int argc, char** argv) {
 
     ml::torch::CCommandParser commandParser{ioMgr.inputStream()};
 
-    commandParser.ioLoop([&module, &ioMgr](ml::torch::CCommandParser::SRequest& request) {
-        return handleRequest(request, module, ioMgr.outputStream());
-    });
+    commandParser.ioLoop(
+        [&module, &ioMgr](ml::torch::CCommandParser::SRequest& request) {
+            return handleRequest(request, module, ioMgr.outputStream());
+        },
+        [&ioMgr](const std::string& requestId, const std::string& message) {
+            writeError(requestId, message, ioMgr.outputStream());
+        });
 
     LOG_DEBUG(<< "ML Torch model prototype exiting");
 


### PR DESCRIPTION
Inference requests are JSON documents, previously the command parser would drop a malformed request with only a log message as evidence of its passing. 

This adds an error handler to the command processor that is called in the event of the bad inference request, the error is returned on the output so a client can expect a response for every request sent. 

In practice it is unlikely that a malformed request is sent during normal operation but I want to establish the contract that a client can always expect some sort of response.