### PR TITLE
[ML] Add validElasticLicenseKeyConfirmed command line arg to ml-cpp binaries (#1944)

### DIFF
--- a/bin/autodetect/CCmdLineParser.cc
+++ b/bin/autodetect/CCmdLineParser.cc
@@ -45,7 +45,8 @@ bool CCmdLineParser::parse(int argc,
                            bool& isPersistFileNamedPipe,
                            bool& isPersistInForeground,
                            std::size_t& maxAnomalyRecords,
-                           bool& memoryUsage) {
+                           bool& memoryUsage,
+                           bool& validElasticLicenseKeyConfirmed) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
         // clang-format off
@@ -95,7 +96,9 @@ bool CCmdLineParser::parse(int argc,
                     "The maximum number of records to be outputted for each bucket. Defaults to 100, a value 0 removes the limit.")
             ("memoryUsage",
                     "Log the model memory usage at the end of the job")
-        ;
+            ("validElasticLicenseKeyConfirmed", boost::program_options::value<bool>(),
+                    "Confirmation that a valid Elastic license key is in use.")
+            ;
         // clang-format on
         boost::program_options::variables_map vm;
         boost::program_options::store(
@@ -188,6 +191,10 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("memoryUsage") > 0) {
             memoryUsage = true;
+        }
+        if (vm.count("validElasticLicenseKeyConfirmed") > 0) {
+            validElasticLicenseKeyConfirmed =
+                vm["validElasticLicenseKeyConfirmed"].as<bool>();
         }
     } catch (std::exception& e) {
         std::cerr << "Error processing command line: " << e.what() << std::endl;

--- a/bin/autodetect/CCmdLineParser.h
+++ b/bin/autodetect/CCmdLineParser.h
@@ -57,7 +57,8 @@ public:
                       bool& isPersistFileNamedPipe,
                       bool& isPersistInForeground,
                       std::size_t& maxAnomalyRecords,
-                      bool& memoryUsage);
+                      bool& memoryUsage,
+                      bool& validElasticLicenseKeyConfirmed);
 
 private:
     static const std::string DESCRIPTION;

--- a/bin/autodetect/Main.cc
+++ b/bin/autodetect/Main.cc
@@ -109,14 +109,15 @@ int main(int argc, char** argv) {
     bool isPersistInForeground{false};
     std::size_t maxAnomalyRecords{100};
     bool memoryUsage{false};
+    bool validElasticLicenseKeyConfirmed{true};
     if (ml::autodetect::CCmdLineParser::parse(
             argc, argv, configFile, filtersConfigFile, eventsConfigFile,
             modelConfigFile, logProperties, logPipe, delimiter, lengthEncodedInput,
             timeFormat, quantilesStateFile, deleteStateFiles, bucketPersistInterval,
-            namedPipeConnectTimeout, inputFileName, isInputFileNamedPipe,
-            outputFileName, isOutputFileNamedPipe, restoreFileName,
-            isRestoreFileNamedPipe, persistFileName, isPersistFileNamedPipe,
-            isPersistInForeground, maxAnomalyRecords, memoryUsage) == false) {
+            namedPipeConnectTimeout, inputFileName, isInputFileNamedPipe, outputFileName,
+            isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe,
+            persistFileName, isPersistFileNamedPipe, isPersistInForeground,
+            maxAnomalyRecords, memoryUsage, validElasticLicenseKeyConfirmed) == false) {
         return EXIT_FAILURE;
     }
 
@@ -148,6 +149,11 @@ int main(int argc, char** argv) {
     // must be done from the program, and NOT a shared library, as each program
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
+
+    if (validElasticLicenseKeyConfirmed == false) {
+        LOG_FATAL(<< "Failed to confirm valid license key.");
+        return EXIT_FAILURE;
+    }
 
     // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();

--- a/bin/categorize/CCmdLineParser.cc
+++ b/bin/categorize/CCmdLineParser.cc
@@ -36,7 +36,8 @@ bool CCmdLineParser::parse(int argc,
                            std::string& persistFileName,
                            bool& isPersistFileNamedPipe,
                            bool& isPersistInForeground,
-                           std::string& categorizationFieldName) {
+                           std::string& categorizationFieldName,
+                           bool& validElasticLicenseKeyConfirmed) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
         // clang-format off
@@ -74,6 +75,8 @@ bool CCmdLineParser::parse(int argc,
             ("persistInForeground", "Persistence occurs in the foreground. Defaults to background persistence.")
             ("categorizationfield", boost::program_options::value<std::string>(),
                     "Field to compute mlcategory from")
+            ("validElasticLicenseKeyConfirmed", boost::program_options::value<bool>(),
+             "Confirmation that a valid Elastic license key is in use.")
         ;
         // clang-format on
 
@@ -143,6 +146,10 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("categorizationfield") > 0) {
             categorizationFieldName = vm["categorizationfield"].as<std::string>();
+        }
+        if (vm.count("validElasticLicenseKeyConfirmed") > 0) {
+            validElasticLicenseKeyConfirmed =
+                vm["validElasticLicenseKeyConfirmed"].as<bool>();
         }
     } catch (std::exception& e) {
         std::cerr << "Error processing command line: " << e.what() << std::endl;

--- a/bin/categorize/CCmdLineParser.h
+++ b/bin/categorize/CCmdLineParser.h
@@ -47,7 +47,8 @@ public:
                       std::string& persistFileName,
                       bool& isPersistFileNamedPipe,
                       bool& isPersistInForeground,
-                      std::string& categorizationFieldName);
+                      std::string& categorizationFieldName,
+                      bool& validElasticLicenseKeyConfirmed);
 
 private:
     static const std::string DESCRIPTION;

