### PR TITLE
[ML] Ensure we have sufficient resolution when we reinitialise component models 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -72,6 +72,17 @@
   - the C++ front end to PyTorch - and performs inference on models stored in the
   TorchScript format. (See {ml-pull}1902[#1902].)
 
+
+== {es} version 7.17.0
+
+=== Bug Fixes
+
+* Avoid transient poor time series modelling after detecting new seasonal components.
+  This can affect cases where we have fast and slow repeats in the data, for example
+  30 mins and 1 day, and the job uses a short bucket length. The outcome can be transient
+  poor predictions and model bounds, and sometimes false positive anomalies. (See
+  {ml-pull}2167[#2167].)
+
 == {es} version 7.16.0
 
 === Enhancements

--- a/include/maths/time_series/CExpandingWindow.h
+++ b/include/maths/time_series/CExpandingWindow.h
@@ -88,6 +88,9 @@ public:
     //! Get the number of bucket values.
     std::size_t size() const;
 
+    //! Check if there are shorter windows.
+    bool haveShorterWindows() const;
+
     //! Get the mean time offset of the data points added with respect to the start
     //! of the sample interval.
     core_t::TTime sampleAverageOffset() const;
@@ -132,7 +135,7 @@ public:
     bool needToCompress(core_t::TTime time) const;
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -59,6 +59,7 @@ public:
     using TMakeTestForSeasonality =
         std::function<CTimeSeriesTestForSeasonality(const CExpandingWindow&,
                                                     core_t::TTime,
+                                                    std::size_t,
                                                     const TFilteredPredictor&)>;
     // clang-format on
 

--- a/include/maths/time_series/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/time_series/CTimeSeriesTestForSeasonality.h
@@ -224,14 +224,17 @@ public:
                                   double outlierFraction = OUTLIER_FRACTION);
 
     //! Check if it is possible to test for \p component given the window \p values.
-    static bool canTestComponent(const TFloatMeanAccumulatorVec& values,
-                                 core_t::TTime bucketsStartTime,
-                                 core_t::TTime bucketLength,
-                                 core_t::TTime minimumPeriod,
-                                 const CSeasonalTime& component);
+    static bool canTestModelledComponent(const TFloatMeanAccumulatorVec& values,
+                                         core_t::TTime bucketsStartTime,
+                                         core_t::TTime bucketLength,
+                                         core_t::TTime minimumPeriod,
+                                         std::size_t minimumResolution,
+                                         const CSeasonalTime& component);
 
     //! Register a seasonal component which is already being modelled.
-    void addModelledSeasonality(const CSeasonalTime& period, std::size_t size);
+    void addModelledSeasonality(const CSeasonalTime& period,
+                                std::size_t minimumResolution,
+                                std::size_t size);
 
     //! Add a predictor for the currently modelled seasonal conponents.
     void modelledSeasonalityPredictor(const TPredictor& predictor);

--- a/lib/maths/time_series/CExpandingWindow.cc
+++ b/lib/maths/time_series/CExpandingWindow.cc
@@ -104,6 +104,10 @@ std::size_t CExpandingWindow::size() const {
     return m_Size;
 }
 
+bool CExpandingWindow::haveShorterWindows() const {
+    return m_BucketLengthIndex > 0;
+}
+
 core_t::TTime CExpandingWindow::sampleAverageOffset() const {
     return static_cast<core_t::TTime>(common::CBasicStatistics::mean(m_MeanOffset) + 0.5);
 }
@@ -246,7 +250,7 @@ bool CExpandingWindow::needToCompress(core_t::TTime time) const {
     return time >= this->endTime();
 }
 
-uint64_t CExpandingWindow::checksum(uint64_t seed) const {
+std::uint64_t CExpandingWindow::checksum(std::uint64_t seed) const {
     CScopeInflate inflate(*this, false);
     seed = common::CChecksum::calculate(seed, m_BucketLengthIndex);
     seed = common::CChecksum::calculate(seed, m_StartTime);

--- a/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
@@ -2172,6 +2172,9 @@ BOOST_FIXTURE_TEST_CASE(testFastAndSlowSeasonality, CTestFixture) {
     }
 
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.06);
+
+    // We should be modelling both seasonalities.
+    BOOST_TEST_REQUIRE(2, decomposition.seasonalComponents().size());
 }
 
 BOOST_FIXTURE_TEST_CASE(testSwap, CTestFixture) {

--- a/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
@@ -2026,7 +2026,7 @@ BOOST_FIXTURE_TEST_CASE(testComponentLifecycle, CTestFixture) {
         debug.addPrediction(time, prediction, trend(time) + noise[0] - prediction);
     }
 
-    double bounds[]{0.01, 0.013, 0.15, 0.02};
+    TDoubleVec bounds{0.01, 0.013, 0.22, 0.02};
     for (std::size_t i = 0; i < 4; ++i) {
         double error{maths::common::CBasicStatistics::mean(errors[i])};
         LOG_DEBUG(<< "error = " << error);

--- a/lib/maths/time_series/unittest/CTimeSeriesTestForSeasonalityTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesTestForSeasonalityTest.cc
@@ -1078,7 +1078,7 @@ BOOST_AUTO_TEST_CASE(testModelledSeasonalityWithNoChange) {
             maths::time_series::CTimeSeriesTestForSeasonality seasonality{
                 0, 0, HOUR, FIVE_MINS, values};
             for (const auto& time : modelledComponents[index[0]]) {
-                seasonality.addModelledSeasonality(time, 24);
+                seasonality.addModelledSeasonality(time, 2, 24);
             }
 
             auto result = seasonality.decompose();
@@ -1136,7 +1136,7 @@ BOOST_AUTO_TEST_CASE(testModelledSeasonalityWithChange) {
             maths::time_series::CTimeSeriesTestForSeasonality seasonality{
                 0, 0, HOUR, FIVE_MINS, values};
             for (const auto& time : modelledComponents[index[0]]) {
-                seasonality.addModelledSeasonality(time, 24);
+                seasonality.addModelledSeasonality(time, 2, 24);
             }
 
             auto result = seasonality.decompose();
@@ -1461,7 +1461,8 @@ BOOST_AUTO_TEST_CASE(testWithSuppliedPredictor) {
 
     maths::time_series::CTimeSeriesTestForSeasonality seasonality{
         startTime, startTime, HOUR, HOUR, values};
-    seasonality.addModelledSeasonality(maths::time_series::CDiurnalTime{0, 0, WEEK, DAY}, 24);
+    seasonality.addModelledSeasonality(
+        maths::time_series::CDiurnalTime{0, 0, WEEK, DAY}, 2, 24);
     seasonality.modelledSeasonalityPredictor([](core_t::TTime time, const TBoolVec&) {
         return std::sin(boost::math::double_constants::pi *
                         static_cast<double>(time % DAY) / static_cast<double>(DAY));


### PR DESCRIPTION
When we retest if a modelled seasonal component is still appropriate or may contain bias we now require higher resolution if shorter time windows are available. This is important because if the time series has a mixture of fast and slow seasonality we will detect the fast seasonality first and then potentially reinitialise it when we detect the slow seasonality. We should only do this if the window provides us with sufficient resolution to initialise it properly.

Closes #2166.