### PR TITLE
[ML] Correct acceptance criterion for incremental training

### DIFF
--- a/include/api/CDataFrameAnalysisInstrumentation.h
+++ b/include/api/CDataFrameAnalysisInstrumentation.h
@@ -194,8 +194,6 @@ public:
     void lossType(const std::string& lossType) override;
     //! Set the validation loss values for \p fold for each forest size to \p lossValues.
     void lossValues(std::size_t fold, TDoubleVec&& lossValues) override;
-    //! Set the fraction of data used for training per fold.
-    void trainingFractionPerFold(double fraction) override;
     //! \return A writable object containing the training hyperparameters.
     SHyperparameters& hyperparameters() override { return m_Hyperparameters; }
 
@@ -208,7 +206,6 @@ private:
 
 private:
     void writeAnalysisStats(std::int64_t timestamp) override;
-    void writeMetaData(rapidjson::Value& parentObject);
     void writeHyperparameters(rapidjson::Value& parentObject);
     void writeValidationLoss(rapidjson::Value& parentObject);
     void writeTimingStats(rapidjson::Value& parentObject);
@@ -222,7 +219,6 @@ private:
     bool m_AnalysisStatsInitialized{false};
     std::string m_LossType;
     TLossVec m_LossValues;
-    double m_TrainingFractionPerFold{0.0};
     SHyperparameters m_Hyperparameters;
 };
 }

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -67,6 +67,7 @@ public:
     static const std::string TASK_TRAIN;
     static const std::string TASK_UPDATE;
     static const std::string TASK_PREDICT;
+    static const std::string LOSS_GAP;
 
     // Output
     static const std::string IS_TRAINING_FIELD_NAME;

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -67,7 +67,8 @@ public:
     static const std::string TASK_TRAIN;
     static const std::string TASK_UPDATE;
     static const std::string TASK_PREDICT;
-    static const std::string LOSS_GAP;
+    static const std::string PREVIOUS_TRAIN_LOSS_GAP;
+    static const std::string PREVIOUS_TRAIN_NUM_ROWS;
 
     // Output
     static const std::string IS_TRAINING_FIELD_NAME;

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -41,11 +41,11 @@ public:
     static const std::string JSON_MEAN_MAGNITUDE_TAG;
     static const std::string JSON_MIN_TAG;
     static const std::string JSON_MODEL_METADATA_TAG;
-    static const std::string JSON_NUM_ROWS_TAG;
-    static const std::string JSON_NUM_TRAINING_ROWS_TAG;
+    static const std::string JSON_NUM_DATA_SUMMARIZATION_ROWS_TAG;
+    static const std::string JSON_NUM_TRAIN_ROWS_TAG;
     static const std::string JSON_RELATIVE_IMPORTANCE_TAG;
     static const std::string JSON_TOTAL_FEATURE_IMPORTANCE_TAG;
-    static const std::string JSON_TRAIN_PARAMETERS_TAG;
+    static const std::string JSON_TRAIN_PROPERTIES_TAG;
 
 public:
     using TVector = maths::CDenseVector<double>;
@@ -58,10 +58,10 @@ public:
 public:
     //! Writes metadata using \p writer.
     void write(TRapidJsonWriter& writer) const;
+    static const std::string& typeString();
     void columnNames(const TStrVec& columnNames);
     void classValues(const TStrVec& classValues);
     void predictionFieldTypeResolverWriter(const TPredictionFieldTypeResolverWriter& resolverWriter);
-    static const std::string& typeString();
     //! Add importances \p values to the feature with index \p i to calculate total feature importance.
     //! Total feature importance is the mean of the magnitudes of importances for individual data points.
     void addToFeatureImportance(std::size_t i, const TVector& values);
@@ -71,9 +71,9 @@ public:
     //! Set the hyperparameter importances.
     void hyperparameterImportance(const THyperparameterImportanceVec& hyperparameterImportance);
     //! Set the number of rows used to train the model.
-    void numTrainingRows(std::size_t numRows);
-    //! Set the fraction of data per fold used for training when tuning hyperparameters.
-    void trainFractionPerFold(double fraction);
+    void numTrainRows(std::size_t numRows);
+    //! Set the mean train test loss gap.
+    void lossGap(double lossGap);
     //! Set the number of rows in the training data summarization.
     void numDataSummarizationRows(std::size_t numRows);
 
@@ -100,7 +100,7 @@ private:
     void writeTotalFeatureImportance(TRapidJsonWriter& writer) const;
     void writeFeatureImportanceBaseline(TRapidJsonWriter& writer) const;
     void writeHyperparameterImportance(TRapidJsonWriter& writer) const;
-    void writeTrainParameters(TRapidJsonWriter& writer) const;
+    void writeTrainProperties(TRapidJsonWriter& writer) const;
     void writeDataSummarization(TRapidJsonWriter& writer) const;
 
 private:
@@ -114,9 +114,9 @@ private:
             writer.String(value);
         }};
     THyperparametersVec m_HyperparameterImportance;
+    std::size_t m_NumTrainRows{0};
+    double m_LossGap{0.0};
     std::size_t m_NumDataSummarizationRows{0};
-    std::size_t m_NumTrainingRows{0};
-    double m_TrainFractionPerFold{0.0};
 };
 }
 }

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -37,6 +37,7 @@ public:
     static const std::string JSON_HYPERPARAMETER_VALUE_TAG;
     static const std::string JSON_HYPERPARAMETER_SUPPLIED_TAG;
     static const std::string JSON_IMPORTANCE_TAG;
+    static const std::string JSON_LOSS_GAP_TAG;
     static const std::string JSON_MAX_TAG;
     static const std::string JSON_MEAN_MAGNITUDE_TAG;
     static const std::string JSON_MIN_TAG;

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -322,6 +322,11 @@ public:
     TSizeVecSizePr resizeColumns(std::size_t numberThreads,
                                  const TSizeAlignmentPrVec& extraColumns);
 
+    //! Resize to contain \p numberRows rows.
+    //!
+    //! \param[in] numberRows The desired number of rows.
+    void resizeRows(std::size_t numberRows);
+
     //! This reads rows using one or more readers.
     //!
     //! One reader is bound to one thread. Each thread reads a disjoint subset

--- a/include/maths/CBoostedTree.h
+++ b/include/maths/CBoostedTree.h
@@ -252,10 +252,10 @@ public:
     THyperparameterImportanceVec hyperparameterImportance() const;
 
     //! Get the number of rows used to train the model.
-    std::size_t numberTrainingRows() const override;
+    std::size_t numberTrainRows() const override;
 
