### PR TITLE
[ML] Write out training fraction and number of train rows in model meta data

### DIFF
--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -194,8 +194,6 @@ public:
     void lossType(const std::string& lossType) override;
     //! Set the validation loss values for \p fold for each forest size to \p lossValues.
     void lossValues(std::size_t fold, TDoubleVec&& lossValues) override;
-    //! Set the fraction of data used for training per fold.
-    void trainingFractionPerFold(double fraction) override;
     //! \return A writable object containing the training hyperparameters.
     SHyperparameters& hyperparameters() override { return m_Hyperparameters; }
 
@@ -208,7 +206,6 @@ private:
 
 private:
     void writeAnalysisStats(std::int64_t timestamp) override;
-    void writeMetaData(rapidjson::Value& parentObject);
     void writeHyperparameters(rapidjson::Value& parentObject);
     void writeValidationLoss(rapidjson::Value& parentObject);
     void writeTimingStats(rapidjson::Value& parentObject);
@@ -222,7 +219,6 @@ private:
     bool m_AnalysisStatsInitialized{false};
     std::string m_LossType;
     TLossVec m_LossValues;
-    double m_TrainingFractionPerFold{0.0};
     SHyperparameters m_Hyperparameters;
 };
 }

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -40,7 +40,7 @@ public:
     static const std::string JSON_MEAN_MAGNITUDE_TAG;
     static const std::string JSON_MIN_TAG;
     static const std::string JSON_MODEL_METADATA_TAG;
-    static const std::string JSON_NUM_TRAINING_ROWS_TAG;
+    static const std::string JSON_NUM_TRAIN_ROWS_TAG;
     static const std::string JSON_RELATIVE_IMPORTANCE_TAG;
     static const std::string JSON_TOTAL_FEATURE_IMPORTANCE_TAG;
     static const std::string JSON_TRAIN_PARAMETERS_TAG;

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -43,7 +43,7 @@ public:
     static const std::string JSON_NUM_TRAIN_ROWS_TAG;
     static const std::string JSON_RELATIVE_IMPORTANCE_TAG;
     static const std::string JSON_TOTAL_FEATURE_IMPORTANCE_TAG;
-    static const std::string JSON_TRAIN_PARAMETERS_TAG;
+    static const std::string JSON_TRAIN_PROPERTIES_TAG;
 
 public:
     using TVector = maths::CDenseVector<double>;
@@ -92,7 +92,7 @@ private:
     void writeTotalFeatureImportance(TRapidJsonWriter& writer) const;
     void writeFeatureImportanceBaseline(TRapidJsonWriter& writer) const;
     void writeHyperparameterImportance(TRapidJsonWriter& writer) const;
-    void writeTrainParameters(TRapidJsonWriter& writer) const;
+    void writeTrainProperties(TRapidJsonWriter& writer) const;
 
 private:
     TSizeMeanAccumulatorUMap m_TotalShapValuesMean;

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -67,9 +67,7 @@ public:
     void featureImportanceBaseline(TVector&& baseline);
     void hyperparameterImportance(const maths::CBoostedTree::THyperparameterImportanceVec& hyperparameterImportance);
     //! Set the number of rows used to train the model.
-    void numberTrainingRows(std::size_t numberRows);
-    //! Set the fraction of data per fold used for training when tuning hyperparameters.
-    void trainFractionPerFold(double fraction);
+    void numberTrainRows(std::size_t numberRows);
 
 private:
     struct SHyperparameterImportance {
@@ -107,8 +105,7 @@ private:
             writer.String(value);
         }};
     THyperparametersVec m_HyperparameterImportance;
-    std::size_t m_NumberTrainingRows{0};
-    double m_TrainFractionPerFold{0.0};
+    std::size_t m_NumberTrainRows{0};
 };
 }
 }

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -237,10 +237,7 @@ public:
     THyperparameterImportanceVec hyperparameterImportance() const;
 
     //! Get the number of rows used to train the model.
