### PR TITLE
[ML] Better vector and matrix checksum implementation

### DIFF
--- a/include/maths/common/CLinearAlgebra.h
+++ b/include/maths/common/CLinearAlgebra.h
@@ -17,6 +17,7 @@
 #include <core/CMemory.h>
 #include <core/CSmallVector.h>
 
+#include <maths/common/CChecksum.h>
 #include <maths/common/CLinearAlgebraFwd.h>
 #include <maths/common/ImportExport.h>
 #include <maths/common/MathsTypes.h>
@@ -188,13 +189,8 @@ struct SSymmetricMatrix {
     }
 
     //! Get a checksum of the elements of this matrix.
-    uint64_t checksum() const {
-        uint64_t result = 0;
-        for (std::size_t i = 0; i < m_LowerTriangle.size(); ++i) {
-            result = core::CHashing::hashCombine(
-                result, static_cast<uint64_t>(m_LowerTriangle[i]));
-        }
-        return result;
+    std::uint64_t checksum() const {
+        return CChecksum::calculate(0, m_LowerTriangle);
     }
 
     STORAGE m_LowerTriangle;
@@ -881,13 +877,7 @@ struct SVector {
     }
 
     //! Get a checksum of the components of this vector.
-    uint64_t checksum() const {
-        uint64_t result = static_cast<uint64_t>(m_X[0]);
-        for (std::size_t i = 1; i < m_X.size(); ++i) {
-            result = core::CHashing::hashCombine(result, static_cast<uint64_t>(m_X[i]));
-        }
-        return result;
-    }
+    std::uint64_t checksum() const { return CChecksum::calculate(0, m_X); }
 
     //! The components
     STORAGE m_X;


### PR DESCRIPTION
We shouldn't just cast `double` to `uint64_t` for the checksum implementation. We have a proper implementation which hashes the raw bytes and we should switch to using that.

This won't actually affect any results so marking as a non-issue.

Closes #2079.