### PR TITLE
[ML] Refactor parameter search initialisation

### DIFF
--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -262,6 +262,10 @@ private:
     //! Initialize the regressors sample distribution.
     bool initializeFeatureSampleDistribution() const;
 
+    //! Apply scaling to hyperparameter ranges based on the difference in the update
+    //! data set and original train data set sizes.
+    void initialHyperparameterScaling();
+
     //! Set the initial values for hyperparameters.
     void initializeHyperparameters(core::CDataFrame& frame);
 

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -45,11 +45,9 @@ class MATHS_ANALYTICS_EXPORT CBoostedTreeFactory final {
 public:
     using TDoubleVec = std::vector<double>;
     using TStrDoublePrVec = std::vector<std::pair<std::string, double>>;
-    using TVector = common::CVectorNx1<double, 3>;
     using TBoostedTreeUPtr = std::unique_ptr<CBoostedTree>;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
     using TLossFunctionUPtr = CBoostedTree::TLossFunctionUPtr;
-    using TAnalysisInstrumentationPtr = CDataFrameAnalysisInstrumentationInterface*;
     using TEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
     using TStrSizeUMap = boost::unordered_map<std::string, std::size_t>;
     using TRestoreDataSummarizationFunc =
@@ -221,15 +219,12 @@ public:
     TBoostedTreeUPtr restoreFor(core::CDataFrame& frame, std::size_t dependentVariable);
 
 private:
+    using TBoolVec = std::vector<bool>;
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
     using TOptionalDouble = boost::optional<double>;
-    using TOptionalSize = boost::optional<std::size_t>;
-    using TOptionalVector = boost::optional<TVector>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TBoostedTreeImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
-    using TApplyParameter = std::function<bool(CBoostedTreeImpl&, double)>;
-    using TAdjustTestLoss = std::function<double(double, double, double)>;
 
 private:
     CBoostedTreeFactory(std::size_t numberThreads, TLossFunctionUPtr loss);
@@ -305,19 +300,6 @@ private:
     TDoubleDoublePrVec estimateTreeGainAndCurvature(core::CDataFrame& frame,
                                                     const TDoubleVec& percentiles) const;
 
-    //! Perform a line search for the test loss w.r.t. a single hyperparameter.
-    //! At the end we use a smooth curve fit through all test loss values (using
-    //! LOWESS regression) and use this to get a best estimate of where the true
-    //! minimum occurs.
-    //!
-    //! \return The interval to search during the main hyperparameter optimisation
-    //! loop or null if this couldn't be found.
-    TOptionalVector testLossLineSearch(core::CDataFrame& frame,
-                                       const TApplyParameter& applyParameterStep,
-                                       double intervalLeftEnd,
-                                       double intervalRightEnd,
-                                       const TAdjustTestLoss& adjustTestLoss = noopAdjustTestLoss) const;
-
     //! Get the number of hyperparameter tuning rounds to use.
     std::size_t numberHyperparameterTuningRounds() const;
 
@@ -378,6 +360,7 @@ private:
     double m_GainPerNode90thPercentile{0.0};
     double m_TotalCurvaturePerNode1stPercentile{0.0};
     double m_TotalCurvaturePerNode90thPercentile{0.0};
+    TBoolVec m_ParameterSupplied;
     std::size_t m_NumberThreads{1};
     TBoostedTreeImplUPtr m_TreeImpl;
     mutable std::size_t m_PaddedExtraColumns{0};

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -292,6 +292,10 @@ private:
     //! to use for retrained trees when training incrementally.
     void initializeUnsetRetrainedTreeEta();
 
+    //! Estimate a good initial value and range to search for the cost of
+    //! changing predictions when training incrementally.
+    void initializePredictionChangeCost();
+
     //! Estimate a good initial value and range to search for the for tree
     //! topology penalty when training incrementally.
     void initializeUnsetTreeTopologyPenalty(core::CDataFrame& frame);
@@ -313,9 +317,6 @@ private:
                                        double intervalLeftEnd,
                                        double intervalRightEnd,
                                        const TAdjustTestLoss& adjustTestLoss = noopAdjustTestLoss) const;
-
-    //! Initialize the state for hyperparameter optimisation.
-    void initializeHyperparameterOptimisation() const;
 
     //! Get the number of hyperparameter tuning rounds to use.
     std::size_t numberHyperparameterTuningRounds() const;
@@ -380,15 +381,6 @@ private:
     std::size_t m_NumberThreads{1};
     TBoostedTreeImplUPtr m_TreeImpl;
     mutable std::size_t m_PaddedExtraColumns{0};
-    TVector m_LogDownsampleFactorSearchInterval{0.0};
-    TVector m_LogFeatureBagFractionInterval{0.0};
-    TVector m_LogDepthPenaltyMultiplierSearchInterval{0.0};
-    TVector m_LogTreeSizePenaltyMultiplierSearchInterval{0.0};
-    TVector m_LogLeafWeightPenaltyMultiplierSearchInterval{0.0};
-    TVector m_SoftDepthLimitSearchInterval{0.0};
-    TVector m_LogEtaSearchInterval{0.0};
-    TVector m_LogRetrainedTreeEtaSearchInterval{0.0};
-    TVector m_LogTreeTopologyChangePenaltySearchInterval{0.0};
     TTrainingStateCallback m_RecordTrainingState{noopRecordTrainingState};
 };
 }

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -219,7 +219,6 @@ public:
     TBoostedTreeUPtr restoreFor(core::CDataFrame& frame, std::size_t dependentVariable);
 
 private:
-    using TBoolVec = std::vector<bool>;
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
     using TOptionalDouble = boost::optional<double>;
@@ -364,7 +363,6 @@ private:
     double m_GainPerNode90thPercentile{0.0};
     double m_TotalCurvaturePerNode1stPercentile{0.0};
     double m_TotalCurvaturePerNode90thPercentile{0.0};
-    TBoolVec m_ParameterSupplied;
     std::size_t m_NumberThreads{1};
     TBoostedTreeImplUPtr m_TreeImpl;
     mutable std::size_t m_PaddedExtraColumns{0};

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -325,7 +325,7 @@ public:
     using THyperparameterImportanceVec =
         std::vector<boosted_tree_detail::SHyperparameterImportance>;
 
