### PR TITLE
[ML] Add threading benchmark mode to LibTorch evaluate.py

### DIFF
--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -40,6 +40,17 @@ LibTorch. If not set LibTorch will choose the defaults. Second, we have
 `--numParallelForwardingThreads` which controls how many threads are
 calling LibTorch's forwarding. If not set it defaults to 1.
 
+THREADING_BENCHMARK MODE
+-----------
+
+This mode will execute multiple runs setting various options to the two threading
+parameters, `--numLibTorchThreads` and `--numParallelForwardingThreads`.
+Define those options by setting the variable `threading_options`.
+At the end of the execution the output will be a CSV format summary of the runs
+with the total runtime and the avg time per request.
+
+Switch to threading benchmark mode by passing the `--threading_benchmark` argument.
+
 EXAMPLES
 --------
 Run this script with input from one of the example directories.
@@ -49,6 +60,9 @@ For test evaluation:
 
 For Benchmarking:
     python3 evaluate.py /path/to/conll03_traced_ner.pt examples/ner/test_run.json --benchmark --numLibTorchThreads=2
+
+For threading benchmark:
+    python3 evaluate.py /path/to/conll03_traced_ner.pt examples/ner/test_run.json --threading_benchmark
 '''
 
 import argparse
@@ -72,8 +86,10 @@ def parse_arguments():
     parser.add_argument('--input_file', default='input_file')
     parser.add_argument('--output_file', default='output_file')
     parser.add_argument('--numLibTorchThreads', type=int, help='The number of inference threads used by LibTorch. The system default is used if not set')
-    parser.add_argument('--benchmark', action='store_true', help='Benchmark inference time rather than evaluting expected results')
     parser.add_argument('--numParallelForwardingThreads', type=int, help='The number of threads for parallel forwarding. Defaults to 1')
+    benchmark_group = parser.add_mutually_exclusive_group()
+    benchmark_group.add_argument('--benchmark', action='store_true', help='Benchmark inference time rather than evaluting expected results')
+    benchmark_group.add_argument('--threading_benchmark', action='store_true', help='Threading benchmark')
 
     return parser.parse_args()
 
@@ -212,6 +228,7 @@ def run_benchmark(args):
     launch_pytorch_app(args)
     end_time = datetime.now()
     runtime_ms = int((end_time - start_time).total_seconds() * 1000)
+    avg_time_ms = 0
 
     print()
     print("reading benchmark results...", flush=True)
@@ -223,15 +240,18 @@ def run_benchmark(args):
 
         # ignore the warmup results
         for i in range(NUM_WARM_UP_REQUESTS, len(result_docs)):
-            print(result_docs[i]['time_ms'])
+            if args.benchmark:
+                print(result_docs[i]['time_ms'])
             total_time_ms += result_docs[i]['time_ms']
             doc_count += 1
 
-        
+        avg_time_ms = total_time_ms / doc_count
         print()
         print(f'Process run in {runtime_ms} ms')
         print(f'{doc_count} requests evaluated in {total_time_ms} ms, avg time {total_time_ms / doc_count} ms')
         print()
+
+    return (runtime_ms, avg_time_ms)
 
 
 def test_evaluation(args):
@@ -297,13 +317,32 @@ def test_evaluation(args):
             print('SUCCESS: inference results match expected', flush=True)
             print()
 
+def threading_benchmark(args):
+    threading_options = [1, 2, 3, 4, 8, 12, 16]
+    results = []
+    for libtorch_threads in threading_options:
+        for mkl_threads in threading_options:
+            for parallel_forwarding_threads in threading_options:
+                args.numLibTorchThreads = libtorch_threads
+                args.numParallelForwardingThreads = parallel_forwarding_threads
+                print(f'Running benchmark with libtorch_threads = [{libtorch_threads}]; mkl_threads = [{mkl_threads}]; parallel_forwarding_threads = [{parallel_forwarding_threads}]')
+                (run_time_ms, avg_time_ms) = run_benchmark(args)
+                result = {'libtorch_threads': libtorch_threads, 'mkl_threads': mkl_threads, 'parallel_forwarding_threads': parallel_forwarding_threads, 'run_time_ms': run_time_ms, 'avg_time_ms': avg_time_ms}
+                results.append(result)
+    print(f'libtorch_threads,mkl_threads,parallel_forwarding_threads,run_time_ms,avg_time_ms')
+    for result in results:
+        print(f"{result['libtorch_threads']},{result['mkl_threads']},{result['parallel_forwarding_threads']},{result['run_time_ms']},{result['avg_time_ms']}")
+
 def main():
 
     args = parse_arguments()
+
     try:
         restore_model(args.model, args.restore_file)
         if args.benchmark: 
             run_benchmark(args)
+        elif args.threading_benchmark:
+            threading_benchmark(args)
         else:
             test_evaluation(args)
     finally:

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -321,17 +321,16 @@ def threading_benchmark(args):
     threading_options = [1, 2, 3, 4, 8, 12, 16]
     results = []
     for libtorch_threads in threading_options:
-        for mkl_threads in threading_options:
-            for parallel_forwarding_threads in threading_options:
-                args.numLibTorchThreads = libtorch_threads
-                args.numParallelForwardingThreads = parallel_forwarding_threads
-                print(f'Running benchmark with libtorch_threads = [{libtorch_threads}]; mkl_threads = [{mkl_threads}]; parallel_forwarding_threads = [{parallel_forwarding_threads}]')
-                (run_time_ms, avg_time_ms) = run_benchmark(args)
-                result = {'libtorch_threads': libtorch_threads, 'mkl_threads': mkl_threads, 'parallel_forwarding_threads': parallel_forwarding_threads, 'run_time_ms': run_time_ms, 'avg_time_ms': avg_time_ms}
-                results.append(result)
-    print(f'libtorch_threads,mkl_threads,parallel_forwarding_threads,run_time_ms,avg_time_ms')
+        for parallel_forwarding_threads in threading_options:
+            args.numLibTorchThreads = libtorch_threads
+            args.numParallelForwardingThreads = parallel_forwarding_threads
+            print(f'Running benchmark with libtorch_threads = [{libtorch_threads}]; parallel_forwarding_threads = [{parallel_forwarding_threads}]')
+            (run_time_ms, avg_time_ms) = run_benchmark(args)
+            result = {'libtorch_threads': libtorch_threads, 'parallel_forwarding_threads': parallel_forwarding_threads, 'run_time_ms': run_time_ms, 'avg_time_ms': avg_time_ms}
+            results.append(result)
+    print(f'libtorch_threads,parallel_forwarding_threads,run_time_ms,avg_time_ms')
     for result in results:
-        print(f"{result['libtorch_threads']},{result['mkl_threads']},{result['parallel_forwarding_threads']},{result['run_time_ms']},{result['avg_time_ms']}")
+        print(f"{result['libtorch_threads']},{result['parallel_forwarding_threads']},{result['run_time_ms']},{result['avg_time_ms']}")
 
 def main():
 


### PR DESCRIPTION
Adds a mode for benchmarking the different threading parameters
of the libtorch process. The new flag is `--threading_benchmark`.