### PR TITLE
[ML][PYTORCH] Update macOS build to libtorch 1.9

### DIFF
--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -155,7 +155,7 @@ Download the graphical installer for Python 3.7.9 from <https://www.python.org/f
 
 Install using all the default options.  When the installer completes a Finder window pops up.  Double click the `Install Certificates.command` file in this folder to install the SSL certificates Python needs.
 
-### PyTorch 1.8.0
+### PyTorch 1.9.0
 
 PyTorch requires that certain Python modules are installed.  To install them:
 
@@ -166,7 +166,7 @@ sudo /Library/Frameworks/Python.framework/Versions/3.7/bin/pip3.7 install instal
 Then obtain the PyTorch code:
 
 ```
-git clone --depth=1 --branch=v1.8.0 https://github.com/pytorch/pytorch.git
+git clone --depth=1 --branch=v1.9.0 https://github.com/pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
@@ -183,18 +183,18 @@ external processes.
 Build as follows:
 
 ```
-# TODO: add BLAS=vecLib when we upgrade to 1.9
+export BLAS=vecLib
 export BUILD_TEST=OFF
 export BUILD_CAFFE2=OFF
 export USE_NUMPY=OFF
 export USE_DISTRIBUTED=OFF
-export USE_MKLDNN=OFF
+export USE_MKLDNN=ON
 export USE_QNNPACK=OFF
 export USE_PYTORCH_QNNPACK=OFF
 [ $(uname -m) = x86_64 ] && export USE_XNNPACK=OFF
 # TODO: recheck if this is still necessary next time we upgrade
 [ $(uname -m) != x86_64 ] && export CMAKE_OSX_ARCHITECTURES=`uname -m`
-export PYTORCH_BUILD_VERSION=1.8.0
+export PYTORCH_BUILD_VERSION=1.9.0
 export PYTORCH_BUILD_NUMBER=1
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 setup.py install
 ```

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -188,10 +188,19 @@ export BUILD_TEST=OFF
 export BUILD_CAFFE2=OFF
 export USE_NUMPY=OFF
 export USE_DISTRIBUTED=OFF
-export USE_MKLDNN=ON
+# TODO: check if this can be made unconditional next time we upgrade.
+# In PyTorch 1.9 the version of oneDNN used doesn't work on Apple M1.
+# In PyTorch 1.10 oneDNN is upgraded and should build, but there
+# might still be further problems.
+[ $(uname -m) = x86_64 ] && export USE_MKLDNN=ON
 export USE_QNNPACK=OFF
 export USE_PYTORCH_QNNPACK=OFF
 [ $(uname -m) = x86_64 ] && export USE_XNNPACK=OFF
+# TODO: recheck if this is still necessary next time we upgrade.
+# At present CMake is set up to build for x86_64 on an Apple M1.
+# This line can be removed if CMake is changed to build for the
+# native architecture on M1.
+[ $(uname -m) != x86_64 ] && export CMAKE_OSX_ARCHITECTURES=`uname -m`
 export PYTORCH_BUILD_VERSION=1.9.0
 export PYTORCH_BUILD_NUMBER=1
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 setup.py install

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -192,8 +192,6 @@ export USE_MKLDNN=ON
 export USE_QNNPACK=OFF
 export USE_PYTORCH_QNNPACK=OFF
 [ $(uname -m) = x86_64 ] && export USE_XNNPACK=OFF
-# TODO: recheck if this is still necessary next time we upgrade
-[ $(uname -m) != x86_64 ] && export CMAKE_OSX_ARCHITECTURES=`uname -m`
 export PYTORCH_BUILD_VERSION=1.9.0
 export PYTORCH_BUILD_NUMBER=1
 /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 setup.py install

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -22,7 +22,7 @@
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-macosx-build
-VERSION=11
+VERSION=12
 
 set -e
 

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-macosx-build:11
+FROM docker.elastic.co/ml-dev/ml-macosx-build:12
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/macosx_image/Dockerfile
+++ b/dev-tools/docker/macosx_image/Dockerfile
@@ -31,7 +31,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
   cd /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.14-3.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.14-4.tar.bz2 | tar jxf - && \
   wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/xcode-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf - && \
   wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/sdk-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf -
 

--- a/dev-tools/download_macos_deps.sh
+++ b/dev-tools/download_macos_deps.sh
@@ -25,7 +25,7 @@ DEST=/usr
 case `uname -m` in
 
     arm64)
-        ARCHIVE=local-arm64-apple-macosx11.1-3.tar.bz2
+        ARCHIVE=local-arm64-apple-macosx11.1-4.tar.bz2
         ;;
 
     *)


### PR DESCRIPTION
Changes the BLAS library to be explicitly set to `vecLib` which is part of the `Accelerate` framework.

non-issue as the change is to unreleased code