### PR TITLE
[ML] Do not persist detectors with only empty models

### DIFF
--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -460,6 +460,9 @@ public:
     //! Get writable model parameters.
     CModelParams& params();
 
+    //! Returns true
+    virtual bool shouldPersist() const;
+
 protected:
     CModel(const CModel&) = default;
 
@@ -601,6 +604,9 @@ public:
 
     //! Returns mixed data type since we don't know.
     maths_t::EDataType dataType() const override;
+
+    //! Returns false
+    virtual bool shouldPersist() const override;
 };
 }
 }

--- a/include/model/CAnomalyDetector.h
+++ b/include/model/CAnomalyDetector.h
@@ -181,6 +181,9 @@ public:
     //! created into which other state can be restored.
     void partitionFieldAcceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
+    //! Determine whether the detector should be persisted.
+    bool shouldPersistDetector() const;
+
     //! Persist state for statics - this is only called from the
     //! simple count detector to ensure singleton behaviour
     void staticsAcceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -207,6 +207,9 @@ public:
     //! Persist the state of the models.
     virtual void persistModelsState(core::CStatePersistInserter& inserter) const = 0;
 
+    //! Should the model be persisted?
+    virtual bool shouldPersistModel() const = 0;
+
     //! Persist state by passing information to the supplied inserter.
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const = 0;
 

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -208,7 +208,7 @@ public:
     virtual void persistModelsState(core::CStatePersistInserter& inserter) const = 0;
 
     //! Should the model be persisted?
-    virtual bool shouldPersistModel() const = 0;
+    virtual bool shouldPersist() const = 0;
 
     //! Persist state by passing information to the supplied inserter.
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const = 0;
@@ -524,6 +524,9 @@ protected:
         void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
         //! Get the memory used by this model.
         std::size_t memoryUsage() const;
+
+        //! Determine whether the model should be persisted or not.
+        bool shouldPersist() const;
 
         //! The feature.
         model_t::EFeature s_Feature;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -90,7 +90,7 @@ public:
     }
 
     //! Counting model is always persisted.
-    bool shouldPersistModel() const override { return true; }
+    bool shouldPersist() const override { return true; }
 
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -89,6 +89,9 @@ public:
         // NO-OP
     }
 
+    //! Counting model is always persisted.
+    bool shouldPersistModel() const override { return true; }
+
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -170,6 +170,9 @@ public:
         // NO-OP
     }
 
+    //! Population models should always be persisted.
+    bool shouldPersistModel() const override { return true; }
+
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -170,8 +170,8 @@ public:
         // NO-OP
     }
 
-    //! Population models should always be persisted.
-    bool shouldPersistModel() const override { return true; }
+    //! Should this model be persisted?
+    bool shouldPersist() const override;
 
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -180,7 +180,7 @@ protected:
     void doPersistModelsState(core::CStatePersistInserter& inserter) const;
 
     //! Should this model be persisted?
-    bool shouldPersistModel() const;
+    bool shouldPersist() const;
 
     //! Persist state by passing information to the supplied inserter.
     void doAcceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -179,6 +179,9 @@ protected:
     //! Persist the state of the models only.
     void doPersistModelsState(core::CStatePersistInserter& inserter) const;
 
+    //! Should this model be persisted?
+    bool shouldPersistModel() const;
+
     //! Persist state by passing information to the supplied inserter.
     void doAcceptPersistInserter(core::CStatePersistInserter& inserter) const;
 

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -153,7 +153,7 @@ public:
         // NO-OP
     }
 
-    //! Should the model should be persisted?
+    //! Should this model be persisted?
     bool shouldPersist() const override;
 
     //! Persist state by passing information to the supplied inserter

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -153,8 +153,8 @@ public:
         // NO-OP
     }
 
-    //! Population models should always be persisted.
-    bool shouldPersistModel() const override { return true; }
+    //! Should the model should be persisted?
+    bool shouldPersist() const override;
 
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -153,6 +153,9 @@ public:
         // NO-OP
     }
 
