### PR TITLE
[ML] Fix multiple 7.15 entries in changelog

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -45,19 +45,13 @@
 == {es} version 7.15.0
 
 === Enhancements
-* Prune models for split fields (by, partition) that haven't seen data updates for
-  a given period of time. (See {ml-pull}1962[#1962].)
-
-=== Bug Fixes
-
-== {es} version 7.15.0
-
-=== Enhancements
 
 * Speed up training of regression and classification models on very large data sets.
   (See {ml-pull}1941[#1941].)
 * Improve regression and classification training accuracy for small data sets.
   (See {ml-pull}1960[#1960].)
+* Prune models for split fields (by, partition) that haven't seen data updates for
+  a given period of time. (See {ml-pull}1962[#1962].)
 
 == {es} version 7.14.0
 


### PR DESCRIPTION
Somehow two sections for version 7.15 exist in the changelog. This
consolidates then to a single section.