### PR TITLE
[ML] Fix deprecation warning for macOS build

### DIFF
--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -153,7 +153,7 @@ public:
                                const TResultWriterFunc& resultWriter,
                                const TPivotWriterFunc& pivotsWriterFunc);
 
-    virtual ~CHierarchicalResultsWriter() override = default;
+   ~CHierarchicalResultsWriter() override = default;
 
     //! Write \p node.
     void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) override;

--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -153,7 +153,7 @@ public:
                                const TResultWriterFunc& resultWriter,
                                const TPivotWriterFunc& pivotsWriterFunc);
 
-   ~CHierarchicalResultsWriter() override = default;
+    ~CHierarchicalResultsWriter() override = default;
 
     //! Write \p node.
     void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) override;

--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -153,6 +153,8 @@ public:
                                const TResultWriterFunc& resultWriter,
                                const TPivotWriterFunc& pivotsWriterFunc);
 
+    virtual ~CHierarchicalResultsWriter() override = default;
+
     //! Write \p node.
     void visit(const model::CHierarchicalResults& results, const TNode& node, bool pivot) override;
 

--- a/include/core/CBase64Filter.h
+++ b/include/core/CBase64Filter.h
@@ -95,7 +95,7 @@ public:
     CBase64Encoder();
 
     //! Destructor
-    virtual ~CBase64Encoder();
+    virtual ~CBase64Encoder() = default;
 
     //! Interface method for handling stream data: n bytes are available from s,
     //! and output is written to snk.
@@ -229,7 +229,7 @@ public:
     CBase64Decoder();
 
     //! Destructor
-    virtual ~CBase64Decoder();
+    virtual ~CBase64Decoder() = default;
 
     //! Interface method: read as many bytes as we need from src, and
     //! put up to n output bytes into s

--- a/include/core/CFastMutex.h
+++ b/include/core/CFastMutex.h
@@ -17,7 +17,7 @@
 
 #ifndef Windows
 #ifdef MacOSX
-#include <libkern/OSAtomic.h>
+#include <os/lock.h>
 #else
 #include <pthread.h>
 #endif
@@ -76,7 +76,7 @@ private:
 #ifdef Windows
     SRWLOCK m_Mutex;
 #elif defined(MacOSX)
-    OSSpinLock m_Mutex;
+    os_unfair_lock m_Mutex;
 #else
     pthread_mutex_t m_Mutex;
 #endif

--- a/include/core/CFastMutex.h
+++ b/include/core/CFastMutex.h
@@ -45,16 +45,10 @@ namespace core {
 //!
 //! All errors are just warnings - no action taken.
 //!
-//! On Mac OS X, spin locks are also used, which might seem strange
-//! given that Mac OS X will have relatively few available CPU cores
-//! (say 2-4).  However, Mac OS X spinlocks are actually quite clever
-//! about yielding if they don't quickly get a lock, and are hence
-//! more akin to adaptive mutexes than pure spinlocks.  The source
-//! code at confirms this:
-//! http://www.opensource.apple.com/source/Libc/Libc-825.25/x86_64/sys/spinlocks_asm.s
-//! The other reason is that pthread mutexes are appallingly slow on
-//! Mac OS X so it's easy to massively outperform them - e.g. see:
-//! http://www.mr-edd.co.uk/blog/sad_state_of_osx_pthread_mutex_t
+//! On Mac OS X, spin locks used to be used, but OSSpinLock has now
+//! been tagged as deprecated as of macOS 10.12. Instead, Apple have
+//! provided os_unfair_lock as a replacement (see the documentation here
+//! https://developer.apple.com/documentation/os/1646466-os_unfair_lock_lock)
 //!
 //! On Linux, standard non-recursive mutexes are used, on the
 //! assumption that Linux may have relatively few available CPU

--- a/include/core/CFastMutex.h
+++ b/include/core/CFastMutex.h
@@ -49,6 +49,8 @@ namespace core {
 //! been tagged as deprecated as of macOS 10.12. Instead, Apple have
 //! provided os_unfair_lock as a replacement (see the documentation here
 //! https://developer.apple.com/documentation/os/1646466-os_unfair_lock_lock)
+//! The other reason is that pthread mutexes are appallingly slow on
+//! Mac OS X so it's easy to massively outperform them
 //!
 //! On Linux, standard non-recursive mutexes are used, on the
 //! assumption that Linux may have relatively few available CPU

--- a/include/core/CVectorRange.h
+++ b/include/core/CVectorRange.h
@@ -91,6 +91,8 @@ public:
         return vector_range_detail::SDoAssign<VECTOR>::dispatch(*this, other);
     }
 
+    CVectorRange(const CVectorRange&) = default;
+
     //! Assign from value.
     template<typename T>
     void assign(size_type n, const T& value) {

--- a/include/core/CXmlNode.h
+++ b/include/core/CXmlNode.h
@@ -71,7 +71,7 @@ public:
 
     CXmlNode(const std::string& name, const std::string& value, const TStrStrMap& attributes);
 
-    virtual ~CXmlNode();
+    virtual ~CXmlNode() = default;
 
     //! Accessors
     const std::string& name() const;

--- a/include/maths/common/CClusterer.h
+++ b/include/maths/common/CClusterer.h
@@ -147,7 +147,7 @@ public:
                         const TMergeFunc& mergeFunc = CDoNothing())
         : m_SplitFunc(splitFunc), m_MergeFunc(mergeFunc) {}
 
-    virtual ~CClusterer() {}
+    virtual ~CClusterer() = default;
 
     //! \name Clusterer Contract
     //@{

--- a/include/maths/common/CMultivariateNormalConjugate.h
+++ b/include/maths/common/CMultivariateNormalConjugate.h
@@ -149,7 +149,7 @@ public:
                                              this, std::placeholders::_1));
     }
 
