### PR TITLE
[ML][PYTORCH] Use InferenceMode RAII guard

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -63,7 +63,7 @@ torch::Tensor infer(torch::jit::script::Module& module,
                                              inputSize, at::dtype(torch::kInt64)));
     }
 
-    torch::NoGradGuard noGrad;
+    torch::InferenceMode inferenceModeGuard;
     auto result = module.forward(inputs);
     if (result.isTuple()) {
         // For BERT models the result tensor is the first element in a tuple


### PR DESCRIPTION
Optimisation for inference only workloads see https://github.com/ailzhang/rfcs/blob/rfc0011/RFC-0011-InferenceMode.md

`InferenceMode` was added to libtorch in version 1.9 so this PR should not be merged until all platforms have been upgraded.

Closes #1954 