### PR TITLE
[ML] Store and restore training jobs with  models

### DIFF
--- a/jupyter/src/.bumpversion.cfg
+++ b/jupyter/src/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 tag = False
 

--- a/jupyter/src/incremental_learning/__init__.py
+++ b/jupyter/src/incremental_learning/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.0'
+VERSION = '0.3.0'

--- a/jupyter/src/incremental_learning/config.py
+++ b/jupyter/src/incremental_learning/config.py
@@ -34,6 +34,7 @@ root_dir = find_ancestor_dir(path=Path(__file__), resource='data/datasets')
 data_dir = root_dir / 'data'
 datasets_dir = data_dir / 'datasets'
 configs_dir = data_dir / 'configs'
+jobs_dir = data_dir / 'jobs'
 dfa_path = ''
 
 # Assumes your host OS is not CentOS.

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -13,11 +13,12 @@ import gzip
 import json
 import random
 import string
+import sys
 import tempfile
 import time
-from typing import Union
 from pathlib import Path
-import sys
+from typing import Union
+
 import libtmux
 import numpy as np
 import pandas
@@ -45,8 +46,8 @@ class Job:
     """Job class .
     """
 
-    def __init__(self, input: Union[str, tempfile._TemporaryFileWrapper] = None,
-                 config: Union[str, tempfile._TemporaryFileWrapper] = None,
+    def __init__(self, input: Union[None, str, tempfile._TemporaryFileWrapper] = None,
+                 config: Union[None, str, tempfile._TemporaryFileWrapper] = None,
                  persist: Union[None, str, tempfile._TemporaryFileWrapper] = None,
                  restore: Union[None, str, tempfile._TemporaryFileWrapper] = None,
                  verbose: bool = True, run=None):
@@ -281,7 +282,7 @@ class Job:
 
     def store(self, destination: Path) -> bool:
         success = True
-        with open(destination, 'wt') as fp:
+        with gzip.open(destination, 'wt') as fp:
             try:
                 json.dump(obj=self, fp=fp, cls=JobJSONEncoder)
             except:
@@ -317,7 +318,7 @@ class Job:
                          .format(path))
             return None
         job = None
-        with open(path, 'rt') as fp:
+        with gzip.open(path, 'rt') as fp:
             state = json.load(fp=fp)
             job = cls.asJob(state)
         return job

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -281,16 +281,23 @@ class Job:
         return self.model
 
     def store(self, destination: Path) -> bool:
+        """
+        Store job with trained model into a file.
+
+        Args:
+            destination (Path): local path to where the job should be stored.
+
+        Returns:
+            bool: True if storing was successfull, False otherwise.
+        """
         success = True
         with gzip.open(destination, 'wt') as fp:
             try:
                 json.dump(obj=self, fp=fp, cls=JobJSONEncoder)
             except:
                 ex = sys.exc_info()
-                # print("Failed storing job {}: {}".format(self.name, ex))
                 logger.error("Failed storing job {}: {}".format(self.name, ex))
                 success = False
-                # raise ex
         return success
 
     @classmethod
@@ -313,6 +320,15 @@ class Job:
 
     @classmethod
     def fromFile(cls, path: Path):
+        """
+        Restore a Job object from file.
+
+        Args:
+            path (Path): local path to where the Job object should be restored from.
+
+        Returns:
+            Job: restored Job object.
+        """
         if path.exists() == False or path.is_file() == False:
             logger.error('File to load Job from file. {} does not exist or is not a file'
                          .format(path))
@@ -337,6 +353,9 @@ class Job:
 
 
 class JobJSONEncoder(json.JSONEncoder):
+    """
+    JSON serialization logic for the Job class.
+    """
     def default(self, obj: Job):
         if isinstance(obj, Job):
             state = {

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -319,22 +319,22 @@ class Job:
         return job
 
     @classmethod
-    def fromFile(cls, path: Path):
+    def fromFile(cls, source: Path):
         """
         Restore a Job object from file.
 
         Args:
-            path (Path): local path to where the Job object should be restored from.
+            source (Path): local path to where the Job object should be restored from.
 
         Returns:
             Job: restored Job object.
         """
-        if path.exists() == False or path.is_file() == False:
+        if source.exists() == False or source.is_file() == False:
             logger.error('File to load Job from file. {} does not exist or is not a file'
-                         .format(path))
+                         .format(source))
             return None
         job = None
