### PR TITLE
[ML] Improve training stability for regression and classification models

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,6 +40,8 @@
 
 * Fix a bug in the tuning of the hyperparameters when training regression
   classification models. (See {ml-pull}2128[#2128].)
+* Improve training stability for regression and classification models
+  (See {ml-pull}2144[#2144].)
 
 == {es} version 8.0.0
 

--- a/include/maths/common/CLbfgs.h
+++ b/include/maths/common/CLbfgs.h
@@ -158,7 +158,7 @@ public:
         VECTOR r2;
 
         // Functions to compute the augmented Lagrangian and its gradient w.r.t. x.
-        auto al = [&](const VECTOR& x_) {
+        auto al = [&](const VECTOR& x_) -> double {
             r1 = x_ - z1 + w1 - a;
             r2 = x_ + z2 + w2 - b;
             double n1{las::norm(r1)};
@@ -166,20 +166,22 @@ public:
             // Explicitly construct the return type before returning from the lambda,
             // otherwise the auto return type may be an Eigen closure type which
             // references temporaries
-            return double{f(x_) + 0.5 * rho * (n1 * n1 + n2 * n2)};
+            return f(x_) + 0.5 * rho * (n1 * n1 + n2 * n2);
         };
-        auto gal = [&](const VECTOR& x_) {
+        auto gal = [&](const VECTOR& x_) -> VECTOR {
             // Explicitly construct the return type before returning from the lambda,
             // otherwise the auto return type may be an Eigen closure type which
             // references temporaries
-            return VECTOR{g(x_) + rho * (2 * x_ - z1 + z2 - a - b + w1 + w2)};
+            return g(x_) + rho * (2 * x_ - z1 + z2 - a - b + w1 + w2);
         };
 
-        VECTOR xmin;
-        double fmin;
+        VECTOR xmin{x};
+        double fmin{f(x)};
 
-        double f0{f(x)};
-        double fl{f0};
+        double f0{fmin};
+        double fl{fmin};
+        double fi;
+        VECTOR xi;
         for (std::size_t i = 0; i < iterations; ++i) {
             // x-minimization.
             std::tie(x, std::ignore) = this->minimize(al, gal, x, eps, iterations);
@@ -195,12 +197,18 @@ public:
             w2 += x + z2 - b;
 
             // Snap to nearest feasible point to test for convergence.
-            xmin = x;
-            las::max(a, xmin);
-            las::min(b, xmin);
-            fmin = f(xmin);
+            xi = x;
+            las::max(a, xi);
+            las::min(b, xi);
+            fi = f(xi);
 
-            if (converged(fmin, fl, f0, eps)) {
+            // Snapping can increase objective so make sure we remember the best we've seen.
+            if (fi < fmin) {
+                xmin = xi;
+                fmin = fi;
+            }
+
+            if (converged(fi, fl, f0, eps)) {
                 break;
             }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1443,7 +1443,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.56);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.57);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -78,7 +78,8 @@ double integrate1dKernelProduct(double theta1, double xit, double xjt) {
         boost::math::constants::root_half_pi<double>() / (2 * c) *
         CTools::stableExp(-0.5 * CTools::pow2(c) * CTools::pow2(xit - xjt)) *
         (CTools::stable(std::erf(c / boost::math::constants::root_two<double>() * (xit + xjt))) -
-         CTools::stable(std::erf(c / boost::math::constants::root_two<double>() * (xit + xjt - 2)))));
+         CTools::stable(std::erf(c / boost::math::constants::root_two<double>() *
+                                 (xit + xjt - 2)))));
 }
 }
 
@@ -255,8 +256,8 @@ double CBayesianOptimisation::evaluate1D(const TVector& Kinvf, double input, int
         TVector x{this->transformTo01(m_FunctionMeanValues[i].first)};
         sum += Kinvf(static_cast<int>(i)) *
                CTools::stableExp(-(CTools::pow2(m_KernelParameters[dimension + 1]) +
-                          MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE) *
-                        CTools::pow2(input - x(dimension))) *
+                                   MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE) *
+                                 CTools::pow2(input - x(dimension))) *
                prodXt(x, dimension);
     }
 

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -76,9 +76,9 @@ double integrate1dKernelProduct(double theta1, double xit, double xjt) {
     double c{std::sqrt(CTools::pow2(theta1) + MINIMUM_KERNEL_SCALE_FOR_EXPECTATION_MAXIMISATION)};
     return CTools::stable(
         boost::math::constants::root_half_pi<double>() / (2 * c) *
-        std::exp(-0.5 * CTools::pow2(c) * CTools::pow2(xit - xjt)) *
-        (std::erf(c / boost::math::constants::root_two<double>() * (xit + xjt)) -
-         std::erf(c / boost::math::constants::root_two<double>() * (xit + xjt - 2))));
+        CTools::stableExp(-0.5 * CTools::pow2(c) * CTools::pow2(xit - xjt)) *
+        (CTools::stable(std::erf(c / boost::math::constants::root_two<double>() * (xit + xjt))) -
+         CTools::stable(std::erf(c / boost::math::constants::root_two<double>() * (xit + xjt - 2)))));
 }
 }
 
@@ -254,7 +254,7 @@ double CBayesianOptimisation::evaluate1D(const TVector& Kinvf, double input, int
     for (std::size_t i = 0; i < m_FunctionMeanValues.size(); ++i) {
         TVector x{this->transformTo01(m_FunctionMeanValues[i].first)};
         sum += Kinvf(static_cast<int>(i)) *
-               std::exp(-(CTools::pow2(m_KernelParameters[dimension + 1]) +
+               CTools::stableExp(-(CTools::pow2(m_KernelParameters[dimension + 1]) +
                           MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE) *
                         CTools::pow2(input - x(dimension))) *
                prodXt(x, dimension);


### PR DESCRIPTION
We need to check that the objective actually decreases after snapping to the constraint bounding box for L-BFGS with constraint. Also, addresses some cross platform variation due to variation `std::exp` and  `std::log` when computing ANOVA for hyperparameter losses.