### PR TITLE
[ML] Fail gracefully on encountering unexpected state

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -58,6 +58,8 @@
   is stopped and restarted, for example, if the node fails. (See {ml-pull}1848[#1848].)
 * Fail gracefully if insufficient data are supplied for classification or regression
   training. (See {ml-pull}1855[#1855].)
+* Fail gracefully on encountering unexpected state in restore from snapshot for anomaly
+  detection. (See {ml-pull}1872[#1872].)
 
 == {es} version 7.12.2
 

--- a/include/maths/CMultivariateMultimodalPrior.h
+++ b/include/maths/CMultivariateMultimodalPrior.h
@@ -1013,9 +1013,11 @@ private:
                                 core::CStateRestoreTraverser& traverser) {
         do {
             const std::string& name = traverser.name();
-            RESTORE_SETUP_TEARDOWN(DECAY_RATE_TAG, double decayRate,
-                                   core::CStringUtils::stringToType(traverser.value(), decayRate),
-                                   this->decayRate(decayRate))
+            RESTORE_SETUP_TEARDOWN(
+                DECAY_RATE_TAG, double decayRate{this->decayRate()},
+                m_Clusterer != nullptr && m_SeedPrior != nullptr &&
+                    core::CStringUtils::stringToType(traverser.value(), decayRate),
+                this->decayRate(decayRate))
             RESTORE(CLUSTERER_TAG, traverser.traverseSubLevel(std::bind<bool>(
                                        CClustererStateSerialiser(), std::cref(params),
                                        std::ref(m_Clusterer), std::placeholders::_1)))

--- a/lib/maths/CMultimodalPrior.cc
+++ b/lib/maths/CMultimodalPrior.cc
@@ -189,7 +189,7 @@ bool CMultimodalPrior::acceptRestoreTraverser(const SDistributionRestoreParams& 
     do {
         const std::string& name = traverser.name();
         RESTORE_SETUP_TEARDOWN(
-            DECAY_RATE_TAG, double decayRate,
+            DECAY_RATE_TAG, double decayRate{this->decayRate()},
             m_Clusterer != nullptr && m_SeedPrior != nullptr &&
                 core::CStringUtils::stringToType(traverser.value(), decayRate),
             this->decayRate(decayRate))


### PR DESCRIPTION
We were missing some checks that member state had been properly initialised to fail gracefully when restoring one of our model types for anomaly detection.

This also fixes a potential uninitialised variable problem (which generates a warning from clang), although would only happen for malformed state.