### PR TITLE
[7.x][ML] Make state traversal unwind more quickly on errors

### DIFF
--- a/include/core/CJsonStateRestoreTraverser.h
+++ b/include/core/CJsonStateRestoreTraverser.h
@@ -6,7 +6,6 @@
 #ifndef INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 #define INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 
-#include <core/CNonCopyable.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
 #include <core/ImportExport.h>
@@ -42,7 +41,7 @@ public:
 
     //! Navigate to the next element at the current level, or return false
     //! if there isn't one
-    virtual bool next();
+    bool next() override;
 
     //! Go to the start of the next object
     //! Stops at the first '}' character so this will not
@@ -50,28 +49,28 @@ public:
     bool nextObject();
 
     //! Does the current element have a sub-level?
-    virtual bool hasSubLevel() const;
+    bool hasSubLevel() const override;
 
     //! Get the name of the current element - the returned reference is only
     //! valid for as long as the traverser is pointing at the same element
-    virtual const std::string& name() const;
+    const std::string& name() const override;
 
     //! Get the value of the current element - the returned reference is
     //! only valid for as long as the traverser is pointing at the same
     //! element
-    virtual const std::string& value() const;
+    const std::string& value() const override;
 
     //! Is the traverser at the end of the inputstream?
-    virtual bool isEof() const;
+    bool isEof() const override;
 
 protected:
     //! Navigate to the start of the sub-level of the current element, or
     //! return false if there isn't one
-    virtual bool descend();
+    bool descend() override;
 
     //! Navigate to the element of the level above from which descend() was
     //! called, or return false if there isn't a level above
-    virtual bool ascend();
+    bool ascend() override;
 
     //! Print debug
     void debug() const;

--- a/include/core/CRapidXmlStateRestoreTraverser.h
+++ b/include/core/CRapidXmlStateRestoreTraverser.h
@@ -37,31 +37,31 @@ public:
 
     //! Navigate to the next element at the current level, or return false
     //! if there isn't one
-    virtual bool next();
+    bool next() override;
 
     //! Does the current element have a sub-level?
-    virtual bool hasSubLevel() const;
+    bool hasSubLevel() const override;
 
     //! Get the name of the current element - the returned reference is only
     //! valid for as long as the traverser is pointing at the same element
-    virtual const std::string& name() const;
+    const std::string& name() const override;
 
     //! Get the value of the current element - the returned reference is
     //! only valid for as long as the traverser is pointing at the same
     //! element
-    virtual const std::string& value() const;
+    const std::string& value() const override;
 
     //! Has the end of the underlying document been reached?
-    virtual bool isEof() const;
+    bool isEof() const override;
 
 protected:
     //! Navigate to the start of the sub-level of the current element, or
     //! return false if there isn't one
-    virtual bool descend();
+    bool descend() override;
 
     //! Navigate to the element of the level above from which descend() was
     //! called, or return false if there isn't a level above
-    virtual bool ascend();
+    bool ascend() override;
 
 private:
     //! Get a pointer to the next node element sibling of the current node,

--- a/include/maths/CMultimodalPriorMode.h
+++ b/include/maths/CMultimodalPriorMode.h
@@ -71,7 +71,15 @@ struct SMultimodalPriorMode {
                                    std::ref(s_Prior), std::placeholders::_1)))
         } while (traverser.next());
 
+        this->checkRestoredInvariants();
+
         return true;
+    }
+
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const {
+        VIOLATES_INVARIANT_NO_EVALUATION(s_Prior, ==, nullptr);
     }
 
     //! Persist state by passing information to the supplied inserter.

--- a/include/model/CSearchKey.h
+++ b/include/model/CSearchKey.h
@@ -120,6 +120,10 @@ private:
     //! Initialise by traversing a state document.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
