### PR TITLE
[ML] Recompute class weights before prediction task

### DIFF
--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -410,7 +410,8 @@ void CDataFrameTrainBoostedTreeRunner::runImpl(core::CDataFrame& frame) {
         break;
     case E_Predict:
         m_BoostedTree = m_BoostedTreeFactory->buildForPredict(frame, dependentVariableColumn);
-        m_BoostedTree->predict(true /*new data only*/);
+        // prediction occurs in buildForPredict
+        // m_BoostedTree->predict(true /*new data only*/);
         break;
     }
 

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -226,10 +226,13 @@ CBoostedTreeFactory::buildForPredict(core::CDataFrame& frame, std::size_t depend
         }
     });
     this->prepareDataFrameForTrain(frame);
-    m_TreeImpl->computeClassificationWeights(frame);
 
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
                 [&] { this->determineFeatureDataTypes(frame); });
+    skipIfAfter(CBoostedTreeImpl::E_NotInitialized, [&] {
+        m_TreeImpl->predict(frame);
+        m_TreeImpl->computeClassificationWeights(frame);
+    });
 
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
     m_TreeImpl->m_Instrumentation->lossType(m_TreeImpl->m_Loss->name());

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -226,6 +226,7 @@ CBoostedTreeFactory::buildForPredict(core::CDataFrame& frame, std::size_t depend
         }
     });
     this->prepareDataFrameForTrain(frame);
+    m_TreeImpl->computeClassificationWeights(frame);
 
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
                 [&] { this->determineFeatureDataTypes(frame); });


### PR DESCRIPTION
Since we don't store class weights, we must recompute them explicitly before performing the prediction task.
