### PR TITLE
[ML] Add an option to force update the model

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -67,6 +67,7 @@ public:
     static const std::string TRAINING_PERCENT_FIELD_NAME;
     static const std::string FEATURE_PROCESSORS;
     static const std::string EARLY_STOPPING_ENABLED;
+    static const std::string FORCE_ACCEPT_INCREMENTAL_TRAINING;
     static const std::string DATA_SUMMARIZATION_FRACTION;
     static const std::string TASK;
     static const std::string TASK_TRAIN;

--- a/include/maths/CBoostedTreeFactory.h
+++ b/include/maths/CBoostedTreeFactory.h
@@ -178,6 +178,8 @@ public:
     CBoostedTreeFactory& previousTrainLossGap(double gap);
     //! Set the number of rows for the last train run.
     CBoostedTreeFactory& previousTrainNumberRows(std::size_t numberRows);
+    //! Set whether or not to always accept the result of incremental training.
+    CBoostedTreeFactory& forceAcceptIncrementalTraining(bool force);
     //! Set the data summarization information.
     CBoostedTreeFactory& featureEncoder(TEncoderUPtr encoder);
     //! Set the best forest from the previous training.

--- a/include/maths/CBoostedTreeImpl.h
+++ b/include/maths/CBoostedTreeImpl.h
@@ -502,6 +502,7 @@ private:
     TLossFunctionUPtr m_Loss;
     CBoostedTree::EClassAssignmentObjective m_ClassAssignmentObjective{CBoostedTree::E_MinimumRecall};
     bool m_IncrementalTraining{false};
+    bool m_ForceAcceptIncrementalTraining{false};
     bool m_StopCrossValidationEarly{true};
     double m_PreviousTrainLossGap{0.0};
     std::size_t m_PreviousTrainNumberRows{0};

--- a/jupyter/scripts/incremental_learning/experiment_driver.py
+++ b/jupyter/scripts/incremental_learning/experiment_driver.py
@@ -40,6 +40,7 @@ ex.logger = logger
 
 @ex.config
 def my_config():
+    force_update = False
     verbose = False
     dataset_name = 'ccpp'
     test_fraction = 0.2
