### PR TITLE
[7.16][ML] Fix for test case assertions (#2110)

### DIFF
--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -2124,8 +2124,8 @@ bool CTimeSeriesCorrelations::correlationModels(std::size_t id,
             continue;
         }
         correlated[end] = correlate;
-        variables.push_back(std::move(variable));
         correlationModels.push_back({i->second.first.get(), variable[0]});
+        variables.push_back(std::move(variable));
         ++end;
     }
 


### PR DESCRIPTION
The upgrade to boost 1.77 has resulted in a few test cases failing. This
PR provides a fix.

Closes #2107
Backports #2110 