### PR TITLE
[ML] Relax test threshold

### DIFF
--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1443,7 +1443,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.52);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.53);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {


### PR DESCRIPTION
One of the thresholds that was tightened up in #2150 causes
failures in builds without optimisation, for example:

1. https://elasticsearch-ci.elastic.co/job/elastic+machine-learning+main+linux-aarch64+debug/130/testReport
2. https://elasticsearch-ci.elastic.co/job/elastic+machine-learning+main+macos-aarch64+debug/130/testReport