### PR TITLE
[ML] Fix C++17 deprecation warnings

### DIFF
--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -136,9 +136,9 @@ void invokeAndWriteResultToPromise(F& f, P& promise, const std::true_type&) {
 //! them. Prefer using high level primitives, such as parallel_for_each, which are
 //! safer.
 template<typename FUNCTION, typename... ARGS>
-std::future<std::result_of_t<std::decay_t<FUNCTION>(std::decay_t<ARGS>...)>>
+std::future<std::invoke_result_t<std::decay_t<FUNCTION>, std::decay_t<ARGS>...>>
 async(CExecutor& executor, FUNCTION&& f, ARGS&&... args) {
-    using R = std::result_of_t<std::decay_t<FUNCTION>(std::decay_t<ARGS>...)>;
+    using R = std::invoke_result_t<std::decay_t<FUNCTION>, std::decay_t<ARGS>...>;
 
     // Note g stores copies of the arguments in the pack, which are moved into place
     // if possible, so this is safe to invoke later in the context of a packaged task.

--- a/include/maths/common/CBjkstUniqueValues.h
+++ b/include/maths/common/CBjkstUniqueValues.h
@@ -19,10 +19,10 @@
 
 #include <maths/common/ImportExport.h>
 
-#include <boost/variant.hpp>
 
 #include <cstddef>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <stdint.h>
@@ -163,7 +163,7 @@ private:
         TUInt8VecVec s_B;
     };
 
-    using TUInt32VecOrSketch = boost::variant<TUInt32Vec, SSketch>;
+    using TUInt32VecOrSketch = std::variant<TUInt32Vec, SSketch>;
 
 private:
     //! Maybe switch to sketching the distinct value set.

--- a/include/maths/common/CBjkstUniqueValues.h
+++ b/include/maths/common/CBjkstUniqueValues.h
@@ -19,7 +19,6 @@
 
 #include <maths/common/ImportExport.h>
 
-
 #include <cstddef>
 #include <utility>
 #include <variant>

--- a/include/maths/common/CBootstrapClusterer.h
+++ b/include/maths/common/CBootstrapClusterer.h
@@ -362,14 +362,14 @@ protected:
             TOutEdgeItr j, endj;
             for (boost::tie(j, endj) = boost::out_edges(u, graph); j != endj; ++j) {
                 std::size_t v = boost::target(*j, graph);
-                double weight = std::get(boost::edge_weight, graph, *j);
+                double weight = boost::get(boost::edge_weight, graph, *j);
 
                 TOutEdgeItr k, endk;
                 for (boost::tie(k, endk) = boost::out_edges(v, graph); k != endk; ++k) {
                     std::size_t w = boost::target(*k, graph);
                     if (this->fromVertex(w).first == i->second) {
                         consistent.push_back(std::make_pair(
-                            weight * std::get(boost::edge_weight, graph, *k), w));
+                            weight * boost::get(boost::edge_weight, graph, *k), w));
                     }
                 }
             }
@@ -548,7 +548,7 @@ protected:
         {
             TEdgeItr i, end;
             for (boost::tie(i, end) = boost::edges(graph); i != end; ++i) {
-                double weight = std::get(boost::edge_weight, graph, *i);
+                double weight = boost::get(boost::edge_weight, graph, *i);
                 weights.push_back(weight);
                 totalWeight += weight;
             }
@@ -787,7 +787,7 @@ private:
                 if (u < v && std::binary_search(inverse.begin(), inverse.end(), v)) {
                     boost::put(boost::edge_weight, result,
                                boost::add_edge(mapping[u], mapping[v], result).first,
-                               std::get(boost::edge_weight, graph, *j));
+                               boost::get(boost::edge_weight, graph, *j));
                 }
             }
         }