-    //! Get the fraction of data per fold used for training when tuning hyperparameters.
-    double trainFractionPerFold() const override;
+    //! Get the mean gap in the loss between test and train examples.
+    double lossGap() const override;
 
     //! Get the column containing the dependent variable.
     std::size_t columnHoldingDependentVariable() const override;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -169,8 +169,10 @@ public:
     CBoostedTreeFactory& newTrainingRowMask(core::CPackedBitVector rowMask);
     //! Set the fraction of trees in the forest to retrain.
     CBoostedTreeFactory& retrainFraction(double fraction);
-    //! Set the gap between the train and test loss.
-    CBoostedTreeFactory& lossGap(double gap);
+    //! Set the gap between the train and test loss for the last train run.
+    CBoostedTreeFactory& previousTrainLossGap(double gap);
+    //! Set the number of rows for the last train run.
+    CBoostedTreeFactory& previousTrainNumberRows(std::size_t numberRows);
     //! Set the data summarization information.
     CBoostedTreeFactory& featureEncoder(TEncoderUPtr encoder);
     //! Set the best forest from the previous training.

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -169,6 +169,8 @@ public:
     CBoostedTreeFactory& newTrainingRowMask(core::CPackedBitVector rowMask);
     //! Set the fraction of trees in the forest to retrain.
     CBoostedTreeFactory& retrainFraction(double fraction);
+    //! Set the gap between the train and test loss.
+    CBoostedTreeFactory& lossGap(double gap);
     //! Set the data summarization information.
     CBoostedTreeFactory& featureEncoder(TEncoderUPtr encoder);
     //! Set the best forest from the previous training.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -478,7 +478,7 @@ private:
 private:
     std::uint64_t m_Seed{0};
     mutable CPRNG::CXorOShiro128Plus m_Rng;
-    EInitializationStage m_InitializationStage = E_NotInitialized;
+    EInitializationStage m_InitializationStage{E_NotInitialized};
     std::size_t m_NumberThreads;
     std::size_t m_DependentVariable{std::numeric_limits<std::size_t>::max()};
     TOptionalSize m_PaddedExtraColumns;

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -127,6 +127,9 @@ public:
     //! Get the model produced by training if it has been run.
     const TNodeVecVec& trainedModel() const;
 
+    //! Get the mean gap in the loss between test and train examples.
+    double lossGap() const;
+
     //! Get the training loss function.
     TLossFunction& loss() const;
 
@@ -180,9 +183,6 @@ public:
 
     //! \return The best hyperparameters for validation error found so far.
     const CBoostedTreeHyperparameters& bestHyperparameters() const;
-
-    //! \return The fraction of data we use for train per fold when tuning hyperparameters.
-    double trainFractionPerFold() const;
 
     //! \return The full training set data mask, i.e. all rows which aren't missing
     //! the dependent variable.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -419,7 +419,9 @@ private:
     void restoreBestHyperparameters();
 
     //! Scale the regulariser multipliers by \p scale.
-    void scaleRegularizers(double scale);
+    //!
+    //! \note If forced this will scale even if the parameters are overriden.
+    void scaleRegularizers(double scale, bool force = false);
 
     //! Check invariants which are assumed to hold after restoring.
     void checkRestoredInvariants() const;
@@ -485,6 +487,8 @@ private:
     CBoostedTree::EClassAssignmentObjective m_ClassAssignmentObjective{CBoostedTree::E_MinimumRecall};
     bool m_IncrementalTraining{false};
     bool m_StopCrossValidationEarly{true};
+    double m_PreviousTrainLossGap{0.0};
+    std::size_t m_PreviousTrainNumberRows{0};
     TRegularizationOverride m_RegularizationOverride;
     TOptionalDouble m_DownsampleFactorOverride;
     TOptionalDouble m_EtaOverride;
@@ -521,7 +525,6 @@ private:
     TPackedBitVectorVec m_TestingRowMasks;
     core::CPackedBitVector m_NewTrainingRowMask;
     double m_BestForestTestLoss{boosted_tree_detail::INF};
-    double m_LossGap{0.0};
     double m_BestForestLossGap{0.0};
     TOptionalDoubleVecVec m_FoldRoundTestLosses;
     CBoostedTreeHyperparameters m_BestHyperparameters;

--- a/include/maths/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/CDataFrameAnalysisInstrumentationInterface.h
@@ -126,8 +126,6 @@ public:
     virtual void lossType(const std::string& lossType) = 0;
     //! Set the validation loss values for \p fold for each forest size to \p lossValues.
     virtual void lossValues(std::size_t fold, TDoubleVec&& lossValues) = 0;
-    //! Set the fraction of data used for training per fold.
-    virtual void trainingFractionPerFold(double fraction) = 0;
     //! \return A writable object containing the training hyperparameters.
     virtual SHyperparameters& hyperparameters() = 0;
 };
@@ -158,7 +156,6 @@ public:
     void iterationTime(std::uint64_t /* delta */) override {}
     void lossType(const std::string& /* lossType */) override {}
     void lossValues(std::size_t /* fold */, TDoubleVec&& /* lossValues */) override {}
-    void trainingFractionPerFold(double /* fraction */) override {}
     SHyperparameters& hyperparameters() override { return m_Hyperparameters; }
 
 private:
@@ -167,4 +164,4 @@ private:
 }
 }
 
-#endif //INCLUDED_ml_maths_CDataFrameAnalysisInstrumentationInterface_h
+#endif // INCLUDED_ml_maths_CDataFrameAnalysisInstrumentationInterface_h

--- a/include/maths/CDataFramePredictiveModel.h
+++ b/include/maths/CDataFramePredictiveModel.h
@@ -70,10 +70,10 @@ public:
     virtual CTreeShapFeatureImportance* shap() const = 0;
 
     //! Get the number of rows used to train the model.
-    virtual std::size_t numberTrainingRows() const = 0;
+    virtual std::size_t numberTrainRows() const = 0;
 
-    //! Get the fraction of data per fold used for training when tuning hyperparameters.
-    virtual double trainFractionPerFold() const = 0;
+    //! Get the mean gap in the loss between test and train examples.
+    virtual double lossGap() const = 0;
 
     //! Get the column containing the dependent variable.
     virtual std::size_t columnHoldingDependentVariable() const = 0;

--- a/include/test/CDataFrameAnalysisSpecificationFactory.h
+++ b/include/test/CDataFrameAnalysisSpecificationFactory.h
@@ -95,6 +95,7 @@ public:
     CDataFrameAnalysisSpecificationFactory& earlyStoppingEnabled(bool earlyStoppingEnabled);
     CDataFrameAnalysisSpecificationFactory& task(TTask task);
     CDataFrameAnalysisSpecificationFactory& dataSummarizationFraction(double fraction);
