### PR TITLE
[ML] Avoid possible referencing out-of-scope temporary in lambda return types

### DIFF
--- a/include/maths/common/CLbfgs.h
+++ b/include/maths/common/CLbfgs.h
@@ -75,6 +75,11 @@ public:
     //! a scalar.
     //! \tparam G must be a Callable with single argument type VECTOR and returning
     //! a VECTOR.
+    //!
+    //! \warning If you use lambdas for F and G you must ensure you don't return
+    //! Eigen expressions which can easily reference temporary variables which are
+    //! out of scope. You can avoid this for example by defining the lambda return
+    //! type explicitly.
     template<typename F, typename G>
     std::pair<VECTOR, double>
     minimize(const F& f, const G& g, VECTOR x0, double eps = 1e-8, std::size_t iterations = 50) {
@@ -283,13 +288,7 @@ private:
             probes[i] = probes[i - 1] / m_StepScale;
         }
 
-        // We need to force the value of s_ * step into a temporary or else we
-        // hit an issue with Eigen expressions which causes the function values
-        // at all probes to be equal.
-        auto f_ = [&](double s_) {
-            VECTOR step_{s_ * step};
-            return f(m_X - step_);
-        };
+        auto f_ = [&](double s_) { return f(m_X - s_ * step); };
 
         double smin;
         double fmin;