-    ~CMultivariateNormalConjugate() override {}
+    ~CMultivariateNormalConjugate() override = default;
 
     // Default copy constructor and assignment operator work.
 

--- a/include/model/CHierarchicalResults.h
+++ b/include/model/CHierarchicalResults.h
@@ -404,7 +404,7 @@ public:
     using TNode = CHierarchicalResults::TNode;
 
 public:
-    virtual ~CHierarchicalResultsVisitor();
+    virtual ~CHierarchicalResultsVisitor() = default;
 
     //! Visit a node.
     virtual void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) = 0;

--- a/include/model/CHierarchicalResultsAggregator.h
+++ b/include/model/CHierarchicalResultsAggregator.h
@@ -52,6 +52,8 @@ public:
 public:
     CHierarchicalResultsAggregator(const CAnomalyDetectorModelConfig& modelConfig);
 
+    virtual ~CHierarchicalResultsAggregator() override = default;
+
     //! Add a job for the subsequent invocations of the normalizer.
     void setJob(EJob job);
 

--- a/include/model/CHierarchicalResultsAggregator.h
+++ b/include/model/CHierarchicalResultsAggregator.h
@@ -52,7 +52,7 @@ public:
 public:
     CHierarchicalResultsAggregator(const CAnomalyDetectorModelConfig& modelConfig);
 
-    virtual ~CHierarchicalResultsAggregator() override = default;
+    ~CHierarchicalResultsAggregator() override = default;
 
     //! Add a job for the subsequent invocations of the normalizer.
     void setJob(EJob job);

--- a/include/model/CHierarchicalResultsLevelSet.h
+++ b/include/model/CHierarchicalResultsLevelSet.h
@@ -59,6 +59,8 @@ protected:
     explicit CHierarchicalResultsLevelSet(const T& bucketElement)
         : m_BucketElement(bucketElement) {}
 
+    virtual ~CHierarchicalResultsLevelSet() override = default;
+
     //! Get the root unique element.
     const T& bucketElement() const { return m_BucketElement; }
     //! Get a writable root unique element.

--- a/include/model/CHierarchicalResultsLevelSet.h
+++ b/include/model/CHierarchicalResultsLevelSet.h
@@ -59,7 +59,7 @@ protected:
     explicit CHierarchicalResultsLevelSet(const T& bucketElement)
         : m_BucketElement(bucketElement) {}
 
-    virtual ~CHierarchicalResultsLevelSet() override = default;
+   ~CHierarchicalResultsLevelSet() override = default;
 
     //! Get the root unique element.
     const T& bucketElement() const { return m_BucketElement; }

