### PR TITLE
[7.x][ML] Make atomic operations safer for aarch64

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 7.14.0
+
+=== Bug Fixes
+
+* Make atomic operations safer for aarch64. (See {ml-pull}1893[#1893].)
+
 == {es} version 7.13.0
 
 === Enhancements

--- a/include/maths/CIntegration.h
+++ b/include/maths/CIntegration.h
@@ -413,10 +413,10 @@ public:
         static const CSparseGaussLegendreQuadrature& instance() {
             const CSparseGaussLegendreQuadrature* tmp =
                 ms_Instance.load(std::memory_order_acquire);
-            if (!tmp) {
+            if (tmp == nullptr) {
                 core::CScopedFastLock scopedLock(CIntegration::ms_Mutex);
-                tmp = ms_Instance.load(std::memory_order_relaxed);
-                if (!tmp) {
+                tmp = ms_Instance.load(std::memory_order_acquire);
+                if (tmp == nullptr) {
                     tmp = new CSparseGaussLegendreQuadrature();
                     ms_Instance.store(tmp, std::memory_order_release);
                 }

--- a/lib/model/CStringStore.cc
+++ b/lib/model/CStringStore.cc
@@ -107,7 +107,7 @@ core::CStoredStringPtr CStringStore::get(const std::string& value) {
             }
         }
     } else {
-        m_Reading.fetch_sub(1, std::memory_order_relaxed);
+        m_Reading.fetch_sub(1, std::memory_order_release);
         // This is leaked in the sense that it will never be shared and won't
         // count towards our reported memory usage.  But it is not leaked
         // in the traditional sense of the word, as its memory will be freed


### PR DESCRIPTION
This PR is a followup to #1888 which makes one more relaxed
store of an atomic variable in the CStringStore class use
release memory ordering rather than relaxed.

Additionally, a relaxed load is changed to use acquire memory
ordering in the CIntegration class.

These changes only have an effect on the aarch64 architecture.

Backport of #1893