### PR TITLE
[ML] Handle field mismatch in incremental training

### DIFF
--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -35,7 +35,9 @@ class CDataFrameAnalysisSpecification;
 //! \brief Handles input to the data_frame_analyzer command.
 class API_EXPORT CDataFrameAnalyzer {
 public:
+    using TSizeVec = std::vector<std::size_t>;
     using TStrVec = std::vector<std::string>;
+    using TSizeVecUPtr = std::unique_ptr<TSizeVec>;
     using TJsonOutputStreamWrapperUPtr = std::unique_ptr<core::CJsonOutputStreamWrapper>;
     using TJsonOutputStreamWrapperUPtrSupplier =
         std::function<TJsonOutputStreamWrapperUPtr()>;
@@ -99,11 +101,12 @@ private:
 
 private:
     // This has values: -2 (unset), -1 (missing), >= 0 (control field index).
-    std::ptrdiff_t m_ControlFieldIndex = FIELD_UNSET;
-    std::ptrdiff_t m_BeginDataFieldValues = FIELD_UNSET;
-    std::ptrdiff_t m_EndDataFieldValues = FIELD_UNSET;
-    std::ptrdiff_t m_DocHashFieldIndex = FIELD_UNSET;
-    bool m_CapturedFieldNames = false;
+    std::ptrdiff_t m_ControlFieldIndex{FIELD_UNSET};
+    std::ptrdiff_t m_BeginDataFieldValues{FIELD_UNSET};
+    std::ptrdiff_t m_EndDataFieldValues{FIELD_UNSET};
+    std::ptrdiff_t m_DocHashFieldIndex{FIELD_UNSET};
+    bool m_CapturedFieldNames{false};
+    TSizeVecUPtr m_ColumnMap;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
     TDataFrameUPtr m_DataFrame;
     TTemporaryDirectoryPtr m_DataFrameDirectory;

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -17,6 +17,7 @@
 #include <core/CRapidJsonConcurrentLineWriter.h>
 
 #include <cinttypes>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
@@ -35,9 +36,9 @@ class CDataFrameAnalysisSpecification;
 //! \brief Handles input to the data_frame_analyzer command.
 class API_EXPORT CDataFrameAnalyzer {
 public:
-    using TSizeVec = std::vector<std::size_t>;
     using TStrVec = std::vector<std::string>;
-    using TSizeVecUPtr = std::unique_ptr<TSizeVec>;
+    using TPtrdiffVec = std::vector<std::ptrdiff_t>;
+    using TPtrdiffVecUPtr = std::unique_ptr<TPtrdiffVec>;
     using TJsonOutputStreamWrapperUPtr = std::unique_ptr<core::CJsonOutputStreamWrapper>;
     using TJsonOutputStreamWrapperUPtrSupplier =
         std::function<TJsonOutputStreamWrapperUPtr()>;
@@ -106,7 +107,7 @@ private:
     std::ptrdiff_t m_EndDataFieldValues{FIELD_UNSET};
     std::ptrdiff_t m_DocHashFieldIndex{FIELD_UNSET};
     bool m_CapturedFieldNames{false};
-    TSizeVecUPtr m_ColumnMap;
+    TPtrdiffVecUPtr m_ColumnMap;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
     TDataFrameUPtr m_DataFrame;
     TTemporaryDirectoryPtr m_DataFrameDirectory;

--- a/include/api/CDataFrameAnalyzer.h
+++ b/include/api/CDataFrameAnalyzer.h
@@ -80,16 +80,18 @@ public:
     const CDataFrameAnalysisRunner* runner() const;
 
 private:
-    static const std::ptrdiff_t FIELD_UNSET{-2};
-    static const std::ptrdiff_t FIELD_MISSING{-1};
+    static const std::ptrdiff_t FIELD_UNSET;
+    static const std::ptrdiff_t FIELD_MISSING;
 
 private:
-    bool sufficientFieldValues(const TStrVec& fieldNames) const;
+    bool sufficientFieldValues(const TStrVec& fieldValues) const;
     bool readyToReceiveControlMessages() const;
     bool prepareToReceiveControlMessages(const TStrVec& fieldNames);
     bool isControlMessage(const TStrVec& fieldValues) const;
     bool handleControlMessage(const TStrVec& fieldValues);
     void captureFieldNames(const TStrVec& fieldNames);
+    void initializeDataFrameColumnMap(TStrVec columnNames);
+    void validateCategoricalColumnsMatch() const;
     void addRowToDataFrame(const TStrVec& fieldValues);
     void writeResultsOf(const CDataFrameAnalysisRunner& analysis,
                         core::CRapidJsonConcurrentLineWriter& writer) const;
@@ -107,9 +109,9 @@ private:
     std::ptrdiff_t m_EndDataFieldValues{FIELD_UNSET};
     std::ptrdiff_t m_DocHashFieldIndex{FIELD_UNSET};
     bool m_CapturedFieldNames{false};
-    TPtrdiffVecUPtr m_ColumnMap;
     TDataFrameAnalysisSpecificationUPtr m_AnalysisSpecification;
     TDataFrameUPtr m_DataFrame;
+    TPtrdiffVecUPtr m_DataFrameColumnMap;
     TTemporaryDirectoryPtr m_DataFrameDirectory;
     TJsonOutputStreamWrapperUPtrSupplier m_ResultsStreamSupplier;
 };

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -472,7 +472,14 @@ public:
     }
 
     //! Parses the strings in \p columnValues and writes one row via writeRow.
