### PR TITLE
[7.12][ML] Restructure Jenkins scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
 String versionQualifier = System.getProperty("build.version_qualifier", "")
 boolean isSnapshot = "true".equals(System.getProperty("build.snapshot", "true"))
+String mlDebug = System.getProperty("build.ml_debug", "")
 
 boolean isWindows = OperatingSystem.current().isWindows()
 boolean isLinux = OperatingSystem.current().isLinux()
@@ -62,7 +63,8 @@ project.ext.make = (isMacOsX || isWindows) ? "gnumake" : "make"
 project.ext.numCpus = Runtime.runtime.availableProcessors()
 project.ext.makeEnvironment = [ 'CPP_CROSS_COMPILE': cppCrossCompile,
                                 'VERSION_QUALIFIER': versionQualifier,
-                                'SNAPSHOT': (isSnapshot ? 'yes' : 'no') ]
+                                'SNAPSHOT': (isSnapshot ? 'yes' : 'no'),
+                                'ML_DEBUG': mlDebug ]
 
 configurations.all {
   // check for updates every build

--- a/dev-tools/aws_creds_from_vault.sh
+++ b/dev-tools/aws_creds_from_vault.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# Gets AWS access credentials from Vault.
+#
+# Designed to be run by sourcing into the script that requires the credentials.
+# Requires the jq utility.  Disables command tracing during execution to
+# prevent sensitive information getting into the console output.
+#
+# When called the following environment variables must be set:
+# - VAULT_ROLE_ID
+# - VAULT_SECRET_ID
+#
+# On success the input environment variables will have been wiped, and the
+# following environment variables will be set that contain the temporary
+# access key and secret key for accessing AWS:
+# - ML_AWS_ACCESS_KEY
+# - ML_AWS_SECRET_KEY
+#
+# On failure this script will exit, so will terminate the script that sourced
+# it.
+#
+# It is pointless to run this script in a sub-process - it must be sourced by
+# some other script to be of any use.
+
+case $- in
+    *x*)
+        set +x
+        REENABLE_X_OPTION=true
+        ;;
+    *)
+        REENABLE_X_OPTION=false
+        ;;
+esac
+
+export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+
+unset ML_AWS_ACCESS_KEY ML_AWS_SECRET_KEY
+FAILURES=0
+while [[ $FAILURES -lt 3 && -z "$ML_AWS_ACCESS_KEY" ]] ; do
+    AWS_CREDS=$(vault read -format=json -field=data aws-dev/creds/prelertartifacts)
+    if [ $? -eq 0 ] ; then
+        export ML_AWS_ACCESS_KEY=$(echo $AWS_CREDS | jq -r '.access_key')
+        export ML_AWS_SECRET_KEY=$(echo $AWS_CREDS | jq -r '.secret_key')
+    fi
+    if [ -z "$ML_AWS_ACCESS_KEY" ] ; then
+        let FAILURES++
+        echo "Attempt $FAILURES to get AWS credentials failed"
+    fi
+done
+
+unset VAULT_TOKEN VAULT_ROLE_ID VAULT_SECRET_ID
+
+if [ -z "$ML_AWS_ACCESS_KEY" -o -z "$ML_AWS_SECRET_KEY" ] ; then
+    echo "Exiting after failing to get AWS credentials $FAILURES times"
+    exit 1
+fi
+
+if [ "$REENABLE_X_OPTION" = true ] ; then
+    set -x
+fi

--- a/dev-tools/docker/linux_aarch64_cross_builder/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_builder/Dockerfile
@@ -21,6 +21,9 @@ ARG VERSION_QUALIFIER=
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 
+# Pass through ML debug option (default blank)
+ARG ML_DEBUG=
+
 # Run the build
 RUN \
   /ml-cpp/dev-tools/docker/docker_entrypoint.sh

--- a/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
@@ -18,6 +18,9 @@ ARG VERSION_QUALIFIER=
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 
+# Pass through ML debug option (default blank)
+ARG ML_DEBUG=
+
 # Run the build
 RUN \
   /ml-cpp/dev-tools/docker/docker_entrypoint.sh