--- a/include/maths/common/CLowessDetail.h
+++ b/include/maths/common/CLowessDetail.h
@@ -90,7 +90,7 @@ void CLowess<N>::fit(TDoubleDoublePrVec data, std::size_t numberFolds) {
     double kmax;
     double likelihoodMax;
     CSolvers::globalMaximize(K,
-                             [&](double k) {
+                             [&](double k) -> double {
                                  return this->likelihood(trainingMasks, testingMasks, k);
                              },
                              kmax, likelihoodMax);
@@ -137,7 +137,8 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     X.push_back(xb);
     double xmin;
     double fmin;
-    CSolvers::globalMinimize(X, [&](double x) { return this->predict(x); }, xmin, fmin);
+    CSolvers::globalMinimize(
+        X, [this](double x) -> double { return this->predict(x); }, xmin, fmin);
 
     // Refine.
     double range{(xb - xa) / static_cast<double>(X.size())};
@@ -150,7 +151,8 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     }
     double xcand;
     double fcand;
-    CSolvers::globalMinimize(X, [&](double x) { return this->predict(x); }, xcand, fcand);
+    CSolvers::globalMinimize(
+        X, [this](double x) -> double { return this->predict(x); }, xcand, fcand);
 
     if (fcand < fmin) {
         xmin = xcand;

--- a/lib/maths/analytics/CBoostedTreeLoss.cc
+++ b/lib/maths/analytics/CBoostedTreeLoss.cc
@@ -351,13 +351,13 @@ CArgMinMultinomialLogisticLossImpl::objective() const {
     TDoubleVector logProbabilities{m_NumberClasses};
     double lambda{std::max(this->lambda(), 1e-6)};
     if (m_Centres.size() == 1) {
-        return [logProbabilities, lambda, this](const TDoubleVector& weight) mutable {
+        return [logProbabilities, lambda, this](const TDoubleVector& weight) mutable -> double {
             logProbabilities = m_Centres[0] + weight;
             common::CTools::inplaceLogSoftmax(logProbabilities);
             return lambda * weight.squaredNorm() - m_ClassCounts.transpose() * logProbabilities;
         };
     }
-    return [logProbabilities, lambda, this](const TDoubleVector& weight) mutable {
+    return [logProbabilities, lambda, this](const TDoubleVector& weight) mutable -> double {
         double loss{0.0};
         for (std::size_t i = 0; i < m_CentresClassCounts.size(); ++i) {
             if (m_CentresClassCounts[i].sum() > 0.0) {
@@ -376,14 +376,16 @@ CArgMinMultinomialLogisticLossImpl::objectiveGradient() const {
     TDoubleVector lossGradient{m_NumberClasses};
     double lambda{std::max(this->lambda(), 1e-6)};
     if (m_Centres.size() == 1) {
-        return [probabilities, lossGradient, lambda, this](const TDoubleVector& weight) mutable {
+        return [probabilities, lossGradient, lambda,
+                this](const TDoubleVector& weight) mutable -> TDoubleVector {
             probabilities = m_Centres[0] + weight;
             common::CTools::inplaceSoftmax(probabilities);
             lossGradient = m_ClassCounts.array().sum() * probabilities - m_ClassCounts;
-            return TDoubleVector{2.0 * lambda * weight + lossGradient};
+            return 2.0 * lambda * weight + lossGradient;
         };
     }
-    return [probabilities, lossGradient, lambda, this](const TDoubleVector& weight) mutable {
+    return [probabilities, lossGradient, lambda,
+            this](const TDoubleVector& weight) mutable -> TDoubleVector {
         lossGradient.array() = 0.0;
         for (std::size_t i = 0; i < m_CentresClassCounts.size(); ++i) {
             double n{m_CentresClassCounts[i].array().sum()};
@@ -393,7 +395,7 @@ CArgMinMultinomialLogisticLossImpl::objectiveGradient() const {
                 lossGradient -= m_CentresClassCounts[i] - n * probabilities;
             }
         }
-        return TDoubleVector{2.0 * lambda * weight + lossGradient};
+        return 2.0 * lambda * weight + lossGradient;
     };
 }
 
@@ -610,7 +612,6 @@ CArgMinPseudoHuberImpl::TDoubleVector CArgMinPseudoHuberImpl::value() const {
 CArgMinPseudoHuberImpl::TObjective CArgMinPseudoHuberImpl::objective() const {
     return [this](double weight) {
         if (m_DeltaSquared > 0) {
-
             double loss{0.0};
             double totalCount{0.0};
             for (const auto& bucket : m_Buckets) {
@@ -624,9 +625,8 @@ CArgMinPseudoHuberImpl::TObjective CArgMinPseudoHuberImpl::objective() const {
                 }
             }
             return loss / totalCount + this->lambda() * common::CTools::pow2(weight);
-        } else {
-            return 0.0;
         }
+        return 0.0;
     };
 }
 }

--- a/lib/maths/analytics/CDataFrameUtils.cc
+++ b/lib/maths/analytics/CDataFrameUtils.cc
@@ -1205,7 +1205,7 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
     // by f_j(w) = max_j{sum_i{1 - softmax_j(w_i p_i)} / n_j}. Note that this isn't
     // convex so we use multiple restarts.
 
-    auto objective = [&](const TDoubleVector& weights) {
+    auto objective = [&](const TDoubleVector& weights) -> double {
         TDoubleVector probabilities;
         TDoubleVector scores;
         auto computeObjective = core::bindRetrievableState(
@@ -1233,10 +1233,11 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
         doReduce(frame.readRows(numberThreads, 0, frame.numberRows(),
                                 computeObjective, &sampleMask),
                  copyObjective, reduceObjective, objective_);
+
         return objective_.maxCoeff();
     };
 
-    auto objectiveGradient = [&](const TDoubleVector& weights) {
+    auto objectiveGradient = [&](const TDoubleVector& weights) -> TDoubleVector {
         TDoubleVector probabilities;
         TDoubleVector scores;
         auto computeObjectiveAndGradient = core::bindRetrievableState(
@@ -1270,7 +1271,8 @@ CDataFrameUtils::maximizeMinimumRecallForMulticlass(std::size_t numberThreads,
                  copyObjectiveAndGradient, reduceObjectiveAndGradient, objectiveAndGradient);
         std::size_t max;
         objectiveAndGradient.col(0).maxCoeff(&max);
-        return TDoubleVector{objectiveAndGradient.col(max + 1)};
+
+        return objectiveAndGradient.col(max + 1);
     };
 
     // We always try initialising with all weights equal because our minimization

--- a/lib/maths/analytics/unittest/CBoostedTreeLossTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeLossTest.cc
@@ -14,7 +14,6 @@
 #include <maths/analytics/CBoostedTreeLoss.h>
 
 #include <maths/common/CBasicStatistics.h>
-#include <maths/common/CLbfgs.h>
 #include <maths/common/CPRNG.h>
 #include <maths/common/CSolvers.h>
 #include <maths/common/CTools.h>

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -238,7 +238,7 @@ double CBayesianOptimisation::evaluate(const TVector& Kinvf, const TVector& inpu
 }
 
 double CBayesianOptimisation::evaluate1D(const TVector& Kinvf, double input, int dimension) const {
-    auto prodXt = [this](const TVector& x, int t) {
+    auto prodXt = [this](const TVector& x, int t) -> double {
         double prod{1.0};
         for (int d = 0; d < m_MinBoundary.size(); ++d) {
             if (d != t) {
@@ -295,7 +295,7 @@ double CBayesianOptimisation::anovaConstantFactor() const {
 }
 
 double CBayesianOptimisation::anovaTotalVariance(const TVector& Kinvf) const {
-    auto prodIj = [&Kinvf, this](std::size_t i, std::size_t j) {
+    auto prodIj = [&Kinvf, this](std::size_t i, std::size_t j) -> double {
         TVector xi{this->transformTo01(m_FunctionMeanValues[i].first)};
         TVector xj{this->transformTo01(m_FunctionMeanValues[j].first)};
         double prod{1.0};
@@ -331,7 +331,7 @@ double CBayesianOptimisation::anovaTotalVariance() const {
 }
 
 double CBayesianOptimisation::anovaMainEffect(const TVector& Kinvf, int dimension) const {
-    auto prodXt = [this](const TVector& x, int t) {
+    auto prodXt = [this](const TVector& x, int t) -> double {
         double prod{1.0};
         for (int d = 0; d < m_MinBoundary.size(); ++d) {
             if (d != t) {
@@ -406,7 +406,7 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
     TMatrix Kinv;
     TMatrix dKdai;
 
-    auto minusLogLikelihood = [=](const TVector& a) mutable {
+    auto minusLogLikelihood = [=](const TVector& a) mutable -> double {
         K = this->kernel(a, v);
         Eigen::LDLT<Eigen::MatrixXd> Kldl{K};
         Kinvf = Kldl.solve(f);
@@ -420,7 +420,7 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
                       Kldl.vectorD().cwiseMax(eps).array().log().sum());
     };
 
-    auto minusLogLikelihoodGradient = [=](const TVector& a) mutable {
+    auto minusLogLikelihoodGradient = [=](const TVector& a) mutable -> TVector {
         K = this->kernel(a, v);
         Eigen::LDLT<Eigen::MatrixXd> Kldl{K};
 
@@ -472,7 +472,7 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
                          })
             ->second};
 
-    auto EI = [=](const TVector& x) mutable {
+    auto EI = [=](const TVector& x) mutable -> double {
         double Kxx;
         std::tie(Kxn, Kxx) = this->kernelCovariates(m_KernelParameters, x, vx);
 
@@ -491,7 +491,7 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
         return -sigma * (z * cdfz + pdfz);
     };
 
-    auto EIGradient = [=](const TVector& x) mutable {
+    auto EIGradient = [=](const TVector& x) mutable -> TVector {
         double Kxx;
         std::tie(Kxn, Kxx) = this->kernelCovariates(m_KernelParameters, x, vx);
 
@@ -527,7 +527,7 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
 
         zGradient = ((mu - fmin) / CTools::pow2(sigma)) * sigmaGradient - muGradient / sigma;
 
-        return TVector{-(z * cdfz + pdfz) * sigmaGradient - sigma * cdfz * zGradient};
+        return -(z * cdfz + pdfz) * sigmaGradient - sigma * cdfz * zGradient;
     };
 
     return {std::move(EI), std::move(EIGradient)};

--- a/lib/maths/common/CXMeansOnline1d.cc
+++ b/lib/maths/common/CXMeansOnline1d.cc
@@ -26,7 +26,6 @@
 #include <maths/common/CNormalMeanPrecConjugate.h>
 #include <maths/common/CPrior.h>
 #include <maths/common/CRestoreParams.h>
-#include <maths/common/CSolvers.h>
 #include <maths/common/CTools.h>
 #include <maths/common/Constants.h>
 #include <maths/common/MathsTypes.h>

--- a/lib/maths/common/unittest/CLbfgsTest.cc
+++ b/lib/maths/common/unittest/CLbfgsTest.cc
@@ -39,10 +39,12 @@ BOOST_AUTO_TEST_CASE(testQuadtratic) {
         diagonal(i) = static_cast<double>(i);
     }
 
-    auto f = [&](const TVector& x) {
-        return static_cast<double>(x.transpose() * diagonal.asDiagonal() * x);
+    auto f = [&](const TVector& x) -> double {
+        return x.transpose() * diagonal.asDiagonal() * x;
     };
-    auto g = [&](const TVector& x) { return 2.0 * diagonal.asDiagonal() * x; };
+    auto g = [&](const TVector& x) -> TVector {
+        return 2.0 * diagonal.asDiagonal() * x;
+    };
 
     maths::common::CLbfgs<TVector> lbfgs{10};
 
@@ -124,14 +126,14 @@ BOOST_AUTO_TEST_CASE(testSingularHessian) {
         }
         return result;
     };
-    auto g = [&](const TVector& x) {
+    auto g = [&](const TVector& x) -> TVector {
         TVector furthest{x};
         for (const auto& p : points) {
             if ((p - x).norm() > (furthest - x).norm()) {
                 furthest = p;
             }
         }
-        return TVector{(x - furthest) / (x - furthest).norm()};
+        return (x - furthest) / (x - furthest).norm();
     };
 
     maths::common::CLbfgs<TVector> lbfgs{5};
@@ -177,10 +179,12 @@ BOOST_AUTO_TEST_CASE(testConstrainedMinimize) {
         diagonal(i) = static_cast<double>(i);
     }
 
-    auto f = [&](const TVector& x) {
+    auto f = [&](const TVector& x) -> double {
         return x.transpose() * diagonal.asDiagonal() * x;
     };
-    auto g = [&](const TVector& x) { return 2.0 * diagonal.asDiagonal() * x; };
+    auto g = [&](const TVector& x) -> TVector {
+        return 2.0 * diagonal.asDiagonal() * x;
+    };
 
     maths::common::CLbfgs<TVector> lbfgs{10};
 
@@ -241,10 +245,10 @@ BOOST_AUTO_TEST_CASE(testMinimizeWithVerySmallGradient) {
     TVector xmin{TVector::fromStdVector({1000.0, 1000.0, 1000.0})};
     TVector x0{TVector::fromStdVector({1200.0, 1200.0, 1200.0})};
 
-    auto f = [&](const TVector& x) {
+    auto f = [&](const TVector& x) -> double {
         return eps * (x - xmin).transpose() * (x - xmin);
     };
-    auto g = [&](const TVector& x) { return 2.0 * eps * (x - xmin); };
+    auto g = [&](const TVector& x) -> TVector { return 2.0 * eps * (x - xmin); };
 
     maths::common::CLbfgs<TVector> lbfgs{10};
 
@@ -264,10 +268,12 @@ BOOST_AUTO_TEST_CASE(testMinimizeWithInitialZeroGradient) {
     TVector xmin{TVector::fromStdVector({1000.0, 1000.0, 1000.0})};
     TVector x0{TVector::fromStdVector({1200.0, 1200.0, 1200.0})};
 
-    auto f = [&](const TVector& x) {
+    auto f = [&](const TVector& x) -> double {
         return (x - xmin).transpose() * (x - xmin);
     };
-    auto g = [&](const TVector& x) { return x == x0 ? zero : 2.0 * (x - xmin); };
+    auto g = [&](const TVector& x) -> TVector {
+        return x == x0 ? zero : 2.0 * (x - xmin);
+    };
 
     maths::common::CLbfgs<TVector> lbfgs{10};
 


### PR DESCRIPTION
If an Eigen expression is deduced as the return type of a lambda one can run into the problem that it is only evaluated after the function returns and references out-of-scope variables. `CLbfgs/testMinimizeWithVerySmallGradient` was failing for our debug build as a result of this problem.

This change audits the use of lambdas in minimisation routines in the code base, which are related to this problem, and adds explicit return types.

Given how easy it is to introduce subtle errors in this area it may be worthwhile mandating in our coding standard to always explicitly define lambda return types. However, this is beyond the scope of the change we want to make to address the failing test and possibly related problems.

Although this is a potential bug, as far as we know this was only affecting test code. Also it is a low level detail with uncertain effects. Therefore I've decide not to document this change and mark it a non-issue accordingly.

Fixes #2081