### PR TITLE
[ML] Pass row iterators by constant reference to callbacks

### DIFF
--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -236,7 +236,7 @@ public:
     using TSizeAlignmentPrVec = std::vector<std::pair<std::size_t, CAlignment::EType>>;
     using TRowRef = data_frame_detail::CRowRef;
     using TRowItr = data_frame_detail::CRowIterator;
-    using TRowFunc = std::function<void(TRowItr, TRowItr)>;
+    using TRowFunc = std::function<void(const TRowItr&, const TRowItr&)>;
     using TRowFuncVec = std::vector<TRowFunc>;
     using TRowFuncVecBoolPr = std::pair<TRowFuncVec, bool>;
     using TWriteFunc = std::function<void(TFloatVecItr, std::int32_t&)>;

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -172,7 +172,7 @@ public:
         tree->train();
         tree->predict();
 
-        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 auto prediction = tree->readAndAdjustPrediction(*row);
                 appendPrediction(*frame, weights.size(), prediction, expectedPredictions);

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -311,12 +311,7 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
     std::size_t numberThreads{1};
 
     using TRowItr = core::CDataFrame::TRowItr;
-    m_DataFrame->readRows(numberThreads, [&](TRowItr beginRows, TRowItr endRows) {
-        TMeanVarAccumulator timeAccumulator;
-        core::CStopWatch stopWatch;
-        stopWatch.start();
-        std::uint64_t lastLap{stopWatch.lap()};
-
+    m_DataFrame->readRows(numberThreads, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             writer.StartObject();
             writer.Key(ROW_RESULTS);
@@ -330,12 +325,6 @@ void CDataFrameAnalyzer::writeResultsOf(const CDataFrameAnalysisRunner& analysis
             writer.EndObject();
             writer.EndObject();
             writer.EndObject();
-
-            std::uint64_t currentLap{stopWatch.lap()};
-            std::uint64_t delta{currentLap - lastLap};
-
-            timeAccumulator.add(static_cast<double>(delta));
-            lastLap = currentLap;
         }
     });
 

--- a/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
+++ b/lib/api/unittest/CDataFrameAnalysisInstrumentationTest.cc
@@ -86,7 +86,7 @@ void addOutlierTestData(TStrVec fieldNames,
     expectedScores.resize(numberInliers + numberOutliers);
     expectedFeatureInfluences.resize(numberInliers + numberOutliers, TDoubleVec(5));
 
-    frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             expectedScores[row->index()] = (*row)[5];
             if (computeFeatureInfluence) {

--- a/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerOutlierTest.cc
@@ -94,7 +94,7 @@ void addOutlierTestData(TStrVec fieldNames,
     expectedScores.resize(numberInliers + numberOutliers);
     expectedFeatureInfluences.resize(numberInliers + numberOutliers, TDoubleVec(5));
 
-    frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             expectedScores[row->index()] = (*row)[5];
             if (computeFeatureInfluence) {

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(testMissingString) {
         }
         analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
-        analyzer.dataFrame().readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        analyzer.dataFrame().readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             std::size_t i{0};
             for (auto row = beginRows; row != endRows; ++row, ++i) {
                 BOOST_REQUIRE_EQUAL(isMissing[row->index()],
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(testMissingString) {
         }
         analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
-        analyzer.dataFrame().readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        analyzer.dataFrame().readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             std::size_t i{0};
             for (auto row = beginRows; row != endRows; ++row, ++i) {
                 BOOST_REQUIRE_EQUAL(isMissing[row->index()],
@@ -792,7 +792,7 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeClassifierWithUserClassWeights) {
     classifier->predict();
 
     TStrVec expectedPredictions(frame->numberRows());
-    frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             auto scores = classifier->readAndAdjustPrediction(*row);
             std::size_t prediction(scores[1] < scores[0] ? 0 : 1);
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFields) {
         bool passed{true};
 
         const core::CDataFrame& frame{analyzer.dataFrame()};
-        frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame.readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             std::size_t i{0};
             for (auto row = beginRows; row != endRows; ++row, ++i) {
                 core::CFloatStorage expected[]{static_cast<double>(i % x[0].size()),
@@ -888,7 +888,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFields) {
         std::size_t i{0};
 
         const core::CDataFrame& frame{analyzer.dataFrame()};
-        frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame.readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row, ++i) {
                 core::CFloatStorage expected{
                     i < core::CDataFrame::MAX_CATEGORICAL_CARDINALITY
@@ -957,7 +957,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalFieldsEmptyAsMissing) {
     analyzer.receivedAllRows();
 
     const core::CDataFrame& frame{analyzer.dataFrame()};
-    frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame.readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         std::vector<TRowRef> rows;
         std::copy(beginRows, endRows, std::back_inserter(rows));
         BOOST_REQUIRE_EQUAL(std::size_t{10}, rows.size());

--- a/lib/api/unittest/CDataFrameTrainBoostedTreeClassifierRunnerTest.cc
+++ b/lib/api/unittest/CDataFrameTrainBoostedTreeClassifierRunnerTest.cc
@@ -99,7 +99,7 @@ void testWriteOneRow(const std::string& dependentVariableField,
         core::CJsonOutputStreamWrapper outputStreamWrapper(output);
         core::CRapidJsonConcurrentLineWriter writer(outputStreamWrapper);
 
-        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             auto columnHoldingDependentVariable =
                 std::find(columnNames.begin(), columnNames.end(), dependentVariableField) -
                 columnNames.begin();

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -270,7 +270,7 @@ void CBoostedTreeFactory::initializeMissingFeatureMasks(const core::CDataFrame& 
 
     m_TreeImpl->m_MissingFeatureRowMasks.resize(frame.numberColumns());
 
-    auto result = frame.readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    auto result = frame.readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             for (std::size_t i = 0; i < row->numberColumns(); ++i) {
                 double value{(*row)[i]};
@@ -295,7 +295,8 @@ void CBoostedTreeFactory::initializeNumberFolds(core::CDataFrame& frame) const {
         auto result = frame.readRows(
             m_NumberThreads,
             core::bindRetrievableState(
-                [this](std::size_t& numberTrainingRows, TRowItr beginRows, TRowItr endRows) {
+                [this](std::size_t& numberTrainingRows,
+                       const TRowItr& beginRows, const TRowItr& endRows) {
                     for (auto row = beginRows; row != endRows; ++row) {
                         double target{(*row)[m_TreeImpl->m_DependentVariable]};
                         if (CDataFrameUtils::isMissing(target) == false) {
@@ -354,7 +355,7 @@ void CBoostedTreeFactory::resizeDataFrame(core::CDataFrame& frame) const {
 
     core::CPackedBitVector allTrainingRowsMask{m_TreeImpl->allTrainingRowsMask()};
     frame.writeColumns(m_NumberThreads, 0, frame.numberRows(),
-                       [&](TRowItr beginRows, TRowItr endRows) {
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
                            for (auto row = beginRows; row != endRows; ++row) {
                                writeExampleWeight(*row, m_TreeImpl->m_ExtraColumns, 1.0);
                            }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -305,7 +305,8 @@ void CBoostedTreeImpl::predict(core::CDataFrame& frame) const {
     }
     bool successful;
     std::tie(std::ignore, successful) = frame.writeColumns(
-        m_NumberThreads, 0, frame.numberRows(), [&](TRowItr beginRows, TRowItr endRows) {
+        m_NumberThreads, 0, frame.numberRows(),
+        [&](const TRowItr& beginRows, const TRowItr& endRows) {
             std::size_t numberLossParameters{m_Loss->numberParameters()};
             for (auto row = beginRows; row != endRows; ++row) {
                 auto prediction = readPrediction(*row, m_ExtraColumns, numberLossParameters);
@@ -587,7 +588,7 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
     core::CPackedBitVector updateRowMask{trainingRowMask | testingRowMask};
     frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(),
-        [this](TRowItr beginRows, TRowItr endRows) {
+        [this](const TRowItr& beginRows, const TRowItr& endRows) {
             std::size_t numberLossParameters{m_Loss->numberParameters()};
             for (auto row = beginRows; row != endRows; ++row) {
                 zeroPrediction(*row, m_ExtraColumns, numberLossParameters);
@@ -1194,7 +1195,7 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
         auto result = frame.readRows(
             m_NumberThreads, 0, frame.numberRows(),
             core::bindRetrievableState(
-                [&](TArgMinLossVec& leafValues_, TRowItr beginRows, TRowItr endRows) {
+                [&](TArgMinLossVec& leafValues_, const TRowItr& beginRows, const TRowItr& endRows) {
                     std::size_t numberLossParameters{m_Loss->numberParameters()};
                     const auto& rootNode = root(tree);
                     for (auto row_ = beginRows; row_ != endRows; ++row_) {
@@ -1229,7 +1230,7 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
     core::CPackedBitVector updateRowMask{trainingRowMask | testingRowMask};
     frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(),
-        [&](TRowItr beginRows, TRowItr endRows) {
+        [&](const TRowItr& beginRows, const TRowItr& endRows) {
             std::size_t numberLossParameters{m_Loss->numberParameters()};
             const auto& rootNode = root(tree);
             for (auto row_ = beginRows; row_ != endRows; ++row_) {
@@ -1251,7 +1252,7 @@ double CBoostedTreeImpl::meanLoss(const core::CDataFrame& frame,
     auto results = frame.readRows(
         m_NumberThreads, 0, frame.numberRows(),
         core::bindRetrievableState(
-            [&](TMeanAccumulator& loss, TRowItr beginRows, TRowItr endRows) {
+            [&](TMeanAccumulator& loss, const TRowItr& beginRows, const TRowItr& endRows) {
                 std::size_t numberLossParameters{m_Loss->numberParameters()};
                 for (auto row = beginRows; row != endRows; ++row) {
                     auto prediction = readPrediction(*row, m_ExtraColumns, numberLossParameters);

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -255,7 +255,7 @@ void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivatives(
     for (std::size_t i = 0; i < numberThreads; ++i) {
         auto& splitsDerivatives = workspace.derivatives()[i];
         splitsDerivatives.zero();
-        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
+        aggregators.push_back([&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 this->addRowDerivatives(featureBag, encoder.encode(*row), splitsDerivatives);
             }
@@ -285,7 +285,7 @@ void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivatives(
         auto& splitsDerivatives = workspace.derivatives()[i];
         mask.clear();
         splitsDerivatives.zero();
-        aggregators.push_back([&](TRowItr beginRows, TRowItr endRows) {
+        aggregators.push_back([&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 auto encodedRow = encoder.encode(*row);
                 if (split.assignToLeft(encodedRow) == isLeftChild) {

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -185,7 +185,7 @@ regressionStratifiedCrossValiationRowSampler(std::size_t numberThreads,
     };
 
     auto countBucketRows = core::bindRetrievableState(
-        [&](TDoubleVec& bucketCounts, TRowItr beginRows, TRowItr endRows) {
+        [&](TDoubleVec& bucketCounts, const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 bucketCounts[bucketSelector(*row)] += 1.0;
             }
@@ -319,7 +319,7 @@ bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataF
     }
 
     auto readColumnMoments = core::bindRetrievableState(
-        [](TMeanVarAccumulatorVec& moments_, TRowItr beginRows, TRowItr endRows) {
+        [](TMeanVarAccumulatorVec& moments_, const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t i = 0; i < row->numberColumns(); ++i) {
                     if (isMissing((*row)[i]) == false) {
@@ -358,7 +358,8 @@ bool CDataFrameUtils::standardizeColumns(std::size_t numberThreads, core::CDataF
     LOG_TRACE(<< "means = " << core::CContainerPrinter::print(mean));
     LOG_TRACE(<< "scales = " << core::CContainerPrinter::print(scale));
 
-    auto standardiseColumns = [&mean, &scale](TRowItr beginRows, TRowItr endRows) {
+    auto standardiseColumns = [&mean, &scale](const TRowItr& beginRows,
+                                              const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             for (std::size_t i = 0; i < row->numberColumns(); ++i) {
                 row->writeColumn(i, scale[i] * ((*row)[i] - mean[i]));
@@ -384,7 +385,7 @@ CDataFrameUtils::columnDataTypes(std::size_t numberThreads,
     using TMinMaxBoolPrVec = std::vector<std::pair<TMinMax, bool>>;
 
     auto readDataTypes = core::bindRetrievableState(
-        [&](TMinMaxBoolPrVec& types, TRowItr beginRows, TRowItr endRows) {
+        [&](TMinMaxBoolPrVec& types, const TRowItr& beginRows, const TRowItr& endRows) {
             double integerPart;
             if (encoder != nullptr) {
                 for (auto row = beginRows; row != endRows; ++row) {
@@ -448,7 +449,7 @@ CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
                                  const TWeightFunc& weight) {
 
     auto readQuantiles = core::bindRetrievableState(
-        [&](TQuantileSketchVec& quantiles, TRowItr beginRows, TRowItr endRows) {
+        [&](TQuantileSketchVec& quantiles, const TRowItr& beginRows, const TRowItr& endRows) {
             if (encoder != nullptr) {
                 for (auto row = beginRows; row != endRows; ++row) {
                     CEncodedDataFrameRowRef encodedRow{encoder->encode(*row)};
@@ -525,7 +526,7 @@ CDataFrameUtils::stratifiedCrossValidationRowMasks(std::size_t numberThreads,
     core::CPackedBitVector candidateTestingRowsMask{allTrainingRowsMask};
     for (std::size_t fold = 0; fold < numberFolds - 1; ++fold) {
         frame.readRows(1, 0, frame.numberRows(),
-                       [&](TRowItr beginRows, TRowItr endRows) {
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
                            for (auto row = beginRows; row != endRows; ++row) {
                                sampler->sample(*row);
                            }
@@ -569,7 +570,7 @@ CDataFrameUtils::categoryFrequencies(std::size_t numberThreads,
 
     // Note this can throw a length_error in resize hence the try block around read.
     auto readCategoryCounts = core::bindRetrievableState(
-        [&](TDoubleVecVec& counts, TRowItr beginRows, TRowItr endRows) {
+        [&](TDoubleVecVec& counts, const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t i : columnMask) {
                     if (isMissing((*row)[i]) == false) {
@@ -632,7 +633,7 @@ CDataFrameUtils::meanValueOfTargetForCategories(const CColumnValue& target,
 
     // Note this can throw a length_error in resize hence the try block around read.
     auto readColumnMeans = core::bindRetrievableState(
-        [&](TMeanAccumulatorVecVec& means_, TRowItr beginRows, TRowItr endRows) {
+        [&](TMeanAccumulatorVecVec& means_, const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t i : columnMask) {
                     if (isMissing((*row)[i]) == false && isMissing(target(*row)) == false) {
@@ -787,7 +788,7 @@ CDataFrameUtils::TSizeDoublePrVecVecVec CDataFrameUtils::categoricalMicWithColum
             TRowSampler sampler{numberSamples, rowFeatureSampler(i, target, samples)};
             frame.readRows(
                 1, 0, frame.numberRows(),
-                [&](TRowItr beginRows, TRowItr endRows) {
+                [&](const TRowItr& beginRows, const TRowItr& endRows) {
                     for (auto row = beginRows; row != endRows; ++row) {
                         if (isMissing((*row)[i]) || isMissing(target(*row))) {
                             continue;
@@ -856,7 +857,7 @@ CDataFrameUtils::TSizeDoublePrVecVecVec CDataFrameUtils::categoricalMicWithColum
         samples.clear();
         TRowSampler sampler{numberSamples, rowSampler(samples)};
         frame.readRows(1, 0, frame.numberRows(),
-                       [&](TRowItr beginRows, TRowItr endRows) {
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
                            for (auto row = beginRows; row != endRows; ++row) {
                                if (isMissing(target(*row)) == false) {
                                    sampler.sample(*row);
@@ -913,7 +914,7 @@ CDataFrameUtils::metricMicWithColumnDataFrameInMemory(const CColumnValue& target
         auto missingCount = frame.readRows(
             1, 0, frame.numberRows(),
             core::bindRetrievableState(
-                [&](std::size_t& missing, TRowItr beginRows, TRowItr endRows) {
+                [&](std::size_t& missing, const TRowItr& beginRows, const TRowItr& endRows) {
                     for (auto row = beginRows; row != endRows; ++row) {
                         if (isMissing((*row)[i])) {
                             ++missing;
@@ -964,7 +965,7 @@ CDataFrameUtils::metricMicWithColumnDataFrameOnDisk(const CColumnValue& target,
     auto missingCounts = frame.readRows(
         1, 0, frame.numberRows(),
         core::bindRetrievableState(
-            [&](TSizeVec& missing, TRowItr beginRows, TRowItr endRows) {
+            [&](TSizeVec& missing, const TRowItr& beginRows, const TRowItr& endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
                     for (std::size_t i = 0; i < row->numberColumns(); ++i) {
                         missing[i] += isMissing((*row)[i]) ? 1 : 0;
@@ -1011,7 +1012,7 @@ CDataFrameUtils::maximizeMinimumRecallForBinary(std::size_t numberThreads,
                                                 const TReadPredictionFunc& readPrediction) {
     TDoubleVector probabilities;
     auto readQuantiles = core::bindRetrievableState(
-        [=](TQuantileSketchVec& quantiles, TRowItr beginRows, TRowItr endRows) mutable {
+        [=](TQuantileSketchVec& quantiles, const TRowItr& beginRows, const TRowItr& endRows) mutable {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (isMissing((*row)[targetColumn]) == false) {
                     std::size_t actualClass{static_cast<std::size_t>((*row)[targetColumn])};
@@ -1088,7 +1089,7 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
 
         TSizeVec rowIndices;
         frame.readRows(1, 0, frame.numberRows(),
-                       [&](TRowItr beginRows, TRowItr endRows) {
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
                            for (auto row = beginRows; row != endRows; ++row) {
                                sampler->sample(*row);
                            }
@@ -1109,7 +1110,7 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
 
     // Compute the count of each class in the sample set.
     auto readClassCountsAndRecalls = core::bindRetrievableState(
-        [&](TDoubleVector& state, TRowItr beginRows, TRowItr endRows) {
+        [&](TDoubleVector& state, const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (isMissing((*row)[targetColumn]) == false) {
                     int j{static_cast<int>((*row)[targetColumn])};
@@ -1166,7 +1167,7 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
         TDoubleVector probabilities;
         TDoubleVector scores;
         auto computeObjective = core::bindRetrievableState(
-            [=](TDoubleVector& state, TRowItr beginRows, TRowItr endRows) mutable {
+            [=](TDoubleVector& state, const TRowItr& beginRows, const TRowItr& endRows) mutable {
                 for (auto row = beginRows; row != endRows; ++row) {
                     if (isMissing((*row)[targetColumn]) == false) {
                         std::size_t j{static_cast<std::size_t>((*row)[targetColumn])};
@@ -1197,7 +1198,7 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
         TDoubleVector probabilities;
         TDoubleVector scores;
         auto computeObjectiveAndGradient = core::bindRetrievableState(
-            [=](TDoubleMatrix& state, TRowItr beginRows, TRowItr endRows) mutable {
+            [=](TDoubleMatrix& state, const TRowItr& beginRows, const TRowItr& endRows) mutable {
                 for (auto row = beginRows; row != endRows; ++row) {
                     if (isMissing((*row)[targetColumn]) == false) {
                         std::size_t j{static_cast<std::size_t>((*row)[targetColumn])};

--- a/lib/maths/COutliers.cc
+++ b/lib/maths/COutliers.cc
@@ -865,7 +865,7 @@ CEnsemble<POINT> buildEnsemble(const COutliers::SComputeParameters& params,
     auto builders = CEnsemble<POINT>::makeBuilders(
         methods, frame.numberRows(), frame.numberColumns(), params.s_NumberNeighbours);
 
-    frame.readRows(1, [&builders](TRowItr beginRows, TRowItr endRows) {
+    frame.readRows(1, [&builders](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             for (auto& builder : builders) {
                 builder.addPoint(*row);
@@ -905,7 +905,7 @@ bool computeOutliersNoPartitions(const COutliers::SComputeParameters& params,
         std::int64_t pointsMemory{signedMemoryUsage(points)};
         instrumentation.updateMemoryUsage(pointsMemory);
 
-        auto rowsToPoints = [&points](TRowItr beginRows, TRowItr endRows) {
+        auto rowsToPoints = [&points](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 points[row->index()] = CDataFrameUtils::rowTo<TPoint>(*row);
             }
@@ -939,7 +939,7 @@ bool computeOutliersNoPartitions(const COutliers::SComputeParameters& params,
 
     std::size_t dimension{frame.numberColumns()};
 
-    auto writeScores = [&](TRowItr beginRows, TRowItr endRows) {
+    auto writeScores = [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             std::size_t index{dimension};
             for (auto value : scores[row->index()].compute(params.s_OutlierFraction)) {
@@ -1005,8 +1005,8 @@ bool computeOutliersPartitioned(const COutliers::SComputeParameters& params,
         LOG_TRACE(<< "rows [" << beginPartitionRows << "," << endPartitionRows << ")");
         points.resize(std::min(rowsPerPartition, frame.numberRows() - beginPartitionRows));
 
-        auto rowsToPoints = [beginPartitionRows, dimension,
-                             &points](TRowItr beginRows, TRowItr endRows) {
+        auto rowsToPoints = [beginPartitionRows, dimension, &points](
+                                const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 for (std::size_t j = 0; j < dimension; ++j) {
                     points[row->index() - beginPartitionRows](j) = (*row)[j];
@@ -1028,7 +1028,7 @@ bool computeOutliersPartitioned(const COutliers::SComputeParameters& params,
         core::CProgramCounters::counter(counter_t::E_DFOTimeToComputeScores) +=
             watch.stop();
 
-        auto writeScores = [&](TRowItr beginRows, TRowItr endRows) {
+        auto writeScores = [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 std::size_t offset{row->index() - beginPartitionRows};
                 std::size_t index{dimension};

--- a/lib/maths/CTreeShapFeatureImportance.cc
+++ b/lib/maths/CTreeShapFeatureImportance.cc
@@ -118,7 +118,7 @@ void CTreeShapFeatureImportance::computeNumberSamples(std::size_t numberThreads,
             auto result = frame.readRows(
                 numberThreads,
                 core::bindRetrievableState(
-                    [&](TSizeVec& samplesPerNode, TRowItr beginRows, TRowItr endRows) {
+                    [&](TSizeVec& samplesPerNode, const TRowItr& beginRows, const TRowItr& endRows) {
                         for (auto row = beginRows; row != endRows; ++row) {
                             auto encodedRow{encoder.encode(*row)};
                             const CBoostedTreeNode* node{&tree[0]};

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -180,7 +180,7 @@ auto computeEvaluationMetrics(const core::CDataFrame& frame,
     TMeanVarAccumulator functionMoments;
     TMeanVarAccumulator modelPredictionErrorMoments;
 
-    frame.readRows(1, beginTestRows, endTestRows, [&](TRowItr beginRows, TRowItr endRows) {
+    frame.readRows(1, beginTestRows, endTestRows, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             if (std::binary_search(outliers.begin(), outliers.end(), row->index()) == false) {
                 functionMoments.add(target(*row));
@@ -221,7 +221,7 @@ void fillDataFrame(std::size_t trainRows,
         });
     }
     frame.finishWritingRows();
-    frame.writeColumns(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame.writeColumns(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             double targetValue{row->index() < trainRows
                                    ? target(*row) + noise[row->index()]
@@ -757,7 +757,7 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
         TMeanVarAccumulator modelPredictionErrorMoments;
 
-        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 modelPredictionErrorMoments.add(
                     target(*row) - regression->readPrediction(*row)[0]);
@@ -853,7 +853,7 @@ BOOST_AUTO_TEST_CASE(testConstantTarget) {
 
     TMeanAccumulator modelPredictionError;
 
-    frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             modelPredictionError.add(1.0 - regression->readPrediction(*row)[0]);
         }
@@ -909,7 +909,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
         });
     }
     frame->finishWritingRows();
-    frame->writeColumns(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame->writeColumns(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             double targetValue{row->index() < trainRows
                                    ? target(*row)
@@ -986,7 +986,7 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
         });
     }
     frame->finishWritingRows();
-    frame->writeColumns(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame->writeColumns(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             double targetValue{row->index() < trainRows
                                    ? target(*row)
@@ -1340,7 +1340,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         classifier->predict();
 
         TMeanAccumulator logRelativeError;
-        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (row->index() >= trainRows) {
                     double expectedProbability{probability(*row)};
@@ -1416,7 +1416,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
         TDoubleVec trueNegatives(2, 0.0);
         TDoubleVec falsePositives(2, 0.0);
         TDoubleVec falseNegatives(2, 0.0);
-        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 auto scores = classifier->readAndAdjustPrediction(*row);
                 std::size_t prediction(scores[1] < scores[0] ? 0 : 1);
@@ -1569,7 +1569,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         classifier->predict();
 
         TMeanAccumulator logRelativeError;
-        frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+        frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (row->index() >= trainRows) {
                     TVector expectedProbability{probability(*row)};
@@ -1872,7 +1872,7 @@ BOOST_AUTO_TEST_CASE(testMissingFeatures) {
     TDoubleVec expectedPredictions{17.5, 17.5, 17.5, 22.0};
     TDoubleVec actualPredictions;
 
-    frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             if (maths::CDataFrameUtils::isMissing((*row)[cols - 1])) {
                 actualPredictions.push_back(regression->readPrediction(*row)[0]);

--- a/lib/maths/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/unittest/CDataFrameUtilsTest.cc
@@ -241,8 +241,8 @@ BOOST_AUTO_TEST_CASE(testStandardizeColumns) {
             // Check the column values are what we expect given the data we generated.
 
             bool passed{true};
-            frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
-                                   core::CDataFrame::TRowItr endRows) {
+            frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
+                                   const core::CDataFrame::TRowItr& endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
                     for (std::size_t j = 0; j < row->numberColumns(); ++j) {
                         double mean{maths::CBasicStatistics::mean(moments[j])};
@@ -262,8 +262,8 @@ BOOST_AUTO_TEST_CASE(testStandardizeColumns) {
             // respectively.
 
             TMeanVarAccumulatorVec columnsMoments(cols);
-            frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
-                                   core::CDataFrame::TRowItr endRows) {
+            frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
+                                   const core::CDataFrame::TRowItr& endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
                     for (std::size_t j = 0; j < row->numberColumns(); ++j) {
                         columnsMoments[j].add((*row)[j]);
@@ -432,7 +432,8 @@ BOOST_AUTO_TEST_CASE(testColumnQuantilesWithEncoding) {
 
     TQuantileSketchVec expectedQuantiles{columnMask.size(),
                                          {maths::CQuantileSketch::E_Linear, 100}};
-    frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows, core::CDataFrame::TRowItr endRows) {
+    frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
+                           const core::CDataFrame::TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             maths::CEncodedDataFrameRowRef encodedRow{encoder.encode(*row)};
             for (std::size_t i = 0; i < columnMask.size(); ++i) {
@@ -528,8 +529,8 @@ BOOST_AUTO_TEST_CASE(testStratifiedCrossValidationRowMasks) {
 
             TDoubleDoubleUMap testingCategoryCounts;
             frame->readRows(1, 0, frame->numberRows(),
-                            [&](core::CDataFrame::TRowItr beginRows,
-                                core::CDataFrame::TRowItr endRows) {
+                            [&](const core::CDataFrame::TRowItr& beginRows,
+                                const core::CDataFrame::TRowItr& endRows) {
                                 for (auto row = beginRows; row != endRows; ++row) {
                                     testingCategoryCounts[(*row)[0]] += 1.0;
                                 }
@@ -581,8 +582,8 @@ BOOST_AUTO_TEST_CASE(testStratifiedCrossValidationRowMasks) {
 
             TDoubleVec values;
             frame->readRows(1, 0, frame->numberRows(),
-                            [&](core::CDataFrame::TRowItr beginRows,
-                                core::CDataFrame::TRowItr endRows) {
+                            [&](const core::CDataFrame::TRowItr& beginRows,
+                                const core::CDataFrame::TRowItr& endRows) {
                                 for (auto row = beginRows; row != endRows; ++row) {
                                     values.push_back((*row)[0]);
                                 }
@@ -1263,8 +1264,8 @@ BOOST_AUTO_TEST_CASE(testMaximumMinimumRecallClassWeights) {
                                          TDoubleVector::Zero(numberClasses)};
                 TDoubleVector counts{TDoubleVector::Zero(numberClasses)};
 
-                frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
-                                       core::CDataFrame::TRowItr endRows) {
+                frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
+                                       const core::CDataFrame::TRowItr& endRows) {
                     for (auto row = beginRows; row != endRows; ++row) {
                         prediction = readPrediction(*row);
                         maths::CTools::inplaceSoftmax(prediction);

--- a/lib/maths/unittest/COutliersTest.cc
+++ b/lib/maths/unittest/COutliersTest.cc
@@ -166,8 +166,8 @@ void outlierErrorStatisticsForEnsemble(std::size_t numberThreads,
                                                     0.05}; // Outlier fraction
         maths::COutliers::compute(params, *frame, instrumentation);
 
-        frame->readRows(1, [&scores](core::CDataFrame::TRowItr beginRows,
-                                     core::CDataFrame::TRowItr endRows) {
+        frame->readRows(1, [&scores](const core::CDataFrame::TRowItr& beginRows,
+                                     const core::CDataFrame::TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 scores[row->index()] = (*row)[6];
             }
@@ -516,8 +516,8 @@ BOOST_AUTO_TEST_CASE(testFeatureInfluences) {
             bool passed{true};
             TMeanAccumulator averageSignificances[2];
 
-            frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
-                                   core::CDataFrame::TRowItr endRows) {
+            frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
+                                   const core::CDataFrame::TRowItr& endRows) {
                 for (auto row = beginRows; row != endRows; ++row) {
                     passed &= (std::fabs((*row)[3] + (*row)[4] - 1.0) < 1e-6);
                     if (row->index() == outlierIndexes[0]) {
@@ -739,8 +739,8 @@ BOOST_AUTO_TEST_CASE(testMostlyDuplicate) {
         maths::COutliers::compute(params, *frame, instrumentation);
 
         TDoubleVec outlierScores(outliers.size());
-        frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
-                               core::CDataFrame::TRowItr endRows) {
+        frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
+                               const core::CDataFrame::TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 auto outlier = std::find_if(
                     outliers.begin(),
@@ -797,8 +797,8 @@ BOOST_AUTO_TEST_CASE(testFewPoints) {
 
         bool passed{true};
 
-        frame->readRows(1, [&](core::CDataFrame::TRowItr beginRows,
-                               core::CDataFrame::TRowItr endRows) {
+        frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
+                               const core::CDataFrame::TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 // Check score is in range 0 to 1.
                 LOG_DEBUG(<< "outlier score = " << (*row)[rows]);

--- a/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/unittest/CTreeShapFeatureImportanceTest.cc
@@ -447,7 +447,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleTreeShap, SFixtureSingleTree) {
 
     TSizeVec expectedIndices{0, 0, 0, 0};
 
-    s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    s_Frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             s_TreeFeatureImportance->shap(*row, [&](const TSizeVec& indices, const TStrVec& names,
                                                     const TVectorVec& shap) {
@@ -481,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleTreesShap, SFixtureMultipleTrees) {
 
     TSizeVec expectedIndices{0, 0, 0, 0, 0, 1, 0, 0, 0, 0};
 
-    s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    s_Frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             s_TreeFeatureImportance->shap(*row, [&](const TSizeVec& indices, const TStrVec& names,
                                                     const TVectorVec& shap) {
@@ -536,7 +536,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleRandomTreeShap, SFixtureRandomTrees) {
         std::sort(expectedIndices[i].begin(), expectedIndices[i].end());
     }
 
-    s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    s_Frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             s_TreeFeatureImportance->shap(*row, [&](const TSizeVec& indices, const TStrVec& names,
                                                     const TVectorVec& shap) {
@@ -565,7 +565,7 @@ BOOST_FIXTURE_TEST_CASE(testThreadedRandomTreeShap, SFixtureRandomTrees) {
 
     core::startDefaultAsyncExecutor();
 
-    s_Frame->readRows(1, [&](TRowItr beginRows, TRowItr endRows) {
+    s_Frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         TSizeVec expectedIndices;
         TStrVec expectedNames;
         TVectorVec expectedShap;


### PR DESCRIPTION
This migrates the callback to read and write rows on a data frame to pass the iterators by constant reference. This generates clang-tidy warnings. Although the types are small and relatively a lot of work happens for each copy, each one is 64 bytes and there is no need to copy them.

I've marked as a non-issue because I don't think there is any need to document this change.