### PR TITLE
[ML] Read summarisation and model from chunked state

### DIFF
--- a/include/api/CDataSummarizationJsonSerializer.h
+++ b/include/api/CDataSummarizationJsonSerializer.h
@@ -34,7 +34,7 @@ namespace api {
 //! DESCRIPTION:\n
 //! The data summarization contains data rows as well as the feature value encoding
 //! information.
-class API_EXPORT CDataSummarizationJsonWriter final : public CSerializableToJsonDocumentCompressed {
+class API_EXPORT CDataSummarizationJsonWriter final : public CSerializableToCompressedChunkedJson {
 public:
     CDataSummarizationJsonWriter(const core::CDataFrame& frame,
                                  core::CPackedBitVector rowMask,
@@ -48,12 +48,7 @@ public:
     void addToJsonStream(TGenericLineWriter& writer) const override;
 
     //! Write a compressed and chunked JSON data summarisation.
-    void addToDocumentCompressed(TRapidJsonWriter& writer) const override;
-
-    //! \name Test Only
-    //@{
-    std::string jsonString() const;
-    //@}
+    void addCompressedToJsonStream(TRapidJsonWriter& writer) const override;
 
 private:
     core::CPackedBitVector m_RowMask;
@@ -65,8 +60,7 @@ private:
 //! \brief Reads a compressed, base64 encoded chunked JSON representation of a
 //! data summarisation and an inference model which can be used to initialise
 //! incremental training.
-// TODO #1849 reading from chunked output is not supported yet.
-class API_EXPORT CRetrainableModelJsonReader {
+class API_EXPORT CRetrainableModelJsonReader : private CSerializableFromCompressedChunkedJson {
 public:
     using TEncoderUPtr = maths::CBoostedTreeFactory::TEncoderUPtr;
     using TStrSizeUMap = boost::unordered_map<std::string, std::size_t>;
@@ -93,9 +87,9 @@ public:
 
 private:
     static TEncoderUPtrStrSizeUMapPr
-    dataSummarizationFromJson(std::istream& istream, core::CDataFrame& frame);
-    static TNodeVecVecUPtr bestForestFromJson(std::istream& istream,
-                                              const TStrSizeUMap& encodingIndices);
+    doDataSummarizationFromJsonStream(std::istream& istream, core::CDataFrame& frame);
+    static TNodeVecVecUPtr doBestForestFromJsonStream(std::istream& istream,
+                                                      const TStrSizeUMap& encodingIndices);
 };
 }
 }

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -191,7 +191,7 @@ public:
 public:
     void addToJsonStream(TGenericLineWriter& writer) const override;
     //! Names of the features used by the model.
-    virtual const TStringVec& featureNames() const;
+    const TStringVec& featureNames() const;
     //! Names of the features used by the model.
     virtual void featureNames(TStringVec featureNames);
     //! Sets target type (regression or classification).
@@ -210,6 +210,9 @@ public:
     virtual const TOptionalDoubleVec& classificationWeights() const;
     //! Get the object for model size with information for estimation.
     virtual TSizeInfoUPtr sizeInfo() const = 0;
+
+protected:
+    TStringVec& featureNames();
 
 private:
     TStringVec m_FeatureNames;
@@ -532,7 +535,7 @@ private:
 };
 
 //! \brief Technical details required for model evaluation.
-class API_EXPORT CInferenceModelDefinition : public CSerializableToJsonDocumentCompressed {
+class API_EXPORT CInferenceModelDefinition : public CSerializableToCompressedChunkedJson {
 public:
     using TApiEncodingUPtr = std::unique_ptr<api::CEncoding>;
     using TApiEncodingUPtrVec = std::vector<TApiEncodingUPtr>;
@@ -581,8 +584,7 @@ public:
     TTrainedModelUPtr& trainedModel();
     const TTrainedModelUPtr& trainedModel() const;
     void addToJsonStream(TGenericLineWriter& writer) const final;
-    void addToDocumentCompressed(TRapidJsonWriter& writer) const final;
-    std::string jsonString() const;
+    void addCompressedToJsonStream(TRapidJsonWriter& writer) const final;
     void fieldNames(TStringVec&& fieldNames);
     const TStringVec& fieldNames() const;
     const std::string& typeString() const;

--- a/include/api/CSerializableToJson.h
+++ b/include/api/CSerializableToJson.h
@@ -7,11 +7,16 @@
 #define INCLUDED_ml_api_CSerializableToJson_h
 
 #include <core/CRapidJsonConcurrentLineWriter.h>
+#include <core/Constants.h>
 
 #include <api/ImportExport.h>
 
 #include <rapidjson/document.h>
 #include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/rapidjson.h>
+
+#include <sstream>
+#include <stdexcept>
 
 namespace ml {
 namespace api {
@@ -37,22 +42,154 @@ public:
 
 public:
     virtual ~CSerializableToJsonStream() = default;
-    virtual void addToJsonStream(TGenericLineWriter& /*writer*/) const = 0;
+
+    //! Write the type as JSON using \p writer.
+    virtual void addToJsonStream(TGenericLineWriter& writer) const = 0;
+
+    //! Get as string.
+    std::string jsonString() const;
 };
 
-//! \brief Interface for writing the inference model definition JSON description
-//! to a stream which first compresses, base64 encodes and chunks.
-class API_EXPORT CSerializableToJsonDocumentCompressed : public CSerializableToJsonStream {
+//! \brief Interface for writing the inference model and training data summarization
+//! JSON descriptions to a stream which first compresses, base64 encodes and chunks.
+//!
+//! IMPLEMENTATION:\n
+//! This splits large state objects across multiple documents which can be reassembled
+//! by CSerializableFromCompressedChunkedJson. Typically this writes documents of the
+//! form
+//! \code
+//! "<doc_tag>": {
+//!   "doc_num": <number>,
+//!   "<payload_tag>": "compressed blob",
+//!   ["eos": True]
+//! }
+//! \endcode
+//! where derived types supply `doc_tag` and `payload_tag`. This should be used in
+//! conjunction with `CSerializableFromCompressedChunkedJson` to read compressed
+//! chunked documents.
+class API_EXPORT CSerializableToCompressedChunkedJson : public CSerializableToJsonStream {
 public:
     using TRapidJsonWriter = core::CRapidJsonConcurrentLineWriter;
 
 public:
-    virtual void addToDocumentCompressed(TRapidJsonWriter& writer) const = 0;
-    virtual void addToDocumentCompressed(TRapidJsonWriter& writer,
-                                         const std::string& compressedDocTag,
-                                         const std::string& payloadTag) const;
-    virtual std::stringstream jsonCompressedStream() const;
-    virtual void jsonStream(std::ostream& jsonStrm) const;
+    static constexpr std::size_t MAX_DOCUMENT_SIZE{16 * core::constants::BYTES_IN_MEGABYTES};
+
+public:
+    explicit CSerializableToCompressedChunkedJson(std::size_t maxDocumentSize = MAX_DOCUMENT_SIZE);
+
+    //! Write the JSON compressed and encoded using \p writer.
+    //!
+    //! This chunks the compressed encoded JSON into documents no larger than the
+    //! specified maximum document size and writes them as individual JSON documents.
+    virtual void addCompressedToJsonStream(TRapidJsonWriter& writer) const = 0;
+
+    //! \name Test Only
+    //@{
+    //! \return A stream to the raw compressed encoded state (no chunking).
+    std::stringstream jsonCompressedStream() const;
+    //@}
+
+protected:
+    void addCompressedToJsonStream(const std::string& compressedDocTag,
+                                   const std::string& payloadTag,
+                                   TRapidJsonWriter& writer) const;
+    auto callableAddToJsonStream() const {
+        return
+            [this](TGenericLineWriter& writer) { this->addToJsonStream(writer); };
+    }
+
+private:
+    std::size_t m_MaxDocumentSize;
+};
+
+//! \brief Utility for reading the inference model and training data summarization
+//! JSON descriptions from a stream which dechunks, decodes and decompresses.
+//!
+//! DESCRIPTION:\n
+//! This provides a utility method to dechunk the state and return a stream over the
+//! decoded and decompressed JSON. Derived classes are expected to use this to parse
+//! and return the objects from their JSON representation.
+class API_EXPORT CSerializableFromCompressedChunkedJson {
+protected:
+    using TIStreamPtr = std::shared_ptr<std::istream>;
+
+    //! Read chunked compressed data from \p inputStream merge chunks decompress and return
+    //! a stream for the raw JSON.
+    //!
+    //! \param[in] compressedDocTag The tag for the compressed state chunk object.
+    //! \param[in] payloadTag The tag for the compressed state chunk member.
+    //! \param[in] inputStream The stream to read for the compressed chunked docs.
+    //! \param[in] buffer The buffer to hold the dechunked state. This needs to stay alive
+    //! while the returned stream is in use.
+    //! \warning Returns a null pointer on failure to read the state.
+    //! \note Expects state in a format written by a CSerializableToCompressedChunkedJson
+    //! object using tags \p compressedDocTag and \p payloadTag.
+    static TIStreamPtr rawJsonStream(const std::string& compressedDocTag,
+                                     const std::string& payloadTag,
+                                     TIStreamPtr inputStream,
+                                     std::iostream& buffer);
+
+    template<typename GET, typename VALUE>
+    static auto ifExists(const std::string& tag, const GET& get, const VALUE& value)
+        -> decltype(get(value[tag])) {
+        if (value.HasMember(tag)) {
+            try {
+                return get(value[tag]);
+            } catch (const std::runtime_error& e) {
+                throw std::runtime_error{"Field '" + tag + "' " + e.what() + "."};
+            }
+        }
+        throw std::runtime_error{"Field '" + tag + "' is missing."};
+    }
+
+    static auto getAsObjectFrom(const rapidjson::Value& value) {
+        if (value.IsObject()) {
+            return value.GetObject();
+        }
+        throw std::runtime_error{"is not an object"};
+    }
+
+    static auto getAsArrayFrom(const rapidjson::Value& value) {
+        if (value.IsArray()) {
+            return value.GetArray();
+        }
+        throw std::runtime_error{"is not an array"};
+    }
+
+    static bool getAsBoolFrom(const rapidjson::Value& value) {
+        if (value.IsBool()) {
+            return value.GetBool();
+        }
+        throw std::runtime_error{"is not a bool"};
+    }
+
+    static std::uint64_t getAsUint64From(const rapidjson::Value& value) {
+        if (value.IsUint64()) {
+            return value.GetUint64();
+        }
+        throw std::runtime_error{"is not a uint64"};
+    }
+
+    static double getAsDoubleFrom(const rapidjson::Value& value) {
+        if (value.IsDouble()) {
+            return value.GetDouble();
+        }
+        throw std::runtime_error{"is not a double"};
+    }
+
+    static auto getAsStringFrom(const rapidjson::Value& value) {
+        if (value.IsString()) {
+            return value.GetString();
+        }
+        throw std::runtime_error{"is not a string"};
+    }
+
+    static std::size_t getStringLengthFrom(const rapidjson::Value& value) {
+        if (value.IsString()) {
+            return value.GetStringLength();
+        }
+        throw std::runtime_error{"is not a string"};
+    }
 };
 }
 }

--- a/include/api/CSerializableToJson.h
+++ b/include/api/CSerializableToJson.h
@@ -12,6 +12,7 @@
 #include <api/ImportExport.h>
 
 #include <rapidjson/document.h>
+#include <rapidjson/error/en.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/rapidjson.h>
 
@@ -128,6 +129,15 @@ protected:
                                      const std::string& payloadTag,
                                      TIStreamPtr inputStream,
                                      std::iostream& buffer);
+
+    static void assertNoParseError(const rapidjson::Document& doc) {
+        if (doc.HasParseError()) {
+            const char* error{rapidjson::GetParseError_En(doc.GetParseError())};
+            throw std::runtime_error{"Error parsing JSON at offset " +
+                                     std::to_string(doc.GetErrorOffset()) + ": " +
+                                     ((error != nullptr) ? error : "No message")};
+        }
+    }
 
     template<typename GET, typename VALUE>
     static auto ifExists(const std::string& tag, const GET& get, const VALUE& value)

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -276,7 +276,7 @@ void CDataFrameAnalyzer::writeInferenceModel(const CDataFrameAnalysisRunner& ana
         writer.Key(modelDefinitionSizeInfo->typeString());
         writer.write(sizeInfoObject);
         writer.EndObject();
-        modelDefinition->addToDocumentCompressed(writer);
+        modelDefinition->addCompressedToJsonStream(writer);
     }
     writer.flush();
 }
@@ -301,7 +301,7 @@ void CDataFrameAnalyzer::writeDataSummarization(const CDataFrameAnalysisRunner& 
     // Write training data summarization
     auto dataSummarization = analysis.dataSummarization();
     if (dataSummarization != nullptr) {
-        dataSummarization->addToDocumentCompressed(writer);
+        dataSummarization->addCompressedToJsonStream(writer);
     }
     writer.flush();
 }

--- a/lib/api/CDataSummarizationJsonSerializer.cc
+++ b/lib/api/CDataSummarizationJsonSerializer.cc
@@ -221,6 +221,7 @@ CRetrainableModelJsonReader::doDataSummarizationFromJsonStream(std::istream& ist
     rapidjson::IStreamWrapper isw(istream);
     rapidjson::Document doc;
     doc.ParseStream(isw);
+    assertNoParseError(doc);
 
     std::size_t numberColumns{ifExists(JSON_NUM_COLUMNS_TAG, getAsUint64From, doc)};
 
@@ -318,6 +319,8 @@ CRetrainableModelJsonReader::doBestForestFromJsonStream(std::istream& istream,
     rapidjson::IStreamWrapper isw{istream};
     rapidjson::Document doc;
     doc.ParseStream(isw);
+    assertNoParseError(doc);
+
     auto inferenceModel = ifExists(CInferenceModelDefinition::JSON_TRAINED_MODEL_TAG,
                                    getAsObjectFrom, doc);
     auto ensemble = ifExists(CEnsemble::JSON_ENSEMBLE_TAG, getAsObjectFrom, inferenceModel);

--- a/lib/api/CInferenceModelDefinition.cc
+++ b/lib/api/CInferenceModelDefinition.cc
@@ -327,15 +327,9 @@ const CTree::TStringVec& CTree::removeUnusedFeatures() {
     return this->featureNames();
 }
 
-std::string CInferenceModelDefinition::jsonString() const {
-    std::ostringstream jsonStrm;
-    this->jsonStream(jsonStrm);
-    return jsonStrm.str();
-}
-
-void CInferenceModelDefinition::addToDocumentCompressed(TRapidJsonWriter& writer) const {
-    CSerializableToJsonDocumentCompressed::addToDocumentCompressed(
-        writer, JSON_COMPRESSED_INFERENCE_MODEL_TAG, JSON_DEFINITION_TAG);
+void CInferenceModelDefinition::addCompressedToJsonStream(TRapidJsonWriter& writer) const {
+    this->CSerializableToCompressedChunkedJson::addCompressedToJsonStream(
+        JSON_COMPRESSED_INFERENCE_MODEL_TAG, JSON_DEFINITION_TAG, writer);
 }
 
 void CInferenceModelDefinition::addToJsonStream(TGenericLineWriter& writer) const {
@@ -392,6 +386,10 @@ void CTrainedModel::addToJsonStream(TGenericLineWriter& writer) const {
 }
 
 const CTrainedModel::TStringVec& CTrainedModel::featureNames() const {
+    return m_FeatureNames;
+}
+
+CTrainedModel::TStringVec& CTrainedModel::featureNames() {
     return m_FeatureNames;
 }
 

--- a/lib/api/CSerializableToJson.cc
+++ b/lib/api/CSerializableToJson.cc
@@ -134,7 +134,7 @@ CSerializableFromCompressedChunkedJson::rawJsonStream(const std::string& compres
                 buffer.write(ifExists(payloadTag, getAsStringFrom, chunk),
                              ifExists(payloadTag, getStringLengthFrom, chunk));
                 done = chunk.HasMember(JSON_EOS_TAG);
-            } while (done == false && inputStream->eof() == false);
+            } while (done == false);
             consumeSpace(*inputStream);
             return decodeAndDecompress(buffer);
         } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }

--- a/lib/api/CSerializableToJson.cc
+++ b/lib/api/CSerializableToJson.cc
@@ -53,6 +53,12 @@ auto decodeAndDecompress(std::istream& inputStream) {
     return result;
 }
 
+void consumeSpace(std::istream& stream) {
+    while (std::isspace(stream.peek()) != 0) {
+        stream.get();
+    }
+}
+
 const std::string JSON_DOC_NUM_TAG{"doc_num"};
 const std::string JSON_EOS_TAG{"eos"};
 }
@@ -129,6 +135,7 @@ CSerializableFromCompressedChunkedJson::rawJsonStream(const std::string& compres
                              ifExists(payloadTag, getStringLengthFrom, chunk));
                 done = chunk.HasMember(JSON_EOS_TAG);
             } while (done == false && inputStream->eof() == false);
+            consumeSpace(*inputStream);
             return decodeAndDecompress(buffer);
         } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }
     }

