### PR TITLE
[ML] Tree to retrain selection

### DIFF
--- a/include/maths/CBoostedTreeLoss.h
+++ b/include/maths/CBoostedTreeLoss.h
@@ -42,6 +42,7 @@ public:
     virtual std::unique_ptr<CArgMinLossImpl> clone() const = 0;
     virtual bool nextPass() = 0;
     virtual void add(const CEncodedDataFrameRowRef& row,
+                     bool newExample,
                      const TMemoryMappedFloatVector& prediction,
                      double actual,
                      double weight = 1.0) = 0;
@@ -63,6 +64,7 @@ public:
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(const CEncodedDataFrameRowRef& /*row*/,
+             bool /*newExample*/,
              const TMemoryMappedFloatVector& prediction,
              double actual,
              double weight = 1.0) override {
@@ -92,6 +94,7 @@ public:
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(const CEncodedDataFrameRowRef& row,
+             bool newExample,
              const TMemoryMappedFloatVector& prediction,
              double actual,
              double weight = 1.0) override;
@@ -120,6 +123,7 @@ public:
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(const CEncodedDataFrameRowRef& /*row*/,
+             bool /*newExample*/,
              const TMemoryMappedFloatVector& prediction,
              double actual,
              double weight = 1.0) override {
@@ -187,6 +191,7 @@ public:
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(const CEncodedDataFrameRowRef& /*row*/,
+             bool /*newExample*/,
              const TMemoryMappedFloatVector& prediction,
              double actual,
              double weight = 1.0) override {
@@ -249,6 +254,7 @@ public:
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(const CEncodedDataFrameRowRef& /*row*/,
+             bool /*newExample*/,
              const TMemoryMappedFloatVector& prediction,
              double actual,
              double weight = 1.0) override {
@@ -326,6 +332,7 @@ public:
     std::unique_ptr<CArgMinLossImpl> clone() const override;
     bool nextPass() override;
     void add(const CEncodedDataFrameRowRef& /*row*/,
+             bool /*newExample*/,
              const TMemoryMappedFloatVector& prediction,
              double actual,
              double weight = 1.0) override {
@@ -388,6 +395,7 @@ public:
 
     //! Update with a point prediction and actual value.
     void add(const CEncodedDataFrameRowRef& row,
+             bool newExample,
              const TMemoryMappedFloatVector& prediction,
              double actual,
              double weight = 1.0);
@@ -442,12 +450,14 @@ public:
                          double weight = 1.0) const = 0;
     //! The gradient of the loss function.
     virtual void gradient(const CEncodedDataFrameRowRef& row,
+                          bool newExample,
                           const TMemoryMappedFloatVector& prediction,
                           double actual,
                           const TWriter& writer,
                           double weight = 1.0) const = 0;
     //! The Hessian of the loss function (flattened).
     virtual void curvature(const CEncodedDataFrameRowRef& row,
+                           bool newExample,
                            const TMemoryMappedFloatVector& prediction,
                            double actual,
                            const TWriter& writer,
@@ -497,7 +507,8 @@ public:
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef&,
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
                   const TMemoryMappedFloatVector& prediction,
                   double actual,
                   const TWriter& writer,
@@ -508,7 +519,8 @@ public:
                   double actual,
                   const TWriter& writer,
                   double weight = 1.0) const;
-    void curvature(const CEncodedDataFrameRowRef&,
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
                    const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,
@@ -548,18 +560,21 @@ public:
                  double actual,
                  double weight = 1.0) const override;
     void gradient(const CEncodedDataFrameRowRef& row,
+                  bool newExample,
                   const TMemoryMappedFloatVector& prediction,
                   double actual,
                   const TWriter& writer,
                   double weight = 1.0) const override;
-    void curvature(const CEncodedDataFrameRowRef&,
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool newExample,
                    const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,
                    double weight = 1.0) const override {
-        this->curvature(prediction, actual, writer, weight);
+        this->curvature(newExample, prediction, actual, writer, weight);
     }
-    void curvature(const TMemoryMappedFloatVector& prediction,
+    void curvature(bool newExample,
+                   const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,
                    double weight = 1.0) const;
@@ -603,7 +618,8 @@ public:
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef&,
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
                   const TMemoryMappedFloatVector& prediction,
                   double actual,
                   const TWriter& writer,
@@ -614,7 +630,8 @@ public:
                   double actual,
                   const TWriter& writer,
                   double weight = 1.0) const;
-    void curvature(const CEncodedDataFrameRowRef&,
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
                    const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,
@@ -662,7 +679,8 @@ public:
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef&,
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
                   const TMemoryMappedFloatVector& prediction,
                   double actual,
                   const TWriter& writer,
@@ -673,7 +691,8 @@ public:
                   double actual,
                   const TWriter& writer,
                   double weight = 1.0) const;
-    void curvature(const CEncodedDataFrameRowRef&,
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
                    const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,
@@ -726,7 +745,8 @@ public:
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef&,
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
                   const TMemoryMappedFloatVector& prediction,
                   double actual,
                   const TWriter& writer,
@@ -737,7 +757,8 @@ public:
                   double actual,
                   const TWriter& writer,
                   double weight = 1.0) const;
-    void curvature(const CEncodedDataFrameRowRef&,
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
                    const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,
@@ -796,10 +817,11 @@ public:
     TLossUPtr clone() const override;
     TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
     std::size_t numberParameters() const override;
-    double value(const TMemoryMappedFloatVector& predictionVec,
+    double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef&,
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
                   const TMemoryMappedFloatVector& prediction,
                   double actual,
                   const TWriter& writer,
@@ -810,7 +832,8 @@ public:
                   double actual,
                   const TWriter& writer,
                   double weight = 1.0) const;
-    void curvature(const CEncodedDataFrameRowRef&,
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
                    const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -22,6 +22,8 @@ namespace boosted_tree {
 class CLoss;
 }
 class CBoostedTreeNode;
+template<typename>
+class CBoostedTreeRegularization;
 class CDataFrameCategoryEncoder;
 namespace boosted_tree_detail {
 using TDoubleVec = std::vector<double>;
@@ -31,6 +33,7 @@ using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage>;
 using TSizeAlignmentPrVec = std::vector<std::pair<std::size_t, core::CAlignment::EType>>;
 using TAlignedMemoryMappedFloatVector =
     CMemoryMappedDenseVector<CFloatStorage, Eigen::Aligned16>;
+using TRegularization = CBoostedTreeRegularization<double>;
 
 enum EExtraColumn { E_Prediction = 0, E_Gradient, E_Curvature, E_Weight };
 
@@ -172,6 +175,9 @@ retrainTreeSelectionProbabilities(std::size_t numberThreads,
                                   const core::CPackedBitVector& oldTrainingDataRowMask,
                                   const core::CPackedBitVector& newTrainingDataRowMask,
                                   const boosted_tree::CLoss& loss,
+                                  const TRegularization& regularization,
+                                  double eta,
+                                  double etaGrowthRate,
                                   const std::vector<std::vector<CBoostedTreeNode>>& forest);
 
 constexpr double INF{std::numeric_limits<double>::max()};

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -68,8 +68,9 @@ struct SHyperparameterImportance {
 };
 
 //! Get the index of the root node in a canonical tree node vector.
-MATHS_EXPORT
-std::size_t rootIndex();
+inline std::size_t rootIndex() {
+    return 0;
+}
 
 //! Get the root node of \p tree.
 MATHS_EXPORT
@@ -172,12 +173,8 @@ retrainTreeSelectionProbabilities(std::size_t numberThreads,
                                   const TSizeVec& extraColumns,
                                   std::size_t dependentVariable,
                                   const CDataFrameCategoryEncoder& encoder,
-                                  const core::CPackedBitVector& oldTrainingDataRowMask,
-                                  const core::CPackedBitVector& newTrainingDataRowMask,
+                                  const core::CPackedBitVector& trainingDataRowMask,
                                   const boosted_tree::CLoss& loss,
-                                  const TRegularization& regularization,
-                                  double eta,
-                                  double etaGrowthRate,
                                   const std::vector<std::vector<CBoostedTreeNode>>& forest);
 
 constexpr double INF{std::numeric_limits<double>::max()};

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -24,6 +24,7 @@ class CLoss;
 class CBoostedTreeNode;
 class CDataFrameCategoryEncoder;
 namespace boosted_tree_detail {
+using TDoubleVec = std::vector<double>;
 using TSizeVec = std::vector<std::size_t>;
 using TRowRef = core::CDataFrame::TRowRef;
 using TMemoryMappedFloatVector = CMemoryMappedDenseVector<CFloatStorage>;
@@ -114,6 +115,7 @@ void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::siz
 //! Write the loss gradient to \p row.
 MATHS_EXPORT
 void writeLossGradient(const TRowRef& row,
+                       bool newExample,
                        const TSizeVec& extraColumns,
                        const CDataFrameCategoryEncoder& encoder,
                        const boosted_tree::CLoss& loss,
@@ -136,9 +138,10 @@ void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::si
 //! Write the loss Hessian to \p row.
 MATHS_EXPORT
 void writeLossCurvature(const TRowRef& row,
+                        bool newExample,
                         const TSizeVec& extraColumns,
                         const CDataFrameCategoryEncoder& encoder,
-                        const boosted_tree::CLoss& curvature,
+                        const boosted_tree::CLoss& loss,
                         const TMemoryMappedFloatVector& prediction,
                         double actual,
                         double weight = 1.0);
@@ -157,6 +160,19 @@ inline void writeExampleWeight(const TRowRef& row, const TSizeVec& extraColumns,
 inline double readActual(const TRowRef& row, std::size_t dependentVariable) {
     return row[dependentVariable];
 }
+
+//! Compute the probabilities with which to select each tree for retraining.
+MATHS_EXPORT
+TDoubleVec
+retrainSelectionProbabilities(std::size_t numberThreads,
+                              const core::CDataFrame& frame,
+                              const TSizeVec& extraColumns,
+                              std::size_t dependentVariable,
+                              const CDataFrameCategoryEncoder& encoder,
+                              const core::CPackedBitVector& oldTrainingDataRowMask,
+                              const core::CPackedBitVector& newTrainingDataRowMask,
+                              const boosted_tree::CLoss& loss,
+                              const std::vector<std::vector<CBoostedTreeNode>>& forest);
 
 constexpr double INF{std::numeric_limits<double>::max()};
 }

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -164,15 +164,15 @@ inline double readActual(const TRowRef& row, std::size_t dependentVariable) {
 //! Compute the probabilities with which to select each tree for retraining.
 MATHS_EXPORT
 TDoubleVec
-retrainSelectionProbabilities(std::size_t numberThreads,
-                              const core::CDataFrame& frame,
-                              const TSizeVec& extraColumns,
-                              std::size_t dependentVariable,
-                              const CDataFrameCategoryEncoder& encoder,
-                              const core::CPackedBitVector& oldTrainingDataRowMask,
-                              const core::CPackedBitVector& newTrainingDataRowMask,
-                              const boosted_tree::CLoss& loss,
-                              const std::vector<std::vector<CBoostedTreeNode>>& forest);
+retrainTreeSelectionProbabilities(std::size_t numberThreads,
+                                  const core::CDataFrame& frame,
+                                  const TSizeVec& extraColumns,
+                                  std::size_t dependentVariable,
+                                  const CDataFrameCategoryEncoder& encoder,
+                                  const core::CPackedBitVector& oldTrainingDataRowMask,
+                                  const core::CPackedBitVector& newTrainingDataRowMask,
+                                  const boosted_tree::CLoss& loss,
+                                  const std::vector<std::vector<CBoostedTreeNode>>& forest);
 
 constexpr double INF{std::numeric_limits<double>::max()};
 }

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -30,7 +30,6 @@
 namespace ml {
 namespace maths {
 using namespace boosted_tree_detail;
-using TDoubleVec = std::vector<double>;
 using TRowItr = core::CDataFrame::TRowItr;
 
 namespace {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1236,7 +1236,7 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
                         double actual{readActual(row, m_DependentVariable)};
                         double weight{readExampleWeight(row, m_ExtraColumns)};
                         leafValues_[rootNode.leafIndex(encodedRow, tree)].add(
-                            encodedRow, prediction, actual, weight);
+                            encodedRow, true /*new example*/, prediction, actual, weight);
                     }
                 },
                 std::move(leafValues)),
@@ -1270,10 +1270,10 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
                 double actual{readActual(row, m_DependentVariable)};
                 double weight{readExampleWeight(row, m_ExtraColumns)};
                 prediction += rootNode.value(m_Encoder->encode(row), tree);
-                writeLossGradient(row, m_ExtraColumns, *m_Encoder, *m_Loss,
-                                  prediction, actual, weight);
-                writeLossCurvature(row, m_ExtraColumns, *m_Encoder, *m_Loss,
-                                   prediction, actual, weight);
+                writeLossGradient(row, true /*new example*/, m_ExtraColumns,
+                                  *m_Encoder, *m_Loss, prediction, actual, weight);
+                writeLossCurvature(row, true /*new example*/, m_ExtraColumns,
+                                   *m_Encoder, *m_Loss, prediction, actual, weight);
             }
         },
         &updateRowMask);

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -6,14 +6,41 @@
 
 #include <maths/CBoostedTreeUtils.h>
 
+#include <core/Concurrency.h>
+
 #include <maths/CBoostedTree.h>
 #include <maths/CBoostedTreeLoss.h>
 #include <maths/CDataFrameCategoryEncoder.h>
+#include <maths/CLinearAlgebraEigen.h>
+#include <maths/MathsTypes.h>
 
 namespace ml {
 namespace maths {
 namespace boosted_tree_detail {
 using namespace boosted_tree;
+
+namespace {
+using TDoubleVector = CDenseVector<double>;
+using TDoubleVectorVec = std::vector<TDoubleVector>;
+using TDoubleVectorVecVec = std::vector<TDoubleVectorVec>;
+
+void propagateLossGradients(std::size_t node,
+                            const std::vector<CBoostedTreeNode>& tree,
+                            TDoubleVectorVec& lossGradients) {
+
+    if (tree[node].isLeaf()) {
+        return;
+    }
+
+    propagateLossGradients(tree[node].leftChildIndex(), tree, lossGradients);
+    propagateLossGradients(tree[node].rightChildIndex(), tree, lossGradients);
+
+    // A post order depth first traversal means that loss gradients are written
+    // to child nodes before they are read here.
+    lossGradients[node] += lossGradients[tree[node].leftChildIndex()];
+    lossGradients[node] += lossGradients[tree[node].rightChildIndex()];
+}
+}
 
 std::size_t rootIndex() {
     return 0;
@@ -40,6 +67,7 @@ void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::siz
 }
 
 void writeLossGradient(const TRowRef& row,
+                       bool newExample,
                        const TSizeVec& extraColumns,
                        const CDataFrameCategoryEncoder& encoder,
                        const CLoss& loss,
@@ -51,7 +79,7 @@ void writeLossGradient(const TRowRef& row,
     };
     // We wrap the writer in another lambda which we know takes advantage
     // of std::function small size optimization to avoid heap allocations.
-    loss.gradient(encoder.encode(row), prediction, actual,
+    loss.gradient(encoder.encode(row), newExample, prediction, actual,
                   [&writer](std::size_t i, double value) { writer(i, value); }, weight);
 }
 
@@ -63,6 +91,7 @@ void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::si
 }
 
 void writeLossCurvature(const TRowRef& row,
+                        bool newExample,
                         const TSizeVec& extraColumns,
                         const CDataFrameCategoryEncoder& encoder,
                         const CLoss& loss,
@@ -74,8 +103,112 @@ void writeLossCurvature(const TRowRef& row,
     };
     // We wrap the writer in another lambda which we know takes advantage
     // of std::function small size optimization to avoid heap allocations.
-    loss.curvature(encoder.encode(row), prediction, actual,
+    loss.curvature(encoder.encode(row), newExample, prediction, actual,
                    [&writer](std::size_t i, double value) { writer(i, value); }, weight);
+}
+
+TDoubleVec
+retrainSelectionProbabilities(std::size_t numberThreads,
+                              const core::CDataFrame& frame,
+                              const TSizeVec& extraColumns,
+                              std::size_t dependentVariable,
+                              const CDataFrameCategoryEncoder& encoder,
+                              const core::CPackedBitVector& oldTrainingDataRowMask,
+                              const core::CPackedBitVector& newTrainingDataRowMask,
+                              const boosted_tree::CLoss& loss,
+                              const std::vector<std::vector<CBoostedTreeNode>>& forest) {
+
+    using TFloatVec = std::vector<CFloatStorage>;
+    using TRowItr = core::CDataFrame::TRowItr;
+
+    std::size_t numberLossParameters{loss.numberParameters()};
+
+    auto makeComputeTotalLossGradient = [&](const bool& isOldTrainingData) {
+        return [&](TDoubleVectorVecVec& leafLossGradients, TRowItr beginRows, TRowItr endRows) {
+            TFloatVec storage(numberLossParameters);
+            for (auto row = beginRows; row != endRows; ++row) {
+                auto prediction = readPrediction(*row, extraColumns, numberLossParameters);
+                double actual{readActual(*row, dependentVariable)};
+                double weight{readExampleWeight(*row, extraColumns)};
+                for (std::size_t i = 0; i < forest.size(); ++i) {
+                    auto encodedRow = encoder.encode(*row);
+                    std::size_t leaf{root(forest[i]).leafIndex(encodedRow, forest[i])};
+                    for (int j = 0; j < prediction.size(); ++j) {
+                        storage[j] = prediction(j) - forest[i][leaf].value()(i);
+                    }
+                    // The prediction after removing the tree from the ensemble.
+                    auto predictionMinusTree = TMemoryMappedFloatVector(
+                        storage.data(), static_cast<int>(numberLossParameters));
+                    auto writer = [&](std::size_t j, double gradient) {
+                        leafLossGradients[i][leaf](j) = gradient;
+                    };
+                    loss.gradient(encodedRow, isOldTrainingData,
+                                  predictionMinusTree, actual, writer, weight);
+                }
+            }
+        };
+    };
+
+    auto makeZeroLeafLossGradients = [&] {
+        TDoubleVectorVecVec leafLossGradients;
+        leafLossGradients.reserve(forest.size());
+        for (const auto& tree : forest) {
+            leafLossGradients.emplace_back(tree.size(), TDoubleVector::Zero(numberLossParameters));
+        }
+        return leafLossGradients;
+    };
+
+    auto computeLeafLossGradients = [&](bool oldTrainingData,
+                                        const core::CPackedBitVector& rowMask) {
+        auto results = frame.readRows(
+            numberThreads, 0, frame.numberRows(),
+            core::bindRetrievableState(makeComputeTotalLossGradient(oldTrainingData),
+                                       makeZeroLeafLossGradients()),
+            &rowMask);
+
+        TDoubleVectorVecVec leafLossGradients{std::move(results.first[0].s_FunctionState)};
+        for (std::size_t i = 1; i < results.first.size(); ++i) {
+            auto& resultsForWorker = results.first[i].s_FunctionState;
+            for (std::size_t j = 0; j < resultsForWorker.size(); ++j) {
+                for (std::size_t k = 0; k < resultsForWorker[j].size(); ++k) {
+                    leafLossGradients[j][k] += resultsForWorker[j][k];
+                }
+            }
+        }
+
+        return leafLossGradients;
+    };
+
+    // Compute the sum of loss gradients for each leaf for the old and
+    // new data.
+
+    auto oldTrainingDataLossGradients = computeLeafLossGradients(true, oldTrainingDataRowMask);
+    auto newTrainingDataLossGradients = computeLeafLossGradients(false, newTrainingDataRowMask);
+
+    for (std::size_t i = 0; i < forest.size(); ++i) {
+        propagateLossGradients(rootIndex(), forest[i], oldTrainingDataLossGradients[i]);
+        propagateLossGradients(rootIndex(), forest[i], newTrainingDataLossGradients[i]);
+    }
+
+    // We interested in choosing trees for which the total gradient at all
+    // nodes is the largest. These at least locally would give the largest
+    // gain in loss by adjusting.
+
+    TDoubleVec result(forest.size(), 0.0);
+    double Z{0.0};
+    for (std::size_t i = 0; i < forest.size(); ++i) {
+        for (std::size_t j = 0; j < forest[i].size(); ++j) {
+            result[i] += (newTrainingDataLossGradients[i][j] +
+                          oldTrainingDataLossGradients[i][j])
+                             .lpNorm<1>();
+        }
+        Z += result[i];
+    }
+    for (auto& p : result) {
+        p /= Z;
+    }
+
+    return result;
 }
 }
 }

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -126,6 +126,19 @@ retrainTreeSelectionProbabilities(std::size_t numberThreads,
     using TRowItr = core::CDataFrame::TRowItr;
     using TLossUPtrVec = std::vector<CLoss::TLossUPtr>;
 
+    // The first tree is used to centre the data and we never retrain this.
+
+    if (forest.size() < 2) {
+        return {};
+    }
+    if (newTrainingDataRowMask.size() == 0) {
+        TDoubleVec result(forest.size(), 0.0);
+        for (std::size_t i = 1; i < result.size(); ++i) {
+            result[i] = 1.0 / static_cast<double>(result.size() - 1);
+        }
+        return result;
+    }
+
     std::size_t numberLossParameters{loss.numberParameters()};
 
     TLossUPtrVec losses;
@@ -209,7 +222,7 @@ retrainTreeSelectionProbabilities(std::size_t numberThreads,
 
     TDoubleVec result(forest.size(), 0.0);
     double Z{0.0};
-    for (std::size_t i = 0; i < forest.size(); ++i) {
+    for (std::size_t i = 1; i < forest.size(); ++i) {
         for (std::size_t j = 0; j < forest[i].size(); ++j) {
             result[i] += (newTrainingDataLossGradients[i][j] +
                           oldTrainingDataLossGradients[i][j])

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -108,15 +108,15 @@ void writeLossCurvature(const TRowRef& row,
 }
 
 TDoubleVec
-retrainSelectionProbabilities(std::size_t numberThreads,
-                              const core::CDataFrame& frame,
-                              const TSizeVec& extraColumns,
-                              std::size_t dependentVariable,
-                              const CDataFrameCategoryEncoder& encoder,
-                              const core::CPackedBitVector& oldTrainingDataRowMask,
-                              const core::CPackedBitVector& newTrainingDataRowMask,
-                              const boosted_tree::CLoss& loss,
-                              const std::vector<std::vector<CBoostedTreeNode>>& forest) {
+retrainTreeSelectionProbabilities(std::size_t numberThreads,
+                                  const core::CDataFrame& frame,
+                                  const TSizeVec& extraColumns,
+                                  std::size_t dependentVariable,
+                                  const CDataFrameCategoryEncoder& encoder,
+                                  const core::CPackedBitVector& oldTrainingDataRowMask,
+                                  const core::CPackedBitVector& newTrainingDataRowMask,
+                                  const boosted_tree::CLoss& loss,
+                                  const std::vector<std::vector<CBoostedTreeNode>>& forest) {
 
     using TFloatVec = std::vector<CFloatStorage>;
     using TRowItr = core::CDataFrame::TRowItr;

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -174,20 +174,20 @@ retrainTreeSelectionProbabilities(std::size_t numberThreads,
         return leafLossGradients;
     };
 
-    // Compute the sum of loss gradients for each leaf for the old and
-    // new data.
-
+    // Compute the sum of loss gradients for each node.
     auto trainingDataLossGradients = computeLeafLossGradients(trainingDataRowMask);
-
     for (std::size_t i = 0; i < forest.size(); ++i) {
         propagateLossGradients(rootIndex(), forest[i], trainingDataLossGradients[i]);
     }
     LOG_TRACE(<< "loss gradients = "
               << core::CContainerPrinter::print(trainingDataLossGradients));
 
-    // We interested in choosing trees for which the total gradient at all
-    // nodes is the largest. These at least locally would give the largest
-    // gain in loss by adjusting.
+    // We are interested in choosing trees for which the total gradient of the
+    // loss at the current predictions for all nodes is the largest. These trees,
+    // at least locally, give the largest gain in loss by adjusting. Gradients
+    // of internal nodes are defined as the sum of the leaf gradients below them.
+    // We include these it captures the fact that certain branches of specific
+    // trees may be retrained for greater effect.
 
     TDoubleVec result(forest.size(), 0.0);
     double Z{0.0};

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -884,9 +884,9 @@ CMakeDataFrameCategoryEncoder::selectFeatures(TSizeVec metricColumnMask,
     LOG_TRACE(<< "features MICe = " << core::CContainerPrinter::print(mics));
 
     std::size_t numberAvailableFeatures{this->numberAvailableFeatures(mics)};
-    std::size_t maximumNumberFeatures{
-        (static_cast<std::size_t>(m_RowMask.manhattan()) + m_MinimumRowsPerFeature / 2) /
-        m_MinimumRowsPerFeature};
+    std::size_t maximumNumberFeatures{std::max(
+        (static_cast<std::size_t>(m_RowMask.manhattan()) + m_MinimumRowsPerFeature / 2) / m_MinimumRowsPerFeature,
+        static_cast<std::size_t>(5))};
     LOG_TRACE(<< "number possible features = " << numberAvailableFeatures
               << " maximum permitted features = " << maximumNumberFeatures);
 

--- a/lib/maths/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/CDataFrameCategoryEncoder.cc
@@ -884,9 +884,9 @@ CMakeDataFrameCategoryEncoder::selectFeatures(TSizeVec metricColumnMask,
     LOG_TRACE(<< "features MICe = " << core::CContainerPrinter::print(mics));
 
     std::size_t numberAvailableFeatures{this->numberAvailableFeatures(mics)};
-    std::size_t maximumNumberFeatures{std::max(
-        (static_cast<std::size_t>(m_RowMask.manhattan()) + m_MinimumRowsPerFeature / 2) / m_MinimumRowsPerFeature,
-        static_cast<std::size_t>(5))};
+    std::size_t maximumNumberFeatures{
+        (static_cast<std::size_t>(m_RowMask.manhattan()) + m_MinimumRowsPerFeature / 2) /
+        m_MinimumRowsPerFeature};
     LOG_TRACE(<< "number possible features = " << numberAvailableFeatures
               << " maximum permitted features = " << maximumNumberFeatures);
 

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -74,7 +74,7 @@ public:
     using TSamplerSelector = std::function<std::size_t(const TRowRef&)>;
 
 public:
-    CStratifiedSampler(std::size_t size) : m_SampledRowIndices(size) {
+    explicit CStratifiedSampler(std::size_t size) : m_SampledRowIndices(size) {
         m_DesiredCounts.reserve(size);
         m_Samplers.reserve(size);
     }
@@ -122,6 +122,7 @@ private:
     TRowSamplerVec m_Samplers;
     TSamplerSelector m_Selector;
 };
+
 using TStratifiedSamplerPtr = std::unique_ptr<CStratifiedSampler>;
 
 //! Get a classifier stratified row sampler for cross fold validation.

--- a/lib/maths/unittest/BoostedTreeTestData.cc
+++ b/lib/maths/unittest/BoostedTreeTestData.cc
@@ -6,6 +6,9 @@
 
 #include "BoostedTreeTestData.h"
 
+#include <core/CContainerPrinter.h>
+#include <core/CPackedBitVector.h>
+
 #include <test/CRandomNumbers.h>
 
 #include <vector>
@@ -17,36 +20,61 @@ using TDoubleVecVec = std::vector<TDoubleVec>;
 using TRowItr = core::CDataFrame::TRowItr;
 using TRowRef = core::CDataFrame::TRowRef;
 
-std::unique_ptr<core::CDataFrame> setupRegressionProblem(test::CRandomNumbers& rng,
-                                                         const TTargetFunc& target,
-                                                         double noiseVariance,
-                                                         std::size_t rows,
-                                                         std::size_t cols) {
-    TDoubleVecVec x(cols - 1);
-    for (std::size_t i = 0; i < cols - 1; ++i) {
-        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+void addRegressionData(test::CRandomNumbers& rng,
+                       const TTargetFunc& target,
+                       const TDoubleVecVec& x,
+                       double noiseVariance,
+                       core::CDataFrame& frame) {
+
+    if (x.empty()) {
+        return;
+    }
+
+    std::size_t rows{x[0].size()};
+    std::size_t cols{x.size() + 1};
+    std::size_t offset{frame.numberRows()};
+
+    core::CPackedBitVector mask{frame.numberRows(), false};
+    for (std::size_t i = 0; i < rows; ++i) {
+        mask.extend(true);
     }
 
     TDoubleVec noise;
     rng.generateNormalSamples(0.0, noiseVariance, rows, noise);
 
-    auto frame = core::makeMainStorageDataFrame(cols, rows).first;
-
-    frame->categoricalColumns(TBoolVec(cols, false));
     for (std::size_t i = 0; i < rows; ++i) {
-        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+        frame.writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             for (std::size_t j = 0; j < cols - 1; ++j, ++column) {
                 *column = x[j][i];
             }
         });
     }
-    frame->finishWritingRows();
-    frame->writeColumns(1, [&](TRowItr beginRows, TRowItr endRows) {
-        for (auto row = beginRows; row != endRows; ++row) {
-            double targetValue{target(*row) + noise[row->index()]};
-            row->writeColumn(cols - 1, targetValue);
-        }
-    });
+    frame.finishWritingRows();
+    frame.writeColumns(1, 0, frame.numberRows(),
+                       [&](TRowItr beginRows, TRowItr endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               double targetValue{target(*row) + noise[row->index() - offset]};
+                               row->writeColumn(cols - 1, targetValue);
+                           }
+                       },
+                       &mask);
+}
+
+std::unique_ptr<core::CDataFrame> setupRegressionProblem(test::CRandomNumbers& rng,
+                                                         const TTargetFunc& target,
+                                                         double noiseVariance,
+                                                         std::size_t rows,
+                                                         std::size_t cols) {
+
+    auto frame = core::makeMainStorageDataFrame(cols, rows).first;
+
+    TDoubleVecVec x(cols - 1);
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    frame->categoricalColumns(TBoolVec(cols, false));
+    addRegressionData(rng, target, x, noiseVariance, *frame);
 
     return frame;
 }

--- a/lib/maths/unittest/BoostedTreeTestData.cc
+++ b/lib/maths/unittest/BoostedTreeTestData.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include "BoostedTreeTestData.h"
+
+#include <test/CRandomNumbers.h>
+
+#include <vector>
+
+using namespace ml;
+using TBoolVec = std::vector<bool>;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TRowItr = core::CDataFrame::TRowItr;
+using TRowRef = core::CDataFrame::TRowRef;
+
+std::unique_ptr<core::CDataFrame> setupRegressionProblem(test::CRandomNumbers& rng,
+                                                         const TTargetFunc& target,
+                                                         double noiseVariance,
+                                                         std::size_t rows,
+                                                         std::size_t cols) {
+    TDoubleVecVec x(cols - 1);
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    TDoubleVec noise;
+    rng.generateNormalSamples(0.0, noiseVariance, rows, noise);
+
+    auto frame = core::makeMainStorageDataFrame(cols, rows).first;
+
+    frame->categoricalColumns(TBoolVec(cols, false));
+    for (std::size_t i = 0; i < rows; ++i) {
+        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            for (std::size_t j = 0; j < cols - 1; ++j, ++column) {
+                *column = x[j][i];
+            }
+        });
+    }
+    frame->finishWritingRows();
+    frame->writeColumns(1, [&](TRowItr beginRows, TRowItr endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            double targetValue{target(*row) + noise[row->index()]};
+            row->writeColumn(cols - 1, targetValue);
+        }
+    });
+
+    return frame;
+}
+
+TTargetFunc linearRegression(test::CRandomNumbers& rng, std::size_t cols) {
+    TDoubleVec m;
+    TDoubleVec s;
+    rng.generateUniformSamples(0.0, 10.0, cols - 1, m);
+    rng.generateUniformSamples(-10.0, 10.0, cols - 1, s);
+    return [=](const TRowRef& row) {
+        double result{0.0};
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            result += m[i] + s[i] * row[i];
+        }
+        return result;
+    };
+}
+
+std::unique_ptr<core::CDataFrame> setupLinearRegressionProblem(std::size_t rows,
+                                                               std::size_t cols) {
+    test::CRandomNumbers rng;
+    double noiseVariance{100.0};
+    auto target = linearRegression(rng, cols);
+    return setupRegressionProblem(rng, target, noiseVariance, rows, cols);
+}

--- a/lib/maths/unittest/BoostedTreeTestData.h
+++ b/lib/maths/unittest/BoostedTreeTestData.h
@@ -14,15 +14,47 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <vector>
 
 using TTargetFunc = std::function<double(const ml::core::CDataFrame::TRowRef&)>;
 
+//! Add regression data which comprises feature vectors \p x and the predictions
+//! of \p target on \p x to \p frame.
+//!
+//! \param rng The random number generator.
+//! \param target Defines the regression target as a function of \p cols - 1 features.
+//! \param x The feature values indexed by feature/column then row.
+//! \param noiseVariance The variance of the noise added to the output of \p target.
+//! \param frame The data frame to which to add the examples \p x.
+void addRegressionData(ml::test::CRandomNumbers& rng,
+                       const TTargetFunc& target,
+                       const std::vector<std::vector<double>>& x,
+                       double noiseVariance,
+                       ml::core::CDataFrame& frame);
+
+//! Create and return a data frame containing the regression problem defined by
+//! \p target.
+//!
+//! The regression target is written into the last column of \p frame.
+//!
+//! \param rng The random number generator.
+//! \param target Defines the regression target as a function of \p cols - 1 features.
+//! \param noiseVariance The variance of the noise added to the output of \p target.
+//! \param rows The number of examples of the regression relationship to generate.
+//! \param cols The number of features + one for the regression target.
 std::unique_ptr<ml::core::CDataFrame> setupRegressionProblem(ml::test::CRandomNumbers& rng,
                                                              const TTargetFunc& target,
                                                              double noiseVariance,
                                                              std::size_t rows,
                                                              std::size_t cols);
+
+//! Set up a random linear regression with \p cols - 1 features.
 TTargetFunc linearRegression(ml::test::CRandomNumbers& rng, std::size_t cols);
+
+//! Create and return a data frame containing a noisy linear regression problem.
+//!
+//! \param rows The number of examples of the regression relationship to generate.
+//! \param cols The number of features + one for the regression target.
 std::unique_ptr<ml::core::CDataFrame>
 setupLinearRegressionProblem(std::size_t rows, std::size_t cols);
 

--- a/lib/maths/unittest/BoostedTreeTestData.h
+++ b/lib/maths/unittest/BoostedTreeTestData.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_BoostedTreeTestData_h
+#define INCLUDED_BoostedTreeTestData_h
+
+#include <core/CDataFrame.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+using TTargetFunc = std::function<double(const ml::core::CDataFrame::TRowRef&)>;
+
+std::unique_ptr<ml::core::CDataFrame> setupRegressionProblem(ml::test::CRandomNumbers& rng,
+                                                             const TTargetFunc& target,
+                                                             double noiseVariance,
+                                                             std::size_t rows,
+                                                             std::size_t cols);
+TTargetFunc linearRegression(ml::test::CRandomNumbers& rng, std::size_t cols);
+std::unique_ptr<ml::core::CDataFrame>
+setupLinearRegressionProblem(std::size_t rows, std::size_t cols);
+
+#endif // INCLUDED_BoostedTreeTestData_h

--- a/lib/maths/unittest/CBoostedTreeLossTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLossTest.cc
@@ -1231,7 +1231,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalLogisticMinimizer) {
                                row, regression->columnHoldingDependentVariable())};
                            double weight{readExampleWeight(row, extraColumns)};
                            leafValues_[rootNode.leafIndex(encodedRow, tree)].add(
-                               encodedRow, prediction, actual, weight);
+                               encodedRow, true /*new example*/, prediction, actual, weight);
                        }
                    },
                    std::move(leafValues)));
@@ -1326,12 +1326,12 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalLossGradientAndCurvature) {
                 mse.curvature(prediction, actual, [&](std::size_t, double curvature) {
                     expectedCurvature = curvature;
                 });
-                mseIncremental.gradient(encodedRow, prediction, actual,
-                                        [&](std::size_t, double gradient) {
+                mseIncremental.gradient(encodedRow, false /*new example*/, prediction,
+                                        actual, [&](std::size_t, double gradient) {
                                             actualGradient = gradient;
                                         });
-                mseIncremental.curvature(encodedRow, prediction, actual,
-                                         [&](std::size_t, double curvature) {
+                mseIncremental.curvature(encodedRow, false /*new example*/, prediction,
+                                         actual, [&](std::size_t, double curvature) {
                                              actualCurvature = curvature;
                                          });
                 BOOST_TEST_REQUIRE(expectedGradient, actualGradient);
@@ -1356,8 +1356,8 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalLossGradientAndCurvature) {
                 mse.gradient(prediction, actual, [&](std::size_t, double gradient) {
                     mseGradient = gradient;
                 });
-                mseIncremental.gradient(encodedRow, prediction, actual,
-                                        [&](std::size_t, double gradient) {
+                mseIncremental.gradient(encodedRow, false /*new example*/, prediction,
+                                        actual, [&](std::size_t, double gradient) {
                                             mseIncrementalGradient = gradient;
                                         });
                 LOG_TRACE(<< "tree prediction = " << treePrediction

--- a/lib/maths/unittest/CBoostedTreeUtilsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeUtilsTest.cc
@@ -16,7 +16,6 @@
 #include <test/CRandomNumbers.h>
 
 #include "BoostedTreeTestData.h"
-#include "maths/COrderings.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -72,7 +71,10 @@ BOOST_AUTO_TEST_CASE(testRetrainTreeSelectionProbabilities) {
         BOOST_TEST_REQUIRE(probabilities.empty());
     }
 
-    // Test some invariants of the probabilities.
+    // Test some invariants of the probabilities:
+    //   1. That number probabilities is equal to the number of trees,
+    //   2. That the probabilities are non-negative, and
+    //   3. That the probabilities are normalized.
     for (std::size_t test = 0; test < 5; ++test) {
         m[0] += 5.0;
         s[0] -= 0.1;

--- a/lib/maths/unittest/CBoostedTreeUtilsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeUtilsTest.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <core/CDataFrame.h>
+
+#include <maths/CBoostedTree.h>
+#include <maths/CBoostedTreeFactory.h>
+#include <maths/CBoostedTreeImpl.h>
+#include <maths/CBoostedTreeLoss.h>
+#include <maths/CBoostedTreeUtils.h>
+
+#include <test/CRandomNumbers.h>
+
+#include "BoostedTreeTestData.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <utility>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(CBoostedTreeUtilsTest)
+
+using namespace ml;
+using TDoubleVec = std::vector<double>;
+
+BOOST_AUTO_TEST_CASE(testRetrainTreeSelectionProbabilities) {
+
+    // 1. Edge cases such as empty forest,
+    // 2. If all the new training data is applies to a particular leaf node
+    //    that tree is selected with high probability.
+
+    std::size_t rows{100};
+    std::size_t cols{4};
+    TDoubleVec m{10.0, 2.0, 5.0};
+    TDoubleVec s{1.0, -0.9, 0.8};
+
+    TTargetFunc target{[&](const core::CDataFrame::TRowRef& row) {
+        double result{0.0};
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            result += m[i] + s[i] * row[i];
+        }
+        return result;
+    }};
+
+    test::CRandomNumbers rng;
+
+    // Edge cases
+    {
+        auto frame = setupRegressionProblem(rng, target, 1.0, rows, cols);
+
+        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                              1, std::make_unique<maths::boosted_tree::CMse>())
+                              .buildFor(*frame, cols - 1);
+        regression->train();
+
+        const auto& hyperparameters = regression->impl().bestHyperparameters();
+        core::CPackedBitVector allRows{rows, true};
+        core::CPackedBitVector noRows;
+
+        std::vector<std::vector<maths::CBoostedTreeNode>> emptyForest;
+        auto probabilities = maths::boosted_tree_detail::retrainTreeSelectionProbabilities(
+            1, *frame, regression->impl().extraColumns(), cols - 1,
+            regression->impl().encoder(), allRows, noRows, regression->impl().loss(),
+            hyperparameters.regularization(), hyperparameters.eta(),
+            hyperparameters.etaGrowthRatePerTree(), emptyForest);
+        BOOST_TEST_REQUIRE(probabilities.empty());
+
+        probabilities = maths::boosted_tree_detail::retrainTreeSelectionProbabilities(
+            1, *frame, regression->impl().extraColumns(), cols - 1,
+            regression->impl().encoder(), allRows, noRows, regression->impl().loss(),
+            hyperparameters.regularization(), hyperparameters.eta(),
+            hyperparameters.etaGrowthRatePerTree(), regression->impl().trainedModel());
+        BOOST_REQUIRE_EQUAL(regression->impl().trainedModel().size(),
+                            probabilities.size());
+        BOOST_REQUIRE_EQUAL(0.0, probabilities[0]);
+        for (std::size_t i = 1; i < probabilities.size(); ++i) {
+            BOOST_REQUIRE_EQUAL(1.0 / static_cast<double>(probabilities.size() - 1),
+                                probabilities[i]);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/unittest/CBoostedTreeUtilsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeUtilsTest.cc
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 
 #include <maths/CBoostedTree.h>
@@ -15,6 +16,7 @@
 #include <test/CRandomNumbers.h>
 
 #include "BoostedTreeTestData.h"
+#include "maths/COrderings.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -22,26 +24,26 @@
 #include <cmath>
 #include <cstddef>
 #include <limits>
+#include <map>
 #include <utility>
 #include <vector>
 
 BOOST_AUTO_TEST_SUITE(CBoostedTreeUtilsTest)
 
 using namespace ml;
+using namespace maths::boosted_tree_detail;
 using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
 
 BOOST_AUTO_TEST_CASE(testRetrainTreeSelectionProbabilities) {
-
-    // 1. Edge cases such as empty forest,
-    // 2. If all the new training data is applies to a particular leaf node
-    //    that tree is selected with high probability.
 
     std::size_t rows{100};
     std::size_t cols{4};
     TDoubleVec m{10.0, 2.0, 5.0};
     TDoubleVec s{1.0, -0.9, 0.8};
+    double noiseVariance{1.0};
 
-    TTargetFunc target{[&](const core::CDataFrame::TRowRef& row) {
+    TTargetFunc target{[=](const core::CDataFrame::TRowRef& row) {
         double result{0.0};
         for (std::size_t i = 0; i < cols - 1; ++i) {
             result += m[i] + s[i] * row[i];
@@ -51,39 +53,70 @@ BOOST_AUTO_TEST_CASE(testRetrainTreeSelectionProbabilities) {
 
     test::CRandomNumbers rng;
 
-    // Edge cases
+    auto frame = setupRegressionProblem(rng, target, noiseVariance, rows, cols);
+
+    auto regression = maths::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::boosted_tree::CMse>())
+                          .buildFor(*frame, cols - 1);
+    regression->train();
+
+    const auto& impl = regression->impl();
+
+    // Edge case.
     {
-        auto frame = setupRegressionProblem(rng, target, 1.0, rows, cols);
-
-        auto regression = maths::CBoostedTreeFactory::constructFromParameters(
-                              1, std::make_unique<maths::boosted_tree::CMse>())
-                              .buildFor(*frame, cols - 1);
-        regression->train();
-
-        const auto& hyperparameters = regression->impl().bestHyperparameters();
-        core::CPackedBitVector allRows{rows, true};
-        core::CPackedBitVector noRows;
-
+        core::CPackedBitVector allRowsMask{rows, true};
         std::vector<std::vector<maths::CBoostedTreeNode>> emptyForest;
-        auto probabilities = maths::boosted_tree_detail::retrainTreeSelectionProbabilities(
-            1, *frame, regression->impl().extraColumns(), cols - 1,
-            regression->impl().encoder(), allRows, noRows, regression->impl().loss(),
-            hyperparameters.regularization(), hyperparameters.eta(),
-            hyperparameters.etaGrowthRatePerTree(), emptyForest);
+        auto probabilities = retrainTreeSelectionProbabilities(
+            1, *frame, impl.extraColumns(), cols - 1, impl.encoder(),
+            allRowsMask, impl.loss(), emptyForest);
         BOOST_TEST_REQUIRE(probabilities.empty());
+    }
 
-        probabilities = maths::boosted_tree_detail::retrainTreeSelectionProbabilities(
-            1, *frame, regression->impl().extraColumns(), cols - 1,
-            regression->impl().encoder(), allRows, noRows, regression->impl().loss(),
-            hyperparameters.regularization(), hyperparameters.eta(),
-            hyperparameters.etaGrowthRatePerTree(), regression->impl().trainedModel());
-        BOOST_REQUIRE_EQUAL(regression->impl().trainedModel().size(),
-                            probabilities.size());
-        BOOST_REQUIRE_EQUAL(0.0, probabilities[0]);
-        for (std::size_t i = 1; i < probabilities.size(); ++i) {
-            BOOST_REQUIRE_EQUAL(1.0 / static_cast<double>(probabilities.size() - 1),
-                                probabilities[i]);
+    // Test some invariants of the probabilities.
+    for (std::size_t test = 0; test < 5; ++test) {
+        m[0] += 5.0;
+        s[0] -= 0.1;
+        m[2] += 1.0;
+        s[2] += 0.1;
+        TTargetFunc deltaTarget{[=](const core::CDataFrame::TRowRef& row) {
+            double result{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                result += m[i] + s[i] * row[i];
+            }
+            return result;
+        }};
+
+        TDoubleVecVec x(cols - 1);
+        for (std::size_t i = 0; i < cols - 1; ++i) {
+            rng.generateUniformSamples(0.0, 10.0, 10, x[i]);
         }
+        addRegressionData(rng, deltaTarget, x, noiseVariance, *frame);
+
+        core::CPackedBitVector allRowsMask{frame->numberRows(), true};
+        core::CPackedBitVector newRowsMask{frame->numberRows() - 10, false};
+        for (std::size_t i = 0; i < 10; ++i) {
+            newRowsMask.extend(true);
+        }
+
+        frame->writeColumns(
+            1, 0, frame->numberRows(),
+            [&](core::CDataFrame::TRowItr beginRows, core::CDataFrame::TRowItr endRows) {
+                for (auto row = beginRows; row != endRows; ++row) {
+                    writeExampleWeight(*row, impl.extraColumns(), 1.0);
+                }
+            },
+            &newRowsMask);
+        regression->predict();
+
+        auto probabilities = retrainTreeSelectionProbabilities(
+            1, *frame, impl.extraColumns(), cols - 1, impl.encoder(),
+            allRowsMask, impl.loss(), impl.trainedModel());
+
+        BOOST_REQUIRE_EQUAL(impl.trainedModel().size(), probabilities.size());
+        BOOST_TEST_REQUIRE(*std::max_element(probabilities.begin(),
+                                             probabilities.end()) >= 0.0);
+        BOOST_REQUIRE_CLOSE(
+            1.0, std::accumulate(probabilities.begin(), probabilities.end(), 0.0), 1e-6);
     }
 }
 

--- a/lib/maths/unittest/Makefile
+++ b/lib/maths/unittest/Makefile
@@ -19,6 +19,7 @@ all: build
 
 SRCS=\
 	Main.cc \
+	BoostedTreeTestData.cc \
 	CAdaptiveBucketingTest.cc \
 	CAgglomerativeClustererTest.cc \
 	CAssignmentTest.cc \
@@ -28,6 +29,7 @@ SRCS=\
 	CBoostedTreeLeafNodeStatisticsTest.cc \
 	CBoostedTreeLossTest.cc \
 	CBoostedTreeTest.cc \
+	CBoostedTreeUtilsTest.cc \
 	CBootstrapClustererTest.cc \
 	CBoundingBoxTest.cc \
 	CCalendarComponentAdaptiveBucketingTest.cc \


### PR DESCRIPTION
This selects trees with probability proportional to the total loss derivative for training examples for the leaves below each node. This tells you at least locally how much you can improve results by just adjusting the tree predictions (from their current values) and selecting this tree to retrain is analogous to gradient decent. I think however it makes sense to randomise selection since this is a heuristic and it gives us a simple way to refine: randomly sample from this distribution and choose the result which minimises the final training loss. This represents a relatively relatively simple to implement baseline strategy.

This also makes the necessary adjustments to not penalise changing predictions on the new training data. Since this could be out of domain of the original training data this is the right thing to do.

A step towards #1721.