### PR TITLE
[ML] Some improvements to Bayesian Optimisation implementation

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@
 * Fix a bug in the tuning of the hyperparameters when training regression
   classification models. (See {ml-pull}2128[#2128].)
 * Improve training stability for regression and classification models
-  (See {ml-pull}2144[#2144].)
+  (See {ml-pull}2144[#2144] and {ml-pull}2147[#2147].)
 
 == {es} version 8.0.0
 

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -163,6 +163,15 @@ private:
     static const double MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE;
 
 private:
+    //! \name ANOVA
+    //@{
+    double evaluate(const TVector& Kinvf, const TVector& input) const;
+    double evaluate1D(const TVector& Kinvf, double input, int dimension) const;
+    double anovaConstantFactor(const TVector& Kinvf) const;
+    double anovaTotalVariance(const TVector& Kinvf) const;
+    double anovaMainEffect(const TVector& Kinvf, int dimension) const;
+    //@}
+
     void precondition();
     TVector function() const;
     double meanErrorVariance() const;
@@ -170,13 +179,9 @@ private:
     TMatrix kernel(const TVector& a, double v) const;
     TVectorDoublePr kernelCovariates(const TVector& a, const TVector& x, double vx) const;
     double kernel(const TVector& a, const TVector& x, const TVector& y) const;
-    double evaluate(const TVector& Kinvf, const TVector& input) const;
-    double evaluate1D(const TVector& Kinvf, double input, int dimension) const;
-    double anovaConstantFactor(const TVector& Kinvf) const;
-    double anovaTotalVariance(const TVector& Kinvf) const;
-    double anovaMainEffect(const TVector& Kinvf, int dimension) const;
     TVector kinvf() const;
     TVector transformTo01(const TVector& x) const;
+    double dissimilarity(const TVector& x) const;
     void checkRestoredInvariants() const;
 
 private:

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -68,6 +68,10 @@ public:
 
 public:
     static const std::size_t RESTARTS;
+    // For values less than this the EI is treated as zero and we fallback to using
+    // dissimilarity (i.e. maximizing diversity). Note that the supplied function
+    // values are scaled so their variance is one thus this is a relative constant.
+    static const double NEGLIGIBLE_EXPECTED_IMPROVEMENT;
 
 public:
     CBayesianOptimisation(TDoubleDoublePrVec parameterBounds, std::size_t restarts = RESTARTS);
@@ -86,7 +90,8 @@ public:
 
     //! Compute the location which maximizes the expected improvement given the
     //! function evaluations added so far.
-    std::pair<TVector, TOptionalDouble> maximumExpectedImprovement();
+    std::pair<TVector, TOptionalDouble>
+    maximumExpectedImprovement(double negligibleExpectedImprovement = NEGLIGIBLE_EXPECTED_IMPROVEMENT);
 
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;

--- a/include/maths/common/CLbfgs.h
+++ b/include/maths/common/CLbfgs.h
@@ -202,7 +202,8 @@ public:
             las::min(b, xi);
             fi = f(xi);
 
-            // Snapping can increase objective so make sure we remember the best we've seen.
+            // Snapping can increase the objective so make sure we remember the best
+            // we've seen.
             if (fi < fmin) {
                 xmin = xi;
                 fmin = fi;

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1015,7 +1015,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.1);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.95);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.94);
 }
 
 BOOST_AUTO_TEST_CASE(testFeatureBags) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
             0.0, modelBias[i][0],
             8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.94);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.92);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(testLinear) {
             0.0, modelBias[i][0],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
@@ -1227,7 +1227,7 @@ BOOST_AUTO_TEST_CASE(testSingleSplit) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.21);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.97);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testTranslationInvariance) {
@@ -1679,7 +1679,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 1.4);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 1.6);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -510,13 +510,13 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
             0.0, modelBias[i][0],
             8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.92);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.91);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
 
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testLinear) {
@@ -571,7 +571,7 @@ BOOST_AUTO_TEST_CASE(testLinear) {
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.98);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.97);
 }
 
 BOOST_AUTO_TEST_CASE(testNonLinear) {
@@ -1015,7 +1015,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.1);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.94);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.93);
 }
 
 BOOST_AUTO_TEST_CASE(testFeatureBags) {
@@ -1227,7 +1227,7 @@ BOOST_AUTO_TEST_CASE(testSingleSplit) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.21);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.95);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.94);
 }
 
 BOOST_AUTO_TEST_CASE(testTranslationInvariance) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1015,7 +1015,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.1);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.97);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testFeatureBags) {
@@ -1673,7 +1673,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 1.8);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 2.4);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -510,13 +510,13 @@ BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
             0.0, modelBias[i][0],
             8.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.91);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.94);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
 
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.94);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
 }
 
 BOOST_AUTO_TEST_CASE(testLinear) {
@@ -566,12 +566,12 @@ BOOST_AUTO_TEST_CASE(testLinear) {
             0.0, modelBias[i][0],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.93);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testNonLinear) {
@@ -632,12 +632,12 @@ BOOST_AUTO_TEST_CASE(testNonLinear) {
             0.0, modelBias[i][0],
             4.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testHuber) {
@@ -695,13 +695,13 @@ BOOST_AUTO_TEST_CASE(testHuber) {
             0.0, modelBias[i],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.95);
+        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.94);
 
         meanModelRSquared.add(modelRSquared[i]);
     }
 
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testMsle) {
@@ -1014,8 +1014,8 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.16);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.93);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.1);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.97);
 }
 
 BOOST_AUTO_TEST_CASE(testFeatureBags) {
@@ -1437,13 +1437,13 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.81);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.8);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.57);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.56);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
@@ -1673,13 +1673,13 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 2.2);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 1.8);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 1.5);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 1.4);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {
@@ -2015,8 +2015,8 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
 
         regression->train();
 
-        // We use a single leaf to centre the data so end up with limit + 1 trees.
-        BOOST_REQUIRE_EQUAL(11, regression->bestHyperparameters().maximumNumberTrees());
+        // We use a single leaf to centre the data so end up with *at most* limit + 1 trees.
+        BOOST_TEST_REQUIRE(regression->bestHyperparameters().maximumNumberTrees() <= 11);
         BOOST_REQUIRE_EQUAL(
             0.1, regression->bestHyperparameters().regularization().treeSizePenaltyMultiplier());
         BOOST_REQUIRE_EQUAL(

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -143,7 +143,7 @@ CBayesianOptimisation::maximumExpectedImprovement(double negligibleExpectedImpro
     // Use random restarts inside the constraint bounding box.
     TVector interpolate(m_MinBoundary.size());
     TDoubleVec interpolates;
-    CSampling::uniformSample(m_Rng, 0.0, 1.0, 3 * m_Restarts * interpolate.size(), interpolates);
+    CSampling::uniformSample(m_Rng, 0.0, 1.0, 5 * m_Restarts * interpolate.size(), interpolates);
 
     TVector a{m_MinBoundary.cwiseQuotient(m_MaxBoundary - m_MinBoundary)};
     TVector b{m_MaxBoundary.cwiseQuotient(m_MaxBoundary - m_MinBoundary)};

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -537,7 +537,7 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
 
     // We restart optimization with initial guess on different scales for global probing.
     TDoubleVec scales;
-    scales.reserve((m_Restarts - 1) * n);
+    scales.reserve(10 * (m_Restarts - 1) * n);
     CSampling::uniformSample(m_Rng, CTools::stableLog(0.2), CTools::stableLog(5.0),
                              10 * (m_Restarts - 1) * n, scales);
 

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -31,6 +31,7 @@
 #include <boost/optional/optional_io.hpp>
 
 #include <exception>
+#include <limits>
 
 namespace ml {
 namespace maths {
@@ -730,13 +731,13 @@ double CBayesianOptimisation::dissimilarity(const TVector& x) const {
     //      existing point tells us accurately what the loss will be in its immediate
     //      neighbourhood and running there again is duplicate work.
     double sum{0.0};
-    double min{0.0};
+    double min{std::numeric_limits<double>::max()};
     for (const auto& y : m_FunctionMeanValues) {
         double dxy{las::distance(x, y.first)};
         sum += dxy;
-        min += std::min(min, -dxy);
+        min += std::min(min, dxy);
     }
-    return sum / static_cast<double>(m_FunctionMeanValues.size()) - min;
+    return sum / static_cast<double>(m_FunctionMeanValues.size()) + min;
 }
 
 void CBayesianOptimisation::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -714,6 +714,15 @@ CBayesianOptimisation::TVector CBayesianOptimisation::transformTo01(const TVecto
 }
 
 double CBayesianOptimisation::dissimilarity(const TVector& x) const {
+    // This is used as a fallback when GP is very unsure we can actually make progress,
+    // i.e. EI is miniscule. In this case we fallback to a different strategy to break
+    // ties at the probes we used for the GP. We use two criteria:
+    //   1. The average distance to points we already tried: we prefer evaluation points
+    //      where the density of points is low,
+    //   2. The minimum distance to any point we've already tried: we assume the loss
+    //      is fairly smooth (to bother trying to do better than random search) so any
+    //      existing point tells us accurately what the loss will be in its immediate
+    //      neighbourhood and running there again is duplicate work.
     double sum{0.0};
     double min{0.0};
     for (const auto& y : m_FunctionMeanValues) {

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -143,7 +143,7 @@ CBayesianOptimisation::maximumExpectedImprovement(double negligibleExpectedImpro
     // Use random restarts inside the constraint bounding box.
     TVector interpolate(m_MinBoundary.size());
     TDoubleVec interpolates;
-    CSampling::uniformSample(m_Rng, 0.0, 1.0, 5 * m_Restarts * interpolate.size(), interpolates);
+    CSampling::uniformSample(m_Rng, 0.0, 1.0, 10 * m_Restarts * interpolate.size(), interpolates);
 
     TVector a{m_MinBoundary.cwiseQuotient(m_MaxBoundary - m_MinBoundary)};
     TVector b{m_MaxBoundary.cwiseQuotient(m_MaxBoundary - m_MinBoundary)};

--- a/lib/maths/common/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/common/unittest/CBayesianOptimisationTest.cc
@@ -279,10 +279,12 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
     TVector a(vector({-10.0, -10.0, -10.0, -10.0}));
     TVector b(vector({10.0, 10.0, 10.0, 10.0}));
 
+    std::size_t wins{0};
+    std::size_t losses{0};
     TMeanAccumulator meanImprovementBopt;
     TMeanAccumulator meanImprovementRs;
 
-    for (std::size_t test = 0; test < 20; ++test) {
+    for (std::size_t test = 0; test < 50; ++test) {
 
         rng.generateUniformSamples(-10.0, 10.0, 12, centreCoordinates);
         rng.generateUniformSamples(0.3, 4.0, 12, coordinateScales);
@@ -323,9 +325,9 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
 
         LOG_TRACE(<< "Bayesian optimisation...");
         double f0Bopt{fminBopt};
-        for (std::size_t i = 0; i < 20; ++i) {
+        for (std::size_t i = 0; i < 30; ++i) {
             TVector x;
-            std::tie(x, std::ignore) = bopt.maximumExpectedImprovement(0.0);
+            std::tie(x, std::ignore) = bopt.maximumExpectedImprovement();
             LOG_TRACE(<< "x = " << x.transpose() << ", f(x) = " << f(x));
             bopt.add(x, f(x), 10.0);
             fminBopt = std::min(fminBopt, f(x));
@@ -334,7 +336,7 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
 
         LOG_TRACE(<< "random search...");
         double f0Rs{fminRs};
-        for (std::size_t i = 0; i < 20; ++i) {
+        for (std::size_t i = 0; i < 30; ++i) {
             rng.generateUniformSamples(0.0, 1.0, 4, randomSearch);
             TVector x{a + vector(randomSearch).asDiagonal() * (b - a)};
             LOG_TRACE(<< "x = " << x.transpose() << ", f(x) = " << f(x));
@@ -344,17 +346,20 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
 
         LOG_DEBUG(<< "% improvement BO = " << 100.0 * improvementBopt
                   << ", % improvement RS = " << 100.0 * improvementRs);
-        BOOST_TEST_REQUIRE(improvementBopt > improvementRs);
+        wins += improvementBopt > improvementRs ? 1 : 0;
+        losses += improvementBopt > improvementRs ? 0 : 1;
         meanImprovementBopt.add(improvementBopt);
         meanImprovementRs.add(improvementRs);
     }
 
+    LOG_DEBUG(<< "wins = " << wins << ", losses = " << losses);
     LOG_DEBUG(<< "mean % improvement BO = "
               << 100.0 * maths::common::CBasicStatistics::mean(meanImprovementBopt));
     LOG_DEBUG(<< "mean % improvement RS = "
               << 100.0 * maths::common::CBasicStatistics::mean(meanImprovementRs));
+    BOOST_TEST_REQUIRE(wins > static_cast<std::size_t>(0.95 * 50)); // 95% better
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanImprovementBopt) >
-                       1.8 * maths::common::CBasicStatistics::mean(meanImprovementRs)); // 80%
+                       1.6 * maths::common::CBasicStatistics::mean(meanImprovementRs)); // 60% mean improvement
 }
 
 BOOST_AUTO_TEST_CASE(testPersistRestore) {

--- a/lib/maths/common/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/common/unittest/CBayesianOptimisationTest.cc
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
         double f0Bopt{fminBopt};
         for (std::size_t i = 0; i < 20; ++i) {
             TVector x;
-            std::tie(x, std::ignore) = bopt.maximumExpectedImprovement();
+            std::tie(x, std::ignore) = bopt.maximumExpectedImprovement(0.0);
             LOG_TRACE(<< "x = " << x.transpose() << ", f(x) = " << f(x));
             bopt.add(x, f(x), 10.0);
             fminBopt = std::min(fminBopt, f(x));


### PR DESCRIPTION
These were found debugging sources of cross-platform variation.
1. `1 + erf` underflows when `erf` is within double epsilon of 1. `boost::normal` distribution has a better cdf implementation which computes values accurate to double precision as small as minimum (positive) double. This means we get better estimates of EI and its gradient.
2. Depending on the kernel parameters EI can be very small. In the case when it underflows we broke ties by dimension lexicograpical order for the points. From an optimisation standpoint this is a silly choice. I've changed it to prefer the we tried point which is most dissimilar to points we've already tried (i.e. pure exploration).

Both of these incidentally mean the exact choice of points BO will propose is more sensitive to numerics which can vary slightly between platforms, because, for example, there are differences in standard library implementations.