### PR TITLE
[ML] Make CI scripts independent of initial working directory

### DIFF
--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -33,15 +33,15 @@
 
 set +x
 
+# Change directory to the directory containing this script
+cd "$(dirname $0)"
+
 # If this isn't a PR build or a debug build then obtain credentials from Vault
 if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
     . ./aws_creds_from_vault.sh
 fi
 
 set -e
-
-# Change directory to the directory containing this script
-cd "$(dirname $0)"
 
 # Default to a snapshot build
 if [ -z "$BUILD_SNAPSHOT" ] ; then

--- a/dev-tools/jenkins_cross_compile.sh
+++ b/dev-tools/jenkins_cross_compile.sh
@@ -30,6 +30,9 @@
 
 set +x
 
+# Change directory to the directory containing this script
+cd "$(dirname $0)"
+
 # If this isn't a PR build or a debug build then obtain credentials from Vault
 if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
     . ./aws_creds_from_vault.sh
@@ -39,11 +42,8 @@ set -e
 
 if [[ `uname` != Linux || `uname -m` != x86_64 ]] ; then
     echo "This script must be run on linux-x86_64"
-    exit 1
+    exit 2
 fi
-
-# Change directory to the directory containing this script
-cd "$(dirname $0)"
 
 # Default to a snapshot build
 if [ -z "$BUILD_SNAPSHOT" ] ; then
@@ -60,7 +60,7 @@ fi
 # Version qualifier shouldn't be used in PR builds
 if [[ -n "$PR_AUTHOR" && -n "$VERSION_QUALIFIER" ]] ; then
     echo "VERSION_QUALIFIER should not be set in PR builds: was $VERSION_QUALIFIER"
-    exit 2
+    exit 3
 fi
 
 # Remove any old builds


### PR DESCRIPTION
This is a followup to #1835 that makes the scripts work
reliably nomatter where they are started from.