-    std::size_t numberTrainingRows() const override;
-
-    //! Get the fraction of data per fold used for training when tuning hyperparameters.
-    double trainFractionPerFold() const override;
+    std::size_t numberTrainRows() const override;
 
     //! Get the column containing the dependent variable.
     std::size_t columnHoldingDependentVariable() const override;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -150,9 +150,6 @@ public:
     //! \return The best hyperparameters for validation error found so far.
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
 
-    //! \return The fraction of data we use for train per fold when tuning hyperparameters.
-    double trainFractionPerFold() const;
-
     //! \return The full training set data mask, i.e. all rows which aren't missing
     //! the dependent variable.
     core::CPackedBitVector allTrainingRowsMask() const;

--- a/include/maths/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/CDataFrameAnalysisInstrumentationInterface.h
@@ -136,8 +136,6 @@ public:
     virtual void lossType(const std::string& lossType) = 0;
     //! Set the validation loss values for \p fold for each forest size to \p lossValues.
     virtual void lossValues(std::size_t fold, TDoubleVec&& lossValues) = 0;
-    //! Set the fraction of data used for training per fold.
-    virtual void trainingFractionPerFold(double fraction) = 0;
     //! \return A writable object containing the training hyperparameters.
     virtual SHyperparameters& hyperparameters() = 0;
 };
@@ -168,7 +166,6 @@ public:
     void iterationTime(std::uint64_t /* delta */) override {}
     void lossType(const std::string& /* lossType */) override {}
     void lossValues(std::size_t /* fold */, TDoubleVec&& /* lossValues */) override {}
-    void trainingFractionPerFold(double /* fraction */) override {}
     SHyperparameters& hyperparameters() override { return m_Hyperparameters; }
 
 private:
@@ -177,4 +174,4 @@ private:
 }
 }
 
-#endif //INCLUDED_ml_maths_CDataFrameAnalysisInstrumentationInterface_h
+#endif // INCLUDED_ml_maths_CDataFrameAnalysisInstrumentationInterface_h

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -62,10 +62,7 @@ public:
     virtual CTreeShapFeatureImportance* shap() const = 0;
 
     //! Get the number of rows used to train the model.
-    virtual std::size_t numberTrainingRows() const = 0;
-
-    //! Get the fraction of data per fold used for training when tuning hyperparameters.
-    virtual double trainFractionPerFold() const = 0;
+    virtual std::size_t numberTrainRows() const = 0;
 
     //! Get the column containing the dependent variable.
     virtual std::size_t columnHoldingDependentVariable() const = 0;

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -46,7 +46,6 @@ const std::string MEMORY_STATUS_HARD_LIMIT_TAG{"hard_limit"};
 const std::string MEMORY_STATUS_OK_TAG{"ok"};
 const std::string MEMORY_STATUS_TAG{"status"};
 const std::string MEMORY_TYPE_TAG{"analytics_memory_usage"};
-const std::string META_DATA_TAG{"meta_data"};
 const std::string OUTLIER_DETECTION_STATS{"outlier_detection_stats"};
 const std::string PARAMETERS_TAG{"parameters"};
 const std::string PEAK_MEMORY_USAGE_TAG{"peak_usage_bytes"};
@@ -66,7 +65,6 @@ const std::string VALIDATION_LOSS_VALUES_TAG{"values"};
 
 // Hyperparameters
 // TODO we should expose these in the analysis config.
-const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
 const std::string MAX_ATTEMPTS_TO_ADD_TREE_TAG{"max_attempts_to_add_tree"};
 const std::string NUM_SPLITS_PER_FEATURE_TAG{"num_splits_per_feature"};
 
@@ -137,7 +135,7 @@ void CDataFrameAnalysisInstrumentation::startNewProgressMonitoredTask(const std:
         m_ProgressMonitoredTask = task;
         m_FractionalProgress.store(0.0);
     }
