### PR TITLE
[7.x][ML] Aggressively prune dead split fields (#1962)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,17 @@
 
 //=== Regressions
 
+== {es} version 7.15.0
+
+=== Enhancements
+
+* Speed up training of regression and classification models on very large data sets.
+  (See {ml-pull}1941[#1941].)
+* Improve regression and classification training accuracy for small data sets.
+  (See {ml-pull}1960[#1960].)
+* Prune models for split fields (by, partition) that haven't seen data updates for
+  a given period of time. (See {ml-pull}1962[#1962].)
+
 == {es} version 7.14.0
 
 === Enhancements

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -404,7 +404,7 @@ protected:
     //! Get all the detectors.
     void detectors(TAnomalyDetectorPtrVec& detectors) const;
 
-    //! Get the detectors by parition
+    //! Get the detectors by partition
     const TKeyAnomalyDetectorPtrUMap& detectorPartitionMap() const;
 
     //! Get all sorted references to the detectors.
@@ -417,8 +417,10 @@ protected:
                                               const std::string& partitionFieldValue,
                                               model::CResourceMonitor& resourceMonitor);
 
-    //! Prune all the models
-    void pruneAllModels();
+    //! Prune all the models that exceed \p buckets in age
+    //! A value of 0 for \buckets indicates that only 'obsolete' models will
+    //! be pruned, i.e. those which are so old as to be effectively dead.
+    void pruneAllModels(std::size_t buckets = 0);
 
 private:
     //! The job ID

--- a/include/api/CAnomalyJobConfig.h
+++ b/include/api/CAnomalyJobConfig.h
@@ -187,6 +187,9 @@ public:
 
     public:
         static const std::string BUCKET_SPAN;
+
+        static const std::string MODEL_PRUNE_WINDOW;
+
         static const std::string SUMMARY_COUNT_FIELD_NAME;
         static const std::string CATEGORIZATION_FIELD_NAME;
         static const std::string CATEGORIZATION_FILTERS;
@@ -247,6 +250,12 @@ public:
         bool updateScheduledEvents(const boost::property_tree::ptree& propTree);
 
         core_t::TTime bucketSpan() const { return m_BucketSpan; }
+
+        //! Return the size of the model prune window expressed as a whole number of seconds.
+        //! Note that throughout the code the model prune window may sometimes be expressed in
+        //! seconds, as here, and sometimes as number of buckets. Where any doubt exists
+        //! a comment will explain which is in use.
+        core_t::TTime modelPruneWindow() const { return m_ModelPruneWindow; }
 
         std::string summaryCountFieldName() const {
             return m_SummaryCountFieldName;
@@ -321,6 +330,10 @@ public:
 
     private:
         core_t::TTime m_BucketSpan{DEFAULT_BUCKET_SPAN};
+
+        //! The size of the model prune window expressed as a whole number of seconds.
+        core_t::TTime m_ModelPruneWindow{0};
+
         std::string m_SummaryCountFieldName{};
         std::string m_CategorizationFieldName{};
         std::string m_CategorizationPartitionFieldName{};

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -249,6 +249,10 @@ public:
     //! that may be deleted as a result of this call.
     virtual void pruneModels();
 
+    //! Remove dead models - i.e. those that have not seen activity
+    //! in the last \p pruneWindow buckets
+    virtual void pruneModels(std::size_t pruneWindow);
+
     //! Reset bucket.
     void resetBucket(core_t::TTime bucketStart);
 

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -341,6 +341,14 @@ public:
     //! Get the bucket length.
     core_t::TTime bucketLength() const;
 
+    //! Get the period of time at which to perform a potential prune of the models
+    //! expressed in number of seconds.
+    core_t::TTime modelPruneWindow() const;
+
+    //! Set the period of time at which to perform a potential prune of the models
+    //! expressed in number of seconds.
+    void modelPruneWindow(core_t::TTime modelPruneWindow);
+
     //! Get the maximum latency in the arrival of out of order data.
     core_t::TTime latency() const;
 
@@ -445,10 +453,13 @@ public:
 
 private:
     //! Bucket length.
-    core_t::TTime m_BucketLength;
+    core_t::TTime m_BucketLength{0};
+
+    //! Prune window length (in seconds)
+    core_t::TTime m_ModelPruneWindow{0};
 
     //! Should multivariate analysis of correlated 'by' fields be performed?
-    bool m_MultivariateByFields;
+    bool m_MultivariateByFields{false};
 
     //! The single interim bucket correction calculator.
     TInterimBucketCorrectorPtr m_InterimBucketCorrector;

--- a/include/model/FunctionTypes.h
+++ b/include/model/FunctionTypes.h
@@ -232,6 +232,10 @@ bool isMetric(EFunction function);
 MODEL_EXPORT
 bool isForecastSupported(EFunction function);
 
+//! Is this function for use with aggressive pruning of dead split fields?
+MODEL_EXPORT
+bool isAggressivePruningSupported(EFunction function);
+
 //! Get the mapping from function to data features.
 MODEL_EXPORT
 const model_t::TFeatureVec& features(EFunction function);

--- a/lib/api/CAnomalyJobConfig.cc
+++ b/lib/api/CAnomalyJobConfig.cc
@@ -57,6 +57,9 @@ const core_t::TTime CAnomalyJobConfig::BASE_MAX_QUANTILE_INTERVAL{21600}; // 6 h
 const core_t::TTime CAnomalyJobConfig::DEFAULT_BASE_PERSIST_INTERVAL{10800}; // 3 hours
 
 const std::string CAnomalyJobConfig::CAnalysisConfig::BUCKET_SPAN{"bucket_span"};
+
+const std::string CAnomalyJobConfig::CAnalysisConfig::MODEL_PRUNE_WINDOW{"model_prune_window"};
+
 const std::string CAnomalyJobConfig::CAnalysisConfig::SUMMARY_COUNT_FIELD_NAME{
     "summary_count_field_name"};
 const std::string CAnomalyJobConfig::CAnalysisConfig::CATEGORIZATION_FIELD_NAME{
@@ -278,6 +281,8 @@ const CAnomalyJobConfigReader CONFIG_READER{[] {
 const CAnomalyJobConfigReader ANALYSIS_CONFIG_READER{[] {
     CAnomalyJobConfigReader theReader;
     theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::BUCKET_SPAN,
+                           CAnomalyJobConfigReader::E_OptionalParameter);
+    theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::MODEL_PRUNE_WINDOW,
                            CAnomalyJobConfigReader::E_OptionalParameter);
     theReader.addParameter(CAnomalyJobConfig::CAnalysisConfig::SUMMARY_COUNT_FIELD_NAME,
                            CAnomalyJobConfigReader::E_OptionalParameter);
@@ -681,6 +686,22 @@ void CAnomalyJobConfig::CAnalysisConfig::parse(const rapidjson::Value& analysisC
     m_SummaryCountFieldName = parameters[SUMMARY_COUNT_FIELD_NAME].fallback(EMPTY_STRING);
     m_CategorizationFieldName = parameters[CATEGORIZATION_FIELD_NAME].fallback(EMPTY_STRING);
     m_CategorizationFilters = parameters[CATEGORIZATION_FILTERS].fallback(TStrVec{});
+    const std::string& modelPruneWindowString{
+        parameters[MODEL_PRUNE_WINDOW].fallback(EMPTY_STRING)};
+
+    if (modelPruneWindowString.empty() == false) {
+        m_ModelPruneWindow = CAnomalyJobConfig::CAnalysisConfig::durationSeconds(
+            modelPruneWindowString, core_t::TTime{0});
+
+        // Ensure that the model prune window is never smaller than twice the bucket span.
+        if (m_ModelPruneWindow < (2 * m_BucketSpan)) {
+            LOG_WARN(<< "The value of configuration setting \"model_prune_window\" ("
+                     << m_ModelPruneWindow << ") is less than twice the value of \"bucket_span\" ("
+                     << m_BucketSpan << "). Setting \"model_prune_window\" to "
+                     << (2 * m_BucketSpan));
+            m_ModelPruneWindow = 2 * m_BucketSpan;
+        }
+    }
 
     auto ppc = parameters[PER_PARTITION_CATEGORIZATION].jsonObject();
     if (ppc != nullptr) {
@@ -801,6 +822,8 @@ CAnomalyJobConfig::CAnalysisConfig::makeModelConfig() const {
 
     modelConfig.scheduledEvents(
         model::CAnomalyDetectorModelConfig::TStrDetectionRulePrVecCRef(m_ScheduledEvents));
+
+    modelConfig.modelPruneWindow(m_ModelPruneWindow);
 
     return modelConfig;
 }

--- a/lib/api/unittest/CAnomalyJobConfigTest.cc
+++ b/lib/api/unittest/CAnomalyJobConfigTest.cc
@@ -124,6 +124,19 @@ BOOST_AUTO_TEST_CASE(testParse) {
         BOOST_TEST_REQUIRE(!jobConfig.isInitialized());
     }
     {
+        const std::string inValidModelPruneWindowType{
+            "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":10800,\"summary_count_field_name\":\"doc_count\","
+            "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"detector_index\":0}],\"influencers\":[]},"
+            "\"analysis_limits\":{\"model_memory_limit\":\"11mb\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
+            "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
+            "\"daily_model_snapshot_retention_after_days\":1,\"results_index_name\":\"shared\",\"allow_lazy_open\":false}"};
+
+        ml::api::CAnomalyJobConfig jobConfig;
+        BOOST_TEST_REQUIRE(!jobConfig.parse(inValidModelPruneWindowType));
+        BOOST_TEST_REQUIRE(!jobConfig.isInitialized());
+    }
+    {
         const std::string missingRequiredJobId{
             "{\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
             "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
@@ -138,7 +151,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"28d\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"background_persist_interval\":\"3h\",\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true,\"terms\":\"customer_id\"},\"model_snapshot_retention_days\":10,"
@@ -156,6 +169,8 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL(2419200, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
 
@@ -194,7 +209,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"24h\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"by_field_name\":\"customer_id\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":false,\"annotations_enabled\":true,\"terms\":\"customer_id\"},\"model_snapshot_retention_days\":10,"
@@ -221,6 +236,8 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL(86400, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
 
@@ -259,7 +276,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"1800s\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"all\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"background_persist_interval\":\"1d\",\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
@@ -277,6 +294,11 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        // This one's a bit special, we enforce that the model_prune_window value
+        // be at least 2 multiples of the bucket_span, i.e. if it is configured
+        // as less then the value is modified to the minimum acceptable value.
+        BOOST_REQUIRE_EQUAL(3600, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
 
@@ -315,7 +337,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string invalidAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\","
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"15m\",\"summary_count_field_name\":\"doc_count\","
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"whatever\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"model_snapshot_retention_days\":10,"
@@ -328,7 +350,7 @@ BOOST_AUTO_TEST_CASE(testParse) {
     {
         const std::string validAnomalyJobConfig{
             "{\"job_id\":\"flight_event_rate\",\"job_type\":\"anomaly_detector\",\"job_version\":\"8.0.0\",\"create_time\":1603110779167,"
-            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"summary_count_field_name\":\"doc_count\",\"multivariate_by_fields\":true,"
+            "\"description\":\"\",\"analysis_config\":{\"bucket_span\":\"30m\",\"model_prune_window\":\"60m\",\"summary_count_field_name\":\"doc_count\",\"multivariate_by_fields\":true,"
             "\"detectors\":[{\"detector_description\":\"count\",\"function\":\"count\",\"exclude_frequent\":\"by\",\"by_field_name\":\"customer_id\",\"over_field_name\":\"category.keyword\",\"detector_index\":0}],\"influencers\":[]},"
             "\"analysis_limits\":{\"model_memory_limit\":\"4195304b\",\"categorization_examples_limit\":4},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},"
             "\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true,\"terms\":\"customer_id,category.keyword\"},\"model_snapshot_retention_days\":10,"
@@ -356,6 +378,8 @@ BOOST_AUTO_TEST_CASE(testParse) {
         const TAnalysisConfig& analysisConfig = jobConfig.analysisConfig();
 
         BOOST_REQUIRE_EQUAL(1800, analysisConfig.bucketSpan());
+
+        BOOST_REQUIRE_EQUAL(3600, analysisConfig.modelPruneWindow());
 
         BOOST_REQUIRE_EQUAL("doc_count", analysisConfig.summaryCountFieldName());
         BOOST_REQUIRE_EQUAL(true, analysisConfig.multivariateByFields());

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -590,6 +590,15 @@ void CAnomalyDetector::pruneModels() {
     m_Model->prune(m_Model->defaultPruneWindow());
 }
 
+void CAnomalyDetector::pruneModels(std::size_t buckets) {
+    // Purge out any models that haven't seen activity in the given number of buckets.
+
+    function_t::EFunction function{m_DataGatherer->function()};
+    if (function_t::isAggressivePruningSupported(function)) {
+        m_Model->prune(buckets);
+    }
+}
+
 void CAnomalyDetector::resetBucket(core_t::TTime bucketStart) {
     m_DataGatherer->resetBucket(bucketStart);
 }

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -697,6 +697,10 @@ core_t::TTime CAnomalyDetectorModelConfig::bucketLength() const {
     return m_BucketLength;
 }
 
+core_t::TTime CAnomalyDetectorModelConfig::modelPruneWindow() const {
+    return m_ModelPruneWindow;
+}
+
 core_t::TTime CAnomalyDetectorModelConfig::latency() const {
     return m_BucketLength * m_Factories.begin()->second->modelParams().s_LatencyBuckets;
 }
@@ -761,6 +765,10 @@ void CAnomalyDetectorModelConfig::detectionRules(TIntDetectionRuleVecUMapCRef de
 
 void CAnomalyDetectorModelConfig::scheduledEvents(TStrDetectionRulePrVecCRef scheduledEvents) {
     m_ScheduledEvents = scheduledEvents;
+}
+
+void CAnomalyDetectorModelConfig::modelPruneWindow(core_t::TTime modelPruneWindow) {
+    m_ModelPruneWindow = modelPruneWindow;
 }
 
 core_t::TTime CAnomalyDetectorModelConfig::samplingAgeCutoff() const {

--- a/lib/model/FunctionTypes.cc
+++ b/lib/model/FunctionTypes.cc
@@ -530,6 +530,125 @@ bool isForecastSupported(EFunction function) {
     return false;
 }
 
+bool isAggressivePruningSupported(EFunction function) {
+    switch (function) {
+    case E_IndividualCount:
+    case E_IndividualNonZeroCount:
+    case E_IndividualRareCount:
+    case E_IndividualRareNonZeroCount:
+        return true;
+    case E_IndividualRare:
+        return false;
+    case E_IndividualLowCounts:
+    case E_IndividualHighCounts:
+    case E_IndividualLowNonZeroCount:
+    case E_IndividualHighNonZeroCount:
+    case E_IndividualDistinctCount:
+    case E_IndividualLowDistinctCount:
+    case E_IndividualHighDistinctCount:
+    case E_IndividualInfoContent:
+    case E_IndividualHighInfoContent:
+    case E_IndividualLowInfoContent:
+        return true;
+
+    case E_IndividualTimeOfDay:
+    case E_IndividualTimeOfWeek:
+        return false;
+
+    case E_IndividualMetric:
+    case E_IndividualMetricMean:
+    case E_IndividualMetricLowMean:
+    case E_IndividualMetricHighMean:
+    case E_IndividualMetricMedian:
+    case E_IndividualMetricLowMedian:
+    case E_IndividualMetricHighMedian:
+    case E_IndividualMetricMin:
+    case E_IndividualMetricMax:
+    case E_IndividualMetricVariance:
+    case E_IndividualMetricLowVariance:
+    case E_IndividualMetricHighVariance:
+    case E_IndividualMetricSum:
+    case E_IndividualMetricLowSum:
+    case E_IndividualMetricHighSum:
+    case E_IndividualMetricNonNullSum:
+    case E_IndividualMetricLowNonNullSum:
+    case E_IndividualMetricHighNonNullSum:
+        return true;
+    case E_IndividualLatLong:
+        return false;
+    case E_IndividualMaxVelocity:
+    case E_IndividualMinVelocity:
+    case E_IndividualMeanVelocity:
+    case E_IndividualSumVelocity:
+        return true;
+
+    case E_PopulationCount:
+    case E_PopulationDistinctCount:
+    case E_PopulationLowDistinctCount:
+    case E_PopulationHighDistinctCount:
+        return true;
+
+    case E_PopulationRare:
+        return false;
+
+    case E_PopulationRareCount:
+    case E_PopulationFreqRare:
+    case E_PopulationFreqRareCount:
+    case E_PopulationLowCounts:
+    case E_PopulationHighCounts:
+    case E_PopulationInfoContent:
+    case E_PopulationLowInfoContent:
+    case E_PopulationHighInfoContent:
+        return true;
+
+    case E_PopulationTimeOfDay:
+    case E_PopulationTimeOfWeek:
+        return false;
+
+    case E_PopulationMetric:
+    case E_PopulationMetricMean:
+    case E_PopulationMetricLowMean:
+    case E_PopulationMetricHighMean:
+    case E_PopulationMetricMedian:
+    case E_PopulationMetricLowMedian:
+    case E_PopulationMetricHighMedian:
+    case E_PopulationMetricMin:
+    case E_PopulationMetricMax:
+    case E_PopulationMetricVariance:
+    case E_PopulationMetricLowVariance:
+    case E_PopulationMetricHighVariance:
+    case E_PopulationMetricSum:
+    case E_PopulationMetricLowSum:
+    case E_PopulationMetricHighSum:
+        return true;
+
+    case E_PopulationLatLong:
+        return false;
+
+    case E_PopulationMaxVelocity:
+    case E_PopulationMinVelocity:
+    case E_PopulationMeanVelocity:
+    case E_PopulationSumVelocity:
+        return false;
+
+    case E_PeersCount:
+    case E_PeersLowCounts:
+    case E_PeersHighCounts:
+    case E_PeersDistinctCount:
+    case E_PeersLowDistinctCount:
+    case E_PeersHighDistinctCount:
+    case E_PeersInfoContent:
+    case E_PeersLowInfoContent:
+    case E_PeersHighInfoContent:
+    case E_PeersTimeOfDay:
+    case E_PeersTimeOfWeek:
+        return false;
+    }
+
+    LOG_ERROR(<< "Unexpected function = " << static_cast<int>(function));
+    return false;
+}
+
 namespace {
 
 using TFeatureFunctionVecMap = std::map<model_t::EFeature, TFunctionVec>;


### PR DESCRIPTION
Prune models (excluding for functions rare, freq_rare, time_of_day,
time_of_week, lat_long) that haven't seen data updates for a
given period of time.

Backports #1962 