### PR TITLE
[PYTORCH] Limit total number of model & inference threads <= max threads

### DIFF
--- a/bin/pytorch_inference/Makefile
+++ b/bin/pytorch_inference/Makefile
@@ -31,6 +31,7 @@ SRCS= \
     CBufferedIStreamAdapter.cc \
     CCmdLineParser.cc \
     CCommandParser.cc \
+    SettingsValidator.cc \
 
 include $(CPP_SRC_HOME)/mk/stdapp.mk
 

--- a/bin/pytorch_inference/SettingsValidator.cc
+++ b/bin/pytorch_inference/SettingsValidator.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#include "SettingsValidator.h"
+
+#include <core/CLogger.h>
+
+#include <algorithm>
+#include <thread>
+
+namespace ml {
+namespace torch {
+
+void validateThreadingParameters(std::int32_t maxThreads,
+                                 std::int32_t& inferenceThreads,
+                                 std::int32_t& modelThreads) {
+    if (maxThreads == 0) {
+        LOG_WARN(<< "Could not determine hardware concurrency; setting max threads to 1");
+        maxThreads = 1;
+    }
+    if (inferenceThreads < 1) {
+        LOG_WARN(<< "Setting inference threads to minimum value of 1; value was "
+                 << inferenceThreads);
+        inferenceThreads = 1;
+    } else if (inferenceThreads > maxThreads) {
+        LOG_WARN(<< "Setting inference threads to maximum value of "
+                 << maxThreads << "; value was " << inferenceThreads);
+        inferenceThreads = maxThreads;
+    }
+    if (modelThreads < 1) {
+        LOG_WARN(<< "Setting model threads to minimum value of 1; value was " << modelThreads);
+        modelThreads = 1;
+    } else if (modelThreads >= maxThreads) {
+        // leave one thread for inference
+        LOG_WARN(<< "Setting model threads to maximum value of "
+                 << std::max(1, maxThreads - 1) << "; value was " << modelThreads);
+        modelThreads = std::max(1, maxThreads - 1);
+    }
+
+    if (modelThreads + inferenceThreads > maxThreads) {
+        // 1 model thread is essentially unthreaded as there is no paralisation.
+        // When modelThreads == 1 inferenceThreads is capped at maxThreads
+        if (modelThreads != 1) {
+            std::int32_t oldInferenceThreadCount{inferenceThreads};
+            inferenceThreads = std::max(1, maxThreads - modelThreads);
+            LOG_WARN(<< "Sum of model threads [" << modelThreads << "] and inference threads ["
+                     << oldInferenceThreadCount << "] is greater than max threads ["
+                     << maxThreads << "]. Setting model threads to " << modelThreads
+                     << " and inference threads to " << inferenceThreads);
+        }
+    }
+}
+}
+}

--- a/bin/pytorch_inference/SettingsValidator.h
+++ b/bin/pytorch_inference/SettingsValidator.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#ifndef INCLUDED_ml_torch_SettingsValidator_h
+#define INCLUDED_ml_torch_SettingsValidator_h
+
+#include <cstdint>
+
+namespace ml {
+namespace torch {
+void validateThreadingParameters(std::int32_t maxThreads,
+                                 std::int32_t& inferenceThreads,
+                                 std::int32_t& modelThreads);
+}
+}
+
+#endif // INCLUDED_ml_torch_SettingsValidator_h

--- a/bin/pytorch_inference/unittest/Makefile
+++ b/bin/pytorch_inference/unittest/Makefile
@@ -23,9 +23,11 @@ all: build
 
 TESTED_OBJS=\
     ../.objs/C*$(OBJECT_FILE_EXT) \
+    ../.objs/SettingsValidator$(OBJECT_FILE_EXT)
 
 SRCS=\
     Main.cc \
     CCommandParserTest.cc \
+    SettingsValidatorTest.cc \
 
 include $(CPP_SRC_HOME)/mk/stdboosttest.mk