--- a/lib/api/CSerializableToJson.cc
+++ b/lib/api/CSerializableToJson.cc
@@ -128,7 +128,7 @@ CSerializableFromCompressedChunkedJson::rawJsonStream(const std::string& compres
                 buffer.write(ifExists(payloadTag, getAsStringFrom, chunk),
                              ifExists(payloadTag, getStringLengthFrom, chunk));
                 done = chunk.HasMember(JSON_EOS_TAG);
-            } while (done == false);
+            } while (done == false || inputStream->eof());
             return decodeAndDecompress(buffer);
         } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }
     }

--- a/lib/api/CSerializableToJson.cc
+++ b/lib/api/CSerializableToJson.cc
@@ -7,75 +7,132 @@
 #include <api/CSerializableToJson.h>
 
 #include <core/CBase64Filter.h>
-#include <core/Constants.h>
 
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/rapidjson.h>
+
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/stream.hpp>
 
-#include <ostream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 
 namespace ml {
 namespace api {
-
 namespace {
+namespace io = boost::iostreams;
+using TFilteredInput = io::filtering_stream<io::input>;
+using TFilteredOutput = io::filtering_stream<io::output>;
+using TGenericLineWriter = core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>;
+
+void compressAndEncode(std::function<void(TGenericLineWriter&)> addToJsonStream,
+                       std::ostream& sink) {
+    TFilteredOutput outFilter;
+    outFilter.push(io::gzip_compressor());
+    outFilter.push(core::CBase64Encoder());
+    outFilter.push(sink);
+    rapidjson::OStreamWrapper osw{outFilter};
+    TGenericLineWriter writer{osw};
+    addToJsonStream(writer);
+    outFilter.flush();
+}
+
+auto decodeAndDecompress(std::istream& inputStream) {
+    auto result = std::make_shared<TFilteredInput>();
+    result->push(io::gzip_decompressor());
+    result->push(core::CBase64Decoder());
+    result->push(inputStream);
+    return result;
+}
+
 const std::string JSON_DOC_NUM_TAG{"doc_num"};
 const std::string JSON_EOS_TAG{"eos"};
-const std::size_t MAX_DOCUMENT_SIZE(16 * core::constants::BYTES_IN_MEGABYTES);
 }
 
-void CSerializableToJsonDocumentCompressed::jsonStream(std::ostream& jsonStrm) const {
-    rapidjson::OStreamWrapper wrapper{jsonStrm};
-    TGenericLineWriter writer{wrapper};
-    this->addToJsonStream(writer);
-    jsonStrm.flush();
-}
-
-std::stringstream CSerializableToJsonDocumentCompressed::jsonCompressedStream() const {
-    std::stringstream compressedStream;
-    using TFilteredOutput = boost::iostreams::filtering_stream<boost::iostreams::output>;
+std::string CSerializableToJsonStream::jsonString() const {
+    std::ostringstream jsonStream;
     {
-        TFilteredOutput outFilter;
-        outFilter.push(boost::iostreams::gzip_compressor());
-        outFilter.push(core::CBase64Encoder());
-        outFilter.push(compressedStream);
-        this->jsonStream(outFilter);
+        rapidjson::OStreamWrapper osw{jsonStream};
+        TGenericLineWriter writer{osw};
+        this->addToJsonStream(writer);
     }
-    return compressedStream;
+    return jsonStream.str();
 }
 
-void CSerializableToJsonDocumentCompressed::addToDocumentCompressed(
-    TRapidJsonWriter& writer,
+CSerializableToCompressedChunkedJson::CSerializableToCompressedChunkedJson(std::size_t maxDocumentSize)
+    : m_MaxDocumentSize{std::min(maxDocumentSize, MAX_DOCUMENT_SIZE)} {
+}
+
+std::stringstream CSerializableToCompressedChunkedJson::jsonCompressedStream() const {
+    std::stringstream result;
+    compressAndEncode(this->callableAddToJsonStream(), result);
+    return result;
+}
+
+void CSerializableToCompressedChunkedJson::addCompressedToJsonStream(
     const std::string& compressedDocTag,
-    const std::string& payloadTag) const {
-    std::stringstream compressedStream{this->jsonCompressedStream()};
-    std::streamsize processed{0};
-    compressedStream.seekg(0, compressedStream.end);
-    std::streamsize remained{compressedStream.tellg()};
-    compressedStream.seekg(0, compressedStream.beg);
+    const std::string& payloadTag,
+    TRapidJsonWriter& writer) const {
+
+    using TCharVec = std::vector<char>;
+
+    TCharVec buffer;
+    buffer.reserve(m_MaxDocumentSize);
+    io::stream<io::back_insert_device<TCharVec>> output{io::back_inserter(buffer)};
+    compressAndEncode(this->callableAddToJsonStream(), output);
+
     std::size_t docNum{0};
-    std::string buffer;
-    while (remained > 0) {
-        std::size_t bytesToProcess{std::min(MAX_DOCUMENT_SIZE, static_cast<size_t>(remained))};
-        buffer.clear();
-        std::copy_n(std::istreambuf_iterator<char>(compressedStream.seekg(processed)),
-                    bytesToProcess, std::back_inserter(buffer));
-        remained -= bytesToProcess;
-        processed += bytesToProcess;
+    for (std::size_t i = 0; i < buffer.size(); i += m_MaxDocumentSize) {
+        rapidjson::SizeType bytesToWrite{static_cast<rapidjson::SizeType>(
+            std::min(m_MaxDocumentSize, buffer.size() - i))};
+
         writer.StartObject();
         writer.Key(compressedDocTag);
         writer.StartObject();
         writer.Key(JSON_DOC_NUM_TAG);
         writer.Uint64(docNum);
         writer.Key(payloadTag);
-        writer.String(buffer);
-        if (remained == 0) {
+        writer.String(&buffer[i], bytesToWrite);
+        if (i + bytesToWrite == buffer.size()) {
             writer.Key(JSON_EOS_TAG);
             writer.Bool(true);
         }
         writer.EndObject();
         writer.EndObject();
+
         ++docNum;
     }
+}
+
+CSerializableFromCompressedChunkedJson::TIStreamPtr
+CSerializableFromCompressedChunkedJson::rawJsonStream(const std::string& compressedDocTag,
+                                                      const std::string& payloadTag,
+                                                      TIStreamPtr inputStream,
+                                                      std::iostream& buffer) {
+    if (inputStream != nullptr) {
+        rapidjson::IStreamWrapper isw{*inputStream};
+        try {
+            rapidjson::Document doc;
+            bool done{false};
+            do {
+                doc.ParseStream<rapidjson::kParseStopWhenDoneFlag>(isw);
+                auto chunk = ifExists(compressedDocTag, getAsObjectFrom, doc);
+                buffer.write(ifExists(payloadTag, getAsStringFrom, chunk),
+                             ifExists(payloadTag, getStringLengthFrom, chunk));
+                done = chunk.HasMember(JSON_EOS_TAG);
+            } while (done == false);
+            return decodeAndDecompress(buffer);
+        } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }
+    }
+    return nullptr;
 }
 }
 }

--- a/lib/api/CSerializableToJson.cc
+++ b/lib/api/CSerializableToJson.cc
@@ -128,7 +128,7 @@ CSerializableFromCompressedChunkedJson::rawJsonStream(const std::string& compres
                 buffer.write(ifExists(payloadTag, getAsStringFrom, chunk),
                              ifExists(payloadTag, getStringLengthFrom, chunk));
                 done = chunk.HasMember(JSON_EOS_TAG);
-            } while (done == false || inputStream->eof());
+            } while (done == false && inputStream->eof() == false);
             return decodeAndDecompress(buffer);
         } catch (const std::runtime_error& e) { LOG_ERROR(<< e.what()); }
     }

