### PR TITLE
[ML] Adding --include-build docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,15 @@ Please adhere to the general guideline that you should never force push to a pub
 1.  Write a test, unit tests are located under `lib/{module}/unittest`
 1.  Test your changes (`make test`)
 
+If you need to test C++ changes in this repo in conjunction with Elasticsearch changes then use
+Gradle's `--include-build` option to tell your Elasticsearch build to build the C++ locally
+instead of downloading the latest pre-built bundle. For example, if `elasticsearch` and `ml-cpp`
+are cloned in adjacent directories then you could run this in the `elasticsearch` directory:
+
+```
+./gradlew :x-pack:plugin:ml:qa:native-multi-node-tests:javaRestTest --tests "org.elasticsearch.xpack.ml.integration.MlJobIT" --include-build ../ml-cpp
+```
+
 ## Pull Requests
 
 Every change made to ml-cpp must be held to a high standard, Pull Requests are equally important as they document changes and decissions that have been made. `You Know, for Search` - a descriptive and relevant summary of the change helps people to find your PR later on.


### PR DESCRIPTION
The --include-build option replaces elasticsearch-extra
as the approved mechanism for testing ml-cpp and
elasticsearch changes together.