### PR TITLE
[ML] Time inference calls in the pytorch app

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -31,9 +31,9 @@
 namespace {
 const std::string INFERENCE{"inference"};
 const std::string ERROR{"error"};
-const std::string TIME{"time"};
+const std::string TIME_MS{"time_ms"};
 
-ml::core::CStopWatch stopWatch; 
+ml::core::CStopWatch stopWatch;
 }
 
 torch::Tensor infer(torch::jit::script::Module& module,
@@ -103,12 +103,12 @@ void writeError(const std::string& requestId,
 }
 
 void writeDocumentOpening(const std::string& requestId,
-                          std::uint64_t timeMs,  
+                          std::uint64_t timeMs,
                           ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
     jsonWriter.StartObject();
     jsonWriter.Key(ml::torch::CCommandParser::REQUEST_ID);
     jsonWriter.String(requestId);
-    jsonWriter.Key(TIME);
+    jsonWriter.Key(TIME_MS);
     jsonWriter.Uint64(timeMs);
     jsonWriter.Key(INFERENCE);
     jsonWriter.StartArray();
@@ -153,7 +153,7 @@ void writePrediction(const torch::Tensor& prediction,
 bool handleRequest(ml::torch::CCommandParser::SRequest& request,
                    torch::jit::script::Module& module,
                    ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
-    
+
     try {
         LOG_DEBUG(<< "Inference request with id: " << request.s_RequestId);
         stopWatch.reset(true);

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -8,6 +8,7 @@
 #include <core/CLogger.h>
 #include <core/CProcessPriority.h>
 #include <core/CRapidJsonLineWriter.h>
+#include <core/CStopWatch.h>
 
 #include <seccomp/CSystemCallFilter.h>
 
@@ -30,6 +31,9 @@
 namespace {
 const std::string INFERENCE{"inference"};
 const std::string ERROR{"error"};
+const std::string TIME{"time"};
+
+ml::core::CStopWatch stopWatch; 
 }
 
 torch::Tensor infer(torch::jit::script::Module& module,
@@ -99,10 +103,13 @@ void writeError(const std::string& requestId,
 }
 
 void writeDocumentOpening(const std::string& requestId,
+                          std::uint64_t timeMs,  
                           ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
     jsonWriter.StartObject();
     jsonWriter.Key(ml::torch::CCommandParser::REQUEST_ID);
     jsonWriter.String(requestId);
+    jsonWriter.Key(TIME);
+    jsonWriter.Uint64(timeMs);
     jsonWriter.Key(INFERENCE);
     jsonWriter.StartArray();
 }
@@ -115,6 +122,7 @@ void writeDocumentClosing(ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapp
 template<std::size_t N>
 void writePrediction(const torch::Tensor& prediction,
                      const std::string& requestId,
+                     std::uint64_t timeMs,
                      ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
 
     // creating the accessor will throw if the tensor does
@@ -125,14 +133,14 @@ void writePrediction(const torch::Tensor& prediction,
     if (prediction.dtype() == torch::kFloat32) {
         auto accessor = prediction.accessor<float, N>();
 
-        writeDocumentOpening(requestId, jsonWriter);
+        writeDocumentOpening(requestId, timeMs, jsonWriter);
         writeTensor(accessor, jsonWriter);
         writeDocumentClosing(jsonWriter);
 
     } else if (prediction.dtype() == torch::kFloat64) {
         auto accessor = prediction.accessor<double, N>();
 
-        writeDocumentOpening(requestId, jsonWriter);
+        writeDocumentOpening(requestId, timeMs, jsonWriter);
         writeTensor(accessor, jsonWriter);
         writeDocumentClosing(jsonWriter);
     } else {
@@ -145,19 +153,22 @@ void writePrediction(const torch::Tensor& prediction,
 bool handleRequest(ml::torch::CCommandParser::SRequest& request,
                    torch::jit::script::Module& module,
                    ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+    
     try {
         LOG_DEBUG(<< "Inference request with id: " << request.s_RequestId);
+        stopWatch.reset(true);
         torch::Tensor results = infer(module, request);
+        std::uint64_t timeMs = stopWatch.stop();
         LOG_DEBUG(<< "Got results for request with id: " << request.s_RequestId);
         auto sizes = results.sizes();
         // Some models return a 3D tensor in which case
         // the first dimension must have size == 1
         if (sizes.size() == 3 && sizes[0] == 1) {
-            writePrediction<2>(results[0], request.s_RequestId, jsonWriter);
+            writePrediction<2>(results[0], request.s_RequestId, timeMs, jsonWriter);
         } else if (sizes.size() == 2) {
-            writePrediction<2>(results, request.s_RequestId, jsonWriter);
+            writePrediction<2>(results, request.s_RequestId, timeMs, jsonWriter);
         } else if (sizes.size() == 1) {
-            writePrediction<1>(results, request.s_RequestId, jsonWriter);
+            writePrediction<1>(results, request.s_RequestId, timeMs, jsonWriter);
         } else {
             std::ostringstream ss;
             ss << "Cannot convert results tensor of size [" << sizes << "]";

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -166,7 +166,7 @@ def main():
                     tolerance = test_evaluation[doc_count]['how_close']                    
 
 
-                total_time_ms += result['time']
+                total_time_ms += result['time_ms']
 
 
                 # compare to expected

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -149,6 +149,7 @@ def main():
         print("reading results...", flush=True)
         with open(args.output_file) as output_file:
 
+            total_time_ms = 0
             doc_count = 0
             results_match = True
             try:
@@ -164,6 +165,10 @@ def main():
                 if 'how_close' in test_evaluation[doc_count]:
                     tolerance = test_evaluation[doc_count]['how_close']                    
 
+
+                total_time_ms += result['time']
+
+
                 # compare to expected
                 if compare_results(expected, result, tolerance) == False:
                     print()
@@ -172,6 +177,10 @@ def main():
                     results_match = False
 
                 doc_count = doc_count +1
+
+            print()
+            print('{} requests evaluated in {} ms'.format(doc_count, total_time_ms))
+            print()
 
             if doc_count != len(test_evaluation): 
                 print()


### PR DESCRIPTION
Adds a stopwatch timer and records the time in milliseconds for each inference call. The time is reported back in the result document. 

The total round trip time for an inference API call will also be of interest but this measure eliminates the vagaries of network overhead by being as close as possible to the libtorch call. 