### PR TITLE
[7.12][ML] Output max num trees in hyperparameters metadata

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,11 +20,16 @@ nbactions.xml
 #vscode files
 .vscode
 .clangd
+.cache
 
 # gradle stuff
 .gradle/
 build/
 generated-resources/
+
+# python environment stuff
+**/env/*
+*.pyc
 
 # testing stuff
 **/.local*

--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,16 @@ nbactions.xml
 #vscode files
 .vscode
 .clangd
+.cache
 
 # gradle stuff
 .gradle/
 build/
 generated-resources/
+
+# python environment stuff
+**/env/*
+*.pyc
 
 # testing stuff
 **/.local*

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,10 +28,22 @@
 
 //=== Regressions
 
+== {es} version 7.12.2
+
+=== Bug Fixes
+
+* Add missing hyperparamter to the model metadata. (See {ml-pull}1867[#1867].)
+
 == {es} version 7.12.1
 
 === Enhancements
 
+* Speed up training of regression and classification model training for data sets
+  with many features. (See {ml-pull}1746[#1746].)
+* Avoid overfitting in final training by scaling regularizers to account for the
+  difference in the number of training examples. This results in a better match
+  between train and test error for classification and regression and often slightly
+  improved test errors. (See {ml-pull}1755[#1755].)
 * Make ML native processes work with glibc 2.33 on x86_64. (See {ml-pull}1828[#1828].)
 
 == {es} version 7.12.0

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -56,7 +56,7 @@ public:
     void columnNames(const TStrVec& columnNames);
     void classValues(const TStrVec& classValues);
     void predictionFieldTypeResolverWriter(const TPredictionFieldTypeResolverWriter& resolverWriter);
-    const std::string& typeString() const;
+    static const std::string& typeString();
     //! Add importances \p values to the feature with index \p i to calculate total feature importance.
     //! Total feature importance is the mean of the magnitudes of importances for individual data points.
     void addToFeatureImportance(std::size_t i, const TVector& values);
@@ -67,19 +67,13 @@ public:
 
 private:
     struct SHyperparameterImportance {
-        SHyperparameterImportance(std::string hyperparameterName,
-                                  double value,
-                                  double absoluteImportance,
-                                  double relativeImportance,
-                                  bool supplied)
-            : s_HyperparameterName(hyperparameterName), s_Value(value),
-              s_AbsoluteImportance(absoluteImportance),
-              s_RelativeImportance(relativeImportance), s_Supplied(supplied) {}
+        enum EType { E_Double, E_Uint64 };
         std::string s_HyperparameterName;
         double s_Value;
         double s_AbsoluteImportance;
         double s_RelativeImportance;
         bool s_Supplied;
+        EType s_Type;
     };
 
     using TMeanAccumulator =

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -40,25 +40,20 @@ enum EHyperparameters {
     E_SoftTreeDepthTolerance,
     E_Eta,
     E_EtaGrowthRatePerTree,
+    E_MaximumNumberTrees,
     E_FeatureBagFraction
 };
 
 constexpr std::size_t NUMBER_HYPERPARAMETERS = E_FeatureBagFraction + 1; // This must be last hyperparameter
 
 struct SHyperparameterImportance {
-    SHyperparameterImportance(EHyperparameters hyperparameter,
-                              double value,
-                              double absoluteImportance,
-                              double relativeImportance,
-                              bool supplied)
-        : s_Hyperparameter(hyperparameter), s_Value(value),
-          s_AbsoluteImportance(absoluteImportance),
-          s_RelativeImportance(relativeImportance), s_Supplied(supplied) {}
+    enum EType { E_Double = 0, E_Uint64 };
     EHyperparameters s_Hyperparameter;
     double s_Value;
     double s_AbsoluteImportance;
     double s_RelativeImportance;
     bool s_Supplied;
+    EType s_Type;
 };
 
 //! Get the size of upper triangle of the loss Hessain.

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -76,6 +76,8 @@ public:
     CDataFrameAnalysisSpecificationFactory& predictionSoftTreeDepthLimit(double limit);
     CDataFrameAnalysisSpecificationFactory& predictionSoftTreeDepthTolerance(double tolerance);
     CDataFrameAnalysisSpecificationFactory& predictionEta(double eta);
+    CDataFrameAnalysisSpecificationFactory&
+    predictionEtaGrowthRatePerTree(double etaGrowthRatePerTree);
     CDataFrameAnalysisSpecificationFactory& predictionMaximumNumberTrees(std::size_t number);
     CDataFrameAnalysisSpecificationFactory& predictionDownsampleFactor(double downsampleFactor);
     CDataFrameAnalysisSpecificationFactory& predictionFeatureBagFraction(double fraction);
@@ -119,37 +121,38 @@ private:
     TOptionalSize m_Columns;
     TOptionalSize m_MemoryLimit;
     std::string m_MissingString;
-    bool m_DiskUsageAllowed = true;
+    bool m_DiskUsageAllowed{true};
     // Outliers
     std::string m_Method;
-    std::size_t m_NumberNeighbours = 0;
-    bool m_ComputeFeatureInfluence = false;
+    std::size_t m_NumberNeighbours{0};
+    bool m_ComputeFeatureInfluence{false};
     // Prediction
-    std::size_t m_NumberRoundsPerHyperparameter = 0;
-    std::size_t m_BayesianOptimisationRestarts = 0;
+    std::size_t m_NumberRoundsPerHyperparameter{0};
+    std::size_t m_BayesianOptimisationRestarts{0};
     TStrVec m_CategoricalFieldNames;
     std::string m_PredictionFieldName;
-    double m_Alpha = -1.0;
-    double m_Lambda = -1.0;
-    double m_Gamma = -1.0;
-    double m_SoftTreeDepthLimit = -1.0;
-    double m_SoftTreeDepthTolerance = -1.0;
-    double m_Eta = -1.0;
-    std::size_t m_MaximumNumberTrees = 0;
-    double m_DownsampleFactor = 0.0;
-    double m_FeatureBagFraction = -1.0;
-    std::size_t m_NumberTopShapValues = 0;
-    TPersisterSupplier* m_PersisterSupplier = nullptr;
-    TRestoreSearcherSupplier* m_RestoreSearcherSupplier = nullptr;
+    double m_Alpha{-1.0};
+    double m_Lambda{-1.0};
+    double m_Gamma{-1.0};
+    double m_SoftTreeDepthLimit{-1.0};
+    double m_SoftTreeDepthTolerance{-1.0};
+    double m_Eta{-1.0};
+    double m_EtaGrowthRatePerTree{-1.0};
+    std::size_t m_MaximumNumberTrees{0};
+    double m_DownsampleFactor{0.0};
+    double m_FeatureBagFraction{-1.0};
+    std::size_t m_NumberTopShapValues{0};
+    TPersisterSupplier* m_PersisterSupplier{nullptr};
+    TRestoreSearcherSupplier* m_RestoreSearcherSupplier{nullptr};
     rapidjson::Document m_CustomProcessors;
     // Regression
     TOptionalLossFunctionType m_RegressionLossFunction;
     TOptionalDouble m_RegressionLossFunctionParameter;
     // Classification
-    std::size_t m_NumberClasses = 2;
-    std::size_t m_NumberTopClasses = 0;
+    std::size_t m_NumberClasses{2};
+    std::size_t m_NumberTopClasses{0};
     std::string m_PredictionFieldType;
-    bool m_EarlyStoppingEnabled = true;
+    bool m_EarlyStoppingEnabled{true};
     TStrDoublePrVec m_ClassificationWeights;
 };
 }

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -21,6 +21,8 @@
 #include <test/CRandomNumbers.h>
 #include <test/ImportExport.h>
 
+#include <boost/optional/optional_fwd.hpp>
+
 #include <string>
 #include <vector>
 
@@ -35,15 +37,20 @@ public:
     using TLossUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;
     using TTargetTransformer = std::function<double(double)>;
     using TLossFunctionType = maths::boosted_tree::ELossType;
+    using TSizeOptional = boost::optional<std::size_t>;
 
 public:
     static void addPredictionTestData(TLossFunctionType type,
                                       const TStrVec& fieldNames,
                                       TStrVec fieldValues,
                                       api::CDataFrameAnalyzer& analyzer,
-                                      std::size_t numberExamples = 100) {
+                                      std::size_t numberExamples = 100,
+                                      TSizeOptional seed = {}) {
 
         test::CRandomNumbers rng;
+        if (seed) {
+            rng.seed(seed.get());
+        }
 
         TDoubleVec weights;
         rng.generateUniformSamples(-1.0, 1.0, fieldNames.size() - 3, weights);
@@ -86,9 +93,13 @@ public:
                                       double eta = 0.0,
                                       std::size_t maximumNumberTrees = 0,
                                       double featureBagFraction = 0.0,
-                                      double lossFunctionParameter = 1.0) {
+                                      double lossFunctionParameter = 1.0,
+                                      TSizeOptional seed = {}) {
 
         test::CRandomNumbers rng;
+        if (seed) {
+            rng.seed(seed.get());
+        }
 
         TDoubleVec weights;
         rng.generateUniformSamples(-1.0, 1.0, fieldNames.size() - 3, weights);

--- a/lib/api/unittest/CInferenceModelMetadataTest.cc
+++ b/lib/api/unittest/CInferenceModelMetadataTest.cc
@@ -8,6 +8,7 @@
 #include <maths/CBoostedTreeLoss.h>
 
 #include <api/CDataFrameAnalyzer.h>
+#include <api/CDataFrameTrainBoostedTreeRunner.h>
 
 #include <test/CDataFrameAnalysisSpecificationFactory.h>
 #include <test/CDataFrameAnalyzerTrainingFactory.h>
@@ -20,6 +21,9 @@
 #include <fstream>
 #include <string>
 
+namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
+
 BOOST_AUTO_TEST_SUITE(CInferenceModelMetadataTest)
 
 using namespace ml;
@@ -27,6 +31,7 @@ using namespace ml;
 namespace {
 using TDoubleVec = std::vector<double>;
 using TStrVec = std::vector<std::string>;
+using TSizeVec = std::vector<std::size_t>;
 using TLossFunctionType = maths::boosted_tree::ELossType;
 }
 
@@ -57,7 +62,6 @@ BOOST_AUTO_TEST_CASE(testJsonSchema) {
 
     rapidjson::Document results;
     rapidjson::ParseResult ok(results.Parse(output.str()));
-    LOG_DEBUG(<< output.str());
     BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
 
     std::ifstream modelMetaDataSchemaFileStream("testfiles/model_meta_data/model_meta_data.schema.json");
@@ -94,4 +98,116 @@ BOOST_AUTO_TEST_CASE(testJsonSchema) {
     BOOST_TEST_REQUIRE(hasModelMetadata);
 }
 
+BOOST_AUTO_TEST_CASE(testHyperparameterReproducibility, *utf::tolerance(0.000001)) {
+    // insure that training leads to the same results if all identified hyperparameters
+    // are explicitly specified
+    std::stringstream output;
+    auto outputWriterFactory = [&output]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(output);
+    };
+
+    std::size_t numberSamples{100};
+    test::CRandomNumbers rng;
+    TSizeVec seed{0};
+    rng.generateUniformSamples(0, 1000, 1, seed);
+
+    TDoubleVec expectedPredictions;
+    expectedPredictions.reserve(numberSamples);
+    TDoubleVec actualPredictions;
+    actualPredictions.reserve(numberSamples);
+
+    TStrVec fieldNames{"f1", "f2", "f3", "f4", "target", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    test::CDataFrameAnalysisSpecificationFactory spec;
+    {
+        api::CDataFrameAnalyzer analyzer{
+            test::CDataFrameAnalysisSpecificationFactory{}.predictionSpec(
+                test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
+            outputWriterFactory};
+        test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
+            TLossFunctionType::E_MseRegression, fieldNames, fieldValues,
+            analyzer, numberSamples, seed[0]);
+
+        analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(output.str()));
+        LOG_DEBUG(<< output.str());
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        // read hyperparameter into the new spec and expected predictions
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("model_metadata")) {
+                for (const auto& hyperparameter :
+                     result["model_metadata"]["hyperparameters"].GetArray()) {
+                    std::string hyperparameterName{hyperparameter["name"].GetString()};
+                    if (hyperparameterName == api::CDataFrameTrainBoostedTreeRunner::ALPHA) {
+                        spec.predictionAlpha(hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_FACTOR) {
+                        spec.predictionDownsampleFactor(hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::ETA) {
+                        spec.predictionEta(hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::ETA_GROWTH_RATE_PER_TREE) {
+                        spec.predictionEtaGrowthRatePerTree(
+                            hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION) {
+                        spec.predictionFeatureBagFraction(
+                            hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::GAMMA) {
+                        spec.predictionGamma(hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::LAMBDA) {
+                        spec.predictionLambda(hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT) {
+                        spec.predictionSoftTreeDepthLimit(
+                            hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE) {
+                        spec.predictionSoftTreeDepthTolerance(
+                            hyperparameter["value"].GetDouble());
+                    } else if (hyperparameterName ==
+                               api::CDataFrameTrainBoostedTreeRunner::MAX_TREES) {
+                        spec.predictionMaximumNumberTrees(
+                            hyperparameter["value"].GetUint64());
+                    }
+                }
+
+            } else if (result.HasMember("row_results")) {
+                expectedPredictions.emplace_back(
+                    result["row_results"]["results"]["ml"]["target_prediction"].GetDouble());
+            }
+        }
+    }
+    BOOST_REQUIRE_EQUAL(expectedPredictions.size(), numberSamples);
+    output.str("");
+    {
+        api::CDataFrameAnalyzer analyzer{
+            spec.predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(), "target"),
+            outputWriterFactory};
+
+        test::CDataFrameAnalyzerTrainingFactory::addPredictionTestData(
+            TLossFunctionType::E_MseRegression, fieldNames, fieldValues,
+            analyzer, numberSamples, seed[0]);
+
+        analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+        rapidjson::Document results;
+        rapidjson::ParseResult ok(results.Parse(output.str()));
+        LOG_DEBUG(<< output.str());
+        BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+        for (const auto& result : results.GetArray()) {
+            if (result.HasMember("row_results")) {
+                actualPredictions.emplace_back(
+                    result["row_results"]["results"]["ml"]["target_prediction"].GetDouble());
+            }
+        }
+    }
+    BOOST_REQUIRE_EQUAL(actualPredictions.size(), numberSamples);
+    BOOST_TEST(actualPredictions == expectedPredictions, tt::per_element());
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/CLoopProgress.cc
+++ b/lib/core/CLoopProgress.cc
@@ -32,7 +32,7 @@ CLoopProgress::CLoopProgress(std::size_t range,
                              const TProgressCallback& recordProgress,
                              double scale,
                              std::size_t steps)
-    : m_Range{range}, m_Steps{std::min(range, steps)},
+    : m_Range{std::max(range, static_cast<std::size_t>(1))}, m_Steps{std::min(range, steps)},
       m_StepProgress{scale / static_cast<double>(m_Steps)}, m_RecordProgress{recordProgress} {
 }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -163,9 +163,8 @@ CBoostedTreeFactory::restoreFor(core::CDataFrame& frame, std::size_t dependentVa
 }
 
 std::size_t CBoostedTreeFactory::numberHyperparameterTuningRounds() const {
-    return std::max(m_TreeImpl->m_MaximumOptimisationRoundsPerHyperparameter *
-                        m_TreeImpl->numberHyperparametersToTune(),
-                    std::size_t{1});
+    return m_TreeImpl->m_MaximumOptimisationRoundsPerHyperparameter *
+           m_TreeImpl->numberHyperparametersToTune();
 }
 
 void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {
@@ -256,6 +255,10 @@ void CBoostedTreeFactory::initializeHyperparameterOptimisation() const {
         m_BayesianOptimisationRestarts.value_or(CBayesianOptimisation::RESTARTS));
     m_TreeImpl->m_NumberRounds = this->numberHyperparameterTuningRounds();
     m_TreeImpl->m_CurrentRound = 0; // for first start
+    m_TreeImpl->m_BestHyperparameters = CBoostedTreeHyperparameters(
+        m_TreeImpl->m_Regularization, m_TreeImpl->m_DownsampleFactor,
+        m_TreeImpl->m_Eta, m_TreeImpl->m_EtaGrowthRatePerTree,
+        m_TreeImpl->m_MaximumNumberTrees, m_TreeImpl->m_FeatureBagFraction);
 }
 
 void CBoostedTreeFactory::initializeMissingFeatureMasks(const core::CDataFrame& frame) const {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -553,8 +553,8 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                                                  -mainLoopSearchInterval / 2.0,
                                                  mainLoopSearchInterval / 2.0)
                             .value_or(fallback);
-                    m_SoftDepthLimitSearchInterval =
-                        max(m_SoftDepthLimitSearchInterval, TVector{1.0});
+                    m_SoftDepthLimitSearchInterval = max(
+                        m_SoftDepthLimitSearchInterval, TVector{MIN_SOFT_DEPTH_LIMIT});
                     LOG_TRACE(<< "soft depth limit search interval = ["
                               << m_SoftDepthLimitSearchInterval.toDelimited() << "]");
                     m_TreeImpl->m_Regularization.softTreeDepthLimit(

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -34,6 +34,7 @@
 #include <boost/circular_buffer.hpp>
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 
 namespace ml {
@@ -262,6 +263,9 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
         this->restoreBestHyperparameters();
         this->startProgressMonitoringFinalTrain();
+        // reinitialize random number generator for reproducible results
+        // TODO #1866 introduce accept randomize_seed configuration parameter
+        m_Rng = CPRNG::CXorOShiro128Plus{};
         std::tie(m_BestForest, std::ignore, std::ignore) = this->trainForest(
             frame, allTrainingRowsMask, allTrainingRowsMask, m_TrainingProgress);
 
@@ -298,7 +302,7 @@ void CBoostedTreeImpl::recordState(const TTrainingStateCallback& recordTrainStat
 }
 
 void CBoostedTreeImpl::predict(core::CDataFrame& frame) const {
-    if (m_BestForestTestLoss == INF) {
+    if (m_BestForest.empty()) {
         HANDLE_FATAL(<< "Internal error: no model available for prediction. "
                      << "Please report this problem.")
         return;
@@ -1327,6 +1331,9 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         case E_FeatureBagFraction:
             parameters(i) = m_FeatureBagFraction;
             break;
+        case E_MaximumNumberTrees:
+            parameters(i) = static_cast<double>(m_MaximumNumberTrees);
+            break;
         case E_Gamma:
             parameters(i) = CTools::stableLog(
                 m_Regularization.treeSizePenaltyMultiplier() / scale);
@@ -1394,6 +1401,9 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
         case E_FeatureBagFraction:
             m_FeatureBagFraction = parameters(i);
             break;
+        case E_MaximumNumberTrees:
+            m_MaximumNumberTrees = static_cast<std::size_t>(std::ceil(parameters(i)));
+            break;
         case E_Gamma:
             m_Regularization.treeSizePenaltyMultiplier(
                 scale * CTools::stableExp(parameters(i)));
@@ -1403,7 +1413,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
                 scale * CTools::stableExp(parameters(i)));
             break;
         case E_SoftTreeDepthLimit:
-            m_Regularization.softTreeDepthLimit(parameters(i));
+            m_Regularization.softTreeDepthLimit(std::max(parameters(i), 2.0));
             break;
         case E_SoftTreeDepthTolerance:
             m_Regularization.softTreeDepthTolerance(parameters(i));
@@ -1977,6 +1987,8 @@ CBoostedTreeImpl::hyperparameterImportance() const {
             std::tie(absoluteImportance, relativeImportance) = anovaMainEffects[tunableIndex];
         }
         double hyperparameterValue;
+        SHyperparameterImportance::EType hyperparameterType{
+            boosted_tree_detail::SHyperparameterImportance::E_Double};
         switch (i) {
         case E_Alpha:
             hyperparameterValue = m_Regularization.depthPenaltyMultiplier();
@@ -1993,6 +2005,10 @@ CBoostedTreeImpl::hyperparameterImportance() const {
         case E_FeatureBagFraction:
             hyperparameterValue = m_FeatureBagFraction;
             break;
+        case E_MaximumNumberTrees:
+            hyperparameterValue = static_cast<double>(m_MaximumNumberTrees);
+            hyperparameterType = boosted_tree_detail::SHyperparameterImportance::E_Uint64;
+            break;
         case E_Gamma:
             hyperparameterValue = m_Regularization.treeSizePenaltyMultiplier();
             break;
@@ -2006,9 +2022,9 @@ CBoostedTreeImpl::hyperparameterImportance() const {
             hyperparameterValue = m_Regularization.softTreeDepthTolerance();
             break;
         }
-        hyperparameterImportances.emplace_back(static_cast<EHyperparameters>(i),
-                                               hyperparameterValue, absoluteImportance,
-                                               relativeImportance, supplied);
+        hyperparameterImportances.push_back(
+            {static_cast<EHyperparameters>(i), hyperparameterValue,
+             absoluteImportance, relativeImportance, supplied, hyperparameterType});
     }
     return hyperparameterImportances;
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1413,7 +1413,7 @@ bool CBoostedTreeImpl::selectNextHyperparameters(const TMeanVarAccumulator& loss
                 scale * CTools::stableExp(parameters(i)));
             break;
         case E_SoftTreeDepthLimit:
-            m_Regularization.softTreeDepthLimit(std::max(parameters(i), 2.0));
+            m_Regularization.softTreeDepthLimit(parameters(i));
             break;
         case E_SoftTreeDepthTolerance:
             m_Regularization.softTreeDepthTolerance(parameters(i));

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -496,7 +496,7 @@ BOOST_AUTO_TEST_CASE(testLinear) {
         // Unbiased...
         BOOST_REQUIRE_CLOSE_ABSOLUTE(
             0.0, modelBias[i][0],
-            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            4.5 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
 
@@ -627,7 +627,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
             0.0, modelBias[i],
             4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.97);
+        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.95);
 
         meanModelRSquared.add(modelRSquared[i]);
     }

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1535,7 +1535,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 2.0);
+        BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(logRelativeError) < 2.2);
         meanLogRelativeError.add(maths::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1308,7 +1308,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.51);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanLogRelativeError) < 0.53);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
@@ -1390,7 +1390,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
     LOG_DEBUG(<< "recalls    = " << core::CContainerPrinter::print(recalls));
 
     BOOST_TEST_REQUIRE(std::fabs(precisions[0] - precisions[1]) < 0.1);
-    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.11);
+    BOOST_TEST_REQUIRE(std::fabs(recalls[0] - recalls[1]) < 0.16);
 }
 
 BOOST_AUTO_TEST_CASE(testClassificationWeightsOverride) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
     }
 
     LOG_DEBUG(<< "mean R^2 = " << maths::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    BOOST_TEST_REQUIRE(maths::CBasicStatistics::mean(meanModelRSquared) > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testMsle) {

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -145,6 +145,12 @@ CDataFrameAnalysisSpecificationFactory::predictionEta(double eta) {
 }
 
 CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::predictionEtaGrowthRatePerTree(double etaGrowthRatePerTree) {
+    m_EtaGrowthRatePerTree = etaGrowthRatePerTree;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::predictionMaximumNumberTrees(std::size_t number) {
     m_MaximumNumberTrees = number;
     return *this;
@@ -312,6 +318,10 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
     if (m_Eta > 0.0) {
         writer.Key(TRunner::ETA);
         writer.Double(m_Eta);
+    }
+    if (m_EtaGrowthRatePerTree > 0.0) {
+        writer.Key(TRunner::ETA_GROWTH_RATE_PER_TREE);
+        writer.Double(m_EtaGrowthRatePerTree);
     }
     if (m_DownsampleFactor > 0.0) {
         writer.Key(TRunner::DOWNSAMPLE_FACTOR);


### PR DESCRIPTION
We output max number trees as a hyperparameter in the model metadata and add a unit test to ensure that we achieve reproducible results when retraining a model with all hyperparameters specified.

Fixes #1853 .

Backport of #1867 and #1870.