### PR TITLE
[ML] Improve incremental training test coverage

### DIFF
--- a/include/maths/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/CBoostedTreeLeafNodeStatistics.h
@@ -510,6 +510,9 @@ public:
         CWorkspace& operator=(const CWorkspace& other) = delete;
         CWorkspace& operator=(CWorkspace&&) = default;
 
+        //! Get a list of features which must be included in training.
+        TSizeVec featuresToInclude() const;
+
         //! Define the tree to retrain.
         void retraining(const TNodeVec& tree) { m_TreeToRetrain = &tree; }
 

--- a/include/maths/CBoostedTreeUtils.h
+++ b/include/maths/CBoostedTreeUtils.h
@@ -112,6 +112,20 @@ inline TMemoryMappedFloatVector readPrediction(const TRowRef& row,
 MATHS_EXPORT
 void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters);
 
+//! Write \p value to \p row prediction column(s).
+MATHS_EXPORT
+void writePrediction(const TRowRef& row,
+                     const TSizeVec& extraColumns,
+                     std::size_t numberLossParameters,
+                     const TMemoryMappedFloatVector& value);
+
+//! Write \p value to \p row previous prediction column(s).
+MATHS_EXPORT
+void writePreviousPrediction(const TRowRef& row,
+                             const TSizeVec& extraColumns,
+                             std::size_t numberLossParameters,
+                             const TMemoryMappedFloatVector& value);
+
 //! Read the previous prediction for \p row if training incementally.
 MATHS_EXPORT
 inline TMemoryMappedFloatVector readPreviousPrediction(const TRowRef& row,

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -764,15 +764,15 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
             std::size_t numberLossParameters{m_Loss->numberParameters()};
             for (auto row_ = beginRows; row_ != endRows; ++row_) {
                 auto row = *row_;
-                if (m_IncrementalTraining == false) {
-                    zeroPrediction(row, m_ExtraColumns, numberLossParameters);
-                } else {
+                if (m_IncrementalTraining) {
                     writePrediction(row, m_ExtraColumns, numberLossParameters,
                                     readPreviousPrediction(row, m_ExtraColumns,
                                                            numberLossParameters));
+                } else {
+                    zeroPrediction(row, m_ExtraColumns, numberLossParameters);
+                    zeroLossGradient(row, m_ExtraColumns, numberLossParameters);
+                    zeroLossCurvature(row, m_ExtraColumns, numberLossParameters);
                 }
-                zeroLossGradient(row, m_ExtraColumns, numberLossParameters);
-                zeroLossCurvature(row, m_ExtraColumns, numberLossParameters);
             }
         },
         &updateRowMask);
