### PR TITLE
[ML] Clang-tidy config update

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,8 @@ Checks: >
   -*,
   bugprone-*,
   -bugprone-incorrect-roundings,
+  -bugprone-narrowing-conversions,
+  -bugprone-easily-swappable-parameters,
 
   clang-diagnostic-*,
   -clang-diagnostic-sign-conversion,
@@ -27,6 +29,7 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-redundant-access-specifiers,
+  -readability-simplify-boolean-expr,
   
 WarningsAsErrors: false
 AnalyzeTemporaryDtors: false
@@ -55,4 +58,6 @@ CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '2'
   - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           'true'
+  - key:             readability-function-cognitive-complexity.IgnoreMacros
     value:           'true'


### PR DESCRIPTION
Clang-tidy version 13 adds new checks (cognitive complexity, easily swappable parameters, etc.). This leads to noisy results. This PR adds new filters to the clang-tidy config of the project.