### PR TITLE
[8.0] [ML] Upload combined artifacts to GCS as well as S3

### DIFF
--- a/dev-tools/docker/build_check_style_image.sh
+++ b/dev-tools/docker/build_check_style_image.sh
@@ -28,7 +28,7 @@ cd `dirname $0`
 
 . ./prefetch_docker_image.sh
 CONTEXT=check_style_image
-prefetch_docker_image $CONTEXT/Dockerfile
+prefetch_docker_base_image $CONTEXT/Dockerfile
 docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
 # Get a username and password for this by visiting
 # https://docker-auth.elastic.co and allowing it to authenticate against your

--- a/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
@@ -30,7 +30,7 @@ cd `dirname $0`
 
 . ./prefetch_docker_image.sh
 CONTEXT=linux_aarch64_cross_image
-prefetch_docker_image $CONTEXT/Dockerfile
+prefetch_docker_base_image $CONTEXT/Dockerfile
 docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
 # Get a username and password for this by visiting
 # https://docker-auth.elastic.co and allowing it to authenticate against your

--- a/dev-tools/docker/build_linux_aarch64_native_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_native_build_image.sh
@@ -42,7 +42,7 @@ cd `dirname $0`
 
 . ./prefetch_docker_image.sh
 CONTEXT=linux_aarch64_native_image
-prefetch_docker_image $CONTEXT/Dockerfile
+prefetch_docker_base_image $CONTEXT/Dockerfile
 docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
 # Get a username and password for this by visiting
 # https://docker-auth.elastic.co and allowing it to authenticate against your

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -42,7 +42,7 @@ cd `dirname $0`
 
 . ./prefetch_docker_image.sh
 CONTEXT=linux_image
-prefetch_docker_image $CONTEXT/Dockerfile
+prefetch_docker_base_image $CONTEXT/Dockerfile
 docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
 # Get a username and password for this by visiting
 # https://docker-auth.elastic.co and allowing it to authenticate against your

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -30,7 +30,7 @@ cd `dirname $0`
 
 . ./prefetch_docker_image.sh
 CONTEXT=macosx_image
-prefetch_docker_image $CONTEXT/Dockerfile
+prefetch_docker_base_image $CONTEXT/Dockerfile
 docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
 # Get a username and password for this by visiting
 # https://docker-auth.elastic.co and allowing it to authenticate against your

--- a/dev-tools/docker/prefetch_docker_image.sh
+++ b/dev-tools/docker/prefetch_docker_image.sh
@@ -15,11 +15,8 @@
 # Making sure the "FROM" image is present locally before building an image
 # based on it removes the risk of a "docker build" failing due to transient
 # Docker registry problems.
