### PR TITLE
[ML] Cleanly handle mismatch in the classification config num_classes and the number classes in the data

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeClassifierRunner.h
@@ -96,6 +96,7 @@ private:
                                      core::CRapidJsonConcurrentLineWriter& writer) const;
 
 private:
+    std::size_t m_NumClasses;
     std::ptrdiff_t m_NumTopClasses;
     EPredictionFieldType m_PredictionFieldType;
     mutable CInferenceModelMetadata m_InferenceModelMetadata;

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -316,10 +316,10 @@ void CDataFrameTrainBoostedTreeClassifierRunner::validate(const core::CDataFrame
                      << "The number of rows read is '" << frame.numberRows() << "'.");
     } else if (categoryCount != m_NumClasses) {
         HANDLE_FATAL(<< "Input error: " << m_NumClasses << " provided for " << NUM_CLASSES
-                     << " but there are " << categoryCount << " in the data ("
+                     << " but there are " << categoryCount << " in the data: "
                      << core::CContainerPrinter::print(
                             frame.categoricalColumnValues()[dependentVariableColumn])
-                     << ")");
+                     << ".");
     }
 }
 

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -1108,13 +1108,21 @@ CDataFrameUtils::maximizeMinimumRecallForBinary(std::size_t numberThreads,
                                                 const TReadPredictionFunc& readPrediction) {
     TDoubleVector probabilities;
     auto readQuantiles = core::bindRetrievableState(
-        [=](TQuantileSketchVec& quantiles, const TRowItr& beginRows, const TRowItr& endRows) mutable {
+        [&](TQuantileSketchVec& quantiles, const TRowItr& beginRows, const TRowItr& endRows) mutable {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (isMissing((*row)[targetColumn]) == false) {
                     std::size_t actualClass{static_cast<std::size_t>((*row)[targetColumn])};
-                    probabilities = readPrediction(*row);
-                    CTools::inplaceSoftmax(probabilities);
-                    quantiles[actualClass].add(probabilities(1));
+                    if (actualClass < quantiles.size()) {
+                        probabilities = readPrediction(*row);
+                        CTools::inplaceSoftmax(probabilities);
+                        quantiles[actualClass].add(probabilities(1));
+                    } else {
+                        LOG_WARN(<< "Ignoring class " << actualClass << " whic is out-of-range. "
+                                 << "Should be less than " << quantiles.size() << ". Classes "
+                                 << core::CContainerPrinter::print(
+                                        frame.categoricalColumnValues()[targetColumn])
+                                 << ".");
+                    }
                 }
             }
         },

--- a/lib/maths/CDataFrameUtils.cc
+++ b/lib/maths/CDataFrameUtils.cc
@@ -1117,7 +1117,7 @@ CDataFrameUtils::maximizeMinimumRecallForBinary(std::size_t numberThreads,
                         CTools::inplaceSoftmax(probabilities);
                         quantiles[actualClass].add(probabilities(1));
                     } else {
-                        LOG_WARN(<< "Ignoring class " << actualClass << " whic is out-of-range. "
+                        LOG_WARN(<< "Ignoring class " << actualClass << " which is out-of-range. "
                                  << "Should be less than " << quantiles.size() << ". Classes "
                                  << core::CContainerPrinter::print(
                                         frame.categoricalColumnValues()[targetColumn])


### PR DESCRIPTION
An error in the transforms was causing us to generate spurious classes in the transformed data set. This showed up we weren't properly validating the input and in fact failed by SIGSEGV in this case. I've update the validate method to check the data is consistent with the config and also put in explicit protection at the point where we got the undefined behaviour.