### PR TITLE
[7.15] [ML] Lock the clang version used to build Boost in ARM CI

### DIFF
--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -99,6 +99,15 @@ case `uname` in
         else
             TASKS="clean buildZip check"
         fi
+        # For macOS we usually only use a particular version as our build platform
+        # once Xcode has stopped receiving updates for it. However, with Big Sur
+        # on ARM we couldn't do this, as Big Sur was the first macOS version for
+        # ARM. Therefore, the compiler may get upgraded on a CI server, and we
+        # need to hardcode the version that was used to build Boost for that
+        # version of Elasticsearch.
+        if [ "$HARDWARE_ARCH" = aarch64 ] ; then
+            export BOOSTCLANGVER=120
+        fi
         (cd .. && ./gradlew --info -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT -Dbuild.ml_debug=$ML_DEBUG $TASKS)
         ;;
 

--- a/mk/macosx.mk
+++ b/mk/macosx.mk
@@ -61,7 +61,9 @@ BOOSTARCH=x64
 else
 BOOSTARCH=a64
 endif
-BOOSTCLANGVER:=$(shell $(CXX) --version | grep ' version ' | sed 's/.* version //' | awk -F. '{ print $$1$$2; }')
+# The clang version used to build Boost may be overridden if the
+# compiler on the build machine is upgraded without rebuilding Boost
+BOOSTCLANGVER?=$(shell $(CXX) --version | grep ' version ' | sed 's/.* version //' | awk -F. '{ print $$1$$2; }')
 # Use -isystem instead of -I for Boost headers to suppress warnings from Boost
 BOOSTINCLUDES=-isystem /usr/local/include/boost-$(BOOSTVER)
 BOOSTCPPFLAGS=-DBOOST_ALL_DYN_LINK -DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS


### PR DESCRIPTION
If we upgrade Xcode on one of our macOS ARM build servers
then we won't rebuild Boost for old branches that are past
feature freeze, but Boost adds the compiler version into
the names of its libraries. Therefore when running in CI
we need to hardcode the version of clang that was used to
build Boost for each branch.

We used to avoid this problem by always using a macOS
build platform for which Xcode was no longer being updated.
For example, the last version of Xcode that works on
Mojave is 11.3, so by advancing the build platform to
Mojave after Xcode 11.4 was released we could be sure that
Xcode would never be upgraded on a build server where we
build for release. (Plus this meant the code was proven by
unit tests to run on old versions of macOS.) With Big Sur
on ARM this approach wasn't possible, as Big Sur was the
first version of macOS to work on ARM. As the years go by
we should revert to the old approach of building on an
older version of macOS for releases.

Backport of #2098