-    this->writeProgress(lastTask, 100, m_Writer.get());
+    writeProgress(lastTask, 100, m_Writer.get());
 }
 
 void CDataFrameAnalysisInstrumentation::updateProgress(double fractionalProgress) {
@@ -292,7 +290,7 @@ counter_t::ECounterTypes CDataFrameTrainBoostedTreeInstrumentation::memoryCounte
 }
 
 void CDataFrameOutliersInstrumentation::writeAnalysisStats(std::int64_t timestamp) {
-    auto writer = this->writer();
+    auto* writer = this->writer();
     if (writer != nullptr && m_AnalysisStatsInitialized == true) {
         writer->Key(OUTLIER_DETECTION_STATS);
         writer->StartObject();
@@ -340,9 +338,7 @@ void CDataFrameOutliersInstrumentation::writeTimingStats(rapidjson::Value& paren
 
 void CDataFrameOutliersInstrumentation::writeParameters(rapidjson::Value& parentObject) {
     auto* writer = this->writer();
-
     if (writer != nullptr) {
-
         writer->addMember(
             CDataFrameOutliersRunner::N_NEIGHBORS,
             rapidjson::Value(static_cast<std::uint64_t>(this->m_Parameters.s_NumberNeighbours))
@@ -391,10 +387,6 @@ void CDataFrameTrainBoostedTreeInstrumentation::lossValues(std::size_t fold,
     m_LossValues.emplace_back(fold, std::move(lossValues));
 }
 
-void CDataFrameTrainBoostedTreeInstrumentation::trainingFractionPerFold(double fraction) {
-    m_TrainingFractionPerFold = fraction;
-}
-
 void CDataFrameTrainBoostedTreeInstrumentation::writeAnalysisStats(std::int64_t timestamp) {
     auto* writer = this->writer();
     if (writer != nullptr && m_AnalysisStatsInitialized == true) {
@@ -429,12 +421,6 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeAnalysisStats(std::int64_t 
         writer->Key(TIMING_STATS_TAG);
         writer->write(timingStatsObject);
 
-        // TODO enable with Java changes.
-        //rapidjson::Value metaDataObject{writer->makeObject()};
-        //this->writeMetaData(metaDataObject);
-        //writer->Key(META_DATA_TAG);
-        //writer->write(metaDataObject);
-
         writer->EndObject();
     }
     this->reset();
@@ -443,14 +429,6 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeAnalysisStats(std::int64_t 
 void CDataFrameTrainBoostedTreeInstrumentation::reset() {
     // Clear the map of loss values before the next iteration
     m_LossValues.clear();
-}
-
-void CDataFrameTrainBoostedTreeInstrumentation::writeMetaData(rapidjson::Value& parentObject) {
-    auto* writer = this->writer();
-    if (writer != nullptr) {
-        writer->addMember(CDataFrameTrainBoostedTreeRunner::TRAIN_FRACTION_PER_FOLD,
-                          rapidjson::Value(m_TrainingFractionPerFold).Move(), parentObject);
-    }
 }
 
 void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::Value& parentObject) {
@@ -512,7 +490,7 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
             rapidjson::Value(this->m_Hyperparameters.s_FeatureBagFraction).Move(),
             parentObject);
         writer->addMember(
-            ETA_GROWTH_RATE_PER_TREE_TAG,
+            CDataFrameTrainBoostedTreeRunner::ETA_GROWTH_RATE_PER_TREE,
             rapidjson::Value(this->m_Hyperparameters.s_EtaGrowthRatePerTree).Move(),
             parentObject);
         writer->addMember(

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -328,8 +328,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
     }
     m_InferenceModelMetadata.hyperparameterImportance(
         this->boostedTree().hyperparameterImportance());
-    m_InferenceModelMetadata.numberTrainingRows(this->boostedTree().numberTrainingRows());
-    m_InferenceModelMetadata.trainFractionPerFold(this->boostedTree().trainFractionPerFold());
+    m_InferenceModelMetadata.numberTrainRows(this->boostedTree().numberTrainRows());
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -162,7 +162,7 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
     }
     m_InferenceModelMetadata.hyperparameterImportance(
         this->boostedTree().hyperparameterImportance());
-    m_InferenceModelMetadata.trainFractionPerFold(this->boostedTree().trainFractionPerFold());
+    m_InferenceModelMetadata.numberTrainRows(this->boostedTree().numberTrainRows());
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -176,7 +176,7 @@ void CInferenceModelMetadata::writeTrainParameters(TRapidJsonWriter& writer) con
     if (m_NumberTrainRows > 0) {
         writer.Key(JSON_TRAIN_PARAMETERS_TAG);
         writer.StartObject();
-        writer.Key(JSON_NUM_TRAINING_ROWS_TAG);
+        writer.Key(JSON_NUM_TRAIN_ROWS_TAG);
         writer.Uint64(m_NumberTrainRows);
         writer.EndObject();
     }
@@ -291,7 +291,7 @@ const std::string CInferenceModelMetadata::JSON_MAX_TAG{"max"};
 const std::string CInferenceModelMetadata::JSON_MEAN_MAGNITUDE_TAG{"mean_magnitude"};
 const std::string CInferenceModelMetadata::JSON_MIN_TAG{"min"};
 const std::string CInferenceModelMetadata::JSON_MODEL_METADATA_TAG{"model_metadata"};
-const std::string CInferenceModelMetadata::JSON_NUM_TRAINING_ROWS_TAG{"num_training_rows"};
+const std::string CInferenceModelMetadata::JSON_NUM_TRAIN_ROWS_TAG{"num_train_rows"};
 const std::string CInferenceModelMetadata::JSON_RELATIVE_IMPORTANCE_TAG{"relative_importance"};
 const std::string CInferenceModelMetadata::JSON_TOTAL_FEATURE_IMPORTANCE_TAG{"total_feature_importance"};
 const std::string CInferenceModelMetadata::JSON_TRAIN_PARAMETERS_TAG{"train_parameters"};

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -173,17 +173,13 @@ void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& wr
 }
 
 void CInferenceModelMetadata::writeTrainParameters(TRapidJsonWriter& writer) const {
-    // TODO enable with Java changes.
-    // Only write out if it has been set.
-    //if (m_TrainingFractionPerFold > 0.0) {
-    //    writer.Key(JSON_TRAIN_PARAMETERS_TAG);
-    //    writer.StartObject();
-    //    writer.Key(JSON_NUM_TRAINING_ROWS_TAG);
-    //    writer.Uint64(m_NumberRowsUsedForTrain);
-    //    writer.Key(CDataFrameTrainBoostedTreeRunner::TRAIN_FRACTION_PER_FOLD);
-    //    writer.Double(m_TrainingFractionPerFold);
-    //    writer.EndObject();
-    //}
+    if (m_NumberTrainRows > 0) {
+        writer.Key(JSON_TRAIN_PARAMETERS_TAG);
+        writer.StartObject();
+        writer.Key(JSON_NUM_TRAINING_ROWS_TAG);
+        writer.Uint64(m_NumberTrainRows);
+        writer.EndObject();
+    }
 }
 
 const std::string& CInferenceModelMetadata::typeString() {
@@ -275,12 +271,8 @@ void CInferenceModelMetadata::hyperparameterImportance(
               });
 }
 
-void CInferenceModelMetadata::numberTrainingRows(std::size_t numberRows) {
-    m_NumberTrainingRows = numberRows;
-}
-
-void CInferenceModelMetadata::trainFractionPerFold(double fraction) {
-    m_TrainFractionPerFold = fraction;
+void CInferenceModelMetadata::numberTrainRows(std::size_t numberRows) {
+    m_NumberTrainRows = numberRows;
 }
 
 // clang-format off

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -19,7 +19,7 @@ void CInferenceModelMetadata::write(TRapidJsonWriter& writer) const {
     this->writeTotalFeatureImportance(writer);
     this->writeFeatureImportanceBaseline(writer);
     this->writeHyperparameterImportance(writer);
-    this->writeTrainParameters(writer);
+    this->writeTrainProperties(writer);
 }
 
 void CInferenceModelMetadata::writeTotalFeatureImportance(TRapidJsonWriter& writer) const {
@@ -172,9 +172,9 @@ void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& wr
     writer.EndArray();
 }
 
-void CInferenceModelMetadata::writeTrainParameters(TRapidJsonWriter& writer) const {
+void CInferenceModelMetadata::writeTrainProperties(TRapidJsonWriter& writer) const {
     if (m_NumberTrainRows > 0) {
-        writer.Key(JSON_TRAIN_PARAMETERS_TAG);
+        writer.Key(JSON_TRAIN_PROPERTIES_TAG);
         writer.StartObject();
         writer.Key(JSON_NUM_TRAIN_ROWS_TAG);
         writer.Uint64(m_NumberTrainRows);
@@ -294,7 +294,7 @@ const std::string CInferenceModelMetadata::JSON_MODEL_METADATA_TAG{"model_metada
 const std::string CInferenceModelMetadata::JSON_NUM_TRAIN_ROWS_TAG{"num_train_rows"};
 const std::string CInferenceModelMetadata::JSON_RELATIVE_IMPORTANCE_TAG{"relative_importance"};
 const std::string CInferenceModelMetadata::JSON_TOTAL_FEATURE_IMPORTANCE_TAG{"total_feature_importance"};
-const std::string CInferenceModelMetadata::JSON_TRAIN_PARAMETERS_TAG{"train_parameters"};
+const std::string CInferenceModelMetadata::JSON_TRAIN_PROPERTIES_TAG{"train_properties"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
+++ b/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
@@ -92,8 +92,8 @@
             },
             "additionalItems": false
         },
-        "train_parameters": {
-            "description": "additional training parameters",
+        "train_properties": {
+            "description": "properies of the training run which produced this model",
             "type": "object",
             "properties": {
                 "num_train_rows": {

--- a/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
+++ b/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
@@ -91,6 +91,19 @@
                 ]
             },
             "additionalItems": false
+        },
+        "train_parameters": {
+            "description": "additional training parameters",
+            "type": "object",
+            "properties": {
+                "num_train_rows": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "num_train_rows"
+            ],
+            "additionalProperties": false
         }
     },
     "additionalProperties": false

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -167,12 +167,8 @@ CBoostedTree::THyperparameterImportanceVec CBoostedTree::hyperparameterImportanc
     return m_Impl->hyperparameterImportance();
 }
 
-std::size_t CBoostedTree::numberTrainingRows() const {
+std::size_t CBoostedTree::numberTrainRows() const {
     return static_cast<std::size_t>(m_Impl->allTrainingRowsMask().manhattan());
-}
-
-double CBoostedTree::trainFractionPerFold() const {
-    return m_Impl->trainFractionPerFold();
 }
 
 std::size_t CBoostedTree::columnHoldingDependentVariable() const {

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -1530,7 +1530,6 @@ std::size_t CBoostedTreeImpl::maximumTreeSize(std::size_t numberRows) const {
 }
 
 void CBoostedTreeImpl::recordHyperparameters() {
-    m_Instrumentation->trainingFractionPerFold(m_TrainFractionPerFold);
     m_Instrumentation->hyperparameters().s_Eta = m_Eta;
     m_Instrumentation->hyperparameters().s_ClassAssignmentObjective = m_ClassAssignmentObjective;
     m_Instrumentation->hyperparameters().s_DownsampleFactor = m_DownsampleFactor;
@@ -2130,10 +2129,6 @@ const CBoostedTreeImpl::TSizeVec& CBoostedTreeImpl::extraColumns() const {
 
 const CBoostedTreeImpl::TVector& CBoostedTreeImpl::classificationWeights() const {
     return m_ClassificationWeights;
-}
-
-double CBoostedTreeImpl::trainFractionPerFold() const {
-    return m_TrainFractionPerFold;
 }
 
 core::CPackedBitVector CBoostedTreeImpl::allTrainingRowsMask() const {


### PR DESCRIPTION
This finishes up the TODOs from #1941. In particular, I remove all reference to train fraction per fold from instrumentation since it doesn't change from round to round and so isn't really a useful addition to the model stats. I also start writing out the number of rows used in training in the model meta data because these are needed to handle scaling hyperparameters properly when rerunning training on a different amount of data. This will be important, for example, when running incremental training.

To do this I've introduced a new section `train_parameters` into the model metadata object. Ultimately this should include other parameters the user overrides which are needed to reproduce training. These can be read directly from the model config and so can be managed in Java.

Note this PR can't be merged until the Java is updated to read the new metadata result format.