+    //! Population models should always be persisted.
+    bool shouldPersistModel() const override { return true; }
+
     //! Persist state by passing information to the supplied inserter
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -1309,6 +1309,11 @@ bool CAnomalyJob::persistCopiedState(const std::string& description,
                                   << pairDebug(detector_.first) << '\'');
                         continue;
                     }
+                    if (detector->shouldPersistDetector() == false) {
+                        LOG_TRACE(<< "Not persisting state for '"
+                                  << detector->description() << "'");
+                        continue;
+                    }
                     inserter.insertLevel(
                         TOP_LEVEL_DETECTOR_TAG,
                         std::bind(&CAnomalyJob::persistIndividualDetector,

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -433,7 +433,9 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
                             model::CStringStore::influencers().m_Strings.size());
 
         // While the 3 composers from the second partition should have been culled in the prune,
-        // their names still exist in the first partition, so will still be in the string store
+        // their names still exist in the first partition, so will still be in the string store.
+        // The 2nd partition should have been culled entirely, including removal of its name
+        // from the string store.
         BOOST_TEST_REQUIRE(this->nameExists("count"));
         BOOST_TEST_REQUIRE(this->nameExists("notes"));
         BOOST_TEST_REQUIRE(this->nameExists("composer"));
@@ -441,7 +443,7 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         BOOST_TEST_REQUIRE(this->nameExists("Elgar"));
         BOOST_TEST_REQUIRE(this->nameExists("Holst"));
         BOOST_TEST_REQUIRE(this->nameExists("Delius"));
-        BOOST_TEST_REQUIRE(this->nameExists("flute"));
+        BOOST_TEST_REQUIRE(this->nameExists("flute") == false);
         BOOST_TEST_REQUIRE(this->nameExists("tuba"));
 
         // Play some more data to cull out the third person
@@ -484,7 +486,7 @@ BOOST_FIXTURE_TEST_CASE(testAttributeStringPruning, CTestFixture) {
         BOOST_TEST_REQUIRE(this->nameExists("Holst"));
         BOOST_TEST_REQUIRE(this->nameExists("flute"));
         BOOST_TEST_REQUIRE(this->nameExists("tuba"));
-        BOOST_TEST_REQUIRE(!this->nameExists("Delius"));
+        BOOST_TEST_REQUIRE(this->nameExists("Delius") == false);
     }
 }
 

--- a/lib/api/unittest/CStringStoreTest.cc
+++ b/lib/api/unittest/CStringStoreTest.cc
@@ -220,7 +220,8 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         BOOST_TEST_REQUIRE(this->nameExists("flute"));
         BOOST_TEST_REQUIRE(this->nameExists("tuba"));
 
-        // play some data in a lot later, to bring about pruning
+        // play some data in a lot later, to bring about pruning. One partition
+        // should have been culled.
         time += BUCKET_SPAN * 5000;
         time = playData(time, BUCKET_SPAN, 100, 3, 1, 101, job);
 
@@ -248,7 +249,9 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         BOOST_REQUIRE_EQUAL(0, model::CStringStore::influencers().m_Strings.size());
 
         // While the 3 composers from the second partition should have been culled in the prune,
-        // their names still exist in the first partition, so will still be in the string store
+        // their names still exist in the first partition, so will still be in the string store.
+        // The 2nd partition should have been culled entirely, including removal of its name
+        // from the string store.
         BOOST_TEST_REQUIRE(this->nameExists("count"));
         BOOST_TEST_REQUIRE(this->nameExists("notes"));
         BOOST_TEST_REQUIRE(this->nameExists("composer"));
@@ -256,10 +259,10 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         BOOST_TEST_REQUIRE(this->nameExists("Elgar"));
         BOOST_TEST_REQUIRE(this->nameExists("Holst"));
         BOOST_TEST_REQUIRE(this->nameExists("Delius"));
-        BOOST_TEST_REQUIRE(this->nameExists("flute"));
+        BOOST_TEST_REQUIRE(this->nameExists("flute") == false);
         BOOST_TEST_REQUIRE(this->nameExists("tuba"));
 
-        // Play some more data to cull out the third person
+        // Play some more data to cull out the third person and to add back the 2nd partition
         time += BUCKET_SPAN * 5000;
         time = playData(time, BUCKET_SPAN, 100, 2, 2, 101, job);
 
