### PR TITLE
[ML] Data summarization num rows in model metadata

### DIFF
--- a/include/api/CDataSummarizationJsonTags.h
+++ b/include/api/CDataSummarizationJsonTags.h
@@ -16,17 +16,18 @@ namespace api {
 
 //! \brief Shared tags used by the JSON data summarization object.
 struct API_EXPORT CDataSummarizationJsonTags {
+    static const std::string JSON_CATEGORICAL_COLUMN_VALUES_TAG;
+    static const std::string JSON_COLUMN_IS_CATEGORICAL_TAG;
+    static const std::string JSON_COLUMN_NAMES_TAG;
     static const std::string JSON_COMPRESSED_DATA_SUMMARIZATION_TAG;
     static const std::string JSON_DATA_SUMMARIZATION_TAG;
-    static const std::string JSON_NUM_COLUMNS_TAG;
-    static const std::string JSON_COLUMN_NAMES_TAG;
-    static const std::string JSON_COLUMN_IS_CATEGORICAL_TAG;
-    static const std::string JSON_CATEGORICAL_COLUMN_VALUES_TAG;
-    static const std::string JSON_ENCODING_NAME_INDEX_MAP_TAG;
+    static const std::string JSON_DATA_TAG;
     static const std::string JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG;
+    static const std::string JSON_ENCODING_NAME_INDEX_MAP_TAG;
     static const std::string JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG;
     static const std::string JSON_ENCODINGS_TAG;
-    static const std::string JSON_DATA_TAG;
+    static const std::string JSON_NUM_COLUMNS_TAG;
+    static const std::string JSON_NUM_ROWS_TAG;
 };
 }
 }

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -29,6 +29,7 @@ public:
     static const std::string JSON_BASELINE_TAG;
     static const std::string JSON_CLASS_NAME_TAG;
     static const std::string JSON_CLASSES_TAG;
+    static const std::string JSON_DATA_SUMMARIZATION_TAG;
     static const std::string JSON_FEATURE_IMPORTANCE_BASELINE_TAG;
     static const std::string JSON_FEATURE_NAME_TAG;
     static const std::string JSON_HYPERPARAMETERS_TAG;
@@ -40,6 +41,7 @@ public:
     static const std::string JSON_MEAN_MAGNITUDE_TAG;
     static const std::string JSON_MIN_TAG;
     static const std::string JSON_MODEL_METADATA_TAG;
+    static const std::string JSON_NUM_ROWS_TAG;
     static const std::string JSON_RELATIVE_IMPORTANCE_TAG;
     static const std::string JSON_TOTAL_FEATURE_IMPORTANCE_TAG;
 
@@ -64,6 +66,7 @@ public:
     //! to the baseline value).
     void featureImportanceBaseline(TVector&& baseline);
     void hyperparameterImportance(const maths::CBoostedTree::THyperparameterImportanceVec& hyperparameterImportance);
+    void dataSummarizationNumRows(std::size_t numRows);
 
 private:
     struct SHyperparameterImportance {
@@ -88,6 +91,7 @@ private:
     void writeTotalFeatureImportance(TRapidJsonWriter& writer) const;
     void writeHyperparameterImportance(TRapidJsonWriter& writer) const;
     void writeFeatureImportanceBaseline(TRapidJsonWriter& writer) const;
+    void writeDataSummarizationMetadata(TRapidJsonWriter& writer) const;
 
 private:
     TSizeMeanAccumulatorUMap m_TotalShapValuesMean;
@@ -100,6 +104,7 @@ private:
             writer.String(value);
         };
     THyperparametersVec m_HyperparameterImportance;
+    std::size_t m_DataSummarizationNumRows{0};
 };
 }
 }

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -91,7 +91,7 @@ private:
     void writeTotalFeatureImportance(TRapidJsonWriter& writer) const;
     void writeHyperparameterImportance(TRapidJsonWriter& writer) const;
     void writeFeatureImportanceBaseline(TRapidJsonWriter& writer) const;
-    void writeDataSummarizationMetadata(TRapidJsonWriter& writer) const;
+    void writeDataSummarization(TRapidJsonWriter& writer) const;
 
 private:
     TSizeMeanAccumulatorUMap m_TotalShapValuesMean;

--- a/jupyter/notebooks/utils/misc.py
+++ b/jupyter/notebooks/utils/misc.py
@@ -199,6 +199,19 @@ class Job:
                                     ] = hyperparameter['value']
         return hyperparameters
 
