### PR TITLE
[7.x][ML] Improve aspects of skip_model_update rule (#2053)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 7.16.0
+
+=== Enhancements
+
+* Speed up training of regression and classification models (See {ml-pull}2024[#2024].)
+* Improve aspects of implementation of skip_model_update rule (See {ml-pull}2053[#2053].)
+
 == {es} version 7.15.0
 
 === Enhancements
@@ -38,15 +45,6 @@
   (See {ml-pull}1960[#1960].)
 * Prune models for split fields (by, partition) that haven't seen data updates for
   a given period of time. (See {ml-pull}1962[#1962].)
-
-== {es} version 7.15.0
-
-=== Enhancements
-
-* Speed up training of regression and classification models on very large data sets.
-  (See {ml-pull}1941[#1941].)
-* Improve regression and classification training accuracy for small data sets.
-  (See {ml-pull}1960[#1960].)
 
 === Bug Fixes
 

--- a/include/maths/CModel.h
+++ b/include/maths/CModel.h
@@ -203,10 +203,10 @@ public:
     //! Get whether or not to use the anomaly model.
     bool useAnomalyModel() const;
 
-    //! Set whether or not to skip updating the anomaly model.
-    CModelProbabilityParams& skipAnomalyModelUpdate(bool skipAnomalyModelUpdate);
-    //! Get whether or not to skip updating the anomaly model.
-    bool skipAnomalyModelUpdate() const;
+    //! Set the initial value of the count weight to apply to the model's samples.
+    CModelProbabilityParams& initialCountWeight(double initialCountWeight);
+    //! Get the initial value of the count weight to apply to the model's samples..
+    double initialCountWeight() const;
 
 private:
     //! The coordinates' probability calculations.
@@ -223,9 +223,8 @@ private:
     bool m_UseMultibucketFeatures = true;
     //! Whether or not to use the anomaly model.
     bool m_UseAnomalyModel = true;
-    //! Whether or not to skip updating the anomaly model
-    //! because a rule triggered.
-    bool m_SkipAnomalyModelUpdate = false;
+    //! The initial value of the count weight, in the range 0.0 to 1.0.
+    double m_InitialCountWeight = 1.0;
 };
 
 //! \brief Describes the result of the model probability calculation.

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -681,11 +681,12 @@ protected:
     //! Get the object which calculates corrections for interim buckets.
     virtual const CInterimBucketCorrector& interimValueCorrector() const = 0;
 
-    //! Check if any of the sample-filtering detection rules apply to this series.
-    bool shouldIgnoreSample(model_t::EFeature feature,
-                            std::size_t pid,
-                            std::size_t cid,
-                            core_t::TTime time) const;
+    //! Get the value of the initial count weight to apply to the model's
+    //! samples, as determined by the detection rules.
+    double initialCountWeight(model_t::EFeature feature,
+                              std::size_t pid,
+                              std::size_t cid,
+                              core_t::TTime time) const;
 
     //! Check if any of the result-filtering detection rules apply to this series.
     bool shouldIgnoreResult(model_t::EFeature feature,

--- a/lib/maths/CModel.cc
+++ b/lib/maths/CModel.cc
@@ -231,13 +231,13 @@ bool CModelProbabilityParams::useAnomalyModel() const {
     return m_UseAnomalyModel;
 }
 
-CModelProbabilityParams& CModelProbabilityParams::skipAnomalyModelUpdate(bool skipAnomalyModelUpdate) {
-    m_SkipAnomalyModelUpdate = skipAnomalyModelUpdate;
+CModelProbabilityParams& CModelProbabilityParams::initialCountWeight(double initialCountWeight) {
+    m_InitialCountWeight = initialCountWeight;
     return *this;
 }
 
-bool CModelProbabilityParams::skipAnomalyModelUpdate() const {
-    return m_SkipAnomalyModelUpdate;
+double CModelProbabilityParams::initialCountWeight() const {
+    return m_InitialCountWeight;
 }
 
 //////// SModelProbabilityResult::SFeatureProbability ////////

--- a/lib/maths/CTimeSeriesModel.cc
+++ b/lib/maths/CTimeSeriesModel.cc
@@ -437,9 +437,11 @@ void CTimeSeriesAnomalyModel::sample(const CModelProbabilityParams& params, doub
     // this is the bit that we want to skip.
     // The rest of sample is necessary as it creates
     // the feature vector related to the current anomaly.
-    if (params.skipAnomalyModelUpdate() == false) {
+    double initialCountWeight{params.initialCountWeight()};
+    if (initialCountWeight > 0.0) {
         auto& model = m_AnomalyFeatureModels[m_Anomaly->positive() ? 0 : 1];
-        model.addSamples({m_Anomaly->features()}, {maths_t::countWeight(weight, 2)});
+        model.addSamples({m_Anomaly->features()},
+                         {maths_t::countWeight(weight * initialCountWeight, 2)});
     }
 }
 

--- a/lib/maths/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/unittest/CTimeSeriesModelTest.cc
@@ -2465,7 +2465,7 @@ BOOST_AUTO_TEST_CASE(testSkipAnomalyModelUpdate) {
             // We create anomalies in 10 consecutive buckets
             if (bucket >= 1700 && bucket < 1710) {
                 sample = 100.0;
-                currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
+                currentComputeProbabilityParams.initialCountWeight(0.0);
                 model.probability(currentComputeProbabilityParams, {{time}},
                                   {{sample}}, result);
                 probabilities.push_back(result.s_Probability);
@@ -2509,7 +2509,7 @@ BOOST_AUTO_TEST_CASE(testSkipAnomalyModelUpdate) {
                 for (auto& coordinate : sample) {
                     coordinate += 100.0;
                 }
-                currentComputeProbabilityParams.skipAnomalyModelUpdate(true);
+                currentComputeProbabilityParams.initialCountWeight(0.0);
                 model.probability(currentComputeProbabilityParams, {{time}},
                                   {(sample)}, result);
                 probabilities.push_back(result.s_Probability);

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -43,6 +43,7 @@ const std::string MODEL_TAG{"a"};
 const std::string EMPTY;
 
 const model_t::CResultType SKIP_SAMPLING_RESULT_TYPE;
+const double SKIP_SAMPLING_WEIGHT{0.005};
 
 const CAnomalyDetectorModel::TStr1Vec EMPTY_STRING_LIST;
 
@@ -451,19 +452,21 @@ bool CAnomalyDetectorModel::shouldIgnoreResult(model_t::EFeature feature,
     return shouldIgnore;
 }
 
-bool CAnomalyDetectorModel::shouldIgnoreSample(model_t::EFeature feature,
-                                               std::size_t pid,
-                                               std::size_t cid,
-                                               core_t::TTime time) const {
-    bool shouldIgnore =
-        checkScheduledEvents(this->params().s_ScheduledEvents.get(), std::cref(*this),
+double CAnomalyDetectorModel::initialCountWeight(model_t::EFeature feature,
+                                                 std::size_t pid,
+                                                 std::size_t cid,
+                                                 core_t::TTime time) const {
+    if (checkScheduledEvents(this->params().s_ScheduledEvents.get(), *this,
                              feature, CDetectionRule::E_SkipModelUpdate,
-                             SKIP_SAMPLING_RESULT_TYPE, pid, cid, time) ||
-        checkRules(this->params().s_DetectionRules.get(), std::cref(*this),
-                   feature, CDetectionRule::E_SkipModelUpdate,
-                   SKIP_SAMPLING_RESULT_TYPE, pid, cid, time);
-
-    return shouldIgnore;
+                             SKIP_SAMPLING_RESULT_TYPE, pid, cid, time) == true) {
+        return 0.0;
+    }
+    if (checkRules(this->params().s_DetectionRules.get(), *this, feature,
+                   CDetectionRule::E_SkipModelUpdate, SKIP_SAMPLING_RESULT_TYPE,
+                   pid, cid, time) == true) {
+        return SKIP_SAMPLING_WEIGHT;
+    }
+    return 1.0;
 }
 
 const CAnomalyDetectorModel::TStr1Vec&

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -285,9 +285,21 @@ void CEventRateModel::sample(core_t::TTime startTime,
                     continue;
                 }
 
+                // initialCountWeight returns a weight value as double:
+                // 0.0 if checkScheduledEvents is true
+                // 1.0 if both checkScheduledEvents and checkRules are false
+                // A small weight - 0.005 - if checkRules is true.
+                // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
+                // This reduces the impact of the values affected by the skip_model_update rule
+                // on the model while not completely ignoring them. This still allows the model to
+                // learn from the affected values - addressing point 1. and 2. in
+                // https://github.com/elastic/ml-cpp/issues/1272, Namely
+                // 1. If you apply it from the start of the modelling it can stop the model learning anything at all.
+                // 2. It can stop the model ever adapting to some change in data characteristics
                 core_t::TTime sampleTime = model_t::sampleTime(feature, time, bucketLength);
-                if (this->shouldIgnoreSample(feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID,
-                                             sampleTime)) {
+                double initialCountWeight = this->initialCountWeight(
+                    feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, sampleTime);
+                if (initialCountWeight == 0.0) {
                     model->skipTime(sampleTime - lastBucketTimesMap[pid]);
                     continue;
                 }
@@ -304,7 +316,7 @@ void CEventRateModel::sample(core_t::TTime startTime,
                     feature, static_cast<double>(data_.second.s_Count));
                 TDouble2Vec value{count};
                 double winsorisationDerate = this->derate(pid, sampleTime);
-                double countWeight = this->learnRate(feature);
+                double countWeight = initialCountWeight * this->learnRate(feature);
                 // Note we need to scale the amount of data we'll "age out" of the residual
                 // model in one bucket by the empty bucket weight so the posterior doesn't
                 // end up too flat.
@@ -631,8 +643,8 @@ bool CEventRateModel::fill(model_t::EFeature feature,
         model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time, result);
         return maths_t::seasonalVarianceScaleWeight(result);
     }()};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
-        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    double initialCountWeight{this->initialCountWeight(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -650,7 +662,7 @@ bool CEventRateModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weights)
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     return true;
 }
@@ -668,8 +680,8 @@ void CEventRateModel::fill(model_t::EFeature feature,
     const TSize2Vec1Vec& correlates{model->correlates()};
     const TTimeVec& firstBucketTimes{this->firstBucketTimes()};
     core_t::TTime time{model_t::sampleTime(feature, bucketTime, gatherer.bucketLength())};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(
-        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time);
+    double initialCountWeight{this->initialCountWeight(
+        feature, pid, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -682,7 +694,7 @@ void CEventRateModel::fill(model_t::EFeature feature,
     params.s_Correlated.resize(correlates.size());
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     // These are indexed as follows:
     //   influenceValues["influencer name"]["correlate"]["influence value"]

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -435,7 +435,20 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                     LOG_ERROR(<< "Missing model for " << this->attributeName(cid));
                     continue;
                 }
-                if (this->shouldIgnoreSample(feature, pid, cid, sampleTime)) {
+                // initialCountWeight returns a weight value as double:
+                // 0.0 if checkScheduledEvents is true
+                // 1.0 if both checkScheduledEvents and checkRules are false
+                // A small weight - 0.005 - if checkRules is true.
+                // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
+                // This reduces the impact of the values affected by the skip_model_update rule
+                // on the model while not completely ignoring them. This still allows the model to
+                // learn from the affected values - addressing point 1. and 2. in
+                // https://github.com/elastic/ml-cpp/issues/1272, Namely
+                // 1. If you apply it from the start of the modelling it can stop the model learning anything at all.
+                // 2. It can stop the model ever adapting to some change in data characteristics
+                double initialCountWeight{
+                    this->initialCountWeight(feature, pid, cid, sampleTime)};
+                if (initialCountWeight == 0.0) {
                     core_t::TTime skipTime = sampleTime - attributeLastBucketTimesMap[cid];
                     if (skipTime > 0) {
                         model->skipTime(skipTime);
@@ -449,7 +462,8 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 double count =
                     static_cast<double>(CDataGatherer::extractData(data_).s_Count);
                 double value = model_t::offsetCountToZero(feature, count);
-                double countWeight = this->sampleRateWeight(pid, cid) *
+                double countWeight = initialCountWeight *
+                                     this->sampleRateWeight(pid, cid) *
                                      this->learnRate(feature);
                 LOG_TRACE(<< "Adding " << value
                           << " for person = " << gatherer.personName(pid)
@@ -1069,7 +1083,7 @@ bool CEventRatePopulationModel::fill(model_t::EFeature feature,
     }()};
     double value{model_t::offsetCountToZero(
         feature, static_cast<double>(CDataGatherer::extractData(*data).s_Count))};
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, cid, time);
+    double initialCountWeight{this->initialCountWeight(feature, pid, cid, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -1087,7 +1101,7 @@ bool CEventRatePopulationModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weight)
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     return true;
 }

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -385,8 +385,21 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                     LOG_ERROR(<< "Missing model for " << this->attributeName(cid));
                     continue;
                 }
+                // initialCountWeight returns a weight value as double:
+                // 0.0 if checkScheduledEvents is true
+                // 1.0 if both checkScheduledEvents and checkRules are false
+                // A small weight - 0.005 - if checkRules is true.
+                // This weight is applied to countWeight (and therefore scaledCountWeight) as multiplier.
+                // This reduces the impact of the values affected by the skip_model_update rule
+                // on the model while not completely ignoring them. This still allows the model to
+                // learn from the affected values - addressing point 1. and 2. in
+                // https://github.com/elastic/ml-cpp/issues/1272, Namely
+                // 1. If you apply it from the start of the modelling it can stop the model learning anything at all.
+                // 2. It can stop the model ever adapting to some change in data characteristics
                 core_t::TTime sampleTime = model_t::sampleTime(feature, time, bucketLength);
-                if (this->shouldIgnoreSample(feature, pid, cid, sampleTime)) {
+                double initialCountWeight{
+                    this->initialCountWeight(feature, pid, cid, sampleTime)};
+                if (initialCountWeight == 0.0) {
                     core_t::TTime skipTime = sampleTime - attributeLastBucketTimesMap[cid];
                     if (skipTime > 0) {
                         model->skipTime(skipTime);
@@ -423,7 +436,8 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                                                   return sample.time() >= cutoff;
                                               });
                 double updatesPerBucket = this->params().s_MaximumUpdatesPerBucket;
-                double countWeight = this->sampleRateWeight(pid, cid) *
+                double countWeight = initialCountWeight *
+                                     this->sampleRateWeight(pid, cid) *
                                      this->learnRate(feature) *
                                      (updatesPerBucket > 0.0 && n > 0
                                           ? updatesPerBucket / static_cast<double>(n)
@@ -975,7 +989,7 @@ bool CMetricPopulationModel::fill(model_t::EFeature feature,
     model->seasonalWeight(maths::DEFAULT_SEASONAL_CONFIDENCE_INTERVAL, time, seasonalWeight);
     maths_t::setSeasonalVarianceScale(seasonalWeight, weights);
     maths_t::setCountVarianceScale(TDouble2Vec(dimension, bucket->varianceScale()), weights);
-    bool skipAnomalyModelUpdate = this->shouldIgnoreSample(feature, pid, cid, time);
+    double initialCountWeight{this->initialCountWeight(feature, pid, cid, time)};
 
     params.s_Feature = feature;
     params.s_Model = model;
@@ -994,7 +1008,7 @@ bool CMetricPopulationModel::fill(model_t::EFeature feature,
     params.s_ComputeProbabilityParams
         .addCalculation(model_t::probabilityCalculation(feature))
         .addWeights(weights)
-        .skipAnomalyModelUpdate(skipAnomalyModelUpdate);
+        .initialCountWeight(initialCountWeight);
 
     return true;
 }

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -2858,7 +2858,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
             modelNoSkipView->model(model_t::E_IndividualCountByBucketAndPerson, 0))
             ->residualModel()
             .checksum()};
-    BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);
+    // Checksums differ due to different weighting applied to samples for the "skip" model
+    BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
     // Check the last value times of the underlying models are the same
     const maths::CUnivariateTimeSeriesModel* timeSeriesModel =

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -2230,10 +2230,10 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForHighMedian, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     // Create 2 models, one of which has a skip sampling rule.
-    // Feed the same data into both models then add extra data
-    // into the first model we know will be filtered out.
-    // At the end the checksums for the underlying models should
-    // be the same.
+    // The skip sampling rule doesn't cause the samples to be completely ignored,
+    // instead it applies a small multiplicative weighting when the rule applies.
+    // Feed the same data into both models including the case when the rule will apply
+    // for one model but not the other.
 
     // Create a rule to filter buckets where the actual value > 100
     CRuleCondition condition;
@@ -2245,7 +2245,7 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     rule.addCondition(condition);
 
     std::size_t bucketLength(300);
-    std::size_t startTime(300);
+    std::size_t startTime(0);
 
     // Model without the skip sampling rule
     SModelParams paramsNoRules(bucketLength);
@@ -2270,8 +2270,19 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     std::size_t endTime = startTime + bucketLength;
 
+    // Add a few buckets to both models (this seems to be necessary to ensure subsequent calls to 'sample'
+    // actually result in samples being added to the model)
+    for (std::size_t j = 0; j < 3; ++j) {
+        for (std::size_t i = 0; i < bucketLength; i++) {
+            this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererNoSkip);
+            this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererWithSkip);
+        }
+        startTime = endTime;
+        endTime += bucketLength;
+    }
+
     // Add a bucket to both models
-    for (std::size_t i = 0; i < 60; i++) {
+    for (std::size_t i = 0; i < bucketLength; i++) {
         this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererNoSkip);
         this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererWithSkip);
     }
@@ -2281,62 +2292,72 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     endTime += bucketLength;
     BOOST_REQUIRE_EQUAL(modelWithSkip->checksum(), modelNoSkip->checksum());
 
-    // Add a bucket to both models
-    for (std::size_t i = 0; i < 60; i++) {
-        this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererNoSkip);
-        this->addArrival(SMessage(startTime + i, "p1", 1.0), gathererWithSkip);
-    }
-    modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
-    modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
-    startTime = endTime;
-    endTime += bucketLength;
-    BOOST_REQUIRE_EQUAL(modelWithSkip->checksum(), modelNoSkip->checksum());
-
-    // this sample will be skipped by the detection rule
-    for (std::size_t i = 0; i < 60; i++) {
+    // Add data to both models
+    // the model with the detection rule will apply a small weighting to the sample
+    for (std::size_t i = 0; i < bucketLength; i++) {
+        this->addArrival(SMessage(startTime + i, "p1", 110.0), gathererNoSkip);
         this->addArrival(SMessage(startTime + i, "p1", 110.0), gathererWithSkip);
     }
+    modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
+
+    // Checksums will be different due to the small weighting applied to the sample
+    // added to the model with the detector rule.
+    BOOST_TEST_REQUIRE(modelWithSkip->checksum() != modelNoSkip->checksum());
 
     startTime = endTime;
     endTime += bucketLength;
 
-    // Wind the other model forward
-    modelNoSkip->skipSampling(startTime);
-
-    for (std::size_t i = 0; i < 60; i++) {
+    // Add more data to both models, for which the detection rule will not apply
+    for (std::size_t i = 0; i < bucketLength; i++) {
         this->addArrival(SMessage(startTime + i, "p1", 2.0), gathererNoSkip);
         this->addArrival(SMessage(startTime + i, "p1", 2.0), gathererWithSkip);
     }
     modelNoSkip->sample(startTime, endTime, m_ResourceMonitor);
     modelWithSkip->sample(startTime, endTime, m_ResourceMonitor);
 
-    // Checksums will be different due to the data gatherers
+    // Checksums will be different due to the small weighting applied to the sample
+    // added to the model with the detector rule.
     BOOST_TEST_REQUIRE(modelWithSkip->checksum() != modelNoSkip->checksum());
 
-    // TODO this test fails due a different checksums for the decay rate and prior
-    // but the underlying models should be the same.
-    // See elastic/ml-cpp/issues/2043
-    // CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
-    //     modelWithSkip->details();
-    // CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
+    // The underlying models should also differ due to the different weighting applied to the samples.
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
+        modelWithSkip->details();
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
 
-    // uint64_t withSkipChecksum = modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0)->checksum();
-    // uint64_t noSkipChecksum = modelNoSkipView->model(model_t::E_IndividualMeanByPerson, 0)->checksum();
-    // BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);
+    const maths::CModel* mathsModelWithSkip =
+        modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0);
+    BOOST_TEST_REQUIRE(mathsModelWithSkip != nullptr);
+    uint64_t withSkipChecksum = mathsModelWithSkip->checksum();
+    const maths::CModel* mathsModelNoSkip =
+        modelNoSkipView->model(model_t::E_IndividualMeanByPerson, 0);
+    BOOST_TEST_REQUIRE(mathsModelNoSkip != nullptr);
+    uint64_t noSkipChecksum = mathsModelNoSkip->checksum();
+    BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
-    // TODO These checks fail see elastic/ml-cpp/issues/2043
     // Check the last value times of the underlying models are the same
-    // const maths::CUnivariateTimeSeriesModel *timeSeriesModel =
-    //     dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0));
-    // BOOST_TEST_REQUIRE(timeSeriesModel != 0);
+    const maths::CUnivariateTimeSeriesModel* timeSeriesModel =
+        dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(
+            modelNoSkipView->model(model_t::E_IndividualMeanByPerson, 0));
+    BOOST_TEST_REQUIRE(timeSeriesModel != nullptr);
+    const auto* trendModel = dynamic_cast<const maths::CTimeSeriesDecomposition*>(
+        &timeSeriesModel->trendModel());
+    BOOST_TEST_REQUIRE(trendModel != nullptr);
+    core_t::TTime modelNoSkipTime = trendModel->lastValueTime();
 
-    // core_t::TTime time = timeSeriesModel->trend().lastValueTime();
-    // BOOST_REQUIRE_EQUAL(model_t::sampleTime(model_t::E_IndividualMeanByPerson, startTime, bucketLength), time);
+    // The last times of model with a skip should be the same
+    timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(
+        modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0));
+    BOOST_TEST_REQUIRE(timeSeriesModel);
+    trendModel = dynamic_cast<const maths::CTimeSeriesDecomposition*>(
+        &timeSeriesModel->trendModel());
+    BOOST_TEST_REQUIRE(trendModel != nullptr);
+    core_t::TTime modelWithSkipTime = trendModel->lastValueTime();
 
-    // // The last times of model with a skip should be the same
-    // timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0));
-    // BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
+    BOOST_REQUIRE_EQUAL(modelNoSkipTime, modelWithSkipTime);
+    BOOST_REQUIRE_EQUAL(model_t::sampleTime(model_t::E_IndividualMeanByPerson,
+                                            startTime, bucketLength),
+                        modelNoSkipTime);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -89,7 +89,7 @@ public:
         //  (bucket, people) | (15,3), |         | (44,9)  | (80,1)  |
         //                   | (40,6)  |         |         |         |
         //
-        // There are 10 people, 4 attributes and 100 buckets.
+        // There are 10 people, 5 attributes and 100 buckets.
 
         const std::size_t numberBuckets{100u};
 
@@ -1148,17 +1148,17 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     // Create 2 models, one of which has a skip sampling rule.
-    // Feed the same data into both models then add extra data
-    // into the first model we know will be filtered out.
-    // At the end the checksums for the underlying models should
-    // be the same.
+    // The skip sampling rule doesn't cause the samples to be completely ignored,
+    // instead it applies a small multiplicative weighting when the rule applies.
+    // Feed the same data into both models including the case when the rule will apply
+    // for one model but not the other.
 
-    core_t::TTime startTime{1367280000};
-    const core_t::TTime bucketLength{3600};
+    core_t::TTime startTime{0};
+    const core_t::TTime bucketLength{300};
     core_t::TTime endTime = startTime + bucketLength * 100u;
 
-    // Create a categorical rule to reduce the weight applied to samples for attribute c3
-    std::string filterJson("[\"c3\"]");
+    // Create a categorical rule to reduce the weight applied to samples for attribute c4
+    std::string filterJson("[\"c4\"]");
     core::CPatternSet valueFilter;
     valueFilter.initFromJson(filterJson);
 
@@ -1196,7 +1196,6 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // Use the existing test function to generate a set of messages sufficiently complex
     // that we know some will cause samples to be added to the models.
-    // Restrict the messages to those for persons p1 and p2.
     TMessageVec messages;
     generateTestMessages(1, startTime, bucketLength, messages);
 
@@ -1205,14 +1204,12 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     std::vector<TDataGathererPtrModelPtrPr> configs{
         TDataGathererPtrModelPtrPr{gathererNoSkip, modelNoSkip},
         TDataGathererPtrModelPtrPr{gathererWithSkip, modelWithSkip}};
-    // Run the same data through both models, ignoring messages with the c3 attribute so the skip sampling rule won't apply
+    // Run the same data through both models, ignoring messages with the c4 attribute
+    // so the skip sampling rule won't apply
     for (auto& config : configs) {
         core_t::TTime start{startTime};
         for (auto& message : messages) {
-            if (message.s_Person != "p1" && message.s_Person != "p2") {
-                continue;
-            }
-            if (message.s_Attribute.get() == "c3") {
+            if (message.s_Attribute.get() == "c4") {
                 continue;
             }
             if (message.s_Time >= start + bucketLength) {
@@ -1226,68 +1223,117 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     // The checksums should match
     BOOST_REQUIRE_EQUAL(modelWithSkip->checksum(), modelNoSkip->checksum());
 
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
+        modelWithSkip->details();
+    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
+    const maths::CModel* mathsModelWithSkipView = nullptr;
+    const maths::CModel* mathsModelNoSkipView = nullptr;
+
+    // expect models for attributes c0 - c3...
+    for (std::size_t i = 0; i < 4; ++i) {
+        mathsModelWithSkipView = modelWithSkipView->model(
+            model_t::E_PopulationMeanByPersonAndAttribute, i);
+        BOOST_TEST_REQUIRE(mathsModelWithSkipView != nullptr);
+
+        mathsModelNoSkipView =
+            modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, i);
+        BOOST_TEST_REQUIRE(mathsModelNoSkipView != nullptr);
+    }
+
+    // ...But not for c4
+    mathsModelWithSkipView =
+        modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 4);
+    BOOST_REQUIRE_EQUAL(mathsModelWithSkipView, nullptr);
+
+    mathsModelNoSkipView =
+        modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 4);
+    BOOST_REQUIRE_EQUAL(mathsModelNoSkipView, nullptr);
+
     messages.clear();
     startTime = endTime;
 
     generateTestMessages(1, startTime, bucketLength, messages);
 
-    // These all should be filtered out by the skip sampling rule
-    core_t::TTime start{startTime};
-    for (auto& message : messages) {
-        if (message.s_Person != "p1" && message.s_Person != "p2") {
-            continue;
+    // Now add messages with the c4 attribute only to both models.
+    // The model with the skip sampling rule will have a small weighting applied
+    // to the samples.
+    for (auto& config : configs) {
+        core_t::TTime start{startTime};
+        for (auto& message : messages) {
+            if (message.s_Attribute.get() != "c4") {
+                continue;
+            }
+            if (message.s_Time >= start + bucketLength) {
+                config.second->sample(start, start + bucketLength, m_ResourceMonitor);
+                start += bucketLength;
+            }
+            this->addArrival(message, config.first);
         }
-        if (message.s_Attribute.get() != "c3") {
-            continue;
-        }
-        if (message.s_Time >= start + bucketLength) {
-            modelWithSkip->sample(start, start + bucketLength, m_ResourceMonitor);
-            start += bucketLength;
-        }
-        this->addArrival(message, gathererWithSkip);
     }
 
-    // Checksums will be different because a 3rd model is created for attribute c3
-    BOOST_TEST_REQUIRE(modelWithSkip->checksum() != modelNoSkip->checksum());
+    // This time we expect the model checksums to differ because of the
+    // different weightings applied to the samples for attribute c4
+    uint64_t withSkipChecksum = modelWithSkip->checksum();
+    uint64_t noSkipChecksum = modelNoSkip->checksum();
+    BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
-    CAnomalyDetectorModel::TModelDetailsViewUPtr modelWithSkipView =
-        modelWithSkip->details();
-    CAnomalyDetectorModel::TModelDetailsViewUPtr modelNoSkipView = modelNoSkip->details();
+    // expect models for attributes c0 - c4
+    for (std::size_t i = 0; i < 5; ++i) {
+        mathsModelWithSkipView = modelWithSkipView->model(
+            model_t::E_PopulationMeanByPersonAndAttribute, i);
+        BOOST_TEST_REQUIRE(mathsModelWithSkipView != nullptr);
 
-    // but the underlying models for people p1 and p2 are the same
-    uint64_t withSkipChecksum = modelWithSkipView
-                                    ->model(model_t::E_PopulationMeanByPersonAndAttribute, 0)
-                                    ->checksum();
-    uint64_t noSkipChecksum =
-        modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 0)->checksum();
-    BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);
+        mathsModelNoSkipView =
+            modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, i);
+        BOOST_TEST_REQUIRE(mathsModelNoSkipView != nullptr);
+    }
 
-    withSkipChecksum = modelWithSkipView
-                           ->model(model_t::E_PopulationMeanByPersonAndAttribute, 1)
-                           ->checksum();
-    noSkipChecksum =
-        modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1)->checksum();
-    BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);
+    // The underlying models for attributes c0 - c3 are the same
+    for (std::size_t i = 0; i < 4; ++i) {
+        mathsModelWithSkipView = modelWithSkipView->model(
+            model_t::E_PopulationMeanByPersonAndAttribute, i);
+        withSkipChecksum = mathsModelWithSkipView->checksum();
+        mathsModelNoSkipView =
+            modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, i);
+        noSkipChecksum = mathsModelNoSkipView->checksum();
+        BOOST_REQUIRE_EQUAL(withSkipChecksum, noSkipChecksum);
+    }
 
-    // TODO These checks fail see elastic/ml-cpp/issues/2043
-    // Check the last value times of all the underlying models are the same
-    //     const maths::CUnivariateTimeSeriesModel *timeSeriesModel =
-    //         dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1));
-    //     BOOST_TEST_REQUIRE(timeSeriesModel != 0);
+    // While the underlying models for attribute c4 differ due to the different weighting applied to the samples
+    mathsModelWithSkipView =
+        modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 4);
+    BOOST_TEST_REQUIRE(mathsModelWithSkipView != nullptr);
+    withSkipChecksum = mathsModelWithSkipView->checksum();
 
-    //     core_t::TTime time = timeSeriesModel->trend().lastValueTime();
-    //     BOOST_REQUIRE_EQUAL(model_t::sampleTime(model_t::E_PopulationMeanByPersonAndAttribute, startTime, bucketLength), time);
+    mathsModelNoSkipView =
+        modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 4);
+    BOOST_TEST_REQUIRE(mathsModelNoSkipView != nullptr);
+    noSkipChecksum = mathsModelNoSkipView->checksum();
 
-    //     // The last times of the underlying time series models should all be the same
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
+    BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 0));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 1));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
-    //     timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, 2));
-    //     BOOST_REQUIRE_EQUAL(time, timeSeriesModel->trend().lastValueTime());
+    // Check the last value times are the same for each of the underlying models with the skip rule
+    // and the corresponding model with no skip rule
+    for (std::size_t i = 0; i < 5; ++i) {
+        const maths::CUnivariateTimeSeriesModel* timeSeriesModel =
+            dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(
+                modelWithSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, i));
+        BOOST_TEST_REQUIRE(timeSeriesModel != nullptr);
+        const auto* trendModel = dynamic_cast<const maths::CTimeSeriesDecomposition*>(
+            &timeSeriesModel->trendModel());
+        BOOST_TEST_REQUIRE(trendModel != nullptr);
+        core_t::TTime modelWithSkipTime = trendModel->lastValueTime();
+
+        timeSeriesModel = dynamic_cast<const maths::CUnivariateTimeSeriesModel*>(
+            modelNoSkipView->model(model_t::E_PopulationMeanByPersonAndAttribute, i));
+        BOOST_TEST_REQUIRE(timeSeriesModel != nullptr);
+        trendModel = dynamic_cast<const maths::CTimeSeriesDecomposition*>(
+            &timeSeriesModel->trendModel());
+        BOOST_TEST_REQUIRE(trendModel != nullptr);
+        core_t::TTime modelNoSkipTime = trendModel->lastValueTime();
+
+        BOOST_REQUIRE_EQUAL(modelWithSkipTime, modelNoSkipTime);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Move away from completely ignoring a sample when the skip_model_update
rule applies to instead adding the sample with a small multiplicative
weight applied. This has the benefit of reducing the impact of the
matched samples on the model while still allowing the model to react to
changes in data characteristics.

Backports #2053 