### PR TITLE
[ML] Fix warnings due to -Wsuggest-override compiler flag

### DIFF
--- a/include/api/CAnomalyJobConfigReader.h
+++ b/include/api/CAnomalyJobConfigReader.h
@@ -65,7 +65,7 @@ public:
     public:
         explicit CParseError(const std::string& what)
             : std::runtime_error{what} {}
-        virtual ~CParseError() noexcept override = default;
+        ~CParseError() noexcept override = default;
     };
 
 public:

--- a/include/api/CAnomalyJobConfigReader.h
+++ b/include/api/CAnomalyJobConfigReader.h
@@ -65,7 +65,7 @@ public:
     public:
         explicit CParseError(const std::string& what)
             : std::runtime_error{what} {}
-        virtual ~CParseError() noexcept = default;
+        virtual ~CParseError() noexcept override = default;
     };
 
 public:

--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -154,9 +154,7 @@ public:
                                const TPivotWriterFunc& pivotsWriterFunc);
 
     //! Write \p node.
-    virtual void visit(const model::CHierarchicalResults& results,
-                       const TNode& node,
-                       bool pivot) override;
+    void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) override;
 
 private:
     //! Write out a population person result if \p node is a

--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -154,7 +154,9 @@ public:
                                const TPivotWriterFunc& pivotsWriterFunc);
 
     //! Write \p node.
-    virtual void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot);
+    virtual void visit(const model::CHierarchicalResults& results,
+                       const TNode& node,
+                       bool pivot) override;
 
 private:
     //! Write out a population person result if \p node is a

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -164,7 +164,7 @@ public:
     using TSizeInfoUPtr = std::unique_ptr<CSizeInfo>;
 
 public:
-    ~CTrainedModel() override = default;
+    virtual ~CTrainedModel() override = default;
     void addToJsonStream(TGenericLineWriter& writer) const override;
     //! Names of the features used by the model.
     virtual const TStringVec& featureNames() const;

--- a/include/api/CInferenceModelDefinition.h
+++ b/include/api/CInferenceModelDefinition.h
@@ -164,7 +164,7 @@ public:
     using TSizeInfoUPtr = std::unique_ptr<CSizeInfo>;
 
 public:
-    virtual ~CTrainedModel() override = default;
+    ~CTrainedModel() override = default;
     void addToJsonStream(TGenericLineWriter& writer) const override;
     //! Names of the features used by the model.
     virtual const TStringVec& featureNames() const;

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -150,8 +150,8 @@ private:
 
     protected:
         //! Inherited virtual interface
-        virtual void run() override;
-        virtual void shutdown() override;
+        void run() override;
+        void shutdown() override;
 
     private:
         //! Reference to the owning background persister

--- a/include/api/CPersistenceManager.h
+++ b/include/api/CPersistenceManager.h
@@ -150,8 +150,8 @@ private:
 
     protected:
         //! Inherited virtual interface
-        virtual void run();
-        virtual void shutdown();
+        virtual void run() override;
+        virtual void shutdown() override;
 
     private:
         //! Reference to the owning background persister

--- a/include/api/CSimpleOutputWriter.h
+++ b/include/api/CSimpleOutputWriter.h
@@ -66,8 +66,8 @@ public:
     //! overrideDataRowFields and dataRowFields, the value in
     //! overrideDataRowFields will be written.  The time will be passed
     //! as an empty optional, i.e. unknown.
-    bool writeRow(const TStrStrUMap& dataRowFields,
-                  const TStrStrUMap& overrideDataRowFields) = 0;
+    virtual bool writeRow(const TStrStrUMap& dataRowFields,
+                          const TStrStrUMap& overrideDataRowFields) = 0;
 
 protected:
     //! Class to cache a hash value so that it doesn't have to be repeatedly

--- a/include/api/CSimpleOutputWriter.h
+++ b/include/api/CSimpleOutputWriter.h
@@ -66,8 +66,8 @@ public:
     //! overrideDataRowFields and dataRowFields, the value in
     //! overrideDataRowFields will be written.  The time will be passed
     //! as an empty optional, i.e. unknown.
-    virtual bool writeRow(const TStrStrUMap& dataRowFields,
-                          const TStrStrUMap& overrideDataRowFields) = 0;
+    bool writeRow(const TStrStrUMap& dataRowFields,
+                  const TStrStrUMap& overrideDataRowFields) = 0;
 
 protected:
     //! Class to cache a hash value so that it doesn't have to be repeatedly

--- a/include/core/CBlockingCallCancellingTimer.h
+++ b/include/core/CBlockingCallCancellingTimer.h
@@ -56,11 +56,11 @@ protected:
     //! Derived classes must implement this such that it waits for the
     //! appropriate indication that the blocking call should be cancelled,
     //! or until it is told to stop waiting by stopWaitForCondition().
-    virtual void waitForCondition();
+    virtual void waitForCondition() override;
 
     //! Derived classes must implement this such that when called it causes
     //! the waitForCondition() method to return false immediately.
-    virtual void stopWaitForCondition();
+    virtual void stopWaitForCondition() override;
 
 private:
     using TMutexUniqueLock = std::unique_lock<std::mutex>;

--- a/include/core/CBlockingCallCancellingTimer.h
+++ b/include/core/CBlockingCallCancellingTimer.h
@@ -56,11 +56,11 @@ protected:
     //! Derived classes must implement this such that it waits for the
     //! appropriate indication that the blocking call should be cancelled,
     //! or until it is told to stop waiting by stopWaitForCondition().
-    virtual void waitForCondition() override;
+    void waitForCondition() override;
 
     //! Derived classes must implement this such that when called it causes
     //! the waitForCondition() method to return false immediately.
-    virtual void stopWaitForCondition() override;
+    void stopWaitForCondition() override;
 
 private:
     using TMutexUniqueLock = std::unique_lock<std::mutex>;

--- a/include/core/CCompressOStream.h
+++ b/include/core/CCompressOStream.h
@@ -39,7 +39,7 @@ public:
     CCompressOStream(CStateCompressor::CChunkFilter& filter);
 
     //! Destructor will close the stream
-    virtual ~CCompressOStream();
+    virtual ~CCompressOStream() override;
 
     //! Close the stream
     void close();
@@ -53,8 +53,8 @@ private:
 
     protected:
         //! Implementation of inherited interface
-        virtual void run();
-        virtual void shutdown();
+        virtual void run() override;
+        virtual void shutdown() override;
 
     public:
         //! Reference to the owning stream

--- a/include/core/CCompressOStream.h
+++ b/include/core/CCompressOStream.h
@@ -39,7 +39,7 @@ public:
     CCompressOStream(CStateCompressor::CChunkFilter& filter);
 
     //! Destructor will close the stream
-    virtual ~CCompressOStream() override;
+    ~CCompressOStream() override;
 
     //! Close the stream
     void close();
@@ -53,8 +53,8 @@ private:
 
     protected:
         //! Implementation of inherited interface
-        virtual void run() override;
-        virtual void shutdown() override;
+        void run() override;
+        void shutdown() override;
 
     public:
         //! Reference to the owning stream

--- a/include/core/CDualThreadStreamBuf.h
+++ b/include/core/CDualThreadStreamBuf.h
@@ -88,32 +88,32 @@ protected:
     //! Get an estimate of the number of characters still to read after an
     //! underflow.  In the case of this class we return the amount of data
     //! in the intermediate buffer.
-    virtual std::streamsize showmanyc();
+    virtual std::streamsize showmanyc() override;
 
     //! Switch the buffers immediately.  Effectively this flushes data
     //! through with lower latency but also less efficiently.
-    virtual int sync();
+    virtual int sync() override;
 
     //! Get up to n characters from the read buffer and store them in the
     //! array pointed to by s.
-    virtual std::streamsize xsgetn(char* s, std::streamsize n);
+    virtual std::streamsize xsgetn(char* s, std::streamsize n) override;
 
     //! Try to obtain more data for the write buffer.  This is done by
     //! swapping it with the intermediate buffer.  This may block if no data
     //! is available to read in the intermediate buffer.
-    virtual int underflow();
+    virtual int underflow() override;
 
     //! Put character back in the case of backup underflow.
-    virtual int pbackfail(int c = traits_type::eof());
+    virtual int pbackfail(int c = traits_type::eof()) override;
 
     //! Write up to n characters from the array pointed to by s into the
     //! write buffer.
-    virtual std::streamsize xsputn(const char* s, std::streamsize n);
+    virtual std::streamsize xsputn(const char* s, std::streamsize n) override;
 
     //! Try to obtain more space in the write buffer.  This is done by
     //! swapping it with the intermediate buffer.  This may block if no data
     //! is available to read in the intermediate buffer.
-    virtual int overflow(int c = traits_type::eof());
+    virtual int overflow(int c = traits_type::eof()) override;
 
     //! In a random access stream this would seek to the specified position.
     //! This class does not support such seeking, but implements this method
@@ -122,7 +122,7 @@ protected:
     virtual std::streampos
     seekoff(std::streamoff off,
             std::ios_base::seekdir way,
-            std::ios_base::openmode which = std::ios_base::in | std::ios_base::out);
+            std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
 
 private:
     //! Swap the intermediate buffer with the write buffer.  Will block if

--- a/include/core/CDualThreadStreamBuf.h
+++ b/include/core/CDualThreadStreamBuf.h
@@ -88,41 +88,41 @@ protected:
     //! Get an estimate of the number of characters still to read after an
     //! underflow.  In the case of this class we return the amount of data
     //! in the intermediate buffer.
-    virtual std::streamsize showmanyc() override;
+    std::streamsize showmanyc() override;
 
     //! Switch the buffers immediately.  Effectively this flushes data
     //! through with lower latency but also less efficiently.
-    virtual int sync() override;
+    int sync() override;
 
     //! Get up to n characters from the read buffer and store them in the
     //! array pointed to by s.
-    virtual std::streamsize xsgetn(char* s, std::streamsize n) override;
+    std::streamsize xsgetn(char* s, std::streamsize n) override;
 
     //! Try to obtain more data for the write buffer.  This is done by
     //! swapping it with the intermediate buffer.  This may block if no data
     //! is available to read in the intermediate buffer.
-    virtual int underflow() override;
+    int underflow() override;
 
     //! Put character back in the case of backup underflow.
-    virtual int pbackfail(int c = traits_type::eof()) override;
+    int pbackfail(int c = traits_type::eof()) override;
 
     //! Write up to n characters from the array pointed to by s into the
     //! write buffer.
-    virtual std::streamsize xsputn(const char* s, std::streamsize n) override;
+    std::streamsize xsputn(const char* s, std::streamsize n) override;
 
     //! Try to obtain more space in the write buffer.  This is done by
     //! swapping it with the intermediate buffer.  This may block if no data
     //! is available to read in the intermediate buffer.
-    virtual int overflow(int c = traits_type::eof()) override;
+    int overflow(int c = traits_type::eof()) override;
 
     //! In a random access stream this would seek to the specified position.
     //! This class does not support such seeking, but implements this method
     //! allowing a zero byte seek in order to allow tellg() and tellp() to
     //! work on the connected stream.
-    virtual std::streampos
-    seekoff(std::streamoff off,
-            std::ios_base::seekdir way,
-            std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
+    std::streampos seekoff(std::streamoff off,
+                           std::ios_base::seekdir way,
+                           std::ios_base::openmode which = std::ios_base::in |
+                                                           std::ios_base::out) override;
 
 private:
     //! Swap the intermediate buffer with the write buffer.  Will block if

--- a/include/core/CJsonStatePersistInserter.h
+++ b/include/core/CJsonStatePersistInserter.h
@@ -45,10 +45,10 @@ public:
     CJsonStatePersistInserter(std::ostream& outputStream);
 
     //! Destructor flushes
-    virtual ~CJsonStatePersistInserter();
+    virtual ~CJsonStatePersistInserter() override;
 
     //! Store a name/value
-    virtual void insertValue(const std::string& name, const std::string& value);
+    virtual void insertValue(const std::string& name, const std::string& value) override;
 
     //! Write as an integer avoiding the string conversion
     //! overloads
@@ -62,10 +62,10 @@ public:
 
 protected:
     //! Start a new level with the given name
-    virtual void newLevel(const std::string& name);
+    virtual void newLevel(const std::string& name) override;
 
     //! End the current level
-    virtual void endLevel();
+    virtual void endLevel() override;
 
 private:
     //! JSON writer ostream wrapper

--- a/include/core/CJsonStatePersistInserter.h
+++ b/include/core/CJsonStatePersistInserter.h
@@ -45,10 +45,10 @@ public:
     CJsonStatePersistInserter(std::ostream& outputStream);
 
     //! Destructor flushes
-    virtual ~CJsonStatePersistInserter() override;
+    ~CJsonStatePersistInserter() override;
 
     //! Store a name/value
-    virtual void insertValue(const std::string& name, const std::string& value) override;
+    void insertValue(const std::string& name, const std::string& value) override;
 
     //! Write as an integer avoiding the string conversion
     //! overloads
@@ -62,10 +62,10 @@ public:
 
 protected:
     //! Start a new level with the given name
-    virtual void newLevel(const std::string& name) override;
+    void newLevel(const std::string& name) override;
 
     //! End the current level
-    virtual void endLevel() override;
+    void endLevel() override;
 
 private:
     //! JSON writer ostream wrapper

--- a/include/core/CRapidJsonConcurrentLineWriter.h
+++ b/include/core/CRapidJsonConcurrentLineWriter.h
@@ -51,7 +51,7 @@ public:
     //! \p outStream reference to an wrapped output stream
     CRapidJsonConcurrentLineWriter(CJsonOutputStreamWrapper& outStream);
 
-    ~CRapidJsonConcurrentLineWriter();
+    ~CRapidJsonConcurrentLineWriter() override;
 
     //! Flush buffers, including the output stream.
     //! Note: flush still happens asynchronous
@@ -72,7 +72,7 @@ public:
     //! are not virtual and we need to avoid "slicing" the writer to ensure that
     //! that the correct StartObject/EndObject functions are called when this is
     //! passed to \p doc Accept.
-    void write(const rapidjson::Value& doc) { doc.Accept(*this); }
+    void write(const rapidjson::Value& doc) override { doc.Accept(*this); }
 
 private:
     //! The stream object

--- a/include/core/CRapidJsonLineWriter.h
+++ b/include/core/CRapidJsonLineWriter.h
@@ -64,7 +64,7 @@ public:
     //! are not virtual and we need to avoid "slicing" the writer to ensure that
     //! that the correct StartObject/EndObject functions are called when this is
     //! passed to \p doc Accept.
-    void write(const rapidjson::Value& doc) { doc.Accept(*this); }
+    void write(const rapidjson::Value& doc) override { doc.Accept(*this); }
 
 private:
     size_t m_ObjectCount = 0;

--- a/include/core/CRapidXmlParser.h
+++ b/include/core/CRapidXmlParser.h
@@ -70,58 +70,58 @@ public:
 
 public:
     CRapidXmlParser();
-    virtual ~CRapidXmlParser();
+    virtual ~CRapidXmlParser() override;
 
     //! Parse XML stored in a string
-    virtual bool parseString(const std::string& xml);
+    virtual bool parseString(const std::string& xml) override;
 
     //! Parse XML stored in a char buffer
-    virtual bool parseBuffer(const char* begin, size_t length);
+    virtual bool parseBuffer(const char* begin, size_t length) override;
 
     //! Parse XML stored in a char buffer that may be modified by the
     //! parsing and will outlive this object
-    virtual bool parseBufferInSitu(char* begin, size_t length);
+    virtual bool parseBufferInSitu(char* begin, size_t length) override;
 
     //! Parse a string ignoring CDATA elements
     bool parseStringIgnoreCdata(const std::string& xml);
 
     //! Return the root element name (empty string if not parsed yet)
-    virtual std::string rootElementName() const;
+    virtual std::string rootElementName() const override;
 
     //! Get the root element attributes (returns false if not parsed yet)
     bool rootElementAttributes(TStrStrMap& rootAttributes) const;
 
     //! Dump the document to string
-    virtual std::string dumpToString() const;
+    virtual std::string dumpToString() const override;
 
     //! Convert the entire XML document into a hierarchy of node objects.
     //! This is much more efficient than making repeated calls to
     //! evalXPathExpression() to retrieve the entire contents of a parsed
     //! document.
-    virtual bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+    virtual bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a pool to avoid XML node memory allocations where possible
     virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a string cache to avoid string representation memory
     //! allocations where possible
     virtual bool toNodeHierarchy(CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use both a node pool and a string cache
     virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
                                  CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! Functions for navigating an XML document without converting it to a
     //! node hierarchy
-    virtual bool navigateRoot();
-    virtual bool navigateFirstChild();
-    virtual bool navigateNext();
-    virtual bool navigateParent();
-    virtual bool currentNodeName(std::string& name);
-    virtual bool currentNodeValue(std::string& value);
+    virtual bool navigateRoot() override;
+    virtual bool navigateFirstChild() override;
+    virtual bool navigateNext() override;
+    virtual bool navigateParent() override;
+    virtual bool currentNodeName(std::string& name) override;
+    virtual bool currentNodeValue(std::string& value) override;
 
     //! Convert a node hierarchy to XML.
     //! (This will escape the text correctly.)

--- a/include/core/CRapidXmlParser.h
+++ b/include/core/CRapidXmlParser.h
@@ -70,58 +70,58 @@ public:
 
 public:
     CRapidXmlParser();
-    virtual ~CRapidXmlParser() override;
+    ~CRapidXmlParser() override;
 
     //! Parse XML stored in a string
-    virtual bool parseString(const std::string& xml) override;
+    bool parseString(const std::string& xml) override;
 
     //! Parse XML stored in a char buffer
-    virtual bool parseBuffer(const char* begin, size_t length) override;
+    bool parseBuffer(const char* begin, size_t length) override;
 
     //! Parse XML stored in a char buffer that may be modified by the
     //! parsing and will outlive this object
-    virtual bool parseBufferInSitu(char* begin, size_t length) override;
+    bool parseBufferInSitu(char* begin, size_t length) override;
 
     //! Parse a string ignoring CDATA elements
     bool parseStringIgnoreCdata(const std::string& xml);
 
     //! Return the root element name (empty string if not parsed yet)
-    virtual std::string rootElementName() const override;
+    std::string rootElementName() const override;
 
     //! Get the root element attributes (returns false if not parsed yet)
     bool rootElementAttributes(TStrStrMap& rootAttributes) const;
 
     //! Dump the document to string
-    virtual std::string dumpToString() const override;
+    std::string dumpToString() const override;
 
     //! Convert the entire XML document into a hierarchy of node objects.
     //! This is much more efficient than making repeated calls to
     //! evalXPathExpression() to retrieve the entire contents of a parsed
     //! document.
-    virtual bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a pool to avoid XML node memory allocations where possible
-    virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
+                         CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a string cache to avoid string representation memory
     //! allocations where possible
-    virtual bool toNodeHierarchy(CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CStringCache& cache,
+                         CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use both a node pool and a string cache
-    virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
-                                 CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
+                         CStringCache& cache,
+                         CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! Functions for navigating an XML document without converting it to a
     //! node hierarchy
-    virtual bool navigateRoot() override;
-    virtual bool navigateFirstChild() override;
-    virtual bool navigateNext() override;
-    virtual bool navigateParent() override;
-    virtual bool currentNodeName(std::string& name) override;
-    virtual bool currentNodeValue(std::string& value) override;
+    bool navigateRoot() override;
+    bool navigateFirstChild() override;
+    bool navigateNext() override;
+    bool navigateParent() override;
+    bool currentNodeName(std::string& name) override;
+    bool currentNodeValue(std::string& value) override;
 
     //! Convert a node hierarchy to XML.
     //! (This will escape the text correctly.)

--- a/include/core/CRapidXmlStatePersistInserter.h
+++ b/include/core/CRapidXmlStatePersistInserter.h
@@ -46,7 +46,7 @@ public:
     CRapidXmlStatePersistInserter(const std::string& rootName, const TStrStrMap& rootAttributes);
 
     //! Store a name/value
-    virtual void insertValue(const std::string& name, const std::string& value);
+    virtual void insertValue(const std::string& name, const std::string& value) override;
 
     // Bring extra base class overloads into scope
     using CStatePersistInserter::insertValue;
@@ -59,10 +59,10 @@ public:
 
 protected:
     //! Start a new level with the given name
-    virtual void newLevel(const std::string& name);
+    virtual void newLevel(const std::string& name) override;
 
     //! End the current level
-    virtual void endLevel();
+    virtual void endLevel() override;
 
 private:
     //! Get a const char * version of a string that will last at least as

--- a/include/core/CRapidXmlStatePersistInserter.h
+++ b/include/core/CRapidXmlStatePersistInserter.h
@@ -46,7 +46,7 @@ public:
     CRapidXmlStatePersistInserter(const std::string& rootName, const TStrStrMap& rootAttributes);
 
     //! Store a name/value
-    virtual void insertValue(const std::string& name, const std::string& value) override;
+    void insertValue(const std::string& name, const std::string& value) override;
 
     // Bring extra base class overloads into scope
     using CStatePersistInserter::insertValue;
@@ -59,10 +59,10 @@ public:
 
 protected:
     //! Start a new level with the given name
-    virtual void newLevel(const std::string& name) override;
+    void newLevel(const std::string& name) override;
 
     //! End the current level
-    virtual void endLevel() override;
+    void endLevel() override;
 
 private:
     //! Get a const char * version of a string that will last at least as

--- a/include/core/CXmlNodeWithChildren.h
+++ b/include/core/CXmlNodeWithChildren.h
@@ -51,7 +51,7 @@ public:
 
     CXmlNodeWithChildren(const CXmlNodeWithChildren& arg);
 
-    virtual ~CXmlNodeWithChildren() override;
+    ~CXmlNodeWithChildren() override;
 
     CXmlNodeWithChildren& operator=(const CXmlNodeWithChildren& rhs);
 
@@ -68,7 +68,7 @@ public:
     const TChildNodePVec& children() const;
 
     //! Debug dump of hierarchy
-    virtual std::string dump() const override;
+    std::string dump() const override;
     virtual std::string dump(size_t indent) const;
 
 private:

--- a/include/core/CXmlNodeWithChildren.h
+++ b/include/core/CXmlNodeWithChildren.h
@@ -51,7 +51,7 @@ public:
 
     CXmlNodeWithChildren(const CXmlNodeWithChildren& arg);
 
-    virtual ~CXmlNodeWithChildren();
+    virtual ~CXmlNodeWithChildren() override;
 
     CXmlNodeWithChildren& operator=(const CXmlNodeWithChildren& rhs);
 
@@ -68,7 +68,7 @@ public:
     const TChildNodePVec& children() const;
 
     //! Debug dump of hierarchy
-    virtual std::string dump() const;
+    virtual std::string dump() const override;
     virtual std::string dump(size_t indent) const;
 
 private:

--- a/include/core/CXmlParser.h
+++ b/include/core/CXmlParser.h
@@ -84,22 +84,22 @@ public:
 
 public:
     CXmlParser();
-    virtual ~CXmlParser() override;
+    ~CXmlParser() override;
 
     bool parseFile(const std::string& fileName);
 
     //! Parse XML stored in a string
-    virtual bool parseString(const std::string& xml) override;
+    bool parseString(const std::string& xml) override;
 
     //! Parse XML stored in a char buffer
-    virtual bool parseBuffer(const char* begin, size_t length) override;
+    bool parseBuffer(const char* begin, size_t length) override;
 
     //! Parse XML stored in a char buffer that may be modified by the
     //! parsing and will outlive this object
-    virtual bool parseBufferInSitu(char* begin, size_t length) override;
+    bool parseBufferInSitu(char* begin, size_t length) override;
 
     //! Return the root element name (empty string if not parsed yet)
-    virtual std::string rootElementName() const override;
+    std::string rootElementName() const override;
 
     //! Return result from an XPath expression, if the number of matches != 1
     //! return false.
@@ -144,7 +144,7 @@ public:
     void dumpToStdout() const;
 
     //! Dump the document to string
-    virtual std::string dumpToString() const override;
+    std::string dumpToString() const override;
 
     //! Convert a node hierarchy to XML.
     //! (This will escape the text correctly.)
@@ -181,30 +181,30 @@ public:
     //! This is much more efficient than making repeated calls to
     //! evalXPathExpression() to retrieve the entire contents of a parsed
     //! document.
-    virtual bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a pool to avoid XML node memory allocations where possible
-    virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
+                         CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a string cache to avoid string representation memory
     //! allocations where possible
-    virtual bool toNodeHierarchy(CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CStringCache& cache,
+                         CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use both a node pool and a string cache
-    virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
-                                 CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
+    bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
+                         CStringCache& cache,
+                         CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! Functions for navigating an XML document without converting it to a
     //! node hierarchy
-    virtual bool navigateRoot() override;
-    virtual bool navigateFirstChild() override;
-    virtual bool navigateNext() override;
-    virtual bool navigateParent() override;
-    virtual bool currentNodeName(std::string& name) override;
-    virtual bool currentNodeValue(std::string& value) override;
+    bool navigateRoot() override;
+    bool navigateFirstChild() override;
+    bool navigateNext() override;
+    bool navigateParent() override;
+    bool currentNodeName(std::string& name) override;
+    bool currentNodeValue(std::string& value) override;
 
     //! Set root name
     bool setRootNode(const std::string&);

--- a/include/core/CXmlParser.h
+++ b/include/core/CXmlParser.h
@@ -84,22 +84,22 @@ public:
 
 public:
     CXmlParser();
-    virtual ~CXmlParser();
+    virtual ~CXmlParser() override;
 
     bool parseFile(const std::string& fileName);
 
     //! Parse XML stored in a string
-    virtual bool parseString(const std::string& xml);
+    virtual bool parseString(const std::string& xml) override;
 
     //! Parse XML stored in a char buffer
-    virtual bool parseBuffer(const char* begin, size_t length);
+    virtual bool parseBuffer(const char* begin, size_t length) override;
 
     //! Parse XML stored in a char buffer that may be modified by the
     //! parsing and will outlive this object
-    virtual bool parseBufferInSitu(char* begin, size_t length);
+    virtual bool parseBufferInSitu(char* begin, size_t length) override;
 
     //! Return the root element name (empty string if not parsed yet)
-    virtual std::string rootElementName() const;
+    virtual std::string rootElementName() const override;
 
     //! Return result from an XPath expression, if the number of matches != 1
     //! return false.
@@ -144,7 +144,7 @@ public:
     void dumpToStdout() const;
 
     //! Dump the document to string
-    virtual std::string dumpToString() const;
+    virtual std::string dumpToString() const override;
 
     //! Convert a node hierarchy to XML.
     //! (This will escape the text correctly.)
@@ -181,30 +181,30 @@ public:
     //! This is much more efficient than making repeated calls to
     //! evalXPathExpression() to retrieve the entire contents of a parsed
     //! document.
-    virtual bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+    virtual bool toNodeHierarchy(CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a pool to avoid XML node memory allocations where possible
     virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use a string cache to avoid string representation memory
     //! allocations where possible
     virtual bool toNodeHierarchy(CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! As above, but use both a node pool and a string cache
     virtual bool toNodeHierarchy(CXmlNodeWithChildrenPool& pool,
                                  CStringCache& cache,
-                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const;
+                                 CXmlNodeWithChildren::TXmlNodeWithChildrenP& rootNodePtr) const override;
 
     //! Functions for navigating an XML document without converting it to a
     //! node hierarchy
-    virtual bool navigateRoot();
-    virtual bool navigateFirstChild();
-    virtual bool navigateNext();
-    virtual bool navigateParent();
-    virtual bool currentNodeName(std::string& name);
-    virtual bool currentNodeValue(std::string& value);
+    virtual bool navigateRoot() override;
+    virtual bool navigateFirstChild() override;
+    virtual bool navigateNext() override;
+    virtual bool navigateParent() override;
+    virtual bool currentNodeName(std::string& name) override;
+    virtual bool currentNodeValue(std::string& value) override;
 
     //! Set root name
     bool setRootNode(const std::string&);

--- a/include/maths/common/CConstantPrior.h
+++ b/include/maths/common/CConstantPrior.h
@@ -56,73 +56,76 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CConstantPrior* clone() const;
+    virtual CConstantPrior* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns false.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! No-op.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Returns zero.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Set the constant if it hasn't been set.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! No-op.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! All confidence intervals are the point [constant, constant].
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Returns a large value if all samples are equal to the constant
     //! and zero otherwise.
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Get \p numberSamples times the constant.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
     //! A large number if any sample is less than the constant and
     //! zero otherwise.
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! A large number if any sample is larger than the constant and
     //! zero otherwise.
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Returns one if all samples equal the constant and one otherwise.
     virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
@@ -130,37 +133,37 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    bool isNonInformative() const;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the marginal likelihood function.
-    virtual std::string printMarginalLikelihoodFunction(double weight = 1.0) const;
+    virtual std::string printMarginalLikelihoodFunction(double weight = 1.0) const override;
 
     //! Print the prior density function of the parameters.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the constant value.

--- a/include/maths/common/CConstantPrior.h
+++ b/include/maths/common/CConstantPrior.h
@@ -56,84 +56,79 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CConstantPrior* clone() const override;
+    CConstantPrior* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns false.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! No-op.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Returns zero.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Set the constant if it hasn't been set.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! No-op.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! All confidence intervals are the point [constant, constant].
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Returns a large value if all samples are equal to the constant
     //! and zero otherwise.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
 
     //! Get \p numberSamples times the constant.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
     //! A large number if any sample is less than the constant and
     //! zero otherwise.
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! A large number if any sample is larger than the constant and
     //! zero otherwise.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Returns one if all samples equal the constant and one otherwise.
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
     bool isNonInformative() const override;
@@ -142,28 +137,28 @@ public:
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the marginal likelihood function.
-    virtual std::string printMarginalLikelihoodFunction(double weight = 1.0) const override;
+    std::string printMarginalLikelihoodFunction(double weight = 1.0) const override;
 
     //! Print the prior density function of the parameters.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the constant value.

--- a/include/maths/common/CGammaRateConjugate.h
+++ b/include/maths/common/CGammaRateConjugate.h
@@ -113,24 +113,24 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CGammaRateConjugate* clone() const override;
+    CGammaRateConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Get the margin between the smallest value and the support left
     //! end. Priors with non-negative support, automatically adjust the
     //! offset if a value is seen which is smaller than offset + margin.
-    virtual double offsetMargin() const override;
+    double offsetMargin() const override;
 
     //! Returns true.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! Reset m_Offset so the smallest sample is not within some minimum
     //! offset of the support left end. Note that translating the mean of
@@ -143,19 +143,17 @@ public:
     //! \param[in] samples The samples from which to determine the offset.
     //! \param[in] weights The weights of each sample in \p samples.
     //! \return The penalty to apply in model selection.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Update the prior with a collection of independent samples from the
     //! gamma variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -165,21 +163,19 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -193,7 +189,7 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
@@ -205,7 +201,7 @@ public:
     //! \param[out] result Filled in with the joint likelihood of \p samples.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
@@ -217,8 +213,7 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -249,10 +244,10 @@ public:
     //! \f$(0,\infty)\f$, i.e. a value of zero is not well defined and
     //! a value of infinity is not well handled. (Very large values are
     //! handled though.)
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -260,10 +255,10 @@ public:
     //! can return is the minimum double rather than epsilon.
     //!
     //! \see minusLogJointCdf for more details.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -282,41 +277,41 @@ public:
     //! \warning The variance scales must be in the range \f$(0,\infty)\f$,
     //! i.e. a value of zero is not well defined and a value of infinity
     //! is not well handled. (Very large values are handled though.)
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the current estimate of the likelihood shape.
@@ -363,7 +358,7 @@ private:
     bool isBad() const;
 
     //! Full debug dump of the state of this prior.
-    virtual std::string debug() const override;
+    std::string debug() const override;
 
 private:
     //! The shape parameter of a non-informative prior.

--- a/include/maths/common/CGammaRateConjugate.h
+++ b/include/maths/common/CGammaRateConjugate.h
@@ -113,24 +113,24 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CGammaRateConjugate* clone() const;
+    virtual CGammaRateConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Get the margin between the smallest value and the support left
     //! end. Priors with non-negative support, automatically adjust the
     //! offset if a value is seen which is smaller than offset + margin.
-    virtual double offsetMargin() const;
+    virtual double offsetMargin() const override;
 
     //! Returns true.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! Reset m_Offset so the smallest sample is not within some minimum
     //! offset of the support left end. Note that translating the mean of
@@ -144,17 +144,18 @@ public:
     //! \param[in] weights The weights of each sample in \p samples.
     //! \return The penalty to apply in model selection.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Update the prior with a collection of independent samples from the
     //! gamma variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -164,20 +165,21 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -191,9 +193,9 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the gamma rate.
@@ -206,7 +208,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -215,7 +217,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -249,7 +252,7 @@ public:
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -260,7 +263,7 @@ public:
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -284,36 +287,36 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the current estimate of the likelihood shape.
@@ -340,7 +343,7 @@ private:
 private:
     //! Generate statistics - mean and standard deviation - that are useful in providing a description of this prior
     //! \return A pair of strings containing representations of the marginal likelihood mean and standard deviation
-    TStrStrPr doPrintMarginalLikelihoodStatistics() const;
+    TStrStrPr doPrintMarginalLikelihoodStatistics() const override;
 
     //! Read parameters from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
@@ -360,7 +363,7 @@ private:
     bool isBad() const;
 
     //! Full debug dump of the state of this prior.
-    virtual std::string debug() const;
+    virtual std::string debug() const override;
 
 private:
     //! The shape parameter of a non-informative prior.

--- a/include/maths/common/CGradientDescent.h
+++ b/include/maths/common/CGradientDescent.h
@@ -58,7 +58,7 @@ public:
     public:
         CEmpiricalCentralGradient(const CFunction& f, double eps);
 
-        virtual bool operator()(const TVector& x, TVector& result) const;
+        virtual bool operator()(const TVector& x, TVector& result) const override;
 
     private:
         //! The shift used to get the offset points.

--- a/include/maths/common/CGradientDescent.h
+++ b/include/maths/common/CGradientDescent.h
@@ -58,7 +58,7 @@ public:
     public:
         CEmpiricalCentralGradient(const CFunction& f, double eps);
 
-        virtual bool operator()(const TVector& x, TVector& result) const override;
+        bool operator()(const TVector& x, TVector& result) const override;
 
     private:
         //! The shift used to get the offset points.

--- a/include/maths/common/CLogNormalMeanPrecConjugate.h
+++ b/include/maths/common/CLogNormalMeanPrecConjugate.h
@@ -115,24 +115,24 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CLogNormalMeanPrecConjugate* clone() const;
+    virtual CLogNormalMeanPrecConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Get the margin between the smallest value and the support left
     //! end. Priors with non-negative support, automatically adjust the
     //! offset if a value is seen which is smaller than offset + margin.
-    virtual double offsetMargin() const;
+    virtual double offsetMargin() const override;
 
     //! Returns true.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! Reset m_Offset so the smallest sample is not within some minimum
     //! offset of the support left end. Note that translating the mean of
@@ -147,17 +147,18 @@ public:
     //! \param[in] weights The weights of each sample in \p samples.
     //! \return The penalty to apply in model selection.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Update the prior with a collection of independent samples from
     //! the log-normal variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -167,20 +168,21 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -194,9 +196,9 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the exponentiated normal mean
@@ -210,7 +212,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -219,7 +221,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -260,7 +263,7 @@ public:
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -271,7 +274,7 @@ public:
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -295,36 +298,36 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the current expected mean for the exponentiated normal.
@@ -369,7 +372,7 @@ public:
 private:
     //! Generate statistics - mean and standard deviation - that are useful in providing a description of this prior
     //! \return A pair of strings containing representations of the marginal likelihood mean and standard deviation
-    CPrior::TStrStrPr doPrintMarginalLikelihoodStatistics() const;
+    CPrior::TStrStrPr doPrintMarginalLikelihoodStatistics() const override;
 
     //! Read parameters from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
@@ -381,7 +384,7 @@ private:
     bool isBad() const;
 
     //! Full debug dump of the state of this prior.
-    virtual std::string debug() const;
+    virtual std::string debug() const override;
 
 private:
     //! The mean parameter of a non-informative prior.

--- a/include/maths/common/CLogNormalMeanPrecConjugate.h
+++ b/include/maths/common/CLogNormalMeanPrecConjugate.h
@@ -115,24 +115,24 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CLogNormalMeanPrecConjugate* clone() const override;
+    CLogNormalMeanPrecConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Get the margin between the smallest value and the support left
     //! end. Priors with non-negative support, automatically adjust the
     //! offset if a value is seen which is smaller than offset + margin.
-    virtual double offsetMargin() const override;
+    double offsetMargin() const override;
 
     //! Returns true.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! Reset m_Offset so the smallest sample is not within some minimum
     //! offset of the support left end. Note that translating the mean of
@@ -146,19 +146,17 @@ public:
     //! \param[in] samples The samples from which to determine the offset.
     //! \param[in] weights The weights of each sample in \p samples.
     //! \return The penalty to apply in model selection.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Update the prior with a collection of independent samples from
     //! the log-normal variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -168,21 +166,19 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -196,7 +192,7 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
@@ -209,7 +205,7 @@ public:
     //! \param[out] result Filled in with the joint likelihood of \p samples.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
@@ -221,8 +217,7 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -260,10 +255,10 @@ public:
     //! \f$(0,\infty)\f$, i.e. a value of zero is not well defined and
     //! a value of infinity is not well handled. The approximations we
     //! make are less good for \f$\gamma_i\f$ a long way from one.
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -271,10 +266,10 @@ public:
     //! can return is the minimum double rather than epsilon.
     //!
     //! \see minusLogJointCdf for more details.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -293,41 +288,41 @@ public:
     //! \warning The variance scales must be in the range \f$(0,\infty)\f$,
     //! i.e. a value of zero is not well defined and a value of infinity
     //! is not well handled. (Very large values are handled though.)
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the current expected mean for the exponentiated normal.
@@ -384,7 +379,7 @@ private:
     bool isBad() const;
 
     //! Full debug dump of the state of this prior.
-    virtual std::string debug() const override;
+    std::string debug() const override;
 
 private:
     //! The mean parameter of a non-informative prior.

--- a/include/maths/common/CModel.h
+++ b/include/maths/common/CModel.h
@@ -608,7 +608,7 @@ public:
     maths_t::EDataType dataType() const override;
 
     //! Returns false
-    bool shouldPersist() const override;
+    virtual bool shouldPersist() const override;
 };
 }
 }

--- a/include/maths/common/CModel.h
+++ b/include/maths/common/CModel.h
@@ -608,7 +608,7 @@ public:
     maths_t::EDataType dataType() const override;
 
     //! Returns false
-    virtual bool shouldPersist() const override;
+    bool shouldPersist() const override;
 };
 }
 }