--- a/bin/categorize/Main.cc
+++ b/bin/categorize/Main.cc
@@ -84,12 +84,14 @@ int main(int argc, char** argv) {
     bool isPersistFileNamedPipe{false};
     bool isPersistInForeground{false};
     std::string categorizationFieldName;
+    bool validElasticLicenseKeyConfirmed{true};
     if (ml::categorize::CCmdLineParser::parse(
             argc, argv, limitConfigFile, jobId, logProperties, logPipe, delimiter,
-            lengthEncodedInput, persistInterval, namedPipeConnectTimeout, inputFileName,
-            isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe, restoreFileName,
-            isRestoreFileNamedPipe, persistFileName, isPersistFileNamedPipe,
-            isPersistInForeground, categorizationFieldName) == false) {
+            lengthEncodedInput, persistInterval, namedPipeConnectTimeout,
+            inputFileName, isInputFileNamedPipe, outputFileName,
+            isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe,
+            persistFileName, isPersistFileNamedPipe, isPersistInForeground,
+            categorizationFieldName, validElasticLicenseKeyConfirmed) == false) {
         return EXIT_FAILURE;
     }
 
@@ -121,6 +123,11 @@ int main(int argc, char** argv) {
     // must be done from the program, and NOT a shared library, as each program
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
+
+    if (validElasticLicenseKeyConfirmed == false) {
+        LOG_FATAL(<< "Failed to confirm valid license key.");
+        return EXIT_FAILURE;
+    }
 
     // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();

--- a/bin/data_frame_analyzer/CCmdLineParser.cc
+++ b/bin/data_frame_analyzer/CCmdLineParser.cc
@@ -32,7 +32,8 @@ bool CCmdLineParser::parse(int argc,
                            std::string& restoreFileName,
                            bool& isRestoreFileNamedPipe,
                            std::string& persistFileName,
-                           bool& isPersistFileNamedPipe) {
+                           bool& isPersistFileNamedPipe,
+                           bool& validElasticLicenseKeyConfirmed) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
         // clang-format off
@@ -62,6 +63,8 @@ bool CCmdLineParser::parse(int argc,
             ("persist", boost::program_options::value<std::string>(),
                     "File to persist state to - not present means no state persistence")
             ("persistIsPipe", "Specified persist file is a named pipe")
+            ("validElasticLicenseKeyConfirmed", boost::program_options::value<bool>(),
+             "Confirmation that a valid Elastic license key is in use.")
         ;
         // clang-format on
 
@@ -119,6 +122,10 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("persistIsPipe") > 0) {
             isPersistFileNamedPipe = true;
+        }
+        if (vm.count("validElasticLicenseKeyConfirmed") > 0) {
+            validElasticLicenseKeyConfirmed =
+                vm["validElasticLicenseKeyConfirmed"].as<bool>();
         }
     } catch (std::exception& e) {
         std::cerr << "Error processing command line: " << e.what() << std::endl;

--- a/bin/data_frame_analyzer/CCmdLineParser.h
+++ b/bin/data_frame_analyzer/CCmdLineParser.h
@@ -41,7 +41,8 @@ public:
                       std::string& restoreFileName,
                       bool& isRestoreFileNamedPipe,
                       std::string& persistFileName,
-                      bool& isPersistFileNamedPipe);
+                      bool& isPersistFileNamedPipe,
+                      bool& validElasticLicenseKeyConfirmed);
 
 private:
     static const std::string DESCRIPTION;

