### PR TITLE
[ML] Improve regression and classification training stability

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@
 * Fix a bug in the tuning of the hyperparameters when training regression
   classification models. (See {ml-pull}2128[#2128].)
 * Improve training stability for regression and classification models
-  (See {ml-pull}2144[#2144].)
+  (See {ml-pull}2144[#2144] and {ml-pull}2150[#2150].)
 
 == {es} version 8.0.0
 

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -99,6 +99,25 @@ private:
     std::int64_t m_MemoryUsage;
 };
 
+//! \brief Resets a random number generator then jumps 2^64 values using the RAII idiom.
+class CResetAndJumpOnExit {
+public:
+    explicit CResetAndJumpOnExit(common::CPRNG::CXorOShiro128Plus& rng)
+        : m_Rng{rng}, m_RngCopy{rng} {}
+
+    ~CResetAndJumpOnExit() {
+        m_Rng = m_RngCopy;
+        m_Rng.jump();
+    }
+
+    CResetAndJumpOnExit(const CResetAndJumpOnExit&) = delete;
+    CResetAndJumpOnExit& operator=(const CResetAndJumpOnExit&) = delete;
+
+private:
+    common::CPRNG::CXorOShiro128Plus& m_Rng;
+    common::CPRNG::CXorOShiro128Plus m_RngCopy;
+};
+
 //! \brief Manages exiting from the loop adding trees to the forest.
 //!
 //! DESCRIPTION:\n
@@ -635,6 +654,12 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
                               core::CLoopProgress& trainingProgress) const {
 
     LOG_TRACE(<< "Training one forest...");
+
+    // We always advance the rng a fixed number of steps training one forest.
+    // This ensures even if decisions change for a single forest then we produce
+    // the same sequence of random numbers next time round. We advance the rng
+    // enough so that the sequences for different calls won't overlap.
+    CResetAndJumpOnExit resetAndJumpOnExit{m_Rng};
 
     std::size_t maximumTreeSize{this->maximumTreeSize(trainingRowMask)};
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(testLinear) {
             0.0, modelBias[i][0],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.96);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
@@ -701,7 +701,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
     }
 
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.95);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
 }
 
 BOOST_AUTO_TEST_CASE(testMsle) {
@@ -1015,7 +1015,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.1);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.93);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testFeatureBags) {
@@ -1227,7 +1227,7 @@ BOOST_AUTO_TEST_CASE(testSingleSplit) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.21);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.94);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.98);
 }
 
 BOOST_AUTO_TEST_CASE(testTranslationInvariance) {
@@ -1437,13 +1437,13 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.8);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.7);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.56);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.52);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
@@ -1673,13 +1673,13 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 2.4);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 1.9);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 1.6);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 1.4);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByTrain) {


### PR DESCRIPTION
Currently, if we make any different choice in any round of training it affects the random number generator state which will affect the numbers we choose for all subsequent rounds. This tends to amplify differences in results especially those related to say slightly different numerics on different platforms.

With this change I reset the rng and then jump (by 2^64 values) after each forest we train. This means different choices for a particular round don't affect random numbers drawn in subsequent rounds. The jump is large enough that sequences don't overlap.