### PR TITLE
[ML] Obtain prediction probabilities

### DIFF
--- a/jupyter/src/.bumpversion.cfg
+++ b/jupyter/src/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.7.0
 commit = True
 tag = False
 

--- a/jupyter/src/.bumpversion.cfg
+++ b/jupyter/src/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 commit = True
 tag = False
 

--- a/jupyter/src/incremental_learning/__init__.py
+++ b/jupyter/src/incremental_learning/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.4.0'
+VERSION = '0.5.0'

--- a/jupyter/src/incremental_learning/__init__.py
+++ b/jupyter/src/incremental_learning/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.6.0'
+VERSION = '0.7.0'

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -98,6 +98,7 @@ class Job:
             self._set_analysis_name()
             if self.is_classification():
                 self._set_num_classes()
+                self._configure_num_top_classes()
             self.initialized = True
         else:
             self.initialized = False
@@ -118,6 +119,13 @@ class Job:
             with open(self.config_filename) as fp:
                 config = json.load(fp)
             self.num_classes = config['analysis']['parameters']['num_classes']
+
+    def _configure_num_top_classes(self):
+        with open(self.config_filename) as fc:
+            config = json.load(fc)
+        config['analysis']['parameters']['num_top_classes'] = self.num_classes
+        with open(self.config_filename, 'wt') as fc:
+            json.dump(config, fc)
 
     def clean(self):
         if is_temp(self.output):
@@ -236,7 +244,8 @@ class Job:
         for item in self.results:
             if 'row_results' in item:
                 top_classes = item['row_results']['results']['ml']['top_classes']
-                probabilities.append({x['class_name']: x['class_probability'] for x in top_classes})
+                probabilities.append(
+                    {x['class_name']: x['class_probability'] for x in top_classes})
         return probabilities
 
     def get_hyperparameters(self) -> dict:
@@ -387,6 +396,7 @@ class JobJSONEncoder(json.JSONEncoder):
     """
     JSON serialization logic for the Job class.
     """
+
     def default(self, obj: Job):
         if isinstance(obj, Job):
             state = {

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -200,6 +200,30 @@ class Job:
                                    ['ml']['{}_prediction'.format(self.dependent_variable)])
         return np.array(predictions)
 