--- a/include/maths/common/CMultimodalPrior.h
+++ b/include/maths/common/CMultimodalPrior.h
@@ -108,41 +108,42 @@ public:
     //! \name Prior Contract.
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CMultimodalPrior* clone() const;
+    virtual CMultimodalPrior* clone() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value);
+    virtual void dataType(maths_t::EDataType value) override;
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value);
+    virtual void decayRate(double value) override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Check if any of the modes needs an offset to be applied.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! Forward the offset to the mode priors.
     //!
     //! \return The penalty to apply in model selection.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Update the prior with a collection of independent samples from
     //! the variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -151,27 +152,28 @@ public:
     //! constructor).
     //!
     //! \param[in] time The time increment to apply.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Get the nearest mean of the multimodal prior marginal likelihood.
-    virtual double nearestMarginalLikelihoodMean(double value) const;
+    virtual double nearestMarginalLikelihoodMean(double value) const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the local maxima of the marginal likelihood function.
     virtual TDouble1Vec
-    marginalLikelihoodModes(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodModes(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -185,9 +187,9 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the mode parameters and summing
@@ -201,7 +203,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -210,7 +212,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -228,7 +231,7 @@ public:
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -239,7 +242,7 @@ public:
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -263,36 +266,36 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component.
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the current number of modes.
@@ -339,12 +342,12 @@ private:
     void checkRestoredInvariants() const;
 
     //! We should only use this prior when it has multiple modes.
-    virtual bool participatesInModelSelection() const;
+    virtual bool participatesInModelSelection() const override;
 
     //! Get the number of nuisance parameters in the marginal likelihood.
     //!
     //! This is just number modes - 1 due to the normalization constraint.
-    virtual double unmarginalizedParameters() const;
+    virtual double unmarginalizedParameters() const override;
 
     //! Implementation of log of the joint c.d.f. of the marginal likelihood.
     template<typename CDF>

--- a/include/maths/common/CMultimodalPrior.h
+++ b/include/maths/common/CMultimodalPrior.h
@@ -108,42 +108,40 @@ public:
     //! \name Prior Contract.
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CMultimodalPrior* clone() const override;
+    CMultimodalPrior* clone() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value) override;
+    void dataType(maths_t::EDataType value) override;
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value) override;
+    void decayRate(double value) override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Check if any of the modes needs an offset to be applied.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! Forward the offset to the mode priors.
     //!
     //! \return The penalty to apply in model selection.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Update the prior with a collection of independent samples from
     //! the variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -152,28 +150,25 @@ public:
     //! constructor).
     //!
     //! \param[in] time The time increment to apply.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Get the nearest mean of the multimodal prior marginal likelihood.
-    virtual double nearestMarginalLikelihoodMean(double value) const override;
+    double nearestMarginalLikelihoodMean(double value) const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the local maxima of the marginal likelihood function.
-    virtual TDouble1Vec
-    marginalLikelihoodModes(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    TDouble1Vec marginalLikelihoodModes(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -187,7 +182,7 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
@@ -200,7 +195,7 @@ public:
     //! \param[out] result Filled in with the joint likelihood of \p samples.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
@@ -212,8 +207,7 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -228,10 +222,10 @@ public:
     //! \f$(0,\infty)\f$, i.e. a value of zero is not well defined and
     //! a value of infinity is not well handled. (Very large values are
     //! handled though.)
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -239,10 +233,10 @@ public:
     //! can return is the minimum double rather than epsilon.
     //!
     //! \see minusLogJointCdf for more details.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -261,41 +255,41 @@ public:
     //! \warning The variance scales must be in the range \f$(0,\infty)\f$,
     //! i.e. a value of zero is not well defined and a value of infinity is
     //! not well handled. (Very large values are handled though.)
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual std::uint64_t checksum(std::uint64_t seed = 0) const override;
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component.
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Get the current number of modes.
@@ -342,12 +336,12 @@ private:
     void checkRestoredInvariants() const;
 
     //! We should only use this prior when it has multiple modes.
-    virtual bool participatesInModelSelection() const override;
+    bool participatesInModelSelection() const override;
 
     //! Get the number of nuisance parameters in the marginal likelihood.
     //!
     //! This is just number modes - 1 due to the normalization constraint.
-    virtual double unmarginalizedParameters() const override;
+    double unmarginalizedParameters() const override;
 
     //! Implementation of log of the joint c.d.f. of the marginal likelihood.
     template<typename CDF>

--- a/include/maths/common/CMultinomialConjugate.h
+++ b/include/maths/common/CMultinomialConjugate.h
@@ -89,33 +89,34 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CMultinomialConjugate* clone() const;
+    virtual CMultinomialConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns false.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! No-op.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Returns zero.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Update the prior with a collection of independent samples from the
     //! multinomial variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
-    //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    //! \param[in] weights The weights of each sample in \p samples override.
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -125,20 +126,21 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -153,9 +155,9 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Ignored.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the category probability parameters.
@@ -171,7 +173,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -182,7 +184,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint cumulative density function
     //! of the marginal likelihood at \p samples.
@@ -201,7 +204,7 @@ public:
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint cumulative density
     //! function of the marginal likelihood at \p samples without losing
@@ -213,7 +216,7 @@ public:
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -238,41 +241,41 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the marginal likelihood function in a specified format.
     //!
     //! \see CPrior::printMarginalLikelihoodFunction for details.
-    virtual std::string printMarginalLikelihoodFunction(double weight = 1.0) const;
+    virtual std::string printMarginalLikelihoodFunction(double weight = 1.0) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Remove the categories in \p categoriesToRemove.

--- a/include/maths/common/CMultinomialConjugate.h
+++ b/include/maths/common/CMultinomialConjugate.h
@@ -89,34 +89,32 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CMultinomialConjugate* clone() const override;
+    CMultinomialConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns false.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! No-op.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Returns zero.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Update the prior with a collection of independent samples from the
     //! multinomial variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples override.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -126,21 +124,19 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -155,7 +151,7 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Ignored.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
@@ -170,7 +166,7 @@ public:
     //! the model collection, so this is appropriate.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
@@ -184,8 +180,7 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint cumulative density function
     //! of the marginal likelihood at \p samples.
@@ -201,10 +196,10 @@ public:
     //! the c.d.f. and \f$\{x_i\}\f$ are the samples. Otherwise, it is
     //! filled in with a sharp upper bound.
     //! \note The samples are assumed to be independent.
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint cumulative density
     //! function of the marginal likelihood at \p samples without losing
@@ -213,10 +208,10 @@ public:
     //! epsilon.
     //!
     //! \see minusLogJointCdf for more details.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -236,46 +231,46 @@ public:
     //! \param[out] tail The tail that (left or right) that all the samples
     //! are in or neither.
     //! \note The samples are assumed to be independent.
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the marginal likelihood function in a specified format.
     //!
     //! \see CPrior::printMarginalLikelihoodFunction for details.
-    virtual std::string printMarginalLikelihoodFunction(double weight = 1.0) const override;
+    std::string printMarginalLikelihoodFunction(double weight = 1.0) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Remove the categories in \p categoriesToRemove.

--- a/include/maths/common/CMultivariateConstantPrior.h
+++ b/include/maths/common/CMultivariateConstantPrior.h
@@ -60,58 +60,58 @@ public:
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CMultivariateConstantPrior* clone() const override;
+    CMultivariateConstantPrior* clone() const override;
 
     //! Get the dimension of the prior.
-    virtual std::size_t dimension() const override;
+    std::size_t dimension() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! No-op.
-    virtual void adjustOffset(const TDouble10Vec1Vec& samples,
-                              const TDouble10VecWeightsAry1Vec& weights) override;
+    void adjustOffset(const TDouble10Vec1Vec& samples,
+                      const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! Set the constant if it hasn't been set.
-    virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble10Vec1Vec& samples,
+                    const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! No-op.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the corresponding constant univariate prior.
-    virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override;
+    TUnivariatePriorPtrDoublePr univariate(const TSize10Vec& marginalize,
+                                           const TSizeDoublePr10Vec& condition) const override;
 
     //! Compute the bivariate const bivariate prior.
-    virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const override;
+    TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
+                                const TSizeDoublePr10Vec& condition) const override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override;
+    TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual TDouble10Vec marginalLikelihoodMean() const override;
+    TDouble10Vec marginalLikelihoodMean() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const override;
+    TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const override;
 
     //! Get the covariance matrix of the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override;
+    TDouble10Vec10Vec marginalLikelihoodCovariance() const override;
 
     //! Get the diagonal of the covariance matrix of the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const override;
+    TDouble10Vec marginalLikelihoodVariances() const override;
 
     //! Returns a large value if all samples are equal to the constant
     //! and zero otherwise.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
                                double& result) const override;
 
     //! Get \p numberSamples times the constant.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples,
+                                  TDouble10Vec1Vec& samples) const override;
 
     //! Check if this is a non-informative prior.
     bool isNonInformative() const override;
@@ -120,25 +120,25 @@ public:
     //!
     //! \param[in] separator String used to separate priors.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const override;
+    void print(const std::string& separator, std::string& result) const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const override;
+    std::string persistenceTag() const override;
     //@}
 
     //! Get the constant value.

--- a/include/maths/common/CMultivariateConstantPrior.h
+++ b/include/maths/common/CMultivariateConstantPrior.h
@@ -60,85 +60,85 @@ public:
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CMultivariateConstantPrior* clone() const;
+    virtual CMultivariateConstantPrior* clone() const override;
 
     //! Get the dimension of the prior.
-    virtual std::size_t dimension() const;
+    virtual std::size_t dimension() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! No-op.
     virtual void adjustOffset(const TDouble10Vec1Vec& samples,
-                              const TDouble10VecWeightsAry1Vec& weights);
+                              const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! Set the constant if it hasn't been set.
     virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights);
+                            const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! No-op.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the corresponding constant univariate prior.
     virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const;
+    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override;
 
     //! Compute the bivariate const bivariate prior.
     virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const;
+                                        const TSizeDoublePr10Vec& condition) const override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const;
+    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual TDouble10Vec marginalLikelihoodMean() const;
+    virtual TDouble10Vec marginalLikelihoodMean() const override;
 
     //! Returns constant or zero if unset (by equidistribution).
-    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const;
+    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const override;
 
     //! Get the covariance matrix of the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const;
+    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override;
 
     //! Get the diagonal of the covariance matrix of the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const;
+    virtual TDouble10Vec marginalLikelihoodVariances() const override;
 
     //! Returns a large value if all samples are equal to the constant
     //! and zero otherwise.
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Get \p numberSamples times the constant.
     virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const;
+                                          TDouble10Vec1Vec& samples) const override;
 
     //! Check if this is a non-informative prior.
-    bool isNonInformative() const;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] separator String used to separate priors.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const;
+    virtual void print(const std::string& separator, std::string& result) const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const;
+    virtual std::string persistenceTag() const override;
     //@}
 
     //! Get the constant value.

