### PR TITLE
[ML] Prediction task

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -34,7 +34,7 @@ class CBoostedTreeInferenceModelBuilder;
 //! \brief Runs boosted tree regression on a core::CDataFrame.
 class API_EXPORT CDataFrameTrainBoostedTreeRunner : public CDataFrameAnalysisRunner {
 public:
-    enum ETask { E_Train, E_Update };
+    enum ETask { E_Train = 0, E_Update, E_Predict };
 
     static const std::string DEPENDENT_VARIABLE_NAME;
     static const std::string PREDICTION_FIELD_NAME;
@@ -62,6 +62,7 @@ public:
     static const std::string TASK;
     static const std::string TASK_TRAIN;
     static const std::string TASK_UPDATE;
+    static const std::string TASK_PREDICT;
 
     // Output
     static const std::string IS_TRAINING_FIELD_NAME;
@@ -114,6 +115,8 @@ protected:
 
     //! Write the boosted tree and custom processors to \p builder.
     void accept(CBoostedTreeInferenceModelBuilder& builder) const;
+
+    ETask task() const { return m_Task; };
 
 private:
     using TBoostedTreeFactoryUPtr = std::unique_ptr<maths::CBoostedTreeFactory>;

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -120,8 +120,14 @@ public:
     //! Get the index of the left child node.
     TNodeIndex leftChildIndex() const { return m_LeftChild.get(); }
 
+    //! Set the left child index to \p value.
+    void leftChildIndex(TNodeIndex value) { m_LeftChild = value; }
+
     //! Get the index of the right child node.
     TNodeIndex rightChildIndex() const { return m_RightChild.get(); }
+
+    //! Set the right child index to \p value.
+    void rightChildIndex(TNodeIndex value) { m_RightChild = value; }
 
     //! Split this node and add its child nodes to \p tree.
     TNodeIndexNodeIndexPr split(std::size_t splitFeature,

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -183,6 +183,9 @@ public:
     //! Build a boosted tree object for training on \p frame.
     TBoostedTreeUPtr buildForTrain(core::CDataFrame& frame, std::size_t dependentVariable);
 
+    //! Build a boosted tree object for prediction on \p frame.
+    TBoostedTreeUPtr buildForPredict(core::CDataFrame& frame, std::size_t dependentVariable);
+
     //! Build a boosted tree object for incremental training on \p frame.
     TBoostedTreeUPtr buildForTrainIncremental(core::CDataFrame& frame);
 

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -21,6 +21,8 @@
 #include <test/CRandomNumbers.h>
 #include <test/ImportExport.h>
 
+#include <boost/optional/optional_fwd.hpp>
+
 #include <string>
 #include <vector>
 
@@ -35,15 +37,20 @@ public:
     using TLossUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
     using TTargetTransformer = std::function<double(double)>;
     using TLossFunctionType = maths::boosted_tree::ELossType;
+    using TSizeOptional = boost::optional<std::size_t>;
 
 public:
     static void addPredictionTestData(TLossFunctionType type,
                                       const TStrVec& fieldNames,
                                       TStrVec fieldValues,
                                       api::CDataFrameAnalyzer& analyzer,
-                                      std::size_t numberExamples = 100) {
+                                      std::size_t numberExamples = 100,
+                                      TSizeOptional seed = {}) {
 
         test::CRandomNumbers rng;
+        if (seed) {
+            rng.seed(seed.get());
+        }
 
         TDoubleVec weights;
         rng.generateUniformSamples(-1.0, 1.0, fieldNames.size() - 3, weights);
@@ -86,9 +93,13 @@ public:
                                       double eta = 0.0,
                                       std::size_t maximumNumberTrees = 0,
                                       double featureBagFraction = 0.0,
-                                      double lossFunctionParameter = 1.0) {
+                                      double lossFunctionParameter = 1.0,
+                                      TSizeOptional seed = {}) {
 
         test::CRandomNumbers rng;
+        if (seed) {
+            rng.seed(seed.get());
+        }
 
         TDoubleVec weights;
         rng.generateUniformSamples(-1.0, 1.0, fieldNames.size() - 3, weights);

--- a/jupyter/notebooks/utils/misc.py
+++ b/jupyter/notebooks/utils/misc.py
@@ -304,6 +304,7 @@ def evaluate(dataset_name: str, dataset: pandas.DataFrame, model: str, verbose: 
     with open('configs/{}.json'.format(dataset_name)) as fc:
         config = json.load(fc)
     config['rows'] = dataset.shape[0]
+    config['analysis']['parameters']['task'] = 'predict'
     fconfig = tempfile.NamedTemporaryFile(mode='wt')
     json.dump(config, fconfig)
     fconfig.file.close()

--- a/lib/api/CBoostedTreeInferenceModelBuilder.cc
+++ b/lib/api/CBoostedTreeInferenceModelBuilder.cc
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include "core/CContainerPrinter.h"
 #include <api/CBoostedTreeInferenceModelBuilder.h>
 
 #include <core/LogMacros.h>
@@ -82,8 +83,10 @@ CInferenceModelDefinition&& CBoostedTreeInferenceModelBuilder::build() {
     this->setAggregateOutput(ensemble);
 
     this->setTargetType();
+    LOG_DEBUG(<< "Model Builder Feature Names "
+              << core::CContainerPrinter::print(m_FeatureNames));
     ensemble->featureNames(m_FeatureNames);
-    ensemble->removeUnusedFeatures();
+    // ensemble->removeUnusedFeatures();
 
     return std::move(m_Definition);
 }

--- a/lib/api/CBoostedTreeInferenceModelBuilder.cc
+++ b/lib/api/CBoostedTreeInferenceModelBuilder.cc
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include "core/CContainerPrinter.h"
 #include <api/CBoostedTreeInferenceModelBuilder.h>
 
 #include <core/LogMacros.h>
@@ -79,13 +78,12 @@ CInferenceModelDefinition&& CBoostedTreeInferenceModelBuilder::build() {
     }
 
     // Add aggregated output after the number of trees is known
-    auto ensemble{static_cast<CEnsemble*>(m_Definition.trainedModel().get())};
+    auto* ensemble{static_cast<CEnsemble*>(m_Definition.trainedModel().get())};
     this->setAggregateOutput(ensemble);
 
     this->setTargetType();
-    LOG_DEBUG(<< "Model Builder Feature Names "
-              << core::CContainerPrinter::print(m_FeatureNames));
     ensemble->featureNames(m_FeatureNames);
+    // TODO #1869 reactivate once we have a way to map feature names to correct encoding using definition only.
     // ensemble->removeUnusedFeatures();
 
     return std::move(m_Definition);

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -326,8 +326,10 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
     if (featureImportance) {
         m_InferenceModelMetadata.featureImportanceBaseline(featureImportance->baseline());
     }
-    m_InferenceModelMetadata.hyperparameterImportance(
-        this->boostedTree().hyperparameterImportance());
+    if (this->task() != E_Predict) {
+        m_InferenceModelMetadata.hyperparameterImportance(
+            this->boostedTree().hyperparameterImportance());
+    }
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -159,8 +159,10 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
     if (featureImportance) {
         m_InferenceModelMetadata.featureImportanceBaseline(featureImportance->baseline());
     }
-    m_InferenceModelMetadata.hyperparameterImportance(
-        this->boostedTree().hyperparameterImportance());
+    if (this->task() != E_Predict) {
+        m_InferenceModelMetadata.hyperparameterImportance(
+            this->boostedTree().hyperparameterImportance());
+    }
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -73,9 +73,10 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(EARLY_STOPPING_ENABLED,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
-        theReader.addParameter(
-            TASK, CDataFrameAnalysisConfigReader::E_OptionalParameter,
-            {{TASK_TRAIN, int{ETask::E_Train}}, {TASK_UPDATE, int{ETask::E_Update}}});
+        theReader.addParameter(TASK, CDataFrameAnalysisConfigReader::E_OptionalParameter,
+                               {{TASK_TRAIN, int{ETask::E_Train}},
+                                {TASK_UPDATE, int{ETask::E_Update}},
+                                {TASK_PREDICT, int{ETask::E_Predict}}});
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -170,7 +171,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
                 this->spec().numberThreads(), std::move(loss)));
         break;
     }
-    case E_Update: {
+    case E_Update:
+    case E_Predict: {
         auto restoreSearcher = this->spec().restoreSearcher();
         auto dataSummarizationRestorer = [](const core::CDataSearcher::TIStreamP& istream) {
             return api::CRetrainableModelJsonDeserializer::dataSummarizationFromDocumentCompressed(
@@ -357,19 +359,25 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
             treeRestored = this->restoreBoostedTree(frame, dependentVariableColumn,
                                                     restoreSearcher);
         }
-        if (treeRestored == false) {
+        if (treeRestored == false && m_Task == E_Train) {
             m_BoostedTree = m_BoostedTreeFactory->buildForTrain(frame, dependentVariableColumn);
+        }
+        if (m_Task == E_Predict) {
+            m_BoostedTree = m_BoostedTreeFactory->buildForPredict(frame, dependentVariableColumn);
         }
     }
 
     this->validate(frame, dependentVariableColumn);
     switch (m_Task) {
-    case (E_Train):
+    case E_Train:
         m_BoostedTree->train();
         m_BoostedTree->predict();
         break;
-    case (E_Update):
+    case E_Update:
         m_BoostedTree->trainIncremental();
+        m_BoostedTree->predict();
+        break;
+    case E_Predict:
         m_BoostedTree->predict();
     }
 
@@ -478,6 +486,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ENABLED{"earl
 const std::string CDataFrameTrainBoostedTreeRunner::TASK{"task"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_TRAIN{"train"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_UPDATE{"update"};
+const std::string CDataFrameTrainBoostedTreeRunner::TASK_PREDICT{"predict"};
 // clang-format on
 }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -171,7 +171,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
                 this->spec().numberThreads(), std::move(loss)));
         break;
     }
-    case E_Update:
+    case E_Update: // use the same factory initialization as for the predict task
     case E_Predict: {
         auto restoreSearcher = this->spec().restoreSearcher();
         auto dataSummarizationRestorer = [](const core::CDataSearcher::TIStreamP& istream) {
@@ -187,7 +187,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
                     this->spec().numberThreads(), std::move(loss), *restoreSearcher,
                     dataSummarizationRestorer, bestForestRestorer));
         } else {
-            HANDLE_FATAL(<< "Trying to start incremental training without specified restore information.");
+            HANDLE_FATAL(<< "Trying to start prediction or incremental training without specified restore information.");
         }
         break;
     }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -362,9 +362,6 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
         if (treeRestored == false && m_Task == E_Train) {
             m_BoostedTree = m_BoostedTreeFactory->buildForTrain(frame, dependentVariableColumn);
         }
-        if (m_Task == E_Predict) {
-            m_BoostedTree = m_BoostedTreeFactory->buildForPredict(frame, dependentVariableColumn);
-        }
     }
 
     this->validate(frame, dependentVariableColumn);
@@ -378,6 +375,7 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
         m_BoostedTree->predict();
         break;
     case E_Predict:
+        m_BoostedTree = m_BoostedTreeFactory->buildForPredict(frame, dependentVariableColumn);
         m_BoostedTree->predict();
     }
 

