### PR TITLE
[ML] Splitting beta1 changelog into its own section

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,6 +30,12 @@
 
 == {es} version 8.0.0
 
+=== Bug Fixes
+
+* ...
+
+== {es} version 8.0.0-beta1
+
 === Enhancements
 
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 10.3. (See


### PR DESCRIPTION
Now that 8.0.0-beta1 is feature frozen the changelog for
it should be split into its own section.