### PR TITLE
[ML] Improve error checking when reading trainable model

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -153,7 +153,8 @@ public:
     inferenceModelDefinition(const TStrVec& fieldNames, const TStrVecVec& categoryNames) const;
 
     //! \return A serialisable summarization of the training data if appropriate or a null pointer.
-    virtual TDataSummarizationJsonWriterUPtr dataSummarization(const core::CDataFrame& dataFrame) const;
+    virtual TDataSummarizationJsonWriterUPtr
+    dataSummarization(const core::CDataFrame& dataFrame) const;
 
     //! \return A serialisable metadata of the trained model.
     virtual TOptionalInferenceModelMetadata inferenceModelMetadata() const;

--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -71,7 +71,7 @@ public:
     using TStrVecVec = std::vector<TStrVec>;
     using TInferenceModelDefinitionUPtr = std::unique_ptr<CInferenceModelDefinition>;
     using TOptionalInferenceModelMetadata = boost::optional<const CInferenceModelMetadata&>;
-    using TDataSummarizationUPtr = std::unique_ptr<CDataSummarizationJsonSerializer>;
+    using TDataSummarizationJsonWriterUPtr = std::unique_ptr<CDataSummarizationJsonWriter>;
     using TDataFrameUPtr = std::unique_ptr<core::CDataFrame>;
     using TTemporaryDirectoryPtr = std::shared_ptr<core::CTemporaryDirectory>;
     using TDataFrameUPtrTemporaryDirectoryPtrPr =
@@ -153,7 +153,7 @@ public:
     inferenceModelDefinition(const TStrVec& fieldNames, const TStrVecVec& categoryNames) const;
 
     //! \return A serialisable summarization of the training data if appropriate or a null pointer.
-    virtual TDataSummarizationUPtr dataSummarization(const core::CDataFrame& dataFrame) const;
+    virtual TDataSummarizationJsonWriterUPtr dataSummarization(const core::CDataFrame& dataFrame) const;
 
     //! \return A serialisable metadata of the trained model.
     virtual TOptionalInferenceModelMetadata inferenceModelMetadata() const;

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -88,7 +88,8 @@ public:
     CDataFrameAnalysisInstrumentation& instrumentation() override;
 
     //! \return A serialisable data summarization for the trained model.
-    TDataSummarizationJsonWriterUPtr dataSummarization(const core::CDataFrame& dataFrame) const override;
+    TDataSummarizationJsonWriterUPtr
+    dataSummarization(const core::CDataFrame& dataFrame) const override;
 
 protected:
     using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -88,7 +88,7 @@ public:
     CDataFrameAnalysisInstrumentation& instrumentation() override;
 
     //! \return A serialisable data summarization for the trained model.
-    TDataSummarizationUPtr dataSummarization(const core::CDataFrame& dataFrame) const override;
+    TDataSummarizationJsonWriterUPtr dataSummarization(const core::CDataFrame& dataFrame) const override;
 
 protected:
     using TLossFunctionUPtr = std::unique_ptr<maths::boosted_tree::CLoss>;

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -211,12 +211,12 @@ CDataFrameAnalysisRunner::TStatePersister CDataFrameAnalysisRunner::statePersist
 CDataFrameAnalysisRunner::TInferenceModelDefinitionUPtr
 CDataFrameAnalysisRunner::inferenceModelDefinition(const TStrVec& /*fieldNames*/,
                                                    const TStrVecVec& /*categoryNames*/) const {
-    return TInferenceModelDefinitionUPtr();
+    return {};
 }
 
