### PR TITLE
[6.8] [ML] Switch to backup repo for Eigen

### DIFF
--- a/3rd_party/pull-eigen.sh
+++ b/3rd_party/pull-eigen.sh
@@ -21,6 +21,6 @@ grep '^#define EIGEN_MAJOR_VERSION 2' "$VERSION_FILE" > /dev/null 2>&1 && \
 grep '^#define EIGEN_MINOR_VERSION 5' "$VERSION_FILE" > /dev/null 2>&1
 if [ $? -ne 0 ] ; then
     rm -rf eigen
-    git -c advice.detachedHead=false clone --depth=1 --branch=3.2.5 https://gitlab.com/libeigen/eigen.git
+    git -c advice.detachedHead=false clone --depth=1 --branch=3.2.5 https://gitlab.com/libeigen/eigen-backup.git eigen
 fi
 


### PR DESCRIPTION
The main Eigen repo on GitLab has been accidentally
deleted. Hopefully it will be recovered by tomorrow,
but if not we can merge this PR, which instead clones
a temporary repo that's been created as an interim
workaround.

Backport of #2058