+    CDataFrameAnalysisSpecificationFactory& previousTrainLossGap(double lossGap);
 
     // Regression
     CDataFrameAnalysisSpecificationFactory& regressionLossFunction(TLossFunctionType lossFunction);
@@ -156,6 +157,7 @@ private:
     rapidjson::Document m_CustomProcessors;
     TTask m_Task{TTask::E_Train};
     double m_DataSummarizationFraction{-1.0};
+    double m_PreviousTrainLossGap{-1.0};
     // Regression
     TOptionalLossFunctionType m_RegressionLossFunction;
     TOptionalDouble m_RegressionLossFunctionParameter;

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -46,7 +46,6 @@ const std::string MEMORY_STATUS_HARD_LIMIT_TAG{"hard_limit"};
 const std::string MEMORY_STATUS_OK_TAG{"ok"};
 const std::string MEMORY_STATUS_TAG{"status"};
 const std::string MEMORY_TYPE_TAG{"analytics_memory_usage"};
-const std::string META_DATA_TAG{"meta_data"};
 const std::string OUTLIER_DETECTION_STATS{"outlier_detection_stats"};
 const std::string PARAMETERS_TAG{"parameters"};
 const std::string PEAK_MEMORY_USAGE_TAG{"peak_usage_bytes"};
@@ -66,7 +65,6 @@ const std::string VALIDATION_LOSS_VALUES_TAG{"values"};
 
 // Hyperparameters
 // TODO we should expose these in the analysis config.
-const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
 const std::string MAX_ATTEMPTS_TO_ADD_TREE_TAG{"max_attempts_to_add_tree"};
 const std::string NUM_SPLITS_PER_FEATURE_TAG{"num_splits_per_feature"};
 
@@ -137,7 +135,7 @@ void CDataFrameAnalysisInstrumentation::startNewProgressMonitoredTask(const std:
         m_ProgressMonitoredTask = task;
         m_FractionalProgress.store(0.0);
     }
