### PR TITLE
[ML] Raise runtime error when C++ process fails

### DIFF
--- a/jupyter/src/.bumpversion.cfg
+++ b/jupyter/src/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 commit = True
 tag = False
 

--- a/jupyter/src/incremental_learning/__init__.py
+++ b/jupyter/src/incremental_learning/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.4.0'
+VERSION = '0.5.0'

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -185,6 +185,7 @@ class Job:
                 print('Job failed')
             if clean:
                 self.clean()
+            raise RuntimeError("Running data_frame_analyzer failed.")
         return self.stop_time - self.start_time
 
     def get_config(self) -> dict:

--- a/jupyter/src/setup.py
+++ b/jupyter/src/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup, find_packages
 
 setup(name="incremental_learning",
-      version="0.4.0", packages=find_packages())
+      version="0.5.0", packages=find_packages())


### PR DESCRIPTION
When the training job fails, we want the failure to propagate through the Python framework to mark the experiment as failed.