### PR TITLE
[ML] Replace rapidjson::istreamwrapper in CJsonStateRestoreTraverser

### DIFF
--- a/include/core/CJsonStateRestoreTraverser.h
+++ b/include/core/CJsonStateRestoreTraverser.h
@@ -11,12 +11,12 @@
 #ifndef INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 #define INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 
+#include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
 #include <core/ImportExport.h>
 
 #include <rapidjson/document.h>
-#include <rapidjson/istreamwrapper.h>
 #include <rapidjson/reader.h>
 
 #include <iosfwd>
@@ -158,7 +158,7 @@ private:
     };
 
     //! JSON reader istream wrapper
-    rapidjson::IStreamWrapper m_ReadStream;
+    core::CRapidJsonUnbufferedIStreamWrapper m_ReadStream;
 
     //! JSON reader
     rapidjson::Reader m_Reader;

--- a/lib/core/CJsonStateRestoreTraverser.cc
+++ b/lib/core/CJsonStateRestoreTraverser.cc
@@ -29,7 +29,7 @@ CJsonStateRestoreTraverser::CJsonStateRestoreTraverser(std::istream& inputStream
 }
 
 bool CJsonStateRestoreTraverser::isEof() const {
-    // Rapid JSON istreamwrapper returns \0 when it reaches EOF
+    // CRapidJsonUnbufferedIStreamWrapper returns \0 when it reaches EOF
     return m_ReadStream.Peek() == '\0';
 }
 


### PR DESCRIPTION
One of the changes of #2135 applies to the main branch as well
as the incremental learning branch. Although it doesn't cause
any test failures it should be replaced before 8.1 feature
freeze just in case there's a place where buffering makes a
difference in a scenario not covered by our testing.