### PR TITLE
[ML] Don't enable trace logging in categorizer tests

### DIFF
--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -61,16 +61,6 @@ void checkMemoryUsageInstrumentation(const TTokenListDataCategorizerKeepsFields&
 
 class CTestFixture {
 public:
-    CTestFixture() {
-        // Enable trace level logging for these unit tests
-        ml::core::CLogger::instance().setLoggingLevel(ml::core::CLogger::E_Trace);
-    }
-
-    ~CTestFixture() {
-        // Revert to debug level logging for any subsequent unit tests
-        ml::core::CLogger::instance().setLoggingLevel(ml::core::CLogger::E_Debug);
-    }
-
     std::string makeUniqueToken() {
         std::string token;
         for (std::uint32_t workSeed = ++m_Seed; workSeed > 0; workSeed /= 20) {


### PR DESCRIPTION
At some point in the distant past there was a good reason
to enable trace logging in categorizer tests. Times have
changed and this is no longer a good idea:

1. We compile out trace logging when optimisation is
   enabled, so it generally has no effect
2. When we do debug builds the extra logging generates
   huge output files, which can blow Jenkins limits

In the future if somebody needs extra detailed logging
about categorization they can enable it manually on a
local test run.