--- a/include/model/CHierarchicalResultsLevelSet.h
+++ b/include/model/CHierarchicalResultsLevelSet.h
@@ -59,7 +59,7 @@ protected:
     explicit CHierarchicalResultsLevelSet(const T& bucketElement)
         : m_BucketElement(bucketElement) {}
 
-   ~CHierarchicalResultsLevelSet() override = default;
+    ~CHierarchicalResultsLevelSet() override = default;
 
     //! Get the root unique element.
     const T& bucketElement() const { return m_BucketElement; }

--- a/include/model/CHierarchicalResultsNormalizer.h
+++ b/include/model/CHierarchicalResultsNormalizer.h
@@ -108,7 +108,7 @@ public:
 public:
     CHierarchicalResultsNormalizer(const CAnomalyDetectorModelConfig& modelConfig);
 
-    virtual ~CHierarchicalResultsNormalizer() override = default;
+    ~CHierarchicalResultsNormalizer() override = default;
 
     //! Add a job for the subsequent invocations of the normalizer.
     void setJob(EJob job);

--- a/include/model/CHierarchicalResultsNormalizer.h
+++ b/include/model/CHierarchicalResultsNormalizer.h
@@ -108,6 +108,8 @@ public:
 public:
     CHierarchicalResultsNormalizer(const CAnomalyDetectorModelConfig& modelConfig);
 
+    virtual ~CHierarchicalResultsNormalizer() override = default;
+
     //! Add a job for the subsequent invocations of the normalizer.
     void setJob(EJob job);
 

--- a/include/model/CHierarchicalResultsPopulator.h
+++ b/include/model/CHierarchicalResultsPopulator.h
@@ -28,7 +28,7 @@ public:
     //! Constructor
     CHierarchicalResultsPopulator(const CLimits& limits);
 
-    virtual ~CHierarchicalResultsPopulator() override = default;
+    ~CHierarchicalResultsPopulator() override = default;
 
     //! Visit \p node.
     void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;

--- a/include/model/CHierarchicalResultsPopulator.h
+++ b/include/model/CHierarchicalResultsPopulator.h
@@ -28,6 +28,8 @@ public:
     //! Constructor
     CHierarchicalResultsPopulator(const CLimits& limits);
 
+    virtual ~CHierarchicalResultsPopulator() override = default;
+
     //! Visit \p node.
     void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 