-    //! \brief The arguments to initialize the
+    //! \brief The arguments to the initial search we perform for each parameter.
     class MATHS_ANALYTICS_EXPORT CInitializeFineTuneArguments {
     public:
         using TUpdateParameter = std::function<bool(CBoostedTreeImpl&, double)>;
@@ -556,6 +556,13 @@ public:
     //! At the end we use a smooth curve fit through all test loss values (using
     //! LOWESS regression) and use this to get a best estimate of where the true
     //! minimum occurs.
+    //!
+    //! \return A vector comprising
+    //! <pre>
+    //!   | minimum value for fine tune |
+    //!   |       initial value         |
+    //!   | maximum value for fine tune |
+    //! </pre>
     TOptionalVector3x1 testLossLineSearch(const CInitializeFineTuneArguments& args,
                                           double intervalLeftEnd,
                                           double intervalRightEnd) const;

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -664,6 +664,17 @@ private:
 
 private:
     void initializeTunableHyperparameters();
+    void initialTestLossLineSearch(const CInitializeFineTuneArguments& args,
+                                   double intervalLeftEnd,
+                                   double intervalRightEnd,
+                                   TDoubleDoublePrVec& testLosses) const;
+    void fineTineTestLoss(const CInitializeFineTuneArguments& args,
+                          double intervalLeftEnd,
+                          double intervalRightEnd,
+                          TDoubleDoublePrVec& testLosses) const;
+    TVector3x1 minimizeTestLoss(double intervalLeftEnd,
+                                double intervalRightEnd,
+                                const TDoubleDoublePrVec& testLosses) const;
     void saveCurrent();
 
 private:

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -112,6 +112,9 @@ public:
     //! Get the hyperparameters.
     const CBoostedTreeHyperparameters& hyperparameters() const;
 
+    //! Get the writeable hyperparameters.
+    CBoostedTreeHyperparameters& hyperparameters();
+
     //! Get the SHAP value calculator.
     //!
     //! \warning Will return a nullptr if a trained model isn't available.
@@ -311,6 +314,10 @@ private:
                        std::size_t maximumNumberInternalNodes,
                        const TMakeRootLeafNodeStatistics& makeRootLeafNodeStatistics,
                        TWorkspace& workspace) const;
+
+    //! Scale the multipliers of the regularisation terms in the loss function to
+    //! account for the difference in data size for final training.
+    void scaleRegularizationMultipliersForFinalTrain();
 
     //! Compute the minimum mean test loss per fold for any round.
     double minimumTestLoss() const;

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -191,6 +191,8 @@ private:
     using TFloatVec = std::vector<common::CFloatStorage>;
     using TFloatVecVec = std::vector<TFloatVec>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
+    using TDoubleParameter = CBoostedTreeParameter<double>;
+    using TSizeParameter = CBoostedTreeParameter<std::size_t>;
     using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
@@ -446,8 +448,8 @@ private:
 
     //! \name Cross-validation
     //@{
-    CBoostedTreeParameter<std::size_t> m_NumberFolds{4};
-    CBoostedTreeParameter<double> m_TrainFractionPerFold{0.75};
+    TSizeParameter m_NumberFolds{4};
+    TDoubleParameter m_TrainFractionPerFold{0.75};
     bool m_StopCrossValidationEarly{true};
     TOptionalDoubleVecVec m_FoldRoundTestLosses;
     //@}
@@ -501,6 +503,7 @@ private:
 
 private:
     friend class CBoostedTreeFactory;
+    friend class CBoostedTreeHyperparameters;
     friend class CBoostedTreeImplForTest;
 };
 }

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -52,24 +52,22 @@ enum EExtraColumnTag {
 };
 
 enum EHyperparameter {
-    // Train parameters.
     E_DownsampleFactor = 0,
     E_Alpha,
     E_Lambda,
     E_Gamma,
     E_SoftTreeDepthLimit,
     E_SoftTreeDepthTolerance,
-    E_Eta,
-    E_EtaGrowthRatePerTree,
-    E_MaximumNumberTrees,
+    E_Eta,                  //!< Train only.
+    E_EtaGrowthRatePerTree, //!< Train only.
+    E_MaximumNumberTrees,   //!< Train only.
     E_FeatureBagFraction,
-    // Incremental train parameters.
-    E_PredictionChangeCost,
-    E_RetrainedTreeEta,
-    E_TreeTopologyChangePenalty
+    E_PredictionChangeCost,     //!< Incremental train only.
+    E_RetrainedTreeEta,         //!< Incremental train only.
+    E_TreeTopologyChangePenalty //!< Incremental train only.
 };
 
