### PR TITLE
[8.0] [ML] Tighten up the pattern used to copy Torch dependencies

### DIFF
--- a/3rd_party/3rd_party.sh
+++ b/3rd_party/3rd_party.sh
@@ -248,9 +248,9 @@ if [ ! -z "$TORCH_LOCATION" ] ; then
         if [ -n "$INSTALL_DIR" ] ; then
             for LIBRARY in $TORCH_LIBRARIES
             do
-                rm -f $INSTALL_DIR/*$LIBRARY*$TORCH_EXTENSION
-                cp $TORCH_LOCATION/*$LIBRARY*$TORCH_EXTENSION $INSTALL_DIR
-                chmod u+wx $INSTALL_DIR/*$LIBRARY*$TORCH_EXTENSION
+                rm -f $INSTALL_DIR/*$LIBRARY$TORCH_EXTENSION
+                cp $TORCH_LOCATION/*$LIBRARY$TORCH_EXTENSION $INSTALL_DIR
+                chmod u+wx $INSTALL_DIR/*$LIBRARY$TORCH_EXTENSION
             done
         fi
     else


### PR DESCRIPTION
The old pattern was too lax, copying all files with "c10" in
their names, which also matches "gcc10". This was causing us
to copy the symlinked versions of the Boost libraries and hence
ship each Boost library twice on Linux.

Backport of #2164