### PR TITLE
[ML] Scripting to generate full incremental training test matrix

### DIFF
--- a/jupyter/Makefile
+++ b/jupyter/Makefile
@@ -1,8 +1,11 @@
-#
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-# or more contributor license agreements. Licensed under the Elastic License;
-# you may not use this file except in compliance with the Elastic License.
-#
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
 
 ENV = env
 REQUIRE = requirements.txt

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -44,7 +44,7 @@
 
 ### Complete the configuration
 
-1. Specify `cloud_id`, `user`, and `password` in the `[cloud]` section of the `config.ini` file.
+1. Specify `cloud_id`, `user`, and `password` in the `[cloud]` section of the `config.ini` file. Note that we commit `template_config.ini` to avoid accidentally committing real credentials and this should be copied to create a `config.ini` file.
 
 2. Generate the service account json file by following using [instructions below](#how-to-generate-the-service-account-key-json-file).
 

--- a/jupyter/data/configs/boston.json
+++ b/jupyter/data/configs/boston.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "boston",
+    "rows": 506,
+    "cols": 14,
+    "memory_limit": 50000000,
+    "threads": 1,
+    "results_field": "ml",
+    "categorical_fields": ["CHAS", "RAD"],
+    "analysis": {
+      "name": "regression",
+      "parameters": {
+        "dependent_variable": "MEDV"
+      }
+    }
+  }