-#
-# The argument is the path to the Dockerfile to be built.
 function prefetch_docker_image {
-    DOCKERFILE="$1"
-    IMAGE=$(grep '^FROM' "$DOCKERFILE" | awk '{ print $2 }' | head -1)
+    IMAGE="$1"
     ATTEMPT=0
     MAX_RETRIES=5
   
@@ -41,3 +38,12 @@ function prefetch_docker_image {
     done
 }
 
+# Similar to above, but taking a Dockerfile as an argument instead of the
+# image name and prefetching the base image.
+#
+# The argument is the path to the Dockerfile to be built.
+function prefetch_docker_base_image {
+    DOCKERFILE="$1"
+    IMAGE=$(grep '^FROM' "$DOCKERFILE" | awk '{ print $2 }' | head -1)
+    prefetch_docker_image "$IMAGE"
+}

--- a/dev-tools/docker_build.sh
+++ b/dev-tools/docker_build.sh
@@ -79,7 +79,7 @@ do
     DOCKERFILE="$TOOLS_DIR/docker/${PLATFORM}_builder/Dockerfile"
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
-    prefetch_docker_image "$DOCKERFILE"
+    prefetch_docker_base_image "$DOCKERFILE"
     docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT --build-arg ML_DEBUG=$ML_DEBUG -f "$DOCKERFILE" .
     # Using tar to copy the build artifacts out of the container seems more reliable
     # than docker cp, and also means the files end up with the correct uid/gid

--- a/dev-tools/docker_check_style.sh
+++ b/dev-tools/docker_check_style.sh
@@ -32,7 +32,7 @@ DOCKERFILE="$TOOLS_DIR/docker/style_checker/Dockerfile"
 TEMP_TAG=`git rev-parse --short=14 HEAD`-style-$$
 
 . "$TOOLS_DIR/docker/prefetch_docker_image.sh"
-prefetch_docker_image "$DOCKERFILE"
+prefetch_docker_base_image "$DOCKERFILE"
 docker build --no-cache --force-rm -t $TEMP_TAG -f "$DOCKERFILE" .
 docker run --rm --workdir=/ml-cpp $TEMP_TAG dev-tools/check-style.sh --all
 RC=$?

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -80,7 +80,7 @@ do
     DOCKERFILE="$TOOLS_DIR/docker/${PLATFORM}_tester/Dockerfile"
     TEMP_TAG=`git rev-parse --short=14 HEAD`-$PLATFORM-$$
 
-    prefetch_docker_image "$DOCKERFILE"
+    prefetch_docker_base_image "$DOCKERFILE"
     docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT --build-arg ML_DEBUG=$ML_DEBUG -f "$DOCKERFILE" .
     # Using tar to copy the build and test artifacts out of the container seems
     # more reliable than docker cp, and also means the files end up with the

--- a/dev-tools/jenkins_combine_artifacts.sh
+++ b/dev-tools/jenkins_combine_artifacts.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+
+# The post-processing step of ML C++ CI does the following:
+#
+# 1. Download the platform-specific artifacts built by the the first phase
+#    of the ML CI job.
+# 2. Combine the platform-specific artifacts into an all-platforms bundle,
+#    as used by the Elasticsearch build.
+# 3. Upload the all-platforms bundle to S3, where day-to-day Elasticsearch
+#    builds will download it from.
+# 4. Upload all artifacts, both platform-specific and all-platforms, to
+#    GCS, where release manager builds will download them from.
+#
+
+: "${HOME:?Need to set HOME to a non-empty value.}"
+: "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
+
+set +x
+
+# Change directory to the directory containing this script
+cd "$(dirname $0)"
+
+# Obtain AWS credentials from Vault
+. ./aws_creds_from_vault.sh
+
+set -e
+
+. docker/prefetch_docker_image.sh
+
+cd ..
+rm -rf build/distributions
+
+# Default to a snapshot build
+if [ -z "$BUILD_SNAPSHOT" ] ; then
+    BUILD_SNAPSHOT=true
+fi
+
+# The "branch" here selects which "$BRANCH.gradle" file of release manager is used
+VERSION=$(cat gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo)
+MAJOR=$(echo $VERSION | awk -F. '{ print $1 }')
+MINOR=$(echo $VERSION | awk -F. '{ print $2 }')
+if [ -n "$(git ls-remote --heads origin $MAJOR.$MINOR)" ] ; then
+    BRANCH=$MAJOR.$MINOR
+elif [ -n "$(git ls-remote --heads origin $MAJOR.x)" ] ; then
+    BRANCH=$MAJOR.x
+else
+    # TODO: keep an eye on this in case it changes to main
+    BRANCH=master
+fi
+
+# Jenkins sets BUILD_SNAPSHOT, but the Docker container requires a workflow that
+# is staging or snapshot
+if [ "$BUILD_SNAPSHOT" = false ] ; then
+    WORKFLOW=staging
+else
+    WORKFLOW=snapshot
+fi
+
+# Download from S3, combine, and upload to S3 using the AWS credentials obtained
+# above, and discarding the GCS credentials in the sub-shell before running
+# anything that might log the environment
+(unset GCS_VAULT_ROLE_ID GCS_VAULT_SECRET_ID && ./gradlew --info -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT uberUpload)
+
+# Allow other users access to read the artifacts so they are readable in the
+# container
+chmod a+r build/distributions/*
+
+# Allow other users write access to create checksum files
+chmod a+w build/distributions
+
+# Flip the Vault variables over to the GCS credentials
+case $- in
+    *x*)
+        set +x
+        REENABLE_X_OPTION=true
+        ;;
+    *)
+        REENABLE_X_OPTION=false
+        ;;
+esac
+export VAULT_ROLE_ID="$GCS_VAULT_ROLE_ID"
+export VAULT_SECRET_ID="$GCS_VAULT_SECRET_ID"
+unset GCS_VAULT_ROLE_ID GCS_VAULT_SECRET_ID
+if [ "$REENABLE_X_OPTION" = true ] ; then
+    set -x
+fi
+
+IMAGE=docker.elastic.co/infra/release-manager:latest
+prefetch_docker_image "$IMAGE"
+
+# Generate checksum files and upload to GCS
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR \
+  -e VAULT_ROLE_ID \
+  -e VAULT_SECRET_ID \
+  --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
+  "$IMAGE" \
+    cli collect \
+      --project ml-cpp \
+      --branch "$BRANCH" \
+      --commit `git rev-parse HEAD` \
+      --workflow "$WORKFLOW" \
+      --qualifier "$VERSION_QUALIFIER" \
+      --artifact-set main
+


### PR DESCRIPTION
The upload to S3 is done in the same way as before, except
that the call to Gradle is now made from a script rather
than being part of the Jenkins job config. This will make
it easier to evolve in the future without making infra
changes.

The upload to GCS is done by a Docker image owned by the
release team that generates checksums and metadata such
that release manager can generate a release from a specific
ml-cpp commit rather than always using the latest commit on
a given branch.

Backport of #2173