### PR TITLE
[ML] Fix potential undefined behaviour in classification and regression training

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -59,6 +59,11 @@
 * Prune models for split fields (by, partition) that haven't seen data updates for
   a given period of time. (See {ml-pull}1962[#1962].)
 
+=== Bug Fixes
+
+* Fix potential "process stopped unexpectedly: Fatal error" for training regression
+  and classification models. (See {ml-pull}1997[#1997], issue {ml-pull}1956[#1956].)
+
 == {es} version 7.14.0
 
 === Enhancements

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -30,11 +30,11 @@ namespace {
 const std::size_t ASSIGN_MISSING_TO_LEFT{0};
 const std::size_t ASSIGN_MISSING_TO_RIGHT{1};
 
-struct SChildredGainStats {
-    double s_MinLossLeft = -INF;
-    double s_MinLossRight = -INF;
-    double s_GLeft = -INF;
-    double s_GRight = -INF;
+struct SChildrenGainStats {
+    double s_MinLossLeft{-INF};
+    double s_MinLossRight{-INF};
+    double s_GLeft{-INF};
+    double s_GRight{-INF};
 };
 }
 
@@ -64,7 +64,7 @@ CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(
     m_BestSplit = this->computeBestSplitStatistics(regularization, nodeFeatureBag);
     workspace.reducedDerivatives().swap(m_Derivatives);
 
-    if (this->gain() > workspace.minimumGain()) {
+    if (this->gain() >= workspace.minimumGain()) {
         m_RowMask = rowMask;
         CSplitsDerivatives tmp{workspace.derivatives()[0]};
         m_Derivatives = std::move(tmp);
@@ -408,8 +408,8 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(const TRegularization
     double gain[2];
     double minLossLeft[2]{0.0, 0.0};
     double minLossRight[2]{0.0, 0.0};
-    SChildredGainStats childrenGainStatsGlobal;
-    SChildredGainStats childrenGainStatsPerFeature;
+    SChildrenGainStats childrenGainStatsGlobal;
+    SChildrenGainStats childrenGainStatsPerFeature;
 
     for (auto feature : featureBag) {
         std::size_t c{m_Derivatives.missingCount(feature)};


### PR DESCRIPTION
The issue was caused by a mismatch in the condition to decide whether to split the root node and the condition to decide whether to bother to initialise all its state. In particular, we would, if we got very unlucky, try and split having not properly initialised state. This updates the offending condition so we always properly initialise state when we're going to try and split. (There was also a typo this fixes.)

Closes #1956.