### PR TITLE
[ML] Use unbufferred RapidJSON istream wrapper everywhere in the code

### DIFF
--- a/include/core/CJsonStateRestoreTraverser.h
+++ b/include/core/CJsonStateRestoreTraverser.h
@@ -11,6 +11,7 @@
 #ifndef INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 #define INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
 #include <core/ImportExport.h>
@@ -158,7 +159,7 @@ private:
     };
 
     //! JSON reader istream wrapper
-    rapidjson::IStreamWrapper m_ReadStream;
+    core::CRapidJsonUnbufferedIStreamWrapper m_ReadStream;
 
     //! JSON reader
     rapidjson::Reader m_Reader;

--- a/include/core/CJsonStateRestoreTraverser.h
+++ b/include/core/CJsonStateRestoreTraverser.h
@@ -17,7 +17,6 @@
 #include <core/ImportExport.h>
 
 #include <rapidjson/document.h>
-#include <rapidjson/istreamwrapper.h>
 #include <rapidjson/reader.h>
 
 #include <iosfwd>

--- a/lib/api/CRetrainableModelJsonReader.cc
+++ b/lib/api/CRetrainableModelJsonReader.cc
@@ -13,6 +13,7 @@
 
 #include <core/CDataFrame.h>
 #include <core/CJsonStateRestoreTraverser.h>
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 
 #include <maths/analytics/CBoostedTree.h>
 #include <maths/analytics/CDataFrameCategoryEncoder.h>
@@ -69,7 +70,7 @@ CRetrainableModelJsonReader::dataSummarizationFromJsonStream(TIStreamSPtr istrea
 CRetrainableModelJsonReader::TEncoderUPtrStrSizeUMapPr
 CRetrainableModelJsonReader::doDataSummarizationFromJsonStream(std::istream& istream,
                                                                core::CDataFrame& frame) {
-    rapidjson::IStreamWrapper isw{istream};
+    core::CRapidJsonUnbufferedIStreamWrapper isw{istream};
     rapidjson::Document doc;
     doc.ParseStream(isw);
     assertNoParseError(doc);
@@ -167,7 +168,7 @@ CRetrainableModelJsonReader::doBestForestFromJsonStream(std::istream& istream,
     using TNodeVec = maths::analytics::CBoostedTreeFactory::TNodeVec;
     using TNodeVecVec = maths::analytics::CBoostedTreeFactory::TNodeVecVec;
 
-    rapidjson::IStreamWrapper isw{istream};
+    core::CRapidJsonUnbufferedIStreamWrapper isw{istream};
     rapidjson::Document doc;
     doc.ParseStream(isw);
     assertNoParseError(doc);

--- a/lib/api/CRetrainableModelJsonReader.cc
+++ b/lib/api/CRetrainableModelJsonReader.cc
@@ -22,7 +22,6 @@
 #include <api/CInferenceModelDefinition.h>
 
 #include <rapidjson/document.h>
-#include <rapidjson/istreamwrapper.h>
 #include <rapidjson/rapidjson.h>
 
 #include <memory>

--- a/lib/api/CSerializableToJson.cc
+++ b/lib/api/CSerializableToJson.cc
@@ -12,6 +12,7 @@
 #include <api/CSerializableToJson.h>
 
 #include <core/CBase64Filter.h>
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
@@ -129,7 +130,7 @@ CSerializableFromCompressedChunkedJson::rawJsonStream(const std::string& compres
                                                       TIStreamPtr inputStream,
                                                       std::iostream& buffer) {
     if (inputStream != nullptr) {
-        rapidjson::IStreamWrapper isw{*inputStream};
+        core::CRapidJsonUnbufferedIStreamWrapper isw{*inputStream};
         try {
             rapidjson::Document doc;
             bool done{false};

--- a/lib/api/CSerializableToJson.cc
+++ b/lib/api/CSerializableToJson.cc
@@ -15,7 +15,6 @@
 #include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 
 #include <rapidjson/document.h>
-#include <rapidjson/istreamwrapper.h>
 #include <rapidjson/rapidjson.h>
 
 #include <boost/iostreams/copy.hpp>


### PR DESCRIPTION
After #2121, there were still some places in the code where the old rapidjson istream wrapper was used. This led to errors, and this PR fixes this.