--- a/jupyter/data/configs/boston.json
+++ b/jupyter/data/configs/boston.json
@@ -1,15 +1,15 @@
 {
-    "job_id": "boston",
-    "rows": 506,
-    "cols": 14,
-    "memory_limit": 50000000,
-    "threads": 1,
-    "results_field": "ml",
-    "categorical_fields": ["CHAS", "RAD"],
-    "analysis": {
-      "name": "regression",
-      "parameters": {
-        "dependent_variable": "MEDV"
-      }
+  "job_id": "boston",
+  "rows": 506,
+  "cols": 14,
+  "memory_limit": 50000000,
+  "threads": 1,
+  "results_field": "ml",
+  "categorical_fields": ["CHAS", "RAD"],
+  "analysis": {
+    "name": "regression",
+    "parameters": {
+      "dependent_variable": "MEDV"
     }
   }
+}

--- a/jupyter/data/configs/ccpp.json
+++ b/jupyter/data/configs/ccpp.json
@@ -1,14 +1,14 @@
 {
-    "job_id": "ccpp",
-    "rows": 9568,
-    "cols": 5,
-    "memory_limit": 50000000,
-    "threads": 3,
-    "results_field": "ml",
-    "analysis": {
-      "name": "regression",
-      "parameters": {
-        "dependent_variable": "PE"
-      }
+  "job_id": "ccpp",
+  "rows": 9568,
+  "cols": 5,
+  "memory_limit": 50000000,
+  "threads": 3,
+  "results_field": "ml",
+  "analysis": {
+    "name": "regression",
+    "parameters": {
+      "dependent_variable": "PE"
     }
   }
+}

--- a/jupyter/data/configs/classification-2d.json
+++ b/jupyter/data/configs/classification-2d.json
@@ -5,7 +5,7 @@
     "memory_limit": 50000000,
     "threads": 3,
     "results_field": "ml",
-      "categorical_fields": ["target"],
+    "categorical_fields": ["target"],
     "analysis": {
       "name": "classification",
       "parameters": {

--- a/jupyter/scripts/incremental_learning/experiment_driver.py
+++ b/jupyter/scripts/incremental_learning/experiment_driver.py
@@ -146,73 +146,48 @@ def transform_dataset(dataset: pd.DataFrame,
         update_dataset, test2_dataset = train_test_split(update_dataset, test_size=test_fraction)
         return train_dataset, update_dataset, test1_dataset, test2_dataset
 
+    transform = None
+
     if transform_name == 'resample_metric_features':
-        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = resample_metric_features(
-            dataset=train_dataset,
+        transform = lambda dataset : resample_metric_features(
+            dataset=dataset,
             seed=_seed, 
             fraction=transform_parameters['fraction'], 
             magnitude=transform_parameters['magnitude'],
             metric_features=transform_parameters['metric_features'])
-        test2_dataset = resample_metric_features(
-            dataset=test1_dataset,
-            seed=_seed, 
-            fraction=transform_parameters['fraction'], 
-            magnitude=transform_parameters['magnitude'],
-            metric_features=transform_parameters['metric_features'])
-        return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     if transform_name == 'shift_metric_features':
-        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = shift_metric_features(
-            dataset=train_dataset,
+        transform = lambda dataset : shift_metric_features(
+            dataset=dataset,
             seed=_seed,
             fraction=transform_parameters['fraction'],
             magnitude=transform_parameters['magnitude'],
             categorical_features=transform_parameters['categorical_features'])
-        test2_dataset = shift_metric_features(
-            dataset=test1_dataset,
-            seed=_seed,
-            fraction=transform_parameters['fraction'],
-            magnitude=transform_parameters['magnitude'],
-            categorical_features=transform_parameters['categorical_features'])
-        return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     if transform_name == 'rotate_metric_features':
-        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = rotate_metric_features(
-            dataset=train_dataset,
+        transform = lambda dataset : rotate_metric_features(
+            dataset=dataset,
             seed=_seed,
             fraction=transform_parameters['fraction'],
             magnitude=transform_parameters['magnitude'],
             categorical_features=transform_parameters['categorical_features'])
-        test2_dataset = rotate_metric_features(
-            dataset=test1_dataset,
-            seed=_seed,
-            fraction=transform_parameters['fraction'],
-            magnitude=transform_parameters['magnitude'],
-            categorical_features=transform_parameters['categorical_features'])
-        return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     if transform_name == 'regression_category_drift':
-        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = regression_category_drift(
-            dataset=train_dataset,
+        transform = lambda dataset : regression_category_drift(
+            dataset=dataset,
             seed=_seed,
             fraction=transform_parameters['fraction'],
             magnitude=transform_parameters['magnitude'],
             categorical_features=transform_parameters['categorical_features'],
             target=transform_parameters['target'])
-        test2_dataset = regression_category_drift(
-            dataset=test1_dataset,
-            seed=_seed,
-            fraction=transform_parameters['fraction'],
-            magnitude=transform_parameters['magnitude'],
-            categorical_features=transform_parameters['categorical_features'],
-            target=transform_parameters['target'])
-        return train_dataset, update_dataset, test1_dataset, test2_dataset
 
-    raise NotImplementedError(transform_name + ' is not implemented.')
+    if transform != None:
+        raise NotImplementedError(transform_name + ' is not implemented.')
+
+    train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
+    update_dataset = transform(train_dataset)
+    test2_dataset = transform(test1_dataset)
+    return train_dataset, update_dataset, test1_dataset, test2_dataset
 
 
 @ex.main

--- a/jupyter/scripts/incremental_learning/experiment_driver.py
+++ b/jupyter/scripts/incremental_learning/experiment_driver.py
@@ -22,11 +22,15 @@ from sacred import Experiment
 from sacred.observers import FileStorageObserver
 from sklearn.model_selection import train_test_split
 
-from incremental_learning.config import datasets_dir, logger, root_dir
+from incremental_learning.config import datasets_dir, logger
 from incremental_learning.elasticsearch import push2es
 from incremental_learning.job import evaluate, train, update
 from incremental_learning.storage import download_dataset
+from incremental_learning.transforms import partition_on_metric_ranges
+from incremental_learning.transforms import regression_category_drift
 from incremental_learning.transforms import resample_metric_features
+from incremental_learning.transforms import rotate_metric_features
+from incremental_learning.transforms import shift_metric_features
 
 experiment_name = 'generic-train-update'
 experiment_data_path = Path('/tmp/'+experiment_name)
@@ -128,42 +132,100 @@ def read_dataset(_run, dataset_name):
 
 
 @ex.capture
-def transform_dataset(dataset: pd.DataFrame, transform_name: str, transform_parameters, _seed: int) -> pd.DataFrame:
+def transform_dataset(dataset: pd.DataFrame,
+                      test_fraction: float,
+                      transform_name: str,
+                      transform_parameters,
+                      _seed: int) -> pd.DataFrame:
+    if transform_name == 'partition_on_metric_ranges':
+        train_dataset, update_dataset = partition_on_metric_ranges(dataset=dataset,
+                                                                   seed=_seed,
+                                                                   features=transform_parameters['features'])
+        train_dataset, test1_dataset = train_test_split(train_dataset, test_size=test_fraction)
+        update_dataset, test2_dataset = train_test_split(update_dataset, test_size=test_fraction)
+        return train_dataset, update_dataset, test1_dataset, test2_dataset
+
     if transform_name == 'resample_metric_features':
-        transformed_dataset = resample_metric_features(data_frame=dataset,
-                                                       seed=_seed, 
-                                                       fraction=transform_parameters['fraction'], 
-                                                       magnitude=transform_parameters['magnitude'],
-                                                       features=transform_parameters['features'])
-        return transformed_dataset
-    # TODO extend to other transforms
-    else:
-        raise NotImplementedError("This dataset transform is not integrated yet.")
+        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
+        update_dataset = resample_metric_features(dataset=train_dataset,
+                                                  seed=_seed, 
+                                                  fraction=transform_parameters['fraction'], 
+                                                  magnitude=transform_parameters['magnitude'],
+                                                  features=transform_parameters['features'])
+        test2_dataset = resample_metric_features(dataset=test1_dataset,
+                                                 seed=_seed, 
+                                                 fraction=transform_parameters['fraction'], 
+                                                 magnitude=transform_parameters['magnitude'],
+                                                 features=transform_parameters['features'])
+        return train_dataset, update_dataset, test1_dataset, test2_dataset
+
+    if transform_name == 'shift_metric_features':
+        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
+        update_dataset = shift_metric_features(dataset=train_dataset,
+                                               seed=_seed,
+                                               fraction=transform_parameters['fraction'],
+                                               magnitude=transform_parameters['magnitude'],
+                                               categorical_features=transform_parameters['categorical_features'])
+        test2_dataset = shift_metric_features(dataset=test1_dataset,
+                                              seed=_seed,
+                                              fraction=transform_parameters['fraction'],
+                                              magnitude=transform_parameters['magnitude'],
+                                              categorical_features=transform_parameters['categorical_features'])
+        return train_dataset, update_dataset, test1_dataset, test2_dataset
+
+    if transform_name == 'rotate_metric_features':
+        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
+        update_dataset = rotate_metric_features(dataset=train_dataset,
+                                                seed=_seed,
+                                                fraction=transform_parameters['fraction'],
+                                                magnitude=transform_parameters['magnitude'],
+                                                categorical_features=transform_parameters['categorical_features'])
+        test2_dataset = rotate_metric_features(dataset=test1_dataset,
+                                               seed=_seed,
+                                               fraction=transform_parameters['fraction'],
+                                               magnitude=transform_parameters['magnitude'],
+                                               categorical_features=transform_parameters['categorical_features'])
+        return train_dataset, update_dataset, test1_dataset, test2_dataset
+
+    if transform_name == 'regression_category_drift':
+        train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
+        update_dataset = regression_category_drift(dataset=train_dataset,
+                                                   seed=_seed,
+                                                   fraction=transform_parameters['fraction'],
+                                                   magnitude=transform_parameters['magnitude'],
+                                                   categorical_features=transform_parameters['categorical_features'],
+                                                   target=transform_parameters['target'])
+        test2_dataset = regression_category_drift(dataset=test1_dataset,
+                                                  seed=_seed,
+                                                  fraction=transform_parameters['fraction'],
+                                                  magnitude=transform_parameters['magnitude'],
+                                                  categorical_features=transform_parameters['categorical_features'],
+                                                  target=transform_parameters['target'])
+        return train_dataset, update_dataset, test1_dataset, test2_dataset
+
+    raise NotImplementedError(transform_name + ' is not implemented.')
 
 
 @ex.main
-def my_main(_run, dataset_name, test_fraction):
+def my_main(_run, dataset_name):
     results = {}
 
     original_dataset = read_dataset()
-    train_dataset, test1_dataset = train_test_split(original_dataset, test_size=test_fraction)
-    update_dataset = transform_dataset(dataset=train_dataset)
-    test2_dataset = transform_dataset(dataset=test1_dataset)
-
+    train_dataset, update_dataset, test1_dataset, test2_dataset = transform_dataset(dataset=original_dataset)
     baseline_dataset = pd.concat([train_dataset, update_dataset])
     test_dataset = pd.concat([test1_dataset, test2_dataset])
     
     _run.run_logger.info("Baseline training started")
-    baseline = train(dataset_name, baseline_dataset, verbose=False, run=_run)
-    elapsed_time = baseline.wait_to_complete(clean=False)
+    baseline_model = train(dataset_name, baseline_dataset, verbose=False, run=_run)
+    elapsed_time = baseline_model.wait_to_complete(clean=False)
     results['baseline'] = {}
-    results['baseline']['config'] = baseline.get_config()
-    results['baseline']['hyperparameters'] = baseline.get_hyperparameters()
+    results['baseline']['config'] = baseline_model.get_config()
+    results['baseline']['hyperparameters'] = baseline_model.get_hyperparameters()
     results['baseline']['elapsed_time'] = elapsed_time
-    baseline.clean()
+    baseline_model.clean()
     _run.run_logger.info("Baseline training completed")
 
-    dependent_variable = baseline.dependent_variable
+    dependent_variable = baseline_model.dependent_variable
 
     _run.run_logger.info("Initial training started")
     trained_model = train(dataset_name, train_dataset, verbose=False, run=_run)
@@ -187,7 +249,7 @@ def my_main(_run, dataset_name, test_fraction):
 
     y_true = test_dataset[dependent_variable]
 
-    baseline_eval = evaluate(dataset_name, test_dataset, baseline, verbose=False)
+    baseline_eval = evaluate(dataset_name, test_dataset, baseline_model, verbose=False)
     baseline_eval.wait_to_complete()
 
     trained_model_eval = evaluate(dataset_name, test_dataset, trained_model, verbose=False)
@@ -198,12 +260,12 @@ def my_main(_run, dataset_name, test_fraction):
 
     scores = {}
 
-    if baseline.is_regression():
+    if baseline_model.is_regression():
         scores = compute_regression_metrics(y_true,
                                             baseline_eval.get_predictions(),
                                             trained_model_eval.get_predictions(),
                                             updated_model_eval.get_predictions())
-    elif baseline.is_classification():
+    elif baseline_model.is_classification():
         scores = compute_classification_metrics(y_true,
                                                 baseline_eval.get_predictions(),
                                                 trained_model_eval.get_predictions(),

--- a/jupyter/scripts/incremental_learning/experiment_driver.py
+++ b/jupyter/scripts/incremental_learning/experiment_driver.py
@@ -138,69 +138,78 @@ def transform_dataset(dataset: pd.DataFrame,
                       transform_parameters,
                       _seed: int) -> pd.DataFrame:
     if transform_name == 'partition_on_metric_ranges':
-        train_dataset, update_dataset = partition_on_metric_ranges(dataset=dataset,
-                                                                   seed=_seed,
-                                                                   features=transform_parameters['features'])
+        train_dataset, update_dataset = partition_on_metric_ranges(
+            dataset=dataset,
+            seed=_seed,
+            metric_features=transform_parameters['metric_features'])
         train_dataset, test1_dataset = train_test_split(train_dataset, test_size=test_fraction)
         update_dataset, test2_dataset = train_test_split(update_dataset, test_size=test_fraction)
         return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     if transform_name == 'resample_metric_features':
         train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = resample_metric_features(dataset=train_dataset,
-                                                  seed=_seed, 
-                                                  fraction=transform_parameters['fraction'], 
-                                                  magnitude=transform_parameters['magnitude'],
-                                                  features=transform_parameters['features'])
-        test2_dataset = resample_metric_features(dataset=test1_dataset,
-                                                 seed=_seed, 
-                                                 fraction=transform_parameters['fraction'], 
-                                                 magnitude=transform_parameters['magnitude'],
-                                                 features=transform_parameters['features'])
+        update_dataset = resample_metric_features(
+            dataset=train_dataset,
+            seed=_seed, 
+            fraction=transform_parameters['fraction'], 
+            magnitude=transform_parameters['magnitude'],
+            metric_features=transform_parameters['metric_features'])
+        test2_dataset = resample_metric_features(
+            dataset=test1_dataset,
+            seed=_seed, 
+            fraction=transform_parameters['fraction'], 
+            magnitude=transform_parameters['magnitude'],
+            metric_features=transform_parameters['metric_features'])
         return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     if transform_name == 'shift_metric_features':
         train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = shift_metric_features(dataset=train_dataset,
-                                               seed=_seed,
-                                               fraction=transform_parameters['fraction'],
-                                               magnitude=transform_parameters['magnitude'],
-                                               categorical_features=transform_parameters['categorical_features'])
-        test2_dataset = shift_metric_features(dataset=test1_dataset,
-                                              seed=_seed,
-                                              fraction=transform_parameters['fraction'],
-                                              magnitude=transform_parameters['magnitude'],
-                                              categorical_features=transform_parameters['categorical_features'])
+        update_dataset = shift_metric_features(
+            dataset=train_dataset,
+            seed=_seed,
+            fraction=transform_parameters['fraction'],
+            magnitude=transform_parameters['magnitude'],
+            categorical_features=transform_parameters['categorical_features'])
+        test2_dataset = shift_metric_features(
+            dataset=test1_dataset,
+            seed=_seed,
+            fraction=transform_parameters['fraction'],
+            magnitude=transform_parameters['magnitude'],
+            categorical_features=transform_parameters['categorical_features'])
         return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     if transform_name == 'rotate_metric_features':
         train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = rotate_metric_features(dataset=train_dataset,
-                                                seed=_seed,
-                                                fraction=transform_parameters['fraction'],
-                                                magnitude=transform_parameters['magnitude'],
-                                                categorical_features=transform_parameters['categorical_features'])
-        test2_dataset = rotate_metric_features(dataset=test1_dataset,
-                                               seed=_seed,
-                                               fraction=transform_parameters['fraction'],
-                                               magnitude=transform_parameters['magnitude'],
-                                               categorical_features=transform_parameters['categorical_features'])
+        update_dataset = rotate_metric_features(
+            dataset=train_dataset,
+            seed=_seed,
+            fraction=transform_parameters['fraction'],
+            magnitude=transform_parameters['magnitude'],
+            categorical_features=transform_parameters['categorical_features'])
+        test2_dataset = rotate_metric_features(
+            dataset=test1_dataset,
+            seed=_seed,
+            fraction=transform_parameters['fraction'],
+            magnitude=transform_parameters['magnitude'],
+            categorical_features=transform_parameters['categorical_features'])
         return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     if transform_name == 'regression_category_drift':
         train_dataset, test1_dataset = train_test_split(dataset, test_size=test_fraction)
-        update_dataset = regression_category_drift(dataset=train_dataset,
-                                                   seed=_seed,
-                                                   fraction=transform_parameters['fraction'],
-                                                   magnitude=transform_parameters['magnitude'],
-                                                   categorical_features=transform_parameters['categorical_features'],
-                                                   target=transform_parameters['target'])
-        test2_dataset = regression_category_drift(dataset=test1_dataset,
-                                                  seed=_seed,
-                                                  fraction=transform_parameters['fraction'],
-                                                  magnitude=transform_parameters['magnitude'],
-                                                  categorical_features=transform_parameters['categorical_features'],
-                                                  target=transform_parameters['target'])
+        update_dataset = regression_category_drift(
+            dataset=train_dataset,
+            seed=_seed,
+            fraction=transform_parameters['fraction'],
+            magnitude=transform_parameters['magnitude'],
+            categorical_features=transform_parameters['categorical_features'],
+            target=transform_parameters['target'])
+        test2_dataset = regression_category_drift(
+            dataset=test1_dataset,
+            seed=_seed,
+            fraction=transform_parameters['fraction'],
+            magnitude=transform_parameters['magnitude'],
+            categorical_features=transform_parameters['categorical_features'],
+            target=transform_parameters['target'])
         return train_dataset, update_dataset, test1_dataset, test2_dataset
 
     raise NotImplementedError(transform_name + ' is not implemented.')

--- a/jupyter/scripts/incremental_learning/experiments.json
+++ b/jupyter/scripts/incremental_learning/experiments.json
@@ -1,36 +1,158 @@
-{
-    "configurations": [
-        {
-            "dataset_name": "ccpp",
-            "seed": 42,
-            "threads": 1,
-            "transform_name": "resample_metric_features",
+[
+    {
+        "dataset_name": "ccpp",
+        "seed": 58076675,
+        "threads": 1,
+        "transform_name": "partition_on_metric_ranges",
+        "transform_parameters": {
+            "transform_name": "partition_on_metric_ranges",
             "transform_parameters": {
-                "fraction": 0.5,
-                "magnitude": 0.5,
-                "features": [
-                    "AP",
-                    "AT",
-                    "RH",
-                    "V"
-                ]
-            }
-        },
-        {
-            "dataset_name": "ccpp",
-            "seed": 4200000,
-            "threads": 1,
-            "transform_name": "resample_metric_features",
-            "transform_parameters": {
-                "fraction": 0.5,
-                "magnitude": 0.5,
-                "features": [
-                    "AP",
-                    "AT",
-                    "RH",
-                    "V"
-                ]
+                "metric_fraction": []
             }
         }
-    ]
-}
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 31639532,
+        "threads": 1,
+        "transform_name": "partition_on_metric_ranges",
+        "transform_parameters": {
+            "transform_name": "partition_on_metric_ranges",
+            "transform_parameters": {
+                "metric_fraction": []
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 9098806,
+        "threads": 1,
+        "transform_name": "partition_on_metric_ranges",
+        "transform_parameters": {
+            "transform_name": "partition_on_metric_ranges",
+            "transform_parameters": {
+                "metric_fraction": []
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 30429823,
+        "threads": 1,
+        "transform_name": "resample_metric_features",
+        "transform_parameters": {
+            "transform_name": "resample_metric_features",
+            "transform_parameters": {
+                "features": [],
+                "magnitude": 0.57,
+                "metric_fraction": 0.0
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 77429843,
+        "threads": 1,
+        "transform_name": "resample_metric_features",
+        "transform_parameters": {
+            "transform_name": "resample_metric_features",
+            "transform_parameters": {
+                "features": [],
+                "magnitude": 0.16,
+                "metric_fraction": 0.0
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 9946445,
+        "threads": 1,
+        "transform_name": "resample_metric_features",
+        "transform_parameters": {
+            "transform_name": "resample_metric_features",
+            "transform_parameters": {
+                "features": [],
+                "magnitude": 0.59,
+                "metric_fraction": 0.0
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 7450670,
+        "threads": 1,
+        "transform_name": "shift_metric_features",
+        "transform_parameters": {
+            "transform_name": "shift_metric_features",
+            "transform_parameters": {
+                "fraction": 0.14,
+                "magnitude": 0.83
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 23508332,
+        "threads": 1,
+        "transform_name": "shift_metric_features",
+        "transform_parameters": {
+            "transform_name": "shift_metric_features",
+            "transform_parameters": {
+                "fraction": 0.73,
+                "magnitude": 0.76
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 57666096,
+        "threads": 1,
+        "transform_name": "shift_metric_features",
+        "transform_parameters": {
+            "transform_name": "shift_metric_features",
+            "transform_parameters": {
+                "fraction": 0.79,
+                "magnitude": 0.56
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 34186102,
+        "threads": 1,
+        "transform_name": "rotate_metric_features",
+        "transform_parameters": {
+            "transform_name": "rotate_metric_features",
+            "transform_parameters": {
+                "fraction": 0.65,
+                "magnitude": 0.54
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 89433471,
+        "threads": 1,
+        "transform_name": "rotate_metric_features",
+        "transform_parameters": {
+            "transform_name": "rotate_metric_features",
+            "transform_parameters": {
+                "fraction": 0.73,
+                "magnitude": 0.65
+            }
+        }
+    },
+    {
+        "dataset_name": "ccpp",
+        "seed": 94941708,
+        "threads": 1,
+        "transform_name": "rotate_metric_features",
+        "transform_parameters": {
+            "transform_name": "rotate_metric_features",
+            "transform_parameters": {
+                "fraction": 0.63,
+                "magnitude": 0.7
+            }
+        }
+    }
+]

--- a/jupyter/scripts/incremental_learning/experiments.json
+++ b/jupyter/scripts/incremental_learning/experiments.json
@@ -3,11 +3,11 @@
         {
             "dataset_name": "ccpp",
             "seed": 42,
-            "threads": 4,
+            "threads": 1,
             "transform_name": "resample_metric_features",
             "transform_parameters": {
                 "fraction": 0.5,
-                "magnitude": 0.1,
+                "magnitude": 0.5,
                 "features": [
                     "AP",
                     "AT",
@@ -15,11 +15,11 @@
                     "V"
                 ]
             }
-        }, 
+        },
         {
             "dataset_name": "ccpp",
-            "seed": 42,
-            "threads": 4,
+            "seed": 4200000,
+            "threads": 1,
             "transform_name": "resample_metric_features",
             "transform_parameters": {
                 "fraction": 0.5,

--- a/jupyter/scripts/incremental_learning/generate_experiment_matrix.py
+++ b/jupyter/scripts/incremental_learning/generate_experiment_matrix.py
@@ -1,3 +1,12 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
 import argparse
 import copy
 import csv

--- a/jupyter/scripts/incremental_learning/generate_experiment_matrix.py
+++ b/jupyter/scripts/incremental_learning/generate_experiment_matrix.py
@@ -22,7 +22,7 @@ def feature_fields(dataset_name : str):
 
 def features():
     result = {}
-    for dataset_name in args.categorisation_datasets:
+    for dataset_name in args.classification_datasets:
         if download_dataset(dataset_name):
             result[dataset_name] = feature_fields(dataset_name)
     for dataset_name in args.regression_datasets:
@@ -76,7 +76,7 @@ def generate_parameters(transform: dict,
 
 parser = argparse.ArgumentParser(description='Generates the experiments.json file for a collection of data and transforms')
 parser.add_argument('--experiments_file', default='experiments.json', help='The experiments file to write')
-parser.add_argument('--categorisation_datasets', nargs='+', default=[], help='The categorisation datasets to use')
+parser.add_argument('--classification_datasets', nargs='+', default=[], help='The classification datasets to use')
 parser.add_argument('--regression_datasets', nargs='+', default=[], help='The regression datasets to use')
 parser.add_argument('--transforms_file', default='transform_templates.json', help='The transforms to apply to each dataset')
 parser.add_argument('--number_random_copies', default=3, help='The number of random verions to use for each base experiment')
@@ -94,7 +94,7 @@ with open(args.transforms_file, 'r') as transforms_file:
         print('Generating experiments for', transform)
         for _ in range(args.number_random_copies):
             for categorisation, dataset_names in zip([True, False],
-                                                     [args.categorisation_datasets, args.regression_datasets]):
+                                                     [args.classification_datasets, args.regression_datasets]):
                 for dataset_name in dataset_names:
                     target, metric_features, categorical_features = dataset_features[dataset_name]
                     params = generate_parameters(transform=transform,

--- a/jupyter/scripts/incremental_learning/transform_templates.json
+++ b/jupyter/scripts/incremental_learning/transform_templates.json
@@ -2,15 +2,15 @@
     {
         "transform_name": "partition_on_metric_ranges",
         "transform_parameters": {
-            "metric_fraction": []
+            "fraction": 0.0
         }
     },
     {
         "transform_name": "resample_metric_features",
         "transform_parameters": {
-            "metric_fraction": 0.0,
+            "fraction": 0.0,
             "magnitude": 0.0,
-            "features": []
+            "metric_features": []
         }
     },
     {

--- a/jupyter/scripts/incremental_learning/transform_templates.json
+++ b/jupyter/scripts/incremental_learning/transform_templates.json
@@ -1,0 +1,41 @@
+[
+    {
+        "transform_name": "partition_on_metric_ranges",
+        "transform_parameters": {
+            "metric_fraction": []
+        }
+    },
+    {
+        "transform_name": "resample_metric_features",
+        "transform_parameters": {
+            "metric_fraction": 0.0,
+            "magnitude": 0.0,
+            "features": []
+        }
+    },
+    {
+        "transform_name": "shift_metric_features",
+        "transform_parameters": {
+            "fraction": 0.0,
+            "magnitude": 0.0,
+            "categorical_features": []
+        }
+    },
+    {
+        "transform_name": "rotate_metric_features",
+        "transform_parameters": {
+            "fraction": 0.0,
+            "magnitude": 0.0,
+            "categorical_features": []
+        }
+    }    
+    ,
+    {
+        "transform_name": "regression_category_drift",
+        "transform_parameters": {
+            "fraction": 0.0,
+            "magnitude": 0.0,
+            "categorical_features": [],
+            "target": ""
+        }
+    }]

--- a/jupyter/src/incremental_learning/config.py
+++ b/jupyter/src/incremental_learning/config.py
@@ -32,7 +32,7 @@ datasets_dir = data_dir / 'datasets'
 configs_dir = data_dir / 'configs'
 dfa_path = ''
 
-# I assume, your host OS is not CentOS
+# Assumes your host OS is not CentOS.
 cloud = (platform.system() == 'Linux') and (platform.dist()[0] == 'centos')
 if cloud:
     search_location = Path('/ml-cpp')
@@ -53,7 +53,7 @@ formatter = logging.Formatter('[%(levelname).1s] %(name)s >> %(message)s')
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-# Read config file
+# Read config file.
 config = configparser.ConfigParser()
 config_file = root_dir / 'config.ini'
 if not config_file.exists():
@@ -66,7 +66,8 @@ if len(config.read(root_dir / 'config.ini')) == 0:
 es_cloud_id = ""
 es_user = ""
 es_password = ""
-# Elasticsearch deployment configuration
+
+# Elasticsearch deployment configuration.
 if (not config['cloud']['cloud_id']) or (not config['cloud']['user']) or (not config['cloud']['password']):
     logger.error("Cloud configuration is missing or incomplete. Some functionality will be broken")
 else:
@@ -77,7 +78,7 @@ else:
 if config['logging']['level']:
     logger.setLevel(config['logging']['level'])
 
-# Google cloud storage bucket with datasets
+# Google cloud storage bucket with datasets.
 if not config['storage']['bucket_name']:
     logger.error("Storage bucket configuration is missing")
     exit(1)

--- a/jupyter/src/incremental_learning/config.py
+++ b/jupyter/src/incremental_learning/config.py
@@ -12,9 +12,21 @@ import logging
 import platform
 from sys import exit
 
-from pathlib2 import Path
+from pathlib import Path
 
-root_dir = Path(__file__).parent.parent.parent.absolute()
+# Check for resource called in ancestor directories of path.
+def find_ancestor_dir(path: Path, resource: str):
+    current = path
+    parent = current.parent
+    while parent != current:
+        if (parent / resource).exists():
+            return parent.absolute()
+        current = parent
+        parent = current.parent
+    print('Did not find', resource, 'in parent of', path)
+    exit(1)
+
+root_dir = find_ancestor_dir(path=Path(__file__), resource='data/datasets')
 data_dir = root_dir / 'data'
 datasets_dir = data_dir / 'datasets'
 configs_dir = data_dir / 'configs'
@@ -26,7 +38,7 @@ if cloud:
     search_location = Path('/ml-cpp')
     dfa_path = Path('/ml-cpp/bin/data_frame_analyzer')
 else:
-    search_location = Path(__file__).parent.parent.parent.parent
+    search_location = find_ancestor_dir(path=root_dir, resource='build/distribution')
     runners = list(search_location.glob(
         '**/build/distribution/platform/**/data_frame_analyzer'))
     if len(runners) == 0:

--- a/jupyter/src/incremental_learning/config.py
+++ b/jupyter/src/incremental_learning/config.py
@@ -14,8 +14,12 @@ from sys import exit
 
 from pathlib import Path
 
-# Check for resource called in ancestor directories of path.
 def find_ancestor_dir(path: Path, resource: str):
+    '''
+    This searches each parent directory of path looking resource until it finds
+    it or reaches the root directory. If it didn't find resource it calls exit
+    with failure.
+    '''
     current = path
     parent = current.parent
     while parent != current:

--- a/jupyter/template_config.ini
+++ b/jupyter/template_config.ini
@@ -5,6 +5,6 @@ level = INFO
 bucket_name = ml-incremental-learning-datasets
 
 [cloud]
-cloud_id = 
-user = 
-password = 
+cloud_id =
+user =
+password =

--- a/jupyter/tests/incremental_learning/test_transforms.py
+++ b/jupyter/tests/incremental_learning/test_transforms.py
@@ -41,7 +41,7 @@ class TransformsTest(unittest.TestCase):
         '''
         partition = transforms.partition_on_metric_ranges(
             seed=self.seed,
-            features=['this feature does not exist'],
+            metric_features=['this feature does not exist'],
             dataset=self.dataset
         )
         self.assertEqual(partition[0], None)
@@ -49,7 +49,7 @@ class TransformsTest(unittest.TestCase):
 
         partition = transforms.partition_on_metric_ranges(
             seed=self.seed,
-            features=['AGE', 'DIS'],
+            metric_features=['AGE', 'DIS'],
             dataset=self.dataset
         )
         self.assertAlmostEqual(
@@ -71,12 +71,12 @@ class TransformsTest(unittest.TestCase):
 
         partition_with_same_seed = transforms.partition_on_metric_ranges(
             seed=self.seed,
-            features=['AGE', 'DIS'],
+            metric_features=['AGE', 'DIS'],
             dataset=self.dataset
         )
         partition_with_different_seed = transforms.partition_on_metric_ranges(
             seed=self.seed + 1,
-            features=['AGE', 'DIS'],
+            metric_features=['AGE', 'DIS'],
             dataset=self.dataset
         )
 
@@ -94,14 +94,14 @@ class TransformsTest(unittest.TestCase):
         '''
         partition = transforms.partition_on_categories(
             seed=self.seed,
-            features=['this feature does not exist'],
+            categorical_features=['this feature does not exist'],
             dataset=self.dataset)
         self.assertEqual(partition[0], None)
         self.assertEqual(partition[1], None)
 
         partition = transforms.partition_on_categories(
             seed=self.seed,
-            features=['CHAS', 'RAD'],
+            categorical_features=['CHAS', 'RAD'],
             dataset=self.dataset
         )
         self.assertAlmostEqual(
@@ -131,12 +131,12 @@ class TransformsTest(unittest.TestCase):
 
         partition_with_same_seed = transforms.partition_on_categories(
             seed=self.seed,
-            features=['CHAS', 'RAD'],
+            categorical_features=['CHAS', 'RAD'],
             dataset=self.dataset
         )
         partition_with_different_seed = transforms.partition_on_categories(
             seed=self.seed + 1,
-            features=['CHAS', 'RAD'],
+            categorical_features=['CHAS', 'RAD'],
             dataset=self.dataset
         )
 
@@ -155,7 +155,7 @@ class TransformsTest(unittest.TestCase):
             seed=self.seed,
             fraction=0.2,
             magnitude=0.9,
-            features=['this feature does not exist'],
+            metric_features=['this feature does not exist'],
             dataset=self.dataset
         )
         self.assertEqual(resampled_dataset, None)
@@ -164,7 +164,7 @@ class TransformsTest(unittest.TestCase):
             seed=self.seed,
             fraction=0.2,
             magnitude=0.9,
-            features=['AGE', 'MEDV'],
+            metric_features=['AGE', 'MEDV'],
             dataset=self.dataset
         )
         self.assertAlmostEqual(

--- a/jupyter/tests/incremental_learning/test_transforms.py
+++ b/jupyter/tests/incremental_learning/test_transforms.py
@@ -200,7 +200,7 @@ class TransformsTest(unittest.TestCase):
             fraction=1.0,
             magnitude=0.1,
             categorical_features=['CHAS', 'RAD'],
-            dataset=shifted_dataset
+            dataset=self.dataset
         )
         self.assertEqual(len(shifted_dataset.index), len(self.dataset.index))
 


### PR DESCRIPTION
This adds a script to generate random test cases from the full test matrix which comprises our target data sets and transforms. It also makes configuration of various directories more robust to different layouts and usage (for example it didn't work properly after installing the `incremental_learning` package using `setup.py` previously). I also changed transform to always copy the data set before transforming (this fits in better with `experiment_driver.py`) and made variable naming more consistent. Finally, this finishes up the implementation of `experiment_driver.py` to support all transform types.

The full experiments.json configuration file will added be a separate PR which migrates the data sets in this repo to our cloud bucket.