-    void parseAndWriteRow(const TStrCRng& columnValues, const std::string* hash = nullptr);
+    //!
+    //! \param[in] columnValues The column values.
+    //! \param[in] columnMap If non-null defines a map between columnValues and
+    //! their position in the data frame.
+    //! \param[in] hash If non-null a hash which identifies the row document.
+    void parseAndWriteRow(const TStrCRng& columnValues,
+                          const TSizeVec* columnMap = nullptr,
+                          const std::string* hash = nullptr);
 
     //! This writes a single row of the data frame via a callback.
     //!

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -232,6 +232,7 @@ public:
     using TBoolVec = std::vector<bool>;
     using TSizeVec = std::vector<std::size_t>;
     using TSizeVecSizePr = std::pair<TSizeVec, std::size_t>;
+    using TPtrdiffVec = std::vector<std::ptrdiff_t>;
     using TStrVec = std::vector<std::string>;
     using TStrVecVec = std::vector<TStrVec>;
     using TStrCRng = CVectorRange<const TStrVec>;
@@ -475,10 +476,10 @@ public:
     //!
     //! \param[in] columnValues The column values.
     //! \param[in] columnMap If non-null defines a map between columnValues and
-    //! their position in the data frame.
+    //! their position in the data frame. Negative values denote missing columns.
     //! \param[in] hash If non-null a hash which identifies the row document.
     void parseAndWriteRow(const TStrCRng& columnValues,
-                          const TSizeVec* columnMap = nullptr,
+                          const TPtrdiffVec* columnMap = nullptr,
                           const std::string* hash = nullptr);
 
     //! This writes a single row of the data frame via a callback.

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -497,6 +497,9 @@ public:
     //! writing rows.
     void writeRow(const TWriteFunc& writeRow);
 