--- a/lib/api/unittest/CSerializableToJsonTest.cc
+++ b/lib/api/unittest/CSerializableToJsonTest.cc
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CSerializableToJson.h>
+
+#include <boost/test/tools/interface.hpp>
+#include <rapidjson/istreamwrapper.h>
+#include <test/CRandomNumbers.h>
+
+#include <boost/test/unit_test.hpp>
+#include <rapidjson/document.h>
+
+#include <iostream>
+#include <sstream>
+
+BOOST_AUTO_TEST_SUITE(CSerializableToJsonTest)
+
+using namespace ml;
+
+namespace {
+using TDoubleVec = std::vector<double>;
+
+class CSerializableVector : public api::CSerializableToCompressedChunkedJson,
+                            public api::CSerializableFromCompressedChunkedJson {
+public:
+    CSerializableVector() = default;
+    CSerializableVector(std::string name, TDoubleVec values)
+        : CSerializableToCompressedChunkedJson{50}, m_Name{std::move(name)}, m_Values{std::move(values)} {
+    }
+
+    std::string compare(const CSerializableVector& rhs) const {
+        if (m_Name != rhs.m_Name) {
+            return m_Name + " vs " + rhs.m_Name;
+        }
+        if (m_Values.size() != rhs.m_Values.size()) {
+            return std::to_string(m_Values.size()) + " vs " +
+                   std::to_string(rhs.m_Values.size());
+        }
+        for (std::size_t i = 0; i < m_Values.size(); ++i) {
+            if (std::fabs(m_Values[i] - rhs.m_Values[i]) > 1e-6) {
+                return std::to_string(i) + "/" + std::to_string(m_Values[i]) +
+                       " vs " + std::to_string(rhs.m_Values[i]);
+            }
+        }
+        return "";
+    }
+
+    void fromCompressedJsonStream(TIStreamPtr inputStream) {
+        std::stringstream buffer;
+        auto state = rawJsonStream("state_doc", "state", std::move(inputStream), buffer);
+        this->readFromJsonStream(std::move(state));
+    }
+
+    void addCompressedToJsonStream(TRapidJsonWriter& writer) const override {
+        this->CSerializableToCompressedChunkedJson::addCompressedToJsonStream(
+            "state_doc", "state", writer);
+    }
+
+private:
+    void addToJsonStream(TGenericLineWriter& writer) const override {
+        writer.StartObject();
+        writer.Key("name");
+        writer.String(m_Name);
+        writer.EndObject();
+        writer.StartObject();
+        writer.Key("values");
+        writer.StartArray();
+        for (const auto& value : m_Values) {
+            writer.Double(value);
+        }
+        writer.EndArray();
+        writer.EndObject();
+    }
+
+    void readFromJsonStream(TIStreamPtr inputStream) {
+        if (inputStream != nullptr) {
+            rapidjson::IStreamWrapper isw{*inputStream};
+            rapidjson::Document doc;
+            doc.ParseStream<rapidjson::kParseStopWhenDoneFlag>(isw);
+            m_Name = doc["name"].GetString();
+            doc.ParseStream<rapidjson::kParseStopWhenDoneFlag>(isw);
+            m_Values.reserve(doc["values"].Size());
+            for (const auto& value : doc["values"].GetArray()) {
+                m_Values.push_back(value.GetDouble());
+            }
+        }
+    }
+
+private:
+    std::string m_Name;
+    TDoubleVec m_Values;
+};
+
+void arrayToNdJson(std::string array, std::ostream& ndjson) {
+    array.erase(std::remove(array.begin(), array.end(), '\n'), array.end());
+    rapidjson::Document doc;
+    doc.Parse(array);
+    for (const auto& chunk : doc.GetArray()) {
+        rapidjson::StringBuffer string;
+        core::CRapidJsonLineWriter<rapidjson::StringBuffer> printer{string};
+        chunk.Accept(printer);
+        ndjson << string.GetString();
+    }
+}
+}
+
+BOOST_AUTO_TEST_CASE(testRoundTrip) {
+
+    test::CRandomNumbers rng;
+
+    for (std::size_t number = 10; number < 200; number += 10) {
+
+        TDoubleVec values;
+        rng.generateUniformSamples(0.0, 100.0, number, values);
+
+        CSerializableVector original{"test_vector", std::move(values)};
+
+        auto ndjson = std::make_shared<std::stringstream>();
+        std::ostringstream storage;
+        {
+            core::CJsonOutputStreamWrapper osw{storage};
+            CSerializableVector::TRapidJsonWriter writer{osw};
+            original.addCompressedToJsonStream(writer);
+        }
+        arrayToNdJson(storage.str(), *ndjson);
+
+        CSerializableVector restored;
+        restored.fromCompressedJsonStream(ndjson);
+
+        auto result = restored.compare(original);
+        if (result.empty() == false) {
+            BOOST_TEST_FAIL(result);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/api/unittest/Makefile
+++ b/lib/api/unittest/Makefile
@@ -60,6 +60,7 @@ SRCS=\
 	CPersistenceManagerTest.cc \
 	CRestorePreviousStateTest.cc \
 	CResultNormalizerTest.cc \
+	CSerializableToJsonTest.cc \
 	CSingleFieldDataCategorizerTest.cc \
 	CSingleStreamDataAdderTest.cc \
 	CStateRestoreStreamFilterTest.cc \


### PR DESCRIPTION
Currently, we write large state documents out chunked but then only try and read the first chunk when restoring for incremental training. This means if our compressed state exceeds the maximum document size we fail to restore.

This change introduces a new `CSerializableFromCompressedChunkedJson` class which dechunks the compressed state into a temporary buffer. We expand this stream as we read it, so provided we read one document at a time (there is an enhancement for this), then the memory overhead is small if the compression factor is large, which it is.

I also took the opportunity to avoid all the temporary copies of compressed state by reading directly into a char array and then using pointers into this array to initialise the `rapidjson::String` objects during persist.

Fixes #1849.