### PR TITLE
[ML][PYTORCH] Pass --validElasticLicenseKeyConfirmed argument from evaluate.py

### DIFF
--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -69,6 +69,7 @@ def launch_pytorch_app(args):
         '--restore=' + args.restore_file,
         '--input=' + args.input_file,
         '--output=' + args.output_file,
+        '--validElasticLicenseKeyConfirmed=true',
         '--numThreads=4',
         '--numInterOpThreads=1'
         ]


### PR DESCRIPTION
When launching the pytorch app from `evaluate.py` pass `--validElasticLicenseKeyConfirmed=true` as required by #1944