### PR TITLE
[ML] Capture best hyperparameters after restoring for final train

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -55,6 +55,8 @@
 
 * Speed up training of regression and classification models (See {ml-pull}2024[#2024].)
 * Improve aspects of implementation of skip_model_update rule (See {ml-pull}2053[#2053].)
+* Make sure instrumentation captures the best hyperparameters we found for training
+  classification and regression models. (See {ml-pull}2057{#2057}.)
 
 == {es} version 7.15.0
 

--- a/lib/maths/CBoostedTreeImpl.cc
+++ b/lib/maths/CBoostedTreeImpl.cc
@@ -267,6 +267,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
         LOG_TRACE(<< "Test loss = " << m_BestForestTestLoss);
 
         this->restoreBestHyperparameters();
+        this->recordHyperparameters();
         this->scaleRegularizers(allTrainingRowsMask.manhattan() /
                                 this->meanNumberTrainingRowsPerFold());
         this->startProgressMonitoringFinalTrain();


### PR DESCRIPTION
We were missing a capture of the best hyperparameters by instrumentation after restoring for final train. This is most noticeable when training with all parameters overridden in which case we see uninitialised values in the analysis stats for the job, i.e. before
[
![Screenshot 2021-10-04 at 09 46 18](https://user-images.githubusercontent.com/7591487/135821263-987d90fd-9bf5-4cb8-8c21-36a41f4cc4cd.png)
](url)
after
![Screenshot 2021-10-04 at 09 46 45](https://user-images.githubusercontent.com/7591487/135821286-c7b8df51-c23c-477c-bdaf-75d611f8fc4b.png)

As above I've confirmed it works manually and I don't think the cost benefit means it is worthwhile writing a unit test since  the test is not straightforward to write and it is unlikely that this behaviour will get broken.