### PR TITLE
[ML] Re-run seccomp unit tests on more Linux distributions

### DIFF
--- a/3rd_party/3rd_party.sh
+++ b/3rd_party/3rd_party.sh
@@ -48,7 +48,7 @@ case `uname` in
             BOOST_ARCH=a64
         fi
         BOOST_EXTENSION=mt-${BOOST_ARCH}-1_77.dylib
-        BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread'
+        BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread unit_test_framework'
         XML_LOCATION=
         GCC_RT_LOCATION=
         OMP_LOCATION=
@@ -73,7 +73,7 @@ case `uname` in
                 MKL_LIBRARIES=`cd "$MKL_LOCATION" && ls $MKL_PREFIX*$MKL_EXTENSION`
             fi
             BOOST_EXTENSION=mt-${BOOST_ARCH}-1_77.so.1.77.0
-            BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread'
+            BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread unit_test_framework'
             XML_LOCATION=/usr/local/gcc103/lib
             XML_EXTENSION=.so.2
             GCC_RT_LOCATION=/usr/local/gcc103/lib64
@@ -92,7 +92,7 @@ case `uname` in
             BOOST_LOCATION=$SYSROOT/usr/local/lib
             BOOST_COMPILER=clang
             BOOST_EXTENSION=mt-x64-1_77.dylib
-            BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread'
+            BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread unit_test_framework'
             XML_LOCATION=
             GCC_RT_LOCATION=
             OMP_LOCATION=
@@ -112,7 +112,7 @@ case `uname` in
                 exit 3
             fi
             BOOST_EXTENSION=mt-${BOOST_ARCH}-1_77.so.1.77.0
-            BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread'
+            BOOST_LIBRARIES='atomic chrono date_time filesystem iostreams log log_setup program_options regex system thread unit_test_framework'
             XML_LOCATION=$SYSROOT/usr/local/gcc103/lib
             XML_EXTENSION=.so.2
             GCC_RT_LOCATION=$SYSROOT/usr/local/gcc103/lib64
@@ -138,7 +138,7 @@ case `uname` in
         BOOST_LOCATION=/$LOCAL_DRIVE/usr/local/lib
         BOOST_COMPILER=vc
         BOOST_EXTENSION=mt-x64-1_77.dll
