### PR TITLE
[ML] Don't link libnsl on Linux when USE_NET is defined

### DIFF
--- a/mk/linux.mk
+++ b/mk/linux.mk
@@ -48,7 +48,7 @@ SHELL_SCRIPT_EXT=.sh
 UT_TMP_DIR=/tmp/$(LOGNAME)
 RESOURCES_DIR=resources
 LOCALLIBS=-lm -lpthread -ldl -lrt
-NETLIBS=-lnsl
+NETLIBS=
 BOOSTVER=1_71
 ifeq ($(HARDWARE_ARCH),aarch64)
 BOOSTARCH=a64

--- a/mk/linux_crosscompile_linux.mk
+++ b/mk/linux_crosscompile_linux.mk
@@ -49,7 +49,7 @@ SHELL_SCRIPT_EXT=.sh
 UT_TMP_DIR=/tmp/$(LOGNAME)
 RESOURCES_DIR=resources
 LOCALLIBS=-lm -lpthread -ldl -lrt
-NETLIBS=-lnsl
+NETLIBS=
 BOOSTVER=1_71
 ifeq ($(HARDWARE_ARCH),aarch64)
 BOOSTARCH=a64


### PR DESCRIPTION
#1933 shows that libnsl is no longer present on newer Linux distributions. The library should not be required on Linux as we do not use the networking functions.

This change makes setting `USE_NET=1` in a makefile a no-op for Linux and macOS, on Windows `WS2_32.lib` is linked (for the network to host byte order functions in one case). 

Closes #1933 