@@ -921,7 +921,7 @@ CBoostedTreeImpl::updateForest(core::CDataFrame& frame,
     std::size_t maximumNumberInternalNodes{maximumTreeSize(trainingRowMask)};
 
     TNodeVecVec retrainedTrees;
-    retrainedTrees.reserve(m_TreesToRetrain.size());
+    retrainedTrees.reserve(m_TreesToRetrain.size() + 1);
     this->initializePredictionsAndLossDerivatives(frame, trainingRowMask, testingRowMask);
 
     CScopeRecordMemoryUsage scopeMemoryUsage{
@@ -945,24 +945,28 @@ CBoostedTreeImpl::updateForest(core::CDataFrame& frame,
     //  1. Rebuild one tree on fixed upfront candidate splits of features.
     //  2. Update predictions and loss derivatives.
 
+    retrainedTrees.emplace_back();
     for (const auto& index : m_TreesToRetrain) {
 
-        LOG_TRACE(<< "Retraining = "
+        LOG_TRACE(<< "Retraining ="
                   << root(m_BestForest[index]).print(m_BestForest[index]));
 
-        workspace.retraining(m_BestForest[index]);
-        this->removePredictions(frame, trainingRowMask, testingRowMask, m_BestForest[index]);
+        const auto& treeToRetrain = m_BestForest[index];
+
+        workspace.retraining(treeToRetrain);
+        this->removePredictions(frame, trainingRowMask, testingRowMask, treeToRetrain);
+
+        double eta{this->etaForTreeAtPosition(index)};
+        auto loss = m_Loss->incremental(eta, m_PredictionChangeCost, treeToRetrain);
+        this->refreshPredictionsAndLossDerivatives(
+            frame, trainingRowMask, testingRowMask, *loss, eta,
+            m_Regularization.leafWeightPenaltyMultiplier(), retrainedTrees.back());
 
         auto tree = this->trainTree(frame, downsampledRowMask, candidateSplits,
                                     maximumNumberInternalNodes,
                                     makeRootLeafNodeStatistics, workspace);
 
         scopeMemoryUsage.add(tree);
-        double eta{this->etaForTreeAtPosition(index)};
-        auto loss = m_Loss->incremental(eta, m_PredictionChangeCost, m_BestForest[index]);
-        this->refreshPredictionsAndLossDerivatives(
-            frame, trainingRowMask, testingRowMask, *loss, eta,
-            m_Regularization.leafWeightPenaltyMultiplier(), tree);
         retrainedTrees.push_back(std::move(tree));
         trainingProgress.increment();
 
@@ -971,10 +975,12 @@ CBoostedTreeImpl::updateForest(core::CDataFrame& frame,
 
         losses.push_back(this->meanAdjustedLoss(frame, testingRowMask));
     }
+    retrainedTrees.erase(retrainedTrees.begin());
 
     auto bestLoss = static_cast<std::size_t>(
         std::min_element(losses.begin(), losses.end()) - losses.begin());
     retrainedTrees.resize(bestLoss + 1);
+    LOG_TRACE(<< "# retrained trees = " << retrainedTrees.size());
 
     return {std::move(retrainedTrees), losses[bestLoss], std::move(losses)};
 }
@@ -1485,44 +1491,49 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(
     double lambda,
     TNodeVec& tree) const {
 
-    TArgMinLossVec leafValues(tree.size(), loss.minimizer(lambda, m_Rng));
-    auto nextPass = [&] {
-        bool done{true};
-        for (const auto& value : leafValues) {
-            done &= (value.nextPass() == false);
-        }
-        return done == false;
-    };
+    TArgMinLossVec leafValues;
 
-    do {
-        TArgMinLossVecVec result(m_NumberThreads, leafValues);
-        if (m_IncrementalTraining) {
-            this->minimumLossLeafValues(false /*new example*/, frame,
-                                        trainingRowMask & ~m_NewTrainingRowMask,
-                                        loss, tree, result);
-            this->minimumLossLeafValues(true /*new example*/, frame,
-                                        trainingRowMask & m_NewTrainingRowMask,
-                                        loss, tree, result);
-        } else {
-            this->minimumLossLeafValues(false /*new example*/, frame,
-                                        trainingRowMask, loss, tree, result);
-        }
+    if (tree.empty() == false) {
 
-        leafValues = std::move(result[0]);
-        for (std::size_t i = 1; i < result.size(); ++i) {
-            for (std::size_t j = 0; j < leafValues.size(); ++j) {
-                leafValues[j].merge(result[i][j]);
+        auto nextPass = [&] {
+            bool done{true};
+            for (const auto& value : leafValues) {
+                done &= (value.nextPass() == false);
+            }
+            return done == false;
+        };
+
+        leafValues.resize(tree.size(), loss.minimizer(lambda, m_Rng));
+        do {
+            TArgMinLossVecVec result(m_NumberThreads, leafValues);
+            if (m_IncrementalTraining) {
+                this->minimumLossLeafValues(false /*new example*/, frame,
+                                            trainingRowMask & ~m_NewTrainingRowMask,
+                                            loss, tree, result);
+                this->minimumLossLeafValues(true /*new example*/, frame,
+                                            trainingRowMask & m_NewTrainingRowMask,
+                                            loss, tree, result);
+            } else {
+                this->minimumLossLeafValues(false /*new example*/, frame,
+                                            trainingRowMask, loss, tree, result);
+            }
+
+            leafValues = std::move(result[0]);
+            for (std::size_t i = 1; i < result.size(); ++i) {
+                for (std::size_t j = 0; j < leafValues.size(); ++j) {
+                    leafValues[j].merge(result[i][j]);
+                }
+            }
+        } while (nextPass());
+
+        for (std::size_t i = 0; i < tree.size(); ++i) {
+            if (tree[i].isLeaf()) {
+                tree[i].value(eta * leafValues[i].value());
             }
         }
-    } while (nextPass());
 
-    for (std::size_t i = 0; i < tree.size(); ++i) {
-        if (tree[i].isLeaf()) {
-            tree[i].value(eta * leafValues[i].value());
-        }
+        LOG_TRACE(<< "tree = " << root(tree).print(tree));
     }
-
-    LOG_TRACE(<< "tree =\n" << root(tree).print(tree));
 
     core::CPackedBitVector updateRowMask{trainingRowMask | testingRowMask};
 
@@ -1569,17 +1580,23 @@ void CBoostedTreeImpl::writeRowDerivatives(bool newExample,
                                            const core::CPackedBitVector& rowMask,
                                            const TLossFunction& loss,
                                            const TNodeVec& tree) const {
+
+    auto addTreePrediction = [&](const TRowRef& row, TMemoryMappedFloatVector& prediction) {
+        if (tree.empty() == false) {
+            prediction += root(tree).value(m_Encoder->encode(row), tree);
+        }
+    };
+
     frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(),
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             std::size_t numberLossParameters{loss.numberParameters()};
-            const auto& rootNode = root(tree);
             for (auto row_ = beginRows; row_ != endRows; ++row_) {
                 auto row = *row_;
                 auto prediction = readPrediction(row, m_ExtraColumns, numberLossParameters);
                 double actual{readActual(row, m_DependentVariable)};
                 double weight{readExampleWeight(row, m_ExtraColumns)};
-                prediction += rootNode.value(m_Encoder->encode(row), tree);
+                addTreePrediction(row, prediction);
                 writeLossGradient(row, newExample, m_ExtraColumns, *m_Encoder,
                                   loss, prediction, actual, weight);
                 writeLossCurvature(row, newExample, m_ExtraColumns, *m_Encoder,

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -12,6 +12,7 @@
 #include <maths/CDataFrameCategoryEncoder.h>
 #include <maths/CDataFrameUtils.h>
 #include <maths/COrderings.h>
+#include <memory>
 
 namespace ml {
 namespace maths {
@@ -309,6 +310,23 @@ std::size_t CBoostedTreeLeafNodeStatistics::numberLossParameters() const {
 const CBoostedTreeLeafNodeStatistics::TImmutableRadixSetVec&
 CBoostedTreeLeafNodeStatistics::candidateSplits() const {
     return m_CandidateSplits;
+}
+
+CBoostedTreeLeafNodeStatistics::TSizeVec
+CBoostedTreeLeafNodeStatistics::CWorkspace::featuresToInclude() const {
+
+    TSizeVec result;
+    if (m_TreeToRetrain != nullptr) {
+        for (const auto& node : *m_TreeToRetrain) {
+            if (node.isLeaf() == false) {
+                result.push_back(node.splitFeature());
+            }
+        }
+    }
+    std::sort(result.begin(), result.end());
+    result.erase(std::unique(result.begin(), result.end()), result.end());
+
+    return result;
 }
 }
 }

--- a/lib/maths/CBoostedTreeUtils.cc
+++ b/lib/maths/CBoostedTreeUtils.cc
@@ -58,6 +58,24 @@ void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_
     }
 }
 
+void writePrediction(const TRowRef& row,
+                     const TSizeVec& extraColumns,
+                     std::size_t numberLossParameters,
+                     const TMemoryMappedFloatVector& value) {
+    for (std::size_t i = 0; i < numberLossParameters; ++i) {
+        row.writeColumn(extraColumns[E_Prediction] + i, value(i));
+    }
+}
+
+void writePreviousPrediction(const TRowRef& row,
+                             const TSizeVec& extraColumns,
+                             std::size_t numberLossParameters,
+                             const TMemoryMappedFloatVector& value) {
+    for (std::size_t i = 0; i < numberLossParameters; ++i) {
+        row.writeColumn(extraColumns[E_PreviousPrediction] + i, value(i));
+    }
+}
+
 void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
     for (std::size_t i = 0; i < numberLossParameters; ++i) {
         row.writeColumn(extraColumns[E_Gradient] + i, 0.0);

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -461,7 +461,6 @@ BOOST_AUTO_TEST_CASE(testMsePiecewiseConstant) {
         for (std::size_t i = 0; i < p.size(); i += 2) {
             std::sort(p.begin() + i, p.begin() + i + 2);
         }
-        double offset{0.0};
 
         return [=](const TRowRef& row) {
             double result{0.0};
@@ -470,7 +469,7 @@ BOOST_AUTO_TEST_CASE(testMsePiecewiseConstant) {
                     result += v[i];
                 }
             }
-            return offset + result;
+            return result;
         };
     };
 
@@ -519,14 +518,13 @@ BOOST_AUTO_TEST_CASE(testMseLinear) {
         TDoubleVec s;
         rng.generateUniformSamples(0.0, 10.0, cols - 1, m);
         rng.generateUniformSamples(-10.0, 10.0, cols - 1, s);
-        double offset{0.0};
 
         return [=](const TRowRef& row) {
             double result{0.0};
             for (std::size_t i = 0; i < cols - 1; ++i) {
                 result += m[i] + s[i] * row[i];
             }
-            return offset + result;
+            return result;
         };
     };
 
@@ -580,7 +578,6 @@ BOOST_AUTO_TEST_CASE(testMseNonLinear) {
         rng.generateUniformSamples(-10.0, 10.0, cols, slope);
         rng.generateUniformSamples(-1.0, 1.0, cols, curve);
         rng.generateUniformSamples(-0.5, 0.5, cols * cols, cross);
-        double offset{0.0};
 
         return [=](const TRowRef& row) {
             double result{0.0};
@@ -592,7 +589,7 @@ BOOST_AUTO_TEST_CASE(testMseNonLinear) {
                     result += cross[i * cols + j] * row[i] * row[j];
                 }
             }
-            return offset + result;
+            return result;
         };
     };
 
@@ -656,7 +653,6 @@ BOOST_AUTO_TEST_CASE(testHuber) {
         TDoubleVec s;
         rng.generateUniformSamples(0.0, 10.0, cols - 1, m);
         rng.generateUniformSamples(-10.0, 10.0, cols - 1, s);
-        double offset{0.0};
 
         return [=](const TRowRef& row) {
             double result{std::binary_search(outliers.begin(), outliers.end(), row.index())
@@ -665,7 +661,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
             for (std::size_t i = 0; i < cols - 1; ++i) {
                 result += m[i] + s[i] * row[i];
             }
-            return offset + result;
+            return result;
         };
     };
 
@@ -703,27 +699,47 @@ BOOST_AUTO_TEST_CASE(testMseIncremental) {
 
     // Test incremental training for the MSE objective.
 
+    using TTargetFunc = std::function<double(const TRowRef&)>;
+
     test::CRandomNumbers rng;
     double noiseVariance{100.0};
-    std::size_t trainRows{200};
-    std::size_t testRows{100};
-    std::size_t extraTrainingRows{50};
-    std::size_t rows{trainRows + testRows};
+    std::size_t rows{300};
     std::size_t cols{6};
+    std::size_t extraTrainingRows{50};
 
-    auto target = [&] {
-        TDoubleVec m;
-        TDoubleVec s;
-        rng.generateUniformSamples(0.0, 10.0, cols - 1, m);
-        rng.generateUniformSamples(-10.0, 10.0, cols - 1, s);
-        double offset{0.0};
-        return [=](const TRowRef& row) {
+    TTargetFunc target;
+    TTargetFunc perturbedTarget;
+    std::tie(target, perturbedTarget) = [&] {
+        TDoubleVec p;
+        TDoubleVec v;
+        TDoubleVec dv;
+        rng.generateUniformSamples(0.0, 10.0, 2 * cols - 2, p);
+        rng.generateUniformSamples(-10.0, 10.0, cols - 1, v);
+        rng.generateUniformSamples(-0.5, 1.0, cols - 1, dv);
+        for (std::size_t i = 0; i < p.size(); i += 2) {
+            std::sort(p.begin() + i, p.begin() + i + 2);
+        }
+
+        auto target_ = [=](const TRowRef& row) {
             double result{0.0};
             for (std::size_t i = 0; i < cols - 1; ++i) {
-                result += m[i] + s[i] * row[i];
+                if (row[i] >= p[2 * i] && row[i] < p[2 * i + 1]) {
+                    result += v[i];
+                }
             }
-            return offset + result;
+            return result;
         };
+        auto perturbedTarget_ = [=](const TRowRef& row) {
+            double result{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                if (row[i] >= p[2 * i] && row[i] < p[2 * i + 1]) {
+                    result += v[i] + std::max(dv[i], 0.0);
+                }
+            }
+            return result;
+        };
+
+        return std::make_pair(target_, perturbedTarget_);
     }();
 
     TDoubleVecVec x(cols - 1);
@@ -735,7 +751,7 @@ BOOST_AUTO_TEST_CASE(testMseIncremental) {
 
     auto frame = core::makeMainStorageDataFrame(cols).first;
 
-    fillDataFrame(trainRows, testRows, cols, x, noise, target, *frame);
+    fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
     auto regression = maths::CBoostedTreeFactory::constructFromParameters(
                           1, std::make_unique<maths::boosted_tree::CMse>())
@@ -743,19 +759,46 @@ BOOST_AUTO_TEST_CASE(testMseIncremental) {
 
     regression->train();
 
+    frame->resizeColumns(1, cols);
     auto newFrame = core::makeMainStorageDataFrame(cols).first;
 
-    fillDataFrame(trainRows, testRows, cols, x, noise, target, *newFrame);
+    fillDataFrame(rows, 0, cols, x, noise, target, *newFrame);
 
     for (std::size_t i = 0; i < cols - 1; ++i) {
         rng.generateUniformSamples(0.0, 10.0, extraTrainingRows, x[i]);
     }
     rng.generateNormalSamples(0.0, noiseVariance, extraTrainingRows, noise);
 
-    fillDataFrame(extraTrainingRows, 0, cols, x, noise, target, *newFrame);
+    fillDataFrame(extraTrainingRows, 0, cols, x, noise, perturbedTarget, *frame);
+    fillDataFrame(extraTrainingRows, 0, cols, x, noise, perturbedTarget, *newFrame);
 
-    core::CPackedBitVector newTrainingRowMask(rows, false);
-    newTrainingRowMask.extend(true, extraTrainingRows);
+    core::CPackedBitVector oldTrainingRowMask{rows, true};
+    oldTrainingRowMask.extend(false, extraTrainingRows);
+    core::CPackedBitVector newTrainingRowMask{~oldTrainingRowMask};
+
+    double mseBeforeIncrementalTraining[]{0.0, 0.0};
+    double mseAfterIncrementalTraining[]{0.0, 0.0};
+
+    frame->resizeColumns(1, cols + 1);
+    regression->predict();
+
+    // Get the average error on the old and new training data from the old model.
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            mseBeforeIncrementalTraining[0] += maths::CTools::pow2(
+                                (*row)[cols - 1] - regression->readPrediction(*row)[0]);
+                        }
+                    },
+                    &oldTrainingRowMask);
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            mseBeforeIncrementalTraining[1] += maths::CTools::pow2(
+                                (*row)[cols - 1] - regression->readPrediction(*row)[0]);
+                        }
+                    },
+                    &newTrainingRowMask);
 
     regression = maths::CBoostedTreeFactory::constructFromModel(std::move(regression))
                      .newTrainingRowMask(newTrainingRowMask)
@@ -763,6 +806,26 @@ BOOST_AUTO_TEST_CASE(testMseIncremental) {
 
     regression->trainIncremental();
     regression->predict();
+
+    // Get the average error on the old and new training data from the new model.
+    newFrame->readRows(1, 0, frame->numberRows(),
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               mseAfterIncrementalTraining[0] += maths::CTools::pow2(
+                                   (*row)[cols - 1] - regression->readPrediction(*row)[0]);
+                           }
+                       },
+                       &oldTrainingRowMask);
+    newFrame->readRows(1, 0, frame->numberRows(),
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               mseAfterIncrementalTraining[1] += maths::CTools::pow2(
+                                   (*row)[cols - 1] - regression->readPrediction(*row)[0]);
+                           }
+                       },
+                       &newTrainingRowMask);
+
+    // TODO test
 }
 
 BOOST_AUTO_TEST_CASE(testThreading) {


### PR DESCRIPTION
This builds out the unit testing of incremental training QoR and fixes the bugs in:
1. The initialisation of the loss derivatives,
2. The initialisation of the predictions and previous predictions,
3. The value of `eta` to use for the retrained tree.

We also need to ensure that the feature bag includes the features used in the original tree so we can make the same choice again if it is appropriate.

(The test is still WIP, but I think there are enough fixes in this PR to be worthwhile pushing, so it doesn't hold up evaluation on real data sets.)