--- a/include/model/CHierarchicalResultsProbabilityFinalizer.h
+++ b/include/model/CHierarchicalResultsProbabilityFinalizer.h
@@ -31,6 +31,8 @@ namespace model {
 //! breadth first pass over the results.
 class MODEL_EXPORT CHierarchicalResultsProbabilityFinalizer : public CHierarchicalResultsVisitor {
 public:
+    virtual ~CHierarchicalResultsProbabilityFinalizer() override = default;
+
     //! Finalize the probability of \p node.
     void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;
 };

--- a/include/model/CHierarchicalResultsProbabilityFinalizer.h
+++ b/include/model/CHierarchicalResultsProbabilityFinalizer.h
@@ -31,7 +31,7 @@ namespace model {
 //! breadth first pass over the results.
 class MODEL_EXPORT CHierarchicalResultsProbabilityFinalizer : public CHierarchicalResultsVisitor {
 public:
-    virtual ~CHierarchicalResultsProbabilityFinalizer() override = default;
+    ~CHierarchicalResultsProbabilityFinalizer() override = default;
 
     //! Finalize the probability of \p node.
     void visit(const CHierarchicalResults& results, const TNode& node, bool pivot) override;

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -177,7 +177,7 @@ void CInferenceModelMetadata::writeHyperparameterImportance(TRapidJsonWriter& wr
     writer.EndArray();
 }
 
-void CInferenceModelMetadata::writeTrainParameters(TRapidJsonWriter& writer) const {
+void CInferenceModelMetadata::writeTrainParameters(TRapidJsonWriter& /*writer*/) const {
     // TODO enable with Java changes.
     // Only write out if it has been set.
     //if (m_TrainingFractionPerFold > 0.0) {

--- a/lib/core/CBase64Filter.cc
+++ b/lib/core/CBase64Filter.cc
@@ -17,14 +17,8 @@ namespace core {
 CBase64Encoder::CBase64Encoder() : m_Buffer(4096) {
 }
 
-CBase64Encoder::~CBase64Encoder() {
-}
-
 CBase64Decoder::CBase64Decoder()
     : m_BufferIn(4096), m_BufferOut(4096), m_Eos(false) {
-}
-
-CBase64Decoder::~CBase64Decoder() {
 }
 
 } // core

--- a/lib/core/CFastMutex_MacOSX.cc
+++ b/lib/core/CFastMutex_MacOSX.cc
@@ -13,21 +13,18 @@
 namespace ml {
 namespace core {
 
-CFastMutex::CFastMutex()
-    // The OSSpinLock type is just an integer, and zero means unlocked.  See
-    // "man spinlock" for details.
-    : m_Mutex(0) {
+CFastMutex::CFastMutex() : m_Mutex(OS_UNFAIR_LOCK_INIT) {
 }
 
 CFastMutex::~CFastMutex() {
 }
 
 void CFastMutex::lock() {
-    OSSpinLockLock(&m_Mutex);
+    os_unfair_lock_lock(&m_Mutex);
 }
 
 void CFastMutex::unlock() {
-    OSSpinLockUnlock(&m_Mutex);
+    os_unfair_lock_unlock(&m_Mutex);
 }
 }
 }

--- a/lib/core/CXmlNode.cc
+++ b/lib/core/CXmlNode.cc
@@ -28,9 +28,6 @@ CXmlNode::CXmlNode(const std::string& name, const std::string& value, const TStr
       m_Attributes(attributes.begin(), attributes.end()) {
 }
 
-CXmlNode::~CXmlNode() {
-}
-
 const std::string& CXmlNode::name() const {
     return m_Name;
 }

--- a/lib/maths/common/unittest/COrderingsTest.cc
+++ b/lib/maths/common/unittest/COrderingsTest.cc
@@ -50,6 +50,8 @@ public:
 public:
     CDictionary(const TStrVec& words) : m_Words(words) {}
 
+    CDictionary(const CDictionary&) = default;
+
     CDictionary& operator=(const CDictionary& other) {
         ++ms_Copies;
         m_Words = other.m_Words;

--- a/lib/model/CHierarchicalResults.cc
+++ b/lib/model/CHierarchicalResults.cc
@@ -167,7 +167,7 @@ void aggregateLayer(ITR beginLayer,
 //! that it is either the person or partition field of that node.
 class CCommonInfluencePropagator : public CHierarchicalResultsVisitor {
 public:
-    virtual ~CCommonInfluencePropagator() override = default;
+    ~CCommonInfluencePropagator() override = default;
 
     void visit(const CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         if (this->isLeaf(node)) {

--- a/lib/model/CHierarchicalResults.cc
+++ b/lib/model/CHierarchicalResults.cc
@@ -167,6 +167,8 @@ void aggregateLayer(ITR beginLayer,
 //! that it is either the person or partition field of that node.
 class CCommonInfluencePropagator : public CHierarchicalResultsVisitor {
 public:
+    virtual ~CCommonInfluencePropagator() override = default;
+
     void visit(const CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         if (this->isLeaf(node)) {
             std::sort(node.s_AnnotatedProbability.s_Influences.begin(),
@@ -587,9 +589,6 @@ void CHierarchicalResults::postorderDepthFirst(const TNode* node,
         this->postorderDepthFirst(child, visitor);
     }
     visitor.visit(*this, *node, /*pivot =*/false);
-}
-
-CHierarchicalResultsVisitor::~CHierarchicalResultsVisitor() {
 }
 
 bool CHierarchicalResultsVisitor::isRoot(const TNode& node) {


### PR DESCRIPTION
Deprecation warnings were enabled for a build on macOS 11.6.1 using clang
13.0.0 by way of adding the `-Wdeprecated` flag to clang's arguments.
The majority of the warnings related to implicit constructors of one
sort or another, with a notable exception being `OSSpinLock` being
deprecated in favour of `os_unfair_lock` since macOS 10.12.

labelling as `>non-issue` as no functional change has been made.