--- a/dev-tools/docker/linux_aarch64_native_tester/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_tester/Dockerfile
@@ -18,6 +18,9 @@ ARG VERSION_QUALIFIER=
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 
+# Pass through ML debug option (default blank)
+ARG ML_DEBUG=
+
 # Run the build and unit tests
 RUN \
   /ml-cpp/dev-tools/docker/docker_entrypoint.sh --test

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -18,6 +18,9 @@ ARG VERSION_QUALIFIER=
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 
+# Pass through ML debug option (default blank)
+ARG ML_DEBUG=
+
 # Run the build
 RUN \
   /ml-cpp/dev-tools/docker/docker_entrypoint.sh

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -18,6 +18,9 @@ ARG VERSION_QUALIFIER=
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 
+# Pass through ML debug option (default blank)
+ARG ML_DEBUG=
+
 # Run the build and unit tests
 RUN \
   /ml-cpp/dev-tools/docker/docker_entrypoint.sh --test

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -21,6 +21,9 @@ ARG VERSION_QUALIFIER=
 # Pass through whether this is a snapshot build (default yes if not specified)
 ARG SNAPSHOT=yes
 
+# Pass through ML debug option (default blank)
+ARG ML_DEBUG=
+
 # Run the build
 RUN \
   /ml-cpp/dev-tools/docker/docker_entrypoint.sh

--- a/dev-tools/docker_build.sh
+++ b/dev-tools/docker_build.sh
@@ -75,7 +75,7 @@ do
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
     prefetch_docker_image "$DOCKERFILE"
-    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
+    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT --build-arg ML_DEBUG=$ML_DEBUG -f "$DOCKERFILE" .
     # Using tar to copy the build artifacts out of the container seems more reliable
     # than docker cp, and also means the files end up with the correct uid/gid
     docker run --rm --workdir=/ml-cpp $TEMP_TAG tar cf - build/distributions | tar xvf -

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -76,7 +76,7 @@ do
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
     prefetch_docker_image "$DOCKERFILE"
-    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT -f "$DOCKERFILE" .
+    docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT --build-arg ML_DEBUG=$ML_DEBUG -f "$DOCKERFILE" .
     # Using tar to copy the build and test artifacts out of the container seems
     # more reliable than docker cp, and also means the files end up with the
     # correct uid/gid

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -6,14 +6,15 @@
 
 # The Windows part of ML C++ CI does the following:
 #
-# 1. If this is not a PR build, obtain credentials from Vault for the accessing
-#    S3
+# 1. If this is not a PR build nor a debug build, obtain credentials from Vault
+#    for the accessing S3
 # 2. Build and unit test the Windows version of the C++
-# 3. If this is not a PR build, upload the build to the artifacts directory on
-#    S3 that subsequent Java builds will download the C++ components from
+# 3. If this is not a PR build nor a debug build, upload the builds to the
+#    artifacts directory on S3 that subsequent Java builds will download the C++
+#    components from
 
