### PR TITLE
[7.17] [ML] Include version in dependency report file name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,7 +327,7 @@ task buildUberZipFromDownloads(type: Zip, dependsOn: downloadPlatformSpecific) {
 }
 
 task buildDependencyReport(type: Exec) {
-  outputs.file("${buildDir}/distributions/dependencies.csv")
+  outputs.file("${buildDir}/distributions/dependencies-${version}.csv")
   environment makeEnvironment
   commandLine bash
   args '-c', "source ./set_env.sh && 3rd_party/dependency_report.sh --csv \"${outputs.files.singleFile}\""


### PR DESCRIPTION
Currently the dependency report is always simply "dependencies.csv".

For integration into the new release manager workflow the file name
needs to also contain the qualified version.

Backport of #2180