--- a/bin/pytorch_inference/unittest/SettingsValidatorTest.cc
+++ b/bin/pytorch_inference/unittest/SettingsValidatorTest.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#include "../SettingsValidator.h"
+
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+
+BOOST_AUTO_TEST_SUITE(SettingsValidatorTest)
+
+BOOST_AUTO_TEST_CASE(testValidationNoChanges) {
+    std::int32_t modelThreads{4};
+    std::int32_t inferenceThreads{4};
+    ml::torch::validateThreadingParameters(16, inferenceThreads, modelThreads);
+    BOOST_REQUIRE_EQUAL(4, modelThreads);
+    BOOST_REQUIRE_EQUAL(4, inferenceThreads);
+}
+
+BOOST_AUTO_TEST_CASE(testValidationValuesAreCapped) {
+    std::int32_t modelThreads{1};
+    std::int32_t inferenceThreads{32};
+    ml::torch::validateThreadingParameters(16, inferenceThreads, modelThreads);
+    BOOST_REQUIRE_EQUAL(1, modelThreads);
+    BOOST_REQUIRE_EQUAL(16, inferenceThreads);
+
+    modelThreads = 32;
+    inferenceThreads = 1;
+    ml::torch::validateThreadingParameters(16, inferenceThreads, modelThreads);
+    BOOST_REQUIRE_EQUAL(15, modelThreads);
+    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+}
+
+BOOST_AUTO_TEST_CASE(testValidationNegativeValues) {
+    std::int32_t modelThreads{-1};
+    std::int32_t inferenceThreads{-2};
+    ml::torch::validateThreadingParameters(16, inferenceThreads, modelThreads);
+    BOOST_REQUIRE_EQUAL(1, modelThreads);
+    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+}
+
+BOOST_AUTO_TEST_CASE(testValidationMaxThreadsUnknown) {
+    std::int32_t modelThreads{4};
+    std::int32_t inferenceThreads{4};
+    // 0 == maxThreads is not known
+    ml::torch::validateThreadingParameters(0, inferenceThreads, modelThreads);
+    BOOST_REQUIRE_EQUAL(1, modelThreads);
+    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+}
+
+BOOST_AUTO_TEST_CASE(testValidationTotalGreaterThanMaxThreads) {
+    {
+        std::int32_t modelThreads{10};
+        std::int32_t inferenceThreads{10};
+        ml::torch::validateThreadingParameters(16, inferenceThreads, modelThreads);
+        BOOST_REQUIRE_EQUAL(10, modelThreads);
+        BOOST_REQUIRE_EQUAL(6, inferenceThreads);
+    }
+    {
+        std::int32_t modelThreads{1};
+        std::int32_t inferenceThreads{32};
+        ml::torch::validateThreadingParameters(16, inferenceThreads, modelThreads);
+        BOOST_REQUIRE_EQUAL(1, modelThreads);
+        BOOST_REQUIRE_EQUAL(16, inferenceThreads);
+    }
+    {
+        std::int32_t modelThreads{4};
+        std::int32_t inferenceThreads{1};
+        ml::torch::validateThreadingParameters(4, inferenceThreads, modelThreads);
+        BOOST_REQUIRE_EQUAL(3, modelThreads);
+        BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+    }
+    {
+        std::int32_t modelThreads{1};
+        std::int32_t inferenceThreads{4};
+        ml::torch::validateThreadingParameters(4, inferenceThreads, modelThreads);
+        BOOST_REQUIRE_EQUAL(1, modelThreads);
+        BOOST_REQUIRE_EQUAL(4, inferenceThreads);
+    }
+    {
+        std::int32_t modelThreads{2};
+        std::int32_t inferenceThreads{4};
+        ml::torch::validateThreadingParameters(4, inferenceThreads, modelThreads);
+        BOOST_REQUIRE_EQUAL(2, modelThreads);
+        BOOST_REQUIRE_EQUAL(2, inferenceThreads);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The validation of the `inferenceThreads` and `modelThreads` parameters should not allow the sum to exceed `maxThreads` (std::thread::hardware_concurrency()).

The validation logic is a little complicated as when `modelThreads ==1` no thread pool is setup which effectively means `modelThreads == 0` and inference can use the rest of the threads. I pulled the validation method out into a new file so it can be unit tested. 