+    def get_probabilities(self) -> Union[None, np.array]:
+        """Return prediction probabilities for the class "true".
+
+        Note: Only works for binary classification.
+
+        Returns:
+            Union[None, np.array]: prediction probabilities. 
+        """
+        if self.analysis_name == 'regression':
+            logger.warning(
+                "Failed to obtain prediction probabilities for the regression job {}."
+                .format(self.name))
+            return None
+        probabilities = []
+        for item in self.results:
+            if 'row_results' in item:
+                target_prediction = item['row_results']['results']['ml']['{}_prediction'.format(
+                    self.dependent_variable)]
+                prediction_probability = item['row_results']['results']['ml']['prediction_probability']
+                if target_prediction == 'false':
+                    prediction_probability = 1.0 - prediction_probability
+                probabilities.append(prediction_probability)
+        return np.array(probabilities)
+
     def get_hyperparameters(self) -> dict:
         """Get all the hyperparameter values for the model.
 

--- a/jupyter/src/setup.py
+++ b/jupyter/src/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup, find_packages
 
 setup(name="incremental_learning",
-      version="0.4.0", packages=find_packages())
+      version="0.5.0", packages=find_packages())

--- a/jupyter/src/setup.py
+++ b/jupyter/src/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup, find_packages
 
 setup(name="incremental_learning",
-      version="0.6.0", packages=find_packages())
+      version="0.7.0", packages=find_packages())

--- a/jupyter/tests/incremental_learning/test_classification.py
+++ b/jupyter/tests/incremental_learning/test_classification.py
@@ -42,13 +42,15 @@ class TestClassification(unittest.TestCase):
         job.wait_to_complete()
 
         y_true = self.dataset_train['target']
+        classes = np.unique(y_true)
         y_pred = job.get_predictions()
         top_classes = job.get_probabilities()
-        y_score = [prob[c] for c, prob in  zip(y_true, top_classes)]
-        self.assertTrue(metrics.accuracy_score(
-            y_true=y_true, y_pred=y_pred) > 0.96)
-        self.assertTrue(metrics.roc_auc_score(
-            y_true=y_true, y_score=y_score) > 0.5)
+        # roc_auc_score requires the probability of the "greater" class label
+        y_score = np.array([prob[classes[1]] for c, prob in  zip(y_true, top_classes)])
+        accuracy = metrics.accuracy_score(y_true=y_true, y_pred=y_pred)
+        self.assertTrue(accuracy > 0.96, msg = "Low accuracy {}".format(accuracy))
+        actual_roc_auc = metrics.roc_auc_score(y_true=y_true, y_score=y_score)
+        self.assertTrue(actual_roc_auc > 0.98, msg="Low roc auc score {}".format(actual_roc_auc))
 
 
 if __name__ == '__main__':

--- a/jupyter/tests/incremental_learning/test_classification.py
+++ b/jupyter/tests/incremental_learning/test_classification.py
@@ -30,7 +30,7 @@ class TestClassification(unittest.TestCase):
 
         D = pd.DataFrame(data=x, columns=['x1', 'x2'])
         D['target'] = y
-        D['target'].replace({True: 'true', False: 'false'}, inplace=True)
+        D['target'].replace({True: 'foo', False: 'bar'}, inplace=True)
         D['training'] = is_training
 
         self.dataset_train = D.where(D['training'] == True).dropna()
@@ -43,11 +43,12 @@ class TestClassification(unittest.TestCase):
 
         y_true = self.dataset_train['target']
         y_pred = job.get_predictions()
-        y_score = job.get_probabilities()
+        top_classes = job.get_probabilities()
+        y_score = [prob[c] for c, prob in  zip(y_true, top_classes)]
         self.assertTrue(metrics.accuracy_score(
             y_true=y_true, y_pred=y_pred) > 0.96)
         self.assertTrue(metrics.roc_auc_score(
-            y_true=y_true, y_score=y_score) > 0.99)
+            y_true=y_true, y_score=y_score) > 0.5)
 
 
 if __name__ == '__main__':

--- a/jupyter/tests/incremental_learning/test_classification.py
+++ b/jupyter/tests/incremental_learning/test_classification.py
@@ -1,0 +1,54 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+import unittest
+
+import numpy as np
+import pandas as pd
+import sklearn.metrics as metrics
+
+from incremental_learning.job import train
+from incremental_learning.storage import download_dataset
+
+
+class TestClassification(unittest.TestCase):
+    def setUp(self) -> None:
+        self.seed = 100
+        self.dataset_name = 'classification-2d'
+
+        download_dataset(self.dataset_name)
+        x = np.random.random(1000).reshape((-1, 2))
+        y = x[:, 1] < (np.sin(x[:, 0]*np.pi/2*4)+1)/2
+        is_training = (x[:, 0] < 0.3) | (x[:, 0] > 0.7) | (
+            x[:, 1] < 0.3) | (x[:, 1] > 0.7)
+
+        D = pd.DataFrame(data=x, columns=['x1', 'x2'])
+        D['target'] = y
+        D['target'].replace({True: 'true', False: 'false'}, inplace=True)
+        D['training'] = is_training
+
+        self.dataset_train = D.where(D['training'] == True).dropna()
+        self.dataset_update = D.where(D['training'] == False).dropna()
+
+    def test_metrics(self) -> None:
+        job = train(self.dataset_name, self.dataset_train[[
+                    'x1', 'x2', 'target']], verbose=False)
+        job.wait_to_complete()
+
+        y_true = self.dataset_train['target']
+        y_pred = job.get_predictions()
+        y_score = job.get_probabilities()
+        self.assertTrue(metrics.accuracy_score(
+            y_true=y_true, y_pred=y_pred) > 0.96)
+        self.assertTrue(metrics.roc_auc_score(
+            y_true=y_true, y_score=y_score) > 0.99)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR extends Job functionality with an ability to return prediction probabilities for label "true" for binary classification. This is important for the computation of ROC AUC.