### PR TITLE
[ML] Sync writing atomic more strongly in CStringStore

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -60,6 +60,8 @@
   training. (See {ml-pull}1855[#1855].)
 * Fail gracefully on encountering unexpected state in restore from snapshot for anomaly
   detection. (See {ml-pull}1872[#1872].)
+* Use appropriate memory ordering flags for aarch64 with string store to avoid excessive
+  string duplication. (See {ml-pull}1888[#1888].)
 
 == {es} version 7.12.2
 

--- a/lib/model/CStringStore.cc
+++ b/lib/model/CStringStore.cc
@@ -98,7 +98,7 @@ core::CStoredStringPtr CStringStore::get(const std::string& value) {
                 }
                 m_Writing.fetch_sub(1, std::memory_order_release);
             } else {
-                m_Writing.fetch_sub(1, std::memory_order_relaxed);
+                m_Writing.fetch_sub(1, std::memory_order_release);
                 // This is leaked in the sense that it will never be shared and
                 // won't count towards our reported memory usage.  But it is not
                 // leaked in the traditional sense of the word, as its memory

--- a/lib/model/unittest/CStringStoreTest.cc
+++ b/lib/model/unittest/CStringStoreTest.cc
@@ -36,7 +36,7 @@ private:
 
 public:
     CStringThread(std::size_t i, const TStrVec& strings)
-        : m_I(i), m_Strings(strings) {}
+        : m_I{i}, m_Strings{strings} {}
 
     void uniques(TStrCPtrUSet& result) const {
         result.insert(m_UniquePtrs.begin(), m_UniquePtrs.end());
@@ -148,6 +148,12 @@ BOOST_FIXTURE_TEST_CASE(testStringStore, CTestFixture) {
         for (std::size_t i = 0; i < threads.size(); ++i) {
             BOOST_TEST_REQUIRE(threads[i]->waitForFinish());
         }
+
+        TStrCPtrUSet uniques;
+        for (std::size_t i = 0; i < threads.size(); ++i) {
+            threads[i]->uniques(uniques);
+        }
+        LOG_DEBUG(<< "unique counts = " << uniques.size());
 
         BOOST_REQUIRE_EQUAL(strings.size(), CStringStore::names().m_Strings.size());
         CStringStore::names().pruneNotThreadSafe();


### PR DESCRIPTION
Decrementing the write count with a relaxed memory order
on aarch64 can result in other threads not noticing for
a very long time.  Instead the "release" memory order
needs to be used.  (As we never saw this problem on x86
I suspect this is a case of us taking advantage of
atomics on x86 offering better synchronization than
required by the language constructs.)

Followup to #1887
Fixes #1885