### PR TITLE
[ML] Fix sources of undefined behaviour

### DIFF
--- a/include/maths/common/CLbfgs.h
+++ b/include/maths/common/CLbfgs.h
@@ -292,13 +292,8 @@ private:
             for (std::size_t i = 0; i < k; ++i) {
                 double beta{m_Rho[i] * (las::inner(m_Dg[i], m_P) + eps)};
                 double gk{m_Alpha[i] - beta};
-                auto normDxi = las::norm(m_Dx[i]);
-                if (normDxi == 0.0) {
-                    m_P += std::copysign(std::fabs(gk), gk) * m_Dx[i];
-                } else {
-                    double gmax{hmax / normDxi};
-                    m_P += std::copysign(std::min(std::fabs(gk), gmax), gk) * m_Dx[i];
-                }
+                double gmax{hmax / las::norm(m_Dx[i])};
+                m_P += std::copysign(std::min(std::fabs(gk), gmax), gk) * m_Dx[i];
             }
 
             if (las::inner(m_Gx, m_P) <= 0.0) {
@@ -310,11 +305,7 @@ private:
     }
 
     double minimumDecrease(double s) const {
-        auto normP = las::norm(m_P);
-        if (normP == 0.0) {
-            return std::numeric_limits<double>::max();
-        }
-        return m_BacktrackingMinDecrease * s * las::inner(m_Gx, m_P) / normP;
+        return m_BacktrackingMinDecrease * s * las::inner(m_Gx, m_P) / las::norm(m_P);
     }
 
     double minimumStepSize() const {


### PR DESCRIPTION
The maths/analytics library unit test `CBoostedTreeTest/testFeatureBags` was run after compiling and linking the code with `-fsanitize=undefined' flags (on macos). A few cases of division by zero were detected.

```
include/maths/common/CLbfgs.h:295:34: runtime error: division by zero
include/maths/common/CLbfgs.h:308:70: runtime error: division by zero
include/maths/common/CLowessDetail.h:192:41: runtime error: division by zero
include/maths/common/CLowessDetail.h:193:41: runtime error: division by zero
```

These changes resolve the errors.