### PR TITLE
[7.x][ML] Compute bucket counts for 1s bucket spans (#1909)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,6 +38,8 @@
 === Bug Fixes
 
 * Make atomic operations safer for aarch64. (See {ml-pull}1893[#1893].)
+* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans.
+  (See {ml-pull}1908[#1908].)
 
 == {es} version 7.13.0
 

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -282,7 +282,7 @@ bool CCountingModel::computeProbability(std::size_t pid,
                                         SAnnotatedProbability& result) const {
     result = SAnnotatedProbability(1.0);
     result.s_CurrentBucketCount =
-        this->currentBucketCount(pid, (startTime + endTime) / 2 - 1);
+        this->currentBucketCount(pid, (startTime + endTime + 1) / 2 - 1);
     result.s_BaselineBucketCount = this->baselineBucketCount(pid);
     return true;
 }


### PR DESCRIPTION
Fix a bug where calls to calculate the current bucket count for simple count
models always failed to return a value when the bucket span was one
second.

Backports #1909 