### PR TITLE
[7.x][ML] Fix CStringStore unit test

### DIFF
--- a/include/core/CStoredStringPtr.h
+++ b/include/core/CStoredStringPtr.h
@@ -51,6 +51,8 @@ public:
     explicit operator bool() const noexcept;
 
     //! Is there only one pointer for this stored string?
+    //! This method is inefficient and should only be used in unit test
+    //! code (and then only infrequently).
     bool isUnique() const noexcept;
 
     //! Equality operator for NULL.

--- a/lib/core/CStoredStringPtr.cc
+++ b/lib/core/CStoredStringPtr.cc
@@ -46,7 +46,13 @@ CStoredStringPtr::operator bool() const noexcept {
 }
 
 bool CStoredStringPtr::isUnique() const noexcept {
-    return m_String.unique();
+    // Use count is updated in a relaxed manner, so will not necessarily be
+    // accurate in this thread unless this thread has recently done something
+    // that has updated the value. Updating the value like this is obviously
+    // inefficient, so this method should only be used infrequently and only
+    // in unit test code.
+    TStrCPtr sync{m_String};
+    return sync.use_count() == 2;
 }
 
 bool CStoredStringPtr::operator==(std::nullptr_t rhs) const noexcept {

--- a/lib/model/unittest/CStringStoreTest.cc
+++ b/lib/model/unittest/CStringStoreTest.cc
@@ -60,7 +60,7 @@ public:
     }
 
 private:
-    virtual void run() {
+    void run() override {
         std::size_t n = m_Strings.size();
         for (std::size_t i = m_I; i < 1000; ++i) {
             m_Ptrs.push_back(core::CStoredStringPtr());
@@ -79,7 +79,7 @@ private:
         }
     }
 
-    virtual void shutdown() {}
+    void shutdown() override {}
 
     bool isMismatch(std::size_t i, std::size_t n, const core::CStoredStringPtr& p) {
         if (m_Strings[i % n] != *p) {
@@ -109,23 +109,10 @@ public:
 };
 
 BOOST_FIXTURE_TEST_CASE(testStringStore, CTestFixture) {
-    TStrVec strings;
-    strings.emplace_back("Milano");
-    strings.emplace_back("Monza");
-    strings.emplace_back("Amalfi");
-    strings.emplace_back("Pompei");
-    strings.emplace_back("Gragnano");
-    strings.emplace_back("Roma");
-    strings.emplace_back("Bologna");
-    strings.emplace_back("Torina");
-    strings.emplace_back("Napoli");
-    strings.emplace_back("Rimini");
-    strings.emplace_back("Genova");
-    strings.emplace_back("Capri");
-    strings.emplace_back("Ravello");
-    strings.emplace_back("Reggio");
-    strings.emplace_back("Palermo");
-    strings.emplace_back("Focaccino");
+    TStrVec strings{"Milano",   "Monza",  "Amalfi",  "Pompei",
+                    "Gragnano", "Roma",   "Bologna", "Torina",
+                    "Napoli",   "Rimini", "Genova",  "Capri",
+                    "Ravello",  "Reggio", "Palermo", "Focaccino"};
 
     LOG_DEBUG(<< "*** CStringStoreTest ***");
     {
@@ -140,11 +127,11 @@ BOOST_FIXTURE_TEST_CASE(testStringStore, CTestFixture) {
         BOOST_REQUIRE_EQUAL(pG.get(), pG2.get());
         BOOST_REQUIRE_EQUAL(*pG, *pG2);
 
-        BOOST_REQUIRE_EQUAL(std::size_t(1), CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(1, CStringStore::names().m_Strings.size());
     }
-    BOOST_REQUIRE_EQUAL(std::size_t(1), CStringStore::names().m_Strings.size());
+    BOOST_REQUIRE_EQUAL(1, CStringStore::names().m_Strings.size());
     CStringStore::names().pruneNotThreadSafe();
-    BOOST_REQUIRE_EQUAL(std::size_t(0), CStringStore::names().m_Strings.size());
+    BOOST_REQUIRE_EQUAL(0, CStringStore::names().m_Strings.size());
 
     {
         LOG_DEBUG(<< "Testing multi-threaded");
@@ -165,8 +152,7 @@ BOOST_FIXTURE_TEST_CASE(testStringStore, CTestFixture) {
         BOOST_REQUIRE_EQUAL(strings.size(), CStringStore::names().m_Strings.size());
         CStringStore::names().pruneNotThreadSafe();
         BOOST_REQUIRE_EQUAL(strings.size(), CStringStore::names().m_Strings.size());
-        BOOST_REQUIRE_EQUAL(std::size_t(0),
-                            CStringStore::influencers().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, CStringStore::influencers().m_Strings.size());
 
         for (std::size_t i = 0; i < threads.size(); ++i) {
             // Propagate problems to main testing thread
@@ -178,9 +164,9 @@ BOOST_FIXTURE_TEST_CASE(testStringStore, CTestFixture) {
 
         BOOST_REQUIRE_EQUAL(strings.size(), CStringStore::names().m_Strings.size());
         CStringStore::names().pruneNotThreadSafe();
-        BOOST_REQUIRE_EQUAL(std::size_t(0), CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, CStringStore::names().m_Strings.size());
         threads.clear();
-        BOOST_REQUIRE_EQUAL(std::size_t(0), CStringStore::names().m_Strings.size());
+        BOOST_REQUIRE_EQUAL(0, CStringStore::names().m_Strings.size());
     }
     {
         LOG_DEBUG(<< "Testing multi-threaded string duplication rate");


### PR DESCRIPTION
We have seen numerous failures of CStringStoreTest.testStringStore
caused by pruning not working as it should.

These failures invariably occur on aarch64 (both Mac and Linux).

The problem is that the pruning relies on std::shared_ptr::unique()
and this is not accurate. (In fact C++20 removes this method.)

The reason it's not accurate is that it returns the usage count
in a relaxed manner, i.e. returning the last value visible to the
current thread, but not forcing a resync between threads first.
The x86 architecture is more forgiving of theoretical memory
ordering bugs like this than the aarch64 architecture.

The solution is to change the use count in the thread that's
checking its value to be sure that this thread has accurate
visibility of the value.  Obviously this is inefficient, so we
only do this in unit test code.

Backport of #1887