-CDataFrameAnalysisRunner::TDataSummarizationUPtr
+CDataFrameAnalysisRunner::TDataSummarizationJsonWriterUPtr
 CDataFrameAnalysisRunner::dataSummarization(const core::CDataFrame& /*dataFrame*/) const {
-    return TDataSummarizationUPtr();
+    return {};
 }
 
 CDataFrameAnalysisRunner::TOptionalInferenceModelMetadata

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -385,11 +385,11 @@ CDataFrameTrainBoostedTreeRunner::boostedTreeFactory(TLossFunctionUPtr loss,
             *frameAndDirectory = this->makeDataFrame();
             auto dataSummarizationRestorer = [](const core::CDataSearcher::TIStreamP& inputStream,
                                                 core::CDataFrame& frame) {
-                return CRetrainableModelJsonDeserializer::dataSummarizationFromDocumentCompressed(
+                return CRetrainableModelJsonReader::dataSummarizationFromDocumentCompressed(
                     inputStream, frame);
             };
             auto bestForestRestorer = [](const core::CDataSearcher::TIStreamP& inputStream) {
-                return CRetrainableModelJsonDeserializer::bestForestFromDocumentCompressed(inputStream);
+                return CRetrainableModelJsonReader::bestForestFromDocumentCompressed(inputStream);
             };
             auto& frame = frameAndDirectory->first;
             auto result = std::make_unique<maths::CBoostedTreeFactory>(
@@ -465,7 +465,7 @@ CDataFrameAnalysisInstrumentation& CDataFrameTrainBoostedTreeRunner::instrumenta
     return m_Instrumentation;
 }
 
-CDataFrameAnalysisRunner::TDataSummarizationUPtr
+CDataFrameAnalysisRunner::TDataSummarizationJsonWriterUPtr
 CDataFrameTrainBoostedTreeRunner::dataSummarization(const core::CDataFrame& dataFrame) const {
     std::stringstream output;
 
@@ -477,10 +477,10 @@ CDataFrameTrainBoostedTreeRunner::dataSummarization(const core::CDataFrame& data
 
     auto rowMask = this->boostedTree().dataSummarization(dataFrame, encodingRecorder);
     if (rowMask.manhattan() > 0) {
-        return std::make_unique<CDataSummarizationJsonSerializer>(
+        return std::make_unique<CDataSummarizationJsonWriter>(
             dataFrame, rowMask, this->spec().numberColumns(), std::move(output));
     }
-    return TDataSummarizationUPtr();
+    return {};
 }
 
 // clang-format off

--- a/lib/api/CDataSummarizationJsonSerializer.cc
+++ b/lib/api/CDataSummarizationJsonSerializer.cc
@@ -133,7 +133,8 @@ CDataSummarizationJsonWriter::CDataSummarizationJsonWriter(const core::CDataFram
                                                            core::CPackedBitVector rowMask,
                                                            std::size_t numberColumns,
                                                            std::stringstream encodings)
-    : m_RowMask{std::move(rowMask)}, m_NumberColumns{numberColumns}, m_Frame{frame}, m_Encodings{std::move(encodings)} {
+    : m_RowMask{std::move(rowMask)}, m_NumberColumns{numberColumns}, m_Frame{frame},
+      m_Encodings{std::move(encodings)} {
 }
 
 void CDataSummarizationJsonWriter::addToDocumentCompressed(TRapidJsonWriter& writer) const {
@@ -383,7 +384,8 @@ CRetrainableModelJsonReader::bestForestFromJson(std::istream& istream) {
                 }
             } else {
                 // Add a split node.
-                std::size_t splitFeature{ifExists(CTree::CTreeNode::JSON_SPLIT_FEATURE_TAG, getUint64, node)};
+                std::size_t splitFeature{ifExists(
+                    CTree::CTreeNode::JSON_SPLIT_FEATURE_TAG, getUint64, node)};
                 double gain{ifExists(CTree::CTreeNode::JSON_SPLIT_GAIN_TAG, getDouble, node)};
                 double splitValue{ifExists(CTree::CTreeNode::JSON_THRESHOLD_TAG,
                                            getDouble, node)};

--- a/lib/api/CDataSummarizationJsonSerializer.cc
+++ b/lib/api/CDataSummarizationJsonSerializer.cc
@@ -52,12 +52,10 @@ auto ifExists(const std::string& tag, const GET& get, const VALUE& value)
         try {
             return get(value[tag]);
         } catch (const std::runtime_error& e) {
-            LOG_ERROR(<< "Field '" << tag << "' " << e.what() << ".");
+            throw std::runtime_error("Field '" + tag + "' " + e.what() + ".");
         }
-    } else {
-        LOG_ERROR(<< "Field '" << tag << "' is missing.");
     }
-    throw std::runtime_error{""};
+    throw std::runtime_error{"Field '" + tag + "' is missing."};
 }
 
 auto getObject(const rapidjson::Value& value) {
@@ -227,9 +225,7 @@ CRetrainableModelJsonReader::dataSummarizationFromJsonStream(TIStreamSPtr istrea
     }
     try {
         return dataSummarizationFromJson(*istream, frame);
-    } catch (...) {
-        // Logging is handled at the point of throw.
-    }
+    } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }
     return nullptr;
 }
 
@@ -315,9 +311,7 @@ CRetrainableModelJsonReader::dataSummarizationFromDocumentCompressed(TIStreamSPt
                              ifExists(JSON_DATA_SUMMARIZATION_TAG, getStringLength,
                                       compressedDataSummarization)};
         return dataSummarizationFromJsonStream(decompressStream(buffer), frame);
-    } catch (...) {
-        // Logging is handled at the point of throw.
-    }
+    } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }
     return nullptr;
 }
 
