### PR TITLE
[ML] Aggressively prune dead split fields

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -56,12 +56,12 @@
 
 * Give higher weight to multiple adjacent dictionary words when performing categorization. (See
   {ml-pull}1903[#1903].)
-* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans.
-(See {ml-pull}1908[#1908].)
 
 === Bug Fixes
 
 * Make atomic operations safer for aarch64. (See {ml-pull}1893[#1893].)
+* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans.
+(See {ml-pull}1908[#1908].)
 
 == {es} version 7.13.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -41,6 +41,8 @@
 * Added a new application for evaluating PyTorch models. The app depends on LibTorch
   - the C++ front end to PyTorch and performs inference on models stored in the 
   TorchScript format. (See {ml-pull}1902[#1902].)
+* Prune models for split fields (by, partition) that haven't seen data updates for
+  a given period of time. (See {ml-pull}1962[#1962].)
 
 === Bug Fixes
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -50,15 +50,14 @@
 
 === Bug Fixes
 
-* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans.
-  (See {ml-pull}1908[#1908].)
-
 == {es} version 7.14.0
 
 === Enhancements
 
 * Give higher weight to multiple adjacent dictionary words when performing categorization. (See
   {ml-pull}1903[#1903].)
+* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans.
+(See {ml-pull}1908[#1908].)
 
 === Bug Fixes
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -41,6 +41,10 @@
 * Added a new application for evaluating PyTorch models. The app depends on LibTorch
   - the C++ front end to PyTorch and performs inference on models stored in the 
   TorchScript format. (See {ml-pull}1902[#1902].)
+
+== {es} version 7.15.0
+
+=== Enhancements
 * Prune models for split fields (by, partition) that haven't seen data updates for
   a given period of time. (See {ml-pull}1962[#1962].)
 

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -413,6 +413,8 @@ protected:
                                               model::CResourceMonitor& resourceMonitor);
 
     //! Prune all the models that exceed \p buckets in age
+    //! A value of 0 for \buckets indicates that only 'obsolete' models will
+    //! be pruned, i.e. those which are so old as to be effectively dead.
     void pruneAllModels(std::size_t buckets = 0);
 
 private:

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -399,7 +399,7 @@ protected:
     //! Get all the detectors.
     void detectors(TAnomalyDetectorPtrVec& detectors) const;
 
-    //! Get the detectors by parition
+    //! Get the detectors by partition
     const TKeyAnomalyDetectorPtrUMap& detectorPartitionMap() const;
 
     //! Get all sorted references to the detectors.
@@ -412,8 +412,8 @@ protected:
                                               const std::string& partitionFieldValue,
                                               model::CResourceMonitor& resourceMonitor);
 
-    //! Prune all the models
-    void pruneAllModels();
+    //! Prune all the models that exceed \p buckets in age
+    void pruneAllModels(std::size_t buckets = 0);
 
 private:
     //! The job ID

--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -246,6 +246,10 @@ public:
 
         core_t::TTime bucketSpan() const { return m_BucketSpan; }
 
+        //! Return the size of the model prune window expressed as a whole number of seconds.
+        //! Note that throughout the code the model prune window may sometimes be expressed in
+        //! seconds, as here, and sometimes as number of buckets. Where any doubt exists
+        //! a comment will explain which is in use.
         core_t::TTime modelPruneWindow() const { return m_ModelPruneWindow; }
 
         std::string summaryCountFieldName() const {
@@ -321,7 +325,10 @@ public:
 
     private:
         core_t::TTime m_BucketSpan{DEFAULT_BUCKET_SPAN};
+
+        //! The size of the model prune window expressed as a whole number of seconds.
         core_t::TTime m_ModelPruneWindow{0};
+
         std::string m_SummaryCountFieldName{};
         std::string m_CategorizationFieldName{};
         std::string m_CategorizationPartitionFieldName{};

--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -182,6 +182,9 @@ public:
 
     public:
         static const std::string BUCKET_SPAN;
+
+        static const std::string MODEL_PRUNE_WINDOW;
+
         static const std::string SUMMARY_COUNT_FIELD_NAME;
         static const std::string CATEGORIZATION_FIELD_NAME;
         static const std::string CATEGORIZATION_FILTERS;
@@ -242,6 +245,8 @@ public:
         bool updateScheduledEvents(const boost::property_tree::ptree& propTree);
 
         core_t::TTime bucketSpan() const { return m_BucketSpan; }
+
+        core_t::TTime modelPruneWindow() const { return m_ModelPruneWindow; }
 
         std::string summaryCountFieldName() const {
             return m_SummaryCountFieldName;
@@ -316,6 +321,7 @@ public:
 
     private:
         core_t::TTime m_BucketSpan{DEFAULT_BUCKET_SPAN};
+        core_t::TTime m_ModelPruneWindow{0};
         std::string m_SummaryCountFieldName{};
         std::string m_CategorizationFieldName{};
         std::string m_CategorizationPartitionFieldName{};

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -244,6 +244,10 @@ public:
     //! that may be deleted as a result of this call.
     virtual void pruneModels();
 
+    // Remove dead models - i.e. those that have not seen activity
+    // in the last \p pruneWindow buckets
+    virtual void pruneModels(std::size_t pruneWindow);
+
     //! Reset bucket.
     void resetBucket(core_t::TTime bucketStart);
 

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -244,8 +244,8 @@ public:
     //! that may be deleted as a result of this call.
     virtual void pruneModels();
 
-    // Remove dead models - i.e. those that have not seen activity
-    // in the last \p pruneWindow buckets
+    //! Remove dead models - i.e. those that have not seen activity
+    //! in the last \p pruneWindow buckets
     virtual void pruneModels(std::size_t pruneWindow);
 
     //! Reset bucket.

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -336,6 +336,12 @@ public:
     //! Get the bucket length.
     core_t::TTime bucketLength() const;
 
+    // Get the period of time at which to perform a potential prune of the models
+    core_t::TTime modelPruneWindow() const;
+
+    // Set the period of time at which to perform a potential prune of the models
+    void modelPruneWindow(core_t::TTime modelPruneWindow);
+
     //! Get the maximum latency in the arrival of out of order data.
     core_t::TTime latency() const;
 
@@ -441,6 +447,8 @@ public:
 private:
     //! Bucket length.
     core_t::TTime m_BucketLength;
+
+    core_t::TTime m_ModelPruneWindow;
 
     //! Should multivariate analysis of correlated 'by' fields be performed?
     bool m_MultivariateByFields;

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -336,10 +336,12 @@ public:
     //! Get the bucket length.
     core_t::TTime bucketLength() const;
 
-    // Get the period of time at which to perform a potential prune of the models
+    //! Get the period of time at which to perform a potential prune of the models
+    //! expressed in number of seconds.
     core_t::TTime modelPruneWindow() const;
 
-    // Set the period of time at which to perform a potential prune of the models
+    //! Set the period of time at which to perform a potential prune of the models
+    //! expressed in number of seconds.
     void modelPruneWindow(core_t::TTime modelPruneWindow);
 
     //! Get the maximum latency in the arrival of out of order data.
@@ -448,6 +450,7 @@ private:
     //! Bucket length.
     core_t::TTime m_BucketLength;
 
+    //! Prune window length (in seconds)
     core_t::TTime m_ModelPruneWindow;
 
     //! Should multivariate analysis of correlated 'by' fields be performed?

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -448,13 +448,13 @@ public:
 
 private:
     //! Bucket length.
-    core_t::TTime m_BucketLength;
+    core_t::TTime m_BucketLength{0};
 
     //! Prune window length (in seconds)
-    core_t::TTime m_ModelPruneWindow;
+    core_t::TTime m_ModelPruneWindow{0};
 
     //! Should multivariate analysis of correlated 'by' fields be performed?
-    bool m_MultivariateByFields;
+    bool m_MultivariateByFields{false};
 
     //! The single interim bucket correction calculator.
     TInterimBucketCorrectorPtr m_InterimBucketCorrector;

--- a/include/model/FunctionTypes.h
+++ b/include/model/FunctionTypes.h
@@ -227,6 +227,10 @@ bool isMetric(EFunction function);
 MODEL_EXPORT
 bool isForecastSupported(EFunction function);
 
+//! Is this function for use with aggressive pruning of dead split fields?
+MODEL_EXPORT
+bool isAggressivePruningSupported(EFunction function);
+
 //! Get the mapping from function to data features.
 MODEL_EXPORT
 const model_t::TFeatureVec& features(EFunction function);

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -688,7 +688,7 @@ void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
     this->writeOutAnnotations(annotations);
     this->writeOutResults(false, results, bucketStartTime, processingTime);
 
-    if (m_ModelConfig.modelPruneWindow() > core_t::TTime{0}) {
+    if (m_ModelConfig.modelPruneWindow() > 0) {
         core_t::TTime bucketPruneWindow{m_ModelConfig.modelPruneWindow() /
                                         m_ModelConfig.bucketLength()};
         this->pruneAllModels(bucketPruneWindow);
@@ -1583,7 +1583,7 @@ CAnomalyJob::detectorForKey(bool isRestoring,
 
 void CAnomalyJob::pruneAllModels(std::size_t buckets) {
     if (buckets == 0) {
-        LOG_INFO(<< "Pruning all models");
+        LOG_INFO(<< "Pruning obsolete models");
     } else {
         LOG_DEBUG(<< "Pruning all models older than " << buckets << " buckets");
     }

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -689,8 +689,13 @@ void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
     this->writeOutResults(false, results, bucketStartTime, processingTime);
 
     if (m_ModelConfig.modelPruneWindow() > 0) {
-        core_t::TTime bucketPruneWindow{m_ModelConfig.modelPruneWindow() /
-                                        m_ModelConfig.bucketLength()};
+        // Ensure that bucketPruneWindow is always rounded _up_
+        // to the next whole number of buckets (this doesn't really matter if we enforce
+        // that the model prune window always be an exact multiple of bucket span in the
+        // corresponding Java code)
+        core_t::TTime bucketPruneWindow{
+            m_ModelConfig.modelPruneWindow() / m_ModelConfig.bucketLength() +
+            (m_ModelConfig.modelPruneWindow() % m_ModelConfig.bucketLength() != 0)};
         this->pruneAllModels(bucketPruneWindow);
     }
 

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -694,8 +694,8 @@ void CAnomalyJob::outputResults(core_t::TTime bucketStartTime) {
         // that the model prune window always be an exact multiple of bucket span in the
         // corresponding Java code)
         core_t::TTime bucketPruneWindow{
-            m_ModelConfig.modelPruneWindow() / m_ModelConfig.bucketLength() +
-            (m_ModelConfig.modelPruneWindow() % m_ModelConfig.bucketLength() != 0)};
+            (m_ModelConfig.modelPruneWindow() + m_ModelConfig.bucketLength() - 1) /
+            m_ModelConfig.bucketLength()};
         this->pruneAllModels(bucketPruneWindow);
     }
 

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -690,8 +690,12 @@ void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisC
             modelPruneWindowString, core_t::TTime{0});
 
         // Ensure that the model prune window is never smaller than the bucket span.
-        const core_t::TTime minModelPruneWindow{m_BucketSpan};
-        m_ModelPruneWindow = std::max(m_ModelPruneWindow, minModelPruneWindow);
+        if (m_ModelPruneWindow < m_BucketSpan) {
+            LOG_WARN(<< "The value of configuration setting \"model_prune_window\" (" << m_ModelPruneWindow
+                     << ") is less than the value of \"bucket_span\" (" << m_BucketSpan
+                     << "). Setting \"model_prune_window\" to " << m_BucketSpan);
+            m_ModelPruneWindow = m_BucketSpan;
+        }
     }
 
     auto ppc = parameters[PER_PARTITION_CATEGORIZATION].jsonObject();

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -681,7 +681,6 @@ void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisC
     m_SummaryCountFieldName = parameters[SUMMARY_COUNT_FIELD_NAME].fallback(EMPTY_STRING);
     m_CategorizationFieldName = parameters[CATEGORIZATION_FIELD_NAME].fallback(EMPTY_STRING);
     m_CategorizationFilters = parameters[CATEGORIZATION_FILTERS].fallback(TStrVec{});
-
     const std::string& modelPruneWindowString{
         parameters[MODEL_PRUNE_WINDOW].fallback(EMPTY_STRING)};
 
@@ -689,12 +688,13 @@ void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisC
         m_ModelPruneWindow = CAnomalyJobConfig::CAnalysisConfig::durationSeconds(
             modelPruneWindowString, core_t::TTime{0});
 
-        // Ensure that the model prune window is never smaller than the bucket span.
-        if (m_ModelPruneWindow < m_BucketSpan) {
-            LOG_WARN(<< "The value of configuration setting \"model_prune_window\" (" << m_ModelPruneWindow
-                     << ") is less than the value of \"bucket_span\" (" << m_BucketSpan
-                     << "). Setting \"model_prune_window\" to " << m_BucketSpan);
-            m_ModelPruneWindow = m_BucketSpan;
+        // Ensure that the model prune window is never smaller than twice the bucket span.
+        if (m_ModelPruneWindow < (2 * m_BucketSpan)) {
+            LOG_WARN(<< "The value of configuration setting \"model_prune_window\" ("
+                     << m_ModelPruneWindow << ") is less than twice the value of \"bucket_span\" ("
+                     << m_BucketSpan << "). Setting \"model_prune_window\" to "
+                     << (2 * m_BucketSpan));
+            m_ModelPruneWindow = 2 * m_BucketSpan;
         }
     }
 

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -52,6 +52,9 @@ const core_t::TTime CAnomalyJobConfig::BASE_MAX_QUANTILE_INTERVAL{21600}; // 6 h
 const core_t::TTime CAnomalyJobConfig::DEFAULT_BASE_PERSIST_INTERVAL{10800}; // 3 hours
 
 const std::string CAnomalyJobConfig::CAnalysisConfig::BUCKET_SPAN{"bucket_span"};
+
+const std::string CAnomalyJobConfig::CAnalysisConfig::MODEL_PRUNE_WINDOW{"model_prune_window"};
+
 const std::string CAnomalyJobConfig::CAnalysisConfig::SUMMARY_COUNT_FIELD_NAME{
     "summary_count_field_name"};
 const std::string CAnomalyJobConfig::CAnalysisConfig::CATEGORIZATION_FIELD_NAME{
@@ -273,6 +276,8 @@ const CAnomalyJobConfigReader CONFIG_READER{[] {
 const CAnomalyJobConfigReader ANALYSIS_CONFIG_READER{[] {
     CAnomalyJobConfigReader theReader;
     theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::BUCKET_SPAN,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::MODEL_PRUNE_WINDOW,
                            CAnomalyJobConfigReader::E_OptionalParameter);
     theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::SUMMARY_COUNT_FIELD_NAME,
                            CAnomalyJobConfigReader::E_OptionalParameter);
@@ -677,6 +682,18 @@ void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisC
     m_CategorizationFieldName = parameters[CATEGORIZATION_FIELD_NAME].fallback(EMPTY_STRING);
     m_CategorizationFilters = parameters[CATEGORIZATION_FILTERS].fallback(TStrVec{});
 
+    const std::string& modelPruneWindowString{
+        parameters[MODEL_PRUNE_WINDOW].fallback(EMPTY_STRING)};
+
+    if (modelPruneWindowString.empty() == false) {
+        m_ModelPruneWindow = CAnomalyJobConfig::CAnalysisConfig::durationSeconds(
+            modelPruneWindowString, core_t::TTime{0});
+
+        // Ensure that the model prune window is never smaller than the bucket span.
+        const core_t::TTime minModelPruneWindow{m_BucketSpan};
+        m_ModelPruneWindow = std::max(m_ModelPruneWindow, minModelPruneWindow);
+    }
+
     auto ppc = parameters[PER_PARTITION_CATEGORIZATION].jsonObject();
     if (ppc != nullptr) {
         auto ppcParameters = PPC_CONFIG_READER.read(*ppc);
@@ -796,6 +813,8 @@ CAnomalyJobConfig::CAnalysisConfig::makeModelConfig() const {
 
     modelConfig.scheduledEvents(
         model::CAnomalyDetectorModelConfig::TStrDetectionRulePrVecCRef(m_ScheduledEvents));
+
+    modelConfig.modelPruneWindow(m_ModelPruneWindow);
 
     return modelConfig;
 }

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -290,7 +290,10 @@ BOOST_AUTO_TEST_CASE(testParse) {
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
 
-        BOOST_REQUIRE_EQUAL(1800, analysisConfig.modelPruneWindow());
+        // This one's a bit special, we enforce that the model_prune_window value
+        // be at least 2 multiples of the bucket_span, i.e. if it is configured
+        // as less then the value is modified to the minimum acceptable value.
+        BOOST_REQUIRE_EQUAL(3600, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
 
@@ -342,7 +345,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"15m\",\"summary_count_field_name\":\"doc_count\",\"multivariate_by_fields\":true,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"60m\",\"summary_count_field_name\":\"doc_count\",\"multivariate_by_fields\":true,"
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"by\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true,\"terms\":\"customer_id,category.keyword\"},\"model_snapshot_retention_days\":10,"
@@ -371,8 +374,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
 
-        // We expect the model prune window to be no smaller than the bucket span
-        BOOST_REQUIRE_EQUAL(1800, analysisConfig.modelPruneWindow());
+        BOOST_REQUIRE_EQUAL(3600, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
         BOOST_REQUIRE_EQUAL(true, analysisConfig.multivariateByFields());

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -119,6 +119,19 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_TEST_REQUIRE(!jobConfig.isInitialized());
     }
     {
+        const std::string inValidModelPruneWindowType{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":10800,\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"11mb\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(inValidModelPruneWindowType));
+        BOOST_TEST_REQUIRE(!jobConfig.isInitialized());
+    }
+    {
         const std::string missingRequiredJobId{
             "{\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
             "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
@@ -133,7 +146,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"28d\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"background_persist_interval\":\"3h\",\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true,\"terms\":\"customer_id\"},\"model_snapshot_retention_days\":10,"
@@ -151,6 +164,8 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL(2419200, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
 
@@ -189,7 +204,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"24h\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"by_field_name\":\"customer_id\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":false,\"annotations_enabled\":true,\"terms\":\"customer_id\"},\"model_snapshot_retention_days\":10,"
@@ -216,6 +231,8 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL(86400, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
 
@@ -254,7 +271,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"1800s\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"background_persist_interval\":\"1d\",\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
@@ -272,6 +289,8 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
 
@@ -310,7 +329,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string invalidAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"15m\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"whatever\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
@@ -323,7 +342,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\",\"multivariate_by_fields\":true,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"15m\",\"summary_count_field_name\":\"doc_count\",\"multivariate_by_fields\":true,"
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"by\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true,\"terms\":\"customer_id,category.keyword\"},\"model_snapshot_retention_days\":10,"
@@ -351,6 +370,9 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        // We expect the model prune window to be no smaller than the bucket span
+        BOOST_REQUIRE_EQUAL(1800, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
         BOOST_REQUIRE_EQUAL(true, analysisConfig.multivariateByFields());

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -585,6 +585,15 @@ void CAnomalyDetector::pruneModels() {
     m_Model->prune(m_Model->defaultPruneWindow());
 }
 
+void CAnomalyDetector::pruneModels(std::size_t buckets) {
+    // Purge out any models that haven't seen activity in the given number of buckets.
+
+    function_t::EFunction function{m_DataGatherer->function()};
+    if (function_t::isAggressivePruningSupported(function)) {
+        m_Model->prune(buckets);
+    }
+}
+
 void CAnomalyDetector::resetBucket(core_t::TTime bucketStart) {
     m_DataGatherer->resetBucket(bucketStart);
 }

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -692,6 +692,10 @@ core_t::TTime CAnomalyDetectorModelConfig::bucketLength() const {
     return m_BucketLength;
 }
 
+core_t::TTime CAnomalyDetectorModelConfig::modelPruneWindow() const {
+    return m_ModelPruneWindow;
+}
+
 core_t::TTime CAnomalyDetectorModelConfig::latency() const {
     return m_BucketLength * m_Factories.begin()->second->modelParams().s_LatencyBuckets;
 }
@@ -756,6 +760,10 @@ void CAnomalyDetectorModelConfig::detectionRules(TIntDetectionRuleVecUMapCRef de
 
 void CAnomalyDetectorModelConfig::scheduledEvents(TStrDetectionRulePrVecCRef scheduledEvents) {
     m_ScheduledEvents = scheduledEvents;
+}
+
+void CAnomalyDetectorModelConfig::modelPruneWindow(core_t::TTime modelPruneWindow) {
+    m_ModelPruneWindow = modelPruneWindow;
 }
 
 core_t::TTime CAnomalyDetectorModelConfig::samplingAgeCutoff() const {

--- a/lib/model/FunctionTypes.cc
+++ b/lib/model/FunctionTypes.cc
@@ -525,6 +525,125 @@ bool isForecastSupported(EFunction function) {
     return false;
 }
 
+bool isAggressivePruningSupported(EFunction function) {
+    switch (function) {
+    case E_IndividualCount:
+    case E_IndividualNonZeroCount:
+    case E_IndividualRareCount:
+    case E_IndividualRareNonZeroCount:
+        return true;
+    case E_IndividualRare:
+        return false;
+    case E_IndividualLowCounts:
+    case E_IndividualHighCounts:
+    case E_IndividualLowNonZeroCount:
+    case E_IndividualHighNonZeroCount:
+    case E_IndividualDistinctCount:
+    case E_IndividualLowDistinctCount:
+    case E_IndividualHighDistinctCount:
+    case E_IndividualInfoContent:
+    case E_IndividualHighInfoContent:
+    case E_IndividualLowInfoContent:
+        return true;
+
+    case E_IndividualTimeOfDay:
+    case E_IndividualTimeOfWeek:
+        return false;
+
+    case E_IndividualMetric:
+    case E_IndividualMetricMean:
+    case E_IndividualMetricLowMean:
+    case E_IndividualMetricHighMean:
+    case E_IndividualMetricMedian:
+    case E_IndividualMetricLowMedian:
+    case E_IndividualMetricHighMedian:
+    case E_IndividualMetricMin:
+    case E_IndividualMetricMax:
+    case E_IndividualMetricVariance:
+    case E_IndividualMetricLowVariance:
+    case E_IndividualMetricHighVariance:
+    case E_IndividualMetricSum:
+    case E_IndividualMetricLowSum:
+    case E_IndividualMetricHighSum:
+    case E_IndividualMetricNonNullSum:
+    case E_IndividualMetricLowNonNullSum:
+    case E_IndividualMetricHighNonNullSum:
+        return true;
+    case E_IndividualLatLong:
+        return false;
+    case E_IndividualMaxVelocity:
+    case E_IndividualMinVelocity:
+    case E_IndividualMeanVelocity:
+    case E_IndividualSumVelocity:
+        return true;
+
+    case E_PopulationCount:
+    case E_PopulationDistinctCount:
+    case E_PopulationLowDistinctCount:
+    case E_PopulationHighDistinctCount:
+        return true;
+
+    case E_PopulationRare:
+        return false;
+
+    case E_PopulationRareCount:
+    case E_PopulationFreqRare:
+    case E_PopulationFreqRareCount:
+    case E_PopulationLowCounts:
+    case E_PopulationHighCounts:
+    case E_PopulationInfoContent:
+    case E_PopulationLowInfoContent:
+    case E_PopulationHighInfoContent:
+        return true;
+
+    case E_PopulationTimeOfDay:
+    case E_PopulationTimeOfWeek:
+        return false;
+
+    case E_PopulationMetric:
+    case E_PopulationMetricMean:
+    case E_PopulationMetricLowMean:
+    case E_PopulationMetricHighMean:
+    case E_PopulationMetricMedian:
+    case E_PopulationMetricLowMedian:
+    case E_PopulationMetricHighMedian:
+    case E_PopulationMetricMin:
+    case E_PopulationMetricMax:
+    case E_PopulationMetricVariance:
+    case E_PopulationMetricLowVariance:
+    case E_PopulationMetricHighVariance:
+    case E_PopulationMetricSum:
+    case E_PopulationMetricLowSum:
+    case E_PopulationMetricHighSum:
+        return true;
+
+    case E_PopulationLatLong:
+        return false;
+
+    case E_PopulationMaxVelocity:
+    case E_PopulationMinVelocity:
+    case E_PopulationMeanVelocity:
+    case E_PopulationSumVelocity:
+        return false;
+
+    case E_PeersCount:
+    case E_PeersLowCounts:
+    case E_PeersHighCounts:
+    case E_PeersDistinctCount:
+    case E_PeersLowDistinctCount:
+    case E_PeersHighDistinctCount:
+    case E_PeersInfoContent:
+    case E_PeersLowInfoContent:
+    case E_PeersHighInfoContent:
+    case E_PeersTimeOfDay:
+    case E_PeersTimeOfWeek:
+        return false;
+    }
+
+    LOG_ERROR(<< "Unexpected function = " << static_cast<int>(function));
+    return false;
+}
+
 namespace {
 
 using TFeatureFunctionVecMap = std::map<model_t::EFeature, TFunctionVec>;


### PR DESCRIPTION
Prune models (excluding for functions rare, freq_rare, time_of_day, time_of_week, lat_long) that haven't seen data updates for a
given period of time.

The window of time over which to prune is supplied in the `model_prune_window` field, which is an optional field in the job's `analysis_config` configuration. If not present no aggressive pruning is performed, no default value is used. However, the `bucket_span` value is used as a minimum value for the `model_prune_window` i.e. if the provided `model_prune_window` value is smaller than the `bucket_span` then the value of the `bucket_span` is used instead.