### PR TITLE
[ML] Split out 8.0.0-alpha1 in the changelog

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -32,6 +32,12 @@
 
 === Enhancements
 
+* ...
+
+== {es} version 8.0.0-alpha1
+
+=== Enhancements
+
 * The Windows build platform for the {ml} C++ code now uses Visual Studio 2019. (See
   {ml-pull}1352[#1352].)
 * The macOS build platform for the {ml} C++ code is now Mojave running Xcode 11.3.1,
@@ -39,7 +45,7 @@
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3. (See
   {ml-pull}1170[#1170].)
 * Added a new application for evaluating PyTorch models. The app depends on LibTorch
-  - the C++ front end to PyTorch and performs inference on models stored in the 
+  - the C++ front end to PyTorch - and performs inference on models stored in the
   TorchScript format. (See {ml-pull}1902[#1902].)
 
 == {es} version 7.15.0
@@ -131,7 +137,7 @@
 
 === Enhancements
 
-* During regression and classification training prefer smaller models if performance is 
+* During regression and classification training prefer smaller models if performance is
   similar (See {ml-pull}1516[#1516].)
 * Add a response mechanism for commands sent to the native controller. (See
   {ml-pull}1520[#1520], {es-pull}63542[#63542], issue: {es-issue}62823[#62823].)
@@ -139,7 +145,7 @@
   using longer bucket lengths. (See {ml-pull}1549[#1549].)
 * Fix an edge case which could cause typical and model plot bounds to blow up to around
   max double. (See {ml-pull}1551[#1551].)
-* Estimate upper bound of potential gains before splitting a decision tree node to avoid 
+* Estimate upper bound of potential gains before splitting a decision tree node to avoid
   unnecessary computation. (See {ml-pull}1537[#1537].)
 * Improvements to time series modeling particularly in relation to adaption to change.
   (See {ml-pull})1614[#1614].)
@@ -243,7 +249,7 @@
 * Reduce CPU scheduling priority of native analysis processes to favor the ES JVM
   when CPU is constrained. This change is only implemented for Linux and macOS, not
   for Windows. (See {ml-pull}1109[#1109].)
-* Take `training_percent` into account when estimating memory usage for classification and regression. 
+* Take `training_percent` into account when estimating memory usage for classification and regression.
   (See {ml-pull}1111[#1111].)
 * Support maximize minimum recall when assigning class labels for multiclass classification.
   (See {ml-pull}1113[#1113].)
@@ -293,12 +299,12 @@
 
 * Fixed background persistence of categorizer state (See {ml-pull}1137[#1137],
   issue: {ml-issue}1136[#1136].)
-* Fix classification job failures when number of classes in configuration differs 
+* Fix classification job failures when number of classes in configuration differs
   from the number of classes present in the training data. (See {ml-pull}1144[#1144].)
 * Fix underlying cause for "Failed to calculate splitting significance" log errors.
   (See {ml-pull}1157[#1157].)
 * Fix possible root cause for "Bad variance scale nan" log errors. (See {ml-pull}1225[#1225].)
-* Change data frame analytics instrumentation timestamp resolution to milliseconds. (See 
+* Change data frame analytics instrumentation timestamp resolution to milliseconds. (See
   {ml-pull}1237[#1237].)
 * Fix "autodetect process stopped unexpectedly: Fatal error: 'terminate called after
   throwing an instance of 'std::bad_function_call'". (See {ml-pull}1246[#1246],
@@ -419,7 +425,7 @@ boosted tree training. Hard depth based regularization is often the strategy of
 choice to prevent over fitting for XGBoost. By smoothing we can make better tradeoffs.
 Also, the parameters of the penalty function are mode suited to optimising with our
 Bayesian optimisation based hyperparameter search. (See {ml-pull}698[#698].)
-* Binomial logistic regression targeting cross entropy. (See {ml-pull}713[#713].) 
+* Binomial logistic regression targeting cross entropy. (See {ml-pull}713[#713].)
 * Improvements to count and sum anomaly detection for sparse data. This primarily
 aims to improve handling of data which are predictably present: detecting when they
 are unexpectedly missing. (See {ml-pull}721[#721].)


### PR DESCRIPTION
8.0.0-alpha1 will be released soon. This PR moves the changelog
items that went into alpha1 into a separate section so that it's
clear which items (if any) need to be release noted for alpha2
and beyond.