### PR TITLE
[8.0] [ML] Download debug symbols as well as binaries in combine step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,6 +300,13 @@ class DownloadPlatformSpecific extends DefaultTask {
         }
       }
       zip.close()
+      // Also download the corresponding zip of debug symbols, but there's no need to extract this
+      File debugZipFile = new File(downloadDirectory, "${baseName}-debug-${version}-${it}.zip")
+      new URL("https://prelert-artifacts.s3.amazonaws.com/maven/${artifactGroupPath}/${baseName}/${version}/${debugZipFile.name}").withInputStream { i ->
+        debugZipFile.withOutputStream { o ->
+          o << i
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
The "combine artifacts" step of the ML CI workflow previously
used to download platform-specific binaries from S3 and upload
an artifact built by combining them to S3. It didn't need to
do anything with the platform-specific debug symbols that were
already on S3.

Now that the "combine artifacts" step also uploads artifacts to
GCS it also needs to upload the zips containing the debug symbols.
Therefore, this commit changes the step that downloads
platform-specific artifacts to get the debug symbols too.

Backport of #2177