-    this->writeProgress(lastTask, 100, m_Writer.get());
+    writeProgress(lastTask, 100, m_Writer.get());
 }
 
 void CDataFrameAnalysisInstrumentation::updateProgress(double fractionalProgress) {
@@ -292,7 +290,7 @@ counter_t::ECounterTypes CDataFrameTrainBoostedTreeInstrumentation::memoryCounte
 }
 
 void CDataFrameOutliersInstrumentation::writeAnalysisStats(std::int64_t timestamp) {
-    auto writer = this->writer();
+    auto* writer = this->writer();
     if (writer != nullptr && m_AnalysisStatsInitialized == true) {
         writer->Key(OUTLIER_DETECTION_STATS);
         writer->StartObject();
@@ -340,9 +338,7 @@ void CDataFrameOutliersInstrumentation::writeTimingStats(rapidjson::Value& paren
 
 void CDataFrameOutliersInstrumentation::writeParameters(rapidjson::Value& parentObject) {
     auto* writer = this->writer();
-
     if (writer != nullptr) {
-
         writer->addMember(
             CDataFrameOutliersRunner::N_NEIGHBORS,
             rapidjson::Value(static_cast<std::uint64_t>(m_Parameters.s_NumberNeighbours))
@@ -389,10 +385,6 @@ void CDataFrameTrainBoostedTreeInstrumentation::lossValues(std::size_t fold,
     m_LossValues.emplace_back(fold, std::move(lossValues));
 }
 
-void CDataFrameTrainBoostedTreeInstrumentation::trainingFractionPerFold(double fraction) {
-    m_TrainingFractionPerFold = fraction;
-}
-
 void CDataFrameTrainBoostedTreeInstrumentation::writeAnalysisStats(std::int64_t timestamp) {
     auto* writer = this->writer();
     if (writer != nullptr && m_AnalysisStatsInitialized == true) {
@@ -427,12 +419,6 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeAnalysisStats(std::int64_t 
         writer->Key(TIMING_STATS_TAG);
         writer->write(timingStatsObject);
 
-        // TODO enable with Java changes.
-        //rapidjson::Value metaDataObject{writer->makeObject()};
-        //this->writeMetaData(metaDataObject);
-        //writer->Key(META_DATA_TAG);
-        //writer->write(metaDataObject);
-
         writer->EndObject();
     }
     this->reset();
@@ -441,14 +427,6 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeAnalysisStats(std::int64_t 
 void CDataFrameTrainBoostedTreeInstrumentation::reset() {
     // Clear the map of loss values before the next iteration
     m_LossValues.clear();
-}
-
-void CDataFrameTrainBoostedTreeInstrumentation::writeMetaData(rapidjson::Value& parentObject) {
-    auto* writer = this->writer();
-    if (writer != nullptr) {
-        writer->addMember(CDataFrameTrainBoostedTreeRunner::TRAIN_FRACTION_PER_FOLD,
-                          rapidjson::Value(m_TrainingFractionPerFold).Move(), parentObject);
-    }
 }
 
 void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::Value& parentObject) {
@@ -508,7 +486,7 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
             CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION,
             rapidjson::Value(m_Hyperparameters.s_FeatureBagFraction).Move(), parentObject);
         writer->addMember(
-            ETA_GROWTH_RATE_PER_TREE_TAG,
+            CDataFrameTrainBoostedTreeRunner::ETA_GROWTH_RATE_PER_TREE,
             rapidjson::Value(m_Hyperparameters.s_EtaGrowthRatePerTree).Move(), parentObject);
         writer->addMember(
             CDataFrameTrainBoostedTreeRunner::PREDICTION_CHANGE_COST,

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -196,10 +196,10 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
         m_InferenceModelMetadata.columnNames(featureImportance->columnNames());
         m_InferenceModelMetadata.classValues(classValues);
         m_InferenceModelMetadata.predictionFieldTypeResolverWriter(
-                [this](const std::string& categoryValue,
-                       core::CRapidJsonConcurrentLineWriter& writer_) {
-                    this->writePredictedCategoryValue(categoryValue, writer_);
-                });
+            [this](const std::string& categoryValue,
+                   core::CRapidJsonConcurrentLineWriter& writer_) {
+                this->writePredictedCategoryValue(categoryValue, writer_);
+            });
         featureImportance->shap(
             row, [&](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
                      const TStrVec& featureNames,
@@ -334,7 +334,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
     m_InferenceModelMetadata.numTrainRows(this->boostedTree().numberTrainRows());
     m_InferenceModelMetadata.lossGap(this->boostedTree().lossGap());
     m_InferenceModelMetadata.numDataSummarizationRows(static_cast<std::size_t>(
-            this->boostedTree().dataSummarization().manhattan()));
+        this->boostedTree().dataSummarization().manhattan()));
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -196,10 +196,10 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
         m_InferenceModelMetadata.columnNames(featureImportance->columnNames());
         m_InferenceModelMetadata.classValues(classValues);
         m_InferenceModelMetadata.predictionFieldTypeResolverWriter(
-            [this](const std::string& categoryValue,
-                   core::CRapidJsonConcurrentLineWriter& writer_) {
-                this->writePredictedCategoryValue(categoryValue, writer_);
-            });
+                [this](const std::string& categoryValue,
+                       core::CRapidJsonConcurrentLineWriter& writer_) {
+                    this->writePredictedCategoryValue(categoryValue, writer_);
+                });
         featureImportance->shap(
             row, [&](const maths::CTreeShapFeatureImportance::TSizeVec& indices,
                      const TStrVec& featureNames,
@@ -331,13 +331,10 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
         m_InferenceModelMetadata.hyperparameterImportance(
             this->boostedTree().hyperparameterImportance());
     }
-    m_InferenceModelMetadata.numTrainingRows(this->boostedTree().numberTrainingRows());
-    m_InferenceModelMetadata.trainFractionPerFold(this->boostedTree().trainFractionPerFold());
-    std::size_t numDataSummarizationRows{static_cast<std::size_t>(
-        this->boostedTree().dataSummarization().manhattan())};
-    if (numDataSummarizationRows > 0) {
-        m_InferenceModelMetadata.numDataSummarizationRows(numDataSummarizationRows);
-    }
+    m_InferenceModelMetadata.numTrainRows(this->boostedTree().numberTrainRows());
+    m_InferenceModelMetadata.lossGap(this->boostedTree().lossGap());
+    m_InferenceModelMetadata.numDataSummarizationRows(static_cast<std::size_t>(
+            this->boostedTree().dataSummarization().manhattan()));
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -167,7 +167,7 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
     m_InferenceModelMetadata.numTrainRows(this->boostedTree().numberTrainRows());
     m_InferenceModelMetadata.lossGap(this->boostedTree().lossGap());
     m_InferenceModelMetadata.numDataSummarizationRows(static_cast<std::size_t>(
-            this->boostedTree().dataSummarization().manhattan()));
+        this->boostedTree().dataSummarization().manhattan()));
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -164,13 +164,10 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
         m_InferenceModelMetadata.hyperparameterImportance(
             this->boostedTree().hyperparameterImportance());
     }
-    m_InferenceModelMetadata.numTrainingRows(this->boostedTree().numberTrainingRows());
-    m_InferenceModelMetadata.trainFractionPerFold(this->boostedTree().trainFractionPerFold());
-    std::size_t numDataSummarizationRows{static_cast<std::size_t>(
-        this->boostedTree().dataSummarization().manhattan())};
-    if (numDataSummarizationRows > 0) {
-        m_InferenceModelMetadata.numDataSummarizationRows(numDataSummarizationRows);
-    }
+    m_InferenceModelMetadata.numTrainRows(this->boostedTree().numberTrainRows());
+    m_InferenceModelMetadata.lossGap(this->boostedTree().lossGap());
+    m_InferenceModelMetadata.numDataSummarizationRows(static_cast<std::size_t>(
+            this->boostedTree().dataSummarization().manhattan()));
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -127,21 +127,17 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
 
     m_Task = parameters[TASK].fallback(E_Train);
 
-    bool earlyStoppingEnabled = parameters[EARLY_STOPPING_ENABLED].fallback(true);
-    double dataSummarizationFraction =
-        parameters[DATA_SUMMARIZATION_FRACTION].fallback(-1.0);
-
     std::size_t seed{parameters[RANDOM_NUMBER_GENERATOR_SEED].fallback(std::size_t{0})};
-    std::size_t downsampleRowsPerFeature{
-        parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
-    double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
 
     std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
     std::size_t numberFolds{parameters[NUM_FOLDS].fallback(std::size_t{0})};
+    std::size_t downsampleRowsPerFeature{
+        parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
     double trainFractionPerFold{parameters[TRAIN_FRACTION_PER_FOLD].fallback(-1.0)};
     std::size_t numberRoundsPerHyperparameter{
         parameters[MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER].fallback(
             NUMBER_ROUNDS_PER_HYPERPARAMETER_IS_UNSET)};
+    bool earlyStoppingEnabled{parameters[EARLY_STOPPING_ENABLED].fallback(true)};
     std::size_t bayesianOptimisationRestarts{
         parameters[BAYESIAN_OPTIMISATION_RESTARTS].fallback(std::size_t{0})};
     bool stopCrossValidationEarly{parameters[STOP_CROSS_VALIDATION_EARLY].fallback(true)};
@@ -156,12 +152,16 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double retrainedTreeEta{parameters[RETRAINED_TREE_ETA].fallback(-1.0)};
     double softTreeDepthLimit{parameters[SOFT_TREE_DEPTH_LIMIT].fallback(-1.0)};
     double softTreeDepthTolerance{parameters[SOFT_TREE_DEPTH_TOLERANCE].fallback(-1.0)};
+    double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
     double featureBagFraction{parameters[FEATURE_BAG_FRACTION].fallback(-1.0)};
     double predictionChangeCost{parameters[PREDICTION_CHANGE_COST].fallback(-1.0)};
     double treeTopologyChangePenalty{parameters[TREE_TOPOLOGY_CHANGE_PENALTY].fallback(-1.0)};
+
+    double dataSummarizationFraction{parameters[DATA_SUMMARIZATION_FRACTION].fallback(-1.0)};
     double previousTrainLossGap{parameters[PREVIOUS_TRAIN_LOSS_GAP].fallback(-1.0)};
     std::size_t previousTrainNumberRows{
         parameters[PREVIOUS_TRAIN_NUM_ROWS].fallback(std::size_t{0})};
+
     if (parameters[FEATURE_PROCESSORS].jsonObject() != nullptr) {
         m_CustomProcessors.CopyFrom(*parameters[FEATURE_PROCESSORS].jsonObject(),
                                     m_CustomProcessors.GetAllocator());

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -94,7 +94,10 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                {{TASK_TRAIN, int{ETask::E_Train}},
                                 {TASK_UPDATE, int{ETask::E_Update}},
                                 {TASK_PREDICT, int{ETask::E_Predict}}});
-        theReader.addParameter(LOSS_GAP, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(PREVIOUS_TRAIN_LOSS_GAP,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(PREVIOUS_TRAIN_NUM_ROWS,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -156,7 +159,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double featureBagFraction{parameters[FEATURE_BAG_FRACTION].fallback(-1.0)};
     double predictionChangeCost{parameters[PREDICTION_CHANGE_COST].fallback(-1.0)};
     double treeTopologyChangePenalty{parameters[TREE_TOPOLOGY_CHANGE_PENALTY].fallback(-1.0)};
-    double lossGap{parameters[LOSS_GAP].fallback(-1.0)};
+    double previousTrainLossGap{parameters[PREVIOUS_TRAIN_LOSS_GAP].fallback(-1.0)};
+    std::size_t previousTrainNumberRows{
+        parameters[PREVIOUS_TRAIN_NUM_ROWS].fallback(std::size_t{0})};
     if (parameters[FEATURE_PROCESSORS].jsonObject() != nullptr) {
         m_CustomProcessors.CopyFrom(*parameters[FEATURE_PROCESSORS].jsonObject(),
                                     m_CustomProcessors.GetAllocator());
@@ -273,8 +278,11 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     if (dataSummarizationFraction > 0) {
         m_BoostedTreeFactory->dataSummarizationFraction(dataSummarizationFraction);
     }
-    if (lossGap > 0.0) {
-        m_BoostedTreeFactory->lossGap(lossGap);
+    if (previousTrainLossGap > 0.0) {
+        m_BoostedTreeFactory->previousTrainLossGap(previousTrainLossGap);
+    }
+    if (previousTrainNumberRows > 0) {
+        m_BoostedTreeFactory->previousTrainNumberRows(previousTrainNumberRows);
     }
 }
 
@@ -566,7 +574,8 @@ const std::string CDataFrameTrainBoostedTreeRunner::TASK{"task"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_TRAIN{"train"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_UPDATE{"update"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_PREDICT{"predict"};
-const std::string CDataFrameTrainBoostedTreeRunner::LOSS_GAP{"loss_gap"};
+const std::string CDataFrameTrainBoostedTreeRunner::PREVIOUS_TRAIN_LOSS_GAP{"previous_train_loss_gap"};
+const std::string CDataFrameTrainBoostedTreeRunner::PREVIOUS_TRAIN_NUM_ROWS{"previous_train_num_rows"};
 // clang-format on
 }
 }

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -94,6 +94,7 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                {{TASK_TRAIN, int{ETask::E_Train}},
                                 {TASK_UPDATE, int{ETask::E_Update}},
                                 {TASK_PREDICT, int{ETask::E_Predict}}});
+        theReader.addParameter(LOSS_GAP, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         return theReader;
     }()};
     return PARAMETER_READER;
@@ -155,6 +156,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double featureBagFraction{parameters[FEATURE_BAG_FRACTION].fallback(-1.0)};
     double predictionChangeCost{parameters[PREDICTION_CHANGE_COST].fallback(-1.0)};
     double treeTopologyChangePenalty{parameters[TREE_TOPOLOGY_CHANGE_PENALTY].fallback(-1.0)};
+    double lossGap{parameters[LOSS_GAP].fallback(-1.0)};
     if (parameters[FEATURE_PROCESSORS].jsonObject() != nullptr) {
         m_CustomProcessors.CopyFrom(*parameters[FEATURE_PROCESSORS].jsonObject(),
                                     m_CustomProcessors.GetAllocator());
@@ -271,6 +273,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     if (dataSummarizationFraction > 0) {
         m_BoostedTreeFactory->dataSummarizationFraction(dataSummarizationFraction);
     }
+    if (lossGap > 0.0) {
+        m_BoostedTreeFactory->lossGap(lossGap);
+    }
 }
 
 CDataFrameTrainBoostedTreeRunner::~CDataFrameTrainBoostedTreeRunner() = default;
@@ -303,11 +308,9 @@ CDataFrameTrainBoostedTreeRunner::rowsToWriteMask(const core::CDataFrame& frame)
     switch (m_Task) {
     case E_Train:
         return {frame.numberRows(), true};
-        break;
     case E_Predict:
     case E_Update:
         return m_BoostedTree->newTrainingRowMask();
-        break;
     }
 }
 
@@ -563,6 +566,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::TASK{"task"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_TRAIN{"train"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_UPDATE{"update"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_PREDICT{"predict"};
+const std::string CDataFrameTrainBoostedTreeRunner::LOSS_GAP{"loss_gap"};
 // clang-format on
 }
 }

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -190,7 +190,7 @@ void CInferenceModelMetadata::writeTrainProperties(TRapidJsonWriter& writer) con
         writer.StartObject();
         writer.Key(JSON_NUM_TRAIN_ROWS_TAG);
         writer.Uint64(m_NumTrainRows);
-        writer.Key(CDataFrameTrainBoostedTreeRunner::LOSS_GAP);
+        writer.Key(JSON_LOSS_GAP_TAG);
         writer.Double(m_LossGap);
         writer.EndObject();
     }
@@ -322,6 +322,7 @@ const std::string CInferenceModelMetadata::JSON_HYPERPARAMETER_NAME_TAG{"name"};
 const std::string CInferenceModelMetadata::JSON_HYPERPARAMETER_VALUE_TAG{"value"};
 const std::string CInferenceModelMetadata::JSON_HYPERPARAMETER_SUPPLIED_TAG{"supplied"};
 const std::string CInferenceModelMetadata::JSON_IMPORTANCE_TAG{"importance"};
+const std::string CInferenceModelMetadata::JSON_LOSS_GAP_TAG{"loss_gap"};
 const std::string CInferenceModelMetadata::JSON_MAX_TAG{"max"};
 const std::string CInferenceModelMetadata::JSON_MEAN_MAGNITUDE_TAG{"mean_magnitude"};
 const std::string CInferenceModelMetadata::JSON_MIN_TAG{"min"};

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -19,7 +19,7 @@ void CInferenceModelMetadata::write(TRapidJsonWriter& writer) const {
     this->writeTotalFeatureImportance(writer);
     this->writeFeatureImportanceBaseline(writer);
     this->writeHyperparameterImportance(writer);
-    this->writeTrainParameters(writer);
+    this->writeTrainProperties(writer);
     this->writeDataSummarization(writer);
 }
 
@@ -178,24 +178,22 @@ void CInferenceModelMetadata::writeDataSummarization(TRapidJsonWriter& writer) c
     if (m_NumDataSummarizationRows > 0) {
         writer.Key(JSON_DATA_SUMMARIZATION_TAG);
         writer.StartObject();
-        writer.Key(JSON_NUM_ROWS_TAG);
+        writer.Key(JSON_NUM_DATA_SUMMARIZATION_ROWS_TAG);
         writer.Uint64(m_NumDataSummarizationRows);
         writer.EndObject();
     }
 }
 
-void CInferenceModelMetadata::writeTrainParameters(TRapidJsonWriter& writer) const {
-    // TODO enable with Java changes.
-    // Only write out if it has been set.
-    //if (m_TrainingFractionPerFold > 0.0) {
-    //    writer.Key(JSON_TRAIN_PARAMETERS_TAG);
-    //    writer.StartObject();
-    //    writer.Key(JSON_NUM_TRAINING_ROWS_TAG);
-    //    writer.Uint64(m_NumberRowsUsedForTrain);
-    //    writer.Key(CDataFrameTrainBoostedTreeRunner::TRAIN_FRACTION_PER_FOLD);
-    //    writer.Double(m_TrainingFractionPerFold);
-    //    writer.EndObject();
-    //}
+void CInferenceModelMetadata::writeTrainProperties(TRapidJsonWriter& writer) const {
+    if (m_NumTrainRows > 0) {
+        writer.Key(JSON_TRAIN_PROPERTIES_TAG);
+        writer.StartObject();
+        writer.Key(JSON_NUM_TRAIN_ROWS_TAG);
+        writer.Uint64(m_NumTrainRows);
+        writer.Key(CDataFrameTrainBoostedTreeRunner::LOSS_GAP);
+        writer.Double(m_LossGap);
+        writer.EndObject();
+    }
 }
 
 const std::string& CInferenceModelMetadata::typeString() {
@@ -298,12 +296,12 @@ void CInferenceModelMetadata::hyperparameterImportance(const THyperparameterImpo
               });
 }
 
-void CInferenceModelMetadata::numTrainingRows(std::size_t numRows) {
-    m_NumTrainingRows = numRows;
+void CInferenceModelMetadata::numTrainRows(std::size_t numRows) {
+    m_NumTrainRows = numRows;
 }
 
-void CInferenceModelMetadata::trainFractionPerFold(double fraction) {
-    m_TrainFractionPerFold = fraction;
+void CInferenceModelMetadata::lossGap(double lossGap) {
+    m_LossGap = lossGap;
 }
 
 void CInferenceModelMetadata::numDataSummarizationRows(std::size_t numRows) {
@@ -316,7 +314,7 @@ const std::string CInferenceModelMetadata::JSON_BASELINE_TAG{"baseline"};
 const std::string CInferenceModelMetadata::JSON_CLASS_NAME_TAG{"class_name"};
 const std::string CInferenceModelMetadata::JSON_CLASSES_TAG{"classes"};
 const std::string CInferenceModelMetadata::JSON_DATA_SUMMARIZATION_TAG{"data_summarization"};
-const std::string CInferenceModelMetadata::JSON_NUM_ROWS_TAG{"num_rows"};
+const std::string CInferenceModelMetadata::JSON_NUM_DATA_SUMMARIZATION_ROWS_TAG{"num_rows"};
 const std::string CInferenceModelMetadata::JSON_FEATURE_IMPORTANCE_BASELINE_TAG{"feature_importance_baseline"};
 const std::string CInferenceModelMetadata::JSON_FEATURE_NAME_TAG{"feature_name"};
 const std::string CInferenceModelMetadata::JSON_HYPERPARAMETERS_TAG{"hyperparameters"};
@@ -328,10 +326,10 @@ const std::string CInferenceModelMetadata::JSON_MAX_TAG{"max"};
 const std::string CInferenceModelMetadata::JSON_MEAN_MAGNITUDE_TAG{"mean_magnitude"};
 const std::string CInferenceModelMetadata::JSON_MIN_TAG{"min"};
 const std::string CInferenceModelMetadata::JSON_MODEL_METADATA_TAG{"model_metadata"};
-const std::string CInferenceModelMetadata::JSON_NUM_TRAINING_ROWS_TAG{"num_training_rows"};
+const std::string CInferenceModelMetadata::JSON_NUM_TRAIN_ROWS_TAG{"num_train_rows"};
 const std::string CInferenceModelMetadata::JSON_RELATIVE_IMPORTANCE_TAG{"relative_importance"};
 const std::string CInferenceModelMetadata::JSON_TOTAL_FEATURE_IMPORTANCE_TAG{"total_feature_importance"};
-const std::string CInferenceModelMetadata::JSON_TRAIN_PARAMETERS_TAG{"train_parameters"};
+const std::string CInferenceModelMetadata::JSON_TRAIN_PROPERTIES_TAG{"train_properties"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -971,7 +971,6 @@ BOOST_AUTO_TEST_CASE(testRegressionIncrementalTraining) {
             .predictionRestoreSearcherSupplier(restorerSupplier)
             .regressionLossFunction(TLossFunctionType::E_MseRegression)
             .task(test::CDataFrameAnalysisSpecificationFactory::TTask::E_Train)
-            .dataSummarizationFraction(1.0)
             .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::regression(),
                             dependentVariable, &frameAndDirectory);
     };

--- a/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
+++ b/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
@@ -102,6 +102,23 @@
                 ]
             },
             "additionalItems": false
+        },
+        "train_properties" : {
+            "description" : "Properies of the training process which produced the model.",
+            "type" : "object",
+            "properties" : {
+                "num_train_rows" : {
+                    "type" : "number"
+                },
+                "loss_gap" : {
+                    "type" : "number"
+                }
+            },
+            "required" : [
+                "num_train_rows",
+                "loss_gap"
+            ],
+            "additionalProperties" : false
         }
     },
     "additionalProperties": false

--- a/lib/maths/CBoostedTree.cc
+++ b/lib/maths/CBoostedTree.cc
@@ -175,12 +175,12 @@ CBoostedTree::THyperparameterImportanceVec CBoostedTree::hyperparameterImportanc
     return m_Impl->hyperparameterImportance();
 }
 
-std::size_t CBoostedTree::numberTrainingRows() const {
+std::size_t CBoostedTree::numberTrainRows() const {
     return static_cast<std::size_t>(m_Impl->allTrainingRowsMask().manhattan());
 }
 
-double CBoostedTree::trainFractionPerFold() const {
-    return m_Impl->trainFractionPerFold();
+double CBoostedTree::lossGap() const {
+    return m_Impl->lossGap();
 }
 
 std::size_t CBoostedTree::columnHoldingDependentVariable() const {

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1198,7 +1198,7 @@ CBoostedTreeFactory::estimateTreeGainAndCurvature(core::CDataFrame& frame,
     std::size_t maximumNumberOfTrees{1};
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
     CBoostedTreeImpl::TNodeVecVec forest;
-    std::tie(forest, std::ignore, std::ignore) = m_TreeImpl->trainForest(
+    std::tie(forest, std::ignore, std::ignore, std::ignore) = m_TreeImpl->trainForest(
         frame, m_TreeImpl->m_TrainingRowMasks[0],
         m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
@@ -1259,7 +1259,7 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
 
         CBoostedTreeImpl::TNodeVecVec forest;
         double testLoss;
-        std::tie(forest, testLoss, std::ignore) = m_TreeImpl->trainForest(
+        std::tie(forest, testLoss, std::ignore, std::ignore) = m_TreeImpl->trainForest(
             frame, m_TreeImpl->m_TrainingRowMasks[0],
             m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
         minTestLoss.add(testLoss);
@@ -1304,7 +1304,7 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
 
         CBoostedTreeImpl::TNodeVecVec forest;
         double testLoss;
-        std::tie(forest, testLoss, std::ignore) = m_TreeImpl->trainForest(
+        std::tie(forest, testLoss, std::ignore, std::ignore) = m_TreeImpl->trainForest(
             frame, m_TreeImpl->m_TrainingRowMasks[0],
             m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
 
@@ -1405,6 +1405,7 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromModel(TBoostedTreeUPtr mod
     result.m_TreeImpl->m_FeatureBagFractionOverride = result.m_TreeImpl->m_FeatureBagFraction;
     result.m_TreeImpl->m_CurrentRound = 0;
     result.m_TreeImpl->m_BestForestTestLoss = boosted_tree_detail::INF;
+    result.m_TreeImpl->m_LossGap = result.m_TreeImpl->m_BestForestLossGap;
     result.m_TreeImpl->m_FoldRoundTestLosses.clear();
     result.m_TreeImpl->m_InitializationStage = CBoostedTreeImpl::E_NotInitialized;
     result.m_TreeImpl->m_MeanForestSizeAccumulator = CBoostedTreeImpl::TMeanAccumulator{};
@@ -1693,6 +1694,11 @@ CBoostedTreeFactory& CBoostedTreeFactory::newTrainingRowMask(core::CPackedBitVec
 
 CBoostedTreeFactory& CBoostedTreeFactory::retrainFraction(double fraction) {
     m_TreeImpl->m_RetrainFraction = fraction;
+    return *this;
+}
+
+CBoostedTreeFactory& CBoostedTreeFactory::lossGap(double gap) {
+    m_TreeImpl->m_LossGap = gap;
     return *this;
 }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1405,6 +1405,8 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromModel(TBoostedTreeUPtr mod
     result.m_TreeImpl->m_FeatureBagFractionOverride = result.m_TreeImpl->m_FeatureBagFraction;
     result.m_TreeImpl->m_CurrentRound = 0;
     result.m_TreeImpl->m_BestForestTestLoss = boosted_tree_detail::INF;
+    result.m_TreeImpl->m_PreviousTrainNumberRows = static_cast<std::size_t>(
+        result.m_TreeImpl->allTrainingRowsMask().manhattan());
     result.m_TreeImpl->m_PreviousTrainLossGap = result.m_TreeImpl->m_BestForestLossGap;
     result.m_TreeImpl->m_FoldRoundTestLosses.clear();
     result.m_TreeImpl->m_InitializationStage = CBoostedTreeImpl::E_NotInitialized;

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1197,10 +1197,11 @@ CBoostedTreeFactory::estimateTreeGainAndCurvature(core::CDataFrame& frame,
 
     std::size_t maximumNumberOfTrees{1};
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
-    CBoostedTreeImpl::TNodeVecVec forest;
-    std::tie(forest, std::ignore, std::ignore, std::ignore) = m_TreeImpl->trainForest(
-        frame, m_TreeImpl->m_TrainingRowMasks[0],
-        m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
+    CBoostedTreeImpl::TNodeVecVec forest{
+        m_TreeImpl
+            ->trainForest(frame, m_TreeImpl->m_TrainingRowMasks[0],
+                          m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress)
+            .s_Forest};
     std::swap(maximumNumberOfTrees, m_TreeImpl->m_MaximumNumberTrees);
 
     TDoubleDoublePrVec result;
@@ -1259,9 +1260,11 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
 
         CBoostedTreeImpl::TNodeVecVec forest;
         double testLoss;
-        std::tie(forest, testLoss, std::ignore, std::ignore) = m_TreeImpl->trainForest(
-            frame, m_TreeImpl->m_TrainingRowMasks[0],
-            m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
+        std::tie(forest, testLoss, std::ignore, std::ignore) =
+            m_TreeImpl
+                ->trainForest(frame, m_TreeImpl->m_TrainingRowMasks[0],
+                              m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress)
+                .asTuple();
         minTestLoss.add(testLoss);
         testLosses.emplace_back(parameter, testLoss);
     }
@@ -1304,9 +1307,11 @@ CBoostedTreeFactory::testLossLineSearch(core::CDataFrame& frame,
 
         CBoostedTreeImpl::TNodeVecVec forest;
         double testLoss;
-        std::tie(forest, testLoss, std::ignore, std::ignore) = m_TreeImpl->trainForest(
-            frame, m_TreeImpl->m_TrainingRowMasks[0],
-            m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress);
+        std::tie(forest, testLoss, std::ignore, std::ignore) =
+            m_TreeImpl
+                ->trainForest(frame, m_TreeImpl->m_TrainingRowMasks[0],
+                              m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress)
+                .asTuple();
 
         minTestLoss.add(testLoss);
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1405,7 +1405,7 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromModel(TBoostedTreeUPtr mod
     result.m_TreeImpl->m_FeatureBagFractionOverride = result.m_TreeImpl->m_FeatureBagFraction;
     result.m_TreeImpl->m_CurrentRound = 0;
     result.m_TreeImpl->m_BestForestTestLoss = boosted_tree_detail::INF;
-    result.m_TreeImpl->m_LossGap = result.m_TreeImpl->m_BestForestLossGap;
+    result.m_TreeImpl->m_PreviousTrainLossGap = result.m_TreeImpl->m_BestForestLossGap;
     result.m_TreeImpl->m_FoldRoundTestLosses.clear();
     result.m_TreeImpl->m_InitializationStage = CBoostedTreeImpl::E_NotInitialized;
     result.m_TreeImpl->m_MeanForestSizeAccumulator = CBoostedTreeImpl::TMeanAccumulator{};
@@ -1697,8 +1697,13 @@ CBoostedTreeFactory& CBoostedTreeFactory::retrainFraction(double fraction) {
     return *this;
 }
 
-CBoostedTreeFactory& CBoostedTreeFactory::lossGap(double gap) {
-    m_TreeImpl->m_LossGap = gap;
+CBoostedTreeFactory& CBoostedTreeFactory::previousTrainLossGap(double gap) {
+    m_TreeImpl->m_PreviousTrainLossGap = gap;
+    return *this;
+}
+
+CBoostedTreeFactory& CBoostedTreeFactory::previousTrainNumberRows(std::size_t numberRows) {
+    m_TreeImpl->m_PreviousTrainNumberRows = numberRows;
     return *this;
 }
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -352,6 +352,8 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
         return;
     }
 
+    LOG_TRACE(<< "Main incremental training loop...");
+
     this->selectTreesToRetrain(frame);
 
     std::int64_t lastMemoryUsage(this->memoryUsage());

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -2111,13 +2111,12 @@ void CBoostedTreeImpl::initializeTunableHyperparameters() {
                 m_TunableHyperparameters.push_back(E_FeatureBagFraction);
             }
             break;
+        // Incremental train hyperparameters.
         case E_PredictionChangeCost:
-            if (m_IncrementalTraining == false &&
-                m_PredictionChangeCostOverride == boost::none) {
+            if (m_IncrementalTraining && m_PredictionChangeCostOverride == boost::none) {
                 m_TunableHyperparameters.push_back(E_PredictionChangeCost);
             }
             break;
-        // Incremental train hyperparameters.
         case E_RetrainedTreeEta:
             if (m_IncrementalTraining && m_RetrainedTreeEtaOverride == boost::none) {
                 m_TunableHyperparameters.push_back(E_RetrainedTreeEta);

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -457,6 +457,8 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
     LOG_TRACE(<< "Incremental training finished after " << m_CurrentRound << " iterations. "
               << "Time per iteration in ms mean: " << CBasicStatistics::mean(timeAccumulator)
               << " std. dev:  " << std::sqrt(CBasicStatistics::variance(timeAccumulator)));
+    LOG_TRACE(<< "best forest loss = " << m_BestForestTestLoss
+              << ", initial loss = " << initialLoss);
 
     if (m_BestForestTestLoss < initialLoss) {
         this->restoreBestHyperparameters();

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -2010,7 +2010,6 @@ std::size_t CBoostedTreeImpl::numberTreesToRetrain() const {
 }
 
 void CBoostedTreeImpl::recordHyperparameters() {
-    m_Instrumentation->trainingFractionPerFold(m_TrainFractionPerFold);
     m_Instrumentation->hyperparameters().s_Eta = m_Eta;
     m_Instrumentation->hyperparameters().s_RetrainedTreeEta = m_RetrainedTreeEta;
     m_Instrumentation->hyperparameters().s_ClassAssignmentObjective = m_ClassAssignmentObjective;
@@ -2762,6 +2761,10 @@ const CBoostedTreeImpl::TNodeVecVec& CBoostedTreeImpl::trainedModel() const {
     return m_BestForest;
 }
 
+double CBoostedTreeImpl::lossGap() const {
+    return m_BestForestLossGap;
+}
+
 CBoostedTreeImpl::TLossFunction& CBoostedTreeImpl::loss() const {
     if (m_Loss == nullptr) {
         HANDLE_FATAL(<< "Internal error: loss function unavailable. "
@@ -2784,10 +2787,6 @@ const CBoostedTreeImpl::TSizeVec& CBoostedTreeImpl::extraColumns() const {
 
 const CBoostedTreeImpl::TVector& CBoostedTreeImpl::classificationWeights() const {
     return m_ClassificationWeights;
-}
-
-double CBoostedTreeImpl::trainFractionPerFold() const {
-    return m_TrainFractionPerFold;
 }
 
 core::CPackedBitVector CBoostedTreeImpl::allTrainingRowsMask() const {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1042,7 +1042,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 90.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testThreading) {

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1720,9 +1720,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForTargetDrift) {
     // target value.
 }
 
-// TODO this needs the fix to acceptance criterion.
-BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain,
-                     *boost::unit_test::disabled()) {
+BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
 
     // Test incremental training for binomial logistic objective for values out of the
     // training data domain.

--- a/lib/maths/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/unittest/CBoostedTreeTest.cc
@@ -1859,7 +1859,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 1.5 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 1.2 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/test/CDataFrameAnalysisSpecificationFactory.cc
+++ b/lib/test/CDataFrameAnalysisSpecificationFactory.cc
@@ -206,6 +206,12 @@ CDataFrameAnalysisSpecificationFactory::dataSummarizationFraction(double fractio
 }
 
 CDataFrameAnalysisSpecificationFactory&
+CDataFrameAnalysisSpecificationFactory::previousTrainLossGap(double lossGap) {
+    m_PreviousTrainLossGap = lossGap;
+    return *this;
+}
+
+CDataFrameAnalysisSpecificationFactory&
 CDataFrameAnalysisSpecificationFactory::numberClasses(std::size_t number) {
     m_NumberClasses = number;
     return *this;
@@ -371,10 +377,13 @@ CDataFrameAnalysisSpecificationFactory::predictionParams(const std::string& anal
         writer.Key(TRunner::EARLY_STOPPING_ENABLED);
         writer.Bool(m_EarlyStoppingEnabled);
     }
-
-    if (m_DataSummarizationFraction > 0) {
+    if (m_DataSummarizationFraction > 0.0) {
         writer.Key(TRunner::DATA_SUMMARIZATION_FRACTION);
         writer.Double(m_DataSummarizationFraction);
+    }
+    if (m_PreviousTrainLossGap > 0.0) {
+        writer.Key(TRunner::PREVIOUS_TRAIN_LOSS_GAP);
+        writer.Double(m_PreviousTrainLossGap);
     }
 
     writer.Key(TRunner::TASK);


### PR DESCRIPTION
When we decide whether to accept the results of incremental training we compare the loss calculated for the best candidate with the loss calculated for the original model. Since the data summary comprises a subset of the training data we are in effect comparing training error on old data + validation error on new training data with something closer to validation error on all data. If we don't have much new data, or the improvement we can make on it is small, this typically causes us to reject models which actually perform better in test.

This pull request records the gap between the train and validation loss on the old training data and adds it on to the threshold to accept. This is recorded in the model meta data and needs to be added to the configuration parameters when Java calls incremental training. Also it became clear that there is no value in storing the per fold training percentage in the instrumentation since it is fixed for the duration of train and is determined either by user override or from the training data size and it is only needed for the initial train so I just removed it.