--- a/include/maths/common/CMultivariateMultimodalPrior.h
+++ b/include/maths/common/CMultivariateMultimodalPrior.h
@@ -240,15 +240,15 @@ public:
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CMultivariatePrior* clone() const {
+    virtual CMultivariatePrior* clone() const override {
         return new CMultivariateMultimodalPrior(*this);
     }
 
     //! Get the dimension of the prior.
-    virtual std::size_t dimension() const { return N; }
+    virtual std::size_t dimension() const override { return N; }
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value) {
+    virtual void dataType(maths_t::EDataType value) override {
         this->CMultivariatePrior::dataType(value);
         m_Clusterer->dataType(value);
         for (const auto& mode : m_Modes) {
@@ -257,7 +257,7 @@ public:
     }
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value) {
+    virtual void decayRate(double value) override {
         this->CMultivariatePrior::decayRate(value);
         m_Clusterer->decayRate(this->decayRate());
         for (const auto& mode : m_Modes) {
@@ -267,7 +267,7 @@ public:
     }
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double /*offset*/, double decayRate) {
+    virtual void setToNonInformative(double /*offset*/, double decayRate) override {
         m_Clusterer->clear();
         m_Modes.clear();
         this->decayRate(decayRate);
@@ -280,7 +280,7 @@ public:
     //! \param[in] samples The samples from which to determine the offset.
     //! \param[in] weights The weights of each sample in \p samples.
     virtual void adjustOffset(const TDouble10Vec1Vec& samples,
-                              const TDouble10VecWeightsAry1Vec& weights) {
+                              const TDouble10VecWeightsAry1Vec& weights) override {
         // This has to adjust offsets for its modes because it must be
         // possible to call jointLogMarginalLikelihood before the samples
         // have been added to the prior in order for model selection to
@@ -296,7 +296,7 @@ public:
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
     virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights) {
+                            const TDouble10VecWeightsAry1Vec& weights) override {
         if (samples.empty()) {
             return;
         }
@@ -375,7 +375,7 @@ public:
     }
 
     //! Update the prior for the specified elapsed time.
-    virtual void propagateForwardsByTime(double time) {
+    virtual void propagateForwardsByTime(double time) override {
         if (CMathsFuncs::isFinite(time) == false || time < 0.0) {
             LOG_ERROR(<< "Bad propagation time " << time);
             return;
@@ -426,7 +426,7 @@ public:
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
     virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const {
+    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override {
         std::size_t n = m_Modes.size();
 
         CMultimodalPrior::TPriorPtrVec modes;
@@ -474,7 +474,7 @@ public:
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
     virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const {
+                                        const TSizeDoublePr10Vec& condition) const override {
         if (N == 2) {
             return {TPriorPtr(this->clone()), 0.0};
         }
@@ -514,7 +514,7 @@ public:
     }
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const {
+    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override {
         if (m_Modes.size() == 0) {
             return {TPoint::smallest().template toVector<TDouble10Vec>(),
                     TPoint::largest().template toVector<TDouble10Vec>()};
@@ -538,7 +538,7 @@ public:
     }
 
     //! Get the mean of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMean() const {
+    virtual TDouble10Vec marginalLikelihoodMean() const override {
         if (m_Modes.size() == 0) {
             return TDouble10Vec(N, 0.0);
         }
@@ -550,7 +550,7 @@ public:
 
     //! Get the nearest mean of the multimodal prior marginal likelihood,
     //! otherwise the marginal likelihood mean.
-    virtual TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value_) const {
+    virtual TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value_) const override {
         if (m_Modes.empty()) {
             return TDouble10Vec(N, 0.0);
         }
@@ -575,7 +575,7 @@ public:
     }
 
     //! Get the mode of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weight) const {
+    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weight) const override {
 
         if (m_Modes.size() == 0) {
             return TDouble10Vec(N, 0.0);
@@ -617,7 +617,7 @@ public:
     }
 
     //! Get the local maxima of the marginal likelihood functions.
-    TDouble10Vec1Vec marginalLikelihoodModes(const TDouble10VecWeightsAry& weights) const {
+    TDouble10Vec1Vec marginalLikelihoodModes(const TDouble10VecWeightsAry& weights) const override {
         TDouble10Vec1Vec result;
         result.reserve(m_Modes.size());
         for (const auto& mode : m_Modes) {
@@ -627,7 +627,7 @@ public:
     }
 
     //! Get the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const {
+    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override {
         if (m_Modes.size() == 0) {
             return TPoint::largest().asDiagonal().template toVectors<TDouble10Vec10Vec>();
         }
@@ -638,7 +638,7 @@ public:
     }
 
     //! Get the diagonal of the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const {
+    virtual TDouble10Vec marginalLikelihoodVariances() const override {
         if (m_Modes.size() == 0) {
             return TPoint::largest().template toVector<TDouble10Vec>();
         }
@@ -657,7 +657,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
-                               double& result) const {
+                               double& result) const override {
         result = 0.0;
 
         if (samples.empty()) {
@@ -767,7 +767,7 @@ public:
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
     virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const {
+                                          TDouble10Vec1Vec& samples) const override {
         namespace detail = multivariate_multimodal_prior_detail;
 
         samples.clear();
@@ -780,7 +780,7 @@ public:
     }
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const {
+    virtual bool isNonInformative() const override {
         return m_Modes.empty() ||
                (m_Modes.size() == 1 && m_Modes[0].s_Prior->isNonInformative());
     }
@@ -789,7 +789,7 @@ public:
     //!
     //! \param[in] separator String used to separate priors.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const {
+    virtual void print(const std::string& separator, std::string& result) const override {
         namespace detail = multivariate_multimodal_prior_detail;
         result += "\n" + separator + " multivariate multimodal";
         if (this->isNonInformative()) {
@@ -801,7 +801,7 @@ public:
     }
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const {
+    virtual uint64_t checksum(uint64_t seed = 0) const override {
         seed = this->CMultivariatePrior::checksum(seed);
         seed = CChecksum::calculate(seed, m_Clusterer);
         seed = CChecksum::calculate(seed, m_SeedPrior);
@@ -809,7 +809,7 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CMultivariateMultimodalPrior");
         core::CMemoryDebug::dynamicSize("m_Clusterer", m_Clusterer, mem);
         core::CMemoryDebug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);
@@ -817,7 +817,7 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const {
+    virtual std::size_t memoryUsage() const override {
         std::size_t mem = core::CMemory::dynamicSize(m_Clusterer);
         mem += core::CMemory::dynamicSize(m_SeedPrior);
         mem += core::CMemory::dynamicSize(m_Modes);
@@ -825,15 +825,15 @@ public:
     }
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const { return sizeof(*this); }
+    virtual std::size_t staticSize() const override { return sizeof(*this); }
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const {
+    virtual std::string persistenceTag() const override {
         return MULTIMODAL_TAG + core::CStringUtils::typeToString(N);
     }
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
         inserter.insertLevel(CLUSTERER_TAG, std::bind<void>(CClustererStateSerialiser(),
                                                             std::cref(*m_Clusterer),
                                                             std::placeholders::_1));
@@ -1051,14 +1051,14 @@ private:
     }
 
     //! We should only use this prior when it has multiple modes.
-    virtual bool participatesInModelSelection() const {
+    virtual bool participatesInModelSelection() const override {
         return m_Modes.size() > 1;
     }
 
     //! Get the number of nuisance parameters in the marginal likelihood.
     //!
     //! This is just number modes - 1 due to the normalization constraint.
-    virtual double unmarginalizedParameters() const {
+    virtual double unmarginalizedParameters() const override {
         return std::max(static_cast<double>(m_Modes.size()), 1.0) - 1.0;
     }
 

--- a/include/maths/common/CMultivariateMultimodalPrior.h
+++ b/include/maths/common/CMultivariateMultimodalPrior.h
@@ -240,15 +240,15 @@ public:
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CMultivariatePrior* clone() const override {
+    CMultivariatePrior* clone() const override {
         return new CMultivariateMultimodalPrior(*this);
     }
 
     //! Get the dimension of the prior.
-    virtual std::size_t dimension() const override { return N; }
+    std::size_t dimension() const override { return N; }
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value) override {
+    void dataType(maths_t::EDataType value) override {
         this->CMultivariatePrior::dataType(value);
         m_Clusterer->dataType(value);
         for (const auto& mode : m_Modes) {
@@ -257,7 +257,7 @@ public:
     }
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value) override {
+    void decayRate(double value) override {
         this->CMultivariatePrior::decayRate(value);
         m_Clusterer->decayRate(this->decayRate());
         for (const auto& mode : m_Modes) {
@@ -267,7 +267,7 @@ public:
     }
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double /*offset*/, double decayRate) override {
+    void setToNonInformative(double /*offset*/, double decayRate) override {
         m_Clusterer->clear();
         m_Modes.clear();
         this->decayRate(decayRate);
@@ -279,8 +279,8 @@ public:
     //!
     //! \param[in] samples The samples from which to determine the offset.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void adjustOffset(const TDouble10Vec1Vec& samples,
-                              const TDouble10VecWeightsAry1Vec& weights) override {
+    void adjustOffset(const TDouble10Vec1Vec& samples,
+                      const TDouble10VecWeightsAry1Vec& weights) override {
         // This has to adjust offsets for its modes because it must be
         // possible to call jointLogMarginalLikelihood before the samples
         // have been added to the prior in order for model selection to
@@ -295,8 +295,8 @@ public:
     //!
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights) override {
+    void addSamples(const TDouble10Vec1Vec& samples,
+                    const TDouble10VecWeightsAry1Vec& weights) override {
         if (samples.empty()) {
             return;
         }
@@ -375,7 +375,7 @@ public:
     }
 
     //! Update the prior for the specified elapsed time.
-    virtual void propagateForwardsByTime(double time) override {
+    void propagateForwardsByTime(double time) override {
         if (CMathsFuncs::isFinite(time) == false || time < 0.0) {
             LOG_ERROR(<< "Bad propagation time " << time);
             return;
@@ -425,8 +425,8 @@ public:
     //! \note The caller must specify dimension - 1 variables between
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
-    virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override {
+    TUnivariatePriorPtrDoublePr univariate(const TSize10Vec& marginalize,
+                                           const TSizeDoublePr10Vec& condition) const override {
         std::size_t n = m_Modes.size();
 
         CMultimodalPrior::TPriorPtrVec modes;
@@ -473,8 +473,8 @@ public:
     //! \note The caller must specify dimension - 2 variables between
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
-    virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const override {
+    TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
+                                const TSizeDoublePr10Vec& condition) const override {
         if (N == 2) {
             return {TPriorPtr(this->clone()), 0.0};
         }
@@ -514,7 +514,7 @@ public:
     }
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override {
+    TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override {
         if (m_Modes.size() == 0) {
             return {TPoint::smallest().template toVector<TDouble10Vec>(),
                     TPoint::largest().template toVector<TDouble10Vec>()};
@@ -538,7 +538,7 @@ public:
     }
 
     //! Get the mean of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMean() const override {
+    TDouble10Vec marginalLikelihoodMean() const override {
         if (m_Modes.size() == 0) {
             return TDouble10Vec(N, 0.0);
         }
@@ -550,7 +550,7 @@ public:
 
     //! Get the nearest mean of the multimodal prior marginal likelihood,
     //! otherwise the marginal likelihood mean.
-    virtual TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value_) const override {
+    TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value_) const override {
         if (m_Modes.empty()) {
             return TDouble10Vec(N, 0.0);
         }
@@ -575,7 +575,7 @@ public:
     }
 
     //! Get the mode of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weight) const override {
+    TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weight) const override {
 
         if (m_Modes.size() == 0) {
             return TDouble10Vec(N, 0.0);
@@ -627,7 +627,7 @@ public:
     }
 
     //! Get the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override {
+    TDouble10Vec10Vec marginalLikelihoodCovariance() const override {
         if (m_Modes.size() == 0) {
             return TPoint::largest().asDiagonal().template toVectors<TDouble10Vec10Vec>();
         }
@@ -638,7 +638,7 @@ public:
     }
 
     //! Get the diagonal of the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const override {
+    TDouble10Vec marginalLikelihoodVariances() const override {
         if (m_Modes.size() == 0) {
             return TPoint::largest().template toVector<TDouble10Vec>();
         }
@@ -654,7 +654,7 @@ public:
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
     //! \param[out] result Filled in with the joint likelihood of \p samples.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
                                double& result) const override {
@@ -766,8 +766,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const override {
+    void sampleMarginalLikelihood(std::size_t numberSamples,
+                                  TDouble10Vec1Vec& samples) const override {
         namespace detail = multivariate_multimodal_prior_detail;
 
         samples.clear();
@@ -780,7 +780,7 @@ public:
     }
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override {
+    bool isNonInformative() const override {
         return m_Modes.empty() ||
                (m_Modes.size() == 1 && m_Modes[0].s_Prior->isNonInformative());
     }
@@ -789,7 +789,7 @@ public:
     //!
     //! \param[in] separator String used to separate priors.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const override {
+    void print(const std::string& separator, std::string& result) const override {
         namespace detail = multivariate_multimodal_prior_detail;
         result += "\n" + separator + " multivariate multimodal";
         if (this->isNonInformative()) {
@@ -801,7 +801,7 @@ public:
     }
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override {
+    uint64_t checksum(uint64_t seed = 0) const override {
         seed = this->CMultivariatePrior::checksum(seed);
         seed = CChecksum::calculate(seed, m_Clusterer);
         seed = CChecksum::calculate(seed, m_SeedPrior);
@@ -809,7 +809,7 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CMultivariateMultimodalPrior");
         core::CMemoryDebug::dynamicSize("m_Clusterer", m_Clusterer, mem);
         core::CMemoryDebug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);
@@ -817,7 +817,7 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override {
+    std::size_t memoryUsage() const override {
         std::size_t mem = core::CMemory::dynamicSize(m_Clusterer);
         mem += core::CMemory::dynamicSize(m_SeedPrior);
         mem += core::CMemory::dynamicSize(m_Modes);
@@ -825,15 +825,15 @@ public:
     }
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override { return sizeof(*this); }
+    std::size_t staticSize() const override { return sizeof(*this); }
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const override {
+    std::string persistenceTag() const override {
         return MULTIMODAL_TAG + core::CStringUtils::typeToString(N);
     }
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
         inserter.insertLevel(CLUSTERER_TAG, std::bind<void>(CClustererStateSerialiser(),
                                                             std::cref(*m_Clusterer),
                                                             std::placeholders::_1));
@@ -1051,14 +1051,14 @@ private:
     }
 
     //! We should only use this prior when it has multiple modes.
-    virtual bool participatesInModelSelection() const override {
+    bool participatesInModelSelection() const override {
         return m_Modes.size() > 1;
     }
 
     //! Get the number of nuisance parameters in the marginal likelihood.
     //!
     //! This is just number modes - 1 due to the normalization constraint.
-    virtual double unmarginalizedParameters() const override {
+    double unmarginalizedParameters() const override {
         return std::max(static_cast<double>(m_Modes.size()), 1.0) - 1.0;
     }
 

--- a/include/maths/common/CMultivariateNormalConjugate.h
+++ b/include/maths/common/CMultivariateNormalConjugate.h
@@ -149,7 +149,7 @@ public:
                                              this, std::placeholders::_1));
     }
 
-    virtual ~CMultivariateNormalConjugate() {}
+    virtual ~CMultivariateNormalConjugate() override {}
 
     // Default copy constructor and assignment operator work.
 
@@ -172,21 +172,21 @@ public:
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CMultivariateNormalConjugate* clone() const {
+    virtual CMultivariateNormalConjugate* clone() const override {
         return new CMultivariateNormalConjugate(*this);
     }
 
     //! Get the dimension of the prior.
-    std::size_t dimension() const { return N; }
+    std::size_t dimension() const override { return N; }
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double /*offset = 0.0*/, double decayRate = 0.0) {
+    virtual void setToNonInformative(double /*offset = 0.0*/, double decayRate = 0.0) override {
         *this = nonInformativePrior(this->dataType(), decayRate);
     }
 
     //! No-op.
     virtual void adjustOffset(const TDouble10Vec1Vec& /*samples*/,
-                              const TDouble10VecWeightsAry1Vec& /*weights*/) {}
+                              const TDouble10VecWeightsAry1Vec& /*weights*/) override {}
 
     //! Update the prior with a collection of independent samples from the
     //! process.
@@ -194,7 +194,7 @@ public:
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
     virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights) {
+                            const TDouble10VecWeightsAry1Vec& weights) override {
         if (samples.empty()) {
             return;
         }
@@ -296,7 +296,7 @@ public:
     }
 
     //! Update the prior for the specified elapsed time.
-    virtual void propagateForwardsByTime(double time) {
+    virtual void propagateForwardsByTime(double time) override {
         if (!CMathsFuncs::isFinite(time) || time < 0.0) {
             LOG_ERROR(<< "Bad propagation time " << time);
             return;
@@ -352,7 +352,7 @@ public:
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
     virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const {
+    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override {
         if (!this->check(marginalize, condition)) {
             return {};
         }
@@ -437,7 +437,7 @@ public:
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
     virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const {
+                                        const TSizeDoublePr10Vec& condition) const override {
         if (N == 2) {
             return {TPriorPtr(this->clone()), 0.0};
         }
@@ -522,28 +522,29 @@ public:
     }
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const {
+    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override {
         return {TPoint::smallest().template toVector<TDouble10Vec>(),
                 TPoint::largest().template toVector<TDouble10Vec>()};
     }
 
     //! Get the mean of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMean() const {
+    virtual TDouble10Vec marginalLikelihoodMean() const override {
         return this->mean().template toVector<TDouble10Vec>();
     }
 
     //! Get the mode of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& /*weights*/) const {
+    virtual TDouble10Vec
+    marginalLikelihoodMode(const TDouble10VecWeightsAry& /*weights*/) const override {
         return this->marginalLikelihoodMean();
     }
 
     //! Get the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const {
+    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override {
         return this->covarianceMatrix().template toVectors<TDouble10Vec10Vec>();
     }
 
     //! Get the diagonal of the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const {
+    virtual TDouble10Vec marginalLikelihoodVariances() const override {
         return this->covarianceMatrix().template diagonal<TDouble10Vec>();
     }
 
@@ -556,7 +557,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
-                               double& result) const {
+                               double& result) const override {
         result = 0.0;
 
         if (samples.empty()) {
@@ -656,7 +657,7 @@ public:
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
     virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const {
+                                          TDouble10Vec1Vec& samples) const override {
         samples.clear();
 
         if (numberSamples == 0 || this->numberSamples() == 0.0) {
@@ -702,7 +703,7 @@ public:
     }
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const {
+    virtual bool isNonInformative() const override {
         return m_WishartDegreesFreedom <= static_cast<double>(N + 1);
     }
 
@@ -710,7 +711,7 @@ public:
     //!
     // \param[in] separator String used to separate priors.
     // \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const {
+    virtual void print(const std::string& separator, std::string& result) const override {
         result += "\n" + separator + " multivariate normal";
         if (this->isNonInformative()) {
             result += " non-informative";
@@ -725,7 +726,7 @@ public:
     }
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const {
+    virtual uint64_t checksum(uint64_t seed = 0) const override {
         seed = this->CMultivariatePrior::checksum(seed);
         seed = CChecksum::calculate(seed, m_GaussianMean);
         seed = CChecksum::calculate(seed, m_GaussianPrecision);
@@ -734,18 +735,18 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CMultivariateNormalConjugate");
     }
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const { return 0; }
+    virtual std::size_t memoryUsage() const override { return 0; }
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const { return sizeof(*this); }
+    virtual std::size_t staticSize() const override { return sizeof(*this); }
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const {
+    virtual std::string persistenceTag() const override {
         return NORMAL_TAG + core::CStringUtils::typeToString(N);
     }
 
@@ -773,7 +774,7 @@ public:
     }
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
         inserter.insertValue(DECAY_RATE_TAG, this->decayRate(), core::CIEEE754::E_SinglePrecision);
         inserter.insertValue(NUMBER_SAMPLES_TAG, this->numberSamples(),
                              core::CIEEE754::E_SinglePrecision);

--- a/include/maths/common/CMultivariateNormalConjugate.h
+++ b/include/maths/common/CMultivariateNormalConjugate.h
@@ -149,7 +149,7 @@ public:
                                              this, std::placeholders::_1));
     }
 
-    virtual ~CMultivariateNormalConjugate() override {}
+    ~CMultivariateNormalConjugate() override {}
 
     // Default copy constructor and assignment operator work.
 
@@ -172,7 +172,7 @@ public:
     //! Create a copy of the prior.
     //!
     //! \warning Caller owns returned object.
-    virtual CMultivariateNormalConjugate* clone() const override {
+    CMultivariateNormalConjugate* clone() const override {
         return new CMultivariateNormalConjugate(*this);
     }
 
@@ -180,21 +180,21 @@ public:
     std::size_t dimension() const override { return N; }
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double /*offset = 0.0*/, double decayRate = 0.0) override {
+    void setToNonInformative(double /*offset = 0.0*/, double decayRate = 0.0) override {
         *this = nonInformativePrior(this->dataType(), decayRate);
     }
 
     //! No-op.
-    virtual void adjustOffset(const TDouble10Vec1Vec& /*samples*/,
-                              const TDouble10VecWeightsAry1Vec& /*weights*/) override {}
+    void adjustOffset(const TDouble10Vec1Vec& /*samples*/,
+                      const TDouble10VecWeightsAry1Vec& /*weights*/) override {}
 
     //! Update the prior with a collection of independent samples from the
     //! process.
     //!
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights) override {
+    void addSamples(const TDouble10Vec1Vec& samples,
+                    const TDouble10VecWeightsAry1Vec& weights) override {
         if (samples.empty()) {
             return;
         }
@@ -296,7 +296,7 @@ public:
     }
 
     //! Update the prior for the specified elapsed time.
-    virtual void propagateForwardsByTime(double time) override {
+    void propagateForwardsByTime(double time) override {
         if (!CMathsFuncs::isFinite(time) || time < 0.0) {
             LOG_ERROR(<< "Bad propagation time " << time);
             return;
@@ -351,8 +351,8 @@ public:
     //! \note The caller must specify dimension - 1 variables between
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
-    virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override {
+    TUnivariatePriorPtrDoublePr univariate(const TSize10Vec& marginalize,
+                                           const TSizeDoublePr10Vec& condition) const override {
         if (!this->check(marginalize, condition)) {
             return {};
         }
@@ -436,8 +436,8 @@ public:
     //! \note The caller must specify dimension - 2 variables between
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
-    virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const override {
+    TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
+                                const TSizeDoublePr10Vec& condition) const override {
         if (N == 2) {
             return {TPriorPtr(this->clone()), 0.0};
         }
@@ -522,29 +522,28 @@ public:
     }
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override {
+    TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override {
         return {TPoint::smallest().template toVector<TDouble10Vec>(),
                 TPoint::largest().template toVector<TDouble10Vec>()};
     }
 
     //! Get the mean of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMean() const override {
+    TDouble10Vec marginalLikelihoodMean() const override {
         return this->mean().template toVector<TDouble10Vec>();
     }
 
     //! Get the mode of the marginal likelihood function.
-    virtual TDouble10Vec
-    marginalLikelihoodMode(const TDouble10VecWeightsAry& /*weights*/) const override {
+    TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& /*weights*/) const override {
         return this->marginalLikelihoodMean();
     }
 
     //! Get the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override {
+    TDouble10Vec10Vec marginalLikelihoodCovariance() const override {
         return this->covarianceMatrix().template toVectors<TDouble10Vec10Vec>();
     }
 
     //! Get the diagonal of the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const override {
+    TDouble10Vec marginalLikelihoodVariances() const override {
         return this->covarianceMatrix().template diagonal<TDouble10Vec>();
     }
 
@@ -554,7 +553,7 @@ public:
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
     //! \param[out] result Filled in with the joint likelihood of \p samples.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
                                double& result) const override {
@@ -656,8 +655,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const override {
+    void sampleMarginalLikelihood(std::size_t numberSamples,
+                                  TDouble10Vec1Vec& samples) const override {
         samples.clear();
 
         if (numberSamples == 0 || this->numberSamples() == 0.0) {
@@ -703,7 +702,7 @@ public:
     }
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override {
+    bool isNonInformative() const override {
         return m_WishartDegreesFreedom <= static_cast<double>(N + 1);
     }
 
@@ -711,7 +710,7 @@ public:
     //!
     // \param[in] separator String used to separate priors.
     // \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const override {
+    void print(const std::string& separator, std::string& result) const override {
         result += "\n" + separator + " multivariate normal";
         if (this->isNonInformative()) {
             result += " non-informative";
@@ -726,7 +725,7 @@ public:
     }
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override {
+    uint64_t checksum(uint64_t seed = 0) const override {
         seed = this->CMultivariatePrior::checksum(seed);
         seed = CChecksum::calculate(seed, m_GaussianMean);
         seed = CChecksum::calculate(seed, m_GaussianPrecision);
@@ -735,18 +734,18 @@ public:
     }
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CMultivariateNormalConjugate");
     }
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override { return 0; }
+    std::size_t memoryUsage() const override { return 0; }
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override { return sizeof(*this); }
+    std::size_t staticSize() const override { return sizeof(*this); }
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const override {
+    std::string persistenceTag() const override {
         return NORMAL_TAG + core::CStringUtils::typeToString(N);
     }
 
@@ -774,7 +773,7 @@ public:
     }
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
         inserter.insertValue(DECAY_RATE_TAG, this->decayRate(), core::CIEEE754::E_SinglePrecision);
         inserter.insertValue(NUMBER_SAMPLES_TAG, this->numberSamples(),
                              core::CIEEE754::E_SinglePrecision);

--- a/include/maths/common/CMultivariateOneOfNPrior.h
+++ b/include/maths/common/CMultivariateOneOfNPrior.h
@@ -140,23 +140,23 @@ public:
     //!
     //! \return A pointer to a newly allocated clone of this model.
     //! \warning The caller owns the object returned.
-    virtual CMultivariateOneOfNPrior* clone() const;
+    virtual CMultivariateOneOfNPrior* clone() const override;
 
     //! Get the dimension of the prior.
-    std::size_t dimension() const;
+    std::size_t dimension() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value);
+    virtual void dataType(maths_t::EDataType value) override;
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value);
+    virtual void decayRate(double value) override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Forward the offset to the model priors.
     virtual void adjustOffset(const TDouble10Vec1Vec& samples,
-                              const TDouble10VecWeightsAry1Vec& weights);
+                              const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! Update the model weights using the marginal likelihoods for
     //! the data. The component prior parameters are then updated.
@@ -164,7 +164,7 @@ public:
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
     virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights);
+                            const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -174,7 +174,7 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Compute the univariate prior marginalizing over the variables
     //! \p marginalize and conditioning on the variables \p condition.
@@ -190,7 +190,7 @@ public:
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
     virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const;
+    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override;
 
     //! Compute the bivariate prior marginalizing over the variables
     //! \p marginalize and conditioning on the variables \p condition.
@@ -205,25 +205,25 @@ public:
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
     virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const;
+                                        const TSizeDoublePr10Vec& condition) const override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const;
+    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMean() const;
+    virtual TDouble10Vec marginalLikelihoodMean() const override;
 
     //! Get the weighted mean of the model nearest marginal likelihood means.
-    virtual TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value) const;
+    virtual TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value) const override;
 
     //! Get the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const;
+    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override;
 
     //! Get the diagonal of the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const;
+    virtual TDouble10Vec marginalLikelihoodVariances() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const;
+    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the distribution parameters.
@@ -236,7 +236,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -249,34 +249,34 @@ public:
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
     virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const;
+                                          TDouble10Vec1Vec& samples) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] separator String used to separate priors.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const;
+    virtual void print(const std::string& separator, std::string& result) const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component.
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies.
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const;
+    virtual std::string persistenceTag() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! \name Test Functions

--- a/include/maths/common/CMultivariateOneOfNPrior.h
+++ b/include/maths/common/CMultivariateOneOfNPrior.h
@@ -140,31 +140,31 @@ public:
     //!
     //! \return A pointer to a newly allocated clone of this model.
     //! \warning The caller owns the object returned.
-    virtual CMultivariateOneOfNPrior* clone() const override;
+    CMultivariateOneOfNPrior* clone() const override;
 
     //! Get the dimension of the prior.
     std::size_t dimension() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value) override;
+    void dataType(maths_t::EDataType value) override;
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value) override;
+    void decayRate(double value) override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Forward the offset to the model priors.
-    virtual void adjustOffset(const TDouble10Vec1Vec& samples,
-                              const TDouble10VecWeightsAry1Vec& weights) override;
+    void adjustOffset(const TDouble10Vec1Vec& samples,
+                      const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! Update the model weights using the marginal likelihoods for
     //! the data. The component prior parameters are then updated.
     //!
     //! \param[in] samples A collection of samples of the process.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble10Vec1Vec& samples,
-                            const TDouble10VecWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble10Vec1Vec& samples,
+                    const TDouble10VecWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -174,7 +174,7 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Compute the univariate prior marginalizing over the variables
     //! \p marginalize and conditioning on the variables \p condition.
@@ -189,8 +189,8 @@ public:
     //! \note The caller must specify dimension - 1 variables between
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
-    virtual TUnivariatePriorPtrDoublePr
-    univariate(const TSize10Vec& marginalize, const TSizeDoublePr10Vec& condition) const override;
+    TUnivariatePriorPtrDoublePr univariate(const TSize10Vec& marginalize,
+                                           const TSizeDoublePr10Vec& condition) const override;
 
     //! Compute the bivariate prior marginalizing over the variables
     //! \p marginalize and conditioning on the variables \p condition.
@@ -204,26 +204,26 @@ public:
     //! \note The caller must specify dimension - 2 variables between
     //! \p marginalize and \p condition so the resulting distribution
     //! is univariate.
-    virtual TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
-                                        const TSizeDoublePr10Vec& condition) const override;
+    TPriorPtrDoublePr bivariate(const TSize10Vec& marginalize,
+                                const TSizeDoublePr10Vec& condition) const override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override;
+    TDouble10VecDouble10VecPr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMean() const override;
+    TDouble10Vec marginalLikelihoodMean() const override;
 
     //! Get the weighted mean of the model nearest marginal likelihood means.
-    virtual TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value) const override;
+    TDouble10Vec nearestMarginalLikelihoodMean(const TDouble10Vec& value) const override;
 
     //! Get the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec10Vec marginalLikelihoodCovariance() const override;
+    TDouble10Vec10Vec marginalLikelihoodCovariance() const override;
 
     //! Get the diagonal of the covariance matrix for the marginal likelihood.
-    virtual TDouble10Vec marginalLikelihoodVariances() const override;
+    TDouble10Vec marginalLikelihoodVariances() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const override;
+    TDouble10Vec marginalLikelihoodMode(const TDouble10VecWeightsAry& weights) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the distribution parameters.
@@ -233,7 +233,7 @@ public:
     //! \param[out] result Filled in with the joint likelihood of \p samples.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble10Vec1Vec& samples,
                                const TDouble10VecWeightsAry1Vec& weights,
                                double& result) const override;
@@ -248,35 +248,35 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble10Vec1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples,
+                                  TDouble10Vec1Vec& samples) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] separator String used to separate priors.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& separator, std::string& result) const override;
+    void print(const std::string& separator, std::string& result) const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component.
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies.
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Get the tag name for this prior.
-    virtual std::string persistenceTag() const override;
+    std::string persistenceTag() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! \name Test Functions

--- a/include/maths/common/CNaiveBayes.h
+++ b/include/maths/common/CNaiveBayes.h
@@ -99,47 +99,47 @@ public:
     //! Create and return a clone.
     //!
     //! \note The caller owns this.
-    virtual CNaiveBayesFeatureDensityFromPrior* clone() const override;
+    CNaiveBayesFeatureDensityFromPrior* clone() const override;
 
     //! Initialize by reading state from \p traverser.
-    virtual bool acceptRestoreTraverser(const SDistributionRestoreParams& params,
-                                        core::CStateRestoreTraverser& traverser) override;
+    bool acceptRestoreTraverser(const SDistributionRestoreParams& params,
+                                core::CStateRestoreTraverser& traverser) override;
 
     //! Persist state by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Check whether the density is improper.
-    virtual bool improper() const override;
+    bool improper() const override;
 
     //! Add the value \p x.
-    virtual void add(const TDouble1Vec& x) override;
+    void add(const TDouble1Vec& x) override;
 
     //! Compute the log value of the density function at \p x.
-    virtual double logValue(const TDouble1Vec& x) const override;
+    double logValue(const TDouble1Vec& x) const override;
 
     //! Compute the density at the mode.
-    virtual double logMaximumValue() const override;
+    double logMaximumValue() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType dataType) override;
+    void dataType(maths_t::EDataType dataType) override;
 
     //! Age out old values density to account for \p time passing.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the static size of this object.
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed) const override;
+    uint64_t checksum(uint64_t seed) const override;
 
     //! Get a human readable description of the class density function.
-    virtual std::string print() const override;
+    std::string print() const override;
 
 private:
     //! Check the state invariants after restoration

--- a/include/maths/common/CNaiveBayes.h
+++ b/include/maths/common/CNaiveBayes.h
@@ -99,47 +99,47 @@ public:
     //! Create and return a clone.
     //!
     //! \note The caller owns this.
-    virtual CNaiveBayesFeatureDensityFromPrior* clone() const;
+    virtual CNaiveBayesFeatureDensityFromPrior* clone() const override;
 
     //! Initialize by reading state from \p traverser.
     virtual bool acceptRestoreTraverser(const SDistributionRestoreParams& params,
-                                        core::CStateRestoreTraverser& traverser);
+                                        core::CStateRestoreTraverser& traverser) override;
 
     //! Persist state by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Check whether the density is improper.
-    virtual bool improper() const;
+    virtual bool improper() const override;
 
     //! Add the value \p x.
-    virtual void add(const TDouble1Vec& x);
+    virtual void add(const TDouble1Vec& x) override;
 
     //! Compute the log value of the density function at \p x.
-    virtual double logValue(const TDouble1Vec& x) const;
+    virtual double logValue(const TDouble1Vec& x) const override;
 
     //! Compute the density at the mode.
-    virtual double logMaximumValue() const;
+    virtual double logMaximumValue() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType dataType);
+    virtual void dataType(maths_t::EDataType dataType) override;
 
     //! Age out old values density to account for \p time passing.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the static size of this object.
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed) const;
+    virtual uint64_t checksum(uint64_t seed) const override;
 
     //! Get a human readable description of the class density function.
-    virtual std::string print() const;
+    virtual std::string print() const override;
 
 private:
     //! Check the state invariants after restoration

--- a/include/maths/common/CNormalMeanPrecConjugate.h
+++ b/include/maths/common/CNormalMeanPrecConjugate.h
@@ -112,34 +112,32 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CNormalMeanPrecConjugate* clone() const override;
+    CNormalMeanPrecConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns false.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! No-op.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Returns zero.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Update the prior with a collection of independent samples from
     //! the normal variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -149,21 +147,19 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -177,7 +173,7 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
@@ -189,7 +185,7 @@ public:
     //! \param[out] result Filled in with the joint likelihood of \p samples.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
@@ -201,8 +197,7 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -227,10 +222,10 @@ public:
     //! \f$(0,\infty)\f$, i.e. a value of zero is not well defined and
     //! a value of infinity is not well handled. (Very large values are
     //! handled though.)
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -238,10 +233,10 @@ public:
     //! can return is the minimum double rather than epsilon.
     //!
     //! \see minusLogJointCdf for more details.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -260,41 +255,41 @@ public:
     //! \warning The variance scales must be in the range \f$(0,\infty)\f$,
     //! i.e. a value of zero is not well defined and a value of infinity
     //! is not well handled. (Very large values are handled though.)
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! The current expected mean for the variable.

--- a/include/maths/common/CNormalMeanPrecConjugate.h
+++ b/include/maths/common/CNormalMeanPrecConjugate.h
@@ -112,33 +112,34 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CNormalMeanPrecConjugate* clone() const;
+    virtual CNormalMeanPrecConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns false.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! No-op.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Returns zero.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Update the prior with a collection of independent samples from
     //! the normal variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -148,20 +149,21 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -175,9 +177,9 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the normal mean and precision.
@@ -190,7 +192,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -199,7 +201,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -227,7 +230,7 @@ public:
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -238,7 +241,7 @@ public:
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -262,36 +265,36 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! The current expected mean for the variable.
@@ -318,7 +321,7 @@ public:
 private:
     //! Generate statistics - mean and standard deviation - that are useful in providing a description of this prior
     //! \return A pair of strings containing representations of the marginal likelihood mean and standard deviation
-    CPrior::TStrStrPr doPrintMarginalLikelihoodStatistics() const;
+    CPrior::TStrStrPr doPrintMarginalLikelihoodStatistics() const override;
 
     //! Read parameters from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
@@ -327,7 +330,7 @@ private:
     bool isBad() const;
 
     //! Full debug dump of the state of this prior.
-    std::string debug() const;
+    std::string debug() const override;
 
 private:
     //! The mean parameter of a non-informative prior.

--- a/include/maths/common/COneOfNPrior.h
+++ b/include/maths/common/COneOfNPrior.h
@@ -113,45 +113,43 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this model.
     //! \warning The caller owns the object returned.
-    virtual COneOfNPrior* clone() const override;
+    COneOfNPrior* clone() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value) override;
+    void dataType(maths_t::EDataType value) override;
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value) override;
+    void decayRate(double value) override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Remove models marked by \p filter.
-    virtual void removeModels(CModelFilter& filter) override;
+    void removeModels(CModelFilter& filter) override;
 
     //! Check if any of the models needs an offset to be applied.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! Forward the offset to the model priors.
     //!
     //! \return The penalty to apply in model selection.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the maximum model offset.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Update the model weights using the marginal likelihoods for
     //! the data. The component prior parameters are then updated.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -161,24 +159,22 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Get the weighted mean of the model nearest means.
-    virtual double nearestMarginalLikelihoodMean(double value) const override;
+    double nearestMarginalLikelihoodMean(double value) const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -192,7 +188,7 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range (0.0, 100.0].
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
@@ -204,7 +200,7 @@ public:
     //! \param[out] result Filled in with the joint likelihood of \p samples.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
@@ -219,8 +215,7 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
 private:
     //! The common c.d.f. implementation.
@@ -246,10 +241,10 @@ public:
     //! \warning The variance scales must be in the range \f$(0,\infty)\f$,
     //! i.e. a value of zero is not well defined and a value of infinity is
     //! not well handled. (Very large values are handled though.)
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -257,10 +252,10 @@ public:
     //! can return is the minimum double rather than epsilon.
     //!
     //! \see minusLogJointCdf for more details.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -279,41 +274,41 @@ public:
     //! \warning The variance scales must be in the range \f$(0,\infty)\f$,
     //! i.e. a value of zero is not well defined and a value of infinity is
     //! not well handled. (Very large values are handled though.)
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component.
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! \name Test Functions

--- a/include/maths/common/COneOfNPrior.h
+++ b/include/maths/common/COneOfNPrior.h
@@ -113,44 +113,45 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this model.
     //! \warning The caller owns the object returned.
-    virtual COneOfNPrior* clone() const;
+    virtual COneOfNPrior* clone() const override;
 
     //! Set the data type.
-    virtual void dataType(maths_t::EDataType value);
+    virtual void dataType(maths_t::EDataType value) override;
 
     //! Set the rate at which the prior returns to non-informative.
-    virtual void decayRate(double value);
+    virtual void decayRate(double value) override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Remove models marked by \p filter.
-    virtual void removeModels(CModelFilter& filter);
+    virtual void removeModels(CModelFilter& filter) override;
 
     //! Check if any of the models needs an offset to be applied.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! Forward the offset to the model priors.
     //!
     //! \return The penalty to apply in model selection.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the maximum model offset.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Update the model weights using the marginal likelihoods for
     //! the data. The component prior parameters are then updated.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -160,23 +161,24 @@ public:
     //!
     //! \param[in] time The time increment to apply.
     //! \note \p time must be non negative.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Get the weighted mean of the model nearest means.
-    virtual double nearestMarginalLikelihoodMean(double value) const;
+    virtual double nearestMarginalLikelihoodMean(double value) const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -190,9 +192,9 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range (0.0, 100.0].
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the distribution parameters.
@@ -205,7 +207,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -217,7 +219,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
 private:
     //! The common c.d.f. implementation.
@@ -246,7 +249,7 @@ public:
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -257,7 +260,7 @@ public:
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Compute the probability of a less likely, i.e. lower likelihood,
     //! collection of independent samples from the variable.
@@ -281,36 +284,36 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Debug the memory used by this component.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component.
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! \name Test Functions

--- a/include/maths/common/CPoissonMeanConjugate.h
+++ b/include/maths/common/CPoissonMeanConjugate.h
@@ -88,19 +88,19 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const override;
+    EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CPoissonMeanConjugate* clone() const override;
+    CPoissonMeanConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
+    void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns true.
-    virtual bool needsOffset() const override;
+    bool needsOffset() const override;
 
     //! Reset m_Offset so the smallest sample is not less that the support
     //! left end. Note that translating the mean of a Poisson R.V. affects
@@ -113,19 +113,17 @@ public:
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
     //! \return The penalty to apply in model selection.
-    virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights) override;
+    double adjustOffset(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const override;
+    double offset() const override;
 
     //! Update the prior with a collection of independent samples from the
     //! Poisson variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples,
-                            const TDoubleWeightsAry1Vec& weights) override;
+    void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -134,21 +132,19 @@ public:
     //! constructor).
     //!
     //! \param[in] time The time increment to apply.
-    virtual void propagateForwardsByTime(double time) override;
+    void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
+    TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const override;
+    double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double
-    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
-    virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
+    double marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -162,7 +158,7 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+    TDoubleDoublePr marginalLikelihoodConfidenceInterval(
         double percentage,
         const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
@@ -174,7 +170,7 @@ public:
     //! \param[out] result Filled in with the joint likelihood of \p samples.
     //! \note The samples are assumed to be independent and identically
     //! distributed.
-    virtual maths_t::EFloatingPointErrorStatus
+    maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
                                double& result) const override;
@@ -186,8 +182,7 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
-                                          TDouble1Vec& samples) const override;
+    void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -198,10 +193,10 @@ public:
     //! where \f$F(.)\f$ is the c.d.f. and \f$\{x_i\}\f$ are the samples.
     //! \param[out] upperBound Equal to \p lowerBound.
     //! \note The samples are assumed to be independent.
-    virtual bool minusLogJointCdf(const TDouble1Vec& samples,
-                                  const TDoubleWeightsAry1Vec& weights,
-                                  double& lowerBound,
-                                  double& upperBound) const override;
+    bool minusLogJointCdf(const TDouble1Vec& samples,
+                          const TDoubleWeightsAry1Vec& weights,
+                          double& lowerBound,
+                          double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -209,10 +204,10 @@ public:
     //! can return is the minimum double rather than epsilon.
     //!
     //! \see minusLogJointCdf for more details.
-    virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
-                                            const TDoubleWeightsAry1Vec& weights,
-                                            double& lowerBound,
-                                            double& upperBound) const override;
+    bool minusLogJointCdfComplement(const TDouble1Vec& samples,
+                                    const TDoubleWeightsAry1Vec& weights,
+                                    double& lowerBound,
+                                    double& upperBound) const override;
 
     //! Compute the probability of a less likely collection of independent
     //! samples from the variable.
@@ -228,41 +223,41 @@ public:
     //! \param[out] tail The tail that (left or right) that all the samples
     //! are in or neither.
     //! \note The samples are assumed to be independent.
-    virtual bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
-                                                const TDouble1Vec& samples,
-                                                const TDoubleWeightsAry1Vec& weights,
-                                                double& lowerBound,
-                                                double& upperBound,
-                                                maths_t::ETail& tail) const override;
+    bool probabilityOfLessLikelySamples(maths_t::EProbabilityCalculation calculation,
+                                        const TDouble1Vec& samples,
+                                        const TDoubleWeightsAry1Vec& weights,
+                                        double& lowerBound,
+                                        double& upperBound,
+                                        maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const override;
+    bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const override;
+    void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const override;
+    std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override;
+    uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Compute the mean of the prior distribution.

--- a/include/maths/common/CPoissonMeanConjugate.h
+++ b/include/maths/common/CPoissonMeanConjugate.h
@@ -88,19 +88,19 @@ public:
     //! \name Prior Contract
     //@{
     //! Get the type of this prior.
-    virtual EPrior type() const;
+    virtual EPrior type() const override;
 
     //! Create a copy of the prior.
     //!
     //! \return A pointer to a newly allocated clone of this prior.
     //! \warning The caller owns the object returned.
-    virtual CPoissonMeanConjugate* clone() const;
+    virtual CPoissonMeanConjugate* clone() const override;
 
     //! Reset the prior to non-informative.
-    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0);
+    virtual void setToNonInformative(double offset = 0.0, double decayRate = 0.0) override;
 
     //! Returns true.
-    virtual bool needsOffset() const;
+    virtual bool needsOffset() const override;
 
     //! Reset m_Offset so the smallest sample is not less that the support
     //! left end. Note that translating the mean of a Poisson R.V. affects
@@ -114,17 +114,18 @@ public:
     //! \param[in] weights The weights of each sample in \p samples.
     //! \return The penalty to apply in model selection.
     virtual double adjustOffset(const TDouble1Vec& samples,
-                                const TDoubleWeightsAry1Vec& weights);
+                                const TDoubleWeightsAry1Vec& weights) override;
 
     //! Get the current offset.
-    virtual double offset() const;
+    virtual double offset() const override;
 
     //! Update the prior with a collection of independent samples from the
     //! Poisson variable.
     //!
     //! \param[in] samples A collection of samples of the variable.
     //! \param[in] weights The weights of each sample in \p samples.
-    virtual void addSamples(const TDouble1Vec& samples, const TDoubleWeightsAry1Vec& weights);
+    virtual void addSamples(const TDouble1Vec& samples,
+                            const TDoubleWeightsAry1Vec& weights) override;
 
     //! Propagate the prior density function forwards by \p time.
     //!
@@ -133,20 +134,21 @@ public:
     //! constructor).
     //!
     //! \param[in] time The time increment to apply.
-    virtual void propagateForwardsByTime(double time);
+    virtual void propagateForwardsByTime(double time) override;
 
     //! Get the support for the marginal likelihood function.
-    virtual TDoubleDoublePr marginalLikelihoodSupport() const;
+    virtual TDoubleDoublePr marginalLikelihoodSupport() const override;
 
     //! Get the mean of the marginal likelihood function.
-    virtual double marginalLikelihoodMean() const;
+    virtual double marginalLikelihoodMean() const override;
 
     //! Get the mode of the marginal likelihood function.
-    virtual double marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual double
+    marginalLikelihoodMode(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the variance of the marginal likelihood.
     virtual double
-    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    marginalLikelihoodVariance(const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Get the \p percentage symmetric confidence interval for the marginal
     //! likelihood function, i.e. the values \f$a\f$ and \f$b\f$ such that:
@@ -160,9 +162,9 @@ public:
     //! \param[in] percentage The percentage of interest.
     //! \param[in] weights Optional variance scale weights.
     //! \note \p percentage should be in the range [0.0, 100.0).
-    virtual TDoubleDoublePr
-    marginalLikelihoodConfidenceInterval(double percentage,
-                                         const TDoubleWeightsAry& weights = TWeights::UNIT) const;
+    virtual TDoubleDoublePr marginalLikelihoodConfidenceInterval(
+        double percentage,
+        const TDoubleWeightsAry& weights = TWeights::UNIT) const override;
 
     //! Compute the log marginal likelihood function at \p samples integrating
     //! over the prior density function for the Poisson mean.
@@ -175,7 +177,7 @@ public:
     virtual maths_t::EFloatingPointErrorStatus
     jointLogMarginalLikelihood(const TDouble1Vec& samples,
                                const TDoubleWeightsAry1Vec& weights,
-                               double& result) const;
+                               double& result) const override;
 
     //! Sample the marginal likelihood function.
     //!
@@ -184,7 +186,8 @@ public:
     //! \param[in] numberSamples The number of samples required.
     //! \param[out] samples Filled in with samples from the prior.
     //! \note \p numberSamples is truncated to the number of samples received.
-    virtual void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const;
+    virtual void sampleMarginalLikelihood(std::size_t numberSamples,
+                                          TDouble1Vec& samples) const override;
 
     //! Compute minus the log of the joint c.d.f. of the marginal likelihood
     //! at \p samples.
@@ -198,7 +201,7 @@ public:
     virtual bool minusLogJointCdf(const TDouble1Vec& samples,
                                   const TDoubleWeightsAry1Vec& weights,
                                   double& lowerBound,
-                                  double& upperBound) const;
+                                  double& upperBound) const override;
 
     //! Compute minus the log of the one minus the joint c.d.f. of the
     //! marginal likelihood at \p samples without losing precision due to
@@ -209,7 +212,7 @@ public:
     virtual bool minusLogJointCdfComplement(const TDouble1Vec& samples,
                                             const TDoubleWeightsAry1Vec& weights,
                                             double& lowerBound,
-                                            double& upperBound) const;
+                                            double& upperBound) const override;
 
     //! Compute the probability of a less likely collection of independent
     //! samples from the variable.
@@ -230,36 +233,36 @@ public:
                                                 const TDoubleWeightsAry1Vec& weights,
                                                 double& lowerBound,
                                                 double& upperBound,
-                                                maths_t::ETail& tail) const;
+                                                maths_t::ETail& tail) const override;
 
     //! Check if this is a non-informative prior.
-    virtual bool isNonInformative() const;
+    virtual bool isNonInformative() const override;
 
     //! Get a human readable description of the prior.
     //!
     //! \param[in] indent The indent to use at the start of new lines.
     //! \param[in,out] result Filled in with the description.
-    virtual void print(const std::string& indent, std::string& result) const;
+    virtual void print(const std::string& indent, std::string& result) const override;
 
     //! Print the prior density function in a specified format.
     //!
     //! \see CPrior::printJointDensityFunction for details.
-    virtual std::string printJointDensityFunction() const;
+    virtual std::string printJointDensityFunction() const override;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const;
+    virtual uint64_t checksum(uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this component
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
     //@}
 
     //! Compute the mean of the prior distribution.
@@ -281,7 +284,7 @@ public:
 private:
     //! Generate statistics - mean and standard deviation - that are useful in providing a description of this prior
     //! \return A pair of strings containing representations of the marginal likelihood mean and standard deviation
-    CPrior::TStrStrPr doPrintMarginalLikelihoodStatistics() const;
+    CPrior::TStrStrPr doPrintMarginalLikelihoodStatistics() const override;
 
     //! Read parameters from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);

--- a/include/maths/common/CRandomProjectionClusterer.h
+++ b/include/maths/common/CRandomProjectionClusterer.h
@@ -226,14 +226,14 @@ public:
     CRandomProjectionClustererBatch(double compression)
         : m_Compression(compression) {}
 
-    virtual ~CRandomProjectionClustererBatch() = default;
+    virtual ~CRandomProjectionClustererBatch() override = default;
 
     //! Create the \p numberProjections random projections.
     //!
     //! \param[in] numberProjections The number of projections
     //! to create.
     //! \param[in] dimension The dimension of the space to project.
-    virtual bool initialise(std::size_t numberProjections, std::size_t dimension) {
+    virtual bool initialise(std::size_t numberProjections, std::size_t dimension) override {
         m_ProjectedData.resize(numberProjections);
         return this->CRandomProjectionClusterer<N>::initialise(numberProjections, dimension);
     }

--- a/include/maths/common/CRandomProjectionClusterer.h
+++ b/include/maths/common/CRandomProjectionClusterer.h
@@ -226,14 +226,14 @@ public:
     CRandomProjectionClustererBatch(double compression)
         : m_Compression(compression) {}
 
-    virtual ~CRandomProjectionClustererBatch() override = default;
+    ~CRandomProjectionClustererBatch() override = default;
 
     //! Create the \p numberProjections random projections.
     //!
     //! \param[in] numberProjections The number of projections
     //! to create.
     //! \param[in] dimension The dimension of the space to project.
-    virtual bool initialise(std::size_t numberProjections, std::size_t dimension) override {
+    bool initialise(std::size_t numberProjections, std::size_t dimension) override {
         m_ProjectedData.resize(numberProjections);
         return this->CRandomProjectionClusterer<N>::initialise(numberProjections, dimension);
     }

--- a/include/maths/time_series/CSeasonalTime.h
+++ b/include/maths/time_series/CSeasonalTime.h
@@ -159,32 +159,32 @@ public:
                  core_t::TTime period);
 
     //! Get a copy of this time.
-    CDiurnalTime* clone() const;
+    CDiurnalTime* clone() const override;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(std::string value);
+    virtual bool fromString(std::string value) override;
 
     //! Convert to a string.
-    virtual std::string toString() const;
+    virtual std::string toString() const override;
 
     //! Get the length of a week.
-    virtual core_t::TTime windowRepeat() const;
+    virtual core_t::TTime windowRepeat() const override;
 
     //! Get the start of the week.
-    virtual core_t::TTime windowRepeatStart() const;
+    virtual core_t::TTime windowRepeatStart() const override;
 
     //! Get the start of the window.
-    virtual core_t::TTime windowStart() const;
+    virtual core_t::TTime windowStart() const override;
 
     //! Get the end of the window.
-    virtual core_t::TTime windowEnd() const;
+    virtual core_t::TTime windowEnd() const override;
 
     //! Get a checksum for this object.
-    virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
 private:
     //! Get the scale to apply when computing the regression time.
-    virtual core_t::TTime regressionTimeScale() const;
+    virtual core_t::TTime regressionTimeScale() const override;
 
 private:
     //! The start of the week.
@@ -203,32 +203,32 @@ public:
     CGeneralPeriodTime(core_t::TTime period);
 
     //! Get a copy of this time.
-    CGeneralPeriodTime* clone() const;
+    CGeneralPeriodTime* clone() const override;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(std::string value);
+    virtual bool fromString(std::string value) override;
 
     //! Convert to a string.
-    virtual std::string toString() const;
+    virtual std::string toString() const override;
 
     //! Return the period.
-    virtual core_t::TTime windowRepeat() const;
+    virtual core_t::TTime windowRepeat() const override;
 
     //! Returns zero.
-    virtual core_t::TTime windowRepeatStart() const;
+    virtual core_t::TTime windowRepeatStart() const override;
 
     //! Returns zero.
-    virtual core_t::TTime windowStart() const;
+    virtual core_t::TTime windowStart() const override;
 
     //! Returns the period.
-    virtual core_t::TTime windowEnd() const;
+    virtual core_t::TTime windowEnd() const override;
 
     //! Get a checksum for this object.
-    virtual std::uint64_t checksum(std::uint64_t seed = 0) const;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
 private:
     //! Get the scale to apply when computing the regression time.
-    virtual core_t::TTime regressionTimeScale() const;
+    virtual core_t::TTime regressionTimeScale() const override;
 };
 
 //! \brief Convert CSeasonalTime sub-classes to/from text representations.

--- a/include/maths/time_series/CSeasonalTime.h
+++ b/include/maths/time_series/CSeasonalTime.h
@@ -162,29 +162,29 @@ public:
     CDiurnalTime* clone() const override;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(std::string value) override;
+    bool fromString(std::string value) override;
 
     //! Convert to a string.
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
     //! Get the length of a week.
-    virtual core_t::TTime windowRepeat() const override;
+    core_t::TTime windowRepeat() const override;
 
     //! Get the start of the week.
-    virtual core_t::TTime windowRepeatStart() const override;
+    core_t::TTime windowRepeatStart() const override;
 
     //! Get the start of the window.
-    virtual core_t::TTime windowStart() const override;
+    core_t::TTime windowStart() const override;
 
     //! Get the end of the window.
-    virtual core_t::TTime windowEnd() const override;
+    core_t::TTime windowEnd() const override;
 
     //! Get a checksum for this object.
-    virtual std::uint64_t checksum(std::uint64_t seed = 0) const override;
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
 private:
     //! Get the scale to apply when computing the regression time.
-    virtual core_t::TTime regressionTimeScale() const override;
+    core_t::TTime regressionTimeScale() const override;
 
 private:
     //! The start of the week.
@@ -206,29 +206,29 @@ public:
     CGeneralPeriodTime* clone() const override;
 
     //! Initialize from a string created by persist.
-    virtual bool fromString(std::string value) override;
+    bool fromString(std::string value) override;
 
     //! Convert to a string.
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
     //! Return the period.
-    virtual core_t::TTime windowRepeat() const override;
+    core_t::TTime windowRepeat() const override;
 
     //! Returns zero.
-    virtual core_t::TTime windowRepeatStart() const override;
+    core_t::TTime windowRepeatStart() const override;
 
     //! Returns zero.
-    virtual core_t::TTime windowStart() const override;
+    core_t::TTime windowStart() const override;
 
     //! Returns the period.
-    virtual core_t::TTime windowEnd() const override;
+    core_t::TTime windowEnd() const override;
 
     //! Get a checksum for this object.
-    virtual std::uint64_t checksum(std::uint64_t seed = 0) const override;
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
 private:
     //! Get the scale to apply when computing the regression time.
-    virtual core_t::TTime regressionTimeScale() const override;
+    core_t::TTime regressionTimeScale() const override;
 };
 
 //! \brief Convert CSeasonalTime sub-classes to/from text representations.

--- a/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
@@ -148,15 +148,15 @@ public:
 public:
     explicit CTimeSeriesMultibucketMean(std::size_t length = 0)
         : m_SlidingWindow(length) {}
-    virtual ~CTimeSeriesMultibucketMean() = default;
+    virtual ~CTimeSeriesMultibucketMean() override = default;
 
     //! Clone this feature.
-    virtual TPtr clone() const {
+    virtual TPtr clone() const override {
         return std::make_unique<CTimeSeriesMultibucketMean>(*this);
     }
 
     //! Get the feature value and weight.
-    virtual TT1VecTWeightAry1VecPr value() const {
+    virtual TT1VecTWeightAry1VecPr value() const override {
         if (4 * m_SlidingWindow.size() >= 3 * m_SlidingWindow.capacity()) {
             return {{this->mean()}, {maths_t::countWeight(this->count())}};
         }
@@ -164,7 +164,7 @@ public:
     }
 
     //! Get the correlation of this feature with the bucket value.
-    virtual double correlationWithBucketValue() const {
+    virtual double correlationWithBucketValue() const override {
         // This follows from the weighting applied to values in the
         // window and linearity of expectation.
         double r{WINDOW_GEOMETRIC_WEIGHT * WINDOW_GEOMETRIC_WEIGHT};
@@ -173,13 +173,13 @@ public:
     }
 
     //! Clear the feature state.
-    virtual void clear() { m_SlidingWindow.clear(); }
+    virtual void clear() override { m_SlidingWindow.clear(); }
 
     //! Add \p values and \p time.
     virtual void add(core_t::TTime time,
                      core_t::TTime bucketLength,
                      const TT1Vec& values,
-                     const TWeightsAry1Vec& weights) {
+                     const TWeightsAry1Vec& weights) override {
         // Remove any old samples.
         core_t::TTime cutoff{time - this->windowInterval(bucketLength)};
         while (m_SlidingWindow.size() > 0 && m_SlidingWindow.front().first < cutoff) {
@@ -208,27 +208,27 @@ public:
     }
 
     //! Compute a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const {
+    virtual uint64_t checksum(uint64_t seed = 0) const override {
         seed = common::CChecksum::calculate(seed, m_SlidingWindow.capacity());
         return common::CChecksum::calculate(seed, m_SlidingWindow);
     }
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CTimeSeriesMultibucketMean");
         core::CMemoryDebug::dynamicSize("m_SlidingWindow", m_SlidingWindow, mem);
     }
 
     //! Get the static size of object.
-    virtual std::size_t staticSize() const { return sizeof(*this); }
+    virtual std::size_t staticSize() const override { return sizeof(*this); }
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const {
+    virtual std::size_t memoryUsage() const override {
         return core::CMemory::dynamicSize(m_SlidingWindow);
     }
 
     //! Initialize reading state from \p traverser.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override {
         do {
             const std::string& name{traverser.name()};
             RESTORE_SETUP_TEARDOWN(CAPACITY_TAG, std::size_t capacity,
@@ -241,7 +241,7 @@ public:
     }
 
     //! Persist by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
         inserter.insertValue(CAPACITY_TAG, m_SlidingWindow.capacity());
         core::CPersistUtils::persist(SLIDING_WINDOW_TAG, m_SlidingWindow, inserter);
     }

--- a/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
@@ -148,15 +148,15 @@ public:
 public:
     explicit CTimeSeriesMultibucketMean(std::size_t length = 0)
         : m_SlidingWindow(length) {}
-    virtual ~CTimeSeriesMultibucketMean() override = default;
+    ~CTimeSeriesMultibucketMean() override = default;
 
     //! Clone this feature.
-    virtual TPtr clone() const override {
+    TPtr clone() const override {
         return std::make_unique<CTimeSeriesMultibucketMean>(*this);
     }
 
     //! Get the feature value and weight.
-    virtual TT1VecTWeightAry1VecPr value() const override {
+    TT1VecTWeightAry1VecPr value() const override {
         if (4 * m_SlidingWindow.size() >= 3 * m_SlidingWindow.capacity()) {
             return {{this->mean()}, {maths_t::countWeight(this->count())}};
         }
@@ -164,7 +164,7 @@ public:
     }
 
     //! Get the correlation of this feature with the bucket value.
-    virtual double correlationWithBucketValue() const override {
+    double correlationWithBucketValue() const override {
         // This follows from the weighting applied to values in the
         // window and linearity of expectation.
         double r{WINDOW_GEOMETRIC_WEIGHT * WINDOW_GEOMETRIC_WEIGHT};
@@ -173,13 +173,13 @@ public:
     }
 
     //! Clear the feature state.
-    virtual void clear() override { m_SlidingWindow.clear(); }
+    void clear() override { m_SlidingWindow.clear(); }
 
     //! Add \p values and \p time.
-    virtual void add(core_t::TTime time,
-                     core_t::TTime bucketLength,
-                     const TT1Vec& values,
-                     const TWeightsAry1Vec& weights) override {
+    void add(core_t::TTime time,
+             core_t::TTime bucketLength,
+             const TT1Vec& values,
+             const TWeightsAry1Vec& weights) override {
         // Remove any old samples.
         core_t::TTime cutoff{time - this->windowInterval(bucketLength)};
         while (m_SlidingWindow.size() > 0 && m_SlidingWindow.front().first < cutoff) {
@@ -208,27 +208,27 @@ public:
     }
 
     //! Compute a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const override {
+    uint64_t checksum(uint64_t seed = 0) const override {
         seed = common::CChecksum::calculate(seed, m_SlidingWindow.capacity());
         return common::CChecksum::calculate(seed, m_SlidingWindow);
     }
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CTimeSeriesMultibucketMean");
         core::CMemoryDebug::dynamicSize("m_SlidingWindow", m_SlidingWindow, mem);
     }
 
     //! Get the static size of object.
-    virtual std::size_t staticSize() const override { return sizeof(*this); }
+    std::size_t staticSize() const override { return sizeof(*this); }
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const override {
+    std::size_t memoryUsage() const override {
         return core::CMemory::dynamicSize(m_SlidingWindow);
     }
 
     //! Initialize reading state from \p traverser.
-    virtual bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override {
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override {
         do {
             const std::string& name{traverser.name()};
             RESTORE_SETUP_TEARDOWN(CAPACITY_TAG, std::size_t capacity,
@@ -241,7 +241,7 @@ public:
     }
 
     //! Persist by passing information to \p inserter.
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
         inserter.insertValue(CAPACITY_TAG, m_SlidingWindow.capacity());
         core::CPersistUtils::persist(SLIDING_WINDOW_TAG, m_SlidingWindow, inserter);
     }

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -584,19 +584,19 @@ protected:
                                            std::size_t maxNumberCorrelations);
 
         //! Check if we can still allocate any correlations.
-        virtual bool areAllocationsAllowed() const override;
+        bool areAllocationsAllowed() const override;
 
         //! Check if \p correlations exceeds the memory limit.
-        virtual bool exceedsLimit(std::size_t correlations) const override;
+        bool exceedsLimit(std::size_t correlations) const override;
 
         //! Get the maximum number of correlations we should model.
-        virtual std::size_t maxNumberCorrelations() const override;
+        std::size_t maxNumberCorrelations() const override;
 
         //! Get the chunk size in which to allocate correlations.
-        virtual std::size_t chunkSize() const override;
+        std::size_t chunkSize() const override;
 
         //! Create a new prior for a correlation model.
-        virtual TMultivariatePriorUPtr newPrior() const override;
+        TMultivariatePriorUPtr newPrior() const override;
 
         //! Set the prototype prior.
         void prototypePrior(const TMultivariatePriorSPtr& prior);

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -584,19 +584,19 @@ protected:
                                            std::size_t maxNumberCorrelations);
 
         //! Check if we can still allocate any correlations.
-        virtual bool areAllocationsAllowed() const;
+        virtual bool areAllocationsAllowed() const override;
 
         //! Check if \p correlations exceeds the memory limit.
-        virtual bool exceedsLimit(std::size_t correlations) const;
+        virtual bool exceedsLimit(std::size_t correlations) const override;
 
         //! Get the maximum number of correlations we should model.
-        virtual std::size_t maxNumberCorrelations() const;
+        virtual std::size_t maxNumberCorrelations() const override;
 
         //! Get the chunk size in which to allocate correlations.
-        virtual std::size_t chunkSize() const;
+        virtual std::size_t chunkSize() const override;
 
         //! Create a new prior for a correlation model.
-        virtual TMultivariatePriorUPtr newPrior() const;
+        virtual TMultivariatePriorUPtr newPrior() const override;
 
         //! Set the prototype prior.
         void prototypePrior(const TMultivariatePriorSPtr& prior);

--- a/include/model/CCountingModelFactory.h
+++ b/include/model/CCountingModelFactory.h
@@ -43,7 +43,7 @@ public:
                           const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CCountingModelFactory* clone() const;
+    virtual CCountingModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -51,7 +51,8 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new counting model from part of a state document.
     //!
@@ -59,15 +60,17 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
-                                             core::CStateRestoreTraverser& traverser) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData,
+              core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new event rate data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the data
     //! gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const;
+    virtual CDataGatherer*
+    makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new event rate data gatherer from part of a state document.
     //!
@@ -75,61 +78,62 @@ public:
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
     virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const;
+                                            core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
     //@{
     //! Get the default prior for \p feature which is a stub.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const;
+    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
+                                   const SModelParams& params) const override;
 
     //! Get the default prior for \p feature which is a stub.
     virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature which is a stub.
     virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const;
+    virtual const CSearchKey& searchKey() const override;
 
     //! Check if this makes the model used for a simple counting search.
-    virtual bool isSimpleCount() const;
+    virtual bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const;
+    virtual model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const;
+    virtual maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex);
+    virtual void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
                             const std::string& overFieldName,
                             const std::string& byFieldName,
                             const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames);
+                            const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person fields.
-    virtual void useNull(bool useNull);
+    virtual void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features);
+    virtual void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const;
+    virtual double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const;
+    virtual TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CCountingModelFactory.h
+++ b/include/model/CCountingModelFactory.h
@@ -43,7 +43,7 @@ public:
                           const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CCountingModelFactory* clone() const override;
+    CCountingModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -51,8 +51,7 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new counting model from part of a state document.
     //!
@@ -60,80 +59,77 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData,
-              core::CStateRestoreTraverser& traverser) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
+                                     core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new event rate data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the data
     //! gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer*
-    makeDataGatherer(const SGathererInitializationData& initData) const override;
+    CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new event rate data gatherer from part of a state document.
     //!
     //! \param[in] partitionFieldValue The partition field value.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const override;
+    CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
+                                    core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
     //@{
     //! Get the default prior for \p feature which is a stub.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
-                                   const SModelParams& params) const override;
+    TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default prior for \p feature which is a stub.
-    virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultMultivariatePrior(model_t::EFeature feature,
+                                                    const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature which is a stub.
-    virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultCorrelatePrior(model_t::EFeature feature,
+                                                 const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const override;
+    const CSearchKey& searchKey() const override;
 
     //! Check if this makes the model used for a simple counting search.
-    virtual bool isSimpleCount() const override;
+    bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const override;
+    model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const override;
+    maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex) override;
+    void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
-    virtual void fieldNames(const std::string& partitionFieldName,
-                            const std::string& overFieldName,
-                            const std::string& byFieldName,
-                            const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames) override;
+    void fieldNames(const std::string& partitionFieldName,
+                    const std::string& overFieldName,
+                    const std::string& byFieldName,
+                    const std::string& valueFieldName,
+                    const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person fields.
-    virtual void useNull(bool useNull) override;
+    void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features) override;
+    void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const override;
+    double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const override;
+    TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CEventRateBucketGatherer.h
+++ b/include/model/CEventRateBucketGatherer.h
@@ -157,7 +157,7 @@ public:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Create a clone of this data gatherer that will result in the same
     //! persisted state.  The clone may be incomplete in ways that do not
@@ -165,10 +165,10 @@ public:
     //! other purpose.
     //!
     //! \warning The caller owns the object returned.
-    virtual CBucketGatherer* cloneForPersistence() const override;
+    CBucketGatherer* cloneForPersistence() const override;
 
     //! The persistence tag name of this derived class.
-    virtual const std::string& persistenceTag() const override;
+    const std::string& persistenceTag() const override;
     //@}
 
     //! \name Fields
@@ -179,20 +179,20 @@ public:
     //! probabilities are aggregated, i.e. the "over" field name for
     //! population searches and the "by" field name for individual
     //! searches.
-    virtual const std::string& personFieldName() const override;
+    const std::string& personFieldName() const override;
 
     //! Get the attribute field name if one exists, i.e. the "by" for
     //! population searches, field name and returns empty otherwise.
-    virtual const std::string& attributeFieldName() const override;
+    const std::string& attributeFieldName() const override;
 
     //! Returns an empty string.
-    virtual const std::string& valueFieldName() const override;
+    const std::string& valueFieldName() const override;
 
     //! Get an iterator at the beginning the influencing field names.
-    virtual TStrVecCItr beginInfluencers() const override;
+    TStrVecCItr beginInfluencers() const override;
 
     //! Get an iterator at the end of the influencing field names.
-    virtual TStrVecCItr endInfluencers() const override;
+    TStrVecCItr endInfluencers() const override;
 
     //! Get the fields for which to gather data.
     //!
@@ -202,11 +202,11 @@ public:
     //! attributes which are being analyzed. An empty string acts like
     //! a wild card and matches all records. This is used for analysis
     //! which is attribute independent such as total count.
-    virtual const TStrVec& fieldsOfInterest() const override;
+    const TStrVec& fieldsOfInterest() const override;
     //@}
 
     //! Get a description of the search.
-    virtual std::string description() const override;
+    std::string description() const override;
 
     //! \name Update
     //@{
@@ -218,51 +218,51 @@ public:
     //! contain two fields. The first field should contain the over clause
     //! field value. The second field should the by clause field value
     //! or a generic name if none was specified.
-    virtual bool processFields(const TStrCPtrVec& fieldValues,
-                               CEventData& result,
-                               CResourceMonitor& resourceMonitor) override;
+    bool processFields(const TStrCPtrVec& fieldValues,
+                       CEventData& result,
+                       CResourceMonitor& resourceMonitor) override;
     //@}
 
     //! \name Person
     //@{
     //! Stop gathering data on the people identified by \p peopleToRemove.
-    virtual void recyclePeople(const TSizeVec& peopleToRemove) override;
+    void recyclePeople(const TSizeVec& peopleToRemove) override;
 
     //! Remove all traces of people whose identifiers are greater than
     //! or equal to \p lowestPersonToRemove.
-    virtual void removePeople(std::size_t lowestPersonToRemove) override;
+    void removePeople(std::size_t lowestPersonToRemove) override;
     //@}
 
     //! \name Attribute
     //@{
     //! Stop gathering data on the attributes identified by \p attributesToRemove.
-    virtual void recycleAttributes(const TSizeVec& attributesToRemove) override;
+    void recycleAttributes(const TSizeVec& attributesToRemove) override;
 
     //! Remove all traces of attributes whose identifiers are greater than
     //! or equal to \p lowestAttributeToRemove.
-    virtual void removeAttributes(std::size_t lowestAttributeToRemove) override;
+    void removeAttributes(std::size_t lowestAttributeToRemove) override;
     //@}
 
     //! Get the checksum of this gatherer.
-    virtual uint64_t checksum() const override;
+    uint64_t checksum() const override;
 
     //! Get the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Clear this data gatherer.
-    virtual void clear() override;
+    void clear() override;
 
     //! Reset bucket and return true if bucket was successfully reset or false otherwise.
-    virtual bool resetBucket(core_t::TTime bucketStart) override;
+    bool resetBucket(core_t::TTime bucketStart) override;
 
     //! Release memory that is no longer needed
-    virtual void releaseMemory(core_t::TTime samplingCutoffTime) override;
+    void releaseMemory(core_t::TTime samplingCutoffTime) override;
 
     //! \name Features
     //@{
@@ -271,14 +271,14 @@ public:
     //!
     //! \param[in] time The time of interest.
     //! \param[out] result Filled in with the feature data at \p time.
-    virtual void featureData(core_t::TTime time,
-                             core_t::TTime bucketLength,
-                             TFeatureAnyPrVec& result) const override;
+    void featureData(core_t::TTime time,
+                     core_t::TTime bucketLength,
+                     TFeatureAnyPrVec& result) const override;
     //@}
 
 private:
     //! No-op.
-    virtual void sample(core_t::TTime time) override;
+    void sample(core_t::TTime time) override;
 
     //! Append the counts by person for the bucketing interval containing
     //! \p time.
@@ -419,7 +419,7 @@ private:
     //!
     //! \param[in] pid The identifier of the person to accommodate.
     //! \param[in] cid The identifier of the attribute to accommodate.
-    virtual void resize(std::size_t pid, std::size_t cid) override;
+    void resize(std::size_t pid, std::size_t cid) override;
 
     //! Record the arrival of the \p values for the person identified
     //! by \p pid.
@@ -435,16 +435,16 @@ private:
     //! if there is one or null.
     //! \param[in] influences The influencing field values which label
     //! the value.
-    virtual void addValue(std::size_t pid,
-                          std::size_t cid,
-                          core_t::TTime time,
-                          const CEventData::TDouble1VecArray& values,
-                          std::size_t count,
-                          const CEventData::TOptionalStr& stringValue,
-                          const TStoredStringPtrVec& influences) override;
+    void addValue(std::size_t pid,
+                  std::size_t cid,
+                  core_t::TTime time,
+                  const CEventData::TDouble1VecArray& values,
+                  std::size_t count,
+                  const CEventData::TOptionalStr& stringValue,
+                  const TStoredStringPtrVec& influences) override;
 
     //! Start a new bucket.
-    virtual void startNewBucket(core_t::TTime time, bool skipUpdates) override;
+    void startNewBucket(core_t::TTime time, bool skipUpdates) override;
 
     //! Initialize the field names collection.
     void initializeFieldNames(const std::string& personFieldName,

--- a/include/model/CEventRateBucketGatherer.h
+++ b/include/model/CEventRateBucketGatherer.h
@@ -157,7 +157,7 @@ public:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Create a clone of this data gatherer that will result in the same
     //! persisted state.  The clone may be incomplete in ways that do not
@@ -165,10 +165,10 @@ public:
     //! other purpose.
     //!
     //! \warning The caller owns the object returned.
-    virtual CBucketGatherer* cloneForPersistence() const;
+    virtual CBucketGatherer* cloneForPersistence() const override;
 
     //! The persistence tag name of this derived class.
-    virtual const std::string& persistenceTag() const;
+    virtual const std::string& persistenceTag() const override;
     //@}
 
     //! \name Fields
@@ -179,20 +179,20 @@ public:
     //! probabilities are aggregated, i.e. the "over" field name for
     //! population searches and the "by" field name for individual
     //! searches.
-    virtual const std::string& personFieldName() const;
+    virtual const std::string& personFieldName() const override;
 
     //! Get the attribute field name if one exists, i.e. the "by" for
     //! population searches, field name and returns empty otherwise.
-    virtual const std::string& attributeFieldName() const;
+    virtual const std::string& attributeFieldName() const override;
 
     //! Returns an empty string.
-    virtual const std::string& valueFieldName() const;
+    virtual const std::string& valueFieldName() const override;
 
     //! Get an iterator at the beginning the influencing field names.
-    virtual TStrVecCItr beginInfluencers() const;
+    virtual TStrVecCItr beginInfluencers() const override;
 
     //! Get an iterator at the end of the influencing field names.
-    virtual TStrVecCItr endInfluencers() const;
+    virtual TStrVecCItr endInfluencers() const override;
 
     //! Get the fields for which to gather data.
     //!
@@ -202,11 +202,11 @@ public:
     //! attributes which are being analyzed. An empty string acts like
     //! a wild card and matches all records. This is used for analysis
     //! which is attribute independent such as total count.
-    virtual const TStrVec& fieldsOfInterest() const;
+    virtual const TStrVec& fieldsOfInterest() const override;
     //@}
 
     //! Get a description of the search.
-    virtual std::string description() const;
+    virtual std::string description() const override;
 
     //! \name Update
     //@{
@@ -220,49 +220,49 @@ public:
     //! or a generic name if none was specified.
     virtual bool processFields(const TStrCPtrVec& fieldValues,
                                CEventData& result,
-                               CResourceMonitor& resourceMonitor);
+                               CResourceMonitor& resourceMonitor) override;
     //@}
 
     //! \name Person
     //@{
     //! Stop gathering data on the people identified by \p peopleToRemove.
-    virtual void recyclePeople(const TSizeVec& peopleToRemove);
+    virtual void recyclePeople(const TSizeVec& peopleToRemove) override;
 
     //! Remove all traces of people whose identifiers are greater than
     //! or equal to \p lowestPersonToRemove.
-    virtual void removePeople(std::size_t lowestPersonToRemove);
+    virtual void removePeople(std::size_t lowestPersonToRemove) override;
     //@}
 
     //! \name Attribute
     //@{
     //! Stop gathering data on the attributes identified by \p attributesToRemove.
-    virtual void recycleAttributes(const TSizeVec& attributesToRemove);
+    virtual void recycleAttributes(const TSizeVec& attributesToRemove) override;
 
     //! Remove all traces of attributes whose identifiers are greater than
     //! or equal to \p lowestAttributeToRemove.
-    virtual void removeAttributes(std::size_t lowestAttributeToRemove);
+    virtual void removeAttributes(std::size_t lowestAttributeToRemove) override;
     //@}
 
     //! Get the checksum of this gatherer.
-    virtual uint64_t checksum() const;
+    virtual uint64_t checksum() const override;
 
     //! Get the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Clear this data gatherer.
-    virtual void clear();
+    virtual void clear() override;
 
     //! Reset bucket and return true if bucket was successfully reset or false otherwise.
-    virtual bool resetBucket(core_t::TTime bucketStart);
+    virtual bool resetBucket(core_t::TTime bucketStart) override;
 
     //! Release memory that is no longer needed
-    virtual void releaseMemory(core_t::TTime samplingCutoffTime);
+    virtual void releaseMemory(core_t::TTime samplingCutoffTime) override;
 
     //! \name Features
     //@{
@@ -273,12 +273,12 @@ public:
     //! \param[out] result Filled in with the feature data at \p time.
     virtual void featureData(core_t::TTime time,
                              core_t::TTime bucketLength,
-                             TFeatureAnyPrVec& result) const;
+                             TFeatureAnyPrVec& result) const override;
     //@}
 
 private:
     //! No-op.
-    virtual void sample(core_t::TTime time);
+    virtual void sample(core_t::TTime time) override;
 
     //! Append the counts by person for the bucketing interval containing
     //! \p time.
@@ -419,7 +419,7 @@ private:
     //!
     //! \param[in] pid The identifier of the person to accommodate.
     //! \param[in] cid The identifier of the attribute to accommodate.
-    virtual void resize(std::size_t pid, std::size_t cid);
+    virtual void resize(std::size_t pid, std::size_t cid) override;
 
     //! Record the arrival of the \p values for the person identified
     //! by \p pid.
@@ -441,10 +441,10 @@ private:
                           const CEventData::TDouble1VecArray& values,
                           std::size_t count,
                           const CEventData::TOptionalStr& stringValue,
-                          const TStoredStringPtrVec& influences);
+                          const TStoredStringPtrVec& influences) override;
 
     //! Start a new bucket.
-    virtual void startNewBucket(core_t::TTime time, bool skipUpdates);
+    virtual void startNewBucket(core_t::TTime time, bool skipUpdates) override;
 
     //! Initialize the field names collection.
     void initializeFieldNames(const std::string& personFieldName,

--- a/include/model/CEventRateModelFactory.h
+++ b/include/model/CEventRateModelFactory.h
@@ -44,7 +44,7 @@ public:
                            const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CEventRateModelFactory* clone() const;
+    virtual CEventRateModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,7 +52,8 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new event rate model from part of a state document.
     //!
@@ -60,15 +61,17 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
-                                             core::CStateRestoreTraverser& traverser) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData,
+              core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new event rate data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the data
     //! gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const;
+    virtual CDataGatherer*
+    makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new event rate data gatherer from part of a state document.
     //!
@@ -76,7 +79,7 @@ public:
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
     virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const;
+                                            core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -85,14 +88,15 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const;
+    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
+                                   const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
@@ -100,46 +104,46 @@ public:
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const;
+    virtual const CSearchKey& searchKey() const override;
 
     //! Check if this makes the model used for a simple counting search.
-    virtual bool isSimpleCount() const;
+    virtual bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const;
+    virtual model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const;
+    virtual maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex);
+    virtual void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
                             const std::string& overFieldName,
                             const std::string& byFieldName,
                             const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames);
+                            const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person fields.
-    virtual void useNull(bool useNull);
+    virtual void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features);
+    virtual void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const;
+    virtual double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const;
+    virtual TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CEventRateModelFactory.h
+++ b/include/model/CEventRateModelFactory.h
@@ -44,7 +44,7 @@ public:
                            const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CEventRateModelFactory* clone() const override;
+    CEventRateModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,8 +52,7 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new event rate model from part of a state document.
     //!
@@ -61,25 +60,23 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData,
-              core::CStateRestoreTraverser& traverser) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
+                                     core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new event rate data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the data
     //! gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer*
-    makeDataGatherer(const SGathererInitializationData& initData) const override;
+    CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new event rate data gatherer from part of a state document.
     //!
     //! \param[in] partitionFieldValue The partition field value.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const override;
+    CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
+                                    core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -88,62 +85,61 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
-                                   const SModelParams& params) const override;
+    TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultMultivariatePrior(model_t::EFeature feature,
+                                                    const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultCorrelatePrior(model_t::EFeature feature,
+                                                 const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const override;
+    const CSearchKey& searchKey() const override;
 
     //! Check if this makes the model used for a simple counting search.
-    virtual bool isSimpleCount() const override;
+    bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const override;
+    model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const override;
+    maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex) override;
+    void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
-    virtual void fieldNames(const std::string& partitionFieldName,
-                            const std::string& overFieldName,
-                            const std::string& byFieldName,
-                            const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames) override;
+    void fieldNames(const std::string& partitionFieldName,
+                    const std::string& overFieldName,
+                    const std::string& byFieldName,
+                    const std::string& valueFieldName,
+                    const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person fields.
-    virtual void useNull(bool useNull) override;
+    void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features) override;
+    void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const override;
+    double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const override;
+    TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CEventRatePopulationModelFactory.h
+++ b/include/model/CEventRatePopulationModelFactory.h
@@ -44,7 +44,7 @@ public:
                                      const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CEventRatePopulationModelFactory* clone() const;
+    virtual CEventRatePopulationModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,7 +52,8 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new population event rate model from part of a state
     //! document.
@@ -61,14 +62,16 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
-                                             core::CStateRestoreTraverser& traverser) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData,
+              core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new event rate population data gatherer.
     //! \param[in] initData The parameters needed to initialize the
     //! data gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const;
+    virtual CDataGatherer*
+    makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new population event rate data gatherer from part of
     //! a state document.
@@ -77,7 +80,7 @@ public:
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
     virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const;
+                                            core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -86,14 +89,15 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const;
+    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
+                                   const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
@@ -101,47 +105,47 @@ public:
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const;
+    virtual const CSearchKey& searchKey() const override;
 
     //! Returns false.
-    virtual bool isSimpleCount() const;
+    virtual bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const;
+    virtual model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const;
+    virtual maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex);
+    virtual void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
                             const std::string& overFieldName,
                             const std::string& byFieldName,
                             const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames);
+                            const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person and
     //! attribute fields.
-    virtual void useNull(bool useNull);
+    virtual void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features);
+    virtual void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const;
+    virtual double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const;
+    virtual TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CEventRatePopulationModelFactory.h
+++ b/include/model/CEventRatePopulationModelFactory.h
@@ -44,7 +44,7 @@ public:
                                      const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CEventRatePopulationModelFactory* clone() const override;
+    CEventRatePopulationModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,8 +52,7 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new population event rate model from part of a state
     //! document.
@@ -62,16 +61,14 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData,
-              core::CStateRestoreTraverser& traverser) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
+                                     core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new event rate population data gatherer.
     //! \param[in] initData The parameters needed to initialize the
     //! data gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer*
-    makeDataGatherer(const SGathererInitializationData& initData) const override;
+    CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new population event rate data gatherer from part of
     //! a state document.
@@ -79,8 +76,8 @@ public:
     //! \param[in] partitionFieldValue The partition field value.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const override;
+    CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
+                                    core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -89,63 +86,62 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
-                                   const SModelParams& params) const override;
+    TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultMultivariatePrior(model_t::EFeature feature,
+                                                    const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultCorrelatePrior(model_t::EFeature feature,
+                                                 const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const override;
+    const CSearchKey& searchKey() const override;
 
     //! Returns false.
-    virtual bool isSimpleCount() const override;
+    bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const override;
+    model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const override;
+    maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex) override;
+    void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
-    virtual void fieldNames(const std::string& partitionFieldName,
-                            const std::string& overFieldName,
-                            const std::string& byFieldName,
-                            const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames) override;
+    void fieldNames(const std::string& partitionFieldName,
+                    const std::string& overFieldName,
+                    const std::string& byFieldName,
+                    const std::string& valueFieldName,
+                    const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person and
     //! attribute fields.
-    virtual void useNull(bool useNull) override;
+    void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features) override;
+    void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const override;
+    double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const override;
+    TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CHierarchicalResultsAggregator.h
+++ b/include/model/CHierarchicalResultsAggregator.h
@@ -62,7 +62,7 @@ public:
     void clear();
 
     //! Compute the aggregate probability for \p node.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
+    void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 
     //! Age the quantile sketches.
     void propagateForwardByTime(double time);

--- a/include/model/CHierarchicalResultsAggregator.h
+++ b/include/model/CHierarchicalResultsAggregator.h
@@ -62,7 +62,7 @@ public:
     void clear();
 
     //! Compute the aggregate probability for \p node.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot);
+    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 
     //! Age the quantile sketches.
     void propagateForwardByTime(double time);

--- a/include/model/CHierarchicalResultsNormalizer.h
+++ b/include/model/CHierarchicalResultsNormalizer.h
@@ -118,7 +118,7 @@ public:
     void resetBigChange();
 
     //! Update the normalizer with the node's anomaly score.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
+    void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 
     //! Age the maximum scores and quantile summaries.
     void propagateForwardByTime(double time);

--- a/include/model/CHierarchicalResultsNormalizer.h
+++ b/include/model/CHierarchicalResultsNormalizer.h
@@ -118,7 +118,7 @@ public:
     void resetBigChange();
 
     //! Update the normalizer with the node's anomaly score.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot);
+    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 
     //! Age the maximum scores and quantile summaries.
     void propagateForwardByTime(double time);

--- a/include/model/CHierarchicalResultsPopulator.h
+++ b/include/model/CHierarchicalResultsPopulator.h
@@ -29,7 +29,7 @@ public:
     CHierarchicalResultsPopulator(const CLimits& limits);
 
     //! Visit \p node.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot);
+    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 
 private:
     const CLimits& m_Limits;

--- a/include/model/CHierarchicalResultsPopulator.h
+++ b/include/model/CHierarchicalResultsPopulator.h
@@ -29,7 +29,7 @@ public:
     CHierarchicalResultsPopulator(const CLimits& limits);
 
     //! Visit \p node.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
+    void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 
 private:
     const CLimits& m_Limits;

--- a/include/model/CHierarchicalResultsProbabilityFinalizer.h
+++ b/include/model/CHierarchicalResultsProbabilityFinalizer.h
@@ -32,7 +32,7 @@ namespace model {
 class MODEL_EXPORT CHierarchicalResultsProbabilityFinalizer : public CHierarchicalResultsVisitor {
 public:
     //! Finalize the probability of \p node.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot);
+    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 };
 }
 }

--- a/include/model/CHierarchicalResultsProbabilityFinalizer.h
+++ b/include/model/CHierarchicalResultsProbabilityFinalizer.h
@@ -32,7 +32,7 @@ namespace model {
 class MODEL_EXPORT CHierarchicalResultsProbabilityFinalizer : public CHierarchicalResultsVisitor {
 public:
     //! Finalize the probability of \p node.
-    virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
+    void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 };
 }
 }

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -90,7 +90,7 @@ public:
     //@}
 
     //! Returns false.
-    virtual bool isPopulation() const override;
+    bool isPopulation() const override;
 
     //! \name Bucket Statistics
     //@{
@@ -99,10 +99,10 @@ public:
     //!
     //! \param[in] pid The person of interest.
     //! \param[in] time The time of interest.
-    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
+    TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
 
     //! Check if bucket statistics are available for the specified time.
-    virtual bool bucketStatsAvailable(core_t::TTime time) const override;
+    bool bucketStatsAvailable(core_t::TTime time) const override;
     //@}
 
     //! \name Update
@@ -113,9 +113,9 @@ public:
     //!
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
-    virtual void sampleBucketStatistics(core_t::TTime startTime,
-                                        core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor) override = 0;
+    void sampleBucketStatistics(core_t::TTime startTime,
+                                core_t::TTime endTime,
+                                CResourceMonitor& resourceMonitor) override = 0;
 
     //! Update the model with features samples from the time interval
     //! [\p startTime, \p endTime].
@@ -123,22 +123,22 @@ public:
     //! \param[in] startTime The start of the time interval to sample.
     //! \param[in] endTime The end of the time interval to sample.
     //! \param[in] resourceMonitor The resourceMonitor.
-    virtual void sample(core_t::TTime startTime,
-                        core_t::TTime endTime,
-                        CResourceMonitor& resourceMonitor) override = 0;
+    void sample(core_t::TTime startTime,
+                core_t::TTime endTime,
+                CResourceMonitor& resourceMonitor) override = 0;
 
     //! Prune any person models which haven't been updated for a
     //! specified period.
-    virtual void prune(std::size_t maximumAge) override;
+    void prune(std::size_t maximumAge) override;
     //@}
 
     //! \name Probability
     //@{
     //! Clears \p probability and \p attributeProbabilities.
-    virtual bool computeTotalProbability(const std::string& person,
-                                         std::size_t numberAttributeProbabilities,
-                                         TOptionalDouble& probability,
-                                         TAttributeProbability1Vec& attributeProbabilities) const override;
+    bool computeTotalProbability(const std::string& person,
+                                 std::size_t numberAttributeProbabilities,
+                                 TOptionalDouble& probability,
+                                 TAttributeProbability1Vec& attributeProbabilities) const override;
     //@}
 
     //! Get the checksum of this model.
@@ -147,19 +147,19 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const override = 0;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override = 0;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override = 0;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override = 0;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const override = 0;
+    std::size_t memoryUsage() const override = 0;
 
     //! Get the static size of this object - used for virtual hierarchies.
-    virtual std::size_t staticSize() const override = 0;
+    std::size_t staticSize() const override = 0;
 
     //! Get the non-estimated value of the the memory used by this model.
-    virtual std::size_t computeMemoryUsage() const override = 0;
+    std::size_t computeMemoryUsage() const override = 0;
 
     //! Get the first time each person was seen.
     const TTimeVec& firstBucketTimes() const;
@@ -189,26 +189,25 @@ protected:
     bool doAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Get the start time of the current bucket.
-    virtual core_t::TTime currentBucketStartTime() const override = 0;
+    core_t::TTime currentBucketStartTime() const override = 0;
 
     //! Set the start time of the current bucket.
-    virtual void currentBucketStartTime(core_t::TTime time) override = 0;
+    void currentBucketStartTime(core_t::TTime time) override = 0;
 
     //! Monitor the resource usage while creating new models.
     void createUpdateNewModels(core_t::TTime time, CResourceMonitor& resourceMonitor);
 
     //! Create the time series models for "n" newly observed people.
-    virtual void createNewModels(std::size_t n, std::size_t m) override;
+    void createNewModels(std::size_t n, std::size_t m) override;
 
     //! Reinitialize the time series models for recycled people.
-    virtual void updateRecycledModels() override;
+    void updateRecycledModels() override;
 
     //! Update the correlation models.
     void refreshCorrelationModels(std::size_t resourceLimit, CResourceMonitor& resourceMonitor);
 
     //! Clear out large state objects for people that are pruned.
-    virtual void clearPrunedResources(const TSizeVec& people,
-                                      const TSizeVec& attributes) override = 0;
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override = 0;
 
     //! Get the person unique identifiers which have a feature value
     //! in the bucketing time interval including \p time.
@@ -280,13 +279,13 @@ private:
     std::size_t numberCorrelations() const;
 
     //! Returns one.
-    virtual double attributeFrequency(std::size_t cid) const override;
+    double attributeFrequency(std::size_t cid) const override;
 
     //! Perform derived class specific operations to accomplish skipping sampling
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
+    void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
 
     //! Get the model memory usage estimator
-    virtual CMemoryUsageEstimator* memoryUsageEstimator() const override;
+    CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
 private:
     //! The time that each person was first seen.

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -90,7 +90,7 @@ public:
     //@}
 
     //! Returns false.
-    virtual bool isPopulation() const;
+    virtual bool isPopulation() const override;
 
     //! \name Bucket Statistics
     //@{
@@ -99,10 +99,10 @@ public:
     //!
     //! \param[in] pid The person of interest.
     //! \param[in] time The time of interest.
-    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const;
+    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
 
     //! Check if bucket statistics are available for the specified time.
-    virtual bool bucketStatsAvailable(core_t::TTime time) const;
+    virtual bool bucketStatsAvailable(core_t::TTime time) const override;
     //@}
 
     //! \name Update
@@ -115,7 +115,7 @@ public:
     //! \param[in] endTime The end of the time interval to sample.
     virtual void sampleBucketStatistics(core_t::TTime startTime,
                                         core_t::TTime endTime,
-                                        CResourceMonitor& resourceMonitor) = 0;
+                                        CResourceMonitor& resourceMonitor) override = 0;
 
     //! Update the model with features samples from the time interval
     //! [\p startTime, \p endTime].
@@ -125,11 +125,11 @@ public:
     //! \param[in] resourceMonitor The resourceMonitor.
     virtual void sample(core_t::TTime startTime,
                         core_t::TTime endTime,
-                        CResourceMonitor& resourceMonitor) = 0;
+                        CResourceMonitor& resourceMonitor) override = 0;
 
     //! Prune any person models which haven't been updated for a
     //! specified period.
-    virtual void prune(std::size_t maximumAge);
+    virtual void prune(std::size_t maximumAge) override;
     //@}
 
     //! \name Probability
@@ -138,7 +138,7 @@ public:
     virtual bool computeTotalProbability(const std::string& person,
                                          std::size_t numberAttributeProbabilities,
                                          TOptionalDouble& probability,
-                                         TAttributeProbability1Vec& attributeProbabilities) const;
+                                         TAttributeProbability1Vec& attributeProbabilities) const override;
     //@}
 
     //! Get the checksum of this model.
@@ -147,19 +147,19 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const = 0;
+    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const override = 0;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override = 0;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const = 0;
+    virtual std::size_t memoryUsage() const override = 0;
 
     //! Get the static size of this object - used for virtual hierarchies.
-    virtual std::size_t staticSize() const = 0;
+    virtual std::size_t staticSize() const override = 0;
 
     //! Get the non-estimated value of the the memory used by this model.
-    virtual std::size_t computeMemoryUsage() const = 0;
+    virtual std::size_t computeMemoryUsage() const override = 0;
 
     //! Get the first time each person was seen.
     const TTimeVec& firstBucketTimes() const;
@@ -180,7 +180,7 @@ protected:
     void doPersistModelsState(core::CStatePersistInserter& inserter) const;
 
     //! Should this model be persisted?
-    bool shouldPersist() const;
+    bool shouldPersist() const override;
 
     //! Persist state by passing information to the supplied inserter.
     void doAcceptPersistInserter(core::CStatePersistInserter& inserter) const;
@@ -189,25 +189,26 @@ protected:
     bool doAcceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Get the start time of the current bucket.
-    virtual core_t::TTime currentBucketStartTime() const = 0;
+    virtual core_t::TTime currentBucketStartTime() const override = 0;
 
     //! Set the start time of the current bucket.
-    virtual void currentBucketStartTime(core_t::TTime time) = 0;
+    virtual void currentBucketStartTime(core_t::TTime time) override = 0;
 
     //! Monitor the resource usage while creating new models.
     void createUpdateNewModels(core_t::TTime time, CResourceMonitor& resourceMonitor);
 
     //! Create the time series models for "n" newly observed people.
-    virtual void createNewModels(std::size_t n, std::size_t m);
+    virtual void createNewModels(std::size_t n, std::size_t m) override;
 
     //! Reinitialize the time series models for recycled people.
-    virtual void updateRecycledModels();
+    virtual void updateRecycledModels() override;
 
     //! Update the correlation models.
     void refreshCorrelationModels(std::size_t resourceLimit, CResourceMonitor& resourceMonitor);
 
     //! Clear out large state objects for people that are pruned.
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) = 0;
+    virtual void clearPrunedResources(const TSizeVec& people,
+                                      const TSizeVec& attributes) override = 0;
 
     //! Get the person unique identifiers which have a feature value
     //! in the bucketing time interval including \p time.
@@ -279,13 +280,13 @@ private:
     std::size_t numberCorrelations() const;
 
     //! Returns one.
-    virtual double attributeFrequency(std::size_t cid) const;
+    virtual double attributeFrequency(std::size_t cid) const override;
 
     //! Perform derived class specific operations to accomplish skipping sampling
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime);
+    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
 
     //! Get the model memory usage estimator
-    virtual CMemoryUsageEstimator* memoryUsageEstimator() const;
+    virtual CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
 private:
     //! The time that each person was first seen.

--- a/include/model/CMetricBucketGatherer.h
+++ b/include/model/CMetricBucketGatherer.h
@@ -95,7 +95,7 @@ public:
     //! \name Persistence
     //@{
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Fill in the state from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
@@ -105,10 +105,10 @@ public:
     //! affect the persisted representation, and must not be used for any
     //! other purpose.
     //! \warning The caller owns the object returned.
-    virtual CBucketGatherer* cloneForPersistence() const;
+    virtual CBucketGatherer* cloneForPersistence() const override;
 
     //! The persistence tag name of this derived class.
-    virtual const std::string& persistenceTag() const;
+    virtual const std::string& persistenceTag() const override;
 
 private:
     //! Internal restore function.
@@ -125,20 +125,20 @@ public:
     //! probabilities are aggregated, i.e. the "over" field name for
     //! population searches and the "by" field name for individual
     //! searches.
-    virtual const std::string& personFieldName() const;
+    virtual const std::string& personFieldName() const override;
 
     //! Get the attribute field name if one exists, i.e. the "by" for
     //! population searches, field name and returns empty otherwise.
-    virtual const std::string& attributeFieldName() const;
+    virtual const std::string& attributeFieldName() const override;
 
     //! Returns an empty string.
-    virtual const std::string& valueFieldName() const;
+    virtual const std::string& valueFieldName() const override;
 
     //! Get an iterator at the beginning the influencing field names.
-    virtual TStrVecCItr beginInfluencers() const;
+    virtual TStrVecCItr beginInfluencers() const override;
 
     //! Get an iterator at the end of the influencing field names.
-    virtual TStrVecCItr endInfluencers() const;
+    virtual TStrVecCItr endInfluencers() const override;
 
     //! Get the fields for which to gather data.
     //!
@@ -148,11 +148,11 @@ public:
     //! attributes which are being analyzed. An empty string acts like
     //! a wild card and matches all records. This is used for analysis
     //! which is attribute independent such as total count.
-    virtual const TStrVec& fieldsOfInterest() const;
+    virtual const TStrVec& fieldsOfInterest() const override;
     //@}
 
     //! Get a description of the search.
-    virtual std::string description() const;
+    virtual std::string description() const override;
 
     //! \name Update
     //@{
@@ -169,49 +169,49 @@ public:
     //! to the metric value.
     virtual bool processFields(const TStrCPtrVec& fieldValues,
                                CEventData& result,
-                               CResourceMonitor& resourceMonitor);
+                               CResourceMonitor& resourceMonitor) override;
     //@}
 
     //! \name Person
     //@{
     //! Stop gathering data on the people identified by \p peopleToRemove.
-    virtual void recyclePeople(const TSizeVec& peopleToRemove);
+    virtual void recyclePeople(const TSizeVec& peopleToRemove) override;
 
     //! Remove all traces of people whose identifiers are greater than
     //! or equal to \p lowestPersonToRemove.
-    virtual void removePeople(std::size_t lowestPersonToRemove);
+    virtual void removePeople(std::size_t lowestPersonToRemove) override;
     //@}
 
     //! \name Attribute
     //@{
     //! Stop gathering data on the attributes identified by \p attributesToRemove.
-    virtual void recycleAttributes(const TSizeVec& attributesToRemove);
+    virtual void recycleAttributes(const TSizeVec& attributesToRemove) override;
 
     //! Remove all traces of attributes whose identifiers are greater
     //! than or equal to \p lowestAttributeToRemove.
-    virtual void removeAttributes(std::size_t lowestAttributeToRemove);
+    virtual void removeAttributes(std::size_t lowestAttributeToRemove) override;
     //@}
 
     //! Get the checksum of this gatherer.
-    virtual uint64_t checksum() const;
+    virtual uint64_t checksum() const override;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const;
+    virtual std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const;
+    virtual std::size_t staticSize() const override;
 
     //! Clear this data gatherer.
-    virtual void clear();
+    virtual void clear() override;
 
     //! Reset bucket and return true if bucket was successfully reset or false otherwise.
-    virtual bool resetBucket(core_t::TTime bucketStart);
+    virtual bool resetBucket(core_t::TTime bucketStart) override;
 
     //! Release memory that is no longer needed
-    virtual void releaseMemory(core_t::TTime samplingCutoffTime);
+    virtual void releaseMemory(core_t::TTime samplingCutoffTime) override;
 
     //! \name Features
     //@{
@@ -222,12 +222,12 @@ public:
     //! \param[out] result Filled in with the feature data at \p time.
     virtual void featureData(core_t::TTime time,
                              core_t::TTime bucketLength,
-                             TFeatureAnyPrVec& result) const;
+                             TFeatureAnyPrVec& result) const override;
     //@}
 
 private:
     //! Create samples if possible for the bucket pointed out by \p time.
-    virtual void sample(core_t::TTime time);
+    virtual void sample(core_t::TTime time) override;
 
     //! Resize the necessary data structures so they can accommodate
     //! the person and attribute identified by \p pid and \p cid,
@@ -235,7 +235,7 @@ private:
     //!
     //! \param[in] pid The identifier of the person to accommodate.
     //! \param[in] cid The identifier of the attribute to accommodate.
-    virtual void resize(std::size_t pid, std::size_t cid);
+    virtual void resize(std::size_t pid, std::size_t cid) override;
 
     //! Record the arrival of \p values for attribute identified by
     //! \p cid and person identified by \p pid.
@@ -256,10 +256,10 @@ private:
                           const CEventData::TDouble1VecArray& values,
                           std::size_t count,
                           const CEventData::TOptionalStr& stringValue,
-                          const TStoredStringPtrVec& influences);
+                          const TStoredStringPtrVec& influences) override;
 
     //! Start a new bucket.
-    virtual void startNewBucket(core_t::TTime time, bool skipUpdates);
+    virtual void startNewBucket(core_t::TTime time, bool skipUpdates) override;
 
     //! Initialize the field names collection.
     //! initializeFieldNamesPart2() must be called after this.

--- a/include/model/CMetricBucketGatherer.h
+++ b/include/model/CMetricBucketGatherer.h
@@ -95,7 +95,7 @@ public:
     //! \name Persistence
     //@{
     //! Persist state by passing information to the supplied inserter
-    virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
     //! Fill in the state from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
@@ -105,10 +105,10 @@ public:
     //! affect the persisted representation, and must not be used for any
     //! other purpose.
     //! \warning The caller owns the object returned.
-    virtual CBucketGatherer* cloneForPersistence() const override;
+    CBucketGatherer* cloneForPersistence() const override;
 
     //! The persistence tag name of this derived class.
-    virtual const std::string& persistenceTag() const override;
+    const std::string& persistenceTag() const override;
 
 private:
     //! Internal restore function.
@@ -125,20 +125,20 @@ public:
     //! probabilities are aggregated, i.e. the "over" field name for
     //! population searches and the "by" field name for individual
     //! searches.
-    virtual const std::string& personFieldName() const override;
+    const std::string& personFieldName() const override;
 
     //! Get the attribute field name if one exists, i.e. the "by" for
     //! population searches, field name and returns empty otherwise.
-    virtual const std::string& attributeFieldName() const override;
+    const std::string& attributeFieldName() const override;
 
     //! Returns an empty string.
-    virtual const std::string& valueFieldName() const override;
+    const std::string& valueFieldName() const override;
 
     //! Get an iterator at the beginning the influencing field names.
-    virtual TStrVecCItr beginInfluencers() const override;
+    TStrVecCItr beginInfluencers() const override;
 
     //! Get an iterator at the end of the influencing field names.
-    virtual TStrVecCItr endInfluencers() const override;
+    TStrVecCItr endInfluencers() const override;
 
     //! Get the fields for which to gather data.
     //!
@@ -148,11 +148,11 @@ public:
     //! attributes which are being analyzed. An empty string acts like
     //! a wild card and matches all records. This is used for analysis
     //! which is attribute independent such as total count.
-    virtual const TStrVec& fieldsOfInterest() const override;
+    const TStrVec& fieldsOfInterest() const override;
     //@}
 
     //! Get a description of the search.
-    virtual std::string description() const override;
+    std::string description() const override;
 
     //! \name Update
     //@{
@@ -167,51 +167,51 @@ public:
     //! should the by clause field value or a generic name if none was
     //! specified. The third field should contain a number corresponding
     //! to the metric value.
-    virtual bool processFields(const TStrCPtrVec& fieldValues,
-                               CEventData& result,
-                               CResourceMonitor& resourceMonitor) override;
+    bool processFields(const TStrCPtrVec& fieldValues,
+                       CEventData& result,
+                       CResourceMonitor& resourceMonitor) override;
     //@}
 
     //! \name Person
     //@{
     //! Stop gathering data on the people identified by \p peopleToRemove.
-    virtual void recyclePeople(const TSizeVec& peopleToRemove) override;
+    void recyclePeople(const TSizeVec& peopleToRemove) override;
 
     //! Remove all traces of people whose identifiers are greater than
     //! or equal to \p lowestPersonToRemove.
-    virtual void removePeople(std::size_t lowestPersonToRemove) override;
+    void removePeople(std::size_t lowestPersonToRemove) override;
     //@}
 
     //! \name Attribute
     //@{
     //! Stop gathering data on the attributes identified by \p attributesToRemove.
-    virtual void recycleAttributes(const TSizeVec& attributesToRemove) override;
+    void recycleAttributes(const TSizeVec& attributesToRemove) override;
 
     //! Remove all traces of attributes whose identifiers are greater
     //! than or equal to \p lowestAttributeToRemove.
-    virtual void removeAttributes(std::size_t lowestAttributeToRemove) override;
+    void removeAttributes(std::size_t lowestAttributeToRemove) override;
     //@}
 
     //! Get the checksum of this gatherer.
-    virtual uint64_t checksum() const override;
+    uint64_t checksum() const override;
 
     //! Debug the memory used by this object.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the memory used by this object.
-    virtual std::size_t memoryUsage() const override;
+    std::size_t memoryUsage() const override;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override;
+    std::size_t staticSize() const override;
 
     //! Clear this data gatherer.
-    virtual void clear() override;
+    void clear() override;
 
     //! Reset bucket and return true if bucket was successfully reset or false otherwise.
-    virtual bool resetBucket(core_t::TTime bucketStart) override;
+    bool resetBucket(core_t::TTime bucketStart) override;
 
     //! Release memory that is no longer needed
-    virtual void releaseMemory(core_t::TTime samplingCutoffTime) override;
+    void releaseMemory(core_t::TTime samplingCutoffTime) override;
 
     //! \name Features
     //@{
@@ -220,14 +220,14 @@ public:
     //!
     //! \param[in] time The time of interest.
     //! \param[out] result Filled in with the feature data at \p time.
-    virtual void featureData(core_t::TTime time,
-                             core_t::TTime bucketLength,
-                             TFeatureAnyPrVec& result) const override;
+    void featureData(core_t::TTime time,
+                     core_t::TTime bucketLength,
+                     TFeatureAnyPrVec& result) const override;
     //@}
 
 private:
     //! Create samples if possible for the bucket pointed out by \p time.
-    virtual void sample(core_t::TTime time) override;
+    void sample(core_t::TTime time) override;
 
     //! Resize the necessary data structures so they can accommodate
     //! the person and attribute identified by \p pid and \p cid,
@@ -235,7 +235,7 @@ private:
     //!
     //! \param[in] pid The identifier of the person to accommodate.
     //! \param[in] cid The identifier of the attribute to accommodate.
-    virtual void resize(std::size_t pid, std::size_t cid) override;
+    void resize(std::size_t pid, std::size_t cid) override;
 
     //! Record the arrival of \p values for attribute identified by
     //! \p cid and person identified by \p pid.
@@ -250,16 +250,16 @@ private:
     //! \param[in] stringValue Ignored.
     //! \param[in] influences The influencing field values which
     //! label the value.
-    virtual void addValue(std::size_t pid,
-                          std::size_t cid,
-                          core_t::TTime time,
-                          const CEventData::TDouble1VecArray& values,
-                          std::size_t count,
-                          const CEventData::TOptionalStr& stringValue,
-                          const TStoredStringPtrVec& influences) override;
+    void addValue(std::size_t pid,
+                  std::size_t cid,
+                  core_t::TTime time,
+                  const CEventData::TDouble1VecArray& values,
+                  std::size_t count,
+                  const CEventData::TOptionalStr& stringValue,
+                  const TStoredStringPtrVec& influences) override;
 
     //! Start a new bucket.
-    virtual void startNewBucket(core_t::TTime time, bool skipUpdates) override;
+    void startNewBucket(core_t::TTime time, bool skipUpdates) override;
 
     //! Initialize the field names collection.
     //! initializeFieldNamesPart2() must be called after this.

--- a/include/model/CMetricModelFactory.h
+++ b/include/model/CMetricModelFactory.h
@@ -44,7 +44,7 @@ public:
                         const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CMetricModelFactory* clone() const override;
+    CMetricModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,8 +52,7 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new metric model from part of a state document.
     //!
@@ -61,25 +60,23 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData,
-              core::CStateRestoreTraverser& traverser) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
+                                     core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new metric data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the
     //! data gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer*
-    makeDataGatherer(const SGathererInitializationData& initData) const override;
+    CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new metric data gatherer from part of a state document.
     //!
     //! \param[in] partitionFieldValue The partition field value.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const override;
+    CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
+                                    core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -88,65 +85,64 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
-                                   const SModelParams& params) const override;
+    TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultMultivariatePrior(model_t::EFeature feature,
+                                                    const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultCorrelatePrior(model_t::EFeature feature,
+                                                 const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const override;
+    const CSearchKey& searchKey() const override;
 
     //! Returns false.
-    virtual bool isSimpleCount() const override;
+    bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const override;
+    model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const override;
+    maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex) override;
+    void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
-    virtual void fieldNames(const std::string& partitionFieldName,
-                            const std::string& overFieldName,
-                            const std::string& byFieldName,
-                            const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames) override;
+    void fieldNames(const std::string& partitionFieldName,
+                    const std::string& overFieldName,
+                    const std::string& byFieldName,
+                    const std::string& valueFieldName,
+                    const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person fields.
-    virtual void useNull(bool useNull) override;
+    void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features) override;
+    void features(const TFeatureVec& features) override;
 
     //! Set the modeled bucket length.
     virtual void bucketLength(core_t::TTime bucketLength);
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const override;
+    double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const override;
+    TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CMetricModelFactory.h
+++ b/include/model/CMetricModelFactory.h
@@ -44,7 +44,7 @@ public:
                         const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CMetricModelFactory* clone() const;
+    virtual CMetricModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,7 +52,8 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new metric model from part of a state document.
     //!
@@ -60,15 +61,17 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
-                                             core::CStateRestoreTraverser& traverser) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData,
+              core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new metric data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the
     //! data gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const;
+    virtual CDataGatherer*
+    makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new metric data gatherer from part of a state document.
     //!
@@ -76,7 +79,7 @@ public:
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
     virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const;
+                                            core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -85,14 +88,15 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const;
+    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
+                                   const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
@@ -100,49 +104,49 @@ public:
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const;
+    virtual const CSearchKey& searchKey() const override;
 
     //! Returns false.
-    virtual bool isSimpleCount() const;
+    virtual bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const;
+    virtual model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const;
+    virtual maths_t::EDataType dataType() const override;
 
     //! \name Customization by a specific search
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex);
+    virtual void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
                             const std::string& overFieldName,
                             const std::string& byFieldName,
                             const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames);
+                            const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person fields.
-    virtual void useNull(bool useNull);
+    virtual void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features);
+    virtual void features(const TFeatureVec& features) override;
 
     //! Set the modeled bucket length.
     virtual void bucketLength(core_t::TTime bucketLength);
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const;
+    virtual double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const;
+    virtual TStrCRefVec partitioningFields() const override;
 
 private:
     //! The identifier of the search for which this generates models.

--- a/include/model/CMetricPopulationModelFactory.h
+++ b/include/model/CMetricPopulationModelFactory.h
@@ -44,7 +44,7 @@ public:
                                   const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CMetricPopulationModelFactory* clone() const;
+    virtual CMetricPopulationModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,7 +52,8 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new metric population model from part of a state document.
     //!
@@ -60,15 +61,17 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
-                                             core::CStateRestoreTraverser& traverser) const;
+    virtual CAnomalyDetectorModel*
+    makeModel(const SModelInitializationData& initData,
+              core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new metric population data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the data
     //! gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const;
+    virtual CDataGatherer*
+    makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new metric population data gatherer from part of a state
     //! document.
@@ -77,7 +80,7 @@ public:
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
     virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const;
+                                            core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -86,14 +89,15 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const;
+    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
+                                   const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
@@ -101,47 +105,47 @@ public:
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
     virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const;
+    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const;
+    virtual const CSearchKey& searchKey() const override;
 
     //! Returns false.
-    virtual bool isSimpleCount() const;
+    virtual bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const;
+    virtual model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const;
+    virtual maths_t::EDataType dataType() const override;
 
     //! \name Customization
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex);
+    virtual void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
     virtual void fieldNames(const std::string& partitionFieldName,
                             const std::string& overFieldName,
                             const std::string& byFieldName,
                             const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames);
+                            const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person and
     //! attribute fields.
-    virtual void useNull(bool useNull);
+    virtual void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features);
+    virtual void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const;
+    virtual double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const;
+    virtual TStrCRefVec partitioningFields() const override;
 
     //! Restores a single population metric model.
     bool modelAcceptRestoreTraverser(const SModelInitializationData& initData,

--- a/include/model/CMetricPopulationModelFactory.h
+++ b/include/model/CMetricPopulationModelFactory.h
@@ -44,7 +44,7 @@ public:
                                   const std::string& summaryCountFieldName = "");
 
     //! Create a copy of the factory owned by the calling code.
