### PR TITLE
[ML] Cross compile solely in dedicated script

### DIFF
--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -10,7 +10,7 @@
 # 1. If this is not a PR build nor a debug build, obtain credentials from Vault
 #    for the accessing S3
 # 2. Build and unit test the C++ on the native architecture
-# 3. For Linux builds, also run some Java integration tests using the newly
+# 3. For Linux PR builds, also run some Java integration tests using the newly
 #    built C++ code
 # 4. If this is not a PR build nor a debug build, upload the builds to the
 #    artifacts directory on S3 that subsequent Java builds will download the C++

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -9,12 +9,10 @@
 #
 # 1. If this is not a PR build nor a debug build, obtain credentials from Vault
 #    for the accessing S3
-# 2. If this is a PR build and running on linux-x86_64, check the code style
-# 3. Build and unit test the C++ on the native architecture
-# 4. If running on linux-x86_64, cross compile the darwin-x86_64 build of the C++
-# 5. If this is not a PR build and running on linux-x86_64, cross compile the
-#    linux-aarch64 build of the C++
-# 6. If this is not a PR build nor a debug build, upload the builds to the
+# 2. Build and unit test the C++ on the native architecture
+# 3. For Linux builds, also run some Java integration tests using the newly
+#    built C++ code
+# 4. If this is not a PR build nor a debug build, upload the builds to the
 #    artifacts directory on S3 that subsequent Java builds will download the C++
 #    components from
 #
@@ -25,8 +23,6 @@
 # that were previously built on a reference build server.  However, care still
 # needs to be taken that the machines running this script are set up
 # appropriately for generating builds for redistribution.
-#
-# Cross-compiled platforms cannot be unit tested.
 
 : "${HOME:?Need to set HOME to a non-empty value.}"
 : "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
@@ -110,12 +106,6 @@ case `uname` in
         # Build and test the native Linux architecture
         if [ "$HARDWARE_ARCH" = x86_64 ] ; then
 
-            # TODO - let the dedicated cross compile script do this once it's integrated into Jenkins
-            # If this is a PR build then fail fast on style checks
-            if [ -n "$PR_AUTHOR" ] ; then
-                ./docker_check_style.sh
-            fi
-
             if [ "$RUN_TESTS" = false ] ; then
                 ./docker_build.sh linux
             else
@@ -136,16 +126,6 @@ case `uname` in
             mkdir -p "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION"
             cp "../build/distributions/ml-cpp-$VERSION-linux-$HARDWARE_ARCH.zip" "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-$VERSION.zip"
             ./run_es_tests.sh "${GIT_TOPLEVEL}/.." "$(cd "${IVY_REPO}" && pwd)"
-        fi
-
-        # TODO - remove the cross compiles once the dedicated script is integrated into Jenkins
-        # Cross compile macOS
-        if [ "$HARDWARE_ARCH" = x86_64 ] ; then
-            ./docker_build.sh macosx
-            # If this isn't a PR build cross compile aarch64 too
-            if [ -z "$PR_AUTHOR" ] ; then
-                ./docker_build.sh linux_aarch64_cross
-            fi
         fi
         ;;
 


### PR DESCRIPTION
The changes of #1835 introduced a separate script for
cross compiling in Jenkins builds.  However, at that
time cross compiles still had to be done in the original
CI script too because Jenkins was not running the
dedicated script.

Now Jenkins _is_ running the dedicated script, and we
are in the situation where cross compiles are being done
twice for each build.  This PR tidies that up by making
jenkins_ci.sh dedicated to native compilation.

This should improve end-to-end build times.