### PR TITLE
[ML] Random seed support for experiment tracking

### DIFF
--- a/jupyter/src/.bumpversion.cfg
+++ b/jupyter/src/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = True
 tag = False
 

--- a/jupyter/src/incremental_learning/__init__.py
+++ b/jupyter/src/incremental_learning/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.7.0'
+VERSION = '0.8.0'

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -487,6 +487,8 @@ def train(dataset_name: str, dataset: pandas.DataFrame, verbose: bool = True, ru
     config['rows'] = dataset.shape[0]
     if run and 'threads' in run.config.keys():
         config['threads'] = run.config['threads']
+    if run and 'seed' in run.config.keys():
+        config['analysis']['parameters']['seed'] = run.config['seed']
 
     config_file = tempfile.NamedTemporaryFile(mode='wt')
     json.dump(config, config_file)
@@ -521,6 +523,9 @@ def evaluate(dataset_name: str, dataset: pandas.DataFrame, original_job: Job, ve
     config['analysis']['parameters']['task'] = 'predict'
     if run and 'threads' in run.config.keys():
         config['threads'] = run.config['threads']
+    if run and 'seed' in run.config.keys():
+        config['analysis']['parameters']['seed'] = run.config['seed']
+
     fconfig = tempfile.NamedTemporaryFile(mode='wt')
     json.dump(config, fconfig)
     fconfig.file.close()
@@ -553,6 +558,9 @@ def update(dataset_name: str, dataset: pandas.DataFrame, original_job: Job, verb
         original_job.get_data_summarization_num_rows()
     if run and 'threads' in run.config.keys():
         config['threads'] = run.config['threads']
+    if run and 'seed' in run.config.keys():
+        config['analysis']['parameters']['seed'] = run.config['seed']
+
     for name, value in original_job.get_hyperparameters().items():
         if name not in ['retrained_tree_eta', 'tree_topology_change_penalty']:
             config['analysis']['parameters'][name] = value

--- a/jupyter/src/setup.py
+++ b/jupyter/src/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup, find_packages
 
 setup(name="incremental_learning",
-      version="0.7.0", packages=find_packages())
+      version="0.8.0", packages=find_packages())

--- a/jupyter/tests/incremental_learning/test_regression.py
+++ b/jupyter/tests/incremental_learning/test_regression.py
@@ -1,3 +1,12 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
 import pandas as pd
 import unittest
 

--- a/jupyter/tests/incremental_learning/test_sacred.py
+++ b/jupyter/tests/incremental_learning/test_sacred.py
@@ -1,0 +1,63 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+from sacred import Experiment
+from sacred.run import Run
+
+from incremental_learning.config import datasets_dir
+from incremental_learning.job import evaluate, train, update
+from incremental_learning.storage import download_dataset
+
+
+class TestSacred(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataset_name = 'test_regression'
+        download_successful = download_dataset(self.dataset_name)
+        if download_successful == False:
+            self.fail("Dataset is not available")
+        self.dataset = pd.read_csv(
+            datasets_dir / '{}.csv'.format(self.dataset_name))
+
+    def test_seed(self) -> None:
+        def run_tests(dataset_name, dataset, _run) -> None:
+            # make sure results are identical for the same seed
+            job1 = train(dataset_name, dataset, verbose=False, run=_run)
+            success = job1.wait_to_complete()
+            self.assertTrue(success)
+            prediction1 = job1.get_predictions()
+
+            job2 = train(dataset_name, dataset, verbose=False, run=_run)
+            success = job2.wait_to_complete()
+            self.assertTrue(success)
+            prediction2 = job2.get_predictions()
+
+            self.assertTrue(np.array_equal(prediction1, prediction2))
+
+            # change seed and make sure results are different
+            _run.config['seed'] = 120
+            job3 = train(dataset_name, dataset, verbose=False, run=_run)
+            success = job3.wait_to_complete()
+            self.assertTrue(success)
+            prediction3 = job3.get_predictions()
+            self.assertFalse(np.array_equal(prediction1, prediction3))
+
+        ex = Experiment('test_seed')
+        ex.add_config(seed=100, dataset_name=self.dataset_name,
+                      dataset=self.dataset)
+        ex.main(run_tests)
+        ex.run()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change allows passing the `seed` parameter to the configuration of the `data_frame_analytics`. It also adds a unit test for reproducible runs with sacred.