-        BOOST_LIBRARIES='chrono date_time filesystem iostreams log log_setup program_options regex system thread'
+        BOOST_LIBRARIES='chrono date_time filesystem iostreams log log_setup program_options regex system thread unit_test_framework'
         XML_LOCATION=/$LOCAL_DRIVE/usr/local/bin
         XML_EXTENSION=.dll
         GCC_RT_LOCATION=

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,8 @@ def zipSpec = copySpec {
   from("${buildDir}/distribution") {
     // Don't copy Windows import libraries
     exclude "**/*.lib"
-    // Don't copy the test support library
+    // Don't copy the test support libraries
+    exclude "**/*unit_test_framework*"
     exclude "**/libMlTest.*"
     // Don't copy debug files
     exclude "**/*-debug"

--- a/dev-tools/docker/docker_entrypoint.sh
+++ b/dev-tools/docker/docker_entrypoint.sh
@@ -47,8 +47,8 @@ ARTIFACT_NAME=`cat "$CPP_SRC_HOME/gradle.properties" | grep '^artifactName' | aw
 # Create the output artifacts
 cd build/distribution
 mkdir ../distributions
-# Exclude import libraries, test support library, debug files and core dumps
-zip -9 ../distributions/$ARTIFACT_NAME-$PRODUCT_VERSION-$BUNDLE_PLATFORM.zip `find * | egrep -v '\.lib$|libMlTest|\.dSYM|-debug$|\.pdb$|/core'`
+# Exclude import libraries, test support libraries, debug files and core dumps
+zip -9 ../distributions/$ARTIFACT_NAME-$PRODUCT_VERSION-$BUNDLE_PLATFORM.zip `find * | egrep -v '\.lib$|unit_test_framework|libMlTest|\.dSYM|-debug$|\.pdb$|/core'`
 # Include only debug files
 zip -9 ../distributions/$ARTIFACT_NAME-debug-$PRODUCT_VERSION-$BUNDLE_PLATFORM.zip `find * | egrep '\.dSYM|-debug$|\.pdb$'`
 cd ../..

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -25,11 +25,17 @@ usage() {
 }
 
 PLATFORMS=
+EXTRACT_FIND="-name boost_test_results.xml"
+EXTRACT_EXPLICIT="build/distributions build/test_status.txt"
 
 while [ -n "$1" ]
 do
 
     case "$1" in
+        --extract-unit-tests)
+            EXTRACT_FIND="$EXTRACT_FIND -o -name ml_test"
+            EXTRACT_EXPLICIT="$EXTRACT_EXPLICIT build/distribution"
+            ;;
         linux|linux_aarch64_native)
             PLATFORMS="$1 $PLATFORMS"
             ;;
@@ -85,7 +91,7 @@ do
     # Using tar to copy the build and test artifacts out of the container seems
     # more reliable than docker cp, and also means the files end up with the
     # correct uid/gid
-    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c 'find . -name boost_test_results.xml | xargs tar cf - build/distributions build/test_status.txt' | tar xvf -
+    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c "find . $EXTRACT_FIND | xargs tar cf - $EXTRACT_EXPLICIT" | tar xvf -
     docker rmi --force $TEMP_TAG
     # The image build is set to return zero (i.e. succeed as far as Docker is
     # concerned) when the only problem is that the unit tests fail, as this

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -117,20 +117,27 @@ case `uname` in
         # The Docker version is helpful to identify version-specific Docker bugs
         docker --version
 
+        KERNEL_VERSION=`uname -r`
+        GLIBC_VERSION=`ldconfig --version | head -1 | sed 's/ldconfig//'`
+
         # Build and test the native Linux architecture
         if [ "$HARDWARE_ARCH" = x86_64 ] ; then
 
             if [ "$RUN_TESTS" = false ] ; then
                 ./docker_build.sh linux
             else
-                ./docker_test.sh linux
+                ./docker_test.sh --extract-unit-tests linux
+                echo "Re-running seccomp unit tests outside of Docker container - kernel: $KERNEL_VERSION glibc: $GLIBC_VERSION"
+                (cd ../lib/seccomp/unittest && LD_LIBRARY_PATH=`cd ../../../build/distribution/platform/linux-x86_64/lib && pwd` ./ml_test)
             fi
 
         elif [ "$HARDWARE_ARCH" = aarch64 ] ; then
             if [ "$RUN_TESTS" = false ] ; then
                 ./docker_build.sh linux_aarch64_native
             else
-                ./docker_test.sh linux_aarch64_native
+                ./docker_test.sh --extract-unit-tests linux_aarch64_native
+                echo "Re-running seccomp unit tests outside of Docker container - kernel: $KERNEL_VERSION glibc: $GLIBC_VERSION"
+                (cd ../lib/seccomp/unittest && LD_LIBRARY_PATH=`cd ../../../build/distribution/platform/linux-aarch64/lib && pwd` ./ml_test)
             fi
         fi
 


### PR DESCRIPTION
Our system call filtering is particularly sensitive to the
exact glibc and kernel versions being used. At present our
CI builds only run the C++ unit tests inside the Docker
container. This means the seccomp unit tests will only run
in CI on glibc 2.17 (with our current CentOS 7 build Docker
images). We can improve coverage by copying the test program
out of the Docker container and running it again on the host
operating system. Then it will run against the glibc version
on the host operating system, which is likely to be much
newer than the version in the Docker container. (The Docker
container deliberately uses the oldest glibc version that we
need to be able to run on.)

Potentially we could re-run more unit tests in the future
using the same approach, but some would dramatically increase
CI runtimes. For example, the maths library unit tests take
16 minutes to run. This PR is starting small by just re-running
the seccomp library tests, which are very fast. We can iterate
in the future.