### PR TITLE
[ML] Fix a bug in hyperparameter scaling for classification and regression model training

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,11 @@
 * Upgrade Boost libraries to version 1.77. (See {ml-pull}2095[#2095].)
 * Upgrade RapidJSON to 31st October 2021 version. (See {ml-pull}2106[#2106].)
 
+=== Bug Fixes
+
+* Fix a bug in the tuning of the hyperparameters when training regression
+  classification models. (See {ml-pull}2128[#2128].)
+
 == {es} version 8.0.0
 
 === Bug Fixes

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -808,7 +808,7 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
                 // We need to scale the regularisation terms to account for the difference
                 // in the downsample factor compared to the value used in the line search.
                 auto scaleRegularizers = [&](CBoostedTreeImpl& tree, double downsampleFactor) {
-                    double scale{initialDownsampleFactor / downsampleFactor};
+                    double scale{downsampleFactor / initialDownsampleFactor};
                     tree.m_Regularization.depthPenaltyMultiplier(initialDepthPenaltyMultiplier);
                     tree.m_Regularization.treeSizePenaltyMultiplier(initialTreeSizePenaltyMultiplier);
                     tree.m_Regularization.leafWeightPenaltyMultiplier(

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1437,7 +1437,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.77);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.81);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1443,7 +1443,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.53);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.56);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -693,7 +693,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
         // Unbiased...
         BOOST_REQUIRE_CLOSE_ABSOLUTE(
             0.0, modelBias[i],
-            4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
+            6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
         BOOST_TEST_REQUIRE(modelRSquared[i] > 0.95);
 
@@ -1180,8 +1180,8 @@ BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.08);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.98);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.07);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.97);
 }
 
 BOOST_AUTO_TEST_CASE(testSingleSplit) {


### PR DESCRIPTION
When we adjust the downsample factor we scale the parameters which are added to terms which are proportional to the amount of data so that the degree of regularisation remains constant in expectation. We do this correctly when we fine tune, but using the wrong scaling when doing the initial search for downsample factor. This is liable to lead to us choosing smaller downsample factors than we otherwise might.