--- a/lib/api/CDataSummarizationJsonSerializer.cc
+++ b/lib/api/CDataSummarizationJsonSerializer.cc
@@ -11,6 +11,7 @@
 #include <core/CJsonStateRestoreTraverser.h>
 #include <core/Constants.h>
 
+#include <maths/CBoostedTree.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 
 #include <api/CInferenceModelDefinition.h>
@@ -37,6 +38,7 @@ using TRowItr = core::CDataFrame::TRowItr;
 using TFilteredInput = boost::iostreams::filtering_stream<boost::iostreams::input>;
 using Device = boost::iostreams::basic_array_source<char>;
 using TStreamBuffer = boost::iostreams::stream_buffer<Device>;
+using TStrVec = std::vector<std::string>;
 
 using TUint64Optional = boost::optional<std::uint64_t>;
 
@@ -341,6 +343,13 @@ CRetrainableModelJsonDeserializer::bestForestFromJsonStream(const core::CDataSea
                       << "' is missing in the model definition.");
             return nullptr;
         }
+        const auto& featureNamesArray =
+            tree[CTree::JSON_TREE_TAG][CTree::JSON_FEATURE_NAMES_TAG].GetArray();
+        TStrVec featureNames;
+        featureNames.reserve(featureNamesArray.Size());
+        for (const auto& item : featureNamesArray) {
+            featureNames.push_back(item.GetString());
+        }
         auto treeArray =
             tree[CTree::JSON_TREE_TAG][CTree::JSON_TREE_STRUCTURE_TAG].GetArray();
         TNodeVec nodes;
