### PR TITLE
[ML] Add logging so we know which round we exited hyperparameter tuning

### DIFF
--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -234,7 +234,8 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
             this->captureBestHyperparameters(lossMoments, maximumNumberTrees, numberNodes);
 
             if (this->selectNextHyperparameters(lossMoments, *m_BayesianOptimization) == false) {
-                LOG_INFO(<< "Exiting hyperparameter optimisation loop early");
+                LOG_INFO(<< "Exiting hyperparameter optimisation loop on round "
+                         << m_CurrentRound << " out of " << m_NumberRounds << ".");
                 break;
             }
 


### PR DESCRIPTION
We can exit hyperparameter tuning early if we don't think we're making progress up to the estimation error in the validation loss. Currently, we report that we do this but not which round we stopped. This decision is a candidate for causing variation in our QoR from run to run in our QA suite, but since we don't output which round we actually stopped we can't tell. Here I update the logging to report exactly which round we exit on.