### PR TITLE
[ML] Update boost download URL

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -171,7 +171,7 @@ to install.
 
 ### Boost 1.71.0
 
-Download version 1.71.0 of Boost from <https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2>. You must get this exact version, as the Machine Learning Makefiles expect it.
+Download version 1.71.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2>. You must get this exact version, as the Machine Learning Makefiles expect it.
 
 Assuming you chose the `.bz2` version, extract it to a temporary directory:
 

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -68,7 +68,7 @@ at the command prompt.
 
 ### Boost 1.71.0
 
-Download version 1.71.0 of Boost from <https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2>. You must get this exact version, as the Machine Learning Makefiles expect it.
+Download version 1.71.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2>. You must get this exact version, as the Machine Learning Makefiles expect it.
 
 Assuming you chose the `.bz2` version, extract it to a temporary directory:
 

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -135,7 +135,7 @@ nmake install
 
 ### Boost 1.71.0
 
-Download version 1.71.0 of Boost from <https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2> . You must get this exact version, as the Machine Learning Makefiles expect it.
+Download version 1.71.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2> . You must get this exact version, as the Machine Learning Makefiles expect it.
 
 Assuming you chose the `.bz2` version, extract it in a Git bash shell using the GNU tar that comes with Git for Windows, e.g.:
 

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -67,6 +67,8 @@ RUN \
   rm -rf libxml2-2.9.4
 
 # Build Boost
+# TODO update the download URL to https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2
+# when the image is next rebuilt
 RUN \
   wget --quiet -O - http://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 | tar jxf - && \
   cd boost_1_71_0 && \

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -67,6 +67,8 @@ RUN \
   rm -rf libxml2-2.9.4
 
 # Build Boost
+# TODO update the download URL to https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2
+# when the image is next rebuilt
 RUN \
   wget --quiet -O - http://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2 | tar jxf - && \
   cd boost_1_71_0 && \


### PR DESCRIPTION
As announced in https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html

Backport of #2004