-    virtual CMetricPopulationModelFactory* clone() const override;
+    CMetricPopulationModelFactory* clone() const override;
 
     //! \name Factory Methods
     //@{
@@ -52,8 +52,7 @@ public:
     //!
     //! \param[in] initData The parameters needed to initialize the model.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData) const override;
 
     //! Make a new metric population model from part of a state document.
     //!
@@ -61,17 +60,15 @@ public:
     //! the model.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CAnomalyDetectorModel*
-    makeModel(const SModelInitializationData& initData,
-              core::CStateRestoreTraverser& traverser) const override;
+    CAnomalyDetectorModel* makeModel(const SModelInitializationData& initData,
+                                     core::CStateRestoreTraverser& traverser) const override;
 
     //! Make a new metric population data gatherer.
     //!
     //! \param[in] initData The parameters needed to initialize the data
     //! gatherer.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer*
-    makeDataGatherer(const SGathererInitializationData& initData) const override;
+    CDataGatherer* makeDataGatherer(const SGathererInitializationData& initData) const override;
 
     //! Make a new metric population data gatherer from part of a state
     //! document.
@@ -79,8 +76,8 @@ public:
     //! \param[in] partitionFieldValue The partition field value.
     //! \param[in,out] traverser A state document traverser.
     //! \warning It is owned by the calling code.
