### PR TITLE
[6.8][ML] Abort more explicitly

### DIFF
--- a/include/core/CLogger.h
+++ b/include/core/CLogger.h
@@ -116,10 +116,10 @@ public:
     log4cxx::LoggerPtr logger();
 
 #ifdef Windows
-    //! Throw a fatal exception
+    //! Terminate the program.
     __declspec(noreturn) static void fatal();
 #else
-    //! Throw a fatal exception
+    //! Terminate the program.
     __attribute__((noreturn)) static void fatal();
 #endif
 

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -23,9 +23,9 @@
 #include <log4cxx/propertyconfigurator.h>
 #include <log4cxx/writerappender.h>
 
+#include <exception>
 #include <iostream>
 #include <sstream>
-#include <stdexcept>
 
 #include <errno.h>
 #include <stdlib.h>
@@ -164,7 +164,7 @@ log4cxx::LoggerPtr CLogger::logger() {
 }
 
 void CLogger::fatal() {
-    throw std::runtime_error("Ml Fatal Exception");
+    std::terminate();
 }
 
 bool CLogger::setLoggingLevel(ELevel level) {

--- a/lib/core/unittest/CLoggerTest.cc
+++ b/lib/core/unittest/CLoggerTest.cc
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <ios>
 #include <iterator>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -61,11 +60,8 @@ void CLoggerTest::testLogging() {
     LOG_AT_LEVEL("ERROR", << "Dynamic ERROR");
     LOG_FATAL(<< "Fatal - application to handle exit");
     LOG_AT_LEVEL("FATAL", << "Dynamic FATAL " << t);
-    try {
-        LOG_ABORT(<< "Throwing exception " << 1221U << ' ' << 0.23124);
 
-        CPPUNIT_ASSERT(false);
-    } catch (std::runtime_error&) { CPPUNIT_ASSERT(true); }
+    // It's not possible to test LOG_ABORT as it calls std::terminate
 }
 
 void CLoggerTest::testReconfiguration() {


### PR DESCRIPTION
The LOG_ABORT macro calls CLogger::fatal(), which, prior
to this change, used to throw an exception.

We have a rule of thumb that we don't use exceptions in
our code and exceptions from third party libraries are
caught as close as possible to the call into that library.
When CLogger::fatal() was originally written this rule
was pretty universally applied, and it was a reasonable
assumption that a thrown exception would not be handled
and would hence abort the program. However, we now have so
many exceptions to this rule that an exception thrown by
a LOG_ABORT macro is quite likely to get caught, logged,
and cause some sort of minor workaround code to run. This
is not the intention for LOG_ABORT; it is intended to be
used only when the program is in a fatally compromised
state due to some unforeseen bug and we do not want to
be continuing execution.

This change makes CLogger::fatal() unconditionally call
std::terminate(), i.e. the effect of an unhandled
exception. This puts the functionality back to what it
originally did before we had so many catch blocks.

Backport of #1821