### PR TITLE
[ML] Split data summarisation writing and retrainable model reading

### DIFF
--- a/include/api/CDataFrameAnalysisRunner.h
+++ b/include/api/CDataFrameAnalysisRunner.h
@@ -11,7 +11,6 @@
 #include <core/CStatePersistInserter.h>
 
 #include <api/CDataFrameAnalysisInstrumentation.h>
-#include <api/CDataSummarizationJsonSerializer.h>
 #include <api/CInferenceModelDefinition.h>
 #include <api/CInferenceModelMetadata.h>
 #include <api/ImportExport.h>
@@ -38,6 +37,7 @@ class CRowRef;
 }
 namespace api {
 class CDataFrameAnalysisSpecification;
+class CDataSummarizationJsonWriter;
 class CMemoryUsageEstimationResultJsonWriter;
 
 //! \brief Hierarchy for running a specific core::CDataFrame analyses.

--- a/include/api/CDataSummarizationJsonTags.h
+++ b/include/api/CDataSummarizationJsonTags.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_api_CDataSummarizationJsonTags_h
+#define INCLUDED_ml_api_CDataSummarizationJsonTags_h
+
+#include <api/ImportExport.h>
+
+#include <string>
+
+namespace ml {
+namespace api {
+
+//! \brief Shared tags used by the JSON data summarization object.
+struct API_EXPORT CDataSummarizationJsonTags {
+    static const std::string JSON_COMPRESSED_DATA_SUMMARIZATION_TAG;
+    static const std::string JSON_DATA_SUMMARIZATION_TAG;
+    static const std::string JSON_NUM_COLUMNS_TAG;
+    static const std::string JSON_COLUMN_NAMES_TAG;
+    static const std::string JSON_COLUMN_IS_CATEGORICAL_TAG;
+    static const std::string JSON_CATEGORICAL_COLUMN_VALUES_TAG;
+    static const std::string JSON_ENCODING_NAME_INDEX_MAP_TAG;
+    static const std::string JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG;
+    static const std::string JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG;
+    static const std::string JSON_ENCODINGS_TAG;
+    static const std::string JSON_DATA_TAG;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CDataSummarizationJsonTags_h

--- a/include/api/CDataSummarizationJsonWriter.h
+++ b/include/api/CDataSummarizationJsonWriter.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_api_CDataSummarizationJsonWriter_h
+#define INCLUDED_ml_api_CDataSummarizationJsonWriter_h
+
+#include <core/CPackedBitVector.h>
+
+#include <api/CDataSummarizationJsonTags.h>
+#include <api/CSerializableToJson.h>
+#include <api/ImportExport.h>
+
+#include <cstddef>
+
+namespace ml {
+namespace core {
+class CDataFrame;
+}
+namespace maths {
+class CDataFrameCategoryEncoder;
+}
+namespace api {
+
+//! \brief Class which writes the data summarization as a compressed, base64 encoded
+//! and chunked JSON blob.
+//!
+//! DESCRIPTION:\n
+//! The data summarization contains data rows as well as the feature value encoding
+//! information.
+class API_EXPORT CDataSummarizationJsonWriter final
+    : public CSerializableToCompressedChunkedJson,
+      public CDataSummarizationJsonTags {
+public:
+    CDataSummarizationJsonWriter(const core::CDataFrame& frame,
+                                 core::CPackedBitVector rowMask,
+                                 std::size_t numberColumns,
+                                 const maths::CDataFrameCategoryEncoder& encodings);
+
+    CDataSummarizationJsonWriter(const CDataSummarizationJsonWriter&) = delete;
+    CDataSummarizationJsonWriter& operator=(const CDataSummarizationJsonWriter&) = delete;
+
+    //! Write the JSON data summarisation.
+    void addToJsonStream(TGenericLineWriter& writer) const override;
+
+    //! Write a compressed and chunked JSON data summarisation.
+    void addCompressedToJsonStream(TRapidJsonWriter& writer) const override;
+
+private:
+    core::CPackedBitVector m_RowMask;
+    std::size_t m_NumberColumns;
+    const core::CDataFrame& m_Frame;
+    const maths::CDataFrameCategoryEncoder& m_Encodings;
+};
+}
+}
+
+#endif // INCLUDED_ml_api_CDataSummarizationJsonWriter_h

--- a/include/api/CRetrainableModelJsonReader.h
+++ b/include/api/CRetrainableModelJsonReader.h
@@ -3,20 +3,19 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-#ifndef INCLUDED_ml_api_CDataSummarizationJsonSerializer_h
-#define INCLUDED_ml_api_CDataSummarizationJsonSerializer_h
 
-#include <core/CPackedBitVector.h>
+#ifndef INCLUDED_ml_api_CRetrainableModelJsonReader_h
+#define INCLUDED_ml_api_CRetrainableModelJsonReader_h
 
 #include <maths/CBoostedTreeFactory.h>
 
+#include <api/CDataSummarizationJsonTags.h>
 #include <api/CSerializableToJson.h>
+#include <api/ImportExport.h>
 
 #include <boost/unordered/unordered_map.hpp>
 
 #include <istream>
-#include <memory>
-#include <sstream>
 #include <string>
 
 namespace ml {
@@ -27,52 +26,6 @@ namespace maths {
 class CDataFrameCategoryEncoder;
 }
 namespace api {
-
-//! \brief Shared tags used by the JSON data summarization object.
-struct API_EXPORT CDataSummarizationJsonTags {
-    static const std::string JSON_COMPRESSED_DATA_SUMMARIZATION_TAG;
-    static const std::string JSON_DATA_SUMMARIZATION_TAG;
-    static const std::string JSON_NUM_COLUMNS_TAG;
-    static const std::string JSON_COLUMN_NAMES_TAG;
-    static const std::string JSON_COLUMN_IS_CATEGORICAL_TAG;
-    static const std::string JSON_CATEGORICAL_COLUMN_VALUES_TAG;
-    static const std::string JSON_ENCODING_NAME_INDEX_MAP_TAG;
-    static const std::string JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG;
-    static const std::string JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG;
-    static const std::string JSON_ENCODINGS_TAG;
-    static const std::string JSON_DATA_TAG;
-};
-
-//! \brief Class which writes the data summarization as a compressed, base64 encoded
-//! and chunked JSON blob.
-//!
-//! DESCRIPTION:\n
-//! The data summarization contains data rows as well as the feature value encoding
-//! information.
-class API_EXPORT CDataSummarizationJsonWriter final
-    : public CSerializableToCompressedChunkedJson,
-      public CDataSummarizationJsonTags {
-public:
-    CDataSummarizationJsonWriter(const core::CDataFrame& frame,
-                                 core::CPackedBitVector rowMask,
-                                 std::size_t numberColumns,
-                                 const maths::CDataFrameCategoryEncoder& encodings);
-
-    CDataSummarizationJsonWriter(const CDataSummarizationJsonWriter&) = delete;
-    CDataSummarizationJsonWriter& operator=(const CDataSummarizationJsonWriter&) = delete;
-
-    //! Write the JSON data summarisation.
-    void addToJsonStream(TGenericLineWriter& writer) const override;
-
-    //! Write a compressed and chunked JSON data summarisation.
-    void addCompressedToJsonStream(TRapidJsonWriter& writer) const override;
-
-private:
-    core::CPackedBitVector m_RowMask;
-    std::size_t m_NumberColumns;
-    const core::CDataFrame& m_Frame;
-    const maths::CDataFrameCategoryEncoder& m_Encodings;
-};
 
 //! \brief Reads a compressed, base64 encoded chunked JSON representation of a
 //! data summarisation and an inference model which can be used to initialise
@@ -112,4 +65,5 @@ private:
 };
 }
 }
-#endif //INCLUDED_ml_api_CDataSummarizationJsonSerializer_h
+
+#endif //INCLUDED_ml_api_CRetrainableModelJsonReader_h

--- a/lib/api/CDataFrameAnalysisRunner.cc
+++ b/lib/api/CDataFrameAnalysisRunner.cc
@@ -13,6 +13,7 @@
 #include <core/Constants.h>
 
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataSummarizationJsonWriter.h>
 #include <api/CMemoryUsageEstimationResultJsonWriter.h>
 #include <api/CSingleStreamDataAdder.h>
 #include <api/ElasticsearchStateIndex.h>

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -16,6 +16,7 @@
 
 #include <api/CDataFrameAnalysisInstrumentation.h>
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataSummarizationJsonWriter.h>
 
 #include <cmath>
 #include <limits>

--- a/lib/api/CDataFrameOutliersRunner.cc
+++ b/lib/api/CDataFrameOutliersRunner.cc
@@ -91,7 +91,7 @@ std::size_t CDataFrameOutliersRunner::dataFrameSliceCapacity() const {
 
 core::CPackedBitVector
 CDataFrameOutliersRunner::rowsToWriteMask(const core::CDataFrame& frame) const {
-    return core::CPackedBitVector{frame.numberRows(), true};
+    return {frame.numberRows(), true};
 }
 
 void CDataFrameOutliersRunner::writeOneRow(const core::CDataFrame& frame,

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -18,7 +18,6 @@
 #include <api/CBoostedTreeInferenceModelBuilder.h>
 #include <api/CDataFrameAnalysisConfigReader.h>
 #include <api/CDataFrameAnalysisSpecification.h>
-#include <api/CDataSummarizationJsonSerializer.h>
 #include <api/ElasticsearchStateIndex.h>
 
 #include <cmath>

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -274,7 +274,7 @@ CDataFrameTrainBoostedTreeRunner::rowsToWriteMask(const core::CDataFrame& frame)
     switch (m_Task) {
     case E_Train:
     case E_Predict:
-        return core::CPackedBitVector{frame.numberRows(), true};
+        return {frame.numberRows(), true};
     case E_Update:
         return m_BoostedTree->newTrainingRowMask();
     }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -23,7 +23,9 @@
 #include <api/CBoostedTreeInferenceModelBuilder.h>
 #include <api/CDataFrameAnalysisConfigReader.h>
 #include <api/CDataFrameAnalysisSpecification.h>
+#include <api/CDataSummarizationJsonWriter.h>
 #include <api/CInferenceModelDefinition.h>
+#include <api/CRetrainableModelJsonReader.h>
 #include <api/ElasticsearchStateIndex.h>
 
 #include <rapidjson/document.h>

--- a/lib/api/CDataSummarizationJsonTags.cc
+++ b/lib/api/CDataSummarizationJsonTags.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CDataSummarizationJsonTags.h>
+
+namespace ml {
+namespace api {    
+// clang-format off
+const std::string CDataSummarizationJsonTags::JSON_COMPRESSED_DATA_SUMMARIZATION_TAG{"compressed_data_summarization"};
+const std::string CDataSummarizationJsonTags::JSON_DATA_SUMMARIZATION_TAG{"data_summarization"};
+const std::string CDataSummarizationJsonTags::JSON_NUM_COLUMNS_TAG{"num_columns"};
+const std::string CDataSummarizationJsonTags::JSON_COLUMN_NAMES_TAG{"column_names"};
+const std::string CDataSummarizationJsonTags::JSON_COLUMN_IS_CATEGORICAL_TAG{"column_is_categorical"};
+const std::string CDataSummarizationJsonTags::JSON_CATEGORICAL_COLUMN_VALUES_TAG{"categorical_column_values"};
+const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_TAG{"encodings_indices"};
+const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG{"encoding_name"};
+const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG{"encoding_index"};
+const std::string CDataSummarizationJsonTags::JSON_ENCODINGS_TAG{"encodings"};
+const std::string CDataSummarizationJsonTags::JSON_DATA_TAG{"data"};
+// clang-format on
+}
+}

--- a/lib/api/CDataSummarizationJsonTags.cc
+++ b/lib/api/CDataSummarizationJsonTags.cc
@@ -7,7 +7,7 @@
 #include <api/CDataSummarizationJsonTags.h>
 
 namespace ml {
-namespace api {    
+namespace api {
 // clang-format off
 const std::string CDataSummarizationJsonTags::JSON_COMPRESSED_DATA_SUMMARIZATION_TAG{"compressed_data_summarization"};
 const std::string CDataSummarizationJsonTags::JSON_DATA_SUMMARIZATION_TAG{"data_summarization"};

--- a/lib/api/CDataSummarizationJsonWriter.cc
+++ b/lib/api/CDataSummarizationJsonWriter.cc
@@ -126,7 +126,9 @@ void CDataSummarizationJsonWriter::addToJsonStream(TGenericLineWriter& writer) c
     }
     rapidjson::ParseResult ok(doc.Parse(encodings.str()));
     if (static_cast<bool>(ok) == false) {
-        LOG_ERROR(<< "Failed parsing encoding json. Please report this error.");
+        LOG_ERROR(<< "Failed parsing encoding json: "
+                  << rapidjson::GetParseError_En(doc.GetParseError())
+                  << ". Please report this error.");
     } else {
         writer.Key(JSON_ENCODINGS_TAG);
         writer.write(doc);

--- a/lib/api/CDataSummarizationJsonWriter.cc
+++ b/lib/api/CDataSummarizationJsonWriter.cc
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <api/CDataSummarizationJsonWriter.h>
+
+#include <core/CDataFrame.h>
+#include <core/CJsonStatePersistInserter.h>
+
+#include <maths/CDataFrameCategoryEncoder.h>
+
+#include <api/CInferenceModelDefinition.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/rapidjson.h>
+
+#include <memory>
+#include <sstream>
+#include <utility>
+
+namespace ml {
+namespace api {
+
+namespace {
+using TDoubleVec = std::vector<double>;
+using TStrVec = std::vector<std::string>;
+using TStrVecVec = std::vector<TStrVec>;
+using TRowItr = core::CDataFrame::TRowItr;
+
+class CEncoderNameIndexMapBuilder final : public maths::CDataFrameCategoryEncoder::CVisitor {
+public:
+    using TStrSizePrVec = std::vector<std::pair<std::string, std::size_t>>;
+    using TStrSizePrVecCItr = TStrSizePrVec::const_iterator;
+
+public:
+    CEncoderNameIndexMapBuilder(TStrVec fieldNames, TStrVecVec categoryNames)
+        : m_FeatureNameProvider{std::move(fieldNames), std::move(categoryNames)} {}
+
+    void addIdentityEncoding(std::size_t inputColumnIndex) override {
+        m_Map.emplace_back(m_FeatureNameProvider.identityEncodingName(inputColumnIndex),
+                           m_Map.size());
+    }
+    void addOneHotEncoding(std::size_t inputColumnIndex, std::size_t hotCategory) override {
+        m_Map.emplace_back(m_FeatureNameProvider.oneHotEncodingName(inputColumnIndex, hotCategory),
+                           m_Map.size());
+    }
+    void addTargetMeanEncoding(std::size_t inputColumnIndex, const TDoubleVec&, double) override {
+        m_Map.emplace_back(m_FeatureNameProvider.targetMeanEncodingName(inputColumnIndex),
+                           m_Map.size());
+    }
+    void addFrequencyEncoding(std::size_t inputColumnIndex, const TDoubleVec&) override {
+        m_Map.emplace_back(m_FeatureNameProvider.frequencyEncodingName(inputColumnIndex),
+                           m_Map.size());
+    }
+
+    TStrSizePrVecCItr begin() const { return m_Map.begin(); }
+    TStrSizePrVecCItr end() const { return m_Map.end(); }
+
+private:
+    CTrainedModel::CFeatureNameProvider m_FeatureNameProvider;
+    TStrSizePrVec m_Map;
+};
+}
+
+CDataSummarizationJsonWriter::CDataSummarizationJsonWriter(const core::CDataFrame& frame,
+                                                           core::CPackedBitVector rowMask,
+                                                           std::size_t numberColumns,
+                                                           const maths::CDataFrameCategoryEncoder& encodings)
+    : m_RowMask{std::move(rowMask)}, m_NumberColumns{numberColumns}, m_Frame{frame}, m_Encodings{encodings} {
+}
+
+void CDataSummarizationJsonWriter::addCompressedToJsonStream(TRapidJsonWriter& writer) const {
+    this->CSerializableToCompressedChunkedJson::addCompressedToJsonStream(
+        JSON_COMPRESSED_DATA_SUMMARIZATION_TAG, JSON_DATA_SUMMARIZATION_TAG, writer);
+}
+
+void CDataSummarizationJsonWriter::addToJsonStream(TGenericLineWriter& writer) const {
+
+    // Note that the data frame has extra columns added to it when running training.
+    // These are at the end and should not be serialized since it is wasteful and they
+    // are reinitialised anyway. m_NumberColumns is the number of supplied columns,
+    // i.e. the feature values and target variable.
+
+    writer.StartObject();
+
+    writer.Key(JSON_NUM_COLUMNS_TAG);
+    writer.Uint64(m_NumberColumns);
+
+    writer.Key(JSON_COLUMN_NAMES_TAG);
+    writer.StartArray();
+    for (std::size_t i = 0; i < m_NumberColumns; ++i) {
+        writer.String(m_Frame.columnNames()[i]);
+    }
+    writer.EndArray();
+
+    writer.Key(JSON_COLUMN_IS_CATEGORICAL_TAG);
+    writer.StartArray();
+    for (std::size_t i = 0; i < m_NumberColumns; ++i) {
+        writer.Bool(m_Frame.columnIsCategorical()[i]);
+    }
+    writer.EndArray();
+
+    CEncoderNameIndexMapBuilder encodingIndices{m_Frame.columnNames(),
+                                                m_Frame.categoricalColumnValues()};
+    m_Encodings.accept(encodingIndices);
+    writer.Key(JSON_ENCODING_NAME_INDEX_MAP_TAG);
+    writer.StartArray();
+    for (const auto& index : encodingIndices) {
+        writer.StartObject();
+        writer.Key(JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG);
+        writer.String(index.first);
+        writer.Key(JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG);
+        writer.Uint64(index.second);
+        writer.EndObject();
+    }
+    writer.EndArray();
+
+    rapidjson::Document doc;
+    std::stringstream encodings;
+    {
+        core::CJsonStatePersistInserter inserter{encodings};
+        m_Encodings.acceptPersistInserter(inserter);
+    }
+    rapidjson::ParseResult ok(doc.Parse(encodings.str()));
+    if (static_cast<bool>(ok) == false) {
+        LOG_ERROR(<< "Failed parsing encoding json. Please report this error.");
+    } else {
+        writer.Key(JSON_ENCODINGS_TAG);
+        writer.write(doc);
+    }
+
+    writer.Key(JSON_CATEGORICAL_COLUMN_VALUES_TAG);
+    writer.StartArray();
+    for (std::size_t i = 0; i < m_NumberColumns; ++i) {
+        writer.StartArray();
+        for (const auto& category : m_Frame.categoricalColumnValues()[i]) {
+            writer.String(category);
+        }
+        writer.EndArray();
+    }
+    writer.EndArray();
+
+    writer.Key(JSON_DATA_TAG);
+    writer.StartArray();
+    auto writeRowsToJson = [&](const TRowItr& beginRows, const TRowItr& endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            writer.StartArray();
+            for (std::size_t i = 0; i < m_NumberColumns; ++i) {
+                auto value = (*row)[i];
+                if (core::CDataFrame::isMissing(value)) {
+                    writer.String(m_Frame.missingString());
+                } else if (m_Frame.categoricalColumnValues()[i].empty()) {
+                    writer.String(value.toString());
+                } else {
+                    writer.String(
+                        m_Frame.categoricalColumnValues()[i][static_cast<std::size_t>(value)]);
+                }
+            }
+            writer.EndArray();
+        }
+    };
+    m_Frame.readRows(1, 0, m_Frame.numberRows(), writeRowsToJson, &m_RowMask);
+    writer.EndArray();
+    writer.EndObject();
+}
+}
+}

--- a/lib/api/CRetrainableModelJsonReader.cc
+++ b/lib/api/CRetrainableModelJsonReader.cc
@@ -4,17 +4,15 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-#include <api/CDataSummarizationJsonSerializer.h>
+#include <api/CRetrainableModelJsonReader.h>
 
-#include <core/CBase64Filter.h>
 #include <core/CDataFrame.h>
-#include <core/CJsonStatePersistInserter.h>
 #include <core/CJsonStateRestoreTraverser.h>
-#include <core/Constants.h>
 
 #include <maths/CBoostedTree.h>
 #include <maths/CDataFrameCategoryEncoder.h>
 
+#include <api/CDataSummarizationJsonWriter.h>
 #include <api/CInferenceModelDefinition.h>
 
 #include <rapidjson/document.h>
@@ -32,45 +30,9 @@ namespace api {
 
 namespace {
 using TBoolVec = std::vector<bool>;
-using TDoubleVec = std::vector<double>;
 using TStrVec = std::vector<std::string>;
 using TStrVecVec = std::vector<TStrVec>;
-using TRowItr = core::CDataFrame::TRowItr;
 using TStrSizeUMap = CRetrainableModelJsonReader::TStrSizeUMap;
-
-class CEncoderNameIndexMapBuilder final : public maths::CDataFrameCategoryEncoder::CVisitor {
-public:
-    using TStrSizePrVec = std::vector<std::pair<std::string, std::size_t>>;
-    using TStrSizePrVecCItr = TStrSizePrVec::const_iterator;
-
-public:
-    CEncoderNameIndexMapBuilder(TStrVec fieldNames, TStrVecVec categoryNames)
-        : m_FeatureNameProvider{std::move(fieldNames), std::move(categoryNames)} {}
-
-    void addIdentityEncoding(std::size_t inputColumnIndex) override {
-        m_Map.emplace_back(m_FeatureNameProvider.identityEncodingName(inputColumnIndex),
-                           m_Map.size());
-    }
-    void addOneHotEncoding(std::size_t inputColumnIndex, std::size_t hotCategory) override {
-        m_Map.emplace_back(m_FeatureNameProvider.oneHotEncodingName(inputColumnIndex, hotCategory),
-                           m_Map.size());
-    }
-    void addTargetMeanEncoding(std::size_t inputColumnIndex, const TDoubleVec&, double) override {
-        m_Map.emplace_back(m_FeatureNameProvider.targetMeanEncodingName(inputColumnIndex),
-                           m_Map.size());
-    }
-    void addFrequencyEncoding(std::size_t inputColumnIndex, const TDoubleVec&) override {
-        m_Map.emplace_back(m_FeatureNameProvider.frequencyEncodingName(inputColumnIndex),
-                           m_Map.size());
-    }
-
-    TStrSizePrVecCItr begin() const { return m_Map.begin(); }
-    TStrSizePrVecCItr end() const { return m_Map.end(); }
-
-private:
-    CTrainedModel::CFeatureNameProvider m_FeatureNameProvider;
-    TStrSizePrVec m_Map;
-};
 
 std::size_t lookup(const TStrSizeUMap& encodingsIndices,
                    const TStrVec& featureNames,
@@ -88,122 +50,6 @@ std::size_t lookup(const TStrSizeUMap& encodingsIndices,
 }
 }
 
-// clang-format off
-const std::string CDataSummarizationJsonTags::JSON_COMPRESSED_DATA_SUMMARIZATION_TAG{"compressed_data_summarization"};
-const std::string CDataSummarizationJsonTags::JSON_DATA_SUMMARIZATION_TAG{"data_summarization"};
-const std::string CDataSummarizationJsonTags::JSON_NUM_COLUMNS_TAG{"num_columns"};
-const std::string CDataSummarizationJsonTags::JSON_COLUMN_NAMES_TAG{"column_names"};
-const std::string CDataSummarizationJsonTags::JSON_COLUMN_IS_CATEGORICAL_TAG{"column_is_categorical"};
-const std::string CDataSummarizationJsonTags::JSON_CATEGORICAL_COLUMN_VALUES_TAG{"categorical_column_values"};
-const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_TAG{"encodings_indices"};
-const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG{"encoding_name"};
-const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG{"encoding_index"};
-const std::string CDataSummarizationJsonTags::JSON_ENCODINGS_TAG{"encodings"};
-const std::string CDataSummarizationJsonTags::JSON_DATA_TAG{"data"};
-// clang-format on
-
-CDataSummarizationJsonWriter::CDataSummarizationJsonWriter(const core::CDataFrame& frame,
-                                                           core::CPackedBitVector rowMask,
-                                                           std::size_t numberColumns,
-                                                           const maths::CDataFrameCategoryEncoder& encodings)
-    : m_RowMask{std::move(rowMask)}, m_NumberColumns{numberColumns}, m_Frame{frame}, m_Encodings{encodings} {
-}
-
-void CDataSummarizationJsonWriter::addCompressedToJsonStream(TRapidJsonWriter& writer) const {
-    this->CSerializableToCompressedChunkedJson::addCompressedToJsonStream(
-        JSON_COMPRESSED_DATA_SUMMARIZATION_TAG, JSON_DATA_SUMMARIZATION_TAG, writer);
-}
-
-void CDataSummarizationJsonWriter::addToJsonStream(TGenericLineWriter& writer) const {
-
-    // Note that the data frame has extra columns added to it when running training.
-    // These are at the end and should not be serialized since it is wasteful and they
-    // are reinitialised anyway. m_NumberColumns is the number of supplied columns,
-    // i.e. the feature values and target variable.
-
-    writer.StartObject();
-
-    writer.Key(JSON_NUM_COLUMNS_TAG);
-    writer.Uint64(m_NumberColumns);
-
-    writer.Key(JSON_COLUMN_NAMES_TAG);
-    writer.StartArray();
-    for (std::size_t i = 0; i < m_NumberColumns; ++i) {
-        writer.String(m_Frame.columnNames()[i]);
-    }
-    writer.EndArray();
-
-    writer.Key(JSON_COLUMN_IS_CATEGORICAL_TAG);
-    writer.StartArray();
-    for (std::size_t i = 0; i < m_NumberColumns; ++i) {
-        writer.Bool(m_Frame.columnIsCategorical()[i]);
-    }
-    writer.EndArray();
-
-    CEncoderNameIndexMapBuilder encodingIndices{m_Frame.columnNames(),
-                                                m_Frame.categoricalColumnValues()};
-    m_Encodings.accept(encodingIndices);
-    writer.Key(JSON_ENCODING_NAME_INDEX_MAP_TAG);
-    writer.StartArray();
-    for (const auto& index : encodingIndices) {
-        writer.StartObject();
-        writer.Key(JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG);
-        writer.String(index.first);
-        writer.Key(JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG);
-        writer.Uint64(index.second);
-        writer.EndObject();
-    }
-    writer.EndArray();
-
-    rapidjson::Document doc;
-    std::stringstream encodings;
-    {
-        core::CJsonStatePersistInserter inserter{encodings};
-        m_Encodings.acceptPersistInserter(inserter);
-    }
-    rapidjson::ParseResult ok(doc.Parse(encodings.str()));
-    if (static_cast<bool>(ok) == false) {
-        LOG_ERROR(<< "Failed parsing encoding json. Please report this error.");
-    } else {
-        writer.Key(JSON_ENCODINGS_TAG);
-        writer.write(doc);
-    }
-
-    writer.Key(JSON_CATEGORICAL_COLUMN_VALUES_TAG);
-    writer.StartArray();
-    for (std::size_t i = 0; i < m_NumberColumns; ++i) {
-        writer.StartArray();
-        for (const auto& category : m_Frame.categoricalColumnValues()[i]) {
-            writer.String(category);
-        }
-        writer.EndArray();
-    }
-    writer.EndArray();
-
-    writer.Key(JSON_DATA_TAG);
-    writer.StartArray();
-    auto writeRowsToJson = [&](const TRowItr& beginRows, const TRowItr& endRows) {
-        for (auto row = beginRows; row != endRows; ++row) {
-            writer.StartArray();
-            for (std::size_t i = 0; i < m_NumberColumns; ++i) {
-                auto value = (*row)[i];
-                if (core::CDataFrame::isMissing(value)) {
-                    writer.String(m_Frame.missingString());
-                } else if (m_Frame.categoricalColumnValues()[i].empty()) {
-                    writer.String(value.toString());
-                } else {
-                    writer.String(
-                        m_Frame.categoricalColumnValues()[i][static_cast<std::size_t>(value)]);
-                }
-            }
-            writer.EndArray();
-        }
-    };
-    m_Frame.readRows(1, 0, m_Frame.numberRows(), writeRowsToJson, &m_RowMask);
-    writer.EndArray();
-    writer.EndObject();
-}
-
 CRetrainableModelJsonReader::TEncoderUPtrStrSizeUMapPr
 CRetrainableModelJsonReader::dataSummarizationFromJsonStream(TIStreamSPtr istream,
                                                              core::CDataFrame& frame) {
@@ -218,7 +64,7 @@ CRetrainableModelJsonReader::dataSummarizationFromJsonStream(TIStreamSPtr istrea
 CRetrainableModelJsonReader::TEncoderUPtrStrSizeUMapPr
 CRetrainableModelJsonReader::doDataSummarizationFromJsonStream(std::istream& istream,
                                                                core::CDataFrame& frame) {
-    rapidjson::IStreamWrapper isw(istream);
+    rapidjson::IStreamWrapper isw{istream};
     rapidjson::Document doc;
     doc.ParseStream(isw);
     assertNoParseError(doc);

--- a/lib/api/Makefile.first
+++ b/lib/api/Makefile.first
@@ -41,7 +41,8 @@ CDataFrameTrainBoostedTreeClassifierRunner.cc \
 CDataFrameTrainBoostedTreeRegressionRunner.cc \
 CDataFrameTrainBoostedTreeRunner.cc \
 CDataProcessor.cc \
-CDataSummarizationJsonSerializer.cc \
+CDataSummarizationJsonTags.cc \
+CDataSummarizationJsonWriter.cc \
 CDetectionRulesJsonParser.cc \
 CFieldDataCategorizer.cc \
 CForecastRunner.cc \
@@ -64,6 +65,7 @@ CNoopCategoryIdMapper.cc \
 CPerPartitionCategoryIdMapper.cc \
 CPersistenceManager.cc \
 CResultNormalizer.cc \
+CRetrainableModelJsonReader.cc \
 CSerializableToJson.cc \
 CSimpleOutputWriter.cc \
 CSingleFieldDataCategorizer.cc \

--- a/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
+++ b/lib/api/unittest/CDataFrameMockAnalysisRunner.cc
@@ -25,7 +25,7 @@ std::size_t CDataFrameMockAnalysisRunner::dataFrameSliceCapacity() const {
 
 ml::core::CPackedBitVector
 CDataFrameMockAnalysisRunner::rowsToWriteMask(const ml::core::CDataFrame& frame) const {
-    return ml::core::CPackedBitVector{frame.numberRows(), true};
+    return {frame.numberRows(), true};
 }
 
 void CDataFrameMockAnalysisRunner::writeOneRow(const ml::core::CDataFrame&,

--- a/lib/api/unittest/CDataSummarizationJsonSerializerTest.cc
+++ b/lib/api/unittest/CDataSummarizationJsonSerializerTest.cc
@@ -13,7 +13,8 @@
 #include <maths/CBoostedTreeLoss.h>
 
 #include <api/CDataFrameAnalyzer.h>
-#include <api/CDataSummarizationJsonSerializer.h>
+#include <api/CDataSummarizationJsonWriter.h>
+#include <api/CRetrainableModelJsonReader.h>
 
 #include <test/CDataFrameAnalysisSpecificationFactory.h>
 #include <test/CDataFrameAnalyzerTrainingFactory.h>


### PR DESCRIPTION
This implements the delayed suggestion in #1894 to split up the file containing the data summarisation writing and the retrainable model reading.