### PR TITLE
[ML] Only start thread pool for parallel forwarding if multiple threads

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -312,7 +312,11 @@ int main(int argc, char** argv) {
 
     ml::core::CJsonOutputStreamWrapper wrappedOutputStream{ioMgr.outputStream()};
 
-    ml::core::startDefaultAsyncExecutor(numParallelForwardingThreads);
+    // Starting the executor with 1 thread will use an extra thread that isn't necessary
+    // so we only start it when more than 1 threads are set.
+    if (numParallelForwardingThreads > 1) {
+        ml::core::startDefaultAsyncExecutor(numParallelForwardingThreads);
+    }
 
     commandParser.ioLoop(
         [&module, &wrappedOutputStream](const ml::torch::CCommandParser::SRequest& request) {


### PR DESCRIPTION
... are used. This is a follow up to #2023. Now that we start the
thread pool for parallel forwarding to LibTorch models, if the setting
is `1` we start an additional thread that isn't necessary. This commit
removes the use of that extra thread if `numParallelForwardingThreads`
is set to `1`.