### PR TITLE
[ML] Fix invalid reference when initialising input sizes

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -53,8 +53,9 @@ torch::Tensor infer(torch::jit::script::Module& module,
 
     LOG_DEBUG(<< "batch size: " << request.s_NumberInferences
               << ", number of tokens: " << request.s_NumberInputTokens);
-    
-    std::array<std::int64_t, 2> dimensions = {request.s_NumberInferences, request.s_NumberInputTokens};
+
+    std::array<std::int64_t, 2> dimensions = {request.s_NumberInferences,
+                                              request.s_NumberInputTokens};
     at::IntArrayRef inputSize{dimensions};
     LOG_DEBUG(<< "input size: " << inputSize);
 

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -53,7 +53,9 @@ torch::Tensor infer(torch::jit::script::Module& module,
 
     LOG_DEBUG(<< "batch size: " << request.s_NumberInferences
               << ", number of tokens: " << request.s_NumberInputTokens);
-    at::IntArrayRef inputSize{{request.s_NumberInferences, request.s_NumberInputTokens}};
+    
+    std::array<std::int64_t, 2> dimensions = {request.s_NumberInferences, request.s_NumberInputTokens};
+    at::IntArrayRef inputSize{dimensions};
     LOG_DEBUG(<< "input size: " << inputSize);
 
     // BERT UInt tokens


### PR DESCRIPTION
Use a local var with same lifespan.

I've left the debug logging in place while this is tested and will clean it up once the tests have passed. 