-    virtual CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
-                                            core::CStateRestoreTraverser& traverser) const override;
+    CDataGatherer* makeDataGatherer(const std::string& partitionFieldValue,
+                                    core::CStateRestoreTraverser& traverser) const override;
     //@}
 
     //! \name Defaults
@@ -89,63 +86,62 @@ public:
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TPriorPtr defaultPrior(model_t::EFeature feature,
-                                   const SModelParams& params) const override;
+    TPriorPtr defaultPrior(model_t::EFeature feature, const SModelParams& params) const override;
 
     //! Get the default multivariate prior for \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultMultivariatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultMultivariatePrior(model_t::EFeature feature,
+                                                    const SModelParams& params) const override;
 
     //! Get the default prior for pairs of correlated time series
     //! of \p feature.
     //!
     //! \param[in] feature The feature for which to get the prior.
     //! \param[in] params The model parameters.
-    virtual TMultivariatePriorUPtr
-    defaultCorrelatePrior(model_t::EFeature feature, const SModelParams& params) const override;
+    TMultivariatePriorUPtr defaultCorrelatePrior(model_t::EFeature feature,
+                                                 const SModelParams& params) const override;
     //@}
 
     //! Get the search key corresponding to this factory.
-    virtual const CSearchKey& searchKey() const override;
+    const CSearchKey& searchKey() const override;
 
     //! Returns false.