+    //! Check if this has named columns.
+    bool hasColumnNames() const;
+
     //! Write the column names.
     void columnNames(TStrVec columnNames);
 

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -260,8 +260,8 @@ void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
         if (m_DataFrame->columnNames().empty() == false &&
             m_DataFrame->columnNames() != columnNames) {
 
-            // We take the view that missing features are not fatal, since they may
-            // not be available for the new set, but extra features are likely to
+            // We take the view that missing fields are not fatal, since they may
+            // not be available for the new set, but extra fields are likely to
             // indicate user error.
 
             TSizeVec positions(columnNames.size());

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -8,8 +8,7 @@
  * compliance with the Elastic License 2.0 and the foregoing additional
  * limitation.
  */
-#include "maths/COrderings.h"
-#include <algorithm>
+
 #include <api/CDataFrameAnalyzer.h>
 
 #include <core/CContainerPrinter.h>
@@ -19,14 +18,16 @@
 #include <core/CLogger.h>
 #include <core/CStopWatch.h>
 
-#include <iterator>
 #include <maths/CBasicStatistics.h>
+#include <maths/COrderings.h>
 
 #include <api/CDataFrameAnalysisInstrumentation.h>
 #include <api/CDataFrameAnalysisSpecification.h>
 #include <api/CDataSummarizationJsonWriter.h>
 
+#include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <string>

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -265,14 +265,14 @@ void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
             // not be available for the new set, but extra fields are likely to
             // indicate user error.
 
-            TSizeVec positions(columnNames.size());
+            TPtrdiffVec positions(columnNames.size());
             std::iota(positions.begin(), positions.end(), 0);
             maths::COrderings::simultaneousSort(columnNames, positions);
 
             TStrVec originalColumnNames{m_DataFrame->columnNames()};
             std::sort(originalColumnNames.begin(), originalColumnNames.end());
 
-            m_ColumnMap = std::make_unique<TSizeVec>();
+            m_ColumnMap = std::make_unique<TPtrdiffVec>();
             m_ColumnMap->reserve(columnNames.size());
 
             TStrVec extraColumnNames;
@@ -288,7 +288,7 @@ void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
                 auto i = std::lower_bound(columnNames.begin(), columnNames.end(), name);
                 if (i == columnNames.end() || *i != name) {
                     LOG_WARN(<< "Missing column '" << name << "'");
-                    m_ColumnMap->push_back(columnNames.size());
+                    m_ColumnMap->push_back(FIELD_MISSING);
                 } else {
                     m_ColumnMap->push_back(positions[i - columnNames.begin()]);
                 }

--- a/lib/api/CDataFrameAnalyzer.cc
+++ b/lib/api/CDataFrameAnalyzer.cc
@@ -255,10 +255,11 @@ void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
         return;
     }
     if (m_DataFrame != nullptr && m_CapturedFieldNames == false) {
+
         TStrVec columnNames{fieldNames.begin() + m_BeginDataFieldValues,
                             fieldNames.begin() + m_EndDataFieldValues};
-        if (m_DataFrame->columnNames().empty() == false &&
-            m_DataFrame->columnNames() != columnNames) {
+
+        if (m_DataFrame->hasColumnNames()) {
 
             // We take the view that missing fields are not fatal, since they may
             // not be available for the new set, but extra fields are likely to
@@ -275,12 +276,12 @@ void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
             m_ColumnMap->reserve(columnNames.size());
 
             TStrVec extraColumnNames;
-            std::set_intersection(
-                columnNames.begin(), columnNames.end(), originalColumnNames.begin(),
-                originalColumnNames.end(), std::back_inserter(extraColumnNames));
+            std::set_difference(columnNames.begin(), columnNames.end(),
+                                originalColumnNames.begin(), originalColumnNames.end(),
+                                std::back_inserter(extraColumnNames));
             if (extraColumnNames.empty() == false) {
-                HANDLE_FATAL(<< "Input error: supplying additional columns '"
-                             << core::CContainerPrinter::print(extraColumnNames) << "'.");
+                HANDLE_FATAL(<< "Input error: supplying additional columns "
+                             << core::CContainerPrinter::print(extraColumnNames) << ".");
             }
 
             for (const auto& name : m_DataFrame->columnNames()) {
@@ -292,6 +293,7 @@ void CDataFrameAnalyzer::captureFieldNames(const TStrVec& fieldNames) {
                     m_ColumnMap->push_back(positions[i - columnNames.begin()]);
                 }
             }
+            LOG_TRACE(<< "mapping = " << core::CContainerPrinter::print(*m_ColumnMap));
         } else {
             m_DataFrame->columnNames(columnNames);
             m_DataFrame->categoricalColumns(m_AnalysisSpecification->categoricalFieldNames());

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -1053,7 +1053,6 @@ BOOST_AUTO_TEST_CASE(testRegressionIncrementalTraining) {
     // Retrieve documents from the result stream that will be used to restore the model.
 
     std::stringstream incrementalTrainingState;
-    rapidjson::OStreamWrapper incrementalTrainingStateWrapper(incrementalTrainingState);
     readIncrementalTrainingState(outputStream.str(), alpha, lambda, gamma,
                                  softTreeDepthLimit, softTreeDepthTolerance,
                                  eta, etaGrowthRatePerTree, downsampleFactor,
@@ -1458,7 +1457,6 @@ BOOST_AUTO_TEST_CASE(testClassificationIncrementalTraining) {
     // Retrieve documents from the result stream that will be used to restore the model.
 
     std::stringstream incrementalTrainingState;
-    rapidjson::OStreamWrapper incrementalTrainingStateWrapper(incrementalTrainingState);
     readIncrementalTrainingState(outputStream.str(), alpha, lambda, gamma,
                                  softTreeDepthLimit, softTreeDepthTolerance,
                                  eta, etaGrowthRatePerTree, downsampleFactor,
@@ -1659,7 +1657,6 @@ BOOST_AUTO_TEST_CASE(testIncrementalTrainingFieldMismatch) {
 
     // Retrieve documents from the result stream that will be used to restore the model.
     std::stringstream incrementalTrainingState;
-    rapidjson::OStreamWrapper incrementalTrainingStateWrapper(incrementalTrainingState);
     readIncrementalTrainingState(outputStream.str(), alpha, lambda, gamma,
                                  softTreeDepthLimit, softTreeDepthTolerance,
                                  eta, etaGrowthRatePerTree, downsampleFactor,

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -1796,14 +1796,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalTrainingFieldMismatch) {
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 double expectedPrediction{classification->readPrediction(*row)[0]};
-                // The prediction_probability result contains the highest scoring
-                // class probability which is usually, but not always, the highest
-                // class probability. The probability of the prediction result is
-                // therefore not a consistent class while readPrediction always
-                // returns the probability of class 1. Here, we simply check that
-                // the prediction_probability matches the probability of one of the
-                // classes, since it is very unlikely to match the wrong class by
-                // chance.
+                // See testClassificationIncrementalTraining for an explanation.
                 BOOST_REQUIRE((std::fabs(*prediction - expectedPrediction) < 1e-6) ||
                               (std::fabs(*prediction + expectedPrediction - 1.0) < 1e-6));
                 ++prediction;

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -40,8 +40,10 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/unordered_map.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 namespace utf = boost::unit_test;
@@ -1052,9 +1054,6 @@ BOOST_AUTO_TEST_CASE(testRegressionIncrementalTraining) {
 
     std::stringstream incrementalTrainingState;
     rapidjson::OStreamWrapper incrementalTrainingStateWrapper(incrementalTrainingState);
-    core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> dataSummarizationWriter{
-        incrementalTrainingStateWrapper};
-
     readIncrementalTrainingState(outputStream.str(), alpha, lambda, gamma,
                                  softTreeDepthLimit, softTreeDepthTolerance,
                                  eta, etaGrowthRatePerTree, downsampleFactor,
@@ -1460,9 +1459,6 @@ BOOST_AUTO_TEST_CASE(testClassificationIncrementalTraining) {
 
     std::stringstream incrementalTrainingState;
     rapidjson::OStreamWrapper incrementalTrainingStateWrapper(incrementalTrainingState);
-    core::CRapidJsonLineWriter<rapidjson::OStreamWrapper> dataSummarizationWriter{
-        incrementalTrainingStateWrapper};
-
     readIncrementalTrainingState(outputStream.str(), alpha, lambda, gamma,
                                  softTreeDepthLimit, softTreeDepthTolerance,
                                  eta, etaGrowthRatePerTree, downsampleFactor,
@@ -1523,6 +1519,255 @@ BOOST_AUTO_TEST_CASE(testClassificationIncrementalTraining) {
             row->copyTo(newTrainingData.back().begin());
         }
     });
+
+    frame->resizeRows(0);
+    for (std::size_t i = 0; i < newTrainingData.size(); ++i) {
+        frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t& id) {
+            for (std::size_t j = 0; j < newTrainingData[i].size(); ++j, ++column) {
+                *column = newTrainingData[i][j];
+                id = static_cast<std::int32_t>(i);
+            }
+        });
+    }
+    frame->finishWritingRows();
+
+    core::CPackedBitVector newTrainingRowMask(
+        static_cast<std::size_t>(summarisation.manhattan()), false);
+    newTrainingRowMask.extend(true, numberExamples);
+
+    classification = maths::CBoostedTreeFactory::constructFromModel(std::move(classification))
+                         .newTrainingRowMask(newTrainingRowMask)
+                         .buildForTrainIncremental(*frame, weights.size());
+
+    classification->trainIncremental();
+    classification->predict();
+
+    auto prediction = predictions.begin();
+    frame->readRows(
+        1, 0, frame->numberRows(),
+        [&](const TRowItr& beginRows, const TRowItr& endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                double expectedPrediction{classification->readPrediction(*row)[0]};
+                // The prediction_probability result contains the highest scoring
+                // class probability which is usually, but not always, the highest
+                // class probability. The probability of the prediction result is
+                // therefore not a consistent class while readPrediction always
+                // returns the probability of class 1. Here, we simply check that
+                // the prediction_probability matches the probability of one of the
+                // classes, since it is very unlikely to match the wrong class by
+                // chance.
+                BOOST_REQUIRE((std::fabs(*prediction - expectedPrediction) < 1e-6) ||
+                              (std::fabs(*prediction + expectedPrediction - 1.0) < 1e-6));
+                ++prediction;
+            }
+        },
+        &newTrainingRowMask);
+}
+
+BOOST_AUTO_TEST_CASE(testIncrementalTrainingFieldMismatch) {
+
+    // Test running incremental with reordered fields and extra fields.
+
+    std::size_t maximumNumberTrees{30};
+    std::size_t numberExamples{100};
+
+    auto makeTrainSpec = [&](const std::string& dependentVariable,
+                             TDataFrameUPtrTemporaryDirectoryPtrPr& frameAndDirectory,
+                             TPersisterSupplier* persisterSupplier,
+                             TRestoreSearcherSupplier* restorerSupplier) {
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        return specFactory.rows(numberExamples)
+            .memoryLimit(15000000)
+            .predictionCategoricalFieldNames({dependentVariable})
+            .predictionMaximumNumberTrees(maximumNumberTrees)
+            .predictionPersisterSupplier(persisterSupplier)
+            .predictionRestoreSearcherSupplier(restorerSupplier)
+            .regressionLossFunction(TLossFunctionType::E_BinaryClassification)
+            .task(test::CDataFrameAnalysisSpecificationFactory::TTask::E_Train)
+            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(),
+                            dependentVariable, &frameAndDirectory);
+    };
+
+    double alpha;
+    double lambda;
+    double gamma;
+    double softTreeDepthLimit;
+    double softTreeDepthTolerance;
+    double eta;
+    double etaGrowthRatePerTree;
+    double downsampleFactor;
+    double featureBagFraction;
+    double lossGap;
+
+    auto makeUpdateSpec = [&](const std::string& dependentVariable,
+                              TDataFrameUPtrTemporaryDirectoryPtrPr& frameAndDirectory,
+                              TPersisterSupplier* persisterSupplier,
+                              TRestoreSearcherSupplier* restorerSupplier) {
+        test::CDataFrameAnalysisSpecificationFactory specFactory;
+        return specFactory.rows(2 * numberExamples)
+            .memoryLimit(15000000)
+            .predictionCategoricalFieldNames({dependentVariable})
+            .predictionAlpha(alpha)
+            .predictionLambda(lambda)
+            .predictionGamma(gamma)
+            .predictionSoftTreeDepthLimit(softTreeDepthLimit)
+            .predictionSoftTreeDepthTolerance(softTreeDepthTolerance)
+            .predictionEta(eta)
+            .predictionEtaGrowthRatePerTree(etaGrowthRatePerTree)
+            .predictionMaximumNumberTrees(maximumNumberTrees)
+            .predictionDownsampleFactor(downsampleFactor)
+            .predictionFeatureBagFraction(featureBagFraction)
+            .previousTrainLossGap(lossGap)
+            .previousTrainNumberRows(numberExamples)
+            .predictionPersisterSupplier(persisterSupplier)
+            .predictionRestoreSearcherSupplier(restorerSupplier)
+            .regressionLossFunction(TLossFunctionType::E_BinaryClassification)
+            .task(test::CDataFrameAnalysisSpecificationFactory::TTask::E_Update)
+            .predictionSpec(test::CDataFrameAnalysisSpecificationFactory::classification(),
+                            dependentVariable, &frameAndDirectory);
+    };
+
+    std::stringstream outputStream;
+    auto outputWriterFactory = [&outputStream]() {
+        return std::make_unique<core::CJsonOutputStreamWrapper>(outputStream);
+    };
+
+    // Run once.
+    TStrVec fieldNames{"f1", "f2", "f3", "f4", "target", ".", "."};
+    TStrVec fieldValues{"", "", "", "", "", "0", ""};
+    TDoubleVec weights{0.1, 2.0, 0.4, -0.5};
+    TDoubleVec regressors;
+    test::CRandomNumbers rng;
+    rng.generateUniformSamples(-10.0, 10.0, weights.size() * numberExamples, regressors);
+    TDataFrameUPtrTemporaryDirectoryPtrPr frameAndDirectory;
+    auto spec = makeTrainSpec("target", frameAndDirectory, nullptr, nullptr);
+    api::CDataFrameAnalyzer analyzer{std::move(spec), std::move(frameAndDirectory),
+                                     outputWriterFactory};
+    TStrVec targets;
+    auto frame = test::CDataFrameAnalyzerTrainingFactory::setupBinaryClassificationData(
+        fieldNames, fieldValues, analyzer, weights, regressors, targets);
+    analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    // Train a model for comparison.
+    auto classification =
+        maths::CBoostedTreeFactory::constructFromParameters(
+            1, std::make_unique<maths::boosted_tree::CBinomialLogisticLoss>())
+            .maximumNumberTrees(maximumNumberTrees)
+            .buildForTrain(*frame, weights.size());
+    classification->train();
+    classification->predict();
+
+    // Retrieve documents from the result stream that will be used to restore the model.
+    std::stringstream incrementalTrainingState;
+    rapidjson::OStreamWrapper incrementalTrainingStateWrapper(incrementalTrainingState);
+    readIncrementalTrainingState(outputStream.str(), alpha, lambda, gamma,
+                                 softTreeDepthLimit, softTreeDepthTolerance,
+                                 eta, etaGrowthRatePerTree, downsampleFactor,
+                                 featureBagFraction, lossGap, incrementalTrainingState);
+
+    outputStream.clear();
+    outputStream.str("");
+
+    LOG_DEBUG(<< "Test extra field");
+
+    {
+        std::stringstream incrementalTrainingStateCopy;
+        incrementalTrainingStateCopy << incrementalTrainingState.str();
+
+        // Pass model definition and data summarization into the restore stream.
+        auto restoreStreamPtr = std::make_shared<std::stringstream>(
+            std::move(incrementalTrainingStateCopy));
+        TRestoreSearcherSupplier restorerSupplier{[&restoreStreamPtr]() {
+            return std::make_unique<api::CSingleStreamSearcher>(restoreStreamPtr);
+        }};
+
+        // Create a new spec for incremental training.
+        spec = makeUpdateSpec("target", frameAndDirectory, nullptr, &restorerSupplier);
+
+        api::CDataFrameAnalyzer analyzerIncremental{
+            std::move(spec), std::move(frameAndDirectory), outputWriterFactory};
+
+        auto errorHandler = [](std::string error) {
+            throw std::runtime_error(error);
+        };
+        core::CLogger::CScopeSetFatalErrorHandler scope{errorHandler};
+
+        fieldNames.assign({"f1", "f2", "f3", "f5", "target", ".", "."});
+
+        // Adding an unseen field should be a fatal error.
+        bool throws{false};
+        try {
+            test::CDataFrameAnalyzerTrainingFactory::setupBinaryClassificationData(
+                fieldNames, fieldValues, analyzerIncremental, weights, regressors, targets);
+        } catch (const std::exception& e) {
+            LOG_DEBUG(<< "Caught '" << e.what() << "'");
+            throws = true;
+        }
+        BOOST_TEST_REQUIRE(throws);
+    }
+
+    LOG_DEBUG(<< "Test permute fields");
+
+    auto restoreStreamPtr =
+        std::make_shared<std::stringstream>(std::move(incrementalTrainingState));
+    TRestoreSearcherSupplier restorerSupplier{[&restoreStreamPtr]() {
+        return std::make_unique<api::CSingleStreamSearcher>(restoreStreamPtr);
+    }};
+
+    // Create a new spec for incremental training.
+    spec = makeUpdateSpec("target", frameAndDirectory, nullptr, &restorerSupplier);
+
+    api::CDataFrameAnalyzer analyzerIncremental{
+        std::move(spec), std::move(frameAndDirectory), outputWriterFactory};
+
+    // Permuting the field order should have no effect.
+    fieldNames.assign({"f2", "f3", "f4", "f1", "target", ".", "."});
+
+    // Create new analyzer and run incremental training.
+    auto newTrainingDataFrame = test::CDataFrameAnalyzerTrainingFactory::setupBinaryClassificationData(
+        fieldNames, fieldValues, analyzerIncremental, weights, regressors, targets);
+    analyzerIncremental.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
+
+    rapidjson::Document results;
+    rapidjson::ParseResult ok(results.Parse(outputStream.str()));
+    BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
+
+    // Read the predictions.
+    TDoubleVec predictions;
+    for (const auto& result : results.GetArray()) {
+        if (result.HasMember("row_results")) {
+            predictions.emplace_back(
+                result["row_results"]["results"]["ml"]["prediction_probability"].GetDouble());
+        }
+    }
+    BOOST_REQUIRE_EQUAL(numberExamples, predictions.size());
+
+    frame->resizeColumns(1, weights.size() + 1);
+
+    auto summarisation = classification->dataSummarization();
+
+    TDoubleVecVec newTrainingData;
+    newTrainingData.reserve(numberExamples +
+                            static_cast<std::size_t>(summarisation.manhattan()));
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            newTrainingData.push_back(TDoubleVec(row->numberColumns()));
+                            row->copyTo(newTrainingData.back().begin());
+                        }
+                    },
+                    &summarisation);
+    TSizeVec permutation{3, 0, 1, 2, 4};
+    newTrainingDataFrame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
+        for (auto row = beginRows; row != endRows; ++row) {
+            newTrainingData.emplace_back();
+            newTrainingData.back().reserve(permutation.size());
+            for (auto i : permutation) {
+                newTrainingData.back().push_back((*row)[i]);
+            }
+        }
+    });
+
     frame->resizeRows(0);
     for (std::size_t i = 0; i < newTrainingData.size(); ++i) {
         frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t& id) {

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -283,7 +283,7 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::writeColumns(std::size_t numberThreads
 }
 
 void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues,
-                                  const TSizeVec* columnMap,
+                                  const TPtrdiffVec* columnMap,
                                   const std::string* hash) {
 
     auto stringToValue = [this](bool isCategorical, TStrSizeUMap& categoryLookup,
@@ -341,11 +341,11 @@ void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues,
     this->writeRow([&](TFloatVecItr columns, std::int32_t& docHash) {
         if (columnMap != nullptr) {
             for (std::size_t i = 0; i < columnMap->size(); ++i, ++columns) {
-                std::size_t j{(*columnMap)[i]};
-                *columns = stringToValue(
-                    m_ColumnIsCategorical[i], m_CategoricalColumnValueLookup[i],
-                    m_CategoricalColumnValues[i],
-                    j < columnValues.size() ? columnValues[j] : m_MissingString);
+                std::ptrdiff_t j{(*columnMap)[i]};
+                *columns = stringToValue(m_ColumnIsCategorical[i],
+                                         m_CategoricalColumnValueLookup[i],
+                                         m_CategoricalColumnValues[i],
+                                         j >= 0 ? columnValues[j] : m_MissingString);
             }
         } else {
             for (std::size_t i = 0; i < columnValues.size(); ++i, ++columns) {

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -282,7 +282,9 @@ CDataFrame::TRowFuncVecBoolPr CDataFrame::writeColumns(std::size_t numberThreads
     return {std::move(writers), successful};
 }
 
-void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues, const std::string* hash) {
+void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues,
+                                  const TSizeVec* columnMap,
+                                  const std::string* hash) {
 
     auto stringToValue = [this](bool isCategorical, TStrSizeUMap& categoryLookup,
                                 TStrVec& categories, const std::string& columnValue) {
@@ -337,10 +339,20 @@ void CDataFrame::parseAndWriteRow(const TStrCRng& columnValues, const std::strin
     }
 
     this->writeRow([&](TFloatVecItr columns, std::int32_t& docHash) {
-        for (std::size_t i = 0; i < columnValues.size(); ++i, ++columns) {
-            *columns = stringToValue(m_ColumnIsCategorical[i],
-                                     m_CategoricalColumnValueLookup[i],
-                                     m_CategoricalColumnValues[i], columnValues[i]);
+        if (columnMap != nullptr) {
+            for (std::size_t i = 0; i < columnMap->size(); ++i, ++columns) {
+                std::size_t j{(*columnMap)[i]};
+                *columns = stringToValue(
+                    m_ColumnIsCategorical[i], m_CategoricalColumnValueLookup[i],
+                    m_CategoricalColumnValues[i],
+                    j < columnValues.size() ? columnValues[j] : m_MissingString);
+            }
+        } else {
+            for (std::size_t i = 0; i < columnValues.size(); ++i, ++columns) {
+                *columns = stringToValue(
+                    m_ColumnIsCategorical[i], m_CategoricalColumnValueLookup[i],
+                    m_CategoricalColumnValues[i], columnValues[i]);
+            }
         }
         docHash = 0;
         if (hash != nullptr &&

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -371,6 +371,11 @@ void CDataFrame::writeRow(const TWriteFunc& writeRow) {
     (*m_Writer)(writeRow);
 }
 
+bool CDataFrame::hasColumnNames() const {
+    return std::any_of(m_ColumnNames.begin(), m_ColumnNames.end(),
+                       [](const auto& name) { return name.empty() == false; });
+}
+
 void CDataFrame::columnNames(TStrVec columnNames) {
     if (columnNames.size() != m_NumberColumns) {
         HANDLE_FATAL(<< "Expected '" << m_NumberColumns << "' column names values but got "

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -231,7 +231,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
     m_TrainingProgress.progressCallback(m_Instrumentation->progressCallback());
 
-    std::int64_t lastMemoryUsage(this->memoryUsage());
+    std::int64_t lastMemoryUsage{static_cast<std::int64_t>(this->memoryUsage())};
 
     core::CPackedBitVector allTrainingRowsMask{this->allTrainingRowsMask()};
     core::CPackedBitVector noRowsMask{allTrainingRowsMask.size(), false};
@@ -359,7 +359,7 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
 
     this->selectTreesToRetrain(frame);
 
-    std::int64_t lastMemoryUsage(this->memoryUsage());
+    std::int64_t lastMemoryUsage{static_cast<std::int64_t>(this->memoryUsage())};
 
     this->startProgressMonitoringTrainIncremental();
 

--- a/lib/maths/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/CBoostedTreeLeafNodeStatistics.cc
@@ -11,9 +11,9 @@
 
 #include <maths/CBoostedTreeLeafNodeStatistics.h>
 
-#include <core/CMemory.h>
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
+#include <core/CMemory.h>
 
 #include <maths/CBoostedTree.h>
 #include <maths/CDataFrameCategoryEncoder.h>


### PR DESCRIPTION
The data which was prepared for incremental training of the DGA model from sunburst domains used a different field order and renamed one of the fields. Whilst this wouldn't typically happen in Java, which sorts the field values it supplies by name, it is fragile to rely on this. It is also conceivable that a subset of features aren't available for the update data. This checks that there are no additional fields supplied (likely to indicate a user error) and handles the case that the fields are supplied in a different order or are missing altogether.