### PR TITLE
[7.x][ML] Abort more explicitly

### DIFF
--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -136,7 +136,7 @@ public:
     //! Access to underlying logger (must only be called from macros)
     TLevelSeverityLogger& logger();
 
-    //! Throw a fatal exception
+    //! Terminate the program.
     [[noreturn]] static void fatal();
 
     //! Register a new global fatal error handler.

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -26,10 +26,10 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <stdexcept>
 
 // environ is a global variable from the C runtime library
 #ifdef Windows
@@ -209,7 +209,7 @@ CLogger::TLevelSeverityLogger& CLogger::logger() {
 }
 
 void CLogger::fatal() {
-    throw std::runtime_error("Ml Fatal Exception");
+    std::terminate();
 }
 
 void CLogger::fatalErrorHandler(const TFatalErrorHandler& handler) {

--- a/lib/core/unittest/CLoggerTest.cc
+++ b/lib/core/unittest/CLoggerTest.cc
@@ -18,7 +18,6 @@
 #include <ios>
 #include <iterator>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -104,11 +103,8 @@ BOOST_FIXTURE_TEST_CASE(testLogging, CTestFixture) {
     LOG_AT_LEVEL(ml::core::CLogger::E_Error, << "Dynamic ERROR");
     LOG_FATAL(<< "Fatal - application to handle exit");
     LOG_AT_LEVEL(ml::core::CLogger::E_Fatal, << "Dynamic FATAL " << t);
-    try {
-        LOG_ABORT(<< "Throwing exception " << 1221U << ' ' << 0.23124);
 
-        BOOST_TEST_REQUIRE(false);
-    } catch (std::runtime_error&) { BOOST_TEST_REQUIRE(true); }
+    // It's not possible to test LOG_ABORT as it calls std::terminate
 }
 
 BOOST_FIXTURE_TEST_CASE(testReconfiguration, CTestFixture) {


### PR DESCRIPTION
The LOG_ABORT macro calls CLogger::fatal(), which, prior
to this change, used to throw an exception.

We have a rule of thumb that we don't use exceptions in
our code and exceptions from third party libraries are
caught as close as possible to the call into that library.
When CLogger::fatal() was originally written this rule
was pretty universally applied, and it was a reasonable
assumption that a thrown exception would not be handled
and would hence abort the program. However, we now have so
many exceptions to this rule that an exception thrown by
a LOG_ABORT macro is quite likely to get caught, logged,
and cause some sort of minor workaround code to run. This
is not the intention for LOG_ABORT; it is intended to be
used only when the program is in a fatally compromised
state due to some unforeseen bug and we do not want to
be continuing execution.

This change makes CLogger::fatal() unconditionally call
std::terminate(), i.e. the effect of an unhandled
exception. This puts the functionality back to what it
originally did before we had so many catch blocks.

Backport of #1821