-    virtual bool isSimpleCount() const override;
+    bool isSimpleCount() const override;
 
     //! Check the pre-summarisation mode for this factory.
-    virtual model_t::ESummaryMode summaryMode() const override;
+    model_t::ESummaryMode summaryMode() const override;
 
     //! Get the default data type for models from this factory.
-    virtual maths_t::EDataType dataType() const override;
+    maths_t::EDataType dataType() const override;
 
     //! \name Customization
     //@{
     //! Set the identifier of the search for which this generates models.
-    virtual void detectorIndex(int detectorIndex) override;
+    void detectorIndex(int detectorIndex) override;
 
     //! Set the name of the field whose values will be counted.
-    virtual void fieldNames(const std::string& partitionFieldName,
-                            const std::string& overFieldName,
-                            const std::string& byFieldName,
-                            const std::string& valueFieldName,
-                            const TStrVec& influenceFieldNames) override;
+    void fieldNames(const std::string& partitionFieldName,
+                    const std::string& overFieldName,
+                    const std::string& byFieldName,
+                    const std::string& valueFieldName,
+                    const TStrVec& influenceFieldNames) override;
 
     //! Set whether the models should process missing person and
     //! attribute fields.
-    virtual void useNull(bool useNull) override;
+    void useNull(bool useNull) override;
 
     //! Set the features which will be modeled.
-    virtual void features(const TFeatureVec& features) override;
+    void features(const TFeatureVec& features) override;
     //@}
 
     //! Get the minimum seasonal variance scale
-    virtual double minimumSeasonalVarianceScale() const override;
+    double minimumSeasonalVarianceScale() const override;
 
 private:
     //! Get the field values which partition the data for modeling.
