### PR TITLE
[ML] Parallelize calls to forward on pytorch models

### DIFF
--- a/bin/pytorch_inference/CCmdLineParser.cc
+++ b/bin/pytorch_inference/CCmdLineParser.cc
@@ -34,8 +34,8 @@ bool CCmdLineParser::parse(int argc,
                            bool& isRestoreFileNamedPipe,
                            std::string& loggingFileName,
                            std::string& logProperties,
-                           std::int32_t& numThreads,
-                           std::int32_t& numInterOpThreads,
+                           std::int32_t& numLibTorchThreads,
+                           std::int32_t& numLibTorchInterOpThreads,
                            std::int32_t& numParallelForwardingThreads,
                            bool& validElasticLicenseKeyConfirmed) {
     try {
@@ -60,9 +60,9 @@ bool CCmdLineParser::parse(int argc,
             ("logPipe", boost::program_options::value<std::string>(),
                         "Named pipe to write log messages to")
             ("logProperties", "Optional logger properties file")
-            ("numThreads", boost::program_options::value<std::int32_t>(),
+            ("numLibTorchThreads", boost::program_options::value<std::int32_t>(),
                         "Optionaly set number of threads LibTorch can use for inference - not present means use the LibTorch defaults")
-            ("numInterOpThreads", boost::program_options::value<std::int32_t>(),
+            ("numLibTorchInterOpThreads", boost::program_options::value<std::int32_t>(),
                         "Optionaly set number of threads LibTorch can use for inter operation parallelism - not present means use the LibTorch defaults")
             ("numParallelForwardingThreads", boost::program_options::value<std::int32_t>(),
                         "Optionaly set number of threads to parallelize model forwarding - not present means 1")
@@ -116,11 +116,11 @@ bool CCmdLineParser::parse(int argc,
         if (vm.count("logProperties") > 0) {
             logProperties = vm["logProperties"].as<std::string>();
         }
-        if (vm.count("numThreads") > 0) {
-            numThreads = vm["numThreads"].as<std::int32_t>();
+        if (vm.count("numLibTorchThreads") > 0) {
+            numLibTorchThreads = vm["numLibTorchThreads"].as<std::int32_t>();
         }
-        if (vm.count("numInterOpThreads") > 0) {
-            numInterOpThreads = vm["numInterOpThreads"].as<std::int32_t>();
+        if (vm.count("numLibTorchInterOpThreads") > 0) {
+            numLibTorchInterOpThreads = vm["numLibTorchInterOpThreads"].as<std::int32_t>();
         }
         if (vm.count("numParallelForwardingThreads") > 0) {
             numParallelForwardingThreads =

--- a/bin/pytorch_inference/CCmdLineParser.cc
+++ b/bin/pytorch_inference/CCmdLineParser.cc
@@ -36,6 +36,7 @@ bool CCmdLineParser::parse(int argc,
                            std::string& logProperties,
                            std::int32_t& numThreads,
                            std::int32_t& numInterOpThreads,
+                           std::int32_t& numParallelForwardingThreads,
                            bool& validElasticLicenseKeyConfirmed) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
@@ -63,6 +64,8 @@ bool CCmdLineParser::parse(int argc,
                         "Optionaly set number of threads LibTorch can use for inference - not present means use the LibTorch defaults")
             ("numInterOpThreads", boost::program_options::value<std::int32_t>(),
                         "Optionaly set number of threads LibTorch can use for inter operation parallelism - not present means use the LibTorch defaults")
+            ("numParallelForwardingThreads", boost::program_options::value<std::int32_t>(),
+                        "Optionaly set number of threads to parallelize model forwarding - not present means 1")
             ("validElasticLicenseKeyConfirmed", boost::program_options::value<bool>(),
              "Confirmation that a valid Elastic license key is in use.")
             ;
@@ -118,6 +121,10 @@ bool CCmdLineParser::parse(int argc,
         }
         if (vm.count("numInterOpThreads") > 0) {
             numInterOpThreads = vm["numInterOpThreads"].as<std::int32_t>();
+        }
+        if (vm.count("numParallelForwardingThreads") > 0) {
+            numParallelForwardingThreads =
+                vm["numParallelForwardingThreads"].as<std::int32_t>();
         }
         if (vm.count("validElasticLicenseKeyConfirmed") > 0) {
             validElasticLicenseKeyConfirmed =

--- a/bin/pytorch_inference/CCmdLineParser.h
+++ b/bin/pytorch_inference/CCmdLineParser.h
@@ -49,6 +49,7 @@ public:
                       std::string& logProperties,
                       std::int32_t& numThreads,
                       std::int32_t& numInterOpThreads,
+                      std::int32_t& numParallelForwardingThreads,
                       bool& validElasticLicenseKeyConfirmed);
 
 private:

--- a/bin/pytorch_inference/CCmdLineParser.h
+++ b/bin/pytorch_inference/CCmdLineParser.h
@@ -47,8 +47,8 @@ public:
                       bool& isRestoreFileNamedPipe,
                       std::string& loggingFileName,
                       std::string& logProperties,
-                      std::int32_t& numThreads,
-                      std::int32_t& numInterOpThreads,
+                      std::int32_t& numLibTorchThreads,
+                      std::int32_t& numLibTorchInterOpThreads,
                       std::int32_t& numParallelForwardingThreads,
                       bool& validElasticLicenseKeyConfirmed);
 

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -10,10 +10,12 @@
  */
 
 #include <core/CBlockingCallCancellingTimer.h>
+#include <core/CJsonOutputStreamWrapper.h>
 #include <core/CLogger.h>
 #include <core/CProcessPriority.h>
-#include <core/CRapidJsonLineWriter.h>
+#include <core/CRapidJsonConcurrentLineWriter.h>
 #include <core/CStopWatch.h>
+#include <core/Concurrency.h>
 
 #include <seccomp/CSystemCallFilter.h>
 
@@ -39,8 +41,6 @@ namespace {
 const std::string INFERENCE{"inference"};
 const std::string ERROR{"error"};
 const std::string TIME_MS{"time_ms"};
-
-ml::core::CStopWatch stopWatch;
 }
 
 torch::Tensor infer(torch::jit::script::Module& module,
@@ -81,7 +81,7 @@ torch::Tensor infer(torch::jit::script::Module& module,
 
 template<typename T>
 void writeTensor(const torch::TensorAccessor<T, 1UL>& accessor,
-                 ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+                 ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
     jsonWriter.StartArray();
     for (int i = 0; i < accessor.size(0); ++i) {
         jsonWriter.Double(static_cast<double>(accessor[i]));
@@ -91,7 +91,7 @@ void writeTensor(const torch::TensorAccessor<T, 1UL>& accessor,
 
 template<typename T, std::size_t N_DIMS>
 void writeTensor(const torch::TensorAccessor<T, N_DIMS>& accessor,
-                 ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+                 ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
     jsonWriter.StartArray();
     for (int i = 0; i < accessor.size(0); ++i) {
         writeTensor(accessor[i], jsonWriter);
@@ -101,7 +101,7 @@ void writeTensor(const torch::TensorAccessor<T, N_DIMS>& accessor,
 
 template<typename T>
 void writeInferenceResults(const torch::TensorAccessor<T, 3UL>& accessor,
-                           ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+                           ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
 
     jsonWriter.Key(INFERENCE);
     writeTensor(accessor, jsonWriter);
@@ -109,7 +109,7 @@ void writeInferenceResults(const torch::TensorAccessor<T, 3UL>& accessor,
 
 template<typename T>
 void writeInferenceResults(const torch::TensorAccessor<T, 2UL>& accessor,
-                           ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+                           ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
 
     jsonWriter.Key(INFERENCE);
     // output must be a 3D array so wrap the 2D result in an outer array
@@ -120,7 +120,7 @@ void writeInferenceResults(const torch::TensorAccessor<T, 2UL>& accessor,
 
 void writeError(const std::string& requestId,
                 const std::string& message,
-                ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+                ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
     jsonWriter.StartObject();
     jsonWriter.Key(ml::torch::CCommandParser::REQUEST_ID);
     jsonWriter.String(requestId);
@@ -131,7 +131,7 @@ void writeError(const std::string& requestId,
 
 void writeDocumentOpening(const std::string& requestId,
                           std::uint64_t timeMs,
-                          ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+                          ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
     jsonWriter.StartObject();
     jsonWriter.Key(ml::torch::CCommandParser::REQUEST_ID);
     jsonWriter.String(requestId);
@@ -139,7 +139,7 @@ void writeDocumentOpening(const std::string& requestId,
     jsonWriter.Uint64(timeMs);
 }
 
-void writeDocumentClosing(ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+void writeDocumentClosing(ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
     jsonWriter.EndObject();
 }
 
@@ -147,7 +147,7 @@ template<std::size_t N>
 void writePrediction(const torch::Tensor& prediction,
                      const std::string& requestId,
                      std::uint64_t timeMs,
-                     ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
+                     ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
 
     // creating the accessor will throw if the tensor does
     // not have exactly N dimensions. Do this before writing
@@ -174,10 +174,10 @@ void writePrediction(const torch::Tensor& prediction,
     }
 }
 
-bool handleRequest(ml::torch::CCommandParser::SRequest& request,
-                   torch::jit::script::Module& module,
-                   ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper>& jsonWriter) {
-
+void inferAndWriteResult(ml::torch::CCommandParser::SRequest& request,
+                         torch::jit::script::Module& module,
+                         ml::core::CRapidJsonConcurrentLineWriter& jsonWriter) {
+    ml::core::CStopWatch stopWatch;
     try {
         stopWatch.reset(true);
         torch::Tensor results = infer(module, request);
@@ -200,8 +200,19 @@ bool handleRequest(ml::torch::CCommandParser::SRequest& request,
     } catch (std::runtime_error& e) {
         writeError(request.s_RequestId, e.what(), jsonWriter);
     }
-
     jsonWriter.Flush();
+}
+
+bool handleRequest(const ml::torch::CCommandParser::SRequest& request,
+                   torch::jit::script::Module& module,
+                   ml::core::CJsonOutputStreamWrapper& wrappedOutputStream) {
+
+    ml::core::async(
+        ml::core::defaultAsyncExecutor(),
+        [ requestCopy = request, &module, &wrappedOutputStream ]() mutable {
+            ml::core::CRapidJsonConcurrentLineWriter jsonWriter(wrappedOutputStream);
+            inferAndWriteResult(requestCopy, module, jsonWriter);
+        });
     return true;
 }
 
@@ -306,18 +317,22 @@ int main(int argc, char** argv) {
 
     ml::torch::CCommandParser commandParser{ioMgr.inputStream()};
 
-    rapidjson::OStreamWrapper writeStream(ioMgr.outputStream());
-    ml::core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> jsonWriter(writeStream);
+    ml::core::CJsonOutputStreamWrapper wrappedOutputStream{ioMgr.outputStream()};
 
-    jsonWriter.StartArray();
+    ml::core::startDefaultAsyncExecutor(1);
+
     commandParser.ioLoop(
-        [&module, &jsonWriter](ml::torch::CCommandParser::SRequest& request) {
-            return handleRequest(request, module, jsonWriter);
+        [&module, &wrappedOutputStream](ml::torch::CCommandParser::SRequest request) {
+            return handleRequest(request, module, wrappedOutputStream);
         },
-        [&jsonWriter](const std::string& requestId, const std::string& message) {
-            writeError(requestId, message, jsonWriter);
+        [&wrappedOutputStream](const std::string& requestId, const std::string& message) {
+            ml::core::CRapidJsonConcurrentLineWriter errorWriter(wrappedOutputStream);
+            writeError(requestId, message, errorWriter);
         });
-    jsonWriter.EndArray();
+
+    // Stopping the executor forces this to block until all work is done
+    ml::core::stopDefaultAsyncExecutor();
+
     LOG_DEBUG(<< "ML Torch model prototype exiting");
 
     return EXIT_SUCCESS;

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -228,15 +228,15 @@ int main(int argc, char** argv) {
     std::string logProperties;
     ml::core_t::TTime namedPipeConnectTimeout{
         ml::core::CBlockingCallCancellingTimer::DEFAULT_TIMEOUT_SECONDS};
-    std::int32_t numThreads{-1};
-    std::int32_t numInterOpThreads{-1};
+    std::int32_t numLibTorchThreads{-1};
+    std::int32_t numLibTorchInterOpThreads{-1};
     std::int32_t numParallelForwardingThreads{1};
     bool validElasticLicenseKeyConfirmed{false};
 
     if (ml::torch::CCmdLineParser::parse(
-            argc, argv, modelId, namedPipeConnectTimeout, inputFileName,
-            isInputFileNamedPipe, outputFileName, isOutputFileNamedPipe, restoreFileName,
-            isRestoreFileNamedPipe, logFileName, logProperties, numThreads, numInterOpThreads,
+            argc, argv, modelId, namedPipeConnectTimeout, inputFileName, isInputFileNamedPipe,
+            outputFileName, isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe,
+            logFileName, logProperties, numLibTorchThreads, numLibTorchInterOpThreads,
             numParallelForwardingThreads, validElasticLicenseKeyConfirmed) == false) {
         return EXIT_FAILURE;
     }
@@ -291,11 +291,11 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (numThreads != -1) {
-        at::set_num_threads(numThreads);
+    if (numLibTorchThreads != -1) {
+        at::set_num_threads(numLibTorchThreads);
     }
-    if (numInterOpThreads != -1) {
-        at::set_num_interop_threads(numInterOpThreads);
+    if (numLibTorchInterOpThreads != -1) {
+        at::set_num_interop_threads(numLibTorchInterOpThreads);
     }
     LOG_DEBUG(<< at::get_parallel_info());
     LOG_DEBUG(<< "Number of parallel forwarding threads: " << numParallelForwardingThreads);

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -49,6 +49,7 @@ For Benchmarking:
 '''
 
 import argparse
+from datetime import datetime
 import json
 import math
 import os
@@ -69,6 +70,7 @@ def parse_arguments():
     parser.add_argument('--output_file', default='output_file')
     parser.add_argument('--numThreads', type=int, help='The number of inference threads. The system default is used if not set')
     parser.add_argument('--benchmark', action='store_true', help='Benchmark inference time rather than evaluting expected results')
+    parser.add_argument('--numParallelForwardingThreads', type=int, help='The number of threads for parallel forwarding. Defaults to 1')
 
     return parser.parse_args()
 
@@ -101,6 +103,9 @@ def launch_pytorch_app(args):
     if args.numThreads:
         command.append('--numThreads=' + str(args.numThreads))
         command.append('--numInterOpThreads=1')
+
+    if args.numParallelForwardingThreads:
+        command.append('--numParallelForwardingThreads=' + str(args.numParallelForwardingThreads))
 
     subprocess.Popen(command).communicate()
 
@@ -200,7 +205,10 @@ def run_benchmark(args):
                     if benchmark_count == NUM_BENCHMARK_REQUEST:
                         break
    
+    start_time = datetime.now()
     launch_pytorch_app(args)
+    end_time = datetime.now()
+    runtime_ms = int((end_time - start_time).total_seconds() * 1000)
 
     print()
     print("reading benchmark results...", flush=True)
@@ -218,6 +226,7 @@ def run_benchmark(args):
 
         
         print()
+        print(f'Process run in {runtime_ms} ms')
         print(f'{doc_count} requests evaluated in {total_time_ms} ms, avg time {total_time_ms / doc_count} ms')
         print()
 

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -34,8 +34,11 @@ the actual benchmarking are controlled by the hard coded values
 Switch to benchmark mode by passing the `--benchmark` argument.
 
 Setting the number of threads used by inference has the biggest affect
-on performance and is controlled by the `--numThreads` argument. If not
-set LibTorch will choose the defaults.
+on performance and is controlled two arguments. First, there is
+`--numLibTorchThreads` which controls the number of threads used by
+LibTorch. If not set LibTorch will choose the defaults. Second, we have
+`--numParallelForwardingThreads` which controls how many threads are
+calling LibTorch's forwarding. If not set it defaults to 1.
 
 EXAMPLES
 --------
@@ -45,7 +48,7 @@ For test evaluation:
     python3 evaluate.py /path/to/conll03_traced_ner.pt examples/ner/test_run.json
 
 For Benchmarking:
-    python3 evaluate.py /path/to/conll03_traced_ner.pt examples/ner/test_run.json --benchmark --numThreads=2
+    python3 evaluate.py /path/to/conll03_traced_ner.pt examples/ner/test_run.json --benchmark --numLibTorchThreads=2
 '''
 
 import argparse
@@ -68,7 +71,7 @@ def parse_arguments():
     parser.add_argument('--restore_file', default='restore_file')
     parser.add_argument('--input_file', default='input_file')
     parser.add_argument('--output_file', default='output_file')
-    parser.add_argument('--numThreads', type=int, help='The number of inference threads. The system default is used if not set')
+    parser.add_argument('--numLibTorchThreads', type=int, help='The number of inference threads used by LibTorch. The system default is used if not set')
     parser.add_argument('--benchmark', action='store_true', help='Benchmark inference time rather than evaluting expected results')
     parser.add_argument('--numParallelForwardingThreads', type=int, help='The number of threads for parallel forwarding. Defaults to 1')
 
@@ -100,9 +103,9 @@ def launch_pytorch_app(args):
         '--validElasticLicenseKeyConfirmed=true'
         ]
 
-    if args.numThreads:
-        command.append('--numThreads=' + str(args.numThreads))
-        command.append('--numInterOpThreads=1')
+    if args.numLibTorchThreads:
+        command.append('--numLibTorchThreads=' + str(args.numLibTorchThreads))
+        command.append('--numLibTorchInterOpThreads=1')
 
     if args.numParallelForwardingThreads:
         command.append('--numParallelForwardingThreads=' + str(args.numParallelForwardingThreads))


### PR DESCRIPTION
Parallelizes model forwarding. A new parameter called `numParallelForwardingThreads`
specifies the size of the thread pool used to do model forwarding in parallel. The default
value is `1` for now.