### PR TITLE
[7.x][ML] Fix unit tests for skip_model_update rule (#2036)

### DIFF
--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -1194,13 +1194,14 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     CDetectionRule rule;
     rule.action(CDetectionRule::E_SkipModelUpdate);
-    rule.includeScope("", valueFilter);
+    rule.includeScope("byFieldName", valueFilter);
 
     SModelParams paramsNoRules(bucketLength);
     auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
     CEventRatePopulationModelFactory factory(paramsNoRules, interimBucketCorrector);
     model_t::TFeatureVec features{model_t::E_PopulationCountByBucketPersonAndAttribute};
     factory.features(features);
+    factory.fieldNames("partitionFieldName", "", "byFieldName", "", {});
 
     CModelFactory::SGathererInitializationData gathererNoSkipInitData(startTime);
     CModelFactory::TDataGathererPtr gathererNoSkip(
@@ -1217,6 +1218,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     CEventRatePopulationModelFactory factoryWithSkipRule(
         paramsWithRules, interimBucketCorrectorWithRules);
     factoryWithSkipRule.features(features);
+    factoryWithSkipRule.fieldNames("partitionFieldName", "", "byFieldName", "", {});
 
     CModelFactory::SGathererInitializationData gathererWithSkipInitData(startTime);
     CModelFactory::TDataGathererPtr gathererWithSkip(

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2252,6 +2252,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     auto interimBucketCorrector = std::make_shared<CInterimBucketCorrector>(bucketLength);
     CMetricModelFactory factory(paramsNoRules, interimBucketCorrector);
     model_t::TFeatureVec features{model_t::E_IndividualMeanByPerson};
+    factory.features(features);
     CModelFactory::TDataGathererPtr gathererNoSkip(factory.makeDataGatherer(startTime));
     CModelFactory::TModelPtr modelPtrNoSkip(factory.makeModel(gathererNoSkip));
     CMetricModel* modelNoSkip = dynamic_cast<CMetricModel*>(modelPtrNoSkip.get());
@@ -2261,6 +2262,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     SModelParams::TDetectionRuleVec rules{rule};
     paramsWithRules.s_DetectionRules = SModelParams::TDetectionRuleVecCRef(rules);
     CMetricModelFactory factoryWithSkip(paramsWithRules, interimBucketCorrector);
+    factoryWithSkip.features(features);
     CModelFactory::TDataGathererPtr gathererWithSkip(
         factoryWithSkip.makeDataGatherer(startTime));
     CModelFactory::TModelPtr modelPtrWithSkip(factoryWithSkip.makeModel(gathererWithSkip));
@@ -2312,12 +2314,13 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     // Checksums will be different due to the data gatherers
     BOOST_TEST_REQUIRE(modelWithSkip->checksum() != modelNoSkip->checksum());
 
-    // but the underlying models should be the same
-    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
-        modelWithSkip->details();
-    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
-
     // TODO this test fails due a different checksums for the decay rate and prior
+
+    // // but the underlying models should be the same
+    // CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
+    //     modelWithSkip->details();
+    // CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
+
     // uint64_t withSkipChecksum = modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0)->checksum();
     // uint64_t noSkipChecksum = modelNoSkipView->model(model_t::E_IndividualMeanByPerson, 0)->checksum();
     // BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);


### PR DESCRIPTION
A number of minor fixes for the testIgnoreSamplingGivenDetectionRules
tests that exercise the skip_model_update rule.

In some test cases the rule was improperly configured leading to it
never being executed.

In the case of
CMetricPopulationModelTest/testIgnoreSamplingGivenDetectionRules
messages were not being sampled by the models, leading to the rule never
firing as no data was being passed to it. This was resolved by
generating a more complex set of messages to pass to the models.

Backports #2036