### PR TITLE
[ML] Adding upload tasks to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,12 @@
 description = 'Builds the Machine Learning native binaries'
 
+import org.elastic.gradle.UploadS3Task
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
-import org.gradle.util.GradleVersion
 import org.gradle.util.DistributionLocator
+import org.gradle.util.GradleVersion
+
+import java.util.zip.ZipFile
 
 import static org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 
@@ -26,9 +29,25 @@ allprojects {
   }
 }
 
+// Secret key and access key are only needed when
+// using the upload tasks near the end of this file.
+String envMlAwsAccessKey = System.env.ML_AWS_ACCESS_KEY
+if (envMlAwsAccessKey != null) {
+  project.ext.mlAwsAccessKey = envMlAwsAccessKey
+} else if (project.hasProperty('ML_AWS_ACCESS_KEY')) {
+  project.ext.mlAwsAccessKey = ML_AWS_ACCESS_KEY
+}
+
+String envMlAwsSecretKey = System.env.ML_AWS_SECRET_KEY
+if (envMlAwsSecretKey != null) {
+  project.ext.mlAwsSecretKey = envMlAwsSecretKey
+} else if (project.hasProperty('ML_AWS_SECRET_KEY')) {
+  project.ext.mlAwsSecretKey = ML_AWS_SECRET_KEY
+}
+
 String cppCrossCompile = System.env.CPP_CROSS_COMPILE
 if (cppCrossCompile == null) {
-  if (project.hasProperty("CPP_CROSS_COMPILE")) {
+  if (project.hasProperty('CPP_CROSS_COMPILE')) {
     cppCrossCompile = CPP_CROSS_COMPILE
   } else {
     cppCrossCompile = ''
@@ -185,6 +204,8 @@ artifacts {
   'default' buildUberZip
 }
 
+String artifactGroupPath = project.group.replaceAll("\\.", "/")
+
 task test(type: Exec) {
   environment makeEnvironment
   commandLine bash
@@ -207,6 +228,124 @@ task assemble {
 task build(dependsOn: [check, assemble]) {
   group = 'Build'
   description = 'Assemble and test the C++ part of Machine Learning'
+}
+
+/**
+ * Gradle 6 gets confused if we try to use its standard dependency management to
+ * convert artifacts with a classifier to an artifact for the same project
+ * without a classifier.  Therefore this class uses low level functionality to
+ * get the platform-specific artifacts.
+ */
+class DownloadPlatformSpecific extends DefaultTask {
+
+  @Input
+  String version = project.version
+
+  @Input
+  String artifactGroupPath = project.group.replaceAll("\\.", "/")
+
+  /**
+   * Base name for the artifacts
+   */
+  @Input
+  String baseName
+
+  /**
+   * Directory to download platform specific zip files into
+   */
+  @Input
+  String downloadDirectory
+
+  /**
+   * Directory to extract downloaded zip files into
+   */
+  @OutputDirectory
+  File extractDirectory
+
+  @Input
+  List<String> platforms = [ 'darwin-aarch64', 'darwin-x86_64', 'linux-aarch64', 'linux-x86_64', 'windows-x86_64' ]
+
+  DownloadPlatformSpecific() {
+    // Always run this task, in case the platform-specific zips have changed
+    outputs.upToDateWhen {
+      return false
+    }
+  }
+
+  @TaskAction
+  void combine() {
+    extractDirectory.deleteDir()
+    platforms.each {
+      File zipFile = new File(downloadDirectory, "${baseName}-${version}-${it}.zip")
+      zipFile.parentFile.mkdirs()
+      new URL("https://prelert-artifacts.s3.amazonaws.com/maven/${artifactGroupPath}/${baseName}/${version}/${zipFile.name}").withInputStream { i ->
+        zipFile.withOutputStream { o ->
+          o << i
+        }
+      }
+      ZipFile zip = new ZipFile(zipFile)
+      zip.entries().each {
+        File target = new File(extractDirectory, it.name)
+        // There can be overlaps between the platform-specific zips, so skip duplicates
+        if (target.exists() == false) {
+          if (it.isDirectory()) {
+            target.mkdirs()
+          } else {
+            target.parentFile.mkdirs()
+            target.withOutputStream { o ->
+              o << zip.getInputStream(it)
+            }
+            target.setLastModified(it.getTime())
+          }
+        }
+      }
+      zip.close()
+    }
+  }
+}
+
+// This intentionally doesn't depend on assemble.
+// This gives us the flexibility to build in different
+// ways and still use the same upload code.
+task upload(type: UploadS3Task) {
+  bucket 'prelert-artifacts'
+  // Only upload the platform-specific artifacts in this task
+  def zipFileDir = fileTree("${buildDir}/distributions").matching { include "*-aarch64.zip", "*-x86_64.zip" }
+  for (zipFile in zipFileDir) {
+    upload zipFile, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${zipFile.name}"
+  }
+  description = 'Upload C++ zips to S3 Bucket'
+}
+
+task downloadPlatformSpecific(type: DownloadPlatformSpecific) {
+  baseName = artifactName
+  downloadDirectory = "${buildDir}/distributions"
+  extractDirectory = file("${buildDir}/temp")
+  description = 'Download and extract previously created platform-specific C++ zips'
+}
+
+task buildUberZipFromDownloads(type: Zip, dependsOn: downloadPlatformSpecific) {
+  archiveBaseName = artifactName
+  archiveVersion = project.version
+  destinationDirectory = file("${buildDir}/distributions")
+  from(fileTree(downloadPlatformSpecific.outputs.files.singleFile))
+  description = 'Create an uber zip from combined platform-specific C++ distributions'
+}
+
+task buildDependencyReport(type: Exec) {
+  outputs.file("${buildDir}/distributions/dependencies.csv")
+  environment makeEnvironment
+  commandLine bash
+  args '-c', "source ./set_env.sh && 3rd_party/dependency_report.sh --csv \"${outputs.files.singleFile}\""
+  workingDir "${projectDir}"
+  description = 'Create a CSV report on 3rd party dependencies we redistribute'
+}
+
+task uberUpload(type: UploadS3Task, dependsOn: [buildUberZipFromDownloads, buildDependencyReport]) {
+  bucket 'prelert-artifacts'
+  upload buildUberZipFromDownloads.outputs.files.singleFile, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${buildUberZipFromDownloads.outputs.files.singleFile.name}"
+  upload buildDependencyReport.outputs.files.singleFile, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${buildDependencyReport.outputs.files.singleFile.name}"
+  description = 'Upload C++ uber zip and dependency report to S3 Bucket'
 }
 
 // The wrapper task causes an error when ml-cpp is in elasticsearch-extra

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -107,7 +107,7 @@ if ($LastExitCode -ne 0) {
 # If this isn't a PR build and isn't a debug build then upload the artifacts
 if (!(Test-Path Env:PR_AUTHOR) -And !(Test-Path Env:ML_DEBUG)) {
     # The | % { "$_" } at the end converts any error objects on stderr to strings
-    & ".\gradlew.bat" --info -b "upload.gradle" "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" upload 2>&1 | % { "$_" }
+    & ".\gradlew.bat" --info "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" upload 2>&1 | % { "$_" }
     if ($LastExitCode -ne 0) {
         Exit $LastExitCode
     }

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -142,6 +142,6 @@ esac
 
 # If this isn't a PR build and isn't a debug build then upload the artifacts
 if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
-    (cd .. && ./gradlew --info -b upload.gradle -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
+    (cd .. && ./gradlew --info -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
 fi
 

--- a/dev-tools/jenkins_cross_compile.sh
+++ b/dev-tools/jenkins_cross_compile.sh
@@ -94,6 +94,6 @@ fi
 
 # If this isn't a PR build and isn't a debug build then upload the artifacts
 if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
-    (cd .. && ./gradlew --info -b upload.gradle -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
+    (cd .. && ./gradlew --info -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
 fi
 


### PR DESCRIPTION
Gradle has deprecated the -b option, which means that we
cannot continue to split functionality between build.gradle
and upload.gradle in the long term.

This PR starts the combination process by adding the tasks
from upload.gradle into build.gradle.

The PR does _not_ remove upload.gradle, as it is referenced
by CI jobs.  The overall change needs to be done as a
multi-stage process, first adding functionality to
build.gradle, then updating CI jobs, and finally removing
the upload.gradle file.

Fixes one more deprecation identified in #1963