### PR TITLE
[ML] Fix Windows debug build of pytorch_inference

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -22,6 +22,19 @@
 #include <sstream>
 #include <string>
 
+#ifdef Windows
+// rapidjson::Writer<rapidjson::StringBuffer> gets instantiated in the core
+// library, and on Windows it gets exported too, because
+// CRapidJsonConcurrentLineWriter inherits from it and is also exported.
+// To avoid breaching the one-definition rule we must reuse this exported
+// instantiation, as deduplication of template instantiations doesn't work
+// across DLLs.  To make this even more confusing, this is only strictly
+// necessary when building without optimisation, because with optimisation
+// enabled the instantiation in this library gets inlined to the extent that
+// there are no clashing symbols.
+template class CORE_EXPORT rapidjson::Writer<rapidjson::StringBuffer>;
+#endif
+
 namespace rapidjson {
 
 std::ostream& operator<<(std::ostream& os, const rapidjson::Document& doc) {


### PR DESCRIPTION
The [Windows debug build](https://elasticsearch-ci.elastic.co/job/elastic+machine-learning+main+windows+debug/) of pytorch_inference has been
failing with this error:

```
libMlCore.lib(libMlCore.dll) : error LNK2005: "public: bool __cdecl rapidjson::Writer<class rapidjson::GenericStringBuffer<struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator>,struct rapidjson::UTF8<char>,struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator,0>::Uint64(unsigned __int64)" (?Uint64@?$Writer@V?$GenericStringBuffer@U?$UTF8@D@rapidjson@@VCrtAllocator@2@@rapidjson@@U?$UTF8@D@2@U32@VCrtAllocator@2@$0A@@rapidjson@@QEAA_N_K@Z) already defined in CCommandParser.obj
libMlCore.lib(libMlCore.dll) : error LNK2005: "public: bool __cdecl rapidjson::Writer<class rapidjson::GenericStringBuffer<struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator>,struct rapidjson::UTF8<char>,struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator,0>::StartArray(void)" (?StartArray@?$Writer@V?$GenericStringBuffer@U?$UTF8@D@rapidjson@@VCrtAllocator@2@@rapidjson@@U?$UTF8@D@2@U32@VCrtAllocator@2@$0A@@rapidjson@@QEAA_NXZ) already defined in CCommandParser.obj
libMlCore.lib(libMlCore.dll) : error LNK2005: "public: bool __cdecl rapidjson::Writer<class rapidjson::GenericStringBuffer<struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator>,struct rapidjson::UTF8<char>,struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator,0>::EndArray(unsigned int)" (?EndArray@?$Writer@V?$GenericStringBuffer@U?$UTF8@D@rapidjson@@VCrtAllocator@2@@rapidjson@@U?$UTF8@D@2@U32@VCrtAllocator@2@$0A@@rapidjson@@QEAA_NI@Z) already defined in CCommandParser.obj
libMlCore.lib(libMlCore.dll) : error LNK2005: "public: void __cdecl rapidjson::Writer<class rapidjson::GenericStringBuffer<struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator>,struct rapidjson::UTF8<char>,struct rapidjson::UTF8<char>,class rapidjson::CrtAllocator,0>::Flush(void)" (?Flush@?$Writer@V?$GenericStringBuffer@U?$UTF8@D@rapidjson@@VCrtAllocator@2@@rapidjson@@U?$UTF8@D@2@U32@VCrtAllocator@2@$0A@@rapidjson@@QEAAXXZ) already defined in CCommandParser.obj
.objs\pytorch_inference.exe : fatal error LNK1169: one or more multiply defined symbols found
```

We have seen this before with some classes in the api library.
This change copies the fix over to pytorch_inference.