### PR TITLE
[ML] Fix sources of cross platform variation in incremental training

### DIFF
--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -106,11 +106,13 @@ public:
     //!
     //! \note Has no effect if the parameter is fixed.
     void setToRangeMidpointOr(T value) {
-        m_Value = m_FixedToRange
-                      ? this->fromSearchValue((this->toSearchValue(m_MinValue) +
-                                               this->toSearchValue(m_MaxValue)) /
-                                              T{2})
-                      : value;
+        if (this->fixed() == false) {
+            m_Value = m_FixedToRange
+                          ? this->fromSearchValue((this->toSearchValue(m_MinValue) +
+                                                   this->toSearchValue(m_MaxValue)) /
+                                                  T{2})
+                          : value;
+        }
     }
 
     //! Fix to \p value.

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2075,7 +2075,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 5.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -827,7 +827,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
     TDoubleVecVec x(cols - 1);
     TDoubleVec noise;
     for (std::size_t i = 0; i < cols - 1; ++i) {
-        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+        rng.generateUniformSamples(0.0, 4.0, rows, x[i]);
     }
     rng.generateNormalSamples(0.0, noiseVariance, rows, noise);
 
@@ -933,7 +933,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 2.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
@@ -965,7 +965,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
 
     TDoubleVecVec x(cols - 1);
     for (std::size_t i = 0; i < cols - 1; ++i) {
-        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+        rng.generateUniformSamples(0.0, 4.0, rows, x[i]);
     }
 
     TDoubleVec noise;
@@ -1071,7 +1071,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 60.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testThreading) {
@@ -1819,8 +1819,10 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForTargetDrift) {
     fillDataFrame(rows, 0, cols, {false, false, false, false, true}, x,
                   TDoubleVec(rows, 0.0), target, *newFrame);
 
+    // If the target drift isn't on a subset of feature space it is an even trade increasing
+    // errors for old and decreasing for new.
     for (std::size_t i = 0; i < cols - 1; ++i) {
-        rng.generateUniformSamples(-3.0, 3.0, extraTrainingRows, x[i]);
+        rng.generateUniformSamples(0.0, 3.0, extraTrainingRows, x[i]);
     }
 
     fillDataFrame(extraTrainingRows, 0, cols, {false, false, false, false, true},
@@ -1920,7 +1922,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForTargetDrift) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 2.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
@@ -1934,9 +1936,9 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
     std::size_t extraTrainingRows{250};
 
     auto probability = [&] {
-        TDoubleVec weights{-0.6, 1.0, 0.8, -1.2};
+        TDoubleVec weights{-0.6, 1.0, -0.8, 1.2};
         TDoubleVec noise;
-        rng.generateNormalSamples(0.0, 0.5, rows + extraTrainingRows, noise);
+        rng.generateNormalSamples(0.0, 0.2, rows + extraTrainingRows, noise);
         return [=](const TRowRef& row) {
             double x{0.0};
             for (std::size_t i = 0; i < cols - 1; ++i) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -837,6 +837,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
 
     auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
+                          .eta({0.02}) // Ensure there are enough trees.
                           .buildForTrain(*frame, cols - 1);
 
     regression->train();
@@ -933,7 +934,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 25.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
@@ -975,6 +976,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
 
     auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
+                          .eta({0.02}) // Ensure there are enough trees.
                           .buildForTrain(*frame, cols - 1);
     regression->train();
 
@@ -1439,7 +1441,7 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
                static_cast<double>(std::accumulate(selected.begin(), selected.end(), 0));
     };
 
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.0073);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.008);
     BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.01);
 }
 
@@ -1530,7 +1532,7 @@ BOOST_AUTO_TEST_CASE(testSingleSplit) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.21);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.98);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testTranslationInvariance) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2075,7 +2075,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 40.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2645,7 +2645,7 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
         regression->train();
 
         // We use a single leaf to centre the data so end up with *at most* limit + 1 trees.
-        BOOST_TEST_REQUIRE(regression->bestHyperparameters().maximumNumberTrees() <= 11);
+        BOOST_TEST_REQUIRE(regression->hyperparameters().maximumNumberTrees().value() <= 11);
         BOOST_REQUIRE_EQUAL(
             10, regression->hyperparameters().maximumNumberTrees().value());
         BOOST_REQUIRE_EQUAL(


### PR DESCRIPTION
We were computing downsampled old and new training data masks as follows:
```
this->downsample(oldTrainingRowMask) | this->downsample(newTrainingRowMask);
```
The compiler is at liberty to reorder evaluation of calls to compute `operator|` arguments. Since this changes the state of our internal random number generator this changes the rows we select to compute splits. We now split these calls into separate statements.

We also need to follow the paradigm used by train from scratch and reseed the rng when performing final train so running again with parameters overridden produces identical results.