@@ -830,7 +830,7 @@ private:
         std::size_t n = state.s_ToVisit.size();
         TOutEdgeItr i, end;
         for (boost::tie(i, end) = boost::out_edges(u, graph); i != end; ++i) {
-            double weight = std::get(boost::edge_weight, graph, *i);
+            double weight = boost::get(boost::edge_weight, graph, *i);
             std::size_t v = boost::target(*i, graph);
             if (parities[v]) {
                 state.s_Adjacency[v] += weight;

--- a/include/maths/common/CBootstrapClusterer.h
+++ b/include/maths/common/CBootstrapClusterer.h
@@ -362,14 +362,14 @@ protected:
             TOutEdgeItr j, endj;
             for (boost::tie(j, endj) = boost::out_edges(u, graph); j != endj; ++j) {
                 std::size_t v = boost::target(*j, graph);
-                double weight = boost::get(boost::edge_weight, graph, *j);
+                double weight = std::get(boost::edge_weight, graph, *j);
 
                 TOutEdgeItr k, endk;
                 for (boost::tie(k, endk) = boost::out_edges(v, graph); k != endk; ++k) {
                     std::size_t w = boost::target(*k, graph);
                     if (this->fromVertex(w).first == i->second) {
                         consistent.push_back(std::make_pair(
-                            weight * boost::get(boost::edge_weight, graph, *k), w));
+                            weight * std::get(boost::edge_weight, graph, *k), w));
                     }
                 }
             }
@@ -548,7 +548,7 @@ protected:
         {
             TEdgeItr i, end;
             for (boost::tie(i, end) = boost::edges(graph); i != end; ++i) {
-                double weight = boost::get(boost::edge_weight, graph, *i);
+                double weight = std::get(boost::edge_weight, graph, *i);
                 weights.push_back(weight);
                 totalWeight += weight;
             }
@@ -787,7 +787,7 @@ private:
                 if (u < v && std::binary_search(inverse.begin(), inverse.end(), v)) {
                     boost::put(boost::edge_weight, result,
                                boost::add_edge(mapping[u], mapping[v], result).first,
-                               boost::get(boost::edge_weight, graph, *j));
+                               std::get(boost::edge_weight, graph, *j));
                 }
             }
         }
