### PR TITLE
[ML] Fixing 7.12.1 and 7.13.0 changelogs

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,10 @@
 
 * Speed up training of regression and classification model training for data sets
   with many features. (See {ml-pull}1746[#1746].)
+* Avoid overfitting in final training by scaling regularizers to account for the
+  difference in the number of training examples. This results in a better match
+  between train and test error for classification and regression and often slightly
+  improved test errors. (See {ml-pull}1755[#1755].)
 * Adjust the syscall filter to allow mremap and avoid spurious audit logging.
   (See {ml-pull}1819[#1819].)
 
@@ -56,12 +60,6 @@
 
 === Enhancements
 
-* Speed up training of regression and classification model training for data sets
-  with many features. (See {ml-pull}1746[#1746].)
-* Avoid overfitting in final training by scaling regularizers to account for the
-  difference in the number of training examples. This results in a better match
-  between train and test error for classification and regression and often slightly
-  improved test errors. (See {ml-pull}1755[#1755].)
 * Make ML native processes work with glibc 2.33 on x86_64. (See {ml-pull}1828[#1828].)
 
 == {es} version 7.12.0


### PR DESCRIPTION
One PR that went into 7.13.0 was listed under 7.12.1
and another that went into 7.13.0 was duplicated under
7.12.1.