### PR TITLE
[ML] Output logs from data_frame_analyzer

### DIFF
--- a/jupyter/src/.bumpversion.cfg
+++ b/jupyter/src/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = False
 

--- a/jupyter/src/incremental_learning/__init__.py
+++ b/jupyter/src/incremental_learning/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.3.0'
+VERSION = '0.4.0'

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -158,6 +158,9 @@ class Job:
             time.sleep(5.0)
         self.stop_time = time.time()
 
+        if self.run:
+            self.run.run_logger.info(err)
+
         if success:
             with open(self.output.name) as fp:
                 self.results = json.load(fp)

--- a/jupyter/src/setup.py
+++ b/jupyter/src/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup, find_packages
 
 setup(name="incremental_learning",
-      version="0.3.0", packages=find_packages())
+      version="0.4.0", packages=find_packages())


### PR DESCRIPTION
This is a minor changes that adds the stderr output from the `data_frame_analyzer` run to the logs of the SACRED run object.