### PR TITLE
[ML] Set LibTorch math lib threads to one

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -14,6 +14,7 @@
 #include <core/CLogger.h>
 #include <core/CProcessPriority.h>
 #include <core/CRapidJsonConcurrentLineWriter.h>
+#include <core/CSetEnv.h>
 #include <core/CStopWatch.h>
 #include <core/Concurrency.h>
 
@@ -232,6 +233,11 @@ int main(int argc, char** argv) {
             numParallelForwardingThreads, validElasticLicenseKeyConfirmed) == false) {
         return EXIT_FAILURE;
     }
+
+    // Disable multithreading for the math libs.
+    ml::core::CSetEnv::setEnv("MKL_NUM_THREADS", "1", 0);
+    ml::core::CSetEnv::setEnv("OMP_NUM_THREADS", "1", 0);
+    ml::core::CSetEnv::setEnv("VECLIB_MAXIMUM_THREADS", "1", 0);
 
     ml::core::CBlockingCallCancellingTimer cancellerThread{
         ml::core::CThread::currentThreadId(), std::chrono::seconds{namedPipeConnectTimeout}};

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -235,9 +235,10 @@ int main(int argc, char** argv) {
     }
 
     // Disable multithreading for the math libs.
-    ml::core::CSetEnv::setEnv("MKL_NUM_THREADS", "1", 0);
-    ml::core::CSetEnv::setEnv("OMP_NUM_THREADS", "1", 0);
-    ml::core::CSetEnv::setEnv("VECLIB_MAXIMUM_THREADS", "1", 0);
+    // It doesn't hurt to set variables that won't have any effect on some platforms.
+    ml::core::CSetEnv::setEnv("MKL_NUM_THREADS", "1", 0); // Only expected to affect linux-x86_64
+    ml::core::CSetEnv::setEnv("OMP_NUM_THREADS", "1", 0); // Only expected to affect Linux
+    ml::core::CSetEnv::setEnv("VECLIB_MAXIMUM_THREADS", "1", 0); // Only expected to affect macOS
 
     ml::core::CBlockingCallCancellingTimer cancellerThread{
         ml::core::CThread::currentThreadId(), std::chrono::seconds{namedPipeConnectTimeout}};


### PR DESCRIPTION
In order to simplify control of threading for the LibTorch
process, we set the known environment variables for the threading
of the math lib to one. In this commit, those include:

  - MKL_NUM_THREADS: for the MKL lib
  - OMP_NUM_THREADS: for OpenMP
  - VECLIB_MAXIMUM_THREADS: for Mac's Accelerated framework

Note we do not override the variables if they are already set
in order to allow experimenting in benchmarking. Depending on
findings, we might revisit this and override them.