-constexpr std::size_t NUMBER_HYPERPARAMETERS(E_TreeTopologyChangePenalty + 1); // This must be last hyperparameter
+constexpr std::size_t NUMBER_HYPERPARAMETERS{E_TreeTopologyChangePenalty + 1}; // This must be last hyperparameter
 
 //! \brief Hyperparameter importance information.
 struct SHyperparameterImportance {

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -63,14 +63,15 @@ enum EHyperparameter {
     E_EtaGrowthRatePerTree,
     E_MaximumNumberTrees,
     E_FeatureBagFraction,
-    E_PredictionChangeCost,
     // Incremental train parameters.
+    E_PredictionChangeCost,
     E_RetrainedTreeEta,
     E_TreeTopologyChangePenalty
 };
 
-constexpr std::size_t NUMBER_HYPERPARAMETERS = E_TreeTopologyChangePenalty + 1; // This must be last hyperparameter
+constexpr std::size_t NUMBER_HYPERPARAMETERS(E_TreeTopologyChangePenalty + 1); // This must be last hyperparameter
 
+//! \brief Hyperparameter importance information.
 struct SHyperparameterImportance {
     enum EType { E_Double = 0, E_Uint64 };
     EHyperparameter s_Hyperparameter;

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -1621,7 +1621,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalTrainingFieldMismatch) {
             .predictionDownsampleFactor(downsampleFactor)
             .predictionFeatureBagFraction(featureBagFraction)
             .previousTrainLossGap(lossGap)
-            .previousTrainNumberRows(4 * numberExamples / 5) // This needs to count for a train fold.
+            .previousTrainNumberRows(numberExamples)
             .predictionPersisterSupplier(persisterSupplier)
             .predictionRestoreSearcherSupplier(restorerSupplier)
             .regressionLossFunction(TLossFunctionType::E_BinaryClassification)

--- a/lib/api/unittest/CInferenceModelMetadataTest.cc
+++ b/lib/api/unittest/CInferenceModelMetadataTest.cc
@@ -144,7 +144,6 @@ BOOST_AUTO_TEST_CASE(testHyperparameterReproducibility, *utf::tolerance(0.000001
 
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(output.str()));
-        LOG_DEBUG(<< output.str());
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
 
         // Read hyperparameter into the new spec and the expected predictions.
@@ -216,7 +215,6 @@ BOOST_AUTO_TEST_CASE(testHyperparameterReproducibility, *utf::tolerance(0.000001
 
         rapidjson::Document results;
         rapidjson::ParseResult ok(results.Parse(output.str()));
-        LOG_DEBUG(<< output.str());
         BOOST_TEST_REQUIRE(static_cast<bool>(ok) == true);
         for (const auto& result : results.GetArray()) {
             if (result.HasMember("row_results")) {

--- a/lib/maths/analytics/CBoostedTree.cc
+++ b/lib/maths/analytics/CBoostedTree.cc
@@ -248,7 +248,7 @@ CBoostedTree::THyperparameterImportanceVec CBoostedTree::hyperparameterImportanc
 }
 
 std::size_t CBoostedTree::numberTrainRows() const {
-    return static_cast<std::size_t>(m_Impl->meanNumberTrainingRowsPerFold() + 0.5);
+    return static_cast<std::size_t>(m_Impl->allTrainingRowsMask().manhattan() + 0.5);
 }
 
 double CBoostedTree::lossGap() const {

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -625,9 +625,16 @@ void CBoostedTreeFactory::initializeHyperparametersSetup(core::CDataFrame& frame
     // This needs to be tied to the learn rate to avoid bias.
     hyperparameters.maximumNumberTrees().setToRangeMidpointOr(
         computeMaximumNumberTrees(hyperparameters.eta().value()));
-    hyperparameters.retrainedTreeEta().setToRangeMidpointOr(1.0);
     hyperparameters.treeTopologyChangePenalty().setToRangeMidpointOr(0.0);
     hyperparameters.predictionChangeCost().setToRangeMidpointOr(0.5);
+    // If we're trying to preserve predictions then we'll naturally pull the leaf
+    // values towards the old scaled values and we can get away with a higher value
+    // for eta. If we've overridden this to zero chances are this is part of train
+    // by query and we should start off assuming the initial eta is reasonable.
+    hyperparameters.retrainedTreeEta().setToRangeMidpointOr(
+        hyperparameters.predictionChangeCost().value() > 0.0
+            ? 1.0
+            : hyperparameters.eta().value());
 }
 
 void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDataFrame& frame) {

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -653,8 +653,11 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
     if (hyperparameters.softTreeDepthLimit().rangeFixed() == false) {
         if (this->skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_SoftTreeDepthLimitInitialized, [&] {
                 if (m_GainPerNode90thPercentile > 0.0) {
-                    double minSoftDepthLimit{MIN_SOFT_DEPTH_LIMIT};
                     double maxSoftDepthLimit{MIN_SOFT_DEPTH_LIMIT + log2MaxTreeSize};
+                    double minSearchValue{hyperparameters.softTreeDepthLimit().toSearchValue(
+                        MIN_SOFT_DEPTH_LIMIT)};
+                    double maxSearchValue{hyperparameters.softTreeDepthLimit().toSearchValue(
+                        maxSoftDepthLimit)};
                     hyperparameters.depthPenaltyMultiplier().set(m_GainPerNode50thPercentile);
                     hyperparameters.initializeFineTuneSearchInterval(
                         CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
@@ -665,7 +668,7 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                                 return true;
                             }}
                             .truncateParameter([&](TVector& range) {
-                                range = truncate(range, minSoftDepthLimit, maxSoftDepthLimit);
+                                range = truncate(range, minSearchValue, maxSearchValue);
                             }),
                         hyperparameters.softTreeDepthLimit());
                 } else {

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -1162,18 +1162,18 @@ CBoostedTreeFactory CBoostedTreeFactory::constructFromModel(TBoostedTreeUPtr mod
     result.m_TreeImpl = std::move(model->m_Impl);
     result.m_TreeImpl->m_Rng.seed(result.m_TreeImpl->m_Seed);
     auto& hyperparameters = result.m_TreeImpl->m_Hyperparameters;
-    hyperparameters.depthPenaltyMultiplier().fix();
-    hyperparameters.treeSizePenaltyMultiplier().fix();
-    hyperparameters.leafWeightPenaltyMultiplier().fix();
-    hyperparameters.softTreeDepthLimit().fix();
-    hyperparameters.softTreeDepthTolerance().fix();
-    hyperparameters.downsampleFactor().fix();
-    hyperparameters.eta().fix();
-    hyperparameters.etaGrowthRatePerTree().fix();
-    hyperparameters.featureBagFraction().fix();
+    hyperparameters.depthPenaltyMultiplier().captureScale().fix();
+    hyperparameters.treeSizePenaltyMultiplier().captureScale().fix();
+    hyperparameters.leafWeightPenaltyMultiplier().captureScale().fix();
+    hyperparameters.softTreeDepthLimit().captureScale().fix();
+    hyperparameters.softTreeDepthTolerance().captureScale().fix();
+    hyperparameters.downsampleFactor().captureScale().fix();
+    hyperparameters.eta().captureScale().fix();
+    hyperparameters.etaGrowthRatePerTree().captureScale().fix();
+    hyperparameters.featureBagFraction().captureScale().fix();
     hyperparameters.resetSearch();
     result.m_TreeImpl->m_PreviousTrainNumberRows = static_cast<std::size_t>(
-        result.m_TreeImpl->meanNumberTrainingRowsPerFold() + 0.5);
+        result.m_TreeImpl->allTrainingRowsMask().manhattan() + 0.5);
     result.m_TreeImpl->m_PreviousTrainLossGap = hyperparameters.bestForestLossGap();
     result.m_TreeImpl->m_FoldRoundTestLosses.clear();
     result.m_TreeImpl->m_InitializationStage = CBoostedTreeImpl::E_NotInitialized;

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -847,10 +847,9 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
                     CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
                         frame, *m_TreeImpl, maxDownsampleFactor, searchIntervalSize,
                         [&](CBoostedTreeImpl& tree, double downsampleFactor) {
-                            downsampleFactor =
-                                tree.m_Hyperparameters.downsampleFactor().fromSearchValue(
-                                    downsampleFactor);
-                            tree.m_Hyperparameters.downsampleFactor().set(downsampleFactor);
+                            auto& parameter = tree.m_Hyperparameters.downsampleFactor();
+                            downsampleFactor = parameter.fromSearchValue(downsampleFactor);
+                            parameter.set(downsampleFactor);
                             scaleRegularizers(tree, downsampleFactor);
                             return downsampleFactor * numberTrainingRows > 10.0;
                         }}
@@ -908,10 +907,9 @@ void CBoostedTreeFactory::initializeUnsetFeatureBagFraction(core::CDataFrame& fr
                     CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
                         frame, *m_TreeImpl, maxFeatureBagFraction, searchIntervalSize,
                         [&](CBoostedTreeImpl& tree, double featureBagFraction) {
-                            featureBagFraction =
-                                tree.m_Hyperparameters.featureBagFraction().fromSearchValue(
-                                    featureBagFraction);
-                            tree.m_Hyperparameters.featureBagFraction().set(featureBagFraction);
+                            auto& parameter = tree.m_Hyperparameters.featureBagFraction();
+                            featureBagFraction = parameter.fromSearchValue(featureBagFraction);
+                            parameter.set(featureBagFraction);
                             return tree.featureBagSize(featureBagFraction) > 1;
                         }}
                         .adjustLoss([&](double featureBagFraction, double minTestLoss, double testLoss) {
@@ -951,8 +949,9 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
                 double minSearchValue{hyperparameters.eta().toSearchValue(MIN_ETA)};
 
                 auto applyEta = [](CBoostedTreeImpl& tree, double eta) {
-                    eta = tree.m_Hyperparameters.eta().fromSearchValue(eta);
-                    tree.m_Hyperparameters.eta().set(eta);
+                    auto& parameter = tree.m_Hyperparameters.eta();
+                    eta = parameter.fromSearchValue(eta);
+                    parameter.set(eta);
                     tree.m_Hyperparameters.etaGrowthRatePerTree().set(1.0 + eta / 2.0);
                     tree.m_Hyperparameters.maximumNumberTrees().set(
                         computeMaximumNumberTrees(eta));

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -50,7 +50,6 @@ const double MIN_SOFT_DEPTH_LIMIT{2.0};
 const double MIN_SOFT_DEPTH_LIMIT_TOLERANCE{0.05};
 const double MAX_SOFT_DEPTH_LIMIT_TOLERANCE{0.25};
 const double MIN_ETA{1e-3};
-const double MAX_ETA{0.3};
 const double MIN_ETA_SCALE{0.5};
 const double MAX_ETA_SCALE{2.0};
 const double MIN_ETA_GROWTH_RATE_SCALE{0.5};
@@ -942,8 +941,8 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
     if (hyperparameters.eta().rangeFixed() == false) {
         if (skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_EtaInitialized, [&] {
                 double searchIntervalSize{5.0 * MAX_ETA_SCALE / MIN_ETA_SCALE};
-                double maxEta{std::min(
-                    std::sqrt(searchIntervalSize) * hyperparameters.eta().value(), MAX_ETA)};
+                double maxEta{std::sqrt(searchIntervalSize) *
+                              hyperparameters.eta().value()};
                 double maxSearchValue{hyperparameters.eta().toSearchValue(1.0)};
                 double minSearchValue{hyperparameters.eta().toSearchValue(MIN_ETA)};
 

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -191,7 +191,7 @@ CBoostedTreeHyperparameters::testLossLineSearch(const CInitializeFineTuneArgumen
     auto boptVector = [](double parameter) {
         return common::SConstant<common::CBayesianOptimisation::TVector>::get(1, parameter);
     };
-    auto adjustTestLoss = [&](double parameter, double testLoss) {
+    auto adjustTestLoss = [testLosses, &args](double parameter, double testLoss) {
         auto min = std::min_element(testLosses.begin(), testLosses.end(),
                                     common::COrderings::SSecondLess{});
         return args.adjustLoss()(parameter, min->second, testLoss);

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -835,48 +835,47 @@ void CBoostedTreeHyperparameters::initializeTunableHyperparameters() {
         switch (static_cast<EHyperparameter>(i)) {
         // Train hyperparameters.
         case E_DownsampleFactor:
-            if ((m_IncrementalTraining || m_DownsampleFactor.fixed()) == false) {
+            if (m_DownsampleFactor.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_DownsampleFactor);
             }
             break;
         case E_Alpha:
-            if ((m_IncrementalTraining || m_DepthPenaltyMultiplier.fixed()) == false) {
+            if (m_DepthPenaltyMultiplier.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_Alpha);
             }
             break;
         case E_Lambda:
-            if ((m_IncrementalTraining || m_LeafWeightPenaltyMultiplier.fixed()) == false) {
+            if (m_LeafWeightPenaltyMultiplier.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_Lambda);
             }
             break;
         case E_Gamma:
-            if ((m_IncrementalTraining || m_TreeSizePenaltyMultiplier.fixed()) == false) {
+            if (m_TreeSizePenaltyMultiplier.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_Gamma);
             }
             break;
         case E_SoftTreeDepthLimit:
-            if ((m_IncrementalTraining || m_SoftTreeDepthLimit.fixed()) == false) {
+            if (m_SoftTreeDepthLimit.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_SoftTreeDepthLimit);
             }
             break;
         case E_SoftTreeDepthTolerance:
-            if ((m_IncrementalTraining || m_SoftTreeDepthTolerance.fixed()) == false) {
+            if (m_SoftTreeDepthTolerance.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_SoftTreeDepthTolerance);
             }
             break;
         case E_Eta:
-            if ((m_IncrementalTraining || m_Eta.fixed()) == false) {
+            if (m_Eta.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_Eta);
             }
             break;
         case E_EtaGrowthRatePerTree:
-            if ((m_IncrementalTraining || m_Eta.fixed() ||
-                 m_EtaGrowthRatePerTree.fixed()) == false) {
+            if ((m_Eta.fixed() || m_EtaGrowthRatePerTree.fixed()) == false) {
                 m_TunableHyperparameters.push_back(E_EtaGrowthRatePerTree);
             }
             break;
         case E_FeatureBagFraction:
-            if ((m_IncrementalTraining || m_FeatureBagFraction.fixed()) == false) {
+            if (m_FeatureBagFraction.fixed() == false) {
                 m_TunableHyperparameters.push_back(E_FeatureBagFraction);
             }
             break;

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -111,7 +111,7 @@ void CBoostedTreeHyperparameters::initializeFineTuneSearchInterval(
     const CInitializeFineTuneArguments& args,
     TDoubleParameter& parameter) const {
 
-    if (parameter.valid(args.maxValue()) == false) {
+    if (parameter.valid(args.maxValue())) {
 
         double maxValue{parameter.toSearchValue(args.maxValue())};
         double minValue{maxValue - parameter.toSearchValue(args.searchInterval())};

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -123,6 +123,7 @@ void CBoostedTreeHyperparameters::initializeFineTuneSearchInterval(
         fallback(MID_VALUE_INDEX) = meanValue;
         fallback(MAX_VALUE_INDEX) = maxValue;
         auto interval = this->testLossLineSearch(args, minValue, maxValue).value_or(fallback);
+        args.truncateParameter()(interval);
         LOG_TRACE(<< "search interval = [" << interval.toDelimited() << "]");
 
         parameter.fixToRange(parameter.fromSearchValue(interval(MIN_VALUE_INDEX)),

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1409,14 +1409,22 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
 void CBoostedTreeImpl::scaleRegularizationMultipliersForFinalTrain() {
     double scale{this->allTrainingRowsMask().manhattan() /
                  this->meanNumberTrainingRowsPerFold()};
-    m_Hyperparameters.depthPenaltyMultiplier().scale(
-        scale * m_Hyperparameters.depthPenaltyMultiplier().scale());
-    m_Hyperparameters.treeSizePenaltyMultiplier().scale(
-        scale * m_Hyperparameters.treeSizePenaltyMultiplier().scale());
-    m_Hyperparameters.leafWeightPenaltyMultiplier().scale(
-        scale * m_Hyperparameters.leafWeightPenaltyMultiplier().scale());
-    m_Hyperparameters.treeTopologyChangePenalty().scale(
-        scale * m_Hyperparameters.treeTopologyChangePenalty().scale());
+    if (m_Hyperparameters.depthPenaltyMultiplier().fixed() == false) {
+        m_Hyperparameters.depthPenaltyMultiplier().scale(
+            scale * m_Hyperparameters.depthPenaltyMultiplier().scale());
+    }
+    if (m_Hyperparameters.treeSizePenaltyMultiplier().fixed() == false) {
+        m_Hyperparameters.treeSizePenaltyMultiplier().scale(
+            scale * m_Hyperparameters.treeSizePenaltyMultiplier().scale());
+    }
+    if (m_Hyperparameters.leafWeightPenaltyMultiplier().fixed() == false) {
+        m_Hyperparameters.leafWeightPenaltyMultiplier().scale(
+            scale * m_Hyperparameters.leafWeightPenaltyMultiplier().scale());
+    }
+    if (m_Hyperparameters.treeTopologyChangePenalty().fixed() == false) {
+        m_Hyperparameters.treeTopologyChangePenalty().scale(
+            scale * m_Hyperparameters.treeTopologyChangePenalty().scale());
+    }
 }
 
 double CBoostedTreeImpl::minimumTestLoss() const {

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -307,16 +307,16 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
         LOG_TRACE(<< "Test loss = " << m_Hyperparameters.bestForestTestLoss());
 
-        m_Hyperparameters.restoreBest();
-        m_Hyperparameters.recordHyperparameters(*m_Instrumentation);
-        this->scaleRegularizationMultipliersForFinalTrain();
-
-        this->startProgressMonitoringFinalTrain();
-
-        // Reinitialize random number generator for reproducible results.
-        m_Rng.seed(m_Seed);
-
         if (m_BestForest.empty()) {
+            m_Hyperparameters.restoreBest();
+            m_Hyperparameters.recordHyperparameters(*m_Instrumentation);
+            this->scaleRegularizationMultipliersForFinalTrain();
+
+            this->startProgressMonitoringFinalTrain();
+
+            // Reinitialize random number generator for reproducible results.
+            m_Rng.seed(m_Seed);
+
             m_BestForest = this->trainForest(frame, allTrainingRowsMask,
                                              allTrainingRowsMask, m_TrainingProgress)
                                .s_Forest;

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -70,26 +70,6 @@ const std::string HYPERPARAMETER_OPTIMIZATION_ROUND{"hyperparameter_optimization
 const std::string TRAIN_FINAL_FOREST{"train_final_forest"};
 const double BYTES_IN_MB{static_cast<double>(core::constants::BYTES_IN_MEGABYTES)};
 
-//! \brief Executes a register function at the end of its life.
-class CScopeRunAtExit {
-public:
-    using TFunc = std::function<void()>;
-
-public:
-    explicit CScopeRunAtExit(TFunc func) : m_Func{std::move(func)} {}
-    ~CScopeRunAtExit() {
-        if (m_Func != nullptr) {
-            m_Func();
-        }
-    }
-
-    CScopeRunAtExit(const CScopeRunAtExit&) = delete;
-    CScopeRunAtExit& operator=(const CScopeRunAtExit&) = delete;
-
-private:
-    TFunc m_Func;
-};
-
 //! \brief Record the memory used by a supplied object using the RAII idiom.
 class CScopeRecordMemoryUsage {
 public:
@@ -329,9 +309,8 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
         m_Hyperparameters.restoreBest();
         m_Hyperparameters.recordHyperparameters(*m_Instrumentation);
-        double scale{allTrainingRowsMask.manhattan() / this->meanNumberTrainingRowsPerFold()};
-        CScopeBoostedTreeParameterOverrides<double> overrides;
-        m_Hyperparameters.scaleRegularizationMultipliers(scale, overrides);
+        this->scaleRegularizationMultipliersForFinalTrain();
+
         this->startProgressMonitoringFinalTrain();
 
         // Reinitialize random number generator for reproducible results.
@@ -434,28 +413,6 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
     LOG_TRACE(<< "Number trees to retrain = " << numberTreesToRetrain << "/"
               << m_BestForest.size());
 
-    // In the event we fail over and start from a checkpoint we'll apply the scale
-    // to regularisation multipliers again. In order for this to have no effect we
-    // set the previous number of train rows to this->meanNumberTrainingRowsPerFold()
-    // which means that the scale is 1 on re-entry.
-    CScopeRunAtExit _(
-        [ savedPreviousTrainNumberRows = m_PreviousTrainNumberRows, this ] {
-            m_PreviousTrainNumberRows = savedPreviousTrainNumberRows;
-        });
-
-    CScopeBoostedTreeParameterOverrides<double> overrides;
-    if (m_PreviousTrainNumberRows > 0) {
-        // We do not undo these changes because we store the mean number of rows
-        // per fold with the model at the end of update. Therefore, if call update
-        // repeatedly we are always scaling w.r.t. m_PreviousTrainNumberRows is
-        // updated each time.
-        double scale{this->meanNumberTrainingRowsPerFold() /
-                     static_cast<double>(m_PreviousTrainNumberRows)};
-        m_Hyperparameters.scaleRegularizationMultipliers(scale, overrides, false /*undo*/);
-        m_PreviousTrainNumberRows =
-            static_cast<std::size_t>(this->meanNumberTrainingRowsPerFold() + 0.5);
-    }
-
     for (m_Hyperparameters.startSearch(); m_Hyperparameters.searchNotFinished(); /**/) {
 
         LOG_TRACE(<< "Optimisation round = " << m_Hyperparameters.currentRound() + 1);
@@ -520,12 +477,7 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
     if (m_ForceAcceptIncrementalTraining || m_Hyperparameters.bestForestTestLoss() < initialLoss) {
         m_Hyperparameters.restoreBest();
         m_Hyperparameters.recordHyperparameters(*m_Instrumentation);
-
-        if (m_PreviousTrainNumberRows > 0) {
-            double scale{allTrainingRowsMask.manhattan() /
-                         this->meanNumberTrainingRowsPerFold()};
-            m_Hyperparameters.scaleRegularizationMultipliers(scale, overrides);
-        }
+        this->scaleRegularizationMultipliersForFinalTrain();
 
         TNodeVecVec retrainedTrees{this->updateForest(frame, allTrainingRowsMask,
                                                       allTrainingRowsMask, m_TrainingProgress)
@@ -1454,6 +1406,19 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
     return tree;
 }
 
+void CBoostedTreeImpl::scaleRegularizationMultipliersForFinalTrain() {
+    double scale{this->allTrainingRowsMask().manhattan() /
+                 this->meanNumberTrainingRowsPerFold()};
+    m_Hyperparameters.depthPenaltyMultiplier().scale(
+        scale * m_Hyperparameters.depthPenaltyMultiplier().scale());
+    m_Hyperparameters.treeSizePenaltyMultiplier().scale(
+        scale * m_Hyperparameters.treeSizePenaltyMultiplier().scale());
+    m_Hyperparameters.leafWeightPenaltyMultiplier().scale(
+        scale * m_Hyperparameters.leafWeightPenaltyMultiplier().scale());
+    m_Hyperparameters.treeTopologyChangePenalty().scale(
+        scale * m_Hyperparameters.treeTopologyChangePenalty().scale());
+}
+
 double CBoostedTreeImpl::minimumTestLoss() const {
     using TMinAccumulator = common::CBasicStatistics::SMin<double>::TAccumulator;
     TMinAccumulator minimumTestLoss;
@@ -2283,6 +2248,10 @@ void CBoostedTreeImpl::accept(CBoostedTree::CVisitor& visitor) {
 }
 
 const CBoostedTreeHyperparameters& CBoostedTreeImpl::hyperparameters() const {
+    return m_Hyperparameters;
+}
+
+CBoostedTreeHyperparameters& CBoostedTreeImpl::hyperparameters() {
     return m_Hyperparameters;
 }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
@@ -228,8 +228,6 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationWithOverrides) {
     hyperparameters.maximumOptimisationRoundsPerHyperparameter(2);
 
     hyperparameters.depthPenaltyMultiplier().fixToRange(0.1, 1.0);
-
-    hyperparameters.depthPenaltyMultiplier().fixToRange(0.1, 1.0);
     hyperparameters.treeSizePenaltyMultiplier().fixToRange(0.1, 1.0);
     hyperparameters.leafWeightPenaltyMultiplier().fixToRange(0.1, 1.0);
     hyperparameters.softTreeDepthLimit().fixToRange(0.1, 1.0);
@@ -243,15 +241,14 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationWithOverrides) {
 
         parameter.fixTo(TDoubleVec{0.5});
 
+        hyperparameters.initializeSearch();
+
         BOOST_REQUIRE_EQUAL(--numberToTune, hyperparameters.numberToTune());
         BOOST_REQUIRE_EQUAL(2 * hyperparameters.numberToTune(),
                             hyperparameters.numberRounds());
 
         test::CRandomNumbers rng;
         TDoubleVec losses;
-
-        hyperparameters.initializeSearch();
-
         for (hyperparameters.startSearch(); hyperparameters.searchNotFinished();
              hyperparameters.startNextSearchRound()) {
 

--- a/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
@@ -9,7 +9,6 @@
  * limitation.
  */
 
-#include "core/CDataFrame.h"
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CJsonStateRestoreTraverser.h>
 
@@ -22,7 +21,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <limits>
-#include <memory>
 #include <utility>
 
 BOOST_AUTO_TEST_SUITE(CBoostedTreeHyperparametersTest)

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1632,7 +1632,7 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
                 .treeSizePenaltyMultiplier({0.0})
                 .leafWeightPenaltyMultiplier({0.0})
                 .softTreeDepthLimit({targetDepth})
-                .softTreeDepthTolerance({0.01})
+                .softTreeDepthTolerance({0.05})
                 .buildForTrain(*frame, cols - 1);
 
         regression->train();
@@ -1640,7 +1640,7 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
         TMeanAccumulator meanDepth;
         for (const auto& tree : regression->trainedModel()) {
             BOOST_TEST_REQUIRE(maxDepth(tree, tree[0], 0) <=
-                               static_cast<std::size_t>(targetDepth));
+                               static_cast<std::size_t>(targetDepth + 1));
             meanDepth.add(static_cast<double>(maxDepth(tree, tree[0], 0)));
         }
         LOG_DEBUG(<< "mean depth = " << maths::common::CBasicStatistics::mean(meanDepth));
@@ -2460,9 +2460,11 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
         BOOST_REQUIRE_EQUAL(
             10, regression->hyperparameters().maximumNumberTrees().value());
         BOOST_REQUIRE_EQUAL(
-            0.1, regression->hyperparameters().treeSizePenaltyMultiplier().value());
+            0.1, regression->hyperparameters().treeSizePenaltyMultiplier().value() /
+                     regression->hyperparameters().treeSizePenaltyMultiplier().scale());
         BOOST_REQUIRE_EQUAL(
-            0.01, regression->hyperparameters().leafWeightPenaltyMultiplier().value());
+            0.01, regression->hyperparameters().leafWeightPenaltyMultiplier().value() /
+                      regression->hyperparameters().treeSizePenaltyMultiplier().scale());
     }
     {
         auto regression =
@@ -2495,7 +2497,8 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
         regression->train();
 
         BOOST_REQUIRE_EQUAL(
-            1.0, regression->hyperparameters().depthPenaltyMultiplier().value());
+            1.0, regression->hyperparameters().depthPenaltyMultiplier().value() /
+                     regression->hyperparameters().depthPenaltyMultiplier().scale());
         BOOST_REQUIRE_EQUAL(
             0.4, regression->hyperparameters().featureBagFraction().value());
         BOOST_REQUIRE_EQUAL(
@@ -2516,7 +2519,8 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
 
         regression->train();
         BOOST_REQUIRE_EQUAL(
-            1.0, regression->hyperparameters().depthPenaltyMultiplier().value());
+            1.0, regression->hyperparameters().depthPenaltyMultiplier().value() /
+                     regression->hyperparameters().depthPenaltyMultiplier().scale());
         BOOST_REQUIRE_EQUAL(
             3.0, regression->hyperparameters().softTreeDepthLimit().value());
         BOOST_REQUIRE_EQUAL(

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2460,11 +2460,9 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
         BOOST_REQUIRE_EQUAL(
             10, regression->hyperparameters().maximumNumberTrees().value());
         BOOST_REQUIRE_EQUAL(
-            0.1, regression->hyperparameters().treeSizePenaltyMultiplier().value() /
-                     regression->hyperparameters().treeSizePenaltyMultiplier().scale());
+            0.1, regression->hyperparameters().treeSizePenaltyMultiplier().value());
         BOOST_REQUIRE_EQUAL(
-            0.01, regression->hyperparameters().leafWeightPenaltyMultiplier().value() /
-                      regression->hyperparameters().treeSizePenaltyMultiplier().scale());
+            0.01, regression->hyperparameters().leafWeightPenaltyMultiplier().value());
     }
     {
         auto regression =
@@ -2497,8 +2495,7 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
         regression->train();
 
         BOOST_REQUIRE_EQUAL(
-            1.0, regression->hyperparameters().depthPenaltyMultiplier().value() /
-                     regression->hyperparameters().depthPenaltyMultiplier().scale());
+            1.0, regression->hyperparameters().depthPenaltyMultiplier().value());
         BOOST_REQUIRE_EQUAL(
             0.4, regression->hyperparameters().featureBagFraction().value());
         BOOST_REQUIRE_EQUAL(
@@ -2519,8 +2516,7 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
 
         regression->train();
         BOOST_REQUIRE_EQUAL(
-            1.0, regression->hyperparameters().depthPenaltyMultiplier().value() /
-                     regression->hyperparameters().depthPenaltyMultiplier().scale());
+            1.0, regression->hyperparameters().depthPenaltyMultiplier().value());
         BOOST_REQUIRE_EQUAL(
             3.0, regression->hyperparameters().softTreeDepthLimit().value());
         BOOST_REQUIRE_EQUAL(

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1751,6 +1751,177 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForTargetDrift) {
 
     // Test incremental training for the binomial logistic objective for drift in the
     // target value.
+
+    test::CRandomNumbers rng;
+    std::size_t rows{750};
+    std::size_t cols{5};
+    std::size_t extraTrainingRows{500};
+
+    auto probability = [&] {
+        TDoubleVec weights{-0.6, 1.0, 0.8, -1.2};
+        TDoubleVec noise;
+        rng.generateNormalSamples(0.0, 0.5, rows + extraTrainingRows, noise);
+        return [=](const TRowRef& row) {
+            double x{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                x += weights[i] * row[i];
+            }
+            return maths::common::CTools::logisticFunction(x + noise[row.index()]);
+        };
+    }();
+    auto perturbedProbability = [&] {
+        TDoubleVec weights{-0.4, 1.3, 0.9, -1.8};
+        TDoubleVec noise;
+        rng.generateNormalSamples(0.0, 0.5, rows + extraTrainingRows, noise);
+        return [=](const TRowRef& row) {
+            double x{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                x += weights[i] * row[i];
+            }
+            return maths::common::CTools::logisticFunction(x + noise[row.index()]);
+        };
+    }();
+
+    auto target = [&] {
+        TDoubleVec uniform01;
+        rng.generateUniformSamples(0.0, 1.0, rows + extraTrainingRows, uniform01);
+        return [=](const TRowRef& row) {
+            return uniform01[row.index()] < probability(row) ? 1.0 : 0.0;
+        };
+    }();
+    auto perturbedTarget = [&] {
+        TDoubleVec uniform01;
+        rng.generateUniformSamples(0.0, 1.0, rows + extraTrainingRows, uniform01);
+        return [=](const TRowRef& row) {
+            return uniform01[row.index()] < perturbedProbability(row) ? 1.0 : 0.0;
+        };
+    }();
+
+    auto frame = core::makeMainStorageDataFrame(cols).first;
+
+    TDoubleVecVec x(cols - 1);
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(-3.0, 3.0, rows, x[i]);
+    }
+
+    fillDataFrame(rows, 0, cols, {false, false, false, false, true}, x,
+                  TDoubleVec(rows, 0.0), target, *frame);
+
+    auto classifier =
+        maths::analytics::CBoostedTreeFactory::constructFromParameters(
+            1, std::make_unique<maths::analytics::boosted_tree::CBinomialLogisticLoss>())
+            .buildForTrain(*frame, cols - 1);
+    classifier->train();
+
+    frame->resizeColumns(1, cols);
+    auto newFrame = core::makeMainStorageDataFrame(cols).first;
+
+    fillDataFrame(rows, 0, cols, {false, false, false, false, true}, x,
+                  TDoubleVec(rows, 0.0), target, *newFrame);
+
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(-3.0, 3.0, extraTrainingRows, x[i]);
+    }
+
+    fillDataFrame(extraTrainingRows, 0, cols, {false, false, false, false, true},
+                  x, TDoubleVec(extraTrainingRows, 0.0), perturbedTarget, *frame);
+    fillDataFrame(extraTrainingRows, 0, cols, {false, false, false, false, true}, x,
+                  TDoubleVec(extraTrainingRows, 0.0), perturbedTarget, *newFrame);
+
+    classifier->predict();
+
+    core::CPackedBitVector oldTrainingRowMask{rows, true};
+    oldTrainingRowMask.extend(false, extraTrainingRows);
+    core::CPackedBitVector newTrainingRowMask{~oldTrainingRowMask};
+
+    TMeanAccumulator logRelativeErrorBeforeIncrementalTraining[2];
+    TMeanAccumulator logRelativeErrorAfterIncrementalTraining[2];
+
+    auto addToRelativeError = [&](const TRowRef& row, TMeanAccumulator& logRelativeError) {
+        double expectedProbability{probability(row)};
+        double actualProbability{classifier->readPrediction(row)[1]};
+        logRelativeError.add(std::log(std::max(actualProbability, expectedProbability) /
+                                      std::min(actualProbability, expectedProbability)));
+    };
+    auto addToPerturbedRelativeError = [&](const TRowRef& row, TMeanAccumulator& logRelativeError) {
+        double expectedProbability{perturbedProbability(row)};
+        double actualProbability{classifier->readPrediction(row)[1]};
+        logRelativeError.add(std::log(std::max(actualProbability, expectedProbability) /
+                                      std::min(actualProbability, expectedProbability)));
+    };
+
+    frame->resizeColumns(1, cols + 1);
+    classifier->predict();
+
+    // Get the average error on the old and new training data from the old model.
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            addToRelativeError(
+                                *row, logRelativeErrorBeforeIncrementalTraining[OLD_TRAINING_DATA]);
+                        }
+                    },
+                    &oldTrainingRowMask);
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            addToPerturbedRelativeError(
+                                *row, logRelativeErrorBeforeIncrementalTraining[NEW_TRAINING_DATA]);
+                        }
+                    },
+                    &newTrainingRowMask);
+
+    double alpha{classifier->hyperparameters().depthPenaltyMultiplier().value()};
+    double gamma{classifier->hyperparameters().treeSizePenaltyMultiplier().value()};
+    double lambda{classifier->hyperparameters().leafWeightPenaltyMultiplier().value()};
+    classifier = maths::analytics::CBoostedTreeFactory::constructFromModel(std::move(classifier))
+                     .newTrainingRowMask(newTrainingRowMask)
+                     .depthPenaltyMultiplier({0.5 * alpha, 2.0 * alpha})
+                     .treeSizePenaltyMultiplier({0.5 * gamma, 2.0 * gamma})
+                     .leafWeightPenaltyMultiplier({0.5 * lambda, 2.0 * lambda})
+                     .buildForTrainIncremental(*newFrame, cols - 1);
+
+    classifier->trainIncremental();
+    classifier->predict();
+
+    LOG_DEBUG(<< "UPDATED...");
+    // Get the average error on the old and new training data from the new model.
+    newFrame->readRows(1, 0, frame->numberRows(),
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               addToRelativeError(
+                                   *row, logRelativeErrorAfterIncrementalTraining[OLD_TRAINING_DATA]);
+                           }
+                       },
+                       &oldTrainingRowMask);
+    newFrame->readRows(1, 0, frame->numberRows(),
+                       [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                           for (auto row = beginRows; row != endRows; ++row) {
+                               addToPerturbedRelativeError(
+                                   *row, logRelativeErrorAfterIncrementalTraining[NEW_TRAINING_DATA]);
+                           }
+                       },
+                       &newTrainingRowMask);
+
+    // We should see little change in the prediction errors on the old data
+    // set which doesn't overlap the new data, but a large improvement on
+    // the new data for constant extrapolation performs poorly.
+    double errorIncreaseOnOld{
+        maths::common::CBasicStatistics::mean(
+            logRelativeErrorAfterIncrementalTraining[OLD_TRAINING_DATA]) /
+            maths::common::CBasicStatistics::mean(
+                logRelativeErrorBeforeIncrementalTraining[OLD_TRAINING_DATA]) -
+        1.0};
+    double errorDecreaseOnNew{
+        maths::common::CBasicStatistics::mean(
+            logRelativeErrorBeforeIncrementalTraining[NEW_TRAINING_DATA]) /
+            maths::common::CBasicStatistics::mean(
+                logRelativeErrorAfterIncrementalTraining[NEW_TRAINING_DATA]) -
+        1.0};
+
+    LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
+    LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 2.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
@@ -1829,7 +2000,6 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
         double actualProbability{classifier->readPrediction(row)[1]};
         logRelativeError.add(std::log(std::max(actualProbability, expectedProbability) /
                                       std::min(actualProbability, expectedProbability)));
-
     };
 
     frame->resizeColumns(1, cols + 1);
@@ -1902,7 +2072,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 1.5 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 5.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -884,8 +884,14 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
         },
         &newTrainingRowMask);
 
+    double alpha{regression->hyperparameters().depthPenaltyMultiplier().value()};
+    double gamma{regression->hyperparameters().treeSizePenaltyMultiplier().value()};
+    double lambda{regression->hyperparameters().leafWeightPenaltyMultiplier().value()};
     regression = maths::analytics::CBoostedTreeFactory::constructFromModel(std::move(regression))
                      .newTrainingRowMask(newTrainingRowMask)
+                     .depthPenaltyMultiplier({0.5 * alpha, 2.0 * alpha})
+                     .treeSizePenaltyMultiplier({0.5 * gamma, 2.0 * gamma})
+                     .leafWeightPenaltyMultiplier({0.5 * lambda, 2.0 * lambda})
                      .buildForTrainIncremental(*newFrame, cols - 1);
 
     regression->trainIncremental();
@@ -1017,8 +1023,14 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
         },
         &newTrainingRowMask);
 
+    double alpha{regression->hyperparameters().depthPenaltyMultiplier().value()};
+    double gamma{regression->hyperparameters().treeSizePenaltyMultiplier().value()};
+    double lambda{regression->hyperparameters().leafWeightPenaltyMultiplier().value()};
     regression = maths::analytics::CBoostedTreeFactory::constructFromModel(std::move(regression))
                      .newTrainingRowMask(newTrainingRowMask)
+                     .depthPenaltyMultiplier({0.5 * alpha, 2.0 * alpha})
+                     .treeSizePenaltyMultiplier({0.5 * gamma, 2.0 * gamma})
+                     .leafWeightPenaltyMultiplier({0.5 * lambda, 2.0 * lambda})
                      .buildForTrainIncremental(*newFrame, cols - 1);
 
     regression->trainIncremental();
@@ -1841,8 +1853,14 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
                     },
                     &newTrainingRowMask);
 
+    double alpha{classifier->hyperparameters().depthPenaltyMultiplier().value()};
+    double gamma{classifier->hyperparameters().treeSizePenaltyMultiplier().value()};
+    double lambda{classifier->hyperparameters().leafWeightPenaltyMultiplier().value()};
     classifier = maths::analytics::CBoostedTreeFactory::constructFromModel(std::move(classifier))
                      .newTrainingRowMask(newTrainingRowMask)
+                     .depthPenaltyMultiplier({0.5 * alpha, 2.0 * alpha})
+                     .treeSizePenaltyMultiplier({0.5 * gamma, 2.0 * gamma})
+                     .leafWeightPenaltyMultiplier({0.5 * lambda, 2.0 * lambda})
                      .buildForTrainIncremental(*newFrame, cols - 1);
 
     classifier->trainIncremental();

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -576,12 +576,12 @@ BOOST_AUTO_TEST_CASE(testMseLinear) {
             0.0, modelBias[i][0],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.93);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.91);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testMseNonLinear) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -576,12 +576,12 @@ BOOST_AUTO_TEST_CASE(testMseLinear) {
             0.0, modelBias[i][0],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.93);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
 }
 
 BOOST_AUTO_TEST_CASE(testMseNonLinear) {


### PR DESCRIPTION
This moves handling of initialisation of parameter search ranges largely into `CBoostedTreeHyperparameters`. Previously it was split between there and `CBoostedTreeFactory`. It also improves handling of user overrides of parameter search ranges and properly encapsulates the logic for searching logged values or not in the parameter definition.