@@ -176,7 +177,7 @@ def transform_dataset(dataset: pd.DataFrame,
 
 
 @ex.main
-def my_main(_run, dataset_name, verbose):
+def my_main(_run, dataset_name, force_update, verbose):
     results = {}
 
     original_dataset = read_dataset()
@@ -207,7 +208,7 @@ def my_main(_run, dataset_name, verbose):
     _run.run_logger.info("Initial training completed")
 
     _run.run_logger.info("Update started")
-    updated_model = update(dataset_name, update_dataset, trained_model, verbose=verbose, run=_run)
+    updated_model = update(dataset_name, update_dataset, trained_model, force=force_update, verbose=verbose, run=_run)
     elapsed_time = updated_model.wait_to_complete(clean=False)
     results['updated_model'] = {}
     results['updated_model']['config'] = updated_model.get_config()

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -493,14 +493,21 @@ def evaluate(dataset_name: str, dataset: pandas.DataFrame, original_job: Job, ve
     return job
 
 
-def update(dataset_name: str, dataset: pandas.DataFrame, original_job: Job, verbose: bool = True, run=None) -> Job:
+def update(dataset_name: str,
+           dataset: pandas.DataFrame,
+           original_job: Job,
+           force: bool = False,
+           verbose: bool = True,
+           run = None) -> Job:
     """Train a new model incrementally using the model and hyperparameters from the original job.
 
     Args:
         dataset_name (str): dataset name (to get configuration)
         dataset (pandas.DataFrame): new dataset
         original_job (Job): Job object of the original training
-        verbose (bool): Verbosity flag (defalt: True)
+        force (bool): Force accept the update (default: False)
+        verbose (bool): Verbosity flag (default: True)
+        run: The run context (default: None)
 
     Returns:
         Job: new Job object
@@ -514,6 +521,8 @@ def update(dataset_name: str, dataset: pandas.DataFrame, original_job: Job, verb
         original_job.get_data_summarization_num_rows()
     if run and 'threads' in run.config.keys():
         config['threads'] = run.config['threads']
+    if force:
+        config['analysis']['parameters']['force_accept_incremental_training'] = True
     for name, value in original_job.get_hyperparameters().items():
         if name not in ['retrained_tree_eta', 'tree_topology_change_penalty']:
             config['analysis']['parameters'][name] = value

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -93,6 +93,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(EARLY_STOPPING_ENABLED,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(FORCE_ACCEPT_INCREMENTAL_TRAINING,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(DATA_SUMMARIZATION_FRACTION,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(TASK, CDataFrameAnalysisConfigReader::E_OptionalParameter,
@@ -162,6 +164,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double predictionChangeCost{parameters[PREDICTION_CHANGE_COST].fallback(-1.0)};
     double treeTopologyChangePenalty{parameters[TREE_TOPOLOGY_CHANGE_PENALTY].fallback(-1.0)};
 
+    bool forceAcceptIncrementalTraining{
+        parameters[FORCE_ACCEPT_INCREMENTAL_TRAINING].fallback(false)};
     double dataSummarizationFraction{parameters[DATA_SUMMARIZATION_FRACTION].fallback(-1.0)};
     double previousTrainLossGap{parameters[PREVIOUS_TRAIN_LOSS_GAP].fallback(-1.0)};
     std::size_t previousTrainNumberRows{
@@ -220,7 +224,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
-        .earlyStoppingEnabled(earlyStoppingEnabled);
+        .earlyStoppingEnabled(earlyStoppingEnabled)
+        .forceAcceptIncrementalTraining(forceAcceptIncrementalTraining);
 
     if (downsampleRowsPerFeature > 0) {
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(
@@ -575,6 +580,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::IMPORTANCE_FIELD_NAME{"impor
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_IMPORTANCE_FIELD_NAME{"feature_importance"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_PROCESSORS{"feature_processors"};
 const std::string CDataFrameTrainBoostedTreeRunner::EARLY_STOPPING_ENABLED{"early_stopping_enabled"};
+const std::string CDataFrameTrainBoostedTreeRunner::FORCE_ACCEPT_INCREMENTAL_TRAINING{"force_accept_incremental_training"};
 const std::string CDataFrameTrainBoostedTreeRunner::DATA_SUMMARIZATION_FRACTION{"data_summarization_fraction"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK{"task"};
 const std::string CDataFrameTrainBoostedTreeRunner::TASK_TRAIN{"train"};

--- a/lib/maths/CBoostedTreeFactory.cc
+++ b/lib/maths/CBoostedTreeFactory.cc
@@ -1754,6 +1754,11 @@ CBoostedTreeFactory& CBoostedTreeFactory::previousTrainNumberRows(std::size_t nu
     return *this;
 }
 
+CBoostedTreeFactory& CBoostedTreeFactory::forceAcceptIncrementalTraining(bool force) {
+    m_TreeImpl->m_ForceAcceptIncrementalTraining = force;
+    return *this;
+}
+
 CBoostedTreeFactory& CBoostedTreeFactory::featureEncoder(TEncoderUPtr encoder) {
     m_TreeImpl->m_Encoder = std::move(encoder);
     return *this;

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -463,7 +463,7 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
     LOG_TRACE(<< "best forest loss = " << m_BestForestTestLoss
               << ", initial loss = " << initialLoss);
 
-    if (m_BestForestTestLoss < initialLoss) {
+    if (m_ForceAcceptIncrementalTraining || m_BestForestTestLoss < initialLoss) {
         this->restoreBestHyperparameters();
         core::CPackedBitVector allTrainingRowsMask{this->allTrainingRowsMask()};
 
@@ -2224,6 +2224,7 @@ const std::string FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
 const std::string FEATURE_DATA_TYPES_TAG{"feature_data_types"};
 const std::string FEATURE_SAMPLE_PROBABILITIES_TAG{"feature_sample_probabilities"};
 const std::string FOLD_ROUND_TEST_LOSSES_TAG{"fold_round_test_losses"};
+const std::string FORCE_ACCEPT_INCREMENTAL_TRAINING_TAG{"force_accept_incremental_training"};
 const std::string INITIALIZATION_STAGE_TAG{"initialization_progress"};
 const std::string INCREMENTAL_TRAINING_TAG{"incremental_training"};
 const std::string LOSS_TAG{"loss"};
@@ -2316,6 +2317,8 @@ void CBoostedTreeImpl::acceptPersistInserter(core::CStatePersistInserter& insert
     core::CPersistUtils::persist(FEATURE_SAMPLE_PROBABILITIES_TAG,
                                  m_FeatureSampleProbabilities, inserter);
     core::CPersistUtils::persist(FOLD_ROUND_TEST_LOSSES_TAG, m_FoldRoundTestLosses, inserter);
+    core::CPersistUtils::persist(FORCE_ACCEPT_INCREMENTAL_TRAINING_TAG,
+                                 m_ForceAcceptIncrementalTraining, inserter);
     core::CPersistUtils::persist(INCREMENTAL_TRAINING_TAG, m_IncrementalTraining, inserter);
     core::CPersistUtils::persist(INITIALIZATION_STAGE_TAG,
                                  static_cast<int>(m_InitializationStage), inserter);
@@ -2454,6 +2457,9 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
         RESTORE(FOLD_ROUND_TEST_LOSSES_TAG,
                 core::CPersistUtils::restore(FOLD_ROUND_TEST_LOSSES_TAG,
                                              m_FoldRoundTestLosses, traverser))
+        RESTORE(FORCE_ACCEPT_INCREMENTAL_TRAINING_TAG,
+                core::CPersistUtils::restore(FORCE_ACCEPT_INCREMENTAL_TRAINING_TAG,
+                                             m_ForceAcceptIncrementalTraining, traverser))
         RESTORE(INCREMENTAL_TRAINING_TAG,
                 core::CPersistUtils::restore(INCREMENTAL_TRAINING_TAG,
                                              m_IncrementalTraining, traverser))


### PR DESCRIPTION
Currently, we assess whether we think that incremental training will reduce loss vs the original model before committing the change. This relies on us being able to accurately estimate the test error for the original model. I've run into cases where we seem to significantly underestimate this on the transformed data we simulate in our test framework. It isn't clear why this is happening: I'm still investigating. However, it is also convenient to simply force accept the best change we found, both for test and also as a user (if one can assess model generalisation error independently). This adds the option and a parameter to the test framework.