### PR TITLE
[ML] Compute bucket counts for 1s bucket spans

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,7 +44,7 @@
 
 === Bug Fixes
 
-* Ensure bucket count calculation is performed for simple count jobs with 1s bucket spans.
+* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans.
   (See {ml-pull}1908[#1908].)
 
 == {es} version 7.14.0

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,11 @@
   - the C++ front end to PyTorch and performs inference on models stored in the 
   TorchScript format. (See {ml-pull}1902[#1902].)
 
+=== Bug Fixes
+
+*. Ensure bucket count calculation is performed for simple count jobs with 1s bucket spans.
+  (See {ml-pull}1908[#1908].)
+
 == {es} version 7.14.0
 
 === Enhancements

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,7 +44,7 @@
 
 === Bug Fixes
 
-*. Ensure bucket count calculation is performed for simple count jobs with 1s bucket spans.
+* Ensure bucket count calculation is performed for simple count jobs with 1s bucket spans.
   (See {ml-pull}1908[#1908].)
 
 == {es} version 7.14.0

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -282,7 +282,7 @@ bool CCountingModel::computeProbability(std::size_t pid,
                                         SAnnotatedProbability& result) const {
     result = SAnnotatedProbability(1.0);
     result.s_CurrentBucketCount =
-        this->currentBucketCount(pid, (startTime + endTime) / 2 - 1);
+        this->currentBucketCount(pid, (startTime + endTime + 1) / 2 - 1);
     result.s_BaselineBucketCount = this->baselineBucketCount(pid);
     return true;
 }


### PR DESCRIPTION
Fix a bug where calls to calculate the current bucket count for simple count
models always failed to return a value when the bucket span was one
second.

fixes #1908