+    def get_data_summarization_num_rows(self)->int:
+        """Get the number of examples used in data summarization.
+
+        Returns:
+            int: number of examples
+        """
+        num_rows = 0
+        for item in self.results:
+            if 'model_metadata' in item:
+                if 'data_summarization' in item['model_metadata']:
+                    num_rows = item['model_metadata']['data_summarization']['num_rows']
+        return num_rows
+
     def get_model_definition(self) -> dict:
         """
         Get model definition json.
@@ -361,7 +374,7 @@ def update(dataset_name: str, dataset: pandas.DataFrame, original_job: Job, verb
     fdata.file.close()
     with open('../configs/{}.json'.format(dataset_name)) as fc:
         config = json.load(fc)
-    config['rows'] = dataset.shape[0]
+    config['rows'] = dataset.shape[0] + original_job.get_data_summarization_num_rows()
     for name, value  in original_job.get_hyperparameters().items():
         config['analysis']['parameters'][name] = value
     config['analysis']['parameters']['task'] = 'update'

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -331,7 +331,8 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
         m_InferenceModelMetadata.hyperparameterImportance(
             this->boostedTree().hyperparameterImportance());
     }
-    std::size_t dataSummarizationNumRows{static_cast<std::size_t>(this->boostedTree().dataSummarization().manhattan())};
+    std::size_t dataSummarizationNumRows{static_cast<std::size_t>(
+        this->boostedTree().dataSummarization().manhattan())};
     if (dataSummarizationNumRows > 0) {
         m_InferenceModelMetadata.dataSummarizationNumRows(dataSummarizationNumRows);
     }

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -331,6 +331,10 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
         m_InferenceModelMetadata.hyperparameterImportance(
             this->boostedTree().hyperparameterImportance());
     }
+    std::size_t dataSummarizationNumRows{static_cast<std::size_t>(this->boostedTree().dataSummarization().manhattan())};
+    if (dataSummarizationNumRows > 0) {
+        m_InferenceModelMetadata.dataSummarizationNumRows(dataSummarizationNumRows);
+    }
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -164,6 +164,10 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
         m_InferenceModelMetadata.hyperparameterImportance(
             this->boostedTree().hyperparameterImportance());
     }
+    std::size_t dataSummarizationNumRows{static_cast<std::size_t>(this->boostedTree().dataSummarization().manhattan())};
+    if (dataSummarizationNumRows > 0) {
+        m_InferenceModelMetadata.dataSummarizationNumRows(dataSummarizationNumRows);
+    }
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -164,7 +164,8 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
         m_InferenceModelMetadata.hyperparameterImportance(
             this->boostedTree().hyperparameterImportance());
     }
-    std::size_t dataSummarizationNumRows{static_cast<std::size_t>(this->boostedTree().dataSummarization().manhattan())};
+    std::size_t dataSummarizationNumRows{static_cast<std::size_t>(
+        this->boostedTree().dataSummarization().manhattan())};
     if (dataSummarizationNumRows > 0) {
         m_InferenceModelMetadata.dataSummarizationNumRows(dataSummarizationNumRows);
     }

--- a/lib/api/CDataSummarizationJsonTags.cc
+++ b/lib/api/CDataSummarizationJsonTags.cc
@@ -9,17 +9,18 @@
 namespace ml {
 namespace api {
 // clang-format off
+const std::string CDataSummarizationJsonTags::JSON_CATEGORICAL_COLUMN_VALUES_TAG{"categorical_column_values"};
+const std::string CDataSummarizationJsonTags::JSON_COLUMN_IS_CATEGORICAL_TAG{"column_is_categorical"};
+const std::string CDataSummarizationJsonTags::JSON_COLUMN_NAMES_TAG{"column_names"};
 const std::string CDataSummarizationJsonTags::JSON_COMPRESSED_DATA_SUMMARIZATION_TAG{"compressed_data_summarization"};
 const std::string CDataSummarizationJsonTags::JSON_DATA_SUMMARIZATION_TAG{"data_summarization"};
-const std::string CDataSummarizationJsonTags::JSON_NUM_COLUMNS_TAG{"num_columns"};
-const std::string CDataSummarizationJsonTags::JSON_COLUMN_NAMES_TAG{"column_names"};
-const std::string CDataSummarizationJsonTags::JSON_COLUMN_IS_CATEGORICAL_TAG{"column_is_categorical"};
-const std::string CDataSummarizationJsonTags::JSON_CATEGORICAL_COLUMN_VALUES_TAG{"categorical_column_values"};
-const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_TAG{"encodings_indices"};
+const std::string CDataSummarizationJsonTags::JSON_DATA_TAG{"data"};
 const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_KEY_TAG{"encoding_name"};
+const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_TAG{"encodings_indices"};
 const std::string CDataSummarizationJsonTags::JSON_ENCODING_NAME_INDEX_MAP_VALUE_TAG{"encoding_index"};
 const std::string CDataSummarizationJsonTags::JSON_ENCODINGS_TAG{"encodings"};
-const std::string CDataSummarizationJsonTags::JSON_DATA_TAG{"data"};
+const std::string CDataSummarizationJsonTags::JSON_NUM_COLUMNS_TAG{"num_columns"};
+const std::string CDataSummarizationJsonTags::JSON_NUM_ROWS_TAG{"num_rows"};
 // clang-format on
 }
 }

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -19,6 +19,7 @@ void CInferenceModelMetadata::write(TRapidJsonWriter& writer) const {
     this->writeTotalFeatureImportance(writer);
     this->writeFeatureImportanceBaseline(writer);
     this->writeHyperparameterImportance(writer);
+    this->writeDataSummarizationMetadata(writer);
 }
 
 void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writer) const {
@@ -171,6 +172,16 @@ void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& wr
     writer.EndArray();
 }
 
+void CInferenceModelMetadata::writeDataSummarizationMetadata(TRapidJsonWriter& writer) const {
+    if (m_DataSummarizationNumRows > 0) {
+        writer.Key(JSON_DATA_SUMMARIZATION_TAG);
+        writer.StartObject();
+        writer.Key(JSON_NUM_ROWS_TAG);
+        writer.Uint64(m_DataSummarizationNumRows);
+        writer.EndObject();
+    }
+}
+
 const std::string& CInferenceModelMetadata::typeString() {
     return JSON_MODEL_METADATA_TAG;
 }
@@ -266,11 +277,17 @@ void CInferenceModelMetadata::hyperparameterImportance(
               });
 }
 
+void CInferenceModelMetadata::dataSummarizationNumRows(std::size_t numRows) {
+    m_DataSummarizationNumRows = numRows;
+}
+
 // clang-format off
 const std::string CInferenceModelMetadata::JSON_ABSOLUTE_IMPORTANCE_TAG{"absolute_importance"};
 const std::string CInferenceModelMetadata::JSON_BASELINE_TAG{"baseline"};
 const std::string CInferenceModelMetadata::JSON_CLASS_NAME_TAG{"class_name"};
 const std::string CInferenceModelMetadata::JSON_CLASSES_TAG{"classes"};
+const std::string CInferenceModelMetadata::JSON_DATA_SUMMARIZATION_TAG{"data_summarization"};
+const std::string CInferenceModelMetadata::JSON_NUM_ROWS_TAG{"num_rows"};
 const std::string CInferenceModelMetadata::JSON_FEATURE_IMPORTANCE_BASELINE_TAG{"feature_importance_baseline"};
 const std::string CInferenceModelMetadata::JSON_FEATURE_NAME_TAG{"feature_name"};
 const std::string CInferenceModelMetadata::JSON_HYPERPARAMETERS_TAG{"hyperparameters"};

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -19,7 +19,7 @@ void CInferenceModelMetadata::write(TRapidJsonWriter& writer) const {
     this->writeTotalFeatureImportance(writer);
     this->writeFeatureImportanceBaseline(writer);
     this->writeHyperparameterImportance(writer);
-    this->writeDataSummarizationMetadata(writer);
+    this->writeDataSummarization(writer);
 }
 
 void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writer) const {
@@ -172,7 +172,8 @@ void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& wr
     writer.EndArray();
 }
 
-void CInferenceModelMetadata::writeDataSummarizationMetadata(TRapidJsonWriter& writer) const {
+void CInferenceModelMetadata::writeDataSummarization(TRapidJsonWriter& writer) const {
+    // only write out if data summarization exists
     if (m_DataSummarizationNumRows > 0) {
         writer.Key(JSON_DATA_SUMMARIZATION_TAG);
         writer.StartObject();

--- a/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
+++ b/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
@@ -5,8 +5,19 @@
     "title": "model_meta_data",
     "type": "object",
     "properties": {
+        "data_summarization": {
+            "description": "Information regarding data summarization for incremental learning.",
+            "type": "object",
+            "properties": {
+                "num_rows": {
+                    "type": "number"
+                }
+            },
+            "required": ["num_rows"],
+            "additionalProperties": false
+        },
         "total_feature_importance": {
-            "description": "Average feature importance for all features used by the model",
+            "description": "Average feature importance for all features used by the model.",
             "type": "array",
             "items": {
                 "type": "object",


### PR DESCRIPTION
We write a number of rows in data summarization as a part of model metadata. This helps to estimate the correct number of rows for incremental learning.