### PR TITLE
[ML] Improve robustness of tensor result processing

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -70,7 +70,7 @@ torch::Tensor infer(torch::jit::script::Module& module,
 }
 
 template<typename T>
-void writeTensor(torch::TensorAccessor<T, 1>& accessor,
+void writeTensor(const torch::TensorAccessor<T, 1UL>& accessor,
                  ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
     jsonWriter.StartArray();
     for (int i = 0; i < accessor.size(0); ++i) {
@@ -80,14 +80,10 @@ void writeTensor(torch::TensorAccessor<T, 1>& accessor,
 }
 
 template<typename T>
-void writeTensor(torch::TensorAccessor<T, 2>& accessor,
+void writeTensor(const torch::TensorAccessor<T, 2UL>& accessor,
                  ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
     for (int i = 0; i < accessor.size(0); ++i) {
-        jsonWriter.StartArray();
-        for (int j = 0; j < accessor.size(1); ++j) {
-            jsonWriter.Double(static_cast<double>(accessor[i][j]));
-        }
-        jsonWriter.EndArray();
+        writeTensor(accessor[i], jsonWriter);
     }
 }
 


### PR DESCRIPTION
Tensors are read via `accessors` which have template parameters type (float, int, etc) and a dimension count. If the type or dimension is wrong the accessor will throw. Previously the only support type was a hard coded float, this change inspects the underlying tensor type and will either create a `double` or `float32` accessor. If the tensor is not one of those types an error is returned. 

