### PR TITLE
[ML] Gracefully handle insufficient training data for classification and regression model training

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -56,6 +56,8 @@
 
 * Ensure the same hyperparameters are chosen if classification or regression training
   is stopped and restarted, for example, if the node fails. (See {ml-pull}1848[#1848].)
+* Fail gracefully if insufficient data are supplied for classification or regression
+  training. (See {ml-pull}1855[#1855].)
 
 == {es} version 7.12.1
 

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -500,6 +500,11 @@ CDataFrameUtils::stratifiedCrossValidationRowMasks(std::size_t numberThreads,
     TStratifiedSamplerPtr sampler;
 
     double numberTrainingRows{allTrainingRowsMask.manhattan()};
+    if (numberTrainingRows < 2.0) {
+        HANDLE_FATAL(<< "Input error: unsufficient training data provided.");
+        return {{}, {}, {}};
+    }
+
     std::size_t desiredCount{
         (static_cast<std::size_t>(numberTrainingRows) + numberFolds / 2) / numberFolds};
 


### PR DESCRIPTION
This explicitly checks we have enough data to even create a hold out set. This is a very weak condition and this isn't really enough data anyway, but before we could either throw (reserving collection with max size due to unsigned integer underflow) or hang (downsampling). This just adds an assertion at the point we create cross-validation row masks.