### PR TITLE
[ML] Rename LibTorch threading parameters

### DIFF
--- a/bin/pytorch_inference/CCmdLineParser.cc
+++ b/bin/pytorch_inference/CCmdLineParser.cc
@@ -34,9 +34,8 @@ bool CCmdLineParser::parse(int argc,
                            bool& isRestoreFileNamedPipe,
                            std::string& loggingFileName,
                            std::string& logProperties,
-                           std::int32_t& numLibTorchThreads,
-                           std::int32_t& numLibTorchInterOpThreads,
-                           std::int32_t& numParallelForwardingThreads,
+                           std::int32_t& inferenceThreads,
+                           std::int32_t& modelThreads,
                            bool& validElasticLicenseKeyConfirmed) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
@@ -60,12 +59,10 @@ bool CCmdLineParser::parse(int argc,
             ("logPipe", boost::program_options::value<std::string>(),
                         "Named pipe to write log messages to")
             ("logProperties", "Optional logger properties file")
-            ("numLibTorchThreads", boost::program_options::value<std::int32_t>(),
-                        "Optionaly set number of threads LibTorch can use for inference - not present means use the LibTorch defaults")
-            ("numLibTorchInterOpThreads", boost::program_options::value<std::int32_t>(),
-                        "Optionaly set number of threads LibTorch can use for inter operation parallelism - not present means use the LibTorch defaults")
-            ("numParallelForwardingThreads", boost::program_options::value<std::int32_t>(),
-                        "Optionaly set number of threads to parallelize model forwarding - not present means 1")
+            ("inferenceThreads", boost::program_options::value<std::int32_t>(),
+                        "Optionaly set number of threads used per inference request - default is 1")
+            ("modelThreads", boost::program_options::value<std::int32_t>(),
+                        "Optionaly set number of threads to parallelize model forwarding - default is 1")
             ("validElasticLicenseKeyConfirmed", boost::program_options::value<bool>(),
              "Confirmation that a valid Elastic license key is in use.")
             ;
@@ -116,15 +113,11 @@ bool CCmdLineParser::parse(int argc,
         if (vm.count("logProperties") > 0) {
             logProperties = vm["logProperties"].as<std::string>();
         }
-        if (vm.count("numLibTorchThreads") > 0) {
-            numLibTorchThreads = vm["numLibTorchThreads"].as<std::int32_t>();
+        if (vm.count("inferenceThreads") > 0) {
+            inferenceThreads = vm["inferenceThreads"].as<std::int32_t>();
         }
-        if (vm.count("numLibTorchInterOpThreads") > 0) {
-            numLibTorchInterOpThreads = vm["numLibTorchInterOpThreads"].as<std::int32_t>();
-        }
-        if (vm.count("numParallelForwardingThreads") > 0) {
-            numParallelForwardingThreads =
-                vm["numParallelForwardingThreads"].as<std::int32_t>();
+        if (vm.count("modelThreads") > 0) {
+            modelThreads = vm["modelThreads"].as<std::int32_t>();
         }
         if (vm.count("validElasticLicenseKeyConfirmed") > 0) {
             validElasticLicenseKeyConfirmed =

--- a/bin/pytorch_inference/CCmdLineParser.h
+++ b/bin/pytorch_inference/CCmdLineParser.h
@@ -47,9 +47,8 @@ public:
                       bool& isRestoreFileNamedPipe,
                       std::string& loggingFileName,
                       std::string& logProperties,
-                      std::int32_t& numLibTorchThreads,
-                      std::int32_t& numLibTorchInterOpThreads,
-                      std::int32_t& numParallelForwardingThreads,
+                      std::int32_t& inferenceThreads,
+                      std::int32_t& modelThreads,
                       bool& validElasticLicenseKeyConfirmed);
 
 private:

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -209,6 +209,31 @@ bool handleRequest(const ml::torch::CCommandParser::SRequest& request,
     return true;
 }
 
+void validateThreadingParameters(std::int32_t& inferenceThreads, std::int32_t& modelThreads) {
+    std::int32_t maxThreads{static_cast<int32_t>(std::thread::hardware_concurrency())};
+    if (maxThreads == 0) {
+        LOG_WARN(<< "Could not determine hardware concurrency; setting max threads to 1");
+        maxThreads = 1;
+    }
+    if (inferenceThreads < 1) {
+        LOG_WARN(<< "Setting inference threads to minimum value of 1; value was "
+                 << inferenceThreads);
+        inferenceThreads = 1;
+    } else if (inferenceThreads > maxThreads) {
+        LOG_WARN(<< "Setting inference threads to maximum value of "
+                 << maxThreads << "; value was " << inferenceThreads);
+        inferenceThreads = maxThreads;
+    }
+    if (modelThreads < 1) {
+        LOG_WARN(<< "Setting model threads to minimum value of 1; value was " << modelThreads);
+        modelThreads = 1;
+    } else if (modelThreads > maxThreads) {
+        LOG_WARN(<< "Setting model threads to maximum value of " << maxThreads
+                 << "; value was " << modelThreads);
+        modelThreads = maxThreads;
+    }
+}
+
 int main(int argc, char** argv) {
     // command line options
     std::string modelId;
@@ -233,6 +258,8 @@ int main(int argc, char** argv) {
             modelThreads, validElasticLicenseKeyConfirmed) == false) {
         return EXIT_FAILURE;
     }
+
+    validateThreadingParameters(inferenceThreads, modelThreads);
 
     // Setting the number of threads used by libtorch also sets
     // the number of threads used by MKL or OMP libs. However,


### PR DESCRIPTION
Renames `--numLibTorchThreads` to `--inferenceThreads`.
Renames `--numParallelForwardingThreads` to `--modelThreads`.