### PR TITLE
[ML] Ensure initialiser list ctor is used

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -51,7 +51,7 @@ torch::Tensor infer(torch::jit::script::Module& module,
     LOG_DEBUG(<< "2ndary args size: " << request.s_SecondaryArguments.size());
     inputs.reserve(1 + request.s_SecondaryArguments.size());
 
-    at::IntArrayRef inputSize{request.s_NumberInferences, request.s_NumberInputTokens};
+    at::IntArrayRef inputSize{{request.s_NumberInferences, request.s_NumberInputTokens}};
     LOG_DEBUG(<< "input size: " << inputSize);
 
     // BERT UInt tokens

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -51,6 +51,8 @@ torch::Tensor infer(torch::jit::script::Module& module,
     LOG_DEBUG(<< "2ndary args size: " << request.s_SecondaryArguments.size());
     inputs.reserve(1 + request.s_SecondaryArguments.size());
 
+    LOG_DEBUG(<< "batch size: " << request.s_NumberInferences
+              << ", number of tokens: " << request.s_NumberInputTokens);
     at::IntArrayRef inputSize{{request.s_NumberInferences, request.s_NumberInputTokens}};
     LOG_DEBUG(<< "input size: " << inputSize);
 


### PR DESCRIPTION
From the debug logging added in #2003 it is clear the input size is not being initialised correctly

`input size: [4354725592, 140222092279815]`

This change ensures the initialiser list ctor is called