### PR TITLE
[ML] Persist state for correcting loss to account for model size when training a boosted tree

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -51,6 +51,9 @@
   improved test errors. (See {ml-pull}1755[#1755].)
 * Adjust the syscall filter to allow mremap and avoid spurious audit logging.
   (See {ml-pull}1819[#1819].)
+
+=== Bug Fixes
+
 * Ensure the same hyperparameters are chosen if classification or regression training
   is stopped and restarted, for example, if the node fails. (See {ml-pull}1848[#1848].)
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -51,6 +51,8 @@
   improved test errors. (See {ml-pull}1755[#1755].)
 * Adjust the syscall filter to allow mremap and avoid spurious audit logging.
   (See {ml-pull}1819[#1819].)
+* Ensure the same hyperparameters are chosen if classification or regression training
+  is stopped and restarted, for example, if the node fails. (See {ml-pull}1848[#1848].)
 
 == {es} version 7.12.1
 

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -404,8 +404,8 @@ private:
     std::size_t m_NumberTopShapValues = 0;
     TTreeShapFeatureImportanceUPtr m_TreeShap;
     TAnalysisInstrumentationPtr m_Instrumentation;
-    mutable TMeanAccumulator m_ForestSizeAccumulator;
-    mutable TMeanAccumulator m_MeanLossAccumulator;
+    TMeanAccumulator m_MeanForestSizeAccumulator;
+    TMeanAccumulator m_MeanLossAccumulator;
     THyperparametersVec m_TunableHyperparameters;
     TDoubleVecVec m_HyperparameterSamples;
     bool m_StopHyperparameterOptimizationEarly = true;


### PR DESCRIPTION
We were missing state used to adjust the loss function to select the best hyperparameters based on model size. This would sometimes cause us to select different hyperparameters if the modelling failed and was restarted during training.

Note that this already tested by `testRunBoostedTreeRegressionTrainingWithStateRecovery` but only fails if the change causes us to select a different model so this doesn't reliably fail.