### PR TITLE
[ML] Adding an unbuffered istream wrapper for RapidJSON

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -12,9 +12,9 @@
 #include "CCommandParser.h"
 
 #include <core/CLogger.h>
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 
 #include <rapidjson/error/en.h>
-#include <rapidjson/istreamwrapper.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
@@ -59,16 +59,7 @@ CCommandParser::CCommandParser(std::istream& strmIn) : m_StrmIn(strmIn) {
 bool CCommandParser::ioLoop(const TRequestHandlerFunc& requestHandler,
                             const TErrorHandlerFunc& errorHandler) {
 
-    // We tell RapidJSON's istream wrapper to use a one character
-    // buffer. In some ways this is inefficient, but it matches the
-    // behaviour of the 2017 version of RapidJSON. If we use a bigger
-    // buffer here then we'll need to send spaces after each command
-    // to ensure the istream wrapper doesn't block on a buffer read
-    // at the end of a command. It shouldn't be _that_ inefficient
-    // to use a one character buffer in the wrapper, as the
-    // underlying named pipe has buffering at the OS level.
-    char buffer{'\0'};
-    rapidjson::IStreamWrapper isw{m_StrmIn, &buffer, sizeof(buffer)};
+    core::CRapidJsonUnbufferedIStreamWrapper isw{m_StrmIn};
 
     while (true) {
         rapidjson::Document doc;

--- a/include/core/CRapidJsonUnbufferedIStreamWrapper.h
+++ b/include/core/CRapidJsonUnbufferedIStreamWrapper.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#ifndef INCLUDED_ml_core_CRapidJsonUnbufferedIStreamWrapper_h
+#define INCLUDED_ml_core_CRapidJsonUnbufferedIStreamWrapper_h
+
+#include <core/ImportExport.h>
+
+#include <rapidjson/rapidjson.h>
+
+#include <istream>
+
+namespace ml {
+namespace core {
+
+//! \brief
+//! An unbuffered RapidJSON istream wrapper.
+//!
+//! DESCRIPTION:\n
+//! RapidJSON has a class IStreamWrapper that must be used to
+//! wrap istreams before they can be accessed by the parsing
+//! functions.
+//!
+//! In the 2017 versions of RapidJSON, IStreamWrapper was
+//! unbuffered. We came to depend on it being unbuffered because
+//! we use it to parse documents from a stream that contains
+//! additional data after the JSON document currently being
+//! parsed, and hence we don't want the wrapper to consume any
+//! characters beyond those in the document it's parsing.
+//!
+//! In the 2021 versions of RapidJSON, IStreamWrapper was
+//! changed to read multiple characters from the underlying
+//! istream and buffer them. This broke our code. It's also
+//! not possible to simply use a single character buffer, as
+//! in debug mode RapidJSON asserts that the buffer is at least
+//! 4 characters in size.
+//!
+//! This class is an unbuffered istream wrapper compatible
+//! with the RapidJSON parser functions, similar to the class
+//! that existed in RapidJSON itself in 2017. It should be
+//! more efficient that a buffered wrapper with a single
+//! character buffer, as it avoids the extra function call to
+//! fill that buffer per character in the stream.
+//!
+//! IMPLEMENTATION DECISIONS:\n
+//! Only works with char, not wchar_t.
+//!
+//! Method names have to match those required by RapidJSON,
+//! which is why they do not conform to our coding standards.
+//!
+//! The Peek4() method used to detect character encodings
+//! pretends that the stream contains fewer than 4 characters
+//! in total, which disables character encoding detection.
+//! This is not a problem for us as we know our input is
+//! always UTF-8.
+//!
+class CORE_EXPORT CRapidJsonUnbufferedIStreamWrapper {
+public:
+    //! The stream's char type must be available as Ch.
+    using Ch = char;
+
+public:
+    CRapidJsonUnbufferedIStreamWrapper(std::istream& strm);
+
+    //! No default constructor.
+    CRapidJsonUnbufferedIStreamWrapper() = delete;
+
+    //! No copying.
+    CRapidJsonUnbufferedIStreamWrapper(const CRapidJsonUnbufferedIStreamWrapper&) = delete;
+    CRapidJsonUnbufferedIStreamWrapper&
+    operator=(const CRapidJsonUnbufferedIStreamWrapper&) = delete;
+
+    //! Peek the next character. Returns '\0' when the end of the stream is
+    //! reached.
+    char Peek() const {
+        int c{m_Stream.peek()};
+        return RAPIDJSON_LIKELY(c != std::istream::traits_type::eof())
+                   ? static_cast<char>(c)
+                   : '\0';
+    }
+
+    //! Take the next character. Returns '\0' when the end of the stream is
+    //! reached.
+    char Take();
+
+    //! Return the number of characters taken.
+    std::size_t Tell() const { return m_Count; }
+
+    //! Not implemented.
+    void Put(char) { RAPIDJSON_ASSERT(false); }
+
+    //! Not implemented.
+    void Flush() { RAPIDJSON_ASSERT(false); }
+
+    //! Not implemented.
+    char* PutBegin() {
+        RAPIDJSON_ASSERT(false);
+        return nullptr;
+    }
+
+    //! Not implemented.
+    std::size_t PutEnd(char*) {
+        RAPIDJSON_ASSERT(false);
+        return 0;
+    }
+
+    //! For encoding detection only. In this implementation we pretend there are
+    //! fewer than four characters remaining in the stream, which disables
+    //! encoding detection. This is not a problem for our use case as we always
+    //! work in UTF-8.
+    const char* Peek4() const { return nullptr; }
+
+private:
+    //! Reference to the stream.
+    std::istream& m_Stream;
+
+    //! Count of characters taken.
+    std::size_t m_Count{0};
+};
+}
+}
+
+#endif /*  INCLUDED_ml_core_CRapidJsonUnbufferedIStreamWrapper_h */

--- a/include/core/CStateDecompressor.h
+++ b/include/core/CStateDecompressor.h
@@ -12,11 +12,11 @@
 #define INCLUDED_ml_core_CStateDecompressor_h
 
 #include <core/CDataSearcher.h>
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 #include <core/ImportExport.h>
 
 #include <boost/iostreams/filtering_stream.hpp>
 
-#include <rapidjson/istreamwrapper.h>
 #include <rapidjson/reader.h>
 
 namespace ml {
@@ -132,17 +132,6 @@ public:
         //! The sequential document number currently being written to
         std::size_t m_CurrentDocNum;
 
-        //! Single character buffer for the input stream wrapper.
-        //! It's clearly inefficient to be using a single character buffer,
-        //! but it's necessary to match the functionality of 2017 RapidJSON
-        //! in 2021 RapidJSON. The older version's istream wrapper read one
-        //! character at a time off the stream which meant that our single
-        //! stream searcher could rely on the \0 characters that delimit
-        //! separate state chunks not being consumed by the parsing of the
-        //! previous state chunk. If RapidJSON consumes characters beyond the
-        //! document it's parsing then this approach breaks down.
-        char m_BufferChar{'\0'};
-
         //! Have we read all the data possible from downstream?
         bool m_EndOfStream;
 
@@ -150,7 +139,7 @@ public:
         std::string m_SearchString;
 
         //! Wrapper around the downstream reader
-        std::shared_ptr<rapidjson::IStreamWrapper> m_InputStreamWrapper;
+        std::shared_ptr<CRapidJsonUnbufferedIStreamWrapper> m_InputStreamWrapper;
 
         //! JSON reader for the downstream stream
         std::shared_ptr<rapidjson::Reader> m_Reader;

--- a/lib/core/CRapidJsonUnbufferedIStreamWrapper.cc
+++ b/lib/core/CRapidJsonUnbufferedIStreamWrapper.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
+
+namespace ml {
+namespace core {
+
+CRapidJsonUnbufferedIStreamWrapper::CRapidJsonUnbufferedIStreamWrapper(std::istream& strm)
+    : m_Stream{strm} {};
+
+char CRapidJsonUnbufferedIStreamWrapper::Take() {
+    int c{m_Stream.get()};
+    if (RAPIDJSON_UNLIKELY(c == std::istream::traits_type::eof())) {
+        return '\0';
+    }
+    ++m_Count;
+    return static_cast<char>(c);
+}
+}
+}

--- a/lib/core/CStateDecompressor.cc
+++ b/lib/core/CStateDecompressor.cc
@@ -74,8 +74,7 @@ std::streamsize CStateDecompressor::CDechunkFilter::read(char* s, std::streamsiz
                 return this->endOfStream(s, n, bytesDone);
             }
 
-            m_InputStreamWrapper.reset(new rapidjson::IStreamWrapper(
-                *m_IStream, &m_BufferChar, sizeof(m_BufferChar)));
+            m_InputStreamWrapper.reset(new CRapidJsonUnbufferedIStreamWrapper(*m_IStream));
             m_Reader.reset(new rapidjson::Reader);
 
             if (!this->readHeader()) {

--- a/lib/core/Makefile
+++ b/lib/core/Makefile
@@ -104,6 +104,7 @@ CPatternSet.cc \
 CPersistUtils.cc \
 CProgramCounters.cc \
 CRapidJsonConcurrentLineWriter.cc \
+CRapidJsonUnbufferedIStreamWrapper.cc \
 CRapidXmlParser.cc \
 CRapidXmlStatePersistInserter.cc \
 CRapidXmlStateRestoreTraverser.cc \

--- a/lib/core/unittest/CRapidJsonUnbufferedIStreamWrapperTest.cc
+++ b/lib/core/unittest/CRapidJsonUnbufferedIStreamWrapperTest.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+
+BOOST_AUTO_TEST_SUITE(CRapidJsonUnbufferedIStreamWrapperTest)
+
+BOOST_AUTO_TEST_CASE(testWrap) {
+
+    std::istringstream strm{"abc"};
+    ml::core::CRapidJsonUnbufferedIStreamWrapper wrapper{strm};
+
+    BOOST_REQUIRE_EQUAL(nullptr, wrapper.Peek4());
+    BOOST_REQUIRE_EQUAL('a', wrapper.Peek());
+    BOOST_REQUIRE_EQUAL('a', wrapper.Take());
+    BOOST_REQUIRE_EQUAL(1, wrapper.Tell());
+    BOOST_REQUIRE_EQUAL('b', wrapper.Take());
+    BOOST_REQUIRE_EQUAL(2, wrapper.Tell());
+    BOOST_REQUIRE_EQUAL('c', wrapper.Peek());
+    BOOST_REQUIRE_EQUAL('c', wrapper.Peek());
+    BOOST_REQUIRE_EQUAL('c', wrapper.Take());
+    BOOST_REQUIRE_EQUAL(3, wrapper.Tell());
+    BOOST_REQUIRE_EQUAL('\0', wrapper.Peek());
+    BOOST_REQUIRE_EQUAL('\0', wrapper.Take());
+    BOOST_REQUIRE_EQUAL(3, wrapper.Tell());
+    BOOST_REQUIRE_EQUAL(nullptr, wrapper.Peek4());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/unittest/Makefile
+++ b/lib/core/unittest/Makefile
@@ -71,6 +71,7 @@ CProgNameTest.cc \
 CProgramCountersTest.cc \
 CRapidJsonLineWriterTest.cc\
 CRapidJsonWriterBaseTest.cc\
+CRapidJsonUnbufferedIStreamWrapperTest.cc \
 CRapidXmlParserTest.cc \
 CRapidXmlStatePersistInserterTest.cc \
 CRapidXmlStateRestoreTraverserTest.cc \


### PR DESCRIPTION
In #2106 it became apparent that the behaviour of RapidJSON's
own IStreamWrapper class had changed between the 2017 version
we used previously and the latest 2021 version. In the older
version it was unbuffered and in the newer version it was
buffered.

An attempt was made to work around this in #2106 by specifying
a single character buffer, however, in debug builds this then
fell foul of an assertion that the buffer size was at least 4
characters.

This PR adds a separate unbuffered istream wrapper class that
we can use with RapidJSON in cases where we don't want the
wrapper to consume extra characters beyond the end of the
document that's being parsed. Having a separate class should
also reduce the inefficiency of taking one character at a
time, as there's no need to call a stream method to refill
the buffer on every read.