### PR TITLE
[ML] Output max num trees in hyperparameters metadata

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,11 +20,16 @@ nbactions.xml
 #vscode files
 .vscode
 .clangd
+.cache
 
 # gradle stuff
 .gradle/
 build/
 generated-resources/
+
+# python environment stuff
+**/env/*
+*.pyc
 
 # testing stuff
 **/.local*

--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,16 @@ nbactions.xml
 #vscode files
 .vscode
 .clangd
+.cache
 
 # gradle stuff
 .gradle/
 build/
 generated-resources/
+
+# python environment stuff
+**/env/*
+*.pyc
 
 # testing stuff
 **/.local*

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -59,6 +59,12 @@
 * Fail gracefully if insufficient data are supplied for classification or regression
   training. (See {ml-pull}1855[#1855].)
 
+== {es} version 7.12.2
+
+=== Bug Fixes
+
+* Add missing hyperparamter to the model metadata. (See {ml-pull}1867[#1867].)
+
 == {es} version 7.12.1
 
 === Enhancements

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -67,19 +67,13 @@ public:
 
 private:
     struct SHyperparameterImportance {
-        SHyperparameterImportance(std::string hyperparameterName,
-                                  double value,
-                                  double absoluteImportance,
-                                  double relativeImportance,
-                                  bool supplied)
-            : s_HyperparameterName(hyperparameterName), s_Value(value),
-              s_AbsoluteImportance(absoluteImportance),
-              s_RelativeImportance(relativeImportance), s_Supplied(supplied) {}
+        enum EType { E_Double, E_Uint64 };
         std::string s_HyperparameterName;
         double s_Value;
         double s_AbsoluteImportance;
         double s_RelativeImportance;
         bool s_Supplied;
+        EType s_Type;
     };
 
     using TMeanAccumulator =

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -56,7 +56,7 @@ public:
     void columnNames(const TStrVec& columnNames);
     void classValues(const TStrVec& classValues);
     void predictionFieldTypeResolverWriter(const TPredictionFieldTypeResolverWriter& resolverWriter);
-    const std::string& typeString() const;
+    static const std::string& typeString();
     //! Add importances \p values to the feature with index \p i to calculate total feature importance.
     //! Total feature importance is the mean of the magnitudes of importances for individual data points.
     void addToFeatureImportance(std::size_t i, const TVector& values);

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -47,19 +47,13 @@ enum EHyperparameters {
 constexpr std::size_t NUMBER_HYPERPARAMETERS = E_FeatureBagFraction + 1; // This must be last hyperparameter
 
 struct SHyperparameterImportance {
-    SHyperparameterImportance(EHyperparameters hyperparameter,
-                              double value,
-                              double absoluteImportance,
-                              double relativeImportance,
-                              bool supplied)
-        : s_Hyperparameter(hyperparameter), s_Value(value),
-          s_AbsoluteImportance(absoluteImportance),
-          s_RelativeImportance(relativeImportance), s_Supplied(supplied) {}
+    enum EType { E_Double = 0, E_Uint64 };
     EHyperparameters s_Hyperparameter;
     double s_Value;
     double s_AbsoluteImportance;
     double s_RelativeImportance;
     bool s_Supplied;
+    EType s_Type;
 };
 
 //! Get the size of upper triangle of the loss Hessain.

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -40,6 +40,7 @@ enum EHyperparameters {
     E_SoftTreeDepthTolerance,
     E_Eta,
     E_EtaGrowthRatePerTree,
+    E_MaximumNumberTrees,
     E_FeatureBagFraction
 };
 

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -76,6 +76,8 @@ public:
     CDataFrameAnalysisSpecificationFactory& predictionSoftTreeDepthLimit(double limit);
     CDataFrameAnalysisSpecificationFactory& predictionSoftTreeDepthTolerance(double tolerance);
     CDataFrameAnalysisSpecificationFactory& predictionEta(double eta);
+    CDataFrameAnalysisSpecificationFactory&
+    predictionEtaGrowthRatePerTree(double etaGrowthRatePerTree);
     CDataFrameAnalysisSpecificationFactory& predictionMaximumNumberTrees(std::size_t number);
     CDataFrameAnalysisSpecificationFactory& predictionDownsampleFactor(double downsampleFactor);
     CDataFrameAnalysisSpecificationFactory& predictionFeatureBagFraction(double fraction);
@@ -119,37 +121,38 @@ private:
     TOptionalSize m_Columns;
     TOptionalSize m_MemoryLimit;
     std::string m_MissingString;
-    bool m_DiskUsageAllowed = true;
+    bool m_DiskUsageAllowed{true};
     // Outliers
     std::string m_Method;
-    std::size_t m_NumberNeighbours = 0;
-    bool m_ComputeFeatureInfluence = false;
+    std::size_t m_NumberNeighbours{0};
+    bool m_ComputeFeatureInfluence{false};
     // Prediction
-    std::size_t m_NumberRoundsPerHyperparameter = 0;
-    std::size_t m_BayesianOptimisationRestarts = 0;
+    std::size_t m_NumberRoundsPerHyperparameter{0};
+    std::size_t m_BayesianOptimisationRestarts{0};
     TStrVec m_CategoricalFieldNames;
     std::string m_PredictionFieldName;
-    double m_Alpha = -1.0;
-    double m_Lambda = -1.0;
-    double m_Gamma = -1.0;
-    double m_SoftTreeDepthLimit = -1.0;
-    double m_SoftTreeDepthTolerance = -1.0;
-    double m_Eta = -1.0;
-    std::size_t m_MaximumNumberTrees = 0;
-    double m_DownsampleFactor = 0.0;
-    double m_FeatureBagFraction = -1.0;
-    std::size_t m_NumberTopShapValues = 0;
-    TPersisterSupplier* m_PersisterSupplier = nullptr;
-    TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
+    double m_Alpha{-1.0};
+    double m_Lambda{-1.0};
+    double m_Gamma{-1.0};
+    double m_SoftTreeDepthLimit{-1.0};
+    double m_SoftTreeDepthTolerance{-1.0};
+    double m_Eta{-1.0};
+    double m_EtaGrowthRatePerTree{-1.0};
+    std::size_t m_MaximumNumberTrees{0};
+    double m_DownsampleFactor{0.0};
+    double m_FeatureBagFraction{-1.0};
+    std::size_t m_NumberTopShapValues{0};
+    TPersisterSupplier* m_PersisterSupplier{nullptr};
+    TRestoreSearcherSupplier* m_RestoreSearcherSupplier{nullptr};
     rapidjson::Document m_CustomProcessors;
     // Regression
     TOptionalLossFunctionType m_RegressionLossFunction;
     TOptionalDouble m_RegressionLossFunctionParameter;
     // Classification
-    std::size_t m_NumberClasses = 2;
-    std::size_t m_NumberTopClasses = 0;
+    std::size_t m_NumberClasses{2};
+    std::size_t m_NumberTopClasses{0};
     std::string m_PredictionFieldType;
-    bool m_EarlyStoppingEnabled = true;
+    bool m_EarlyStoppingEnabled{true};
     TStrDoublePrVec m_ClassificationWeights;
 };
 }

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -21,6 +21,8 @@
 #include <test/CRandomNumbers.h>
 #include <test/ImportExport.h>
 
+#include <boost/optional/optional_fwd.hpp>
+
 #include <string>
 #include <vector>
 
@@ -35,15 +37,20 @@ public:
     using TLossUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
     using TTargetTransformer = std::function<double(double)>;
     using TLossFunctionType = maths::boosted_tree::ELossType;
+    using TSizeOptional = boost::optional<std::size_t>;
 
 public:
     static void addPredictionTestData(TLossFunctionType type,
                                       const TStrVec& fieldNames,
                                       TStrVec fieldValues,
                                       api::CDataFrameAnalyzer& analyzer,
-                                      std::size_t numberExamples = 100) {
+                                      std::size_t numberExamples = 100,
+                                      TSizeOptional seed = {}) {
 
         test::CRandomNumbers rng;
+        if (seed) {
+            rng.seed(seed.get());
+        }
 
         TDoubleVec weights;
         rng.generateUniformSamples(-1.0, 1.0, fieldNames.size() - 3, weights);
@@ -86,9 +93,13 @@ public:
                                       double eta = 0.0,
                                       std::size_t maximumNumberTrees = 0,
                                       double featureBagFraction = 0.0,
-                                      double lossFunctionParameter = 1.0) {
+                                      double lossFunctionParameter = 1.0,
+                                      TSizeOptional seed = {}) {
 
         test::CRandomNumbers rng;
+        if (seed) {
+            rng.seed(seed.get());
+        }
 
         TDoubleVec weights;
         rng.generateUniformSamples(-1.0, 1.0, fieldNames.size() - 3, weights);

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -142,7 +142,6 @@ void CInferenceModelMetadata::writeFeatureImportanceBaseline(TRapidJsonWriter& w
 }
 
 void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& writer) const {
-    // TODO use struct instead of a tuple
     writer.Key(JSON_HYPERPARAMETERS_TAG);
     writer.StartArray();
     for (const auto& item : m_HyperparameterImportance) {
@@ -150,7 +149,11 @@ void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& wr
         writer.Key(JSON_HYPERPARAMETER_NAME_TAG);
         writer.String(item.s_HyperparameterName);
         writer.Key(JSON_HYPERPARAMETER_VALUE_TAG);
-        writer.Double(item.s_Value);
+        if (item.s_HyperparameterName == CDataFrameTrainBoostedTreeRunner::MAX_TREES) {
+            writer.Uint64(static_cast<std::size_t>(item.s_Value));
+        } else {
+            writer.Double(item.s_Value);
+        }
         if (item.s_Supplied == false) {
             writer.Key(JSON_ABSOLUTE_IMPORTANCE_TAG);
             writer.Double(item.s_AbsoluteImportance);
@@ -164,7 +167,7 @@ void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& wr
     writer.EndArray();
 }
 
-const std::string& CInferenceModelMetadata::typeString() const {
+const std::string& CInferenceModelMetadata::typeString() {
     return JSON_MODEL_METADATA_TAG;
 }
 
@@ -232,6 +235,9 @@ void CInferenceModelMetadata::hyperparameterImportance(
             break;
         case maths::boosted_tree_detail::E_SoftTreeDepthTolerance:
             hyperparameterName = CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE;
+            break;
+        case maths::boosted_tree_detail::E_MaximumNumberTrees:
+            hyperparameterName = CDataFrameTrainBoostedTreeRunner::MAX_TREES;
             break;
         }
         double absoluteImportance{(std::fabs(item.s_AbsoluteImportance) < 1e-8)

--- a/lib/api/unittest/CInferenceModelMetadataTest.cc
+++ b/lib/api/unittest/CInferenceModelMetadataTest.cc
@@ -132,6 +132,7 @@ BOOST_AUTO_TEST_CASE(testHyperparameterReproducibility, *utf::tolerance(0.000001
 
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(output.str()));
+        LOG_DEBUG(<< output.str());
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
         // read hyperparameter into the new spec and expected predictions
         for (const auto& result : results.GetArray()) {
@@ -197,6 +198,7 @@ BOOST_AUTO_TEST_CASE(testHyperparameterReproducibility, *utf::tolerance(0.000001
 
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(output.str()));
+        LOG_DEBUG(<< output.str());
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
         for (const auto& result : results.GetArray()) {
             if (result.HasMember("row_results")) {

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -32,7 +32,7 @@ CLoopProgress::CLoopProgress(std::size_t range,
                              const TProgressCallback& recordProgress,
                              double scale,
                              std::size_t steps)
-    : m_Range{std::max(range, 1UL)}, m_Steps{std::min(range, steps)},
+    : m_Range{std::max(range, static_cast<std::size_t>(1))}, m_Steps{std::min(range, steps)},
       m_StepProgress{scale / static_cast<double>(m_Steps)}, m_RecordProgress{recordProgress} {
 }
 

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -32,7 +32,7 @@ CLoopProgress::CLoopProgress(std::size_t range,
                              const TProgressCallback& recordProgress,
                              double scale,
                              std::size_t steps)
-    : m_Range{range}, m_Steps{std::min(range, steps)},
+    : m_Range{std::max(range, 1UL)}, m_Steps{std::min(range, steps)},
       m_StepProgress{scale / static_cast<double>(m_Steps)}, m_RecordProgress{recordProgress} {
 }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -124,14 +124,6 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
         this->initializeHyperparameterOptimisation();
     }
 
-    m_TreeImpl->m_BestHyperparameters =
-        CBoostedTreeHyperparameters(m_TreeImpl->m_Regularization,
-                                    m_TreeImpl->m_DownsampleFactor,
-                                    m_TreeImpl->m_Eta,
-                                    m_TreeImpl->m_EtaGrowthRatePerTree,
-                                    m_TreeImpl->m_MaximumNumberTrees,
-                                    m_TreeImpl->m_FeatureBagFraction);
-
     auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads,
                                                        m_TreeImpl->m_Loss->clone());
     std::swap(m_TreeImpl, treeImpl);
@@ -271,6 +263,10 @@ void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {
         m_BayesianOptimisationRestarts.value_or(CBayesianOptimisation::RESTARTS));
     m_TreeImpl->m_NumberRounds = this->numberHyperparameterTuningRounds();
     m_TreeImpl->m_CurrentRound = 0; // for first start
+    m_TreeImpl->m_BestHyperparameters = CBoostedTreeHyperparameters(
+        m_TreeImpl->m_Regularization, m_TreeImpl->m_DownsampleFactor,
+        m_TreeImpl->m_Eta, m_TreeImpl->m_EtaGrowthRatePerTree,
+        m_TreeImpl->m_MaximumNumberTrees, m_TreeImpl->m_FeatureBagFraction);
 }
 
 void CBoostedTreeFactory::initializeMissingFeatureMasks(const core::CDataFrame& frame) const {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -40,7 +40,7 @@ const std::size_t MAX_PARAMETER_INDEX{2};
 const std::size_t MAX_LINE_SEARCH_ITERATIONS{10};
 const double LINE_SEARCH_MINIMUM_RELATIVE_EI_TO_CONTINUE{0.01};
 const double MIN_ROWS_PER_FEATURE{20.0};
-const double MIN_SOFT_DEPTH_LIMIT{2.0};
+const double MIN_SOFT_DEPTH_LIMIT{0.0};
 const double MIN_SOFT_DEPTH_LIMIT_TOLERANCE{0.05};
 const double MAX_SOFT_DEPTH_LIMIT_TOLERANCE{0.25};
 const double MIN_ETA{1e-3};

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -169,9 +169,8 @@ CBoostedTreeFactory::restoreFor(core::CDataFrame& frame, std::size_t dependentVa
 }
 
 std::size_t CBoostedTreeFactory::numberHyperparameterTuningRounds() const {
-    return std::max(m_TreeImpl->m_MaximumOptimisationRoundsPerHyperparameter *
-                        m_TreeImpl->numberHyperparametersToTune(),
-                    std::size_t{1});
+    return m_TreeImpl->m_MaximumOptimisationRoundsPerHyperparameter *
+           m_TreeImpl->numberHyperparametersToTune();
 }
 
 void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -124,6 +124,14 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
         this->initializeHyperparameterOptimisation();
     }
 
+    m_TreeImpl->m_BestHyperparameters =
+        CBoostedTreeHyperparameters(m_TreeImpl->m_Regularization,
+                                    m_TreeImpl->m_DownsampleFactor,
+                                    m_TreeImpl->m_Eta,
+                                    m_TreeImpl->m_EtaGrowthRatePerTree,
+                                    m_TreeImpl->m_MaximumNumberTrees,
+                                    m_TreeImpl->m_FeatureBagFraction);
+
     auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads,
                                                        m_TreeImpl->m_Loss->clone());
     std::swap(m_TreeImpl, treeImpl);

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -40,7 +40,7 @@ const std::size_t MAX_PARAMETER_INDEX{2};
 const std::size_t MAX_LINE_SEARCH_ITERATIONS{10};
 const double LINE_SEARCH_MINIMUM_RELATIVE_EI_TO_CONTINUE{0.01};
 const double MIN_ROWS_PER_FEATURE{20.0};
-const double MIN_SOFT_DEPTH_LIMIT{0.0};
+const double MIN_SOFT_DEPTH_LIMIT{2.0};
 const double MIN_SOFT_DEPTH_LIMIT_TOLERANCE{0.05};
 const double MAX_SOFT_DEPTH_LIMIT_TOLERANCE{0.25};
 const double MIN_ETA{1e-3};

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -196,12 +196,6 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     this->startProgressMonitoringFineTuneHyperparameters();
 
-    // We need to initialize best hyperparameter in case we drop
-    // through hyperparameter optimization directly to final training.
-    m_BestForestTestLoss = std::numeric_limits<double>::infinity();
-    m_BestHyperparameters = CBoostedTreeHyperparameters{
-        m_Regularization,       m_DownsampleFactor,   m_Eta,
-        m_EtaGrowthRatePerTree, m_MaximumNumberTrees, m_FeatureBagFraction};
 
     if (this->canTrain() == false) {
 
@@ -309,7 +303,7 @@ void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainStat
 }
 
 void CBoostedTreeImpl::predict(core::CDataFrame& frame) const {
-    if (m_BestForestTestLoss == INF) {
+    if (m_BestForest.empty()) {
         HANDLE_FATAL(<< "Internal error: no model available for prediction. "
                      << "Please report this problem.");
         return;
@@ -1340,6 +1334,9 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         case E_FeatureBagFraction:
             parameters(i) = m_FeatureBagFraction;
             break;
+        case E_MaximumNumberTrees:
+            parameters(i) = static_cast<double>(m_MaximumNumberTrees);
+            break;
         case E_Gamma:
             parameters(i) = CTools::stableLog(
                 m_Regularization.treeSizePenaltyMultiplier() / scale);
@@ -1407,6 +1404,9 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
             break;
         case E_FeatureBagFraction:
             m_FeatureBagFraction = parameters(i);
+            break;
+        case E_MaximumNumberTrees:
+            m_MaximumNumberTrees = static_cast<std::size_t>(std::ceil(parameters(i)));
             break;
         case E_Gamma:
             m_Regularization.treeSizePenaltyMultiplier(
@@ -2017,6 +2017,8 @@ CBoostedTreeImpl::hyperparameterImportance() const {
             std::tie(absoluteImportance, relativeImportance) = anovaMainEffects[tunableIndex];
         }
         double hyperparameterValue;
+        SHyperparameterImportance::EType hyperparameterType{
+            boosted_tree_detail::SHyperparameterImportance::E_Double};
         switch (i) {
         case E_Alpha:
             hyperparameterValue = m_Regularization.depthPenaltyMultiplier();
@@ -2035,6 +2037,7 @@ CBoostedTreeImpl::hyperparameterImportance() const {
             break;
         case E_MaximumNumberTrees:
             hyperparameterValue = static_cast<double>(m_MaximumNumberTrees);
+            hyperparameterType = boosted_tree_detail::SHyperparameterImportance::E_Uint64;
             break;
         case E_Gamma:
             hyperparameterValue = m_Regularization.treeSizePenaltyMultiplier();
@@ -2049,9 +2052,9 @@ CBoostedTreeImpl::hyperparameterImportance() const {
             hyperparameterValue = m_Regularization.softTreeDepthTolerance();
             break;
         }
-        hyperparameterImportances.emplace_back(static_cast<EHyperparameters>(i),
-                                               hyperparameterValue, absoluteImportance,
-                                               relativeImportance, supplied);
+        hyperparameterImportances.push_back(
+            {static_cast<EHyperparameters>(i), hyperparameterValue,
+             absoluteImportance, relativeImportance, supplied, hyperparameterType});
     }
     return hyperparameterImportances;
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -196,7 +196,6 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     this->startProgressMonitoringFineTuneHyperparameters();
 
-
     if (this->canTrain() == false) {
 
         // Fallback to using the constant predictor which minimises the loss.

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1416,7 +1416,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
                 scale * CTools::stableExp(parameters(i)));
             break;
         case E_SoftTreeDepthLimit:
-            m_Regularization.softTreeDepthLimit(parameters(i));
+            m_Regularization.softTreeDepthLimit(std::max(parameters(i), 2.0));
             break;
         case E_SoftTreeDepthTolerance:
             m_Regularization.softTreeDepthTolerance(parameters(i));

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1442,7 +1442,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     LOG_DEBUG(<< "recalls    = " << core::CContainerPrinter::print(recalls));
 
     BOOST_TEST_REQUIRE(std::fabs(precisions[0] - precisions[1]) < 0.1);
-    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.13);
+    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.16);
 }
 
 BOOST_AUTO_TEST_CASE(testClassificationWeightsOverride) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1360,7 +1360,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.52);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.53);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -145,6 +145,12 @@ CDataFrameAnalysisSpecificationFactory::predictionEta(double eta) {
 }
 
 CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::predictionEtaGrowthRatePerTree(double etaGrowthRatePerTree) {
+    m_EtaGrowthRatePerTree = etaGrowthRatePerTree;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::predictionMaximumNumberTrees(std::size_t number) {
     m_MaximumNumberTrees = number;
     return *this;
@@ -312,6 +318,10 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
     if (m_Eta > 0.0) {
         writer.Key(TRunner::ETA);
         writer.Double(m_Eta);
+    }
+    if (m_EtaGrowthRatePerTree > 0.0) {
+        writer.Key(TRunner::ETA_GROWTH_RATE_PER_TREE);
+        writer.Double(m_EtaGrowthRatePerTree);
     }
     if (m_DownsampleFactor > 0.0) {
         writer.Key(TRunner::DOWNSAMPLE_FACTOR);


### PR DESCRIPTION
We output max number trees as a hyperparameter in the model metadata and add a unit test to ensure that we achieve reproducible results when retraining a model with all hyperparameters specified.

Fixes #1853 .