@@ -328,9 +322,7 @@ CRetrainableModelJsonReader::bestForestFromJsonStream(TIStreamSPtr istream) {
     }
     try {
         return bestForestFromJson(*istream);
-    } catch (...) {
-        // Logging is handled at the point of throw.
-    }
+    } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }
     return nullptr;
 }
 
@@ -426,9 +418,7 @@ CRetrainableModelJsonReader::bestForestFromDocumentCompressed(TIStreamSPtr istre
                              ifExists(CInferenceModelDefinition::JSON_DEFINITION_TAG,
                                       getStringLength, compressedDataSummarization)};
         return bestForestFromJsonStream(decompressStream(buffer));
-    } catch (...) {
-        // Logging is handled at the point of throw.
-    }
+    } catch (const std::exception& e) { LOG_ERROR(<< e.what()); }
     return nullptr;
 }
 }

--- a/lib/api/unittest/CDataSummarizationJsonSerializerTest.cc
+++ b/lib/api/unittest/CDataSummarizationJsonSerializerTest.cc
@@ -95,7 +95,7 @@ void testSchema(TLossFunctionType lossType) {
         std::string dataSummarizationStr{dataSummarization->jsonString()};
         std::stringstream decompressedStream{
             decompressStream(dataSummarization->jsonCompressedStream())};
-        api::CRetrainableModelJsonDeserializer::dataSummarizationFromJsonStream(
+        api::CRetrainableModelJsonReader::dataSummarizationFromJsonStream(
             std::make_shared<std::istringstream>(dataSummarizationStr), *frame);
         BOOST_TEST_REQUIRE(decompressedStream.str() == dataSummarizationStr);
     }
@@ -165,12 +165,12 @@ BOOST_AUTO_TEST_CASE(testDeserialization) {
         expectedEncoder.acceptPersistInserter(inserter);
     }
 
-    api::CDataSummarizationJsonSerializer serializer{
+    api::CDataSummarizationJsonWriter writer{
         *expectedFrame, core::CPackedBitVector(expectedFrame->numberRows(), true),
         columnNames.size(), std::move(persistedEncoderStream)};
-    auto istream = std::make_shared<std::istringstream>(serializer.jsonString());
+    auto istream = std::make_shared<std::istringstream>(writer.jsonString());
     auto actualFrame = core::makeMainStorageDataFrame(columnNames.size()).first;
-    auto encoder = api::CRetrainableModelJsonDeserializer::dataSummarizationFromJsonStream(
+    auto encoder = api::CRetrainableModelJsonReader::dataSummarizationFromJsonStream(
         istream, *actualFrame);
     BOOST_REQUIRE(encoder != nullptr);
     BOOST_REQUIRE(expectedFrame->checksum() == actualFrame->checksum());


### PR DESCRIPTION
If fields are missing or the type doesn't match then rapidjson accessors result in undefined behaviour when compiled in release mode. We do not trust our state document and so need to verify that every field we expect exists and has the appropriate type. In the retrainable model state we were not reliably doing this. In this change I migrate to wrap all accessors in methods which check that both the fields exist and their type is correct. I also renamed the classes to match naming the names used for similar classes in the api library.