@@ -298,7 +301,7 @@ BOOST_FIXTURE_TEST_CASE(testPersonStringPruning, CTestFixture) {
         BOOST_TEST_REQUIRE(this->nameExists("Holst"));
         BOOST_TEST_REQUIRE(this->nameExists("flute"));
         BOOST_TEST_REQUIRE(this->nameExists("tuba"));
-        BOOST_TEST_REQUIRE(!this->nameExists("Delius"));
+        BOOST_TEST_REQUIRE(this->nameExists("Delius") == false);
     }
 }
 

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -270,6 +270,10 @@ CModelParams& CModel::params() {
     return m_Params;
 }
 
+bool CModel::shouldPersist() const {
+    return true;
+}
+
 //////// CModelStub ////////
 
 CModelStub::CModelStub() : CModel(stubParameters()) {
@@ -409,6 +413,10 @@ void CModelStub::persistModelsState(core::CStatePersistInserter& /*inserter*/) c
 
 maths_t::EDataType CModelStub::dataType() const {
     return maths_t::E_MixedData;
+}
+
+bool CModelStub::shouldPersist() const {
+    return false;
 }
 }
 }

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -304,6 +304,19 @@ void CAnomalyDetector::partitionFieldAcceptPersistInserter(core::CStatePersistIn
     inserter.insertValue(PARTITION_FIELD_VALUE_TAG, m_DataGatherer->partitionFieldValue());
 }
 