@@ -352,6 +361,7 @@ CRetrainableModelJsonDeserializer::bestForestFromJsonStream(const core::CDataSea
             nodes[nodeIndex].numberSamples(numberSamples);
 
             if (node.HasMember(CTree::CTreeNode::JSON_LEAF_VALUE_TAG)) {
+                // leaf node
                 if (node[CTree::CTreeNode::JSON_LEAF_VALUE_TAG].IsArray()) {
                     auto leafValueArray =
                         node[CTree::CTreeNode::JSON_LEAF_VALUE_TAG].GetArray();
@@ -367,13 +377,21 @@ CRetrainableModelJsonDeserializer::bestForestFromJsonStream(const core::CDataSea
                 }
 
             } else {
+                // inner node
                 std::size_t splitFeature{getUint64(node, CTree::CTreeNode::JSON_SPLIT_FEATURE_TAG)};
                 double gain{getDouble(node, CTree::CTreeNode::JSON_SPLIT_GAIN_TAG)};
                 double splitValue{getDouble(node, CTree::CTreeNode::JSON_THRESHOLD_TAG)};
                 bool assignMissingToLeft{getBool(node, CTree::CTreeNode::JSON_DEFAULT_LEFT_TAG)};
+                std::size_t leftChildIndex{getUint64(node, CTree::CTreeNode::JSON_LEFT_CHILD_TAG)};
+                std::size_t rightChildIndex{
+                    getUint64(node, CTree::CTreeNode::JSON_RIGHT_CHILD_TAG)};
                 nodes[nodeIndex].split(splitFeature, splitValue,
                                        assignMissingToLeft, gain, 0.0, nodes);
                 nodes[nodeIndex].numberSamples(numberSamples);
+                nodes[nodeIndex].leftChildIndex(
+                    static_cast<maths::CBoostedTreeNode::TNodeIndex>(leftChildIndex));
+                nodes[nodeIndex].rightChildIndex(
+                    static_cast<maths::CBoostedTreeNode::TNodeIndex>(rightChildIndex));
             }
         }
         forest->push_back(nodes);

--- a/lib/api/CDataSummarizationJsonSerializer.cc
+++ b/lib/api/CDataSummarizationJsonSerializer.cc
@@ -343,13 +343,6 @@ CRetrainableModelJsonDeserializer::bestForestFromJsonStream(const core::CDataSea
                       << "' is missing in the model definition.");
             return nullptr;
         }