-# If this isn't a PR build then obtain credentials from Vault
-if (!(Test-Path Env:PR_AUTHOR)) {
+# If this isn't a PR build or a debug build then obtain credentials from Vault
+if (!(Test-Path Env:PR_AUTHOR) -And !(Test-Path Env:ML_DEBUG)) {
     # Generate a Vault token
     $Env:VAULT_TOKEN=& vault write -field=token auth/approle/login "role_id=$Env:VAULT_ROLE_ID" "secret_id=$Env:VAULT_SECRET_ID"
     if ($LastExitCode -ne 0) {
@@ -56,23 +57,53 @@ if (!(Test-Path Env:BUILD_SNAPSHOT)) {
     $Env:BUILD_SNAPSHOT="true"
 }
 
+# Default to running tests
+if (!(Test-Path Env:RUN_TESTS)) {
+    $Env:RUN_TESTS="true"
+}
+
+# Default to no version qualifier
+if (!(Test-Path Env:VERSION_QUALIFIER)) {
+    $Env:VERSION_QUALIFIER=""
+} elseif (Test-Path Env:PR_AUTHOR) {
+    Write-Output "VERSION_QUALIFIER should not be set in PR builds: was $Env:VERSION_QUALIFIER"
+    Exit 2
+}
+
+if (Test-Path Env:PR_AUTHOR) {
+    if ($Env:RUN_TESTS -eq "false") {
+        Write-Output "RUN_TESTS should not be false in PR builds"
+        Exit 3
+    }
+    $Tasks="clean", "buildZip", "check"
+} elseif ($Env:RUN_TESTS -eq "false") {
+    $Tasks="clean", "buildZip", "buildZipSymbols"
+} else {
+    $Tasks="clean", "buildZip", "buildZipSymbols", "check"
+}
+
+if (Test-Path Env:ML_DEBUG) {
+    $DebugOption="-Dbuild.ml_debug=$Env:ML_DEBUG"
+} else {
+    $DebugOption=""
+}
+
 # The exit code of the gradlew commands is checked explicitly, and their
 # stderr is treated as an error by PowerShell without this
 $ErrorActionPreference="Continue"
 
 # Run the build and unit tests
 # The | % { "$_" } at the end converts any error objects on stderr to strings
-& ".\gradlew.bat" --info "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" clean buildZip buildZipSymbols check 2>&1 | % { "$_" }
+& ".\gradlew.bat" --info "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" $DebugOption $Tasks 2>&1 | % { "$_" }
 if ($LastExitCode -ne 0) {
     Exit $LastExitCode
 }
 
-# If this isn't a PR build then upload the artifacts
-if (!(Test-Path Env:PR_AUTHOR)) {
+# If this isn't a PR build and isn't a debug build then upload the artifacts
+if (!(Test-Path Env:PR_AUTHOR) -And !(Test-Path Env:ML_DEBUG)) {
     # The | % { "$_" } at the end converts any error objects on stderr to strings
-    & ".\gradlew.bat" --info -b "upload.gradle" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" upload 2>&1 | % { "$_" }
+    & ".\gradlew.bat" --info -b "upload.gradle" "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" upload 2>&1 | % { "$_" }
     if ($LastExitCode -ne 0) {
         Exit $LastExitCode
     }
 }
-

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -28,15 +28,15 @@
 
 set +x
 
+# Change directory to the directory containing this script
+cd "$(dirname $0)"
+
 # If this isn't a PR build or a debug build then obtain credentials from Vault
 if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
     . ./aws_creds_from_vault.sh
 fi
 
 set -e
-
-# Change directory to the directory containing this script
-cd "$(dirname $0)"
 
 # Default to a snapshot build
 if [ -z "$BUILD_SNAPSHOT" ] ; then

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -7,15 +7,16 @@
 
 # The non-Windows part of ML C++ CI does the following:
 #
-# 1. If this is not a PR build, obtain credentials from Vault for the accessing
-#    S3
+# 1. If this is not a PR build nor a debug build, obtain credentials from Vault
+#    for the accessing S3
 # 2. If this is a PR build and running on x86_64, check the code style
 # 3. Build and unit test the Linux version of the C++ on the native architecture
 # 4. If running on x86_64, cross compile the macOS build of the C++
 # 5. If this is not a PR build and running on x86_64, cross compile the aarch
 #    build of the C++
-# 6. If this is not a PR build, upload the builds to the artifacts directory on
-#    S3 that subsequent Java builds will download the C++ components from
+# 6. If this is not a PR build nor a debug build, upload the builds to the
+#    artifacts directory on S3 that subsequent Java builds will download the C++
+#    components from
 #
 # The steps run in Docker containers that ensure OS dependencies
 # are appropriate given the support matrix.
@@ -25,31 +26,11 @@
 : "${HOME:?Need to set HOME to a non-empty value.}"
 : "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
 
-# If this isn't a PR build then obtain credentials from Vault
-if [ -z "$PR_AUTHOR" ] ; then
-    set +x
-    export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+set +x
 
-    unset ML_AWS_ACCESS_KEY ML_AWS_SECRET_KEY
-    FAILURES=0
-    while [ $FAILURES -lt 3 -a -z "$ML_AWS_ACCESS_KEY" ] ; do
-        AWS_CREDS=$(vault read -format=json -field=data aws-dev/creds/prelertartifacts)
-        if [ $? -eq 0 ] ; then
-            export ML_AWS_ACCESS_KEY=$(echo $AWS_CREDS | jq -r '.access_key')
-            export ML_AWS_SECRET_KEY=$(echo $AWS_CREDS | jq -r '.secret_key')
-        else
-            let FAILURES++
-            echo "Attempt $FAILURES to get AWS credentials failed"
-        fi
-    done
-
-    unset VAULT_TOKEN VAULT_ROLE_ID VAULT_SECRET_ID
-
-    if [ -z "$ML_AWS_ACCESS_KEY" -o -z "$ML_AWS_SECRET_KEY" ] ; then
-        echo "Exiting after failing to get AWS credentials $FAILURES times"
-        exit 1
-    fi
-    set -x
+# If this isn't a PR build or a debug build then obtain credentials from Vault
+if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
+    . ./aws_creds_from_vault.sh
 fi
 
 set -e
@@ -60,6 +41,11 @@ cd "$(dirname $0)"
 # Default to a snapshot build
 if [ -z "$BUILD_SNAPSHOT" ] ; then
     BUILD_SNAPSHOT=true
+fi
+
+# Default to running tests
+if [ -z "$RUN_TESTS" ] ; then
+    RUN_TESTS=true
 fi
 
 VERSION=$(cat ../gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo)
@@ -77,6 +63,18 @@ if [ "$BUILD_SNAPSHOT" = false ] ; then
 else
     export SNAPSHOT=yes
     VERSION=${VERSION}-SNAPSHOT
+fi
+
+# Version qualifier shouldn't be used in PR builds
+if [[ -n "$PR_AUTHOR" && -n "$VERSION_QUALIFIER" ]] ; then
+    echo "VERSION_QUALIFIER should not be set in PR builds: was $VERSION_QUALIFIER"
+    exit 2
+fi
+
+# Tests must be run in PR builds
+if [[ -n "$PR_AUTHOR" && "$RUN_TESTS" = false ]] ; then
+    echo "RUN_TESTS should not be false PR builds"
+    exit 3
 fi
 
 # Remove any old builds
@@ -98,9 +96,18 @@ if [ "$HARDWARE_ARCH" = x86_64 ] ; then
         ./docker_check_style.sh
     fi
 
-    ./docker_test.sh linux
+    if [ "$RUN_TESTS" = false ] ; then
+        ./docker_build.sh linux
+    else
+        ./docker_test.sh linux
+    fi
+
 elif [ "$HARDWARE_ARCH" = aarch64 ] ; then
-    ./docker_test.sh linux_aarch64_native
+    if [ "$RUN_TESTS" = false ] ; then
+        ./docker_build.sh linux_aarch64_native
+    else
+        ./docker_test.sh linux_aarch64_native
+    fi
 fi
 
 # If this is a PR build then run some Java integration tests
@@ -115,17 +122,18 @@ if [ -n "$PR_AUTHOR" ] ; then
     fi
 fi
 
+# TODO - remove the cross compiles once the dedicated script is integrated into Jenkins
 # Cross compile macOS
 if [ "$HARDWARE_ARCH" = x86_64 ] ; then
     ./docker_build.sh macosx
-fi
-
-# If this isn't a PR build then cross compile aarch64 and upload the artifacts
-if [ -z "$PR_AUTHOR" ] ; then
-    if [ "$HARDWARE_ARCH" = x86_64 ] ; then
+    # If this isn't a PR build cross compile aarch64 too
+    if [ -z "$PR_AUTHOR" ] ; then
         ./docker_build.sh linux_aarch64_cross
     fi
-    cd ..
-    ./gradlew --info -b upload.gradle -Dbuild.snapshot=$BUILD_SNAPSHOT upload
+fi
+
+# If this isn't a PR build and isn't a debug build then upload the artifacts
+if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
+    (cd .. && ./gradlew --info -b upload.gradle -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
 fi
 

--- a/dev-tools/jenkins_cross_compile.sh
+++ b/dev-tools/jenkins_cross_compile.sh
@@ -30,6 +30,9 @@
 
 set +x
 
+# Change directory to the directory containing this script
+cd "$(dirname $0)"
+
 # If this isn't a PR build or a debug build then obtain credentials from Vault
 if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
     . ./aws_creds_from_vault.sh
@@ -39,11 +42,8 @@ set -e
 
 if [[ `uname` != Linux || `uname -m` != x86_64 ]] ; then
     echo "This script must be run on linux-x86_64"
-    exit 1
+    exit 2
 fi
-
-# Change directory to the directory containing this script
-cd "$(dirname $0)"
 
 # Default to a snapshot build
 if [ -z "$BUILD_SNAPSHOT" ] ; then
@@ -60,7 +60,7 @@ fi
 # Version qualifier shouldn't be used in PR builds
 if [[ -n "$PR_AUTHOR" && -n "$VERSION_QUALIFIER" ]] ; then
     echo "VERSION_QUALIFIER should not be set in PR builds: was $VERSION_QUALIFIER"
-    exit 2
+    exit 3
 fi
 
 # Remove any old builds

--- a/dev-tools/jenkins_cross_compile.sh
+++ b/dev-tools/jenkins_cross_compile.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# The part of ML C++ CI that cross compiles platforms that are not going to be
+# natively compiled.
+#
+# This script must run on linux-x86_64, as that is always the host OS for our
+# cross compilation.
+#
+# 1. If this is not a PR build nor a debug build, obtain credentials from Vault
+#    for the accessing S3
+# 2. If this is a PR build, check the code style
+# 3. Cross compile the darwin-x86_64 build of the C++
+# 4. If this is not a PR build, cross compile the linux-aarch64 build of the C++
+# 5. If this is not a PR build nor a debug build, upload the builds to the
+#    artifacts directory on S3 that subsequent Java builds will download the C++
+#    components from
+#
+# All steps run in Docker containers that ensure OS dependencies are appropriate
+# given the support matrix.
+#
+# Cross-compiled platforms cannot be unit tested.
+
+: "${HOME:?Need to set HOME to a non-empty value.}"
+: "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
+
+set +x
+
+# If this isn't a PR build or a debug build then obtain credentials from Vault
+if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
+    . ./aws_creds_from_vault.sh
+fi
+
+set -e
+
+if [[ `uname` != Linux || `uname -m` != x86_64 ]] ; then
+    echo "This script must be run on linux-x86_64"
+    exit 1
+fi
+
+# Change directory to the directory containing this script
+cd "$(dirname $0)"
+
+# Default to a snapshot build
+if [ -z "$BUILD_SNAPSHOT" ] ; then
+    BUILD_SNAPSHOT=true
+fi
+
+# Jenkins sets BUILD_SNAPSHOT, but our Docker scripts require SNAPSHOT
+if [ "$BUILD_SNAPSHOT" = false ] ; then
+    export SNAPSHOT=no
+else
+    export SNAPSHOT=yes
+fi
+
+# Version qualifier shouldn't be used in PR builds
+if [[ -n "$PR_AUTHOR" && -n "$VERSION_QUALIFIER" ]] ; then
+    echo "VERSION_QUALIFIER should not be set in PR builds: was $VERSION_QUALIFIER"
+    exit 2
+fi
+
+# Remove any old builds
+rm -rf ../builds
+
+# Disassociate from reference repo
+git repack -a -d
+readonly GIT_TOPLEVEL=$(git rev-parse --show-toplevel 2> /dev/null)
+rm -f "${GIT_TOPLEVEL}/.git/objects/info/alternates"
+
+# The Docker version is helpful to identify version-specific Docker bugs
+docker --version
+
+# If this is a PR build then fail fast on style checks
+if [ -n "$PR_AUTHOR" ] ; then
+    ./docker_check_style.sh
+fi
+
+# Cross compile macOS
+./docker_build.sh macosx
+
+# If this isn't a PR build cross compile aarch64 too
+if [ -z "$PR_AUTHOR" ] ; then
+    ./docker_build.sh linux_aarch64_cross
+fi
+
+# If this isn't a PR build and isn't a debug build then upload the artifacts
+if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
+    (cd .. && ./gradlew --info -b upload.gradle -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
+fi
+

--- a/mk/toplevel.mk
+++ b/mk/toplevel.mk
@@ -14,7 +14,7 @@ include $(CPP_SRC_HOME)/mk/rules.mk
 # - TOP_DIR_MKF_LAST is used to perform actions at this level AFTER
 #   recursing into the sub-directories
 #
-# If $ML_DEBUG is set then the recursion will stop at the first error;
+# If $ML_KEEP_GOING is set then the recursion will stop at the first error;
 # otherwise it will attempt to build every directory even after an earlier
 # one fails.  This latter behaviour is useful during nightly builds as it
 # means each nightly build has a chance to uncover more than one error.

--- a/set_env.sh
+++ b/set_env.sh
@@ -184,11 +184,3 @@ if [ -n "$JOB_NAME" ] ; then
     export ML_KEEP_GOING=1
 fi
 
-# Finally, switch off debug if we are not in Jenkins doing the debug build
-if [[ ! "$JOB_NAME" == *Debug* ]] ; then
-    unset ML_DEBUG
-    echo "Building $JOB_NAME with ML_DEBUG unset"
-else
-    echo "Building $JOB_NAME with ML_DEBUG=$ML_DEBUG"
-fi
-


### PR DESCRIPTION
This is the first phase of a refactor that will eventually enable
the same Jenkins setup in elasticsearch-ci to run:

1. PR builds
2. Branch builds that cache artifacts for developers
3. Daily debug builds with assertions enabled
4. Builds for release to end users

A secondary goal is to speed up CI by spreading the build over
more servers.

In this first stage of the changes:

1. The extra options needed by debug builds and release builds are
   passed through to the low level build commands
2. The cross compile steps are split into a separate build script,
   which, eventually, will be run on a different server

Completing this project without lengthy ML CI downtime will
require a series of changes alternating between the ml-cpp repo
and the Jenkins configuration.  This is just the first step of
many.

Backport of #1835/#1836