--- a/bin/data_frame_analyzer/Main.cc
+++ b/bin/data_frame_analyzer/Main.cc
@@ -98,11 +98,13 @@ int main(int argc, char** argv) {
     bool isRestoreFileNamedPipe{false};
     std::string persistFileName;
     bool isPersistFileNamedPipe{false};
+    bool validElasticLicenseKeyConfirmed{true};
     if (ml::data_frame_analyzer::CCmdLineParser::parse(
             argc, argv, configFile, memoryUsageEstimationOnly, logProperties,
             logPipe, lengthEncodedInput, namedPipeConnectTimeout, inputFileName,
-            isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe, restoreFileName,
-            isRestoreFileNamedPipe, persistFileName, isPersistFileNamedPipe) == false) {
+            isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe,
+            restoreFileName, isRestoreFileNamedPipe, persistFileName,
+            isPersistFileNamedPipe, validElasticLicenseKeyConfirmed) == false) {
         return EXIT_FAILURE;
     }
 
@@ -139,6 +141,11 @@ int main(int argc, char** argv) {
     // must be done from the program, and NOT a shared library, as each program
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
+
+    if (validElasticLicenseKeyConfirmed == false) {
+        LOG_FATAL(<< "Failed to confirm valid license key.");
+        return EXIT_FAILURE;
+    }
 
     // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();

--- a/bin/normalize/CCmdLineParser.cc
+++ b/bin/normalize/CCmdLineParser.cc
@@ -31,7 +31,8 @@ bool CCmdLineParser::parse(int argc,
                            bool& isOutputFileNamedPipe,
                            std::string& quantilesState,
                            bool& deleteStateFiles,
-                           bool& writeCsv) {
+                           bool& writeCsv,
+                           bool& validElasticLicenseKeyConfirmed) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
         // clang-format off
@@ -62,6 +63,8 @@ bool CCmdLineParser::parse(int argc,
                     "If this flag is set then delete the normalizer state files once they have been read")
             ("writeCsv",
                     "Write the results in CSV format (default is ND-JSON)")
+            ("validElasticLicenseKeyConfirmed", boost::program_options::value<bool>(),
+             "Confirmation that a valid Elastic license key is in use.")
         ;
         // clang-format on
 
@@ -116,6 +119,10 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("writeCsv") > 0) {
             writeCsv = true;
+        }
+        if (vm.count("validElasticLicenseKeyConfirmed") > 0) {
+            validElasticLicenseKeyConfirmed =
+                vm["validElasticLicenseKeyConfirmed"].as<bool>();
         }
     } catch (std::exception& e) {
         std::cerr << "Error processing command line: " << e.what() << std::endl;

--- a/bin/normalize/CCmdLineParser.h
+++ b/bin/normalize/CCmdLineParser.h
@@ -44,7 +44,8 @@ public:
                       bool& isOutputFileNamedPipe,
                       std::string& quantilesState,
                       bool& deleteStateFiles,
-                      bool& writeCsv);
+                      bool& writeCsv,
+                      bool& validElasticLicenseKeyConfirmed);
 
 private:
     static const std::string DESCRIPTION;

--- a/bin/normalize/Main.cc
+++ b/bin/normalize/Main.cc
@@ -56,11 +56,12 @@ int main(int argc, char** argv) {
     std::string quantilesStateFile;
     bool deleteStateFiles{false};
     bool writeCsv{false};
+    bool validElasticLicenseKeyConfirmed{true};
     if (ml::normalize::CCmdLineParser::parse(
             argc, argv, modelConfigFile, logProperties, logPipe, bucketSpan,
             lengthEncodedInput, namedPipeConnectTimeout, inputFileName,
-            isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe,
-            quantilesStateFile, deleteStateFiles, writeCsv) == false) {
+            isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe, quantilesStateFile,
+            deleteStateFiles, writeCsv, validElasticLicenseKeyConfirmed) == false) {
         return EXIT_FAILURE;
     }
 
@@ -90,6 +91,11 @@ int main(int argc, char** argv) {
     // must be done from the program, and NOT a shared library, as each program
     // statically links its own version library.
     LOG_DEBUG(<< ml::ver::CBuildInfo::fullInfo());
+
+    if (validElasticLicenseKeyConfirmed == false) {
+        LOG_FATAL(<< "Failed to confirm valid license key.");
+        return EXIT_FAILURE;
+    }
 
     // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();


### PR DESCRIPTION
All ml-cpp binaries (except controller) now must have
'--validElasticLicenseKeyConfirmed=true' present in the
command line arguments in order to run. Failure to do so
will result in the binary to exit with an appropriate error message.

In order to keep integration tests happy, the default
value of the validElasticLicenseKeyConfirmed command line argument
is  temporarily set to `false`.

Backports #1944 