@@ -830,7 +830,7 @@ private:
         std::size_t n = state.s_ToVisit.size();
         TOutEdgeItr i, end;
         for (boost::tie(i, end) = boost::out_edges(u, graph); i != end; ++i) {
-            double weight = boost::get(boost::edge_weight, graph, *i);
+            double weight = std::get(boost::edge_weight, graph, *i);
             std::size_t v = boost::target(*i, graph);
             if (parities[v]) {
                 state.s_Adjacency[v] += weight;

--- a/include/maths/common/CMixtureDistribution.h
+++ b/include/maths/common/CMixtureDistribution.h
@@ -25,11 +25,11 @@
 #include <boost/math/distributions/lognormal.hpp>
 #include <boost/math/distributions/normal.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
-#include <boost/variant.hpp>
 
 #include <cmath>
 #include <exception>
 #include <functional>
+#include <variant>
 #include <vector>
 
 namespace ml {
@@ -48,17 +48,17 @@ public:
 
     template<typename F>
     typename F::result_type visit(const F& f, double x) const {
-        return boost::apply_visitor(std::bind(f, std::placeholders::_1, x), m_Distribution);
+        return std::visit(std::bind(f, std::placeholders::_1, x), m_Distribution);
     }
 
     template<typename F>
     typename F::result_type visit(const F& f) const {
-        return boost::apply_visitor(f, m_Distribution);
+        return std::visit(f, m_Distribution);
     }
 
 private:
     using TDistribution =
-        boost::variant<boost::math::normal_distribution<>, boost::math::gamma_distribution<>, boost::math::lognormal_distribution<>>;
+        std::variant<boost::math::normal_distribution<>, boost::math::gamma_distribution<>, boost::math::lognormal_distribution<>>;
 
 private:
     //! The actual distribution.

--- a/include/maths/common/CSetTools.h
+++ b/include/maths/common/CSetTools.h
@@ -14,7 +14,6 @@
 
 #include <maths/common/ImportExport.h>
 
-
 #include <cstddef>
 #include <set>
 #include <variant>

--- a/include/maths/common/CSetTools.h
+++ b/include/maths/common/CSetTools.h
@@ -14,10 +14,10 @@
 
 #include <maths/common/ImportExport.h>
 
-#include <boost/variant.hpp>
 
 #include <cstddef>
 #include <set>
+#include <variant>
 #include <vector>
 
 namespace ml {
@@ -45,16 +45,16 @@ public:
 
         template<typename T>
         bool operator()(const T& indexedObject) const {
-            const std::size_t* index = boost::get<std::size_t>(&m_IndexSet);
+            const std::size_t* index = std::get_if<std::size_t>(&m_IndexSet);
             if (index) {
                 return indexedObject.s_Index == *index;
             }
-            const TSizeSet& indexSet = boost::get<TSizeSet>(m_IndexSet);
+            const TSizeSet& indexSet = std::get<TSizeSet>(m_IndexSet);
             return indexSet.count(indexedObject.s_Index) > 0;
         }
 
     private:
-        using TSizeOrSizeSet = boost::variant<std::size_t, TSizeSet>;
+        using TSizeOrSizeSet = std::variant<std::size_t, TSizeSet>;
 
     private:
         TSizeOrSizeSet m_IndexSet;

--- a/include/maths/time_series/CCountMinSketch.h
+++ b/include/maths/time_series/CCountMinSketch.h
@@ -21,7 +21,7 @@
 
 #include <maths/common/MathsTypes.h>
 
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace ml {
 namespace maths {
@@ -147,7 +147,7 @@ private:
 
     using TUInt32FloatPr = std::pair<uint32_t, common::CFloatStorage>;
     using TUInt32FloatPrVec = std::vector<TUInt32FloatPr>;
-    using TUInt32FloatPrVecOrSketch = boost::variant<TUInt32FloatPrVec, SSketch>;
+    using TUInt32FloatPrVecOrSketch = std::variant<TUInt32FloatPrVec, SSketch>;
 
     //! Maybe switch to sketching the counts.
     void sketch();

--- a/include/model/CModelTools.h
+++ b/include/model/CModelTools.h
@@ -29,10 +29,10 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/variant.hpp>
 
 #include <cstddef>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace ml {
@@ -138,7 +138,7 @@ public:
     class MODEL_EXPORT CProbabilityAggregator {
     public:
         using TAggregator =
-            boost::variant<maths::common::CJointProbabilityOfLessLikelySamples, maths::common::CProbabilityOfExtremeSample>;
+            std::variant<maths::common::CJointProbabilityOfLessLikelySamples, maths::common::CProbabilityOfExtremeSample>;
         using TAggregatorDoublePr = std::pair<TAggregator, double>;
         using TAggregatorDoublePrVec = std::vector<TAggregatorDoublePr>;
 

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -212,6 +212,13 @@ private:
 template<typename T>
 class CTrackingAllocator : public std::allocator<T> {
 public:
+    using value_type = T;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
     using allocator_type = CTrackingAllocator<T>;
     using traits_type = std::allocator_traits<allocator_type>;
 

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -219,7 +219,7 @@ public:
     using const_reference = const value_type&;
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
-    using allocator_type = CTrackingAllocator<T>;
+    using allocator_type = std::allocator<T>;
     using traits_type = std::allocator_traits<allocator_type>;
 
 public:

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -214,6 +214,7 @@ class CTrackingAllocator : public std::allocator<T> {
 public:
     using allocator_type = CTrackingAllocator<T>;
     using traits_type = std::allocator_traits<allocator_type>;
+
 public:
     // convert an allocator<T> to allocator<U>
     template<typename U>
@@ -234,8 +235,7 @@ public:
     inline const_pointer address(const_reference r) { return &r; }
 
     // memory allocation
-    inline pointer allocate(size_type cnt,
-                            typename traits_type::const_pointer = nullptr) {
+    inline pointer allocate(size_type cnt, typename traits_type::const_pointer = nullptr) {
         ms_Allocated += cnt;
         return reinterpret_cast<pointer>(::operator new(cnt * sizeof(T)));
     }

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -210,16 +210,10 @@ private:
 
 //! A basic allocator that tracks memory usage
 template<typename T>
-class CTrackingAllocator {
+class CTrackingAllocator : public std::allocator<T> {
 public:
-    using value_type = T;
-    using pointer = value_type*;
-    using const_pointer = const value_type*;
-    using reference = value_type&;
-    using const_reference = const value_type&;
-    using size_type = std::size_t;
-    using difference_type = std::ptrdiff_t;
-
+    using allocator_type = CTrackingAllocator<T>;
+    using traits_type = std::allocator_traits<allocator_type>;
 public:
     // convert an allocator<T> to allocator<U>
     template<typename U>
@@ -241,7 +235,7 @@ public:
 
     // memory allocation
     inline pointer allocate(size_type cnt,
-                            typename std::allocator<void>::const_pointer = nullptr) {
+                            typename traits_type::const_pointer = nullptr) {
         ms_Allocated += cnt;
         return reinterpret_cast<pointer>(::operator new(cnt * sizeof(T)));
     }

--- a/lib/maths/time_series/CCountMinSketch.cc
+++ b/lib/maths/time_series/CCountMinSketch.cc
@@ -65,38 +65,38 @@ void CCountMinSketch::swap(CCountMinSketch& other) noexcept {
     std::swap(m_TotalCount, other.m_TotalCount);
 
     try {
-        TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+        TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
         if (counts) {
             TUInt32FloatPrVec* otherCounts =
-                boost::get<TUInt32FloatPrVec>(&other.m_Sketch);
+                std::get_if<TUInt32FloatPrVec>(&other.m_Sketch);
             if (otherCounts) {
                 counts->swap(*otherCounts);
             } else {
-                SSketch& otherSketch = boost::get<SSketch>(other.m_Sketch);
+                SSketch& otherSketch = std::get<SSketch>(other.m_Sketch);
                 TUInt32FloatPrVec tmp;
                 tmp.swap(*counts);
                 m_Sketch = SSketch();
-                boost::get<SSketch>(m_Sketch).s_Hashes.swap(otherSketch.s_Hashes);
-                boost::get<SSketch>(m_Sketch).s_Counts.swap(otherSketch.s_Counts);
+                std::get<SSketch>(m_Sketch).s_Hashes.swap(otherSketch.s_Hashes);
+                std::get<SSketch>(m_Sketch).s_Counts.swap(otherSketch.s_Counts);
                 other.m_Sketch = TUInt32FloatPrVec();
-                boost::get<TUInt32FloatPrVec>(other.m_Sketch).swap(tmp);
+                std::get<TUInt32FloatPrVec>(other.m_Sketch).swap(tmp);
             }
         } else {
-            SSketch& sketch = boost::get<SSketch>(m_Sketch);
-            SSketch* otherSketch = boost::get<SSketch>(&other.m_Sketch);
+            SSketch& sketch = std::get<SSketch>(m_Sketch);
+            SSketch* otherSketch = std::get_if<SSketch>(&other.m_Sketch);
             if (otherSketch) {
                 sketch.s_Hashes.swap(otherSketch->s_Hashes);
                 sketch.s_Counts.swap(otherSketch->s_Counts);
             } else {
                 TUInt32FloatPrVec& otherCounts =
-                    boost::get<TUInt32FloatPrVec>(other.m_Sketch);
+                    std::get<TUInt32FloatPrVec>(other.m_Sketch);
                 TUInt32FloatPrVec tmp;
                 tmp.swap(otherCounts);
                 other.m_Sketch = SSketch();
-                sketch.s_Hashes.swap(boost::get<SSketch>(other.m_Sketch).s_Hashes);
-                sketch.s_Counts.swap(boost::get<SSketch>(other.m_Sketch).s_Counts);
+                sketch.s_Hashes.swap(std::get<SSketch>(other.m_Sketch).s_Hashes);
+                sketch.s_Counts.swap(std::get<SSketch>(other.m_Sketch).s_Counts);
                 m_Sketch = TUInt32FloatPrVec();
-                boost::get<TUInt32FloatPrVec>(m_Sketch).swap(tmp);
+                std::get<TUInt32FloatPrVec>(m_Sketch).swap(tmp);
             }
         }
     } catch (const std::exception& e) {
@@ -124,7 +124,7 @@ bool CCountMinSketch::acceptRestoreTraverser(core::CStateRestoreTraverser& trave
             }
         } else if (name == CATEGORY_COUNTS_TAG) {
             m_Sketch = TUInt32FloatPrVec();
-            TUInt32FloatPrVec& counts = boost::get<TUInt32FloatPrVec>(m_Sketch);
+            TUInt32FloatPrVec& counts = std::get<TUInt32FloatPrVec>(m_Sketch);
             if (core::CPersistUtils::fromString(traverser.value(), counts, DELIMITER,
                                                 PAIR_DELIMITER) == false) {
                 LOG_ERROR(<< "Invalid category counts in " << traverser.value());
@@ -132,7 +132,7 @@ bool CCountMinSketch::acceptRestoreTraverser(core::CStateRestoreTraverser& trave
             }
         } else if (name == SKETCH_TAG) {
             m_Sketch = SSketch();
-            SSketch& sketch = boost::get<SSketch>(m_Sketch);
+            SSketch& sketch = std::get<SSketch>(m_Sketch);
             sketch.s_Hashes.reserve(m_Rows);
             sketch.s_Counts.reserve(m_Rows);
             if (traverser.traverseSubLevel(
@@ -149,13 +149,13 @@ void CCountMinSketch::acceptPersistInserter(core::CStatePersistInserter& inserte
     inserter.insertValue(ROWS_TAG, m_Rows);
     inserter.insertValue(COLUMNS_TAG, m_Columns);
     inserter.insertValue(TOTAL_COUNT_TAG, m_TotalCount, core::CIEEE754::E_SinglePrecision);
-    const TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    const TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         inserter.insertValue(CATEGORY_COUNTS_TAG,
                              core::CPersistUtils::toString(*counts, DELIMITER, PAIR_DELIMITER));
     } else {
         try {
-            const SSketch& sketch = boost::get<SSketch>(m_Sketch);
+            const SSketch& sketch = std::get<SSketch>(m_Sketch);
             inserter.insertLevel(SKETCH_TAG, std::bind(&SSketch::acceptPersistInserter,
                                                        &sketch, std::placeholders::_1));
         } catch (const std::exception& e) {
@@ -173,7 +173,7 @@ std::size_t CCountMinSketch::columns() const {
 }
 
 double CCountMinSketch::delta() const {
-    const SSketch* sketch = boost::get<SSketch>(&m_Sketch);
+    const SSketch* sketch = std::get_if<SSketch>(&m_Sketch);
     if (!sketch) {
         return 0.0;
     }
@@ -181,7 +181,7 @@ double CCountMinSketch::delta() const {
 }
 
 double CCountMinSketch::oneMinusDeltaError() const {
-    const SSketch* sketch = boost::get<SSketch>(&m_Sketch);
+    const SSketch* sketch = std::get_if<SSketch>(&m_Sketch);
     if (!sketch) {
         return 0.0;
     }
@@ -194,7 +194,7 @@ void CCountMinSketch::add(uint32_t category, double count) {
 
     m_TotalCount += count;
 
-    TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         auto itr = std::lower_bound(counts->begin(), counts->end(), category,
                                     common::COrderings::SFirstLess());
@@ -212,7 +212,7 @@ void CCountMinSketch::add(uint32_t category, double count) {
         }
     } else {
         try {
-            SSketch& sketch = boost::get<SSketch>(m_Sketch);
+            SSketch& sketch = std::get<SSketch>(m_Sketch);
             for (std::size_t i = 0; i < sketch.s_Hashes.size(); ++i) {
                 uint32_t hash = (sketch.s_Hashes[i])(category);
                 std::size_t j = static_cast<std::size_t>(hash) % m_Columns;
@@ -227,7 +227,7 @@ void CCountMinSketch::add(uint32_t category, double count) {
 }
 
 void CCountMinSketch::removeFromMap(uint32_t category) {
-    TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         auto itr = std::lower_bound(counts->begin(), counts->end(), category,
                                     common::COrderings::SFirstLess());
@@ -238,14 +238,14 @@ void CCountMinSketch::removeFromMap(uint32_t category) {
 }
 
 void CCountMinSketch::age(double alpha) {
-    TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         for (std::size_t i = 0; i < counts->size(); ++i) {
             (*counts)[i].second *= alpha;
         }
     } else {
         try {
-            SSketch& sketch = boost::get<SSketch>(m_Sketch);
+            SSketch& sketch = std::get<SSketch>(m_Sketch);
             for (std::size_t i = 0; i < sketch.s_Counts.size(); ++i) {
                 for (std::size_t j = 0; j < sketch.s_Counts[i].size(); ++j) {
                     sketch.s_Counts[i][j] *= alpha;
@@ -264,7 +264,7 @@ double CCountMinSketch::totalCount() const {
 double CCountMinSketch::count(uint32_t category) const {
     using TMinAccumulator = common::CBasicStatistics::COrderStatisticsStack<double, 1>;
 
-    const TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    const TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         auto itr = std::lower_bound(counts->begin(), counts->end(), category,
                                     common::COrderings::SFirstLess());
@@ -276,7 +276,7 @@ double CCountMinSketch::count(uint32_t category) const {
 
     TMinAccumulator result;
     try {
-        const SSketch& sketch = boost::get<SSketch>(m_Sketch);
+        const SSketch& sketch = std::get<SSketch>(m_Sketch);
         for (std::size_t i = 0; i < sketch.s_Hashes.size(); ++i) {
             uint32_t hash = (sketch.s_Hashes[i])(category);
             std::size_t j = static_cast<std::size_t>(hash) % m_Columns;
@@ -295,7 +295,7 @@ double CCountMinSketch::fraction(uint32_t category) const {
 }
 
 bool CCountMinSketch::sketched() const {
-    return boost::get<SSketch>(&m_Sketch) != nullptr;
+    return std::get_if<SSketch>(&m_Sketch) != nullptr;
 }
 
 uint64_t CCountMinSketch::checksum(uint64_t seed) const {
@@ -303,10 +303,10 @@ uint64_t CCountMinSketch::checksum(uint64_t seed) const {
     seed = common::CChecksum::calculate(seed, m_Columns);
     seed = common::CChecksum::calculate(seed, m_TotalCount);
 
-    const TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    const TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts == nullptr) {
         try {
-            const SSketch& sketch = boost::get<SSketch>(m_Sketch);
+            const SSketch& sketch = std::get<SSketch>(m_Sketch);
             seed = common::CChecksum::calculate(seed, sketch.s_Hashes);
             return common::CChecksum::calculate(seed, sketch.s_Counts);
         } catch (const std::exception& e) {
@@ -318,12 +318,12 @@ uint64_t CCountMinSketch::checksum(uint64_t seed) const {
 
 void CCountMinSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCountMinSketch");
-    const TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    const TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         core::CMemoryDebug::dynamicSize("m_Counts", *counts, mem);
     } else {
         try {
-            const SSketch& sketch = boost::get<SSketch>(m_Sketch);
+            const SSketch& sketch = std::get<SSketch>(m_Sketch);
             mem->addItem("SSketch", sizeof(SSketch));
             core::CMemoryDebug::dynamicSize("sketch", sketch, mem);
             core::CMemoryDebug::dynamicSize("s_Hashes", sketch.s_Hashes, mem);
@@ -336,12 +336,12 @@ void CCountMinSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr
 
 std::size_t CCountMinSketch::memoryUsage() const {
     std::size_t mem = 0;
-    const TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    const TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         mem += core::CMemory::dynamicSize(*counts);
     } else {
         try {
-            const SSketch& sketch = boost::get<SSketch>(m_Sketch);
+            const SSketch& sketch = std::get<SSketch>(m_Sketch);
             mem += sizeof(SSketch);
             mem += core::CMemory::dynamicSize(sketch.s_Hashes);
             mem += core::CMemory::dynamicSize(sketch.s_Counts);
@@ -360,7 +360,7 @@ void CCountMinSketch::sketch() {
     static const std::size_t VEC_SIZE = sizeof(TUInt32FloatPrVec);
     static const std::size_t SKETCH_SIZE = sizeof(SSketch);
 
-    TUInt32FloatPrVec* counts = boost::get<TUInt32FloatPrVec>(&m_Sketch);
+    TUInt32FloatPrVec* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts) {
         std::size_t countsSize = VEC_SIZE + PAIR_SIZE * counts->capacity();
         std::size_t sketchSize = SKETCH_SIZE + m_Rows * (m_Columns * FLOAT_SIZE + HASH_SIZE);

--- a/lib/model/CModelTools.cc
+++ b/lib/model/CModelTools.cc
@@ -204,9 +204,9 @@ void CModelTools::CProbabilityAggregator::add(const TAggregator& aggregator, dou
 void CModelTools::CProbabilityAggregator::add(double probability, double weight) {
     m_TotalWeight += weight;
     for (auto& aggregator : m_Aggregators) {
-        std::visit(std::bind<void>(SAddProbability(), probability,
-                                             weight, std::placeholders::_1),
-                             aggregator.first);
+        std::visit(std::bind<void>(SAddProbability(), probability, weight,
+                                   std::placeholders::_1),
+                   aggregator.first);
     }
 }
 
@@ -232,10 +232,9 @@ bool CModelTools::CProbabilityAggregator::calculate(double& result) const {
             n += aggregator.second;
         }
         for (const auto& aggregator : m_Aggregators) {
-            if (!std::visit(
-                    std::bind<bool>(SReadProbability(), aggregator.second / n,
-                                    std::ref(p), std::placeholders::_1),
-                    aggregator.first)) {
+            if (!std::visit(std::bind<bool>(SReadProbability(), aggregator.second / n,
+                                            std::ref(p), std::placeholders::_1),
+                            aggregator.first)) {
                 return false;
             }
         }
@@ -244,9 +243,8 @@ bool CModelTools::CProbabilityAggregator::calculate(double& result) const {
     case E_Min: {
         TMinAccumulator p_;
         for (const auto& aggregator : m_Aggregators) {
-            if (!std::visit(std::bind<bool>(SReadProbability(), std::ref(p_),
-                                                      std::placeholders::_1),
-                                      aggregator.first)) {
+            if (!std::visit(std::bind<bool>(SReadProbability(), std::ref(p_), std::placeholders::_1),
+                            aggregator.first)) {
                 return false;
             }
         }


### PR DESCRIPTION
Fixes or workarounds for C++17 deprecation warnings emanating directly
from the ml-cpp codebase (not 3rd-party)

Relates #2120