### PR TITLE
[ML] Improve aspects of skip_model_update rule

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@
 === Enhancements
 
 * Speed up training of regression and classification models (See {ml-pull}2024[#2024].)
+* Improve aspects of implementation of skip_model_update rule (See {ml-pull}2053[#2053].)
 
 == {es} version 7.15.0
 

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -205,7 +205,7 @@ public:
 
     //! Set the initial value of the count weight to apply to the model's samples.
     CModelProbabilityParams& initialCountWeight(double initialCountWeight);
-    //! Get the initial value of the count weight to aaply to the model's samples..
+    //! Get the initial value of the count weight to apply to the model's samples..
     double initialCountWeight() const;
 
 private:

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -204,9 +204,9 @@ public:
     bool useAnomalyModel() const;
 
     //! Set whether or not to skip updating the anomaly model.
-    CModelProbabilityParams& skipAnomalyModelUpdate(bool skipAnomalyModelUpdate);
+    CModelProbabilityParams& initialCountWeight(double initialCountWeight);
     //! Get whether or not to skip updating the anomaly model.
-    bool skipAnomalyModelUpdate() const;
+    double initialCountWeight() const;
 
 private:
     //! The coordinates' probability calculations.
@@ -223,9 +223,8 @@ private:
     bool m_UseMultibucketFeatures = true;
     //! Whether or not to use the anomaly model.
     bool m_UseAnomalyModel = true;
-    //! Whether or not to skip updating the anomaly model
-    //! because a rule triggered.
-    bool m_SkipAnomalyModelUpdate = false;
+    //! The initial value of the count weight, in the range 0.0 to 1.0.
+    double m_InitialCountWeight = 1.0;
 };
 
 //! \brief Describes the result of the model probability calculation.

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -203,9 +203,9 @@ public:
     //! Get whether or not to use the anomaly model.
     bool useAnomalyModel() const;
 
-    //! Set whether or not to skip updating the anomaly model.
+    //! Set the initial value of the count weight to aaply to the model's samples.
     CModelProbabilityParams& initialCountWeight(double initialCountWeight);
-    //! Get whether or not to skip updating the anomaly model.
+    //! Get the initial value of the count weight to aaply to the model's samples..
     double initialCountWeight() const;
 
 private:

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -203,7 +203,7 @@ public:
     //! Get whether or not to use the anomaly model.
     bool useAnomalyModel() const;
 
-    //! Set the initial value of the count weight to aaply to the model's samples.
+    //! Set the initial value of the count weight to apply to the model's samples.
     CModelProbabilityParams& initialCountWeight(double initialCountWeight);
     //! Get the initial value of the count weight to aaply to the model's samples..
     double initialCountWeight() const;

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -681,7 +681,8 @@ protected:
     //! Get the object which calculates corrections for interim buckets.
     virtual const CInterimBucketCorrector& interimValueCorrector() const = 0;
 
-    //! Check if any of the sample-filtering detection rules apply to this series.
+    //! Get the value of the initial count weight to apply to the model's
+    //! samples, as determined by the detection rules.
     double initialCountWeight(model_t::EFeature feature,
                               std::size_t pid,
                               std::size_t cid,

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -682,10 +682,10 @@ protected:
     virtual const CInterimBucketCorrector& interimValueCorrector() const = 0;
 
     //! Check if any of the sample-filtering detection rules apply to this series.
-    bool shouldIgnoreSample(model_t::EFeature feature,
-                            std::size_t pid,
-                            std::size_t cid,
-                            core_t::TTime time) const;
+    double initialCountWeight(model_t::EFeature feature,
+                              std::size_t pid,
+                              std::size_t cid,
+                              core_t::TTime time) const;
 
     //! Check if any of the result-filtering detection rules apply to this series.
     bool shouldIgnoreResult(model_t::EFeature feature,

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -231,13 +231,13 @@ bool CModelProbabilityParams::useAnomalyModel() const {
     return m_UseAnomalyModel;
 }
 
-CModelProbabilityParams& CModelProbabilityParams::skipAnomalyModelUpdate(bool skipAnomalyModelUpdate) {
-    m_SkipAnomalyModelUpdate = skipAnomalyModelUpdate;
+CModelProbabilityParams& CModelProbabilityParams::initialCountWeight(double initialCountWeight) {
+    m_InitialCountWeight = initialCountWeight;
     return *this;
 }
 
-bool CModelProbabilityParams::skipAnomalyModelUpdate() const {
-    return m_SkipAnomalyModelUpdate;
+double CModelProbabilityParams::initialCountWeight() const {
+    return m_InitialCountWeight;
 }
 
 //////// SModelProbabilityResult::SFeatureProbability ////////

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -437,9 +437,11 @@ void CTimeSeriesAnomalyModel::sample(const CModelProbabilityParams& params, doub
     // this is the bit that we want to skip.
     // The rest of sample is necessary as it creates
     // the feature vector related to the current anomaly.
-    if (params.skipAnomalyModelUpdate() == false) {
+    double initialCountWeight{params.initialCountWeight()};
+    if (initialCountWeight > 0.0) {
         auto& model = m_AnomalyFeatureModels[m_Anomaly->positive() ? 0 : 1];
-        model.addSamples({m_Anomaly->features()}, {maths_t::countWeight(weight, 2)});
+        model.addSamples({m_Anomaly->features()},
+                         {maths_t::countWeight(weight * initialCountWeight, 2)});
     }
 }
 

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2465,7 +2465,7 @@ BOOST_AUTO_TEST_CASE(testSkipAnomalyModelUpdate) {
             // We create anomalies in 10 consecutive buckets
             if (bucket >= 1700 && bucket < 1710) {
                 sample = 100.0;
-                currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
+                currentComputeProbabilityParams.initialCountWeight(0.0);
                 model.probability(currentComputeProbabilityParams, {{time}},
                                   {{sample}}, result);
                 probabilities.push_back(result.s_Probability);
@@ -2509,7 +2509,7 @@ BOOST_AUTO_TEST_CASE(testSkipAnomalyModelUpdate) {
                 for (auto& coordinate : sample) {
                     coordinate += 100.0;
                 }
-                currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
+                currentComputeProbabilityParams.initialCountWeight(0.0);
                 model.probability(currentComputeProbabilityParams, {{time}},
                                   {(sample)}, result);
                 probabilities.push_back(result.s_Probability);

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -456,14 +456,14 @@ double CAnomalyDetectorModel::initialCountWeight(model_t::EFeature feature,
                                                  std::size_t pid,
                                                  std::size_t cid,
                                                  core_t::TTime time) const {
-    if (checkScheduledEvents(this->params().s_ScheduledEvents.get(), std::cref(*this),
+    if (checkScheduledEvents(this->params().s_ScheduledEvents.get(), *this,
                              feature, CDetectionRule::E_SkipModelUpdate,
                              SKIP_SAMPLING_RESULT_TYPE, pid, cid, time) == true) {
         return 0.0;
     }
-    if (checkRules(this->params().s_DetectionRules.get(), std::cref(*this),
-                   feature, CDetectionRule::E_SkipModelUpdate,
-                   SKIP_SAMPLING_RESULT_TYPE, pid, cid, time) == true) {
+    if (checkRules(this->params().s_DetectionRules.get(), *this, feature,
+                   CDetectionRule::E_SkipModelUpdate, SKIP_SAMPLING_RESULT_TYPE,
+                   pid, cid, time) == true) {
         return SKIP_SAMPLING_WEIGHT;
     }
     return 1.0;

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -285,9 +285,21 @@ void CEventRateModel::sample(core_t::TTime startTime,
                     continue;
                 }
 
+                // initialCountWeight returns a weight value as double:
+                // 0.0 if checkScheduledEvents is true
+                // 1,0 if both checkScheduledEvents and checkRules are false
+                // A small weight - 0.005 - if checkRules is true.
+                // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
+                // This reduces the impact of the values affected by the skip_model_update rule
+                // on the model while not completely ignoring them. This still allows the model to
+                // learn from the affected values - addressing point 1. and 2. in
+                // https://github.com/elastic/ml-cpp/issues/1272, Namely
+                // 1. If you apply it from the start of the modelling it can stop the model learning anything at all.
+                // 2. It can stop the model ever adapting to some change in data characteristics
                 core_t::TTime sampleTime = model_t::sampleTime(feature, time, bucketLength);
-                if (this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
-                                             sampleTime)) {
+                double initialCountWeight = this->initialCountWeight(
+                    feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, sampleTime);
+                if (initialCountWeight == 0.0) {
                     model->skipTime(sampleTime - lastBucketTimesMap[pid]);
                     continue;
                 }
@@ -304,7 +316,7 @@ void CEventRateModel::sample(core_t::TTime startTime,
                     feature, static_cast<double>(data_.second.s_Count));
                 TDouble2Vec value{count};
                 double winsorisationDerate = this->derate(pid, sampleTime);
-                double countWeight = this->learnRate(feature);
+                double countWeight = initialCountWeight * this->learnRate(feature);
                 // Note we need to scale the amount of data we'll "age out" of the residual
                 // model in one bucket by the empty bucket weight so the posterior doesn't
                 // end up too flat.
@@ -631,8 +643,8 @@ bool CEventRateModel::fill(model_t::EFeature feature,
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time, result);
         return maths_t::seasonalVarianceScaleWeight(result);
     }()};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
-        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    double initialCountWeight{this->initialCountWeight(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -650,7 +662,7 @@ bool CEventRateModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weights)
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     return true;
 }
@@ -668,8 +680,8 @@ void CEventRateModel::fill(model_t::EFeature feature,
     const TSize2Vec1Vec& correlates{model->correlates()};
     const TTimeVec& firstBucketTimes{this->firstBucketTimes()};
     core_t::TTime time{model_t::sampleTime(feature, bucketTime, gatherer.bucketLength())};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
-        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    double initialCountWeight{this->initialCountWeight(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -682,7 +694,7 @@ void CEventRateModel::fill(model_t::EFeature feature,
     params.s_Correlated.resize(correlates.size());
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     // These are indexed as follows:
     //   influenceValues["influencer name"]["correlate"]["influence value"]

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -287,7 +287,7 @@ void CEventRateModel::sample(core_t::TTime startTime,
 
                 // initialCountWeight returns a weight value as double:
                 // 0.0 if checkScheduledEvents is true
-                // 1,0 if both checkScheduledEvents and checkRules are false
+                // 1.0 if both checkScheduledEvents and checkRules are false
                 // A small weight - 0.005 - if checkRules is true.
                 // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
                 // This reduces the impact of the values affected by the skip_model_update rule

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -435,7 +435,20 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                     LOG_ERROR(<< "Missing model for " << this->attributeName(cid));
                     continue;
                 }
-                if (this->shouldIgnoreSample(feature, pid, cid, sampleTime)) {
+                // initialCountWeight returns a weight value as double:
+                // 0.0 if checkScheduledEvents is true
+                // 1,0 if both checkScheduledEvents and checkRules are false
+                // A small weight - 0.005 - if checkRules is true.
+                // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
+                // This reduces the impact of the values affected by the skip_model_update rule
+                // on the model while not completely ignoring them. This still allows the model to
+                // learn from the affected values - addressing point 1. and 2. in
+                // https://github.com/elastic/ml-cpp/issues/1272, Namely
+                // 1. If you apply it from the start of the modelling it can stop the model learning anything at all.
+                // 2. It can stop the model ever adapting to some change in data characteristics
+                double initialCountWeight{
+                    this->initialCountWeight(feature, pid, cid, sampleTime)};
+                if (initialCountWeight == 0.0) {
                     core_t::TTime skipTime = sampleTime - attributeLastBucketTimesMap[cid];
                     if (skipTime > 0) {
                         model->skipTime(skipTime);
@@ -449,7 +462,8 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 double count =
                     static_cast<double>(CDataGatherer::extractData(data_).s_Count);
                 double value = model_t::offsetCountToZero(feature, count);
-                double countWeight = this->sampleRateWeight(pid, cid) *
+                double countWeight = initialCountWeight *
+                                     this->sampleRateWeight(pid, cid) *
                                      this->learnRate(feature);
                 LOG_TRACE(<< "Adding " << value
                           << " for person = " << gatherer.personName(pid)
@@ -1069,7 +1083,7 @@ bool CEventRatePopulationModel::fill(model_t::EFeature feature,
     }()};
     double value{model_t::offsetCountToZero(
         feature, static_cast<double>(CDataGatherer::extractData(*data).s_Count))};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, cid, time);
+    double initialCountWeight{this->initialCountWeight(feature, pid, cid, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -1087,7 +1101,7 @@ bool CEventRatePopulationModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weight)
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     return true;
 }

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -437,7 +437,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 }
                 // initialCountWeight returns a weight value as double:
                 // 0.0 if checkScheduledEvents is true
-                // 1,0 if both checkScheduledEvents and checkRules are false
+                // 1.0 if both checkScheduledEvents and checkRules are false
                 // A small weight - 0.005 - if checkRules is true.
                 // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
                 // This reduces the impact of the values affected by the skip_model_update rule

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -246,7 +246,7 @@ void CMetricModel::sample(core_t::TTime startTime,
 
                 // initialCountWeight returns a weight value as double:
                 // 0.0 if checkScheduledEvents is true
-                // 1,0 if both checkScheduledEvents and checkRules are false
+                // 1.0 if both checkScheduledEvents and checkRules are false
                 // A small weight - 0.005 - if checkRules is true.
                 // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
                 // This reduces the impact of the values affected by the skip_model_update rule

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -244,9 +244,22 @@ void CMetricModel::sample(core_t::TTime startTime,
                     continue;
                 }
 
+                // initialCountWeight returns a weight value as double:
+                // 0.0 if checkScheduledEvents is true
+                // 1,0 if both checkScheduledEvents and checkRules are false
+                // A small weight - 0.005 - if checkRules is true.
+                // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
+                // This reduces the impact of the values affected by the skip_model_update rule
+                // on the model while not completely ignoring them. This still allows the model to
+                // learn from the affected values - addressing point 1. and 2. in
+                // https://github.com/elastic/ml-cpp/issues/1272, Namely
+                // 1. If you apply it from the start of the modelling it can stop the model learning anything at all.
+                // 2. It can stop the model ever adapting to some change in data characteristics
+
                 core_t::TTime sampleTime = model_t::sampleTime(feature, time, bucketLength);
-                if (this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
-                                             sampleTime)) {
+                double initialCountWeight{this->initialCountWeight(
+                    feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, sampleTime)};
+                if (initialCountWeight == 0.0) {
                     model->skipTime(time - lastBucketTimesMap[pid]);
                     continue;
                 }
@@ -272,7 +285,7 @@ void CMetricModel::sample(core_t::TTime startTime,
                     (this->params().s_MaximumUpdatesPerBucket > 0.0 && n > 0
                          ? this->params().s_MaximumUpdatesPerBucket / static_cast<double>(n)
                          : 1.0) *
-                    this->learnRate(feature);
+                    this->learnRate(feature) * initialCountWeight;
                 double winsorisationDerate = this->derate(pid, sampleTime);
                 // Note we need to scale the amount of data we'll "age out" of the residual
                 // model in one bucket by the empty bucket weight so the posterior doesn't
@@ -579,8 +592,8 @@ bool CMetricModel::fill(model_t::EFeature feature,
     model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time, seasonalWeight);
     maths_t::setSeasonalVarianceScale(seasonalWeight, weights);
     maths_t::setCountVarianceScale(TDouble2Vec(dimension, bucket->varianceScale()), weights);
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
-        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    double initialCountWeight{this->initialCountWeight(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -599,7 +612,7 @@ bool CMetricModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weights)
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     return true;
 }
@@ -618,9 +631,9 @@ void CMetricModel::fill(model_t::EFeature feature,
     const TSize2Vec1Vec& correlates{model->correlates()};
     const TTimeVec& firstBucketTimes{this->firstBucketTimes()};
     core_t::TTime bucketLength{gatherer.bucketLength()};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
+    double initialCountWeight{this->initialCountWeight(
         feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
-        model_t::sampleTime(feature, bucketTime, bucketLength));
+        model_t::sampleTime(feature, bucketTime, bucketLength))};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -633,7 +646,7 @@ void CMetricModel::fill(model_t::EFeature feature,
     params.s_Correlated.resize(correlates.size());
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     // These are indexed as follows:
     //   influenceValues["influencer name"]["correlate"]["influence value"]

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -387,7 +387,7 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                 }
                 // initialCountWeight returns a weight value as double:
                 // 0.0 if checkScheduledEvents is true
-                // 1,0 if both checkScheduledEvents and checkRules are false
+                // 1.0 if both checkScheduledEvents and checkRules are false
                 // A small weight - 0.005 - if checkRules is true.
                 // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
                 // This reduces the impact of the values affected by the skip_model_update rule

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2858,7 +2858,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
             modelNoSkipView->model(model_t::E_IndividualCountByBucketAndPerson, 0))
             ->residualModel()
             .checksum()};
-    BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);
+    // Checksums differ due to different weighting applied to samples for the "skip" model
+    BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
     // Check the last value times of the underlying models are the same
     const maths::CUnivariateTimeSeriesModel* timeSeriesModel =

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2334,19 +2334,6 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     BOOST_TEST_REQUIRE(mathsModelNoSkip != nullptr);
     uint64_t noSkipChecksum = mathsModelNoSkip->checksum();
     BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
-
-    // TODO These checks fail see elastic/ml-cpp/issues/2043
-    // Check the last value times of the underlying models are the same
-    // const maths::CUnivariateTimeSeriesModel *timeSeriesModel =
-    //     dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0));
-    // BOOST_TEST_REQUIRE(timeSeriesModel != nullptr);
-
-    // core_t::TTime time = timeSeriesModel->trend().lastValueTime();
-    // BOOST_REQUIRE_EQUAL(model_t::sampleTime(model_t::E_IndividualMeanByPerson, startTime, bucketLength), time);
-
-    // // The last times of model with a skip should be the same
-    // timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0));
-    // BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2320,16 +2320,20 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     // added to the model with the detector rule.
     BOOST_TEST_REQUIRE(modelWithSkip->checksum() != modelNoSkip->checksum());
 
-    // TODO this test fails due a different checksums for the decay rate and prior
-    // but the underlying models should be the same.
-    // See elastic/ml-cpp/issues/2043
-    // CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
-    //     modelWithSkip->details();
-    // CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
+    // The underlying models should also differ due to the different weighting applied to the samples.
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
+        modelWithSkip->details();
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
 
-    // uint64_t withSkipChecksum = modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0)->checksum();
-    // uint64_t noSkipChecksum = modelNoSkipView->model(model_t::E_IndividualMeanByPerson, 0)->checksum();
-    // BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);
+    const maths::CModel* mathsModelWithSkip =
+        modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0);
+    BOOST_TEST_REQUIRE(mathsModelWithSkip != nullptr);
+    uint64_t withSkipChecksum = mathsModelWithSkip->checksum();
+    const maths::CModel* mathsModelNoSkip =
+        modelNoSkipView->model(model_t::E_IndividualMeanByPerson, 0);
+    BOOST_TEST_REQUIRE(mathsModelNoSkip != nullptr);
+    uint64_t noSkipChecksum = mathsModelNoSkip->checksum();
+    BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
     // TODO These checks fail see elastic/ml-cpp/issues/2043
     // Check the last value times of the underlying models are the same

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -1316,7 +1316,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     // Check the last value times of all the underlying models are the same
     //     const maths::CUnivariateTimeSeriesModel *timeSeriesModel =
     //         dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1));
-    //     BOOST_TEST_REQUIRE(timeSeriesModel != 0);
+    //     BOOST_TEST_REQUIRE(timeSeriesModel != nullptr);
 
     //     core_t::TTime time = timeSeriesModel->trend().lastValueTime();
     //     BOOST_REQUIRE_EQUAL(model_t::sampleTime(model_t::E_PopulationMeanByPersonAndAttribute, startTime, bucketLength), time);

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -1311,26 +1311,6 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     noSkipChecksum = mathsModelNoSkipView->checksum();
 
     BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
-
-    // TODO These checks fail see elastic/ml-cpp/issues/2043
-    // Check the last value times of all the underlying models are the same
-    //     const maths::CUnivariateTimeSeriesModel *timeSeriesModel =
-    //         dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1));
-    //     BOOST_TEST_REQUIRE(timeSeriesModel != nullptr);
-
-    //     core_t::TTime time = timeSeriesModel->trend().lastValueTime();
-    //     BOOST_REQUIRE_EQUAL(model_t::sampleTime(model_t::E_PopulationMeanByPersonAndAttribute, startTime, bucketLength), time);
-
-    //     // The last times of the underlying time series models should all be the same
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
-
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 0));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 2));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Move away from completely ignoring a sample when the skip_model_update
rule applies to instead adding the sample with a small multiplicative
weight applied. This has the benefit of reducing the impact of the
matched samples on the model while still allowing the model to react to
changes in data characteristics.

Related to elastic/ml-cpp#1272