### PR TITLE
[ML] Fix for test case assertions

### DIFF
--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -2124,8 +2124,8 @@ bool CTimeSeriesCorrelations::correlationModels(std::size_t id,
             continue;
         }
         correlated[end] = correlate;
-        variables.push_back(std::move(variable));
         correlationModels.push_back({i->second.first.get(), variable[0]});
+        variables.push_back(std::move(variable));
         ++end;
     }
 


### PR DESCRIPTION
The upgrade to boost 1.77 has resulted in a few test cases failing. This
PR provides a fix.

Labelling as a non-issue as it doesn't seem that this would ever cause a problem in production code.

Closes #2107