-    virtual TStrCRefVec partitioningFields() const override;
+    TStrCRefVec partitioningFields() const override;
 
     //! Restores a single population metric model.
     bool modelAcceptRestoreTraverser(const SModelInitializationData& initData,

--- a/include/model/CModelDetailsView.h
+++ b/include/model/CModelDetailsView.h
@@ -120,17 +120,17 @@ public:
     CEventRateModelDetailsView(const CEventRateModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const;
+    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
     virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const;
+                                               std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const;
+    virtual const CAnomalyDetectorModel& base() const override;
     virtual double countVarianceScale(model_t::EFeature feature,
                                       std::size_t byFieldId,
-                                      core_t::TTime time) const;
+                                      core_t::TTime time) const override;
 
 private:
     //! The model.
@@ -145,17 +145,17 @@ public:
     CEventRatePopulationModelDetailsView(const CEventRatePopulationModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const;
+    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
     virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const;
+                                               std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const;
+    virtual const CAnomalyDetectorModel& base() const override;
     virtual double countVarianceScale(model_t::EFeature feature,
                                       std::size_t byFieldId,
-                                      core_t::TTime time) const;
+                                      core_t::TTime time) const override;
 
 private:
     //! The model.
@@ -170,17 +170,17 @@ public:
     CMetricModelDetailsView(const CMetricModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const;
+    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
     virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const;
+                                               std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const;
+    virtual const CAnomalyDetectorModel& base() const override;
     virtual double countVarianceScale(model_t::EFeature feature,
                                       std::size_t byFieldId,
-                                      core_t::TTime time) const;
+                                      core_t::TTime time) const override;
 
 private:
     //! The model.
@@ -195,17 +195,17 @@ public:
     CMetricPopulationModelDetailsView(const CMetricPopulationModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const;
+    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
     virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const;
+                                               std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const;
+    virtual const CAnomalyDetectorModel& base() const override;
     virtual double countVarianceScale(model_t::EFeature feature,
                                       std::size_t byFieldId,
-                                      core_t::TTime time) const;
+                                      core_t::TTime time) const override;
 
 private:
     //! The model.

--- a/include/model/CModelDetailsView.h
+++ b/include/model/CModelDetailsView.h
@@ -120,17 +120,17 @@ public:
     CEventRateModelDetailsView(const CEventRateModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
+    TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
-    virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const override;
+    const maths::common::CModel* model(model_t::EFeature feature,
+                                       std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const override;
-    virtual double countVarianceScale(model_t::EFeature feature,
-                                      std::size_t byFieldId,
-                                      core_t::TTime time) const override;
+    const CAnomalyDetectorModel& base() const override;
+    double countVarianceScale(model_t::EFeature feature,
+                              std::size_t byFieldId,
+                              core_t::TTime time) const override;
 
 private:
     //! The model.
@@ -145,17 +145,17 @@ public:
     CEventRatePopulationModelDetailsView(const CEventRatePopulationModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
+    TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
-    virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const override;
+    const maths::common::CModel* model(model_t::EFeature feature,
+                                       std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const override;
-    virtual double countVarianceScale(model_t::EFeature feature,
-                                      std::size_t byFieldId,
-                                      core_t::TTime time) const override;
+    const CAnomalyDetectorModel& base() const override;
+    double countVarianceScale(model_t::EFeature feature,
+                              std::size_t byFieldId,
+                              core_t::TTime time) const override;
 
 private:
     //! The model.
@@ -170,17 +170,17 @@ public:
     CMetricModelDetailsView(const CMetricModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
+    TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
-    virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const override;
+    const maths::common::CModel* model(model_t::EFeature feature,
+                                       std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const override;
-    virtual double countVarianceScale(model_t::EFeature feature,
-                                      std::size_t byFieldId,
-                                      core_t::TTime time) const override;
+    const CAnomalyDetectorModel& base() const override;
+    double countVarianceScale(model_t::EFeature feature,
+                              std::size_t byFieldId,
+                              core_t::TTime time) const override;
 
 private:
     //! The model.
@@ -195,17 +195,17 @@ public:
     CMetricPopulationModelDetailsView(const CMetricPopulationModel& model);
 
     //! Get the time interval from the first to last data point of \p byFieldId.
-    virtual TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
+    TTimeTimePr dataTimeInterval(std::size_t byFieldId) const override;
 
     //! Get the time series model for \p feature and \p byFieldId.
-    virtual const maths::common::CModel* model(model_t::EFeature feature,
-                                               std::size_t byFieldId) const override;
+    const maths::common::CModel* model(model_t::EFeature feature,
+                                       std::size_t byFieldId) const override;
 
 private:
-    virtual const CAnomalyDetectorModel& base() const override;
-    virtual double countVarianceScale(model_t::EFeature feature,
-                                      std::size_t byFieldId,
-                                      core_t::TTime time) const override;
+    const CAnomalyDetectorModel& base() const override;
+    double countVarianceScale(model_t::EFeature feature,
+                              std::size_t byFieldId,
+                              core_t::TTime time) const override;
 
 private:
     //! The model.

--- a/include/model/CPopulationModel.h
+++ b/include/model/CPopulationModel.h
@@ -98,16 +98,16 @@ public:
     //@}
 
     //! Returns true.
-    virtual bool isPopulation() const;
+    virtual bool isPopulation() const override;
 
     //! \name Bucket Statistics
     //@{
     //! Get the count of the bucketing interval containing \p time
     //! for the person identified by \p pid.
-    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const;
+    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
 
     //! Returns null.
-    virtual TOptionalDouble baselineBucketCount(std::size_t pid) const;
+    virtual TOptionalDouble baselineBucketCount(std::size_t pid) const override;
 
 protected:
     //! Get the index range [begin, end) of the person corresponding to
@@ -142,7 +142,7 @@ public:
     //! \param[in] time The time of interest.
     //! \param[out] result Filled in with the person identifiers
     //! in the bucketing time interval of interest.
-    virtual void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const;
+    virtual void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const override;
     //@}
 
     //! \name Update
@@ -150,7 +150,7 @@ public:
     //! Update the rates for \p feature and \p people.
     virtual void sample(core_t::TTime startTime,
                         core_t::TTime endTime,
-                        CResourceMonitor& resourceMonitor) = 0;
+                        CResourceMonitor& resourceMonitor) override = 0;
     //@}
 
     //! Get the checksum of this model.
@@ -158,22 +158,22 @@ public:
     //! \param[in] includeCurrentBucketStats If true then include the
     //! current bucket statistics. (This is designed to handle serialization,
     //! for which we don't serialize the current bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const = 0;
+    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const override = 0;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override = 0;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const = 0;
+    virtual std::size_t memoryUsage() const override = 0;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const = 0;
+    virtual std::size_t staticSize() const override = 0;
 
     //! Get the non-estimated value of the the memory used by this model.
-    virtual std::size_t computeMemoryUsage() const = 0;
+    virtual std::size_t computeMemoryUsage() const override = 0;
 
     //! Get the frequency of the attribute identified by \p cid.
-    virtual double attributeFrequency(std::size_t cid) const;
+    virtual double attributeFrequency(std::size_t cid) const override;
 
     //! Get the first time each attribute was seen.
     const TTimeVec& attributeFirstBucketTimes() const;
@@ -223,25 +223,26 @@ protected:
     virtual const TSizeUInt64PrVec& personCounts() const = 0;
 
     //! Check if bucket statistics are available for the specified time.
-    virtual bool bucketStatsAvailable(core_t::TTime time) const = 0;
+    virtual bool bucketStatsAvailable(core_t::TTime time) const override = 0;
 
     //! Monitor the resource usage while creating new models
     void createUpdateNewModels(core_t::TTime time, CResourceMonitor& resourceMonitor);
 
     //! Initialize the time series models for "n" newly observed people
     //! and "m" newly observed attributes.
-    virtual void createNewModels(std::size_t n, std::size_t m) = 0;
+    virtual void createNewModels(std::size_t n, std::size_t m) override = 0;
 
     //! Initialize the time series models for recycled attributes
     //! and/or people.
-    virtual void updateRecycledModels() = 0;
+    virtual void updateRecycledModels() override = 0;
 
     //! Update the correlation models.
     virtual void refreshCorrelationModels(std::size_t resourceLimit,
                                           CResourceMonitor& resourceMonitor) = 0;
 
     //! Clear out large state objects for people/attributes that are pruned.
-    virtual void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) = 0;
+    virtual void clearPrunedResources(const TSizeVec& people,
+                                      const TSizeVec& attributes) override = 0;
 
     //! Correct \p baseline with \p corrections for interim results.
     void correctBaselineForInterim(model_t::EFeature feature,
@@ -273,7 +274,7 @@ protected:
     void removePeople(const TSizeVec& peopleToRemove);
 
     //! Skip sampling the interval \p endTime - \p startTime.
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) = 0;
+    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override = 0;
 
 private:
     using TOptionalCountMinSketch = boost::optional<maths::time_series::CCountMinSketch>;

--- a/include/model/CPopulationModel.h
+++ b/include/model/CPopulationModel.h
@@ -98,16 +98,16 @@ public:
     //@}
 
     //! Returns true.
-    virtual bool isPopulation() const override;
+    bool isPopulation() const override;
 
     //! \name Bucket Statistics
     //@{
     //! Get the count of the bucketing interval containing \p time
     //! for the person identified by \p pid.
-    virtual TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
+    TOptionalUInt64 currentBucketCount(std::size_t pid, core_t::TTime time) const override;
 
     //! Returns null.
-    virtual TOptionalDouble baselineBucketCount(std::size_t pid) const override;
+    TOptionalDouble baselineBucketCount(std::size_t pid) const override;
 
 protected:
     //! Get the index range [begin, end) of the person corresponding to
@@ -142,15 +142,15 @@ public:
     //! \param[in] time The time of interest.
     //! \param[out] result Filled in with the person identifiers
     //! in the bucketing time interval of interest.
-    virtual void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const override;
+    void currentBucketPersonIds(core_t::TTime time, TSizeVec& result) const override;
     //@}
 
     //! \name Update
     //@{
     //! Update the rates for \p feature and \p people.
-    virtual void sample(core_t::TTime startTime,
-                        core_t::TTime endTime,
-                        CResourceMonitor& resourceMonitor) override = 0;
+    void sample(core_t::TTime startTime,
+                core_t::TTime endTime,
+                CResourceMonitor& resourceMonitor) override = 0;
     //@}
 
     //! Get the checksum of this model.
@@ -158,22 +158,22 @@ public:
     //! \param[in] includeCurrentBucketStats If true then include the
     //! current bucket statistics. (This is designed to handle serialization,
     //! for which we don't serialize the current bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const override = 0;
+    uint64_t checksum(bool includeCurrentBucketStats = true) const override = 0;
 
     //! Debug the memory used by this model.
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override = 0;
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override = 0;
 
     //! Get the memory used by this model.
-    virtual std::size_t memoryUsage() const override = 0;
+    std::size_t memoryUsage() const override = 0;
 
     //! Get the static size of this object - used for virtual hierarchies
-    virtual std::size_t staticSize() const override = 0;
+    std::size_t staticSize() const override = 0;
 
     //! Get the non-estimated value of the the memory used by this model.
-    virtual std::size_t computeMemoryUsage() const override = 0;
+    std::size_t computeMemoryUsage() const override = 0;
 
     //! Get the frequency of the attribute identified by \p cid.
-    virtual double attributeFrequency(std::size_t cid) const override;
+    double attributeFrequency(std::size_t cid) const override;
 
     //! Get the first time each attribute was seen.
     const TTimeVec& attributeFirstBucketTimes() const;
@@ -223,26 +223,25 @@ protected:
     virtual const TSizeUInt64PrVec& personCounts() const = 0;
 
     //! Check if bucket statistics are available for the specified time.
-    virtual bool bucketStatsAvailable(core_t::TTime time) const override = 0;
+    bool bucketStatsAvailable(core_t::TTime time) const override = 0;
 
     //! Monitor the resource usage while creating new models
     void createUpdateNewModels(core_t::TTime time, CResourceMonitor& resourceMonitor);
 
     //! Initialize the time series models for "n" newly observed people
     //! and "m" newly observed attributes.
-    virtual void createNewModels(std::size_t n, std::size_t m) override = 0;
+    void createNewModels(std::size_t n, std::size_t m) override = 0;
 
     //! Initialize the time series models for recycled attributes
     //! and/or people.
-    virtual void updateRecycledModels() override = 0;
+    void updateRecycledModels() override = 0;
 
     //! Update the correlation models.
     virtual void refreshCorrelationModels(std::size_t resourceLimit,
                                           CResourceMonitor& resourceMonitor) = 0;
 
     //! Clear out large state objects for people/attributes that are pruned.
-    virtual void clearPrunedResources(const TSizeVec& people,
-                                      const TSizeVec& attributes) override = 0;
+    void clearPrunedResources(const TSizeVec& people, const TSizeVec& attributes) override = 0;
 
     //! Correct \p baseline with \p corrections for interim results.
     void correctBaselineForInterim(model_t::EFeature feature,
@@ -274,7 +273,7 @@ protected:
     void removePeople(const TSizeVec& peopleToRemove);
 
     //! Skip sampling the interval \p endTime - \p startTime.
-    virtual void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override = 0;
+    void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override = 0;
 
 private:
     using TOptionalCountMinSketch = boost::optional<maths::time_series::CCountMinSketch>;

--- a/include/model/CProbabilityAndInfluenceCalculator.h
+++ b/include/model/CProbabilityAndInfluenceCalculator.h
@@ -411,16 +411,16 @@ public:
 //! can't be calculated.
 class MODEL_EXPORT CInfluenceUnavailableCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const;
-    virtual void computeInfluences(TCorrelateParams& params) const;
+    virtual void computeInfluences(TParams& params) const override;
+    virtual void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief A stub implementation for the case that every influence
 //! is 1, irrespective of the feature value and influence values.
 class MODEL_EXPORT CIndicatorInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const;
-    virtual void computeInfluences(TCorrelateParams& params) const;
+    virtual void computeInfluences(TParams& params) const override;
+    virtual void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for sum like features.
@@ -446,8 +446,8 @@ public:
 //! know what its typical count is and we don't have this information.
 class MODEL_EXPORT CLogProbabilityComplementInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const;
-    virtual void computeInfluences(TCorrelateParams& params) const;
+    virtual void computeInfluences(TParams& params) const override;
+    virtual void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for minimum like features.
@@ -477,8 +477,8 @@ public:
 //! the left or right tail.
 class MODEL_EXPORT CLogProbabilityInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const;
-    virtual void computeInfluences(TCorrelateParams& params) const;
+    virtual void computeInfluences(TParams& params) const override;
+    virtual void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for the mean feature.
@@ -498,8 +498,8 @@ public:
 //! on the calculation.
 class MODEL_EXPORT CMeanInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const;
-    virtual void computeInfluences(TCorrelateParams& params) const;
+    virtual void computeInfluences(TParams& params) const override;
+    virtual void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for the mean feature.
@@ -519,8 +519,8 @@ public:
 //! on the calculation.
 class MODEL_EXPORT CVarianceInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const;
-    virtual void computeInfluences(TCorrelateParams& params) const;
+    virtual void computeInfluences(TParams& params) const override;
+    virtual void computeInfluences(TCorrelateParams& params) const override;
 };
 }
 }

--- a/include/model/CProbabilityAndInfluenceCalculator.h
+++ b/include/model/CProbabilityAndInfluenceCalculator.h
@@ -411,16 +411,16 @@ public:
 //! can't be calculated.
 class MODEL_EXPORT CInfluenceUnavailableCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const override;
-    virtual void computeInfluences(TCorrelateParams& params) const override;
+    void computeInfluences(TParams& params) const override;
+    void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief A stub implementation for the case that every influence
 //! is 1, irrespective of the feature value and influence values.
 class MODEL_EXPORT CIndicatorInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const override;
-    virtual void computeInfluences(TCorrelateParams& params) const override;
+    void computeInfluences(TParams& params) const override;
+    void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for sum like features.
@@ -446,8 +446,8 @@ public:
 //! know what its typical count is and we don't have this information.
 class MODEL_EXPORT CLogProbabilityComplementInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const override;
-    virtual void computeInfluences(TCorrelateParams& params) const override;
+    void computeInfluences(TParams& params) const override;
+    void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for minimum like features.
@@ -477,8 +477,8 @@ public:
 //! the left or right tail.
 class MODEL_EXPORT CLogProbabilityInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const override;
-    virtual void computeInfluences(TCorrelateParams& params) const override;
+    void computeInfluences(TParams& params) const override;
+    void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for the mean feature.
@@ -498,8 +498,8 @@ public:
 //! on the calculation.
 class MODEL_EXPORT CMeanInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const override;
-    virtual void computeInfluences(TCorrelateParams& params) const override;
+    void computeInfluences(TParams& params) const override;
+    void computeInfluences(TCorrelateParams& params) const override;
 };
 
 //! \brief Computes the influences for the mean feature.
@@ -519,8 +519,8 @@ public:
 //! on the calculation.
 class MODEL_EXPORT CVarianceInfluenceCalculator : public CInfluenceCalculator {
 public:
-    virtual void computeInfluences(TParams& params) const override;
-    virtual void computeInfluences(TCorrelateParams& params) const override;
+    void computeInfluences(TParams& params) const override;
+    void computeInfluences(TCorrelateParams& params) const override;
 };
 }
 }

--- a/include/model/CSimpleCountDetector.h
+++ b/include/model/CSimpleCountDetector.h
@@ -54,15 +54,15 @@ public:
     CSimpleCountDetector(bool isForPersistence, const CAnomalyDetector& other);
 
     //! Returns true.
-    virtual bool isSimpleCount() const;
+    virtual bool isSimpleCount() const override;
 
     //! Don't prune the simple count detector!
-    virtual void pruneModels();
+    virtual void pruneModels() override;
 
 private:
     //! This function is called before adding a record allowing
     //! for varied preprocessing.
-    virtual const TStrCPtrVec& preprocessFieldValues(const TStrCPtrVec& fieldValues);
+    virtual const TStrCPtrVec& preprocessFieldValues(const TStrCPtrVec& fieldValues) override;
 
 private:
     //! Field values are strange compared to other anomaly detectors,

--- a/include/model/CSimpleCountDetector.h
+++ b/include/model/CSimpleCountDetector.h
@@ -54,15 +54,15 @@ public:
     CSimpleCountDetector(bool isForPersistence, const CAnomalyDetector& other);
 
     //! Returns true.
-    virtual bool isSimpleCount() const override;
+    bool isSimpleCount() const override;
 
     //! Don't prune the simple count detector!
-    virtual void pruneModels() override;
+    void pruneModels() override;
 
 private:
     //! This function is called before adding a record allowing
     //! for varied preprocessing.
-    virtual const TStrCPtrVec& preprocessFieldValues(const TStrCPtrVec& fieldValues) override;
+    const TStrCPtrVec& preprocessFieldValues(const TStrCPtrVec& fieldValues) override;
 
 private:
     //! Field values are strange compared to other anomaly detectors,

--- a/include/test/CMultiFileSearcher.h
+++ b/include/test/CMultiFileSearcher.h
@@ -48,7 +48,7 @@ public:
 
     //! Load the file
     //! \return Pointer to the input stream - may be NULL
-    virtual TIStreamP search(size_t currentDocNum, size_t limit);
+    virtual TIStreamP search(size_t currentDocNum, size_t limit) override;
 
 private:
     //! Name of the file to serialise models to

--- a/include/test/CMultiFileSearcher.h
+++ b/include/test/CMultiFileSearcher.h
@@ -48,7 +48,7 @@ public:
 
     //! Load the file
     //! \return Pointer to the input stream - may be NULL
-    virtual TIStreamP search(size_t currentDocNum, size_t limit) override;
+    TIStreamP search(size_t currentDocNum, size_t limit) override;
 
 private:
     //! Name of the file to serialise models to

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -102,7 +102,7 @@ class CReadableJsonStatePersistInserter : public core::CJsonStatePersistInserter
 public:
     explicit CReadableJsonStatePersistInserter(std::ostream& outputStream)
         : core::CJsonStatePersistInserter(outputStream) {}
-    virtual bool readableTags() const { return true; }
+    virtual bool readableTags() const override { return true; }
 };
 
 //! Persist state as XML (wrapped in a JSON object) with meaningful tag names.
@@ -111,12 +111,12 @@ public:
     explicit CReadableRapidXmlStatePersistInserter(std::ostream& strm)
         : core::CRapidXmlStatePersistInserter("root"), m_WriteStream(strm) {}
 
-    ~CReadableRapidXmlStatePersistInserter() {
+    ~CReadableRapidXmlStatePersistInserter() override {
         std::string xml;
         this->toXml(false, xml);
         m_WriteStream << "{\"xml\":\"" << xml << "\"}\n";
     }
-    virtual bool readableTags() const { return true; }
+    virtual bool readableTags() const override { return true; }
 
 private:
     std::ostream& m_WriteStream;

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -102,7 +102,7 @@ class CReadableJsonStatePersistInserter : public core::CJsonStatePersistInserter
 public:
     explicit CReadableJsonStatePersistInserter(std::ostream& outputStream)
         : core::CJsonStatePersistInserter(outputStream) {}
-    virtual bool readableTags() const override { return true; }
+    bool readableTags() const override { return true; }
 };
 
 //! Persist state as XML (wrapped in a JSON object) with meaningful tag names.
@@ -116,7 +116,7 @@ public:
         this->toXml(false, xml);
         m_WriteStream << "{\"xml\":\"" << xml << "\"}\n";
     }
-    virtual bool readableTags() const override { return true; }
+    bool readableTags() const override { return true; }
 
 private:
     std::ostream& m_WriteStream;

--- a/lib/api/unittest/CAnomalyJobTest.cc
+++ b/lib/api/unittest/CAnomalyJobTest.cc
@@ -49,7 +49,7 @@ namespace {
 class CEmptySearcher : public ml::core::CDataSearcher {
 public:
     //! Do a search that results in an empty input stream.
-    virtual TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) {
+    virtual TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) override {
         return TIStreamP(new std::istringstream());
     }
 };