-        const auto& featureNamesArray =
-            tree[CTree::JSON_TREE_TAG][CTree::JSON_FEATURE_NAMES_TAG].GetArray();
-        TStrVec featureNames;
-        featureNames.reserve(featureNamesArray.Size());
-        for (const auto& item : featureNamesArray) {
-            featureNames.push_back(item.GetString());
-        }
         auto treeArray =
             tree[CTree::JSON_TREE_TAG][CTree::JSON_TREE_STRUCTURE_TAG].GetArray();
         TNodeVec nodes;

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include <core/CBase64Filter.h>
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 #include <core/CDataSearcher.h>
@@ -32,12 +33,17 @@
 
 #include <rapidjson/prettywriter.h>
 
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/unordered_map.hpp>
-
 #include <memory>
 #include <sstream>
 #include <string>
+
+namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
 
 using TDoubleVec = std::vector<double>;
 using TStrVec = std::vector<std::string>;
@@ -51,6 +57,8 @@ using namespace ml;
 namespace {
 using TBoolVec = std::vector<bool>;
 using TSizeVec = std::vector<std::size_t>;
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
 using TRowItr = core::CDataFrame::TRowItr;
 using TRowRef = core::CDataFrame::TRowRef;
 using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
@@ -59,6 +67,19 @@ using TPersisterSupplier = std::function<TDataAdderUPtr()>;
 using TDataSearcherUPtr = std::unique_ptr<core::CDataSearcher>;
 using TRestoreSearcherSupplier = std::function<TDataSearcherUPtr()>;
 using TLossFunctionType = maths::boosted_tree::ELossType;
+using TFilteredInput = boost::iostreams::filtering_stream<boost::iostreams::input>;
+
+std::stringstream decompressStream(std::stringstream&& stream) {
+    std::stringstream decompressedStream;
+    {
+        TFilteredInput inFilter;
+        inFilter.push(boost::iostreams::gzip_decompressor());
+        inFilter.push(core::CBase64Decoder());
+        inFilter.push(stream);
+        boost::iostreams::copy(inFilter, decompressedStream);
+    }
+    return decompressedStream;
+}
 
 class CTestDataSearcher : public core::CDataSearcher {
 public:
@@ -107,6 +128,26 @@ auto restoreTree(std::string persistedState, TDataFrameUPtr& frame, std::size_t 
     auto stream = decompressor->search(1, 1);
     return maths::CBoostedTreeFactory::constructFromString(*stream).restoreFor(
         *frame, dependentVariable);
+}
+
+auto generateCategoricalData(test::CRandomNumbers& rng,
+                             std::size_t rows,
+                             const TDoubleVec& expectedFrequencies) {
+
+    TDoubleVecVec frequencies;
+    rng.generateDirichletSamples(expectedFrequencies, 1, frequencies);
+
+    TDoubleVec values(1);
+    for (std::size_t j = 0; j < frequencies[0].size(); ++j) {
+        std::size_t target{static_cast<std::size_t>(
+            static_cast<double>(rows) * frequencies[0][j] + 0.5)};
+        values.resize(values.size() + target, static_cast<double>(j));
+    }
+    values.resize(rows, values.back());
+    rng.random_shuffle(values.begin(), values.end());
+    rng.discard(1000000); // Make sure the categories are not correlated
+
+    return std::make_pair(frequencies[0], values);
 }
 
 template<typename F>
@@ -610,8 +651,323 @@ BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionTrainingWithStateRecovery) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionIncrementalTraining,
-                     *boost::unit_test::disabled()) {
+BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionNumericalOnlyPredictionTask,
+                     *utf::tolerance(0.000001)) {
+    auto makeSpec = [&](const std::string& dependentVariable, std::size_t numberExamples,
+                        TPersisterSupplier* persisterSupplier,
+                        TRestoreSearcherSupplier* restorerSupplier,
+                        test::CDataFrameAnalysisSpecificationFactory::TTask task) {
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        return specFactory.rows(numberExamples)
+            .memoryLimit(15000000)
+            .predictionMaximumNumberTrees(10)
+            .predictionPersisterSupplier(persisterSupplier)
+            .predictionRestoreSearcherSupplier(restorerSupplier)
+            .regressionLossFunction(TLossFunctionType::E_MseRegression)
+            .earlyStoppingEnabled(false)
+            .task(task)
+            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(),
+                            dependentVariable);
+    };
+
+    std::stringstream outputStream;
+    auto outputWriterFactory = [&outputStream]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(outputStream);
+    };
+    TLossFunctionType lossFunction = TLossFunctionType::E_MseRegression;
+
+    // run once
+    std::size_t numberExamples{100};
+    TStrVec fieldNames{"c1", "c2", "c3", "c4", "target", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    // TDoubleVec weights{0.1, 2.0, 0.4, -0.5};
+    // TDoubleVec regressors;
+    test::CRandomNumbers rng;
+    // rng.generateUniformSamples(-10.0, 10.0, weights.size() * numberExamples, regressors);
+    api::CDataFrameAnalyzer analyzer{
+        makeSpec("target", numberExamples, nullptr, nullptr,
+                 test::CDataFrameAnalysisSpecificationFactory::TTask::E_Train),
+        outputWriterFactory};
+    // TStrVec targets;
+
+    TSizeVec seed{1};
+    rng.generateUniformSamples(0, 1000, 1, seed);
+    LOG_DEBUG(<< "Seed: " << seed[0]);
+
+    TDoubleVec expectedPredictions;
+    expectedPredictions.reserve(numberExamples);
+    TDoubleVec actualPredictions;
+    actualPredictions.reserve(numberExamples);
+
+    test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
+        TLossFunctionType::E_MseRegression, fieldNames, fieldValues, analyzer,
+        numberExamples, seed[0]);
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    // retrieve documents from the result stream that will be used to restore the model
+    std::stringstream inferenceModelStream;
+    std::stringstream dataSummarizationStream;
+    std::string compressedModelDefinition;
+
+    {
+        rapidjson::OStreamWrapper inferenceModelStreamWrapper(inferenceModelStream);
+        core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> inferenceModelWriter{
+            inferenceModelStreamWrapper};
+
+        rapidjson::OStreamWrapper dataSummarizationStreamWrapper(dataSummarizationStream);
+        core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> dataSummarizationWriter{
+            dataSummarizationStreamWrapper};
+
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(outputStream.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        // LOG_DEBUG(<<outputStream.str());
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("compressed_inference_model")) {
+                inferenceModelWriter.write(result);
+
+            } else if (result.HasMember("compressed_data_summarization")) {
+                compressedModelDefinition =
+                    result["compressed_data_summarization"]["data_summarization"]
+                        .GetString();
+                dataSummarizationWriter.write(result);
+            } else if (result.HasMember("row_results")) {
+                expectedPredictions.emplace_back(
+                    result["row_results"]["results"]["ml"]["target_prediction"].GetDouble());
+            }
+        }
+    }
+    BOOST_REQUIRE_EQUAL(expectedPredictions.size(), numberExamples);
+    // LOG_DEBUG(<< "Inference model 1: " << decompressStream(std::stringstream(compressedModelDefinition)).str());
+    dataSummarizationStream << '\0' << inferenceModelStream.str() << '\0';
+
+    // pass model definition and data summarization into the restore stream
+    auto restoreStreamPtr =
+        std::make_shared<std::stringstream>(std::move(dataSummarizationStream));
+    TRestoreSearcherSupplier restorerSupplier{[&restoreStreamPtr]() {
+        return std::make_unique<api::CSingleStreamSearcher>(restoreStreamPtr);
+    }};
+
+    // create a new spec for incremental training
+    outputStream.str("");
+    inferenceModelStream.str("");
+    rapidjson::OStreamWrapper inferenceModelStreamWrapper(inferenceModelStream);
+    core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> inferenceModelWriter{
+        inferenceModelStreamWrapper};
+    // create new analyzer and run incremental training
+    api::CDataFrameAnalyzer analyzerPrediction{
+        makeSpec("target", numberExamples, nullptr, &restorerSupplier,
+                 test::CDataFrameAnalysisSpecificationFactory::TTask::E_Predict),
+        outputWriterFactory};
+    test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
+        TLossFunctionType::E_MseRegression, fieldNames, fieldValues,
+        analyzerPrediction, numberExamples, seed[0]);
+
+    analyzerPrediction.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+    {
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(outputStream.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("row_results")) {
+                actualPredictions.emplace_back(
+                    result["row_results"]["results"]["ml"]["target_prediction"].GetDouble());
+            } else if (result.HasMember("compressed_data_summarization")) {
+                compressedModelDefinition =
+                    result["compressed_data_summarization"]["data_summarization"]
+                        .GetString();
+            }
+        }
+    }
+    // LOG_DEBUG(<<"Inference Model 2: " << decompressStream(std::stringstream(compressedModelDefinition)).str());
+    BOOST_REQUIRE_EQUAL(actualPredictions.size(), numberExamples);
+    BOOST_TEST(actualPredictions == expectedPredictions, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionCategoricalMixPredictionTask,
+                     *utf::tolerance(0.000001)) {
+    auto makeSpec = [&](const std::string& dependentVariable, std::size_t numberExamples,
+                        TPersisterSupplier* persisterSupplier,
+                        TRestoreSearcherSupplier* restorerSupplier,
+                        test::CDataFrameAnalysisSpecificationFactory::TTask task) {
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        return specFactory.rows(numberExamples)
+            .memoryLimit(15000000)
+            .predictionMaximumNumberTrees(10)
+            .predictionPersisterSupplier(persisterSupplier)
+            .predictionRestoreSearcherSupplier(restorerSupplier)
+            .regressionLossFunction(TLossFunctionType::E_MseRegression)
+            .earlyStoppingEnabled(false)
+            .task(task)
+            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(),
+                            dependentVariable);
+    };
+
+    std::stringstream outputStream;
+    auto outputWriterFactory = [&outputStream]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(outputStream);
+    };
+
+    std::size_t numberExamples = 31;
+    std::size_t cols = 3;
+    TDoubleVec weights{10.0, 50.0};
+    // run once
+    test::CRandomNumbers rng;
+
+    TSizeVec seed{1};
+    rng.generateUniformSamples(0, 1000, 1, seed);
+    LOG_DEBUG(<< "Seed: " << seed[0]);
+
+    TDoubleVec expectedPredictions;
+    expectedPredictions.reserve(numberExamples);
+    TDoubleVec actualPredictions;
+    actualPredictions.reserve(numberExamples);
+
+    TStrVec fieldNames{"numeric_col", "categorical_col", "target_col", ".", "."};
+    TStrVec expectedFieldNames{"numeric_col", "categorical_col"};
+
+    TStrVec fieldValues{"", "", "0", "", ""};
+
+    // retrieve documents from the result stream that will be used to restore the model
+    std::stringstream inferenceModelStream;
+    std::stringstream dataSummarizationStream;
+    std::string compressedModelDefinition;
+
+    {
+        rng.seed(seed[0]);
+        TDoubleVecVec frequencies;
+        TDoubleVecVec values(cols);
+        rng.generateUniformSamples(-10.0, 10.0, numberExamples, values[0]);
+        values[1] =
+            generateCategoricalData(rng, numberExamples, {-5.0, 0.0, 5.0}).second;
+
+        for (std::size_t i = 0; i < numberExamples; ++i) {
+            values[2].push_back(values[0][i] * weights[0] + values[1][i] * weights[1]);
+        }
+
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        api::CDataFrameAnalyzer analyzer{
+            specFactory.rows(numberExamples)
+                .columns(cols)
+                .memoryLimit(30000000)
+                .predictionCategoricalFieldNames({"categorical_col"})
+                .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target_col"),
+            outputWriterFactory};
+
+        for (std::size_t i = 0; i < numberExamples; ++i) {
+            for (std::size_t j = 0; j < cols; ++j) {
+                fieldValues[j] = core::CStringUtils::typeToStringPrecise(
+                    values[j][i], core::CIEEE754::E_DoublePrecision);
+            }
+            analyzer.handleRecord(fieldNames, fieldValues);
+        }
+        analyzer.handleRecord(fieldNames, {"", "", "", "", "$"});
+
+        rapidjson::OStreamWrapper inferenceModelStreamWrapper(inferenceModelStream);
+        core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> inferenceModelWriter{
+            inferenceModelStreamWrapper};
+
+        rapidjson::OStreamWrapper dataSummarizationStreamWrapper(dataSummarizationStream);
+        core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> dataSummarizationWriter{
+            dataSummarizationStreamWrapper};
+
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(outputStream.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        // LOG_DEBUG(<<outputStream.str());
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("compressed_inference_model")) {
+                inferenceModelWriter.write(result);
+                compressedModelDefinition =
+                    result["compressed_inference_model"]["definition"].GetString();
+            } else if (result.HasMember("compressed_data_summarization")) {
+                // compressedModelDefinition =
+                // result["compressed_data_summarization"]["data_summarization"].GetString();
+                dataSummarizationWriter.write(result);
+            } else if (result.HasMember("row_results")) {
+                expectedPredictions.emplace_back(
+                    result["row_results"]["results"]["ml"]["target_col_prediction"]
+                        .GetDouble());
+            }
+        }
+    }
+    BOOST_REQUIRE_EQUAL(expectedPredictions.size(), numberExamples);
+    LOG_DEBUG(<< "Inference model 1: "
+              << decompressStream(std::stringstream(compressedModelDefinition)).str());
+    LOG_DEBUG(<< outputStream.str());
+    dataSummarizationStream << '\0' << inferenceModelStream.str() << '\0';
+
+    // pass model definition and data summarization into the restore stream
+    auto restoreStreamPtr =
+        std::make_shared<std::stringstream>(std::move(dataSummarizationStream));
+    TRestoreSearcherSupplier restorerSupplier{[&restoreStreamPtr]() {
+        return std::make_unique<api::CSingleStreamSearcher>(restoreStreamPtr);
+    }};
+
+    // create a new spec for incremental training
+    outputStream.str("");
+    inferenceModelStream.str("");
+    {
+        rapidjson::OStreamWrapper inferenceModelStreamWrapper(inferenceModelStream);
+        core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> inferenceModelWriter{
+            inferenceModelStreamWrapper};
+
+        // create new analyzer and run incremental training
+        rng.seed(seed[0]);
+        TDoubleVecVec frequencies;
+        TDoubleVecVec values(cols);
+        rng.generateUniformSamples(-10.0, 10.0, numberExamples, values[0]);
+        values[1] =
+            generateCategoricalData(rng, numberExamples, {-5.0, 0.0, 5.0}).second;
+
+        for (std::size_t i = 0; i < numberExamples; ++i) {
+            values[2].push_back(values[0][i] * weights[0] + values[1][i] * weights[1]);
+        }
+
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        api::CDataFrameAnalyzer analyzer{
+            specFactory.rows(numberExamples)
+                .columns(cols)
+                .memoryLimit(30000000)
+                .predictionCategoricalFieldNames({"categorical_col"})
+                .predictionRestoreSearcherSupplier(&restorerSupplier)
+                .task(test::CDataFrameAnalysisSpecificationFactory::TTask::E_Predict)
+                .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target_col"),
+            outputWriterFactory};
+
+        for (std::size_t i = 0; i < numberExamples; ++i) {
+            for (std::size_t j = 0; j < cols; ++j) {
+                fieldValues[j] = core::CStringUtils::typeToStringPrecise(
+                    values[j][i], core::CIEEE754::E_DoublePrecision);
+            }
+            analyzer.handleRecord(fieldNames, fieldValues);
+        }
+        analyzer.handleRecord(fieldNames, {"", "", "", "", "$"});
+
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(outputStream.str()));
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("row_results")) {
+                actualPredictions.emplace_back(result["row_results"]["results"]["ml"]["target_col_prediction"]
+                                                   .GetDouble());
+            } else if (result.HasMember("compressed_data_summarization")) {
+                // compressedModelDefinition =
+                // result["compressed_data_summarization"]["data_summarization"].GetString();
+            } else if (result.HasMember("compressed_inference_model")) {
+                compressedModelDefinition =
+                    result["compressed_inference_model"]["definition"].GetString();
+            }
+        }
+    }
+    LOG_DEBUG(<< "Inference Model 2: "
+              << decompressStream(std::stringstream(compressedModelDefinition)).str());
+    LOG_DEBUG(<< outputStream.str());
+    BOOST_REQUIRE_EQUAL(actualPredictions.size(), numberExamples);
+    BOOST_TEST(actualPredictions == expectedPredictions, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(testRunBoostedTreeRegressionIncrementalTraining, *utf::disabled()) {
     auto makeSpec = [&](const std::string& dependentVariable, std::size_t numberExamples,
                         TPersisterSupplier* persisterSupplier,
                         TRestoreSearcherSupplier* restorerSupplier,

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -144,10 +144,6 @@ CBoostedTreeFactory::buildForPredict(core::CDataFrame& frame, std::size_t depend
 
     this->prepareDataFrameForTrain(frame);
 
-    m_TreeImpl->m_InitializationStage != CBoostedTreeImpl::E_NotInitialized
-        ? this->skipProgressMonitoringFeatureSelection()
-        : this->startProgressMonitoringFeatureSelection();
-
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
                 [&] { this->determineFeatureDataTypes(frame); });
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -424,7 +424,7 @@ void CBoostedTreeImpl::predict(core::CDataFrame& frame) const {
 
 void CBoostedTreeImpl::predict(const core::CPackedBitVector& rowMask,
                                core::CDataFrame& frame) const {
-    if (m_BestForestTestLoss == INF) {
+    if (m_BestForest.empty()) {
         HANDLE_FATAL(<< "Internal error: no model available for prediction. "
                      << "Please report this problem.");
         return;
@@ -1625,6 +1625,8 @@ CBoostedTreeImpl::TVector CBoostedTreeImpl::predictRow(const CEncodedDataFrameRo
     for (const auto& tree : m_BestForest) {
         result += root(tree).value(row, tree);
     }
+    // LOG_DEBUG(<<row.unencodedRow().data()->toString()<< " " << result);
+    // LOG_DEBUG(<<core::CContainerPrinter::print(result));
     return result;
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1625,8 +1625,6 @@ CBoostedTreeImpl::TVector CBoostedTreeImpl::predictRow(const CEncodedDataFrameRo
     for (const auto& tree : m_BestForest) {
         result += root(tree).value(row, tree);
     }
-    // LOG_DEBUG(<<row.unencodedRow().data()->toString()<< " " << result);
-    // LOG_DEBUG(<<core::CContainerPrinter::print(result));
     return result;
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -2364,28 +2364,27 @@ void CBoostedTreeImpl::checkTrainInvariants(const core::CDataFrame& frame) const
     if (m_BayesianOptimization == nullptr) {
         HANDLE_FATAL(<< "Internal error: must supply an optimizer. Please report this problem.");
     }
-    // TODO #1811 reactivate the checks once we have a dedicated way to evaluate persisted model on new data.
-    // for (const auto& mask : m_MissingFeatureRowMasks) {
-    //     if (mask.size() != frame.numberRows()) {
-    //         HANDLE_FATAL(<< "Internal error: unexpected missing feature mask ("
-    //                      << mask.size() << " !=  " << frame.numberRows()
-    //                      << "). Please report this problem.");
-    //     }
-    // }
-    // for (const auto& mask : m_TrainingRowMasks) {
-    //     if (mask.size() != frame.numberRows()) {
-    //         HANDLE_FATAL(<< "Internal error: unexpected missing training mask ("
-    //                      << mask.size() << " !=  " << frame.numberRows()
-    //                      << "). Please report this problem.");
-    //     }
-    // }
-    // for (const auto& mask : m_TestingRowMasks) {
-    //     if (mask.size() != frame.numberRows()) {
-    //         HANDLE_FATAL(<< "Internal error: unexpected missing testing mask ("
-    //                      << mask.size() << " !=  " << frame.numberRows()
-    //                      << "). Please report this problem.");
-    //     }
-    // }
+    for (const auto& mask : m_MissingFeatureRowMasks) {
+        if (mask.size() != frame.numberRows()) {
+            HANDLE_FATAL(<< "Internal error: unexpected missing feature mask ("
+                         << mask.size() << " !=  " << frame.numberRows()
+                         << "). Please report this problem.");
+        }
+    }
+    for (const auto& mask : m_TrainingRowMasks) {
+        if (mask.size() != frame.numberRows()) {
+            HANDLE_FATAL(<< "Internal error: unexpected missing training mask ("
+                         << mask.size() << " !=  " << frame.numberRows()
+                         << "). Please report this problem.");
+        }
+    }
+    for (const auto& mask : m_TestingRowMasks) {
+        if (mask.size() != frame.numberRows()) {
+            HANDLE_FATAL(<< "Internal error: unexpected missing testing mask ("
+                         << mask.size() << " !=  " << frame.numberRows()
+                         << "). Please report this problem.");
+        }
+    }
 }
 
 void CBoostedTreeImpl::checkIncrementalTrainInvariants(const core::CDataFrame& frame) const {

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -364,6 +364,9 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
     case TTask::E_Update:
         writer.String(TRunner::TASK_UPDATE);
         break;
+    case TTask::E_Predict:
+        writer.String(TRunner::TASK_PREDICT);
+        break;
     }
 
     if (analysis == classification()) {

--- a/lib/test/CDataFrameAnalyzerTrainingFactory.cc
+++ b/lib/test/CDataFrameAnalyzerTrainingFactory.cc
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+#include "core/CContainerPrinter.h"
 #include <test/CDataFrameAnalyzerTrainingFactory.h>
 
 namespace ml {
@@ -32,7 +33,6 @@ CDataFrameAnalyzerTrainingFactory::setupLinearRegressionData(const TStrVec& fiel
                                                              const TDoubleVec& regressors,
                                                              TStrVec& targets,
                                                              TTargetTransformer targetTransformer) {
-
     auto target = [&weights, &targetTransformer](const TDoubleVec& regressors_) {
         double result{0.0};
         for (std::size_t i = 0; i < weights.size(); ++i) {
@@ -56,11 +56,11 @@ CDataFrameAnalyzerTrainingFactory::setupLinearRegressionData(const TStrVec& fiel
         }
         fieldValues[weights.size()] = target(row);
         targets.push_back(fieldValues[weights.size()]);
-
         analyzer.handleRecord(fieldNames, fieldValues);
         frame->parseAndWriteRow(
             core::CVectorRange<const TStrVec>(fieldValues, 0, weights.size() + 1));
     }
+    // LOG_DEBUG(<<core::CContainerPrinter::print(targets));
 
     frame->finishWritingRows();
 

--- a/lib/test/CDataFrameAnalyzerTrainingFactory.cc
+++ b/lib/test/CDataFrameAnalyzerTrainingFactory.cc
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include "core/CContainerPrinter.h"
 #include <test/CDataFrameAnalyzerTrainingFactory.h>
 
 namespace ml {
@@ -60,7 +59,6 @@ CDataFrameAnalyzerTrainingFactory::setupLinearRegressionData(const TStrVec& fiel
         frame->parseAndWriteRow(
             core::CVectorRange<const TStrVec>(fieldValues, 0, weights.size() + 1));
     }
-    // LOG_DEBUG(<<core::CContainerPrinter::print(targets));
 
     frame->finishWritingRows();
 


### PR DESCRIPTION
This PR introduces a new task "predict" to initialize a trained model and use it only for predicting a new dataset, without updating the model itself. To this end, I implement a new factory method `CBoostedTreeFactory::buildForPredict` that handles the task-specific boosted tree generation.

This also enables us to reactivate the invariance checks, that were temporarily disabled.

I faced the problem of mapping the features from the model definition back to the encoded columns. To fix it temporarily, I deactivated the removal of unused features when the model definition is generated. However, since it is incompatible with our current model definition schema, we still need to properly fix it. I created #1869 to have a reminder.

Closes #1811.