### PR TITLE
[7.13][ML] Persist state for correcting loss to account for model size when training a boosted tree

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,11 @@
 * Adjust the syscall filter to allow mremap and avoid spurious audit logging.
   (See {ml-pull}1819[#1819].)
 
+=== Bug Fixes
+
+* Ensure the same hyperparameters are chosen if classification or regression training
+  is stopped and restarted, for example, if the node fails. (See {ml-pull}1848[#1848].)
+
 == {es} version 7.12.1
 
 === Enhancements

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -404,8 +404,8 @@ private:
     std::size_t m_NumberTopShapValues = 0;
     TTreeShapFeatureImportanceUPtr m_TreeShap;
     TAnalysisInstrumentationPtr m_Instrumentation;
-    mutable TMeanAccumulator m_ForestSizeAccumulator;
-    mutable TMeanAccumulator m_MeanLossAccumulator;
+    TMeanAccumulator m_MeanForestSizeAccumulator;
+    TMeanAccumulator m_MeanLossAccumulator;
     THyperparametersVec m_TunableHyperparameters;
     TDoubleVecVec m_HyperparameterSamples;
     bool m_StopHyperparameterOptimizationEarly = true;


### PR DESCRIPTION
Backport #1848.