-        with gzip.open(path, 'rt') as fp:
+        with gzip.open(source, 'rt') as fp:
             state = json.load(fp=fp)
             job = cls.asJob(state)
         return job

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -301,7 +301,7 @@ class Job:
         return success
 
     @classmethod
-    def asJob(cls, state: dict):
+    def as_job(cls, state: dict):
         if '__job__' in state:
             job = Job(input='', config='')
             job.input_filename = state['input_filename']
@@ -319,7 +319,7 @@ class Job:
         return job
 
     @classmethod
-    def fromFile(cls, source: Path):
+    def from_file(cls, source: Path):
         """
         Restore a Job object from file.
 
@@ -336,7 +336,7 @@ class Job:
         job = None
         with gzip.open(source, 'rt') as fp:
             state = json.load(fp=fp)
-            job = cls.asJob(state)
+            job = cls.as_job(state)
         return job
 
     def __eq__(self, other):

--- a/jupyter/src/incremental_learning/storage.py
+++ b/jupyter/src/incremental_learning/storage.py
@@ -95,7 +95,18 @@ def download_job(job_name) -> Union[None, Path]:
     return result
 
 
-def upload_job(job_name: str, local_job_path: Path) -> bool:
+def upload_job(local_job_path: Path) -> bool:
+    """Upload the job file to the Google storage bucket.
+
+    If a file with the name already exists in the bucket, it will not be overwritten.
+
+    Args:
+        local_job_path (Path): local path to the file.
+
+    Returns:
+        bool: True if upload was successful, False otherwise.
+    """
+    job_name = local_job_path.name
     if job_exists(job_name):
         logger.warning(
             "Job {} already exists in the Google storage bucket. Skip uploading.".format(job_name))
@@ -110,7 +121,12 @@ def upload_job(job_name: str, local_job_path: Path) -> bool:
     return True
 
 
-def delete_job(job_name: str):
+def delete_job(job_name: str) -> None:
+    """Delete job file from the Google storage bucket.
+
+    Args:
+        job_name (str): File name.
+    """
     if not job_exists(job_name, remote=True):
         logger.info(
             "Job {} does not exist in the Google storage bucket. Skip deleting.".format(job_name))
@@ -123,7 +139,17 @@ def delete_job(job_name: str):
     job_blob.delete()
 
 
-def job_exists(job_name, remote=False):
+def job_exists(job_name: str, remote: bool=False) -> bool:
+    """Check if file exists locally or in the Google storage bucket.
+
+    Args:
+        job_name (str): File name.
+        remote (bool, optional): Flag that indicates whether to check the Google storage bucket. 
+                                 Defaults to False.
+
+    Returns:
+        bool: True, if the job file exists, False otherwise.
+    """
     if remote == False:
         local_job_path = jobs_dir / "{}".format(job_name)
         return local_job_path.exists()

--- a/jupyter/src/setup.py
+++ b/jupyter/src/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup, find_packages
 
 setup(name="incremental_learning",
-      version="0.2.0", packages=find_packages())
+      version="0.3.0", packages=find_packages())

--- a/jupyter/tests/incremental_learning/test_store_restore.py
+++ b/jupyter/tests/incremental_learning/test_store_restore.py
@@ -19,7 +19,7 @@ import pandas as pd
 from incremental_learning.config import (datasets_dir, es_cloud_id, jobs_dir,
                                          logger)
 from incremental_learning.job import Job, evaluate, train, update
-from incremental_learning.storage import download_dataset, download_job
+from incremental_learning.storage import download_dataset, download_job, upload_job, delete_job, job_exists
 
 
 class TestJobStoreRestore(unittest.TestCase):
@@ -68,6 +68,14 @@ class TestJobStoreRestore(unittest.TestCase):
 
         restoredJob = Job.fromFile(self.downloaded_path)
         self.assertTrue(restoredJob.initialized)
+
+    def test_job_store_upload(self):
+        job_name = 'test_upload_job'
+        success = upload_job(job_name=job_name, local_job_path=self.path)
+        self.assertTrue(success)
+        self.assertTrue(job_exists(job_name, remote=True))
+        delete_job(job_name)
+        self.assertFalse(job_exists(job_name, remote=True))
 
     def test_job_store_restore(self):
         restored_job = Job.fromFile(path=self.path)

--- a/jupyter/tests/incremental_learning/test_store_restore.py
+++ b/jupyter/tests/incremental_learning/test_store_restore.py
@@ -66,7 +66,7 @@ class TestJobStoreRestore(unittest.TestCase):
         self.assertIsNotNone(self.downloaded_path)
         self.assertTrue(self.downloaded_path.exists())
 
-        restoredJob = Job.fromFile(self.downloaded_path)
+        restoredJob = Job.fromFile(source=self.downloaded_path)
         self.assertTrue(restoredJob.initialized)
 
     def test_job_store_upload(self):
@@ -78,11 +78,11 @@ class TestJobStoreRestore(unittest.TestCase):
         self.assertFalse(job_exists(job_name, remote=True))
 
     def test_job_store_restore(self):
-        restored_job = Job.fromFile(path=self.path)
+        restored_job = Job.fromFile(source=self.path)
         self.assertEqual(self.job, restored_job)
 
     def test_job_restore_evaluate(self):
-        restored_job = Job.fromFile(path=self.path)
+        restored_job = Job.fromFile(source=self.path)
 
         expected_eval_job = evaluate(
             dataset=self.dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
@@ -96,7 +96,7 @@ class TestJobStoreRestore(unittest.TestCase):
             expected_eval_job.get_predictions(), actual_eval_job.get_predictions())
 
     def test_job_restore_update(self):
-        restored_job = Job.fromFile(path=self.path)
+        restored_job = Job.fromFile(source=self.path)
         update_dataset = self.dataset.sample(frac=0.1, random_state=self.seed)
         expected_update_job = update(
             dataset=update_dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)

--- a/jupyter/tests/incremental_learning/test_store_restore.py
+++ b/jupyter/tests/incremental_learning/test_store_restore.py
@@ -66,7 +66,7 @@ class TestJobStoreRestore(unittest.TestCase):
         self.assertIsNotNone(self.downloaded_path)
         self.assertTrue(self.downloaded_path.exists())
 
-        restoredJob = Job.fromFile(source=self.downloaded_path)
+        restoredJob = Job.from_file(source=self.downloaded_path)
         self.assertTrue(restoredJob.initialized)
 
     def test_job_store_upload(self):
@@ -78,11 +78,11 @@ class TestJobStoreRestore(unittest.TestCase):
         self.assertFalse(job_exists(job_name, remote=True))
 
     def test_job_store_restore(self):
-        restored_job = Job.fromFile(source=self.path)
+        restored_job = Job.from_file(source=self.path)
         self.assertEqual(self.job, restored_job)
 
     def test_job_restore_evaluate(self):
-        restored_job = Job.fromFile(source=self.path)
+        restored_job = Job.from_file(source=self.path)
 
         expected_eval_job = evaluate(
             dataset=self.dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
@@ -96,7 +96,7 @@ class TestJobStoreRestore(unittest.TestCase):
             expected_eval_job.get_predictions(), actual_eval_job.get_predictions())
 
     def test_job_restore_update(self):
-        restored_job = Job.fromFile(source=self.path)
+        restored_job = Job.from_file(source=self.path)
         update_dataset = self.dataset.sample(frac=0.1, random_state=self.seed)
         expected_update_job = update(
             dataset=update_dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)

--- a/jupyter/tests/incremental_learning/test_store_restore.py
+++ b/jupyter/tests/incremental_learning/test_store_restore.py
@@ -7,31 +7,19 @@
 # compliance with the Elastic License 2.0 and the foregoing additional
 # limitation.
 
-import pandas as pd
-import unittest
-import tempfile
-from pathlib import Path
-import os
 import logging
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
 import numpy.testing
+import pandas as pd
 
-from incremental_learning.config import datasets_dir, logger, es_cloud_id
-from incremental_learning.job import train, update, evaluate, Job
-from incremental_learning.storage import download_dataset
-
-# create console handler and set level to debug
-ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
-
-# create formatter
-formatter = logging.Formatter(
-    '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-# add formatter to ch
-ch.setFormatter(formatter)
-
-# add ch to logger
-logger.addHandler(ch)
+from incremental_learning.config import (datasets_dir, es_cloud_id, jobs_dir,
+                                         logger)
+from incremental_learning.job import Job, evaluate, train, update
+from incremental_learning.storage import download_dataset, download_job
 
 
 class TestJobStoreRestore(unittest.TestCase):
@@ -55,7 +43,6 @@ class TestJobStoreRestore(unittest.TestCase):
         self.destination.file.close()
         self.assertTrue(success)
 
-
     @classmethod
     def tearDownClass(cls) -> None:
         cls.job.clean()
@@ -64,6 +51,8 @@ class TestJobStoreRestore(unittest.TestCase):
     def tearDown(self) -> None:
         if self.destination:
             self.destination.close()
+        if hasattr(self, 'downloaded_path') and self.downloaded_path:
+            self.downloaded_path.unlink()
         super().tearDown()
 
     def test_job_store(self):
@@ -71,9 +60,14 @@ class TestJobStoreRestore(unittest.TestCase):
         self.assertTrue(self.path.is_file())
         self.assertTrue(self.path.stat().st_size > 0)
 
-    @unittest.skip('')
-    def test_job_restore_remote(self):
-        self.fail()
+    def test_job_download_restore(self):
+        job_name = 'test_regression_job'
+        self.downloaded_path = download_job(job_name)
+        self.assertIsNotNone(self.downloaded_path)
+        self.assertTrue(self.downloaded_path.exists())
+
+        restoredJob = Job.fromFile(self.downloaded_path)
+        self.assertTrue(restoredJob.initialized)
 
     def test_job_store_restore(self):
         restored_job = Job.fromFile(path=self.path)
@@ -82,25 +76,41 @@ class TestJobStoreRestore(unittest.TestCase):
     def test_job_restore_evaluate(self):
         restored_job = Job.fromFile(path=self.path)
 
-        expected_eval_job = evaluate(dataset=self.dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
+        expected_eval_job = evaluate(
+            dataset=self.dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
         expected_eval_job.wait_to_complete()
 
-        actual_eval_job = evaluate(dataset=self.dataset, dataset_name=self.dataset_name, original_job=restored_job, verbose=False)
+        actual_eval_job = evaluate(
+            dataset=self.dataset, dataset_name=self.dataset_name, original_job=restored_job, verbose=False)
         actual_eval_job.wait_to_complete()
 
-        numpy.testing.assert_array_almost_equal(expected_eval_job.get_predictions(), actual_eval_job.get_predictions())
+        numpy.testing.assert_array_almost_equal(
+            expected_eval_job.get_predictions(), actual_eval_job.get_predictions())
 
     def test_job_restore_update(self):
         restored_job = Job.fromFile(path=self.path)
         update_dataset = self.dataset.sample(frac=0.1, random_state=self.seed)
-        expected_update_job = update(dataset=update_dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
+        expected_update_job = update(
+            dataset=update_dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
         expected_update_job.wait_to_complete()
 
-        actual_update_job = update(dataset=update_dataset, dataset_name=self.dataset_name, original_job=restored_job, verbose=False)
+        actual_update_job = update(
+            dataset=update_dataset, dataset_name=self.dataset_name, original_job=restored_job, verbose=False)
         actual_update_job.wait_to_complete()
 
-        numpy.testing.assert_array_almost_equal(expected_update_job.get_predictions(), actual_update_job.get_predictions())
-        self.assertEqual(expected_update_job.get_hyperparameters(), actual_update_job.get_hyperparameters())
+        numpy.testing.assert_array_almost_equal(
+            expected_update_job.get_predictions(), actual_update_job.get_predictions())
+        self.assertEqual(expected_update_job.get_hyperparameters(),
+                         actual_update_job.get_hyperparameters())
+
 
 if __name__ == '__main__':
+    # log into console output for tests
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
     unittest.main()

--- a/jupyter/tests/incremental_learning/test_store_restore.py
+++ b/jupyter/tests/incremental_learning/test_store_restore.py
@@ -70,8 +70,8 @@ class TestJobStoreRestore(unittest.TestCase):
         self.assertTrue(restoredJob.initialized)
 
     def test_job_store_upload(self):
-        job_name = 'test_upload_job'
-        success = upload_job(job_name=job_name, local_job_path=self.path)
+        job_name = self.path.name
+        success = upload_job(local_job_path=self.path)
         self.assertTrue(success)
         self.assertTrue(job_exists(job_name, remote=True))
         delete_job(job_name)

--- a/jupyter/tests/incremental_learning/test_store_restore.py
+++ b/jupyter/tests/incremental_learning/test_store_restore.py
@@ -1,0 +1,106 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+import pandas as pd
+import unittest
+import tempfile
+from pathlib import Path
+import os
+import logging
+import numpy.testing
+
+from incremental_learning.config import datasets_dir, logger, es_cloud_id
+from incremental_learning.job import train, update, evaluate, Job
+from incremental_learning.storage import download_dataset
+
+# create console handler and set level to debug
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+
+# create formatter
+formatter = logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# add formatter to ch
+ch.setFormatter(formatter)
+
+# add ch to logger
+logger.addHandler(ch)
+
+
+class TestJobStoreRestore(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.seed = 100
+        cls.dataset_name = 'test_regression'
+        download_successful = download_dataset(cls.dataset_name)
+        if download_successful == False:
+            cls.fail("Dataset is not available")
+        cls.dataset = pd.read_csv(
+            datasets_dir / '{}.csv'.format(cls.dataset_name))
+        cls.job = train(cls.dataset_name, cls.dataset, verbose=False)
+        cls.job.wait_to_complete(clean=False)
+
+    def setUp(self) -> None:
+        self.destination = tempfile.NamedTemporaryFile(mode='wt')
+        self.path = Path(self.destination.name)
+        success = self.job.store(destination=self.path)
+        self.destination.file.close()
+        self.assertTrue(success)
+
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.job.clean()
+        super().tearDownClass()
+
+    def tearDown(self) -> None:
+        if self.destination:
+            self.destination.close()
+        super().tearDown()
+
+    def test_job_store(self):
+        self.assertTrue(self.path.exists())
+        self.assertTrue(self.path.is_file())
+        self.assertTrue(self.path.stat().st_size > 0)
+
+    @unittest.skip('')
+    def test_job_restore_remote(self):
+        self.fail()
+
+    def test_job_store_restore(self):
+        restored_job = Job.fromFile(path=self.path)
+        self.assertEqual(self.job, restored_job)
+
+    def test_job_restore_evaluate(self):
+        restored_job = Job.fromFile(path=self.path)
+
+        expected_eval_job = evaluate(dataset=self.dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
+        expected_eval_job.wait_to_complete()
+
+        actual_eval_job = evaluate(dataset=self.dataset, dataset_name=self.dataset_name, original_job=restored_job, verbose=False)
+        actual_eval_job.wait_to_complete()
+
+        numpy.testing.assert_array_almost_equal(expected_eval_job.get_predictions(), actual_eval_job.get_predictions())
+
+    def test_job_restore_update(self):
+        restored_job = Job.fromFile(path=self.path)
+        update_dataset = self.dataset.sample(frac=0.1, random_state=self.seed)
+        expected_update_job = update(dataset=update_dataset, dataset_name=self.dataset_name, original_job=self.job, verbose=False)
+        expected_update_job.wait_to_complete()
+
+        actual_update_job = update(dataset=update_dataset, dataset_name=self.dataset_name, original_job=restored_job, verbose=False)
+        actual_update_job.wait_to_complete()
+
+        numpy.testing.assert_array_almost_equal(expected_update_job.get_predictions(), actual_update_job.get_predictions())
+        self.assertEqual(expected_update_job.get_hyperparameters(), actual_update_job.get_hyperparameters())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds functionality to store and restore training jobs. It mainly requires storing the model blob object, but other metadata like `input_filename`, `dependent_variable`, `analysis_name` are also stored for completeness.  Jobs are stored as gzipped JSON files.

The job can be stored with 
```python
job.store(destination=local_path)
```
and restored with 
```python
job = Job.fromFile(source=local_path)
```
See unit tests in `test_store_restore.py` for more examples.

Furthermore, I implemented functionality to upload, download and delete job files in the Google storage bucket.