+bool CAnomalyDetector::shouldPersistDetector() const {
+    // Query the model to determine if it should be persisted.
+    // This may return false if every constituent feature model is effectively
+    // empty, i.e. all the models are stubs due to them being pruned.
+    // If the model should not be persisted neither should the detector.
+    if (m_Model->shouldPersistModel() == false) {
+        LOG_TRACE(<< "NOT persisting detector \"" << this->description()
+                  << "\" due to all feature models being pruned");
+        return false;
+    }
+    return true;
+}
+
 void CAnomalyDetector::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     // Persist static members only once within the simple count detector
     // and do this first so that other model components can use

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -309,7 +309,7 @@ bool CAnomalyDetector::shouldPersistDetector() const {
     // This may return false if every constituent feature model is effectively
     // empty, i.e. all the models are stubs due to them being pruned.
     // If the model should not be persisted neither should the detector.
-    if (m_Model->shouldPersistModel() == false) {
+    if (m_Model->shouldPersist() == false) {
         LOG_TRACE(<< "NOT persisting detector \"" << this->description()
                   << "\" due to all feature models being pruned");
         return false;

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -529,6 +529,11 @@ std::size_t CAnomalyDetectorModel::SFeatureModels::memoryUsage() const {
     return core::CMemory::dynamicSize(s_NewModel) + core::CMemory::dynamicSize(s_Models);
 }
 
+bool CAnomalyDetectorModel::SFeatureModels::shouldPersist() const {
+    return std::any_of(s_Models.begin(), s_Models.end(),
+                       [](const auto& model) { return model->shouldPersist(); });
+}
+
 CAnomalyDetectorModel::SFeatureCorrelateModels::SFeatureCorrelateModels(
     model_t::EFeature feature,
     const TMultivariatePriorSPtr& modelPrior,

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -171,6 +171,11 @@ CEventRatePopulationModel::CEventRatePopulationModel(bool isForPersistence,
     }
 }
 
+bool CEventRatePopulationModel::shouldPersist() const {
+    return std::any_of(m_FeatureModels.begin(), m_FeatureModels.end(),
+                       [](const auto& model) { return model.shouldPersist(); });
+}
+
 void CEventRatePopulationModel::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     inserter.insertLevel(POPULATION_STATE_TAG,
                          std::bind(&CEventRatePopulationModel::doAcceptPersistInserter,

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -339,6 +339,20 @@ void CIndividualModel::doPersistModelsState(core::CStatePersistInserter& inserte
     }
 }
 
+bool CIndividualModel::shouldPersistModel() const {
+    // If a feature model's memory usage is zero, it indicates that the model
+    // has been pruned and replaced with a stub. If all feature models are
+    // such stubs then we choose to not persist the model
+    // in order to reclaim memory after a persist/restore cycle.
+    std::size_t modelMemory{0};
+    for (const auto& feature : m_FeatureModels) {
+        for (const auto& model : feature.s_Models) {
+            modelMemory += model->memoryUsage();
+        }
+    }
+    return modelMemory > 0 ? true : false;
+}
+
 void CIndividualModel::doAcceptPersistInserter(core::CStatePersistInserter& inserter) const {
     inserter.insertValue(WINDOW_BUCKET_COUNT_TAG, this->windowBucketCount(),
                          core::CIEEE754::E_SinglePrecision);

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -339,19 +339,9 @@ void CIndividualModel::doPersistModelsState(core::CStatePersistInserter& inserte
     }
 }
 
-bool CIndividualModel::shouldPersistModel() const {
-    // If a feature model's memory usage is zero, it indicates that the model
-    // has been pruned and replaced with a stub. If all feature models are
-    // such stubs then we choose to not persist the model
-    // in order to reclaim memory after a persist/restore cycle.
-    for (const auto& feature : m_FeatureModels) {
-        for (const auto& model : feature.s_Models) {
-            if (model->memoryUsage() > 0) {
-                return true;
-            }
-        }
-    }
-    return false;
+bool CIndividualModel::shouldPersist() const {
+    return std::any_of(m_FeatureModels.begin(), m_FeatureModels.end(),
+                       [](const auto& model) { return model.shouldPersist(); });
 }
 
 void CIndividualModel::doAcceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -344,13 +344,14 @@ bool CIndividualModel::shouldPersistModel() const {
     // has been pruned and replaced with a stub. If all feature models are
     // such stubs then we choose to not persist the model
     // in order to reclaim memory after a persist/restore cycle.
-    std::size_t modelMemory{0};
     for (const auto& feature : m_FeatureModels) {
         for (const auto& model : feature.s_Models) {
-            modelMemory += model->memoryUsage();
+            if (model->memoryUsage() > 0) {
+                return true;
+            }
         }
     }
-    return modelMemory > 0 ? true : false;
+    return false;
 }
 
 void CIndividualModel::doAcceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -167,6 +167,11 @@ CMetricPopulationModel::CMetricPopulationModel(bool isForPersistence,
     }
 }
 
+bool CMetricPopulationModel::shouldPersist() const {
+    return std::any_of(m_FeatureModels.begin(), m_FeatureModels.end(),
+                       [](const auto& model) { return model.shouldPersist(); });
+}
+
 void CMetricPopulationModel::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     inserter.insertLevel(POPULATION_STATE_TAG,
                          std::bind(&CMetricPopulationModel::doAcceptPersistInserter,

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -23,7 +23,7 @@ CMockModel::CMockModel(const SModelParams& params,
       m_IsPopulation(false), m_InterimBucketCorrector(params.s_BucketLength) {
 }
 
-bool CMockModel::shouldPersistModel() const {
+bool CMockModel::shouldPersist() const {
     return true;
 }
 

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -23,6 +23,10 @@ CMockModel::CMockModel(const SModelParams& params,
       m_IsPopulation(false), m_InterimBucketCorrector(params.s_BucketLength) {
 }
 
+bool CMockModel::shouldPersistModel() const {
+    return true;
+}
+
 void CMockModel::persistModelsState(core::CStatePersistInserter& /*inserter*/) const {
 }
 

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -39,7 +39,7 @@ public:
 
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
-    bool shouldPersistModel() const override;
+    bool shouldPersist() const override;
 
     CAnomalyDetectorModel* cloneForPersistence() const override;
 

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -39,6 +39,8 @@ public:
 
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
+    bool shouldPersistModel() const override;
+
     CAnomalyDetectorModel* cloneForPersistence() const override;
 
     model_t::EModelType category() const override;


### PR DESCRIPTION
Pruning may result in a situation where all the feature models of a detector are effectively empty. This presents an opportunity to reclaim memory by way of excluding such a detector from the persisted state, as on restoration the detector will no longer be present.

Labelling as `<non-issue` as the only observable change of this PR is a potential reduction in model memory size following a persist/restore cycle.

Relates #1962 