+    //! Check the state invariants after restoration
+    //! Abort on failure.
+    void checkRestoredInvariants() const;
+
 public:
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -799,7 +799,9 @@ bool CAnomalyJob::restoreState(core::CDataSearcher& restoreSearcher,
                                core_t::TTime& completeToTime) {
     size_t numDetectors(0);
     try {
-        // Restore from Elasticsearch compressed data
+        // Restore from Elasticsearch compressed data.
+        // (To restore from uncompressed data for testing, comment the next line
+        // and substitute decompressor with restoreSearcher two lines below.)
         core::CStateDecompressor decompressor(restoreSearcher);
 
         core::CDataSearcher::TIStreamP strm(decompressor.search(1, 1));

--- a/lib/api/CFieldDataCategorizer.cc
+++ b/lib/api/CFieldDataCategorizer.cc
@@ -277,7 +277,9 @@ bool CFieldDataCategorizer::restoreState(core::CDataSearcher& restoreSearcher,
     LOG_DEBUG(<< "Restore categorizer state");
 
     try {
-        // Restore from Elasticsearch compressed data
+        // Restore from Elasticsearch compressed data.
+        // (To restore from uncompressed data for testing, comment the next line
+        // and substitute decompressor with restoreSearcher two lines below.)
         core::CStateDecompressor decompressor(restoreSearcher);
 
         core::CDataSearcher::TIStreamP strm(decompressor.search(1, 1));

--- a/lib/core/CJsonStateRestoreTraverser.cc
+++ b/lib/core/CJsonStateRestoreTraverser.cc
@@ -29,6 +29,10 @@ bool CJsonStateRestoreTraverser::isEof() const {
 }
 
 bool CJsonStateRestoreTraverser::next() {
+    if (haveBadState()) {
+        return false;
+    }
+
     if (!m_Started) {
         if (this->start() == false) {
             return false;
@@ -82,6 +86,10 @@ bool CJsonStateRestoreTraverser::hasSubLevel() const {
 }
 
 const std::string& CJsonStateRestoreTraverser::name() const {
+    if (haveBadState()) {
+        return EMPTY_STRING;
+    }
+
     if (!m_Started) {
         if (const_cast<CJsonStateRestoreTraverser*>(this)->start() == false) {
             return EMPTY_STRING;
@@ -92,6 +100,10 @@ const std::string& CJsonStateRestoreTraverser::name() const {
 }
 
 const std::string& CJsonStateRestoreTraverser::value() const {
+    if (haveBadState()) {
+        return EMPTY_STRING;
+    }
+
     if (!m_Started) {
         if (const_cast<CJsonStateRestoreTraverser*>(this)->start() == false) {
             return EMPTY_STRING;
@@ -262,6 +274,10 @@ bool CJsonStateRestoreTraverser::start() {
 }
 
 bool CJsonStateRestoreTraverser::advance() {
+    if (haveBadState()) {
+        return false;
+    }
+
     bool keepGoing(true);
 
     while (keepGoing) {

--- a/lib/core/CRapidXmlStateRestoreTraverser.cc
+++ b/lib/core/CRapidXmlStateRestoreTraverser.cc
@@ -21,6 +21,10 @@ CRapidXmlStateRestoreTraverser::CRapidXmlStateRestoreTraverser(const CRapidXmlPa
 }
 
 bool CRapidXmlStateRestoreTraverser::next() {
+    if (haveBadState()) {
+        return false;
+    }
+
     CRapidXmlParser::TCharRapidXmlNode* next(this->nextNodeElement());
     if (next == nullptr) {
         return false;
@@ -39,6 +43,11 @@ bool CRapidXmlStateRestoreTraverser::hasSubLevel() const {
 }
 
 const std::string& CRapidXmlStateRestoreTraverser::name() const {
+    if (haveBadState()) {
+        m_CachedName.clear();
+        return m_CachedName;
+    }
+
     if (!m_IsNameCacheValid) {
         if (m_CurrentNode != nullptr) {
             m_CachedName.assign(m_CurrentNode->name(), m_CurrentNode->name_size());
@@ -52,6 +61,11 @@ const std::string& CRapidXmlStateRestoreTraverser::name() const {
 }
 
 const std::string& CRapidXmlStateRestoreTraverser::value() const {
+    if (haveBadState()) {
+        m_CachedValue.clear();
+        return m_CachedValue;
+    }
+
     if (!m_IsValueCacheValid) {
         if (m_CurrentNode != nullptr) {
             // NB: this doesn't work for CDATA - see implementation decisions in

--- a/lib/core/CStateRestoreTraverser.cc
+++ b/lib/core/CStateRestoreTraverser.cc
@@ -25,15 +25,11 @@ void CStateRestoreTraverser::setBadState() {
 }
 
 CStateRestoreTraverser::CAutoLevel::CAutoLevel(CStateRestoreTraverser& traverser)
-    : m_Traverser(traverser), m_Descended(traverser.descend()), m_BadState(false) {
-}
-
-void CStateRestoreTraverser::CAutoLevel::setBadState() {
-    m_BadState = true;
+    : m_Traverser{traverser}, m_Descended{traverser.descend()} {
 }
 
 CStateRestoreTraverser::CAutoLevel::~CAutoLevel() {
-    if (m_Descended && !m_BadState) {
+    if (m_Descended && m_Traverser.haveBadState() == false) {
         if (m_Traverser.ascend() == false) {
             LOG_ERROR(<< "Inconsistency - could not ascend following previous descend");
             m_Traverser.setBadState();

--- a/lib/maths/CBjkstUniqueValues.cc
+++ b/lib/maths/CBjkstUniqueValues.cc
@@ -255,8 +255,10 @@ CBjkstUniqueValues::CBjkstUniqueValues(std::size_t numberHashes, std::size_t max
 
 CBjkstUniqueValues::CBjkstUniqueValues(core::CStateRestoreTraverser& traverser)
     : m_MaxSize(0), m_NumberHashes(0) {
-    traverser.traverseSubLevel(std::bind(&CBjkstUniqueValues::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CBjkstUniqueValues::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 void CBjkstUniqueValues::swap(CBjkstUniqueValues& other) noexcept {

--- a/lib/maths/CConstantPrior.cc
+++ b/lib/maths/CConstantPrior.cc
@@ -53,8 +53,10 @@ CConstantPrior::CConstantPrior(const TOptionalDouble& constant)
 
 CConstantPrior::CConstantPrior(core::CStateRestoreTraverser& traverser)
     : CPrior(maths_t::E_DiscreteData, 0.0) {
-    traverser.traverseSubLevel(std::bind(&CConstantPrior::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CConstantPrior::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CConstantPrior::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/CCountMinSketch.cc
+++ b/lib/maths/CCountMinSketch.cc
@@ -43,8 +43,10 @@ CCountMinSketch::CCountMinSketch(std::size_t rows, std::size_t columns)
 
 CCountMinSketch::CCountMinSketch(core::CStateRestoreTraverser& traverser)
     : m_Rows(0), m_Columns(0), m_TotalCount(0.0), m_Sketch() {
-    traverser.traverseSubLevel(std::bind(&CCountMinSketch::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CCountMinSketch::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 void CCountMinSketch::swap(CCountMinSketch& other) noexcept {

--- a/lib/maths/CGammaRateConjugate.cc
+++ b/lib/maths/CGammaRateConjugate.cc
@@ -722,8 +722,10 @@ CGammaRateConjugate::CGammaRateConjugate(const SDistributionRestoreParams& param
                                          double offsetMargin)
     : CPrior(params.s_DataType, 0.0), m_Offset(0.0), m_OffsetMargin(offsetMargin),
       m_LikelihoodShape(1.0), m_PriorShape(0.0), m_PriorRate(0.0) {
-    traverser.traverseSubLevel(std::bind(&CGammaRateConjugate::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CGammaRateConjugate::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CGammaRateConjugate::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/CLogNormalMeanPrecConjugate.cc
+++ b/lib/maths/CLogNormalMeanPrecConjugate.cc
@@ -629,8 +629,10 @@ CLogNormalMeanPrecConjugate::CLogNormalMeanPrecConjugate(const SDistributionRest
     : CPrior(params.s_DataType, params.s_DecayRate), m_Offset(0.0),
       m_OffsetMargin(offsetMargin), m_GaussianMean(0.0),
       m_GaussianPrecision(0.0), m_GammaShape(0.0), m_GammaRate(0.0) {
-    traverser.traverseSubLevel(std::bind(&CLogNormalMeanPrecConjugate::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CLogNormalMeanPrecConjugate::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CLogNormalMeanPrecConjugate::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/CMultinomialConjugate.cc
+++ b/lib/maths/CMultinomialConjugate.cc
@@ -276,8 +276,10 @@ CMultinomialConjugate::CMultinomialConjugate(const SDistributionRestoreParams& p
                                              core::CStateRestoreTraverser& traverser)
     : CPrior(maths_t::E_DiscreteData, params.s_DecayRate),
       m_NumberAvailableCategories(0), m_TotalConcentration(0.0) {
-    traverser.traverseSubLevel(std::bind(&CMultinomialConjugate::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CMultinomialConjugate::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CMultinomialConjugate::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/CNormalMeanPrecConjugate.cc
+++ b/lib/maths/CNormalMeanPrecConjugate.cc
@@ -456,8 +456,10 @@ CNormalMeanPrecConjugate::CNormalMeanPrecConjugate(const SDistributionRestorePar
                                                    core::CStateRestoreTraverser& traverser)
     : CPrior(params.s_DataType, params.s_DecayRate), m_GaussianMean(0.0),
       m_GaussianPrecision(0.0), m_GammaShape(0.0), m_GammaRate(0.0) {
-    traverser.traverseSubLevel(std::bind(&CNormalMeanPrecConjugate::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CNormalMeanPrecConjugate::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CNormalMeanPrecConjugate::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/COneOfNPrior.cc
+++ b/lib/maths/COneOfNPrior.cc
@@ -126,8 +126,11 @@ COneOfNPrior::COneOfNPrior(const TDoublePriorPtrPrVec& models,
 COneOfNPrior::COneOfNPrior(const SDistributionRestoreParams& params,
                            core::CStateRestoreTraverser& traverser)
     : CPrior(params.s_DataType, params.s_DecayRate) {
-    traverser.traverseSubLevel(std::bind(&COneOfNPrior::acceptRestoreTraverser, this,
-                                         std::cref(params), std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&COneOfNPrior::acceptRestoreTraverser,
+                                             this, std::cref(params),
+                                             std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool COneOfNPrior::acceptRestoreTraverser(const SDistributionRestoreParams& params,

--- a/lib/maths/CPoissonMeanConjugate.cc
+++ b/lib/maths/CPoissonMeanConjugate.cc
@@ -182,8 +182,10 @@ CPoissonMeanConjugate::CPoissonMeanConjugate(const SDistributionRestoreParams& p
                                              core::CStateRestoreTraverser& traverser)
     : CPrior(maths_t::E_IntegerData, params.s_DecayRate), m_Offset(0.0),
       m_Shape(0.0), m_Rate(0.0) {
-    traverser.traverseSubLevel(std::bind(&CPoissonMeanConjugate::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CPoissonMeanConjugate::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CPoissonMeanConjugate::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/CSeasonalComponentAdaptiveBucketing.cc
@@ -102,8 +102,10 @@ CSeasonalComponentAdaptiveBucketing::CSeasonalComponentAdaptiveBucketing(
     double minimumBucketLength,
     core::CStateRestoreTraverser& traverser)
     : CAdaptiveBucketing{decayRate, minimumBucketLength} {
-    traverser.traverseSubLevel(std::bind(&CSeasonalComponentAdaptiveBucketing::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CSeasonalComponentAdaptiveBucketing::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 const CSeasonalComponentAdaptiveBucketing& CSeasonalComponentAdaptiveBucketing::

--- a/lib/maths/CStatisticalTests.cc
+++ b/lib/maths/CStatisticalTests.cc
@@ -150,8 +150,10 @@ CStatisticalTests::CCramerVonMises::CCramerVonMises(std::size_t size)
 }
 
 CStatisticalTests::CCramerVonMises::CCramerVonMises(core::CStateRestoreTraverser& traverser) {
-    traverser.traverseSubLevel(std::bind(&CStatisticalTests::CCramerVonMises::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CStatisticalTests::CCramerVonMises::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CStatisticalTests::CCramerVonMises::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -204,7 +204,7 @@ bool CAnomalyDetector::legacyModelEnsembleAcceptRestoreTraverser(const std::stri
         if (name == DATA_GATHERER_TAG) {
             m_DataGatherer.reset(
                 m_ModelFactory->makeDataGatherer(partitionFieldValue, traverser));
-            if (!m_DataGatherer) {
+            if (m_DataGatherer == nullptr || m_DataGatherer->checkInvariants() == false) {
                 LOG_ERROR(<< "Failed to restore the data gatherer from "
                           << traverser.value());
                 return false;

--- a/lib/model/CCategoryExamplesCollector.cc
+++ b/lib/model/CCategoryExamplesCollector.cc
@@ -39,8 +39,10 @@ CCategoryExamplesCollector::CCategoryExamplesCollector(std::size_t maxExamples)
 CCategoryExamplesCollector::CCategoryExamplesCollector(std::size_t maxExamples,
                                                        core::CStateRestoreTraverser& traverser)
     : m_MaxExamples(maxExamples) {
-    traverser.traverseSubLevel(std::bind(&CCategoryExamplesCollector::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CCategoryExamplesCollector::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CCategoryExamplesCollector::add(CLocalCategoryId categoryId, const std::string& example) {

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -46,8 +46,10 @@ CCountingModel::CCountingModel(const SModelParams& params,
     : CAnomalyDetectorModel(params, dataGatherer, {}),
       m_StartTime(CAnomalyDetectorModel::TIME_UNSET),
       m_InterimBucketCorrector(interimBucketCorrector) {
-    traverser.traverseSubLevel(std::bind(&CCountingModel::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CCountingModel::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 CCountingModel::CCountingModel(bool isForPersistence, const CCountingModel& other)

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -756,11 +756,19 @@ core_t::TTime CDataGatherer::earliestBucketStartTime() const {
 }
 
 bool CDataGatherer::checkInvariants() const {
-    LOG_DEBUG(<< "Checking invariants for people registry");
-    bool result = m_PeopleRegistry.checkInvariants();
-    LOG_DEBUG(<< "Checking invariants for attributes registry");
-    result &= m_AttributesRegistry.checkInvariants();
-    return result;
+    if (m_BucketGatherer == nullptr) {
+        LOG_ERROR(<< "No bucket gatherer");
+        return false;
+    }
+    if (m_PeopleRegistry.checkInvariants() == false) {
+        LOG_ERROR(<< "People registry invariants violated");
+        return false;
+    }
+    if (m_AttributesRegistry.checkInvariants() == false) {
+        LOG_ERROR(<< "Attributes registry invariants violated");
+        return false;
+    }
+    return true;
 }
 
 bool CDataGatherer::acceptRestoreTraverser(const std::string& summaryCountFieldName,
@@ -833,6 +841,11 @@ bool CDataGatherer::restoreBucketGatherer(const std::string& summaryCountFieldNa
             }
         }
     } while (traverser.next());
+
+    if (m_BucketGatherer == nullptr) {
+        LOG_ERROR(<< "Failed to restore any bucket gatherer");
+        return false;
+    }
 
     return true;
 }

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -745,8 +745,10 @@ CEventRateBucketGatherer::CEventRateBucketGatherer(CDataGatherer& dataGatherer,
       m_BeginInfluencingFields(0), m_BeginValueField(0), m_BeginSummaryFields(0) {
     this->initializeFieldNames(personFieldName, attributeFieldName, valueFieldName,
                                summaryCountFieldName, influenceFieldNames);
-    traverser.traverseSubLevel(std::bind(&CEventRateBucketGatherer::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CEventRateBucketGatherer::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 CEventRateBucketGatherer::CEventRateBucketGatherer(bool isForPersistence,

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -86,8 +86,10 @@ CEventRateModel::CEventRateModel(const SModelParams& params,
                        influenceCalculators),
       m_CurrentBucketStats(CAnomalyDetectorModel::TIME_UNSET),
       m_InterimBucketCorrector(interimBucketCorrector) {
-    traverser.traverseSubLevel(std::bind(&CEventRateModel::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CEventRateModel::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 CEventRateModel::CEventRateModel(bool isForPersistence, const CEventRateModel& other)

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -103,8 +103,10 @@ CEventRatePopulationModel::CEventRatePopulationModel(
       m_InterimBucketCorrector(interimBucketCorrector), m_Probabilities(0.05) {
     this->initialize(newFeatureModels, newFeatureCorrelateModelPriors,
                      std::move(featureCorrelatesModels));
-    traverser.traverseSubLevel(std::bind(&CEventRatePopulationModel::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CEventRatePopulationModel::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 void CEventRatePopulationModel::initialize(

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -385,6 +385,10 @@ bool CIndividualModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser& tr
         RESTORE_BUILT_IN(UPGRADING_PRE_7_5_STATE, upgradingPre7p5State)
     } while (traverser.next());
 
+    if (traverser.haveBadState()) {
+        return false;
+    }
+
     const double DEFAULT_CUTOFF_TO_MODEL_EMPTY_BUCKETS{0.2};
 
     for (auto& feature : m_FeatureModels) {

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -945,9 +945,12 @@ CMetricBucketGatherer::CMetricBucketGatherer(CDataGatherer& dataGatherer,
     : CBucketGatherer(dataGatherer, 0, influenceFieldNames.size()),
       m_ValueFieldName(valueFieldName), m_BeginValueFields(0) {
     this->initializeFieldNamesPart1(personFieldName, attributeFieldName, influenceFieldNames);
-    traverser.traverseSubLevel(std::bind(&CMetricBucketGatherer::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
-    this->initializeFieldNamesPart2(valueFieldName, summaryCountFieldName);
+    if (traverser.traverseSubLevel(std::bind(&CMetricBucketGatherer::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    } else {
+        this->initializeFieldNamesPart2(valueFieldName, summaryCountFieldName);
+    }
 }
 
 CMetricBucketGatherer::CMetricBucketGatherer(bool isForPersistence,

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -89,8 +89,10 @@ CMetricModel::CMetricModel(const SModelParams& params,
                        influenceCalculators),
       m_CurrentBucketStats(CAnomalyDetectorModel::TIME_UNSET),
       m_InterimBucketCorrector(interimBucketCorrector) {
-    traverser.traverseSubLevel(std::bind(&CMetricModel::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CMetricModel::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 CMetricModel::CMetricModel(bool isForPersistence, const CMetricModel& other)

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -102,8 +102,10 @@ CMetricPopulationModel::CMetricPopulationModel(
       m_InterimBucketCorrector(interimBucketCorrector), m_Probabilities(0.05) {
     this->initialize(newFeatureModels, newFeatureCorrelateModelPriors,
                      std::move(featureCorrelatesModels));
-    traverser.traverseSubLevel(std::bind(&CMetricPopulationModel::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CMetricPopulationModel::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 void CMetricPopulationModel::initialize(const TFeatureMathsModelSPtrPrVec& newFeatureModels,

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -13,6 +13,7 @@
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
+#include <core/RestoreMacros.h>
 
 #include <maths/CChecksum.h>
 
@@ -123,7 +124,16 @@ bool CSearchKey::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser)
         }
     } while (traverser.next());
 
+    this->checkRestoredInvariants();
+
     return true;
+}
+
+void CSearchKey::checkRestoredInvariants() const {
+    VIOLATES_INVARIANT_NO_EVALUATION(m_FieldName, ==, nullptr);
+    VIOLATES_INVARIANT_NO_EVALUATION(m_ByFieldName, ==, nullptr);
+    VIOLATES_INVARIANT_NO_EVALUATION(m_OverFieldName, ==, nullptr);
+    VIOLATES_INVARIANT_NO_EVALUATION(m_PartitionFieldName, ==, nullptr);
 }
 
 void CSearchKey::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -71,8 +71,10 @@ CTokenListCategory::CTokenListCategory(bool isDryRun,
 }
 
 CTokenListCategory::CTokenListCategory(core::CStateRestoreTraverser& traverser) {
-    traverser.traverseSubLevel(std::bind(&CTokenListCategory::acceptRestoreTraverser,
-                                         this, std::placeholders::_1));
+    if (traverser.traverseSubLevel(std::bind(&CTokenListCategory::acceptRestoreTraverser,
+                                             this, std::placeholders::_1)) == false) {
+        traverser.setBadState();
+    }
 }
 
 bool CTokenListCategory::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {


### PR DESCRIPTION
This change makes state traversal cascade failures up the
call stack more quickly than it used to.

The biggest changes are:

1. We no longer traverse a sub-level if there's ever been
   bad state detected
2. Some constructors that used to ignore bad state now
   set the bad state flag

Also adds invariant checking after restore to the
maths::SMultimodalPriorMode and model::CSearchKey classes,
which were missed in #1717 and #1737 respectively.

Backport of #1823