@@ -68,11 +68,11 @@ class CSingleResultVisitor : public ml::model::CHierarchicalResultsVisitor {
 public:
     CSingleResultVisitor() : m_LastResult(0.0) {}
 
-    virtual ~CSingleResultVisitor() {}
+    virtual ~CSingleResultVisitor() override {}
 
     virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
                        const TNode& node,
-                       bool /*pivot*/) {
+                       bool /*pivot*/) override {
         if (!this->isSimpleCount(node) && this->isLeaf(node)) {
             if (node.s_AnnotatedProbability.s_AttributeProbabilities.size() == 0) {
                 return;
@@ -98,11 +98,11 @@ class CMultiResultVisitor : public ml::model::CHierarchicalResultsVisitor {
 public:
     CMultiResultVisitor() : m_LastResult(0.0) {}
 
-    virtual ~CMultiResultVisitor() {}
+    virtual ~CMultiResultVisitor() override {}
 
     virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
                        const TNode& node,
-                       bool /*pivot*/) {
+                       bool /*pivot*/) override {
         if (!this->isSimpleCount(node) && this->isLeaf(node)) {
             if (node.s_AnnotatedProbability.s_AttributeProbabilities.size() == 0) {
                 return;
@@ -136,11 +136,11 @@ class CResultsScoreVisitor : public ml::model::CHierarchicalResultsVisitor {
 public:
     CResultsScoreVisitor(int score) : m_Score(score) {}
 
-    virtual ~CResultsScoreVisitor() {}
+    virtual ~CResultsScoreVisitor() override {}
 
     virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
                        const TNode& node,
-                       bool /*pivot*/) {
+                       bool /*pivot*/) override {
         if (this->isRoot(node)) {
             node.s_NormalizedAnomalyScore = m_Score;
         }

--- a/lib/api/unittest/CAnomalyJobTest.cc
+++ b/lib/api/unittest/CAnomalyJobTest.cc
@@ -49,7 +49,7 @@ namespace {
 class CEmptySearcher : public ml::core::CDataSearcher {
 public:
     //! Do a search that results in an empty input stream.
-    virtual TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) override {
+    TIStreamP search(size_t /*currentDocNum*/, size_t /*limit*/) override {
         return TIStreamP(new std::istringstream());
     }
 };
@@ -68,11 +68,11 @@ class CSingleResultVisitor : public ml::model::CHierarchicalResultsVisitor {
 public:
     CSingleResultVisitor() : m_LastResult(0.0) {}
 
-    virtual ~CSingleResultVisitor() override {}
+    ~CSingleResultVisitor() override {}
 
-    virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const ml::model::CHierarchicalResults& /*results*/,
+               const TNode& node,
+               bool /*pivot*/) override {
         if (!this->isSimpleCount(node) && this->isLeaf(node)) {
             if (node.s_AnnotatedProbability.s_AttributeProbabilities.size() == 0) {
                 return;
@@ -98,11 +98,11 @@ class CMultiResultVisitor : public ml::model::CHierarchicalResultsVisitor {
 public:
     CMultiResultVisitor() : m_LastResult(0.0) {}
 
-    virtual ~CMultiResultVisitor() override {}
+    ~CMultiResultVisitor() override {}
 
-    virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const ml::model::CHierarchicalResults& /*results*/,
+               const TNode& node,
+               bool /*pivot*/) override {
         if (!this->isSimpleCount(node) && this->isLeaf(node)) {
             if (node.s_AnnotatedProbability.s_AttributeProbabilities.size() == 0) {
                 return;
@@ -136,11 +136,11 @@ class CResultsScoreVisitor : public ml::model::CHierarchicalResultsVisitor {
 public:
     CResultsScoreVisitor(int score) : m_Score(score) {}
 
-    virtual ~CResultsScoreVisitor() override {}
+    ~CResultsScoreVisitor() override {}
 
-    virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const ml::model::CHierarchicalResults& /*results*/,
+               const TNode& node,
+               bool /*pivot*/) override {
         if (this->isRoot(node)) {
             node.s_NormalizedAnomalyScore = m_Score;
         }

--- a/lib/core/CDetachedProcessSpawner.cc
+++ b/lib/core/CDetachedProcessSpawner.cc
@@ -133,7 +133,7 @@ public:
     }
 
 protected:
-    virtual void run() {
+    virtual void run() override {
         CScopedLock lock(m_Mutex);
 
         while (!m_Shutdown) {
@@ -149,7 +149,7 @@ protected:
         }
     }
 
-    virtual void shutdown() {
+    virtual void shutdown() override {
         LOG_DEBUG(<< "Shutting down spawned process tracker thread");
         CScopedLock lock(m_Mutex);
         m_Shutdown = true;

--- a/lib/core/CDetachedProcessSpawner.cc
+++ b/lib/core/CDetachedProcessSpawner.cc
@@ -133,7 +133,7 @@ public:
     }
 
 protected:
-    virtual void run() override {
+    void run() override {
         CScopedLock lock(m_Mutex);
 
         while (!m_Shutdown) {
@@ -149,7 +149,7 @@ protected:
         }
     }
 
-    virtual void shutdown() override {
+    void shutdown() override {
         LOG_DEBUG(<< "Shutting down spawned process tracker thread");
         CScopedLock lock(m_Mutex);
         m_Shutdown = true;

--- a/lib/core/CLogger.cc
+++ b/lib/core/CLogger.cc
@@ -70,7 +70,7 @@ private:
 
 public:
     formatter_type create_formatter(const boost::log::attribute_name& name,
-                                    const args_map& args) {
+                                    const args_map& args) override {
         args_map::const_iterator iter{args.find(FORMAT)};
         if (iter != args.end()) {
             return boost::log::expressions::stream

--- a/lib/core/unittest/CDualThreadStreamBufTest.cc
+++ b/lib/core/unittest/CDualThreadStreamBufTest.cc
@@ -60,7 +60,7 @@ public:
     }
 
 protected:
-    virtual void run() {
+    virtual void run() override {
         std::istream strm(&m_Buffer);
         size_t count(0);
         std::string line;
@@ -80,7 +80,7 @@ protected:
         }
     }
 
-    virtual void shutdown() { m_Buffer.signalFatalError(); }
+    virtual void shutdown() override { m_Buffer.signalFatalError(); }
 
 private:
     ml::core::CDualThreadStreamBuf& m_Buffer;

--- a/lib/core/unittest/CDualThreadStreamBufTest.cc
+++ b/lib/core/unittest/CDualThreadStreamBufTest.cc
@@ -60,7 +60,7 @@ public:
     }
 
 protected:
-    virtual void run() override {
+    void run() override {
         std::istream strm(&m_Buffer);
         size_t count(0);
         std::string line;
@@ -80,7 +80,7 @@ protected:
         }
     }
 
-    virtual void shutdown() override { m_Buffer.signalFatalError(); }
+    void shutdown() override { m_Buffer.signalFatalError(); }
 
 private:
     ml::core::CDualThreadStreamBuf& m_Buffer;

--- a/lib/core/unittest/CJsonStatePersistInserterTest.cc
+++ b/lib/core/unittest/CJsonStatePersistInserterTest.cc
@@ -26,7 +26,7 @@ class CReadableJsonStatePersistInserter : public ml::core::CJsonStatePersistInse
 public:
     explicit CReadableJsonStatePersistInserter(std::ostream& outputStream)
         : ml::core::CJsonStatePersistInserter(outputStream) {}
-    virtual bool readableTags() const override { return true; }
+    bool readableTags() const override { return true; }
 };
 
 const ml::core::TPersistenceTag LEVEL1A_TAG{"a", "level1A"};

--- a/lib/core/unittest/CJsonStatePersistInserterTest.cc
+++ b/lib/core/unittest/CJsonStatePersistInserterTest.cc
@@ -26,7 +26,7 @@ class CReadableJsonStatePersistInserter : public ml::core::CJsonStatePersistInse
 public:
     explicit CReadableJsonStatePersistInserter(std::ostream& outputStream)
         : ml::core::CJsonStatePersistInserter(outputStream) {}
-    virtual bool readableTags() const { return true; }
+    virtual bool readableTags() const override { return true; }
 };
 
 const ml::core::TPersistenceTag LEVEL1A_TAG{"a", "level1A"};

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -185,21 +185,21 @@ public:
     CDerived(std::size_t i)
         : CBase(i), m_Strings(i, "This is a secret string") {}
 
-    virtual ~CDerived() override = default;
+    ~CDerived() override = default;
 
-    virtual std::size_t memoryUsage() const override {
+    std::size_t memoryUsage() const override {
         std::size_t mem = core::CMemory::dynamicSize(m_Strings);
         mem += this->CBase::memoryUsage();
         return mem;
     }
 
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CDerived", 0);
         core::CMemoryDebug::dynamicSize("m_Strings", m_Strings, mem);
         this->CBase::debugMemoryUsage(mem->addChild());
     }
 
-    virtual std::size_t staticSize() const override { return sizeof(*this); }
+    std::size_t staticSize() const override { return sizeof(*this); }
 
     const std::uint64_t* fixed() const { return m_Fixed; } // suppress warning
 

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -185,21 +185,21 @@ public:
     CDerived(std::size_t i)
         : CBase(i), m_Strings(i, "This is a secret string") {}
 
-    virtual ~CDerived() = default;
+    virtual ~CDerived() override = default;
 
-    virtual std::size_t memoryUsage() const {
+    virtual std::size_t memoryUsage() const override {
         std::size_t mem = core::CMemory::dynamicSize(m_Strings);
         mem += this->CBase::memoryUsage();
         return mem;
     }
 
-    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
+    virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CDerived", 0);
         core::CMemoryDebug::dynamicSize("m_Strings", m_Strings, mem);
         this->CBase::debugMemoryUsage(mem->addChild());
     }
 
-    virtual std::size_t staticSize() const { return sizeof(*this); }
+    virtual std::size_t staticSize() const override { return sizeof(*this); }
 
     const std::uint64_t* fixed() const { return m_Fixed; } // suppress warning
 

--- a/lib/core/unittest/CProgramCountersTest.cc
+++ b/lib/core/unittest/CProgramCountersTest.cc
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    virtual void run() {
+    virtual void run() override {
         if (m_I < N) {
             ++ml::core::CProgramCounters::counter(TEST_COUNTER + m_I);
         } else {
@@ -51,7 +51,7 @@ private:
         }
     }
 
-    virtual void shutdown() {}
+    virtual void shutdown() override {}
 
     int m_I;
     int m_N;

--- a/lib/core/unittest/CProgramCountersTest.cc
+++ b/lib/core/unittest/CProgramCountersTest.cc
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    virtual void run() override {
+    void run() override {
         if (m_I < N) {
             ++ml::core::CProgramCounters::counter(TEST_COUNTER + m_I);
         } else {
@@ -51,7 +51,7 @@ private:
         }
     }
 
-    virtual void shutdown() override {}
+    void shutdown() override {}
 
     int m_I;
     int m_N;

--- a/lib/core/unittest/CRapidXmlStatePersistInserterTest.cc
+++ b/lib/core/unittest/CRapidXmlStatePersistInserterTest.cc
@@ -23,7 +23,7 @@ public:
     explicit CReadableXmlStatePersistInserter(const std::string& rootName,
                                               ml::core::CRapidXmlStatePersistInserter::TStrStrMap& rootAttributes)
         : ml::core::CRapidXmlStatePersistInserter(rootName, rootAttributes) {}
-    virtual bool readableTags() const { return true; }
+    virtual bool readableTags() const override { return true; }
 };
 
 const ml::core::TPersistenceTag LEVEL1A_TAG{"a", "level1A"};

--- a/lib/core/unittest/CRapidXmlStatePersistInserterTest.cc
+++ b/lib/core/unittest/CRapidXmlStatePersistInserterTest.cc
@@ -23,7 +23,7 @@ public:
     explicit CReadableXmlStatePersistInserter(const std::string& rootName,
                                               ml::core::CRapidXmlStatePersistInserter::TStrStrMap& rootAttributes)
         : ml::core::CRapidXmlStatePersistInserter(rootName, rootAttributes) {}
-    virtual bool readableTags() const override { return true; }
+    bool readableTags() const override { return true; }
 };
 
 const ml::core::TPersistenceTag LEVEL1A_TAG{"a", "level1A"};

--- a/lib/core/unittest/CReadWriteLockTest.cc
+++ b/lib/core/unittest/CReadWriteLockTest.cc
@@ -41,14 +41,14 @@ public:
           m_Increment(increment), m_Variable(variable) {}
 
 protected:
-    void run() {
+    void run() override {
         for (std::uint32_t count = 0; count < m_Iterations; ++count) {
             m_Variable += m_Increment;
             std::this_thread::sleep_for(std::chrono::milliseconds(m_SleepTime));
         }
     }
 
-    void shutdown() {
+    void shutdown() override {
         // Always just wait for run() to complete
     }
 
@@ -69,14 +69,14 @@ public:
           m_Increment(increment), m_Variable(variable) {}
 
 protected:
-    void run() {
+    void run() override {
         for (std::uint32_t count = 0; count < m_Iterations; ++count) {
             m_Variable.fetch_add(m_Increment);
             std::this_thread::sleep_for(std::chrono::milliseconds(m_SleepTime));
         }
     }
 
-    void shutdown() {
+    void shutdown() override {
         // Always just wait for run() to complete
     }
 
@@ -98,7 +98,7 @@ public:
           m_Increment(increment), m_Variable(variable) {}
 
 protected:
-    void run() {
+    void run() override {
         for (std::uint32_t count = 0; count < m_Iterations; ++count) {
             ml::core::CScopedFastLock lock(m_Mutex);
 
@@ -107,7 +107,7 @@ protected:
         }
     }
 
-    void shutdown() {
+    void shutdown() override {
         // Always just wait for run() to complete
     }
 
@@ -130,7 +130,7 @@ public:
           m_Increment(increment), m_Variable(variable) {}
 
 protected:
-    void run() {
+    void run() override {
         for (std::uint32_t count = 0; count < m_Iterations; ++count) {
             ml::core::CScopedLock lock(m_Mutex);
 
@@ -139,7 +139,7 @@ protected:
         }
     }
 
-    void shutdown() {
+    void shutdown() override {
         // Always just wait for run() to complete
     }
 
@@ -162,7 +162,7 @@ public:
           m_Iterations(iterations), m_Increment(increment), m_Variable(variable) {}
 
 protected:
-    void run() {
+    void run() override {
         for (std::uint32_t count = 0; count < m_Iterations; ++count) {
             ml::core::CScopedWriteLock lock(m_ReadWriteLock);
 
@@ -171,7 +171,7 @@ protected:
         }
     }
 
-    void shutdown() {
+    void shutdown() override {
         // Always just wait for run() to complete
     }
 
@@ -195,7 +195,7 @@ public:
     std::uint32_t lastRead() const { return m_LastRead; }
 
 protected:
-    void run() {
+    void run() override {
         for (std::uint32_t count = 0; count < m_Iterations; ++count) {
             ml::core::CScopedReadLock lock(m_ReadWriteLock);
 
@@ -204,7 +204,7 @@ protected:
         }
     }
 
-    void shutdown() {
+    void shutdown() override {
         // Always just wait for run() to complete
     }
 

--- a/lib/core/unittest/CStateMachineTest.cc
+++ b/lib/core/unittest/CStateMachineTest.cc
@@ -69,7 +69,7 @@ public:
     const TSizeVec& states() const { return m_States; }
 
 private:
-    virtual void run() {
+    virtual void run() override {
         std::size_t n = 10000;
         m_States.reserve(n);
         TSizeVec machine;
@@ -86,7 +86,7 @@ private:
         }
     }
 
-    virtual void shutdown() {}
+    virtual void shutdown() override {}
 
 private:
     test::CRandomNumbers m_Rng;

--- a/lib/core/unittest/CStateMachineTest.cc
+++ b/lib/core/unittest/CStateMachineTest.cc
@@ -69,7 +69,7 @@ public:
     const TSizeVec& states() const { return m_States; }
 
 private:
-    virtual void run() override {
+    void run() override {
         std::size_t n = 10000;
         m_States.reserve(n);
         TSizeVec machine;
@@ -86,7 +86,7 @@ private:
         }
     }
 
-    virtual void shutdown() override {}
+    void shutdown() override {}
 
 private:
     test::CRandomNumbers m_Rng;

--- a/lib/core/unittest/CThreadMutexConditionTest.cc
+++ b/lib/core/unittest/CThreadMutexConditionTest.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(testThread) {
         }
 
     private:
-        void run() {
+        void run() override {
             LOG_DEBUG(<< "Thread running");
             m_Mutex.lock();
             m_Running = true;
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(testThread) {
             LOG_DEBUG(<< "Thread exiting");
         }
 
-        void shutdown() {
+        void shutdown() override {
             LOG_DEBUG(<< "Thread shutdown");
             m_Mutex.lock();
             m_Running = false;
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(testThreadCondition) {
         }
 
     private:
-        void run() {
+        void run() override {
             LOG_DEBUG(<< "Thread running");
             this->lock();
             this->signal();
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(testThreadCondition) {
             LOG_DEBUG(<< "Thread exiting");
         }
 
-        void shutdown() {
+        void shutdown() override {
             LOG_DEBUG(<< "Thread shutting down");
             this->lock();
             this->signal();

--- a/lib/maths/analytics/unittest/TestUtils.h
+++ b/lib/maths/analytics/unittest/TestUtils.h
@@ -167,13 +167,13 @@ public:
         : PRIOR(static_cast<const PRIOR&>(other)),
           CPriorTestInterface(static_cast<maths::common::CPrior&>(*this)) {}
 
-    virtual ~CPriorTestInterfaceMixin() override {}
+    ~CPriorTestInterfaceMixin() override {}
 
     //! Swap the contents efficiently.
     void swap(CPriorTestInterfaceMixin& other) { this->PRIOR::swap(other); }
 
     //! Clone the object.
-    virtual CPriorTestInterfaceMixin* clone() const override {
+    CPriorTestInterfaceMixin* clone() const override {
         return new CPriorTestInterfaceMixin(*this);
     }
 };

--- a/lib/maths/analytics/unittest/TestUtils.h
+++ b/lib/maths/analytics/unittest/TestUtils.h
@@ -167,13 +167,13 @@ public:
         : PRIOR(static_cast<const PRIOR&>(other)),
           CPriorTestInterface(static_cast<maths::common::CPrior&>(*this)) {}
 
-    virtual ~CPriorTestInterfaceMixin() {}
+    virtual ~CPriorTestInterfaceMixin() override {}
 
     //! Swap the contents efficiently.
     void swap(CPriorTestInterfaceMixin& other) { this->PRIOR::swap(other); }
 
     //! Clone the object.
-    virtual CPriorTestInterfaceMixin* clone() const {
+    virtual CPriorTestInterfaceMixin* clone() const override {
         return new CPriorTestInterfaceMixin(*this);
     }
 };

--- a/lib/maths/common/unittest/CMultivariateOneOfNPriorTest.cc
+++ b/lib/maths/common/unittest/CMultivariateOneOfNPriorTest.cc
@@ -52,7 +52,8 @@ public:
     CMinusLogLikelihood(const maths::common::CMultivariateOneOfNPrior& prior)
         : m_Prior(&prior) {}
 
-    bool operator()(const maths::common::CGradientDescent::TVector& x, double& result) const {
+    bool operator()(const maths::common::CGradientDescent::TVector& x,
+                    double& result) const override {
         if (m_Prior->jointLogMarginalLikelihood(
                 {x.toVector<TDouble10Vec>()},
                 maths_t::CUnitWeights::singleUnit<TDouble10Vec>(2),

--- a/lib/maths/common/unittest/TestUtils.h
+++ b/lib/maths/common/unittest/TestUtils.h
@@ -167,13 +167,13 @@ public:
         : PRIOR(static_cast<const PRIOR&>(other)),
           CPriorTestInterface(static_cast<maths::common::CPrior&>(*this)) {}
 
-    virtual ~CPriorTestInterfaceMixin() override {}
+    ~CPriorTestInterfaceMixin() override {}
 
     //! Swap the contents efficiently.
     void swap(CPriorTestInterfaceMixin& other) { this->PRIOR::swap(other); }
 
     //! Clone the object.
-    virtual CPriorTestInterfaceMixin* clone() const override {
+    CPriorTestInterfaceMixin* clone() const override {
         return new CPriorTestInterfaceMixin(*this);
     }
 };

--- a/lib/maths/common/unittest/TestUtils.h
+++ b/lib/maths/common/unittest/TestUtils.h
@@ -167,13 +167,13 @@ public:
         : PRIOR(static_cast<const PRIOR&>(other)),
           CPriorTestInterface(static_cast<maths::common::CPrior&>(*this)) {}
 
-    virtual ~CPriorTestInterfaceMixin() {}
+    virtual ~CPriorTestInterfaceMixin() override {}
 
     //! Swap the contents efficiently.
     void swap(CPriorTestInterfaceMixin& other) { this->PRIOR::swap(other); }
 
     //! Clone the object.
-    virtual CPriorTestInterfaceMixin* clone() const {
+    virtual CPriorTestInterfaceMixin* clone() const override {
         return new CPriorTestInterfaceMixin(*this);
     }
 };

--- a/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
@@ -88,21 +88,21 @@ class CTimeSeriesCorrelateModelAllocator
     : public maths::time_series::CTimeSeriesCorrelateModelAllocator {
 public:
     //! Check if we can still allocate any correlations.
-    virtual bool areAllocationsAllowed() const { return true; }
+    virtual bool areAllocationsAllowed() const override { return true; }
 
     //! Check if \p correlations exceeds the memory limit.
-    virtual bool exceedsLimit(std::size_t /*correlations*/) const {
+    virtual bool exceedsLimit(std::size_t /*correlations*/) const override {
         return false;
     }
 
     //! Get the maximum number of correlations we should model.
-    virtual std::size_t maxNumberCorrelations() const { return 5000; }
+    virtual std::size_t maxNumberCorrelations() const override { return 5000; }
 
     //! Get the chunk size in which to allocate correlations.
-    virtual std::size_t chunkSize() const { return 500; }
+    virtual std::size_t chunkSize() const override { return 500; }
 
     //! Create a new prior for a correlation model.
-    virtual TMultivariatePriorPtr newPrior() const {
+    virtual TMultivariatePriorPtr newPrior() const override {
         return TMultivariatePriorPtr(maths::common::CMultivariateNormalConjugate<2>::nonInformativePrior(
                                          maths_t::E_ContinuousData, DECAY_RATE)
                                          .clone());

--- a/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
@@ -88,21 +88,21 @@ class CTimeSeriesCorrelateModelAllocator
     : public maths::time_series::CTimeSeriesCorrelateModelAllocator {
 public:
     //! Check if we can still allocate any correlations.
-    virtual bool areAllocationsAllowed() const override { return true; }
+    bool areAllocationsAllowed() const override { return true; }
 
     //! Check if \p correlations exceeds the memory limit.
-    virtual bool exceedsLimit(std::size_t /*correlations*/) const override {
+    bool exceedsLimit(std::size_t /*correlations*/) const override {
         return false;
     }
 
     //! Get the maximum number of correlations we should model.
-    virtual std::size_t maxNumberCorrelations() const override { return 5000; }
+    std::size_t maxNumberCorrelations() const override { return 5000; }
 
     //! Get the chunk size in which to allocate correlations.
-    virtual std::size_t chunkSize() const override { return 500; }
+    std::size_t chunkSize() const override { return 500; }
 
     //! Create a new prior for a correlation model.
-    virtual TMultivariatePriorPtr newPrior() const override {
+    TMultivariatePriorPtr newPrior() const override {
         return TMultivariatePriorPtr(maths::common::CMultivariateNormalConjugate<2>::nonInformativePrior(
                                          maths_t::E_ContinuousData, DECAY_RATE)
                                          .clone());

--- a/lib/maths/time_series/unittest/TestUtils.h
+++ b/lib/maths/time_series/unittest/TestUtils.h
@@ -167,13 +167,13 @@ public:
         : PRIOR(static_cast<const PRIOR&>(other)),
           CPriorTestInterface(static_cast<maths::common::CPrior&>(*this)) {}
 
-    virtual ~CPriorTestInterfaceMixin() override {}
+    ~CPriorTestInterfaceMixin() override {}
 
     //! Swap the contents efficiently.
     void swap(CPriorTestInterfaceMixin& other) { this->PRIOR::swap(other); }
 
     //! Clone the object.
-    virtual CPriorTestInterfaceMixin* clone() const override {
+    CPriorTestInterfaceMixin* clone() const override {
         return new CPriorTestInterfaceMixin(*this);
     }
 };

--- a/lib/maths/time_series/unittest/TestUtils.h
+++ b/lib/maths/time_series/unittest/TestUtils.h
@@ -167,13 +167,13 @@ public:
         : PRIOR(static_cast<const PRIOR&>(other)),
           CPriorTestInterface(static_cast<maths::common::CPrior&>(*this)) {}
 
-    virtual ~CPriorTestInterfaceMixin() {}
+    virtual ~CPriorTestInterfaceMixin() override {}
 
     //! Swap the contents efficiently.
     void swap(CPriorTestInterfaceMixin& other) { this->PRIOR::swap(other); }
 
     //! Clone the object.
-    virtual CPriorTestInterfaceMixin* clone() const {
+    virtual CPriorTestInterfaceMixin* clone() const override {
         return new CPriorTestInterfaceMixin(*this);
     }
 };

--- a/lib/model/CHierarchicalResults.cc
+++ b/lib/model/CHierarchicalResults.cc
@@ -167,9 +167,7 @@ void aggregateLayer(ITR beginLayer,
 //! that it is either the person or partition field of that node.
 class CCommonInfluencePropagator : public CHierarchicalResultsVisitor {
 public:
-    virtual void visit(const CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         if (this->isLeaf(node)) {
             std::sort(node.s_AnnotatedProbability.s_Influences.begin(),
                       node.s_AnnotatedProbability.s_Influences.end(),

--- a/lib/model/CHierarchicalResults.cc
+++ b/lib/model/CHierarchicalResults.cc
@@ -167,7 +167,9 @@ void aggregateLayer(ITR beginLayer,
 //! that it is either the person or partition field of that node.
 class CCommonInfluencePropagator : public CHierarchicalResultsVisitor {
 public:
-    virtual void visit(const CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) {
+    virtual void visit(const CHierarchicalResults& /*results*/,
+                       const TNode& node,
+                       bool /*pivot*/) override {
         if (this->isLeaf(node)) {
             std::sort(node.s_AnnotatedProbability.s_Influences.begin(),
                       node.s_AnnotatedProbability.s_Influences.end(),

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -63,9 +63,9 @@ public:
         results.bottomUpBreadthFirst(*this);
     }
 
-    virtual void visit(const ml::model::CHierarchicalResults& results,
-                       const ml::model::CHierarchicalResults::TNode& node,
-                       bool pivot) override {
+    void visit(const ml::model::CHierarchicalResults& results,
+               const ml::model::CHierarchicalResults::TNode& node,
+               bool pivot) override {
         if (pivot) {
             return;
         }

--- a/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CEventRateAnomalyDetectorTest.cc
@@ -65,7 +65,7 @@ public:
 
     virtual void visit(const ml::model::CHierarchicalResults& results,
                        const ml::model::CHierarchicalResults::TNode& node,
-                       bool pivot) {
+                       bool pivot) override {
         if (pivot) {
             return;
         }

--- a/lib/model/unittest/CHierarchicalResultsLevelSetTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsLevelSetTest.cc
@@ -50,9 +50,9 @@ public:
         : ml::model::CHierarchicalResultsLevelSet<STestNode>(root) {}
 
     //! Visit a node.
-    virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
-                       const TNode& /*node*/,
-                       bool /*pivot*/) override {}
+    void visit(const ml::model::CHierarchicalResults& /*results*/,
+               const TNode& /*node*/,
+               bool /*pivot*/) override {}
 
     // make public
     using ml::model::CHierarchicalResultsLevelSet<STestNode>::elements;

--- a/lib/model/unittest/CHierarchicalResultsLevelSetTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsLevelSetTest.cc
@@ -52,7 +52,7 @@ public:
     //! Visit a node.
     virtual void visit(const ml::model::CHierarchicalResults& /*results*/,
                        const TNode& /*node*/,
-                       bool /*pivot*/) {}
+                       bool /*pivot*/) override {}
 
     // make public
     using ml::model::CHierarchicalResultsLevelSet<STestNode>::elements;

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -75,7 +75,7 @@ public:
 
     virtual void visit(const model::CHierarchicalResults& /*results*/,
                        const TNode& node,
-                       bool /*pivot*/) {
+                       bool /*pivot*/) override {
         LOG_DEBUG(<< "Visiting " << node.print());
 
         if (node.s_Children.empty()) {
@@ -154,7 +154,7 @@ public:
 public:
     virtual void visit(const model::CHierarchicalResults& /*results*/,
                        const TNode& node,
-                       bool /*pivot*/) {
+                       bool /*pivot*/) override {
         LOG_DEBUG(<< "Visiting " << node.print());
         for (std::size_t i = node.s_Children.size(); i > 0; --i) {
             BOOST_TEST_REQUIRE(!m_Children.empty());
@@ -176,7 +176,9 @@ public:
     CPrinter(bool shouldOnlyPrintWrittenNodes)
         : m_ShouldPrintWrittenNodesOnly(shouldOnlyPrintWrittenNodes) {}
 
-    virtual void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) {
+    virtual void visit(const model::CHierarchicalResults& results,
+                       const TNode& node,
+                       bool pivot) override {
         if (m_ShouldPrintWrittenNodesOnly == false ||
             shouldWriteResult(m_Limits, results, node, pivot)) {
             m_Result = std::string(2 * depth(&node), ' ') + node.print() +
@@ -209,7 +211,7 @@ public:
 public:
     virtual void visit(const model::CHierarchicalResults& /*results*/,
                        const TNode& node,
-                       bool /*pivot*/) {
+                       bool /*pivot*/) override {
         if (this->isPartitioned(node)) {
             m_PartitionedNodes.push_back(&node);
         }
@@ -241,7 +243,7 @@ class CCheckScores : public model::CHierarchicalResultsVisitor {
 public:
     virtual void visit(const model::CHierarchicalResults& /*results*/,
                        const TNode& node,
-                       bool /*pivot*/) {
+                       bool /*pivot*/) override {
         LOG_DEBUG(<< node.s_Spec.print() << " score = " << node.s_RawAnomalyScore << ", expected score = "
                   << maths::common::CTools::anomalyScore(node.probability()));
         BOOST_REQUIRE_CLOSE_ABSOLUTE(maths::common::CTools::anomalyScore(node.probability()),
@@ -256,7 +258,9 @@ class CWriteConsistencyChecker : public model::CHierarchicalResultsVisitor {
 public:
     CWriteConsistencyChecker(const model::CLimits& limits) : m_Limits(limits) {}
 
-    virtual void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) {
+    virtual void visit(const model::CHierarchicalResults& results,
+                       const TNode& node,
+                       bool pivot) override {
         if (!this->shouldWriteResult(m_Limits, results, node, pivot)) {
             return;
         }
@@ -316,8 +320,9 @@ public:
 public:
     CProbabilityGatherer() : TBase(SNodeProbabilities("bucket")) {}
 
-    virtual void
-    visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool pivot) {
+    virtual void visit(const model::CHierarchicalResults& /*results*/,
+                       const TNode& node,
+                       bool pivot) override {
         if (isLeaf(node)) {
             CFactory factory;
             TNodeProbabilitiesPtrVec probabilities;

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -73,9 +73,7 @@ public:
 public:
     CBreadthFirstCheck() : m_Layer(0), m_Layers(1, TNodeCPtrSet()) {}
 
-    virtual void visit(const model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         LOG_DEBUG(<< "Visiting " << node.print());
 
         if (node.s_Children.empty()) {
@@ -152,9 +150,7 @@ public:
     using TNodeCPtrVec = std::vector<const TNode*>;
 
 public:
-    virtual void visit(const model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         LOG_DEBUG(<< "Visiting " << node.print());
         for (std::size_t i = node.s_Children.size(); i > 0; --i) {
             BOOST_TEST_REQUIRE(!m_Children.empty());
@@ -176,9 +172,7 @@ public:
     CPrinter(bool shouldOnlyPrintWrittenNodes)
         : m_ShouldPrintWrittenNodesOnly(shouldOnlyPrintWrittenNodes) {}
 
-    virtual void visit(const model::CHierarchicalResults& results,
-                       const TNode& node,
-                       bool pivot) override {
+    void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) override {
         if (m_ShouldPrintWrittenNodesOnly == false ||
             shouldWriteResult(m_Limits, results, node, pivot)) {
             m_Result = std::string(2 * depth(&node), ' ') + node.print() +
@@ -209,9 +203,7 @@ public:
     using TNodeCPtrVec = std::vector<const TNode*>;
 
 public:
-    virtual void visit(const model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         if (this->isPartitioned(node)) {
             m_PartitionedNodes.push_back(&node);
         }
@@ -241,9 +233,7 @@ private:
 //! \brief Checks our anomaly scores are correct post scoring.
 class CCheckScores : public model::CHierarchicalResultsVisitor {
 public:
-    virtual void visit(const model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool /*pivot*/) override {
+    void visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         LOG_DEBUG(<< node.s_Spec.print() << " score = " << node.s_RawAnomalyScore << ", expected score = "
                   << maths::common::CTools::anomalyScore(node.probability()));
         BOOST_REQUIRE_CLOSE_ABSOLUTE(maths::common::CTools::anomalyScore(node.probability()),
@@ -258,9 +248,7 @@ class CWriteConsistencyChecker : public model::CHierarchicalResultsVisitor {
 public:
     CWriteConsistencyChecker(const model::CLimits& limits) : m_Limits(limits) {}
 
-    virtual void visit(const model::CHierarchicalResults& results,
-                       const TNode& node,
-                       bool pivot) override {
+    void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) override {
         if (!this->shouldWriteResult(m_Limits, results, node, pivot)) {
             return;
         }
@@ -320,9 +308,7 @@ public:
 public:
     CProbabilityGatherer() : TBase(SNodeProbabilities("bucket")) {}
 
-    virtual void visit(const model::CHierarchicalResults& /*results*/,
-                       const TNode& node,
-                       bool pivot) override {
+    void visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool pivot) override {
         if (isLeaf(node)) {
             CFactory factory;
             TNodeProbabilitiesPtrVec probabilities;

--- a/lib/model/unittest/CMetricAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CMetricAnomalyDetectorTest.cc
@@ -77,9 +77,9 @@ public:
     }
 
     //! Visit a node.
-    virtual void visit(const ml::model::CHierarchicalResults& results,
-                       const ml::model::CHierarchicalResults::TNode& node,
-                       bool pivot) override {
+    void visit(const ml::model::CHierarchicalResults& results,
+               const ml::model::CHierarchicalResults::TNode& node,
+               bool pivot) override {
         if (pivot) {
             return;
         }

--- a/lib/model/unittest/CMetricAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CMetricAnomalyDetectorTest.cc
@@ -79,7 +79,7 @@ public:
     //! Visit a node.
     virtual void visit(const ml::model::CHierarchicalResults& results,
                        const ml::model::CHierarchicalResults::TNode& node,
-                       bool pivot) {
+                       bool pivot) override {
         if (pivot) {
             return;
         }

--- a/lib/model/unittest/CResourceLimitTest.cc
+++ b/lib/model/unittest/CResourceLimitTest.cc
@@ -67,9 +67,9 @@ public:
         results.bottomUpBreadthFirst(*this);
     }
 
-    virtual void visit(const ml::model::CHierarchicalResults& results,
-                       const ml::model::CHierarchicalResults::TNode& node,
-                       bool pivot) override {
+    void visit(const ml::model::CHierarchicalResults& results,
+               const ml::model::CHierarchicalResults::TNode& node,
+               bool pivot) override {
         if (pivot) {
             return;
         }
@@ -147,11 +147,11 @@ public:
                           std::make_shared<CInterimBucketCorrector>(params.s_BucketLength)),
           m_ResourceMonitor(resourceMonitor), m_NewPeople(0), m_NewAttributes(0) {}
 
-    virtual void updateRecycledModels() override {
+    void updateRecycledModels() override {
         // Do nothing
     }
 
-    virtual void createNewModels(std::size_t n, std::size_t m) override {
+    void createNewModels(std::size_t n, std::size_t m) override {
         m_NewPeople += n;
         m_NewAttributes += m;
         this->CEventRateModel::createNewModels(n, m);
@@ -190,11 +190,11 @@ public:
                        std::make_shared<CInterimBucketCorrector>(params.s_BucketLength)),
           m_ResourceMonitor(resourceMonitor), m_NewPeople(0), m_NewAttributes(0) {}
 
-    virtual void updateRecycledModels() override {
+    void updateRecycledModels() override {
         // Do nothing
     }
 
-    virtual void createNewModels(std::size_t n, std::size_t m) override {
+    void createNewModels(std::size_t n, std::size_t m) override {
         m_NewPeople += n;
         m_NewAttributes += m;
         this->CMetricModel::createNewModels(n, m);

--- a/lib/model/unittest/CResourceLimitTest.cc
+++ b/lib/model/unittest/CResourceLimitTest.cc
@@ -69,7 +69,7 @@ public:
 
     virtual void visit(const ml::model::CHierarchicalResults& results,
                        const ml::model::CHierarchicalResults::TNode& node,
-                       bool pivot) {
+                       bool pivot) override {
         if (pivot) {
             return;
         }
@@ -147,24 +147,24 @@ public:
                           std::make_shared<CInterimBucketCorrector>(params.s_BucketLength)),
           m_ResourceMonitor(resourceMonitor), m_NewPeople(0), m_NewAttributes(0) {}
 
-    virtual void updateRecycledModels() {
+    virtual void updateRecycledModels() override {
         // Do nothing
     }
 
-    virtual void createNewModels(std::size_t n, std::size_t m) {
+    virtual void createNewModels(std::size_t n, std::size_t m) override {
         m_NewPeople += n;
         m_NewAttributes += m;
         this->CEventRateModel::createNewModels(n, m);
     }
 
-    void test(core_t::TTime time) {
+    void test(core_t::TTime time) override {
         m_ResourceMonitor.clearExtraMemory();
         this->createUpdateNewModels(time, m_ResourceMonitor);
     }
 
-    std::size_t getNewPeople() const { return m_NewPeople; }
+    std::size_t getNewPeople() const override { return m_NewPeople; }
 
-    std::size_t getNewAttributes() const { return m_NewAttributes; }
+    std::size_t getNewAttributes() const override { return m_NewAttributes; }
 
 private:
     CResourceMonitor& m_ResourceMonitor;
@@ -190,24 +190,24 @@ public:
                        std::make_shared<CInterimBucketCorrector>(params.s_BucketLength)),
           m_ResourceMonitor(resourceMonitor), m_NewPeople(0), m_NewAttributes(0) {}
 
-    virtual void updateRecycledModels() {
+    virtual void updateRecycledModels() override {
         // Do nothing
     }
 
-    virtual void createNewModels(std::size_t n, std::size_t m) {
+    virtual void createNewModels(std::size_t n, std::size_t m) override {
         m_NewPeople += n;
         m_NewAttributes += m;
         this->CMetricModel::createNewModels(n, m);
     }
 
-    void test(core_t::TTime time) {
+    void test(core_t::TTime time) override {
         m_ResourceMonitor.clearExtraMemory();
         this->createUpdateNewModels(time, m_ResourceMonitor);
     }
 
-    std::size_t getNewPeople() const { return m_NewPeople; }
+    std::size_t getNewPeople() const override { return m_NewPeople; }
 
-    std::size_t getNewAttributes() const { return m_NewAttributes; }
+    std::size_t getNewAttributes() const override { return m_NewAttributes; }
 
 private:
     CResourceMonitor& m_ResourceMonitor;


### PR DESCRIPTION
When upgrading to macOS `Big Sur` and `Xcode 13.1` a large number of compiler warnings similar to
```
include/maths/common/CNormalMeanPrecConjugate.h:288:25: warning: 'memoryUsage' overrides a member function but is not marked 'override' [-Wsuggest-override]
    virtual std::size_t memoryUsage() const;
```
are generated.

This PR adds the `override` keyword where necessary to subdue such compiler warnings.