### PR TITLE
[ML] Improve concurrency for regression and classification training

### DIFF
--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -722,7 +722,7 @@ CDataFrame::CDataFrameRowSliceWriter::finishWritingRows() {
 }
 
 std::size_t dataFrameDefaultSliceCapacity(std::size_t numberColumns) {
-    std::size_t oneMbChunkSize{constants::BYTES_IN_MEGABYTES /
+    std::size_t oneMbChunkSize{8 * constants::BYTES_IN_MEGABYTES /
                                sizeof(CFloatStorage) / numberColumns};
     return std::max(oneMbChunkSize, std::size_t{128});
 }

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -17,6 +17,7 @@
 #include <core/CPersistUtils.h>
 #include <core/CProgramCounters.h>
 #include <core/CStopWatch.h>
+#include <core/Concurrency.h>
 #include <core/Constants.h>
 #include <core/RestoreMacros.h>
 
@@ -1286,11 +1287,11 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(core::CDataFrame& fr
         }
     } while (nextPass());
 
-    for (std::size_t i = 0; i < tree.size(); ++i) {
+    core::parallel_for_each(0, tree.size(), [&](std::size_t i) {
         if (tree[i].isLeaf()) {
             tree[i].value(eta * leafValues[i].value());
         }
-    }
+    });
 
     LOG_TRACE(<< "tree =\n" << root(tree).print(tree));
 

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -653,10 +653,10 @@ std::size_t CBoostedTreeLeafNodeStatistics::numberThreadsForComputeBestSplitStat
                      CTools::pow2(static_cast<double>(m_NumberLossParameters))};
 
     auto throughput = [&](double threads) {
-        return threads > 1 ? totalWork / 20.0 / threads + 20.0 * threads : totalWork / 20.0;
+        return threads > 1 ? totalWork / 20.0 / threads + 30.0 * threads : totalWork / 20.0;
     };
 
-    double maxThroughputNumberThreads{std::max(std::sqrt(totalWork / 400.0), 1.0)};
+    double maxThroughputNumberThreads{std::max(std::sqrt(totalWork / 600.0), 1.0)};
     TDoubleAry numberThreads{1.0, std::floor(maxThroughputNumberThreads),
                              std::ceil(maxThroughputNumberThreads)};
     TDoubleAry throughputs{throughput(1.0),

--- a/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -248,7 +248,7 @@ void testPerSplitDerivativesFor(std::size_t numberParameters) {
                         columnMajorHessian(numberParameters, curvature);
                 }
             }
-            derivatives.remapCurvature();
+            derivatives.remapCurvature(features);
         };
 
         auto validate = [&](const TSplitsDerivatives& derivatives) {
@@ -288,7 +288,7 @@ void testPerSplitDerivativesFor(std::size_t numberParameters) {
         TSplitsDerivatives derivatives2{featureSplits, numberParameters};
 
         addDerivatives(derivatives2);
-        derivatives1.add(derivatives2);
+        derivatives1.add(derivatives2, features);
         validate(derivatives1);
 
         LOG_TRACE(<< "Test copy");


### PR DESCRIPTION
This makes some profiling driven optimisations for improving concurrency:
1. Reducing the derivatives from each thread is somewhat expensive and we can optimise to only consider features in the tree bag,
2. When we have lots of features computing best splits constitutes enough work that we can parallelise for a performance win,
3. Computing leaf values is expensive for deep trees and we can trivially parallelise.

Using 8 threads, runtime for training Higgs 1M drops from before this change 7641s to after this change 3926s.

This does not change results.